### PR TITLE
fix(subagents): expose announce retry config (maxAnnounceRetryCount, announceRetryBaseDelayMs, announceRetryMaxDelayMs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/subagents: expose `agents.defaults.subagents.maxAnnounceRetryCount`, `announceRetryBaseDelayMs`, and `announceRetryMaxDelayMs` so flaky-channel deployments (e.g. Feishu) can extend the sub-agent completion announce retry budget and backoff window. Defaults preserve the previous behavior (3 retries, 1s→2s→4s→8s exponential backoff). Fixes #86488.
 - CI: keep `OPENCLAW_TESTBOX=1 pnpm check:changed` delegating to Blacksmith Testbox through Crabbox without forwarding local Testbox or worker env into the remote command.
 - iMessage: thread current channel/account inbound attachment roots into the image tool so iMessage-saved attachments under `~/Library/Messages/Attachments` (including the wildcard `/Users/*/Library/Messages/Attachments` root) are read through the existing inbound path policy instead of being rejected as `path-not-allowed`. Literal `localRoots` stays workspace-scoped. Fixes #30170. (#86569)
 - QQ Bot: respect `OPENCLAW_HOME` for outbound media path resolution so `<qqmedia>` sends no longer silently fail when `HOME` and `OPENCLAW_HOME` differ (Docker / multi-user hosts). Persisted QQ Bot data (sessions, known users, refs) stays anchored on the OS home for upgrade compatibility. Fixes #83562. Thanks @sliverp.

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -58,6 +58,11 @@ import {
 } from "./subagent-announce-dispatch.js";
 import type { DeliveryContext } from "./subagent-announce-origin.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
+import {
+  DEFAULT_ANNOUNCE_RETRY_BASE_DELAY_MS,
+  DEFAULT_ANNOUNCE_RETRY_MAX_DELAY_MS,
+  DEFAULT_MAX_ANNOUNCE_RETRY_COUNT,
+} from "./subagent-registry-helpers.js";
 import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
@@ -215,6 +220,48 @@ export function resolveSubagentAnnounceTimeoutMs(cfg: OpenClawConfig): number {
     return DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS;
   }
   return Math.min(Math.max(1, Math.floor(configured)), MAX_TIMER_SAFE_TIMEOUT_MS);
+}
+
+/**
+ * Resolve the maximum number of retries used when announcing sub-agent completion back
+ * to the parent session. Defaults to {@link DEFAULT_MAX_ANNOUNCE_RETRY_COUNT} (3) so the
+ * behavior is unchanged when `agents.defaults.subagents.maxAnnounceRetryCount` is absent.
+ *
+ * See issue #86488: in flaky channels (e.g. Feishu) the previous hardcoded 3 retries
+ * could be exhausted within a few seconds, silently dropping the completion result.
+ */
+export function resolveSubagentMaxAnnounceRetryCount(cfg: OpenClawConfig): number {
+  const configured = cfg.agents?.defaults?.subagents?.maxAnnounceRetryCount;
+  if (typeof configured !== "number" || !Number.isFinite(configured) || configured < 0) {
+    return DEFAULT_MAX_ANNOUNCE_RETRY_COUNT;
+  }
+  return Math.min(Math.floor(configured), 20);
+}
+
+/**
+ * Resolve the base delay (in ms) for the exponential backoff between announce retries.
+ * Defaults to {@link DEFAULT_ANNOUNCE_RETRY_BASE_DELAY_MS} (1000 ms) so the behavior is
+ * unchanged when `agents.defaults.subagents.announceRetryBaseDelayMs` is absent.
+ */
+export function resolveSubagentAnnounceRetryBaseDelayMs(cfg: OpenClawConfig): number {
+  const configured = cfg.agents?.defaults?.subagents?.announceRetryBaseDelayMs;
+  if (typeof configured !== "number" || !Number.isFinite(configured) || configured < 0) {
+    return DEFAULT_ANNOUNCE_RETRY_BASE_DELAY_MS;
+  }
+  return Math.min(Math.floor(configured), MAX_TIMER_SAFE_TIMEOUT_MS);
+}
+
+/**
+ * Resolve the cap (in ms) for the exponential backoff between announce retries.
+ * Defaults to {@link DEFAULT_ANNOUNCE_RETRY_MAX_DELAY_MS} (8000 ms) so the behavior is
+ * unchanged when `agents.defaults.subagents.announceRetryMaxDelayMs` is absent.
+ */
+export function resolveSubagentAnnounceRetryMaxDelayMs(cfg: OpenClawConfig): number {
+  const configured = cfg.agents?.defaults?.subagents?.announceRetryMaxDelayMs;
+  if (typeof configured !== "number" || !Number.isFinite(configured) || configured < 0) {
+    return DEFAULT_ANNOUNCE_RETRY_MAX_DELAY_MS;
+  }
+  return Math.min(Math.floor(configured), MAX_TIMER_SAFE_TIMEOUT_MS);
 }
 
 export function isInternalAnnounceRequesterSession(sessionKey: string | undefined): boolean {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -242,6 +242,11 @@ export function resolveSubagentMaxAnnounceRetryCount(cfg: OpenClawConfig): numbe
  * Resolve the base delay (in ms) for the exponential backoff between announce retries.
  * Defaults to {@link DEFAULT_ANNOUNCE_RETRY_BASE_DELAY_MS} (1000 ms) so the behavior is
  * unchanged when `agents.defaults.subagents.announceRetryBaseDelayMs` is absent.
+ *
+ * Note: a configured value of `0` is honored and short-circuits the backoff so retries fire
+ * with no delay between them. This is intentionally allowed (e.g. for test setups) but
+ * produces a back-to-back burst against the parent channel — see the schema description
+ * before using it in production.
  */
 export function resolveSubagentAnnounceRetryBaseDelayMs(cfg: OpenClawConfig): number {
   const configured = cfg.agents?.defaults?.subagents?.announceRetryBaseDelayMs;

--- a/src/agents/subagent-announce-retry-config.test.ts
+++ b/src/agents/subagent-announce-retry-config.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for #86488: configurable subagent completion announce retry knobs.
+ *
+ * Covers:
+ * - Default config preserves prior behavior (3 retries, 1s→2s→4s→8s backoff)
+ * - `agents.defaults.subagents.maxAnnounceRetryCount` overrides the retry cap
+ * - `agents.defaults.subagents.announceRetryBaseDelayMs` overrides backoff base
+ * - `agents.defaults.subagents.announceRetryMaxDelayMs` overrides backoff cap
+ * - `maxAnnounceRetryCount: 0` disables retries (give-up on the very first decision)
+ * - `announceRetryBaseDelayMs: 0` disables delay (retries fire back-to-back)
+ * - Edge cases: negative/NaN/non-finite values fall back to defaults; absurd values clamped
+ */
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  resolveSubagentAnnounceRetryBaseDelayMs,
+  resolveSubagentAnnounceRetryMaxDelayMs,
+  resolveSubagentMaxAnnounceRetryCount,
+} from "./subagent-announce-delivery.js";
+import { resolveDeferredCleanupDecision } from "./subagent-registry-cleanup.js";
+import {
+  DEFAULT_ANNOUNCE_RETRY_BASE_DELAY_MS,
+  DEFAULT_ANNOUNCE_RETRY_MAX_DELAY_MS,
+  DEFAULT_MAX_ANNOUNCE_RETRY_COUNT,
+  resolveAnnounceRetryDelayMs,
+} from "./subagent-registry-helpers.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+function makeConfig(subagents: Record<string, unknown> = {}): OpenClawConfig {
+  return {
+    agents: { defaults: { subagents } },
+  } as unknown as OpenClawConfig;
+}
+
+function makeEntry(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
+  return {
+    runId: "run-1",
+    childSessionKey: "agent:main:subagent:child",
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "test",
+    cleanup: "keep",
+    createdAt: 0,
+    endedAt: 1_000,
+    ...overrides,
+  };
+}
+
+describe("#86488: configurable subagent announce retry — config resolvers", () => {
+  describe("resolveSubagentMaxAnnounceRetryCount", () => {
+    it("returns the default (3) when no override is configured", () => {
+      expect(resolveSubagentMaxAnnounceRetryCount(makeConfig())).toBe(
+        DEFAULT_MAX_ANNOUNCE_RETRY_COUNT,
+      );
+    });
+
+    it("returns the configured override when present", () => {
+      expect(
+        resolveSubagentMaxAnnounceRetryCount(makeConfig({ maxAnnounceRetryCount: 7 })),
+      ).toBe(7);
+    });
+
+    it("allows 0 (disable retries entirely)", () => {
+      expect(
+        resolveSubagentMaxAnnounceRetryCount(makeConfig({ maxAnnounceRetryCount: 0 })),
+      ).toBe(0);
+    });
+
+    it("clamps unreasonably large overrides to a safe ceiling (20)", () => {
+      expect(
+        resolveSubagentMaxAnnounceRetryCount(makeConfig({ maxAnnounceRetryCount: 9999 })),
+      ).toBe(20);
+    });
+
+    it("falls back to default for negative / NaN / non-finite values", () => {
+      expect(
+        resolveSubagentMaxAnnounceRetryCount(makeConfig({ maxAnnounceRetryCount: -1 })),
+      ).toBe(DEFAULT_MAX_ANNOUNCE_RETRY_COUNT);
+      expect(
+        resolveSubagentMaxAnnounceRetryCount(makeConfig({ maxAnnounceRetryCount: NaN })),
+      ).toBe(DEFAULT_MAX_ANNOUNCE_RETRY_COUNT);
+      expect(
+        resolveSubagentMaxAnnounceRetryCount(
+          makeConfig({ maxAnnounceRetryCount: Number.POSITIVE_INFINITY }),
+        ),
+      ).toBe(DEFAULT_MAX_ANNOUNCE_RETRY_COUNT);
+    });
+  });
+
+  describe("resolveSubagentAnnounceRetryBaseDelayMs", () => {
+    it("returns the default (1000 ms) when no override is configured", () => {
+      expect(resolveSubagentAnnounceRetryBaseDelayMs(makeConfig())).toBe(
+        DEFAULT_ANNOUNCE_RETRY_BASE_DELAY_MS,
+      );
+    });
+
+    it("returns the configured override (e.g. 10s for flaky Feishu)", () => {
+      expect(
+        resolveSubagentAnnounceRetryBaseDelayMs(
+          makeConfig({ announceRetryBaseDelayMs: 10_000 }),
+        ),
+      ).toBe(10_000);
+    });
+
+    it("allows 0 (no delay between retries)", () => {
+      expect(
+        resolveSubagentAnnounceRetryBaseDelayMs(makeConfig({ announceRetryBaseDelayMs: 0 })),
+      ).toBe(0);
+    });
+  });
+
+  describe("resolveSubagentAnnounceRetryMaxDelayMs", () => {
+    it("returns the default (8000 ms) when no override is configured", () => {
+      expect(resolveSubagentAnnounceRetryMaxDelayMs(makeConfig())).toBe(
+        DEFAULT_ANNOUNCE_RETRY_MAX_DELAY_MS,
+      );
+    });
+
+    it("returns the configured override (e.g. 60s max for very flaky channels)", () => {
+      expect(
+        resolveSubagentAnnounceRetryMaxDelayMs(
+          makeConfig({ announceRetryMaxDelayMs: 60_000 }),
+        ),
+      ).toBe(60_000);
+    });
+  });
+});
+
+describe("#86488: resolveAnnounceRetryDelayMs with options", () => {
+  it("preserves the original 1s→2s→4s→8s backoff when called without options", () => {
+    // retryCount is "attempts already made", so retry #1 waits 1s.
+    expect(resolveAnnounceRetryDelayMs(1)).toBe(1_000);
+    expect(resolveAnnounceRetryDelayMs(2)).toBe(2_000);
+    expect(resolveAnnounceRetryDelayMs(3)).toBe(4_000);
+    expect(resolveAnnounceRetryDelayMs(4)).toBe(8_000);
+    expect(resolveAnnounceRetryDelayMs(5)).toBe(8_000); // capped
+  });
+
+  it("scales the backoff sequence with a custom base delay", () => {
+    // base=5000 → 5s, 10s, 20s, 40s (capped at max)
+    expect(resolveAnnounceRetryDelayMs(1, { baseDelayMs: 5_000, maxDelayMs: 30_000 })).toBe(
+      5_000,
+    );
+    expect(resolveAnnounceRetryDelayMs(2, { baseDelayMs: 5_000, maxDelayMs: 30_000 })).toBe(
+      10_000,
+    );
+    expect(resolveAnnounceRetryDelayMs(3, { baseDelayMs: 5_000, maxDelayMs: 30_000 })).toBe(
+      20_000,
+    );
+    expect(resolveAnnounceRetryDelayMs(4, { baseDelayMs: 5_000, maxDelayMs: 30_000 })).toBe(
+      30_000,
+    );
+  });
+
+  it("returns 0 when baseDelayMs is 0 (delay disabled)", () => {
+    expect(resolveAnnounceRetryDelayMs(1, { baseDelayMs: 0 })).toBe(0);
+    expect(resolveAnnounceRetryDelayMs(5, { baseDelayMs: 0 })).toBe(0);
+  });
+
+  it("ensures maxDelayMs is never less than baseDelayMs", () => {
+    // If a user misconfigures with max < base, we floor max at base instead of returning a
+    // smaller number that would invert the backoff.
+    expect(resolveAnnounceRetryDelayMs(1, { baseDelayMs: 10_000, maxDelayMs: 1_000 })).toBe(
+      10_000,
+    );
+  });
+});
+
+describe("#86488: resolveDeferredCleanupDecision honors configurable retry count", () => {
+  const now = 2_000;
+  const baseParams = {
+    now,
+    announceExpiryMs: 5 * 60_000,
+    announceCompletionHardExpiryMs: 30 * 60_000,
+    deferDescendantDelayMs: 1_000,
+    resolveAnnounceRetryDelayMs: (retryCount: number) => retryCount * 1_000,
+  };
+
+  it("preserves default behavior (3 retries) when maxAnnounceRetryCount is the default", () => {
+    // 2 attempts already made → next retry is attempt #3, which hits the 3-retry cap.
+    const decision = resolveDeferredCleanupDecision({
+      ...baseParams,
+      entry: makeEntry({
+        expectsCompletionMessage: true,
+        delivery: { status: "pending", attemptCount: 2 },
+      }),
+      activeDescendantRuns: 0,
+      maxAnnounceRetryCount: 3,
+    });
+    expect(decision).toEqual({ kind: "give-up", reason: "retry-limit", retryCount: 3 });
+  });
+
+  it("respects a higher maxAnnounceRetryCount (e.g. 5 retries for flaky channels)", () => {
+    // With maxRetries=5, attempt #3 should still retry instead of giving up.
+    const decision = resolveDeferredCleanupDecision({
+      ...baseParams,
+      entry: makeEntry({
+        expectsCompletionMessage: true,
+        delivery: { status: "pending", attemptCount: 2 },
+      }),
+      activeDescendantRuns: 0,
+      maxAnnounceRetryCount: 5,
+    });
+    expect(decision).toEqual({ kind: "retry", retryCount: 3, resumeDelayMs: 3_000 });
+  });
+
+  it("gives up immediately when maxAnnounceRetryCount is 0 (retries disabled)", () => {
+    const decision = resolveDeferredCleanupDecision({
+      ...baseParams,
+      entry: makeEntry({
+        expectsCompletionMessage: false,
+        delivery: { status: "pending", attemptCount: 0 },
+      }),
+      activeDescendantRuns: 0,
+      maxAnnounceRetryCount: 0,
+    });
+    // First attempt (retryCount=1) already meets the 0 cap → retry-limit.
+    expect(decision).toEqual({ kind: "give-up", reason: "retry-limit", retryCount: 1 });
+  });
+
+  it("passes the configured delay through to retry decisions", () => {
+    const decision = resolveDeferredCleanupDecision({
+      ...baseParams,
+      entry: makeEntry({
+        expectsCompletionMessage: true,
+        delivery: { status: "pending", attemptCount: 0 },
+      }),
+      activeDescendantRuns: 0,
+      maxAnnounceRetryCount: 3,
+      resolveAnnounceRetryDelayMs: (retryCount) =>
+        // Use the actual production helper with a custom 10s base — this is what
+        // `agents.defaults.subagents.announceRetryBaseDelayMs: 10000` would deliver.
+        resolveAnnounceRetryDelayMs(retryCount, { baseDelayMs: 10_000, maxDelayMs: 60_000 }),
+    });
+    expect(decision).toEqual({ kind: "retry", retryCount: 1, resumeDelayMs: 10_000 });
+  });
+});

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -36,6 +36,14 @@ export const MAX_ANNOUNCE_RETRY_COUNT = 3;
 export const ANNOUNCE_EXPIRY_MS = 5 * 60_000;
 export const ANNOUNCE_COMPLETION_HARD_EXPIRY_MS = 30 * 60_000;
 
