### PR TITLE
fix(feishu): fall back to post mode when markdown tables exceed card limit

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -669,6 +669,81 @@ describe("feishuPlugin actions", () => {
     expect(details.chatId).toBe("oc_group_1");
   });
 
+  it("falls back to text delivery when presentation text exceeds the card table limit", async () => {
+    feishuOutboundSendPayloadMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_fallback",
+      chatId: "oc_group_1",
+    });
+
+    const sixTables = Array.from(
+      { length: 6 },
+      (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+    ).join("\n\n");
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: sixTables,
+        presentation: {
+          title: "Status",
+          blocks: [{ type: "text", text: "Build completed" }],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    // The generated card would embed 6 tables and hit Feishu ErrCode 11310, so it
+    // must be rejected and routed to the sendPayload text fallback instead.
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendPayloadMock).toHaveBeenCalledTimes(1);
+    const payloadArgs = requireRecord(
+      mockCallArg(feishuOutboundSendPayloadMock, 0, 0, "feishuOutbound.sendPayload"),
+      "sendPayload args",
+    );
+    expect(payloadArgs.to).toBe("chat:oc_group_1");
+    expect(payloadArgs.text).toBe(sixTables);
+    const details = resultDetails(result);
+    expect(details.ok).toBe(true);
+    expect(details.messageId).toBe("om_fallback");
+  });
+
+  it("falls back when a presentation text block embeds 6 tables", async () => {
+    feishuOutboundSendPayloadMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_fallback",
+      chatId: "oc_group_1",
+    });
+
+    const sixTables = Array.from(
+      { length: 6 },
+      (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+    ).join("\n\n");
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        presentation: {
+          title: "Report",
+          blocks: [{ type: "text", text: sixTables }],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendPayloadMock).toHaveBeenCalledTimes(1);
+    const details = resultDetails(result);
+    expect(details.ok).toBe(true);
+    expect(details.messageId).toBe("om_fallback");
+  });
+
   it("hides prefixed native-card JSON in oversized presentation fallbacks", async () => {
     feishuOutboundSendPayloadMock.mockResolvedValueOnce({
       channel: "feishu",

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -92,6 +92,7 @@ import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import {
   assertFeishuCardWithinEnvelope,
   buildFeishuPresentationCard,
+  feishuCardWithinTableLimit,
   isFeishuCardWithinEnvelope,
 } from "./presentation-card.js";
 import {
@@ -1085,16 +1086,23 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (textCard && !presentation) {
               assertFeishuCardWithinEnvelope(textCard, "Feishu native card");
             }
+            const presentationFallbackText = textCard
+              ? undefined
+              : resolveLegacyInteractiveTextFallback({ text, interactive });
             const generatedCard = presentation
               ? buildFeishuPresentationCard({
                   presentation,
-                  fallbackText: textCard
-                    ? undefined
-                    : resolveLegacyInteractiveTextFallback({ text, interactive }),
+                  fallbackText: presentationFallbackText,
                 })
               : undefined;
+            // Feishu static cards cap out at 5 table components (ErrCode 11310). Count
+            // tables across every markdown element of the generated card (fallback text
+            // and presentation blocks alike) and fall back to the text path when
+            // exceeded via presentationFellBack.
             const presentationCard =
-              generatedCard && isFeishuCardWithinEnvelope(generatedCard)
+              generatedCard &&
+              feishuCardWithinTableLimit(generatedCard) &&
+              isFeishuCardWithinEnvelope(generatedCard)
                 ? generatedCard
                 : undefined;
             const presentationFellBack = Boolean(generatedCard && !presentationCard);

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -3126,4 +3126,155 @@ describe("feishuOutbound.sendMedia renderMode", () => {
     expect(sendMessageCall()?.accountId).toBe("main");
   });
 });
+
+describe("feishuOutbound table-limit routing", () => {
+  beforeEach(() => {
+    resetOutboundMocks();
+  });
+
+  function makeTableText(count: number): string {
+    return Array.from({ length: count }, (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`).join(
+      "\n\n",
+    );
+  }
+
+  it("routes 5 markdown tables to structured card when renderMode=auto", async () => {
+    const text = makeTableText(5);
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+    });
+
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to post mode for 6 markdown tables when renderMode=auto", async () => {
+    const text = makeTableText(6);
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to post mode for 6 tables even with explicit renderMode=card", async () => {
+    const text = makeTableText(6);
+    await sendText({
+      cfg: cardRenderConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("excludes tables inside code blocks from the table count", async () => {
+    const text = "```\n| a | b |\n| - | - |\n| 1 | 2 |\n```\n\n" + makeTableText(5);
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+    });
+
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to post mode for 6 pipeless GFM tables", async () => {
+    const text = Array.from({ length: 6 }, (_, i) => `a${i} | b${i}\n--- | ---\n1 | 2`).join(
+      "\n\n",
+    );
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("feishuOutbound presentation card table-limit", () => {
+  beforeEach(() => {
+    resetOutboundMocks();
+  });
+
+  function makeTableText(count: number): string {
+    return Array.from({ length: count }, (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`).join(
+      "\n\n",
+    );
+  }
+
+  function makeActionPresentation(): MessagePresentation {
+    return {
+      title: "Confirm",
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [{ label: "Confirm", action: { type: "command", command: "/ok" } }],
+        },
+      ],
+    };
+  }
+
+  it("refuses the presentation card and falls back to post mode for 6 markdown tables", async () => {
+    const text = makeTableText(6);
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text, presentation: makeActionPresentation() },
+    });
+
+    // The presentation card must not be built/sent (would hit ErrCode 11310).
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    // Delivery still happens through the post path with tables converted to code blocks.
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+    expect(sendMessageCall()?.text).toContain("```");
+  });
+
+  it("still builds the presentation card for 5 markdown tables", async () => {
+    const text = makeTableText(5);
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text, presentation: makeActionPresentation() },
+    });
+
+    expect(sendCardFeishuMock).toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses the card when a presentation text block embeds 6 tables", async () => {
+    const presentation: MessagePresentation = {
+      title: "Report",
+      blocks: [{ type: "text", text: makeTableText(6) }],
+    };
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "",
+      accountId: "main",
+      payload: { text: "", presentation },
+    });
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -55,7 +55,9 @@ import type { ChannelOutboundAdapter } from "./outbound-runtime-api.js";
 import {
   assertFeishuCardWithinEnvelope,
   buildFeishuPresentationCardElements,
+  feishuCardWithinTableLimit,
   isFeishuCardWithinEnvelope,
+  withinCardTableLimit,
 } from "./presentation-card.js";
 import {
   sendCardFeishu,
@@ -216,6 +218,7 @@ function buildFeishuPayloadCard(params: {
         text: rawText,
         interactive,
       });
+
   const elements = presentation
     ? buildFeishuPresentationCardElements({ presentation, fallbackText: text })
     : [
@@ -250,7 +253,13 @@ function buildFeishuPayloadCard(params: {
       : {}),
     body: { elements },
   });
-  return isFeishuCardWithinEnvelope(card) ? card : undefined;
+  // Static cards cap out at 5 table components (Feishu ErrCode 11310). Count
+  // tables across every markdown element of the built card (fallback text and
+  // presentation blocks alike) and fall back to the text path when exceeded.
+  if (!isFeishuCardWithinEnvelope(card) || !feishuCardWithinTableLimit(card)) {
+    return undefined;
+  }
+  return card;
 }
 
 // Keep this aligned with the shared fallback renderer: guidance is valid only
