### PR TITLE
fix(doctor): rewrite non-canonical api_key field to key in auth profiles

### DIFF
--- a/src/commands/doctor-auth-canonical-api-key-alias.test.ts
+++ b/src/commands/doctor-auth-canonical-api-key-alias.test.ts
@@ -97,6 +97,46 @@ describe("maybeRepairCanonicalApiKeyFieldAlias", () => {
     );
   });
 
+  it('rewrites non-canonical SecretRef "api_key" fields to canonical "key"', async () => {
+    const state = await makeTestState();
+    const canonical = {
+      version: 1,
+      profiles: {
+        "my-key": {
+          type: "api_key",
+          provider: "my-provider",
+          api_key: { source: "env", provider: "default", id: "MY_PROVIDER_API_KEY" },
+        },
+      },
+    };
+    const authPath = await state.writeAuthProfiles(canonical);
+
+    const result = await maybeRepairCanonicalApiKeyFieldAlias({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 123,
+    });
+
+    expect(result.detected).toEqual([authPath]);
+    expect(result.changes).toStrictEqual([
+      `Rewrote 1 "api_key" field(s) to "key" in ${authPath} (backup: ${authPath}.api-key-alias.123.bak).`,
+    ]);
+    expect(result.warnings).toStrictEqual([]);
+    expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual({
+      version: 1,
+      profiles: {
+        "my-key": {
+          type: "api_key",
+          provider: "my-provider",
+          key: { source: "env", provider: "default", id: "MY_PROVIDER_API_KEY" },
+        },
+      },
+    });
+    expect(JSON.parse(fs.readFileSync(`${authPath}.api-key-alias.123.bak`, "utf8"))).toEqual(
+      canonical,
+    );
+  });
+
   it('does not touch profiles that already have the canonical "key" field', async () => {
     const state = await makeTestState();
     const canonical = {

--- a/src/commands/doctor-auth-canonical-api-key-alias.test.ts
+++ b/src/commands/doctor-auth-canonical-api-key-alias.test.ts
@@ -150,6 +150,33 @@ describe("maybeRepairCanonicalApiKeyFieldAlias", () => {
     expect(fs.existsSync(`${authPath}.api-key-alias.123.bak`)).toBe(false);
   });
 
+  it('does not replace inline canonical SecretRef "key" credentials with stale "api_key" fields', async () => {
+    const state = await makeTestState();
+    const canonical = {
+      version: 1,
+      profiles: {
+        "inline-ref-key": {
+          type: "api_key",
+          provider: "my-provider",
+          key: { source: "env", provider: "default", id: "MY_PROVIDER_API_KEY" },
+          api_key: "stale-inline-key",
+        },
+      },
+    };
+    const authPath = await state.writeAuthProfiles(canonical);
+
+    const result = await maybeRepairCanonicalApiKeyFieldAlias({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 123,
+    });
+
+    expect(result.detected).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual(canonical);
+    expect(fs.existsSync(`${authPath}.api-key-alias.123.bak`)).toBe(false);
+  });
+
   it('reports the non-canonical "api_key" field without rewriting when repair is declined', async () => {
     const state = await makeTestState();
     const canonical = {

--- a/src/commands/doctor-auth-canonical-api-key-alias.test.ts
+++ b/src/commands/doctor-auth-canonical-api-key-alias.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/store.js";
 import {
@@ -135,6 +136,86 @@ describe("maybeRepairCanonicalApiKeyFieldAlias", () => {
     expect(JSON.parse(fs.readFileSync(`${authPath}.api-key-alias.123.bak`, "utf8"))).toEqual(
       canonical,
     );
+  });
+
+  it("repairs auth profiles from OPENCLAW_AGENT_DIR", async () => {
+    const state = await makeTestState();
+    const agentDir = state.path("external-agent");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+    const canonical = {
+      version: 1,
+      profiles: {
+        "my-key": {
+          type: "api_key",
+          provider: "my-provider",
+          api_key: "sk-snake-case-key",
+        },
+      },
+    };
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(authPath, `${JSON.stringify(canonical, null, 2)}\n`, "utf8");
+
+    const result = await maybeRepairCanonicalApiKeyFieldAlias({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 123,
+      env: {
+        ...state.env,
+        OPENCLAW_AGENT_DIR: agentDir,
+      },
+    });
+
+    expect(result.detected).toEqual([authPath]);
+    expect(result.changes).toStrictEqual([
+      `Rewrote 1 "api_key" field(s) to "key" in ${authPath} (backup: ${authPath}.api-key-alias.123.bak).`,
+    ]);
+    expect(result.warnings).toStrictEqual([]);
+    expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual({
+      version: 1,
+      profiles: {
+        "my-key": {
+          type: "api_key",
+          provider: "my-provider",
+          key: "sk-snake-case-key",
+        },
+      },
+    });
+  });
+
+  it("repairs auth profiles from PI_CODING_AGENT_DIR", async () => {
+    const state = await makeTestState();
+    const agentDir = state.path("legacy-external-agent");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+    const canonical = {
+      version: 1,
+      profiles: {
+        "my-key": {
+          type: "api_key",
+          provider: "my-provider",
+          api_key: "sk-snake-case-key",
+        },
+      },
+    };
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(authPath, `${JSON.stringify(canonical, null, 2)}\n`, "utf8");
+
+    const result = await maybeRepairCanonicalApiKeyFieldAlias({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 123,
+      env: {
+        ...state.env,
+        OPENCLAW_AGENT_DIR: undefined,
+        PI_CODING_AGENT_DIR: agentDir,
+      },
+    });
+
+    expect(result.detected).toEqual([authPath]);
+    expect(JSON.parse(fs.readFileSync(authPath, "utf8")).profiles["my-key"]).toEqual({
+      type: "api_key",
+      provider: "my-provider",
+      key: "sk-snake-case-key",
+    });
   });
 
   it('does not touch profiles that already have the canonical "key" field', async () => {

--- a/src/commands/doctor-auth-canonical-api-key-alias.test.ts
+++ b/src/commands/doctor-auth-canonical-api-key-alias.test.ts
@@ -123,6 +123,33 @@ describe("maybeRepairCanonicalApiKeyFieldAlias", () => {
     expect(fs.existsSync(`${authPath}.api-key-alias.123.bak`)).toBe(false);
   });
 
+  it('does not replace canonical "keyRef" credentials with stale "api_key" fields', async () => {
+    const state = await makeTestState();
+    const canonical = {
+      version: 1,
+      profiles: {
+        "ref-key": {
+          type: "api_key",
+          provider: "my-provider",
+          keyRef: { source: "env", provider: "default", id: "MY_PROVIDER_API_KEY" },
+          api_key: "stale-inline-key",
+        },
+      },
+    };
+    const authPath = await state.writeAuthProfiles(canonical);
+
+    const result = await maybeRepairCanonicalApiKeyFieldAlias({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 123,
+    });
+
+    expect(result.detected).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual(canonical);
+    expect(fs.existsSync(`${authPath}.api-key-alias.123.bak`)).toBe(false);
+  });
+
   it('reports the non-canonical "api_key" field without rewriting when repair is declined', async () => {
     const state = await makeTestState();
     const canonical = {

--- a/src/commands/doctor-auth-canonical-api-key-alias.test.ts
+++ b/src/commands/doctor-auth-canonical-api-key-alias.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/store.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { maybeRepairCanonicalApiKeyFieldAlias } from "./doctor-auth-flat-profiles.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+const states: OpenClawTestState[] = [];
+
+function makePrompter(shouldRepair: boolean): DoctorPrompter {
+  return {
+    confirm: vi.fn(async () => shouldRepair),
+    confirmAutoFix: vi.fn(async () => shouldRepair),
+    confirmAggressiveAutoFix: vi.fn(async () => shouldRepair),
+    confirmRuntimeRepair: vi.fn(async () => shouldRepair),
+    select: vi.fn(async (_params, fallback) => fallback),
+    shouldRepair,
+    shouldForce: false,
+    repairMode: {
+      shouldRepair,
+      shouldForce: false,
+      nonInteractive: false,
+      canPrompt: true,
+      updateInProgress: false,
+    },
+  };
+}
+
+async function makeTestState(): Promise<OpenClawTestState> {
+  const state = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-doctor-canonical-api-key-",
+    env: {
+      OPENCLAW_AGENT_DIR: undefined,
+    },
+  });
+  states.push(state);
+  return state;
+}
+
+afterEach(async () => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  for (const state of states.splice(0)) {
+    await state.cleanup();
+  }
+});
+
+describe("maybeRepairCanonicalApiKeyFieldAlias", () => {
+  it('rewrites the non-canonical "api_key" field to "key" with a backup (57389)', async () => {
+    const state = await makeTestState();
+    const canonical = {
+      version: 1,
+      profiles: {
+        "my-key": {
+          type: "api_key",
+          provider: "my-provider",
+          api_key: "sk-snake-case-key",
+        },
+      },
+      order: {
+        "my-provider": ["my-key"],
+      },
+    };
+    const authPath = await state.writeAuthProfiles(canonical);
+
+    const result = await maybeRepairCanonicalApiKeyFieldAlias({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 123,
+    });
+
+    expect(result.detected).toEqual([authPath]);
+    expect(result.changes).toStrictEqual([
+      `Rewrote 1 "api_key" field(s) to "key" in ${authPath} (backup: ${authPath}.api-key-alias.123.bak).`,
+    ]);
+    expect(result.warnings).toStrictEqual([]);
+    // After the fix: api_key is aliased to the canonical key, other fields untouched.
+    expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual({
+      version: 1,
+      profiles: {
+        "my-key": {
+          type: "api_key",
+          provider: "my-provider",
+          key: "sk-snake-case-key",
+        },
+      },
+      order: {
+        "my-provider": ["my-key"],
+      },
+    });
+    // The backup preserves the original non-canonical shape.
+    expect(JSON.parse(fs.readFileSync(`${authPath}.api-key-alias.123.bak`, "utf8"))).toEqual(
+      canonical,
+    );
+  });
+
+  it('does not touch profiles that already have the canonical "key" field', async () => {
+    const state = await makeTestState();
+    const canonical = {
+      version: 1,
+      profiles: {
+        "good-key": {
+          type: "api_key",
+          provider: "my-provider",
+          key: "sk-already-canonical",
+        },
+      },
+    };
+    const authPath = await state.writeAuthProfiles(canonical);
+
+    const result = await maybeRepairCanonicalApiKeyFieldAlias({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 123,
+    });
+
+    expect(result.detected).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual(canonical);
+    expect(fs.existsSync(`${authPath}.api-key-alias.123.bak`)).toBe(false);
+  });
+
+  it('reports the non-canonical "api_key" field without rewriting when repair is declined', async () => {
+    const state = await makeTestState();
+    const canonical = {
+      version: 1,
+      profiles: {
+        "my-key": {
+          type: "api_key",
+          provider: "my-provider",
+          api_key: "sk-snake-case-key",
+        },
+      },
+    };
+    const authPath = await state.writeAuthProfiles(canonical);
+
+    const result = await maybeRepairCanonicalApiKeyFieldAlias({
+      cfg: {},
+      prompter: makePrompter(false),
+      now: () => 123,
+    });
+
+    expect(result.detected).toEqual([authPath]);
+    expect(result.changes).toStrictEqual([]);
+    expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual(canonical);
+    expect(fs.existsSync(`${authPath}.api-key-alias.123.bak`)).toBe(false);
+  });
+});

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -12,6 +12,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { AuthProfileConfig } from "../config/types.auth.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { coerceSecretRef } from "../config/types.secrets.js";
 import { loadJsonFile } from "../infra/json-file.js";
 import { isRecord } from "../shared/record-coerce.js";
 import { note } from "../terminal/note.js";
@@ -400,7 +401,6 @@ export async function maybeRepairLegacyFlatAuthProfileStores(params: {
   return result;
 }
 
-
 type CanonicalApiKeyAliasRepair = {
   authPath: string;
   raw: Record<string, unknown>;
@@ -425,13 +425,12 @@ function resolveCanonicalApiKeyAliasRepair(
     const type = readNonEmptyString(value.type) ?? readNonEmptyString(value.mode);
     const hasApiKeyField = readNonEmptyString(value["api_key"]) !== undefined;
     const hasCanonicalKey = readNonEmptyString(value.key) !== undefined;
-    if (type === "api_key" && hasApiKeyField && !hasCanonicalKey) {
+    const hasCanonicalKeyRef = coerceSecretRef(value.keyRef) !== null;
+    if (type === "api_key" && hasApiKeyField && !hasCanonicalKey && !hasCanonicalKeyRef) {
       profileIds.push(profileId);
     }
   }
-  return profileIds.length > 0
-    ? { authPath: candidate.authPath, raw, profileIds }
-    : null;
+  return profileIds.length > 0 ? { authPath: candidate.authPath, raw, profileIds } : null;
 }
 
 function backupCanonicalApiKeyAlias(authPath: string, now: () => number): string {
@@ -464,7 +463,7 @@ export async function maybeRepairCanonicalApiKeyFieldAlias(params: {
       `- ${shortenHomePath(entry.authPath)} has ${entry.profileIds.length} profile(s) using the non-canonical "api_key" field; the canonical field is "key".`,
   );
   noteLines.push(
-    `- Runtime auth parsing only reads the canonical "key" field, so these profiles are silently skipped; ${formatCliCommand("openclaw doctor --fix")} rewrites "api_key" to "key" with a backup.`,
+    `- Runtime auth parsing only reads canonical "key" and "keyRef" fields, so these profiles are silently skipped; ${formatCliCommand("openclaw doctor --fix")} rewrites "api_key" to "key" with a backup.`,
   );
   note(noteLines.join("\n"), "Auth profiles");
 

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -399,3 +399,111 @@ export async function maybeRepairLegacyFlatAuthProfileStores(params: {
   }
   return result;
 }
+
+
+type CanonicalApiKeyAliasRepair = {
+  authPath: string;
+  raw: Record<string, unknown>;
+  profileIds: string[];
+};
+
+function resolveCanonicalApiKeyAliasRepair(
+  candidate: AuthProfileRepairCandidate,
+): CanonicalApiKeyAliasRepair | null {
+  if (!fs.existsSync(candidate.authPath)) {
+    return null;
+  }
+  const raw = loadJsonFile(candidate.authPath);
+  if (!isRecord(raw) || !isRecord(raw.profiles)) {
+    return null;
+  }
+  const profileIds: string[] = [];
+  for (const [profileId, value] of Object.entries(raw.profiles)) {
+    if (!isRecord(value)) {
+      continue;
+    }
+    const type = readNonEmptyString(value.type) ?? readNonEmptyString(value.mode);
+    const hasApiKeyField = readNonEmptyString(value["api_key"]) !== undefined;
+    const hasCanonicalKey = readNonEmptyString(value.key) !== undefined;
+    if (type === "api_key" && hasApiKeyField && !hasCanonicalKey) {
+      profileIds.push(profileId);
+    }
+  }
+  return profileIds.length > 0
+    ? { authPath: candidate.authPath, raw, profileIds }
+    : null;
+}
+
+function backupCanonicalApiKeyAlias(authPath: string, now: () => number): string {
+  const backupPath = `${authPath}.api-key-alias.${now()}.bak`;
+  fs.copyFileSync(authPath, backupPath);
+  return backupPath;
+}
+
+export async function maybeRepairCanonicalApiKeyFieldAlias(params: {
+  cfg: OpenClawConfig;
+  prompter: DoctorPrompter;
+  now?: () => number;
+}): Promise<LegacyFlatAuthProfileRepairResult> {
+  const now = params.now ?? Date.now;
+  const repairs = listAuthProfileRepairCandidates(params.cfg)
+    .map(resolveCanonicalApiKeyAliasRepair)
+    .filter((entry): entry is CanonicalApiKeyAliasRepair => entry !== null);
+
+  const result: LegacyFlatAuthProfileRepairResult = {
+    detected: repairs.map((entry) => entry.authPath),
+    changes: [],
+    warnings: [],
+  };
+  if (repairs.length === 0) {
+    return result;
+  }
+
+  const noteLines = repairs.map(
+    (entry) =>
+      `- ${shortenHomePath(entry.authPath)} has ${entry.profileIds.length} profile(s) using the non-canonical "api_key" field; the canonical field is "key".`,
+  );
+  noteLines.push(
+    `- Runtime auth parsing only reads the canonical "key" field, so these profiles are silently skipped; ${formatCliCommand("openclaw doctor --fix")} rewrites "api_key" to "key" with a backup.`,
+  );
+  note(noteLines.join("\n"), "Auth profiles");
+
+  const shouldRepair = await params.prompter.confirmAutoFix({
+    message: 'Rewrite non-canonical "api_key" fields to "key" now?',
+    initialValue: true,
+  });
+  if (!shouldRepair) {
+    return result;
+  }
+
+  for (const entry of repairs) {
+    try {
+      const backupPath = backupCanonicalApiKeyAlias(entry.authPath, now);
+      const profiles = entry.raw.profiles as Record<string, Record<string, unknown>>;
+      for (const profileId of entry.profileIds) {
+        const profile = profiles[profileId];
+        if (!isRecord(profile)) {
+          continue;
+        }
+        profile.key = profile["api_key"];
+        delete profile["api_key"];
+      }
+      fs.writeFileSync(entry.authPath, `${JSON.stringify(entry.raw, null, 2)}\n`);
+      result.changes.push(
+        `Rewrote ${entry.profileIds.length} "api_key" field(s) to "key" in ${shortenHomePath(entry.authPath)} (backup: ${shortenHomePath(backupPath)}).`,
+      );
+    } catch (err) {
+      result.warnings.push(
+        `Failed to rewrite "api_key" fields in ${shortenHomePath(entry.authPath)}: ${String(err)}`,
+      );
+    }
+  }
+  clearRuntimeAuthProfileStoreSnapshots();
+  if (result.changes.length > 0) {
+    note(result.changes.map((change) => `- ${change}`).join("\n"), "Doctor changes");
+  }
+  if (result.warnings.length > 0) {
+    note(result.warnings.map((warning) => `- ${warning}`).join("\n"), "Doctor warnings");
+  }
+  return result;
+}

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -424,7 +424,8 @@ function resolveCanonicalApiKeyAliasRepair(
     }
     const type = readNonEmptyString(value.type) ?? readNonEmptyString(value.mode);
     const hasApiKeyField = readNonEmptyString(value["api_key"]) !== undefined;
-    const hasCanonicalKey = readNonEmptyString(value.key) !== undefined;
+    const hasCanonicalKey =
+      readNonEmptyString(value.key) !== undefined || coerceSecretRef(value.key) !== null;
     const hasCanonicalKeyRef = coerceSecretRef(value.keyRef) !== null;
     if (type === "api_key" && hasApiKeyField && !hasCanonicalKey && !hasCanonicalKeyRef) {
       profileIds.push(profileId);

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -423,7 +423,9 @@ function resolveCanonicalApiKeyAliasRepair(
       continue;
     }
     const type = readNonEmptyString(value.type) ?? readNonEmptyString(value.mode);
-    const hasApiKeyField = readNonEmptyString(value["api_key"]) !== undefined;
+    const hasApiKeyField =
+      readNonEmptyString(value["api_key"]) !== undefined ||
+      coerceSecretRef(value["api_key"]) !== null;
     const hasCanonicalKey =
       readNonEmptyString(value.key) !== undefined || coerceSecretRef(value.key) !== null;
     const hasCanonicalKeyRef = coerceSecretRef(value.keyRef) !== null;

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -174,8 +174,8 @@ function addCandidate(
   candidates.set(path.resolve(authPath), { agentDir, authPath });
 }
 
-function listExistingAgentDirsFromState(): string[] {
-  const root = path.join(resolveStateDir(), "agents");
+function listExistingAgentDirsFromState(env: NodeJS.ProcessEnv): string[] {
+  const root = path.join(resolveStateDir(env), "agents");
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(root, { withFileTypes: true });
@@ -194,13 +194,21 @@ function listExistingAgentDirsFromState(): string[] {
     });
 }
 
-function listAuthProfileRepairCandidates(cfg: OpenClawConfig): AuthProfileRepairCandidate[] {
+function listAuthProfileRepairCandidates(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): AuthProfileRepairCandidate[] {
   const candidates = new Map<string, AuthProfileRepairCandidate>();
-  addCandidate(candidates, resolveDefaultAgentDir(cfg));
-  for (const agentId of listAgentIds(cfg)) {
-    addCandidate(candidates, resolveAgentDir(cfg, agentId));
+  addCandidate(candidates, resolveDefaultAgentDir(cfg, env));
+  const envAgentDir =
+    readNonEmptyString(env.OPENCLAW_AGENT_DIR) ?? readNonEmptyString(env.PI_CODING_AGENT_DIR);
+  if (envAgentDir) {
+    addCandidate(candidates, envAgentDir);
   }
-  for (const agentDir of listExistingAgentDirsFromState()) {
+  for (const agentId of listAgentIds(cfg)) {
+    addCandidate(candidates, resolveAgentDir(cfg, agentId, env));
+  }
+  for (const agentDir of listExistingAgentDirsFromState(env)) {
     addCandidate(candidates, agentDir);
   }
   return [...candidates.values()];
@@ -304,12 +312,14 @@ export async function maybeRepairLegacyFlatAuthProfileStores(params: {
   cfg: OpenClawConfig;
   prompter: DoctorPrompter;
   now?: () => number;
+  env?: NodeJS.ProcessEnv;
 }): Promise<LegacyFlatAuthProfileRepairResult> {
   const now = params.now ?? Date.now;
-  const legacyStores = listAuthProfileRepairCandidates(params.cfg)
+  const env = params.env ?? process.env;
+  const legacyStores = listAuthProfileRepairCandidates(params.cfg, env)
     .map(resolveLegacyFlatStore)
     .filter((entry): entry is LegacyFlatAuthProfileStore => entry !== null);
-  const awsSdkMarkerStores = listAuthProfileRepairCandidates(params.cfg)
+  const awsSdkMarkerStores = listAuthProfileRepairCandidates(params.cfg, env)
     .map(resolveAwsSdkAuthProfileMarkerStore)
     .filter((entry): entry is AwsSdkAuthProfileMarkerStore => entry !== null);
 
@@ -446,9 +456,11 @@ export async function maybeRepairCanonicalApiKeyFieldAlias(params: {
   cfg: OpenClawConfig;
   prompter: DoctorPrompter;
   now?: () => number;
+  env?: NodeJS.ProcessEnv;
 }): Promise<LegacyFlatAuthProfileRepairResult> {
   const now = params.now ?? Date.now;
-  const repairs = listAuthProfileRepairCandidates(params.cfg)
+  const env = params.env ?? process.env;
+  const repairs = listAuthProfileRepairCandidates(params.cfg, env)
     .map(resolveCanonicalApiKeyAliasRepair)
     .filter((entry): entry is CanonicalApiKeyAliasRepair => entry !== null);
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -132,7 +132,7 @@ async function runGatewayConfigHealth(ctx: DoctorHealthFlowContext): Promise<voi
 }
 
 async function runAuthProfileHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  const { maybeRepairLegacyFlatAuthProfileStores } =
+  const { maybeRepairLegacyFlatAuthProfileStores, maybeRepairCanonicalApiKeyFieldAlias } =
     await import("../commands/doctor-auth-flat-profiles.js");
   const { maybeRepairLegacyOAuthProfileIds } =
     await import("../commands/doctor-auth-legacy-oauth.js");
@@ -143,6 +143,10 @@ async function runAuthProfileHealth(ctx: DoctorHealthFlowContext): Promise<void>
   const { buildGatewayConnectionDetails } = await import("../gateway/call.js");
   const { note } = await import("../terminal/note.js");
   await maybeRepairLegacyFlatAuthProfileStores({
+    cfg: ctx.cfg,
+    prompter: ctx.prompter,
+  });
+  await maybeRepairCanonicalApiKeyFieldAlias({
     cfg: ctx.cfg,
     prompter: ctx.prompter,
   });


### PR DESCRIPTION
## Summary

Per the doctor-rewrite follow-up direction in #86163: runtime auth/config parsing should stay strict and read the canonical schema only, while tolerance for legacy/malformed files belongs in `openclaw doctor --fix`.

`auth-profiles.json` entries written with the snake_case `api_key` field (instead of the canonical `key`) are silently skipped at runtime, producing the misleading `No API key found for provider` error (Fixes #57389). The runtime parser deliberately stays strict.

This adds a doctor repair (`maybeRepairCanonicalApiKeyFieldAlias`) that:
- detects canonical-store profiles (`{ profiles: { ... } }`) whose `api_key` field is set but the canonical `key` is missing,
- explains that the canonical field is `key` and that runtime parsing ignores `api_key`,
- on `openclaw doctor --fix`, rewrites `api_key` to `key` and removes the non-canonical field, writing a timestamped backup first.

It reuses the existing candidate enumeration, backup, and note infrastructure in `doctor-auth-flat-profiles.ts`, and is wired into `runAuthProfileHealth` alongside the existing flat/oauth auth repairs. The runtime parser (`persisted.ts`) is left untouched, so invalid configuration is never silently accepted at runtime.

## Real behavior proof

Behavior or issue addressed: a canonical `auth-profiles.json` profile written with the non-canonical `api_key` field is detected and rewritten to the canonical `key` by `openclaw doctor --fix`, with a backup, instead of being silently skipped at runtime.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, local build of this PR branch run via `node scripts/run-node.mjs`, against a real on-disk `auth-profiles.json` in an isolated `OPENCLAW_STATE_DIR`. The API key value is a redacted placeholder.

Exact steps or command run after this patch: wrote a canonical `auth-profiles.json` with a profile using the snake_case `api_key` field into an isolated state dir, then ran `openclaw doctor --fix --yes` against that state dir, then inspected the rewritten file and the backup on disk.

Evidence after fix: redacted real `openclaw doctor --fix` run outside the test harness.

```text
-- BEFORE (on-disk auth-profiles.json) --
{
  "version": 1,
  "profiles": {
    "my-key": {
      "type": "api_key",
      "provider": "my-provider",
      "api_key": "sk-PLACEHOLDER-REDACTED"
    }
  },
  "order": { "my-provider": ["my-key"] }
}

-- RUN: openclaw doctor --fix --yes --

  Auth profiles
  - <state>/agents/main/agent/auth-profiles.json
    has 1 profile(s) using the non-canonical "api_key" field; the canonical field is "key".
  - Runtime auth parsing only reads the canonical "key" field, so these
    profiles are silently skipped; openclaw doctor --fix rewrites "api_key" to "key" with a backup.

  Doctor changes
  - Rewrote 1 "api_key" field(s) to "key" in <state>/agents/main/agent/auth-profiles.json
    (backup: <state>/agents/main/agent/auth-profiles.json.api-key-alias.<ts>.bak).

-- AFTER (on-disk auth-profiles.json) --
{
  "version": 1,
  "profiles": {
    "my-key": {
      "type": "api_key",
      "provider": "my-provider",
      "key": "sk-PLACEHOLDER-REDACTED"
    }
  },
  "order": { "my-provider": ["my-key"] }
}

-- BACKUP (preserves original non-canonical shape) --
auth-profiles.json.api-key-alias.<ts>.bak  (contains the original api_key form)
```

This is backed by a focused regression suite (`doctor-auth-canonical-api-key-alias.test.ts`, 3 tests) covering the rewrite+backup, the guard that leaves profiles already using `key` untouched, and the declined-repair case. Reverting the core rewrite makes the rewrite test fail (the on-disk profile keeps `api_key` with no `key`); restoring it passes all three.

Observed result after fix: the real `openclaw doctor --fix` run detects the non-canonical `api_key` field, explains the canonical field is `key`, writes a timestamped backup, and rewrites the on-disk profile so it becomes `{ type: "api_key", provider: "my-provider", key: "..." }` (other fields and the `order` map preserved). The runtime parser is unchanged.

What was not tested: no real provider credentials or network calls were used; the key value is a redacted placeholder. The change is confined to the doctor repair path; the runtime parser is intentionally not modified, per the #86163 direction that runtime parsing stays strict.
