### PR TITLE
fix: avoid exec approvals writes for default no-prompt policy

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -105,6 +105,17 @@ Edit the `AGENTS.md` in `scripts/k8s/manifests/configmap.yaml` and redeploy:
 
 Edit `openclaw.json` in `scripts/k8s/manifests/configmap.yaml`. See [Gateway configuration](/gateway/configuration) for the full reference.
 
+### Persistent state and exec approvals
+
+The default manifests mount the PVC at `/home/node` and let the init container create `/home/node/.openclaw` as the same UID that runs the gateway. Keep that parent-mount shape if you customize storage:
+
+1. Mount the PVC at a parent directory, not directly at `/home/node/.openclaw`.
+2. Create `/home/node/.openclaw` as the gateway runtime UID before the gateway starts.
+3. Keep `HOME`, `OPENCLAW_CONFIG_DIR`, and `OPENCLAW_STATE_DIR` pointed at that state path.
+4. Add or edit `exec-approvals.json` inside that state directory only after the directory is owned and chmod-able by the gateway UID.
+
+This matters on clusters that use `fsGroup` for PVC writes. `fsGroup` can let the gateway write files while still preventing it from tightening permissions with `chmod` when the mounted directory is owned by another UID. Default no-prompt exec can run without an `exec-approvals.json` file, but persisted exec approvals require the state directory itself to be owned and chmod-able by the gateway process.
+
 ### Add providers
 
 Re-run with additional keys exported:
@@ -169,6 +180,8 @@ This deletes the namespace and all resources in it, including the PVC.
 ## Architecture notes
 
 - The gateway binds to loopback inside the pod by default, so the included setup is for `kubectl port-forward`
+- The PVC is mounted at `/home/node`; the init container creates `/home/node/.openclaw` inside it so OpenClaw owns the state directory it later hardens for persisted files such as `exec-approvals.json`
+- On upgrade from older manifests that mounted the PVC directly at `/home/node/.openclaw`, the init container moves root-level PVC state into `/home/node/.openclaw` before starting the gateway
 - No cluster-scoped resources — everything lives in a single namespace
 - Security: `readOnlyRootFilesystem`, `drop: ALL` capabilities, non-root user (UID 1000)
 - The default config keeps the Control UI on the safer local-access path: loopback bind plus `kubectl port-forward` to `http://127.0.0.1:18789`

--- a/scripts/k8s/manifests/deployment.yaml
+++ b/scripts/k8s/manifests/deployment.yaml
@@ -29,6 +29,18 @@ spec:
             - sh
             - -c
             - |
