### PR TITLE
fix(auto-reply): suppress repeated silent tokens

### DIFF
--- a/src/agents/runtime-plan/build.test.ts
+++ b/src/agents/runtime-plan/build.test.ts
@@ -136,6 +136,7 @@ describe("AgentRuntimePlan", () => {
     expect(plan.auth.authProfileProviderForAuth).toBe("openai-codex");
     expect(plan.auth.harnessAuthProvider).toBe("openai-codex");
     expect(plan.auth.forwardedAuthProfileId).toBe("openai-codex:work");
+    expect(plan.delivery.isSilentPayload({ text: "NO_REPLY\n\nNO_REPLY" })).toBe(true);
     expect(plan.delivery.isSilentPayload({ text: '{"action":"NO_REPLY"}' })).toBe(true);
     expect(
       plan.delivery.isSilentPayload({

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -586,11 +586,11 @@ async function runImagePrompt(params: {
         cfg: providerCfg,
         provider,
         model: modelId,
-        providerRegistry: providerRegistry as Map<string, MediaUnderstandingProvider>,
+        providerRegistry,
       });
       const imageProvider = imageToolProviderDeps.getMediaUnderstandingProvider(
         provider,
-        providerRegistry as Map<string, MediaUnderstandingProvider>,
+        providerRegistry,
       );
       if (
         params.images.length > 1 &&

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -152,6 +152,11 @@ describe("normalizeReplyPayload", () => {
   it("records skip reasons for silent/empty payloads", () => {
     const cases = [
       { name: "silent", payload: { text: SILENT_REPLY_TOKEN }, reason: "silent" },
+      {
+        name: "repeated silent",
+        payload: { text: `${SILENT_REPLY_TOKEN}\n\n${SILENT_REPLY_TOKEN}` },
+        reason: "silent",
+      },
       { name: "empty", payload: { text: "   " }, reason: "empty" },
     ] as const;
     for (const testCase of cases) {

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -22,6 +22,11 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText("  No_RePlY  ")).toBe(true);
   });
 
+  it("returns true for repeated token-only text separated by whitespace", () => {
+    expect(isSilentReplyText("NO_REPLY\n\nNO_REPLY")).toBe(true);
+    expect(isSilentReplyText("  no_reply \t No_RePlY  ")).toBe(true);
+  });
+
   it("returns false for undefined/empty", () => {
     expect(isSilentReplyText(undefined)).toBe(false);
     expect(isSilentReplyText("")).toBe(false);
@@ -86,6 +91,11 @@ describe("custom silent tokens", () => {
       name: "substantive text detection",
       check: () => isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK"),
       expected: false,
+    },
+    {
+      name: "repeated-token detection",
+      check: () => isSilentReplyText("HEARTBEAT_OK\nHEARTBEAT_OK", "HEARTBEAT_OK"),
+      expected: true,
     },
     {
       name: "trailing token stripping",

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -13,7 +13,7 @@ function getSilentExactRegex(token: string): RegExp {
     return cached;
   }
   const escaped = escapeRegExp(token);
-  const regex = new RegExp(`^\\s*${escaped}\\s*$`, "i");
+  const regex = new RegExp(`^\\s*${escaped}(?:\\s+${escaped})*\\s*$`, "i");
   silentExactRegexByToken.set(token, regex);
   return regex;
 }
@@ -36,7 +36,7 @@ export function isSilentReplyText(
   if (!text) {
     return false;
   }
-  // Match only the exact silent token with optional surrounding whitespace.
+  // Match only token-only replies, including repeated tokens separated by whitespace.
   // This prevents substantive replies ending with NO_REPLY from being suppressed (#19537).
   return getSilentExactRegex(token).test(text);
 }

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -77,6 +77,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     expect(
       normalizeReplyPayloadsForDelivery([
         { text: "NO_REPLY" },
+        { text: "NO_REPLY\n\nNO_REPLY" },
         { text: "Reasoning:\n_step_", isReasoning: true },
         { text: "final answer" },
       ]),
@@ -157,6 +158,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
       normalizeReplyPayloadsForDelivery([
         { text: "NO_REPLY thanks for the update" },
         { text: "NO_REPLY" },
+        { text: "NO_REPLY\n\nNO_REPLY" },
         { text: "thanks NO_REPLY" },
       ]),
     ).toEqual([

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -1433,6 +1433,9 @@ describe("plugin-sdk subpath exports", () => {
 
     expect(replyChunkingSdk.isSilentReplyText("NO_REPLY\n\nNO_REPLY")).toBe(true);
     expect(replyChunkingSdk.isSilentReplyPayloadText("NO_REPLY\n\nNO_REPLY")).toBe(true);
+    expect(replyChunkingSdk.isSilentReplyText("HEARTBEAT_OK\nHEARTBEAT_OK", "HEARTBEAT_OK")).toBe(
+      true,
+    );
     expect(replyChunkingSdk.isSilentReplyText("Visible update\n\nNO_REPLY")).toBe(false);
   });
 

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -574,7 +574,12 @@ describe("plugin-sdk subpath exports", () => {
       "createResolvedApproverActionAuthAdapter",
       "resolveApprovalApprovers",
     ]);
-    expectSourceMentions("reply-chunking", ["chunkText", "chunkTextWithMode"]);
+    expectSourceMentions("reply-chunking", [
+      "chunkText",
+      "chunkTextWithMode",
+      "isSilentReplyPayloadText",
+      "isSilentReplyText",
+    ]);
     expectSourceMentions("reply-history", [
       "buildInboundHistoryFromEntries",
       "buildInboundHistoryFromMap",
@@ -1419,6 +1424,16 @@ describe("plugin-sdk subpath exports", () => {
       expect(typeof mod).toBe("object");
       expect(Object.keys(mod as object).length, `subpath ${id} should resolve`).toBeGreaterThan(0);
     }
+  });
+
+  it("keeps repeated silent-token semantics visible through the reply-chunking subpath", async () => {
+    const replyChunkingSdk = await importResolvedPluginSdkSubpath(
+      "openclaw/plugin-sdk/reply-chunking",
+    );
+
+    expect(replyChunkingSdk.isSilentReplyText("NO_REPLY\n\nNO_REPLY")).toBe(true);
+    expect(replyChunkingSdk.isSilentReplyPayloadText("NO_REPLY\n\nNO_REPLY")).toBe(true);
+    expect(replyChunkingSdk.isSilentReplyText("Visible update\n\nNO_REPLY")).toBe(false);
   });
 
   it("keeps the Zalouser command-auth compatibility facade importable", () => {


### PR DESCRIPTION
## Summary
- classify replies made only of repeated whitespace-separated silent tokens as silent
- keep substantive replies that merely contain or end with `NO_REPLY` visible, preserving the #19537 boundary
- add focused coverage for the core token predicate, reply normalization, runtime-plan delivery policy, outbound delivery normalization, and the public `openclaw/plugin-sdk/reply-chunking` subpath

Closes #54736.

## Verification
- `git diff --check origin/main...HEAD`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-subpaths.test.ts src/auto-reply/tokens.test.ts src/auto-reply/reply/reply-utils.test.ts src/infra/outbound/payloads.test.ts src/agents/runtime-plan/build.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `pnpm check:changed`

## Real behavior proof
- Behavior or issue addressed: a token-only model reply such as `NO_REPLY\n\nNO_REPLY` should be suppressed instead of normalized into a visible single `NO_REPLY` payload.
- Real environment tested: local OpenClaw source checkout running the production `isSilentReplyText`, `isSilentReplyPayloadText`, `normalizeReplyPayload`, and `normalizeReplyPayloadsForDelivery` implementations through `node --import tsx`.
- Exact steps or command run after this patch:

```sh
node --import tsx --eval "import { isSilentReplyPayloadText, isSilentReplyText } from './src/auto-reply/tokens.ts'; import { normalizeReplyPayload } from './src/auto-reply/reply/normalize-reply.ts'; import { normalizeReplyPayloadsForDelivery } from './src/infra/outbound/payloads.ts'; const input = 'NO_REPLY\n\nNO_REPLY'; const skipReasons = []; const normalized = normalizeReplyPayload({ text: input }, { onSkip: (reason) => skipReasons.push(reason) }); console.log(JSON.stringify({ input, isSilentReplyText: isSilentReplyText(input), isSilentReplyPayloadText: isSilentReplyPayloadText(input), normalized, skipReasons, outboundPayloads: normalizeReplyPayloadsForDelivery([{ text: input }]) }, null, 2));"
```

- Evidence after fix:

```json
{
  "input": "NO_REPLY\n\nNO_REPLY",
  "isSilentReplyText": true,
  "isSilentReplyPayloadText": true,
  "normalized": null,
  "skipReasons": [
    "silent"
  ],
  "outboundPayloads": []
}
```

- Observed result after fix: the repeated token-only reply is classified as silent, normalization returns `null` with a `silent` skip reason, and outbound delivery normalization emits no deliverable payloads.
- What was not tested: this patch intentionally does not change markdown-wrapped, reasoning-prefixed, or arbitrary mixed-content `NO_REPLY` behavior; those broader behaviors have different compatibility tradeoffs and adjacent open PR context.

## Tests and validation
Which commands did you run?
- `git diff --check origin/main...HEAD`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-subpaths.test.ts src/auto-reply/tokens.test.ts src/auto-reply/reply/reply-utils.test.ts src/infra/outbound/payloads.test.ts src/agents/runtime-plan/build.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `pnpm check:changed`

What regression coverage was added or updated?
- `src/auto-reply/tokens.test.ts` now covers repeated token-only `NO_REPLY` and custom silent token payloads.
- `src/auto-reply/reply/reply-utils.test.ts` now verifies repeated silent payloads are skipped with reason `silent`.
- `src/agents/runtime-plan/build.test.ts` now verifies runtime-plan delivery suppression sees repeated silent tokens as silent.
- `src/infra/outbound/payloads.test.ts` now verifies repeated silent tokens do not reach outbound delivery normalization.
- `src/plugins/contracts/plugin-sdk-subpaths.test.ts` now verifies the public `openclaw/plugin-sdk/reply-chunking` import path exposes the same repeated-token silent semantics.

What failed before this fix, if known?
- The exact silent-token regex matched only one token. `NO_REPLY\n\nNO_REPLY` missed the silent predicate, then trailing-token stripping could leave one visible `NO_REPLY`.

If no test was added, why not?
- Tests were added/updated.

## Risk checklist
Did user-visible behavior change? (`Yes/No`)
- Yes

Did config, environment, or migration behavior change? (`Yes/No`)
- No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
- No

What is the highest-risk area?
- Silent reply suppression boundaries for token-only payloads, including the plugin-facing predicate export.

How is that risk mitigated?
- The regex still requires the whole reply to contain only the configured silent token repeated with whitespace separators, so substantive text such as `Here is a helpful response.\n\nNO_REPLY`, `NO_REPLY thanks`, and `Please NO_REPLY to this` remains non-silent.
- The public `openclaw/plugin-sdk/reply-chunking` import path now has contract coverage for the intended repeated-token behavior.

