### PR TITLE
fix(web-search): keep runtime legacy merge out of validation

### DIFF
--- a/src/agents/tools/web-search-provider-config.ts
+++ b/src/agents/tools/web-search-provider-config.ts
@@ -1,5 +1,6 @@
 import { resolvePluginWebSearchConfig } from "../../config/plugin-web-search-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isLegacyWebSearchProviderConfigKey } from "../../config/web-search-legacy-provider-keys.js";
 
 export function getTopLevelCredentialValue(searchConfig?: Record<string, unknown>): unknown {
   return searchConfig?.apiKey;
@@ -52,13 +53,22 @@ export function mergeScopedSearchConfig(
     !Array.isArray(searchConfig[key])
       ? (searchConfig[key] as Record<string, unknown>)
       : {};
-  const next: Record<string, unknown> = {
-    ...searchConfig,
-    [key]: {
+  const next: Record<string, unknown> = { ...searchConfig };
+  const existingDescriptor = searchConfig
+    ? Object.getOwnPropertyDescriptor(searchConfig, key)
+    : undefined;
+  const shouldHideRuntimeInjectedLegacyShape =
+    isLegacyWebSearchProviderConfigKey(key) && existingDescriptor === undefined;
+
+  Object.defineProperty(next, key, {
+    value: {
       ...currentScoped,
       ...pluginConfig,
     },
-  };
+    enumerable: !shouldHideRuntimeInjectedLegacyShape,
+    configurable: true,
+    writable: true,
+  });
 
   if (options?.mirrorApiKeyToTopLevel && pluginConfig.apiKey !== undefined) {
     next.apiKey = pluginConfig.apiKey;

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -144,4 +144,15 @@ describe("web_search scoped config merge", () => {
       brave: { count: 5, apiKey: "brave-test-key" },
     });
   });
+
+  it("keeps newly injected legacy provider config runtime-only for validation", () => {
+    const merged = mergeScopedSearchConfig({ enabled: true, provider: "gemini" }, "perplexity", {
+      apiKey: "perplexity-test-key",
+    });
+
+    expect(merged?.perplexity).toEqual({ apiKey: "perplexity-test-key" });
+    expect(Object.keys(merged ?? {})).toEqual(["enabled", "provider"]);
+
+    expect(Object.getOwnPropertyDescriptor(merged, "perplexity")?.enumerable).toBe(false);
+  });
 });

--- a/src/config/web-search-codex-config.test.ts
+++ b/src/config/web-search-codex-config.test.ts
@@ -1,5 +1,6 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
+import { mergeScopedSearchConfig } from "../agents/tools/web-search-provider-config.js";
 import { validateConfigObjectRaw } from "./validation.js";
 
 describe("web search Codex native config validation", () => {
@@ -52,6 +53,23 @@ describe("web search Codex native config validation", () => {
         mode: "strict",
       });
     }
+  });
+
+  it("accepts runtime-only legacy provider entries injected by web search merge", () => {
+    const search = mergeScopedSearchConfig({ enabled: true, provider: "gemini" }, "perplexity", {
+      apiKey: "perplexity-test-key",
+    });
+    const result = validateConfigObjectRaw({
+      tools: {
+        web: {
+          search,
+        },
+      },
+    });
+
+    expect(search?.perplexity).toEqual({ apiKey: "perplexity-test-key" });
+    expect(Object.keys(search ?? {})).toEqual(["enabled", "provider"]);
+    expect(result.ok).toBe(true);
   });
 
   it.each(["__proto__", "prototype", "constructor"])(

--- a/src/config/web-search-legacy-provider-keys.ts
+++ b/src/config/web-search-legacy-provider-keys.ts
@@ -1,0 +1,18 @@
+export const LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS = new Set([
+  "brave",
+  "duckduckgo",
+  "exa",
+  "firecrawl",
+  "gemini",
+  "grok",
+  "kimi",
+  "minimax",
+  "ollama",
+  "perplexity",
+  "searxng",
+  "tavily",
+]);
+
+export function isLegacyWebSearchProviderConfigKey(key: string): boolean {
+  return LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS.has(key);
+}

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -10,6 +10,7 @@ import {
 } from "../shared/string-coerce.js";
 import { uniqueStrings } from "../shared/string-normalization.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
+import { LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS } from "./web-search-legacy-provider-keys.js";
 import { AgentModelSchema, AgentToolModelSchema } from "./zod-schema.agent-model.js";
 import {
   GroupChatSchema,
@@ -351,21 +352,6 @@ const CodexUserLocationSchema = z
     return value.country || value.region || value.city || value.timezone ? value : undefined;
   })
   .optional();
