### PR TITLE
fix(compaction): add circuit breaker to stop token burn when summarizer unavailable

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -34,8 +34,8 @@ vi.mock("../compaction.js", async () => {
 
 const mockSummarizeInStages = vi.mocked(compactionModule.summarizeInStages);
 
-function summaryResult(text: string): compactionModule.CompactionSummaryResult {
-  return { kind: "summary", text };
+function summaryResult(text: string) {
+  return { kind: "summary" as const, text };
 }
 
 const {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -34,6 +34,10 @@ vi.mock("../compaction.js", async () => {
 
 const mockSummarizeInStages = vi.mocked(compactionModule.summarizeInStages);
 
+function summaryResult(text: string): compactionModule.CompactionSummaryResult {
+  return { kind: "summary", text };
+}
+
 const {
   collectToolFailures,
   formatToolFailuresSection,
@@ -1442,7 +1446,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("uses structured instructions when summarizing dropped history chunks", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("mock summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
 
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();
@@ -1499,7 +1503,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("caps summarization reserve tokens to the model output limit", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("mock summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
 
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture({
@@ -1538,7 +1542,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("adds Copilot IDE headers to built-in compaction summarization", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("mock summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
 
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture({
@@ -1584,7 +1588,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("does not retry summaries unless quality guard is explicitly enabled", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("summary missing headings");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("summary missing headings"));
 
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();
@@ -1633,20 +1637,22 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("retries when generated summary misses headings even if preserved turns contain them", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages
-      .mockResolvedValueOnce("latest ask status")
+      .mockResolvedValueOnce(summaryResult("latest ask status"))
       .mockResolvedValueOnce(
-        [
-          "## Decisions",
-          "Keep current flow.",
-          "## Open TODOs",
-          "None.",
-          "## Constraints/Rules",
-          "Follow rules.",
-          "## Pending user asks",
-          "latest ask status",
-          "## Exact identifiers",
-          "None.",
-        ].join("\n"),
+        summaryResult(
+          [
+            "## Decisions",
+            "Keep current flow.",
+            "## Open TODOs",
+            "None.",
+            "## Constraints/Rules",
+            "Follow rules.",
+            "## Pending user asks",
+            "latest ask status",
+            "## Exact identifiers",
+            "None.",
+          ].join("\n"),
+        ),
       );
 
     const sessionManager = stubSessionManager();
@@ -1733,32 +1739,36 @@ describe("compaction-safeguard recent-turn preservation", () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages
       .mockResolvedValueOnce(
-        [
-          "## Decisions",
-          "Keep current flow.",
-          "## Open TODOs",
-          "None.",
-          "## Constraints/Rules",
-          "Follow rules.",
-          "## Pending user asks",
-          "latest ask status",
-          "## Exact identifiers",
-          "None.",
-        ].join("\n"),
+        summaryResult(
+          [
+            "## Decisions",
+            "Keep current flow.",
+            "## Open TODOs",
+            "None.",
+            "## Constraints/Rules",
+            "Follow rules.",
+            "## Pending user asks",
+            "latest ask status",
+            "## Exact identifiers",
+            "None.",
+          ].join("\n"),
+        ),
       )
       .mockResolvedValueOnce(
-        [
-          "## Decisions",
-          "Keep current flow.",
-          "## Open TODOs",
-          "None.",
-          "## Constraints/Rules",
-          "Follow rules.",
-          "## Pending user asks",
-          "older context",
-          "## Exact identifiers",
-          "None.",
-        ].join("\n"),
+        summaryResult(
+          [
+            "## Decisions",
+            "Keep current flow.",
+            "## Open TODOs",
+            "None.",
+            "## Constraints/Rules",
+            "Follow rules.",
+            "## Pending user asks",
+            "older context",
+            "## Exact identifiers",
+            "None.",
+          ].join("\n"),
+        ),
       );
 
     const sessionManager = stubSessionManager();
@@ -1822,8 +1832,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const oversizedHistorySummary = "history detail ".repeat(MAX_COMPACTION_SUMMARY_CHARS);
     const splitTurnPrefixSummary = "split-turn prefix context that must survive capping";
     mockSummarizeInStages
-      .mockResolvedValueOnce(oversizedHistorySummary)
-      .mockResolvedValueOnce(splitTurnPrefixSummary)
+      .mockResolvedValueOnce(summaryResult(oversizedHistorySummary))
+      .mockResolvedValueOnce(summaryResult(splitTurnPrefixSummary))
       .mockRejectedValueOnce(new Error("retry transient failure"));
 
     const sessionManager = stubSessionManager();
@@ -1949,18 +1959,20 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("re-distills prior summaries on the LLM path instead of preserving them verbatim", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue(
-      [
-        "## Decisions",
-        "Condensed prior context with latest status.",
-        "## Open TODOs",
-        "None.",
-        "## Constraints/Rules",
-        "Preserve identifiers.",
-        "## Pending user asks",
-        "latest ask status",
-        "## Exact identifiers",
-        "None.",
-      ].join("\n"),
+      summaryResult(
+        [
+          "## Decisions",
+          "Condensed prior context with latest status.",
+          "## Open TODOs",
+          "None.",
+          "## Constraints/Rules",
+          "Preserve identifiers.",
+          "## Pending user asks",
+          "latest ask status",
+          "## Exact identifiers",
+          "None.",
+        ].join("\n"),
+      ),
     );
 
     const sessionManager = stubSessionManager();
@@ -2011,6 +2023,54 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(JSON.stringify(messages[0])).toContain("Old duplicated section");
   });
 
+  it("preserves the prior summary when staged summarization returns a generic fallback", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue({
+      kind: "generic-fallback",
+      text: "Context contained 4 messages. Summary unavailable due to size limits.",
+    });
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("test-key"),
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [{ role: "user", content: "latest ask status", timestamp: 1 }],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: {
+          read: [],
+          edited: [],
+          written: [],
+        },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: "## Goal\nKnown context that must survive the outage.",
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(result.compaction?.summary).toContain("Known context that must survive the outage.");
+    expect(result.compaction?.summary).toContain("Summary unavailable due to size limits.");
+  });
+
   it("falls back to LLM when provider throws a provider-side AbortError with signal not aborted", async () => {
     // Reproduce the undici AbortError("This operation was aborted") shape that
     // arrives when the compaction provider's HTTP connection drops mid-stream while
@@ -2018,7 +2078,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     // isAbortError() matched this shape so tryProviderSummarize rethrew and the
     // extension runner swallowed the error — the LLM fallback path was skipped.
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("llm fallback summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("llm fallback summary"));
 
     const providerAbortErr = Object.assign(new Error("This operation was aborted"), {
       name: "AbortError",
@@ -2225,7 +2285,7 @@ describe("compaction-safeguard extension model fallback", () => {
     // neither apiKey nor headers. `ok: true` must be trusted so compaction runs
     // instead of wedging every message with a false "no credentials" cancel.
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("mock summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
 
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture({ provider: "amazon-bedrock" });
@@ -2450,7 +2510,7 @@ describe("compaction-safeguard double-compaction guard", () => {
 
   it("falls back to visible custom session branch entries before writing an empty boundary", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("branch summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("branch summary"));
 
     const now = Date.now();
     const sessionManager = {
@@ -2539,7 +2599,7 @@ describe("compaction-safeguard double-compaction guard", () => {
 
   it("does not replay inter-session sessions_send branch turns as fallback history", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("branch summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("branch summary"));
 
     const now = Date.now();
     const sessionManager = {
@@ -2607,7 +2667,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     { toolName: "functions.sessions_send", expectedRoles: ["user", "assistant"] },
   ])("preserves unfinished inter-session work after a $toolName result", async (scenario) => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("unfinished branch summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("unfinished branch summary"));
 
     const now = Date.now();
     const sessionManager = {
@@ -2694,7 +2754,7 @@ describe("compaction-safeguard double-compaction guard", () => {
 
   it("keeps source-session sends as inert status history", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("completed send summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("completed send summary"));
 
     const now = Date.now();
     const sessionManager = {
@@ -2810,7 +2870,7 @@ describe("compaction-safeguard double-compaction guard", () => {
 
   it("preserves completed historical inter-session turns outside the active tail", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("historical branch summary");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("historical branch summary"));
 
     const now = Date.now();
     const sessionManager = {
@@ -2902,7 +2962,7 @@ describe("compaction-safeguard double-compaction guard", () => {
 
   it("recovers user and assistant branch turns when compaction preparation has only tool output", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("branch summary with visible turns");
+    mockSummarizeInStages.mockResolvedValue(summaryResult("branch summary with visible turns"));
 
     const now = Date.now();
     const sessionManager = {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -397,7 +397,7 @@ async function summarizeViaLLM(params: {
     messages: params.messages,
     previousSummary: params.previousSummary,
   });
-  return compactionSafeguardDeps.summarizeInStages({
+  const result = await compactionSafeguardDeps.summarizeInStages({
     messages,
     model: params.model,
     apiKey: params.apiKey,
@@ -410,6 +410,14 @@ async function summarizeViaLLM(params: {
     summarizationInstructions: params.summarizationInstructions,
     previousSummary: undefined,
   });
+  if (result.kind === "summary") {
+    return result.text;
+  }
+
+  // A generic fallback means redistillation never happened. Preserve the
+  // known summary verbatim so a temporary model outage cannot erase it.
+  const previousSummary = params.previousSummary?.trim();
+  return previousSummary ? `${previousSummary}\n\n${result.text}` : result.text;
 }
 
 /**

--- a/src/agents/compaction.circuit-breaker.test.ts
+++ b/src/agents/compaction.circuit-breaker.test.ts
@@ -66,14 +66,17 @@ describe("compaction staged fallback circuit breaker", () => {
     expect(result.text.match(/Summary unavailable due to size limits\./g)).toHaveLength(1);
   });
 
-  it("resets after a successful split and completes the merge", async () => {
+  it("resets after a successful split, completes the merge, and remains degraded", async () => {
     agentSessionMocks.generateSummary
       .mockRejectedValueOnce(new Error("fetch failed"))
       .mockResolvedValueOnce("middle summary")
       .mockRejectedValueOnce(new Error("fetch failed"))
       .mockResolvedValueOnce("merged summary");
 
-    await expect(summarize()).resolves.toEqual({ kind: "summary", text: "merged summary" });
+    await expect(summarize()).resolves.toEqual({
+      kind: "generic-fallback",
+      text: "merged summary",
+    });
     expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/agents/compaction.circuit-breaker.test.ts
+++ b/src/agents/compaction.circuit-breaker.test.ts
@@ -56,14 +56,14 @@ describe("compaction staged fallback circuit breaker", () => {
     agentSessionMocks.generateSummary.mockReset();
   });
 
-  it("stops the fallback storm before later splits and merge", async () => {
+  it("stops the fallback storm and rejects the incomplete compaction", async () => {
     agentSessionMocks.generateSummary.mockRejectedValue(new Error("fetch failed"));
 
-    const result = await summarize();
+    await expect(summarize()).rejects.toThrow(
+      "Compaction staged summarization stopped after repeated generic fallbacks",
+    );
 
     expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(2);
-    expect(result.kind).toBe("generic-fallback");
-    expect(result.text.match(/Summary unavailable due to size limits\./g)).toHaveLength(1);
   });
 
   it("resets after a successful split, completes the merge, and remains degraded", async () => {

--- a/src/agents/compaction.circuit-breaker.test.ts
+++ b/src/agents/compaction.circuit-breaker.test.ts
@@ -1,0 +1,79 @@
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import type { ExtensionContext } from "openclaw/plugin-sdk/agent-sessions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const agentSessionMocks = vi.hoisted(() => ({
+  estimateTokens: vi.fn((message: { content?: unknown }) => {
+    return typeof message.content === "string" && message.content.startsWith("[Chunk") ? 100 : 1000;
+  }),
+  generateSummary: vi.fn(),
+}));
+
+vi.mock("./sessions/index.js", async () => {
+  const actual = await vi.importActual<typeof import("./sessions/index.js")>("./sessions/index.js");
+  return {
+    ...actual,
+    estimateTokens: agentSessionMocks.estimateTokens,
+    generateSummary: agentSessionMocks.generateSummary,
+  };
+});
+
+const { summarizeInStages } = await import("./compaction.js");
+
+const testModel = {
+  id: "test",
+  name: "test",
+  contextWindow: 200_000,
+  contextTokens: 200_000,
+  maxTokens: 8192,
+} as unknown as NonNullable<ExtensionContext["model"]>;
+
+function transcript(): AgentMessage[] {
+  return Array.from({ length: 6 }, (_unused, index) => ({
+    role: "user",
+    content: `message-${index + 1}`,
+    timestamp: index + 1,
+  }));
+}
+
+async function summarize() {
+  return await summarizeInStages({
+    messages: transcript(),
+    model: testModel,
+    apiKey: "unused",
+    signal: new AbortController().signal,
+    reserveTokens: 1000,
+    maxChunkTokens: 2500,
+    contextWindow: 200_000,
+    parts: 3,
+    minMessagesForSplit: 2,
+  });
+}
+
+describe("compaction staged fallback circuit breaker", () => {
+  beforeEach(() => {
+    agentSessionMocks.estimateTokens.mockClear();
+    agentSessionMocks.generateSummary.mockReset();
+  });
+
+  it("stops the fallback storm before later splits and merge", async () => {
+    agentSessionMocks.generateSummary.mockRejectedValue(new Error("fetch failed"));
+
+    const result = await summarize();
+
+    expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(2);
+    expect(result.kind).toBe("generic-fallback");
+    expect(result.text.match(/Summary unavailable due to size limits\./g)).toHaveLength(1);
+  });
+
+  it("resets after a successful split and completes the merge", async () => {
+    agentSessionMocks.generateSummary
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce("middle summary")
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce("merged summary");
+
+    await expect(summarize()).resolves.toEqual({ kind: "summary", text: "merged summary" });
+    expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -40,7 +40,7 @@ const log = createSubsystemLogger("compaction");
 
 type PartialSummaryError = Error & { partialSummary?: string };
 
-export type CompactionSummaryResult =
+type CompactionSummaryResult =
   | { kind: "summary"; text: string }
   | { kind: "generic-fallback"; text: string };
 

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -46,6 +46,8 @@ type CompactionSummaryResult =
 
 const DEFAULT_SUMMARY_FALLBACK = "No prior history.";
 const MAX_CONSECUTIVE_GENERIC_FALLBACKS = 2;
+const CIRCUIT_OPEN_ERROR =
+  "Compaction staged summarization stopped after repeated generic fallbacks";
 const MERGE_SUMMARIES_INSTRUCTIONS = [
   "Merge these partial summaries into a single cohesive summary.",
   "",
@@ -430,10 +432,9 @@ export async function summarizeInStages(params: {
         consecutiveGenericFallbacks,
         totalSplits: plan.chunks.length,
       });
-      return {
-        kind: "generic-fallback",
-        text: partialSummaries.join("\n\n"),
-      };
+      // The remaining chunks were never attempted. Abort the whole compaction
+      // so the caller keeps the source transcript instead of committing a gap.
+      throw new Error(CIRCUIT_OPEN_ERROR);
     }
     partialSummaries.push(result.text);
   }

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -40,7 +40,12 @@ const log = createSubsystemLogger("compaction");
 
 type PartialSummaryError = Error & { partialSummary?: string };
 
+export type CompactionSummaryResult =
+  | { kind: "summary"; text: string }
+  | { kind: "generic-fallback"; text: string };
+
 const DEFAULT_SUMMARY_FALLBACK = "No prior history.";
+const MAX_CONSECUTIVE_GENERIC_FALLBACKS = 2;
 const MERGE_SUMMARIES_INSTRUCTIONS = [
   "Merge these partial summaries into a single cohesive summary.",
   "",
@@ -258,7 +263,7 @@ function generateSummary(
  * Summarize with progressive fallback for handling oversized messages.
  * If full summarization fails, tries partial summarization excluding oversized messages.
  */
-async function summarizeWithFallback(params: {
+async function summarizeWithFallbackResult(params: {
   messages: AgentMessage[];
   model: NonNullable<ExtensionContext["model"]>;
   apiKey: string;
@@ -270,17 +275,20 @@ async function summarizeWithFallback(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
-}): Promise<string> {
+}): Promise<CompactionSummaryResult> {
   const { messages, contextWindow } = params;
 
   if (messages.length === 0) {
-    return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
+    return {
+      kind: "summary",
+      text: params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK,
+    };
   }
 
   // Try full summarization first
   let partialSummaryFallback: string | undefined;
   try {
-    return await summarizeChunks(params);
+    return { kind: "summary", text: await summarizeChunks(params) };
   } catch (fullError) {
     if (params.signal.aborted) {
       throw fullError;
@@ -305,7 +313,7 @@ async function summarizeWithFallback(params: {
         messages: smallMessages,
       });
       const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
-      return partialSummary + notes;
+      return { kind: "summary", text: partialSummary + notes };
     } catch (partialError) {
       if (params.signal.aborted) {
         throw partialError;
@@ -324,12 +332,20 @@ async function summarizeWithFallback(params: {
 
   // Final fallback: use best available partial summary, otherwise generic note
   if (partialSummaryFallback) {
-    return partialSummaryFallback;
+    return { kind: "summary", text: partialSummaryFallback };
   }
-  return (
-    `Context contained ${messages.length} messages (${oversizedNotes.length} oversized). ` +
-    `Summary unavailable due to size limits.`
-  );
+  return {
+    kind: "generic-fallback",
+    text:
+      `Context contained ${messages.length} messages (${oversizedNotes.length} oversized). ` +
+      `Summary unavailable due to size limits.`,
+  };
+}
+
+async function summarizeWithFallback(
+  params: Parameters<typeof summarizeWithFallbackResult>[0],
+): Promise<string> {
+  return (await summarizeWithFallbackResult(params)).text;
 }
 
 /** Extracts a compact timestamp range from a chunk of messages for merge metadata. */
@@ -372,10 +388,13 @@ export async function summarizeInStages(params: {
   previousSummary?: string;
   parts?: number;
   minMessagesForSplit?: number;
-}): Promise<string> {
+}): Promise<CompactionSummaryResult> {
   const { messages } = params;
   if (messages.length === 0) {
-    return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
+    return {
+      kind: "summary",
+      text: params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK,
+    };
   }
 
   const plan = await buildStageSplitPlanWithWorker({
@@ -387,18 +406,34 @@ export async function summarizeInStages(params: {
   });
 
   if (plan.mode === "single") {
-    return summarizeWithFallback(params);
+    return summarizeWithFallbackResult(params);
   }
 
   const partialSummaries: string[] = [];
-  for (const chunk of plan.chunks) {
-    partialSummaries.push(
-      await summarizeWithFallback({
-        ...params,
-        messages: chunk,
-        previousSummary: undefined,
-      }),
-    );
+  let consecutiveGenericFallbacks = 0;
+  for (const [index, chunk] of plan.chunks.entries()) {
+    const result = await summarizeWithFallbackResult({
+      ...params,
+      messages: chunk,
+      previousSummary: undefined,
+    });
+    consecutiveGenericFallbacks =
+      result.kind === "generic-fallback" ? consecutiveGenericFallbacks + 1 : 0;
+
+    // Keep one placeholder to mark the missing split, but stop before repeated
+    // placeholders trigger more split requests or a doomed merge request.
+    if (consecutiveGenericFallbacks >= MAX_CONSECUTIVE_GENERIC_FALLBACKS) {
+      log.warn("compaction staged summarization stopped after repeated generic fallbacks", {
+        attemptedSplits: index + 1,
+        consecutiveGenericFallbacks,
+        totalSplits: plan.chunks.length,
+      });
+      return {
+        kind: "generic-fallback",
+        text: partialSummaries.join("\n\n"),
+      };
+    }
+    partialSummaries.push(result.text);
   }
 
   if (partialSummaries.length === 1) {
@@ -406,7 +441,7 @@ export async function summarizeInStages(params: {
     if (summary === undefined) {
       throw new Error("Compaction summary plan produced no summary");
     }
-    return summary;
+    return { kind: "summary", text: summary };
   }
 
   // Capture once so timestamps are strictly monotonic across
@@ -440,7 +475,7 @@ export async function summarizeInStages(params: {
     ? `${MERGE_SUMMARIES_INSTRUCTIONS}\n\n${custom}`
     : MERGE_SUMMARIES_INSTRUCTIONS;
 
-  return summarizeWithFallback({
+  return summarizeWithFallbackResult({
     ...params,
     messages: summaryMessages,
     customInstructions: mergeInstructions,

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -411,6 +411,7 @@ export async function summarizeInStages(params: {
 
   const partialSummaries: string[] = [];
   let consecutiveGenericFallbacks = 0;
+  let usedGenericFallback = false;
   for (const [index, chunk] of plan.chunks.entries()) {
     const result = await summarizeWithFallbackResult({
       ...params,
@@ -419,6 +420,7 @@ export async function summarizeInStages(params: {
     });
     consecutiveGenericFallbacks =
       result.kind === "generic-fallback" ? consecutiveGenericFallbacks + 1 : 0;
+    usedGenericFallback ||= result.kind === "generic-fallback";
 
     // Keep one placeholder to mark the missing split, but stop before repeated
     // placeholders trigger more split requests or a doomed merge request.
@@ -441,7 +443,10 @@ export async function summarizeInStages(params: {
     if (summary === undefined) {
       throw new Error("Compaction summary plan produced no summary");
     }
-    return { kind: "summary", text: summary };
+    return {
+      kind: usedGenericFallback ? "generic-fallback" : "summary",
+      text: summary,
+    };
   }
 
   // Capture once so timestamps are strictly monotonic across
@@ -475,11 +480,14 @@ export async function summarizeInStages(params: {
     ? `${MERGE_SUMMARIES_INSTRUCTIONS}\n\n${custom}`
     : MERGE_SUMMARIES_INSTRUCTIONS;
 
-  return summarizeWithFallbackResult({
+  const mergedResult = await summarizeWithFallbackResult({
     ...params,
     messages: summaryMessages,
     customInstructions: mergeInstructions,
   });
+  return usedGenericFallback && mergedResult.kind === "summary"
+    ? { kind: "generic-fallback", text: mergedResult.text }
+    : mergedResult;
 }
 
 /** Resolves a positive context-window token count from model metadata. */


### PR DESCRIPTION
## Summary

Fixes #58838. Staged compaction no longer burns requests across every split when summarization repeatedly falls back generically.

The maintainer rewrite:

- classifies real summaries and generic fallbacks with a discriminated internal result;
- opens the circuit after two consecutive generic split fallbacks;
- cancels the incomplete compaction so unprocessed transcript messages remain intact;
- resets the consecutive counter after a successful split while retaining degraded state through merge;
- preserves a known prior summary when an isolated generic fallback prevents redistillation.

## What Problem This Solves

When the summarizer is persistently unavailable, staged compaction can exhaust the retry/fallback path for every split. That multiplies token and latency cost. Stopping the loop by returning the summaries collected so far is unsafe: later transcript chunks were never processed, yet compaction would commit and drop them. This fix bounds the storm and cancels the incomplete compaction so the transcript survives.

## Evidence

`node scripts/run-vitest.mjs src/agents/compaction.circuit-breaker.test.ts src/agents/compaction.identifier-preservation.test.ts src/agents/compaction.summarize-fallback.test.ts src/agents/compaction-partial-summary.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts` passed 5 files and 133 tests. The breaker test proves exactly two calls before circuit-open and rejection; the intermittent test proves counter reset plus degraded merge state; safeguard coverage proves prior-summary retention. Fresh full-diff autoreview is clean.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #58838
- Related current-main lock ownership: #88919 (inspected; orthogonal)
- [x] This PR fixes a bug or regression

## Motivation

A persistently unavailable summarizer could make every staged split exhaust its retry/fallback path, multiplying token and latency cost. Returning an incomplete partial summary would also risk committing away splits that were never processed. The breaker must stop the request storm and preserve the source transcript.

## Real Behavior Proof

Focused regression command:

```bash
node scripts/run-vitest.mjs src/agents/compaction.circuit-breaker.test.ts src/agents/compaction.identifier-preservation.test.ts src/agents/compaction.summarize-fallback.test.ts src/agents/compaction-partial-summary.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts
```

Result: 5 test files passed, 133 tests passed.

The circuit-breaker regression proves two consecutive generic fallbacks make only two summarization calls and reject the incomplete compaction. The intermittent sequence proves a successful split resets the consecutive counter, the merge still runs, and the typed result remains degraded. Safeguard coverage proves a prior summary survives degraded redistillation.

Scoped changed-gate command:

```bash
node scripts/check-changed.mjs -- src/agents/compaction.ts src/agents/compaction.circuit-breaker.test.ts src/agents/agent-hooks/compaction-safeguard.ts src/agents/agent-hooks/compaction-safeguard.test.ts
```

Conflict markers, max-lines ratchet, changelog attribution, wildcard export guards, duplicate coverage, dependency pins, and formatting passed. The delegated run then encountered pre-existing Plugin SDK API baseline drift on current main; this PR changes no Plugin SDK path or export. Exact-head hosted CI remains the landing gate.

Fresh full-diff autoreview result: clean, no accepted/actionable findings.

## Root Cause

The staged loop treated a generic fallback string like a usable summary and had no typed signal for repeated failure. That made it impossible to bound repeated calls without brittle string matching, and an early partial return could silently discard unprocessed transcript chunks.

## Regression Test Plan

1. Two consecutive generic fallbacks open the circuit after two calls and reject the compaction.
2. A successful split resets the consecutive counter and allows the merge.
3. Any generic split keeps the merged result typed as degraded.
4. A degraded result preserves the previous summary at the safeguard owner.
5. Existing fallback, partial-summary, and identifier-preservation tests remain green.

## User-visible / Behavior Changes

During a sustained summarizer outage, OpenClaw stops staged summarization after two consecutive generic fallbacks and cancels that compaction attempt. The session transcript remains available for a later retry instead of being replaced by an incomplete placeholder summary.

Release-note context: compaction now stops repeated staged fallback storms while preserving session history when the summarizer is unavailable. Thanks @tanshanshan.

## Security Impact (required)

- [ ] New permissions/capabilities? No
- [ ] Secrets/tokens handling changed? No
- [ ] New/changed network calls? No
- [ ] Command/tool execution surface changed? No
- [ ] Data access scope changed? No

## Human Verification (required)

- Verified scenarios: consecutive fallback circuit-open; intermittent fallback recovery; degraded merge classification; prior-summary retention.
- Edge cases checked: partial model output remains a real summary; aborts still propagate; single-pass and custom-provider paths remain unchanged.
- Not verified: a deliberate live production-provider outage. Deterministic regression tests exercise the same internal failure states without spending external tokens.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Risks and Mitigations

Risk: stopping early could lose current transcript context if an incomplete summary were committed. Mitigation: circuit-open throws into the safeguard's existing cancel path, which retains the original transcript. No config, storage schema, or public API changes.
