### PR TITLE
fix(tools): drop delivery-mirror and gateway-injected turns from sessions_history

### DIFF
--- a/src/agents/openclaw-transcript-mirror.test.ts
+++ b/src/agents/openclaw-transcript-mirror.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  isTranscriptOnlyOpenclawAssistant,
+  TRANSCRIPT_ONLY_OPENCLAW_MODELS,
+} from "./openclaw-transcript-mirror.js";
+
+describe("isTranscriptOnlyOpenclawAssistant", () => {
+  it("returns true for the channel-delivery mirror assistant turn", () => {
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for the gateway-injected assistant turn", () => {
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "assistant",
+        provider: "openclaw",
+        model: "gateway-injected",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a real assistant turn from any provider", () => {
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      }),
+    ).toBe(false);
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when provider is openclaw but the model is not a transcript-only marker", () => {
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "assistant",
+        provider: "openclaw",
+        model: "best-effort-summary",
+      }),
+    ).toBe(false);
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "assistant",
+        provider: "openclaw",
+        model: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-assistant roles even with the transcript-only model", () => {
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "user",
+        provider: "openclaw",
+        model: "delivery-mirror",
+      }),
+    ).toBe(false);
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "tool",
+        provider: "openclaw",
+        model: "gateway-injected",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for null/undefined/non-object inputs", () => {
+    expect(isTranscriptOnlyOpenclawAssistant(null)).toBe(false);
+    expect(isTranscriptOnlyOpenclawAssistant(undefined)).toBe(false);
+    expect(isTranscriptOnlyOpenclawAssistant("delivery-mirror")).toBe(false);
+    expect(isTranscriptOnlyOpenclawAssistant(42)).toBe(false);
+  });
+
+  it("returns false when provider field is missing", () => {
+    expect(
+      isTranscriptOnlyOpenclawAssistant({
+        role: "assistant",
+        model: "delivery-mirror",
+      }),
+    ).toBe(false);
+  });
+
+  it("exposes the canonical model identifier set for callers that need both names", () => {
+    expect(TRANSCRIPT_ONLY_OPENCLAW_MODELS.has("delivery-mirror")).toBe(true);
+    expect(TRANSCRIPT_ONLY_OPENCLAW_MODELS.has("gateway-injected")).toBe(true);
+    expect(TRANSCRIPT_ONLY_OPENCLAW_MODELS.size).toBe(2);
+  });
+});

--- a/src/agents/openclaw-transcript-mirror.ts
+++ b/src/agents/openclaw-transcript-mirror.ts
@@ -1,0 +1,30 @@
+// `provider:"openclaw"` assistant entries with these models are user-visible
+// transcript records, not model output:
+// - `delivery-mirror`: written by the channel-delivery transcript mirror, see
+//   `src/config/sessions/transcript.ts`.
+// - `gateway-injected`: written by the Gateway transcript-inject helper, see
+//   `src/gateway/server-methods/chat-transcript-inject.ts`.
+// Surfaces that present "real assistant turns" — provider replay and the
+// `sessions_history` tool / dashboard session viewer — must skip them; the
+// docs claim under `docs/reference/transcript-hygiene.md` is the explicit
+// contract this set defends.
+export const TRANSCRIPT_ONLY_OPENCLAW_MODELS = new Set<string>([
+  "delivery-mirror",
+  "gateway-injected",
+]);
+
+export function isTranscriptOnlyOpenclawAssistant(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as { role?: unknown; provider?: unknown; model?: unknown };
+  if (entry.role !== "assistant") {
+    return false;
+  }
+  const model = entry.model;
+  return (
+    entry.provider === "openclaw" &&
+    typeof model === "string" &&
+    TRANSCRIPT_ONLY_OPENCLAW_MODELS.has(model)
+  );
+}

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -19,6 +19,7 @@ import {
 } from "../../sessions/input-provenance.js";
 import { asFiniteNumber } from "../../shared/number-coercion.js";
 import { resolveImageSanitizationLimits } from "../image-sanitization.js";
+import { isTranscriptOnlyOpenclawAssistant } from "../openclaw-transcript-mirror.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
@@ -230,14 +231,11 @@ function stripStaleAssistantUsageBeforeLatestCompaction(messages: AgentMessage[]
   return touched ? out : messages;
 }
 
