### PR TITLE
docs(doctor): clarify unknown lint selections

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -184,9 +184,10 @@ openclaw doctor --lint --skip core/doctor/skills-readiness
 ```
 
 `--only` and `--skip` accept full check ids and may be repeated. If an `--only`
-id is not registered, no check runs for that id; use the command's `checksRun`
-and `checksSkipped` fields to verify a focused gate is selecting the checks you
-expect.
+id is not registered, `--lint` exits with a `core/doctor/lint-selection` error
+instead of reporting a false-clean run. Use the command's `checksRun`,
+`checksSkipped`, and `findings` fields to verify a focused gate is selecting the
+checks you expect.
 
 Notes:
 


### PR DESCRIPTION
## Summary
- update the doctor CLI docs for unknown `--only` check ids
- document that `doctor --lint` now returns a `core/doctor/lint-selection` error instead of a false-clean run
- mention `findings` alongside `checksRun` and `checksSkipped` for focused gate validation

## Test plan
- git diff --check
- PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec vitest run src/commands/doctor-lint.test.ts

## Duplicate check
- gh search prs --repo openclaw/openclaw --state open "doctor --lint --only unknown lint-selection" -> []
- gh search prs --repo openclaw/openclaw --state open "docs/cli/doctor.md --only" -> []
- gh search prs --repo openclaw/openclaw --state open "core/doctor/lint-selection doctor --lint --only" -> []

Docs-only change; aligns the CLI reference with the current tested behavior.

## Real behavior proof
- Behavior or issue addressed: The doctor CLI reference previously said an unknown `doctor --lint --only <id>` selection simply ran no checks. The current CLI behavior returns a `core/doctor/lint-selection` error, so the docs now describe the real operator-facing result and point readers at `findings` as well as `checksRun` and `checksSkipped`.
- Real environment tested: local OpenClaw checkout on this PR branch (`leno23/docs-doctor-only-unknown-check`) on macOS, using Node with the repository TypeScript loader (`node --import tsx`) and an isolated temporary OpenClaw home/config.
- Exact steps or command run after this patch:
  ```sh
  ROOT=$(mktemp -d /tmp/openclaw-doctor-proof-XXXXXX)
  mkdir -p "$ROOT/home/.openclaw" "$ROOT/state"
  printf '{}' > "$ROOT/home/.openclaw/openclaw.json"
  HOME="$ROOT/home" \
    OPENCLAW_STATE_DIR="$ROOT/state" \
    OPENCLAW_CONFIG_PATH="$ROOT/home/.openclaw/openclaw.json" \
    OPENCLAW_TEST_FAST=1 \
    PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false \
    node --import tsx --input-type=module <<'NODE'
  import { runCli } from './src/cli/run-main.ts';
  await runCli(['node', 'openclaw', 'doctor', '--lint', '--only', 'core/doctor/session-locks', '--json']);
  NODE
  status=$?
  echo "exit=$status"
  ```
- Evidence after fix: terminal output from the patched checkout:
  ```text
  {"ok":false,"checksRun":0,"checksSkipped":18,"findings":[{"checkId":"core/doctor/lint-selection","severity":"error","message":"Unknown health check id selected by --only: core/doctor/session-locks.","path":"core/doctor/session-locks"}]}
  exit=1
  ```
- Observed result after fix: The live CLI command returned `checksRun: 0`, a `core/doctor/lint-selection` finding, and exit code 1 for an unknown `--only` id, matching the updated docs text.
- What was not tested: Full broad checks were not rerun locally; the focused doctor-lint Vitest file and `git diff --check` passed.
