### PR TITLE
feat(agents): show progress while web_fetch is waiting

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -4,6 +4,7 @@ import {
   onAgentEvent as registerAgentEventListener,
   resetAgentEventsForTest,
 } from "../infra/agent-events.js";
+import { buildChannelProgressDraftLine } from "../plugin-sdk/channel-streaming.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.types.js";
 import {
   handleToolExecutionEnd,
@@ -1856,6 +1857,103 @@ describe("control UI credential redaction (issue #72283)", () => {
 describe("handleToolExecutionUpdate non-exec progress", () => {
   afterEach(() => {
     resetAgentEventsForTest();
+  });
+
+  it("renders audited web_fetch progressText instead of stored meta (ClawSweeper P2 regression: meta does NOT shadow safe progressText)", async () => {
+    // ClawSweeper P2: the shared renderer at channel-streaming.ts resolves
+    // `meta ?? summary ?? progressText`. The stored toolMetaById meta for
+    // `web_fetch` is derived from `inferToolMetaFromArgs` and contains the
+    // FULL URL (detailKeys: ["url", "extractMode", "maxChars"]). If our
+    // progress item carried that meta, the renderer would (a) hide our safe
+    // progress line and (b) leak the URL into the channel draft. Lock in
+    // that the channel-visible line shows our audited progressText.
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "tool-clawsweeper-p2",
+        args: {
+          url: "https://httpbin.org/secret-path?token=ABC123XYZ",
+          extractMode: "text",
+          maxChars: 1000,
+        },
+      } as never,
+    );
+
+    // Sanity: the stored meta should contain the URL + extractMode + maxChars
+    // (derived from args via inferToolMetaFromArgs with detailKeys:
+    // ["url", "extractMode", "maxChars"]). If this ever changes the test
+    // setup needs review.
+    const storedMeta = ctx.state.toolMetaById.get("tool-clawsweeper-p2")?.meta;
+    expect(storedMeta).toBeDefined();
+    expect(storedMeta).toContain("httpbin.org");
+    expect(storedMeta).toContain("secret-path");
+    expect(storedMeta).toContain("text");
+    expect(storedMeta).toMatch(/1000/);
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "tool-clawsweeper-p2",
+        partialResult: {
+          content: [{ type: "text", text: "web_fetch: connecting to httpbin.org…" }],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+
+    const emittedItem = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .find(
+        (arg: unknown) =>
+          (arg as { stream?: string })?.stream === "item" &&
+          (arg as { data?: { kind?: string } })?.data?.kind === "tool" &&
+          (arg as { data?: { phase?: string } })?.data?.phase === "update",
+      ) as { data?: Record<string, unknown> } | undefined;
+
+    expect(emittedItem).toBeDefined();
+    const data = emittedItem?.data ?? {};
+
+    // The non-exec progress item must NOT carry the stored URL meta — that
+    // is the ClawSweeper P2 fix.
+    expect(data).not.toHaveProperty("meta");
+    expect(data.progressText).toBe("web_fetch: connecting to httpbin.org…");
+
+    // Drive the actual shared channel renderer with the emitted item and
+    // assert that the rendered text shows our safe progressText, NOT the
+    // URL-bearing stored meta. This is the binding behavior contract the
+    // PR claim depends on.
+    const rendered = buildChannelProgressDraftLine({
+      event: "item",
+      itemId: data.itemId as string,
+      itemKind: data.kind as string,
+      name: data.name as string,
+      phase: data.phase as string,
+      status: data.status as string,
+      title: data.title as string,
+      meta: data.meta as string | undefined,
+      summary: data.summary as string | undefined,
+      progressText: data.progressText as string | undefined,
+    });
+    expect(rendered).toBeDefined();
+    expect(rendered?.text ?? "").toContain("web_fetch: connecting to httpbin.org…");
+    // The full URL with path/query must NOT appear in the rendered text —
+    // privacy regression on the channel-visible side. Also assert that
+    // extractMode and maxChars (which `inferToolMetaFromArgs` packs into
+    // the stored meta string) do not reach the rendered draft either.
+    expect(rendered?.text ?? "").not.toContain("/secret-path");
+    expect(rendered?.text ?? "").not.toContain("ABC123XYZ");
+    expect(rendered?.text ?? "").not.toContain("token=");
+    expect(rendered?.text ?? "").not.toContain("https://httpbin.org/");
+    expect(rendered?.text ?? "").not.toContain("extractMode");
+    expect(rendered?.text ?? "").not.toContain("maxChars");
+    expect(rendered?.text ?? "").not.toMatch(/mode text/);
+    expect(rendered?.text ?? "").not.toMatch(/1000/);
   });
 
   it("populates progressText on the kind:'tool' item for non-exec partialResult", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1852,3 +1852,440 @@ describe("control UI credential redaction (issue #72283)", () => {
     expect(emittedResult).toContain("OPENROUTER_API_KEY=");
   });
 });
+
+describe("handleToolExecutionUpdate non-exec progress", () => {
+  afterEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  it("populates progressText on the kind:'tool' item for non-exec partialResult", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "tool-non-exec-progress",
+        args: { url: "https://example.com/page" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "tool-non-exec-progress",
+        partialResult: {
+          content: [{ type: "text", text: "web_fetch: connecting to example.com…" }],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+
+    const itemUpdates = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (arg: unknown) =>
+          (arg as { stream?: string })?.stream === "item" &&
+          (arg as { data?: { kind?: string; phase?: string } })?.data?.kind === "tool" &&
+          (arg as { data?: { phase?: string } })?.data?.phase === "update",
+      );
+    expect(itemUpdates.length).toBeGreaterThanOrEqual(1);
+    const lastItem = itemUpdates.at(-1) as { data?: Record<string, unknown> };
+    expect(lastItem?.data?.progressText).toBe("web_fetch: connecting to example.com…");
+  });
+
+  it("does not add progressText for exec tools on the kind:'tool' item (regression)", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-no-tool-progressText",
+        args: { command: "ls" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "exec",
+        toolCallId: "tool-exec-no-tool-progressText",
+        partialResult: {
+          details: { status: "running", aggregated: "file1\nfile2" },
+        },
+      } as never,
+    );
+
+    const toolItemUpdates = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (arg: unknown) =>
+          (arg as { stream?: string })?.stream === "item" &&
+          (arg as { data?: { kind?: string } })?.data?.kind === "tool" &&
+          (arg as { data?: { phase?: string } })?.data?.phase === "update",
+      );
+    expect(toolItemUpdates.length).toBeGreaterThanOrEqual(1);
+    for (const evt of toolItemUpdates) {
+      const data = (evt as { data?: Record<string, unknown> }).data ?? {};
+      expect(data).not.toHaveProperty("progressText");
+    }
+    // Exec still flows progressText through the kind:'command' item (the
+    // existing exec path is untouched).
+    const commandItemUpdates = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (arg: unknown) =>
+          (arg as { stream?: string })?.stream === "item" &&
+          (arg as { data?: { kind?: string } })?.data?.kind === "command" &&
+          (arg as { data?: { phase?: string } })?.data?.phase === "update",
+      );
+    expect(commandItemUpdates.length).toBeGreaterThanOrEqual(1);
+    const lastCommand = commandItemUpdates.at(-1) as { data?: Record<string, unknown> };
+    expect(lastCommand?.data?.progressText).toContain("file1");
+  });
+
+  it("emits upstream stream:'tool' partialResult unthrottled for non-exec while throttling channel-visible item updates with a burst budget", async () => {
+    resetAgentEventsForTest();
+    const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "tool-non-exec-throttle",
+        args: { url: "https://example.com/" },
+      } as never,
+    );
+
+    const startEventCount = events.length;
+    const startCallbackCount = onAgentEvent.mock.calls.length;
+
+    // 5 partials back-to-back within the same time window. The upstream
+    // tool stream must deliver all five (ACP/TUI/gateway consumers depend
+    // on it). The channel-visible item path gets a burst budget of 4 then
+    // throttles the 5th.
+    for (let i = 0; i < 5; i += 1) {
+      handleToolExecutionUpdate(
+        ctx as never,
+        {
+          type: "tool_execution_update",
+          toolName: "web_fetch",
+          toolCallId: "tool-non-exec-throttle",
+          partialResult: {
+            content: [{ type: "text", text: `web_fetch: milestone-${i}` }],
+            details: { status: "running" },
+          },
+        } as never,
+      );
+    }
+
+    const upstreamUpdateEvents = events
+      .slice(startEventCount)
+      .filter(
+        (evt) => evt.stream === "tool" && (evt.data as { phase?: string })?.phase === "update",
+      );
+    expect(upstreamUpdateEvents).toHaveLength(5);
+
+    const itemUpdateCallbacks = onAgentEvent.mock.calls
+      .slice(startCallbackCount)
+      .map((call) => call[0])
+      .filter(
+        (arg: unknown) =>
+          (arg as { stream?: string })?.stream === "item" &&
+          (arg as { data?: { kind?: string } })?.data?.kind === "tool" &&
+          (arg as { data?: { phase?: string } })?.data?.phase === "update",
+      );
+    expect(itemUpdateCallbacks).toHaveLength(4);
+    for (const evt of itemUpdateCallbacks) {
+      const data = (evt as { data?: { progressText?: string } }).data ?? {};
+      expect(typeof data.progressText).toBe("string");
+      expect((data.progressText as string).startsWith("web_fetch: milestone-")).toBe(true);
+    }
+
+    resetAgentEventsForTest();
+  });
+
+  it("allows web_fetch's two-emit sequence (connect → headers) within a single throttle window (regression for Codex pass 2 P2)", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "tool-web-fetch-two-emit",
+        args: { url: "https://example.com/" },
+      } as never,
+    );
+
+    const startCallbackCount = onAgentEvent.mock.calls.length;
+
+    // Both web_fetch emit boundaries fire well within 250 ms when TTFB is fast.
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "tool-web-fetch-two-emit",
+        partialResult: {
+          content: [{ type: "text", text: "web_fetch: connecting to example.com…" }],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "tool-web-fetch-two-emit",
+        partialResult: {
+          content: [{ type: "text", text: "web_fetch: HTTP 200 text/html, reading body…" }],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+
+    const itemUpdateProgressTexts = onAgentEvent.mock.calls
+      .slice(startCallbackCount)
+      .map((call) => call[0])
+      .filter(
+        (arg: unknown) =>
+          (arg as { stream?: string })?.stream === "item" &&
+          (arg as { data?: { kind?: string } })?.data?.kind === "tool" &&
+          (arg as { data?: { phase?: string } })?.data?.phase === "update",
+      )
+      .map((evt) => (evt as { data?: { progressText?: string } }).data?.progressText);
+
+    expect(itemUpdateProgressTexts).toEqual([
+      "web_fetch: connecting to example.com…",
+      "web_fetch: HTTP 200 text/html, reading body…",
+    ]);
+  });
+
+  it("non-allowlisted non-exec tools emit upstream partialResult but never produce a channel-visible item update with progressText (privacy)", async () => {
+    resetAgentEventsForTest();
+    const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "third_party_plugin_tool",
+        toolCallId: "tool-non-allowlisted",
+        args: {},
+      } as never,
+    );
+
+    const startEventCount = events.length;
+    const startCallbackCount = onAgentEvent.mock.calls.length;
+
+    // Simulate a non-allowlisted tool emitting an `onUpdate` payload that
+    // contains content which would be unsafe to render (URL + secret).
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "third_party_plugin_tool",
+        toolCallId: "tool-non-allowlisted",
+        partialResult: {
+          content: [
+            {
+              type: "text",
+              text: "fetched https://internal-api.example.com/secrets?token=ABC123 OK 200",
+            },
+          ],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+
+    // Upstream stream:"tool" partialResult must still fire (ACP/TUI/gateway
+    // consumers depend on it for plugin tool partial results).
+    const upstreamUpdates = events
+      .slice(startEventCount)
+      .filter(
+        (evt) => evt.stream === "tool" && (evt.data as { phase?: string })?.phase === "update",
+      );
+    expect(upstreamUpdates).toHaveLength(1);
+
+    // Channel-visible item event must NOT fire because (a) no progressText
+    // would be added (tool not in allow-list) and (b) we skip the bare item
+    // to avoid A/B/A draft churn.
+    const itemUpdateCallbacks = onAgentEvent.mock.calls
+      .slice(startCallbackCount)
+      .map((call) => call[0])
+      .filter(
+        (arg: unknown) =>
+          (arg as { stream?: string })?.stream === "item" &&
+          (arg as { data?: { kind?: string } })?.data?.kind === "tool" &&
+          (arg as { data?: { phase?: string } })?.data?.phase === "update",
+      );
+    expect(itemUpdateCallbacks).toHaveLength(0);
+
+    resetAgentEventsForTest();
+  });
+
+  it("caps non-exec progressText length at LIVE_EXEC_OUTPUT_MAX_CHARS", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+    const huge = "y".repeat(9000);
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "tool-non-exec-cap",
+        args: { url: "https://example.com/" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "tool-non-exec-cap",
+        partialResult: {
+          content: [{ type: "text", text: huge }],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+
+    const itemUpdates = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (arg: unknown) =>
+          (arg as { stream?: string })?.stream === "item" &&
+          (arg as { data?: { kind?: string } })?.data?.kind === "tool",
+      );
+    const lastItem = itemUpdates.at(-1) as { data?: { progressText?: string } } | undefined;
+    expect(typeof lastItem?.data?.progressText).toBe("string");
+    expect((lastItem?.data?.progressText as string).length).toBeLessThan(huge.length);
+    expect(lastItem?.data?.progressText as string).toContain("(live output truncated)");
+  });
+
+  it("clears non-exec throttle state on tool execution end", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "tool-non-exec-cleanup",
+        args: { url: "https://example.com/" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "tool-non-exec-cleanup",
+        partialResult: {
+          content: [{ type: "text", text: "first update" }],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.nonExecLiveUpdateStateById?.has("tool-non-exec-cleanup")).toBe(true);
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "web_fetch",
+        toolCallId: "tool-non-exec-cleanup",
+        isError: false,
+        result: {
+          content: [{ type: "text", text: '{"ok":true}' }],
+          details: { status: "completed" },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.nonExecLiveUpdateStateById?.has("tool-non-exec-cleanup")).toBe(false);
+  });
+
+  it("does not throttle one tool call against another (per-callId state)", async () => {
+    resetAgentEventsForTest();
+    const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "call-A",
+        args: { url: "https://example.com/" },
+      } as never,
+    );
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "call-B",
+        args: { url: "https://example.org/" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "call-A",
+        partialResult: {
+          content: [{ type: "text", text: "A: connecting" }],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "call-B",
+        partialResult: {
+          content: [{ type: "text", text: "B: connecting" }],
+          details: { status: "running" },
+        },
+      } as never,
+    );
+
+    const updateEvents = events.filter(
+      (evt) => evt.stream === "tool" && (evt.data as { phase?: string })?.phase === "update",
+    );
+    // Both calls should emit because the throttle is keyed by toolCallId.
+    expect(updateEvents).toHaveLength(2);
+
+    resetAgentEventsForTest();
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1883,14 +1883,21 @@ describe("handleToolExecutionUpdate non-exec progress", () => {
       } as never,
     );
 
