### PR TITLE
fix(auto-reply): bound pendingFinalDelivery heartbeat replay by attempt cap and TTL

### DIFF
--- a/src/auto-reply/reply/get-reply.heartbeat-replay-bounds.test.ts
+++ b/src/auto-reply/reply/get-reply.heartbeat-replay-bounds.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyPendingFinalDeliveryBound,
+  PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS,
+  PENDING_FINAL_DELIVERY_TTL_MS,
+} from "./get-reply.js";
+
+describe("classifyPendingFinalDeliveryBound", () => {
+  const FRESH_NOW = 1_700_000_000_000;
+  const freshCreatedAt = FRESH_NOW - 60_000;
+
+  it("returns null when attemptCount is below the limit and createdAt is fresh", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 0,
+        createdAt: freshCreatedAt,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBeNull();
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS - 1,
+        createdAt: freshCreatedAt,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns retry-limit when attemptCount reaches the configured max", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS,
+        createdAt: freshCreatedAt,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBe("retry-limit");
+  });
+
+  it("returns retry-limit for the production case observed in #85743 (attempts=189)", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 189,
+        createdAt: FRESH_NOW - 4 * 24 * 60 * 60 * 1000,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBe("retry-limit");
+  });
+
+  it("returns expiry when createdAt is older than TTL and attempt count is still small", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 1,
+        createdAt: FRESH_NOW - PENDING_FINAL_DELIVERY_TTL_MS - 1,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBe("expiry");
+  });
+
+  it("returns null when createdAt age equals the TTL boundary (strict greater-than)", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 0,
+        createdAt: FRESH_NOW - PENDING_FINAL_DELIVERY_TTL_MS,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when createdAt is undefined and attempt count is still under the limit", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 3,
+        createdAt: undefined,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when createdAt is non-finite (treats it as unknown age)", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 1,
+        createdAt: Number.NaN,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBeNull();
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 1,
+        createdAt: Number.POSITIVE_INFINITY,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("treats attemptCount undefined as zero", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: undefined,
+        createdAt: freshCreatedAt,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("retry-limit wins over expiry when both bounds are exceeded", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS + 5,
+        createdAt: FRESH_NOW - PENDING_FINAL_DELIVERY_TTL_MS - 1,
+        nowMs: FRESH_NOW,
+      }),
+    ).toBe("retry-limit");
+  });
+
+  it("honors caller-supplied maxAttempts and ttlMs overrides", () => {
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 3,
+        createdAt: freshCreatedAt,
+        nowMs: FRESH_NOW,
+        maxAttempts: 3,
+      }),
+    ).toBe("retry-limit");
+    expect(
+      classifyPendingFinalDeliveryBound({
+        attemptCount: 0,
+        createdAt: FRESH_NOW - 2,
+        nowMs: FRESH_NOW,
+        ttlMs: 1,
+      }),
+    ).toBe("expiry");
+  });
+});

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -56,6 +56,36 @@ import { createTypingController } from "./typing.js";
 
 type ResetCommandAction = "new" | "reset";
 
