### PR TITLE
fix(lock): expire stale locks by createdAt before pid liveness

### DIFF
--- a/src/infra/stale-lock-file.test.ts
+++ b/src/infra/stale-lock-file.test.ts
@@ -2,28 +2,108 @@ import { describe, expect, it } from "vitest";
 import { shouldRemoveDeadOwnerOrExpiredLock } from "./stale-lock-file.js";
 
 describe("stale lock file ownership", () => {
-  it("treats permission-denied process probes as not definitely dead", () => {
+  it("keeps lock when owner pid probe is inconclusive and createdAt is still fresh", () => {
     expect(
       shouldRemoveDeadOwnerOrExpiredLock({
         payload: {
           pid: 123,
-          createdAt: new Date(Date.now() - 60_000).toISOString(),
+          createdAt: new Date(Date.now() - 5).toISOString(),
         },
-        staleMs: 10,
+        staleMs: 10_000,
         isPidDefinitelyDead: () => false,
       }),
     ).toBe(false);
   });
 
-  it("only removes pid-owned locks when the owner is definitely dead", () => {
+  it("removes lock when the recorded owner is definitely dead", () => {
     expect(
       shouldRemoveDeadOwnerOrExpiredLock({
         payload: {
           pid: 123,
-          createdAt: new Date(Date.now() - 60_000).toISOString(),
+          createdAt: new Date(Date.now() - 5).toISOString(),
         },
-        staleMs: 10,
+        staleMs: 10_000,
         isPidDefinitelyDead: () => true,
+      }),
+    ).toBe(true);
+  });
+
+  it("removes lock when createdAt is older than staleMs even if the recorded pid is currently alive (pid reuse safeguard)", () => {
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: {
+          pid: 12345,
+          createdAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+        },
+        staleMs: 60 * 60 * 1000,
+        isPidDefinitelyDead: () => false,
+      }),
+    ).toBe(true);
+  });
+
+  it("removes lock when createdAt is unparseable", () => {
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { pid: 12345, createdAt: "not-a-date" },
+        staleMs: 1_000,
+        isPidDefinitelyDead: () => false,
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to pid liveness when payload has no createdAt", () => {
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { pid: 12345 },
+        staleMs: 1_000,
+        isPidDefinitelyDead: () => true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { pid: 12345 },
+        staleMs: 1_000,
+        isPidDefinitelyDead: () => false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps lock with no pid and fresh createdAt", () => {
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { createdAt: new Date(Date.now() - 5).toISOString() },
+        staleMs: 10_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("removes lock with no pid when createdAt is older than staleMs", () => {
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { createdAt: new Date(Date.now() - 60_000).toISOString() },
+        staleMs: 1_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for null payload", () => {
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: null,
+        staleMs: 10,
+      }),
+    ).toBe(false);
+  });
+
+  it("honors injected nowMs when comparing createdAt against staleMs", () => {
+    const createdAt = "2026-01-01T00:00:00.000Z";
+    const fixedNow = Date.parse(createdAt) + 2_000;
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { pid: 12345, createdAt },
+        staleMs: 1_000,
+        nowMs: fixedNow,
+        isPidDefinitelyDead: () => false,
       }),
     ).toBe(true);
   });

