### PR TITLE
Fix isolated cron cold runner setup timeout

### DIFF
--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1573,6 +1573,72 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("allows long isolated cron jobs more setup time for cold runner startup", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-10T09:02:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "isolated-cold-runner-setup",
+        name: "cold runner setup",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 1080 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      let settled = false;
+      let abortObserved = false;
+      const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        cleanupTimedOutAgentRun,
+        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+          started.resolve();
+          abortSignal?.addEventListener(
+            "abort",
+            () => {
+              abortObserved = true;
+            },
+            { once: true },
+          );
+          return await new Promise<never>(() => {});
+        }),
+      });
+
+      const timerPromise = onTimer(state).finally(() => {
+        settled = true;
+      });
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      expect(settled).toBe(false);
+      expect(abortObserved).toBe(false);
+      expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(240_000);
+      now += 240_000;
+      await timerPromise;
+
+      const job = requireJob(state, "isolated-cold-runner-setup");
+      expect(abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("setup timed out before runner start");
+      expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("times out isolated agent runs that stall before execution starts (#74803)", async () => {
     vi.useFakeTimers();
     try {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -69,7 +69,8 @@ export { DEFAULT_JOB_TIMEOUT_MS } from "./timeout-policy.js";
 
 const MAX_TIMER_DELAY_MS = 60_000;
 const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
-const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
+const CRON_AGENT_SETUP_MIN_WATCHDOG_MS = 60_000;
+const CRON_AGENT_SETUP_MAX_WATCHDOG_MS = 5 * 60_000;
 const CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
 const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
 
@@ -302,7 +303,7 @@ function createCronAgentWatchdog(params: {
           if (state === "waiting_for_runner") {
             setTimedOut(setupTimeoutErrorMessage(activeExecution));
           }
-        }, CRON_AGENT_SETUP_WATCHDOG_MS);
+        }, resolveCronAgentSetupWatchdogMs(params.jobTimeoutMs));
         return;
       }
       startTimeout();
@@ -398,6 +399,13 @@ function preExecutionTimeoutErrorMessage(execution?: CronAgentExecutionStarted):
 
 function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): string | undefined {
   return formatEmbeddedAgentExecutionPhase(execution?.phase);
+}
+
+function resolveCronAgentSetupWatchdogMs(jobTimeoutMs: number): number {
+  return Math.max(
+    CRON_AGENT_SETUP_MIN_WATCHDOG_MS,
+    Math.min(CRON_AGENT_SETUP_MAX_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2)),
+  );
 }
 
 function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number): number {


### PR DESCRIPTION
## Summary
- let long isolated cron jobs wait up to 5 minutes for cold Codex runner setup
- keep the existing 60s setup watchdog floor for short jobs
- add regression coverage for the long-job watchdog window

## Tests
- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts`

## Real behavior proof
Behavior addressed: isolated cron agent-turn setup no longer aborts at the old fixed 60s runner-start watchdog when the job has a longer timeout budget; the run stays alive past 60s and then reaches the new bounded setup timeout.

Real environment tested: local OpenClaw cron runtime on PR head `2c969858b6389c7e3e056c1a5e51ab894868bc6b`, macOS, Node 26.0.0, isolated temp cron store, no external credentials or network services.

Exact steps or command run after this patch: ran a real-time `node --import tsx --input-type=module` script from the PR checkout that instantiated `CronService`, created an isolated `agentTurn` cron job with `timeoutSeconds: 130`, started a manual run, withheld the runner-start signal, sampled state after 61s, then let cron reach the derived setup bound.

Evidence after fix: copied terminal output from the real-time cron runtime run:

```json
{
  "openclawHead": "2c969858b6389c7e3e056c1a5e51ab894868bc6b",
  "scenario": "isolated cron agent-turn waits before runner start",
  "configuredTimeoutSeconds": 130,
  "expectedPatchedSetupBoundMs": 65000,
  "after61s": {
    "elapsedMs": 61035,
    "runnerHookEnteredMs": 41,
    "abortObserved": false,
    "cleanupCalls": 0
  },
  "final": {
    "elapsedMs": 65067,
    "abortObservedAtMs": 65044,
    "cleanupCalls": 1,
    "cleanupTimeoutMs": 130000,
    "runResult": {
      "ok": true,
      "ran": true
    },
    "lastRunStatus": "error",
    "lastStatus": "error",
    "lastError": "cron: isolated agent setup timed out before runner start",
    "persistedJobs": 1
  },
  "events": [
    {
      "action": "started",
      "elapsedMs": 34,
      "jobId": "2ddaca0a-a12e-4b7c-b7d9-2ab0746ee121"
    },
    {
      "elapsedMs": 65061,
      "level": "warn",
      "message": "cron: job run returned error status",
      "payload": {
        "jobId": "2ddaca0a-a12e-4b7c-b7d9-2ab0746ee121",
        "jobName": "PR 86893 live setup-window proof",
        "error": "cron: isolated agent setup timed out before runner start",
        "diagnosticsSummary": "cron: isolated agent setup timed out before runner start"
      }
    },
    {
      "action": "finished",
      "elapsedMs": 65062,
      "jobId": "2ddaca0a-a12e-4b7c-b7d9-2ab0746ee121",
      "status": "error",
      "error": "cron: isolated agent setup timed out before runner start",
      "durationMs": 65014
    }
  ]
}
```

Observed result after fix: at 61.035s cron had not aborted and cleanup had not run; at about 65.044s cron aborted the pre-runner setup phase and recorded `cron: isolated agent setup timed out before runner start`, matching the patched derived bound for a 130s isolated job instead of the previous fixed 60s abort.

What was not tested: a full external Codex provider cold start with live model credentials was not run; this proof isolates the cron watchdog path before runner start, which is the changed runtime behavior.
