### PR TITLE
fix(agents): finalize abandoned managed-response streams to release undici sockets

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1,7 +1,11 @@
 import type { Model } from "@earendil-works/pi-ai";
 import { Stream } from "openai/streaming";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
+import {
+  buildGuardedModelFetch,
+  resetManagedResponseFinalizersForTest,
+  setManagedResponseFinalizersForTest,
+} from "./provider-transport-fetch.js";
 
 type ProviderRequestPolicyConfigMockResult = {
   allowPrivateNetwork: boolean;
@@ -1093,6 +1097,148 @@ describe("buildGuardedModelFetch", () => {
       );
 
       expect(response.headers.get("x-should-retry")).toBeNull();
+    });
+  });
+
+  describe("managed response abandoned-stream finalize (#67461)", () => {
+    const anthropicModel = {
+      id: "sonnet-4.6",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com/v1",
+    } as unknown as Model<"anthropic-messages">;
+
+    afterEach(() => {
+      resetManagedResponseFinalizersForTest();
+    });
+
+    it("registers a GC-driven finalizer that releases the undici slot even when the wrapped stream is abandoned mid-stream", async () => {
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("data: chunk\n\n"));
+              // Intentionally never close — emulates the Anthropic SDK
+              // returning on `message_stop` without draining to `done`.
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+        finalUrl: "https://api.anthropic.com/v1/messages",
+        release,
+      });
+
+      const registered: Array<{ target: object; finalize: () => Promise<void> }> = [];
+      setManagedResponseFinalizersForTest({
+        register(target, finalize) {
+          registered.push({ target, finalize });
+        },
+      });
+
+      const fetcher = buildGuardedModelFetch(anthropicModel);
+      const response = await fetcher("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+      });
+      // Consumer abandons the body — no drain, no cancel.
+      void response;
+
+      expect(registered).toHaveLength(1);
+      expect(release).not.toHaveBeenCalled();
+
+      // Simulate V8 collecting the abandoned wrapped body and firing the
+      // finalizer callback.
+      await registered[0]!.finalize();
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+
+    it("finalizer remains idempotent with the natural drain path", async () => {
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response("ok", { status: 200 }),
+        finalUrl: "https://api.anthropic.com/v1/messages",
+        release,
+      });
+
+      const registered: Array<{ finalize: () => Promise<void> }> = [];
+      setManagedResponseFinalizersForTest({
+        register(_target, finalize) {
+          registered.push({ finalize });
+        },
+      });
+
+      const fetcher = buildGuardedModelFetch(anthropicModel);
+      const response = await fetcher("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+      });
+      await response.text();
+
+      expect(release).toHaveBeenCalledTimes(1);
+      // GC fires later — must not double-release.
+      await registered[0]!.finalize();
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+
+    it("finalizer also covers the explicit cancel path without double-release", async () => {
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("data: chunk\n\n"));
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        ),
+        finalUrl: "https://api.anthropic.com/v1/messages",
+        release,
+      });
+
+      const registered: Array<{ finalize: () => Promise<void> }> = [];
+      setManagedResponseFinalizersForTest({
+        register(_target, finalize) {
+          registered.push({ finalize });
+        },
+      });
+
+      const fetcher = buildGuardedModelFetch(anthropicModel);
+      const response = await fetcher("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+      });
+      await response.body?.cancel("test-cancel");
+
+      expect(release).toHaveBeenCalledTimes(1);
+      await registered[0]!.finalize();
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not register a finalizer when the response carries no body (no leak surface)", async () => {
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(null, { status: 204 }),
+        finalUrl: "https://api.anthropic.com/v1/messages",
+        release,
+      });
+
+      const registered: Array<{ finalize: () => Promise<void> }> = [];
+      setManagedResponseFinalizersForTest({
+        register(_target, finalize) {
+          registered.push({ finalize });
+        },
+      });
+
+      const fetcher = buildGuardedModelFetch(anthropicModel);
+      const response = await fetcher("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+      });
+      void response;
+
+      expect(registered).toHaveLength(0);
+      // Early-release path runs synchronously inside buildManagedResponse.
+      await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
     });
   });
 });

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -296,6 +296,38 @@ function shouldBypassLongSdkRetry(response: Response): boolean {
   return status === 429;
 }
 
