### PR TITLE
fix: tighten small runtime parsing guards

### DIFF
--- a/src/cli/windows-argv.test.ts
+++ b/src/cli/windows-argv.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
+import { normalizeWindowsArgv } from "./windows-argv.js";
+
+describe("normalizeWindowsArgv", () => {
+  it("removes duplicated Windows node launcher tokens", () => {
+    const platform = mockProcessPlatform("win32");
+    try {
+      expect(
+        normalizeWindowsArgv([
+          "openclaw",
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+          "status",
+        ]),
+      ).toEqual([
+        "openclaw",
+        "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+        "status",
+      ]);
+    } finally {
+      platform.mockRestore();
+    }
+  });
+
+  it("preserves non-launcher arguments containing node.exe", () => {
+    const platform = mockProcessPlatform("win32");
+    try {
+      expect(
+        normalizeWindowsArgv([
+          "openclaw",
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+          "agent",
+          "--message",
+          "debug node.exe-wrapper startup",
+        ]),
+      ).toEqual([
+        "openclaw",
+        "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+        "agent",
+        "--message",
+        "debug node.exe-wrapper startup",
+      ]);
+    } finally {
+      platform.mockRestore();
+    }
+  });
+
+  it("preserves exact node.exe option values outside the launcher prefix", () => {
+    const platform = mockProcessPlatform("win32");
+    try {
+      expect(normalizeWindowsArgv(["openclaw", "run", "--message", "node.exe"])).toEqual([
+        "openclaw",
+        "run",
+        "--message",
+        "node.exe",
+      ]);
+    } finally {
+      platform.mockRestore();
+    }
+  });
+});

