### PR TITLE
fix: preserve config and hook contracts

### DIFF
--- a/src/commands/doctor/shared/legacy-web-search-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.test.ts
@@ -62,6 +62,32 @@ describe("legacy web search config", () => {
     ]);
   });
 
+  it("does not mutate the caller's original config", () => {
+    const input = {
+      tools: {
+        web: {
+          search: {
+            provider: "grok",
+            apiKey: "brave-key",
+            grok: {
+              apiKey: "xai-key",
+              model: "grok-4-search",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const original = structuredClone(input);
+
+    const res = migrateLegacyWebSearchConfig<OpenClawConfig>(input);
+
+    expect(res.config.plugins?.entries?.xai?.config?.webSearch).toEqual({
+      apiKey: "xai-key",
+      model: "grok-4-search",
+    });
+    expect(input).toEqual(original);
+  });
+
   it("preserves unrelated record-valued web search config", () => {
     const res = migrateLegacyWebSearchConfig<OpenClawConfig>({
       tools: {

--- a/src/commands/doctor/shared/legacy-web-search-migrate.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.ts
@@ -180,7 +180,7 @@ export function migrateLegacyWebSearchConfig<T>(raw: T): { config: T; changes: s
     return { config: raw, changes: [] };
   }
 
-  return normalizeLegacyWebSearchConfigRecord(raw, owners);
+  return normalizeLegacyWebSearchConfigRecord(structuredClone(raw) as T & JsonRecord, owners);
 }
 
 function normalizeLegacyWebSearchConfigRecord<T extends JsonRecord>(

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -270,6 +270,23 @@ describe("hooks", () => {
         } satisfies MessageSentHookContext),
         expected: false,
       },
+      {
+        name: "returns false when content is missing",
+        event: createInternalHookEvent("message", "received", "test-session", {
+          from: "+1234567890",
+          channelId: "whatsapp",
+        }),
+        expected: false,
+      },
+      {
+        name: "returns false when content is not a string",
+        event: createInternalHookEvent("message", "received", "test-session", {
+          from: "+1234567890",
+          content: 123,
+          channelId: "whatsapp",
+        }),
+        expected: false,
+      },
     ] satisfies Array<{
       name: string;
       event: ReturnType<typeof createInternalHookEvent>;
@@ -311,6 +328,25 @@ describe("hooks", () => {
           content: "Hello world",
           channelId: "whatsapp",
         } satisfies MessageReceivedHookContext),
+        expected: false,
+      },
+      {
+        name: "returns false when content is missing",
+        event: createInternalHookEvent("message", "sent", "test-session", {
+          to: "+1234567890",
+          success: true,
+          channelId: "telegram",
+        }),
+        expected: false,
+      },
+      {
+        name: "returns false when content is not a string",
+        event: createInternalHookEvent("message", "sent", "test-session", {
+          to: "+1234567890",
+          content: false,
+          success: true,
+          channelId: "telegram",
+        }),
         expected: false,
       },
     ] satisfies Array<{

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -392,7 +392,11 @@ export function isMessageReceivedEvent(
   if (!context) {
     return false;
   }
-  return hasStringContextField(context, "from") && hasStringContextField(context, "channelId");
+  return (
+    hasStringContextField(context, "from") &&
+    hasStringContextField(context, "content") &&
+    hasStringContextField(context, "channelId")
+  );
 }
 
 export function isMessageSentEvent(event: InternalHookEvent): event is MessageSentHookEvent {
@@ -405,6 +409,7 @@ export function isMessageSentEvent(event: InternalHookEvent): event is MessageSe
   }
   return (
     hasStringContextField(context, "to") &&
+    hasStringContextField(context, "content") &&
     hasStringContextField(context, "channelId") &&
     hasBooleanContextField(context, "success")
   );


### PR DESCRIPTION
## Summary
- clone legacy web-search configs before doctor migration so callers do not see their original config mutated
- require `content` in message received/sent hook event guards to match the typed hook contracts
- add focused regression coverage for both contract bugs

## Verification
- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-web-search-migrate.test.ts src/hooks/internal-hooks.test.ts`
- `git diff --check`
- `node ../clawpatch/dist/cli.js --state-dir /tmp/clawpatch-openclaw revalidate --finding fnd_sig-feat-library-01f8445e6b-478d_f0dc7f10d5 --include-dirty --plain`
- `node ../clawpatch/dist/cli.js --state-dir /tmp/clawpatch-openclaw revalidate --finding fnd_sig-feat-library-02b456509d-9f5a_94d243bc6c --include-dirty --plain`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-web-search-migrate.test.ts src/hooks/internal-hooks.test.ts"`

## Real behavior proof
Behavior addressed: doctor legacy web-search migration no longer mutates caller-owned config objects, and message hook event guards no longer accept message events missing required `content`.
Real environment tested: local OpenClaw checkout on macOS with focused unit tests.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-web-search-migrate.test.ts src/hooks/internal-hooks.test.ts`.
Evidence after fix: tests assert the original web-search input remains unchanged after migration and message received/sent guards reject missing or non-string content; clawpatch revalidated both findings as fixed.
Observed result after fix: 2 test files passed, 40 tests passed; autoreview reported no accepted/actionable findings.
What was not tested: full doctor migration suite and live hook plugin execution were not run.
