### PR TITLE
fix: tighten CLI utility failure handling

### DIFF
--- a/scripts/ensure-cli-startup-build.mjs
+++ b/scripts/ensure-cli-startup-build.mjs
@@ -30,6 +30,9 @@ export function ensureCliStartupBuild(params = {}) {
     env: params.env ?? process.env,
     stdio: params.stdio ?? "inherit",
   });
+  if (result.error) {
+    throw result.error;
+  }
   const status = result.status ?? (result.signal ? 1 : 0);
   if (status !== 0) {
     throw new Error(`cliStartup build profile failed with exit code ${status}`);

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -107,4 +107,21 @@ describe("completion-runtime", () => {
       await fs.rm(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects install when the completion cache is missing", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-"));
+
+    process.env.HOME = homeDir;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      await expect(installCompletion("zsh", true, "openclaw")).rejects.toThrow(
+        "Completion cache not found",
+      );
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -233,17 +233,15 @@ export async function usesSlowDynamicCompletion(
 export async function installCompletion(shell: string, yes: boolean, binName = "openclaw") {
   const isShellSupported = isCompletionShell(shell);
   if (!isShellSupported) {
-    console.error(`Automated installation not supported for ${shell} yet.`);
-    return;
+    throw new Error(`Automated installation not supported for ${shell} yet.`);
   }
 
   const cachePath = resolveCompletionCachePath(shell, binName);
   const cacheExists = await pathExists(cachePath);
   if (!cacheExists) {
-    console.error(
+    throw new Error(
       `Completion cache not found at ${cachePath}. Run \`${binName} completion --write-state\` first.`,
     );
-    return;
   }
 
   let profilePath: string;
@@ -305,6 +303,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       );
     }
   } catch (err) {
-    console.error(`Failed to install completion: ${err as string}`);
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to install completion: ${message}`);
   }
 }

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -304,6 +304,6 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to install completion: ${message}`);
+    throw new Error(`Failed to install completion: ${message}`, { cause: err });
   }
 }

--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -427,10 +427,6 @@ export function registerNodesStatusCommands(nodes: Command) {
           });
           const filteredLabel =
             hasFilters && filteredPaired.length !== paired.length ? ` (of ${paired.length})` : "";