+// Bounds the heartbeat replay branch in `getReply` so an orphan `pendingFinalDelivery`
+// (process killed mid-deliver, channel disabled, bot token rotated, etc.) cannot
+// re-emit the cached text forever — see issue #85743 (observed 189 attempts over 4
+// days). Successful dispatch and `heartbeatPending.shouldClear` still own the
+// common-case clearing; these constants gate the orphan fail-safe only.
+export const PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS = 10;
+export const PENDING_FINAL_DELIVERY_TTL_MS = 24 * 60 * 60 * 1000;
+
+export function classifyPendingFinalDeliveryBound(args: {
+  attemptCount: number | undefined;
+  createdAt: number | undefined;
+  nowMs: number;
+  maxAttempts?: number;
+  ttlMs?: number;
+}): "retry-limit" | "expiry" | null {
+  const maxAttempts = args.maxAttempts ?? PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS;
+  const ttlMs = args.ttlMs ?? PENDING_FINAL_DELIVERY_TTL_MS;
+  if ((args.attemptCount ?? 0) >= maxAttempts) {
+    return "retry-limit";
+  }
+  if (
+    typeof args.createdAt === "number" &&
+    Number.isFinite(args.createdAt) &&
+    args.nowMs - args.createdAt > ttlMs
+  ) {
+    return "expiry";
+  }
+  return null;
+}
+
 function classifyHeartbeatPendingFinalDelivery(text: string, ackMaxChars: number) {
   const stripped = stripHeartbeatToken(text, {
     mode: "heartbeat",
@@ -394,6 +424,35 @@ export async function getReplyFromConfig(
   if (sessionEntry?.pendingFinalDelivery && sessionEntry.pendingFinalDeliveryText) {
     const text = sanitizePendingFinalDeliveryText(sessionEntry.pendingFinalDeliveryText);
 
+    const clearPendingFinalDeliveryEntry = async () => {
+      sessionEntry.pendingFinalDelivery = undefined;
+      sessionEntry.pendingFinalDeliveryText = undefined;
+      sessionEntry.pendingFinalDeliveryCreatedAt = undefined;
+      sessionEntry.pendingFinalDeliveryLastAttemptAt = undefined;
+      sessionEntry.pendingFinalDeliveryAttemptCount = undefined;
+      sessionEntry.pendingFinalDeliveryLastError = undefined;
+      sessionEntry.pendingFinalDeliveryContext = undefined;
+      if (sessionKey && sessionStore) {
+        sessionStore[sessionKey] = sessionEntry;
+      }
+      if (sessionKey && storePath) {
+        const { updateSessionStoreEntry } = await import("../../config/sessions.js");
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => ({
+            pendingFinalDelivery: undefined,
+            pendingFinalDeliveryText: undefined,
+            pendingFinalDeliveryCreatedAt: undefined,
+            pendingFinalDeliveryLastAttemptAt: undefined,
+            pendingFinalDeliveryAttemptCount: undefined,
+            pendingFinalDeliveryLastError: undefined,
+            pendingFinalDeliveryContext: undefined,
+          }),
+        });
+      }
+    };
+
     // If it's a heartbeat, we definitely want to try delivering the lost reply now.
     // If it's a user message, we deliver the lost reply first, then continue.
     // For now, let's just return the lost reply if it's a heartbeat.
@@ -403,59 +462,53 @@ export async function getReplyFromConfig(
         resolveHeartbeatAckMaxChars(cfg, agentId),
       );
       if (heartbeatPending.shouldClear) {
-        sessionEntry.pendingFinalDelivery = undefined;
-        sessionEntry.pendingFinalDeliveryText = undefined;
-        sessionEntry.pendingFinalDeliveryCreatedAt = undefined;
-        sessionEntry.pendingFinalDeliveryLastAttemptAt = undefined;
-        sessionEntry.pendingFinalDeliveryAttemptCount = undefined;
-        sessionEntry.pendingFinalDeliveryLastError = undefined;
-        sessionEntry.pendingFinalDeliveryContext = undefined;
-        if (sessionKey && sessionStore) {
-          sessionStore[sessionKey] = sessionEntry;
-        }
-        if (sessionKey && storePath) {
-          const { updateSessionStoreEntry } = await import("../../config/sessions.js");
-          await updateSessionStoreEntry({
-            storePath,
-            sessionKey,
-            update: async () => ({
-              pendingFinalDelivery: undefined,
-              pendingFinalDeliveryText: undefined,
-              pendingFinalDeliveryCreatedAt: undefined,
-              pendingFinalDeliveryLastAttemptAt: undefined,
-              pendingFinalDeliveryAttemptCount: undefined,
-              pendingFinalDeliveryLastError: undefined,
-              pendingFinalDeliveryContext: undefined,
-            }),
-          });
-        }
+        await clearPendingFinalDeliveryEntry();
       } else {
         const updatedAt = Date.now();
-        const attemptCount = (sessionEntry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
-        sessionEntry.pendingFinalDeliveryLastAttemptAt = updatedAt;
-        sessionEntry.pendingFinalDeliveryAttemptCount = attemptCount;
-        sessionEntry.pendingFinalDeliveryLastError = null;
-        const replayText = sanitizePendingFinalDeliveryText(heartbeatPending.replayText);
-        sessionEntry.pendingFinalDeliveryText = replayText;
-        sessionEntry.updatedAt = updatedAt;
-        if (sessionKey && sessionStore) {
-          sessionStore[sessionKey] = sessionEntry;
+        const boundReason = classifyPendingFinalDeliveryBound({
+          attemptCount: sessionEntry.pendingFinalDeliveryAttemptCount,
+          createdAt: sessionEntry.pendingFinalDeliveryCreatedAt,
+          nowMs: updatedAt,
+        });
+        if (boundReason) {
+          const ageSeconds =
+            typeof sessionEntry.pendingFinalDeliveryCreatedAt === "number" &&
+            Number.isFinite(sessionEntry.pendingFinalDeliveryCreatedAt)
+              ? Math.round((updatedAt - sessionEntry.pendingFinalDeliveryCreatedAt) / 1000)
+              : null;
+          logVerbose(
+            `pendingFinalDelivery suspended (${boundReason}): attempts=${sessionEntry.pendingFinalDeliveryAttemptCount ?? 0}${
+              ageSeconds === null ? "" : ` ageSec=${ageSeconds}`
+            }${sessionKey ? ` sessionKey=${sessionKey}` : ""}`,
+          );
+          await clearPendingFinalDeliveryEntry();
+        } else {
+          const attemptCount = (sessionEntry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
+          sessionEntry.pendingFinalDeliveryLastAttemptAt = updatedAt;
+          sessionEntry.pendingFinalDeliveryAttemptCount = attemptCount;
+          sessionEntry.pendingFinalDeliveryLastError = null;
+          const replayText = sanitizePendingFinalDeliveryText(heartbeatPending.replayText);
+          sessionEntry.pendingFinalDeliveryText = replayText;
+          sessionEntry.updatedAt = updatedAt;
+          if (sessionKey && sessionStore) {
+            sessionStore[sessionKey] = sessionEntry;
+          }
+          if (sessionKey && storePath) {
+            const { updateSessionStoreEntry } = await import("../../config/sessions.js");
+            await updateSessionStoreEntry({
+              storePath,
+              sessionKey,
+              update: async () => ({
+                pendingFinalDeliveryText: replayText,
+                pendingFinalDeliveryLastAttemptAt: updatedAt,
+                pendingFinalDeliveryAttemptCount: attemptCount,
+                pendingFinalDeliveryLastError: null,
+                updatedAt,
+              }),
+            });
+          }
+          return { text: replayText };
         }
-        if (sessionKey && storePath) {
-          const { updateSessionStoreEntry } = await import("../../config/sessions.js");
-          await updateSessionStoreEntry({
-            storePath,
-            sessionKey,
-            update: async () => ({
-              pendingFinalDeliveryText: replayText,
-              pendingFinalDeliveryLastAttemptAt: updatedAt,
-              pendingFinalDeliveryAttemptCount: attemptCount,
-              pendingFinalDeliveryLastError: null,
-              updatedAt,
-            }),
-          });
-        }
-        return { text: replayText };
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add `PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS = 10` and `PENDING_FINAL_DELIVERY_TTL_MS = 24h`, plus a pure `classifyPendingFinalDeliveryBound` helper that returns `"retry-limit" | "expiry" | null` so the reason vocabulary stays aligned with the existing `suspendPendingFinalDelivery({ reason: "retry-limit" | "expiry" })` in `src/agents/subagent-registry-lifecycle.ts`.
- Wire the bound into the heartbeat-replay else branch of `getReply` (`src/auto-reply/reply/get-reply.ts`) so an orphan `pendingFinalDelivery` (process killed mid-deliver, channel disabled, bot token rotated, etc.) cannot re-emit the cached text forever — the case in #85743 with `pendingFinalDeliveryAttemptCount: 189` and a 4-day-old `pendingFinalDeliveryCreatedAt` now expires on the next heartbeat tick.
- Extract a local async `clearPendingFinalDeliveryEntry()` inside the existing `if (sessionEntry?.pendingFinalDelivery && …)` block so the existing `heartbeatPending.shouldClear` path and the new bound-triggered clear share the same persist semantics; both leave `sessionStore[sessionKey]` and the on-disk store entry with every `pendingFinalDelivery*` field cleared.
- When the bound trips, emit a `logVerbose` carrying reason / attempt count / age-in-seconds / session key, run the clear, and fall through (no `return { text: replayText }`) — the rest of `getReply` then proceeds as if no pending delivery existed. This matches the fail-safe intent in the issue: the legitimate replay-after-restart path still works (fresh `createdAt`, low attempt count), only stuck orphan buffers are short-circuited.

## Behavior change to flag

Sessions with `pendingFinalDelivery: true` that survive 10 successful heartbeat replays or sit on the same `pendingFinalDeliveryCreatedAt` for over 24 hours are now cleared on the next heartbeat (a `[verbose] pendingFinalDelivery suspended …` log line is emitted) instead of having `pendingFinalDeliveryText` re-emitted indefinitely. Users hit by the orphan-buffer pattern in #85743 stop receiving the stale "CRITICAL ALERT" replay; everyone else is unaffected because successful delivery and `heartbeatPending.shouldClear` still own the common-case clearing path, and the bound only triggers strictly after the limits.

## Real behavior proof

- **Behavior addressed:** `getReply` heartbeat-replay branch now consults `classifyPendingFinalDeliveryBound` before incrementing `pendingFinalDeliveryAttemptCount`. The exact production case described in #85743 — `attemptCount: 189`, `createdAt` ≈ 4 days ago — now returns `"retry-limit"`, which routes through the shared clear and skips the replay return.
- **Real environment tested:** local macOS arm64 source checkout of `openclaw/openclaw` (post-rebase against `upstream/main`); behavior verified through the new colocated unit test surface `src/auto-reply/reply/get-reply.heartbeat-replay-bounds.test.ts` (10 cases exercising production-style counts, boundary equality, TTL strict-greater-than, undefined / non-finite `createdAt`, retry-limit-vs-expiry tie-break, and `maxAttempts`/`ttlMs` overrides). The wired-in branch in `get-reply.ts` is hand-checked against the existing `heartbeatPending.shouldClear` arm — the new path uses the same extracted clear helper, so the persist semantics on `sessionStore[sessionKey]` and the on-disk store entry are structurally identical.
- **Exact steps or command run after this patch:**
  - `pnpm test src/auto-reply/reply/get-reply.heartbeat-replay-bounds.test.ts`
  - `pnpm test:changed`
  - `pnpm check:changed`
- **Evidence after fix:**
  - All 10 bounds-helper cases pass, including the explicit `(attemptCount: 189, createdAt: now − 4d) → "retry-limit"` case mirroring the reporter's `sessions.json` snapshot.
  - The boundary cases pin `attemptCount === max → "retry-limit"`, `nowMs − createdAt === ttl → null` (strict `>`), `attemptCount > max ∧ createdAt > ttl → "retry-limit"` (retry-limit wins), and `Number.NaN` / `Infinity` createdAt → treated as unknown age, no expiry.
- **Observed result after fix:**
  - `src/auto-reply/reply/get-reply.heartbeat-replay-bounds.test.ts`: 10 / 10 passed (2.7s).
  - `pnpm check:changed`: exit 0 (typecheck core + extensions + tests, lint core/extensions/scripts, import-cycles 0 runtime value cycles, all repo-wide guards green).
  - `pnpm test:changed`: 255 / 257 passed across 16 shards. The 2 failures in `src/commands/onboard.test.ts` (`fails fast for invalid --secret-input-mode`, `fails fast for invalid --reset-scope`) reproduce on pristine `upstream/main` with this patch reverted (verified by running `pnpm test src/commands/onboard.test.ts` after `git stash` of the patch — 2 / 7 fail with `expected "vi.fn()" to be called once, but got 2 times` against `runtime.error`) and have no overlap with `src/auto-reply/**`. They are pre-existing main failures, not regressions from this change.
- **What was not tested:** a long-lived production runtime actually exhibiting the 189-attempt heartbeat loop and observing the loop collapse after the patch. The fix is verified through the pure-helper coverage plus the structural match to the existing clear arm; the production timeline, `sessions.json` counters, and observed behavior come from the reporter's setup on `2026.5.18`, not mine.

## Notes

- The new helper and constants are `export`ed because they are unit-tested next to the function they serve, and because the issue explicitly suggested keeping the thresholds local so they can graduate to config later — the `maxAttempts` / `ttlMs` overrides on the helper give us that path without leaking config keys today.
- The extracted `clearPendingFinalDeliveryEntry` is a local arrow inside the existing `if (sessionEntry?.pendingFinalDelivery && …)` block, not a module-level helper. It closes over `sessionEntry`, `sessionStore`, `sessionKey`, and `storePath` so the persist semantics match the in-place clear that already existed; no new public surface is exposed.
- This is the fail-safe described in #85743; the common-case clear-after-success and `target === "none"` paths from #83184 / #83187 / #84679 still own the routine clearing flow.
- Reviewed against root `AGENTS.md` and `CONTRIBUTING.md`. No `CHANGELOG.md` edits (per CONTRIBUTING).

Refs #85743
