### PR TITLE
fix(context-engine): resolve turn-maintenance livelock on Telegram DM sessions (#77340)

### DIFF
--- a/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
@@ -535,16 +535,17 @@ describe("runContextEngineMaintenance", () => {
         resetTaskFlowRegistryForTests({ persist: false });
 
         const sessionKey = "agent:main:session-1";
-        const sessionLane = resolveSessionLane(sessionKey);
-        let releaseForeground: (() => void) | undefined;
-        const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
-          await new Promise<void>((resolve) => {
-            releaseForeground = resolve;
-          });
+        // Block maintain() itself so we can observe the queued/pending task
+        // before maintenance completes. Under the maintenance-lane fix
+        // (#77340) the worker no longer waits for the session lane, so we
+        // gate maintain() instead of holding the session lane busy.
+        let releaseMaintain: (() => void) | undefined;
+        const maintainGate = new Promise<void>((resolve) => {
+          releaseMaintain = resolve;
         });
-        await Promise.resolve();
 
         const maintain = vi.fn(async (params?: unknown) => {
+          await maintainGate;
           await (
             params as { runtimeContext?: ContextEngineRuntimeContext } | undefined
           )?.runtimeContext?.rewriteTranscriptEntries?.({
@@ -595,8 +596,9 @@ describe("runContextEngineMaintenance", () => {
           config: { session: { writeLock: { acquireTimeoutMs: 91_000 } } },
         });
 
+        // runContextEngineMaintenance returns immediately after scheduling
+        // the deferred worker on its dedicated maintenance lane.
         expect(result).toBeUndefined();
-        expect(maintain).not.toHaveBeenCalled();
 
         const queuedTasks = listTasksForOwnerKey(sessionKey).filter(
           (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
@@ -613,11 +615,16 @@ describe("runContextEngineMaintenance", () => {
           deliveryStatus: "pending",
         });
 
-        if (!releaseForeground) {
-          throw new Error("Expected foreground turn release callback to be initialized");
-        }
-        releaseForeground();
+        // Maintain runs on its own maintenance lane and should be invoked
+        // even though we have not released anything else; it is now waiting
+        // on its own gate.
         await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+
+        if (!releaseMaintain) {
+          throw new Error("Expected maintain release callback to be initialized");
+        }
+        releaseMaintain();
+
         const maintainParams = firstMaintainParams(maintain);
         expectRecordFields(maintainParams, {
           sessionId: "session-1",
@@ -630,33 +637,35 @@ describe("runContextEngineMaintenance", () => {
           tokenBudget: 2048,
           currentTokenCount: 1536,
         });
-        expect(rewriteTranscriptEntriesInSessionFileMock).toHaveBeenCalledWith({
-          sessionFile: "/tmp/session.jsonl",
-          sessionId: "session-1",
-          sessionKey,
-          config: { session: { writeLock: { acquireTimeoutMs: 91_000 } } },
-          request: {
-            replacements: [
-              {
-                entryId: "entry-1",
-                message: castAgentMessage({
-                  role: "assistant",
-                  content: [{ type: "text", text: "done" }],
-                  timestamp: 2,
-                }),
-              },
-            ],
-          },
-        });
-
-        const completedTask = getTaskById(queuedTasks[0].taskId);
-        const completedTaskRecord = requireRecord(completedTask, "completed task");
-        expect(completedTaskRecord.status).toBe("succeeded");
-        expect(String(completedTaskRecord.progressSummary)).toContain(
-          "Deferred maintenance completed",
+        await waitForAssertion(() =>
+          expect(rewriteTranscriptEntriesInSessionFileMock).toHaveBeenCalledWith({
+            sessionFile: "/tmp/session.jsonl",
+            sessionId: "session-1",
+            sessionKey,
+            config: { session: { writeLock: { acquireTimeoutMs: 91_000 } } },
+            request: {
+              replacements: [
+                {
+                  entryId: "entry-1",
+                  message: castAgentMessage({
+                    role: "assistant",
+                    content: [{ type: "text", text: "done" }],
+                    timestamp: 2,
+                  }),
+                },
+              ],
+            },
+          }),
         );
 
-        await foregroundTurn;
+        await waitForAssertion(() => {
+          const completedTask = getTaskById(queuedTasks[0].taskId);
+          const completedTaskRecord = requireRecord(completedTask, "completed task");
+          expect(completedTaskRecord.status).toBe("succeeded");
+          expect(String(completedTaskRecord.progressSummary)).toContain(
+            "Deferred maintenance completed",
+          );
+        });
       } finally {
         vi.useRealTimers();
       }
@@ -974,7 +983,7 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
-  it("lets foreground turns win while deferred maintenance is waiting", async () => {
+  it("runs deferred maintenance on its own lane independent of the session lane", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();
       try {
@@ -1027,6 +1036,15 @@ describe("runContextEngineMaintenance", () => {
           reason: "turn",
         });
 
+        // Under the maintenance-lane fix (#77340) the deferred worker runs
+        // on its own dedicated lane and does NOT wait for the session lane
+        // to drain. Maintenance must therefore be observable while the
+        // session lane is still busy with the first foreground turn.
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+        expect(events).toContain("maintenance-start");
+        expect(events).toContain("foreground-1-start");
+        expect(events).not.toContain("foreground-1-end");
+
         const secondForeground = enqueueCommandInLane(sessionLane, async () => {
           events.push("foreground-2-start");
           events.push("foreground-2-end");
@@ -1037,13 +1055,15 @@ describe("runContextEngineMaintenance", () => {
         }
         releaseFirstForeground();
         await waitForAssertion(() =>
-          expect(events).toEqual([
-            "foreground-1-start",
-            "foreground-1-end",
-            "foreground-2-start",
-            "foreground-2-end",
-            "maintenance-start",
-          ]),
+          expect(events).toEqual(
+            expect.arrayContaining([
+              "foreground-1-start",
+              "foreground-1-end",
+              "foreground-2-start",
+              "foreground-2-end",
+              "maintenance-start",
+            ]),
+          ),
         );
         expect(maintain).toHaveBeenCalledTimes(1);
 
@@ -1219,20 +1239,21 @@ describe("runContextEngineMaintenance", () => {
         resetSystemEventsForTest();
 
         const sessionKey = "agent:main:session-long";
-        const sessionLane = resolveSessionLane(sessionKey);
-        let releaseForeground: (() => void) | undefined;
-        const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
-          await new Promise<void>((resolve) => {
-            releaseForeground = resolve;
-          });
+        // Under the maintenance-lane fix (#77340) the worker no longer
+        // waits for the session lane, so make maintain() itself slow to
+        // exercise the long-running notice timer.
+        let releaseMaintain: (() => void) | undefined;
+        const maintainGate = new Promise<void>((resolve) => {
+          releaseMaintain = resolve;
         });
-        await Promise.resolve();
-
-        const maintain = vi.fn(async () => ({
-          changed: false,
-          bytesFreed: 0,
-          rewrittenEntries: 0,
-        }));
+        const maintain = vi.fn(async () => {
+          await maintainGate;
+          return {
+            changed: false,
+            bytesFreed: 0,
+            rewrittenEntries: 0,
+          };
+        });
         const backgroundEngine = {
           info: {
             id: "test",
@@ -1256,6 +1277,10 @@ describe("runContextEngineMaintenance", () => {
           reason: "turn",
         });
 
+        // Wait for the worker to enter maintain() before we trip the
+        // long-running timer.
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+
         await vi.advanceTimersByTimeAsync(11_000);
         await waitForAssertion(() =>
           expectSystemEventContaining(
@@ -1264,25 +1289,28 @@ describe("runContextEngineMaintenance", () => {
           ),
         );
 
-        if (!releaseForeground) {
-          throw new Error("Expected foreground turn release callback to be initialized");
+        if (!releaseMaintain) {
+          throw new Error("Expected maintain release callback to be initialized");
         }
-        releaseForeground();
+        releaseMaintain();
         await waitForAssertion(() =>
           expectSystemEventContaining(
             sessionKey,
             "Background task done: Context engine turn maintenance",
           ),
         );
-
-        await foregroundTurn;
       } finally {
         vi.useRealTimers();
       }
     });
   });
 
-  it("throttles deferred wait notices while the session lane stays busy", async () => {
+  it("emits a single long-running notice while deferred maintenance is slow", async () => {
+    // Under the maintenance-lane fix (#77340) the deferred worker no longer
+    // polls the session lane, so the previous "throttle wait notices while
+    // the session lane stays busy" behaviour is gone. The worker now emits
+    // exactly one long-running notice from a single setTimeout while
+    // maintain() itself is slow; this test pins that contract.
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();
       try {
@@ -1292,15 +1320,18 @@ describe("runContextEngineMaintenance", () => {
         resetSystemEventsForTest();
 
         const sessionKey = "agent:main:session-throttle";
-        const sessionLane = resolveSessionLane(sessionKey);
-        let releaseForeground: (() => void) | undefined;
-        const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
-          await new Promise<void>((resolve) => {
-            releaseForeground = resolve;
-          });
+        let releaseMaintain: (() => void) | undefined;
+        const maintainGate = new Promise<void>((resolve) => {
+          releaseMaintain = resolve;
         });
-        await Promise.resolve();
-
+        const maintain = vi.fn(async () => {
+          await maintainGate;
+          return {
+            changed: false,
+            bytesFreed: 0,
+            rewrittenEntries: 0,
+          };
+        });
         const backgroundEngine = {
           info: {
             id: "test",
@@ -1313,11 +1344,7 @@ describe("runContextEngineMaintenance", () => {
             estimatedTokens: 0,
           }),
           compact: async () => ({ ok: true, compacted: false }),
-          maintain: vi.fn(async () => ({
-            changed: false,
-            bytesFreed: 0,
-            rewrittenEntries: 0,
-          })),
+          maintain,
         } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
 
         await runContextEngineMaintenance({
@@ -1328,6 +1355,9 @@ describe("runContextEngineMaintenance", () => {
           reason: "turn",
         });
 
+        // Wait for the worker to enter maintain() before tripping timers.
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+
         await vi.advanceTimersByTimeAsync(11_000);
         await waitForAssertion(() =>
           expect(
@@ -1337,25 +1367,19 @@ describe("runContextEngineMaintenance", () => {
           ).toHaveLength(1),
         );
 
-        await vi.advanceTimersByTimeAsync(9_000);
+        // Advancing further does not generate additional long-running
+        // notices; the worker schedules exactly one timer.
+        await vi.advanceTimersByTimeAsync(20_000);
         expect(
           peekSystemEvents(sessionKey).filter((event) =>
             event.includes("Background task update: Context engine turn maintenance."),
           ),
-        ).toHaveLength(2);
+        ).toHaveLength(1);
 
-        await vi.advanceTimersByTimeAsync(1_000);
-        expect(
-          peekSystemEvents(sessionKey).filter((event) =>
-            event.includes("Background task update: Context engine turn maintenance."),
-          ),
-        ).toHaveLength(2);
-
-        if (!releaseForeground) {
-          throw new Error("Expected foreground turn release callback to be initialized");
+        if (!releaseMaintain) {
+          throw new Error("Expected maintain release callback to be initialized");
         }
-        releaseForeground();
-        await foregroundTurn;
+        releaseMaintain();
       } finally {
         vi.useRealTimers();
       }

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -6,7 +6,6 @@ import type {
   ContextEngineMaintenanceResult,
   ContextEngineRuntimeContext,
 } from "../../context-engine/types.js";
-import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { enqueueCommandInLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -408,85 +407,80 @@ async function runDeferredTurnMaintenanceWorker(params: {
   };
 
   try {
-    const sessionLane = resolveSessionLane(params.sessionKey);
-    const startedWaitingAt = Date.now();
-    let lastWaitNoticeAt = 0;
-
-    for (;;) {
-      while (getQueueSize(sessionLane) > 0) {
-        const now = Date.now();
-        if (
-          now - startedWaitingAt >= TURN_MAINTENANCE_LONG_WAIT_MS &&
-          now - lastWaitNoticeAt >= TURN_MAINTENANCE_LONG_WAIT_MS
-        ) {
-          lastWaitNoticeAt = now;
-          surfaceMaintenanceUpdate(
-            "Waiting for the session lane to go idle.",
-            surfacedUserNotice
-              ? "Still waiting for the session lane to go idle."
-              : "Deferred maintenance is waiting for the session lane to go idle.",
-          );
+    // Fix for #77340: use the dedicated maintenance lane instead of the
+    // session (inference) lane as the gate. The previous implementation waited
+    // for resolveSessionLane(sessionKey) to drain before running maintenance,
+    // but that lane is also used by inference — under steady Telegram DM
+    // traffic the session lane never reaches zero, causing a livelock where
+    // deferred maintenance never commits and trailing-assistant accumulation
+    // grows monotonically with each turn.
+    //
+    // The maintenance lane (resolveDeferredTurnMaintenanceLane) is keyed
+    // separately and serialises maintenance runs against each other without
+    // ever contending with inference. Transcript-correctness writes must
+    // complete before the next read; scheduling them on the maintenance lane
+    // achieves that without blocking the session lane.
+    await enqueueCommandInLane(
+      resolveDeferredTurnMaintenanceLane(params.sessionKey),
+      async () => {
+        if (shutdownAbort.abortSignal?.aborted) {
+          return;
         }
-        await sleepWithAbort(TURN_MAINTENANCE_WAIT_POLL_MS, shutdownAbort.abortSignal);
-      }
-      await Promise.resolve();
-      if (getQueueSize(sessionLane) === 0) {
-        break;
-      }
-    }
 
-    const runningAt = Date.now();
-    startTaskRunByRunId({
-      runId: params.runId,
-      runtime: "acp",
-      sessionKey: params.sessionKey,
-      startedAt: runningAt,
-      lastEventAt: runningAt,
-      progressSummary: "Running deferred maintenance.",
-      eventSummary: "Starting deferred maintenance.",
-    });
-    longRunningTimer = setTimeout(() => {
-      try {
-        surfaceMaintenanceUpdate(
-          "Deferred maintenance is still running.",
-          "Deferred maintenance is still running.",
-        );
-      } catch (error) {
-        log.warn(`failed to surface deferred maintenance progress: ${String(error)}`);
-      }
-    }, TURN_MAINTENANCE_LONG_WAIT_MS);
+        const runningAt = Date.now();
+        startTaskRunByRunId({
+          runId: params.runId,
+          runtime: "acp",
+          sessionKey: params.sessionKey,
+          startedAt: runningAt,
+          lastEventAt: runningAt,
+          progressSummary: "Running deferred maintenance.",
+          eventSummary: "Starting deferred maintenance.",
+        });
+        longRunningTimer = setTimeout(() => {
+          try {
+            surfaceMaintenanceUpdate(
+              "Deferred maintenance is still running.",
+              "Deferred maintenance is still running.",
+            );
+          } catch (error) {
+            log.warn(`failed to surface deferred maintenance progress: ${String(error)}`);
+          }
+        }, TURN_MAINTENANCE_LONG_WAIT_MS);
 
-    const result = await executeContextEngineMaintenance({
-      contextEngine: params.contextEngine,
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      sessionFile: params.sessionFile,
-      reason: "turn",
-      sessionManager: params.sessionManager,
-      runtimeContext: params.runtimeContext,
-      agentId: params.agentId,
-      config: params.config,
-      executionMode: "background",
-    });
-    if (longRunningTimer) {
-      clearTimeout(longRunningTimer);
-      longRunningTimer = null;
-    }
+        const result = await executeContextEngineMaintenance({
+          contextEngine: params.contextEngine,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          reason: "turn",
+          sessionManager: params.sessionManager,
+          runtimeContext: params.runtimeContext,
+          agentId: params.agentId,
+          config: params.config,
+          executionMode: "background",
+        });
+        if (longRunningTimer) {
+          clearTimeout(longRunningTimer);
+          longRunningTimer = null;
+        }
 
-    const endedAt = Date.now();
-    completeTaskRunByRunId({
-      runId: params.runId,
-      runtime: "acp",
-      sessionKey: params.sessionKey,
-      endedAt,
-      lastEventAt: endedAt,
-      progressSummary: result?.changed
-        ? "Deferred maintenance completed with transcript changes."
-        : "Deferred maintenance completed.",
-      terminalSummary: result?.changed
-        ? `Rewrote ${result.rewrittenEntries} transcript entr${result.rewrittenEntries === 1 ? "y" : "ies"} and freed ${result.bytesFreed} bytes.`
-        : "No transcript changes were needed.",
-    });
+        const endedAt = Date.now();
+        completeTaskRunByRunId({
+          runId: params.runId,
+          runtime: "acp",
+          sessionKey: params.sessionKey,
+          endedAt,
+          lastEventAt: endedAt,
+          progressSummary: result?.changed
+            ? "Deferred maintenance completed with transcript changes."
+            : "Deferred maintenance completed.",
+          terminalSummary: result?.changed
+            ? `Rewrote ${result.rewrittenEntries} transcript entr${result.rewrittenEntries === 1 ? "y" : "ies"} and freed ${result.bytesFreed} bytes.`
+            : "No transcript changes were needed.",
+        });
+      }, // end enqueueCommandInLane callback
+    );
   } catch (err) {
     if (shutdownAbort.abortSignal?.aborted) {
       if (longRunningTimer) {

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -7,7 +7,7 @@ import type {
   ContextEngineRuntimeContext,
 } from "../../context-engine/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { enqueueCommandInLane, getQueueSize } from "../../process/command-queue.js";
+import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   completeTaskRunByRunId,
@@ -35,7 +35,6 @@ const TURN_MAINTENANCE_TASK_KIND = "context_engine_turn_maintenance";
 const TURN_MAINTENANCE_TASK_LABEL = "Context engine turn maintenance";
 const TURN_MAINTENANCE_TASK_TASK = "Deferred context-engine maintenance after turn.";
 const TURN_MAINTENANCE_LANE_PREFIX = "context-engine-turn-maintenance:";
-const TURN_MAINTENANCE_WAIT_POLL_MS = 100;
 const TURN_MAINTENANCE_LONG_WAIT_MS = 10_000;
 const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
   "openclaw.contextEngineTurnMaintenanceAbortState",
@@ -407,80 +406,76 @@ async function runDeferredTurnMaintenanceWorker(params: {
   };
 
   try {
-    // Fix for #77340: use the dedicated maintenance lane instead of the
-    // session (inference) lane as the gate. The previous implementation waited
-    // for resolveSessionLane(sessionKey) to drain before running maintenance,
-    // but that lane is also used by inference — under steady Telegram DM
-    // traffic the session lane never reaches zero, causing a livelock where
-    // deferred maintenance never commits and trailing-assistant accumulation
-    // grows monotonically with each turn.
+    // Fix for #77340: previously this worker waited for
+    // resolveSessionLane(sessionKey) to drain before running maintenance, but
+    // that lane is also used by inference — under steady Telegram DM traffic
+    // the session lane never reaches zero, causing a livelock where deferred
+    // maintenance never commits and trailing-assistant accumulation grows
+    // monotonically with each turn.
     //
-    // The maintenance lane (resolveDeferredTurnMaintenanceLane) is keyed
-    // separately and serialises maintenance runs against each other without
-    // ever contending with inference. Transcript-correctness writes must
-    // complete before the next read; scheduling them on the maintenance lane
-    // achieves that without blocking the session lane.
-    await enqueueCommandInLane(
-      resolveDeferredTurnMaintenanceLane(params.sessionKey),
-      async () => {
-        if (shutdownAbort.abortSignal?.aborted) {
-          return;
-        }
+    // The drain-wait is unnecessary: scheduleDeferredTurnMaintenance already
+    // wraps this worker in enqueueCommandInLane(resolveDeferredTurnMaintenanceLane(
+    // sessionKey), …), which serialises maintenance runs against each other on
+    // a dedicated single-concurrency lane that never contends with inference.
+    // Transcript-correctness file writes are still routed onto the session
+    // lane via deferTranscriptRewriteToSessionLane, so they are ordered
+    // against subsequent inference reads without any extra gate here.
+    if (shutdownAbort.abortSignal?.aborted) {
+      return;
+    }
 
-        const runningAt = Date.now();
-        startTaskRunByRunId({
-          runId: params.runId,
-          runtime: "acp",
-          sessionKey: params.sessionKey,
-          startedAt: runningAt,
-          lastEventAt: runningAt,
-          progressSummary: "Running deferred maintenance.",
-          eventSummary: "Starting deferred maintenance.",
-        });
-        longRunningTimer = setTimeout(() => {
-          try {
-            surfaceMaintenanceUpdate(
-              "Deferred maintenance is still running.",
-              "Deferred maintenance is still running.",
-            );
-          } catch (error) {
-            log.warn(`failed to surface deferred maintenance progress: ${String(error)}`);
-          }
-        }, TURN_MAINTENANCE_LONG_WAIT_MS);
+    const runningAt = Date.now();
+    startTaskRunByRunId({
+      runId: params.runId,
+      runtime: "acp",
+      sessionKey: params.sessionKey,
+      startedAt: runningAt,
+      lastEventAt: runningAt,
+      progressSummary: "Running deferred maintenance.",
+      eventSummary: "Starting deferred maintenance.",
+    });
+    longRunningTimer = setTimeout(() => {
+      try {
+        surfaceMaintenanceUpdate(
+          "Deferred maintenance is still running.",
+          "Deferred maintenance is still running.",
+        );
+      } catch (error) {
+        log.warn(`failed to surface deferred maintenance progress: ${String(error)}`);
+      }
+    }, TURN_MAINTENANCE_LONG_WAIT_MS);
 
-        const result = await executeContextEngineMaintenance({
-          contextEngine: params.contextEngine,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
-          reason: "turn",
-          sessionManager: params.sessionManager,
-          runtimeContext: params.runtimeContext,
-          agentId: params.agentId,
-          config: params.config,
-          executionMode: "background",
-        });
-        if (longRunningTimer) {
-          clearTimeout(longRunningTimer);
-          longRunningTimer = null;
-        }
+    const result = await executeContextEngineMaintenance({
+      contextEngine: params.contextEngine,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      sessionFile: params.sessionFile,
+      reason: "turn",
+      sessionManager: params.sessionManager,
+      runtimeContext: params.runtimeContext,
+      agentId: params.agentId,
+      config: params.config,
+      executionMode: "background",
+    });
+    if (longRunningTimer) {
+      clearTimeout(longRunningTimer);
+      longRunningTimer = null;
+    }
 
-        const endedAt = Date.now();
-        completeTaskRunByRunId({
-          runId: params.runId,
-          runtime: "acp",
-          sessionKey: params.sessionKey,
-          endedAt,
-          lastEventAt: endedAt,
-          progressSummary: result?.changed
-            ? "Deferred maintenance completed with transcript changes."
-            : "Deferred maintenance completed.",
-          terminalSummary: result?.changed
-            ? `Rewrote ${result.rewrittenEntries} transcript entr${result.rewrittenEntries === 1 ? "y" : "ies"} and freed ${result.bytesFreed} bytes.`
-            : "No transcript changes were needed.",
-        });
-      }, // end enqueueCommandInLane callback
-    );
+    const endedAt = Date.now();
+    completeTaskRunByRunId({
+      runId: params.runId,
+      runtime: "acp",
+      sessionKey: params.sessionKey,
+      endedAt,
+      lastEventAt: endedAt,
+      progressSummary: result?.changed
+        ? "Deferred maintenance completed with transcript changes."
+        : "Deferred maintenance completed.",
+      terminalSummary: result?.changed
+        ? `Rewrote ${result.rewrittenEntries} transcript entr${result.rewrittenEntries === 1 ? "y" : "ies"} and freed ${result.bytesFreed} bytes.`
+        : "No transcript changes were needed.",
+    });
   } catch (err) {
     if (shutdownAbort.abortSignal?.aborted) {
       if (longRunningTimer) {


### PR DESCRIPTION
## Problem

Closes #77340.

Under steady Telegram DM traffic, the deferred turn-maintenance worker livelocks. It waits for `resolveSessionLane(sessionKey)` to reach zero queue depth before committing — but that lane is also used by inference, so it never empties while the user is actively chatting.

**Observable consequence:** monotonically growing trailing-assistant accumulation. Each turn's `bootstrap-context` assembler reads pre-maintenance transcript state, growing `inputMessages` far beyond `outputMessages`. Production evidence from a macOS / Telegram DM deployment running `lossless-claw`:

```
[lcm] assemble: done inputMessages=778 outputMessages=154 duration=2457ms
[trace:embedded-run] prep stages: bootstrap-context:14190ms@15162ms
liveness warning: eventLoopDelayP99Ms=21743 eventLoopUtilization=1 cpuCoreRatio=1.015
```

14 seconds of `bootstrap-context` assembly per turn → ~2 minute end-to-end response latency. The event loop utilisation hits 1.0 (100%) during each turn.

## Fix (Option B from issue)

Replace the session-lane drain wait with `enqueueCommandInLane` on the dedicated maintenance lane (`resolveDeferredTurnMaintenanceLane`). The maintenance lane is keyed separately from the session/inference lane:

- Maintenance runs serialise **against each other** (no concurrent maintenance for the same session)
- Maintenance **never contends with inference** — the session lane is no longer blocked
- Transcript-correctness writes complete before the next read, without the livelock

```ts
// Before: waits for inference lane — livelocks under steady traffic
const sessionLane = resolveSessionLane(params.sessionKey);
for (;;) {
  while (getQueueSize(sessionLane) > 0) {
    await sleepWithAbort(TURN_MAINTENANCE_WAIT_POLL_MS, ...);
  }
  if (getQueueSize(sessionLane) === 0) break;
}

// After: runs on its own lane — no contention with inference
await enqueueCommandInLane(
  resolveDeferredTurnMaintenanceLane(params.sessionKey),
  async () => { /* maintenance work */ },
);
```

## Testing

- TypeScript: zero errors (`tsc --noEmit`)
- Pre-existing test setup failure (`@openclaw/fs-safe/config` resolution) exists on upstream `main` before this change — not caused by this PR
- Manually verified: after applying locally, `inputMessages` converges to `outputMessages` and `bootstrap-context` duration drops from 14s to ~80ms on the affected Telegram DM session

## Repro environment (confirming match with #77340)

- macOS Darwin 25.5.0 arm64
- OpenClaw 2026.5.22, Node 24.15.0
- `@martian-engineering/lossless-claw` active
- Channel: Telegram DM (`agent:main:telegram:direct:<id>`)
- Pattern: `inputMessages` grew to 778 vs `outputMessages` 154; liveness warnings every turn