### PR TITLE
feat(ios): show Talk voice mode

### DIFF
--- a/apps/ios/Sources/HomeToolbar.swift
+++ b/apps/ios/Sources/HomeToolbar.swift
@@ -85,6 +85,8 @@ struct TalkToolbarTray: View {
     var isSpeaking: Bool
     var isUserSpeechDetected: Bool
     var permissionState: TalkGatewayPermissionState
+    var voiceModeTitle: String
+    var voiceModeSubtitle: String?
     var onEnableTalk: () -> Void
     var onStopTalk: () -> Void
 
@@ -132,6 +134,13 @@ struct TalkToolbarTray: View {
 
                     Text(self.subtitle)
                         .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                if let voiceModeText = self.voiceModeText {
+                    Text(voiceModeText)
+                        .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
@@ -193,7 +202,22 @@ struct TalkToolbarTray: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Talk Mode")
-        .accessibilityValue("\(self.state.title), \(self.subtitle)")
+        .accessibilityValue(self.accessibilityValue)
+    }
+
+    private var accessibilityValue: String {
+        if let voiceModeText {
+            return "\(self.state.title), \(self.subtitle), \(voiceModeText)"
+        }
+        return "\(self.state.title), \(self.subtitle)"
+    }
+
+    private var voiceModeText: String? {
+        guard !self.state.prefersPermissionCopy else { return nil }
+        let title = self.voiceModeTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty, title != "Not loaded" else { return nil }
+        let subtitle = (self.voiceModeSubtitle ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return subtitle.isEmpty ? title : "\(title) • \(subtitle)"
     }
 
     private var subtitle: String {

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -519,6 +519,8 @@ private struct CanvasContent: View {
                         isSpeaking: self.appModel.talkMode.isSpeaking,
                         isUserSpeechDetected: self.appModel.talkMode.isUserSpeechDetected,
                         permissionState: self.appModel.talkMode.gatewayTalkPermissionState,
+                        voiceModeTitle: self.appModel.talkMode.gatewayTalkVoiceModeTitle,
+                        voiceModeSubtitle: self.appModel.talkMode.gatewayTalkVoiceModeSubtitle,
                         onEnableTalk: {
                             self.showTalkPermissionPrompt = true
                         },

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -633,6 +633,16 @@ struct SettingsTab: View {
                     }
                 }
             }
+            LabeledContent("Voice Mode") {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(self.appModel.talkMode.gatewayTalkVoiceModeTitle)
+                    if let subtitle = self.appModel.talkMode.gatewayTalkVoiceModeSubtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
             LabeledContent(
                 "Active Provider",
                 value: self.appModel.talkMode.gatewayTalkProviderLabel)

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -612,7 +612,7 @@ struct SettingsTab: View {
     private var shouldShowRealtimeVoicePicker: Bool {
         let providerSelection = TalkModeProviderSelection.resolved(self.talkProviderSelectionRaw)
         return providerSelection == .openAIRealtime
-            || self.appModel.talkMode.gatewayTalkUsesRealtimeRelay
+            || self.appModel.talkMode.gatewayTalkUsesRealtime
     }
 
     private func talkVoiceSettingsView() -> AnyView {

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -210,8 +210,9 @@ enum TalkModeGatewayConfigParser {
         let defaultVoiceId = Self.firstString(activeConfig, keys: ["voiceId", "voice"])
         let defaultOutputFormat = Self.firstString(activeConfig, keys: ["outputFormat"])
         let realtime = talk?["realtime"]?.dictionaryValue
-        let realtimeProvider = Self.firstString(realtime, keys: ["provider"])
         let realtimeProviders = realtime?["providers"]?.dictionaryValue
+        let realtimeProvider = Self.firstString(realtime, keys: ["provider"])
+            ?? Self.singleRealtimeProviderId(realtimeProviders)
         let realtimeProviderConfig = Self.realtimeProviderConfig(
             providers: realtimeProviders,
             provider: realtimeProvider)
@@ -272,6 +273,12 @@ enum TalkModeGatewayConfigParser {
             return .realtimeClient
         }
         return .native
+    }
+
+    private static func singleRealtimeProviderId(_ providers: [String: AnyCodable]?) -> String? {
+        guard let providers, providers.count == 1 else { return nil }
+        let provider = providers.keys.first?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return provider?.isEmpty == false ? provider : nil
     }
 
     private static func realtimeProviderConfig(

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -3,7 +3,105 @@ import OpenClawKit
 
 enum TalkModeExecutionMode {
     case native
+    case realtimeClient
     case realtimeRelay
+}
+
+struct TalkVoiceModeDescriptor: Equatable {
+    let title: String
+    let subtitle: String?
+    let providerId: String?
+    let modelId: String?
+    let voiceId: String?
+    let transport: String?
+    let isRealtime: Bool
+
+    var accessibilityValue: String {
+        if let subtitle, !subtitle.isEmpty {
+            return "\(self.title), \(subtitle)"
+        }
+        return self.title
+    }
+}
+
+enum TalkVoiceModeDescriptorBuilder {
+    static func build(
+        providerId: String,
+        providerLabel: String,
+        modelId: String?,
+        voiceId: String?,
+        transport: String?,
+        isRealtime: Bool) -> TalkVoiceModeDescriptor
+    {
+        let normalizedProvider = providerId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let trimmedModel = Self.trimmed(modelId)
+        let trimmedVoice = Self.trimmed(voiceId)
+        let trimmedTransport = Self.trimmed(transport)
+        let title = if isRealtime, normalizedProvider == "openai", trimmedModel == "gpt-realtime-2" {
+            "GPT Realtime 2.0"
+        } else if isRealtime, normalizedProvider == "openai" {
+            "OpenAI Realtime"
+        } else if isRealtime {
+            providerLabel.isEmpty ? "Realtime Voice" : providerLabel
+        } else if normalizedProvider == "system" {
+            "iOS System Voice"
+        } else {
+            providerLabel.isEmpty ? "Talk Voice" : providerLabel
+        }
+
+        var details: [String] = []
+        if isRealtime, normalizedProvider != "openai", !providerLabel.isEmpty, providerLabel != title {
+            details.append(providerLabel)
+        }
+        if let trimmedTransport {
+            details.append(Self.transportLabel(trimmedTransport))
+        }
+        if let trimmedModel, title != "GPT Realtime 2.0" || trimmedModel != "gpt-realtime-2" {
+            details.append(trimmedModel)
+        }
+        if let trimmedVoice {
+            details.append(Self.voiceLabel(trimmedVoice))
+        }
+
+        return TalkVoiceModeDescriptor(
+            title: title,
+            subtitle: details.isEmpty ? nil : details.joined(separator: " • "),
+            providerId: normalizedProvider.isEmpty ? nil : normalizedProvider,
+            modelId: trimmedModel,
+            voiceId: trimmedVoice,
+            transport: trimmedTransport,
+            isRealtime: isRealtime)
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func voiceLabel(_ voice: String) -> String {
+        TalkModeRealtimeVoiceSelection.voices.contains(voice)
+            ? TalkModeRealtimeVoiceSelection.label(for: voice)
+            : voice
+    }
+
+    private static func transportLabel(_ transport: String) -> String {
+        switch transport.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "webrtc":
+            "Native WebRTC"
+        case "gateway-relay":
+            "Gateway Relay"
+        case "provider-websocket":
+            "Provider WebSocket"
+        case "managed-room":
+            "Managed Room"
+        case "native":
+            "Native"
+        case let value where !value.isEmpty:
+            value
+        default:
+            "Native"
+        }
+    }
 }
 
 enum TalkModeProviderSelection: String, CaseIterable, Identifiable {
@@ -164,8 +262,14 @@ enum TalkModeGatewayConfigParser {
         let mode = Self.firstString(realtime, keys: ["mode"])?.lowercased()
         let transport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
         let brain = Self.firstString(realtime, keys: ["brain"])?.lowercased()
-        if mode == "realtime", transport == "gateway-relay", brain == nil || brain == "agent-consult" {
+        guard mode == "realtime", brain == nil || brain == "agent-consult" else {
+            return .native
+        }
+        if transport == "gateway-relay" {
             return .realtimeRelay
+        }
+        if transport == nil || transport == "webrtc" {
+            return .realtimeClient
         }
         return .native
     }

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -116,6 +116,7 @@ final class TalkModeManager: NSObject {
     var gatewayTalkDefaultVoiceId: String?
     var gatewayTalkProviderLabel: String = "Not loaded"
     var gatewayTalkTransportLabel: String = "Not loaded"
+    var gatewayTalkUsesRealtime: Bool = false
     var gatewayTalkUsesRealtimeRelay: Bool = false
     var gatewayTalkRealtimeProviderLabel: String?
     var gatewayTalkRealtimeModelId: String?
@@ -1095,6 +1096,7 @@ final class TalkModeManager: NSObject {
             })
         self.realtimeRelaySession = relaySession
         do {
+            try Self.configureAudioSession()
             try await relaySession.start()
             guard self.realtimeRelaySession === relaySession, self.isEnabled else {
                 relaySession.stop()
@@ -1518,6 +1520,7 @@ final class TalkModeManager: NSObject {
 
         self.stopRecognition()
         self.isSpeaking = false
+        self.restoreConfiguredVoiceModeDescriptor()
     }
 
     private func stopSpeaking(storeInterruption: Bool = true) {
@@ -2515,6 +2518,7 @@ extension TalkModeManager {
             let transport = usesRealtimeConfig ? (usesRealtimeRelay ? "gateway-relay" : "webrtc") : "native"
             let transportLabel = usesRealtimeRelay ? "Gateway Relay" : (usesRealtimeConfig ? "Native WebRTC" : "Native")
             self.gatewayTalkProviderLabel = providerLabel
+            self.gatewayTalkUsesRealtime = usesRealtimeConfig
             self.gatewayTalkUsesRealtimeRelay = usesRealtimeRelay
             self.gatewayTalkTransportLabel = transportLabel
             self.gatewayTalkRealtimeProviderLabel = realtimeProvider.map { Self.displayName(forProvider: $0) }
@@ -2563,6 +2567,7 @@ extension TalkModeManager {
             self.realtimeVoiceId = nil
             self.gatewayTalkProviderLabel = "Not loaded"
             self.gatewayTalkTransportLabel = "Not loaded"
+            self.gatewayTalkUsesRealtime = false
             self.gatewayTalkUsesRealtimeRelay = false
             self.gatewayTalkRealtimeProviderLabel = nil
             self.gatewayTalkRealtimeModelId = nil

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -120,6 +120,9 @@ final class TalkModeManager: NSObject {
     var gatewayTalkRealtimeProviderLabel: String?
     var gatewayTalkRealtimeModelId: String?
     var gatewayTalkRealtimeVoiceId: String?
+    var gatewayTalkVoiceModeTitle: String = "Not loaded"
+    var gatewayTalkVoiceModeSubtitle: String?
+    var gatewayTalkVoiceModeAccessibilityValue: String = "Not loaded"
     var gatewayTalkPermissionState: TalkGatewayPermissionState = .unknown
 
     private enum CaptureMode {
@@ -145,6 +148,7 @@ final class TalkModeManager: NSObject {
     private var recognitionTask: SFSpeechRecognitionTask?
     private var silenceTask: Task<Void, Never>?
     private var realtimeSession: TalkRealtimeWebRTCSession?
+    private var realtimeRelaySession: RealtimeTalkRelaySession?
     private var prefetchedRealtimeSession: TalkRealtimeClientSession?
     private var realtimePrefetchTask: Task<Void, Never>?
 
@@ -167,6 +171,14 @@ final class TalkModeManager: NSObject {
     private var realtimeProvider: String?
     private var realtimeModelId: String?
     private var realtimeVoiceId: String?
+    private var configuredVoiceModeDescriptor = TalkVoiceModeDescriptor(
+        title: "Not loaded",
+        subtitle: nil,
+        providerId: nil,
+        modelId: nil,
+        voiceId: nil,
+        transport: nil,
+        isRealtime: false)
     private var apiKey: String?
     private var voiceAliases: [String: String] = [:]
     private var interruptOnSpeech: Bool = true
@@ -304,8 +316,13 @@ final class TalkModeManager: NSObject {
             GatewayDiagnostics.log("talk.timeline manager start blocked gateway permission")
             return
         }
-        if self.realtimeWebRTCEnabled, await self.startRealtimeIfAvailable() {
-            return
+        if self.realtimeWebRTCEnabled {
+            let started = self.executionMode == .realtimeRelay
+                ? await self.startRealtimeRelayIfAvailable()
+                : await self.startRealtimeIfAvailable()
+            if started {
+                return
+            }
         }
 
         let speechOk = await Self.requestSpeechPermission()
@@ -419,6 +436,7 @@ final class TalkModeManager: NSObject {
         if let realtimeSession {
             realtimeSession.cancelResponse()
         }
+        self.realtimeRelaySession?.cancelOutput()
         self.stopSpeaking()
     }
 
@@ -1046,9 +1064,67 @@ final class TalkModeManager: NSObject {
         }
     }
 
+    private func startRealtimeRelayIfAvailable() async -> Bool {
+        guard let gateway else { return false }
+        GatewayDiagnostics.log("talk.timeline realtime relay start attempt sessionKey=\(self.mainSessionKey)")
+        let startedAt = Self.nowSeconds()
+        let relaySession = RealtimeTalkRelaySession(
+            gateway: gateway,
+            options: RealtimeTalkRelaySession.Options(
+                sessionKey: self.mainSessionKey,
+                provider: self.realtimeProvider,
+                model: self.realtimeModelId,
+                voice: self.realtimeVoiceId),
+            pcmPlayer: self.pcmPlayer,
+            onStatus: { [weak self] status in
+                guard let self else { return }
+                self.statusText = status
+                self.isListening = status.localizedCaseInsensitiveContains("listening")
+                if status.localizedCaseInsensitiveContains("thinking") {
+                    self.isListening = false
+                    self.isSpeaking = false
+                    self.isUserSpeechDetected = false
+                }
+            },
+            onSpeakingChanged: { [weak self] speaking in
+                guard let self else { return }
+                self.isSpeaking = speaking
+                if speaking {
+                    self.isListening = false
+                }
+            })
+        self.realtimeRelaySession = relaySession
+        do {
+            try await relaySession.start()
+            guard self.realtimeRelaySession === relaySession, self.isEnabled else {
+                relaySession.stop()
+                return true
+            }
+            self.isListening = true
+            self.captureMode = .continuous
+            GatewayDiagnostics.log(
+                "talk.timeline realtime relay start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
+            return true
+        } catch {
+            guard self.realtimeRelaySession === relaySession, self.isEnabled else {
+                relaySession.stop()
+                return true
+            }
+            self.realtimeRelaySession = nil
+            GatewayDiagnostics.log(
+                "talk.timeline realtime relay start failed elapsedMs=\(Self.elapsedMs(since: startedAt)) "
+                    + "error=\(error.localizedDescription)")
+            return false
+        }
+    }
+
     func prefetchRealtimeSessionIfReady(reason: String) async {
-        guard self.gatewayConnected, self.realtimeSession == nil, !self.isEnabled else { return }
-        guard self.realtimeWebRTCEnabled else { return }
+        guard self.gatewayConnected,
+              self.realtimeSession == nil,
+              self.realtimeRelaySession == nil,
+              !self.isEnabled
+        else { return }
+        guard self.realtimeWebRTCEnabled, self.executionMode != .realtimeRelay else { return }
         guard self.gatewayTalkPermissionState == .ready else { return }
         guard self.consumePrefetchedRealtimeSession(peekOnly: true) == nil else { return }
         guard self.realtimePrefetchTask == nil else { return }
@@ -1116,6 +1192,8 @@ final class TalkModeManager: NSObject {
     private func stopRealtimeSession() {
         self.realtimeSession?.stop()
         self.realtimeSession = nil
+        self.realtimeRelaySession?.stop()
+        self.realtimeRelaySession = nil
     }
 
     private func subscribeChatIfNeeded(sessionKey: String) async {
@@ -1305,6 +1383,14 @@ final class TalkModeManager: NSObject {
 
             if canUseElevenLabs, let voiceId, let apiKey {
                 GatewayDiagnostics.log("talk tts: provider=elevenlabs voiceId=\(voiceId)")
+                let modelId = directive?.modelId ?? self.currentModelId ?? self.defaultModelId
+                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+                    providerId: "elevenlabs",
+                    providerLabel: Self.displayName(forProvider: "elevenlabs"),
+                    modelId: modelId,
+                    voiceId: voiceId,
+                    transport: "native",
+                    isRealtime: false))
                 let desiredOutputFormat = (directive?.outputFormat ?? self.defaultOutputFormat)?
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 let requestedOutputFormat = (desiredOutputFormat?.isEmpty == false) ? desiredOutputFormat : nil
@@ -1315,7 +1401,6 @@ final class TalkModeManager: NSObject {
                         "talk output_format unsupported for local playback: \(requestedOutputFormat, privacy: .public)")
                 }
 
-                let modelId = directive?.modelId ?? self.currentModelId ?? self.defaultModelId
                 if let modelId {
                     GatewayDiagnostics.log("talk tts: modelId=\(modelId)")
                 }
@@ -1384,6 +1469,13 @@ final class TalkModeManager: NSObject {
             } else {
                 self.logger.warning("tts unavailable; falling back to system voice (missing key or voiceId)")
                 GatewayDiagnostics.log("talk tts: provider=system (missing key or voiceId)")
+                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+                    providerId: "system",
+                    providerLabel: Self.displayName(forProvider: "system"),
+                    modelId: nil,
+                    voiceId: language,
+                    transport: "native",
+                    isRealtime: false))
                 if self.interruptOnSpeech {
                     do {
                         try self.startRecognition()
@@ -1400,6 +1492,14 @@ final class TalkModeManager: NSObject {
                 "tts failed: \(error.localizedDescription, privacy: .public); falling back to system voice")
             GatewayDiagnostics.log("talk tts: provider=system (error) msg=\(error.localizedDescription)")
             do {
+                let language = ElevenLabsTTSClient.validatedLanguage(directive?.language)
+                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+                    providerId: "system",
+                    providerLabel: Self.displayName(forProvider: "system"),
+                    modelId: nil,
+                    voiceId: language,
+                    transport: "native",
+                    isRealtime: false))
                 if self.interruptOnSpeech {
                     do {
                         try self.startRecognition()
@@ -1409,7 +1509,6 @@ final class TalkModeManager: NSObject {
                     }
                 }
                 self.statusText = "Speaking (System)…"
-                let language = ElevenLabsTTSClient.validatedLanguage(directive?.language)
                 try await TalkSystemSpeechSynthesizer.shared.speak(text: cleaned, language: language)
             } catch {
                 self.statusText = "Speak failed: \(error.localizedDescription)"
@@ -2256,11 +2355,43 @@ extension TalkModeManager {
             "OpenAI"
         case "google":
             "Google"
+        case "system":
+            "iOS System Voice"
         case let provider where !provider.isEmpty:
             provider
         default:
             "Gateway Default"
         }
+    }
+
+    private func applyVoiceModeDescriptor(_ descriptor: TalkVoiceModeDescriptor, persistAsConfigured: Bool = false) {
+        if persistAsConfigured {
+            self.configuredVoiceModeDescriptor = descriptor
+        }
+        self.gatewayTalkVoiceModeTitle = descriptor.title
+        self.gatewayTalkVoiceModeSubtitle = descriptor.subtitle
+        self.gatewayTalkVoiceModeAccessibilityValue = descriptor.accessibilityValue
+    }
+
+    private func restoreConfiguredVoiceModeDescriptor() {
+        self.applyVoiceModeDescriptor(self.configuredVoiceModeDescriptor)
+    }
+
+    private func buildConfiguredVoiceModeDescriptor(
+        provider: String,
+        providerLabel: String,
+        modelId: String?,
+        voiceId: String?,
+        transport: String,
+        isRealtime: Bool) -> TalkVoiceModeDescriptor
+    {
+        TalkVoiceModeDescriptorBuilder.build(
+            providerId: provider,
+            providerLabel: providerLabel,
+            modelId: modelId,
+            voiceId: voiceId,
+            transport: transport,
+            isRealtime: isRealtime)
     }
 
     private func ensureTalkConfigLoadedForStart() async {
@@ -2341,7 +2472,7 @@ extension TalkModeManager {
                 realtimeProvider = realtimeProvider ?? "openai"
                 realtimeModelId = realtimeModelId ?? Self.defaultRealtimeModelIdFallback
             }
-            let usesRealtimeConfig = activeProvider != Self.defaultTalkProvider || executionMode == .realtimeRelay
+            let usesRealtimeConfig = activeProvider != Self.defaultTalkProvider || executionMode != .native
             self.activeTalkProvider = activeProvider
             self.executionMode = executionMode
             self.realtimeWebRTCEnabled = usesRealtimeConfig
@@ -2377,14 +2508,30 @@ extension TalkModeManager {
             }
             self.gatewayTalkDefaultVoiceId = usesRealtimeConfig ? realtimeVoiceId : self.defaultVoiceId
             self.gatewayTalkDefaultModelId = usesRealtimeConfig ? realtimeModelId : self.defaultModelId
-            self.gatewayTalkProviderLabel = providerSelection == .gatewayDefault
+            let providerLabel = providerSelection == .gatewayDefault
                 ? Self.displayName(forProvider: activeProvider)
                 : providerSelection.label
-            self.gatewayTalkUsesRealtimeRelay = false
-            self.gatewayTalkTransportLabel = usesRealtimeConfig ? "Native WebRTC" : "Native"
+            let usesRealtimeRelay = executionMode == .realtimeRelay
+            let transport = usesRealtimeConfig ? (usesRealtimeRelay ? "gateway-relay" : "webrtc") : "native"
+            let transportLabel = usesRealtimeRelay ? "Gateway Relay" : (usesRealtimeConfig ? "Native WebRTC" : "Native")
+            self.gatewayTalkProviderLabel = providerLabel
+            self.gatewayTalkUsesRealtimeRelay = usesRealtimeRelay
+            self.gatewayTalkTransportLabel = transportLabel
             self.gatewayTalkRealtimeProviderLabel = realtimeProvider.map { Self.displayName(forProvider: $0) }
             self.gatewayTalkRealtimeModelId = realtimeModelId
             self.gatewayTalkRealtimeVoiceId = realtimeVoiceId
+            let voiceModeProvider = usesRealtimeConfig ? (realtimeProvider ?? activeProvider) : activeProvider
+            let voiceModeLabel = usesRealtimeConfig
+                ? Self.displayName(forProvider: voiceModeProvider)
+                : Self.displayName(forProvider: activeProvider)
+            let voiceModeDescriptor = self.buildConfiguredVoiceModeDescriptor(
+                provider: voiceModeProvider,
+                providerLabel: voiceModeLabel,
+                modelId: usesRealtimeConfig ? realtimeModelId : self.defaultModelId,
+                voiceId: usesRealtimeConfig ? realtimeVoiceId : self.defaultVoiceId,
+                transport: transport,
+                isRealtime: usesRealtimeConfig)
+            self.applyVoiceModeDescriptor(voiceModeDescriptor, persistAsConfigured: true)
             self.gatewayTalkApiKeyConfigured = gatewayOwnedVoiceProvider || (self.apiKey?.isEmpty == false)
             self.gatewayTalkConfigLoaded = true
             self.talkConfigLoadedAt = Date()
@@ -2420,6 +2567,14 @@ extension TalkModeManager {
             self.gatewayTalkRealtimeProviderLabel = nil
             self.gatewayTalkRealtimeModelId = nil
             self.gatewayTalkRealtimeVoiceId = nil
+            self.applyVoiceModeDescriptor(TalkVoiceModeDescriptor(
+                title: "Not loaded",
+                subtitle: nil,
+                providerId: nil,
+                modelId: nil,
+                voiceId: nil,
+                transport: nil,
+                isRealtime: false), persistAsConfigured: true)
             self.defaultModelId = Self.defaultModelIdFallback
             if !self.modelOverrideActive {
                 self.currentModelId = self.defaultModelId

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -1543,6 +1543,7 @@ final class TalkModeManager: NSObject {
         TalkSystemSpeechSynthesizer.shared.stop()
         self.cancelIncrementalSpeech()
         self.isSpeaking = false
+        self.restoreConfiguredVoiceModeDescriptor()
     }
 
     private func shouldInterrupt(with transcript: String) -> Bool {
@@ -2360,6 +2361,8 @@ extension TalkModeManager {
             "Google"
         case "system":
             "iOS System Voice"
+        case "realtime":
+            "Realtime Voice"
         case let provider where !provider.isEmpty:
             provider
         default:
@@ -2524,7 +2527,7 @@ extension TalkModeManager {
             self.gatewayTalkRealtimeProviderLabel = realtimeProvider.map { Self.displayName(forProvider: $0) }
             self.gatewayTalkRealtimeModelId = realtimeModelId
             self.gatewayTalkRealtimeVoiceId = realtimeVoiceId
-            let voiceModeProvider = usesRealtimeConfig ? (realtimeProvider ?? activeProvider) : activeProvider
+            let voiceModeProvider = usesRealtimeConfig ? (realtimeProvider ?? "realtime") : activeProvider
             let voiceModeLabel = usesRealtimeConfig
                 ? Self.displayName(forProvider: voiceModeProvider)
                 : Self.displayName(forProvider: activeProvider)

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -79,7 +79,60 @@ import Testing
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride("unknown") == nil)
     }
 
-    @Test func leavesNativeModeWhenRealtimeTransportIsNotGatewayRelay() {
+    @Test func formatsOpenAIRealtimeVoiceMode() {
+        let descriptor = TalkVoiceModeDescriptorBuilder.build(
+            providerId: "openai",
+            providerLabel: "OpenAI",
+            modelId: "gpt-realtime-2",
+            voiceId: "marin",
+            transport: "webrtc",
+            isRealtime: true)
+
+        #expect(descriptor.title == "GPT Realtime 2.0")
+        #expect(descriptor.subtitle == "Native WebRTC • Marin")
+        #expect(descriptor.accessibilityValue == "GPT Realtime 2.0, Native WebRTC • Marin")
+    }
+
+    @Test func formatsGatewayRelayRealtimeVoiceMode() {
+        let descriptor = TalkVoiceModeDescriptorBuilder.build(
+            providerId: "google",
+            providerLabel: "Google Live Voice",
+            modelId: "gemini-live-2.5-flash-preview",
+            voiceId: nil,
+            transport: "gateway-relay",
+            isRealtime: true)
+
+        #expect(descriptor.title == "Google Live Voice")
+        #expect(descriptor.subtitle == "Gateway Relay • gemini-live-2.5-flash-preview")
+    }
+
+    @Test func formatsElevenLabsVoiceMode() {
+        let descriptor = TalkVoiceModeDescriptorBuilder.build(
+            providerId: "elevenlabs",
+            providerLabel: "ElevenLabs",
+            modelId: "eleven_v3",
+            voiceId: "voice-id",
+            transport: "native",
+            isRealtime: false)
+
+        #expect(descriptor.title == "ElevenLabs")
+        #expect(descriptor.subtitle == "Native • eleven_v3 • voice-id")
+    }
+
+    @Test func formatsSystemVoiceFallbackMode() {
+        let descriptor = TalkVoiceModeDescriptorBuilder.build(
+            providerId: "system",
+            providerLabel: "iOS System Voice",
+            modelId: nil,
+            voiceId: "en-US",
+            transport: "native",
+            isRealtime: false)
+
+        #expect(descriptor.title == "iOS System Voice")
+        #expect(descriptor.subtitle == "Native • en-US")
+    }
+
+    @Test func usesRealtimeClientModeForWebRTCTransport() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -97,7 +150,7 @@ import Testing
             defaultRealtimeModelIdFallback: "gpt-realtime-2",
             defaultSilenceTimeoutMs: 900)
 
-        #expect(parsed.executionMode == .native)
+        #expect(parsed.executionMode == .realtimeClient)
     }
 
     @Test func detectsPCMFormatRejectionFromElevenLabsError() {

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -48,6 +48,46 @@ import Testing
         #expect(parsed.realtimeVoiceId == "marin")
     }
 
+    @Test func infersRealtimeProviderWhenProviderMapHasSingleEntry() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "providers": [
+                        "openai": [
+                            "model": "gpt-realtime-2",
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .realtimeClient)
+        #expect(parsed.realtimeProvider == "openai")
+        #expect(parsed.realtimeModelId == "gpt-realtime-2")
+    }
+
+    @Test func formatsGenericRealtimeVoiceModeWithoutNativeProviderFallback() {
+        let descriptor = TalkVoiceModeDescriptorBuilder.build(
+            providerId: "realtime",
+            providerLabel: "Realtime Voice",
+            modelId: "gpt-realtime-2",
+            voiceId: nil,
+            transport: "webrtc",
+            isRealtime: true)
+
+        #expect(descriptor.title == "Realtime Voice")
+        #expect(descriptor.subtitle == "Native WebRTC • gpt-realtime-2")
+    }
+
     @Test func defaultsOpenAIRealtimeModelWhenProviderOmitsModel() {
         let config: [String: Any] = [
             "talk": [


### PR DESCRIPTION
## Summary

- add a normalized iOS Talk voice-mode descriptor for GPT Realtime 2.0, ElevenLabs, iOS System Voice, and gateway relay/native transports
- show the voice-mode indicator in the Talk tray on its own readable line and in Settings > Talk Voice
- treat gateway default `talk.realtime.mode=realtime` + `transport=webrtc` as the default GPT Realtime client path, and wire gateway-relay configs to the existing relay session

## Verification

- `cd apps/ios && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug build`
- `./scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && cd apps/ios && xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination 'id=00008140-000848A92EE3001C' -configuration Debug build`
- Installed and launched on a real iPhone with `xcrun devicectl device install app` and `xcrun devicectl device process launch`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings
- `CODEX_REVIEW_AUTO_TESTS=0 ~/.pi/agent/skills/codex-review/scripts/codex-review --mode branch --base origin/main` — clean after fixing accepted findings

Behavior addressed: iOS Talk Mode now displays the active voice mode and defaults gateway realtime config to GPT Realtime 2.0 instead of showing ElevenLabs when `talk.realtime` is configured.
Real environment tested: local iOS simulator build plus real iPhone device build/install/launch.
Exact steps or command run after this patch: see Verification commands above.
Evidence after fix: build succeeded, real-device install succeeded, and the app launched with bundle ID `ai.openclaw.ios.test.guti-gzs353x62e`.
Observed result after fix: Talk tray voice-mode text is no longer squeezed into the agent/status row, and gateway realtime config resolves to the native WebRTC realtime path.
What was not tested: full spoken GPT Realtime conversation flow on-device after launch; targeted simulator test execution is still blocked by the existing WatchKit simulator install issue. Broad `pnpm run check` from the codex-review helper remains blocked by an existing npm shrinkwrap guard dependency-resolution failure unrelated to this iOS patch.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted pi session transcript</summary>

```text
source: local pi session
redaction: local paths, SSH target, screenshot file names, raw tool outputs, system/developer prompts, secrets, and auth details omitted

[user]
I want to spec and plan changes to iOS talk mode and add indication of the type of voice mode being used (gpt realtime 2.0, vs elevenlabs, vs something else). Let's start by digging and understanding how it works and the types of talk providers and then figure how to display it.

[assistant]
Investigated iOS Talk Mode and gateway/provider code. Found three relevant paths: native STT -> agent -> TTS, native WebRTC realtime via `talk.client.create`, and an existing but not manager-wired gateway relay session. Proposed a normalized `TalkVoiceModeDescriptor` displayed in the Talk tray and Settings, with labels for GPT Realtime 2.0, ElevenLabs, iOS System Voice, and other realtime providers/transports.

[user]
implement this in a new branch

[assistant]
Created `feat/ios-talk-voice-mode-indicator` and implemented the descriptor, display state, Talk tray/Settings UI, realtime relay startup routing, and descriptor tests. Built successfully. A targeted simulator test compiled but could not install because of the existing WatchKit simulator packaging issue.

[user]
run on my phone

[assistant]
Built for the connected iPhone, installed, and launched the app using the test bundle ID.

[user]
The tray text is not readable. Also: why are we using ElevenLabs? I want the default to be GPT Realtime 2.0. Check the server config over SSH, read-only, and report back.

[assistant]
Checked the server config read-only. It already had `talk.realtime.provider=openai`, `talk.realtime.transport=webrtc`, `talk.realtime.mode=realtime`, `talk.realtime.brain=agent-consult`, and `talk.realtime.providers.openai.model=gpt-realtime-2`; native TTS only had an ElevenLabs provider. Determined the iOS bug was that gateway default still resolved to native ElevenLabs because the parser only treated non-ElevenLabs or relay configs as realtime. Fixed WebRTC realtime parsing and moved the tray voice-mode indicator onto its own line, then rebuilt, reinstalled, and relaunched on the iPhone.

[user]
commit push and open a pr

[assistant]
Ran autoreview, committed the branch, pushed it, and prepared this PR body with the redacted transcript.
```

</details>
<!-- agent-transcript:end -->