-// `provider:"openclaw"` assistant entries written by the channel-delivery
-// transcript mirror (`model:"delivery-mirror"`, see config/sessions/transcript.ts)
-// and by the Gateway transcript-inject helper (`model:"gateway-injected"`, see
-// gateway/server-methods/chat-transcript-inject.ts) are user-visible transcript
-// records, not model output. Replaying them to the actual provider duplicates
-// content and, on Bedrock or strict OpenAI-compatible providers, can also
-// trigger turn-ordering rejections.
-const TRANSCRIPT_ONLY_OPENCLAW_MODELS = new Set<string>(["delivery-mirror", "gateway-injected"]);
+// Replaying transcript-mirror / gateway-injected turns to the actual provider
+// duplicates content and, on Bedrock or strict OpenAI-compatible providers,
+// can also trigger turn-ordering rejections. The classifier lives in
+// `../openclaw-transcript-mirror.ts` because the `sessions_history` tool also
+// needs to filter on the same contract.
 
 function sanitizeUserReplayContent(message: AgentMessage): AgentMessage | null {
   if (!message || message.role !== "user") {
@@ -270,19 +268,6 @@ function sanitizeUserReplayContent(message: AgentMessage): AgentMessage | null {
     return null;
   }
   return touched ? ({ ...message, content: sanitizedContent } as AgentMessage) : message;
-}
-
-function isTranscriptOnlyOpenclawAssistant(message: AgentMessage): boolean {
-  if (!message || message.role !== "assistant") {
-    return false;
-  }
-  const provider = (message as { provider?: unknown }).provider;
-  const model = (message as { model?: unknown }).model;
-  return (
-    provider === "openclaw" &&
-    typeof model === "string" &&
-    TRANSCRIPT_ONLY_OPENCLAW_MODELS.has(model)
-  );
 }
 
 function normalizeAssistantReplayTextContent(message: AgentMessage, replayContent: string) {

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -38,6 +38,18 @@ function createHistoryToolWithMessage(content: string) {
   });
 }
 
+function createHistoryToolWithMessages(messages: Array<Record<string, unknown>>) {
+  return createSessionsHistoryTool({
+    config: {},
+    callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+      if (request.method === "chat.history") {
+        return { messages } as T;
+      }
+      return {} as T;
+    },
+  });
+}
+
 describe("sessions_history redaction", () => {
   beforeAll(async () => {
     previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
@@ -82,5 +94,83 @@ describe("sessions_history redaction", () => {
     expect(serialized).not.toContain("internal-ticket-AbC12345");
     expect(serialized).toContain("intern");
     expect((result.details as { contentRedacted?: unknown }).contentRedacted).toBe(true);
+  });
+
+  it("filters delivery-mirror assistant turns so dashboards no longer see duplicated replies (issue #85669)", async () => {
+    useLoggingConfig("filter-mirror.json", { redactSensitive: "off" });
+    const tool = createHistoryToolWithMessages([
+      { role: "user", content: "ping" },
+      { role: "assistant", provider: "anthropic", model: "claude-opus-4-6", content: "pong" },
+      { role: "assistant", provider: "openclaw", model: "delivery-mirror", content: "pong" },
+    ]);
+
+    const result = await tool.execute("call-1", { sessionKey: "main" });
+    const messages = (result.details as { messages: Array<Record<string, unknown>> }).messages;
+
+    expect(messages).toHaveLength(2);
+    expect(messages.map((m) => `${m.role}:${m.provider ?? ""}`)).toEqual([
+      "user:",
+      "assistant:anthropic",
+    ]);
+  });
+
+  it("filters gateway-injected assistant turns the same way", async () => {
+    useLoggingConfig("filter-gateway-injected.json", { redactSensitive: "off" });
+    const tool = createHistoryToolWithMessages([
+      { role: "user", content: "hello" },
+      { role: "assistant", provider: "openclaw", model: "gateway-injected", content: "noop" },
+      { role: "assistant", provider: "openai", model: "gpt-5.5", content: "hi" },
+    ]);
+
+    const result = await tool.execute("call-1", { sessionKey: "main" });
+    const messages = (result.details as { messages: Array<Record<string, unknown>> }).messages;
+
+    expect(messages).toHaveLength(2);
+    expect(messages.map((m) => m.model ?? null)).toEqual([null, "gpt-5.5"]);
+  });
+
+  it("keeps openclaw-provider assistant turns whose model is not a transcript-only marker", async () => {
+    useLoggingConfig("filter-openclaw-other.json", { redactSensitive: "off" });
+    const tool = createHistoryToolWithMessages([
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "best-effort-summary",
+        content: "summary",
+      },
+      { role: "assistant", provider: "openclaw", model: "delivery-mirror", content: "drop me" },
+    ]);
+
+    const result = await tool.execute("call-1", { sessionKey: "main" });
+    const messages = (result.details as { messages: Array<Record<string, unknown>> }).messages;
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.model).toBe("best-effort-summary");
+  });
+
+  it("preserves turn order when delivery-mirror duplicates are interleaved with real assistant turns", async () => {
+    useLoggingConfig("filter-interleaved.json", { redactSensitive: "off" });
+    const tool = createHistoryToolWithMessages([
+      { role: "user", content: "one" },
+      { role: "assistant", provider: "anthropic", model: "claude-opus-4-6", content: "reply 1" },
+      { role: "assistant", provider: "openclaw", model: "delivery-mirror", content: "reply 1" },
+      { role: "user", content: "two" },
+      { role: "assistant", provider: "anthropic", model: "claude-opus-4-6", content: "reply 2" },
+      { role: "assistant", provider: "openclaw", model: "delivery-mirror", content: "reply 2" },
+    ]);
+
+    const result = await tool.execute("call-1", { sessionKey: "main" });
+    const messages = (
+      result.details as {
+        messages: Array<Record<string, unknown>>;
+      }
+    ).messages;
+
+    expect(messages.map((m) => `${m.role}:${m.content}`)).toEqual([
+      "user:one",
+      "assistant:reply 1",
+      "user:two",
+      "assistant:reply 2",
+    ]);
   });
 });

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -7,6 +7,7 @@ import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { redactToolPayloadText } from "../../logging/redact.js";
 import { readStringValue } from "../../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../../utils.js";
