### PR TITLE
fix(agents): restore current guard checks

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -893,6 +893,48 @@
         "text",
         "channel"
       ]
+    },
+    "transcripts": {
+      "emoji": "🧾",
+      "title": "Transcripts",
+      "actions": {
+        "start": {
+          "label": "start",
+          "detailKeys": [
+            "title",
+            "providerId",
+            "accountId",
+            "guildId",
+            "channelId",
+            "meetingUrl"
+          ]
+        },
+        "stop": {
+          "label": "stop",
+          "detailKeys": [
+            "sessionId",
+            "title"
+          ]
+        },
+        "import": {
+          "label": "import",
+          "detailKeys": [
+            "title",
+            "providerId",
+            "speakerLabel"
+          ]
+        },
+        "summarize": {
+          "label": "summarize",
+          "detailKeys": [
+            "sessionId",
+            "title"
+          ]
+        },
+        "status": {
+          "label": "status"
+        }
+      }
     }
   }
 }

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -567,5 +567,30 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "TTS",
       detailKeys: ["text", "channel"],
     },
+    transcripts: {
+      emoji: "🧾",
+      title: "Transcripts",
+      actions: {
+        start: {
+          label: "start",
+          detailKeys: ["title", "providerId", "accountId", "guildId", "channelId", "meetingUrl"],
+        },
+        stop: {
+          label: "stop",
+          detailKeys: ["sessionId", "title"],
+        },
+        import: {
+          label: "import",
+          detailKeys: ["title", "providerId", "speakerLabel"],
+        },
+        summarize: {
+          label: "summarize",
+          detailKeys: ["sessionId", "title"],
+        },
+        status: {
+          label: "status",
+        },
+      },
+    },
   },
 };

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -586,11 +586,11 @@ async function runImagePrompt(params: {
         cfg: providerCfg,
         provider,
         model: modelId,
-        providerRegistry: providerRegistry as Map<string, MediaUnderstandingProvider>,
+        providerRegistry,
       });
       const imageProvider = imageToolProviderDeps.getMediaUnderstandingProvider(
         provider,
-        providerRegistry as Map<string, MediaUnderstandingProvider>,
+        providerRegistry,
       );
       if (
         params.images.length > 1 &&


### PR DESCRIPTION
## Summary

- remove redundant `providerRegistry` casts in `src/agents/tools/image-tool.ts`
- add missing display metadata for the `transcripts` runtime tool
- refresh the generated OpenClawKit tool-display snapshot
- restore the current-main core lint and guard lanes that were blocking changed-gate proof for #86930 and #86931

## Verification

- `git diff --check`
- `node --import tsx scripts/tool-display.ts --check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/tools/image-tool.ts src/agents/tool-display-config.ts`
- Crabbox: `run_cef1d008eab5`, lease `cbx_c201d63cabf6`, `node scripts/crabbox-wrapper.mjs run -label openclaw-current-guards-unblocker-refresh2 -shell -- "pnpm check:changed"`

## Real behavior proof

Behavior addressed: current-main `pnpm check:changed` failed first in core lint because `src/agents/tools/image-tool.ts` kept two unnecessary `providerRegistry` type assertions, then CI guard checks failed because the `transcripts` runtime tool lacked display metadata.

Real environment tested: Crabbox AWS Linux lease `cbx_c201d63cabf6` from run `run_cef1d008eab5`, with the branch overlaid on base `e96cde7e1493a0753aabc1e70cb3d20602821a78`.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run -label openclaw-current-guards-unblocker-refresh2 -shell -- "pnpm check:changed"`.

Evidence after fix: `pnpm check:changed` selected `core, coreTests, apps`, completed guard checks, core/core-test typecheck, core lint with `Found 0 warnings and 0 errors`, app lint skip on non-macOS as expected, runtime guard checks, import-cycle checks, webhook/body guards, and exited 0.

Observed result after fix: changed-gate no longer fails on the image tool redundant-cast lint errors or the missing transcripts tool-display metadata.

What was not tested: no live image-provider request or live transcript capture; both changes are metadata/type-cleanup guard repairs.