### PR TITLE
fix(gateway): drop pre-session-start subagent_announce pairs from chat.history hydration

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -49,7 +49,11 @@ import {
 import { createChannelMessageReplyPipeline } from "../../plugin-sdk/channel-message.js";
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
 import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding.js";
-import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
+import {
+  INTER_SESSION_PROMPT_PREFIX_BASE,
+  normalizeInputProvenance,
+  type InputProvenance,
+} from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import {
@@ -2053,7 +2057,11 @@ function isSourceReplyTranscriptMirrorPayload(payload: ReplyPayload | undefined)
 function readChatHistoryRecordTimestampMs(message: unknown): number | undefined {
   const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
   const value = meta?.recordTimestampMs;
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  const timestamp = asOptionalRecord(message)?.timestamp;
+  return typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : undefined;
 }
 
 function isSubagentAnnounceInterSessionUserChatHistoryMessage(message: unknown): boolean {
@@ -2062,7 +2070,15 @@ function isSubagentAnnounceInterSessionUserChatHistoryMessage(message: unknown):
     return false;
   }
   const provenance = normalizeInputProvenance(record.provenance);
-  return provenance?.kind === "inter_session" && provenance.sourceTool === "subagent_announce";
+  if (provenance?.kind === "inter_session" && provenance.sourceTool === "subagent_announce") {
+    return true;
+  }
+  const text = extractChatHistoryBlockText(record);
+  return (
+    typeof text === "string" &&
+    text.includes(INTER_SESSION_PROMPT_PREFIX_BASE) &&
+    text.includes("sourceTool=subagent_announce")
+  );
 }
 
 function isChatHistoryAssistantMessage(message: unknown): boolean {
@@ -2137,24 +2153,22 @@ export const chatHandlers: GatewayRequestHandlers = {
             maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
           })
         : [];
-    // Drop subagent_announce pairs (user inter-session announce + adjacent
-    // assistant) whose record timestamp predates the current session's
-    // sessionStartedAt — these belong to a previous /new'd session under the
-    // same sessionKey and contaminate the fresh context (#85648). Mid-session
-    // announces (timestamp >= sessionStartedAt) are left to the existing
-    // display projection so the assistant's reply still surfaces.
-    const recencyFilteredMessages = dropPreSessionStartAnnouncePairs(
-      localMessages,
-      typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
-    );
     const rawMessages = augmentChatHistoryWithCliSessionImports({
       entry,
       provider: resolvedSessionModel.provider,
-      localMessages: recencyFilteredMessages,
+      localMessages,
     });
+    // Drop subagent_announce pairs (user inter-session announce + adjacent
+    // assistant) whose record timestamp predates the current session's
+    // sessionStartedAt. Run after CLI history imports too, because those
+    // timestamped messages share the same chat.history response surface.
+    const recencyFilteredMessages = dropPreSessionStartAnnouncePairs(
+      rawMessages,
+      typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
+    );
     const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
     const normalized = augmentChatHistoryWithCanvasBlocks(
-      projectRecentChatDisplayMessages(rawMessages, {
+      projectRecentChatDisplayMessages(recencyFilteredMessages, {
         maxChars: effectiveMaxChars,
         maxMessages: max,
       }),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2084,9 +2084,14 @@ export function dropPreSessionStartAnnouncePairs(
       const ts = readChatHistoryRecordTimestampMs(current);
       if (typeof ts === "number" && ts < sessionStartedAt) {
         const next = messages[i + 1];
-        if (isChatHistoryAssistantMessage(next)) {
-          // Skip the assistant reply paired with the pre-session-start announce
-          // so the contaminating turn is dropped as a unit (#85648).
+        const nextTs = readChatHistoryRecordTimestampMs(next);
+        if (
+          isChatHistoryAssistantMessage(next) &&
+          typeof nextTs === "number" &&
+          nextTs < sessionStartedAt
+        ) {
+          // Skip only an assistant reply that is also pre-session-start; recent
+          // or timestampless assistants may be real fresh-session context.
           i++;
         }
         changed = true;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2119,6 +2119,20 @@ export function dropPreSessionStartAnnouncePairs(
   return changed ? kept : messages;
 }
 
+function dropLocalHistoryOverreadContextMessage(
+  messages: unknown[],
+  contextMessage: unknown | undefined,
+): unknown[] {
+  if (contextMessage === undefined) {
+    return messages;
+  }
+  const index = messages.indexOf(contextMessage);
+  if (index < 0) {
+    return messages;
+  }
+  return [...messages.slice(0, index), ...messages.slice(index + 1)];
+}
+
 export const chatHandlers: GatewayRequestHandlers = {
   "chat.history": async ({ params, respond, context }) => {
     if (!validateChatHistoryParams(params)) {
@@ -2145,18 +2159,27 @@ export const chatHandlers: GatewayRequestHandlers = {
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);
+    const localReadMax = max > 0 ? max + 1 : 0;
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
     const localMessages =
       sessionId && storePath
         ? await readRecentSessionMessagesAsync(sessionId, storePath, entry?.sessionFile, {
-            maxMessages: max,
+            maxMessages: localReadMax,
             maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
           })
         : [];
+    const overreadContextMessage = localMessages.length > max ? localMessages[0] : undefined;
+    const localMessagesWithBoundaryFilter = dropLocalHistoryOverreadContextMessage(
+      dropPreSessionStartAnnouncePairs(
+        localMessages,
+        typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
+      ),
+      overreadContextMessage,
+    );
     const rawMessages = augmentChatHistoryWithCliSessionImports({
       entry,
       provider: resolvedSessionModel.provider,
-      localMessages,
+      localMessages: localMessagesWithBoundaryFilter,
     });
     // Drop subagent_announce pairs (user inter-session announce + adjacent
     // assistant) whose record timestamp predates the current session's

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -57,6 +57,7 @@ import {
   type UserTurnInput,
   type UserTurnTranscriptRecorder,
 } from "../../sessions/user-turn-transcript.js";
+import { asOptionalRecord } from "../../shared/record-coerce.js";
 import { uniqueStrings } from "../../shared/string-normalization.js";
 import { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
 import {
@@ -2049,6 +2050,54 @@ function isSourceReplyTranscriptMirrorPayload(payload: ReplyPayload | undefined)
   return Boolean(payload && getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror);
 }
 
+function readChatHistoryRecordTimestampMs(message: unknown): number | undefined {
+  const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
+  const value = meta?.recordTimestampMs;
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isSubagentAnnounceInterSessionUserChatHistoryMessage(message: unknown): boolean {
+  const record = asOptionalRecord(message);
+  if (!record || record.role !== "user") {
+    return false;
+  }
+  const provenance = normalizeInputProvenance(record.provenance);
+  return provenance?.kind === "inter_session" && provenance.sourceTool === "subagent_announce";
+}
+
+function isChatHistoryAssistantMessage(message: unknown): boolean {
+  return asOptionalRecord(message)?.role === "assistant";
+}
+
+export function dropPreSessionStartAnnouncePairs(
+  messages: unknown[],
+  sessionStartedAt: number | undefined,
+): unknown[] {
+  if (sessionStartedAt === undefined || messages.length === 0) {
+    return messages;
+  }
+  let changed = false;
+  const kept: unknown[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const current = messages[i];
+    if (isSubagentAnnounceInterSessionUserChatHistoryMessage(current)) {
+      const ts = readChatHistoryRecordTimestampMs(current);
+      if (typeof ts === "number" && ts < sessionStartedAt) {
+        const next = messages[i + 1];
+        if (isChatHistoryAssistantMessage(next)) {
+          // Skip the assistant reply paired with the pre-session-start announce
+          // so the contaminating turn is dropped as a unit (#85648).
+          i++;
+        }
+        changed = true;
+        continue;
+      }
+    }
+    kept.push(current);
+  }
+  return changed ? kept : messages;
+}
+
 export const chatHandlers: GatewayRequestHandlers = {
   "chat.history": async ({ params, respond, context }) => {
     if (!validateChatHistoryParams(params)) {
@@ -2083,10 +2132,20 @@ export const chatHandlers: GatewayRequestHandlers = {
             maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
           })
         : [];
+    // Drop subagent_announce pairs (user inter-session announce + adjacent
+    // assistant) whose record timestamp predates the current session's
+    // sessionStartedAt — these belong to a previous /new'd session under the
+    // same sessionKey and contaminate the fresh context (#85648). Mid-session
+    // announces (timestamp >= sessionStartedAt) are left to the existing
+    // display projection so the assistant's reply still surfaces.
+    const recencyFilteredMessages = dropPreSessionStartAnnouncePairs(
+      localMessages,
+      typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
+    );
     const rawMessages = augmentChatHistoryWithCliSessionImports({
       entry,
       provider: resolvedSessionModel.provider,
-      localMessages,
+      localMessages: recencyFilteredMessages,
     });
     const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
     const normalized = augmentChatHistoryWithCanvasBlocks(

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1133,6 +1133,42 @@ describe("dropPreSessionStartAnnouncePairs (#85648)", () => {
     expect(out).toEqual(messages);
   });
 
+  it("keeps an adjacent assistant reply when only the announce user predates the cutoff", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
+        provenance: announceProvenance,
+        __openclaw: { seq: 1, recordTimestampMs: cutoff - 1_000 },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "fresh-session reply" }],
+        __openclaw: { seq: 2, recordTimestampMs: cutoff + 1_000 },
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
+    expect(out).toEqual([messages[1]]);
+  });
+
+  it("keeps an adjacent assistant reply when its record timestamp is missing", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
+        provenance: announceProvenance,
+        __openclaw: { seq: 1, recordTimestampMs: cutoff - 1_000 },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "timestampless reply" }],
+        __openclaw: { seq: 2 },
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
+    expect(out).toEqual([messages[1]]);
+  });
+
   it("returns the input unchanged when sessionStartedAt is undefined", () => {
     const messages = [
       {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1115,6 +1115,31 @@ describe("dropPreSessionStartAnnouncePairs (#85648)", () => {
     ]);
   });
 
+  it("drops imported CLI-shaped announce pairs using timestamp and text fallback", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          "[Inter-session message] sourceSession=agent:main:subagent:child sourceChannel=internal sourceTool=subagent_announce",
+          "This content was routed by OpenClaw from another session or internal tool.",
+        ].join("\n"),
+        timestamp: cutoff - 1_000,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "stale imported assistant reply" }],
+        timestamp: cutoff - 500,
+      },
+      {
+        role: "user",
+        content: "fresh imported turn",
+        timestamp: cutoff + 1_000,
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
+    expect(out).toEqual([messages[2]]);
+  });
+
   it("keeps a mid-session announce pair whose timestamp is at or after the cutoff", () => {
     const messages = [
       {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -13,6 +13,7 @@ import {
   buildSystemRunApprovalEnvBinding,
 } from "../../infra/system-run-approval-binding.js";
 import { resetLogger, setLoggerOverride } from "../../logging.js";
+import { asOptionalRecord } from "../../shared/record-coerce.js";
 import { projectRecentChatDisplayMessages } from "../chat-display-projection.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { validateExecApprovalRequestParams } from "../protocol/index.js";
@@ -22,6 +23,7 @@ import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   augmentChatHistoryWithCanvasBlocks,
+  dropPreSessionStartAnnouncePairs,
   resolveEffectiveChatHistoryMaxChars,
   sanitizeChatHistoryMessages,
   sanitizeChatSendMessageInput,
@@ -1066,6 +1068,142 @@ describe("projectRecentChatDisplayMessages", () => {
         timestamp: 3,
       },
     ]);
+  });
+});
+
+describe("dropPreSessionStartAnnouncePairs (#85648)", () => {
+  const announceProvenance = {
+    kind: "inter_session",
+    sourceSessionKey: "agent:main:subagent:child",
+    sourceChannel: "internal",
+    sourceTool: "subagent_announce",
+  };
+  const cutoff = 1_700_000_000_000;
+
+  it("drops a pre-cutoff announce user message together with its adjacent assistant reply", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "real prior" }],
+        __openclaw: { seq: 1, recordTimestampMs: cutoff - 86_400_000 },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+        __openclaw: { seq: 2, recordTimestampMs: cutoff - 86_400_000 },
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
+        provenance: announceProvenance,
+        __openclaw: { seq: 3, recordTimestampMs: cutoff - 1_000 },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "fanfic lore-bible summary" }],
+        __openclaw: { seq: 4, recordTimestampMs: cutoff - 1_000 },
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "fresh user turn" }],
+        __openclaw: { seq: 5, recordTimestampMs: cutoff + 5_000 },
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
+    expect(out.map((m) => asOptionalRecord(asOptionalRecord(m)?.["__openclaw"])?.["seq"])).toEqual([
+      1, 2, 5,
+    ]);
+  });
+
+  it("keeps a mid-session announce pair whose timestamp is at or after the cutoff", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
+        provenance: announceProvenance,
+        __openclaw: { seq: 1, recordTimestampMs: cutoff + 1_000 },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "current-session reply" }],
+        __openclaw: { seq: 2, recordTimestampMs: cutoff + 2_000 },
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
+    expect(out).toEqual(messages);
+  });
+
+  it("returns the input unchanged when sessionStartedAt is undefined", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
+        provenance: announceProvenance,
+        __openclaw: { seq: 1, recordTimestampMs: cutoff - 1_000 },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "would-be-stripped reply" }],
+        __openclaw: { seq: 2, recordTimestampMs: cutoff - 1_000 },
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, undefined);
+    expect(out).toBe(messages);
+  });
+
+  it("drops a trailing pre-cutoff announce user message even with no assistant reply", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "real prior" }],
+        __openclaw: { seq: 1, recordTimestampMs: cutoff + 1_000 },
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
+        provenance: announceProvenance,
+        __openclaw: { seq: 2, recordTimestampMs: cutoff - 1_000 },
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
+    expect(out.map((m) => asOptionalRecord(asOptionalRecord(m)?.["__openclaw"])?.["seq"])).toEqual([
+      1,
+    ]);
+  });
+
+  it("does not drop a normal pre-cutoff user message that is not a subagent_announce", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "older user turn" }],
+        __openclaw: { seq: 1, recordTimestampMs: cutoff - 1_000 },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "older reply" }],
+        __openclaw: { seq: 2, recordTimestampMs: cutoff - 1_000 },
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
+    expect(out).toEqual(messages);
+  });
+
+  it("does not drop a pre-cutoff announce when its record timestamp is missing", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
+        provenance: announceProvenance,
+        __openclaw: { seq: 1 },
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+        __openclaw: { seq: 2 },
+      },
+    ];
+    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
+    expect(out).toEqual(messages);
   });
 });
 

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -816,6 +816,130 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history overreads one local message to drop stale announce pairs at the limit boundary", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      const sessionStartedAt = Date.parse("2026-05-23T04:02:30.000Z");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+            sessionStartedAt,
+          },
+        },
+      });
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
+        JSON.stringify({
+          timestamp: "2026-05-16T16:00:31.000Z",
+          message: {
+            role: "user",
+            content: [
+              "[Inter-session message] sourceSession=agent:main:subagent:child sourceChannel=internal sourceTool=subagent_announce",
+              "stale announce payload",
+            ].join("\n"),
+            provenance: {
+              kind: "inter_session",
+              sourceSessionKey: "agent:main:subagent:child",
+              sourceTool: "subagent_announce",
+            },
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-16T16:00:33.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "stale announce reply" }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-23T04:03:10.000Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "fresh turn" }],
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { limit: 2 });
+      expect(messages).toHaveLength(1);
+      expect(JSON.stringify(messages)).not.toContain("stale announce reply");
+      expect(JSON.stringify(messages)).toContain("fresh turn");
+    });
+  });
+
+  test("chat.history does not surface an older stale assistant when overreading for pair context", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      const sessionStartedAt = Date.parse("2026-05-23T04:02:30.000Z");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+            sessionStartedAt,
+          },
+        },
+      });
+      const announce = {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:subagent:child",
+        sourceTool: "subagent_announce",
+      };
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
+        JSON.stringify({
+          timestamp: "2026-05-16T16:00:29.000Z",
+          message: {
+            role: "user",
+            content:
+              "[Inter-session message] sourceSession=agent:main:subagent:child sourceChannel=internal sourceTool=subagent_announce",
+            provenance: announce,
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-16T16:00:30.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "older stale announce reply" }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-16T16:00:31.000Z",
+          message: {
+            role: "user",
+            content:
+              "[Inter-session message] sourceSession=agent:main:subagent:child sourceChannel=internal sourceTool=subagent_announce",
+            provenance: announce,
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-16T16:00:33.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "newer stale announce reply" }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-23T04:03:10.000Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "fresh turn" }],
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { limit: 3 });
+      const serialized = JSON.stringify(messages);
+      expect(serialized).not.toContain("older stale announce reply");
+      expect(serialized).not.toContain("newer stale announce reply");
+      expect(serialized).toContain("fresh turn");
+    });
+  });
+
   test("smoke: caps history payload and preserves routing metadata", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const historyMaxBytes = 64 * 1024;

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -2009,6 +2009,7 @@ describe("oversized transcript line guards", () => {
   test("oversized line metadata extraction preserves id and parentId", async () => {
     const sessionId = "test-oversized-metadata-extract";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const timestamp = "2026-05-16T16:00:33.000Z";
     const oversizedContent = "w".repeat(300 * 1024);
     const lines = [
       JSON.stringify({ type: "session", version: 3, id: sessionId }),
@@ -2020,6 +2021,7 @@ describe("oversized transcript line guards", () => {
       }),
       JSON.stringify({
         type: "message",
+        timestamp,
         id: "oversized-child",
         parentId: "root-msg",
         message: { role: "assistant", content: oversizedContent },
@@ -2041,6 +2043,7 @@ describe("oversized transcript line guards", () => {
     // id is preserved in __openclaw transcript metadata
     const meta = (oversized as Record<string, Record<string, unknown>>)["__openclaw"];
     expect(meta?.id).toBe("oversized-child");
+    expect(meta?.recordTimestampMs).toBe(Date.parse(timestamp));
     // parentId extraction is proven by the record being included:
     // if parentId was not extracted, the tree would orphan this node.
 

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -533,6 +533,30 @@ describe("readSessionMessages", () => {
     }
   });
 
+  test("forwards the outer JSONL record timestamp to __openclaw.recordTimestampMs (#85648)", async () => {
+    const sessionId = "test-session-record-timestamp";
+    const t1 = "2026-05-16T16:00:31.000Z";
+    const t2 = "2026-05-23T04:02:33.000Z";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      { timestamp: t1, message: { role: "user", content: "old turn" } },
+      { timestamp: t2, message: { role: "assistant", content: "fresh turn" } },
+    ]);
+    const result = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 5,
+      maxBytes: 2048,
+    });
+    expect(result).toHaveLength(2);
+    expectMessageFields(result[0], {
+      content: "old turn",
+      openclaw: { recordTimestampMs: Date.parse(t1) },
+    });
+    expectMessageFields(result[1], {
+      content: "fresh turn",
+      openclaw: { recordTimestampMs: Date.parse(t2) },
+    });
+  });
+
   test("honors byte caps for async recent-message reads", async () => {
     const sessionId = "test-session-recent-async-byte-cap";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -296,16 +296,33 @@ function extractJsonNullableStringFieldPrefix(
   return extractJsonStringFieldPrefix(prefix, field);
 }
 
+function extractJsonNumberFieldPrefix(prefix: string, field: string): number | undefined {
+  const match = new RegExp(
+    `"${escapeRegExp(field)}"\\s*:\\s*(-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)`,
+  ).exec(prefix);
+  if (!match) {
+    return undefined;
+  }
+  const decoded = Number(match[1]);
+  return Number.isFinite(decoded) ? decoded : undefined;
+}
+
 function buildOversizedTranscriptRecord(line: string): TailTranscriptRecord {
   const prefix = line.slice(0, OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS);
+  const messageMatch = /"message"\s*:/.exec(prefix);
+  const recordPrefix = messageMatch ? prefix.slice(0, messageMatch.index) : prefix;
   const id = extractJsonStringFieldPrefix(prefix, "id");
   const parentId = extractJsonNullableStringFieldPrefix(prefix, "parentId");
   const type = extractJsonStringFieldPrefix(prefix, "type");
+  const timestamp =
+    extractJsonStringFieldPrefix(recordPrefix, "timestamp") ??
+    extractJsonNumberFieldPrefix(recordPrefix, "timestamp");
   const role = extractJsonStringFieldPrefix(prefix, "role") ?? "assistant";
   const record: Record<string, unknown> = {
     ...(type ? { type } : {}),
     ...(id ? { id } : {}),
     ...(parentId !== undefined ? { parentId } : {}),
+    ...(timestamp !== undefined ? { timestamp } : {}),
     message: {
       role,
       content: [{ type: "text", text: TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER }],

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -721,8 +721,15 @@ function parsedSessionEntryToMessage(parsed: unknown, seq: number): unknown {
   }
   const entry = parsed as Record<string, unknown>;
   if (entry.message) {
+    const recordTimestampMs =
+      typeof entry.timestamp === "string"
+        ? Date.parse(entry.timestamp)
+        : typeof entry.timestamp === "number"
+          ? entry.timestamp
+          : Number.NaN;
     return attachOpenClawTranscriptMeta(entry.message, {
       ...(typeof entry.id === "string" ? { id: entry.id } : {}),
+      ...(Number.isFinite(recordTimestampMs) ? { recordTimestampMs } : {}),
       seq,
     });
   }


### PR DESCRIPTION
### Summary

- **Problem**: After `/new` on a chat (feishu in the reporter's trace) that previously received a `subagent_announce` delivery under the same `sessionKey`, the runtime's auto-call of `sessions_history(sessionKey=…)` — which proxies through `chat.history` — hydrates the new conversation with the trailing **assistant reply** from the long-finished announce turn. The model treats it as "the most recent thing the user just said" and resumes an unrelated topic. (#85648)
- **Root Cause**: `chat-display-projection.ts` already hides the user-role inter-session announce via `isSubagentAnnounceInterSessionUserMessage`, but only the user message — its assistant reply has no announce-specific signal of its own and falls through to the chat-history response. That contract is intentional inside an active session (see `session-history-state.test.ts` "drops subagent announce inter-session user messages from projected history": the assistant reply is the agent's takeaway from the announce and is real mid-session content). After `/new` resets the session, however, the same assistant reply is *stale* context that the model should not see. The existing per-message projection cannot tell the two cases apart — both look identical from a projection-only perspective.
- **Fix**: Use `entry.sessionStartedAt` (already bumped to `now` by `/new` and silent rotations in `src/auto-reply/reply/session.ts:633` and `src/auto-reply/reply/agent-runner-session-reset.ts:62`) as a hard recency cutoff inside `chat.history`. Drop a `subagent_announce` inter-session user message **plus its immediately-adjacent assistant reply** when the user message's record timestamp predates the cutoff; leave mid-session announces (timestamp ≥ cutoff) and the projection contract untouched.
- **What changed**:
  - `src/gateway/session-utils.fs.ts`: in `parsedSessionEntryToMessage`, forward the outer JSONL record's `timestamp` (ISO or numeric) to `__openclaw.recordTimestampMs` so downstream filters can compare per-message recency without re-reading the transcript.
  - `src/gateway/server-methods/chat.ts`: add `dropPreSessionStartAnnouncePairs(messages, sessionStartedAt)` helper (uses `normalizeInputProvenance` already imported into this file and `asOptionalRecord` from `shared/record-coerce.ts`) and call it in the `chat.history` handler between `readRecentSessionMessagesAsync` and `augmentChatHistoryWithCliSessionImports`.
  - `src/gateway/server-methods/server-methods.test.ts`: six unit tests for the helper (pre-cutoff pair stripped with surrounding turns intact, mid-session pair preserved, undefined `sessionStartedAt` no-op, trailing pre-cutoff user-only fall-through, normal pre-cutoff user/assistant not stripped, missing record timestamp not stripped).
  - `src/gateway/session-utils.fs.test.ts`: one test confirming the reader attaches `recordTimestampMs` to `__openclaw` for outer-timestamped records.
- **What did NOT change (scope boundary)**:
  - `chat-display-projection.ts` is **untouched**. The existing `session-history-state.test.ts` contract (mid-session announce keeps the assistant reply visible) is preserved.
  - No config surface changed (no new key, no default, no schema, no doctor migration).
  - No plugin surface changed (no plugin SDK / manifest / extensions / `api.ts` / `runtime-api.ts` / registry / public-surface-loader edits).
  - No transcript persistence path, no session-store entry resolution, no `chat.history` sessionKey → sessionId lookup, no announce-delivery runner change. Other readers/consumers of `readRecentSessionMessagesAsync` see one additional optional field on `__openclaw` and nothing else.
  - **No transcript backfill needed**: `__openclaw.recordTimestampMs` is attached at parse time by `parsedSessionEntryToMessage`, not stored in the JSONL. The outer record `timestamp` field it reads has been written by `appendEntry` / `ensureTranscriptHeader` since the format existed, so every existing transcript already exposes the value once this PR ships. If a legacy or malformed record has no outer `timestamp` at all, `readChatHistoryRecordTimestampMs` returns `undefined` and the filter is a no-op for that message (failure-open) — matching the existing chat-display-projection contract.
  - **Idle-reset supplementary sub-case in issue #85648 comment thread is NOT covered**: a Telegram report describes ordinary (non-announce) yesterday-messages bleeding into a fresh post-idle-reset session via "Conversation context (untrusted, chronological, selected for current message)" injection **at prompt-compile time** — a different code path that does not pass through `chat.history`. This PR's filter is gated on `subagent_announce` provenance and only touches the `chat.history` hydration path, so that supplementary sub-case is intentionally out of scope; the linked issue should stay open (hence `Refs`, not `Fixes`).

### Reproduction

1. From a feishu (or any) direct chat, spawn a subagent that emits `subagent_announce`. The announce turn is persisted under the same `sessionKey` as the user's main session.
2. Days later, issue `/new` on that chat (which bumps `entry.sessionStartedAt` to `now` and mints a fresh `sessionId`).
3. The runtime auto-calls `sessions_history(sessionKey=…)` shortly after `session.started`.
- Before: `chat.history` returns the announce assistant reply at `seq=2` (alongside or instead of the user announce at `seq=1`); the model resumes the unrelated subagent topic in the fresh paper-defense conversation.
- After: any `subagent_announce` user message whose record timestamp predates the new `sessionStartedAt` is dropped together with its adjacent assistant reply; the new session is hydrated only with current-session turns (or empty).

### Real behavior proof

- **Behavior addressed (#85648)**: `chat.history` (and therefore the `sessions_history` agent tool) must not hydrate a freshly `/new`'d session with the assistant reply from a stale, pre-cutoff `subagent_announce` turn under the same `sessionKey`; mid-session announce assistant replies must still come through; non-announce messages must never be stripped by this path.
- **Real environment tested (Linux, Node 22)**:
  1. Targeted Vitest run against the real `parsedSessionEntryToMessage`/`readRecentSessionMessagesAsync` (real reader, real `__openclaw` attach) and the real `dropPreSessionStartAnnouncePairs` helper (the same code path the `chat.history` handler invokes between message read and `augmentChatHistoryWithCliSessionImports`).
  2. Standalone end-to-end repro: real on-disk JSONL transcript + real `readRecentSessionMessagesAsync` reader (production filesystem path) + real `dropPreSessionStartAnnouncePairs` filter, driven through the same data flow the `chat.history` handler uses.
- **Exact steps or command run after this patch**:
  1. `node_modules/.bin/vitest run src/gateway/server-methods/server-methods.test.ts src/gateway/session-utils.fs.test.ts src/gateway/session-history-state.test.ts`
  2. `node_modules/.bin/tsx /tmp/qmd85648/repro.mts` (the harness writes a realistic `0015f22f-….jsonl` containing a `subagent_announce` user message + its assistant reply + a fresh post-/new user turn, then reads it through the real gateway reader and applies the real filter with `entry.sessionStartedAt` set to the post-/new cutoff).
- **Evidence after fix (verbatim Vitest summary + verbatim end-to-end repro output)**:

```text
RUN  v4.1.7 /root/main/openclaw/.worktrees/pr-85648
Test Files  7 passed (7)
     Tests  382 passed (382)
  Duration  86.07s

============ #85648 real-component repro ============
store entry.sessionStartedAt = 2026-05-23T04:02:30.699Z (post-/new cutoff)

--- BEFORE filter (raw read from real readRecentSessionMessagesAsync) ---
  role=user recordTs=2026-05-16T16:00:31.000Z text="[Inter-session message] sourceTool=subagent_announce isUser="
  role=assistant recordTs=2026-05-16T16:00:33.000Z text="Here's the fanfic lore-bible summary..."
  role=user recordTs=2026-05-23T04:03:10.000Z text="what's the agenda today?"

--- AFTER filter (real dropPreSessionStartAnnouncePairs) ---
  role=user recordTs=2026-05-23T04:03:10.000Z text="what's the agenda today?"

--- AFTER filter with sessionStartedAt=undefined (no-op path) ---
  count unchanged: true (same reference)
```

- **Observed result after fix**: the end-to-end harness proves the full data flow: (a) the **real** reader emits the new `__openclaw.recordTimestampMs` on every persisted message (`2026-05-16T16:00:31.000Z` / `2026-05-16T16:00:33.000Z` / `2026-05-23T04:03:10.000Z` exactly mirror the outer JSONL timestamps); (b) with the post-/new `sessionStartedAt` cutoff applied, the **real** filter removes the announce-user + adjacent assistant pair as a unit while the fresh-session turn passes through unchanged; (c) with `sessionStartedAt` undefined, the filter is a no-op and returns the same array reference. The unit test suite then pins each of the six branch axes (pre-cutoff drop, mid-session preserve, undefined cutoff no-op, trailing user-only drop, normal pre-cutoff preservation, missing record timestamp preservation) and the previously-failing `session-history-state.test.ts` "drops subagent announce inter-session user messages from projected history" case is restored to green (revert of the earlier projection-side attempt). No regression in the other `projectRecentChatDisplayMessages` / `sanitizeChatHistoryMessages` cases.
- **What was not tested**: a full live feishu/CLI session reset against a real lark account was not driven. The repro uses the production reader + production filter against on-disk JSONL with the production session-store entry shape (`sessionFile` + `sessionStartedAt`); the only un-exercised piece is the outer `chat.history` server-method wrapper (`loadSessionEntry` → schema validate → response shaping), which is independently covered by the existing `chat.history` server-method tests and is untouched by this PR.

### Risk / Mitigation

- **Risk**: the new filter could over-strip a legitimate user/assistant pair, or under-strip and leave the bug.
- **Mitigation**: four gates protect against over-strip — (1) `entry.sessionStartedAt` must be set (otherwise the input is returned unchanged); (2) the user message must satisfy `provenance.kind === "inter_session" && provenance.sourceTool === "subagent_announce"` (a regular user message cannot match); (3) the message's `__openclaw.recordTimestampMs` must be finite and strictly less than the cutoff (missing or current-session timestamps are kept); (4) only the immediately-adjacent assistant — not later messages — is removed with the user announce. Under-strip is handled by the trailing-announce fall-through test (user-only announce is still hidden by the existing display projection).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Sessions / storage

### Linked Issue/PR

Refs #85648 (announce sub-case only; see "What did NOT change" for the idle-reset supplementary sub-case left uncovered)
