### PR TITLE
Update Discord voice for redesigned libopus-wasm API

### DIFF
--- a/.agents/skills/agent-transcript/scripts/agent-transcript
+++ b/.agents/skills/agent-transcript/scripts/agent-transcript
@@ -56,10 +56,19 @@ function openClawSessionRoots() {
   const agentsDir = path.join(stateDir, "agents");
   if (!fs.existsSync(agentsDir)) return [];
   try {
-    return fs
+    const roots = fs
       .readdirSync(agentsDir, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
-      .map((entry) => path.join(agentsDir, entry.name, "sessions"));
+      .flatMap((entry) => {
+        const agentDir = path.join(agentsDir, entry.name);
+        return [
+          path.join(agentDir, "sessions"),
+          path.join(agentDir, "agent", "sessions"),
+          path.join(agentDir, "agent", "codex-home", "sessions"),
+        ];
+      })
+      .filter((root) => fs.existsSync(root));
+    return [...new Set(roots)];
   } catch {
     return [];
   }

--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
         "@discordjs/voice": "0.19.2",
         "discord-api-types": "0.38.48",
         "https-proxy-agent": "9.0.0",
-        "libopus-wasm": "0.0.1",
+        "libopus-wasm": "0.1.0",
         "prism-media": "1.3.5",
         "typebox": "1.1.38",
         "undici": "8.3.0",
@@ -424,9 +424,9 @@
       }
     },
     "node_modules/libopus-wasm": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/libopus-wasm/-/libopus-wasm-0.0.1.tgz",
-      "integrity": "sha512-w//dxORfJfLl4quaA5nEA0xZlbbtS/Gba+NrZyCDPmAQh2THX4KI6aI600f+jpxf6v3p9ApGCx0/DCCe4Xftug==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/libopus-wasm/-/libopus-wasm-0.1.0.tgz",
+      "integrity": "sha512-/aurGcAVgy0GcBEUzFaX9pm9qv7zYcy8W5hBXFiK+cyqOXAX4lOS6rlFogkY9CcSIajhjnuXyixsbmziSHCDMQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -11,7 +11,7 @@
     "@discordjs/voice": "0.19.2",
     "discord-api-types": "0.38.48",
     "https-proxy-agent": "9.0.0",
