### PR TITLE
fix: respect root options in startup guards

### DIFF
--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -14,10 +14,10 @@ if (!isLinux && !isMac) {
 }
 
 const repoRoot = process.cwd();
-const tmpHome = mkdtempSync(path.join(os.tmpdir(), "openclaw-startup-memory-"));
 const tmpDir = process.env.TMPDIR || process.env.TEMP || process.env.TMP || os.tmpdir();
-const rssHookPath = path.join(tmpHome, "measure-rss.mjs");
 const MAX_RSS_MARKER = "__OPENCLAW_MAX_RSS_KB__=";
+let tmpHome = null;
+let rssHookPath = null;
 
 function parseArgs(argv) {
   const options = {
@@ -58,18 +58,6 @@ function parseArgs(argv) {
   }
   return options;
 }
-
-writeFileSync(
-  rssHookPath,
-  [
-    "process.on('exit', () => {",
-    "  const usage = typeof process.resourceUsage === 'function' ? process.resourceUsage() : null;",
-    `  if (usage && typeof usage.maxRSS === 'number') console.error('${MAX_RSS_MARKER}' + String(usage.maxRSS));`,
-    "});",
-    "",
-  ].join("\n"),
-  "utf8",
-);
 
 const DEFAULT_LIMITS_MB = {
   help: 100,
@@ -146,6 +134,9 @@ function formatCaseCommand(testCase) {
 }
 
 function buildBenchEnv() {
+  if (!tmpHome) {
+    throw new Error("temporary home is not initialized");
+  }
   const env = {
     HOME: tmpHome,
     USERPROFILE: tmpHome,
@@ -181,6 +172,9 @@ function buildBenchEnv() {
 }
 
 function runCase(testCase) {
+  if (!rssHookPath) {
+    throw new Error("RSS hook path is not initialized");
+  }
   const env = buildBenchEnv();
   const result = spawnSync(process.execPath, ["--import", rssHookPath, ...testCase.args], {
     cwd: repoRoot,
@@ -278,6 +272,19 @@ function writeReport(options, results) {
 }
 
 const options = parseArgs(process.argv.slice(2));
+tmpHome = mkdtempSync(path.join(os.tmpdir(), "openclaw-startup-memory-"));
+rssHookPath = path.join(tmpHome, "measure-rss.mjs");
+writeFileSync(
+  rssHookPath,
+  [
+    "process.on('exit', () => {",
+    "  const usage = typeof process.resourceUsage === 'function' ? process.resourceUsage() : null;",
+    `  if (usage && typeof usage.maxRSS === 'number') console.error('${MAX_RSS_MARKER}' + String(usage.maxRSS));`,
+    "});",
+    "",
+  ].join("\n"),
+  "utf8",
+);
 const results = [];
 try {
   for (const testCase of cases) {
@@ -285,7 +292,9 @@ try {
   }
 } finally {
   writeReport(options, results);
-  rmSync(tmpHome, { recursive: true, force: true });
+  if (tmpHome) {
+    rmSync(tmpHome, { recursive: true, force: true });
+  }
 }
 
 const failure = results.find((result) => result.status !== "pass");

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -468,6 +468,8 @@ describe("argv helpers", () => {
     { argv: ["node", "openclaw", "status"], expected: false },
     { argv: ["node", "openclaw", "health"], expected: false },
     { argv: ["node", "openclaw", "sessions"], expected: false },
+    { argv: ["node", "openclaw", "--profile", "work", "status"], expected: false },
+    { argv: ["node", "openclaw", "--log-level=debug", "models", "list"], expected: false },
     { argv: ["node", "openclaw", "config", "get", "update"], expected: false },
     { argv: ["node", "openclaw", "config", "unset", "update"], expected: false },
     { argv: ["node", "openclaw", "models", "list"], expected: false },

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -384,5 +384,5 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
 }
 
 export function shouldMigrateState(argv: string[]): boolean {
-  return shouldMigrateStateFromPath(getCommandPath(argv, 2));
+  return shouldMigrateStateFromPath(getCommandPathWithRootOptions(argv, 2));
 }

--- a/test/scripts/check-cli-startup-memory.test.ts
+++ b/test/scripts/check-cli-startup-memory.test.ts
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempRoots: string[] = [];
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-startup-memory-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("check-cli-startup-memory", () => {
+  it("does not create a temp home before argument validation succeeds", () => {
+    if (process.platform !== "darwin" && process.platform !== "linux") {
+      return;
+    }
+
+    const tempRoot = makeTempRoot();
+    const result = spawnSync(process.execPath, ["scripts/check-cli-startup-memory.mjs", "--json"], {
+      cwd: path.resolve(__dirname, "..", ".."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        TMPDIR: tempRoot,
+        TEMP: tempRoot,
+        TMP: tempRoot,
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(readdirSync(tempRoot)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- make state-migration routing use the root-option-aware command path so commands after `--profile` / `--log-level` keep their intended migration behavior
- defer startup-memory temp-home creation until after argument validation succeeds, so invalid invocations do not leak temp directories
- add focused regressions for both paths

## Verification
Behavior addressed: two clawpatch findings: `fnd_sig-feat-cli-command-5de7641ded-_499bca19f5`, `fnd_sig-feat-cli-command-23edfe2554-_25ca997f69`
Real environment tested: local macOS source checkout, Node/Vitest via repo wrapper
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/argv.test.ts test/scripts/check-cli-startup-memory.test.ts`; `git diff --check`; clawpatch revalidate for each finding ID; `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/cli/argv.test.ts test/scripts/check-cli-startup-memory.test.ts"`
Evidence after fix: focused tests passed: 2 files / 89 tests; clawpatch revalidated both findings as fixed; autoreview initially found a cross-platform test issue, then passed clean after the fix
Observed result after fix: root options no longer confuse state-migration command classification; invalid startup-memory args fail before creating an `openclaw-startup-memory-*` temp home
What was not tested: full repository suite, real CI startup-memory benchmark path
