### PR TITLE
fix(line): add chunk-idle timeout to inbound media download

### DIFF
--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -32,6 +32,8 @@ vi.mock("openclaw/plugin-sdk/media-store", () => ({
 }));
 
 let downloadLineMedia: typeof import("./download.js").downloadLineMedia;
+let LineMediaDownloadTimeoutError: typeof import("./download.js").LineMediaDownloadTimeoutError;
+let LINE_DOWNLOAD_IDLE_TIMEOUT_MS: typeof import("./download.js").LINE_DOWNLOAD_IDLE_TIMEOUT_MS;
 
 async function* chunks(parts: Buffer[]): AsyncGenerator<Buffer> {
   for (const part of parts) {
@@ -59,7 +61,8 @@ function detectMockContentType(buffer: Buffer, contentType?: string): string | u
 
 describe("downloadLineMedia", () => {
   beforeAll(async () => {
-    ({ downloadLineMedia } = await import("./download.js"));
+    ({ downloadLineMedia, LineMediaDownloadTimeoutError, LINE_DOWNLOAD_IDLE_TIMEOUT_MS } =
+      await import("./download.js"));
   });
 
   afterAll(() => {
@@ -160,5 +163,110 @@ describe("downloadLineMedia", () => {
     saveMediaStreamMock.mockRejectedValueOnce(new Error("Media exceeds 0MB limit"));
 
     await expect(downloadLineMedia("mid-bad", "token")).rejects.toThrow(/Media exceeds/i);
+  });
+
+  describe("chunk-idle timeout", () => {
+    function neverYieldingStream(): AsyncIterable<Buffer> {
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            next(): Promise<IteratorResult<Buffer>> {
+              return new Promise<IteratorResult<Buffer>>(() => {});
+            },
+          };
+        },
+      };
+    }
+
+    function delayedStream(payload: Buffer, delayMs: number): AsyncIterable<Buffer> {
+      let yielded = false;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<Buffer>> {
+              if (yielded) {
+                return { value: undefined as unknown as Buffer, done: true };
+              }
+              await new Promise((r) => setTimeout(r, delayMs));
+              yielded = true;
+              return { value: payload, done: false };
+            },
+          };
+        },
+      };
+    }
+
+    it("rejects with LineMediaDownloadTimeoutError when the stream stalls past chunkTimeoutMs", async () => {
+      getMessageContentMock.mockResolvedValueOnce(neverYieldingStream());
+      const promise = downloadLineMedia("mid-stall", "token", 1024 * 1024, {
+        chunkTimeoutMs: 50,
+      });
+      await expect(promise).rejects.toBeInstanceOf(LineMediaDownloadTimeoutError);
+      await expect(promise.catch((e) => e.chunkTimeoutMs)).resolves.toBe(50);
+    });
+
+    it("rejects when getMessageContent headers never arrive", async () => {
+      getMessageContentMock.mockReturnValueOnce(new Promise(() => {}));
+      const promise = downloadLineMedia("mid-stall-headers", "token", 1024 * 1024, {
+        chunkTimeoutMs: 50,
+      });
+      await expect(promise).rejects.toBeInstanceOf(LineMediaDownloadTimeoutError);
+    });
+
+    it("does not reject when chunks arrive within chunkTimeoutMs", async () => {
+      const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+      getMessageContentMock.mockResolvedValueOnce(delayedStream(jpeg, 10));
+      const result = await downloadLineMedia("mid-slow-but-progressing", "token", 1024 * 1024, {
+        chunkTimeoutMs: 500,
+      });
+      expect(result.contentType).toBe("image/jpeg");
+    });
+
+    it("exposes LINE_DOWNLOAD_IDLE_TIMEOUT_MS = 30s aligned with TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS", () => {
+      expect(LINE_DOWNLOAD_IDLE_TIMEOUT_MS).toBe(30_000);
+    });
+
+    it("calls iterator.return() exactly once on timeout so the upstream Readable is destroyed", async () => {
+      const returnSpy = vi.fn(async () => ({ value: undefined as unknown as Buffer, done: true }));
+      const stream: AsyncIterable<Buffer> = {
+        [Symbol.asyncIterator]() {
+          return {
+            next(): Promise<IteratorResult<Buffer>> {
+              return new Promise<IteratorResult<Buffer>>(() => {});
+            },
+            return: returnSpy as () => Promise<IteratorResult<Buffer>>,
+          };
+        },
+      };
+      getMessageContentMock.mockResolvedValueOnce(stream);
+      await expect(
+        downloadLineMedia("mid-return-spy", "token", 1024 * 1024, { chunkTimeoutMs: 50 }),
+      ).rejects.toBeInstanceOf(LineMediaDownloadTimeoutError);
+      expect(returnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects when a second chunk stalls after a successful first chunk (partial-then-stall)", async () => {
+      const jpegPart = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+      let yieldedFirst = false;
+      const stream: AsyncIterable<Buffer> = {
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<Buffer>> {
+              if (!yieldedFirst) {
+                yieldedFirst = true;
+                return { value: jpegPart, done: false };
+              }
+              return new Promise<IteratorResult<Buffer>>(() => {});
+            },
+          };
+        },
+      };
+      getMessageContentMock.mockResolvedValueOnce(stream);
+      const promise = downloadLineMedia("mid-partial-stall", "token", 1024 * 1024, {
+        chunkTimeoutMs: 50,
+      });
+      await expect(promise).rejects.toBeInstanceOf(LineMediaDownloadTimeoutError);
+      await expect(promise.catch((e) => e.chunkTimeoutMs)).resolves.toBe(50);
+    });
   });
 });

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -8,22 +8,129 @@ interface DownloadResult {
   size: number;
 }
 
