### PR TITLE
fix(doctor): warn on stale prompt cache config

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -586,11 +586,11 @@ async function runImagePrompt(params: {
         cfg: providerCfg,
         provider,
         model: modelId,
-        providerRegistry: providerRegistry as Map<string, MediaUnderstandingProvider>,
+        providerRegistry,
       });
       const imageProvider = imageToolProviderDeps.getMediaUnderstandingProvider(
         provider,
-        providerRegistry as Map<string, MediaUnderstandingProvider>,
+        providerRegistry,
       );
       if (
         params.images.length > 1 &&

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -22,6 +22,7 @@ import {
   collectMissingDefaultAccountBindingWarnings,
   collectMissingExplicitDefaultAccountWarnings,
 } from "./doctor/shared/default-account-warnings.js";
+import { collectPromptCacheConfigWarnings } from "./doctor/shared/prompt-cache-config-warnings.js";
 
 function hasLegacyInternalHookHandlers(raw: unknown): boolean {
   const handlers = (raw as { hooks?: { internal?: { handlers?: unknown } } })?.hooks?.internal
@@ -234,6 +235,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   const missingExplicitDefaultWarnings = collectMissingExplicitDefaultAccountWarnings(candidate);
   if (missingExplicitDefaultWarnings.length > 0) {
     note(missingExplicitDefaultWarnings.join("\n"), "Doctor warnings");
+  }
+  const promptCacheConfigWarnings = collectPromptCacheConfigWarnings(candidate);
+  if (promptCacheConfigWarnings.length > 0) {
+    note(sanitizeDoctorNote(promptCacheConfigWarnings.join("\n")), "Doctor warnings");
   }
 
   if (shouldRepair) {

--- a/src/commands/doctor/shared/prompt-cache-config-warnings.test.ts
+++ b/src/commands/doctor/shared/prompt-cache-config-warnings.test.ts
@@ -255,6 +255,16 @@ describe("collectPromptCacheConfigWarnings", () => {
     ]);
   });
 
+  it("warns for Moonshot models because runtime cache-ttl pruning is not enabled there", () => {
+    const cfg = baseCacheTtlConfig("moonshot/kimi-k2.5");
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.model.primary uses moonshot/kimi-k2.5, but agents.defaults.contextPruning.mode="cache-ttl" does not currently run for OpenAI-family models',
+      ),
+    ]);
+  });
+
   it("warns for channel model overrides that bypass a cacheable default model", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/commands/doctor/shared/prompt-cache-config-warnings.test.ts
+++ b/src/commands/doctor/shared/prompt-cache-config-warnings.test.ts
@@ -1,0 +1,642 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { collectPromptCacheConfigWarnings } from "./prompt-cache-config-warnings.js";
+
+function baseCacheTtlConfig(model: string): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: { primary: model },
+        contextPruning: { mode: "cache-ttl", ttl: "1h" },
+        heartbeat: { every: "1h" },
+      },
+    },
+  };
+}
+
+function openAiCompatibleModel(id: string) {
+  return {
+    id,
+    name: id,
+    api: "openai-completions" as const,
+    reasoning: true,
+    input: ["text" as const],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+  };
+}
+
+function anthropicConfiguredModel(id: string) {
+  return {
+    id,
+    name: id,
+    reasoning: true,
+    input: ["text" as const],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  };
+}
+
+describe("collectPromptCacheConfigWarnings", () => {
+  it("warns when Anthropic short cache retention cannot satisfy a longer cache-ttl window", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCacheTtlConfig("anthropic/claude-sonnet-4-6"),
+      agents: {
+        defaults: {
+          ...baseCacheTtlConfig("anthropic/claude-sonnet-4-6").agents?.defaults,
+          models: {
+            "anthropic/claude-sonnet-4-6": { params: { cacheRetention: "short" } },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.contextPruning.ttl="1h" is longer than anthropic/claude-sonnet-4-6\'s effective short prompt-cache retention',
+      ),
+    ]);
+    expect(collectPromptCacheConfigWarnings(cfg)[0]).toContain(
+      'agents.defaults.heartbeat.every="1h" cannot refresh it before that cache usually expires',
+    );
+  });
+
+  it("does not warn when long cache retention has a shorter heartbeat", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
+  it("strips auth-profile suffixes before resolving model cache params", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6@work" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
+  it("resolves configured aliases before checking cache params", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "opus" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": {
+              alias: "opus",
+              params: { cacheRetention: "long" },
+            },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
+  it("warns when long cache retention has a heartbeat at the cache boundary", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCacheTtlConfig("anthropic/claude-opus-4-6"),
+      agents: {
+        defaults: {
+          ...baseCacheTtlConfig("anthropic/claude-opus-4-6").agents?.defaults,
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.heartbeat.every="1h" is not shorter than anthropic/claude-opus-4-6\'s effective long prompt-cache retention',
+      ),
+    ]);
+  });
+
+  it("warns when cache-ttl pruning is configured for OpenAI-family models", () => {
+    const cfg = baseCacheTtlConfig("openai/gpt-5.1-codex");
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.model.primary uses openai/gpt-5.1-codex, but agents.defaults.contextPruning.mode="cache-ttl" does not currently run for OpenAI-family models',
+      ),
+    ]);
+  });
+
+  it("warns for the runtime default model when no default model is configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          contextPruning: { mode: "cache-ttl" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.model (resolved default) uses openai/gpt-5.5, but agents.defaults.contextPruning.mode="cache-ttl" does not currently run for OpenAI-family models',
+      ),
+    ]);
+  });
+
+  it("resolves bare primary refs before checking qualified fallbacks", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "gpt-5.5",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'agents.defaults.model.primary (resolved) uses openai/gpt-5.5, but agents.defaults.contextPruning.mode="cache-ttl" does not currently run for OpenAI-family models',
+        ),
+      ]),
+    );
+  });
+
+  it("resolves bare fallback refs against the selected provider", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["claude-sonnet-4-6"],
+          },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        "anthropic/claude-sonnet-4-6's effective short prompt-cache retention (about 5m) for agents.defaults.model.fallbacks.0 (resolved)",
+      ),
+    ]);
+  });
+
+  it("warns for configured provider fallback models when no default model is configured", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com",
+            models: [anthropicConfiguredModel("claude-sonnet-4-6")],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          contextPruning: { mode: "cache-ttl" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.heartbeat.every="30m" is not shorter than anthropic/claude-sonnet-4-6\'s effective short prompt-cache retention',
+      ),
+    ]);
+  });
+
+  it("warns when a configured provider route uses an OpenAI-compatible API", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCacheTtlConfig("google/gemini-3.1-pro-preview"),
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://proxy.example/v1",
+            api: "openai-completions",
+            models: [openAiCompatibleModel("gemini-3.1-pro-preview")],
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.model.primary uses google/gemini-3.1-pro-preview, but agents.defaults.contextPruning.mode="cache-ttl" does not currently run for OpenAI-family models',
+      ),
+    ]);
+  });
+
+  it("warns for channel model overrides that bypass a cacheable default model", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+        },
+      },
+      channels: {
+        modelByChannel: {
+          telegram: { "*": "openai/gpt-5.1-codex" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'channels.modelByChannel.telegram.* uses openai/gpt-5.1-codex, but agents.defaults.contextPruning.mode="cache-ttl" does not currently run for OpenAI-family models',
+      ),
+    ]);
+  });
+
+  it("uses runtime cache-ttl eligibility for provider-owned proxy models", () => {
+    const cfg = baseCacheTtlConfig("deepinfra/anthropic/claude-sonnet-4-6");
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.contextPruning.ttl="1h" is longer than deepinfra/anthropic/claude-sonnet-4-6\'s effective short prompt-cache retention',
+      ),
+    ]);
+  });
+
+  it("does not warn for unrelated tool and media model refs", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          imageModel: { primary: "openai/gpt-5.1" },
+          imageGenerationModel: { primary: "openai/gpt-image-2" },
+          pdfModel: { primary: "openai/gpt-5.1" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
+  it("honors legacy cacheControlTtl settings that runtime maps to long retention", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheControlTtl: "1h" } },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
+  it("checks agents that inherit the default model and override cache retention", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+        },
+        list: [{ id: "no-cache", params: { cacheRetention: "none" } }],
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.list.0.model (inherits agents.defaults.model).primary uses anthropic/claude-opus-4-6, but effective cacheRetention is "none"',
+      ),
+    ]);
+  });
+
+  it("checks agents that inherit the default model and override heartbeat cadence", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+        },
+        list: [{ id: "slow-heartbeat", heartbeat: { every: "1h" } }],
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.list.0.heartbeat.every="1h" is not shorter than anthropic/claude-sonnet-4-6\'s effective short prompt-cache retention',
+      ),
+    ]);
+  });
+
+  it("warns when Google cache-ttl models omit explicit cache retention", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "google/gemini-3.1-pro-preview" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        "google/gemini-3.1-pro-preview, but this provider/model needs explicit cacheRetention or cacheControlTtl",
+      ),
+    ]);
+  });
+
+  it("warns when custom Anthropic-compatible cache-ttl models omit explicit cache retention", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "litellm/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+        },
+      },
+      models: {
+        providers: {
+          litellm: {
+            baseUrl: "https://litellm.example.test",
+            api: "anthropic-messages",
+            models: [anthropicConfiguredModel("claude-sonnet-4-6")],
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        "litellm/claude-sonnet-4-6, but this provider/model needs explicit cacheRetention or cacheControlTtl",
+      ),
+    ]);
+  });
+
+  it("warns when Bedrock Claude cache-ttl models omit explicit cache retention", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "amazon-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        "amazon-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0, but this provider/model needs explicit cacheRetention or cacheControlTtl",
+      ),
+    ]);
+  });
+
+  it("defaults direct Anthropic cache-ttl models to short retention", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
+  it("ignores model catalog metadata entries that are not active model refs", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+            "anthropic/claude-sonnet-4-6": { params: { cacheRetention: "short" } },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
+  it("uses the runtime default context-pruning ttl when ttl is omitted", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl" },
+          heartbeat: { every: "1h" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.heartbeat.every="1h" is not shorter than anthropic/claude-sonnet-4-6\'s effective short prompt-cache retention',
+      ),
+    ]);
+  });
+
+  it("uses the runtime default heartbeat cadence when heartbeat is omitted", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.heartbeat.every="30m" is not shorter than anthropic/claude-sonnet-4-6\'s effective short prompt-cache retention',
+      ),
+    ]);
+  });
+
+  it("warns when heartbeat model overrides cannot refresh the active model cache", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m", model: "openai/gpt-5.5" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.heartbeat.model="openai/gpt-5.5" does not match anthropic/claude-sonnet-4-6 used by agents.defaults.model.primary',
+      ),
+    ]);
+  });
+
+  it("resolves bare heartbeat model refs against the runtime default provider", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m", model: "claude-sonnet-4-6" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'agents.defaults.heartbeat.model="claude-sonnet-4-6" does not match anthropic/claude-sonnet-4-6 used by agents.defaults.model.fallbacks.0',
+        ),
+      ]),
+    );
+  });
+
+  it("does not resolve heartbeat model refs through config-only compat aliases", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openrouter/moonshotai/kimi-k2.5:free" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m", model: "openrouter:free" },
+        },
+      },
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.example.test",
+            models: [anthropicConfiguredModel("moonshotai/kimi-k2.5:free")],
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.heartbeat.model="openrouter:free" does not match openrouter/moonshotai/kimi-k2.5:free used by agents.defaults.model.primary',
+      ),
+    ]);
+  });
+
+  it("resolves heartbeat model aliases before comparing active model cache keys", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m", model: "sonnet" },
+          models: {
+            "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
+  it("warns for subagent model routes that bypass a cacheable default model", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "1h" },
+          heartbeat: { every: "55m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+          subagents: {
+            model: { primary: "openai/gpt-5.1-codex" },
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.defaults.subagents.model.primary uses openai/gpt-5.1-codex, but agents.defaults.contextPruning.mode="cache-ttl" does not currently run for OpenAI-family models',
+      ),
+    ]);
+  });
+
+  it("checks inherited agents that only override the heartbeat model", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+        },
+        list: [{ id: "wrong-heartbeat-model", heartbeat: { model: "openai/gpt-5.5" } }],
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        'agents.list.0.heartbeat.model="openai/gpt-5.5" does not match anthropic/claude-sonnet-4-6 used by agents.list.0.model (inherits agents.defaults.model).primary',
+      ),
+    ]);
+  });
+
+  it("does not warn when cache-ttl pruning is disabled", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          contextPruning: { mode: "off", ttl: "1h" },
+          heartbeat: { every: "1h" },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+});