+// Safety net for #67461: the Anthropic SDK's SSE parser is observed to return
+// on `message_stop` without draining to `done` and without calling
+// `body.cancel()`, leaving the managed-response wrapper holding an undici
+// dispatcher slot forever (11.5k leaked sockets / 5h in the issue report).
+// FinalizationRegistry lets us reclaim the slot when the wrapped body becomes
+// GC-unreachable through the abandoned-stream path. The registry is module-
+// local and injectable via `setManagedResponseFinalizersForTest` so the
+// abandoned-path behavior is unit-testable without driving real GC.
+type ManagedResponseFinalizerRegistry = {
+  register(target: object, heldValue: () => Promise<void>): void;
+};
+
+const defaultManagedResponseFinalizers: ManagedResponseFinalizerRegistry =
+  typeof FinalizationRegistry === "function"
+    ? new FinalizationRegistry<() => Promise<void>>((finalize) => {
+        void finalize();
+      })
+    : { register: () => undefined };
+
+let currentManagedResponseFinalizers: ManagedResponseFinalizerRegistry =
+  defaultManagedResponseFinalizers;
+
+export function setManagedResponseFinalizersForTest(
+  registry: ManagedResponseFinalizerRegistry,
+): void {
+  currentManagedResponseFinalizers = registry;
+}
+
+export function resetManagedResponseFinalizersForTest(): void {
+  currentManagedResponseFinalizers = defaultManagedResponseFinalizers;
+}
+
 function buildManagedResponse(
   response: Response,
   release: () => Promise<void>,
@@ -350,6 +382,7 @@ function buildManagedResponse(
       }
     },
   });
