### PR TITLE
fix(session-store): rewrite generated transcript paths on rollover

### DIFF
--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -897,6 +897,60 @@ describe("session store writer queue", () => {
     expect(merged.modelProvider).toBeUndefined();
   });
 
+  it("rewrites generated sessionFile paths when session id changes", () => {
+    const previousSessionId = "11111111-1111-4111-8111-111111111111";
+    const nextSessionId = "22222222-2222-4222-8222-222222222222";
+    const merged = mergeSessionEntry(
+      {
+        sessionId: previousSessionId,
+        updatedAt: 100,
+        sessionFile: `/tmp/openclaw/sessions/${previousSessionId}.jsonl`,
+      },
+      {
+        sessionId: nextSessionId,
+        updatedAt: 200,
+      },
+    );
+
+    expect(merged.sessionFile).toBe(`/tmp/openclaw/sessions/${nextSessionId}.jsonl`);
+  });
+
+  it("rewrites stale generated sessionFile patches during session rollover", () => {
+    const previousSessionId = "11111111-1111-4111-8111-111111111111";
+    const nextSessionId = "22222222-2222-4222-8222-222222222222";
+    const previousSessionFile = `/tmp/openclaw/sessions/${previousSessionId}-topic-456.jsonl`;
+    const merged = mergeSessionEntry(
+      {
+        sessionId: previousSessionId,
+        updatedAt: 100,
+        sessionFile: previousSessionFile,
+      },
+      {
+        sessionId: nextSessionId,
+        updatedAt: 200,
+        sessionFile: previousSessionFile,
+      },
+    );
+
+    expect(merged.sessionFile).toBe(`/tmp/openclaw/sessions/${nextSessionId}-topic-456.jsonl`);
+  });
+
+  it("preserves custom sessionFile paths when session id changes", () => {
+    const merged = mergeSessionEntry(
+      {
+        sessionId: "previous-session",
+        updatedAt: 100,
+        sessionFile: "/tmp/openclaw/sessions/custom-transcript.jsonl",
+      },
+      {
+        sessionId: "next-session",
+        updatedAt: 200,
+      },
+    );
+
+    expect(merged.sessionFile).toBe("/tmp/openclaw/sessions/custom-transcript.jsonl");
+  });
+
   it("caps future updatedAt values at the session merge boundary", () => {
     const now = 1_000;
     const merged = mergeSessionEntryWithPolicy(

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -13,6 +13,7 @@ import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
 import type { Skill } from "../../skills/loading/skill-contract.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { TtsAutoMode } from "../types.tts.js";
+import { rewriteSessionFileForNewSessionId } from "./session-file-rotation.js";
 
 export type SessionScope = "per-sender" | "global";
 
@@ -554,6 +555,19 @@ export function mergeSessionEntryWithPolicy(
       patch.sessionStartedAt ??
       (existing.sessionId === sessionId ? existing.sessionStartedAt : updatedAt),
   };
+
+  if (existing.sessionId !== sessionId) {
+    const patchHasSessionFile = Object.hasOwn(patch, "sessionFile");
+    const candidateSessionFile = patchHasSessionFile ? patch.sessionFile : existing.sessionFile;
+    const rewrittenSessionFile = rewriteSessionFileForNewSessionId({
+      sessionFile: candidateSessionFile,
+      previousSessionId: existing.sessionId,
+      nextSessionId: sessionId,
+    });
+    if (rewrittenSessionFile) {
+      next.sessionFile = rewrittenSessionFile;
+    }
+  }
 
   // Guard against stale provider carry-over when callers patch runtime model
   // without also patching runtime provider.


### PR DESCRIPTION
## Summary

- Rewrites generated `sessionFile` paths when a session-store merge changes `sessionId`.
- Prevents stale generated transcript paths like `old-session.jsonl` or `old-session-topic-456.jsonl` from being carried onto a new session id.
- Preserves custom/non-generated `sessionFile` paths when OpenClaw cannot safely derive a replacement.

Refs #65564.

Complements #73809 by hardening generic session-store merges. The heartbeat-specific archival bug is handled by #73809; this PR keeps other session-store writers from persisting a generated transcript path that still embeds the previous session id after a merge rolls the session id forward.

## Verification

- `node scripts/run-vitest.mjs src/config/sessions/sessions.test.ts`
- `node scripts/run-vitest.mjs src/agents/command/session-store.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Generic session-store rollover can preserve a stale generated `sessionFile` while changing `sessionId`, causing a new logical session id to keep appending to an old transcript file. This is a session-store invariant hardening change, not the heartbeat-specific reset archival fix from #73809.

Real environment tested: Local OpenClaw source checkout on Linux with Node v22.20.0, writing a real temporary `agents/main/sessions/sessions.json` file through the agent session-store persistence path.

Exact steps or command run after this patch:

```bash
node --import tsx /tmp/openclaw-session-rollover-proof.mjs
```

Evidence after fix: Terminal output copied from running the command above:

```text
OpenClaw session rollover proof
source path: /tmp/openclaw-upstream
store path: /tmp/openclaw-rollover-proof-dsfpZV/agents/main/sessions/sessions.json
real path exercised: persistSessionEntry -> updateSessionStore -> mergeSessionEntry
before.sessionId: 11111111-1111-4111-8111-111111111111
before.sessionFile.basename: 11111111-1111-4111-8111-111111111111-topic-456.jsonl
rollover patch carried stale sessionFile basename: 11111111-1111-4111-8111-111111111111-topic-456.jsonl
after.sessionId: 22222222-2222-4222-8222-222222222222
after.sessionFile.basename: 22222222-2222-4222-8222-222222222222-topic-456.jsonl
expected generated sessionFile basename: 22222222-2222-4222-8222-222222222222-topic-456.jsonl
persisted object matches store: true
stale sessionFile carried after fix: false
rewritten to current sessionId: true
result: PASS
```

Observed result after fix: The on-disk `sessions.json` entry kept the new `sessionId` and rewrote the generated transcript basename from `11111111-1111-4111-8111-111111111111-topic-456.jsonl` to `22222222-2222-4222-8222-222222222222-topic-456.jsonl`; the stale generated `sessionFile` was not carried forward. This proves the generic merge boundary now preserves the invariant that generated transcript paths follow the current persisted session id.

What was not tested: Full repository test suite, live heartbeat runtime, and packaged npm install/upgrade path.