+/**
+ * Defaults used when `agents.defaults.subagents.*` overrides are absent. These mirror
+ * the original hardcoded constants so behavior is identical when no config is set.
+ */
+export const DEFAULT_ANNOUNCE_RETRY_BASE_DELAY_MS = MIN_ANNOUNCE_RETRY_DELAY_MS;
+export const DEFAULT_ANNOUNCE_RETRY_MAX_DELAY_MS = MAX_ANNOUNCE_RETRY_DELAY_MS;
+export const DEFAULT_MAX_ANNOUNCE_RETRY_COUNT = MAX_ANNOUNCE_RETRY_COUNT;
+
 const FROZEN_RESULT_TEXT_MAX_BYTES = 100 * 1024;
 
 type SubagentRunOrphanReason = "missing-session-entry" | "missing-session-id" | "stale-unended-run";
@@ -58,12 +66,32 @@ export function capFrozenResultText(resultText: string): string {
   return `${payload}${notice}`;
 }
 
-export function resolveAnnounceRetryDelayMs(retryCount: number) {
+/**
+ * Compute the delay before the next announce retry using exponential backoff.
+ *
+ * Behavior preserved from the original hardcoded version when called with the
+ * default base/max values: retry #1 waits 1s, then 2s, 4s, capped at 8s.
+ *
+ * @param retryCount Attempts already made (1-based: pass 1 for the delay before retry #1)
+ * @param options Optional override for base and max delay; defaults match the previous constants.
+ */
+export function resolveAnnounceRetryDelayMs(
+  retryCount: number,
+  options?: { baseDelayMs?: number; maxDelayMs?: number },
+) {
+  const baseDelayMs = Math.max(0, options?.baseDelayMs ?? DEFAULT_ANNOUNCE_RETRY_BASE_DELAY_MS);
+  const maxDelayMs = Math.max(
+    baseDelayMs,
+    options?.maxDelayMs ?? DEFAULT_ANNOUNCE_RETRY_MAX_DELAY_MS,
+  );
+  if (baseDelayMs === 0) {
+    return 0;
+  }
   const boundedRetryCount = Math.max(0, Math.min(retryCount, 10));
-  // retryCount is "attempts already made", so retry #1 waits 1s, then 2s, 4s...
+  // retryCount is "attempts already made", so retry #1 waits base, then base*2, base*4...
   const backoffExponent = Math.max(0, boundedRetryCount - 1);
-  const baseDelay = MIN_ANNOUNCE_RETRY_DELAY_MS * 2 ** backoffExponent;
-  return Math.min(baseDelay, MAX_ANNOUNCE_RETRY_DELAY_MS);
+  const baseDelay = baseDelayMs * 2 ** backoffExponent;
+  return Math.min(baseDelay, maxDelayMs);
 }
 
 function formatAnnounceGiveUpLogField(value: string): string {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -79,6 +79,22 @@ export function createSubagentRegistryLifecycleController(params: {
   runs: Map<string, SubagentRunRecord>;
   resumedRuns: Set<string>;
   subagentAnnounceTimeoutMs: number;
+  /**
+   * Optional resolver for the maximum number of announce retries. Called fresh on every
+   * cleanup decision so runtime config changes take effect without restart. Defaults to
+   * the hardcoded {@link MAX_ANNOUNCE_RETRY_COUNT} (3) to preserve prior behavior.
+   */
+  resolveMaxAnnounceRetryCount?: () => number;
+  /**
+   * Optional resolver for the base delay (ms) used in announce-retry exponential backoff.
+   * Called fresh on every cleanup decision. Defaults to {@link MIN_ANNOUNCE_RETRY_DELAY_MS}.
+   */
+  resolveAnnounceRetryBaseDelayMs?: () => number;
+  /**
+   * Optional resolver for the cap (ms) on announce-retry exponential backoff.
+   * Called fresh on every cleanup decision. Defaults to 8000 ms.
+   */
+  resolveAnnounceRetryMaxDelayMs?: () => number;
   persist(): void;
   clearPendingLifecycleError(runId: string): void;
   countPendingDescendantRuns(rootSessionKey: string): number;
@@ -792,15 +808,24 @@ export function createSubagentRegistryLifecycleController(params: {
     }
 
     const now = Date.now();
+    const effectiveMaxRetries =
+      params.resolveMaxAnnounceRetryCount?.() ?? MAX_ANNOUNCE_RETRY_COUNT;
+    const effectiveBaseDelayMs =
+      params.resolveAnnounceRetryBaseDelayMs?.() ?? MIN_ANNOUNCE_RETRY_DELAY_MS;
+    const effectiveMaxDelayMs = params.resolveAnnounceRetryMaxDelayMs?.();
     const deferredDecision = resolveDeferredCleanupDecision({
       entry,
       now,
       activeDescendantRuns: Math.max(0, params.countPendingDescendantRuns(entry.childSessionKey)),
       announceExpiryMs: ANNOUNCE_EXPIRY_MS,
       announceCompletionHardExpiryMs: ANNOUNCE_COMPLETION_HARD_EXPIRY_MS,
-      maxAnnounceRetryCount: MAX_ANNOUNCE_RETRY_COUNT,
-      deferDescendantDelayMs: MIN_ANNOUNCE_RETRY_DELAY_MS,
-      resolveAnnounceRetryDelayMs,
+      maxAnnounceRetryCount: effectiveMaxRetries,
+      deferDescendantDelayMs: effectiveBaseDelayMs,
+      resolveAnnounceRetryDelayMs: (retryCount) =>
+        resolveAnnounceRetryDelayMs(retryCount, {
+          baseDelayMs: effectiveBaseDelayMs,
+          maxDelayMs: effectiveMaxDelayMs,
+        }),
     });
 
     if (deferredDecision.kind === "defer-descendants") {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -15,6 +15,11 @@ import { removeInternalSessionEffectsTranscript } from "./internal-session-effec
 import { isAbortedAgentStopReason } from "./run-termination.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import {
+  resolveSubagentAnnounceRetryBaseDelayMs,
+  resolveSubagentAnnounceRetryMaxDelayMs,
+  resolveSubagentMaxAnnounceRetryCount,
+} from "./subagent-announce-delivery.js";
+import {
   ensureCompletionState,
   ensureDeliveryState,
   getDeliveryAttemptCount,
@@ -34,7 +39,6 @@ import {
 } from "./subagent-registry-completion.js";
 import {
   ANNOUNCE_EXPIRY_MS,
-  MAX_ANNOUNCE_RETRY_COUNT,
   reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
   resolveAnnounceRetryDelayMs,
@@ -490,6 +494,15 @@ const subagentLifecycleController = createSubagentRegistryLifecycleController({
   runs: subagentRuns,
   resumedRuns,
   subagentAnnounceTimeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
+  // #86488: read retry knobs from runtime config on every cleanup decision so users can
+  // tune behavior for flaky channels (e.g. Feishu) without restart. Defaults preserve
+  // the previous hardcoded behavior (3 retries, 1s base / 8s max exponential backoff).
+  resolveMaxAnnounceRetryCount: () =>
+    resolveSubagentMaxAnnounceRetryCount(subagentRegistryDeps.getRuntimeConfig()),
+  resolveAnnounceRetryBaseDelayMs: () =>
+    resolveSubagentAnnounceRetryBaseDelayMs(subagentRegistryDeps.getRuntimeConfig()),
+  resolveAnnounceRetryMaxDelayMs: () =>
+    resolveSubagentAnnounceRetryMaxDelayMs(subagentRegistryDeps.getRuntimeConfig()),
   persist: persistSubagentRuns,
   clearPendingLifecycleError,
   countPendingDescendantRuns,
@@ -534,7 +547,11 @@ function resumeSubagentRun(runId: string) {
     return;
   }
   // Skip entries that have exhausted their retry budget or expired (#18264).
-  if (getDeliveryAttemptCount(entry) >= MAX_ANNOUNCE_RETRY_COUNT) {
+  // #86488: read the configurable cap so users can raise retries for flaky channels.
+  const effectiveMaxRetries = resolveSubagentMaxAnnounceRetryCount(
+    subagentRegistryDeps.getRuntimeConfig(),
+  );
+  if (getDeliveryAttemptCount(entry) >= effectiveMaxRetries) {
     void finalizeResumedAnnounceGiveUp({
       runId,
       entry,
@@ -557,7 +574,12 @@ function resumeSubagentRun(runId: string) {
 
   const now = Date.now();
   const lastAttemptAt = getDeliveryLastAttemptAt(entry);
-  const delayMs = resolveAnnounceRetryDelayMs(getDeliveryAttemptCount(entry));
+  // #86488: pull the configurable base/max delay so backoff respects user overrides.
+  const cfgForDelay = subagentRegistryDeps.getRuntimeConfig();
+  const delayMs = resolveAnnounceRetryDelayMs(getDeliveryAttemptCount(entry), {
+    baseDelayMs: resolveSubagentAnnounceRetryBaseDelayMs(cfgForDelay),
+    maxDelayMs: resolveSubagentAnnounceRetryMaxDelayMs(cfgForDelay),
+  });
   const earliestRetryAt = (lastAttemptAt ?? 0) + delayMs;
   if (entry.expectsCompletionMessage === true && lastAttemptAt && now < earliestRetryAt) {
     const waitMs = Math.max(1, earliestRetryAt - now);

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -458,6 +458,22 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 120000). */
     announceTimeoutMs?: number;
+    /**
+     * Maximum number of retries when announcing sub-agent completion back to the parent
+     * (default: 3). Set to 0 to disable retries. Increase for flaky channels (e.g. Feishu)
+     * to reduce silently-lost completions (#86488).
+     */
+    maxAnnounceRetryCount?: number;
+    /**
+     * Base delay in milliseconds between sub-agent completion announce retries (default: 1000).
+     * Each retry doubles this delay (exponential backoff) up to announceRetryMaxDelayMs.
+     */
+    announceRetryBaseDelayMs?: number;
+    /**
+     * Maximum delay in milliseconds between sub-agent completion announce retries (default: 8000).
+     * Caps the exponential backoff growth.
+     */
+    announceRetryMaxDelayMs?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
     requireAgentId?: boolean;
   };

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -467,6 +467,9 @@ export type AgentDefaultsConfig = {
     /**
      * Base delay in milliseconds between sub-agent completion announce retries (default: 1000).
      * Each retry doubles this delay (exponential backoff) up to announceRetryMaxDelayMs.
+     * Setting this to 0 disables the delay entirely and fires retries back-to-back; this is
+     * intentionally allowed for advanced cases but will produce a burst that can hammer the
+     * parent channel, so prefer the default or a higher value for normal use.
      */
     announceRetryBaseDelayMs?: number;
     /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -279,6 +279,31 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        maxAnnounceRetryCount: z
+          .number()
+          .int()
+          .min(0)
+          .max(20)
+          .optional()
+          .describe(
+            "Maximum number of retries when announcing sub-agent completion back to the parent (default: 3). Set to 0 to disable retries. Increase for flaky channels (e.g. Feishu) to reduce silently-lost completions (#86488).",
+          ),
+        announceRetryBaseDelayMs: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Base delay in milliseconds between sub-agent completion announce retries (default: 1000). Each retry doubles this delay (exponential backoff) up to announceRetryMaxDelayMs.",
+          ),
+        announceRetryMaxDelayMs: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Maximum delay in milliseconds between sub-agent completion announce retries (default: 8000). Caps the exponential backoff growth.",
+          ),
         requireAgentId: z.boolean().optional(),
       })
       .strict()

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -294,7 +294,7 @@ export const AgentDefaultsSchema = z
           .min(0)
           .optional()
           .describe(
-            "Base delay in milliseconds between sub-agent completion announce retries (default: 1000). Each retry doubles this delay (exponential backoff) up to announceRetryMaxDelayMs.",
+            "Base delay in milliseconds between sub-agent completion announce retries (default: 1000). Each retry doubles this delay (exponential backoff) up to announceRetryMaxDelayMs. Set to 0 to fire all retries back-to-back with no delay (use with caution: this can produce a burst that hammers the parent channel). Use the default or a higher value for well-behaved channels.",
           ),
         announceRetryMaxDelayMs: z
           .number()


### PR DESCRIPTION
Fixes #86488.

## Summary

The sub-agent completion announce flow uses an in-memory retry budget that was hardcoded to **3 attempts** with exponential backoff (1s → 2s → 4s → 8s). On flaky channels (most notably **Feishu**, per the original report) all retries can be burned in well under a minute, after which the completion result is moved to a `suspended` delivery state that the normal resume path skips and the sweeper eventually discards — **silently losing the sub-agent's work**.

This PR takes the **minimally invasive** path: it leaves the existing suspended-delivery state machine intact and exposes the three knobs that were previously hardcoded so users on flaky channels can keep their completions alive long enough to be delivered.

## Root cause

In `src/agents/subagent-registry-helpers.ts` three constants gated the entire retry budget:

```ts
export const MIN_ANNOUNCE_RETRY_DELAY_MS = 1_000;   // base of exponential backoff
const MAX_ANNOUNCE_RETRY_DELAY_MS = 8_000;          // cap on backoff growth
export const MAX_ANNOUNCE_RETRY_COUNT = 3;          // total retries
```

The backoff sequence is `base, base*2, base*4, …` capped at `max`, so with the defaults the **entire 3-retry budget burns in ≈7 s** (1 s + 2 s + 4 s). For a Feishu deployment where the failure mode is a transient gateway/delivery hiccup, that means the result is gone before the channel even recovers.

After `MAX_ANNOUNCE_RETRY_COUNT` is hit, `resolveDeferredCleanupDecision` returns `{ kind: "give-up", reason: "retry-limit" }`, the entry is moved into suspended delivery, and `resumeSubagentRun` short-circuits with `getDeliveryAttemptCount(entry) >= MAX_ANNOUNCE_RETRY_COUNT`, so nothing else ever retries the announce.

## Fix shape

Add three optional config keys under `agents.defaults.subagents` and thread them through the lifecycle controller via fresh resolvers, so runtime config changes take effect without a restart:

| Key | Default | Range | Purpose |
| --- | --- | --- | --- |
| `maxAnnounceRetryCount` | `3` | `0..20` | Total retries before give-up. `0` disables retries. |
| `announceRetryBaseDelayMs` | `1000` | `0..` | Base of exponential backoff. `0` = back-to-back retries. |
| `announceRetryMaxDelayMs` | `8000` | `0..` | Cap on backoff growth. |

All three are optional and default-preserving — **existing deployments see no behavior change**.

## Before / after

| Scenario | Before | After (defaults) | After (Feishu-tuned example) |
| --- | --- | --- | --- |
| Total retries | 3 (hardcoded) | 3 | configurable (e.g. 8) |
| Backoff sequence | 1 s, 2 s, 4 s (8 s cap) | 1 s, 2 s, 4 s | e.g. 10 s, 20 s, 40 s, 60 s (60 s cap) |
| Time to give-up | ≈7 s | ≈7 s | configurable — minutes for flaky channels |
| Result on flaky channel | silently dropped after ≈7 s | unchanged | survives transient channel outages |
| Config required | none | none | `agents.defaults.subagents.{maxAnnounceRetryCount, announceRetryBaseDelayMs, announceRetryMaxDelayMs}` |

## Config example

For a Feishu deployment that wants to ride through ~5 minutes of transient channel hiccups:

```jsonc
{
  "agents": {
    "defaults": {
      "subagents": {
        "maxAnnounceRetryCount": 8,
        "announceRetryBaseDelayMs": 10000,
        "announceRetryMaxDelayMs": 60000
      }
    }
  }
}
```

This sequence is `10 s, 20 s, 40 s, 60 s, 60 s, 60 s, 60 s, 60 s` = up to ~6 minutes of resilient retry.

## Why Option B and not Option A

The issue proposes two options:

- **Option A (robust):** persistent outbox in `~/.openclaw/pending_completions/` with a polling worker that survives process restarts.
- **Option B (quick):** expose the retry config knobs so users can tune behavior.

The ClawSweeper review on #86488 explicitly flagged the durable retry contract as `needs-product-decision` because it touches session-state retention and cleanup semantics. The repo **already has a partial mitigation**: completed runs that exhaust retries are moved to a suspended-delivery state instead of being immediately cleaned up (`src/agents/subagent-registry-lifecycle.test.ts:939`). What's missing for users today is a way to **prevent** hitting the retry limit in the first place on flaky channels.

This PR delivers that without preempting the maintainer's outbox direction. **A persistent outbox can still land as a follow-up** — it would extend the current suspended-delivery state rather than replace anything in this PR.

## Repro (without the fix)

Minimal repro shape that the issue's log evidence describes:

1. Parent agent runs in a Feishu group, sends interim reply, calls `sessions_yield`.
2. Sub-agent completes ~85 s later; announce begins.
3. Channel is mid-hiccup: `runSubagentAnnounceFlow` returns "did not deliver through the message tool" 3× in a row, with the registry-driven retries spaced by exponential backoff `1 s → 2 s → 4 s` ≈ 7 s wall-clock.
4. `resolveDeferredCleanupDecision` returns `{ kind: "give-up", reason: "retry-limit" }`.
5. Completion is moved to suspended delivery; `resumeSubagentRun` short-circuits on the attempt-count check; the sweeper eventually drops it (`subagent suspended delivery discarded reason=expired` in the report logs).

With this PR a user hitting that path can set `maxAnnounceRetryCount: 8` + `announceRetryBaseDelayMs: 10000` and stop losing completions while remaining unaffected if they don't configure anything.

## Tests

Added `src/agents/subagent-announce-retry-config.test.ts` with **18 tests** covering:

- Default config preserves prior behavior (3 retries, 1s→2s→4s→8s backoff).
- `maxAnnounceRetryCount` overrides the retry cap (e.g. 5 retries for flaky channels).
- `announceRetryBaseDelayMs` overrides backoff base (used by `resolveAnnounceRetryDelayMs`).
- `announceRetryMaxDelayMs` overrides backoff cap.
- `maxAnnounceRetryCount: 0` disables retries — give-up on the first decision.
- `announceRetryBaseDelayMs: 0` disables delay — retries fire back-to-back.
- Negative / NaN / non-finite values fall back to defaults.
- Absurd values are clamped to a safe ceiling (e.g. `maxAnnounceRetryCount: 9999 → 20`).
- `resolveDeferredCleanupDecision` honors the configured cap and delay.
- `resolveAnnounceRetryDelayMs` with custom options scales correctly and floors `max` at `base` if a user inverts them.

All existing tests in the affected suites still pass:

```
src/agents/subagent-registry-cleanup.test.ts             5 tests ✓
src/agents/subagent-registry.test.ts                    33 tests ✓
src/agents/subagent-announce-delivery.test.ts           63 tests ✓
src/agents/subagent-registry-lifecycle.test.ts          28 tests ✓
src/agents/subagent-registry-helpers.test.ts             3 tests ✓
src/config/zod-schema.agent-defaults.test.ts            28 tests ✓
+ new src/agents/subagent-announce-retry-config.test.ts 18 tests ✓
```

`pnpm tsgo:core` and `pnpm tsgo:core:test` complete with no errors. `pnpm check:base-config-schema` passes.

## Real-behavior proof note

The original failure mode requires a flaky external channel (Feishu in the report). I did not run a live Feishu repro — that would need a maintainer-side staging account and would only reproduce probabilistically when the channel happens to fail. Instead the test suite proves the **mechanism** end-to-end:

- The config resolvers correctly read each new key, default safely, and clamp.
- `resolveDeferredCleanupDecision` makes different decisions for the same `delivery.attemptCount` based purely on `maxAnnounceRetryCount` (the exact field the original failure flips).
- `resolveAnnounceRetryDelayMs` with a 10 s base / 60 s cap produces the sequence advertised in the config example.

If the maintainer would like a wider live-proof override (e.g. injecting an artificial channel failure into a Testbox lane), happy to add it as a follow-up commit — please let me know which lane and I'll plumb it.

## Scope

Files touched (all in-scope for the fix):

- `src/config/zod-schema.agent-defaults.ts` — Zod schema for the 3 new keys (additive, optional, `.strict()` block preserved).
- `src/config/types.agent-defaults.ts` — TypeScript types for the 3 new keys (additive, optional).
- `src/agents/subagent-registry-helpers.ts` — `resolveAnnounceRetryDelayMs` now takes optional `{ baseDelayMs, maxDelayMs }`; backward compatible (single-arg callers unchanged). Adds exported `DEFAULT_*` constants.
- `src/agents/subagent-announce-delivery.ts` — three new resolver functions mirroring `resolveSubagentAnnounceTimeoutMs`.
- `src/agents/subagent-registry-lifecycle.ts` — controller accepts three optional resolver callbacks; defaults match prior constants.
- `src/agents/subagent-registry.ts` — wires the resolvers to runtime config; updates `resumeSubagentRun` to honor the configurable cap and delay.
- `CHANGELOG.md` — Fixes entry.
- `src/agents/subagent-announce-retry-config.test.ts` — new test file (18 tests).

No other files modified. No behavioral change with default config.

---

*This PR is intentionally minimal — happy to follow up with the persistent-outbox direction if/when maintainers want to land that. Tagging this as the unblocker that users on flaky channels can deploy today without waiting for a larger refactor.*
