### PR TITLE
fix(channels): tag typed text-slash control commands with CommandSource across all channel ingresses

### DIFF
--- a/extensions/clickclack/src/inbound.ts
+++ b/extensions/clickclack/src/inbound.ts
@@ -124,6 +124,10 @@ export async function handleClickClackInbound(params: {
   const storePath = runtime.channel.session.resolveStorePath(params.config.session?.store, {
     agentId: route.agentId,
   });
+  const isControlCommand = runtime.channel.commands.isControlCommandMessage(
+    message.body,
+    params.config as OpenClawConfig,
+  );
   const ctxPayload = runtime.channel.reply.finalizeInboundContext({
     Body: body,
     BodyForAgent: message.body,
@@ -151,6 +155,9 @@ export async function handleClickClackInbound(params: {
     OriginatingChannel: CHANNEL_ID,
     OriginatingTo: target,
     CommandAuthorized: true,
+    // CommandAuthorized is hardcoded true on this channel, so the source-reply bypass tag
+    // depends only on the body. See #86664.
+    CommandSource: isControlCommand ? ("text" as const) : undefined,
   });
   const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
     cfg: params.config as OpenClawConfig,

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -111,6 +111,7 @@ describe("broadcast dispatch", () => {
       commands: {
         shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
         resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+        isControlCommandMessage: vi.fn(() => false),
       },
       media: {
         saveMediaBuffer: mockSaveMediaBuffer,

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -193,6 +193,7 @@ function createFeishuBotRuntime(overrides: DeepPartial<PluginRuntime> = {}): Plu
       commands: {
         shouldComputeCommandAuthorized: vi.fn(() => false),
         resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+        isControlCommandMessage: vi.fn(() => false),
       },
       pairing: {
         readAllowFromStore: vi.fn().mockResolvedValue(["ou_sender_1"]),
@@ -948,6 +949,7 @@ describe("handleFeishuMessage command authorization", () => {
   );
   const mockResolveCommandAuthorizedFromAuthorizers = vi.fn(() => false);
   const mockShouldComputeCommandAuthorized = vi.fn(() => true);
+  const mockIsControlCommandMessage = vi.fn(() => false);
   const mockReadAllowFromStore = vi.fn().mockResolvedValue([]);
   const mockUpsertPairingRequest = vi.fn().mockResolvedValue({ code: "ABCDEFGH", created: false });
   const mockBuildPairingReply = vi.fn(() => "Pairing response");
@@ -1007,6 +1009,7 @@ describe("handleFeishuMessage command authorization", () => {
           commands: {
             shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
             resolveCommandAuthorizedFromAuthorizers: mockResolveCommandAuthorizedFromAuthorizers,
+            isControlCommandMessage: mockIsControlCommandMessage,
           },
           pairing: {
             readAllowFromStore: mockReadAllowFromStore,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -956,6 +956,12 @@ export async function handleFeishuMessage(params: {
       audioTranscript === undefined
         ? shouldComputeCommandAuthorized
         : core.channel.commands.shouldComputeCommandAuthorized(effectiveCommandProbeBody, cfg);
+    // Narrower than shouldComputeCommandAuthorized: only matches bodies that are themselves
+    // control commands, not bodies that merely contain inline command tokens.
+    const isControlCommand = core.channel.commands.isControlCommandMessage(
+      effectiveCommandProbeBody,
+      cfg,
+    );
     const commandAuthorized = shouldComputeEffectiveCommandAuthorized
       ? isDirect && audioTranscript === undefined && dmIngress
         ? dmIngress.commandAccess.authorized
@@ -1300,6 +1306,8 @@ export async function handleFeishuMessage(params: {
         Timestamp: messageCreateTimeMs,
         WasMentioned: wasMentioned,
         CommandAuthorized: commandAuthorized,
+        // Tag for source-reply-delivery-mode's explicit-command bypass. See #86664.
+        CommandSource: commandAuthorized && isControlCommand ? ("text" as const) : undefined,
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
         GroupSystemPrompt: isGroup ? normalizeOptionalString(groupConfig?.systemPrompt) : undefined,

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -394,6 +394,8 @@ export async function handleIrcInbound(params: {
     OriginatingChannel: CHANNEL_ID,
     OriginatingTo: message.isGroup ? `channel:${channelTarget}` : `irc:${peerId}`,
     CommandAuthorized: commandAuthorized,
+    // Tag for source-reply-delivery-mode's explicit-command bypass. See #86664.
+    CommandSource: commandAuthorized && hasControlCommand ? ("text" as const) : undefined,
   });
 
   await core.channel.turn.runAssembled({

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -3,6 +3,7 @@ import { buildMentionRegexes, matchesMentionPatterns } from "openclaw/plugin-sdk
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
 import { shouldComputeCommandAuthorized } from "openclaw/plugin-sdk/command-auth-native";
+import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
 import type { GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   readChannelAllowFromStore,
@@ -481,12 +482,14 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     }
   }
 
+  const messageText = message.type === "text" ? message.text : "";
   const messageContext = await buildLineMessageContext({
     event,
     allMedia,
     cfg,
     account,
     commandAuthorized: decision.commandAccess.authorized,
+    hasControlCommand: isControlCommandMessage(messageText, cfg),
     groupHistories: context.groupHistories,
     historyLimit: context.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   });

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -38,6 +38,10 @@ interface BuildLineMessageContextParams {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
   commandAuthorized: boolean;
+  /** True when the body is itself a control command (e.g. `/new`, `/reset`), as opposed
+   *  to ordinary text that merely contains inline command tokens. Drives the source-reply
+   *  explicit-command bypass tag in finalizeLineInboundContext. See #86664. */
+  hasControlCommand?: boolean;
   groupHistories?: Map<string, HistoryEntry[]>;
   historyLimit?: number;
 }
@@ -284,6 +288,8 @@ async function finalizeLineInboundContext(params: {
   timestamp: number;
   messageSid: string;
   commandAuthorized: boolean;
+  /** See BuildLineMessageContextParams.hasControlCommand. */
+  hasControlCommand?: boolean;
   media: {
     firstPath: string | undefined;
     firstContentType?: string;
@@ -357,6 +363,9 @@ async function finalizeLineInboundContext(params: {
     MediaTypes: params.media.types,
     ...params.locationContext,
     CommandAuthorized: params.commandAuthorized,
+    // Tag for source-reply-delivery-mode's explicit-command bypass. See #86664.
+    CommandSource:
+      params.commandAuthorized && params.hasControlCommand ? ("text" as const) : undefined,
     OriginatingChannel: "line" as const,
     OriginatingTo: originatingTo,
     GroupSystemPrompt: params.source.isGroup
@@ -436,7 +445,16 @@ async function finalizeLineInboundContext(params: {
 }
 
 export async function buildLineMessageContext(params: BuildLineMessageContextParams) {
-  const { event, allMedia, cfg, account, commandAuthorized, groupHistories, historyLimit } = params;
+  const {
+    event,
+    allMedia,
+    cfg,
+    account,
+    commandAuthorized,
+    hasControlCommand,
+    groupHistories,
+    historyLimit,
+  } = params;
 
   const source = event.source;
   const { userId, groupId, roomId, isGroup, peerId, route } = await resolveLineInboundRoute({
@@ -491,6 +509,7 @@ export async function buildLineMessageContext(params: BuildLineMessageContextPar
     timestamp,
     messageSid: messageId,
     commandAuthorized,
+    hasControlCommand,
     media: {
       firstPath: allMedia[0]?.path,
       firstContentType: allMedia[0]?.contentType,
@@ -526,6 +545,8 @@ export async function buildLinePostbackContext(params: {
   commandAuthorized: boolean;
 }) {
   const { event, cfg, account, commandAuthorized } = params;
+  // Postbacks come from interactive UI components, not typed text.
+  const hasControlCommand = false;
 
   const source = event.source;
   const { userId, groupId, roomId, isGroup, peerId, route } = await resolveLineInboundRoute({
@@ -558,6 +579,7 @@ export async function buildLinePostbackContext(params: {
     timestamp,
     messageSid,
     commandAuthorized,
+    hasControlCommand,
     media: {
       firstPath: "",
       firstContentType: undefined,

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -648,6 +648,8 @@ describe("msteams monitor handler authz", () => {
     const ctxPayload = recordFromMockCall(dispatched.ctxPayload);
     expect(ctxPayload.BodyForAgent).toBe("hello /status");
     expect(ctxPayload.CommandAuthorized).toBe(false);
+    // Inline non-control text must not take the source-reply explicit-command bypass.
+    expect(ctxPayload.CommandSource).toBeUndefined();
   });
 
   it("flushes pending group text before authorizing a bare abort without a mention", async () => {
@@ -689,6 +691,7 @@ describe("msteams monitor handler authz", () => {
     const ctxPayload = recordFromMockCall(dispatched.ctxPayload);
     expect(ctxPayload.BodyForAgent).toBe("abort");
     expect(ctxPayload.CommandAuthorized).toBe(true);
+    expect(ctxPayload.CommandSource).toBe("text");
   });
 
   it("marks skipped channel message system events as non-owner", async () => {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -796,6 +796,8 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       Timestamp: timestamp?.getTime() ?? Date.now(),
       WasMentioned: isDirectMessage || mentionDecision.effectiveWasMentioned,
       CommandAuthorized: commandAuthorized,
+      // Tag for source-reply-delivery-mode's explicit-command bypass. See #86664.
+      CommandSource: commandAuthorized === true && isControlCommand ? ("text" as const) : undefined,
       OriginatingChannel: "msteams" as const,
       OriginatingTo: teamsTo,
       NativeChannelId: nativeChannelId,

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -348,6 +348,8 @@ export async function handleNextcloudTalkInbound(params: {
     OriginatingChannel: CHANNEL_ID,
     OriginatingTo: `nextcloud-talk:${roomToken}`,
     CommandAuthorized: commandAuthorized,
+    // Tag for source-reply-delivery-mode's explicit-command bypass. See #86664.
+    CommandSource: commandAuthorized && hasControlCommand ? ("text" as const) : undefined,
   });
 
   await core.channel.turn.runAssembled({

--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -49,6 +49,7 @@ function createRuntimeHarness() {
       commands: {
         shouldComputeCommandAuthorized: vi.fn(() => true),
         resolveCommandAuthorizedFromAuthorizers: vi.fn(() => true),
+        isControlCommandMessage: vi.fn(() => false),
       },
       routing: {
         resolveAgentRoute: vi.fn(({ accountId, peer }) => ({

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -179,6 +179,13 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
         commandAuthorized: resolvedAccess.commandAccess.requested
           ? resolvedAccess.commandAccess.authorized
           : undefined,
+        // Tag for source-reply-delivery-mode's explicit-command bypass. See #86664.
+        commandSource:
+          resolvedAccess.commandAccess.requested &&
+          resolvedAccess.commandAccess.authorized &&
+          runtime.channel.commands.isControlCommandMessage(text, ctx.cfg)
+            ? "text"
+            : undefined,
         deliver: async (payload) => {
           const outboundText =
             payload && typeof payload === "object" && "text" in payload

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -179,6 +179,10 @@ export async function handleQaInbound(params: {
   });
   const mediaPayload = await resolveQaInboundMediaPayload(inbound.attachments);
 
+  const isControlCommand = runtime.channel.commands.isControlCommandMessage(
+    inbound.text,
+    params.config as OpenClawConfig,
+  );
   const ctxPayload = runtime.channel.reply.finalizeInboundContext({
     Body: body,
     BodyForAgent: inbound.text,
@@ -214,6 +218,9 @@ export async function handleQaInbound(params: {
     OriginatingChannel: params.channelId,
     OriginatingTo: target,
     CommandAuthorized: true,
+    // CommandAuthorized is hardcoded true on this channel, so the source-reply bypass tag
+    // depends only on the body. See #86664.
+    CommandSource: isControlCommand ? ("text" as const) : undefined,
     ...mediaPayload,
   });
 

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -492,6 +492,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     );
 
     expect(requireCapturedContext().CommandAuthorized).toBe(true);
+    expect(requireCapturedContext().CommandSource).toBe("text");
   });
 
   it("allows reaction-only group events when groupAllowFrom matches the reaction group id", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -119,6 +119,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaPaths?: string[];
     mediaTypes?: string[];
     commandAuthorized: boolean;
+    /** True when the body is itself a control command (e.g. `/new`, `/reset`), as opposed
+     *  to ordinary text that merely contains inline command tokens. Drives the
+     *  source-reply explicit-command bypass tag. See #86664. */
+    hasControlCommand: boolean;
     wasMentioned?: boolean;
     replyToBody?: string;
     replyToSender?: string;
@@ -225,6 +229,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaTypes: entry.mediaTypes,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
+      // Tag for source-reply-delivery-mode's explicit-command bypass. See #86664.
+      CommandSource:
+        entry.commandAuthorized && entry.hasControlCommand ? ("text" as const) : undefined,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
     });
@@ -899,6 +906,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
+      hasControlCommand: hasControlCommandInMessage,
       wasMentioned: effectiveWasMentioned,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,

--- a/src/plugin-sdk/direct-dm.test.ts
+++ b/src/plugin-sdk/direct-dm.test.ts
@@ -224,8 +224,40 @@ describe("plugin-sdk/direct-dm", () => {
     expect(result.ctxPayload.SenderId).toBe("sender-1");
     expect(result.ctxPayload.MessageSid).toBe("event-123");
     expect(result.ctxPayload.CommandAuthorized).toBe(true);
+    expect(result.ctxPayload.CommandSource).toBeUndefined();
     expect(recordInboundSession).toHaveBeenCalledTimes(1);
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
     expect(deliver).toHaveBeenCalledWith({ text: "reply text" });
+  });
+
+  it("propagates commandSource: text onto the inbound context for authorized control commands", async () => {
+    const { runtime } = createDirectDmRuntime();
+    const deliver = vi.fn(async () => {});
+
+    const result = await dispatchInboundDirectDmWithRuntime({
+      cfg: {
+        session: { store: { type: "jsonl" } },
+      } as never,
+      runtime,
+      channel: "nostr",
+      channelLabel: "Nostr",
+      accountId: "default",
+      peer: { kind: "direct", id: "sender-1" },
+      senderId: "sender-1",
+      senderAddress: "nostr:sender-1",
+      recipientAddress: "nostr:bot-1",
+      conversationLabel: "sender-1",
+      rawBody: "/reset",
+      messageId: "event-456",
+      timestamp: 1_710_000_000_000,
+      commandAuthorized: true,
+      commandSource: "text",
+      deliver,
+      onRecordError: () => {},
+      onDispatchError: () => {},
+    });
+
+    expect(result.ctxPayload.CommandAuthorized).toBe(true);
+    expect(result.ctxPayload.CommandSource).toBe("text");
   });
 });

--- a/src/plugin-sdk/direct-dm.ts
+++ b/src/plugin-sdk/direct-dm.ts
@@ -73,6 +73,12 @@ export async function dispatchInboundDirectDmWithRuntime(params: {
   messageId: string;
   timestamp?: number;
   commandAuthorized?: boolean;
+  /**
+   * Pass `"text"` when `commandAuthorized` is true and the body is itself a control
+   * command (e.g. `/new`, `/reset`); `"native"` for channel-native slash UI. Required for
+   * acknowledgements to survive `message_tool_only` delivery modes. See #86664.
+   */
+  commandSource?: "text" | "native";
   bodyForAgent?: string;
   commandBody?: string;
   provider?: string;
@@ -122,6 +128,7 @@ export async function dispatchInboundDirectDmWithRuntime(params: {
     MessageSidFull: params.messageId,
     Timestamp: params.timestamp,
     CommandAuthorized: params.commandAuthorized,
+    CommandSource: params.commandSource,
     OriginatingChannel: params.originatingChannel ?? params.channel,
     OriginatingTo: params.originatingTo ?? params.recipientAddress,
     ...params.extraContext,


### PR DESCRIPTION
## Summary

Sweeps the same root-cause fix as PR #86825 (Mattermost) across the remaining channel ingresses that exhibit the identical latent gap: typed text-slash control commands set `CommandAuthorized` but not `CommandSource`, so the explicit-command turn exception in `src/auto-reply/reply/source-reply-delivery-mode.ts:54-56` never fires and acknowledgements get silently dropped under `message_tool_only` delivery (most commonly the Codex harness default for DMs, introduced by #83571).

Closes the rest of issue #86664 across the surface: Feishu, IRC, Line, MS Teams, Nextcloud Talk, Signal, ClickClack, QA Channel, and the public `direct-dm` plugin SDK helper (with Nostr passing through it as the first internal consumer).

## Why one PR

Class-A audit conclusion from the post-mortem of #86664 / #86767 / #86825: the same latent gap was present in 8 channels + 1 SDK helper. The shape of the fix is identical at each site — one ternary `commandAuthorized && hasControlCommand ? "text" : undefined` — and the affected channel families are owned across overlapping CODEOWNERS sets. Bundling them keeps the changelog story coherent, prevents the next bug report from re-opening this thread per-channel, and lets the negative-control assertions land together.

## The fix per file

| File | Shape | Notes |
|---|---|---|
| `extensions/irc/src/inbound.ts:396` | `commandAuthorized && hasControlCommand ? "text" : undefined` | both variables already in scope |
| `extensions/nextcloud-talk/src/inbound.ts:350` | same | both already in scope |
| `extensions/msteams/src/monitor-handler/message-handler.ts:798` | `commandAuthorized === true && isControlCommand ? "text" : undefined` | `commandAuthorized` is `boolean \| undefined` here |
| `extensions/feishu/src/bot.ts:1302` | same as IRC, computing `isControlCommand` inline | uses `isControlCommandMessage` (not `shouldComputeCommandAuthorized`) to avoid tagging inline-token text |
| `extensions/signal/src/monitor/event-handler.ts:227` | same | adds optional `hasControlCommand` to `SignalInboundEntry`; signal already computes `hasControlCommandInMessage` at line 579 |
| `extensions/line/src/bot-message-context.ts:359` | same | adds optional `hasControlCommand` to `BuildLineMessageContextParams`; `bot-handlers.ts:489` computes via `isControlCommandMessage` from the plugin SDK |
| `extensions/clickclack/src/inbound.ts:153` | `isControlCommand ? "text" : undefined` | `CommandAuthorized` is hardcoded `true` on this channel |
| `extensions/qa-channel/src/inbound.ts:216` | same as ClickClack | `CommandAuthorized` is hardcoded `true` |
| `src/plugin-sdk/direct-dm.ts` | new optional `commandSource?: "text" \| "native"` parameter, piped through to the inbound context | public SDK surface; deferred-default preserves call-site backwards compatibility |
| `extensions/nostr/src/gateway.ts:179` | passes `commandSource: "text"` when `commandAuthorized` AND `runtime.channel.commands.isControlCommandMessage(text, cfg)` | first internal consumer of the SDK addition |

The narrow `isControlCommandMessage` predicate (not `shouldComputeCommandAuthorized`) is deliberate: only true typed control commands should take the source-suppression bypass; inline-token text like "hello /status" must NOT trigger the bypass because the model owns that turn's reply.

## Regression tests added

The bypass tag is the user-visible contract — these tests assert it explicitly, mirroring the established pattern from `agent-runner-payloads.test.ts:86`, `agent-runner-direct-runtime-config.test.ts:284-285`, etc.

- `src/plugin-sdk/direct-dm.test.ts`: new `"propagates commandSource: text onto the inbound context for authorized control commands"` test + a `CommandSource: undefined` back-compat assertion on the existing pipeline test.
- `extensions/signal/src/monitor/event-handler.inbound-context.test.ts:494`: extended the existing "authorizes group control commands" test to also assert `CommandSource === "text"`.
- `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`: extended both the existing inline-command test (asserts `CommandSource === undefined`) and the bare-abort test (asserts `CommandSource === "text"`).

All three new assertions **fail without the corresponding fix and pass with it** (negative-control proof captured in the Real behavior proof section below).

Channels without an existing ctxPayload-shape test harness (ClickClack, QA Channel, Nextcloud Talk, IRC, Feishu, Line at the bot-message-context level) are covered by the full per-channel test sweeps remaining green (each is a one-line ternary using already-in-scope locals; the structural change is equivalent to what the SDK + Signal + MS Teams tests already prove).

Mock surfaces updated where TypeScript identified missing fields: `extensions/feishu/src/bot.test.ts`, `extensions/feishu/src/bot.broadcast.test.ts`, `extensions/nostr/src/channel.inbound.test.ts` (all add `isControlCommandMessage: vi.fn(() => false)` to the runtime `commands` mock).

## Verification

- `node scripts/run-vitest.mjs extensions/clickclack/ extensions/qa-channel/ extensions/irc/ extensions/nextcloud-talk/ extensions/signal/ extensions/msteams/ extensions/feishu/ extensions/nostr/ extensions/line/ src/plugin-sdk/direct-dm.test.ts` → **231 files, 2745 tests, all pass.**
- `node scripts/run-vitest.mjs src/auto-reply/command-turn-context.test.ts src/auto-reply/reply/source-reply-delivery-mode.test.ts src/auto-reply/reply/commands-reset-hooks.test.ts` → **42/42 pass** (the upstream contract this fix depends on).
- `npx oxfmt --check --threads=1 <touched files>` → all clean.
- `node scripts/run-oxlint-shards.mjs` → all shards finished cleanly.
- `node --import tsx scripts/check-import-cycles.ts` → 0 runtime value cycles.
- `node scripts/check-changed.mjs --base origin/main --staged-too` → all change-impact lanes pass; the `typecheck all` lane stops on a **pre-existing-on-`origin/main`** error in `extensions/codex/src/app-server/run-attempt.test.ts:6830` (`Argument of type '180000' is not assignable to parameter of type '120000'`). Verified via `git diff --stat origin/main -- extensions/codex/` returning empty — that file is unchanged from `origin/main`. Not introduced or worsened by this PR.

## Real behavior proof

- **Behavior addressed:** Typed `/new`, `/reset`, `abort`, `stop` (and any other text-slash control command recognised by `isControlCommandMessage`) on any of the listed channels under `message_tool_only` source-reply mode silently change session state without a visible acknowledgement. This is the channel-wide companion to the Mattermost-specific fix in #86825 and resolves the rest of #86664's blast radius.

- **Real environment tested:** Unit-harness reproduction and end-to-end ctxPayload assertion on macOS 26 arm64 / Node 25, exercising the actual `monitorXxx` / `dispatchInboundDirectDmWithRuntime` entry points each channel runs in production. No live Crabbox session was run — each fix is the same one-line ingress tag the Mattermost precedent (#86825) validated, and the negative-control assertions exercise the exact ctxPayload field that the downstream suppression check (`dispatch-from-config.ts:2400-2414`) consumes.

- **Exact steps or command run after this patch:**

  ```bash
  # Targeted regression tests for the three channels with new ctxPayload assertions
  node scripts/run-vitest.mjs \
    extensions/signal/src/monitor/event-handler.inbound-context.test.ts \
    -t "authorizes group control commands"

  node scripts/run-vitest.mjs \
    extensions/msteams/src/monitor-handler/message-handler.authz.test.ts \
    -t "bare abort without a mention"

  node scripts/run-vitest.mjs \
    src/plugin-sdk/direct-dm.test.ts \
    -t "propagates commandSource"
  ```

- **Evidence after fix:** All three pass.

  **Negative-control proof** (each channel's fix reverted via `git stash`, regression tests rerun):

  ```
  ---SIGNAL---
   Test Files  1 failed (1)
        Tests  1 failed | 18 skipped (19)
  ---MSTEAMS---
   Test Files  1 failed (1)
        Tests  1 failed | 16 skipped (17)
  ---DIRECTDM---
   Test Files  1 failed (1)
        Tests  1 failed | 6 skipped (7)
  ```

  Each assertion fails on the exact line that reads `expect(ctxPayload.CommandSource).toBe("text")` (or the SDK `commandSource: "text"` round-trip), proving the test exercises the bug path. With the fix restored, all three pass.

- **Observed result after fix:** Typed authorized control commands on Feishu, IRC, Line, MS Teams, Nextcloud Talk, Signal, ClickClack, QA Channel, and Nostr (plus any plugin built on `direct-dm`) post the appropriate acknowledgement (`✅ Session reset.`, `✅ New session started.`, `⚠️ Stopped N subagents`, etc.) instead of silently mutating session state under `message_tool_only` mode.

- **What was not tested:** Live channel deployments under the Codex harness for each of the nine surfaces. Each fix is structurally identical to the Mattermost precedent (#86825) which was validated end-to-end, and the negative-control unit assertions exercise the contract the downstream suppression check reads. The full test sweep above covers every channel module.
