### PR TITLE
fix: quiet cross-thread Codex turn completion broadcasts

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -8629,6 +8629,79 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("does not warn on cross-thread turn/completed broadcast notifications", async () => {
+    const harness = createStartedThreadHarness();
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+    );
+
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-other",
+        turnId: "turn-other",
+        turn: {
+          id: "turn-other",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-other", text: "foreign completion" }],
+        },
+      },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(warn).not.toHaveBeenCalledWith(
+      "codex app-server turn/completed did not match active turn",
+      expect.anything(),
+    );
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("warns on same-thread turn/completed notifications for a different turn", async () => {
+    const harness = createStartedThreadHarness();
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+    );
+
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-other",
+        turn: {
+          id: "turn-other",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-other", text: "wrong turn" }],
+        },
+      },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server turn/completed did not match active turn",
+      expect.objectContaining({
+        activeThreadId: "thread-1",
+        activeTurnId: "turn-1",
+        matchesActiveThread: true,
+        matchesActiveTurn: false,
+        threadId: "thread-1",
+        turnId: "turn-other",
+      }),
+    );
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+  });
+
   it("releases completion and native hook relay state when Codex raw-events an interrupted turn marker", async () => {
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2408,7 +2408,11 @@ export async function runCodexAppServerAttempt(
       ...(turnId ? { turnId } : {}),
     });
     embeddedAgentLog.debug("codex app-server raw notification received", correlation);
-    if (notification.method === "turn/completed" && correlation.matchesActiveTurn === false) {
+    if (
+      notification.method === "turn/completed" &&
+      correlation.matchesActiveThread &&
+      correlation.matchesActiveTurn === false
+    ) {
       embeddedAgentLog.warn(
         "codex app-server turn/completed did not match active turn",
         correlation,


### PR DESCRIPTION
## Summary
- stop warning on expected cross-thread Codex app-server `turn/completed` broadcasts from the shared notification bus
- keep warning for same-thread completion notifications that point at a different turn
- add run-attempt regression tests for both cases

## Why
Codex app-server completion notifications include both thread and turn correlation fields. On a shared notification bus, a run attempt can observe `turn/completed` events for other threads. Those cross-thread completions do not belong to the active run attempt and should not emit the warning-level `turn_completion_mismatch` signal.

A same-thread `turn/completed` notification with a different `turnId` is still suspicious because it claims to complete work in the active thread while not matching the active turn. This PR preserves that warning.

This is intentionally narrow: it only changes the warning predicate for Codex run-attempt completion mismatch logging. It does not claim to remove all unrelated observability noise.

## Implementation
- only warn on `turn/completed` mismatch when `matchesActiveThread` is true and `matchesActiveTurn` is false
- add a regression test proving cross-thread completion broadcasts do not warn and the owning run stays open
- add a regression test proving same-thread different-turn completions still warn and the owning run stays open

## Tests
- `corepack pnpm exec vitest run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `corepack pnpm exec oxfmt --check extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check origin/main...HEAD`