### PR TITLE
perf: use typed arrays for audio codec loops

### DIFF
--- a/extensions/voice-call/src/telephony-audio.test.ts
+++ b/extensions/voice-call/src/telephony-audio.test.ts
@@ -29,6 +29,12 @@ function rmsPcm(buffer: Buffer): number {
   return Math.sqrt(sum / samples);
 }
 
+function unalignedCopy(buffer: Buffer): Buffer {
+  const padded = Buffer.alloc(buffer.length + 1);
+  buffer.copy(padded, 1);
+  return padded.subarray(1);
+}
+
 describe("telephony-audio resamplePcmTo8k", () => {
   it("returns identical buffer for 8k input", () => {
     const pcm8k = makeSinePcm(8_000, 1_000, 0.2);
@@ -49,6 +55,13 @@ describe("telephony-audio resamplePcmTo8k", () => {
     const ratio = rmsPcm(highTone) / rmsPcm(lowTone);
     expect(ratio).toBeLessThan(0.1);
   });
+
+  it("matches the typed-array path for unaligned input buffers", () => {
+    const input = makeSinePcm(48_000, 1_000, 0.2);
+    const output = resamplePcmTo8k(input, 48_000);
+    const unalignedOutput = resamplePcmTo8k(unalignedCopy(input), 48_000);
+    expect(unalignedOutput.equals(output)).toBe(true);
+  });
 });
 
 describe("telephony-audio convertPcmToMulaw8k", () => {
@@ -57,5 +70,12 @@ describe("telephony-audio convertPcmToMulaw8k", () => {
     const mulaw = convertPcmToMulaw8k(input, 24_000);
     // 0.5s @ 8kHz => 4000 8-bit samples
     expect(mulaw.length).toBe(4_000);
+  });
+
+  it("matches the typed-array path for unaligned pcm buffers", () => {
+    const input = makeSinePcm(8_000, 1_000, 0.2);
+    const mulaw = convertPcmToMulaw8k(input, 8_000);
+    const unalignedMulaw = convertPcmToMulaw8k(unalignedCopy(input), 8_000);
+    expect(unalignedMulaw.equals(mulaw)).toBe(true);
   });
 });

--- a/src/talk/audio-codec.ts
+++ b/src/talk/audio-codec.ts
@@ -14,8 +14,33 @@ type ResampleKernel = {
   phaseCount: number;
 };
 
+const HOST_IS_LITTLE_ENDIAN = new Uint16Array(new Uint8Array([1, 0]).buffer)[0] === 1;
+
 function clamp16(value: number): number {
   return Math.max(-32768, Math.min(32767, value));
+}
+
+function canUseInt16View(buffer: Buffer): boolean {
+  return HOST_IS_LITTLE_ENDIAN && buffer.byteOffset % Int16Array.BYTES_PER_ELEMENT === 0;
+}
+
+function int16View(buffer: Buffer): Int16Array {
+  return new Int16Array(
+    buffer.buffer,
+    buffer.byteOffset,
+    Math.floor(buffer.byteLength / Int16Array.BYTES_PER_ELEMENT),
+  );
+}
+
+function readInt16Samples(buffer: Buffer): Int16Array {
+  if (canUseInt16View(buffer)) {
+    return int16View(buffer);
+  }
+  const samples = new Int16Array(Math.floor(buffer.byteLength / Int16Array.BYTES_PER_ELEMENT));
+  for (let i = 0; i < samples.length; i += 1) {
+    samples[i] = buffer.readInt16LE(i * Int16Array.BYTES_PER_ELEMENT);
+  }
+  return samples;
 }
 
 function sinc(x: number): number {
@@ -65,8 +90,7 @@ function buildResampleKernel(
 }
 
 function sampleBandlimitedWithCoefficients(
-  input: Buffer,
-  inputSamples: number,
+  input: Int16Array,
   center: number,
   coefficients: Float64Array,
 ): number {
@@ -75,25 +99,24 @@ function sampleBandlimitedWithCoefficients(
 
   for (let tap = -RESAMPLE_HALF_TAPS; tap <= RESAMPLE_HALF_TAPS; tap += 1) {
     const sampleIndex = center + tap;
-    if (sampleIndex < 0 || sampleIndex >= inputSamples) {
+    if (sampleIndex < 0 || sampleIndex >= input.length) {
       continue;
     }
     const coeff = coefficients[tap + RESAMPLE_HALF_TAPS] ?? 0;
-    weighted += input.readInt16LE(sampleIndex * 2) * coeff;
+    weighted += (input[sampleIndex] ?? 0) * coeff;
     weightSum += coeff;
   }
 
   if (weightSum === 0) {
-    const nearest = Math.max(0, Math.min(inputSamples - 1, center));
-    return input.readInt16LE(nearest * 2);
+    const nearest = Math.max(0, Math.min(input.length - 1, center));
+    return input[nearest] ?? 0;
   }
 
   return weighted / weightSum;
 }
 
 function sampleBandlimited(
-  input: Buffer,
-  inputSamples: number,
+  input: Int16Array,
   srcPos: number,
   cutoffCyclesPerSample: number,
 ): number {
@@ -103,20 +126,20 @@ function sampleBandlimited(
 
   for (let tap = -RESAMPLE_HALF_TAPS; tap <= RESAMPLE_HALF_TAPS; tap += 1) {
     const sampleIndex = center + tap;
-    if (sampleIndex < 0 || sampleIndex >= inputSamples) {
+    if (sampleIndex < 0 || sampleIndex >= input.length) {
       continue;
     }
 
     const distance = sampleIndex - srcPos;
     const lowPass = 2 * cutoffCyclesPerSample * sinc(2 * cutoffCyclesPerSample * distance);
     const coeff = lowPass * (RESAMPLE_WINDOW[tap + RESAMPLE_HALF_TAPS] ?? 0);
-    weighted += input.readInt16LE(sampleIndex * 2) * coeff;
+    weighted += (input[sampleIndex] ?? 0) * coeff;
     weightSum += coeff;
   }
 
   if (weightSum === 0) {
-    const nearest = Math.max(0, Math.min(inputSamples - 1, Math.round(srcPos)));
-    return input.readInt16LE(nearest * 2);
+    const nearest = Math.max(0, Math.min(input.length - 1, Math.round(srcPos)));
+    return input[nearest] ?? 0;
   }
 
   return weighted / weightSum;
@@ -143,19 +166,25 @@ export function resamplePcm(
   const cutoffCyclesPerSample = Math.max(0.01, downsampleCutoff * RESAMPLE_CUTOFF_GUARD);
   const kernel = buildResampleKernel(inputSampleRate, outputSampleRate, cutoffCyclesPerSample);
 
+  const inputView = readInt16Samples(input);
+  const outputView = canUseInt16View(output) ? int16View(output) : undefined;
+
   for (let i = 0; i < outputSamples; i += 1) {
     const sample = Math.round(
       kernel
         ? sampleBandlimitedWithCoefficients(
-            input,
-            inputSamples,
+            inputView,
             Math.floor((i * inputSampleRate) / outputSampleRate),
             kernel.coefficients[(i * kernel.inputStep) % kernel.phaseCount] ??
               kernel.coefficients[0],
           )
-        : sampleBandlimited(input, inputSamples, i * ratio, cutoffCyclesPerSample),
+        : sampleBandlimited(inputView, i * ratio, cutoffCyclesPerSample),
     );
-    output.writeInt16LE(clamp16(sample), i * 2);
+    if (outputView) {
+      outputView[i] = clamp16(sample);
+    } else {
+      output.writeInt16LE(clamp16(sample), i * 2);
+    }
   }
 
   return output;
@@ -166,12 +195,11 @@ export function resamplePcmTo8k(input: Buffer, inputSampleRate: number): Buffer 
 }
 
 export function pcmToMulaw(pcm: Buffer): Buffer {
-  const samples = Math.floor(pcm.length / 2);
-  const mulaw = Buffer.alloc(samples);
+  const pcmView = readInt16Samples(pcm);
+  const mulaw = Buffer.alloc(pcmView.length);
 
-  for (let i = 0; i < samples; i += 1) {
-    const sample = pcm.readInt16LE(i * 2);
-    mulaw[i] = linearToMulaw(sample);
+  for (let i = 0; i < pcmView.length; i += 1) {
+    mulaw[i] = linearToMulaw(pcmView[i] ?? 0);
   }
 
   return mulaw;
@@ -179,6 +207,14 @@ export function pcmToMulaw(pcm: Buffer): Buffer {
 
 export function mulawToPcm(mulaw: Buffer): Buffer {
   const pcm = Buffer.alloc(mulaw.length * 2);
+  const pcmView = canUseInt16View(pcm) ? int16View(pcm) : undefined;
+  if (pcmView) {
+    for (let i = 0; i < mulaw.length; i += 1) {
+      pcmView[i] = clamp16(mulawToLinear(mulaw[i] ?? 0));
+    }
+    return pcm;
+  }
+
   for (let i = 0; i < mulaw.length; i += 1) {
     pcm.writeInt16LE(clamp16(mulawToLinear(mulaw[i] ?? 0)), i * 2);
   }


### PR DESCRIPTION
Summary
- Use Int16Array views for aligned PCM input/output loops in the audio codec hot paths.
- Keep a safe copy/read fallback for unaligned or non-little-endian buffers.
- Add regression coverage for unaligned voice-call buffers.

Verification
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- node scripts/run-vitest.mjs extensions/voice-call/src/telephony-audio.test.ts -- --reporter=verbose
- pnpm exec oxfmt --check --threads=1 src/talk/audio-codec.ts extensions/voice-call/src/telephony-audio.test.ts
- git diff --check -- src/talk/audio-codec.ts extensions/voice-call/src/telephony-audio.test.ts
- pnpm tsgo:core

Behavior addressed: PCM resampling and mu-law conversion now avoid per-sample Buffer read/write accessors in the normal aligned little-endian path.
Real environment tested: local macOS checkout on rebased branch perf/audio-codec-typed-arrays.
Exact steps or command run after this patch: focused voice-call Vitest file, formatter check, whitespace check, core tsgo, and branch-mode autoreview against origin/main.
Evidence after fix: voice-call audio tests passed 6/6; oxfmt, git diff --check, pnpm tsgo:core, and autoreview all passed.
Observed result after fix: aligned and unaligned PCM inputs produce matching outputs for resampling and mu-law conversion.
What was not tested: full pnpm check:changed; it is currently blocked by an unrelated extension test type error in extensions/codex/src/app-server/run-attempt.test.ts:6830.