-          defaultRuntime.log(
-            `Pending: ${pendingRows.length} · Paired: ${filteredPaired.length}${filteredLabel}`,
-          );
-
           if (opts.json) {
             defaultRuntime.writeJson({
               pending: pendingRows,
@@ -438,6 +434,10 @@ export function registerNodesStatusCommands(nodes: Command) {
             });
             return;
           }
+
+          defaultRuntime.log(
+            `Pending: ${pendingRows.length} · Paired: ${filteredPaired.length}${filteredLabel}`,
+          );
 
           if (pendingRows.length > 0) {
             const rendered = renderPendingPairingRequestsTable({

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -195,7 +195,8 @@ describe("cli program (nodes basics)", () => {
     expect(JSON.stringify(json)).not.toContain("paired-token");
     expect(JSON.stringify(json)).not.toContain("pair-only-token");
     const output = getRuntimeOutput();
-    expect(output).toContain("Pending: 1 · Paired: 3");
+    expect(output).toMatch(/^\{/);
+    expect(output).not.toContain("Pending: 1 · Paired: 3");
     expect(output).not.toContain("Effective Only Unknown");
     expect(output).not.toContain("unpaired-live");
   });

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -44,6 +44,9 @@ const updateNpmInstalledPlugins = vi.fn();
 const loadInstalledPluginIndexInstallRecords = vi.fn(
   async (params: { config?: OpenClawConfig } = {}) => params.config?.plugins?.installs ?? {},
 );
+const checkShellCompletionStatus = vi.fn();
+const ensureCompletionCacheExists = vi.fn();
+const installCompletion = vi.fn();
 const legacyConfigRepairMocks = vi.hoisted(() => ({
   repairLegacyConfigForUpdateChannel: vi.fn(),
 }));
@@ -277,9 +280,20 @@ vi.mock("./update-cli/restart-helper.js", () => ({
 vi.mock("../commands/doctor.js", () => ({
   doctorCommand: vi.fn(),
 }));
+vi.mock("../commands/doctor-completion.js", () => ({
+  checkShellCompletionStatus: (...args: unknown[]) => checkShellCompletionStatus(...args),
+  ensureCompletionCacheExists: (...args: unknown[]) => ensureCompletionCacheExists(...args),
+}));
 vi.mock("../commands/doctor/legacy-config-repair.js", () => ({
   repairLegacyConfigForUpdateChannel: legacyConfigRepairMocks.repairLegacyConfigForUpdateChannel,
 }));
+vi.mock("./completion-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./completion-runtime.js")>();
+  return {
+    ...actual,
+    installCompletion: (...args: unknown[]) => installCompletion(...args),
+  };
+});
 // Mock the daemon-cli module
 vi.mock("./daemon-cli.js", () => ({
   runDaemonInstall: mockedRunDaemonInstall,
@@ -793,6 +807,15 @@ describe("update-cli", () => {
       config: baseConfig,
       outcomes: [],
     });
+    checkShellCompletionStatus.mockResolvedValue({
+      shell: "zsh",
+      profileInstalled: false,
+      cacheExists: false,
+      cachePath: "/tmp/openclaw-completion.zsh",
+      usesSlowPattern: false,
+    });
+    ensureCompletionCacheExists.mockResolvedValue(true);
+    installCompletion.mockResolvedValue(undefined);
     vi.mocked(runDaemonInstall).mockResolvedValue(undefined);
     vi.mocked(runDaemonRestart).mockResolvedValue(true);
     vi.mocked(doctorCommand).mockResolvedValue(undefined);
@@ -881,6 +904,28 @@ describe("update-cli", () => {
     expect(logOutput).toContain("timed out after 30s");
     expect(logOutput).toContain("openclaw completion --write-state");
     expect(logOutput).not.toContain("Error: spawnSync");
+  });
+
+  it("keeps update completion refresh best-effort when profile install fails", async () => {
+    setTty(true);
+    checkShellCompletionStatus.mockResolvedValue({
+      shell: "zsh",
+      profileInstalled: true,
+      cacheExists: true,
+      cachePath: "/tmp/openclaw-completion.zsh",
+      usesSlowPattern: true,
+    });
+    installCompletion.mockRejectedValueOnce(new Error("EACCES: permission denied"));
+
+    await updateCommand({ yes: true, restart: false });
+
+    expect(installCompletion).toHaveBeenCalledWith("zsh", true, "openclaw");
+    const logOutput = vi
+      .mocked(runtimeCapture.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(logOutput).toContain("Shell completion refresh failed: EACCES: permission denied");
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
 
   it("respawns into the updated package root before running post-update tasks", async () => {
@@ -1186,8 +1231,7 @@ describe("update-cli", () => {
         .mocked(readConfigFileSnapshot)
         .mock.calls.some(
           ([options]) =>
-            options?.skipPluginValidation === true &&
-            options.suppressFutureVersionWarning === true,
+            options?.skipPluginValidation === true && options.suppressFutureVersionWarning === true,
         ),
     ).toBe(true);
     expect(defaultRuntime.exit).toHaveBeenCalledWith(0);

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1268,7 +1268,7 @@ async function tryInstallShellCompletion(opts: {
     defaultRuntime.log(theme.muted("Upgrading shell completion to cached version..."));
     const cacheGenerated = await ensureCompletionCacheExists(CLI_NAME);
     if (cacheGenerated) {
-      await installCompletion(status.shell, true, CLI_NAME);
+      await installShellCompletionForUpdate(status.shell, true);
     }
     return;
   }
@@ -1305,7 +1305,16 @@ async function tryInstallShellCompletion(opts: {
       return;
     }
 
-    await installCompletion(status.shell, opts.skipPrompt, CLI_NAME);
+    await installShellCompletionForUpdate(status.shell, opts.skipPrompt);
+  }
+}
+
+async function installShellCompletionForUpdate(shell: string, yes: boolean): Promise<void> {
+  try {
+    await installCompletion(shell, yes, CLI_NAME);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    defaultRuntime.log(theme.warn(`Shell completion refresh failed: ${message}`));
   }
 }
 

--- a/test/scripts/ensure-cli-startup-build.test.ts
+++ b/test/scripts/ensure-cli-startup-build.test.ts
@@ -85,4 +85,16 @@ describe("ensure-cli-startup-build", () => {
       }),
     ).toThrow("cliStartup build profile failed with exit code 1");
   });
+
+  it("fails when spawning the cliStartup build profile fails", () => {
+    const root = makeTempRoot();
+
+    expect(() =>
+      ensureCliStartupBuild({
+        rootDir: root,
+        spawnSync: () => ({ error: new Error("spawn denied") }),
+        stdio: "pipe",
+      }),
+    ).toThrow("spawn denied");
+  });
 });


### PR DESCRIPTION
## Summary
- keep `openclaw nodes list --json` JSON-only by moving the human summary after the JSON early return
- make completion installation reject missing-cache, unsupported-shell, and profile-write failures instead of reporting success after logging errors
- make `ensureCliStartupBuild` fail when spawning the build profile fails

## Verification
Behavior addressed: three clawpatch findings: `fnd_sig-feat-cli-command-52b7849d0b-_dc289fb547`, `fnd_sig-feat-cli-command-5483b047cc-_34d922245a`, `fnd_sig-feat-cli-command-23edfe2554-_5806f12f04`
Real environment tested: local macOS source checkout, Node/Vitest via repo wrapper
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/completion-runtime.test.ts test/scripts/ensure-cli-startup-build.test.ts`; `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/program.nodes-basic.e2e.test.ts`; `git diff --check`; clawpatch revalidate for each finding ID; `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/cli/completion-runtime.test.ts test/scripts/ensure-cli-startup-build.test.ts && node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/program.nodes-basic.e2e.test.ts"`
Evidence after fix: focused tests passed: 2 files / 10 tests, and e2e file passed: 1 file / 13 tests; clawpatch revalidated all three findings as fixed; autoreview reported no accepted/actionable findings
Observed result after fix: JSON-mode nodes list output starts with JSON rather than a human summary; completion install failures reject; startup build spawn errors throw
What was not tested: full repository suite, broad cross-platform shell profile writes
