### PR TITLE
fix(cron): preview no-deliver explicit targets

### DIFF
--- a/src/cron/delivery-plan.test.ts
+++ b/src/cron/delivery-plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveCronDeliveryPlan } from "./delivery-plan.js";
+import { hasExplicitCronDeliveryTarget, resolveCronDeliveryPlan } from "./delivery-plan.js";
 import { makeCronJob } from "./delivery.test-helpers.js";
 
 describe("resolveCronDeliveryPlan", () => {
@@ -27,5 +27,19 @@ describe("resolveCronDeliveryPlan", () => {
       source: "delivery",
       requested: false,
     });
+  });
+
+  it("treats numeric zero thread id as an explicit target", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          threadId: 0,
+        },
+      }),
+    );
+
+    expect(plan.threadId).toBe(0);
+    expect(hasExplicitCronDeliveryTarget(plan)).toBe(true);
   });
 });

--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -19,6 +19,12 @@ export type CronDeliveryPlan = {
   requested: boolean;
 };
 
+export function hasExplicitCronDeliveryTarget(plan: CronDeliveryPlan): boolean {
+  return Boolean(
+    (plan.channel && plan.channel !== "last") || plan.to || plan.threadId || plan.accountId,
+  );
+}
+
 function normalizeChannel(value: unknown): CronMessageChannel | undefined {
   const trimmed = normalizeOptionalLowercaseString(value);
   if (!trimmed) {

--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -21,7 +21,7 @@ export type CronDeliveryPlan = {
 
 export function hasExplicitCronDeliveryTarget(plan: CronDeliveryPlan): boolean {
   return Boolean(
-    (plan.channel && plan.channel !== "last") || plan.to || plan.threadId || plan.accountId,
+    (plan.channel && plan.channel !== "last") || plan.to || plan.threadId != null || plan.accountId,
   );
 }
 

--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -102,4 +102,42 @@ describe("resolveCronDeliveryPreview", () => {
       detail: "explicit",
     });
   });
+
+  it("does not describe unresolved no-delivery message-tool targets as fail-closed", async () => {
+    mocks.resolveDeliveryTarget.mockResolvedValueOnce({
+      ok: false,
+      mode: "implicit",
+      error: new Error("no route"),
+    });
+    const job = makeCronJob({
+      agentId: "avery",
+      delivery: {
+        mode: "none",
+        threadId: 0,
+      },
+      sessionTarget: "isolated",
+    });
+
+    const preview = await resolveCronDeliveryPreview({
+      cfg: {} as never,
+      job,
+    });
+
+    expect(mocks.resolveDeliveryTarget).toHaveBeenCalledWith(
+      {},
+      "avery",
+      {
+        channel: "last",
+        to: undefined,
+        threadId: 0,
+        accountId: undefined,
+        sessionKey: undefined,
+      },
+      { dryRun: true },
+    );
+    expect(preview).toEqual({
+      label: "none -> last",
+      detail: "message tool target unresolved: no route",
+    });
+  });
 });

--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -66,4 +66,40 @@ describe("resolveCronDeliveryPreview", () => {
     expect(preview).toEqual({ label: "not requested", detail: "not requested" });
     expect(mocks.resolveDeliveryTarget).not.toHaveBeenCalled();
   });
+
+  it("previews explicit message-tool targets on no-delivery jobs", async () => {
+    const job = makeCronJob({
+      agentId: "avery",
+      delivery: {
+        mode: "none",
+        channel: "topicchat",
+        to: "room#42",
+        threadId: 42,
+        accountId: "ops",
+      },
+      sessionTarget: "isolated",
+    });
+
+    const preview = await resolveCronDeliveryPreview({
+      cfg: {} as never,
+      job,
+    });
+
+    expect(mocks.resolveDeliveryTarget).toHaveBeenCalledWith(
+      {},
+      "avery",
+      {
+        channel: "topicchat",
+        to: "room#42",
+        threadId: 42,
+        accountId: "ops",
+        sessionKey: undefined,
+      },
+      { dryRun: true },
+    );
+    expect(preview).toEqual({
+      label: "none -> telegram:direct-123",
+      detail: "explicit",
+    });
+  });
 });

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -1,6 +1,6 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveCronDeliveryPlan } from "./delivery-plan.js";
+import { type CronDeliveryPlan, resolveCronDeliveryPlan } from "./delivery-plan.js";
 import { resolveDeliveryTarget } from "./isolated-agent/delivery-target.js";
 import { resolveCronDeliverySessionKey } from "./session-target.js";
 import type { CronDeliveryPreview, CronJob } from "./types.js";