-    // Sanity: the stored meta should contain the URL + extractMode + maxChars
-    // (derived from args via inferToolMetaFromArgs with detailKeys:
-    // ["url", "extractMode", "maxChars"]). If this ever changes the test
-    // setup needs review.
+    // Sanity: the stored meta is derived from args via `resolveWebFetchDetail`,
+    // which now redacts the URL down to the host only (and keeps the safe
+    // `mode`/`max …` suffix). The pre-redaction state stored the full URL
+    // including path and query — that's the leak surface ClawSweeper P2
+    // flagged in the start-line render. The current host-only contract is
+    // the binding precondition for the rest of this test: the channel
+    // renderer (via the same shared formatter) cannot leak path/query when
+    // the stored meta itself doesn't carry them.
     const storedMeta = ctx.state.toolMetaById.get("tool-clawsweeper-p2")?.meta;
     expect(storedMeta).toBeDefined();
     expect(storedMeta).toContain("httpbin.org");
-    expect(storedMeta).toContain("secret-path");
+    expect(storedMeta).not.toContain("secret-path");
+    expect(storedMeta).not.toContain("ABC123XYZ");
+    expect(storedMeta).not.toContain("token=");
+    expect(storedMeta).not.toMatch(/[?&]/);
     expect(storedMeta).toContain("text");
     expect(storedMeta).toMatch(/1000/);
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1145,6 +1145,20 @@ export function handleToolExecutionUpdate(
   // Exec retains its existing 250 ms throttle on this path because exec lives
   // alone alongside the heavier `kind:"command"` rendering downstream.
   const emitDetailedLiveUpdate = !isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId);
+  // Tools listed in `NON_EXEC_PROGRESS_SAFE_TOOLS` emit a sibling
+  // `stream:"item"` event below carrying the canonical safe `progressText`
+  // for channel renderers. The channel-progress bridge in
+  // `agent-runner-execution.ts` should NOT also render a bare tool-name row
+  // from this `stream:"tool"` `phase:"update"` event (`args` is omitted on
+  // update events, so the channel renderer would produce a duplicate
+  // `🌐 Tool Name` row next to the safe item progress). We mark this event
+  // with `suppressChannelProgress: true` so the bridge skips its
+  // `onToolStart` call for this tick only. Other upstream consumers (ACP
+  // `tool_call_update`, TUI verbose output, gateway subscribers) keep
+  // receiving the raw event with the full `partialResult`. Non-allowlisted
+  // non-exec tools (and exec) do not set the marker and continue to bridge
+  // their `phase:"update"` events as before.
+  const suppressBareChannelToolRow = !isExecTool && isNonExecProgressSafeTool(toolName);
   if (emitDetailedLiveUpdate) {
     emitAgentEvent({
       runId: ctx.params.runId,
@@ -1154,6 +1168,7 @@ export function handleToolExecutionUpdate(
         name: toolName,
         toolCallId,
         partialResult: liveResult,
+        ...(suppressBareChannelToolRow ? { suppressChannelProgress: true } : {}),
       },
     });
   }
@@ -1216,12 +1231,18 @@ export function handleToolExecutionUpdate(
     };
     emitTrackedItemEvent(ctx, itemData);
   }
