### PR TITLE
fix: ignore archived skill directories

### DIFF
--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -86,6 +86,9 @@ Rules:
 
 - Built-in skill roots always include `~/.openclaw/skills`, `~/.agents/skills`,
   `<workspace>/.agents/skills`, and `<workspace>/skills`.
+- Skill discovery ignores folders named `_archive` or `_archived`, including
+  grouped skill layouts under those folders. Use those names for retired skill
+  material that should stay on disk without remaining agent-visible.
 - `allowBundled`: optional allowlist for **bundled** skills only. When set, only
   bundled skills in the list are eligible (managed, agent, and workspace skills unaffected).
 - `load.extraDirs`: additional skill directories to scan (lowest precedence).

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -150,6 +150,9 @@ that up as `<workspace>/skills` on the next session.
 Configured skill roots also support one grouping level, such as
 `skills/<group>/<skill>/SKILL.md`, so related third-party skills can be
 kept under a shared folder without broad recursive scanning.
+Archive folders named `_archive` or `_archived` are ignored during discovery at
+both direct and grouped skill levels. Move retired skills there when you want to
+preserve their files without exposing them to agents.
 
 Git and local directory installs expect a `SKILL.md` at the source root. The
 install slug comes from `SKILL.md` frontmatter `name` when it is a valid slug,

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -659,6 +659,30 @@ describe("loadWorkspaceSkillEntries", () => {
   );
 
   describe("nested skill subdirectories", () => {
+    it("ignores archived skill directories at direct and grouped discovery levels", async () => {
+      const workspaceDir = await createTempWorkspaceDir();
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", "_archived", "retired-skill"),
+        name: "retired-skill",
+        description: "Retired skill",
+      });
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", "_archive"),
+        name: "archive-root-skill",
+        description: "Archived root skill",
+      });
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", "active-skill"),
+        name: "active-skill",
+        description: "Active skill",
+      });
+
+      const names = loadTestWorkspaceSkillEntries(workspaceDir).map((entry) => entry.skill.name);
+      expect(names).toContain("active-skill");
+      expect(names).not.toContain("retired-skill");
+      expect(names).not.toContain("archive-root-skill");
+    });
+
     it("discovers SKILL.md two levels deep under a grouping subfolder", async () => {
       const workspaceDir = await createTempWorkspaceDir();
       // Grouped layout: skills/group/skill/SKILL.md (no SKILL.md at skills/group/).

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -144,6 +144,7 @@ const DEFAULT_MAX_SKILLS_PROMPT_CHARS = 18_000;
 const DEFAULT_MAX_SKILL_FILE_BYTES = 256_000;
 const DEFAULT_MIN_RAW_ENTRIES_PER_DIRECTORY_SCAN = 1_000;
 const DEFAULT_MAX_RAW_ENTRIES_PER_DIRECTORY_SCAN = 10_000;
+const IGNORED_SKILL_DIRECTORY_NAMES = new Set(["_archive", "_archived"]);
 
 type ResolvedSkillsLimits = {
   maxCandidatesPerRoot: number;
@@ -205,7 +206,10 @@ function listChildDirectories(
     maxEntries: maxRawEntriesToScan,
     symlinks: "follow",
     include: (entry) =>
-      entry.kind === "directory" && !entry.name.startsWith(".") && entry.name !== "node_modules",
+      entry.kind === "directory" &&
+      !entry.name.startsWith(".") &&
+      entry.name !== "node_modules" &&
+      !IGNORED_SKILL_DIRECTORY_NAMES.has(entry.name),
   });
   if (scan.scannedEntryCount === 0 && scan.entries.length === 0) {
     return { dirs: [], scannedEntryCount: 0, truncated: false };


### PR DESCRIPTION
## Summary
- skip skill directories named `_archive` or `_archived` during discovery
- cover both direct and grouped skill layouts with a regression test
- document the archive-folder convention in the skills docs/config docs

## Real behavior proof

Behavior addressed: workspace skill discovery was still loading retired skills kept under archive folders, so archived material could remain agent-visible even after being moved out of active use.

Exact build/SHA tested:
- Base/current upstream main: `4007df7f60b6` (`origin/main`, fetched 2026-05-26)
- Patch head: `ddae8d9efbd6` (`fix/ignore-archived-skill-dirs-20260526`)

Real environment used:
- macOS 26.3.1, arm64, Mac Mini M4
- Node `v22.22.3`
- pnpm `11.1.0`
- isolated Git worktrees under `/tmp`, separate from my dirty local development checkout

Live path exercised:
- Created a temporary workspace with:
  - `skills/active-skill/SKILL.md`
  - `skills/_archived/retired-skill/SKILL.md`
  - `skills/_archive/SKILL.md`
- Called `loadWorkspaceSkillEntries()` against that workspace on current upstream main and on the patch head.

Before/after evidence:

```diff
-before=["active-skill","archive-root-skill","browser-automation","clerk-cli","lossless-claw","qqbot-channel","qqbot-media","qqbot-remind","retired-skill","supabase"]
-after=["active-skill","browser-automation","clerk-cli","lossless-claw","qqbot-channel","qqbot-media","qqbot-remind","supabase"]
```

Observed result after the patch:
- `active-skill` remains discoverable.
- `archive-root-skill` from `skills/_archive/SKILL.md` is no longer discoverable.
- `retired-skill` from `skills/_archived/retired-skill/SKILL.md` is no longer discoverable.
- Other non-archive discovered skills are unchanged in the proof run.

Additional checks run:
- `node scripts/test-projects.mjs src/agents/skills.loadworkspaceskillentries.test.ts` → passed, 21 tests
- `oxfmt --check src/agents/skills/workspace.ts src/agents/skills.loadworkspaceskillentries.test.ts docs/tools/skills.md docs/tools/skills-config.md` → passed
- `git diff --check origin/main -- src/agents/skills/workspace.ts src/agents/skills.loadworkspaceskillentries.test.ts docs/tools/skills.md docs/tools/skills-config.md` → passed

Remaining proof gaps:
- This proof covers the workspace skill loader path directly, not a full packaged CLI install.
- Tested on macOS only.
- The PR was auto-closed by the queue-limit bot before review. It should stay closed until I reduce my active PR count below the repo limit, then I can reopen or resubmit it.

## Test plan
- `node scripts/test-projects.mjs src/agents/skills.loadworkspaceskillentries.test.ts`
- `oxfmt --check src/agents/skills/workspace.ts src/agents/skills.loadworkspaceskillentries.test.ts docs/tools/skills.md docs/tools/skills-config.md`
- `git diff --check origin/main -- src/agents/skills/workspace.ts src/agents/skills.loadworkspaceskillentries.test.ts docs/tools/skills.md docs/tools/skills-config.md`