+import { isTranscriptOnlyOpenclawAssistant } from "../openclaw-transcript-mirror.js";
 import {
   describeSessionsHistoryTool,
   SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY,
@@ -257,7 +258,15 @@ export function createSessionsHistoryTool(opts?: {
         params: { sessionKey: resolvedKey, limit },
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
-      const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
+      // `delivery-mirror` / `gateway-injected` assistant turns duplicate the
+      // real assistant reply they were written from (see
+      // `docs/reference/transcript-hygiene.md`). Replay paths already skip
+      // them; this tool surfaces history to dashboards and other agents, so
+      // it must skip them too — otherwise every assistant turn appears twice.
+      const visibleMessages = rawMessages.filter(
+        (message) => !isTranscriptOnlyOpenclawAssistant(message),
+      );
+      const selectedMessages = includeTools ? visibleMessages : stripToolMessages(visibleMessages);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
       const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);


### PR DESCRIPTION
## Summary

- Move the `delivery-mirror` / `gateway-injected` classifier into a small shared module `src/agents/openclaw-transcript-mirror.ts` so the same contract that backs provider-replay filtering can be reused by the `sessions_history` tool. The literal model identifiers (`delivery-mirror`, `gateway-injected`) are the documented contract (`docs/reference/transcript-hygiene.md`); having one Set instead of two prevents drift.
- Update `src/agents/pi-embedded-runner/replay-history.ts` to import the helper from the new module — same behavior, the local copy is removed and replaced with a comment pointer.
- Wire the filter into `src/agents/tools/sessions-history-tool.ts` between the raw gateway response and the existing `stripToolMessages` / sanitize / cap pipeline, so the dashboard session viewer and any caller of the `sessions_history` agent tool no longer see the duplicate transcript-mirror copy that follows every real assistant turn (issue #85669).
- Cover the new module with 8 colocated unit cases and the wired tool with 4 colocated integration cases (delivery-mirror filtered, gateway-injected filtered, other `provider:"openclaw"` models still kept, interleaved order preserved).

## Behavior change to flag

Callers of `sessions_history` (the agent tool and the dashboard session viewer it backs) used to see every assistant reply twice — once as the real model output and once as the `delivery-mirror` copy emitted by the channel-delivery transcript mirror (or `gateway-injected` from the Gateway transcript-inject helper). After this change, those transcript-only assistant turns are dropped from the tool response. Telegram / Slack / WhatsApp / Discord delivery itself is unaffected — the filter is applied in the read path of the tool, not in the persistence path or the delivery path.

## Real behavior proof

- **Behavior addressed:** `sessions_history` tool no longer returns `provider:"openclaw" + model:"delivery-mirror"` or `provider:"openclaw" + model:"gateway-injected"` assistant entries. This was the gap the docs already promised (`docs/reference/transcript-hygiene.md`: "Replay filters OpenClaw delivery-mirror and gateway-injected assistant turns.") — the tool surface now matches the docs claim.
- **Real environment tested:** local macOS arm64 source checkout (post-rebase against `upstream/main`); behavior verified through (a) the new pure-helper unit suite `src/agents/openclaw-transcript-mirror.test.ts` and (b) tool-level integration cases that drive `createSessionsHistoryTool({ config, callGateway })` with a stub gateway returning mixed message arrays exactly matching the production `chat.history` response shape — same scaffolding pattern already used by the existing redaction tests in the same file.
- **Exact steps or command run after this patch:**
  - `pnpm test src/agents/openclaw-transcript-mirror.test.ts`
  - `pnpm test src/agents/pi-embedded-runner/replay-history.test.ts`
  - `pnpm test src/agents/tools/sessions-history-tool.test.ts`
  - `pnpm test:changed`
  - `pnpm check:changed`
- **Evidence after fix:**
  - New `delivery-mirror` filter case: a 3-message gateway response (`user`, real `assistant`, `delivery-mirror` duplicate) now returns 2 messages with role/provider `[user:, assistant:anthropic]`; previously all 3 were surfaced.
  - New `gateway-injected` filter case: returns the real `openai/gpt-5.5` turn and drops the `openclaw/gateway-injected` no-op.
  - Negative case: a `provider:"openclaw" + model:"best-effort-summary"` assistant turn is preserved (only the two canonical transcript-mirror models are dropped).
  - Interleaved order case: 6-message input with 2 real assistant turns each followed by a `delivery-mirror` duplicate produces 4 messages in original order (`user:one, assistant:reply 1, user:two, assistant:reply 2`).
- **Observed result after fix:**
  - `src/agents/openclaw-transcript-mirror.test.ts`: 8 / 8 passed.
  - `src/agents/pi-embedded-runner/replay-history.test.ts`: 25 / 25 passed (no regression after moving the helper to the shared module).
  - `src/agents/tools/sessions-history-tool.test.ts`: 6 / 6 passed (2 existing redaction tests + 4 new filter tests).
  - `pnpm check:changed`: exit 0 (typecheck core + extensions + tests, lint, import-cycles 0 runtime value cycles, all repo-wide guards green).
  - `pnpm test:changed`: 255 / 257 passed across 16 shards. The 2 failures in `src/commands/onboard.test.ts` (`fails fast for invalid --secret-input-mode`, `fails fast for invalid --reset-scope`) reproduce on pristine `upstream/main` and have no overlap with this change.
- **What was not tested:** a live OpenClaw dashboard / session viewer rendering against this build to visually confirm the double assistant turn disappears. The fix is verified at the tool surface that drives the dashboard; the reporter's screenshot ("Dashboard shows duplicate messages for every assistant turn") and the docs claim that documents the contract were the upstream evidence. Telegram / channel-delivery paths were intentionally not exercised because the filter sits in the read path only and cannot affect them by construction.

## Notes

- The new `src/agents/openclaw-transcript-mirror.ts` exports the canonical Set and a permissive classifier (`isTranscriptOnlyOpenclawAssistant(message: unknown)`) so both the pi-embedded runner's typed `AgentMessage` flow and the tool's `unknown[]` gateway-response flow can use the same checker without a type cast at each call site.
- The existing `image-tool.ts` already crosses the `src/agents/tools/ → src/agents/pi-embedded-runner/` boundary; this change avoids adding another such cross-import by placing the classifier at `src/agents/` root level (sibling to both consumers). The module is narrow and single-purpose, in line with the SDK and code guidance under root `AGENTS.md`.
- The filter intentionally has no new output field (no `mirrorTurnsDropped` counter). The behavior is the contract the docs already documented and that the replay path already enforced, so silent agreement keeps the surface lean.
- Reviewed against root `AGENTS.md`, `src/agents/tools/CLAUDE.md`, and `CONTRIBUTING.md`. No `CHANGELOG.md` edits (per CONTRIBUTING).

Refs #85669
