### PR TITLE
fix(agents): disclose scoped session list results

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -49,10 +49,12 @@ effective tool list.
 token counts, and timestamps. Filter by kind (`main`, `group`, `cron`, `hook`,
 `node`), exact `label`, exact `agentId`, search text, or recency
 (`activeMinutes`). When you need mailbox-style triage, it can also ask for a
-visibility-scoped derived title, a last-message preview snippet, or bounded
-recent messages on each row. Derived titles and previews are produced only for
-sessions the caller can already see under the configured session tool
-visibility policy, so unrelated sessions stay hidden.
+visibility-scoped derived title, a last-message preview snippet, or bounded recent
+messages on each row. Derived titles and previews are produced only for sessions
+the caller can already see under the configured session tool visibility policy, so
+unrelated sessions stay hidden. When visibility is restricted, `sessions_list`
+returns optional `visibility` metadata showing the effective mode and a warning that
+results may be scope-limited.
 
 `sessions_history` fetches the conversation transcript for a specific session.
 By default, tool results are excluded -- pass `includeTools: true` to see them.

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -357,6 +357,9 @@ Default: `tree` (current session + sessions spawned by it, such as subagents).
     - `agent`: any session belonging to the current agent id (can include other users if you run per-sender sessions under the same agent id).
     - `all`: any session. Cross-agent targeting still requires `tools.agentToAgent`.
     - Sandbox clamp: when the current session is sandboxed and `agents.defaults.sandbox.sessionToolsVisibility="spawned"`, visibility is forced to `tree` even if `tools.sessions.visibility="all"`.
