### PR TITLE
fix(config): repair profiled tool section grants in doctor

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { OpenClawConfig } from "../../../config/types.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
 
@@ -90,6 +91,712 @@ describe("legacy silent reply config migrate", () => {
       "Removed agents.defaults.silentReplyRewrite",
       "Removed surfaces.telegram.silentReplyRewrite",
     ]);
+  });
+});
+
+describe("profile configured tool section migrate", () => {
+  it("adds explicit global alsoAllow grants for configured tool sections under profiles", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["read", "write"],
+        exec: { security: "allowlist" },
+        fs: { workspaceOnly: true },
+      },
+    });
+
+    expect(res.config?.tools?.alsoAllow).toEqual(["read", "write", "exec", "process", "edit"]);
+    expect(res.changes).toContain(
+      'Added tools.alsoAllow entries (exec, process, edit) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("adds explicit agent alsoAllow grants for configured tool sections under profiles", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              profile: "messaging",
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("does not change profiled tool sections when explicit grants already cover them", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process", "read", "write", "edit"],
+        exec: { security: "allowlist" },
+        fs: { workspaceOnly: true },
+      },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
+  it("adds missing grants to allow when an allowlist already exists", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["message"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools).not.toHaveProperty("alsoAllow");
+    expect(res.changes).toContain(
+      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
+    );
+    expect(res.changes).toContain(
+      'Added tools.allow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("sets profile full when an existing allowlist already contains configured section grants", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["message", "exec", "process"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.changes).toEqual([
+      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
+    ]);
+  });
+
+  it("narrows broad allowlists before making them authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["*"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.allow).toContain("message");
+    expect(res.config?.tools?.allow).toContain("exec");
+    expect(res.config?.tools?.allow).toContain("process");
+    expect(res.config?.tools?.allow).not.toContain("*");
+    expect(res.config?.tools?.allow).not.toContain("read");
+    expect(res.changes).toContain(
+      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+    );
+  });
+
+  it("concretizes profile-bound glob allowlists before making them authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["sessions_*"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.allow).toEqual([
+      "sessions_list",
+      "sessions_history",
+      "sessions_send",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.tools?.allow).not.toContain("session_status");
+    expect(res.config?.tools?.allow).not.toContain("sessions_*");
+  });
+
+  it("preserves plugin allow entries when making profiles authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["gmail_search"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.allow).toEqual(["gmail_search", "exec", "process"]);
+  });
+
+  it("adds missing allow grants even when the selected profile already covers them", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "coding",
+        allow: ["message"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.changes).toContain(
+      'Added tools.allow entries (exec, process) for configured tool sections under profile "coding".',
+    );
+  });
+
+  it("drops allow entries blocked by the original profile before making them authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["message", "web_search"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.allow).not.toContain("web_search");
+    expect(res.changes).toContain(
+      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+    );
+  });
+
+  it("adds provider-scoped alsoAllow grants for configured tool sections under profiles", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("sets provider profile full when provider allow already contains configured section grants", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+            allow: ["message", "exec", "process"],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
+    expect(res.changes).toContain(
+      'Set tools.byProvider.openai.profile to "full" so tools.byProvider.openai.allow controls configured tool sections directly.',
+    );
+  });
+
+  it("narrows broad provider allowlists before making them authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+            allow: ["group:openclaw"],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
+    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("message");
+    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("exec");
+    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("process");
+    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("group:openclaw");
+    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("read");
+    expect(res.changes).toContain(
+      'Replaced tools.byProvider.openai.allow entries with profile "messaging" grants plus configured tool sections.',
+    );
+  });
+
+  it("drops provider allow entries blocked by the original profile", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+            allow: ["message", "web_search"],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
+    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("web_search");
+    expect(res.changes).toContain(
+      'Replaced tools.byProvider.openai.allow entries with profile "messaging" grants plus configured tool sections.',
+    );
+  });
+
+  it("updates restrictive provider allowlists that inherit the active profile", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        byProvider: {
+          openai: {
+            allow: ["message"],
+          },
+        },
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.tools?.byProvider?.openai).not.toHaveProperty("profile");
+    expect(res.changes).toContain(
+      'Added tools.byProvider.openai.allow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("does not use parent alsoAllow as provider profile alsoAllow", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process"],
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("adds agent grants when configured sections inherit the global profile", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("does not grant global configured sections to an agent-owned profile", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        exec: { security: "allowlist" },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              profile: "messaging",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
+    expect(res.changes).not.toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("preserves inherited alsoAllow when creating an agent override", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        exec: { security: "allowlist" },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual([
+      "exec",
+      "process",
+      "read",
+      "write",
+      "edit",
+    ]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process, read, write, edit) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("overrides an inherited profile when an agent allowlist already exists", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              allow: ["message"],
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
+    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
+    expect(res.changes).toContain(
+      'Set agents.list.0.tools.profile to "full" so agents.list.0.tools.allow controls configured tool sections directly.',
+    );
+  });
+
+  it("adds agent allow grants even when inherited alsoAllow already covers them", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process"],
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              allow: ["message"],
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
+    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
+  });
+
+  it("respects an explicit empty agent alsoAllow override", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process"],
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              alsoAllow: [],
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("adds agent allow grants for globally configured sections", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        exec: { security: "allowlist" },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              allow: ["message"],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
+    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+  });
+
+  it("adds agent provider-scoped grants for configured tool sections under profiles", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+              byProvider: {
+                openai: {
+                  profile: "messaging",
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
+      "exec",
+      "process",
+    ]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("adds agent provider-scoped grants for globally configured tool sections", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              byProvider: {
+                openai: {
+                  profile: "messaging",
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
+      "exec",
+      "process",
+    ]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("inherits provider profiles through model-scoped provider overrides", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              byProvider: {
+                "openai/gpt-5": {
+                  allow: ["message"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.profile).toBe(
+      "full",
+    );
+  });
+
+  it("materializes inherited provider profile grants for agent configured sections", () => {
+    const raw = {
+      tools: {
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    };
+    const res = migrateLegacyConfigForTest(raw);
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
+      "exec",
+      "process",
+    ]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).toContain("agents.list");
+  });
+
+  it("adds provider-wide inherited grants even when a model override is also repaired", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+              byProvider: {
+                "openai/gpt-5": {
+                  allow: ["message"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
+      "exec",
+      "process",
+    ]);
+  });
+
+  it("prefers canonical inherited provider policy keys when materializing grants", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        byProvider: {
+          modelstudio: {
+            profile: "coding",
+          },
+          qwen: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+              byProvider: {
+                "qwen/qwen-plus": {
+                  allow: ["message"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["qwen/qwen-plus"]?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["qwen/qwen-plus"]?.profile).toBe(
+      "full",
+    );
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.byProvider.qwen/qwen-plus.allow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
   });
 });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
@@ -6,6 +6,7 @@ describe("legacy config migrate validation", () => {
   let partialValidationResult: ReturnType<typeof migrateLegacyConfig>;
   let agentModelTimeoutResult: ReturnType<typeof migrateLegacyConfig>;
   let modelThinkingFormatResult: ReturnType<typeof migrateLegacyConfig>;
+  let profileConfiguredToolAllowResult: ReturnType<typeof migrateLegacyConfig>;
 
   beforeAll(() => {
     groupChatRoutingResult = migrateLegacyConfig({
@@ -89,6 +90,13 @@ describe("legacy config migrate validation", () => {
         },
       },
     });
+    profileConfiguredToolAllowResult = migrateLegacyConfig({
+      tools: {
+        profile: "messaging",
+        allow: ["message"],
+        exec: { security: "allowlist" },
+      },
+    });
   });
 
   it("returns valid migrated config for legacy group chat routing drift", () => {
@@ -167,5 +175,19 @@ describe("legacy config migrate validation", () => {
     expect(res.config?.models?.providers?.bailian?.models?.[1]?.compat).toEqual({
       thinkingFormat: "qwen",
     });
+  });
+
+  it("returns valid config when migrating profiled tool sections with an existing allowlist", () => {
+    const res = profileConfiguredToolAllowResult;
+
+    expect(res.partiallyValid).toBeUndefined();
+    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.alsoAllow).toBeUndefined();
+    expect(res.changes).toStrictEqual([
+      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
+      'Added tools.allow entries (exec, process) for configured tool sections under profile "messaging".',
+    ]);
   });
 });

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -1,5 +1,9 @@
 import { listLegacyRuntimeModelProviderAliases } from "../../../agents/model-runtime-aliases.js";
 import { normalizeProviderId } from "../../../agents/provider-id.js";
+import { isKnownCoreToolId } from "../../../agents/tool-catalog.js";
+import { isToolAllowedByPolicyName } from "../../../agents/tool-policy-match.js";
+import { expandToolGroups, mergeAlsoAllowPolicy } from "../../../agents/tool-policy.js";
+import { resolveToolProfilePolicy } from "../../../agents/tool-policy-shared.js";
 import {
   defineLegacyConfigMigration,
   ensureRecord,
@@ -9,6 +13,7 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { isBlockedObjectKey } from "../../../config/prototype-keys.js";
+import { uniqueStrings } from "../../../shared/string-normalization.js";
 
 const AGENT_HEARTBEAT_KEYS = new Set([
   "every",
@@ -120,6 +125,39 @@ const IGNORED_AGENT_MODEL_TIMEOUT_RULES: LegacyConfigRule[] = [
     message:
       'agents.list[].model.timeoutMs and agents.list[].subagents.model.timeoutMs are ignored; agent model config only selects primary/fallback models. Run "openclaw doctor --fix" to remove them.',
     match: (value) => hasAgentListModelTimeout(value),
+  },
+];
+
+const PROFILE_CONFIGURED_TOOL_SECTION_RULES: LegacyConfigRule[] = [
+  {
+    path: ["tools"],
+    message:
+      'tools.profile no longer implicitly grants configured tools.exec/tools.fs sections; add explicit tool grants or run "openclaw doctor --fix".',
+    match: (value) => toolProfileConfiguredSectionsNeedAlsoAllow(value),
+  },
+  {
+    path: ["agents", "list"],
+    message:
+      'agents.list[].tools.profile no longer implicitly grants configured tools.exec/tools.fs sections; add explicit tool grants or run "openclaw doctor --fix".',
+    match: (value, root) => {
+      const globalTools = getRecord(root.tools);
+      const inheritedProfile =
+        typeof globalTools?.profile === "string" ? globalTools.profile : undefined;
+      const inheritedAlsoAllow = readToolPolicyGrantList(globalTools, "alsoAllow");
+      return (
+        Array.isArray(value) &&
+        value.some((agent) => {
+          const agentTools = getRecord(getRecord(agent)?.tools);
+          return toolProfileConfiguredSectionsNeedAlsoAllow(
+            agentTools,
+              inheritedProfile,
+              inheritedAlsoAllow,
+              collectEffectiveConfiguredToolSectionGrants(globalTools, agentTools),
+              getRecord(globalTools?.byProvider),
+            );
+          })
+      );
+    },
   },
 ];
 
@@ -472,7 +510,609 @@ function removeLegacySilentReplyConfig(raw: Record<string, unknown>, changes: st
   }
 }
 
+const CONFIGURED_TOOL_SECTION_GRANTS = [
+  { key: "exec", grants: ["exec", "process"] },
+  { key: "fs", grants: ["read", "write", "edit"] },
+] as const;
+
+function readToolPolicyGrantList(value: unknown, key: "allow" | "alsoAllow"): string[] {
+  return readOwnToolPolicyGrantList(value, key) ?? [];
+}
+
+function readOwnToolPolicyGrantList(
+  value: unknown,
+  key: "allow" | "alsoAllow",
+): string[] | undefined {
+  const tools = getRecord(value);
+  return Array.isArray(tools?.[key])
+    ? tools[key].filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+}
+
+function resolveToolProfileForMigration(
+  tools: Record<string, unknown>,
+  inheritedProfile?: string,
+): string | undefined {
+  return typeof tools.profile === "string" ? tools.profile : inheritedProfile;
+}
+
+function missingProfileConfiguredSectionGrants(params: {
+  value: unknown;
+  inheritedProfile?: string;
+  inheritedAlsoAllow?: string[];
+  configuredGrants?: string[];
+}): string[] {
+  const tools = getRecord(params.value);
+  if (!tools) {
+    return [];
+  }
+  const profile = resolveToolProfileForMigration(tools, params.inheritedProfile);
+  if (!profile) {
+    return [];
+  }
+  const explicitAlsoAllow = readOwnToolPolicyGrantList(tools, "alsoAllow");
+  const ownAllow = readToolPolicyGrantList(tools, "allow");
+  const configuredGrants = params.configuredGrants ?? collectConfiguredToolSectionGrants(tools);
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(profile),
+    explicitAlsoAllow ?? params.inheritedAlsoAllow ?? [],
+  );
+  return uniqueStrings(
+    configuredGrants.filter((toolName) =>
+      ownAllow.length > 0
+        ? !isToolAllowedByPolicyName(toolName, { allow: ownAllow })
+        : !isToolAllowedByPolicyName(toolName, profilePolicy),
+    ),
+  );
+}
+
+function toolProfileConfiguredSectionsNeedAlsoAllow(
+  value: unknown,
+  inheritedProfile?: string,
+  inheritedAlsoAllow?: string[],
+  configuredGrantsOverride?: string[],
+  inheritedByProvider?: Record<string, unknown> | null,
+): boolean {
+  const tools = getRecord(value);
+  if (!tools) {
+    return false;
+  }
+  const configuredGrants = configuredGrantsOverride ?? collectConfiguredToolSectionGrants(tools);
+  return (
+    scopeToolProfileConfiguredSectionsNeedMigration({
+      value,
+      inheritedProfile,
+      inheritedAlsoAllow,
+      configuredGrants,
+    }) ||
+    byProviderToolProfilesNeedConfiguredSectionMigration(
+      tools,
+      configuredGrants,
+      resolveToolProfileForMigration(tools, inheritedProfile),
+      readOwnToolPolicyGrantList(tools, "alsoAllow") ?? inheritedAlsoAllow,
+      inheritedByProvider,
+    )
+  );
+}
+
+function collectConfiguredToolSectionGrants(tools: Record<string, unknown>): string[] {
+  const grants: string[] = [];
+  for (const section of CONFIGURED_TOOL_SECTION_GRANTS) {
+    if (getRecord(tools[section.key])) {
+      grants.push(...section.grants);
+    }
+  }
+  return uniqueStrings(grants);
+}
+
+function collectEffectiveConfiguredToolSectionGrants(
+  inheritedTools: Record<string, unknown> | null | undefined,
+  tools: Record<string, unknown> | null | undefined,
+): string[] {
+  const includeInheritedSections = typeof tools?.profile !== "string";
+  return uniqueStrings([
+    ...(includeInheritedSections && inheritedTools
+      ? collectConfiguredToolSectionGrants(inheritedTools)
+      : []),
+    ...(tools ? collectConfiguredToolSectionGrants(tools) : []),
+  ]);
+}
+
+function toolProfileAllowRequiresFull(params: {
+  value: unknown;
+  inheritedProfile?: string;
+  inheritedAlsoAllow?: string[];
+  configuredGrants: string[];
+}): boolean {
+  const tools = getRecord(params.value);
+  if (!tools) {
+    return false;
+  }
+  const profile = resolveToolProfileForMigration(tools, params.inheritedProfile);
+  if (!profile || profile === "full") {
+    return false;
+  }
+  const ownAllow = readToolPolicyGrantList(tools, "allow");
+  if (ownAllow.length === 0) {
+    return false;
+  }
+  const explicitAlsoAllow = readOwnToolPolicyGrantList(tools, "alsoAllow");
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(profile),
+    explicitAlsoAllow ?? params.inheritedAlsoAllow ?? [],
+  );
+  return params.configuredGrants.some(
+    (toolName) =>
+      isToolAllowedByPolicyName(toolName, { allow: ownAllow }) &&
+      !isToolAllowedByPolicyName(toolName, profilePolicy),
+  );
+}
+
+function resolveProfileBoundAllowGrants(params: {
+  tools: Record<string, unknown>;
+  profile: string;
+  allow: string[];
+  inheritedAlsoAllow?: string[];
+  configuredGrants: string[];
+}): string[] {
+  const explicitAlsoAllow = readOwnToolPolicyGrantList(params.tools, "alsoAllow");
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(params.profile),
+    explicitAlsoAllow ?? params.inheritedAlsoAllow ?? [],
+  );
+  const profileAllow = expandToolGroups(profilePolicy?.allow);
+  const coreAllow = profileAllow.includes("*")
+    ? expandToolGroups(params.allow)
+    : profileAllow.filter((toolName) =>
+        isToolAllowedByPolicyName(toolName, { allow: params.allow }),
+      );
+  const pluginAllow = expandToolGroups(params.allow).filter((entry) => {
+    if (entry === "*" || isKnownCoreToolId(entry)) {
+      return false;
+    }
+    return !profileAllow.some((toolName) => isToolAllowedByPolicyName(toolName, { allow: [entry] }));
+  });
+  return uniqueStrings([
+    ...coreAllow,
+    ...pluginAllow,
+    ...params.configuredGrants,
+  ]);
+}
+
+function scopeToolProfileConfiguredSectionsNeedMigration(params: {
+  value: unknown;
+  inheritedProfile?: string;
+  inheritedAlsoAllow?: string[];
+  configuredGrants: string[];
+}): boolean {
+  return (
+    missingProfileConfiguredSectionGrants(params).length > 0 ||
+    toolProfileAllowRequiresFull(params)
+  );
+}
+
+function byProviderToolProfilesNeedConfiguredSectionMigration(
+  tools: Record<string, unknown>,
+  configuredGrants: string[],
+  inheritedProfile?: string,
+  inheritedAlsoAllow?: string[],
+  inheritedByProvider?: Record<string, unknown> | null,
+): boolean {
+  const byProvider = getRecord(tools.byProvider);
+  const ownProviderNeedsMigration = Boolean(
+    byProvider &&
+      Object.entries(byProvider).some(([providerKey, policy]) => {
+        const inheritedProviderPolicy = resolveInheritedProviderPolicy(
+          inheritedByProvider,
+          providerKey,
+        );
+        const inheritedProviderProfile =
+          typeof inheritedProviderPolicy?.profile === "string"
+            ? inheritedProviderPolicy.profile
+            : undefined;
+        return scopeToolProfileConfiguredSectionsNeedMigration({
+          value: policy,
+          inheritedProfile: inheritedProviderProfile ?? inheritedProfile,
+          inheritedAlsoAllow:
+            readOwnToolPolicyGrantList(inheritedProviderPolicy, "alsoAllow") ??
+            inheritedAlsoAllow,
+          configuredGrants,
+        });
+      }),
+  );
+  if (ownProviderNeedsMigration) {
+    return true;
+  }
+  const localConfiguredGrants = collectConfiguredToolSectionGrants(tools);
+  if (localConfiguredGrants.length === 0) {
+    return false;
+  }
+  const handledProviders = new Set(
+    Object.keys(byProvider ?? {}).map((providerKey) => normalizeToolProviderPolicyKey(providerKey)),
+  );
+  return listInheritedProviderPoliciesWithProfiles(inheritedByProvider).some(
+    (inheritedProvider) =>
+      !handledProviders.has(inheritedProvider.normalizedKey) &&
+      scopeToolProfileConfiguredSectionsNeedMigration({
+        value: {},
+        inheritedProfile: inheritedProvider.profile,
+        inheritedAlsoAllow: readOwnToolPolicyGrantList(inheritedProvider.policy, "alsoAllow"),
+        configuredGrants: localConfiguredGrants,
+      }),
+  );
+}
+
+function addProfileConfiguredSectionGrants(
+  value: unknown,
+  pathLabel: string,
+  changes: string[],
+  inheritedProfile?: string,
+  inheritedAlsoAllow?: string[],
+  configuredGrantsOverride?: string[],
+): void {
+  const tools = getRecord(value);
+  if (!tools) {
+    return;
+  }
+  const profile = resolveToolProfileForMigration(tools, inheritedProfile);
+  if (!profile) {
+    return;
+  }
+  const configuredGrants = configuredGrantsOverride ?? collectConfiguredToolSectionGrants(tools);
+  const missing = missingProfileConfiguredSectionGrants({
+    value: tools,
+    inheritedProfile,
+    inheritedAlsoAllow,
+    configuredGrants,
+  });
+  const allow = readToolPolicyGrantList(tools, "allow");
+  const grantKey = allow.length > 0 ? "allow" : "alsoAllow";
+  const needsProfileFull =
+    grantKey === "allow" &&
+    profile !== "full" &&
+    (missing.length > 0 ||
+      toolProfileAllowRequiresFull({
+        value: tools,
+        inheritedProfile,
+        inheritedAlsoAllow,
+        configuredGrants,
+      }));
+  if (missing.length === 0 && !needsProfileFull) {
+    return;
+  }
+  if (needsProfileFull) {
+    tools.allow = resolveProfileBoundAllowGrants({
+      tools,
+      profile,
+      allow,
+      inheritedAlsoAllow,
+      configuredGrants,
+    });
+    changes.push(
+      `Replaced ${pathLabel}.allow entries with profile "${profile}" grants plus configured tool sections.`,
+    );
+  } else if (missing.length > 0) {
+    const ownGrants = readOwnToolPolicyGrantList(tools, grantKey);
+    tools[grantKey] = uniqueStrings([
+      ...(grantKey === "alsoAllow" && ownGrants === undefined ? (inheritedAlsoAllow ?? []) : []),
+      ...(ownGrants ?? []),
+      ...missing,
+    ]);
+  }
+  if (needsProfileFull) {
+    tools.profile = "full";
+    changes.push(
+      `Set ${pathLabel}.profile to "full" so ${pathLabel}.allow controls configured tool sections directly.`,
+    );
+  }
+  if (missing.length > 0) {
+    changes.push(
+      `Added ${pathLabel}.${grantKey} entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
+    );
+  }
+}
+
+function addByProviderProfileConfiguredSectionGrants(
+  value: unknown,
+  pathLabel: string,
+  changes: string[],
+  configuredGrantsOverride?: string[],
+  inheritedProfile?: string,
+  inheritedByProvider?: Record<string, unknown> | null,
+): void {
+  const tools = getRecord(value);
+  if (!tools) {
+    return;
+  }
+  const configuredGrants = configuredGrantsOverride ?? collectConfiguredToolSectionGrants(tools);
+  if (configuredGrants.length === 0) {
+    return;
+  }
+  const byProvider = getRecord(tools.byProvider);
+  const handledProviders = new Set<string>();
+  for (const [providerKey, providerPolicy] of Object.entries(byProvider ?? {})) {
+    if (isBlockedObjectKey(providerKey)) {
+      continue;
+    }
+    addHandledProviderPolicyKey(handledProviders, providerKey);
+    const inheritedProviderPolicy = resolveInheritedProviderPolicy(
+      inheritedByProvider,
+      providerKey,
+    );
+    const ownsProviderProfile = typeof getRecord(providerPolicy)?.profile === "string";
+    const inheritedProviderProfile =
+      typeof inheritedProviderPolicy?.profile === "string" ? inheritedProviderPolicy.profile : undefined;
+    const providerInheritedProfile =
+      inheritedProviderProfile ?? inheritedProfile;
+    const providerInheritedAlsoAllow = readOwnToolPolicyGrantList(
+      inheritedProviderPolicy,
+      "alsoAllow",
+    );
+    addProfileConfiguredSectionGrantsWithConfiguredGrants(
+      providerPolicy,
+      `${pathLabel}.byProvider.${providerKey}`,
+      changes,
+      configuredGrants,
+      providerInheritedProfile,
+      providerInheritedAlsoAllow,
+      ownsProviderProfile || Boolean(inheritedProviderProfile),
+    );
+  }
+  const localConfiguredGrants = collectConfiguredToolSectionGrants(tools);
+  if (localConfiguredGrants.length === 0) {
+    return;
+  }
+  for (const inheritedProvider of listInheritedProviderPoliciesWithProfiles(inheritedByProvider)) {
+    if (handledProviders.has(inheritedProvider.normalizedKey)) {
+      continue;
+    }
+    const providerPolicy: Record<string, unknown> = {};
+    const changeCount = changes.length;
+    addProfileConfiguredSectionGrantsWithConfiguredGrants(
+      providerPolicy,
+      `${pathLabel}.byProvider.${inheritedProvider.key}`,
+      changes,
+      localConfiguredGrants,
+      inheritedProvider.profile,
+      readOwnToolPolicyGrantList(inheritedProvider.policy, "alsoAllow"),
+    );
+    if (changes.length > changeCount) {
+      if (!getRecord(tools.byProvider)) {
+        tools.byProvider = {};
+      }
+      getRecord(tools.byProvider)![inheritedProvider.key] = providerPolicy;
+      addHandledProviderPolicyKey(handledProviders, inheritedProvider.normalizedKey);
+    }
+  }
+}
+
+function addHandledProviderPolicyKey(handledProviders: Set<string>, providerKey: string): void {
+  handledProviders.add(normalizeToolProviderPolicyKey(providerKey));
+}
+
+function normalizeToolProviderPolicyKey(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  const slashIndex = normalized.indexOf("/");
+  if (slashIndex <= 0) {
+    return normalizeProviderId(normalized);
+  }
+  const provider = normalizeProviderId(normalized.slice(0, slashIndex));
+  const modelId = normalized.slice(slashIndex + 1);
+  return modelId ? `${provider}/${modelId}` : provider;
+}
+
+function isCanonicalToolProviderPolicyKey(value: string): boolean {
+  return value.trim().toLowerCase() === normalizeToolProviderPolicyKey(value);
+}
+
+function buildInheritedProviderPolicyLookup(
+  inheritedByProvider: Record<string, unknown> | null | undefined,
+): Map<
+  string,
+  {
+    key: string;
+    policy: Record<string, unknown>;
+    canonical: boolean;
+  }
+> {
+  const lookup = new Map<
+    string,
+    {
+      key: string;
+      policy: Record<string, unknown>;
+      canonical: boolean;
+    }
+  >();
+  for (const [key, value] of Object.entries(inheritedByProvider ?? {})) {
+    const policy = getRecord(value);
+    if (!policy) {
+      continue;
+    }
+    const normalized = normalizeToolProviderPolicyKey(key);
+    if (!normalized) {
+      continue;
+    }
+    const canonical = isCanonicalToolProviderPolicyKey(key);
+    const existing = lookup.get(normalized);
+    if (!existing || (canonical && !existing.canonical)) {
+      lookup.set(normalized, { key, policy, canonical });
+    }
+  }
+  return lookup;
+}
+
+function resolveInheritedProviderPolicy(
+  inheritedByProvider: Record<string, unknown> | null | undefined,
+  providerKey: string,
+): Record<string, unknown> | null {
+  const lookup = buildInheritedProviderPolicyLookup(inheritedByProvider);
+  const normalized = normalizeToolProviderPolicyKey(providerKey);
+  const slashIndex = normalized.indexOf("/");
+  const candidates = slashIndex > 0 ? [normalized, normalized.slice(0, slashIndex)] : [normalized];
+  for (const candidate of candidates) {
+    const match = lookup.get(candidate);
+    if (match) {
+      return match.policy;
+    }
+  }
+  return null;
+}
+
+function listInheritedProviderPoliciesWithProfiles(
+  inheritedByProvider: Record<string, unknown> | null | undefined,
+): Array<{
+  key: string;
+  normalizedKey: string;
+  policy: Record<string, unknown>;
+  profile: string;
+}> {
+  const entries: Array<{
+    key: string;
+    normalizedKey: string;
+    policy: Record<string, unknown>;
+    profile: string;
+  }> = [];
+  for (const [normalizedKey, match] of buildInheritedProviderPolicyLookup(inheritedByProvider)) {
+    if (typeof match.policy.profile !== "string") {
+      continue;
+    }
+    entries.push({
+      key: match.key,
+      normalizedKey,
+      policy: match.policy,
+      profile: match.policy.profile,
+    });
+  }
+  return entries;
+}
+
+function addProfileConfiguredSectionGrantsWithConfiguredGrants(
+  value: unknown,
+  pathLabel: string,
+  changes: string[],
+  configuredGrants: string[],
+  inheritedProfile?: string,
+  inheritedAlsoAllow?: string[],
+  materializeProfile = true,
+): void {
+  const tools = getRecord(value);
+  if (!tools) {
+    return;
+  }
+  const profile = resolveToolProfileForMigration(tools, inheritedProfile);
+  if (!profile) {
+    return;
+  }
+  const missing = missingProfileConfiguredSectionGrants({
+    value: tools,
+    inheritedProfile,
+    inheritedAlsoAllow,
+    configuredGrants,
+  });
+  const allow = readToolPolicyGrantList(tools, "allow");
+  const grantKey = allow.length > 0 ? "allow" : "alsoAllow";
+  if (!materializeProfile) {
+    if (allow.length === 0 || missing.length === 0) {
+      return;
+    }
+    tools.allow = uniqueStrings([...allow, ...missing]);
+    changes.push(
+      `Added ${pathLabel}.allow entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
+    );
+    return;
+  }
+  const needsProfileFull =
+    grantKey === "allow" &&
+    profile !== "full" &&
+    (missing.length > 0 ||
+      toolProfileAllowRequiresFull({
+        value: tools,
+        inheritedProfile,
+        inheritedAlsoAllow,
+        configuredGrants,
+      }));
+  if (missing.length === 0 && !needsProfileFull) {
+    return;
+  }
+  if (needsProfileFull) {
+    tools.allow = resolveProfileBoundAllowGrants({
+      tools,
+      profile,
+      allow,
+      inheritedAlsoAllow,
+      configuredGrants,
+    });
+    changes.push(
+      `Replaced ${pathLabel}.allow entries with profile "${profile}" grants plus configured tool sections.`,
+    );
+  } else if (missing.length > 0) {
+    const ownGrants = readOwnToolPolicyGrantList(tools, grantKey);
+    tools[grantKey] = uniqueStrings([
+      ...(grantKey === "alsoAllow" && ownGrants === undefined ? (inheritedAlsoAllow ?? []) : []),
+      ...(ownGrants ?? []),
+      ...missing,
+    ]);
+  }
+  if (needsProfileFull) {
+    tools.profile = "full";
+    changes.push(
+      `Set ${pathLabel}.profile to "full" so ${pathLabel}.allow controls configured tool sections directly.`,
+    );
+  }
+  if (missing.length > 0) {
+    changes.push(
+      `Added ${pathLabel}.${grantKey} entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
+    );
+  }
+}
+
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "tools.profile-configured-sections-alsoAllow",
+    describe: "Add explicit tool grants for configured tool sections under profiles",
+    legacyRules: PROFILE_CONFIGURED_TOOL_SECTION_RULES,
+    apply: (raw, changes) => {
+      const globalTools = getRecord(raw.tools);
+      const inheritedProfile =
+        typeof globalTools?.profile === "string" ? globalTools.profile : undefined;
+      const inheritedAlsoAllow = readToolPolicyGrantList(globalTools, "alsoAllow");
+      addProfileConfiguredSectionGrants(raw.tools, "tools", changes);
+      addByProviderProfileConfiguredSectionGrants(
+        raw.tools,
+        "tools",
+        changes,
+        undefined,
+        inheritedProfile,
+      );
+      const agents = getRecord(raw.agents);
+      if (!Array.isArray(agents?.list)) {
+        return;
+      }
+      for (const [index, agent] of agents.list.entries()) {
+        const agentTools = getRecord(getRecord(agent)?.tools);
+        const configuredGrants = collectEffectiveConfiguredToolSectionGrants(
+          globalTools,
+          agentTools,
+        );
+        addProfileConfiguredSectionGrants(
+          agentTools,
+          `agents.list.${index}.tools`,
+          changes,
+          inheritedProfile,
+          inheritedAlsoAllow,
+          configuredGrants,
+        );
+        addByProviderProfileConfiguredSectionGrants(
+          agentTools,
+          `agents.list.${index}.tools`,
+          changes,
+          configuredGrants,
+          resolveToolProfileForMigration(agentTools ?? {}, inheritedProfile),
+          getRecord(globalTools?.byProvider),
+        );
+      }
+    },
+  }),
   defineLegacyConfigMigration({
     id: "silentReplyRewrite-removed",
     describe: "Remove legacy silent reply rewrite and direct-chat silent reply config",


### PR DESCRIPTION
## Summary

- Teach doctor migrations to add explicit grants when configured `tools.exec` / `tools.fs` sections sit behind non-full tool profiles.
- Cover top-level, agent, provider-scoped, inherited, allowlist, `alsoAllow`, glob, plugin-tool, and canonical provider-key cases.
- Keep generated migrations schema-valid by promoting profiled allowlists to `profile: "full"` only when the allowlist must directly control configured tool-section grants.

## Verification

- `git diff --check`
- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs run src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts` — 2 files, 89 tests passed.
- `codex review --base origin/main` found no actionable correctness issues after fixes.
- Crabbox `pnpm check:changed`: `run_4017fe7b98a4`, lease `cbx_fc459c9b5332`
  - Passed: conflict markers, changelog attribution, guarded re-export checks, duplicate coverage, dependency pin guard, package patch guard, core typecheck, core test typecheck.
  - Blocked after that by an unrelated current-main oxlint failure in `src/agents/tools/image-tool.ts:589` and `src/agents/tools/image-tool.ts:593`; this PR does not touch that file.
- Current branch was rebased and pushed to `69bda3c4ac69b96c8835e4ff7c38012a67ed0518` on top of current `origin/main`.
- The unrelated mainline lint blocker is isolated in #86934 (head `71e55ad2b6b`) with green GitHub checks and Crabbox changed-gate run: `run_cef1d008eab5`.

## Real behavior proof

Behavior addressed: `doctor --fix` previously did not fully repair configs where configured exec/fs sections were filtered by tool profiles, especially provider-scoped and inherited profile cases.

Real environment tested: local focused Vitest for doctor migration behavior plus Crabbox Linux AWS runner for `pnpm check:changed`.

Exact steps or command run after this patch: `git diff --check`; focused `node scripts/run-vitest.mjs run ...`; `codex review --base origin/main`; `node scripts/crabbox-wrapper.mjs run -label openclaw-tool-profile-doctor-check-rerun -shell -- "pnpm check:changed"`.

Evidence after fix: focused doctor migration tests pass 89/89; Crabbox run `run_4017fe7b98a4` reached core and core-test typecheck lanes green before hitting the unrelated mainline oxlint failure; #86934 proves that current-main lint blocker is fixed independently with green GitHub checks and Crabbox run `run_cef1d008eab5`.

Observed result after fix: migrations now add/preserve the grants needed for profiled configured sections without dropping plugin allow entries or over-widening agent-owned profiles.

What was not tested: a complete `pnpm check:changed` finish on this branch after #86934 lands.