@@ -34,13 +34,19 @@ function formatDeliveryDetail(params: {
   return params.resolved ? "explicit" : (params.error ?? "unresolved");
 }
 
+function hasExplicitDeliveryTarget(plan: CronDeliveryPlan): boolean {
+  return Boolean(
+    (plan.channel && plan.channel !== "last") || plan.to || plan.threadId || plan.accountId,
+  );
+}
+
 export async function resolveCronDeliveryPreview(params: {
   cfg: OpenClawConfig;
   defaultAgentId?: string;
   job: CronJob;
 }): Promise<CronDeliveryPreview> {
   const plan = resolveCronDeliveryPlan(params.job);
-  if (plan.mode === "none") {
+  if (plan.mode === "none" && !hasExplicitDeliveryTarget(plan)) {
     return { label: "not requested", detail: "not requested" };
   }
   if (plan.mode === "webhook") {

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -67,12 +67,15 @@ export async function resolveCronDeliveryPreview(params: {
   if (!resolved.ok) {
     return {
       label: `${plan.mode} -> ${formatTarget(requestedChannel, plan.to ?? null)}`,
-      detail: formatDeliveryDetail({
-        requestedChannel,
-        resolved: false,
-        sessionKey: deliverySessionKey,
-        error: resolved.error.message,
-      }),
+      detail:
+        plan.mode === "none"
+          ? `message tool target unresolved: ${resolved.error.message}`
+          : formatDeliveryDetail({
+              requestedChannel,
+              resolved: false,
+              sessionKey: deliverySessionKey,
+              error: resolved.error.message,
+            }),
     };
   }
   return {

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -1,6 +1,6 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { type CronDeliveryPlan, resolveCronDeliveryPlan } from "./delivery-plan.js";
+import { hasExplicitCronDeliveryTarget, resolveCronDeliveryPlan } from "./delivery-plan.js";
 import { resolveDeliveryTarget } from "./isolated-agent/delivery-target.js";
 import { resolveCronDeliverySessionKey } from "./session-target.js";
 import type { CronDeliveryPreview, CronJob } from "./types.js";
@@ -34,19 +34,13 @@ function formatDeliveryDetail(params: {
   return params.resolved ? "explicit" : (params.error ?? "unresolved");
 }
 
-function hasExplicitDeliveryTarget(plan: CronDeliveryPlan): boolean {
-  return Boolean(
-    (plan.channel && plan.channel !== "last") || plan.to || plan.threadId || plan.accountId,
-  );
-}
-
 export async function resolveCronDeliveryPreview(params: {
   cfg: OpenClawConfig;
   defaultAgentId?: string;
   job: CronJob;
 }): Promise<CronDeliveryPreview> {
   const plan = resolveCronDeliveryPlan(params.job);
-  if (plan.mode === "none" && !hasExplicitDeliveryTarget(plan)) {
+  if (plan.mode === "none" && !hasExplicitCronDeliveryTarget(plan)) {
     return { label: "not requested", detail: "not requested" };
   }
   if (plan.mode === "webhook") {

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -232,7 +232,8 @@ vi.mock("../../config/sessions/store.runtime.js", () => ({
   updateSessionStore: updateSessionStoreMock,
 }));
 
-vi.mock("../delivery-plan.js", () => ({
+vi.mock("../delivery-plan.js", async () => ({
+  ...(await vi.importActual<typeof import("../delivery-plan.js")>("../delivery-plan.js")),
   resolveCronDeliveryPlan: resolveCronDeliveryPlanMock,
 }));
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -27,7 +27,11 @@ import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
-import { resolveCronDeliveryPlan, type CronDeliveryPlan } from "../delivery-plan.js";
+import {
+  hasExplicitCronDeliveryTarget,
+  resolveCronDeliveryPlan,
+  type CronDeliveryPlan,
+} from "../delivery-plan.js";
 import {
   createCronRunDiagnosticsFromAgentResult,
   createCronRunDiagnosticsFromError,
@@ -341,12 +345,6 @@ function canPromptForMessageTool(params: {
     params.toolsAllow === undefined ||
     normalizedToolsAllow?.includes("*") === true ||
     normalizedToolsAllow?.includes("message") === true
-  );
-}
-
-function hasExplicitCronDeliveryTarget(plan: CronDeliveryPlan): boolean {
-  return Boolean(
-    (plan.channel && plan.channel !== "last") || plan.to || plan.threadId || plan.accountId,
   );
 }
 


### PR DESCRIPTION
## Summary

- keep bare `delivery.mode: "none"` cron jobs showing `not requested`
- preserve explicit `channel`/`to`/`threadId`/`accountId` context in no-deliver cron delivery previews
- add regression coverage for `mode: "none"` jobs that still expose a message-tool target

Closes #86736.

## Real behavior proof

- **Behavior or issue addressed**: Cron delivery previews no longer collapse a no-deliver job with explicit message-tool target fields into `not requested`; bare no-deliver jobs still show `not requested`.
- **Real environment tested**: Local OpenClaw checkout on this PR head `4788598d83038f66899a65b07bf407fc36f97e91`, Node v22.22.0, direct production cron delivery preview module invocation.
- **Exact steps or command run after this patch**: Ran `node --import tsx --input-type=module` from the repository root and invoked `resolveCronDeliveryPreview` for two cron jobs: one with `delivery: { mode: "none" }`, and one with `delivery: { mode: "none", channel: "topicchat", to: "room#42", threadId: 42, accountId: "ops" }`.
- **Evidence after fix**: Terminal output from the command:

```text
bare no-deliver preview: {"label":"not requested","detail":"not requested"}
explicit no-deliver target preview: {"label":"none -> topicchat:room#42","detail":"Unsupported channel: topicchat"}
```

- **Observed result after fix**: The bare no-deliver cron job remains `not requested`. The no-deliver cron job with explicit target fields now surfaces `none -> topicchat:room#42` instead of `not requested`, proving the preview keeps the explicit target context.
- **What was not tested**: No additional gaps

## Proof

- `git diff --check`
- `node scripts/run-vitest.mjs src/cron/delivery-preview.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/run-log.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `pnpm check:changed --base origin/main`