+    - When not `all`, `sessions_list` includes a compact `visibility` field
+      describing the effective mode and a warning that some sessions may be
+      omitted outside the current scope.
 
   </Accordion>
 </AccordionGroup>

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -417,9 +417,19 @@ export function createSessionsListTool(opts?: {
         await Promise.all(Array.from({ length: maxConcurrent }, () => worker()));
       }
 
+      const visibilityMetadata =
+        visibility === "all"
+          ? undefined
+          : {
+              mode: visibility,
+              restricted: true,
+              warning: `Session visibility is restricted (effective tools.sessions.visibility=${visibility}). Results may omit sessions outside the current scope.`,
+            };
+
       return jsonResult({
         count: rows.length,
         sessions: rows,
+        ...(visibilityMetadata ? { visibility: visibilityMetadata } : {}),
       });
     },
   };

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -423,7 +423,7 @@ export function createSessionsListTool(opts?: {
           : {
               mode: visibility,
               restricted: true,
-              warning: `Session visibility is restricted (effective tools.sessions.visibility=${visibility}). Results may omit sessions outside the current scope.`,
+              warning: `Session visibility is restricted (effective tools.sessions.visibility=${visibility}). Results may omit sessions outside the current scope. The count field reflects only sessions within the current scope.`,
             };
 
       return jsonResult({

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -538,7 +538,7 @@ describe("sessions_list gating", () => {
       mode: "tree",
       restricted: true,
       warning:
-        "Session visibility is restricted (effective tools.sessions.visibility=tree). Results may omit sessions outside the current scope.",
+        "Session visibility is restricted (effective tools.sessions.visibility=tree). Results may omit sessions outside the current scope. The count field reflects only sessions within the current scope.",
     });
   });
 

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -514,10 +514,32 @@ describe("sessions_list gating", () => {
 
     const details = requireDetails(result);
     expect(details.count).toBe(1);
+    expect(details.visibility).toBeUndefined();
     const session = requireSessions(details)[0];
     expect(session?.key).toBe("agent:codex:acp:child-1");
     expect(session?.parentSessionKey).toBe(MAIN_AGENT_SESSION_KEY);
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes visibility metadata when session visibility is restricted", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: true },
+        sessions: { visibility: "tree" },
+      },
+    });
+
+    const result = await createMainSessionsListTool().execute("call1", {});
+
+    const details = requireDetails(result);
+    expect(details.count).toBe(1);
+    expect(details.visibility).toMatchObject({
+      mode: "tree",
+      restricted: true,
+      warning:
+        "Session visibility is restricted (effective tools.sessions.visibility=tree). Results may omit sessions outside the current scope.",
+    });
   });
 
   it("keeps literal current keys for message previews", async () => {


### PR DESCRIPTION
## Summary

- Problem: `sessions_list` can correctly filter rows under restricted visibility, but the previous result looked complete because it only returned `count` and `sessions`.
- Why it matters: agents and operators can misread a default `tree`-scoped result as the full session inventory.
- What changed: restricted `sessions_list` results now include compact `visibility` metadata with the effective mode and warning text, including that `count` is scoped to visible sessions.
- What did NOT change: visibility policy, filtering, defaults, cross-agent access, and hidden-session counts are unchanged.

## AI assistance

This PR was implemented with Codex assistance. I reviewed the change and understand the affected `sessions_list` visibility path.

## Real behavior proof (required for external PRs)

Behavior addressed:
`sessions_list` now discloses when its result is scoped by effective session visibility instead of returning a complete-looking restricted list.

Real environment tested:
Local OpenClaw source checkout on branch `codex/issue-50646`, using production `createSessionsListTool`, isolated `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`, with a deterministic fake Gateway `sessions.list` response containing one visible current-session row and one off-scope row.

Exact steps or command run after this patch:

```sh
mkdir -p .artifacts/pr-proof
HOME="$(mktemp -d)" \
OPENCLAW_HOME="$HOME/.openclaw" \
OPENCLAW_STATE_DIR="$(mktemp -d)/state" \
OPENCLAW_CONFIG_PATH="$(mktemp -d)/openclaw.json" \
node --import tsx --input-type=module '<production createSessionsListTool proof script>'
```

Evidence after fix:

<details>
<summary>Runtime proof output</summary>

```text
PROOF_NAME=issue-50646-sessions-list-count-warning-rebased
PROOF_ENV=source checkout with isolated HOME/OPENCLAW state and production createSessionsListTool
{
  "result": "PASS",
  "observed": {
    "count": 1,
    "sessions": [
      {
        "key": "main",
        "agentId": "main",
        "kind": "main",
        "channel": "unknown"
      }
    ],
    "visibility": {
      "mode": "tree",
      "restricted": true,
      "warning": "Session visibility is restricted (effective tools.sessions.visibility=tree). Results may omit sessions outside the current scope. The count field reflects only sessions within the current scope."
    }
  }
}
PROOF_STATUS=0
proof_status=0
```

</details>

Observed result after fix:
The restricted `tree`-visibility result still returned only the visible current-session row (`count: 1`), and now included `visibility.mode="tree"`, `restricted: true`, and warning text that explicitly says `count` reflects only sessions within the current scope. The off-scope row remained hidden.

What was not tested:
No live Gateway, Telegram, Discord, or multi-agent channel integration was exercised. This proof targets the agent tool output path directly; unit coverage verifies the same path and keeps hidden-count disclosure absent.

Before evidence:
Before this patch, the same production-path repro returned only `count: 1` and `sessions: [...]` with no `visibility` field or scope warning.

## Root Cause

- Root cause: `createSessionsListTool` already resolved effective session visibility and filtered rows, but discarded that visibility fact before returning the JSON payload.
- Missing detection / guardrail: existing tests asserted filtered `count` and visible rows, but did not require the result to disclose that filtering came from restricted visibility.
- Contributing context: related issues around group/channel and cross-agent visibility need product/security decisions, so this fix intentionally stays observational instead of broadening access.

## Dependency contract

- Source/types/docs checked: `src/plugin-sdk/session-visibility.ts`, `src/agents/tools/sessions-access.ts`, `docs/concepts/session-tool.md`, `docs/gateway/config-tools.md`.
- Contract relied on: `resolveSessionToolsVisibility()` returns `self | tree | agent | all` and defaults invalid/unset config to `tree`; `resolveEffectiveSessionToolsVisibility()` applies sandbox clamps and returns the effective value used by session-list filtering.
- How the patch stays within that contract: it exposes the already-computed effective value only when not `all`; it does not change the helper, schema, defaults, or filtering decisions.

## Regression Test Plan

- Focused test added/updated: `src/agents/tools/sessions.test.ts`.
- Behavior covered: restricted `tree` results include `visibility` metadata and warning; `all` visibility keeps the top-level metadata absent.
- Known test gap: no live channel or Gateway process is started; the production tool export is exercised with a deterministic Gateway stub.

## Security Impact

- Security-relevant paths touched: agent-facing session list output and docs.
- Secrets/credentials exposure: none.
- Permission or sandbox effect: none. The patch does not broaden visibility and does not expose hidden-session counts.

## Human Verification

- Human-understood proof: the proof command exercises the production `sessions_list` tool path with isolated local state and fake session rows.
- Local artifacts, if any: `.artifacts/pr-proof/issue-50646-sessions-list-count-warning-rebased-20260526T170820Z.log` and `.artifacts/issue-50646-fix-guide.html`.

## CODEOWNERS / owner review

- Touched owner-sensitive paths: no explicit `.github/CODEOWNERS` match for the touched files.
- Expected owner review: normal agents/session-tool and docs maintainer review; no secops CODEOWNERS review is required by the current CODEOWNERS file.

## Changelog

No contributor `CHANGELOG.md` edit. Maintainers/ClawSweeper can add the entry during landing if needed.

## Review conversations

Human review from `@martingarramon` suggested making the warning explicit that `count` is also scoped. This branch update addresses that suggestion.

## Risks

- Actual residual risk: strict consumers that reject unknown top-level fields in `sessions_list` details may need to ignore the new additive `visibility` field.
- Mitigation: the field is only added for restricted results; existing `count` and `sessions` semantics are unchanged.

## Behavior tradeoffs

- Intentional behavior tradeoff: the warning says results may be scope-limited rather than proving hidden sessions exist.
- Why it is acceptable: this improves observability without leaking hidden-session counts or changing visibility policy.

## Scope boundaries

- Preserved previous behavior: default `tree` visibility, sandbox clamps, A2A policy, row filtering, and hidden-row suppression.
- Explicit non-goals: no group/channel diagnostic mode, no per-agent visibility design, no cross-agent send/read policy changes, no default visibility change, and no hidden count.

## Validation

- `pnpm docs:list` completed successfully.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm test src/agents/tools/sessions.test.ts src/agents/tools/sessions-list-tool.test.ts` passed: 2 files, 33 tests.
- `git diff --check` passed.
- `pnpm exec oxfmt --check --threads=1 src/agents/tools/sessions-list-tool.ts src/agents/tools/sessions.test.ts docs/concepts/session-tool.md docs/gateway/config-tools.md` passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/tools/sessions-list-tool.ts src/agents/tools/sessions.test.ts` passed.
- `codex review --base origin/main` found no actionable correctness issues.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm check:changed` passed conflict/dependency/package/typecheck lanes, then failed broad core lint on pre-existing unrelated `src/agents/tools/image-tool.ts` no-unnecessary-type-assertion findings outside this diff.
- Real behavior proof passed with `PROOF_STATUS=0`.