--- a/src/commands/doctor/shared/prompt-cache-config-warnings.test.ts
+++ b/src/commands/doctor/shared/prompt-cache-config-warnings.test.ts
@@ -369,6 +369,33 @@ describe("collectPromptCacheConfigWarnings", () => {
     ]);
   });
 
+  it("does not inherit default fallbacks when an agent owns its primary model", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+          models: {
+            "anthropic/claude-opus-4-6": { params: { cacheRetention: "long" } },
+          },
+        },
+        list: [
+          {
+            id: "strict-agent",
+            model: { primary: "anthropic/claude-opus-4-6" },
+            heartbeat: { every: "55m" },
+          },
+        ],
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([]);
+  });
+
   it("warns when Google cache-ttl models omit explicit cache retention", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/commands/doctor/shared/prompt-cache-config-warnings.test.ts
+++ b/src/commands/doctor/shared/prompt-cache-config-warnings.test.ts
@@ -414,6 +414,37 @@ describe("collectPromptCacheConfigWarnings", () => {
     ]);
   });
 
+  it("uses normalized provider keys when reading configured provider APIs", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "myproxy/claude-sonnet-4-6" },
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          heartbeat: { every: "4m" },
+        },
+      },
+      models: {
+        providers: {
+          MyProxy: {
+            baseUrl: "https://myproxy.example.test",
+            models: [
+              {
+                ...anthropicConfiguredModel("MyProxy/claude-sonnet-4-6"),
+                api: "anthropic-messages",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(collectPromptCacheConfigWarnings(cfg)).toEqual([
+      expect.stringContaining(
+        "myproxy/claude-sonnet-4-6, but this provider/model needs explicit cacheRetention or cacheControlTtl",
+      ),
+    ]);
+  });
+
   it("warns when Bedrock Claude cache-ttl models omit explicit cache retention", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/commands/doctor/shared/prompt-cache-config-warnings.ts
+++ b/src/commands/doctor/shared/prompt-cache-config-warnings.ts
@@ -25,7 +25,6 @@ import { parseDurationMs } from "../../../cli/parse-duration.js";
 import { extractProviderFromModelRef } from "../../../config/model-refs.js";
 import type { AgentConfig } from "../../../config/types.agents.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { resolveLoadedProviderRuntimePlugin } from "../../../plugins/provider-hook-runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
 
 type CacheRetention = "none" | "short" | "long";
@@ -441,25 +440,14 @@ function isStaticCacheTtlEligibleProvider(
 }
 
 function isDoctorCacheTtlEligibleProvider(
-  cfg: OpenClawConfig,
+  _cfg: OpenClawConfig,
   provider: string,
   modelId: string,
   modelApi?: string,
 ): boolean {
   const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
   const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
-  const pluginEligibility = resolveLoadedProviderRuntimePlugin({
-    provider: normalizedProvider,
-    config: cfg,
-  })?.isCacheTtlEligible?.({
-    provider: normalizedProvider,
-    modelId: normalizedModelId,
-    modelApi,
-  });
-  return (
-    pluginEligibility ??
-    isStaticCacheTtlEligibleProvider(normalizedProvider, normalizedModelId, modelApi)
-  );
+  return isStaticCacheTtlEligibleProvider(normalizedProvider, normalizedModelId, modelApi);
 }
 
 function requiresExplicitCacheRetention(provider: string, modelId: string, modelApi?: string): boolean {

--- a/src/commands/doctor/shared/prompt-cache-config-warnings.ts
+++ b/src/commands/doctor/shared/prompt-cache-config-warnings.ts
@@ -358,6 +358,9 @@ function resolveDefaultModelApi(provider: string): string | undefined {
   if (normalizedProvider === "google-vertex") {
     return "google-vertex";
   }
+  if (normalizedProvider === "moonshot") {
+    return "openai-completions";
+  }
   return undefined;
 }
 
@@ -428,7 +431,7 @@ function isStaticCacheTtlEligibleProvider(
   ) {
     return true;
   }
-  if (normalizedProvider === "moonshot" || normalizedProvider === "zai") {
+  if (normalizedProvider === "zai") {
     return true;
   }
   if (normalizedProvider === "openrouter") {

--- a/src/commands/doctor/shared/prompt-cache-config-warnings.ts
+++ b/src/commands/doctor/shared/prompt-cache-config-warnings.ts
@@ -1,0 +1,673 @@
+import {
+  modelKey,
+  legacyModelKey,
+  type ModelRef,
+} from "../../../agents/model-selection-normalize.js";
+import {
+  buildModelAliasIndex,
+  resolveModelRefFromString,
+} from "../../../agents/model-selection-shared.js";
+import { resolveDefaultModelForAgent } from "../../../agents/model-selection.js";
+import {
+  isAnthropicBedrockModel,
+  isAnthropicFamilyCacheTtlEligible,
+  isAnthropicModelRef,
+} from "../../../agents/pi-embedded-runner/anthropic-family-cache-semantics.js";
+import { isGooglePromptCacheEligible } from "../../../agents/pi-embedded-runner/prompt-cache-retention.js";
+import { DEFAULT_CONTEXT_PRUNING_SETTINGS } from "../../../agents/pi-hooks/context-pruning/settings.js";
+import { splitTrailingAuthProfile } from "../../../agents/model-ref-profile.js";
+import { DEFAULT_HEARTBEAT_EVERY } from "../../../auto-reply/heartbeat.js";
+import { parseDurationMs } from "../../../cli/parse-duration.js";
+import { extractProviderFromModelRef } from "../../../config/model-refs.js";
+import type { AgentConfig } from "../../../config/types.agents.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolveLoadedProviderRuntimePlugin } from "../../../plugins/provider-hook-runtime.js";
+import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
+
+type CacheRetention = "none" | "short" | "long";
+type CacheProfile = {
+  retention: CacheRetention;
+  retentionMs: number;
+  label: string;
+};
+type ChatModelRef = {
+  path: string;
+  value: string;
+  agentIndex?: number;
+};
+type SplitModelRef = {
+  provider: string;
+  modelId: string;
+};
+type HeartbeatModelOverride = {
+  path: string;
+  raw: string;
+  ref: ModelRef;
+};
+
+const SHORT_CACHE_PROFILE: CacheProfile = {
+  retention: "short",
+  retentionMs: 5 * 60_000,
+  label: "about 5m",
+};
+const LONG_CACHE_PROFILE: CacheProfile = {
+  retention: "long",
+  retentionMs: 60 * 60_000,
+  label: "about 1h",
+};
+
+function parseOptionalDurationMs(raw: unknown): number | undefined {
+  if (typeof raw !== "string" || !raw.trim()) {
+    return undefined;
+  }
+  try {
+    return parseDurationMs(raw, { defaultUnit: "m" });
+  } catch {
+    return undefined;
+  }
+}
+
+function readCacheRetention(raw: unknown): CacheRetention | undefined {
+  return raw === "none" || raw === "short" || raw === "long" ? raw : undefined;
+}
+
+function readCacheRetentionParam(
+  params: Record<string, unknown> | undefined,
+): CacheRetention | undefined {
+  const cacheRetention = readCacheRetention(params?.cacheRetention);
+  if (cacheRetention) {
+    return cacheRetention;
+  }
+  const legacy = params?.cacheControlTtl;
+  if (legacy === "5m") {
+    return "short";
+  }
+  if (legacy === "1h") {
+    return "long";
+  }
+  return undefined;
+}
+
+function readStringParam(raw: unknown): string | undefined {
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
+function isRecord(raw: unknown): raw is Record<string, unknown> {
+  return Boolean(raw && typeof raw === "object" && !Array.isArray(raw));
+}
+
+function splitModelRef(modelRef: string): SplitModelRef | undefined {
+  const modelRefWithoutProfile = splitTrailingAuthProfile(modelRef).model;
+  const provider = extractProviderFromModelRef(modelRefWithoutProfile);
+  if (!provider) {
+    return undefined;
+  }
+  const slash = modelRefWithoutProfile.indexOf("/");
+  const modelId = slash >= 0 ? modelRefWithoutProfile.slice(slash + 1).trim() : "";
+  if (!modelId) {
+    return undefined;
+  }
+  return { provider, modelId };
+}
+
+function modelConfigPrimaryPath(path: string, model: unknown): string {
+  return !model || typeof model === "string" || typeof model !== "object" || Array.isArray(model)
+    ? path
+    : `${path}.primary`;
+}
+
+function hasModelConfigPrimary(model: unknown): boolean {
+  if (typeof model === "string" && model.trim()) {
+    return true;
+  }
+  if (!model || typeof model !== "object" || Array.isArray(model)) {
+    return false;
+  }
+  return typeof (model as Record<string, unknown>).primary === "string";
+}
+
+function collectChatModelRefsFromModelConfig(
+  path: string,
+  model: unknown,
+  agentIndex?: number,
+): ChatModelRef[] {
+  if (typeof model === "string" && model.trim()) {
+    return [{ path, value: model.trim(), agentIndex }];
+  }
+  if (!model || typeof model !== "object" || Array.isArray(model)) {
+    return [];
+  }
+  const record = model as Record<string, unknown>;
+  const refs: ChatModelRef[] = [];
+  if (typeof record.primary === "string" && record.primary.trim()) {
+    refs.push({ path: `${path}.primary`, value: record.primary.trim(), agentIndex });
+  }
+  if (Array.isArray(record.fallbacks)) {
+    for (const [index, fallback] of record.fallbacks.entries()) {
+      if (typeof fallback === "string" && fallback.trim()) {
+        refs.push({ path: `${path}.fallbacks.${index}`, value: fallback.trim(), agentIndex });
+      }
+    }
+  }
+  return refs;
+}
+
+function hasAgentCacheRelevantOverrides(agent: AgentConfig): boolean {
+  return Boolean(
+    readCacheRetentionParam(agent?.params) ||
+    (typeof agent?.heartbeat?.model === "string" && agent.heartbeat.model.trim()) ||
+    (typeof agent?.heartbeat?.every === "string" && agent.heartbeat.every.trim()),
+  );
+}
+
+function collectResolvedDefaultModelRef(
+  cfg: OpenClawConfig,
+  path: string,
+  agentIndex?: number,
+): ChatModelRef[] {
+  const agent = agentIndex === undefined ? undefined : cfg.agents?.list?.[agentIndex];
+  const agentId = typeof agent?.id === "string" && agent.id.trim() ? agent.id : undefined;
+  const resolved = resolveDefaultModelForAgent({
+    cfg,
+    agentId,
+    allowPluginNormalization: false,
+  });
+  return [{ path, value: `${resolved.provider}/${resolved.model}`, agentIndex }];
+}
+
+function resolveModelRefValue(
+  cfg: OpenClawConfig,
+  raw: string,
+  defaultProvider: string,
+): string | undefined {
+  const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider });
+  const resolved = resolveModelRefFromString({
+    cfg,
+    raw,
+    defaultProvider,
+    aliasIndex,
+    allowPluginNormalization: false,
+  })?.ref;
+  return resolved ? `${resolved.provider}/${resolved.model}` : undefined;
+}
+
+function resolveDefaultProviderForModelConfig(
+  cfg: OpenClawConfig,
+  agentIndex?: number,
+): string {
+  const primary = collectResolvedDefaultModelRef(cfg, "", agentIndex)[0];
+  return splitModelRef(primary?.value ?? "")?.provider ?? "openai";
+}
+
+function collectRuntimeChatModelRefsFromModelConfig(
+  cfg: OpenClawConfig,
+  path: string,
+  model: unknown,
+  agentIndex?: number,
+): ChatModelRef[] {
+  const defaultProvider = resolveDefaultProviderForModelConfig(cfg, agentIndex);
+  const refs = collectChatModelRefsFromModelConfig(path, model, agentIndex).flatMap((ref) => {
+    const resolved = resolveModelRefValue(cfg, ref.value, defaultProvider);
+    const rawModelRef = splitTrailingAuthProfile(ref.value).model;
+    if (!resolved) {
+      return splitModelRef(ref.value) ? [ref] : [];
+    }
+    const pathSuffix =
+      normalizeLowercaseStringOrEmpty(resolved) === normalizeLowercaseStringOrEmpty(rawModelRef)
+        ? ""
+        : " (resolved)";
+    return [{ ...ref, path: `${ref.path}${pathSuffix}`, value: resolved }];
+  });
+  if (hasModelConfigPrimary(model)) {
+    return refs;
+  }
+  return [
+    ...collectResolvedDefaultModelRef(
+      cfg,
+      `${modelConfigPrimaryPath(path, model)} (resolved default)`,
+      agentIndex,
+    ),
+    ...refs,
+  ];
+}
+
+function collectChannelModelOverrideRefs(cfg: OpenClawConfig): ChatModelRef[] {
+  const modelByChannel = cfg.channels?.modelByChannel;
+  if (!isRecord(modelByChannel)) {
+    return [];
+  }
+  const refs: ChatModelRef[] = [];
+  for (const [channelId, channelMap] of Object.entries(modelByChannel)) {
+    if (!isRecord(channelMap)) {
+      continue;
+    }
+    for (const [targetId, raw] of Object.entries(channelMap)) {
+      if (typeof raw !== "string" || !raw.trim()) {
+        continue;
+      }
+      refs.push(
+        ...collectRuntimeChatModelRefsFromModelConfig(
+          cfg,
+          `channels.modelByChannel.${channelId}.${targetId}`,
+          raw,
+        ),
+      );
+    }
+  }
+  return refs;
+}
+
+function collectPromptCacheChatModelRefs(cfg: OpenClawConfig): ChatModelRef[] {
+  const refs = collectRuntimeChatModelRefsFromModelConfig(
+    cfg,
+    "agents.defaults.model",
+    cfg.agents?.defaults?.model,
+  );
+  if (
+    collectChatModelRefsFromModelConfig(
+      "agents.defaults.subagents.model",
+      cfg.agents?.defaults?.subagents?.model,
+    ).length > 0
+  ) {
+    refs.push(
+      ...collectRuntimeChatModelRefsFromModelConfig(
+        cfg,
+        "agents.defaults.subagents.model",
+        cfg.agents?.defaults?.subagents?.model,
+      ),
+    );
+  }
+  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  for (const [index, agent] of agents.entries()) {
+    const explicitRefs = collectChatModelRefsFromModelConfig(
+      `agents.list.${index}.model`,
+      agent?.model,
+      index,
+    );
+    if (explicitRefs.length > 0) {
+      refs.push(
+        ...collectRuntimeChatModelRefsFromModelConfig(
+          cfg,
+          `agents.list.${index}.model`,
+          agent?.model,
+          index,
+        ),
+      );
+    } else if (hasAgentCacheRelevantOverrides(agent)) {
+      refs.push(
+        ...collectRuntimeChatModelRefsFromModelConfig(
+          cfg,
+          `agents.list.${index}.model (inherits agents.defaults.model)`,
+          cfg.agents?.defaults?.model,
+          index,
+        ),
+      );
+    }
+    if (
+      collectChatModelRefsFromModelConfig(
+        `agents.list.${index}.subagents.model`,
+        agent?.subagents?.model,
+        index,
+      ).length > 0
+    ) {
+      refs.push(
+        ...collectRuntimeChatModelRefsFromModelConfig(
+          cfg,
+          `agents.list.${index}.subagents.model`,
+          agent?.subagents?.model,
+          index,
+        ),
+      );
+    }
+  }
+  refs.push(...collectChannelModelOverrideRefs(cfg));
+  return refs;
+}
+
+function readEffectiveCacheRetention(
+  cfg: OpenClawConfig,
+  provider: string,
+  modelId: string,
+  agentIndex: number | undefined,
+): CacheRetention | undefined {
+  const defaults = cfg.agents?.defaults;
+  const canonicalKey = modelKey(provider, modelId);
+  const legacyKey = legacyModelKey(provider, modelId);
+  const modelParams =
+    defaults?.models?.[canonicalKey]?.params ??
+    (legacyKey ? defaults?.models?.[legacyKey]?.params : undefined);
+  const agentParams = agentIndex === undefined ? undefined : cfg.agents?.list?.[agentIndex]?.params;
+  return readCacheRetentionParam({
+    ...defaults?.params,
+    ...modelParams,
+    ...agentParams,
+  });
+}
+
+function resolveDefaultModelApi(provider: string): string | undefined {
+  const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+  if (normalizedProvider === "google") {
+    return "google-generative-ai";
+  }
+  if (normalizedProvider === "google-gemini-cli") {
+    return "google-gemini-cli";
+  }
+  if (normalizedProvider === "google-vertex") {
+    return "google-vertex";
+  }
+  return undefined;
+}
+
+function resolveConfiguredModelApi(
+  cfg: OpenClawConfig,
+  provider: string,
+  modelId: string,
+): string | undefined {
+  const providerConfig = cfg.models?.providers?.[provider];
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
+  const modelConfig = providerConfig?.models?.find((model) => {
+    const id = normalizeLowercaseStringOrEmpty(model.id);
+    return (
+      id === normalizedModelId || id === normalizeLowercaseStringOrEmpty(`${provider}/${modelId}`)
+    );
+  });
+  return (
+    readStringParam(modelConfig?.api) ??
+    readStringParam(providerConfig?.api) ??
+    resolveDefaultModelApi(provider)
+  );
+}
+
+function isOpenAiLikeProvider(provider: string): boolean {
+  const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+  return (
+    normalizedProvider === "openai" ||
+    normalizedProvider === "openai-codex" ||
+    normalizedProvider === "openai-responses" ||
+    normalizedProvider === "openai-codex-responses" ||
+    normalizedProvider === "azure-openai" ||
+    normalizedProvider === "azure-openai-responses"
+  );
+}
+
+function isOpenAiLikeModelApi(modelApi: string | undefined): boolean {
+  const normalizedModelApi = normalizeLowercaseStringOrEmpty(modelApi);
+  return (
+    normalizedModelApi === "openai-completions" ||
+    normalizedModelApi === "openai-responses" ||
+    normalizedModelApi === "openai-codex-responses" ||
+    normalizedModelApi === "azure-openai-responses"
+  );
+}
+
+function isStaticCacheTtlEligibleProvider(
+  provider: string,
+  modelId: string,
+  modelApi?: string,
+): boolean {
+  const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
+  if (
+    isAnthropicFamilyCacheTtlEligible({
+      provider: normalizedProvider,
+      modelId: normalizedModelId,
+      modelApi,
+    }) ||
+    ((normalizedProvider === "deepinfra" || normalizedProvider === "kilocode") &&
+      isAnthropicModelRef(normalizedModelId)) ||
+    isGooglePromptCacheEligible({ modelApi, modelId: normalizedModelId })
+  ) {
+    return true;
+  }
+  if (normalizedProvider === "moonshot" || normalizedProvider === "zai") {
+    return true;
+  }
+  if (normalizedProvider === "openrouter") {
+    return ["anthropic/", "deepseek/", "moonshot/", "moonshotai/", "zai/"].some((prefix) =>
+      normalizedModelId.startsWith(prefix),
+    );
+  }
+  return false;
+}
+
+function isDoctorCacheTtlEligibleProvider(
+  cfg: OpenClawConfig,
+  provider: string,
+  modelId: string,
+  modelApi?: string,
+): boolean {
+  const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
+  const pluginEligibility = resolveLoadedProviderRuntimePlugin({
+    provider: normalizedProvider,
+    config: cfg,
+  })?.isCacheTtlEligible?.({
+    provider: normalizedProvider,
+    modelId: normalizedModelId,
+    modelApi,
+  });
+  return (
+    pluginEligibility ??
+    isStaticCacheTtlEligibleProvider(normalizedProvider, normalizedModelId, modelApi)
+  );
+}
+
+function requiresExplicitCacheRetention(provider: string, modelId: string, modelApi?: string): boolean {
+  const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+  if (isGooglePromptCacheEligible({ modelApi, modelId })) {
+    return true;
+  }
+  if (normalizedProvider === "anthropic" || normalizedProvider === "anthropic-vertex") {
+    return false;
+  }
+  if (normalizedProvider === "amazon-bedrock") {
+    return isAnthropicBedrockModel(modelId);
+  }
+  return modelApi === "anthropic-messages";
+}
+
+function formatDurationSetting(path: string, value: unknown): string {
+  return typeof value === "string" && value.trim() ? `${path}="${value}"` : path;
+}
+
+function resolveHeartbeatCadence(
+  cfg: OpenClawConfig,
+  agentIndex: number | undefined,
+): { path: string; raw: unknown; ms: number | undefined } {
+  const agentEvery =
+    agentIndex === undefined ? undefined : cfg.agents?.list?.[agentIndex]?.heartbeat?.every;
+  if (typeof agentEvery === "string" && agentEvery.trim()) {
+    return {
+      path: `agents.list.${agentIndex}.heartbeat.every`,
+      raw: agentEvery,
+      ms: parseOptionalDurationMs(agentEvery),
+    };
+  }
+  const raw = cfg.agents?.defaults?.heartbeat?.every;
+  return {
+    path: "agents.defaults.heartbeat.every",
+    raw: raw ?? DEFAULT_HEARTBEAT_EVERY,
+    ms: parseOptionalDurationMs(raw ?? DEFAULT_HEARTBEAT_EVERY),
+  };
+}
+
+function resolveHeartbeatModelOverride(
+  cfg: OpenClawConfig,
+  agentIndex: number | undefined,
+): HeartbeatModelOverride | undefined {
+  const agentModel =
+    agentIndex === undefined ? undefined : cfg.agents?.list?.[agentIndex]?.heartbeat?.model;
+  const hasAgentModel = typeof agentModel === "string" && agentModel.trim();
+  const path = hasAgentModel
+    ? `agents.list.${agentIndex}.heartbeat.model`
+    : "agents.defaults.heartbeat.model";
+  const raw =
+    readStringParam(agentModel) ?? readStringParam(cfg.agents?.defaults?.heartbeat?.model);
+  if (!raw) {
+    return undefined;
+  }
+  const defaultProvider = resolveDefaultProviderForModelConfig(cfg, agentIndex);
+  const resolved = resolveModelRefFromString({
+    raw,
+    defaultProvider,
+    aliasIndex: buildModelAliasIndex({ cfg, defaultProvider }),
+  })?.ref;
+  return resolved ? { path, raw, ref: resolved } : undefined;
+}
+
+function modelRefMatchesSplit(ref: ModelRef, model: SplitModelRef): boolean {
+  return (
+    normalizeLowercaseStringOrEmpty(ref.provider) ===
+      normalizeLowercaseStringOrEmpty(model.provider) &&
+    normalizeLowercaseStringOrEmpty(ref.model) === normalizeLowercaseStringOrEmpty(model.modelId)
+  );
+}
+
+function collectHeartbeatModelOverrideWarnings(params: {
+  activeModel: SplitModelRef;
+  heartbeatModel: HeartbeatModelOverride | undefined;
+  modelPath: string;
+  modelRef: string;
+}): string[] {
+  const heartbeatModel = params.heartbeatModel;
+  if (!heartbeatModel || modelRefMatchesSplit(heartbeatModel.ref, params.activeModel)) {
+    return [];
+  }
+  return [
+    [
+      `- ${heartbeatModel.path}="${heartbeatModel.raw}" does not match ${params.modelRef} used by ${params.modelPath}, so heartbeat runs cannot refresh that prompt cache.`,
+      `  Fix: remove ${heartbeatModel.path}, set it to ${params.modelRef}, or disable agents.defaults.contextPruning.mode="cache-ttl" for this config.`,
+    ].join("\n"),
+  ];
+}
+
+function collectRetentionWarnings(params: {
+  modelRef: string;
+  path: string;
+  requiresExplicitRetention?: boolean;
+  ttlRaw: unknown;
+  ttlMs: number;
+  heartbeatEveryPath: string;
+  heartbeatEveryRaw: unknown;
+  heartbeatEveryMs?: number;
+  retention: CacheRetention | undefined;
+}): string[] {
+  if (params.requiresExplicitRetention && !params.retention) {
+    return [
+      [
+        `- ${params.path} uses ${params.modelRef}, but this provider/model needs explicit cacheRetention or cacheControlTtl for agents.defaults.contextPruning.mode="cache-ttl" to maintain a prompt cache.`,
+        '  Fix: set cacheRetention="short" or cacheRetention="long" for this model/agent, or set agents.defaults.contextPruning.mode="off" if prompt-cache TTL pruning is not intended.',
+      ].join("\n"),
+    ];
+  }
+
+  const retention = params.retention ?? "short";
+  if (retention === "none") {
+    return [
+      [
+        `- ${params.path} uses ${params.modelRef}, but effective cacheRetention is "none" while agents.defaults.contextPruning.mode="cache-ttl".`,
+        '  Fix: remove cacheRetention="none" for this model/agent, or set agents.defaults.contextPruning.mode="off" if prompt-cache TTL pruning is not intended.',
+      ].join("\n"),
+    ];
+  }
+
+  const profile = retention === "long" ? LONG_CACHE_PROFILE : SHORT_CACHE_PROFILE;
+  const warnings: string[] = [];
+  if (params.ttlMs > profile.retentionMs) {
+    const heartbeatClause =
+      params.heartbeatEveryMs !== undefined && params.heartbeatEveryMs >= profile.retentionMs
+        ? ` ${formatDurationSetting(params.heartbeatEveryPath, params.heartbeatEveryRaw)} cannot refresh it before that cache usually expires.`
+        : "";
+    warnings.push(
+      [
+        `- ${formatDurationSetting("agents.defaults.contextPruning.ttl", params.ttlRaw)} is longer than ${params.modelRef}'s effective ${profile.retention} prompt-cache retention (${profile.label}) for ${params.path}.${heartbeatClause}`,
+        `  Fix: set cacheRetention="long" for this model/agent, or lower agents.defaults.contextPruning.ttl and ${params.heartbeatEveryPath} below ${profile.label}.`,
+      ].join("\n"),
+    );
+  } else if (
+    params.heartbeatEveryMs !== undefined &&
+    params.heartbeatEveryMs >= profile.retentionMs
+  ) {
+    warnings.push(
+      [
+        `- ${formatDurationSetting(params.heartbeatEveryPath, params.heartbeatEveryRaw)} is not shorter than ${params.modelRef}'s effective ${profile.retention} prompt-cache retention (${profile.label}) for ${params.path}.`,
+        `  Fix: lower ${params.heartbeatEveryPath} below ${profile.label}, or set cacheRetention="long" if the provider/model supports it.`,
+      ].join("\n"),
+    );
+  }
+  return warnings;
+}
+
+export function collectPromptCacheConfigWarnings(cfg: OpenClawConfig): string[] {
+  const contextPruning = cfg.agents?.defaults?.contextPruning;
+  if (contextPruning?.mode !== "cache-ttl") {
+    return [];
+  }
+  const ttlMs =
+    parseOptionalDurationMs(contextPruning.ttl) ?? DEFAULT_CONTEXT_PRUNING_SETTINGS.ttlMs;
+  if (ttlMs <= 0) {
+    return [];
+  }
+
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+  for (const ref of collectPromptCacheChatModelRefs(cfg)) {
+    const model = splitModelRef(ref.value);
+    if (!model) {
+      continue;
+    }
+    const key = `${ref.path}:${ref.value}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const modelApi = resolveConfiguredModelApi(cfg, model.provider, model.modelId);
+    const eligible = isDoctorCacheTtlEligibleProvider(
+      cfg,
+      model.provider,
+      model.modelId,
+      modelApi,
+    );
+
+    if (isOpenAiLikeProvider(model.provider) || (!eligible && isOpenAiLikeModelApi(modelApi))) {
+      warnings.push(
+        [
+          `- ${ref.path} uses ${ref.value}, but agents.defaults.contextPruning.mode="cache-ttl" does not currently run for OpenAI-family models.`,
+          "  Fix: remove cache-ttl pruning for this config, or use a cache-ttl eligible provider/model for sessions where TTL-based transcript pruning is required.",
+        ].join("\n"),
+      );
+      continue;
+    }
+
+    if (!eligible) {
+      continue;
+    }
+    const heartbeat = resolveHeartbeatCadence(cfg, ref.agentIndex);
+    warnings.push(
+      ...collectHeartbeatModelOverrideWarnings({
+        activeModel: model,
+        heartbeatModel: resolveHeartbeatModelOverride(cfg, ref.agentIndex),
+        modelPath: ref.path,
+        modelRef: ref.value,
+      }),
+    );
+    warnings.push(
+      ...collectRetentionWarnings({
+        modelRef: ref.value,
+        path: ref.path,
+        requiresExplicitRetention: requiresExplicitCacheRetention(
+          model.provider,
+          model.modelId,
+          modelApi,
+        ),
+        ttlRaw: contextPruning.ttl,
+        ttlMs,
+        heartbeatEveryPath: heartbeat.path,
+        heartbeatEveryRaw: heartbeat.raw,
+        heartbeatEveryMs: heartbeat.ms,
+        retention: readEffectiveCacheRetention(cfg, model.provider, model.modelId, ref.agentIndex),
+      }),
+    );
+  }
+  return warnings;
+}

--- a/src/commands/doctor/shared/prompt-cache-config-warnings.ts
+++ b/src/commands/doctor/shared/prompt-cache-config-warnings.ts
@@ -4,6 +4,10 @@ import {
   type ModelRef,
 } from "../../../agents/model-selection-normalize.js";
 import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+} from "../../../agents/provider-id.js";
+import {
   buildModelAliasIndex,
   resolveModelRefFromString,
 } from "../../../agents/model-selection-shared.js";
@@ -363,12 +367,18 @@ function resolveConfiguredModelApi(
   provider: string,
   modelId: string,
 ): string | undefined {
-  const providerConfig = cfg.models?.providers?.[provider];
+  const providerConfig = findNormalizedProviderValue(cfg.models?.providers, provider);
   const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
   const modelConfig = providerConfig?.models?.find((model) => {
-    const id = normalizeLowercaseStringOrEmpty(model.id);
+    const normalizedId = normalizeLowercaseStringOrEmpty(model.id);
+    if (normalizedId === normalizedModelId) {
+      return true;
+    }
+    const split = splitModelRef(model.id);
     return (
-      id === normalizedModelId || id === normalizeLowercaseStringOrEmpty(`${provider}/${modelId}`)
+      split &&
+      normalizeProviderId(split.provider) === normalizeProviderId(provider) &&
+      normalizeLowercaseStringOrEmpty(split.modelId) === normalizedModelId
     );
   });
   return (


### PR DESCRIPTION
## Summary

- Adds `openclaw doctor` warnings for cache-ttl configs whose selected chat model/provider cannot keep the prompt-cache window warm.
- Covers direct Anthropic, Anthropic-compatible providers, Bedrock Claude, Google prompt-cache models, OpenAI-family unsupported routes, aliases, auth-profile suffixes, subagent/channel routes, inherited agent defaults, fallback models, and heartbeat model/cadence mismatches.
- Keeps the advisory lightweight: no new config seam and no provider-runtime plugin loading from doctor.
- Includes a separate small lint cleanup in `src/agents/tools/image-tool.ts`; the changed gate was failing on stale casts from current main.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Requested by maintainer during beta cache-hit investigation after `/status` reported 0% cache hits with cache-ttl expectations.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw doctor` now warns when cache-ttl pruning is configured with a model/provider setup that will not maintain the expected prompt-cache window.
- Real environment tested: Blacksmith Testbox through Crabbox on final head `5a0b2df21419cffc4f8976eb7ed860025412ba9b` over `origin/main` `d1c8f09b006e0b1e01ca60ac725aa80a2e702a31`.
- Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json --shell -- "corepack pnpm check:changed"`.
- Evidence after fix: Crabbox/Testbox `tbx_01ksjcqg4m7xs3q2gffp9z7553`, Actions run https://github.com/openclaw/openclaw/actions/runs/26456278519, exit 0.
- Observed result after fix: changed gate completed with typecheck core, typecheck core tests, lint core, runtime import cycle guard, and changed-surface guard checks passing.
- What was not tested: live provider cache-hit behavior against external model APIs.
- Proof limitations or environment constraints: local `pnpm test:serial` in this Codex worktree hit the known no-TTY pnpm install trap; direct `tsx` smoke probes passed, the focused prompt-cache Vitest file passed during autoreview, and the full changed gate passed remotely.
- Before evidence: beta `/status` showed `Cache: 0% hit · 0 cached, 20k new` in a cache-ttl setup.

## Tests and validation

Which commands did you run?

- `git diff --check origin/main...HEAD`
- direct `node --import tsx` smoke probes for direct Anthropic clean config, custom `anthropic-messages` explicit-retention warnings, Bedrock Claude explicit-retention warnings, DeepInfra Anthropic static eligibility, normalized provider API lookup, OpenRouter heartbeat mismatch warnings, strict-agent fallback inheritance, and Moonshot/Zai eligibility alignment
- `codex review --base origin/main`: no actionable correctness issues; targeted `src/commands/doctor/shared/prompt-cache-config-warnings.test.ts` passed, 34 tests
- Crabbox/Testbox `corepack pnpm check:changed`: `tbx_01ksjcqg4m7xs3q2gffp9z7553`, exit 0

What regression coverage was added or updated?

- Added focused doctor warning coverage for retention windows, default TTL/heartbeat behavior, OpenAI-family unsupported routes, aliases, auth-profile suffixes, legacy `cacheControlTtl`, normalized configured provider APIs, default/fallback model resolution, per-agent overrides, subagent/channel routes, heartbeat mismatch behavior, plugin/static provider eligibility, explicit-retention requirements for Google/custom Anthropic-compatible/Bedrock Claude routes, strict-agent fallback behavior, and Moonshot unsupported cache-ttl behavior.

What failed before this fix, if known?

- Prior changed-gate attempts caught TS import/fixture issues in the new tests and a current-main oxlint stale-cast failure; all were fixed before this PR was opened.
- Autoreview found normalized provider API lookup, provider-runtime import weight, and Moonshot runtime/advisory alignment issues; all were fixed before this update.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Doctor can now emit advisory warnings for non-ideal prompt cache configs.

Did config, environment, or migration behavior change? (`Yes/No`)

No config writes or migrations change. This is advisory-only.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. Doctor uses static/runtime-aligned checks and avoids loading provider runtime plugins for this advisory.

What is the highest-risk area?

False positives or false negatives on proxy/provider cache semantics.

How is that risk mitigated?

The advisory mirrors runtime cache-retention rules where possible, avoids broad plugin loading, uses explicit retention requirements only where runtime needs explicit cache config, and covers aliases/channel/subagent/inherited routes in tests.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI on the draft PR.

Which bot or reviewer comments were addressed?

Local autoreview findings for normalized configured provider APIs, runtime import weight, strict-agent fallback behavior, and Moonshot runtime/advisory alignment were addressed. Final autoreview reported no actionable correctness issues.