@@ -421,7 +430,10 @@ async function sendOutboundText(params: {
   // Decide card routing on the original text so card content is never
   // modified by post-md newline normalization. Only the post path below
   // materializes CommonMark soft breaks for Feishu rendering.
-  if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
+  if (
+    (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) &&
+    withinCardTableLimit(text)
+  ) {
     return await reportFeishuOutboundDelivery(
       await sendMarkdownCardFeishu({
         cfg,
@@ -862,7 +874,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
 
       const account = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined });
       const renderMode = account.config?.renderMode ?? "auto";
-      const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+      const useCard =
+        (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) &&
+        withinCardTableLimit(text);
       if (useCard) {
         const header = identity
           ? {

--- a/extensions/feishu/src/presentation-card.test.ts
+++ b/extensions/feishu/src/presentation-card.test.ts
@@ -2,7 +2,9 @@ import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-ru
 import { describe, expect, it } from "vitest";
 import {
   buildFeishuPresentationCardElements,
+  feishuCardWithinTableLimit,
   isFeishuCardWithinEnvelope,
+  withinCardTableLimit,
 } from "./presentation-card.js";
 
 describe("buildFeishuPresentationCardElements", () => {
@@ -48,5 +50,77 @@ describe("isFeishuCardWithinEnvelope", () => {
 
     expect(isFeishuCardWithinEnvelope(buildCard(200))).toBe(true);
     expect(isFeishuCardWithinEnvelope(buildCard(201))).toBe(false);
+  });
+});
+
+describe("withinCardTableLimit (parser-backed table counting)", () => {
+  const pipedTable = "| a | b |\n| - | - |\n| 1 | 2 |";
+  const pipelessTable = "a | b\n--- | ---\n1 | 2";
+  const repeat = (table: string, count: number) =>
+    Array.from({ length: count }, () => table).join("\n\n");
+
+  it("accepts piped and pipe-less GFM tables at the 5-table boundary", () => {
+    expect(withinCardTableLimit(repeat(pipedTable, 5))).toBe(true);
+    expect(withinCardTableLimit(repeat(pipedTable, 6))).toBe(false);
+    expect(withinCardTableLimit(repeat(pipelessTable, 5))).toBe(true);
+    expect(withinCardTableLimit(repeat(pipelessTable, 6))).toBe(false);
+  });
+
+  it("counts alignment-colon delimiters toward the limit", () => {
+    const alignPiped = "| a | b |\n|:--|--:|\n| 1 | 2 |";
+    const alignPipeless = "c | d\n:---: | ---\n3 | 4";
+    expect(withinCardTableLimit(repeat(alignPiped, 6))).toBe(false);
+    expect(withinCardTableLimit(repeat(alignPipeless, 6))).toBe(false);
+    expect(withinCardTableLimit(repeat(alignPiped, 5))).toBe(true);
+  });
+
+  it("does not count tables inside fenced code blocks", () => {
+    expect(withinCardTableLimit("```\n" + repeat(pipedTable, 6) + "\n```")).toBe(true);
+    expect(
+      withinCardTableLimit("```\n" + repeat(pipedTable, 2) + "\n```\n\n" + repeat(pipedTable, 6)),
+    ).toBe(false);
+  });
+
+  it("does not count thematic breaks or plain pipes in prose", () => {
+    expect(withinCardTableLimit("---\n\nhello | world\n\n2024 | 2025")).toBe(true);
+  });
+});
+
+describe("feishuCardWithinTableLimit", () => {
+  const table = "| a | b |\n| - | - |\n| 1 | 2 |";
+
+  it("sums tables across all markdown elements of the card", () => {
+    const card = {
+      schema: "2.0",
+      body: {
+        elements: [
+          { tag: "markdown", content: `${table}\n\n${table}\n\n${table}` },
+          { tag: "hr" },
+          { tag: "markdown", content: `${table}\n\n${table}\n\n${table}` },
+        ],
+      },
+    };
+    expect(feishuCardWithinTableLimit(card)).toBe(false);
+  });
+
+  it("accepts cards with at most 5 tables across elements", () => {
+    const card = {
+      schema: "2.0",
+      body: {
+        elements: [
+          { tag: "markdown", content: `${table}\n\n${table}\n\n${table}` },
+          { tag: "markdown", content: `${table}\n\n${table}` },
+        ],
+      },
+    };
+    expect(feishuCardWithinTableLimit(card)).toBe(true);
+  });
+
+  it("accepts cards without markdown tables", () => {
+    const card = {
+      schema: "2.0",
+      body: { elements: [{ tag: "markdown", content: "plain | pipes but no table" }] },
+    };
+    expect(feishuCardWithinTableLimit(card)).toBe(true);
   });
 });

--- a/extensions/feishu/src/presentation-card.ts
+++ b/extensions/feishu/src/presentation-card.ts
@@ -7,6 +7,7 @@ import {
   type MessagePresentationBlock,
   type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import { markdownToIRWithMeta } from "openclaw/plugin-sdk/text-chunking";
 import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 
 type NormalizedMessagePresentation = NonNullable<ReturnType<typeof normalizeMessagePresentation>>;
@@ -55,6 +56,58 @@ export function assertFeishuCardWithinEnvelope(
   if (!isFeishuCardWithinEnvelope(card)) {
     throw new Error(`${label} exceeds the 30 KB or 200-element API limit.`);
   }
+}
+
+/** Feishu allows at most 5 table components per static interactive card (ErrCode 11310). */
+const FEISHU_CARD_TABLE_LIMIT = 5;
+
+/**
+ * Count GFM tables with the shared markdown parser (the same parser used for
+ * post-mode table conversion), so every parser-recognized table form is caught
+ * — including pipe-less GFM tables and alignment-colon delimiters — while
+ * fenced code, thematic breaks, and plain pipes in prose are not counted.
+ */
+function countMarkdownTables(text: string): number {
+  if (!text) {
+    return 0;
+  }
+  return markdownToIRWithMeta(text, { tableMode: "block" }).tables.length;
+}
+
+/** Check whether the number of markdown tables is within Feishu static-card limits. */
+export function withinCardTableLimit(text: string): boolean {
+  return countMarkdownTables(text) <= FEISHU_CARD_TABLE_LIMIT;
+}
+
+function collectFeishuCardMarkdownTexts(value: unknown, out: string[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectFeishuCardMarkdownTexts(item, out);
+    }
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.tag === "markdown" && typeof record.content === "string") {
+    out.push(record.content);
+  }
+  for (const child of Object.values(record)) {
+    collectFeishuCardMarkdownTexts(child, out);
+  }
+}
+
+/**
+ * Check a built Feishu card JSON against the table limit by counting tables in
+ * the combined markdown content of all its elements. Covers generated cards
+ * whose tables come from fallback text as well as presentation blocks.
+ */
+export function feishuCardWithinTableLimit(card: Record<string, unknown>): boolean {
+  const texts: string[] = [];
+  collectFeishuCardMarkdownTexts(card, texts);
+  const total = texts.reduce((sum, text) => sum + countMarkdownTables(text), 0);
+  return total <= FEISHU_CARD_TABLE_LIMIT;
 }
 
 function escapeFeishuCardMarkdownText(text: string): string {

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1863,6 +1863,36 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to post mode when over-limit streaming content was never accepted", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om-post" });
+    const { options } = createDispatcherHarness();
+    const text = Array.from(
+      { length: 6 },
+      (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+    ).join("\n\n");
+    const delivery = await options.deliver({ text }, { kind: "final" });
+    requireStreamingInstance(0).closeWithResult.mockRejectedValueOnce(
+      new FeishuStreamingFinalizationError(new Error("final update failed"), {
+        visibleReplySent: false,
+        messageId: "om-empty-stream",
+      }),
+    );
+
+    await expect(options.onIdle?.()).rejects.toThrow("final update failed");
+    await expect(delivery?.finalization).rejects.toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        content: text,
+        messageIds: ["om-post"],
+        visibleReplySent: true,
+      },
+    });
+    // Over-limit content must recover through the post path, not a static card
+    // that Feishu would reject again with ErrCode 11310.
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("does not repeat an earlier static fallback when a later fallback fails", async () => {
     sendStructuredCardFeishuMock
       .mockResolvedValueOnce({ messageId: "om-first-static" })
@@ -3381,6 +3411,62 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       streamingInstances.push = origPush;
       nowSpy.mockRestore();
     }
+  });
+
+  describe("table-limit routing", () => {
+    function makeTableText(count: number): string {
+      return Array.from(
+        { length: count },
+        (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+      ).join("\n\n");
+    }
+
+    function setupDispatcher() {
+      const result = createFeishuReplyDispatcher({
+        cfg: {} as never,
+        agentId: "agent",
+        runtime: { log: vi.fn(), error: vi.fn() } as never,
+        chatId: "oc_chat",
+        sendTarget: "oc_chat",
+      });
+      return toTypingDispatcherOptions(result);
+    }
+
+    it("routes 5 markdown tables to static card when streaming is off", async () => {
+      useNonStreamingAutoAccount();
+      const options = setupDispatcher();
+      const text = makeTableText(5);
+      await options.deliver({ text }, { kind: "final" });
+
+      expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to post mode for 6 markdown tables when streaming is off", async () => {
+      useNonStreamingAutoAccount();
+      const options = setupDispatcher();
+      const text = makeTableText(6);
+      await options.deliver({ text }, { kind: "final" });
+
+      expect(sendMessageFeishuMock).toHaveBeenCalled();
+      expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to post mode for 6 tables with explicit renderMode=card", async () => {
+      resolveFeishuAccountMock.mockReturnValue({
+        accountId: "main",
+        appId: "app_id",
+        appSecret: "app_secret",
+        domain: "feishu",
+        config: { renderMode: "card", streaming: { mode: "off" } },
+      });
+      const options = setupDispatcher();
+      const text = makeTableText(6);
+      await options.deliver({ text }, { kind: "final" });
+
+      expect(sendMessageFeishuMock).toHaveBeenCalled();
+      expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -28,6 +28,7 @@ import { chunkFeishuPostMarkdown, materializeFeishuPostMarkdownSoftBreaks } from
 import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
+import { withinCardTableLimit } from "./presentation-card.js";
 import {
   createFeishuPartialReplyDeliveryError,
   createFeishuReplyDeliveryResult,
@@ -957,24 +958,39 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     const cardHeader = resolveCardHeader(agentId, identity);
     const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+    // Static cards cap out at 5 table components (Feishu ErrCode 11310). When the
+    // recovered content exceeds the limit, deliver it through the post path instead
+    // of retrying a static card the API would reject again.
+    const useRecoveryCard = withinCardTableLimit(content);
     return await sendChunkedTextReply({
       text: content,
-      useCard: true,
+      useCard: useRecoveryCard,
       infoKind,
       chunkMentions: requiredMentionTargets,
       sendChunk: async ({ chunk, mentions }) =>
-        await sendStructuredCardFeishu({
-          cfg,
-          to: sendTarget,
-          text: chunk,
-          replyToMessageId: sendReplyToMessageId,
-          replyInThread: effectiveReplyInThread,
-          allowTopLevelReplyFallback,
-          accountId,
-          header: cardHeader,
-          note: cardNote,
-          ...(mentions ? { mentions } : {}),
-        }),
+        useRecoveryCard
+          ? await sendStructuredCardFeishu({
+              cfg,
+              to: sendTarget,
+              text: chunk,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              allowTopLevelReplyFallback,
+              accountId,
+              header: cardHeader,
+              note: cardNote,
+              ...(mentions ? { mentions } : {}),
+            })
+          : await sendMessageFeishu({
+              cfg,
+              to: sendTarget,
+              text: chunk,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              allowTopLevelReplyFallback,
+              accountId,
+              ...(mentions ? { mentions } : {}),
+            }),
     });
   };
 
@@ -1289,7 +1305,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         hasText &&
         (renderMode === "card" ||
           (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
-          (renderMode === "auto" && shouldUseCard(text)));
+          (renderMode === "auto" && shouldUseCard(text))) &&
+        withinCardTableLimit(text);
       const useStreamingCard =
         hasText &&
         streamingEnabled &&


### PR DESCRIPTION
## What Problem This Solves

When an agent's reply contains more than 5 Markdown tables, the Feishu plugin detects tables and automatically sends the reply as an interactive card. However, the Feishu card API limits each card to at most 5 table components (`ErrCode: 11310; card table number over limit`). Messages exceeding this limit fail delivery and enter the delivery queue — the user sees nothing in Feishu while the reply sits in the control UI. This PR makes every static-card decision point respect the 5-table ceiling and fall back to the existing post path instead of failing.

The failure affects every static-card decision point:
- Auto-reply (`reply-dispatcher.ts`) — `useStaticCard` decision
- Outbound (`outbound.ts`) — `sendOutboundText` / `sendText` card decision
- Generated presentation cards (`outbound.ts`) — `buildFeishuPayloadCard`
- Message-action delivery (`channel.ts`) — `send` / `thread-reply` with a `presentation` param
- Streaming recovery (`reply-dispatcher.ts`) — `ensureVisibleStreamingDelivery` re-send after an invisible CardKit result

The issue also occurs when `renderMode` is explicitly set to `"card"` (not just `"auto"`).

## Solution

Tables are now counted with the shared GFM markdown parser (`markdownToIRWithMeta`, the same parser used for post-mode table conversion) instead of a delimiter-row regex, so every parser-recognized table form is caught — including **pipe-less GFM tables** (`a | b` / `--- | ---`) and **alignment-colon delimiters** (`|:--|--:|`) — while fenced code, thematic breaks, and plain pipes in prose are not counted. Feishu was empirically verified to reject pipe-less tables exactly like piped ones (both fail with `ErrCode 11310` at 6 tables), so both forms must be counted.

The counting helpers live in one place (`presentation-card.ts`, next to `isFeishuCardWithinEnvelope`) and are used by every static-card decision point:

- `withinCardTableLimit(text)` — parser-backed ≤5 check for a single markdown payload
- `feishuCardWithinTableLimit(card)` — counts tables across **every markdown element of a built card**, covering generated cards whose tables come from fallback text as well as presentation `text`/`context` blocks

When card mode is rejected, delivery falls back to post mode (`convertMarkdownTables(text, "code")` — a reliable, already existing code path).

### Scope note: streaming CardKit cards are intentionally not guarded

Only static interactive cards (`im/v1/messages`, `msg_type: "interactive"`) are guarded. Streaming CardKit cards (`cardkit/v1/cards`) render content inside a markdown element (`PUT .../elements/content/content`) rather than as table components, so the 5-table component limit does not apply there — see "Streaming CardKit verification" below for empirical evidence. The `useStreamingCard` decision is left unchanged; only the static-card recovery re-send after an invisible streaming result is guarded (it would otherwise retry the same over-limit content as a static card and fail again).

Generated presentation cards are static interactive cards: their elements are markdown, subject to the same limit. They are guarded at the card-construction boundary with the card-level check. Opaque native Feishu cards supplied by the caller are not inspected (they are returned before the guard runs).

One nuance, verified empirically: a `context` presentation block renders its text wrapped in `<font color='grey'>…</font>`, and tables inside that decoration are **not** parsed by Feishu as table components — a card whose only content is a font-wrapped 6-table block is accepted by the real API (`code 0`), so it cannot hit the 5-component limit. The card-level check therefore intentionally counts what Feishu counts (bare table components) and leaves font-decorated content unguarded; blocking it would degrade cards that Feishu delivers fine.

## Changes

- `extensions/feishu/src/presentation-card.ts`: parser-backed `withinCardTableLimit` plus card-level `feishuCardWithinTableLimit` (single shared implementation).
- `extensions/feishu/src/reply-dispatcher.ts`: `useStaticCard` checks the table limit before card mode (applies to `renderMode: "card"` and `"auto"` alike); `useStreamingCard` unchanged; the private regex copy is removed in favor of the shared helper; `ensureVisibleStreamingDelivery` (streaming recovery after an invisible CardKit result) delivers over-limit content through the post path instead of retrying a static card.
- `extensions/feishu/src/outbound.ts`: guard applied at the static-card decision points in `sendOutboundText` and `sendText`; `buildFeishuPayloadCard` returns `undefined` when the built card exceeds the limit (card-level check), so generated presentation cards fall back to the existing text path. Opaque native Feishu cards are not altered.
- `extensions/feishu/src/channel.ts`: the message-action path (`send` / `thread-reply` with a `presentation` param) rejects the generated card when the card-level check fails and routes delivery through the existing `presentationFellBack` → `sendPayload` text fallback.

## Release note

> Feishu: replies with more than 5 markdown tables now fall back to post rendering instead of failing card delivery (Feishu hard limit: 5 table components per card). This also applies when `renderMode: "card"` is explicitly configured: such messages render as posts with tables converted to code blocks. Table counting now recognizes all GFM table forms, including pipe-less tables.

## Testing

- Full feishu extension suite: **1593 tests passed**, extension type check clean, knip dead-code checks clean
- Parser-backed counting regression tests: piped tables, pipe-less GFM tables, alignment-colon delimiters, fenced-code exclusion, thematic breaks / plain pipes in prose
- Card-level check tests: tables summed across multiple markdown elements; 5-table boundary accepted
- Routing tests: 5 tables → card; 6 tables → post fallback (auto, explicit card, pipe-less GFM)
- Presentation tests: 6 tables in fallback text or in a `text` block refuse the generated card and deliver via post (both `sendPayload` and message-action paths); 5 tables still build the card
- Streaming recovery test: over-limit content that was never accepted recovers through the post path, not a rejected static card

## Evidence (real Feishu API, exact patched paths)

**After-fix proof through the patched code paths** — the patched `feishuOutbound.sendText` and `feishuOutbound.sendPayload` were executed against the real Feishu API (production tenant, websocket account) with over-limit content; each receipt part `kind` shows which transport was used:

1. `sendText` with **6 tables** → guarded out of card mode, delivered via **post** (`kind: "text"`, tables converted to code blocks):
```
messageId: om_x100b687c343ae53cb1a02a151b50f37   parts[0].kind: "text"
```
2. `sendText` with **5 tables** → card mode preserved at the boundary, delivered as **card** (`kind: "card"`):
```
messageId: om_x100b687c35ccaca8b20a9a7be054a36   parts[0].kind: "card"
```
3. `sendPayload` with an **action-bearing presentation + 6-table text** → generated card refused at the construction boundary, delivered via the `presentationFellBack` **post** path:
```
messageId: om_x100b687c35dfaca4b1cb06cf3f4a73b   parts[0].kind: "text"
```

**Pre-fix failures** (all `HTTP 400 / code 230099 / ErrCode: 11310`):

4. Production delivery-queue failure (2026-05-26, 18 tables):
```
[delivery-recovery] Retry failed: Feishu card send failed:
"feishu_msg": "Failed to create card content, ext=ErrCode: 11310;
ErrMsg: card table number over limit; ErrorValue: table;"
```
5. Static card, 6 piped tables — re-confirmed against the real API (2026-08-06)
6. Static card, 6 **pipe-less** GFM tables — the real API rejects these too (2026-08-06), which is why counting is parser-backed rather than regex-based
7. Generated presentation card embedding 6 tables (built by `sendPayload` with an action-bearing presentation, sent as-is to the real API) — rejected (2026-08-06)
8. Message-action presentation send with 6-table text (production gateway, 2026-08-06):
```
2026-08-06T16:30:24 Feishu card send failed: http_status:400, feishu_code:230099,
"ErrCode: 11310; ErrMsg: card table number over limit; ErrorValue: table"
```
9. Font-wrapped context-block probe (2026-08-06): a card whose only element is a markdown element containing `<font color='grey'>` + 6 tables + `</font>` — the exact bytes `presentation-card.ts` emits for a `context` block — was accepted by the real API: `HTTP 200 / code 0 / success`. Font-decorated tables are not counted by Feishu, so a context block cannot trip the 5-table limit.

Feishu official docs confirm the limit: https://open.feishu.cn/document/feishu-cards/card-json-v2-components/content-components/table?lang=zh-CN — "单张卡片最多支持放置五个表格组件"

## Streaming CardKit verification (real Feishu API)

To determine whether the CardKit streaming path is also subject to the 5-table limit, the full streaming-card API sequence was exercised against the real Feishu API (same sequence as `streaming-card.ts`: `POST cardkit/v1/cards` → send message with card reference → incremental `PUT .../elements/content/content` → `PATCH .../settings` to close streaming):

| Scenario | Result |
|---|---|
| Static card, 6 tables (`im/v1/messages`, inline card JSON) | ❌ HTTP 400 / code 230099 / `ErrCode: 11310` |
| Static card, 6 pipe-less GFM tables | ❌ HTTP 400 / code 230099 / `ErrCode: 11310` |
| Streaming card, 6 tables (create → send → 6 incremental updates → close) | ✅ all API calls succeeded |
| Streaming card, 18 tables | ✅ all API calls succeeded (all 18 updates) |
| Static card, 5 tables | ✅ delivered (boundary check) |

The streaming card carries its content in a single markdown element, so Feishu does not count table components. The original report in #43690 (v2026.3.8, March 2026) predates the current streaming implementation, which creates the card with placeholder content and streams content through the CardKit element API.

Additionally verified end-to-end in a production OpenClaw instance (v2026.5.7): with Feishu streaming enabled and the table guard bypassed, a 6-table agent reply was delivered through a streaming card and rendered correctly; with streaming disabled, the same reply failed with the 11310 error on the static-card path.

## Backward Compatibility

- No change for messages with ≤5 tables
- No change for messages without tables
- No change for `renderMode: "auto"` behavior with code blocks (still uses card mode)
- Behavior change (intended): explicit `renderMode: "card"` messages with >5 tables render as posts instead of failing delivery — see Release note above
