### PR TITLE
fix(telegram): strip language class from code blocks to prevent HTML leak

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -76,7 +76,7 @@ describe("markdownToTelegramHtml", () => {
     expect(markdownToTelegramHtml(commandBlock)).toBe("<code>/queue followup debounce:0\n</code>");
     expect(
       markdownToTelegramHtml('<pre><code class="language-python">print(1)\n</code></pre>'),
-    ).toBe('<pre><code class="language-python">print(1)\n</code></pre>');
+    ).toBe("<pre><code>print(1)\n</code></pre>");
   });
 
   it("renders blockquotes as native Telegram blockquote tags", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -247,9 +247,6 @@ function preserveTelegramHtmlTag(
   const attrs = match[3] ?? "";
   if (!closing && tagName === "code" && TELEGRAM_CODE_LANGUAGE_ATTR_PATTERN.test(attrs)) {
     openTags.push(tagName);
-    if (hasOpenTelegramHtmlTag(openTags, "pre")) {
-      return rawTag;
-    }
     return "<code>";
   }
   if (!isSupportedTelegramHtmlTag(rawTag)) {


### PR DESCRIPTION
## Summary

Fixes Telegram code blocks rendering literal HTML tags instead of formatted code.

When OpenClaw sent `<code class="language-...">` to Telegram, the HTML parser would fail because Telegram doesn't support `class` attributes on `<code>` tags. This caused users to see literal HTML markup like:

```
<code class="language-text">example</code>
```

instead of properly formatted code blocks.

## Changes

- `extensions/telegram/src/format.ts`: Strip `class` attribute from all `<code>` tags before sending to Telegram
- `extensions/telegram/src/format.test.ts`: Updated test expectation to match the fix

## Verification

```bash
pnpm test extensions/telegram/src/format.test.ts --run
pnpm test extensions/telegram/src/send.test.ts --run -t "normalizes raw code language HTML"
pnpm check:changed --staged
```

All tests pass. The fix aligns with existing behavior in `send.test.ts` which already expected `<code class="language-text">` to be normalized to `<code>`.

## Related

Fixes #86805
