### PR TITLE
fix(media): allow workspace-* directories in default local media roots (#86879)

### DIFF
--- a/src/media/local-media-access.test.ts
+++ b/src/media/local-media-access.test.ts
@@ -1,8 +1,15 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveStateDir } from "../config/paths.js";
 import { assertLocalMediaAllowed, LocalMediaAccessError } from "./local-media-access.js";
+
+const { hoistedRoots } = vi.hoisted(() => ({ hoistedRoots: [] as string[] }));
+
+vi.mock("./local-roots.js", () => ({
+  getDefaultMediaLocalRoots: () => hoistedRoots,
+}));
 
 describe("assertLocalMediaAllowed", () => {
   it("allows managed inbound media paths before explicit root checks", async () => {
@@ -43,6 +50,63 @@ describe("assertLocalMediaAllowed", () => {
       );
     } finally {
       await fs.rm(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it("rejects workspace-* sibling paths when localRoots is undefined (unscoped)", async () => {
+    const tmpDir = path.join(
+      os.tmpdir(),
+      `ocl-local-media-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    const workspaceDir = path.join(tmpDir, "workspace");
+    const workspaceXiaoqianDir = path.join(tmpDir, "workspace-xiaoqian");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(workspaceXiaoqianDir, { recursive: true });
+
+    const mediaPath = path.join(workspaceXiaoqianDir, "report.html");
+    await fs.writeFile(mediaPath, "<html>test</html>");
+
+    hoistedRoots.length = 0;
+    hoistedRoots.push(workspaceDir);
+
+    try {
+      let accessError: unknown;
+      try {
+        await assertLocalMediaAllowed(mediaPath, undefined);
+      } catch (error) {
+        accessError = error;
+      }
+      expect(accessError).toBeInstanceOf(LocalMediaAccessError);
+      if (!(accessError instanceof LocalMediaAccessError)) {
+        throw new Error("expected LocalMediaAccessError");
+      }
+      expect(accessError.code).toBe("path-not-allowed");
+    } finally {
+      hoistedRoots.length = 0;
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows workspace-* paths when scoped localRoots include the agent workspace", async () => {
+    const tmpDir = path.join(
+      os.tmpdir(),
+      `ocl-local-media-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    const workspaceDir = path.join(tmpDir, "workspace");
+    const workspaceXiaoqianDir = path.join(tmpDir, "workspace-xiaoqian");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(workspaceXiaoqianDir, { recursive: true });
+
+    const mediaPath = path.join(workspaceXiaoqianDir, "report.html");
+    await fs.writeFile(mediaPath, "<html>test</html>");
+
+    try {
+      // Simulate scoped roots that include the agent's workspace-* directory
+      await expect(
+        assertLocalMediaAllowed(mediaPath, [workspaceDir, workspaceXiaoqianDir]),
+      ).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/media/read-capability.test.ts
+++ b/src/media/read-capability.test.ts
@@ -19,7 +19,10 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
     });
 
     expect(Object.keys(result)).toStrictEqual(["localRoots", "readFile", "workspaceDir"]);
-    expect(result.localRoots).toStrictEqual([...getDefaultMediaLocalRoots()]);
+    expect(result.localRoots).toStrictEqual([
+      ...getDefaultMediaLocalRoots(),
+      "/tmp/media-workspace",
+    ]);
     expect(typeof result.readFile).toBe("function");
     expect(result.workspaceDir).toBe("/tmp/media-workspace");
   });
@@ -32,9 +35,28 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
     });
 
     expect(Object.keys(result)).toStrictEqual(["localRoots", "readFile", "workspaceDir"]);
-    expect(result.localRoots).toStrictEqual([...getDefaultMediaLocalRoots()]);
+    expect(result.localRoots).toStrictEqual([
+      ...getDefaultMediaLocalRoots(),
+      "/tmp/explicit-workspace",
+    ]);
     expect(typeof result.readFile).toBe("function");
     expect(result.workspaceDir).toBe("/tmp/explicit-workspace");
+  });
+
+  it("keeps explicit workspaceDir in localRoots when agent id is unavailable", () => {
+    const workspaceDir = "/tmp/openclaw-home/workspace-xiaoqian";
+    const result = resolveAgentScopedOutboundMediaAccess({
+      cfg: {
+        tools: {
+          fs: { workspaceOnly: true },
+        },
+      } as OpenClawConfig,
+      workspaceDir,
+      mediaSources: [`${workspaceDir}/report.html`],
+    });
+
+    expect(result.localRoots).toContain(workspaceDir);
+    expect(result.workspaceDir).toBe(workspaceDir);
   });
 
   it("does not enable host reads when sender group policy denies read", () => {

--- a/src/media/read-capability.ts
+++ b/src/media/read-capability.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolvePathFromInput } from "../agents/path-policy.js";
 import { resolveGroupToolPolicy } from "../agents/pi-tools.policy.js";
@@ -80,6 +81,23 @@ export function createAgentScopedHostMediaReadFile(
   };
 }
 
+function appendWorkspaceDirToLocalRoots(
+  roots: readonly string[] | undefined,
+  workspaceDir?: string,
+): readonly string[] | undefined {
+  if (!workspaceDir) {
+    return roots;
+  }
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
+  if (!roots?.length) {
+    return [resolvedWorkspaceDir];
+  }
+  if (roots.some((root) => path.resolve(root) === resolvedWorkspaceDir)) {
+    return roots;
+  }
+  return [...roots, resolvedWorkspaceDir];
+}
+
 export function resolveAgentScopedOutboundMediaAccess(
   params: {
     cfg: OpenClawConfig;
@@ -90,8 +108,12 @@ export function resolveAgentScopedOutboundMediaAccess(
     mediaReadFile?: OutboundMediaReadFile;
   } & OutboundHostMediaPolicyContext,
 ): OutboundMediaAccess {
+  const resolvedWorkspaceDir =
+    params.workspaceDir ??
+    params.mediaAccess?.workspaceDir ??
+    (params.agentId ? resolveAgentWorkspaceDir(params.cfg, params.agentId) : undefined);
   const hostMediaReadAllowed = isAgentScopedHostMediaReadAllowed(params);
-  const localRoots =
+  const baseLocalRoots =
     params.mediaAccess?.localRoots ??
     (hostMediaReadAllowed
       ? getAgentScopedMediaLocalRootsForSources({
@@ -100,10 +122,7 @@ export function resolveAgentScopedOutboundMediaAccess(
           mediaSources: params.mediaSources,
         })
       : getAgentScopedMediaLocalRoots(params.cfg, params.agentId));
-  const resolvedWorkspaceDir =
-    params.workspaceDir ??
-    params.mediaAccess?.workspaceDir ??
-    (params.agentId ? resolveAgentWorkspaceDir(params.cfg, params.agentId) : undefined);
+  const localRoots = appendWorkspaceDirToLocalRoots(baseLocalRoots, resolvedWorkspaceDir);
   const readFile =
     params.mediaAccess?.readFile ??
     params.mediaReadFile ??


### PR DESCRIPTION
## Summary

- Fixes MEDIA delivery for agent workspaces named `workspace-*`, such as `~/.openclaw/workspace-xiaoqian/report.html`.
- Keeps the unscoped default media boundary intact: `assertLocalMediaAllowed(path, undefined)` still rejects `workspace-*` sibling directories.
- Repairs scoped outbound media access so an explicit resolved `workspaceDir` is included in `localRoots` even when agent id inference is unavailable or points at the source session.
- Adds regression coverage for unscoped rejection, scoped success, and explicit `workspaceDir` propagation through `resolveAgentScopedOutboundMediaAccess`.

Fixes #86879

## Real behavior proof

Behavior addressed: MEDIA directives from non-main agents with `workspace-*` workspaces failed with `⚠️ Media failed.` because the staged outbound media read did not always carry the resolved agent workspace into scoped local roots.

Real environment tested: local OpenClaw checkout on macOS, Node via repo Vitest wrapper.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/media/read-capability.test.ts src/media/local-media-access.test.ts src/auto-reply/reply/reply-media-paths.test.ts
/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Evidence after fix: focused media tests passed: 3 files, 33 tests. Autoreview reported clean with no accepted/actionable findings.

Observed result after fix: scoped outbound media access includes the explicit `workspace-xiaoqian` directory in `localRoots`, while the unscoped default path still rejects the same `workspace-*` sibling.

What was not tested: live Feishu WebSocket delivery was not run in this checkout; validation is focused on the shared media authorization/staging path used before channel delivery.

## Verification

- `node scripts/run-vitest.mjs src/media/read-capability.test.ts src/media/local-media-access.test.ts`
- `pnpm exec oxfmt --write --threads=1 src/media/read-capability.ts src/media/read-capability.test.ts src/media/local-media-access.test.ts`
- `node scripts/run-vitest.mjs src/media/read-capability.test.ts src/media/local-media-access.test.ts src/auto-reply/reply/reply-media-paths.test.ts`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