--- a/src/cli/windows-argv.ts
+++ b/src/cli/windows-argv.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 export function normalizeWindowsArgv(argv: string[]): string[] {
@@ -27,10 +25,11 @@ export function normalizeWindowsArgv(argv: string[]): string[] {
       .trim();
   const normalizeCandidate = (value: string): string =>
     normalizeArg(value).replace(/^\\\\\\?\\/, "");
+  const basename = (value: string): string => value.split(/[\\/]/).pop() ?? value;
 
   const execPath = normalizeCandidate(process.execPath);
   const execPathLower = normalizeLowercaseStringOrEmpty(execPath);
-  const execBase = normalizeLowercaseStringOrEmpty(path.basename(execPath));
+  const execBase = normalizeLowercaseStringOrEmpty(basename(execPath));
   const isExecPath = (value: string | undefined): boolean => {
     if (!value) {
       return false;
@@ -40,34 +39,35 @@ export function normalizeWindowsArgv(argv: string[]): string[] {
       return false;
     }
     const lower = normalizeLowercaseStringOrEmpty(normalized);
+    const base = basename(lower);
     return (
       lower === execPathLower ||
-      path.basename(lower) === execBase ||
+      base === execBase ||
       lower.endsWith("\\node.exe") ||
       lower.endsWith("/node.exe") ||
-      lower.includes("node.exe") ||
-      (path.basename(lower) === "node.exe" && fs.existsSync(normalized))
+      base === "node.exe"
     );
   };
 
+  const argv0IsExecPath = isExecPath(argv[0]);
   const next = [...argv];
-  for (let i = 1; i <= 3 && i < next.length; ) {
+  let removedLauncherPrefix = false;
+  for (let i = 1; i < next.length; ) {
     if (isExecPath(next[i])) {
       next.splice(i, 1);
+      removedLauncherPrefix = true;
       continue;
     }
-    i += 1;
+    break;
   }
-  const filtered = next.filter((arg, index) => index === 0 || !isExecPath(arg));
-  if (filtered.length < 3) {
-    return filtered;
+  if (next.length < 3 || (!argv0IsExecPath && !removedLauncherPrefix)) {
+    return next;
   }
-  const cleaned = [...filtered];
+  const cleaned = [...next];
   for (let i = 2; i < cleaned.length; ) {
     const arg = cleaned[i];
     if (!arg || arg.startsWith("-")) {
-      i += 1;
-      continue;
+      break;
     }
     if (isExecPath(arg)) {
       cleaned.splice(i, 1);

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -417,7 +417,6 @@ async function readUnixListeners(
 
 function parseNetstatListeners(output: string, port: number): PortListener[] {
   const listeners: PortListener[] = [];
-  const portToken = `:${port}`;
   for (const rawLine of output.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line) {
@@ -426,23 +425,21 @@ function parseNetstatListeners(output: string, port: number): PortListener[] {
     if (!normalizeLowercaseStringOrEmpty(line).includes("listen")) {
       continue;
     }
-    if (!line.includes(portToken)) {
-      continue;
-    }
     const parts = line.split(/\s+/);
     if (parts.length < 4) {
       continue;
     }
+    const localAddr = parts[1];
+    if (!localAddr || parseTcpEndpoint(localAddr)?.port !== port) {
+      continue;
+    }
     const pidRaw = parts.at(-1);
     const pid = pidRaw ? Number.parseInt(pidRaw, 10) : Number.NaN;
-    const localAddr = parts[1];
     const listener: PortListener = {};
     if (Number.isFinite(pid)) {
       listener.pid = pid;
     }
-    if (localAddr?.includes(portToken)) {
-      listener.address = localAddr;
-    }
+    listener.address = localAddr;
     listeners.push(listener);
   }
   return listeners;

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -379,6 +379,27 @@ describe("inspectPortUsage on Windows", () => {
     );
   });
 
+  it("does not match Windows listener ports by substring", async () => {
+    setPlatform("win32");
+    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+      const [command] = argv;
+      if (command === "netstat") {
+        return {
+          stdout:
+            "  TCP    127.0.0.1:187890    0.0.0.0:0    LISTENING    9000\r\n" +
+            "  TCP    [::1]:187890        [::]:0         LISTENING    9001\r\n",
+          stderr: "",
+          code: 0,
+        };
+      }
+      return { stdout: "", stderr: "", code: 1 };
+    });
+
+    const result = await inspectPortUsage(18789);
+
+    expect(result.listeners).toEqual([]);
+  });
+
   it("falls back to wmic when PowerShell cannot read the command line", async () => {
     setPlatform("win32");
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {

--- a/src/talk/turn-context-tracker.test.ts
+++ b/src/talk/turn-context-tracker.test.ts
@@ -125,6 +125,16 @@ describe("realtime voice turn context tracker", () => {
     expect(tracker.consumeIgnoredContext()).toBeUndefined();
   });
 
+  it("retains valid falsy ignored contexts", () => {
+    const numbers = createRealtimeVoiceTurnContextTracker<number>();
+    numbers.rememberIgnoredContext(0);
+    expect(numbers.consumeIgnoredContext()).toBe(0);
+
+    const text = createRealtimeVoiceTurnContextTracker<string>();
+    text.rememberIgnoredContext("");
+    expect(text.consumeIgnoredContext()).toBe("");
+  });
+
   it("expires ignored contexts after the ttl", () => {
     let now = 1_000;
     const tracker = createRealtimeVoiceTurnContextTracker<{ id: string }>({

--- a/src/talk/turn-context-tracker.ts
+++ b/src/talk/turn-context-tracker.ts
@@ -175,7 +175,7 @@ export function createRealtimeVoiceTurnContextTracker<
       return turns.some((turn) => turn.hasAudio);
     },
     rememberIgnoredContext(context) {
-      if (!context) {
+      if (context === undefined) {
         return;
       }
       recentIgnoredContext = { context, createdAt: now() };


### PR DESCRIPTION
## Summary
- preserve Windows CLI arguments that mention `node.exe` unless they are launcher-prefix duplicates
- parse Windows netstat listener ports exactly instead of substring-matching the requested port
- keep valid falsy realtime voice ignored contexts such as `0` and empty strings

## Verification
- `node scripts/run-vitest.mjs src/cli/windows-argv.test.ts src/talk/turn-context-tracker.test.ts src/infra/ports.test.ts`
- `git diff --check`
- `node ../clawpatch/dist/cli.js --state-dir /tmp/clawpatch-openclaw revalidate --finding fnd_sig-feat-cli-command-dbc5eaaee4-_8b37697555 --include-dirty --plain`
- `node ../clawpatch/dist/cli.js --state-dir /tmp/clawpatch-openclaw revalidate --finding fnd_sig-feat-library-023fe89a12-dcdc_b4bdb7ae4b --include-dirty --plain`
- `node ../clawpatch/dist/cli.js --state-dir /tmp/clawpatch-openclaw revalidate --finding fnd_sig-feat-library-01dd022bab-36ca_f93960175e --include-dirty --plain`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/cli/windows-argv.test.ts src/talk/turn-context-tracker.test.ts src/infra/ports.test.ts"`

## Real behavior proof
Behavior addressed: Windows argv normalization no longer drops user option values containing `node.exe`; Windows port inspection no longer treats ports like `187890` as listeners for `18789`; ignored realtime voice contexts no longer discard valid falsy values.
Real environment tested: local OpenClaw checkout on macOS with Windows platform mocked in focused unit tests.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/windows-argv.test.ts src/talk/turn-context-tracker.test.ts src/infra/ports.test.ts`.
Evidence after fix: 3 focused test files passed with regression coverage for each bug, and clawpatch revalidated all three findings as fixed.
Observed result after fix: 3 test files passed, 25 tests passed; autoreview reported no accepted/actionable findings.
What was not tested: live Windows host execution and full suite were not run.