--- a/src/infra/stale-lock-file.ts
+++ b/src/infra/stale-lock-file.ts
@@ -24,12 +24,20 @@ export function shouldRemoveDeadOwnerOrExpiredLock(params: {
   isPidDefinitelyDead?: (pid: number) => boolean;
 }): boolean {
   const payload = readLockFileOwnerPayload(params.payload);
-  if (payload?.pid) {
-    return (params.isPidDefinitelyDead ?? defaultIsPidDefinitelyDead)(payload.pid);
+  if (!payload) {
+    return false;
   }
-  if (payload?.createdAt) {
+  // createdAt expiry must be evaluated before pid liveness: the OS can recycle
+  // a dead owner's pid to an unrelated process, in which case a still-alive
+  // probe would otherwise pin a stale lock open past `staleMs` forever.
+  if (payload.createdAt) {
     const createdAt = Date.parse(payload.createdAt);
-    return !Number.isFinite(createdAt) || (params.nowMs ?? Date.now()) - createdAt > params.staleMs;
+    if (!Number.isFinite(createdAt) || (params.nowMs ?? Date.now()) - createdAt > params.staleMs) {
+      return true;
+    }
+  }
+  if (payload.pid) {
+    return (params.isPidDefinitelyDead ?? defaultIsPidDefinitelyDead)(payload.pid);
   }
   return false;
 }

--- a/src/plugin-sdk/file-lock.test.ts
+++ b/src/plugin-sdk/file-lock.test.ts
@@ -117,7 +117,7 @@ describe("acquireFileLock", () => {
     await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("{");
   });
 
-  it("keeps a reported stale lock when its owner pid is alive", async () => {
+  it("keeps a reported stale lock when its owner pid is alive and createdAt is still fresh", async () => {
     const filePath = path.join(tempDir, "live-owner");
     const lockPath = `${filePath}.lock`;
     const options = {
@@ -127,12 +127,12 @@ describe("acquireFileLock", () => {
         minTimeout: 1,
         maxTimeout: 1,
       },
-      stale: 10,
+      stale: 10_000,
     } as const;
 
     await fs.writeFile(
       lockPath,
-      JSON.stringify({ pid: process.pid, createdAt: new Date(Date.now() - 60_000).toISOString() }),
+      JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }),
       "utf8",
     );
 
@@ -151,6 +151,34 @@ describe("acquireFileLock", () => {
     });
     await expect(fs.realpath(caught?.lockPath ?? "")).resolves.toBe(await fs.realpath(lockPath));
     await expect(fs.readFile(lockPath, "utf8")).resolves.toContain(`"pid":${process.pid}`);
+  });
+
+  it("removes a reported stale lock when createdAt is older than stale even if the recorded pid is currently alive (pid reuse safeguard)", async () => {
+    const filePath = path.join(tempDir, "pid-reuse");
+    const lockPath = `${filePath}.lock`;
+    const options = {
+      retries: {
+        retries: 0,
+        factor: 1,
+        minTimeout: 1,
+        maxTimeout: 1,
+      },
+      stale: 10,
+    } as const;
+
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: process.pid, createdAt: new Date(Date.now() - 60_000).toISOString() }),
+      "utf8",
+    );
+
+    const lock = await acquireFileLock(filePath, options);
+    try {
+      await expect(fs.realpath(lock.lockPath)).resolves.toBe(await fs.realpath(lockPath));
+      await expect(fs.readFile(lockPath, "utf8")).resolves.toContain(`"pid"`);
+    } finally {
+      await lock.release();
+    }
   });
 
   it("closes an opened lock handle when writing the owner payload fails", async () => {


### PR DESCRIPTION
## Summary

- Make `shouldRemoveDeadOwnerOrExpiredLock` evaluate `createdAt` expiry before pid liveness so a lock whose `createdAt` is older than `staleMs` is reclaimed even when the recorded pid currently looks alive — covering the case in #86814 where the OS recycled a dead owner's pid to an unrelated process and pinned an `auth-profiles.json.lock` open past the configured stale window.
- Keep the pid-liveness fast path for fresh locks: no observable behavior change when the recorded `createdAt` is still within `staleMs`.
- Adjust the two `stale-lock-file.test.ts` cases and the one `plugin-sdk/file-lock.test.ts` case that previously asserted the "pid alive trumps everything" semantics; add positive coverage for the pid-reuse scenario, the unparseable-`createdAt` branch, and the injected-`nowMs` path.

## Behavior change to flag

Plugin file-lock callers (e.g. `~/.openclaw/agents/<agent>/agent/auth-profiles.json.lock`) whose `createdAt` is older than `options.stale` are now reclaimed on the next acquire even when the recorded `payload.pid` happens to point at a live process. This matches the documented `stale` contract; the previous behavior pinned the lock open and forced the configured retry-tail (≈50–60s for `auth-profiles` writes per #86814) before recovery.

## Real behavior proof

- **Behavior addressed:** `shouldRemoveDeadOwnerOrExpiredLock` now treats `payload.createdAt > staleMs` as authoritative even when `isPidDefinitelyDead(payload.pid)` returns false (the documented production scenario in #86814 where the OS recycles a dead owner's pid to an unrelated live process).
- **Real environment tested:** local macOS arm64 source checkout of `openclaw/openclaw@e37ac22fdd` (post-rebase against `upstream/main`); behavior verified through both `src/infra/stale-lock-file.test.ts` (pure-function level) and `src/plugin-sdk/file-lock.test.ts` (the `acquireFileLock` integration that exercises the `shouldReclaim` / `shouldRemoveStaleLock` snapshot callbacks against a real `.lock` sidecar in a `tmpdir`).
- **Exact steps or command run after this patch:**
  - `pnpm test src/infra/stale-lock-file.test.ts src/plugin-sdk/file-lock.test.ts`
  - `pnpm test:changed`
  - `pnpm check:changed`
- **Evidence after fix:**
  - The new `removes a reported stale lock when createdAt is older than stale even if the recorded pid is currently alive (pid reuse safeguard)` integration test seeds `<tmpdir>/pid-reuse.lock` with `{ pid: process.pid, createdAt: Date.now() - 60_000 }` and `stale: 10`; `acquireFileLock` now succeeds with `retries: 0` and rewrites the payload, where previously it rejected with `FILE_LOCK_TIMEOUT_ERROR_CODE`.
  - The sibling `keeps a reported stale lock when its owner pid is alive and createdAt is still fresh` (fresh `createdAt`, `stale: 10_000`) still rejects with `FILE_LOCK_TIMEOUT_ERROR_CODE`, confirming the pid-liveness fast path is preserved for non-expired locks.
  - Added unit cases also pin the unparseable-`createdAt` branch, the no-`createdAt` pid-fallback branch, and the injected-`nowMs` comparison.
- **Observed result after fix:**
  - `src/infra/stale-lock-file.test.ts`: 9 / 9 passed.
  - `src/plugin-sdk/file-lock.test.ts`: 6 / 6 passed.
  - `pnpm test:changed`: 73 passed across `unit-fast` (9), `tooling` (58), and `plugin-sdk` (6) shards in 7.52s.
  - `pnpm check:changed`: exit 0 (typecheck core + extensions + tests, lint core/extensions/scripts, import-cycles 0 runtime value cycles, plugin-sdk wildcard / dependency-pin / package-patch guards all green).
- **What was not tested:** the full production runtime from the issue report (live OpenClaw `2026.5.22` instance with Discord delivery, observing the ~50–60s post-`embedded run done` retry tail collapse). The fix is verified through the lock subsystem's own test surface; the upstream production timeline and the reporter's local-hotfix confirmation in #86814 come from the reporter's setup, not mine.

## Notes

- The two existing `shouldRemoveDeadOwnerOrExpiredLock` call sites in `src/plugin-sdk/file-lock.ts` (`shouldReclaimPluginLock`, `shouldRemoveStaleLock`) both pass-through without overriding `isPidDefinitelyDead`, so the new ordering matches their already-true intent ("remove when owner is dead or the staleness window expired"). No SDK contract change.
- Reviewed against root `AGENTS.md`, `src/plugin-sdk/CLAUDE.md`, and `CONTRIBUTING.md`.
- No `CHANGELOG.md` edits (per CONTRIBUTING).

Refs #86814