-
-const LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS = new Set([
-  "brave",
-  "duckduckgo",
-  "exa",
-  "firecrawl",
-  "gemini",
-  "grok",
-  "kimi",
-  "minimax",
-  "ollama",
-  "perplexity",
-  "searxng",
-  "tavily",
-]);
 
 const BLOCKED_WEB_SEARCH_KEYS_ISSUE_FIELD = "__openclawBlockedWebSearchKeys";
 


### PR DESCRIPTION
Fresh v2026.5.22 gateway/container startup can crash-loop when the runtime web-search merge recreates a legacy provider object that the config validator correctly rejects.

Fixes #86779

## Affected surface

- `src/agents/tools/web-search-provider-config.ts` / `mergeScopedSearchConfig`
- `src/config/zod-schema.agent-runtime.ts` web search legacy provider validator
- `src/config/web-search-legacy-provider-keys.ts` shared legacy provider key list
- Regression coverage in `src/agents/tools/web-search.test.ts` and `src/config/web-search-codex-config.test.ts`

## Scope

This keeps the existing validator strict while making only the runtime-injected compatibility shape non-enumerable. Provider runtime code can still read `searchConfig.perplexity`, but validation/serialization no longer sees a freshly injected legacy provider object.

It deliberately does not weaken validation: if a user-authored config already contains an enumerable legacy provider object, the validator still rejects it and points users to `plugins.entries.<plugin>.config.webSearch`. No new config, flag, provider default, or provider-specific policy is added.

## Real behavior proof

- **Behavior or issue addressed:** `mergeScopedSearchConfig()` can auto-inject `tools.web.search.<provider>` from plugin `webSearch` config before runtime validation, recreating the legacy provider shape that `ToolsWebSearchSchema` rejects and causing gateway startup validation failure for #86779.
- **Real environment tested:** Local OpenClaw source checkout on Linux using the current PR head `93402ef5c27e904af27bfdc63de855a69224c640`; commands imported the real TypeScript modules with `node --import tsx` rather than mocks.
- **Exact steps or command run after this patch:** Ran the two `node --import tsx` commands below against `mergeScopedSearchConfig()` and `validateConfigObjectRaw()`, then ran the targeted Vitest shards and `pnpm check:changed --base origin/main`.
- **Evidence after fix:** Terminal output from the real module calls is copied below. The first command proves a runtime-injected provider entry is still accessible to provider code but hidden from validation; the second proves a user-authored enumerable legacy provider object remains rejected.
- **Observed result after fix:** Runtime-injected `perplexity` has `enumerable:false`, `Object.keys(search)` only includes `enabled` and `provider`, and `validateConfigObjectRaw()` returns `ok:true`. User-authored `perplexity` remains enumerable and returns `ok:false` with the existing legacy-config validation message.
- **What was not tested:** I did not run a live fresh-container migration against the published `2026.5.22` package, and I did not exercise external web-search provider API calls; this patch is limited to config merge/validation behavior.

Runtime-injected legacy provider entry remains accessible to provider code but hidden from validation:

