### PR TITLE
fix(codex): raise dynamic tool RPC timeout

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -310,7 +310,7 @@ available timeout in this order:
   image-generation default.
 - For the media-understanding `image` tool, `tools.media.image.timeoutSeconds`
   converted to milliseconds, or the 60 second media default.
-- The 30 second dynamic-tool default.
+- The 90 second dynamic-tool default.
 
 Dynamic tool budgets are capped at 600000 ms. On timeout, OpenClaw aborts the
 tool signal where supported and returns a failed dynamic-tool response to Codex

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -541,7 +541,7 @@ Supported `appServer` fields:
 | `experimental.sandboxExecServer`              | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with Codex app-server 0.132.0 or newer so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                               |
 
 OpenClaw-owned dynamic tool calls are bounded independently from
-`appServer.requestTimeoutMs`: Codex `item/tool/call` requests use a 30 second
+`appServer.requestTimeoutMs`: Codex `item/tool/call` requests use a 90 second
 OpenClaw watchdog by default. A positive per-call `timeoutMs` argument extends
 or shortens that specific tool budget. The `image_generate` tool uses
 `agents.defaults.imageGenerationModel.timeoutMs` when the tool call does not

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3089,6 +3089,22 @@ describe("runCodexAppServerAttempt", () => {
     ).toBe(testing.CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS);
   });
 
