### PR TITLE
fix(agents): recover stale OpenAI Responses continuation state

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2634,6 +2634,104 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("drops Responses replay reasoning and item ids during one-shot recovery", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-responses",
+            provider: "openai",
+            model: "gpt-5.4",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need a tool.",
+                thinkingSignature: JSON.stringify({
+                  type: "reasoning",
+                  id: "rs_prior",
+                  encrypted_content: "ciphertext",
+                }),
+              },
+              {
+                type: "text",
+                text: "Checking the price.",
+                textSignature: JSON.stringify({
+                  v: 1,
+                  id: "msg_prior",
+                  phase: "commentary",
+                }),
+              },
+              {
+                type: "toolCall",
+                id: "call_abc|fc_prior",
+                name: "price_lookup",
+                arguments: { symbol: "SOL" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_abc|fc_prior",
+            toolName: "price_lookup",
+            content: [{ type: "text", text: "$83.95" }],
+            isError: false,
+            timestamp: 2,
+          },
+          { role: "user", content: "Continue", timestamp: 3 },
+        ],
+        tools: [],
+      } as never,
+      { dropOpenAIResponsesReplayState: true },
+    ) as {
+      input?: Array<{
+        type?: string;
+        role?: string;
+        id?: string;
+        call_id?: string;
+      }>;
+    };
+
+    expect(params.input?.some((item) => item.type === "reasoning")).toBe(false);
+    const assistantMessage = params.input?.find(
+      (item) => item.type === "message" && item.role === "assistant",
+    );
+    expectRecordFields(assistantMessage, {
+      type: "message",
+      role: "assistant",
+    });
+    expect(assistantMessage?.id).toBeUndefined();
+    const functionCall = params.input?.find((item) => item.type === "function_call");
+    expectRecordFields(functionCall, {
+      type: "function_call",
+      call_id: "call_abc",
+    });
+    expect(functionCall?.id).toBeUndefined();
+  });
+
   it("drops oversized GitHub Copilot Responses reasoning replay items before send", () => {
     const model = {
       id: "gpt-5.5",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -127,6 +127,7 @@ type BaseStreamOptions = {
   frequencyPenalty?: number;
   presencePenalty?: number;
   seed?: number;
+  dropOpenAIResponsesReplayState?: boolean;
 };
 
 type ModelStreamCooperativeScheduler = {
@@ -2025,6 +2026,7 @@ export function buildOpenAIResponsesParams(
   const compat = getCompat(model as OpenAIModeModel);
   const supportsDeveloperRole =
     typeof compat.supportsDeveloperRole === "boolean" ? compat.supportsDeveloperRole : undefined;
+  const dropReplayState = options?.dropOpenAIResponsesReplayState === true;
   const messages = convertResponsesMessages(
     model,
     context,
@@ -2032,8 +2034,8 @@ export function buildOpenAIResponsesParams(
     {
       includeSystemPrompt: !isCodexResponses,
       supportsDeveloperRole,
-      replayReasoningItems: true,
-      replayResponsesItemIds: !isNativeCodexResponses,
+      replayReasoningItems: !dropReplayState,
+      replayResponsesItemIds: !dropReplayState && !isNativeCodexResponses,
       authProfileId: options?.authProfileId,
       sessionId: options?.sessionId,
     },

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -14,6 +14,7 @@ import {
   isFailoverErrorMessage,
   isImageDimensionErrorMessage,
   isLikelyContextOverflowError,
+  isOpenAIResponsesContinuationCorruptionErrorMessage,
   isTimeoutErrorMessage,
   isTransientHttpError,
   parseImageDimensionError,
@@ -1559,6 +1560,26 @@ describe("classifyProviderRuntimeFailureKind", () => {
     expect(
       classifyProviderRuntimeFailureKind("401 input item ID does not belong to this connection"),
     ).toBe("replay_invalid");
+  });
+
+  it("classifies OpenAI Responses continuation corruption as replay invalid", () => {
+    const samples = [
+      "400 thinking_signature_invalid: invalid thinking signature",
+      "invalid_encrypted_content",
+      "The encrypted content for item rs_example could not be verified",
+      "verification failed for encrypted reasoning item",
+      "Item with id 'rs_example' not found",
+      "previous_response_id expired or not found",
+    ];
+
+    for (const sample of samples) {
+      expect(isOpenAIResponsesContinuationCorruptionErrorMessage(sample)).toBe(true);
+      expect(classifyProviderRuntimeFailureKind(sample)).toBe("replay_invalid");
+    }
+
+    expect(
+      isOpenAIResponsesContinuationCorruptionErrorMessage("tool_use.input: Field required"),
+    ).toBe(false);
   });
 
   it("splits ambiguous provider runtime failures instead of collapsing to unknown", () => {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -37,6 +37,7 @@ export {
   isImageDimensionErrorMessage,
   isImageSizeError,
   isOverloadedErrorMessage,
+  isOpenAIResponsesContinuationCorruptionErrorMessage,
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -353,6 +353,10 @@ const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
 const REPLAY_INVALID_RE =
   /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
+const OPENAI_RESPONSES_CONTINUATION_CORRUPTION_RE =
+  /\bthinking_signature_invalid\b|\binvalid_encrypted_content\b|\bitem\s+with\s+id\s+['"]?rs_[A-Za-z0-9_-]+['"]?\s+not\s+found\b|\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\binput item id does not belong to this connection\b/i;
+const OPENAI_RESPONSES_ENCRYPTED_REASONING_INVALID_RE =
+  /\bencrypted\b.*\b(?:content|reasoning)\b.*\b(?:could not|cannot|can't|failed to|unable to)\b.*\b(?:decrypt|decrypted|decryption|parse|parsed|parsing|verify|verified|verification|validate|validated|validation)\b|\b(?:could not|cannot|can't|failed to|unable to)\b.*\b(?:decrypt|decrypted|decryption|parse|parsed|parsing|verify|verified|verification|validate|validated|validation)\b.*\bencrypted\b.*\b(?:content|reasoning)\b|\b(?:decryption|parsing|verification|validation)\s+failed\b.*\bencrypted\b.*\b(?:content|reasoning)\b|\bencrypted\b.*\b(?:content|reasoning)\b.*\b(?:decryption|parsing|verification|validation)\s+failed\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b|\bexec denied\s*\(/i;
 const NO_BODY_HTTP_WRAPPER_RE =
@@ -471,12 +475,24 @@ function isReplayInvalidErrorMessage(raw: string): boolean {
   return REPLAY_INVALID_RE.test(raw);
 }
 
+export function isOpenAIResponsesContinuationCorruptionErrorMessage(raw: string): boolean {
+  return (
+    OPENAI_RESPONSES_CONTINUATION_CORRUPTION_RE.test(raw) ||
+    OPENAI_RESPONSES_ENCRYPTED_REASONING_INVALID_RE.test(raw)
+  );
+}
+
 function isSandboxBlockedErrorMessage(raw: string): boolean {
   return Boolean(formatExecDeniedUserMessage(raw)) || SANDBOX_BLOCKED_RE.test(raw);
 }
 
 function isSchemaErrorMessage(raw: string): boolean {
-  if (!raw || isReplayInvalidErrorMessage(raw) || isContextOverflowError(raw)) {
+  if (
+    !raw ||
+    isReplayInvalidErrorMessage(raw) ||
+    isOpenAIResponsesContinuationCorruptionErrorMessage(raw) ||
+    isContextOverflowError(raw)
+  ) {
     return false;
   }
   return classifyFailoverReason(raw) === "format" || matchesFormatErrorPattern(raw);
@@ -1016,7 +1032,11 @@ export function classifyProviderRuntimeFailureKind(
   if (message && isSandboxBlockedErrorMessage(message)) {
     return "sandbox_blocked";
   }
-  if (message && isReplayInvalidErrorMessage(message)) {
+  if (
+    message &&
+    (isReplayInvalidErrorMessage(message) ||
+      isOpenAIResponsesContinuationCorruptionErrorMessage(message))
+  ) {
     return "replay_invalid";
   }
   if (message && isSchemaErrorMessage(message)) {

--- a/src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
@@ -1,0 +1,232 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedLog,
+  mockedResolveModelAsync,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+function configureOpenAIResponsesModel(): void {
+  mockedResolveModelAsync.mockResolvedValue({
+    model: {
+      id: "gpt-5.4",
+      provider: "openai",
+      contextWindow: 200000,
+      api: "openai-responses",
+    },
+    error: null,
+    authStorage: {
+      setRuntimeApiKey: vi.fn(),
+    },
+    modelRegistry: {},
+  });
+}
+
+function configureOpenAICompletionsModel(): void {
+  mockedResolveModelAsync.mockResolvedValue({
+    model: {
+      id: "gpt-5.4",
+      provider: "openai",
+      contextWindow: 200000,
+      api: "openai-completions",
+    },
+    error: null,
+    authStorage: {
+      setRuntimeApiKey: vi.fn(),
+    },
+    modelRegistry: {},
+  });
+}
+
+function corruptedPromptAttempt(
+  overrides: Partial<EmbeddedRunAttemptResult> = {},
+): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    promptError: new Error(
+      "400 thinking_signature_invalid: encrypted content could not be verified",
+    ),
+    promptErrorSource: "prompt",
+    assistantTexts: [],
+    ...overrides,
+  });
+}
+
+function successAttempt(): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    promptError: null,
+    assistantTexts: ["Done."],
+  });
+}
+
+function corruptedAssistantAttempt(): EmbeddedRunAttemptResult {
+  const assistant = {
+    role: "assistant",
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "error",
+    errorMessage: "invalid_encrypted_content",
+    timestamp: 1,
+    content: [],
+  } as EmbeddedRunAttemptResult["lastAssistant"];
+
+  return makeAttemptResult({
+    promptError: null,
+    assistantTexts: [],
+    lastAssistant: assistant,
+    currentAttemptAssistant: assistant,
+  });
+}
+
+function requireAttemptParams(index: number): Record<string, unknown> {
+  const call = mockedRunEmbeddedAttempt.mock.calls[index];
+  if (!call?.[0] || typeof call[0] !== "object") {
+    throw new Error(`expected attempt call ${index}`);
+  }
+  return call[0] as Record<string, unknown>;
+}
+
+function loggedWarns(): string {
+  return mockedLog.warn.mock.calls.map((call) => String(call[0])).join("\n");
+}
+
+const unsafeReplayCases: Array<[string, Partial<EmbeddedRunAttemptResult>]> = [
+  [
+    "message tool delivery",
+    {
+      didSendViaMessagingTool: true,
+      messagingToolSentTexts: ["already sent"],
+    },
+  ],
+  ["mutating tool", { toolMetas: [{ toolName: "write" }] }],
+  ["cron add", { successfulCronAdds: 1 }],
+  [
+    "session spawn",
+    {
+      acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "child-session" }],
+    },
+  ],
+];
+
+describe("runEmbeddedPiAgent OpenAI Responses continuation recovery", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+    configureOpenAIResponsesModel();
+  });
+
+  it("retries a replay-safe continuation corruption once with replay state dropped", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(corruptedPromptAttempt())
+      .mockResolvedValueOnce(successAttempt());
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "responses-continuation-recovery",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const retryParams = requireAttemptParams(1);
+    expect(retryParams.suppressNextUserMessagePersistence).toBe(true);
+    expect(retryParams.dropOpenAIResponsesReplayState).toBe(true);
+    expect(String(retryParams.prompt)).toContain("provider continuation state was invalid");
+    expect(retryParams.prompt).not.toBe(overflowBaseRunParams.prompt);
+    expect(result.meta.replayInvalid).not.toBe(true);
+    expect(result.meta.error).toBeUndefined();
+    expect(loggedWarns()).toContain("responses_continuation_recovery_succeeded");
+  });
+
+  it.each(unsafeReplayCases)(
+    "does not retry continuation corruption after %s",
+    async (_label, overrides) => {
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(corruptedPromptAttempt(overrides));
+
+      const result = await runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        model: "gpt-5.4",
+        runId: "responses-continuation-unsafe",
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+      expect(result.meta.livenessState).toBe("blocked");
+      expect(result.meta.replayInvalid).toBe(true);
+      expect(result.meta.error?.kind).toBe("responses_continuation_corruption");
+      expect(loggedWarns()).toContain("responses_continuation_recovery_blocked");
+    },
+  );
+
+  it("also recovers continuation corruption surfaced as an assistant error", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(corruptedAssistantAttempt())
+      .mockResolvedValueOnce(successAttempt());
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "responses-continuation-assistant-error",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(requireAttemptParams(1).dropOpenAIResponsesReplayState).toBe(true);
+    expect(loggedWarns()).toContain("source=assistantError");
+  });
+
+  it("does not use Responses recovery for non-Responses OpenAI APIs", async () => {
+    configureOpenAICompletionsModel();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(corruptedPromptAttempt());
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        model: "gpt-5.4",
+        runId: "responses-continuation-non-responses-api",
+      }),
+    ).rejects.toThrow("thinking_signature_invalid");
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(loggedWarns()).not.toContain("responses_continuation_recovery_retry");
+  });
+
+  it("blocks after the one-shot recovery retry also sees stale continuation state", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(corruptedPromptAttempt()).mockResolvedValueOnce(
+      corruptedPromptAttempt({
+        promptError: new Error("Item with id 'rs_retry' not found"),
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "responses-continuation-retry-fails",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.meta.livenessState).toBe("blocked");
+    expect(result.meta.replayInvalid).toBe(true);
+    expect(result.meta.error?.kind).toBe("responses_continuation_corruption");
+    expect(loggedWarns()).toContain("responses_continuation_recovery_blocked");
+  });
+});

--- a/src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
@@ -175,6 +175,55 @@ describe("runEmbeddedPiAgent OpenAI Responses continuation recovery", () => {
     },
   );
 
+  it("preserves message-tool delivery evidence when blocking unsafe recovery", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      corruptedPromptAttempt({
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["already sent"],
+        messagingToolSentMediaUrls: ["https://example.test/image.png"],
+        messagingToolSentTargets: [{ tool: "message", provider: "test", to: "test-channel" }],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "responses-continuation-message-tool-unsafe",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.livenessState).toBe("blocked");
+    expect(result.meta.replayInvalid).toBe(true);
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["already sent"]);
+    expect(result.messagingToolSentMediaUrls).toEqual(["https://example.test/image.png"]);
+    expect(result.messagingToolSentTargets).toHaveLength(1);
+  });
+
+  it("preserves cron and session-spawn evidence when blocking unsafe recovery", async () => {
+    const acceptedSessionSpawns = [{ runId: "child-run", childSessionKey: "child-session" }];
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      corruptedPromptAttempt({
+        successfulCronAdds: 1,
+        acceptedSessionSpawns,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "responses-continuation-cron-session-unsafe",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.livenessState).toBe("blocked");
+    expect(result.meta.replayInvalid).toBe(true);
+    expect(result.successfulCronAdds).toBe(1);
+    expect(result.acceptedSessionSpawns).toEqual(acceptedSessionSpawns);
+  });
+
   it("also recovers continuation corruption surfaced as an assistant error", async () => {
     mockedRunEmbeddedAttempt
       .mockResolvedValueOnce(corruptedAssistantAttempt())

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -678,6 +678,7 @@ export async function sanitizeSessionHistory(params: {
   sessionId: string;
   policy?: TranscriptPolicy;
   preserveLatestAssistantThinking?: boolean;
+  dropOpenAIResponsesReplayState?: boolean;
 }): Promise<AgentMessage[]> {
   // Keep docs/reference/transcript-hygiene.md in sync with any logic changes here.
   const policy =
@@ -702,6 +703,8 @@ export async function sanitizeSessionHistory(params: {
     params.modelApi === "openai-responses" ||
     params.modelApi === "openai-codex-responses" ||
     params.modelApi === "azure-openai-responses";
+  const dropOpenAIResponsesReplayState =
+    isOpenAIResponsesApi && params.dropOpenAIResponsesReplayState === true;
   const hasSnapshot = Boolean(params.provider || params.modelApi || params.modelId);
   const priorSnapshot = hasSnapshot ? readLastModelSnapshot(params.sessionManager) : null;
   const modelChanged = priorSnapshot
@@ -763,7 +766,7 @@ export async function sanitizeSessionHistory(params: {
   const openAISafeToolCalls = isOpenAIResponsesApi
     ? downgradeOpenAIFunctionCallReasoningPairs(
         downgradeOpenAIReasoningBlocks(openAIRepairedToolCalls, {
-          dropReplayableReasoning: modelChanged,
+          dropReplayableReasoning: modelChanged || dropOpenAIResponsesReplayState,
         }),
       )
     : sanitizedToolCalls;

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -186,6 +186,15 @@ export const mockedIsLikelyContextOverflowError = vi.fn((msg?: string) => {
     lower.includes("prompt is too long")
   );
 });
+export const mockedIsOpenAIResponsesContinuationCorruptionErrorMessage = vi.fn((msg?: string) => {
+  const lower = normalizeLowercaseStringOrEmpty(msg ?? "");
+  return (
+    lower.includes("thinking_signature_invalid") ||
+    lower.includes("invalid_encrypted_content") ||
+    (lower.includes("encrypted content") && lower.includes("verified")) ||
+    (lower.includes("item with id") && lower.includes("rs_") && lower.includes("not found"))
+  );
+});
 export const mockedParseImageSizeError = vi.fn(() => null);
 export const mockedParseImageDimensionError = vi.fn(() => null);
 export const mockedIsRateLimitAssistantError = vi.fn(() => false);
@@ -365,6 +374,16 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
       lower.includes("prompt is too long")
     );
   });
+  mockedIsOpenAIResponsesContinuationCorruptionErrorMessage.mockReset();
+  mockedIsOpenAIResponsesContinuationCorruptionErrorMessage.mockImplementation((msg?: string) => {
+    const lower = normalizeLowercaseStringOrEmpty(msg ?? "");
+    return (
+      lower.includes("thinking_signature_invalid") ||
+      lower.includes("invalid_encrypted_content") ||
+      (lower.includes("encrypted content") && lower.includes("verified")) ||
+      (lower.includes("item with id") && lower.includes("rs_") && lower.includes("not found"))
+    );
+  });
   mockedParseImageSizeError.mockReset();
   mockedParseImageSizeError.mockReturnValue(null);
   mockedParseImageDimensionError.mockReset();
@@ -502,6 +521,8 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     isBillingAssistantError: mockedIsBillingAssistantError,
     isCompactionFailureError: mockedIsCompactionFailureError,
     isLikelyContextOverflowError: mockedIsLikelyContextOverflowError,
+    isOpenAIResponsesContinuationCorruptionErrorMessage:
+      mockedIsOpenAIResponsesContinuationCorruptionErrorMessage,
     isFailoverAssistantError: mockedIsFailoverAssistantError,
     isFailoverErrorMessage: mockedIsFailoverErrorMessage,
     parseImageSizeError: mockedParseImageSizeError,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -84,6 +84,7 @@ import {
   isFailoverAssistantError,
   isFailoverErrorMessage,
   isLikelyContextOverflowError,
+  isOpenAIResponsesContinuationCorruptionErrorMessage,
   isRateLimitAssistantError,
   parseImageDimensionError,
   parseImageSizeError,
@@ -205,7 +206,19 @@ const MID_TURN_PRECHECK_CONTINUATION_PROMPT =
   "Continue from the current transcript after the latest tool result. Do not repeat the original user request, and do not rerun completed tools unless the transcript shows they are still needed.";
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
+const RESPONSES_CONTINUATION_RECOVERY_PROMPT =
+  "The previous provider continuation state was invalid. Rebuild the model context from the visible transcript and answer the latest user request now. Do not repeat completed tools or side effects unless the transcript clearly requires them.";
+const RESPONSES_CONTINUATION_RECOVERY_BLOCKED_TEXT =
+  "OpenAI Responses continuation state is invalid. Please try again, or use /new to start a fresh session.";
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
+
+function isOpenAIResponsesFamilyApi(api?: string | null): boolean {
+  return (
+    api === "openai-responses" ||
+    api === "openai-codex-responses" ||
+    api === "azure-openai-responses"
+  );
+}
 
 function resolveAttemptDispatchApiKey(params: {
   apiKeyInfo: ApiKeyInfo | null;
@@ -1079,6 +1092,9 @@ export async function runEmbeddedPiAgent(
       let emptyResponseRetryInstruction: string | null = null;
       let compactionContinuationRetryInstruction: string | null = null;
       let nextAttemptPromptOverride: string | null = null;
+      let responsesContinuationRecoveryAttempted = false;
+      let dropOpenAIResponsesReplayStateForNextAttempt =
+        params.dropOpenAIResponsesReplayState === true;
       const ackExecutionFastPathInstruction = resolveAckExecutionFastPathInstruction({
         provider,
         modelId,
@@ -1390,6 +1406,9 @@ export async function runEmbeddedPiAgent(
             startupStagesEmitted = true;
           }
 
+          const dropOpenAIResponsesReplayStateForAttempt =
+            dropOpenAIResponsesReplayStateForNextAttempt;
+          dropOpenAIResponsesReplayStateForNextAttempt = false;
           const attemptAbortController = new AbortController();
           postCompactionAbortController = attemptAbortController;
           const parentAbortSignal = params.abortSignal;
@@ -1533,6 +1552,7 @@ export async function runEmbeddedPiAgent(
             suppressTranscriptOnlyAssistantPersistence:
               params.suppressTranscriptOnlyAssistantPersistence,
             suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
+            dropOpenAIResponsesReplayState: dropOpenAIResponsesReplayStateForAttempt,
             onUserMessagePersisted,
             onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
           })
@@ -1688,6 +1708,81 @@ export async function runEmbeddedPiAgent(
             sessionAssistantForCandidate?.stopReason === "error"
               ? sessionAssistantForCandidate.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
+          const handleResponsesContinuationCorruption = (failure: {
+            source: "promptError" | "assistantError";
+            errorText?: string | null;
+          }): "retry" | EmbeddedPiRunResult | null => {
+            const errorText = failure.errorText?.trim();
+            if (
+              !errorText ||
+              !isOpenAIResponsesFamilyApi(effectiveModel.api) ||
+              !isOpenAIResponsesContinuationCorruptionErrorMessage(errorText)
+            ) {
+              return null;
+            }
+            const replayMetadata = resolveAttemptReplayMetadata(attempt);
+            log.warn(
+              `responses_continuation_corruption_detected provider=${sanitizeForLog(activeErrorContext.provider)} ` +
+                `model=${sanitizeForLog(activeErrorContext.model)} source=${failure.source} ` +
+                `replaySafe=${replayMetadata.replaySafe} alreadyRetried=${responsesContinuationRecoveryAttempted}`,
+            );
+            if (!responsesContinuationRecoveryAttempted && replayMetadata.replaySafe) {
+              responsesContinuationRecoveryAttempted = true;
+              suppressNextUserMessagePersistence = true;
+              nextAttemptPromptOverride = RESPONSES_CONTINUATION_RECOVERY_PROMPT;
+              dropOpenAIResponsesReplayStateForNextAttempt = true;
+              accumulatedReplayState = createEmbeddedRunReplayState();
+              log.warn(
+                `responses_continuation_recovery_retry provider=${sanitizeForLog(activeErrorContext.provider)} ` +
+                  `model=${sanitizeForLog(activeErrorContext.model)} source=${failure.source}`,
+              );
+              return "retry";
+            }
+
+            const blockedReason = responsesContinuationRecoveryAttempted
+              ? "already_retried"
+              : "replay_unsafe";
+            log.warn(
+              `responses_continuation_recovery_blocked provider=${sanitizeForLog(activeErrorContext.provider)} ` +
+                `model=${sanitizeForLog(activeErrorContext.model)} source=${failure.source} reason=${blockedReason}`,
+            );
+            attempt.setTerminalLifecycleMeta?.({
+              replayInvalid: true,
+              livenessState: "blocked",
+            });
+            return {
+              payloads: [
+                {
+                  text: RESPONSES_CONTINUATION_RECOVERY_BLOCKED_TEXT,
+                  isError: true,
+                },
+              ],
+              meta: {
+                durationMs: Date.now() - started,
+                agentMeta: buildErrorAgentMeta({
+                  sessionId: sessionIdUsed,
+                  sessionFile: activeSessionFile,
+                  provider,
+                  model: model.id,
+                  contextTokens: ctxInfo.tokens,
+                  usageAccumulator,
+                  lastRunPromptUsage,
+                  lastAssistant: sessionLastAssistant,
+                  lastTurnTotal,
+                }),
+                systemPromptReport: attempt.systemPromptReport,
+                finalAssistantVisibleText: RESPONSES_CONTINUATION_RECOVERY_BLOCKED_TEXT,
+                finalAssistantRawText: RESPONSES_CONTINUATION_RECOVERY_BLOCKED_TEXT,
+                finalPromptText: attempt.finalPromptText,
+                replayInvalid: true,
+                livenessState: "blocked",
+                error: {
+                  kind: "responses_continuation_corruption",
+                  message: "OpenAI Responses continuation state is invalid.",
+                },
+              },
+            };
+          };
           const canRestartForLiveSwitch =
             !hasOutboundDeliveryEvidence(attempt) &&
             !attempt.didSendDeterministicApprovalPrompt &&
@@ -1727,6 +1822,30 @@ export async function runEmbeddedPiAgent(
               `live session model switch requested during active attempt for ${params.sessionId}: ${provider}/${modelId} -> ${requestedSelection.provider}/${requestedSelection.model}`,
             );
             throw new LiveSessionModelSwitchError(requestedSelection);
+          }
+          if (!aborted && promptError && promptErrorSource === "prompt") {
+            const responsesRecovery = handleResponsesContinuationCorruption({
+              source: "promptError",
+              errorText: formatErrorMessage(promptError),
+            });
+            if (responsesRecovery === "retry") {
+              continue;
+            }
+            if (responsesRecovery) {
+              return responsesRecovery;
+            }
+          }
+          if (!aborted && !promptError && assistantErrorText) {
+            const responsesRecovery = handleResponsesContinuationCorruption({
+              source: "assistantError",
+              errorText: assistantErrorText,
+            });
+            if (responsesRecovery === "retry") {
+              continue;
+            }
+            if (responsesRecovery) {
+              return responsesRecovery;
+            }
           }
           // ── Timeout-triggered compaction ──────────────────────────────────
           // When the LLM times out with high context usage, compact before
@@ -3260,6 +3379,12 @@ export async function runEmbeddedPiAgent(
             };
           }
 
+          if (responsesContinuationRecoveryAttempted) {
+            log.warn(
+              `responses_continuation_recovery_succeeded provider=${sanitizeForLog(activeErrorContext.provider)} ` +
+                `model=${sanitizeForLog(activeErrorContext.model)}`,
+            );
+          }
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1746,6 +1746,14 @@ export async function runEmbeddedPiAgent(
               `responses_continuation_recovery_blocked provider=${sanitizeForLog(activeErrorContext.provider)} ` +
                 `model=${sanitizeForLog(activeErrorContext.model)} source=${failure.source} reason=${blockedReason}`,
             );
+            const blockedAttemptToolSummary = buildTraceToolSummary({
+              toolMetas: attempt.toolMetas,
+              hadFailure: Boolean(attempt.lastToolError),
+            });
+            const blockedFailureSignal = resolveEmbeddedRunFailureSignal({
+              trigger: params.trigger,
+              lastToolError: attempt.lastToolError,
+            });
             attempt.setTerminalLifecycleMeta?.({
               replayInvalid: true,
               livenessState: "blocked",
@@ -1776,11 +1784,23 @@ export async function runEmbeddedPiAgent(
                 finalPromptText: attempt.finalPromptText,
                 replayInvalid: true,
                 livenessState: "blocked",
+                toolSummary: blockedAttemptToolSummary,
+                ...(blockedFailureSignal ? { failureSignal: blockedFailureSignal } : {}),
+                agentHarnessResultClassification: attempt.agentHarnessResultClassification,
                 error: {
                   kind: "responses_continuation_corruption",
                   message: "OpenAI Responses continuation state is invalid.",
                 },
               },
+              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+              messagingToolSentTexts: attempt.messagingToolSentTexts,
+              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+              messagingToolSentTargets: attempt.messagingToolSentTargets,
+              messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
+              heartbeatToolResponse: attempt.heartbeatToolResponse,
+              successfulCronAdds: attempt.successfulCronAdds,
+              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
             };
           };
           const canRestartForLiveSwitch =

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3081,16 +3081,25 @@ export async function runEmbeddedAttempt(
           }
           // Strip orphaned reasoning blocks first, then fix function-call
           // pairing — matches the call order in google.ts.
-          const reasoningSanitized = downgradeOpenAIReasoningBlocks(messages as AgentMessage[]);
+          const reasoningSanitized = downgradeOpenAIReasoningBlocks(messages as AgentMessage[], {
+            dropReplayableReasoning: params.dropOpenAIResponsesReplayState === true,
+          });
           const sanitized = downgradeOpenAIFunctionCallReasoningPairs(reasoningSanitized);
+          const nextOptions =
+            params.dropOpenAIResponsesReplayState === true
+              ? ({
+                  ...((options as Record<string, unknown> | undefined) ?? {}),
+                  dropOpenAIResponsesReplayState: true,
+                } as typeof options)
+              : options;
           if (sanitized === messages) {
-            return inner(model, context, options);
+            return inner(model, context, nextOptions);
           }
           const nextContext = {
             ...(context as unknown as Record<string, unknown>),
             messages: sanitized,
           } as unknown;
-          return inner(model, nextContext as typeof context, options);
+          return inner(model, nextContext as typeof context, nextOptions);
         };
       }
 
@@ -3237,6 +3246,7 @@ export async function runEmbeddedAttempt(
             sessionManager,
             sessionId: params.sessionId,
             policy: transcriptPolicy,
+            dropOpenAIResponsesReplayState: params.dropOpenAIResponsesReplayState === true,
           });
           cacheTrace?.recordStage("session:sanitized", { messages: prior });
           const validated = await validateReplayTurns({

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -229,6 +229,11 @@ export type RunEmbeddedPiAgentParams = {
   suppressNextUserMessagePersistence?: boolean;
   suppressTranscriptOnlyAssistantPersistence?: boolean;
   suppressAssistantErrorPersistence?: boolean;
+  /**
+   * Internal one-shot Responses recovery flag. When set, stale provider-owned
+   * reasoning/message/function item replay state is dropped for this attempt.
+   */
+  dropOpenAIResponsesReplayState?: boolean;
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
   onAssistantErrorMessagePersisted?: (
     message: Extract<AgentMessage, { role: "assistant" }>,

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -154,6 +154,7 @@ export type EmbeddedPiRunMeta = {
       | "compaction_failure"
       | "role_ordering"
       | "image_size"
+      | "responses_continuation_corruption"
       | "retry_limit"
       | "hook_block";
     message: string;


### PR DESCRIPTION
## Summary
- Detect stale OpenAI Responses continuation/replay corruption separately from generic schema or timeout failures.
- Add one replay-safe recovery attempt that rebuilds model context from the visible transcript, suppresses duplicate user-message persistence, and drops stale Responses reasoning/item-id replay state.
- If recovery is unsafe or already used, return a terminal blocked result with `replayInvalid=true` while preserving outbound delivery evidence from the failed attempt.

## Scope
- OpenClaw-only change.
- No workspace temp or `/tmp/repo_meta.jsonl` changes.
- Logs only emit sanitized event names/provider/model/source/replay-safety flags.

## Real behavior proof

- Behavior or issue addressed: stale OpenAI Responses continuation state can keep replaying invalid encrypted reasoning or item ids; after this patch, the runner classifies that corruption and one replay-safe retry drops stale Responses replay state instead of replaying old provider item ids again.
- Real environment tested: macOS local OpenClaw gateway is running and reachable; source behavior was exercised from this patched checkout on branch `fix/responses-continuation-replay-reset` with Node 24.15.0.
- Exact steps or command run after this patch: `openclaw --version`, `openclaw gateway status --deep`, and two `node_modules/.bin/tsx` commands importing the patched OpenClaw source functions directly from this checkout.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ openclaw --version
OpenClaw 2026.5.22 (a374c3a)

$ openclaw gateway status --deep
Service: LaunchAgent (loaded)
Gateway: bind=loopback (127.0.0.1), port=18789 (service args)
Probe target: ws://127.0.0.1:18789
CLI version: 2026.5.22 (/usr/local/bin/openclaw)
Gateway version: 2026.5.22
Runtime: running (pid redacted, state active)
Connectivity probe: ok
Listening: 127.0.0.1:18789

$ node_modules/.bin/tsx -e <classifier probe against patched checkout>
{"openclawSource":"patched checkout","continuationCorruptionDetected":[true,true,true,true]}

$ node_modules/.bin/tsx <Responses replay-reset probe against patched checkout>
{"openclawSource":"patched checkout","dropOpenAIResponsesReplayState":true,"replayReasoningItemsSent":false,"assistantMessageIdReplayed":false,"functionItemIdReplayed":false,"functionCallIdPreserved":"call_demo"}

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
Test Files  1 passed (1)
Tests  10 passed (10)
```

- Observed result after fix: the patched source recognizes the continuation-corruption signatures and, when `dropOpenAIResponsesReplayState` is set for the recovery attempt, the outgoing Responses input does not include replayed reasoning items, assistant message ids, or function item ids; the stable tool call id remains available for the transcript link. The patched blocked-recovery path also preserves message-tool, cron-add, and session-spawn delivery evidence on unsafe continuation failures.
- What was not tested: I did not force a live upstream OpenAI account into a real continuation-corruption state, because that requires provider-owned encrypted/reasoning state failure. The proof uses a real local OpenClaw setup plus patched source commands with sanitized continuation-corruption samples.
- Proof limitations or environment constraints: the installed gateway shown above is the local stable OpenClaw service; the behavior probes import this PR branch directly from the checkout rather than replacing the user's installed gateway.
- Before evidence (optional but encouraged): local logs that motivated the fix showed the same failure family, including `thinking_signature_invalid`, encrypted content verification failure, and missing `rs_*` item ids; those logs are not pasted here to avoid exposing account/session details.

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/openai-transport-stream.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts`
- `git diff --check`

Note: `pnpm` is not available on this local PATH, so the targeted Vitest runners above were used directly.