### PR TITLE
fix(auto-reply): compose channel beforeDeliver with message_sending instead of overriding it

### DIFF
--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
+import type { ReplyPayload } from "./types.js";
 
 type DispatchReplyFromConfigFn =
   typeof import("./reply/dispatch-from-config.js").dispatchReplyFromConfig;
@@ -307,6 +308,105 @@ describe("withReplyDispatcher", () => {
         conversationId: "conv-1",
       },
     );
+  });
+
+  // Gap 8: the buffered dispatcher path (used by the Telegram channel via
+  // dispatchReplyWithBufferedBlockDispatcher) must COMPOSE the canonical
+  // message_sending gate with any channel-supplied beforeDeliver — canonical
+  // first — rather than letting the channel's beforeDeliver override it. The
+  // Telegram channel passes an identity no-op `beforeDeliver` (bot-message-
+  // dispatch.ts); under the old `??` wiring that silently discarded the gate,
+  // so message_sending never fired for interactive replies.
+  type ChannelBeforeDeliver = (payload: ReplyPayload) => Promise<ReplyPayload | null>;
+
+  const runBufferedDispatch = async (opts: {
+    runMessageSending: ReturnType<typeof vi.fn>;
+    channelBeforeDeliver?: ChannelBeforeDeliver;
+  }) => {
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName?: string) => hookName === "message_sending"),
+      runMessageSending: opts.runMessageSending,
+    });
+    hoisted.createReplyDispatcherWithTypingMock.mockReturnValueOnce({
+      dispatcher: createDispatcher([]),
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    });
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+
+    await dispatchInboundMessageWithBufferedDispatcher({
+      ctx: buildTestCtx({ From: "telegram:1155284475", To: "telegram:1155284475" }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        ...(opts.channelBeforeDeliver ? { beforeDeliver: opts.channelBeforeDeliver } : {}),
+        deliver: async () => undefined,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    const beforeDeliver = lastTypingDispatcherOptions().beforeDeliver;
+    if (!beforeDeliver) {
+      throw new Error("expected a composed beforeDeliver on the buffered dispatcher");
+    }
+    return beforeDeliver;
+  };
+
+  it("fires message_sending when no channel beforeDeliver is supplied (baseline)", async () => {
+    const runMessageSending = vi.fn(async () => ({ content: "sanitized reply" }));
+    const beforeDeliver = await runBufferedDispatch({ runMessageSending });
+    const payload = await beforeDeliver({ text: "original reply" }, { kind: "final" });
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(payload).toEqual({ text: "sanitized reply" });
+  });
+
+  it("Gap 8 regression: fires message_sending exactly once even when the channel supplies a no-op beforeDeliver", async () => {
+    const runMessageSending = vi.fn(async () => ({ content: "sanitized reply" }));
+    // The live Telegram channel (bot-message-dispatch.ts) passes this identity no-op.
+    const beforeDeliver = await runBufferedDispatch({
+      runMessageSending,
+      channelBeforeDeliver: async (payload) => payload,
+    });
+    const payload = await beforeDeliver({ text: "original reply" }, { kind: "final" });
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(payload).toEqual({ text: "sanitized reply" });
+  });
+
+  it("composes canonical-first: the channel beforeDeliver sees the gated payload", async () => {
+    const runMessageSending = vi.fn(async () => ({ content: "sanitized reply" }));
+    const channelSaw: string[] = [];
+    const beforeDeliver = await runBufferedDispatch({
+      runMessageSending,
+      channelBeforeDeliver: async (payload) => {
+        channelSaw.push(payload.text ?? "");
+        return { ...payload, text: `${payload.text} [ch]` };
+      },
+    });
+    const payload = await beforeDeliver({ text: "original reply" }, { kind: "final" });
+    // Canonical gate ran first (sanitized the model output); the channel transform
+    // then saw the gated payload; the final reply reflects both, canonical-first.
+    expect(channelSaw).toEqual(["sanitized reply"]);
+    expect(payload).toEqual({ text: "sanitized reply [ch]" });
+  });
+
+  it("canonical veto is terminal: a message_sending cancel skips the channel beforeDeliver", async () => {
+    const runMessageSending = vi.fn(async () => ({ cancel: true }));
+    const channelBeforeDeliver = vi.fn(async (payload: ReplyPayload) => payload);
+    const beforeDeliver = await runBufferedDispatch({ runMessageSending, channelBeforeDeliver });
+    const payload = await beforeDeliver({ text: "original reply" }, { kind: "final" });
+    expect(payload).toBeNull();
+    expect(channelBeforeDeliver).not.toHaveBeenCalled();
+  });
+
+  it("channel veto is terminal: a null from the channel beforeDeliver cancels delivery after gating", async () => {
+    const runMessageSending = vi.fn(async () => undefined); // canonical passes the payload through
+    const beforeDeliver = await runBufferedDispatch({
+      runMessageSending,
+      channelBeforeDeliver: async () => null,
+    });
+    const payload = await beforeDeliver({ text: "original reply" }, { kind: "final" });
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(payload).toBeNull();
   });
 
   it("reconciles queuedFinal and counts after dispatcher-side cancellation", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -323,6 +323,40 @@ function buildMessageSendingBeforeDeliver(
   };
 }
 
+/**
+ * Compose the canonical `message_sending` gate with a channel-supplied
+ * `beforeDeliver`, canonical-first. The gate runs on the model's outbound
+ * payload; the channel transform then runs on the gated result, so the
+ * canonical gate always sees the model's raw outbound payload before any
+ * channel-specific transform can mutate it.
+ *
+ * A `null` (veto) from either side is terminal: a canonical veto skips the
+ * channel transform and cancels delivery; a channel veto cancels delivery too
+ * (preserving existing channel-side veto semantics).
+ *
+ * This replaces the previous `??` wiring, under which a channel-supplied
+ * `beforeDeliver` — even an identity no-op — silently discarded the canonical
+ * gate, so `message_sending` never fired for that channel's replies.
+ */
+function composeBeforeDeliver(
+  canonical: ReplyDispatchBeforeDeliver | undefined,
+  channel: ReplyDispatchBeforeDeliver | undefined,
+): ReplyDispatchBeforeDeliver | undefined {
+  if (!canonical) {
+    return channel;
+  }
+  if (!channel) {
+    return canonical;
+  }
+  return async (payload, info) => {
+    const gated = await canonical(payload, info);
+    if (!gated) {
+      return null;
+    }
+    return await channel(gated, info);
+  };
+}
+
 function buildDispatchTimelineAttributes(ctx: MsgContext | FinalizedMsgContext) {
   const commandTurn = resolveCommandTurnContext(ctx);
   return {
@@ -437,8 +471,10 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   const finalized = finalizeInboundContext(params.ctx);
   const foregroundReplyFence = beginForegroundReplyFence(finalized);
   const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
-  const configuredBeforeDeliver =
-    params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized);
+  const configuredBeforeDeliver = composeBeforeDeliver(
+    buildMessageSendingBeforeDeliver(finalized),
+    params.dispatcherOptions.beforeDeliver,
+  );
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
       ? async (payload, info) => {
@@ -519,8 +555,10 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   const silentReplyContext = resolveDispatcherSilentReplyContext(params.ctx, params.cfg);
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,
-    beforeDeliver:
-      params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(params.ctx),
+    beforeDeliver: composeBeforeDeliver(
+      buildMessageSendingBeforeDeliver(params.ctx),
+      params.dispatcherOptions.beforeDeliver,
+    ),
     silentReplyContext: params.dispatcherOptions.silentReplyContext ?? silentReplyContext,
   });
   return await dispatchInboundMessage({


### PR DESCRIPTION
# Compose `message_sending` hook with channel-supplied `beforeDeliver` instead of `??`-overriding

## Summary

The two dispatch wiring sites at `src/auto-reply/dispatch.ts:438` and `:516` use a `??` short-circuit:

```ts
const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized);
```

This means any channel that supplies its own `beforeDeliver` — even an identity no-op — silently disables `message_sending`. The Telegram channel currently does exactly this at `extensions/telegram/src/bot-message-dispatch.ts:1649`, passing `async (payload) => payload`, which prevents `message_sending` from firing on interactive replies through the buffered dispatch path.

## The maintainer question this PR poses

I haven't been able to find a comment, test, or prior PR documenting a rationale for the `??`-override semantics. The doc comments around the channel `beforeDeliver` callers concern delivery routing and durability, not hook gating. My read is that the override semantics are incidental — the wiring pattern happened to be `??` rather than composition, and no caller is intentionally relying on `beforeDeliver` to replace canonical `message_sending` wiring.

If that read is correct, this PR restores consistency by composing the two `beforeDeliver`s instead of letting one silently override the other.

If that read is wrong — if there's a constraint I'm missing, or a caller that intentionally suppresses `message_sending` via this mechanism — please point me at it and I'll adapt the approach.

## The fix

Introduces a `composeBeforeDeliver` helper:

```ts
function composeBeforeDeliver(
  canonical: ReplyDispatchBeforeDeliver | undefined,
  channel: ReplyDispatchBeforeDeliver | undefined,
): ReplyDispatchBeforeDeliver | undefined {
  if (!canonical) return channel;
  if (!channel) return canonical;
  return async (payload, info) => {
    const gated = await canonical(payload, info);
    if (!gated) return null;
    return await channel(gated, info);
  };
}
```

Applied at both wiring sites in place of `??`. Semantics:

- **Canonical-first ordering.** `buildMessageSendingBeforeDeliver` runs first so the `message_sending` hook sees the model's outbound payload before any channel-specific transform. Channel transforms then operate on the gated payload. Rationale: gates assert properties about the model's output; channel transforms (formatting, decoration) should see the gated payload, not transform the payload before gating. This matches the ordering on the standard outbound path, where `deliverOutboundPayloads` runs `message_sending` before downstream presentation/normalization.
- **Either veto is terminal.** If the canonical hook returns `null` (gate veto), the channel's `beforeDeliver` is not invoked. If the channel's `beforeDeliver` returns `null`, delivery is cancelled. This preserves existing veto semantics on both sides.
- **Either side absent → pass-through.** If no canonical hook (shouldn't happen on this path, but defensively), use the channel's. If no channel `beforeDeliver`, use canonical alone — current behavior for callers that don't supply one.

## Tests

Five new tests in `src/auto-reply/dispatch.test.ts`:

1. **Baseline (existing behavior preserved):** when no channel `beforeDeliver` is supplied, `message_sending` fires on the buffered path.
2. **Gap regression lock:** with a channel-supplied no-op `beforeDeliver` (matching Telegram's pattern), `message_sending` fires exactly once. This is the inverted form of the bug-characterizing test that originally demonstrated the issue.
3. **Canonical-first composition:** with a non-no-op channel `beforeDeliver` that mutates the payload, both run; the channel sees the canonically-gated payload; final delivered payload reflects both transforms in the correct order.
4. **Canonical veto terminates:** canonical hook returns `null` → no delivery, channel `beforeDeliver` not invoked.
5. **Channel veto terminates:** canonical hook passes payload through, channel `beforeDeliver` returns `null` → no delivery.

Full auto-reply suite continues to pass with no regressions. Typecheck clean.

## Empirical validation

The patch has been applied to a local OpenClaw build (forked from v2026.5.18, rebased onto current main for this PR) and verified live: prior to the fix, interactive replies on the Telegram channel produced no `message_sending` events in observability logs while scheduled/cron sends did. After the fix, the interactive reply path fired `message_sending` (verified live). This was the original symptom that motivated the investigation.

## Not covered (acknowledged for follow-up)

The bundled `thread-ownership` extension is a `message_sending` consumer that the unit-level test suite cannot exercise (the tests mock `runMessageSending` at the layer where the extension's hook would register). A regression test for `thread-ownership` behavior with `message_sending` firing on the interactive path belongs at the extension/integration test level. I haven't added one in this PR; happy to follow up with one in this PR or a separate one, per your preference.

## Why this matters

The `message_sending` hook is the chokepoint that downstream consumers — gates, audit logging, observation extensions — register on to inspect or modify outbound replies before delivery. The current `??` pattern means any channel that supplies its own `beforeDeliver` for unrelated reasons (formatting, durability, identity passthrough) silently disables all such consumers on that channel's traffic. For deployments that rely on `message_sending` for correctness or safety properties, this is a coverage gap that's invisible until something happens that the hook would have caught.

The fix preserves all existing channel `beforeDeliver` behavior; it just ensures `message_sending` always composes in alongside it.



---

## Real behavior proof

This exercises the patched dispatch path end to end — the real exported `dispatchInboundMessageWithBufferedDispatcher`, the real `composeBeforeDeliver` / `buildMessageSendingBeforeDeliver`, and a real global hook runner with a real `message_sending` hook registered through `initializeGlobalHookRunner`. Only the I/O edges are substituted (the network send and the model text), plus the identity no-op `beforeDeliver` the Telegram channel itself passes.

**Behavior or issue addressed:** A channel-supplied identity no-op `beforeDeliver` — `async (payload) => payload`, the exact value `extensions/telegram/src/bot-message-dispatch.ts` passes — silently discarded the canonical `message_sending` gate under the old `??` wiring, so the gate never ran on interactive replies through the buffered dispatch path. This patch composes the two canonical-first.

**Real environment tested:** A clean checkout of this PR head, built with its own dependencies, run on Node v25.6.0 in an isolated home — `OPENCLAW_HOME` pointed at an empty directory and bundled plugins disabled — so no external configuration or plugins loaded.

**Exact steps or command run after this patch:** Registered a real `message_sending` hook in a real plugin registry via `initializeGlobalHookRunner`, then invoked the real `dispatchInboundMessageWithBufferedDispatcher` with a channel `beforeDeliver` of `async (payload) => payload` and a recording `deliver`, driven by `node --import tsx`. Repeated against current `openclaw/main` (without this patch) for the before/after contrast.

**Evidence after fix:**
```
Node v25.6.0  |  openclaw/main (no fix) 6966c202b9  |  PR #86891 head 96132e4570

======================================================================
BEFORE  (openclaw/main @ 6966c202b9 — no fix, the '??' wiring)
======================================================================
      RESULT → message_sending fired 0 time(s)
      RESULT → delivered payload = {"text":"original model reply"}
      VERDICT → gate NEVER fired; channel no-op discarded it ❌ (the bug)

======================================================================
AFTER  (PR #86891 @ 96132e4570 — composeBeforeDeliver)
======================================================================
      ↳ message_sending hook FIRED (#1); inbound content = "original model reply"
      RESULT → message_sending fired 1 time(s)
      RESULT → delivered payload = {"text":"[gated] original model reply"}
      VERDICT → gate FIRED and gated text reached delivery ✅
```

**Observed result after fix:** On current `openclaw/main`, the gate fires 0 times and the raw payload reaches `deliver`. With this patch, the gate fires exactly once, transforms the payload, and the gated result (`[gated] …`) reaches `deliver` — canonical-first, ahead of the channel no-op.

**What was not tested:** The full live network send over a real Telegram connection was deliberately not exercised, to avoid putting private identifiers (host, chat IDs) into a public PR. The dispatch composition this patch changes is covered above; I'm happy to provide the full interactive path on request.