+  it("uses a 90 second default for generic Codex dynamic tool calls", () => {
+    expect(
+      testing.resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-session-status",
+          namespace: null,
+          tool: "session_status",
+          arguments: { sessionKey: "current" },
+        },
+        config: undefined,
+      }),
+    ).toBe(90_000);
+  });
+
   it("caps dynamic tool timeouts at the bridge maximum", () => {
     expect(
       testing.resolveDynamicToolCallTimeoutMs({

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -207,7 +207,7 @@ import {
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 import { filterToolsForVisionInputs } from "./vision-tools.js";
 
-const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 30_000;
+const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;
 const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
 const CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS = 120_000;
 const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1178,6 +1178,21 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(timeoutMs).toBe(120_000);
   });
 
+  it("uses a 90 second default for generic side-thread dynamic tool calls", () => {
+    const timeoutMs = testing.resolveSideDynamicToolCallTimeoutMs({
+      call: {
+        threadId: "side-thread",
+        turnId: "turn-1",
+        callId: "tool-1",
+        tool: "session_status",
+        arguments: { sessionKey: "current" },
+      },
+      config: {} as never,
+    });
+
+    expect(timeoutMs).toBe(90_000);
+  });
+
   it("cleans up notification handlers when side tool setup fails", async () => {
     const client = createFakeClient();
     createOpenClawCodingToolsMock.mockImplementation(() => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -78,7 +78,7 @@ import {
 } from "./thread-lifecycle.js";
 import { filterToolsForVisionInputs } from "./vision-tools.js";
 
-const CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_MS = 30_000;
+const CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;
 const CODEX_SIDE_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
 const CODEX_SIDE_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS = 120_000;
 const CODEX_SIDE_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- Raises the generic Codex dynamic-tool RPC watchdog from 30 seconds to 90 seconds in both the main run-attempt path and side-question path.
- Keeps existing per-call `timeoutMs`, image-generation, media image, message-tool, and 600s clamp behavior unchanged.

Why does this matter now?
- `session_status` and other enumeration-heavy MCP tools can exceed the previous 30s generic default, causing Codex agents to lose their canonical status/introspection path.

What is the intended outcome?
- Generic OpenClaw-owned Codex dynamic-tool calls get a default budget aligned with slower real-world enumeration workloads while still timing out deterministically.

What is intentionally out of scope?
- Adding a new operator config knob.
- Changing `session_status` schema parameters.
- Changing media/message/image special-case budgets.

What does success look like?
- Generic dynamic tools default to 90s in main and side Codex app-server paths.
- Existing explicit and special-case timeout behavior remains covered.

What should reviewers focus on?
- Whether 90s is the right narrow default bump for generic dynamic tools.
- Whether docs and tests cover both main and side paths.

## Linked context

Which issue does this close?

Addresses #86758

Which issues, PRs, or discussions are related?

Related #86758

Was this requested by a maintainer or owner?

Astra P1 autopilot handoff for issue #86758.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Generic Codex dynamic-tool calls such as `session_status` used the hardcoded 30000ms default in both main and side app-server paths.
- Real environment tested: Local OpenClaw source checkout on branch `fix/86758-dynamic-tool-timeout` under `/Users/miya/Desktop/openclaw-issue-86758`.
- Exact steps or command run after this patch: `node --import tsx -e "import { testing as main } from './extensions/codex/src/app-server/run-attempt.ts'; import { testing as side } from './extensions/codex/src/app-server/side-question.ts'; const mainTimeout = main.resolveDynamicToolCallTimeoutMs({ call: { threadId: 'thread-1', turnId: 'turn-1', callId: 'call-session-status', namespace: null, tool: 'session_status', arguments: { sessionKey: 'current' } }, config: undefined }); const sideTimeout = side.resolveSideDynamicToolCallTimeoutMs({ call: { threadId: 'side-thread', turnId: 'turn-1', callId: 'call-session-status', tool: 'session_status', arguments: { sessionKey: 'current' } }, config: {} }); console.log(JSON.stringify({ mainTimeout, sideTimeout }));"`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal output: `{"mainTimeout":90000,"sideTimeout":90000}`
- Observed result after fix: The patched main and side Codex app-server timeout resolvers both returned `90000` for a `session_status` dynamic-tool call that does not provide a per-call timeout.
- What was not tested: A live large-session-store `session_status` call against a patched installed gateway.
- Proof limitations or environment constraints: The live installed OpenClaw runtime still has the 30s dynamic-tool watchdog, and Clawpatch itself hit that timeout via the OpenClaw tool path. The CLI fallback then failed provider auth with `401 Unauthorized`, so Clawpatch review could not complete in this environment.
- Before evidence (optional but encouraged): The same targeted resolver assertion failed before the production change with `expected 90000` and `received 30000` for both main and side generic dynamic-tool defaults.

## Tests and validation

Which commands did you run?
- `pnpm install`
- `node --import tsx -e "import { testing as main } from './extensions/codex/src/app-server/run-attempt.ts'; import { testing as side } from './extensions/codex/src/app-server/side-question.ts'; const mainTimeout = main.resolveDynamicToolCallTimeoutMs({ call: { threadId: 'thread-1', turnId: 'turn-1', callId: 'call-session-status', namespace: null, tool: 'session_status', arguments: { sessionKey: 'current' } }, config: undefined }); const sideTimeout = side.resolveSideDynamicToolCallTimeoutMs({ call: { threadId: 'side-thread', turnId: 'turn-1', callId: 'call-session-status', tool: 'session_status', arguments: { sessionKey: 'current' } }, config: {} }); console.log(JSON.stringify({ mainTimeout, sideTimeout }));"`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/side-question.test.ts` (red before fix: expected 90000, received 30000)
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/side-question.test.ts` (green after fix: 249 passed)
- `git diff --check`
- `pnpm docs:list`
- `clawpatch_doctor`, `clawpatch_status`, `clawpatch_init`, `clawpatch_map`
- `clawpatch_review` via OpenClaw tool and `/Users/miya/.openclaw/bin/clawpatch review --root /Users/miya/Desktop/openclaw-issue-86758 --provider codex --limit 3 --jobs 1` attempted but blocked as noted above.

What regression coverage was added or updated?
- Added focused assertions for the generic `session_status` dynamic-tool fallback in main run attempts and side questions.

What failed before this fix, if known?
- The new assertions failed because both resolver paths returned `30000`.

If no test was added, why not?
- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, tool execution timeout budget changes for generic Codex dynamic tools.

What is the highest-risk area?

Longer-running generic tool calls may consume a session lane longer before returning timeout.

How is that risk mitigated?

The new default remains bounded at 90s, per-call timeouts still override it, existing media/message/image special cases remain unchanged, and the 600s maximum clamp still applies.

## Current review state

What is the next action?

Review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI and any maintainer-requested live proof against a patched installed gateway.

Which bot or reviewer comments were addressed?

The issue's `clawsweeper:needs-live-repro` concern is addressed with source-level red/green proof for the exact 30s fallback path plus local terminal output from the patched resolver path; a full live large-session-store repro remains a stated proof limitation.

AI-assisted: yes, implemented by Vector/Codex with targeted validation.