+              set -eu
+              mkdir -p /home/node/.openclaw
+              if [ ! -e /home/node/.openclaw/openclaw.json ] && [ -e /home/node/openclaw.json ]; then
+                for path in /home/node/.[!.]* /home/node/..?* /home/node/*; do
+                  [ -e "$path" ] || continue
+                  case "$(basename "$path")" in
+                    .openclaw|lost+found|.snapshot) continue ;;
+                  esac
+                  mv "$path" /home/node/.openclaw/
+                done
+              fi
+              chmod 700 /home/node/.openclaw
               cp /config/openclaw.json /home/node/.openclaw/openclaw.json
               mkdir -p /home/node/.openclaw/workspace
               cp /config/AGENTS.md /home/node/.openclaw/workspace/AGENTS.md
@@ -44,7 +56,7 @@ spec:
               cpu: 100m
           volumeMounts:
             - name: openclaw-home
-              mountPath: /home/node/.openclaw
+              mountPath: /home/node
             - name: config
               mountPath: /config
       containers:
@@ -64,6 +76,8 @@ spec:
             - name: HOME
               value: /home/node
             - name: OPENCLAW_CONFIG_DIR
+              value: /home/node/.openclaw
+            - name: OPENCLAW_STATE_DIR
               value: /home/node/.openclaw
             - name: NODE_ENV
               value: production
@@ -123,7 +137,7 @@ spec:
             timeoutSeconds: 5
           volumeMounts:
             - name: openclaw-home
-              mountPath: /home/node/.openclaw
+              mountPath: /home/node
             - name: tmp-volume
               mountPath: /tmp
           securityContext:

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -23,6 +23,7 @@ let readExecApprovalsSnapshot: ExecApprovalsModule["readExecApprovalsSnapshot"];
 let recordAllowlistMatchesUse: ExecApprovalsModule["recordAllowlistMatchesUse"];
 let recordAllowlistUse: ExecApprovalsModule["recordAllowlistUse"];
 let requestExecApprovalViaSocket: ExecApprovalsModule["requestExecApprovalViaSocket"];
+let resolveExecApprovals: ExecApprovalsModule["resolveExecApprovals"];
 let resolveExecApprovalsPath: ExecApprovalsModule["resolveExecApprovalsPath"];
 let resolveExecApprovalsSocketPath: ExecApprovalsModule["resolveExecApprovalsSocketPath"];
 let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
@@ -42,6 +43,7 @@ beforeAll(async () => {
     recordAllowlistMatchesUse,
     recordAllowlistUse,
     requestExecApprovalViaSocket,
+    resolveExecApprovals,
     resolveExecApprovalsPath,
     resolveExecApprovalsSocketPath,
     saveExecApprovals,
@@ -187,6 +189,93 @@ describe("exec approvals store helpers", () => {
     expect(readApprovalsFile(dir).socket).toEqual(ensured.socket);
   });
 
+  it("does not create an approvals file when resolving the missing default no-prompt policy", () => {
+    const dir = createHomeDir();
+
+    const resolved = resolveExecApprovals("main", {
+      security: "full",
+      ask: "off",
+    });
+
+    expect(resolved.agent.security).toBe("full");
+    expect(resolved.agent.ask).toBe("off");
+    expect(resolved.socketPath).toBe(resolveExecApprovalsSocketPath());
+    expect(resolved.token).toBe("");
+    expect(fs.existsSync(approvalsFilePath(dir))).toBe(false);
+  });
+
+  it("does not treat approvals path access errors as a missing default policy", () => {
+    const dir = createHomeDir();
+    const approvalsPath = approvalsFilePath(dir);
+    const actualLstatSync = fs.lstatSync.bind(fs);
+    vi.spyOn(fs, "lstatSync").mockImplementation((target, options) => {
+      if (String(target) === approvalsPath) {
+        throw Object.assign(new Error("approval path blocked"), { code: "EACCES" });
+      }
+      return actualLstatSync(target, options as never);
+    });
+
+    expect(() =>
+      resolveExecApprovals("main", {
+        security: "full",
+        ask: "off",
+      }),
+    ).toThrow("approval path blocked");
+  });
+
+  it("creates an approvals file when resolving a missing policy that may prompt", () => {
+    const dir = createHomeDir();
+
+    const resolved = resolveExecApprovals("main", {
+      security: "allowlist",
+      ask: "on-miss",
+    });
+
+    expect(resolved.agent.security).toBe("allowlist");
+    expect(resolved.agent.ask).toBe("on-miss");
+    expect(resolved.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(readApprovalsFile(dir).socket).toEqual(resolved.file.socket);
+  });
+
+  it("creates an approvals file for default no-prompt policy when a socket is required", () => {
+    const dir = createHomeDir();
+
+    const resolved = resolveExecApprovals("main", {
+      security: "full",
+      ask: "off",
+      requireSocket: true,
+    });
+
+    expect(resolved.agent.security).toBe("full");
+    expect(resolved.agent.ask).toBe("off");
+    expect(resolved.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(readApprovalsFile(dir).socket).toEqual(resolved.file.socket);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "recovers unreadable existing approvals files through the ensure path",
+    () => {
+      const dir = createHomeDir();
+      fs.mkdirSync(path.dirname(approvalsFilePath(dir)), { recursive: true });
+      fs.writeFileSync(approvalsFilePath(dir), '{"version":1,"agents":{}}\n', "utf8");
+      fs.chmodSync(approvalsFilePath(dir), 0o000);
+
+      try {
+        const resolved = resolveExecApprovals("main", {
+          security: "full",
+          ask: "off",
+        });
+
+        expect(resolved.agent.security).toBe("full");
+        expect(resolved.agent.ask).toBe("off");
+        expect(resolved.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+        expect(readApprovalsFile(dir).socket).toEqual(resolved.file.socket);
+      } finally {
+        fs.chmodSync(approvalsFilePath(dir), 0o600);
+      }
+    },
+  );
+
   it("atomically replaces existing approvals files instead of mutating linked inodes", () => {
     const dir = createHomeDir();
     const approvalsPath = approvalsFilePath(dir);
@@ -235,6 +324,24 @@ describe("exec approvals store helpers", () => {
     expect(fs.readFileSync(approvalsFilePath(dir), "utf8")).toContain('"security": "full"');
     expect(fs.statSync(approvalsDir).mode & 0o777).toBe(0o700);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "keeps exec approvals strict when directory chmod fails",
+    () => {
+      const dir = createHomeDir();
+      const approvalsDir = path.dirname(approvalsFilePath(dir));
+      const actualChmodSync = fs.chmodSync.bind(fs);
+      vi.spyOn(fs, "chmodSync").mockImplementation((target, mode) => {
+        if (String(target) === approvalsDir) {
+          throw Object.assign(new Error("chmod denied"), { code: "EPERM" });
+        }
+        return actualChmodSync(target, mode);
+      });
+
+      expect(() => ensureExecApprovals()).toThrow("chmod denied");
+      expect(fs.existsSync(approvalsFilePath(dir))).toBe(false);
+    },
+  );
 
   it("falls back to copying when rename cannot overwrite the approvals file", () => {
     const dir = createHomeDir();

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -758,6 +758,15 @@ export function ensureExecApprovals(): ExecApprovalsFile {
   return updated;
 }
 
+function isExecApprovalsFileMissing(filePath: string): boolean {
+  try {
+    fs.lstatSync(filePath);
+    return false;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "ENOENT";
+  }
+}
+
 function isExecSecurity(value: unknown): value is ExecSecurity {
   return value === "allowlist" || value === "full" || value === "deny";
 }
@@ -890,12 +899,28 @@ export type ExecApprovalsDefaultOverrides = {
   ask?: ExecAsk;
   askFallback?: ExecSecurity;
   autoAllowSkills?: boolean;
+  requireSocket?: boolean;
 };
 
 export function resolveExecApprovals(
   agentId?: string,
   overrides?: ExecApprovalsDefaultOverrides,
 ): ExecApprovalsResolved {
+  const filePath = resolveExecApprovalsPath();
+  if (!overrides?.requireSocket && isExecApprovalsFileMissing(filePath)) {
+    const file = normalizeExecApprovals({ version: 1, agents: {} });
+    const resolved = resolveExecApprovalsFromFile({
+      file,
+      agentId,
+      overrides,
+      path: filePath,
+      socketPath: resolveExecApprovalsSocketPath(),
+      token: "",
+    });
+    if (resolved.agent.security === "full" && resolved.agent.ask === "off") {
+      return resolved;
+    }
+  }
   const file = ensureExecApprovals();
   return resolveExecApprovalsFromFile({
     file,

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -387,6 +387,7 @@ async function evaluateSystemRunPolicyPhase(
   const approvals = resolveExecApprovals(parsed.agentId, {
     security: configuredSecurity,
     ask: configuredAsk,
+    requireSocket: opts.preferMacAppExecHost,
   });
   const security = approvals.agent.security;
   const ask = approvals.agent.ask;


### PR DESCRIPTION
## Summary

Fixes #83619.

This takes the narrow compatibility path for Kubernetes installs where the default exec policy does not need persisted approval state. When `exec-approvals.json` is missing and the effective policy resolves to the default no-prompt `security=full`, `ask=off` behavior, `resolveExecApprovals()` now resolves that policy without creating the approvals file. That avoids the startup-time chmod/write path that fails on fsGroup-managed PVCs.

The change intentionally keeps approval persistence strict. If a policy may prompt, an approvals file already exists, or a socket/token is required, OpenClaw still creates and hardens `exec-approvals.json` through the existing path.

This is an alternative to #83695. It avoids relaxing chmod behavior for private persisted state stores, so upgrades do not silently widen plugin/task/exec approval state access from owner-only to group- or world-readable/writable modes.

The Kubernetes manifests now mount the PVC at `/home/node` and let the runtime UID create `/home/node/.openclaw`, so deployments that use the included manifests also have a chmod-able state directory for users who later add persisted exec approvals.

## Compatibility and security

- No new user-facing config, schema, env var, or docs option.
- Existing `exec-approvals.json` files continue through the existing normalization and hardening path.
- Non-default approval modes continue to create/persist approval state.
- Mac app exec-host routing still requires socket/token persistence via the internal `requireSocket` option.
- The only observable change is that a missing approvals file is no longer created as a side effect when the effective policy is default `full/off`.
- The Kubernetes manifest mount path changes from direct state-dir mount to parent-home mount, with an init-container migration for PVCs created by the previous manifest shape.

## Real behavior proof

Behavior addressed: default exec policy resolution no longer writes `exec-approvals.json` when the file is missing and no prompt/socket state is needed; the included Kubernetes manifests now create a runtime-owned state directory so persisted `exec-approvals.json` can be added later.

Real environment tested: OpenShift namespace `openclaw-bob`, RBD-backed PVC using `fsGroup`, image `quay.io/sallyom/openclaw-test:latest` resolved in the pod as `quay.io/sallyom/openclaw-test@sha256:7b1042d3bc155e340e7a8c83a107f6339b1408244f00bb9fa18d8de8ca1b63e0`.

Exact steps or command run after this patch: created smoke pods with the PVC mounted at the OpenClaw state dir, `runAsUser=1001730000`, `fsGroup=1001730000`; verified `chmod` on the state dir fails with `EPERM`; removed `exec-approvals.json`; invoked the real OpenClaw `createExecTool({ host: "gateway", security: "full", ask: "off" })` path with `printf openclaw-83619-exec-ok`; separately created `exec-approvals.json` with uid `1001730000` and mode `0600` to confirm the persisted approvals path still fails closed on this PVC ownership shape. Then repeated the add-back path with the PVC mounted at `/home/node` and `.openclaw` created by the runtime UID; created `exec-approvals.json` with a deny policy; verified `resolveExecApprovals()` reads the file and the real exec tool denies the command. Also ran the old-PVC migration script shape and verified root-level state moves under `.openclaw` while `lost+found` stays in the PVC root.

Evidence after fix: the OpenShift pod logged `stateDir.uid=0`, `stateDir.gid=1001730000`, `mode=02775`, `chmod=failed code=EPERM`, `execDetails.status=completed`, `exitCode=0`, `aggregated=openclaw-83619-exec-ok`, and `approvalsExistsAfterExec=false`.

Observed result after fix: the exec pod completed successfully with `exec-smoke=passed`; the real exec command returned the expected output and did not recreate `exec-approvals.json`. The direct-mount add-back pod completed with `add-back-smoke=passed` by confirming that adding `exec-approvals.json` back is not sufficient on that PVC shape: `resolveExecApprovals()` still fails with `EPERM` while chmodding the state directory. The parent-mount add-back pod completed with `parent-addback-smoke=passed`: `.openclaw` was owned by uid `1001730000` with mode `0700`, `exec-approvals.json` was read, `security=deny` resolved, and exec was denied. The old-PVC migration smoke completed with `parent-migration-debug-smoke=passed`.

What was not tested: a full OpenClaw deployment lifecycle. The smoke pods exercised the filesystem ownership, approval resolution, real exec tool path, and init-container migration logic in OpenShift.

## Verification

- `git diff --check origin/main...HEAD`
- `node --no-maglev node_modules/vitest/vitest.mjs run src/infra/exec-approvals-store.test.ts src/agents/bash-tools.exec-host-gateway.test.ts src/node-host/invoke-system-run.test.ts --reporter=verbose`
- `pnpm docs:list`
- `kubectl kustomize scripts/k8s/manifests`
- OpenShift smoke pod: `openclaw-83619-exec` in namespace `openclaw-bob`, result `Succeeded`, exit code `0`
- OpenShift add-back smoke pod: `openclaw-83619-addback` in namespace `openclaw-bob`, result `Succeeded`, exit code `0`
- OpenShift parent-mount add-back smoke pod: `openclaw-83619-parent-addback` in namespace `openclaw-bob`, result `Succeeded`, exit code `0`
- OpenShift old-PVC migration smoke pod: `openclaw-83619-parent-migration-debug` in namespace `openclaw-bob`, result `Succeeded`, exit code `0`
