### PR TITLE
fix(browser): remove unused requireRef import and void workaround (#83878)

### DIFF
--- a/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts
@@ -12,7 +12,7 @@ import {
   type BrowserParentOpts,
 } from "../browser-cli-shared.js";
 import { danger, defaultRuntime } from "../core-api.js";
-import { requireRef, resolveBrowserActionContext } from "./shared.js";
+import { resolveBrowserActionContext } from "./shared.js";
 
 /** Registers Browser navigate and resize commands. */
 export function registerBrowserNavigationCommands(
@@ -94,7 +94,4 @@ export function registerBrowserNavigationCommands(
         defaultRuntime.exit(1);
       }
     });
-
-  // Keep `requireRef` reachable; shared utilities are intended for other modules too.
-  void requireRef;
 }


### PR DESCRIPTION
## Summary

Removes the unused `requireRef` import and its `void requireRef` silencing workaround from `register.navigation.ts`. The import serves no purpose — the file does not call `requireRef`, and documenting the public surface of `shared.ts` belongs in `shared.ts` itself or a barrel export, not as a phantom import.

Closes #83878

## Change Type

- [x] Code cleanup / Dead code removal

## Scope

- [x] Browser extension / CLI

## Linked Issue

- Closes #83878

## Real behavior proof

**Behavior or issue addressed**: `register.navigation.ts` imports `requireRef` from `./shared.js` but never calls it. The `void requireRef` expression at line 84 silences the unused-import lint without creating a real dependency. This is dead code that obscures the actual import graph.

**Real environment tested**: macOS Darwin 25.4.0 arm64, Node v22.22.0, openclaw branch `fix/remove-void-require-ref` rebased on upstream main commit `8e110a21`.

**Exact steps or command run after this patch**:

1. Removed `requireRef` from the import and deleted the `void requireRef` + comment block (4 lines removed, 1 line changed).
2. Verified TypeScript compilation: `node scripts/run-tsgo.mjs -p tsconfig.json` — exit 0.
3. Verified formatting: `pnpm exec oxfmt --check extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts` — clean.
4. Verified linting: `pnpm exec oxlint extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts` — 0 warnings, 0 errors.
5. Drift proof: the removed import (`requireRef`) and `void` expression do not exist in the patched version. Reverting the patch restores the dead import.

**Evidence after fix**:

```
$ node scripts/run-tsgo.mjs -p tsconfig.json
# exit 0

$ pnpm exec oxfmt --check extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts
Finished in 22ms on 1 files using 10 threads.

$ pnpm exec oxlint extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts
Found 0 warnings and 0 errors.
```

Diff (1 file, +1 / -4):
```diff
-import { requireRef, resolveBrowserActionContext } from "./shared.js";
+import { resolveBrowserActionContext } from "./shared.js";
...
-  // Keep `requireRef` reachable; shared utilities are intended for other modules too.
-  void requireRef;
```

**Observed result**: After the patch, `register.navigation.ts` no longer imports or references `requireRef`. TypeScript, format, and lint all pass cleanly. The file is functionally identical — `resolveBrowserActionContext` is still imported and used as before.