```text
$ node --import tsx -e "import { mergeScopedSearchConfig } from './src/agents/tools/web-search-provider-config.ts'; import { validateConfigObjectRaw } from './src/config/validation.ts'; const search = mergeScopedSearchConfig({enabled:true, provider:'gemini'}, 'perplexity', {apiKey:'test-key'}); console.log(JSON.stringify({keys:Object.keys(search), enumerable:Object.getOwnPropertyDescriptor(search,'perplexity')?.enumerable, accessible:search.perplexity, validation:validateConfigObjectRaw({tools:{web:{search}}}).ok}));"
{"keys":["enabled","provider"],"enumerable":false,"accessible":{"apiKey":"test-key"},"validation":true}
```

User-authored legacy provider object remains rejected:

```text
$ node --import tsx -e "import { mergeScopedSearchConfig } from './src/agents/tools/web-search-provider-config.ts'; import { validateConfigObjectRaw } from './src/config/validation.ts'; const search = mergeScopedSearchConfig({provider:'perplexity', perplexity:{model:'old'}}, 'perplexity', {apiKey:'test-key'}); const result = validateConfigObjectRaw({tools:{web:{search}}}); console.log(JSON.stringify({keys:Object.keys(search), enumerable:Object.getOwnPropertyDescriptor(search,'perplexity')?.enumerable, validation:result.ok, issue:result.ok ? null : result.issues[0]}));"
{"keys":["provider","perplexity"],"enumerable":true,"validation":false,"issue":{"path":"tools.web.search.perplexity","message":"legacy web_search provider config must use plugins.entries.<plugin>.config.webSearch"}}
```

Targeted tests:

```text
$ pnpm test src/agents/tools/web-search.test.ts src/config/web-search-codex-config.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts
Test Files  1 passed (1)
Tests  19 passed (19)
[test] starting test/vitest/vitest.runtime-config.config.ts
Test Files  1 passed (1)
Tests  8 passed (8)
[test] passed 2 Vitest shards in 50.83s
```

Changed-file checks:

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=core, coreTests
[check:changed] src/agents/tools/web-search-provider-config.ts: core production
[check:changed] src/agents/tools/web-search.test.ts: core test
[check:changed] src/config/web-search-codex-config.test.ts: core test
[check:changed] src/config/web-search-legacy-provider-keys.ts: core production
[check:changed] src/config/zod-schema.agent-runtime.ts: core production
...
[check:changed] pairing account guard
(exit 0)

$ git diff --check origin/main..HEAD
(exit 0)

$ gitleaks protect --staged --redact
no leaks found
```

## Coverage note

Push-time search audit was rerun with independent queries:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes #86779" --limit 10
# no results

gh search prs --repo openclaw/openclaw --state open "#86779" --limit 10
# no results

gh search prs --repo openclaw/openclaw --state open "mergeScopedSearchConfig" --limit 10
#85158 feat(parallel): add Parallel as a bundled web_search provider

gh search prs --repo openclaw/openclaw --state open "web-search-provider-config" --limit 10
#85828 [codex] web_search: add Perplexity model override
#85158 feat(parallel): add Parallel as a bundled web_search provider
#86440 feat(web-search): add SerpApi plugin with web search provider and 25+ specialized tools
#77736 [codex] Fix explicit custom web_search provider routing
#78574 feat(github-copilot): add native web search for Copilot GPT models
#85317 fix(google): bypass SSRF private network restrictions for Gemini search
#62126 Onboarding improvement: prompt Codex users to enable native web search
#75218 feat(web-fetch): add Tavily as a native web_fetch provider
#76146 fix(cli): resolve SecretRefs in capability web search CLI path
#77219 fix(plugins): repair configured plugins with broken runtime entries

gh search prs --repo openclaw/openclaw --state open "legacy web_search provider config" --limit 10
# no results
```

I inspected the returned PR titles/body snippets and files for the closest hits. They cover provider additions, routing, model override, or plugin install repair; none fixes the runtime merge/validator mismatch from #86779.