+  // Per-run callback path that the channel-progress bridge in
+  // `agent-runner-execution.ts` actually consumes. The marker MUST be set
+  // here too (not just on the global `emitAgentEvent` above) so the
+  // bridge sees `suppressChannelProgress: true` and skips its
+  // `onToolStart` call for allowlisted safe-progress tools.
   void ctx.params.onAgentEvent?.({
     stream: "tool",
     data: {
       phase: "update",
       name: toolName,
       toolCallId,
+      ...(suppressBareChannelToolRow ? { suppressChannelProgress: true } : {}),
     },
   });
   if (isExecTool) {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1188,14 +1188,29 @@ export function handleToolExecutionUpdate(
   // item is just the tool-name label and does not alternate).
   const shouldEmitToolItemUpdate = isExecTool || Boolean(nonExecProgressText);
   if (shouldEmitToolItemUpdate) {
+    // The shared channel renderer at `src/plugin-sdk/channel-streaming.ts`
+    // resolves the item's display text via `input.meta ?? input.summary
+    // ?? input.progressText`. The stored `toolMetaById.meta` for a
+    // non-exec tool like `web_fetch` is derived from `inferToolMetaFromArgs`
+    // and contains the full URL + extractMode + maxChars summary — both
+    // truthy AND privacy-sensitive. Setting it on the same item that
+    // carries our audited safe `progressText` would (a) hide the safe
+    // progress line behind the unsafe meta and (b) leak the URL into the
+    // channel draft. Omit `meta` on the non-exec progress emission so the
+    // renderer falls through to `progressText`. Exec retains its existing
+    // `meta` field because its sibling `kind:"command"` item plus the
+    // `command_output` stream carry stdout through a different render
+    // path; the `kind:"tool"` item label is unchanged for exec.
+    const includeStoredMeta = isExecTool;
+    const storedMeta = ctx.state.toolMetaById.get(toolCallId)?.meta;
     const itemData: AgentItemEventData = {
       itemId: buildToolItemId(toolCallId),
       phase: "update",
       kind: "tool",
-      title: buildToolItemTitle(toolName, ctx.state.toolMetaById.get(toolCallId)?.meta),
+      title: buildToolItemTitle(toolName, storedMeta),
       status: "running",
       name: toolName,
-      meta: ctx.state.toolMetaById.get(toolCallId)?.meta,
+      ...(includeStoredMeta ? { meta: storedMeta } : {}),
       toolCallId,
       ...(nonExecProgressText ? { progressText: nonExecProgressText } : {}),
     };

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -76,6 +76,15 @@ const beforeToolCallModuleLoader = createLazyImportLoader<BeforeToolCallModule>(
 );
 const LIVE_EXEC_OUTPUT_MAX_CHARS = 8000;
 const LIVE_EXEC_UPDATE_MIN_INTERVAL_MS = 250;
+/**
+ * Number of initial `partialResult` updates per non-exec tool call that bypass
+ * the time-based throttle. Set to a small bound so short bounded progress
+ * sequences (e.g. `web_fetch`'s connect + headers-received milestones, which
+ * can both land within 250 ms when the remote TTFB is fast) reach channel
+ * progress drafts without being suppressed.
+ */
+const NON_EXEC_LIVE_UPDATE_UNTHROTTLED_BURST = 4;
+
 const TRACE_REQUIRED_PARAM_GROUPS = {
   read: [{ keys: ["path", "file_path"], label: "path" }],
   write: REQUIRED_PARAM_GROUPS.write,
@@ -356,6 +365,74 @@ function shouldEmitLiveExecUpdate(ctx: ToolHandlerContext, toolCallId: string): 
   }
   state.set(toolCallId, { lastEmittedAtMs: now });
   return true;
+}
+
+/**
+ * Per-tool-call rate-limit for non-exec progress updates. Tools listed in
+ * `NON_EXEC_PROGRESS_SAFE_TOOLS` emit short bounded progress sequences whose
+ * semantic milestones (connect → headers → …) frequently land within a
+ * single 250 ms window when the remote responds quickly. Allow the first
+ * `NON_EXEC_LIVE_UPDATE_UNTHROTTLED_BURST` updates per tool call unthrottled
+ * so those milestones reach channel progress drafts, then apply the same
+ * 250 ms floor as exec to keep behavior predictable for any future tool that
+ * is added to the allow-list with a longer emission tail.
+ */
+function shouldEmitLiveNonExecUpdate(ctx: ToolHandlerContext, toolCallId: string): boolean {
+  const now = Date.now();
+  const state =
+    ctx.state.nonExecLiveUpdateStateById ??
+    new Map<string, { lastEmittedAtMs: number; emitsSoFar: number }>();
+  ctx.state.nonExecLiveUpdateStateById = state;
+  const previous = state.get(toolCallId);
+  const emitsSoFar = previous?.emitsSoFar ?? 0;
+  if (emitsSoFar < NON_EXEC_LIVE_UPDATE_UNTHROTTLED_BURST) {
+    state.set(toolCallId, { lastEmittedAtMs: now, emitsSoFar: emitsSoFar + 1 });
+    return true;
+  }
+  if (previous && now - previous.lastEmittedAtMs < LIVE_EXEC_UPDATE_MIN_INTERVAL_MS) {
+    return false;
+  }
+  state.set(toolCallId, { lastEmittedAtMs: now, emitsSoFar: emitsSoFar + 1 });
+  return true;
+}
+
+/**
+ * Allow-list of non-exec tool names whose `partialResult` `onUpdate` payload
+ * is contractually safe to surface as visible channel progress text.
+ *
+ * Each entry here promises that the tool's `onUpdate` payload first-text-block
+ * contains only host-class / status-class data and never carries:
+ *   - full URL with path/query/fragment
+ *   - request body / response body content
+ *   - response headers (cookies, auth tokens, set-cookie)
+ *   - tool arguments other than safe summaries
+ *
+ * Adding a new entry requires auditing that tool's `onUpdate` call sites and
+ * confirming the contract holds — see `src/agents/tools/web-fetch.ts`
+ * `emitWebFetchProgress` for the reference contract.
+ */
+const NON_EXEC_PROGRESS_SAFE_TOOLS: ReadonlySet<string> = new Set(["web_fetch"]);
+
+function isNonExecProgressSafeTool(toolName: string): boolean {
+  return NON_EXEC_PROGRESS_SAFE_TOOLS.has(toolName);
+}
+
+/**
+ * Extract a safe progress string from a non-exec `partialResult`. Reads the
+ * first text content block produced by the tool's `onUpdate` callback and
+ * caps it at the same character budget as the exec live-output path so it
+ * never flushes large bodies into a channel progress draft.
+ *
+ * The caller MUST gate by `isNonExecProgressSafeTool(toolName)` before
+ * invoking this helper. The safe-tool allow-list is the contract boundary;
+ * this helper performs no semantic filtering of its own.
+ */
+function extractLiveNonExecProgressText(result: unknown): string | undefined {
+  const text = extractToolResultText(result);
+  if (typeof text !== "string" || text.length === 0) {
+    return undefined;
+  }
+  return truncateLiveExecOutput(text);
 }
 
 function readApplyPatchSummary(result: unknown): ApplyPatchSummary | null {
@@ -1062,6 +1139,11 @@ export function handleToolExecutionUpdate(
   const sanitized = sanitizeToolResult(partial);
   const isExecTool = isExecToolName(toolName);
   const liveResult = isExecTool ? capLiveExecResult(sanitized) : sanitized;
+  // Upstream `stream:"tool"` `partialResult` is consumed by ACP `tool_call_update`,
+  // TUI verbose output, and gateway subscribers — keep it unthrottled for non-exec
+  // so existing streaming consumers do not silently drop plugin tool partials.
+  // Exec retains its existing 250 ms throttle on this path because exec lives
+  // alone alongside the heavier `kind:"command"` rendering downstream.
   const emitDetailedLiveUpdate = !isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId);
   if (emitDetailedLiveUpdate) {
     emitAgentEvent({
@@ -1075,17 +1157,50 @@ export function handleToolExecutionUpdate(
       },
     });
   }
-  const itemData: AgentItemEventData = {
-    itemId: buildToolItemId(toolCallId),
-    phase: "update",
-    kind: "tool",
-    title: buildToolItemTitle(toolName, ctx.state.toolMetaById.get(toolCallId)?.meta),
-    status: "running",
-    name: toolName,
-    meta: ctx.state.toolMetaById.get(toolCallId)?.meta,
-    toolCallId,
-  };
-  emitTrackedItemEvent(ctx, itemData);
+  // Channel-visible progress draft path: surface `progressText` on the
+  // `stream:"item"` `kind:"tool"` event so channel renderers (which already
+  // consume `progressText` for exec command items) show a visible draft line
+  // during long silent gaps such as a slow web_fetch connect.
+  //
+  // Privacy: only tools in `NON_EXEC_PROGRESS_SAFE_TOOLS` populate
+  // `progressText` from `partialResult`. Other non-exec tools may emit text
+  // partials carrying URLs, tokens, or response snippets that must not leak
+  // into a channel-visible draft.
+  //
+  // Throttle: a separate `shouldEmitLiveNonExecUpdate` budget governs ONLY
+  // this channel-render path, with a small unthrottled burst so short bounded
+  // progress sequences (web_fetch's connect + headers milestones, which can
+  // both land within 250 ms when TTFB is fast) reach the draft. The upstream
+  // tool stream above is unaffected by this decision.
+  const nonExecProgressText =
+    !isExecTool &&
+    isNonExecProgressSafeTool(toolName) &&
+    shouldEmitLiveNonExecUpdate(ctx, toolCallId)
+      ? extractLiveNonExecProgressText(sanitized)
+      : undefined;
+
+  // For non-exec tools, emit the item update only when there is fresh
+  // `progressText` to render. Letting the bare item event through without
+  // `progressText` would cause the channel progress draft to alternate
+  // between the useful progress text and the default tool-name label
+  // (A/B/A churn). Exec keeps the unconditional emit because its sibling
+  // `kind:"command"` item carries the `progressText` (the `kind:"tool"`
+  // item is just the tool-name label and does not alternate).
+  const shouldEmitToolItemUpdate = isExecTool || Boolean(nonExecProgressText);
+  if (shouldEmitToolItemUpdate) {
+    const itemData: AgentItemEventData = {
+      itemId: buildToolItemId(toolCallId),
+      phase: "update",
+      kind: "tool",
+      title: buildToolItemTitle(toolName, ctx.state.toolMetaById.get(toolCallId)?.meta),
+      status: "running",
+      name: toolName,
+      meta: ctx.state.toolMetaById.get(toolCallId)?.meta,
+      toolCallId,
+      ...(nonExecProgressText ? { progressText: nonExecProgressText } : {}),
+    };
+    emitTrackedItemEvent(ctx, itemData);
+  }
   void ctx.params.onAgentEvent?.({
     stream: "tool",
     data: {
@@ -1155,6 +1270,7 @@ export async function handleToolExecutionEnd(
   const startData = toolStartData.get(toolStartKey);
   toolStartData.delete(toolStartKey);
   ctx.state.execLiveUpdateStateById?.delete(toolCallId);
+  ctx.state.nonExecLiveUpdateStateById?.delete(toolCallId);
   const callSummary = ctx.state.toolMetaById.get(toolCallId);
   const completedMutatingAction = !isToolError && Boolean(callSummary?.mutatingAction);
   const meta = callSummary?.meta;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -47,6 +47,16 @@ export type EmbeddedPiSubscribeState = {
   toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;
   execLiveUpdateStateById?: Map<string, { lastEmittedAtMs: number }>;
+  /**
+   * Per-toolCall throttle state for non-exec tools that emit `partialResult`
+   * progress. The shape differs from `execLiveUpdateStateById` because the
+   * non-exec rate-limit allows a small unthrottled burst before applying the
+   * time-based interval — short bounded progress sequences (e.g. web_fetch's
+   * `connecting` + `headers received` milestones landing within the same
+   * 250 ms window) must both reach channel progress drafts. Cleared in
+   * `handleToolExecutionEnd`.
+   */
+  nonExecLiveUpdateStateById?: Map<string, { lastEmittedAtMs: number; emitsSoFar: number }>;
   itemActiveIds: Set<string>;
   itemStartedCount: number;
   itemCompletedCount: number;
@@ -220,6 +230,7 @@ type ToolHandlerState = Pick<
   | "acceptedSessionSpawns"
   | "toolSummaryById"
   | "execLiveUpdateStateById"
+  | "nonExecLiveUpdateStateById"
   | "itemActiveIds"
   | "itemStartedCount"
   | "itemCompletedCount"

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -616,6 +616,20 @@ function resolveWebFetchDetail(args: unknown): string | undefined {
     return undefined;
   }
 
+  // Privacy: show only the request host, never the URL path, query string,
+  // fragment, or any credentials embedded in the URL. The full URL is
+  // still available to the model via the tool's args and to runtime logs;
+  // this redaction applies only to the channel-visible tool-start /
+  // tool-progress detail that flows through `formatToolDetailText`. Without
+  // this, slow web_fetch calls show a progress line like
+  // `from https://example.com/secret-path?token=…` for the entire wait.
+  let displayHost: string;
+  try {
+    displayHost = new URL(url).host || "url";
+  } catch {
+    displayHost = "url";
+  }
+
   const mode = normalizeOptionalString(record.extractMode);
   const maxChars =
     typeof record.maxChars === "number" && Number.isFinite(record.maxChars) && record.maxChars > 0
@@ -630,7 +644,7 @@ function resolveWebFetchDetail(args: unknown): string | undefined {
     suffix = suffix ? `${suffix}, max ${maxChars} chars` : `max ${maxChars} chars`;
   }
 
-  return suffix ? `from ${url} (${suffix})` : `from ${url}`;
+  return suffix ? `from ${displayHost} (${suffix})` : `from ${displayHost}`;
 }
 
 function resolveActionSpec(

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -428,4 +428,70 @@ describe("tool display details", () => {
     expect(nodeCheckDetail).toContain("check js syntax for /tmp/test.js");
     expect(nodeShortCheckDetail).toContain("check js syntax for /tmp/test.js");
   });
+
+  describe("web_fetch detail redacts URL path / query / credentials (channel-visible privacy)", () => {
+    it("renders the request host only, not the URL path, query string, or token", () => {
+      const detail = formatToolDetail(
+        resolveToolDisplay({
+          name: "web_fetch",
+          args: {
+            url: "https://api.example.com/secret-path/users?token=ABC123XYZ&q=SENSITIVE_QUERY",
+            extractMode: "text",
+            maxChars: 1000,
+          },
+        }),
+      );
+
+      expect(detail).toBe("from api.example.com (mode text, max 1000 chars)");
+      expect(detail).not.toContain("/secret-path");
+      expect(detail).not.toContain("ABC123XYZ");
+      expect(detail).not.toContain("SENSITIVE_QUERY");
+      expect(detail).not.toContain("token=");
+      expect(detail).not.toMatch(/[?&]/);
+    });
+
+    it("redacts URL fragment as well", () => {
+      const detail = formatToolDetail(
+        resolveToolDisplay({
+          name: "web_fetch",
+          args: {
+            url: "https://docs.example.com/page#section-private",
+          },
+        }),
+      );
+
+      expect(detail).toBe("from docs.example.com");
+      expect(detail).not.toContain("#section-private");
+      expect(detail).not.toContain("/page");
+    });
+
+    it("redacts URL userinfo (credentials embedded in URL)", () => {
+      const detail = formatToolDetail(
+        resolveToolDisplay({
+          name: "web_fetch",
+          args: {
+            url: "https://user:p%40ssw0rd@private.example.com/api",
+          },
+        }),
+      );
+
+      expect(detail).toBeDefined();
+      expect(detail).not.toContain("user:");
+      expect(detail).not.toContain("p@ssw0rd");
+      expect(detail).not.toContain("p%40ssw0rd");
+      expect(detail).not.toContain("/api");
+    });
+
+    it("falls back to a safe `url` placeholder when the URL is unparseable", () => {
+      const detail = formatToolDetail(
+        resolveToolDisplay({
+          name: "web_fetch",
+          args: { url: "not-a-valid-url" },
+        }),
+      );
+
+      expect(detail).toBe("from url");
+      expect(detail).not.toContain("not-a-valid-url");
+    });
+  });
 });

--- a/src/agents/tools/web-fetch.progress.test.ts
+++ b/src/agents/tools/web-fetch.progress.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LookupFn } from "../../infra/net/ssrf.js";
+import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import "./web-fetch.test-mocks.js";
+import { createWebFetchTool } from "./web-fetch.js";
+import { createBaseWebFetchToolConfig, makeFetchHeaders } from "./web-fetch.test-harness.js";
+
+const lookupMock = vi.fn();
+const baseToolConfig = createBaseWebFetchToolConfig({
+  lookupFn: lookupMock as unknown as LookupFn,
+});
+
+function makeMarkdownResponse(body: string, extraHeaders: Record<string, string> = {}): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: makeFetchHeaders({
+      "content-type": "text/markdown; charset=utf-8",
+      ...extraHeaders,
+    }),
+    text: async () => body,
+  } as Response;
+}
+
+type ProgressUpdate = { content?: Array<{ type?: string; text?: string }> };
+
+function readProgressTexts(onUpdate: ReturnType<typeof vi.fn>): string[] {
+  return onUpdate.mock.calls.map((call) => {
+    const arg = call[0] as { content?: Array<{ type?: string; text?: string }> };
+    const block = arg?.content?.find((b) => b?.type === "text");
+    return block?.text ?? "";
+  });
+}
+
+describe("web_fetch progress emit", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    lookupMock.mockImplementation(async (hostname: string) => {
+      void hostname;
+      return [{ address: "93.184.216.34", family: 4 }];
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    lookupMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("emits a 'connecting' progress update with host-only label before fetch", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(makeMarkdownResponse("# Test\n\nbody"));
+    global.fetch = withFetchPreconnect(fetchSpy);
+    const onUpdate = vi.fn();
+
+    const tool = createWebFetchTool(baseToolConfig);
+    await tool?.execute?.(
+      "call",
+      { url: "https://example.com/path/page?secret=abc123" },
+      undefined,
+      onUpdate,
+    );
+
+    const texts = readProgressTexts(onUpdate);
+    expect(texts.length).toBeGreaterThanOrEqual(1);
+    expect(texts[0]).toBe("web_fetch: connecting to example.com…");
+  });
+
+  it("emits 'headers received' progress with status + content-type after fetch resolves", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(makeMarkdownResponse("# Test\n\nbody"));
+    global.fetch = withFetchPreconnect(fetchSpy);
+    const onUpdate = vi.fn();
+
+    const tool = createWebFetchTool(baseToolConfig);
+    await tool?.execute?.("call", { url: "https://example.com/" }, undefined, onUpdate);
+
+    const texts = readProgressTexts(onUpdate);
+    expect(texts).toContain("web_fetch: HTTP 200 text/markdown, reading body…");
+  });
+
+  it("never leaks URL query string, path, or sensitive args in progress text", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      makeMarkdownResponse("Bearer SECRET_TOKEN should not appear", {
+        "set-cookie": "session=SUPER_SECRET_SESSION_VALUE",
+        authorization: "Bearer SECRET_TOKEN",
+      }),
+    );
+    global.fetch = withFetchPreconnect(fetchSpy);
+    const onUpdate = vi.fn();
+
+    const tool = createWebFetchTool(baseToolConfig);
+    await tool?.execute?.(
+      "call",
+      {
+        url: "https://example.com/secret-path/page?q=SENSITIVE_QUERY&token=ABC123XYZ",
+      },
+      undefined,
+      onUpdate,
+    );
+
+    const texts = readProgressTexts(onUpdate);
+    expect(texts.length).toBeGreaterThan(0);
+    for (const text of texts) {
+      expect(text).not.toContain("/secret-path");
+      expect(text).not.toContain("SENSITIVE_QUERY");
+      expect(text).not.toContain("ABC123XYZ");
+      expect(text).not.toContain("SECRET_TOKEN");
+      expect(text).not.toContain("SUPER_SECRET_SESSION_VALUE");
+      expect(text).not.toContain("session=");
+      expect(text).not.toContain("Bearer");
+      // Body text should never appear in progress.
+      expect(text).not.toContain("should not appear");
+    }
+  });
+
+  it("does not call onUpdate when no callback is supplied", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(makeMarkdownResponse("# Test\n\nbody"));
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const tool = createWebFetchTool(baseToolConfig);
+    // Call without the onUpdate arg — must not throw.
+    await expect(tool?.execute?.("call", { url: "https://example.com/" })).resolves.not.toThrow();
+  });
+
+  it("emits at most a small constant number of progress updates per fetch (no spam)", async () => {
+    // Even with a large body that goes through readResponseText byte-by-byte,
+    // progress is emitted only at the fetch and headers-received boundaries —
+    // so the count must remain bounded regardless of response size.
+    const largeBody = "x".repeat(50_000);
+    const fetchSpy = vi.fn().mockResolvedValue(makeMarkdownResponse(largeBody));
+    global.fetch = withFetchPreconnect(fetchSpy);
+    const onUpdate = vi.fn();
+
+    const tool = createWebFetchTool(baseToolConfig);
+    await tool?.execute?.("call", { url: "https://example.com/large" }, undefined, onUpdate);
+
+    // Two boundaries (connecting + headers received). Allow ≤4 for forward
+    // compat with a future body-milestone emit but reject unbounded spam.
+    expect(onUpdate.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(onUpdate.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  it("invokes onUpdate before the await on fetch (visibility during slow TTFB)", async () => {
+    // Capture call order: the "connecting" progress must fire before global.fetch
+    // is invoked, so that a slow TTFB does not delay the first visible update.
+    const order: string[] = [];
+    const onUpdate = vi.fn((payload: ProgressUpdate) => {
+      const blocks = payload?.content ?? [];
+      const block = blocks.find((b) => b?.type === "text");
+      const text = block?.text ?? "";
+      order.push(`update:${text}`);
+    });
+
+    const fetchSpy = vi.fn().mockImplementation(async (...args: unknown[]) => {
+      void args;
+      order.push("fetch-called");
+      return makeMarkdownResponse("# Test\n\nbody");
+    });
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const tool = createWebFetchTool(baseToolConfig);
+    await tool?.execute?.("call", { url: "https://example.com/" }, undefined, onUpdate);
+
+    const firstConnect = order.findIndex((entry) =>
+      entry.startsWith("update:web_fetch: connecting"),
+    );
+    const fetchIdx = order.indexOf("fetch-called");
+    expect(firstConnect).toBeGreaterThanOrEqual(0);
+    expect(fetchIdx).toBeGreaterThanOrEqual(0);
+    expect(firstConnect).toBeLessThan(fetchIdx);
+  });
+
+  it("a misbehaving onUpdate callback does not break the fetch result", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(makeMarkdownResponse("# Test\n\nbody"));
+    global.fetch = withFetchPreconnect(fetchSpy);
+    const onUpdate = vi.fn(() => {
+      throw new Error("progress consumer exploded");
+    });
+
+    const tool = createWebFetchTool(baseToolConfig);
+    const result = await tool?.execute?.(
+      "call",
+      { url: "https://example.com/" },
+      undefined,
+      onUpdate,
+    );
+
+    expect(result).toBeDefined();
+    // Both progress emits were attempted even though each threw.
+    expect(onUpdate.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("falls back to a safe label when the URL is malformed", async () => {
+    // runWebFetch normally rejects malformed URLs before progress fires, but
+    // safeHostForProgress is the inner contract: assert directly via a
+    // borderline URL where new URL() succeeds but host is empty (`file:///`
+    // is rejected before parsing; use a URL with an empty hostname surrogate
+    // by going through the public path with an http URL whose hostname is
+    // present — for the malformed branch we rely on the protocol guard
+    // upstream rejecting first, so the helper's fallback is exercised only
+    // when used directly).
+    //
+    // Smoke-test the public path: a valid URL still produces a host label.
+    const fetchSpy = vi.fn().mockResolvedValue(makeMarkdownResponse("ok"));
+    global.fetch = withFetchPreconnect(fetchSpy);
+    const onUpdate = vi.fn();
+
+    const tool = createWebFetchTool(baseToolConfig);
+    await tool?.execute?.("call", { url: "https://localhost.test/" }, undefined, onUpdate);
+
+    const texts = readProgressTexts(onUpdate);
+    expect(texts.some((t) => t.includes("connecting to "))).toBe(true);
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,3 +1,4 @@
+import type { AgentToolResult, AgentToolUpdateCallback } from "@earendil-works/pi-agent-core";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { SsrFBlockedError, type LookupFn, type SsrFPolicy } from "../../infra/net/ssrf.js";
@@ -267,6 +268,44 @@ function normalizeContentType(value: string | null | undefined): string | undefi
   return trimmed || undefined;
 }
 
+/**
+ * Safe host-only label for progress text. Strips path/query/auth/fragment so
+ * progress updates never carry tokens, search terms, or other URL-borne
+ * sensitive data into channel-visible draft lines.
+ */
+function safeHostForProgress(rawUrl: string): string {
+  try {
+    const host = new URL(rawUrl).host;
+    return host || "url";
+  } catch {
+    return "url";
+  }
+}
+
+/** Build a minimal AgentToolResult shape for the `onUpdate` progress callback. */
+function buildWebFetchProgressUpdate(text: string): AgentToolResult<unknown> {
+  return {
+    content: [{ type: "text", text }],
+    details: { status: "running" },
+  };
+}
+
+function emitWebFetchProgress(
+  onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+  text: string,
+): void {
+  if (!onUpdate) {
+    return;
+  }
+  try {
+    onUpdate(buildWebFetchProgressUpdate(text));
+  } catch (error) {
+    // Progress callback is best-effort. A misbehaving consumer must not break
+    // the fetch itself; log and continue.
+    logDebug(`[web-fetch] progress callback failed: ${String(error)}`);
+  }
+}
+
 type WebFetchRuntimeParams = {
   url: string;
   extractMode: ExtractMode;
@@ -286,6 +325,16 @@ type WebFetchRuntimeParams = {
   providerCacheKey?: string;
   lookupFn?: LookupFn;
   resolveProviderFallback: () => Promise<WebFetchProviderFallback>;
+  /**
+   * Optional progress callback. When supplied, runWebFetch emits short status
+   * updates at "connecting" and "headers received" boundaries so channel
+   * progress drafts surface activity during slow TTFB on web_fetch turns.
+   *
+   * Payloads carry only the request host and HTTP status / short content-type;
+   * URL paths, query strings, request bodies, and response headers are never
+   * included.
+   */
+  onUpdate?: AgentToolUpdateCallback<unknown>;
 };
 
 function normalizeProviderFinalUrl(value: unknown): string | undefined {
@@ -425,6 +474,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     throw new Error("Invalid URL: must be http or https");
   }
 
+  const progressHost = safeHostForProgress(params.url);
+  emitWebFetchProgress(params.onUpdate, `web_fetch: connecting to ${progressHost}…`);
+
   const start = Date.now();
   let res: Response;
   let release: (() => Promise<void>) | null = null;
@@ -449,6 +501,12 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     res = result.response;
     finalUrl = result.finalUrl;
     release = result.release;
+
+    const headerContentType = normalizeContentType(res.headers.get("content-type"));
+    const headerStatusLabel = headerContentType
+      ? `HTTP ${res.status} ${headerContentType}`
+      : `HTTP ${res.status}`;
+    emitWebFetchProgress(params.onUpdate, `web_fetch: ${headerStatusLabel}, reading body…`);
 
     // Cloudflare Markdown for Agents — log token budget hint when present
     const markdownTokens = res.headers.get("x-markdown-tokens");
@@ -630,7 +688,7 @@ export function createWebFetchTool(options?: {
     description:
       "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
     parameters: WebFetchSchema,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, _signal, onUpdate) => {
       const { config, preferRuntimeProviders, runtimeWebFetch } = resolveWebFetchToolRuntimeContext(
         {
           config: options?.config,
@@ -702,6 +760,7 @@ export function createWebFetchTool(options?: {
         ...(providerCacheKey ? { providerCacheKey } : {}),
         lookupFn: options?.lookupFn,
         resolveProviderFallback,
+        ...(onUpdate ? { onUpdate } : {}),
       });
       return jsonResult(result);
     },

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -6195,3 +6195,270 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 });
+
+describe("web_fetch full channel callback sequence (ClawSweeper P2 regression)", () => {
+  // Drives the SAME onToolStart + onItemEvent bridges the channel adapters
+  // consume, and pushes every payload through the production shared
+  // renderer `buildChannelProgressDraftLine`. The assertions lock in:
+  //   1. `phase:"update"` tool events with `suppressChannelProgress: true`
+  //      are skipped by the `onToolStart` bridge, so no bare
+  //      "🌐 Web Fetch" row duplicates with the safe progressText line.
+  //      (Non-allowlisted non-exec tools or exec/bash do not set the
+  //      marker and continue to be bridged as before — that path is
+  //      covered by the earlier general regressions.)
+  //   2. The start-line rendered text contains only the request host —
+  //      never the URL path / query / fragment / userinfo, because
+  //      `resolveWebFetchDetail` is now host-only.
+  //   3. The two safe progressText lines render via `onItemEvent`
+  //      through the same shared renderer and never leak URL bits either.
+  it("renders host-only start line, safe progressText updates, and zero bare 'Web Fetch' duplicates across the full sequence", async () => {
+    const { buildChannelProgressDraftLine } = await import("../../plugin-sdk/channel-streaming.js");
+
+    const onToolStart = vi.fn();
+    const onItemEvent = vi.fn();
+
+    const sensitiveUrl =
+      "https://api.example.com/secret-path/users?token=ABC123XYZ&q=SENSITIVE_QUERY";
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      // 1) Tool start — upstream emits BOTH a stream:"tool" phase:"start"
+      //    (which agent-runner-execution.ts bridges to onToolStart) AND a
+      //    stream:"item" kind:"tool" phase:"start" (which bridges to
+      //    onItemEvent).
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          toolCallId: "fetch-1",
+          name: "web_fetch",
+          phase: "start",
+          args: { url: sensitiveUrl, extractMode: "text", maxChars: 1000 },
+        },
+      });
+      await params.onAgentEvent?.({
+        stream: "item",
+        data: {
+          itemId: "tool:fetch-1",
+          toolCallId: "fetch-1",
+          kind: "tool",
+          name: "web_fetch",
+          title: "web_fetch",
+          phase: "start",
+          status: "running",
+        },
+      });
+
+      // 2) Two safe progress milestones (this is what the patch adds).
+      await params.onAgentEvent?.({
+        stream: "item",
+        data: {
+          itemId: "tool:fetch-1",
+          toolCallId: "fetch-1",
+          kind: "tool",
+          name: "web_fetch",
+          title: "web_fetch",
+          phase: "update",
+          status: "running",
+          progressText: "web_fetch: connecting to api.example.com…",
+        },
+      });
+      await params.onAgentEvent?.({
+        stream: "item",
+        data: {
+          itemId: "tool:fetch-1",
+          toolCallId: "fetch-1",
+          kind: "tool",
+          name: "web_fetch",
+          title: "web_fetch",
+          phase: "update",
+          status: "running",
+          progressText: "web_fetch: HTTP 200 application/json, reading body…",
+        },
+      });
+
+      // 3) Upstream stream:"tool" phase:"update" events (ACP/TUI/gateway
+      //    consumers see these) — args is undefined on update. For
+      //    allowlisted tools (web_fetch here) handlers.tools.ts sets
+      //    `suppressChannelProgress: true` so the bridge skips onToolStart
+      //    for them and avoids the bare-row duplicate next to the safe
+      //    progressText line.
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          toolCallId: "fetch-1",
+          name: "web_fetch",
+          phase: "update",
+          suppressChannelProgress: true,
+        },
+      });
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          toolCallId: "fetch-1",
+          name: "web_fetch",
+          phase: "update",
+          suppressChannelProgress: true,
+        },
+      });
+
+      // 3b) Non-allowlisted non-exec tool emitting `phase:"update"` WITHOUT
+      //     the marker. The bridge must still fire onToolStart for it
+      //     (otherwise this PR would regress channel progress for arbitrary
+      //     plugin tools that emit partialResult).
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          toolCallId: "plugin-1",
+          name: "third_party_plugin_tool",
+          phase: "update",
+        },
+      });
+
+      // 4) Tool end.
+      await params.onAgentEvent?.({
+        stream: "item",
+        data: {
+          itemId: "tool:fetch-1",
+          toolCallId: "fetch-1",
+          kind: "tool",
+          name: "web_fetch",
+          title: "web_fetch",
+          phase: "end",
+          status: "completed",
+        },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({
+        opts: { onToolStart, onItemEvent } satisfies GetReplyOptions,
+      }),
+    });
+
+    expect(result.kind).toBe("success");
+
+    // Assertion 1a: onToolStart fires for the web_fetch phase:"start"
+    //               (with full args, which the host-only resolver redacts).
+    // Assertion 1b: onToolStart does NOT fire for the two web_fetch
+    //               phase:"update" events that carried `suppressChannelProgress`.
+    // Assertion 1c: onToolStart STILL fires for the non-allowlisted plugin
+    //               tool's phase:"update" (no marker) so we don't regress
+    //               channel progress for arbitrary plugin tools.
+    const webFetchStartCalls = onToolStart.mock.calls.filter((call) => {
+      const payload = call[0] as { name?: string; phase?: string };
+      return payload.name === "web_fetch" && payload.phase === "start";
+    });
+    expect(webFetchStartCalls).toHaveLength(1);
+    expect(webFetchStartCalls[0]?.[0]).toEqual({
+      name: "web_fetch",
+      phase: "start",
+      args: { url: sensitiveUrl, extractMode: "text", maxChars: 1000 },
+      detailMode: undefined,
+    });
+
+    const webFetchUpdateCalls = onToolStart.mock.calls.filter((call) => {
+      const payload = call[0] as { name?: string; phase?: string };
+      return payload.name === "web_fetch" && payload.phase === "update";
+    });
+    expect(webFetchUpdateCalls).toHaveLength(0);
+
+    const pluginUpdateCalls = onToolStart.mock.calls.filter((call) => {
+      const payload = call[0] as { name?: string; phase?: string };
+      return payload.name === "third_party_plugin_tool" && payload.phase === "update";
+    });
+    expect(pluginUpdateCalls).toHaveLength(1);
+
+    // Render every onToolStart payload through the shared channel renderer
+    // and assert privacy on the rendered text — that is what the channel
+    // adapter actually displays. We separate web_fetch's rendered start
+    // line from the unrelated plugin update line; the web_fetch line MUST
+    // be host-only.
+    const webFetchRenderedLines: string[] = [];
+    for (const call of onToolStart.mock.calls) {
+      const payload = call[0] as {
+        name: string;
+        phase: string;
+        args: Record<string, unknown> | undefined;
+        detailMode?: "explain" | "raw";
+      };
+      if (payload.name !== "web_fetch") {
+        continue;
+      }
+      const line = buildChannelProgressDraftLine(
+        {
+          event: "tool",
+          name: payload.name,
+          phase: payload.phase,
+          args: payload.args,
+        },
+        payload.detailMode ? { detailMode: payload.detailMode } : undefined,
+      );
+      if (line?.text) {
+        webFetchRenderedLines.push(line.text);
+      }
+    }
+    expect(webFetchRenderedLines).toHaveLength(1);
+    expect(webFetchRenderedLines[0]).toContain("api.example.com");
+    expect(webFetchRenderedLines[0]).not.toContain("/secret-path");
+    expect(webFetchRenderedLines[0]).not.toContain("ABC123XYZ");
+    expect(webFetchRenderedLines[0]).not.toContain("SENSITIVE_QUERY");
+    expect(webFetchRenderedLines[0]).not.toContain("token=");
+    expect(webFetchRenderedLines[0]).not.toMatch(/[?&]/);
+
+    // Render every onItemEvent payload through the shared channel renderer
+    // and assert: (a) the two progressText lines render their safe text,
+    // and (b) no rendered item line contains the URL path / query.
+    const itemRenderedLines: string[] = [];
+    for (const call of onItemEvent.mock.calls) {
+      const payload = call[0] as {
+        itemId?: string;
+        kind?: string;
+        title?: string;
+        name?: string;
+        phase?: string;
+        status?: string;
+        summary?: string;
+        progressText?: string;
+        meta?: string;
+      };
+      const line = buildChannelProgressDraftLine({
+        event: "item",
+        itemId: payload.itemId,
+        itemKind: payload.kind,
+        title: payload.title,
+        name: payload.name,
+        phase: payload.phase,
+        status: payload.status,
+        summary: payload.summary,
+        progressText: payload.progressText,
+        meta: payload.meta,
+      });
+      if (line?.text) {
+        itemRenderedLines.push(line.text);
+      }
+    }
+    const progressLines = itemRenderedLines.filter((t) => t.includes("web_fetch: "));
+    expect(progressLines).toHaveLength(2);
+    expect(progressLines[0]).toContain("connecting to api.example.com");
+    expect(progressLines[1]).toContain("HTTP 200 application/json");
+    for (const line of itemRenderedLines) {
+      expect(line).not.toContain("/secret-path");
+      expect(line).not.toContain("ABC123XYZ");
+      expect(line).not.toContain("SENSITIVE_QUERY");
+      expect(line).not.toContain("token=");
+      expect(line).not.toMatch(/[?&]/);
+    }
+
+    // Assertion 2: zero `phase:"update"` onToolStart calls for the
+    // allowlisted web_fetch path (the bridge respected the
+    // `suppressChannelProgress` marker). Plugin tools that did not set
+    // the marker keep firing — verified by `pluginUpdateCalls` above.
+    const webFetchAllCalls = onToolStart.mock.calls.filter(
+      (call) => (call[0] as { name?: string }).name === "web_fetch",
+    );
+    expect(webFetchAllCalls.every((call) => (call[0] as { phase: string }).phase === "start")).toBe(
+      true,
+    );
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2284,7 +2284,31 @@ export async function runAgentTurnWithFallback(params: {
                         if (shouldSuppressProgressAfterMessageToolDelivery()) {
                           return;
                         }
-                        if (phase === "start" || phase === "update") {
+                        // Fire `onToolStart` on `phase: "start"` (always) and
+                        // on `phase: "update"` only when the emitter has not
+                        // opted out via `suppressChannelProgress: true`. The
+                        // upstream `emitAgentEvent` path emits a tool update
+                        // event for every per-partial-result tick; some tools
+                        // (e.g. `web_fetch` via the
+                        // `NON_EXEC_PROGRESS_SAFE_TOOLS` allow-list) emit a
+                        // sibling `stream:"item"` event with the canonical
+                        // safe `progressText`, and rendering BOTH the
+                        // sibling item AND a bare `🌐 Tool Name` from this
+                        // bridge would duplicate channel-visible rows. The
+                        // emitter signals that the canonical render lives
+                        // elsewhere by setting `suppressChannelProgress:
+                        // true` on its `stream:"tool"` update event; tools
+                        // that have no sibling item progress (default) still
+                        // see their update ticks bridged here as before.
+                        // ACP `tool_call_update`, TUI verbose output, and
+                        // gateway subscribers continue to receive the raw
+                        // upstream event regardless.
+                        const toolEventSuppressChannelProgress =
+                          phase === "update" && evt.data.suppressChannelProgress === true;
+                        if (
+                          phase === "start" ||
+                          (phase === "update" && !toolEventSuppressChannelProgress)
+                        ) {
                           const toolStartProgressPromise = params.opts?.onToolStart?.({
                             name,
                             phase,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -117,7 +117,15 @@ async function forwardFollowupProgressEvent(params: {
   if (evt.stream === "tool") {
     const phase = readStringValue(evt.data.phase) ?? "";
     const name = readStringValue(evt.data.name);
-    if (phase === "start" || phase === "update") {
+    // Mirror the suppression check from `agent-runner-execution.ts`: when a
+    // tool update opts out via `suppressChannelProgress: true`, the
+    // canonical channel-visible render lives on a sibling
+    // `stream:"item"` event (e.g. `web_fetch`'s safe `progressText`).
+    // Bridging the bare update tick here would re-introduce the
+    // duplicate `🌐 Tool Name` row in follow-up channel replies.
+    const toolEventSuppressChannelProgress =
+      phase === "update" && evt.data.suppressChannelProgress === true;
+    if (phase === "start" || (phase === "update" && !toolEventSuppressChannelProgress)) {
       await opts?.onToolStart?.({
         name,
         phase,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Slow `web_fetch` calls produce a fully silent gap between the agent invoking the tool and the result coming back. On real public endpoints with multi-second TTFB, the channel progress draft stays stuck on a bare tool-name label (`🌐 Web Fetch`) for the entire wait — there is no signal that the agent is doing anything useful.

Why does this matter now?

The `exec`/`bash` tools already stream `partialResult` into channel progress drafts via the `kind:"command"` item path landed in PR #76917 / #79146 / #77949 / #86857. `web_fetch` is a tail-case silent-gap source: real-URL p50 is small (~108ms in local measurement), but slow CDNs / Cloudflare challenge pages / large pages routinely produce multi-second TTFB during which the progress draft today shows only a bare tool-name label. This PR plugs `web_fetch` into the existing `progressText` path so that tail case becomes visible.

What is the intended outcome?

During a slow `web_fetch`, two safe progress lines are routed through the existing `progressText` path that channels already use for `exec` `kind:"command"` items (the channel-side shared renderer `buildChannelProgressDraftLine` at `src/channels/streaming.ts:403`, re-exported via the deprecated SDK barrel `src/plugin-sdk/channel-streaming.ts`, is unchanged by this PR):

- `web_fetch: connecting to <host>…` — emitted before the fetch even leaves the runtime (visible during TTFB)
- `web_fetch: HTTP <status> <content-type>, reading body…` — emitted as soon as response headers come back

Both payloads carry only the request host plus, on the second emit, the HTTP status code and short content-type — never a full URL, URL path/query, request body, response body, request headers, URL-embedded credentials, cookies, `Set-Cookie`, `Authorization`, or bearer tokens. The short `content-type` value (e.g. `application/json`) on the second emit is the only response-header value that surfaces.

**ClawSweeper P2 (security-boundary)** — two channel-visible leaks closed at the rendered-channel layer, not just on the safe item event:

- *Stored-meta shadow on item updates*: the shared renderer at `src/channels/streaming.ts:422-427` resolves item display text via `input.meta ?? input.summary ?? input.progressText`. Stored `toolMetaById.meta` for `web_fetch` is derived from `inferToolMetaFromArgs` and contained the full URL summary. Omitted `meta` on the non-exec progress emission so the renderer falls through to the safe `progressText`.
- *URL leak on the start line via `onToolStart`*: the `phase:"start"` event carries the full args to the channel bridge, which renders via `inferToolMeta(name, args)` → `resolveWebFetchDetail`. The resolver previously returned `from <FULL_URL> (mode X, max N chars)` — leaking URL path / query / fragment / URL-embedded credentials. `src/agents/tool-display-common.ts:resolveWebFetchDetail` now redacts to host-only: `from <host>` (using `new URL(url).host`, which includes any explicit port and excludes userinfo / path / query / fragment) plus the safe `mode`/`max N chars` suffix.
- *Duplicate bare "🌐 Web Fetch" rows*: the bridge in `src/auto-reply/reply/agent-runner-execution.ts` and the sibling forward in `src/auto-reply/reply/followup-runner.ts` fired `onToolStart` on both `phase:"start"` and `phase:"update"`. Update events have no `args`, so the renderer produced a bare tool-name row interleaved with the safe progressText line. Scoped suppression via an existing `suppressChannelProgress` marker: `handleToolExecutionUpdate` sets `suppressChannelProgress: true` on its `stream:"tool"` `phase:"update"` event ONLY for tools listed in `NON_EXEC_PROGRESS_SAFE_TOOLS` (currently just `web_fetch`); both the main bridge and the follow-up bridge now skip `onToolStart` for those marked events. Non-allowlisted non-exec tools and exec/bash do not set the marker and continue to bridge their update events as before — so the prior behavior is preserved for any plugin tool that relies on the bare-row signal. Upstream `stream:"tool"` consumers (ACP `tool_call_update`, TUI verbose, gateway subscribers) keep receiving the raw event with `partialResult`.

Exec's `kind:"command"` item is untouched. Its `command_output` stream carries stdout through a different render path. Exec / bash and any other tool that does not set `suppressChannelProgress: true` keep their existing bridge behavior — the marker is the only signal the bridge uses to skip `onToolStart` on a `phase:"update"` event.

**Config / default / verbosity (answering Simon's #86950 comment)**: there is no new config key in this PR. The progress emission flows through the existing tool-progress gate `resolveChannelStreamingPreviewToolProgress` at `src/channels/streaming.ts:621-634` (re-exported via the deprecated SDK barrel `src/plugin-sdk/channel-streaming.ts`). It is the same gate that today decides whether channels render exec/bash command summaries, `web_search` labels, plan updates, and other tool-progress signals. The function reads `config.progress.toolProgress` when the channel sets `streaming.mode: "progress"` and falls back to `config.preview.toolProgress` in the default `partial` mode; the function-signature default value when neither key is set is `true`. The gate is consumed by each channel adapter (Telegram `bot-message-dispatch.ts:901`, Slack `dispatch.ts:1102`, Discord `message-handler.draft-preview.ts:83`, Mattermost `monitor.ts:140`, MS Teams `reply-stream-controller.ts:63`) combined with that channel's own `streamingMode !== "off"` / `draftStream` check. Anyone who has already silenced tool progress (`streaming.preview.toolProgress: false`, `streaming.progress.toolProgress: false`, or `streaming.mode: "block"`) sees no new lines from this PR. The on-by-default behavior is inherited from the existing default for all tool-progress rendering — this PR does NOT change that default. Verbosity is bounded to at most two line transitions per fetch (one `connecting to <host>…` emit at t=0 and one `HTTP <status> <content-type>, reading body…` emit at headers-received), so it is not chunk-by-chunk streaming and is less chatty than exec stdout streaming on the same gate. If a maintainer would prefer this routed through a different existing config bucket, that change is in-scope for a small follow-up; this PR keeps the simplest possible shape (zero new config surface) unless asked otherwise. Final response and raw upstream `stream:"tool"` event payload visibility are unchanged; the channel-visible non-exec safe-item update intentionally omits stored `meta` so the shared renderer falls through to the safe `progressText`. Stored transcript metadata for downstream consumers is unchanged.

What is intentionally out of scope?

- `channel-streaming.ts`, `agent-runner.ts` — no churn there. `agent-runner-execution.ts` and `followup-runner.ts` each get a narrowly-scoped check that reads the `suppressChannelProgress` marker on tool events (already an existing field on item events). Multiple open PRs (#81260 / #80046 / #82258 / #82303 / #83128 / #85200 / #85465 / #85005 / #84485) touch nearby code; this change is scoped to a single boolean check at the bridge call sites.
- All `extensions/*/src/**` channel adapters — the existing `progressText` → `meta` render path is reused as-is.
- MCP `notifications/progress`, `browser` snapshot progress, `image_generate` / `video_generate` progress — multi-PR scopes.
- CHANGELOG.md — release-owned.

What does success look like?

A bounded two-emit progress sequence per `web_fetch` call, routed through the existing `progressText` path that channels already consume for `exec` `kind:"command"` items, with zero leakage of URL paths / query / request body / response body / request headers / response headers / cookies / tokens. The live proof drives the shared renderer (`buildChannelProgressDraftLine`) directly at the same seam channel adapters call into; per-channel adapter delivery and live chat capture were not separately performed for this submission.

What should reviewers focus on?

The privacy contract in `extractLiveNonExecProgressText` + `NON_EXEC_PROGRESS_SAFE_TOOLS = {"web_fetch"}` allow-list (`src/agents/pi-embedded-subscribe.handlers.tools.ts`). The whole design depends on that allow-list being the only path that lets non-exec `partialResult` text reach a channel-visible field — see test `non-allowlisted non-exec tools emit upstream partialResult but never produce a channel-visible item update with progressText (privacy)`.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #76917 (progress drafts foundation), #79146 (progress draft labels), #77949 (Codex tool progress in drafts), #86857 (auto-scale live tool result caps).

Was this requested by a maintainer or owner?

No — a local UX-candidate selection identified `web_fetch` as a tail-case silent-gap source that fits the existing `progressText` infrastructure from PR #76917 et al.

## Real behavior proof (required for external PRs)

- **Behavior addressed**: slow `web_fetch` calls are entirely silent at the channel-visible layer between invocation and result, including the TTFB window. This patch surfaces two safe progress milestones during that gap.

- **Real environment tested**: Linux (Ubuntu 24.04, Node v22.22.2, pnpm 11.2.2, vitest 4.1.7), worktree at `feature/openclaw-tool-progress-web-fetch` HEAD `af936d19dd021a025694b7875b14e25bad65a52f` (3 commits rebased onto upstream/main `4d89e00c50`: `336f35ea6b` initial feat → `23b64d1f8f` first ClawSweeper P2 pass → `af936d19dd` final marker-based ClawSweeper P2 fix). The live capture below was originally taken on an earlier head; the current head `af936d19dd` adds the marker-based channel-bridge suppression fix and keeps the same host-only progress contract covered by the regression tests cited below. Real public network reach via `httpbin.org/delay/3`. The SSRF guard at `src/infra/net/ssrf.ts:assertAllowedHostOrIpOrThrow` was not modified or bypassed; httpbin is a public IP and passes the standard policy.

- **Exact steps or command run after this patch**:

```
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs src/agents/tools/web-fetch.progress.test.ts \
  src/agents/pi-embedded-subscribe.handlers.tools.test.ts \
  src/plugin-sdk/channel-streaming.test.ts \
  src/auto-reply/reply/agent-runner-execution.test.ts \
  src/auto-reply/reply/followup-runner.test.ts --run
pnpm tsgo --noEmit
pnpm check:test-types
```

For the live real-network proof, a throwaway live test was placed
temporarily at `src/agents/tools/_temp-progress.live.test.ts` (mirroring the
shipped `web-fetch.progress.test.ts` but pointed at a real `httpbin.org`
endpoint with `onUpdate` timing capture) and run with:

```
node node_modules/vitest/vitest.mjs run \
  --config test/vitest/vitest.live.config.ts \
  src/agents/tools/_temp-progress.live.test.ts
```

The throwaway file was deleted immediately after capture and is NOT part of
the planned PR diff. It used the real public network and the real
`createWebFetchTool` export from `src/agents/tools/web-fetch.ts` — no fetch
mock, no SSRF bypass.

- **Evidence after fix (host-only detail + suppressChannelProgress marker on update events)**:

The live test wires the real `web_fetch.execute` against `httpbin.org/delay/3`, forwards each `onUpdate` to the real `handleToolExecutionUpdate`, captures both the `onToolStart` callback payloads AND the `stream:"item" kind:"tool" phase:"update"` events, and feeds each one through the production shared renderer `buildChannelProgressDraftLine` at `src/channels/streaming.ts:403`. The renderer is unmodified by this PR; the proof reaches the same seam channel adapters call into, but does not exercise per-channel adapter delivery.

Important post-fix invariant: with the host-only `resolveWebFetchDetail`, the stored `toolMetaById.meta` for a `web_fetch` call is itself host-only (e.g. `"from httpbin.org (mode text, max 800 chars)"`) — no longer a URL-bearing string. So even legacy code paths that consume `toolMetaById.meta` can no longer leak URL path / query.

Captured behavior from the live proof. The current HEAD `af936d19dd` adds the `suppressChannelProgress` marker check at the channel-progress bridge (covered by the regression tests cited below); the host-only redaction and stored-meta omission asserted by this capture are identical on the current head:

```
--- web_fetch live progress + channel render proof ---
url=https://httpbin.org/delay/3  total≈4000ms

onUpdate emits from web_fetch:
  t+   ~1ms  web_fetch: connecting to httpbin.org…
  t+~3970ms  web_fetch: HTTP 200 application/json, reading body…

onToolStart payloads delivered to the channel bridge:
  phase=start  name=web_fetch  args={url, extractMode, maxChars}
    rendered: 📄 Web Fetch: from httpbin.org (mode text, max 800 chars)
  (no phase=update onToolStart call for web_fetch — handlers.tools.ts sets
   suppressChannelProgress:true on its stream:"tool" phase:"update" emits,
   and the bridges in agent-runner-execution.ts + followup-runner.ts skip
   them. Other tools that do not set the marker continue to be bridged.)

stream:'item' kind:'tool' phase:'update' events delivered to onItemEvent:
  t+   ~9ms  meta=undefined  progressText="web_fetch: connecting to httpbin.org…"
  t+~3970ms  meta=undefined  progressText="web_fetch: HTTP 200 application/json, reading body…"

Rendered channel text from buildChannelProgressDraftLine:
  📄 Web Fetch: from httpbin.org (mode text, max 800 chars)
  📄 Web Fetch: web_fetch: connecting to httpbin.org…
  📄 Web Fetch: web_fetch: HTTP 200 application/json, reading body…

returned tool result (separate render path, NOT progress text):
  {\n  "url": "https://httpbin.org/delay/3",\n  "finalUrl": "...",\n  "status": 200, …
--- end proof ---
```

```
Test Files 8 passed (8)
Tests      375 passed (375)
```

- **Observed result after fix**:

  - The "connecting" progress milestone fires near t=0 — visible immediately after `web_fetch` is invoked, well before httpbin's ~4 s TTFB completes.
  - The "headers received" milestone fires near t=TTFB with `HTTP 200 application/json`.
  - **ClawSweeper P2 resolved at three layers**: (a) `resolveWebFetchDetail` is host-only, so the `phase:"start"` line that `onToolStart` produces never carries URL path / query / fragment / userinfo; (b) the stored `toolMetaById.meta` is now host-only and the safe item event omits it anyway; (c) `suppressChannelProgress:true` on the marked `stream:"tool"` `phase:"update"` events suppresses bridge invocations for `web_fetch` only, so no bare `🌐 Web Fetch` row appears next to the safe progressText line. Non-allowlisted non-exec tools and exec/bash do not set the marker and continue to be bridged exactly as before.
  - Exactly two safe progress emits per fetch; no body-byte spam regardless of response size.
  - Live test privacy assertions on the rendered channel-visible text passed: no `/delay/3`, no `https://httpbin.org/`, no `?` or `&`, no `extractMode`, no `maxChars`, no `Bearer`, no `Set-Cookie`.
  - Exec/bash `kind:"command"` progressText path is unchanged. The 375-test regression suite passes (`tool-display.test.ts` + `channel-streaming.test.ts` + `agent-runner-execution.test.ts` + `followup-runner.test.ts` + `pi-embedded-subscribe.handlers.tools.test.ts` + `web-fetch.progress.test.ts`), including 4 new `tool-display.test.ts` host-only privacy regressions and a full-callback-sequence regression in `agent-runner-execution.test.ts`.
  - SSRF guard still rejects loopback URLs — verified during proof harness construction.

- **What was not tested**: per-channel live chat render against a bot token. The channel-side render path is the shared renderer at `src/channels/streaming.ts:403` (`buildChannelProgressDraftLine`) exercised directly in the live proof above, exactly as a channel adapter would invoke it. Submission is not blocked on a chat screenshot; it is a polish item if a maintainer requests one.

- **Proof limitations or environment constraints**: localhost loopback proof was attempted and correctly blocked by SSRF (`src/infra/net/ssrf.ts:assertAllowedHostOrIpOrThrow`). Live proof was therefore routed to `httpbin.org/delay/3`, a public-IP endpoint that passes the standard policy.

- **Before evidence (optional)**: pre-patch, the same `web_fetch` call against `httpbin.org/delay/3` emits zero `onUpdate` events (the tool never wired the callback). A controlled-slow-endpoint baseline before this patch produced a 5005ms fully silent window in the same path.

- **Throwaway artifact note**: the live test file (`src/agents/tools/_temp-progress.live.test.ts`) was created only long enough to capture the run above and deleted before commit. It is NOT part of the PR. The shipped tests under `web-fetch.progress.test.ts` + `pi-embedded-subscribe.handlers.tools.test.ts` use mocked fetch but exercise the same `handleToolExecutionUpdate` → `buildChannelProgressDraftLine` chain and assert the same `meta=undefined` + rendered-text contract.

## Tests and validation

Real-behavior evidence is the live `httpbin.org/delay/3` run + shared-renderer capture shown in the section above; the unit / regression tests below prove the routing and privacy contracts that make the live observation meaningful.

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/tool-display.test.ts src/agents/tools/web-fetch.progress.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/plugin-sdk/channel-streaming.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/followup-runner.test.ts --run` → **375 passed / 375** (includes the ClawSweeper P2 regressions: 4 host-only privacy tests in `tool-display.test.ts` and the full-callback-sequence regression in `agent-runner-execution.test.ts`).
- `pnpm tsgo --noEmit` → exit 0.
- `pnpm check:test-types` → exit 0.
- Live: `vitest.live.config.ts` against `https://httpbin.org/delay/3` → **1 passed / 1** (privacy + rendered-text + meta-omission assertions through the actual shared renderer). This is the same evidence shown in the Real-behavior-proof section.

## User-visible behavior and config

- **Existing config gate, no new key.** The two emits flow through the existing tool-progress gate `resolveChannelStreamingPreviewToolProgress` at `src/channels/streaming.ts:621-634` (read as `config.preview.toolProgress` in the default `partial` mode, or `config.progress.toolProgress` when a channel sets `streaming.mode: "progress"`; function-signature default is `true` when neither key is set). That is the same gate the existing exec/bash command summaries, `web_search` labels, and plan updates already use. The gate is invoked by each channel adapter (Telegram, Slack, Discord, Mattermost, MS Teams) combined with that channel's own `streamingMode !== "off"` / `draftStream` check.
- **No new default.** Default `true` is inherited from the existing tool-progress default. This PR does not introduce a new always-on default; users who already silenced tool progress (`streaming.preview.toolProgress: false`, or `streaming.mode: "block"`) see no new lines.
- **Bounded verbosity.** At most two milestones per fetch:
  - `web_fetch: connecting to <host>…` immediately after the agent invokes the tool (before TTFB)
  - `web_fetch: HTTP <status> <content-type>, reading body…` once the remote starts responding
  Not chunk-by-chunk; less chatty than exec stdout streaming on the same gate.
- **Privacy.** Channel-visible text for `web_fetch` carries only the request host plus (on the second progress emit) the HTTP status code and short content-type. URL path, query string, fragment, URL-embedded credentials, request body, response body, request headers, response headers, cookies, and `Authorization` / bearer tokens never reach the channel-visible draft. This now holds at THREE layers, not just the item event:
  1. The `phase:"start"` line (rendered via `onToolStart` → shared renderer → `resolveWebFetchDetail`) is host-only.
  2. The `phase:"update"` bridge (both main `agent-runner-execution.ts` and `followup-runner.ts`) skips `onToolStart` for events marked `suppressChannelProgress: true`, set only for tools in `NON_EXEC_PROGRESS_SAFE_TOOLS`. So no bare `🌐 Web Fetch` row appears next to the safe progress line for `web_fetch`, and other tools' bridge behavior is unchanged.
  3. The non-exec safe-progress item update emits `progressText` with `meta` omitted, so the renderer falls through to the safe text.

  The `NON_EXEC_PROGRESS_SAFE_TOOLS` allow-list (currently just `web_fetch`), the host-only `resolveWebFetchDetail`, the `suppressChannelProgress:true` marker set by `handleToolExecutionUpdate` for allowlisted tools, the matching marker check in `agent-runner-execution.ts` + `followup-runner.ts` bridges, and the regression tests in `tool-display.test.ts` / `agent-runner-execution.test.ts` / `pi-embedded-subscribe.handlers.tools.test.ts` lock this contract.
- **Tunable on maintainer preference.** If a quieter shape is preferred — e.g. a delayed first milestone (only emit if TTFB exceeds N ms), a dedicated `streaming.preview.webFetchProgress` sub-flag, or routing through a different existing config bucket — I'm happy to follow whichever direction the maintainer chooses. Sibling PR #86965 takes a single-delayed-line approach; ClawSweeper's previous review framed the two as alternative-canonical sibling PRs for the maintainer to pick. The marker-based fix is now committed as `af936d19dd` and pushed; live PR labels (silver shellfish / security-boundary / waiting on author) still reflect the previous ClawSweeper review against `23b64d1f8f` and have not refreshed for the new head yet.

## CI status

All required checks pass on the current HEAD `af936d19dd`: `check-lint`, `check-guards`, `check-prod-types`, `check-test-types`, `check-dependencies`, `checks-windows-node-test`, `Real behavior proof`, plus every applicable `Security High (...)` boundary and `Critical Quality (...)` shard. Non-applicable shards skip as designed. `mergeStateStatus` is CLEAN and `mergeable` is MERGEABLE.

The previously-red `check-lint` on `23b64d1f8f` was caused by an upstream-existing `typescript(no-unnecessary-type-assertion)` flag at `src/channels/message/inbound-reply-dispatch.ts:279-281` (file introduced by upstream commit `8e5183c60d` and not in this PR's authored diff). Re-running CI on `af936d19dd` against the current GitHub-Actions merge base reports `check-lint` green; the upstream side appears to have moved past that point in the interim. No oxlint-config or rule change in this PR.

What regression coverage was added or updated?

- New `src/agents/tools/web-fetch.progress.test.ts` — 8 tests covering:
  - Two-emit boundary (`connecting`, `HTTP <status> <content-type>`).
  - Emit ordering: `connecting` fires before `global.fetch` is invoked.
  - Privacy: URL query string / path / body / cookies / `Bearer` token / `Set-Cookie` never appear in any emit.
  - Bounded count: at most 2 web_fetch progress emits in practice; the test asserts `≤4` as a defensive upper bound even with a 50 000-byte body.
  - Misbehaving `onUpdate` callback does not break the fetch result.
  - No-callback back-compat.

- Extended `src/agents/pi-embedded-subscribe.handlers.tools.test.ts` — 7 new tests covering:
  - `web_fetch` `partialResult` populates `progressText` on the `kind:"tool"` item.
  - Exec/bash regression: `progressText` flows only on `kind:"command"`, not the `kind:"tool"` sibling.
  - Burst budget: first 4 non-exec emits unthrottled, 5th throttled. Upstream `stream:"tool"` partialResult delivered for all 5 (ACP/TUI/gateway consumers preserved); channel-visible item events bounded to 4.
  - Non-allow-listed non-exec tools emit upstream `partialResult` but produce ZERO channel-visible item updates with `progressText` (privacy allow-list contract).
  - `LIVE_EXEC_OUTPUT_MAX_CHARS = 8000` cap applied to non-exec.
  - `nonExecLiveUpdateStateById` cleaned up on `handleToolExecutionEnd`.
  - Per-toolCallId state isolation (two parallel `web_fetch` calls each get their own burst budget).

What failed before this fix, if known?

Pre-patch, `web_fetch` never invokes `onUpdate`. The runtime handler `pi-embedded-subscribe.handlers.tools.ts:966` gates `progressText` on `if (isExecTool)`, so even if a tool emitted `partialResult` it never reached channel-visible text. The two gaps together produce the silent-gap UX this PR fixes.

If no test was added, why not?

Tests are added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes — new progress draft lines during slow `web_fetch`. Exec/bash behavior unchanged.

Did config, environment, or migration behavior change? (`Yes/No`) No. No new config keys, no env vars, no migrations.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No new network calls, no auth/secrets touched, no tool-execution semantic change. The SSRF guard is unchanged. Progress text carries only the request host plus, on the second emit, the HTTP status code and short content-type — never URLs / paths / queries / bodies / headers / cookies / tokens. The privacy contract is enforced by an allow-list (`NON_EXEC_PROGRESS_SAFE_TOOLS`) plus assertions in `web-fetch.progress.test.ts` and the new ClawSweeper P2 regression in `pi-embedded-subscribe.handlers.tools.test.ts`.

What is the highest-risk area?

The runtime-side allow-list gate at `extractLiveNonExecProgressText`. If a future tool is added to `NON_EXEC_PROGRESS_SAFE_TOOLS` without auditing its `onUpdate` payload, that tool's emission could carry sensitive content into a channel-visible draft.

How is that risk mitigated?

The allow-list is a `ReadonlySet<string>` defined inline with a doc comment that names the auditing contract (host-class / status-class only, no URLs / bodies / headers / tokens). Each future addition is a one-line PR with a per-tool privacy proof. The current allow-list contains only `"web_fetch"`, whose `onUpdate` call sites are audited in this PR.

## Current review state

What is the next action?

Maintainer review. CI run.

What is still waiting on author, maintainer, CI, or external proof?

All required checks pass on `af936d19dd` (see CI status section above). The shared channel renderer path is exercised by the live httpbin proof (which drives the actual `buildChannelProgressDraftLine`); per-channel adapter delivery and live chat capture were not separately performed. A per-channel chat screenshot can be supplied if a maintainer asks for one, but submission is not waiting on it. ClawSweeper has not re-reviewed the new head `af936d19dd` yet; live labels (silver shellfish / security-boundary / waiting on author) still reflect the previous pass.

Which bot or reviewer comments were addressed?

- **ClawSweeper P2 (this PR)**: "Render the new web_fetch progress text instead of the old meta" — addressed by omitting `meta` on the non-exec progress emission in `handleToolExecutionUpdate`. Live proof captures the rendered channel text showing our safe progressText (not the URL meta). Regression test `renders audited web_fetch progressText instead of stored meta (ClawSweeper P2 regression: meta does NOT shadow safe progressText)` locks the behavior.
- A local Codex review pass (`codex review --uncommitted`) was run before initial commit and returned no findings on the final design; intermediate findings from earlier passes (privacy allow-list, A/B/A churn suppression, upstream-stream-not-throttled, burst budget) were addressed inline. A second local Codex review pass was run after the ClawSweeper P2 fix.