-    "libopus-wasm": "0.0.1",
+    "libopus-wasm": "0.1.0",
     "prism-media": "1.3.5",
     "typebox": "1.1.38",
     "undici": "8.3.0",

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -4,8 +4,8 @@ import {
   Application,
   createDecoder as createLibopusDecoder,
   createEncoder as createLibopusEncoder,
-  type OpusDecoder as LibopusDecoder,
-  type OpusEncoder as LibopusEncoder,
+  type OpusDecoderHandle as LibopusDecoder,
+  type OpusEncoderHandle as LibopusEncoder,
 } from "libopus-wasm";
 import { resamplePcm } from "openclaw/plugin-sdk/realtime-voice";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -80,7 +80,12 @@ async function createOpusDecoder(params: {
   return {
     name: "libopus-wasm",
     decoder: {
-      decode: (buffer) => pcmInt16ToBuffer(decoder.decodeFrame(buffer, DISCORD_OPUS_FRAME_SIZE)),
+      decode: (buffer) =>
+        pcmInt16ToBuffer(
+          decoder.decode(buffer, {
+            maxFrameSize: DISCORD_OPUS_FRAME_SIZE,
+          }),
+        ),
       free: () => decoder.free(),
     },
   };
@@ -141,7 +146,13 @@ class DiscordOpusEncodeStream extends Transform {
       while (this.#buffer.length >= DISCORD_OPUS_FRAME_BYTES) {
         const frame = this.#buffer.subarray(0, DISCORD_OPUS_FRAME_BYTES);
         this.#buffer = this.#buffer.subarray(DISCORD_OPUS_FRAME_BYTES);
-        this.push(Buffer.from(encoder.encodePcm16(frame, DISCORD_OPUS_FRAME_SIZE)));
+        this.push(
+          Buffer.from(
+            encoder.encode(frame, {
+              frameSize: DISCORD_OPUS_FRAME_SIZE,
+            }),
+          ),
+        );
       }
       done();
     } catch (err) {
@@ -156,7 +167,13 @@ class DiscordOpusEncodeStream extends Transform {
         const frame = Buffer.alloc(DISCORD_OPUS_FRAME_BYTES);
         this.#buffer.copy(frame);
         this.#buffer = Buffer.alloc(0);
-        this.push(Buffer.from(encoder.encodePcm16(frame, DISCORD_OPUS_FRAME_SIZE)));
+        this.push(
+          Buffer.from(
+            encoder.encode(frame, {
+              frameSize: DISCORD_OPUS_FRAME_SIZE,
+            }),
+          ),
+        );
       }
       this.#freeEncoder();
       done();

--- a/extensions/discord/src/voice/receive-recovery.test.ts
+++ b/extensions/discord/src/voice/receive-recovery.test.ts
@@ -29,6 +29,15 @@ describe("voice receive recovery", () => {
     });
   });
 
+  it("treats premature stream close as an expected receive end", () => {
+    expect(analyzeVoiceReceiveError(new Error("Premature close"))).toEqual({
+      message: "Premature close",
+      isAbortLike: true,
+      shouldAttemptPassthrough: false,
+      countsAsDecryptFailure: false,
+    });
+  });
+
   it("gates recovery after repeated decrypt failures in the same window", () => {
     const state = createVoiceReceiveRecoveryState();
 

--- a/extensions/discord/src/voice/receive-recovery.ts
+++ b/extensions/discord/src/voice/receive-recovery.ts
@@ -74,6 +74,7 @@ function isAbortLikeReceiveError(err: unknown): boolean {
       : "";
   return (
     name === "AbortError" ||
+    message === "Premature close" ||
     message.includes("The operation was aborted") ||
     message.includes("aborted")
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,8 +616,8 @@ importers:
         specifier: 9.0.0
         version: 9.0.0
       libopus-wasm:
-        specifier: 0.0.1
-        version: 0.0.1
+        specifier: 0.1.0
+        version: 0.1.0
       prism-media:
         specifier: 1.3.5
         version: 1.3.5
@@ -5479,8 +5479,8 @@ packages:
     resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
     engines: {node: '>=22.0.0'}
 
-  libopus-wasm@0.0.1:
-    resolution: {integrity: sha512-w//dxORfJfLl4quaA5nEA0xZlbbtS/Gba+NrZyCDPmAQh2THX4KI6aI600f+jpxf6v3p9ApGCx0/DCCe4Xftug==}
+  libopus-wasm@0.1.0:
+    resolution: {integrity: sha512-/aurGcAVgy0GcBEUzFaX9pm9qv7zYcy8W5hBXFiK+cyqOXAX4lOS6rlFogkY9CcSIajhjnuXyixsbmziSHCDMQ==}
     engines: {node: '>=20'}
 
   libsignal@6.0.0:
@@ -11294,7 +11294,7 @@ snapshots:
 
   kysely@0.29.2: {}
 
-  libopus-wasm@0.0.1: {}
+  libopus-wasm@0.1.0: {}
 
   libsignal@6.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ minimumReleaseAgeExclude:
   - "basic-ftp"
   - "baileys@7.0.0-rc13"
   - "hono"
-  - "libopus-wasm@0.0.1"
+  - "libopus-wasm@0.1.0"
   - "libsignal@6.0.0"
   - "openclaw"
   - "protobufjs"


### PR DESCRIPTION
## Summary

- Updates Discord voice receive and playback code to call the redesigned `libopus-wasm` API: `decode(packet, { maxFrameSize })` and `encode(pcm, { frameSize })`.
- Updates the Discord plugin dependency and lockfiles to published `libopus-wasm@0.1.0`.
- Keeps the minimum-release-age exemption scoped to `libopus-wasm@0.1.0` so future releases still pass through the normal maturity gate.
- Treats Discord receive-stream `Premature close` as a normal stream end instead of warning spam, while preserving decrypt-failure recovery behavior.
- Includes routed OpenClaw transcript roots in the local agent-transcript helper so PR transcript discovery sees `agent/sessions` and `agent/codex-home/sessions` stores.

## Verification

- `npm view libopus-wasm@0.1.0 version dist-tags dist.tarball dist.integrity time --json`
- `pnpm install --lockfile-only --filter @openclaw/discord`
- Node runtime smoke against installed `libopus-wasm@0.1.0`: created encoder/decoder, encoded one 960-frame Discord PCM buffer, decoded it back to 3840 bytes.
- `node scripts/run-vitest.mjs extensions/discord/src/voice/audio.test.ts extensions/discord/src/voice/receive-recovery.test.ts`
- `agent-transcript find/render/append-body` local helper smoke: found the PR session, rendered a redacted transcript section, and inserted it into a temp PR body file.
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean after fixing the version-scoped release-age exemption.
- Live tmux gateway on pushed SHA `e0fa3e3`: Discord voice joined, opened speaker turns, and processed realtime audio with no `decoder.decode is not a function` or `Premature close` warning spam in the captured pane.

## Real behavior proof

Behavior addressed: Discord voice callers now use the redesigned published `libopus-wasm@0.1.0` encode/decode methods, and expected Discord receive stream closes no longer produce warning spam.
Real environment tested: Local OpenClaw checkout on pushed SHA `e0fa3e3`, with `node_modules/libopus-wasm/package.json` at `0.1.0`, plus live Discord gateway tmux.
Exact steps or command run after this patch: Imported `libopus-wasm`, created a 48 kHz stereo encoder/decoder, encoded one 20 ms PCM frame with `encode(..., { frameSize: 960 })`, decoded it with `decode(..., { maxFrameSize: 960 })`, ran focused Discord voice codec/recovery tests, then restarted `pnpm gateway:watch` and observed Discord voice receive.
Evidence after fix: Smoke printed `{ "pkg": "0.1.0", "packet": 3, "decoded": 3840 }`; focused Vitest reported 2 files passed / 9 tests passed; tmux showed realtime bridge ready, voice joined, speaker turns opened/closed, and realtime audio bytes flowing.
Observed result after fix: The caller-side encode/decode path works with the published package and preserves 3840-byte PCM output for one Discord frame; `Premature close` is classified as abort-like and not a decrypt failure; live Discord voice receive is no longer wedged on the missing `decode` method.
What was not tested: Broad full-suite/Crabbox proof; this was validated with focused local tests plus live Discord gateway smoke for the affected voice path.
