### PR TITLE
fix(mattermost): tag typed text-slash control commands so /new and /reset acks survive message_tool_only suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Docs: https://docs.openclaw.ai
 - Agents/Codex: honor yolo app-server approval policy only for the full `never` plus `danger-full-access` case. (#85909) Thanks @earlvanze.
 - Gateway/Gmail: clear Gmail watcher renewal intervals on re-entry so hot reloads do not leak lifecycle timers. (#82947) Thanks @SebTardif.
 - Logging: exit cleanly on broken stdout/stderr pipes without masking existing failure exit codes. (#80059) Thanks @pavelzak.
-- Mattermost: show `/new` and `/reset` acknowledgements (and other typed text-slash commands) in Mattermost direct chats and channels when the active harness defaults source replies to message-tool-only delivery (e.g. Codex), so authorized control commands no longer silently change session state without confirmation. Fixes #86664. Thanks @amknight.
 - Gateway/security: escape transcript metadata field names while extracting oversized session line prefixes. (#85934) Thanks @SebTardif.
 - Plugins/security: validate manifest model pattern regexes with the safe-regex compiler so unsafe patterns are ignored before matching. (#86046) Thanks @SebTardif.
 - Discord: route gateway metadata REST lookups through the configured Discord proxy so proxied accounts do not fall back to direct `discord.com` connections before opening the WebSocket. Fixes #80227. Thanks @Clivilwalker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Codex: honor yolo app-server approval policy only for the full `never` plus `danger-full-access` case. (#85909) Thanks @earlvanze.
 - Gateway/Gmail: clear Gmail watcher renewal intervals on re-entry so hot reloads do not leak lifecycle timers. (#82947) Thanks @SebTardif.
 - Logging: exit cleanly on broken stdout/stderr pipes without masking existing failure exit codes. (#80059) Thanks @pavelzak.
+- Mattermost: show `/new` and `/reset` acknowledgements (and other typed text-slash commands) in Mattermost direct chats and channels when the active harness defaults source replies to message-tool-only delivery (e.g. Codex), so authorized control commands no longer silently change session state without confirmation. Fixes #86664. Thanks @amknight.
 - Gateway/security: escape transcript metadata field names while extracting oversized session line prefixes. (#85934) Thanks @SebTardif.
 - Plugins/security: validate manifest model pattern regexes with the safe-regex compiler so unsafe patterns are ignored before matching. (#86046) Thanks @SebTardif.
 - Discord: route gateway metadata REST lookups through the configured Discord proxy so proxied accounts do not fall back to direct `discord.com` connections before opening the WebSocket. Fixes #80227. Thanks @Clivilwalker.

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -509,6 +509,89 @@ describe("mattermost inbound user posts", () => {
     const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
     expect(ctx?.BodyForAgent).toBe("hello /status");
     expect(ctx?.CommandAuthorized).toBe(false);
+    // Inline non-control text must not be tagged as an explicit text-slash command turn —
+    // only authorized control commands take the source-reply suppression bypass.
+    expect(ctx?.CommandSource).toBeUndefined();
+  });
+
+  // Regression for issue #86664: typed `/reset` (and `/new`) on a Mattermost DM under
+  // message_tool_only source delivery (e.g. Codex harness default) silently dropped the
+  // acknowledgement because the inbound context was not tagged as an explicit text-slash
+  // command turn. The explicit-command exception in source-reply-delivery-mode.ts only
+  // fires when CommandSource is "text" (or "native") AND CommandAuthorized is true. Mirrors
+  // the iMessage fix from #82642.
+  it("tags authorized typed text-slash control commands with CommandSource: text", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const directConfig: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "onmessage",
+          dmPolicy: "allowlist",
+          groupPolicy: "open",
+          allowFrom: ["user-1"],
+        },
+      },
+    };
+    const isControlCommandMessage = vi.fn((text?: string) =>
+      ["/reset", "/new"].includes(text?.trim() ?? ""),
+    );
+    const shouldComputeCommandAuthorized = vi.fn(() => true);
+    mockState.runtimeCore = createRuntimeCore(directConfig, undefined, {
+      isControlCommandMessage,
+      shouldComputeCommandAuthorized,
+      shouldHandleTextCommands: () => true,
+    });
+    mockState.resolveChannelInfo.mockResolvedValue({
+      id: "dm-1",
+      name: "",
+      display_name: "",
+      team_id: "team-1",
+      type: "D",
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: directConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "dm-1",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-reset",
+          channel_id: "dm-1",
+          user_id: "user-1",
+          message: "/reset",
+          create_at: 1_714_000_000_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "dm-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
+    expect(ctx?.BodyForAgent).toBe("/reset");
+    expect(ctx?.CommandAuthorized).toBe(true);
+    expect(ctx?.CommandSource).toBe("text");
   });
 
   it("uses websocket channel type when REST channel lookup fails", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -575,7 +575,7 @@ describe("mattermost inbound user posts", () => {
           id: "post-reset",
           channel_id: "dm-1",
           user_id: "user-1",
-          message: "/reset",
+          message: " /reset",
           create_at: 1_714_000_000_000,
         }),
       },
@@ -590,6 +590,7 @@ describe("mattermost inbound user posts", () => {
     expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
     const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
     expect(ctx?.BodyForAgent).toBe("/reset");
+    expect(ctx?.CommandBody).toBe("/reset");
     expect(ctx?.CommandAuthorized).toBe(true);
     expect(ctx?.CommandSource).toBe("text");
   });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1605,6 +1605,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           Timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
           WasMentioned: kind !== "direct" ? mentionDecision.effectiveWasMentioned : undefined,
           CommandAuthorized: commandAuthorized,
+          // Tag typed text-slash control commands (e.g. ` /new`, ` /reset` sent via the regular
+          // post path rather than Mattermost's native slash UI) so the explicit-command turn
+          // exception in source-reply-delivery-mode.ts surfaces their acknowledgements under
+          // message_tool_only delivery modes (e.g. Codex harness DMs). Mirrors iMessage #82642.
+          CommandSource: commandAuthorized && isControlCommand ? ("text" as const) : undefined,
           OriginatingChannel: "mattermost" as const,
           OriginatingTo: to,
           ...mediaPayload,


### PR DESCRIPTION
## Summary

Closes #86664 (the beta-blocker that PR #86767 attempted but did not actually fix — see [closeout comment on #86767](https://github.com/openclaw/openclaw/pull/86767#issuecomment-4542030958)).

In Mattermost direct chats (and any Mattermost channel) running under a `message_tool_only` source-reply delivery mode — most commonly the Codex harness default (`extensions/codex/harness.ts:41`) — typed control commands like `/new`, `/reset`, ` /new` (leading-space to bypass Mattermost's native slash UI), and the ACP/soft-reset variants silently changed session state because their acknowledgement replies were suppressed.

Root cause: the Mattermost text-post inbound handler (`extensions/mattermost/src/mattermost/monitor.ts:1573-1611`) already sets `CommandAuthorized: commandAuthorized` for typed control commands, but never set `CommandSource`. Without `CommandSource: "text"`, `resolveCommandTurnContext` (`src/auto-reply/command-turn-context.ts:159-176`) defaults the turn `kind` to `"normal"` and forces `authorized: false`, so `isExplicitCommandTurn` returns false and the existing escape hatch in `source-reply-delivery-mode.ts:54-56` (`if (isExplicitSourceReplyCommand(ctx)) return "automatic"`) never fires — `message_tool_only` stays in effect for the turn and the ack gets dropped by `dispatch-from-config.ts:2412`. Every other text-capable channel already tags typed slash commands correctly: Tlon (`extensions/tlon/src/monitor/index.ts:554`), Discord (`extensions/discord/src/monitor/agent-components.dispatch.ts:233`), WhatsApp, and iMessage (added in #82642).

## Fix

One line in `extensions/mattermost/src/mattermost/monitor.ts:1607`, mirroring iMessage PR #82642:

```ts
CommandSource: commandAuthorized && isControlCommand ? ("text" as const) : undefined,
```

Both `isControlCommand` (line 1321) and `commandAuthorized` (line 1337) are already in scope. Once the inbound context is tagged correctly, the existing core escape hatch activates for that turn and **every** slash-command ack on Mattermost text turns becomes visible — not only `/new` and `/reset`, but also the ACP success/failure messages at `commands-reset.ts:148/153`, the soft-reset unavailable notice at `commands-reset.ts:52`, and the other text-command surfaces — with no per-reply opt-ins.

## Why not the approach in #86767?

PR #86767 tried to wrap the `/new` and `/reset` reply payloads with `markReplyPayloadForSourceSuppressionDelivery` in `commands-reset.ts`. Two problems:

1. **It didn't work.** The metadata is stored in a `WeakMap` keyed on the reply object, but `normalizeCommandHandlerResult` in `commands-core.ts:19-31` spreads the reply into a new object literal (`reply: { ...result.reply, replyToId: undefined, replyToCurrent: false }`), which is not in the WeakMap. So the dispatch suppression check at `dispatch-from-config.ts:2400` never saw the flag and continued to drop the ack. (`toEqual` tests are blind to WeakMap metadata, which is why CI was green.)
2. **Even if it had worked**, it would only have addressed `/new` and `/reset` and left the ACP and soft-reset acks at `commands-reset.ts:52/148/153` broken — and would have invited per-reply opt-ins for every future slash-command ack.

This PR addresses the ingress layer instead, which is where the other channel extensions already do this work.

## Verification

- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` → 8 passed (8) (includes the new regression test "tags authorized typed text-slash control commands with CommandSource: text").
- `node scripts/run-vitest.mjs extensions/mattermost/` → 40 files, 436 tests passed.
- `node scripts/run-vitest.mjs src/auto-reply/command-turn-context.test.ts src/auto-reply/reply/source-reply-delivery-mode.test.ts src/auto-reply/reply/commands-reset-hooks.test.ts` → 42 passed (the contract this fix depends on).
- `node scripts/check-changed.mjs --base origin/main --staged-too` → all lanes pass (conflict markers, changelog attributions, wildcard re-export guards, dup-scan coverage, dep-pin, package-patch, media-download helper, runtime-sidecar loader, full typecheck via tsgo, lint shards, runtime import cycles).
- `oxfmt --check` on touched files: clean.

## Real behavior proof

- **Behavior addressed:** Typed `/new` and `/reset` (including the `/<space>command` forms used to bypass Mattermost's native slash UI) on Mattermost direct chats or channels running under a `message_tool_only` source-reply mode (notably the Codex harness default) silently change session state without a visible `✅` acknowledgement.

- **Real environment tested:** Bug source reproduced and fix verified end-to-end via the unit harness on macOS 26 arm64 / Node 25, using the Mattermost monitor inbound test harness. No live Crabbox/Mattermost session was run (this is a one-line ingress tag with the precedent fix already validated in production by iMessage #82642), but the test asserts the exact ctx-payload field that the downstream suppression check consumes.

- **Exact steps or command run after this patch:**

  ```bash
  node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts -t "text-slash"
  ```

- **Evidence after fix:**

  ```
   RUN  v4.1.7 /Users/aknight/Development/worktrees/openclaw-mattermost-text-slash
   Test Files  1 passed (1)
        Tests  1 passed | 7 skipped (8)
  ```

  Negative control — with the `extensions/mattermost/src/mattermost/monitor.ts` change reverted (test file unchanged), the same run fails at the new assertion:

  ```
   ❯ extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts:594:32
       592|     expect(ctx?.BodyForAgent).toBe("/reset");
       593|     expect(ctx?.CommandAuthorized).toBe(true);
       594|     expect(ctx?.CommandSource).toBe("text");
          |                                ^
   Tests  1 failed | 7 skipped (8)
  ```

  i.e. without the fix, the ingress context emits `CommandSource: undefined`, which is the exact precondition for the suppression cascade in the issue. With the fix, `CommandSource: "text"` is set, the explicit-command escape hatch activates, and the ack reaches the user.

- **Observed result after fix:** Typed authorized control commands on Mattermost post the appropriate acknowledgement (`✅ Session reset.`, `✅ New session started.`, `✅ ACP session reset in place.`, `⚠️ ACP session reset failed. …`, `Usage: /reset soft …`) instead of silently mutating session state.

- **What was not tested:** A live Mattermost direct-chat session under the Codex harness was not exercised on Crabbox/Testbox — the surface change is a single-line ingress tag mirroring the iMessage precedent, and the negative-control unit assertion above exercises the exact contract the downstream suppression check reads.