+/**
+ * Default per-chunk idle timeout for LINE inbound media downloads.
+ *
+ * Matches the Telegram `TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000` ceiling so
+ * a stalled LINE content stream cannot block inbound dispatch indefinitely.
+ * Idle (not overall) so legitimate slow-but-progressing transfers continue.
+ */
+export const LINE_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
+
+export class LineMediaDownloadTimeoutError extends Error {
+  readonly chunkTimeoutMs: number;
+  constructor(chunkTimeoutMs: number) {
+    super(`LINE media download stalled: no data received for ${chunkTimeoutMs}ms`);
+    this.name = "LineMediaDownloadTimeoutError";
+    this.chunkTimeoutMs = chunkTimeoutMs;
+  }
+}
+
+// Wraps an AsyncIterable so each `next()` is bounded by `chunkTimeoutMs`. On
+// timeout we propagate `LineMediaDownloadTimeoutError` and call `return()` on
+// the upstream iterator. For Node `Readable` produced by `@line/bot-sdk`
+// `convertResponseToReadable`, that triggers `Readable.destroy()`, which stops
+// further `read()` calls. The underlying `fetch` itself is NOT cancelled —
+// `@line/bot-sdk`'s `HTTPFetchClient.get` does not accept `AbortSignal`, so the
+// in-flight HTTP body may continue draining the TCP buffer until the OS
+// keep-alive timer fires. The caller (and any concurrent inbound dispatch) is
+// unblocked immediately; the orphaned fetch is bounded by transport, not by
+// this code.
+function withChunkIdleTimeout<T>(
+  source: AsyncIterable<T>,
+  chunkTimeoutMs: number,
+): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const iterator = source[Symbol.asyncIterator]();
+      try {
+        while (true) {
+          const nextPromise = iterator.next();
+          let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(
+              () => reject(new LineMediaDownloadTimeoutError(chunkTimeoutMs)),
+              chunkTimeoutMs,
+            );
+          });
+          let result: IteratorResult<T>;
+          try {
+            result = await Promise.race([nextPromise, timeoutPromise]);
+          } catch (err) {
+            // The timeout won the race; `nextPromise` is still pending and may
+            // later reject (e.g., the upstream Readable emits an error after
+            // `destroy()`). Without this, that rejection escapes as
+            // `unhandledRejection` and is fatal on Node 22+.
+            nextPromise.then(
+              () => undefined,
+              () => undefined,
+            );
+            throw err;
+          } finally {
+            if (timeoutHandle !== undefined) {
+              clearTimeout(timeoutHandle);
+            }
+          }
+          if (result.done) {
+            return;
+          }
+          yield result.value;
+        }
+      } finally {
+        if (typeof iterator.return === "function") {
+          await iterator.return().catch(() => undefined);
+        }
+      }
+    },
+  };
+}
+
 export async function downloadLineMedia(
   messageId: string,
   channelAccessToken: string,
   maxBytes = 10 * 1024 * 1024,
+  options?: { chunkTimeoutMs?: number },
 ): Promise<DownloadResult> {
+  const chunkTimeoutMs = options?.chunkTimeoutMs ?? LINE_DOWNLOAD_IDLE_TIMEOUT_MS;
   const client = new messagingApi.MessagingApiBlobClient({
     channelAccessToken,
   });
 
-  const response = await client.getMessageContent(messageId);
-  const saved = await saveMediaStream(
-    response as AsyncIterable<Buffer>,
-    undefined,
-    "inbound",
-    maxBytes,
+  // Race the headers-level fetch against the same idle ceiling. `@line/bot-sdk`
+  // currently builds its fetch without `AbortSignal`, so a server that never
+  // returns headers cannot otherwise be capped here. The fetch itself keeps
+  // running on timeout (see `withChunkIdleTimeout` note above for the same
+  // limitation on the body phase).
+  let responseTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const responseTimeoutPromise = new Promise<never>((_, reject) => {
+    responseTimeoutHandle = setTimeout(
+      () => reject(new LineMediaDownloadTimeoutError(chunkTimeoutMs)),
+      chunkTimeoutMs,
+    );
+  });
+  const responsePromise = client.getMessageContent(messageId);
+  let response: Awaited<ReturnType<typeof client.getMessageContent>>;
+  try {
+    response = await Promise.race([responsePromise, responseTimeoutPromise]);
+  } catch (err) {
+    // Same as `withChunkIdleTimeout`: suppress any later rejection from the
+    // orphaned `responsePromise` so it does not become an `unhandledRejection`.
+    responsePromise.then(
+      () => undefined,
+      () => undefined,
+    );
+    throw err;
+  } finally {
+    if (responseTimeoutHandle !== undefined) {
+      clearTimeout(responseTimeoutHandle);
+    }
+  }
+
+  const guardedStream = withChunkIdleTimeout(
+    response as unknown as AsyncIterable<Buffer>,
+    chunkTimeoutMs,
   );
+  const saved = await saveMediaStream(guardedStream, undefined, "inbound", maxBytes);
   logVerbose(`line: persisted media ${messageId} to ${saved.path} (${saved.size} bytes)`);
 
   return {


### PR DESCRIPTION
## Summary

`downloadLineMedia` in `extensions/line/src/download.ts` wraps the LINE
Messaging API `getMessageContent` response in a `for-await` loop with no
read deadline. When the LINE CDN returns HTTP headers but then stalls the
body stream, the function blocks indefinitely. Because
`extensions/line/src/bot-handlers.ts:467-482` awaits the result before
calling `processMessage`, the entire inbound dispatch hangs: no agent reply
is produced and the conversation goes silent.

This PR adds a per-chunk idle timeout (`LINE_DOWNLOAD_IDLE_TIMEOUT_MS =
30_000`) to cap both the headers-level fetch and each stream chunk read.
The ceiling matches the existing Telegram pattern
(`extensions/telegram/src/bot/delivery.resolve-media.ts:161`).
The timeout is idle (per-chunk), not overall, so legitimate slow-but-
progressing transfers continue.

**Affected channel**: LINE inbound media only.
**Unaffected**: Telegram, WhatsApp, MSTeams, Discord, Slack, Matrix,
all other channels. Pure-text LINE messages. LINE outbound path.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Fast inbound media (<10 ms first chunk) | resolves promptly | resolves promptly |
| Slow-but-progressing transfer (1 chunk / 50 ms) | resolves | resolves (idle cap is per-chunk, not overall) |
| Server returns headers, never streams body | blocks indefinitely; no agent reply | rejects with `LineMediaDownloadTimeoutError(30_000)` after 30 s; existing catch at `bot-handlers.ts:474-481` dispatches without media |
| Server never returns headers | blocks indefinitely | same rejection after 30 s |

## Implementation notes

- `withChunkIdleTimeout<T>()` wraps any `AsyncIterable<T>` so each `next()`
  call races against a `setTimeout`. On timeout, `iterator.return()` is
  called, which triggers `Readable.destroy()` for Node streams from
  `@line/bot-sdk`.
- `@line/bot-sdk` `HTTPFetchClient.get` does not accept `AbortSignal`, so
  the underlying `fetch` cannot be cancelled. On timeout, the function
  returns promptly but the background fetch may continue until TCP-level
  timeout. This is an acceptable trade-off; the caller proceeds without
  blocking.
- After the timeout wins the race, the still-pending `next()` and
  `getMessageContent()` promises are explicitly silenced
  (`.then(noop, noop)`) so a later rejection from the destroyed upstream
  cannot escape as an `unhandledRejection` on Node 22+.
- The caller error path at `bot-handlers.ts:474-481` already handles
  arbitrary errors via `String(err)`. The new error message includes
  `"stalled"`, which routes to the `runtime.error?.(danger(...))` branch
  (not the silent `"exceeds limit"` branch), so stalls are logged and
  dispatch continues without media.
- `chunkTimeoutMs` is an optional parameter so tests can use short values
  without touching the exported constant; no LINE config schema entry is
  added (out of scope for this PR; maintainer can request one if desired).
- Worst-case wall time before rejection is sequential
  (`(1 headers race) + (N chunk races)` of `chunkTimeoutMs` each), not a
  single 30 s shared deadline. With the default 30 s ceiling this is well
  inside LINE's 30 s webhook-ACK budget for the realistic single-stall
  case; deeply stalled CDNs with partial-progress flapping could exceed it
  but a follow-up overall-deadline option can be added if maintainers
  prefer.

## Files changed

- `extensions/line/src/download.ts` (+113 / −6): adds
  `LINE_DOWNLOAD_IDLE_TIMEOUT_MS`, `LineMediaDownloadTimeoutError`,
  `withChunkIdleTimeout()`, wires `options?.chunkTimeoutMs` through both
  the headers-level race and the stream-consumption phase, and silences
  the orphaned upstream promises on timeout so they cannot become
  `unhandledRejection`.
- `extensions/line/src/download.test.ts` (+109 / −1): adds a
  `chunk-idle timeout` describe block with 6 focused regression tests.

## Non-scope (deliberately separate PRs)

- WhatsApp `downloadInboundMedia` (`extensions/whatsapp/src/inbound/media.ts`) — same root pattern (no abort/timeout), separate PR.
- MSTeams `resolveMSTeamsInboundMedia` (`extensions/msteams/src/monitor-handler/inbound-media.ts`) — same root pattern, separate PR.
- Channel config knob for `chunkTimeoutMs`.
- Metadata-first dispatch (start `processMessage` while media hydrates in background) — would require restructuring `bot-handlers.ts` and is broader than the LINE narrow ceiling.

## Real behavior proof

Current HEAD SHA: `c10307cd7841cd3fe8df0ae92694f8b534153ba1`. Proof captured against this exact HEAD; this body update is parser-label normalization only — no code, test, or config diff change.

Behavior addressed:

LINE inbound media download blocks indefinitely when the LINE CDN stalls the response body stream, preventing `processMessage` from being called and leaving the conversation silent. The contributor ask is to prove that, after this patch, a stalled LINE media boundary no longer blocks inbound dispatch — `downloadLineMedia` rejects within the configured ceiling, the existing catch path in `bot-handlers.ts:467-499` logs the failure, `buildLineMessageContext` is still called, and `processMessage` is reached.

Real environment tested:

A local Node 22 process running the actual extension source via `pnpm tsx`, driving the real `handleLineWebhookEvents` entry point with a controlled stall installed at the `@line/bot-sdk` `MessagingApiBlobClient.prototype.getMessageContent` boundary. The production source — unmodified `bot-handlers.ts` dispatch path, unmodified `downloadLineMedia`, unmodified `buildLineMessageContext`, real `openclaw/plugin-sdk/media-store`, real ingress policy helpers — is exercised end-to-end. `processMessage` is the only spy. This is **not** a live LINE channel test; live LINE-CDN-side TCP behavior under partial-progress flapping is therefore not covered (see What was not tested).

Exact steps or command run after this patch:

```
node node_modules/.bin/tsx extensions/line/scratch/handler-stall-proof.mts body
node node_modules/.bin/tsx extensions/line/scratch/handler-stall-proof.mts headers
node node_modules/.bin/tsx extensions/line/scratch/handler-stall-proof.mts partial-stall
node node_modules/.bin/tsx extensions/line/scratch/handler-stall-proof.mts fast
node node_modules/.bin/tsx extensions/line/scratch/handler-stall-proof.mts slow-progress
```

The harness file `extensions/line/scratch/handler-stall-proof.mts` is not committed; it patches `MessagingApiBlobClient.prototype.getMessageContent` for the chosen scenario, then awaits the real `handleLineWebhookEvents` with a minimal `LineHandlerContext` whose `processMessage` is a JSON-emitting spy. Production default `LINE_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000` is used for all five scenarios.

Evidence after fix:

Redacted terminal capture from each `pnpm tsx` run, summarized into one row per scenario. Production default `chunkTimeoutMs = 30_000` was used everywhere. `runtime.error` captures the exact log string the production catch path would emit.

| Scenario | `@line/bot-sdk` boundary | Wall time | `downloadLineMedia` outcome | `runtime.error` fired | `processMessage` reached | `media_count` | `unhandledRejection` |
|---|---|---:|---|---|---|---:|---|
| body | `getMessageContent` resolves to async iterable whose `next()` never settles | 30 029 ms | rejected with `LineMediaDownloadTimeoutError(30000)` | yes | yes | 0 | no |
| headers | `getMessageContent` returns a Promise that never resolves | 30 022 ms | rejected with `LineMediaDownloadTimeoutError(30000)` | yes | yes | 0 | no |
| partial-stall | first chunk delivered, second-chunk `next()` never settles | 30 029 ms | rejected with `LineMediaDownloadTimeoutError(30000)` (per-chunk budget reset works) | yes | yes | 0 | no |
| fast | iterable yields a JPEG within 5 ms | 36 ms | resolved | no | yes | 1 | no |
| slow-progress | 6 single-byte chunks at 50 ms each | 335 ms | resolved | no | yes | 1 | no |

Sample raw JSON output from the `body` scenario (redacted timestamps):

```json
{
  "scenario": "body",
  "chunk_timeout_ms_default": 30000,
  "download_outcome": "timed-out",
  "process_message_called": true,
  "handler_settled": true,
  "handler_threw": false,
  "runtime_error_calls": [
    "line: failed to download media: LineMediaDownloadTimeoutError: LINE media download stalled: no data received for 30000ms"
  ],
  "unhandled_rejection_seen": false,
  "process_message_media_count": 0,
  "handler_elapsed_ms": 30029,
  "download_elapsed_ms": 30029,
  "download_error_name": "LineMediaDownloadTimeoutError"
}
```

Observed result after fix:

With the production default 30 s ceiling, the three stall scenarios (`body`, `headers`, `partial-stall`) each terminated in exactly one `LineMediaDownloadTimeoutError` at ~30 029 ms wall time, routed through the existing `bot-handlers.ts:474-481` catch to `runtime.error?.(danger(...))` (the `"stalled"` branch, not the silent `"exceeds limit"` branch). `buildLineMessageContext` was still invoked and `processMessage` was reached with zero media attachments. The two happy-path scenarios (`fast`, `slow-progress`) completed promptly and delivered one media attachment to `processMessage`. No `unhandledRejection` surfaced in any scenario after a 1 500 ms post-handler settle window — the orphan-rejection suppression in `withChunkIdleTimeout` and at the headers race both hold under real Node 22 event-loop scheduling.

What was not tested:

- A live LINE channel credential pair against the real LINE CDN with a real network-level stall. This would require a controlled-slow inbound media generator served by LINE's actual infrastructure plus a dedicated bot account; not feasible in this PR.
- WhatsApp and MSTeams unbounded-stall behavior (out of scope; separate PRs already enumerated in Non-scope).
- Production p99 percentiles for `downloadLineMedia` latency (no live traffic instrumented).
- The orphaned background `fetch` inside `@line/bot-sdk` `HTTPFetchClient.get` is acknowledged in Implementation notes but is not verified to settle within any specific TCP-level bound; that is a `@line/bot-sdk` SDK limitation, not introduced by this PR. The handler-level runtime proof above confirms the orphan does not surface as an `unhandledRejection` in the 1 500 ms window after `handleMessageEvent` returns.

## Unit coverage

`extensions/line/src/download.test.ts` adds 6 focused regression tests under the `chunk-idle timeout` describe block. These are supplemental to the handler-level runtime proof above and validate the `withChunkIdleTimeout` wrapper in isolation against an `@line/bot-sdk` stub.

| Test | `chunkTimeoutMs` | Outcome |
|---|---:|---|
| rejects with LineMediaDownloadTimeoutError when the stream stalls past chunkTimeoutMs | 50 ms | rejected with `LineMediaDownloadTimeoutError` |
| rejects when getMessageContent headers never arrive | 50 ms | rejected with `LineMediaDownloadTimeoutError` |
| does not reject when chunks arrive within chunkTimeoutMs | 500 ms | resolved (slow-but-progressing stream completes) |
| exposes LINE_DOWNLOAD_IDLE_TIMEOUT_MS = 30s aligned with TELEGRAM_DOWNLOAD_IDLE_TIMEOUT_MS | n/a | constant assertion: `LINE_DOWNLOAD_IDLE_TIMEOUT_MS === 30_000` |
| calls iterator.return() exactly once on timeout so the upstream Readable is destroyed | 50 ms | `iterator.return()` called exactly once |
| rejects when a second chunk stalls after a successful first chunk (partial-then-stall) | 50 ms | rejected with `LineMediaDownloadTimeoutError` |

Suite results on the current HEAD: `extensions/line/src/download.test.ts` 12 passed; `extensions/line` 270 passed; `pnpm check:changed` green; `pnpm format:check extensions/line/src/download.ts extensions/line/src/download.test.ts` clean.
