### PR TITLE
fix(cron): suppress REPLY_SKIP and ANNOUNCE_SKIP on cron-announce delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.cron-suppression.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.cron-suppression.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { normalizeCronOutboundReplyText } from "./delivery-dispatch.js";
+
+describe("normalizeCronOutboundReplyText: cron-announce REPLY_SKIP / ANNOUNCE_SKIP suppression (#85421)", () => {
+  it("drops the body when the whole reply is REPLY_SKIP", () => {
+    const result = normalizeCronOutboundReplyText("REPLY_SKIP");
+    expect(result.text).toBeUndefined();
+    expect(result.strippedTrailingSilentToken).toBe(false);
+  });
+
+  it("drops the body when the whole reply is ANNOUNCE_SKIP", () => {
+    const result = normalizeCronOutboundReplyText("ANNOUNCE_SKIP");
+    expect(result.text).toBeUndefined();
+    expect(result.strippedTrailingSilentToken).toBe(false);
+  });
+
+  it("drops the body when the whole reply is the silent reply token", () => {
+    const result = normalizeCronOutboundReplyText(SILENT_REPLY_TOKEN);
+    expect(result.text).toBeUndefined();
+    expect(result.strippedTrailingSilentToken).toBe(false);
+  });
+
+  it("ignores surrounding whitespace around the control token (the chat-display path already trims)", () => {
+    expect(normalizeCronOutboundReplyText("  REPLY_SKIP  ").text).toBeUndefined();
+    expect(normalizeCronOutboundReplyText("\n\nANNOUNCE_SKIP\n").text).toBeUndefined();
+  });
+
+  it("does not suppress when the control token is embedded in real content (only whole-text tokens are control)", () => {
+    const result = normalizeCronOutboundReplyText(
+      "Daily summary: nothing urgent today. (REPLY_SKIP would suppress.)",
+    );
+    expect(result.text).toBe("Daily summary: nothing urgent today. (REPLY_SKIP would suppress.)");
+    expect(result.strippedTrailingSilentToken).toBe(false);
+  });
+
+  it("preserves the existing partial-trailing silent-token stripping for mixed content", () => {
+    const result = normalizeCronOutboundReplyText(`Here is the report.\n${SILENT_REPLY_TOKEN}`);
+    expect(result.text).toBe("Here is the report.");
+    expect(result.strippedTrailingSilentToken).toBe(true);
+  });
+
+  it("returns the normal reply unchanged for ordinary cron output", () => {
+    const result = normalizeCronOutboundReplyText("All systems green.");
+    expect(result.text).toBe("All systems green.");
+    expect(result.strippedTrailingSilentToken).toBe(false);
+  });
+
+  it("passes through undefined / empty inputs", () => {
+    expect(normalizeCronOutboundReplyText(undefined).text).toBeUndefined();
+    expect(normalizeCronOutboundReplyText("").text).toBe("");
+    expect(normalizeCronOutboundReplyText("   ").strippedTrailingSilentToken).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -17,6 +17,7 @@ import {
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
+import { isSuppressedControlReplyText } from "../../gateway/control-reply-text.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
@@ -58,11 +59,17 @@ type NormalizedSilentReplyText = {
   strippedTrailingSilentToken: boolean;
 };
 
-function normalizeSilentReplyText(text: string | undefined): NormalizedSilentReplyText {
+export function normalizeCronOutboundReplyText(
+  text: string | undefined,
+): NormalizedSilentReplyText {
   if (!text) {
     return { text, strippedTrailingSilentToken: false };
   }
-  if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+  // Whole-text control tokens — SILENT, REPLY_SKIP, ANNOUNCE_SKIP. The
+  // chat-display path already drops these via `isSuppressedControlReplyText`;
+  // applying the same contract here closes the cron-announce leak in #85421
+  // where bare `REPLY_SKIP` replies posted verbatim to Discord.
+  if (isSuppressedControlReplyText(text)) {
     return { text: undefined, strippedTrailingSilentToken: false };
   }
 
@@ -828,7 +835,7 @@ export async function dispatchCronDelivery(
           if (!p.text) {
             return p;
           }
-          const normalized = normalizeSilentReplyText(p.text);
+          const normalized = normalizeCronOutboundReplyText(p.text);
           return Object.assign({}, p, {
             text: normalized.strippedTrailingSilentToken ? undefined : normalized.text,
           });
@@ -1177,7 +1184,7 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    const normalizedSynthesizedText = normalizeSilentReplyText(synthesizedText);
+    const normalizedSynthesizedText = normalizeCronOutboundReplyText(synthesizedText);
     if (
       normalizedSynthesizedText.text === undefined ||
       normalizedSynthesizedText.strippedTrailingSilentToken


### PR DESCRIPTION
## Summary

- Wire `isSuppressedControlReplyText` (from `src/gateway/control-reply-text.ts`) into the cron-announce direct-delivery normalization step in `src/cron/isolated-agent/delivery-dispatch.ts`, so a bare `REPLY_SKIP` / `ANNOUNCE_SKIP` / silent-reply token from an `agentTurn` cron no longer posts verbatim to the destination channel (#85421).
- Rename the local helper `normalizeSilentReplyText` → `normalizeCronOutboundReplyText` and export it. The function previously only recognized `SILENT_REPLY_TOKEN`; it now also short-circuits on whole-text control tokens covered by `isSuppressedControlReplyText` (matching the chat-display and live-chat-projector contract). Both call sites in `deliverViaDirect` and the synthesized-text path are updated.
- Existing trailing-`SILENT_REPLY_TOKEN` partial-stripping behavior for mixed content is preserved — only whole-text control tokens are dropped.
- Add 8 colocated unit cases in `src/cron/isolated-agent/delivery-dispatch.cron-suppression.test.ts` covering `REPLY_SKIP` / `ANNOUNCE_SKIP` / `SILENT_REPLY_TOKEN` whole-text suppression, surrounding-whitespace tolerance, embedded-not-suppressed, trailing-`SILENT_REPLY_TOKEN` mixed content preserved, ordinary reply unchanged, and `undefined` / empty / whitespace-only passthrough.

## Behavior change to flag

`agentTurn` crons whose final assistant reply is exactly `REPLY_SKIP` or `ANNOUNCE_SKIP` (or the silent reply token) no longer post that literal string to the destination channel — the payload is dropped at the cron-announce normalization step and the existing silent-delivery finish path takes over (no Discord / Slack / Telegram / etc. message is sent for that turn, the cron run is recorded as silent). This matches the documented contract on the chat-display side and the `REPLY_SKIP` convention recommended by OpenClaw skill tooling for "I have nothing to report" cron runs. Crons that emit substantive text (with or without trailing `SILENT_REPLY_TOKEN`) are unaffected — the existing trailing-token stripping still keeps the substantive prefix and sends it as before.

This is a fail-safe at the cron-announce delivery layer only; the agent run still completes and its session transcript / output still records the control token, so observability is unchanged.

## Real behavior proof

- **Behavior addressed:** `normalizeCronOutboundReplyText` (formerly `normalizeSilentReplyText`) at `src/cron/isolated-agent/delivery-dispatch.ts:62` now consults `isSuppressedControlReplyText` on whole-text input before falling through to the existing `SILENT_REPLY_TOKEN` partial-strip path. The two call sites at lines 838 and 1187 of `delivery-dispatch.ts` (direct-delivery payload `.map(...)` filter and synthesized-text guard) automatically pick up the broader suppression. The reporter's 9+ leaked `REPLY_SKIP` posts on `pace:it-triage` / `pace:help-page-review` / `pace:marketing-oneup-review` over 2026-05-11 → 2026-05-14 (issue body) come from exactly this code path.
- **Real environment tested:** local macOS arm64 source checkout (post-rebase against `upstream/main`); behavior verified through (a) the new `src/cron/isolated-agent/delivery-dispatch.cron-suppression.test.ts` (8 cases driving `normalizeCronOutboundReplyText` directly) and (b) the full existing `src/cron/isolated-agent/` test suite (28 files, 342 tests including the production-shaped `delivery-dispatch.double-announce.test.ts` regression suite) which still passes against the renamed and extended helper.
- **Exact steps or command run after this patch:**
  - `pnpm test src/cron/isolated-agent/delivery-dispatch.cron-suppression.test.ts`
  - `pnpm test src/cron/isolated-agent/`
  - `pnpm test:changed`
  - `pnpm check:changed`
- **Evidence after fix:**
  - `normalizeCronOutboundReplyText("REPLY_SKIP")` → `{ text: undefined, strippedTrailingSilentToken: false }` (previously `{ text: "REPLY_SKIP", strippedTrailingSilentToken: false }` — the reporter's leaked Discord post).
  - `normalizeCronOutboundReplyText("ANNOUNCE_SKIP")` → `{ text: undefined, … }`.
  - `normalizeCronOutboundReplyText("  REPLY_SKIP  ")` → `{ text: undefined, … }` (existing chat-display `.trim()` semantics inherited from `isSuppressedControlReplyText`).
  - `normalizeCronOutboundReplyText("Daily summary: nothing urgent today. (REPLY_SKIP would suppress.)")` → `{ text: "Daily summary: …", … }` (embedded mention not treated as whole-text control token — no over-suppression).
  - `normalizeCronOutboundReplyText("Here is the report.\n${SILENT_REPLY_TOKEN}")` → `{ text: "Here is the report.", strippedTrailingSilentToken: true }` (existing partial-trailing strip preserved).
  - `normalizeCronOutboundReplyText("All systems green.")` → `{ text: "All systems green.", strippedTrailingSilentToken: false }` (normal reply unchanged).
- **Observed result after fix:**
  - `src/cron/isolated-agent/delivery-dispatch.cron-suppression.test.ts`: 8 / 8 passed.
  - `src/cron/isolated-agent/**` (full directory): 342 / 342 passed across 28 files in 9.09s — no regression from the rename or the new branch.
  - `pnpm test:changed`: 5387 + … passed; only known pre-existing main failures unrelated to `src/cron/**` (`src/commands/onboard.test.ts` — same `runtime.error called twice` pattern documented in prior PRs).
  - `pnpm check:changed`: exit 1 only because of the pre-existing `npm shrinkwrap guard (31 packages)` failure (`.: npm-shrinkwrap.json is stale. Run pnpm deps:shrinkwrap:generate.`). This drift reproduces on pristine `upstream/main` (verified by running `pnpm check:changed` after stashing this patch and removing the new test file — same failure). All `src/cron/**`-touching guards (typecheck core, typecheck core tests, lint core, import cycles, plugin-sdk wildcard / dependency pin / package patch guards, conflict markers, etc.) pass. The shrinkwrap is security-owned per CONTRIBUTING; regenerating it is out of scope for this fix.
- **What was not tested:** a live OpenClaw `2026.4.x` / `2026.5.x` install actually running an `agentTurn` cron that returns the literal `REPLY_SKIP` against a real Discord channel and confirming the leaked post no longer arrives. The fix is verified through the normalization helper that owns the suppression contract; the production timeline, 9+ leaked Discord posts, and the SKP Team userspace workaround that motivated the fix come from the reporter's setup on `2026.4.x` / `2026.5.18`. Markdown-emphasis-wrapped variants (`` **REPLY_SKIP** ``, `` `REPLY_SKIP` ``) called out as a bonus in the issue are **not** handled by this change — `isSuppressedControlReplyText` recognizes the bare token only, matching the chat-display contract. Wiring envelope/markdown variants would be a separate follow-up that also updates the chat-display path so the two stay aligned.

## Notes

- Renaming `normalizeSilentReplyText` → `normalizeCronOutboundReplyText` better reflects the broader contract (now covers SILENT + REPLY_SKIP + ANNOUNCE_SKIP); the helper is module-local and was never exported under the old name, so no external callers are affected. The export is added so the new test file can target the helper directly without standing up the heavy `delivery-dispatch.double-announce.test.ts`-style integration harness.
- Trailing-`SILENT_REPLY_TOKEN` partial stripping inside mixed-content replies is intentionally untouched — that's the legitimate "give me a summary plus a silent ack" path and not part of the #85421 bug surface.
- Reviewed against root `AGENTS.md` and `CONTRIBUTING.md`. No `CHANGELOG.md` edits (per CONTRIBUTING).

Refs #85421