+  currentManagedResponseFinalizers.register(wrappedBody, finalize);
   return new Response(wrappedBody, {
     status: response.status,
     statusText: response.statusText,


### PR DESCRIPTION
## Summary

- Register the per-response `finalize()` (which calls `release()` on the undici dispatcher slot and the local-service lease) with a module-local `FinalizationRegistry` so the slot is reclaimed even when the consumer abandons the wrapped stream without draining to `done` or calling `body.cancel()`.
- The fix targets `buildManagedResponse` in `src/agents/provider-transport-fetch.ts` — the function described in issue #67461 as missing a release path on the SDK-abandoned branch (Anthropic SDK SSE parser observed returning on `message_stop` without draining the inner reader).
- Add `setManagedResponseFinalizersForTest` / `resetManagedResponseFinalizersForTest` so the registration path is unit-testable without driving real V8 GC: tests inject a spy registry and invoke the captured finalize manually to assert the release semantics. 4 new vitest cases cover the abandoned-mid-stream path, the natural-drain idempotency, the explicit-cancel idempotency, and the no-body early-release path.
- No behavior change on the existing pull(done) / cancel(reason) / no-body paths — `released` boolean still gates the finalize() body, so the FinalizationRegistry callback is a true safety net that no-ops on every successful release path.

## Behavior change to flag

When a model-fetch consumer (e.g. the Anthropic SDK's SSE Stream class) returns from its consumption loop without fully draining the response body and without calling `body.cancel()`, the wrapped body becomes unreachable to user code; previously this leaked the underlying undici dispatcher slot (and the local-service lease) until the gateway restarted — production report in #67461 showed 11,508 leaked ESTABLISHED IPv6 sockets to Cloudflare after 5 hours of cron-driven streaming, eventually hitting fd limits and breaking every `exec` tool call with `spawn EBADF`. After this change, the next V8 GC pass over the abandoned wrapped body fires the registered finalizer, runs `release()`, and reclaims the slot.

`FinalizationRegistry` callback timing is not deterministic (V8 may run it on any future GC pass and may, per spec, skip it during shutdown), so the fix is best-effort by design — but every successful GC observation is a slot that would otherwise have leaked forever, and the existing fast paths (drain to done, explicit cancel) are unchanged. Environments lacking `FinalizationRegistry` (synthetic / patched globals) fall through to a no-op registry, preserving prior behavior.

## Real behavior proof

- **Behavior addressed:** `buildManagedResponse` now registers `finalize` on the `wrappedBody` ReadableStream via a module-local `FinalizationRegistry`. When V8 collects the abandoned `wrappedBody`, the registered callback is invoked with `finalize` and runs the same `release()` path that the pull/cancel branches already use. The `released` flag inside `finalize` makes the call idempotent: callers that already finalized via the natural drain or cancel path see the GC-triggered call as a no-op. The fix matches the issue's "Option A (FinalizationRegistry)" sketch but routes through an injectable indirection so abandoned-path coverage is unit-testable.
- **Real environment tested:** local macOS arm64 source checkout of `openclaw/openclaw` post-rebase against `upstream/main`; behavior verified through the 4 new colocated vitest cases under `src/agents/provider-transport-fetch.test.ts`, driving `buildGuardedModelFetch` with `fetchWithSsrFGuard` mocked to return synthetic streams that match the abandoned (no `controller.close()`), natural-drain, explicit-cancel, and no-body shapes. The full existing suite for the same file still passes against the rebuilt managed-response wrapper.
- **Exact steps or command run after this patch:**
  - `pnpm test src/agents/provider-transport-fetch.test.ts`
  - `pnpm test:changed`
  - `pnpm check:changed`
- **Evidence after fix:**
  - `registers a GC-driven finalizer that releases the undici slot even when the wrapped stream is abandoned mid-stream`: spy registry captures `register(wrappedBody, finalize)` exactly once; the captured `finalize` runs `release()` exactly once when invoked manually (simulating the GC callback). Before the fix, no register was called and release would never fire on this code path.
  - `finalizer remains idempotent with the natural drain path`: `response.text()` triggers the existing pull(done) finalize → release is called once; then invoking the registered finalize again leaves `release` at 1 call (idempotency guard intact).
  - `finalizer also covers the explicit cancel path without double-release`: `body.cancel()` triggers cancel-branch finalize → release is called once; then invoking the registered finalize leaves `release` at 1 call.
  - `does not register a finalizer when the response carries no body`: 204 No-Content response skips the wrapper entirely, no registration occurs, and the early `release().finally(finalizeLocalServiceLease)` path runs.
- **Observed result after fix:**
  - `src/agents/provider-transport-fetch.test.ts`: 53 / 53 passed (4 new + 49 existing) in 235ms.
  - `pnpm test:changed`: passed across the affected lanes touching `src/agents/**`. One unrelated PTY e2e failure (`src/tui/tui-pty-local.e2e.test.ts > drives the real local backend with a mocked model endpoint`) is a pre-existing main flake in the TUI subsystem and has no overlap with `provider-transport-fetch`.
  - `pnpm check:changed`: typecheck core + extensions + tests, lint, import cycles, plugin-sdk wildcard / dependency-pin / package-patch guards all pass. The only red is the pre-existing `npm shrinkwrap guard (31 packages)` failure that reproduces on pristine `upstream/main`.
- **What was not tested:** the production scenario from #67461 — running the gateway under launchd for hours with real Anthropic / Vertex streaming traffic and watching `lsof -p $(pgrep openclaw-gateway) | wc -l` drop from 12k+ leaked sockets to baseline. V8 GC timing is non-deterministic in unit tests, so the runtime-side proof of "leak actually stops climbing" depends on the reporter's setup; the test surface here proves the registration happens and the registered callback releases the slot. The reporter's `lsof` output and the `spawn EBADF` symptom in the issue body are the real-world evidence this code path is the leak source.

## Notes

- The `FinalizationRegistry` indirection is module-local. The default registry is a real `FinalizationRegistry` when the global constructor exists; otherwise (synthetic harnesses) a no-op stub keeps the call site safe. Tests opt in via the exported setter and `afterEach` reset.
- The fix preserves the existing fast-path control flow — `released` boolean still short-circuits every subsequent call so the GC-driven finalize never double-releases.
- Reviewed against root `AGENTS.md`, `src/agents/CLAUDE.md` (test-perf guardrails — new tests are colocated and reuse the existing mock harness, no broad runtime imports added), and `CONTRIBUTING.md`. No `CHANGELOG.md` edits (per CONTRIBUTING).

Refs #67461



## Related work in this thread

For reviewer context — three other independent reliability fixes I opened in the same review window touch adjacent session-state / data-loss surfaces. They are not prerequisites for this PR and can be reviewed/landed independently:

- #87088 — `fix(reply): flush memory for pending in-turn auto-compaction even when tokens drop below threshold` (P2, in-turn `memoryFlush` catch-up).
- #87083 — `fix(agents): break bootstrap-context append doomloop with a recent-entry circuit breaker` (P1, `openclaw:bootstrap-context:full` append cap, mitigates the #63998 crash-restart loop).
- #87100 — `fix(channels): defensively handle non-string prompter.text() results in token replace flow` (P2, removes the `Cannot read properties of undefined (reading 'trim')` crash in `openclaw onboard` Telegram token replace, #67366).
