### PR TITLE
fix(exec): avoid default approval store writes

### DIFF
--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -23,6 +23,7 @@ let readExecApprovalsSnapshot: ExecApprovalsModule["readExecApprovalsSnapshot"];
 let recordAllowlistMatchesUse: ExecApprovalsModule["recordAllowlistMatchesUse"];
 let recordAllowlistUse: ExecApprovalsModule["recordAllowlistUse"];
 let requestExecApprovalViaSocket: ExecApprovalsModule["requestExecApprovalViaSocket"];
+let resolveExecApprovals: ExecApprovalsModule["resolveExecApprovals"];
 let resolveExecApprovalsPath: ExecApprovalsModule["resolveExecApprovalsPath"];
 let resolveExecApprovalsSocketPath: ExecApprovalsModule["resolveExecApprovalsSocketPath"];
 let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
@@ -42,6 +43,7 @@ beforeAll(async () => {
     recordAllowlistMatchesUse,
     recordAllowlistUse,
     requestExecApprovalViaSocket,
+    resolveExecApprovals,
     resolveExecApprovalsPath,
     resolveExecApprovalsSocketPath,
     saveExecApprovals,
@@ -187,6 +189,113 @@ describe("exec approvals store helpers", () => {
     expect(readApprovalsFile(dir).socket).toEqual(ensured.socket);
   });
 
+  it("does not create an approvals file when resolving the missing default no-prompt policy", () => {
+    const dir = createHomeDir();
+
+    const resolved = resolveExecApprovals("main", {
+      security: "full",
+      ask: "off",
+    });
+
+    expect(resolved.agent.security).toBe("full");
+    expect(resolved.agent.ask).toBe("off");
+    expect(resolved.socketPath).toBe(resolveExecApprovalsSocketPath());
+    expect(resolved.token).toBe("");
+    expect(fs.existsSync(approvalsFilePath(dir))).toBe(false);
+  });
+
+  it("does not rewrite an empty approvals file for the default no-prompt policy", () => {
+    const dir = createHomeDir();
+    const approvalsPath = approvalsFilePath(dir);
+    fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
+    fs.writeFileSync(approvalsPath, "", "utf8");
+
+    const resolved = resolveExecApprovals("main", {
+      security: "full",
+      ask: "off",
+    });
+
+    expect(resolved.agent.security).toBe("full");
+    expect(resolved.agent.ask).toBe("off");
+    expect(resolved.token).toBe("");
+    expect(fs.statSync(approvalsPath).size).toBe(0);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects symlinked approvals files before resolving the default no-prompt policy",
+    () => {
+      const dir = createHomeDir();
+      const approvalsPath = approvalsFilePath(dir);
+      const linkedPath = path.join(dir, "linked-approvals.json");
+      fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
+      fs.writeFileSync(
+        linkedPath,
+        JSON.stringify({
+          version: 1,
+          defaults: { security: "full", ask: "off" },
+          agents: {},
+        }),
+        "utf8",
+      );
+      fs.symlinkSync(linkedPath, approvalsPath);
+
+      expect(() =>
+        resolveExecApprovals("main", {
+          security: "deny",
+          ask: "always",
+        }),
+      ).toThrow("Refusing to write exec approvals via symlink");
+    },
+  );
+
+  it("does not treat approvals path access errors as a missing default policy", () => {
+    const dir = createHomeDir();
+    const approvalsPath = approvalsFilePath(dir);
+    const actualReadFileSync = fs.readFileSync.bind(fs);
+    vi.spyOn(fs, "readFileSync").mockImplementation((target, options) => {
+      if (String(target) === approvalsPath) {
+        throw Object.assign(new Error("approval path blocked"), { code: "EACCES" });
+      }
+      return actualReadFileSync(target, options as never);
+    });
+
+    expect(() =>
+      resolveExecApprovals("main", {
+        security: "full",
+        ask: "off",
+      }),
+    ).toThrow("approval path blocked");
+  });
+
+  it("creates an approvals file when resolving a missing policy that may prompt", () => {
+    const dir = createHomeDir();
+
+    const resolved = resolveExecApprovals("main", {
+      security: "allowlist",
+      ask: "on-miss",
+    });
+
+    expect(resolved.agent.security).toBe("allowlist");
+    expect(resolved.agent.ask).toBe("on-miss");
+    expect(resolved.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(readApprovalsFile(dir).socket).toEqual(resolved.file.socket);
+  });
+
+  it("creates an approvals file for default no-prompt policy when a socket is required", () => {
+    const dir = createHomeDir();
+
+    const resolved = resolveExecApprovals("main", {
+      security: "full",
+      ask: "off",
+      requireSocket: true,
+    });
+
+    expect(resolved.agent.security).toBe("full");
+    expect(resolved.agent.ask).toBe("off");
+    expect(resolved.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(readApprovalsFile(dir).socket).toEqual(resolved.file.socket);
+  });
+
   it("atomically replaces existing approvals files instead of mutating linked inodes", () => {
     const dir = createHomeDir();
     const approvalsPath = approvalsFilePath(dir);
@@ -235,6 +344,24 @@ describe("exec approvals store helpers", () => {
     expect(fs.readFileSync(approvalsFilePath(dir), "utf8")).toContain('"security": "full"');
     expect(fs.statSync(approvalsDir).mode & 0o777).toBe(0o700);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "keeps exec approvals strict when directory chmod fails",
+    () => {
+      const dir = createHomeDir();
+      const approvalsDir = path.dirname(approvalsFilePath(dir));
+      const actualChmodSync = fs.chmodSync.bind(fs);
+      vi.spyOn(fs, "chmodSync").mockImplementation((target, mode) => {
+        if (String(target) === approvalsDir) {
+          throw Object.assign(new Error("chmod denied"), { code: "EPERM" });
+        }
+        return actualChmodSync(target, mode);
+      });
+
+      expect(() => ensureExecApprovals()).toThrow("chmod denied");
+      expect(fs.existsSync(approvalsFilePath(dir))).toBe(false);
+    },
+  );
 
   it("falls back to copying when rename cannot overwrite the approvals file", () => {
     const dir = createHomeDir();

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -222,6 +222,36 @@ describe("exec approvals store helpers", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "hardens existing token-bearing approvals files before resolving default no-prompt policy",
+    () => {
+      const dir = createHomeDir();
+      const approvalsPath = approvalsFilePath(dir);
+      fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
+      fs.writeFileSync(
+        approvalsPath,
+        JSON.stringify({
+          version: 1,
+          socket: { path: resolveExecApprovalsSocketPath(), token: "existing-token" },
+          defaults: { security: "full", ask: "off" },
+          agents: {},
+        }),
+        { mode: 0o644 },
+      );
+      fs.chmodSync(approvalsPath, 0o644);
+
+      const resolved = resolveExecApprovals("main", {
+        security: "full",
+        ask: "off",
+      });
+
+      expect(resolved.agent.security).toBe("full");
+      expect(resolved.agent.ask).toBe("off");
+      expect(resolved.token).toBe("existing-token");
+      expect(fs.statSync(approvalsPath).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "rejects symlinked approvals files before resolving the default no-prompt policy",
     () => {
       const dir = createHomeDir();

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -758,6 +758,31 @@ export function ensureExecApprovals(): ExecApprovalsFile {
   return updated;
 }
 
+function readExecApprovalsForNoPersistence(filePath: string): ExecApprovalsFile {
+  const dir = path.dirname(filePath);
+  assertNoExecApprovalsSymlinkParents(dir, resolveRequiredHomeDir());
+  assertSafeExecApprovalsDestination(filePath);
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+    return normalizeExecApprovals({ version: 1, agents: {} });
+  }
+  try {
+    const parsed = JSON.parse(raw) as ExecApprovalsFile;
+    if (parsed?.version === 1) {
+      return normalizeExecApprovals(parsed);
+    }
+  } catch {
+    // Empty or invalid persisted approvals have no usable stricter policy.
+  }
+  return normalizeExecApprovals({ version: 1, agents: {} });
+}
+
 function isExecSecurity(value: unknown): value is ExecSecurity {
   return value === "allowlist" || value === "full" || value === "deny";
 }
@@ -890,12 +915,28 @@ export type ExecApprovalsDefaultOverrides = {
   ask?: ExecAsk;
   askFallback?: ExecSecurity;
   autoAllowSkills?: boolean;
+  requireSocket?: boolean;
 };
 
 export function resolveExecApprovals(
   agentId?: string,
   overrides?: ExecApprovalsDefaultOverrides,
 ): ExecApprovalsResolved {
+  const filePath = resolveExecApprovalsPath();
+  if (!overrides?.requireSocket) {
+    const file = readExecApprovalsForNoPersistence(filePath);
+    const resolved = resolveExecApprovalsFromFile({
+      file,
+      agentId,
+      overrides,
+      path: filePath,
+      socketPath: resolveExecApprovalsSocketPath(),
+      token: "",
+    });
+    if (resolved.agent.security === "full" && resolved.agent.ask === "off") {
+      return resolved;
+    }
+  }
   const file = ensureExecApprovals();
   return resolveExecApprovalsFromFile({
     file,

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -933,7 +933,11 @@ export function resolveExecApprovals(
       socketPath: resolveExecApprovalsSocketPath(),
       token: "",
     });
-    if (resolved.agent.security === "full" && resolved.agent.ask === "off") {
+    if (
+      resolved.agent.security === "full" &&
+      resolved.agent.ask === "off" &&
+      !file.socket?.token?.trim()
+    ) {
       return resolved;
     }
   }

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -387,6 +387,7 @@ async function evaluateSystemRunPolicyPhase(
   const approvals = resolveExecApprovals(parsed.agentId, {
     security: configuredSecurity,
     ask: configuredAsk,
+    requireSocket: opts.preferMacAppExecHost,
   });
   const security = approvals.agent.security;
   const ask = approvals.agent.ask;


### PR DESCRIPTION
## Summary

- Fixes the fsGroup/PVC exec regression for the default no-prompt policy by resolving `security=full` + `ask=off` without creating or rewriting `~/.openclaw/exec-approvals.json`.
- Covers both missing and existing empty/invalid approvals files, since the observed broken state can include an empty file.
- Keeps stricter paths unchanged: prompting, allowlist behavior, unreadable approvals files, and Mac app exec-host socket requirements still go through the persisted approvals store and its hardening.
- Intentionally does not broaden chmod tolerance for SQLite/task/plugin state; that should stay in the broader PVC/fsGroup policy discussion.
- Reviewers should focus on whether the no-persistence branch can accidentally skip a stricter persisted policy. It only returns early after resolving the effective policy to `full/off`.

AI-assisted: yes; no agent transcript is included in this PR body.

## Linked context

Fixes #83619

Closure plan after this PR lands:

- #83619 auto-closes from this PR.
- #83695 should be closed as superseded by this narrower landing path; it remains useful broader PVC/fsGroup policy input.
- #86938 should be closed as superseded; it handled the missing-file case but not existing empty/invalid readable approval files.
- #84704 is already closed as a duplicate of the canonical Kubernetes/fsGroup exec approvals report.

Related, but not closed by this PR:

- #77907 is the merged regression provenance for the exec approvals chmod path.
- #77785 is the original Windows rename-overwrite issue fixed by #77907 and is already closed.
- #71205 covers broader multi-uid state-dir hardening policy and remains separate.
- #66747 covers broader task/task-flow/macOS chmod and probe behavior and remains separate.
- #73341 is a merged chmod-tolerance precedent, not a closure target.

Was this requested by a maintainer or owner?

Yes, requested during maintainer investigation of the fsGroup exec approvals regression.

## Real behavior proof (required for external PRs)

Behavior addressed: Kubernetes/fsGroup-style volumes can be writable through group ownership while `chmod` on the mount-owned state directory fails with `EPERM`. Current `main` writes exec approvals state even for default yolo/no-prompt exec policy, so exec can fail before the user command runs.

Real environment tested: AWS Crabbox Linux runner using uid/gid `1000` without capabilities against a directory owned `root:1000` with mode `2775`, matching the fsGroup-owned PVC permission shape. Follow-up checks ran locally and in Blacksmith Testbox.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs src/infra/exec-approvals-store.test.ts src/node-host/invoke-system-run.test.ts src/agents/bash-tools.exec-host-gateway.test.ts
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 30m --ttl 90m --timing-json -- corepack pnpm check:changed
```

Evidence after fix:

```json
{"label":"missing","result":"resolved","security":"full","ask":"off","token":"","approvalsExists":false,"approvalsSize":null}
{"label":"empty","result":"resolved","security":"full","ask":"off","token":"","approvalsExists":true,"approvalsSize":0}
{"result":"strict-path-still-fails-closed","code":"EPERM","message":"chmod denied by fsGroup-style mount","approvalsExists":false,"approvalsDirExists":true}
```

Observed result after fix: default `full/off` exec approval resolution no longer creates or rewrites the approvals file, including when an empty approvals file already exists. Prompting/allowlist paths still attempt the persisted store and fail closed on the simulated chmod denial.

What was not tested: I did not run a full Kubernetes cluster deployment. The permission failure itself was reproduced on a Linux runner with the same uid/gid, ownership, mode, and no-capability shape; the code fix was then covered with focused tests and `check:changed`.

Proof limitations or environment constraints: Local Docker and Podman were not running, so the Linux filesystem proof used Crabbox/Testbox instead of a local Kind cluster.

Before evidence:

```json
{"result":"reproduced","code":"EPERM","message":"EPERM: operation not permitted, chmod '<state-dir>/.openclaw'"}
```

Crabbox before-repro proof: provider `aws`, lease `cbx_d8458871a739`, run `run_d0461590ad59`.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/infra/exec-approvals-store.test.ts src/node-host/invoke-system-run.test.ts src/agents/bash-tools.exec-host-gateway.test.ts` - 4 files, 92 tests passed.
- `git diff --check HEAD~1..HEAD` - passed.
- Blacksmith Testbox via Crabbox: provider `blacksmith-testbox`, lease `tbx_01ksjme8x21sg7majf1rg9qx1v`, `corepack pnpm check:changed` - passed.

What regression coverage was added or updated?

- Missing approvals file + default no-prompt policy does not write state.
- Existing empty approvals file + default no-prompt policy does not rewrite state.
- Symlinked approvals files are rejected before the no-persistence fast path reads or trusts their content.
- Access errors are not treated as harmless missing/default policy state.
- Prompting policy and Mac exec-host socket requirements still create/persist approvals state.
- Directory chmod failures still fail closed for strict store-writing paths.

What failed before this fix, if known?

- Source repro of `resolveExecApprovals("main", { security: "full", ask: "off" })` threw `EPERM` when directory chmod failed.
- The first narrow branch shape only handled missing files; an existing empty approvals file still failed. This PR covers that case too.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Default yolo/no-prompt exec no longer creates default approvals state as a side effect.

Did config, environment, or migration behavior change? (`Yes/No`)

No config or migration change. The runtime no longer materializes default approvals state when no persisted state is needed.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, tool execution behavior changes for default no-prompt exec approval resolution. Security-sensitive persisted approval paths stay strict.

What is the highest-risk area?

Accidentally ignoring a stricter persisted approval policy.

How is that risk mitigated?

The no-persistence path reads existing readable approval content and resolves the same effective policy first. It only returns early when the effective agent policy is `security=full` and `ask=off`; all other cases call `ensureExecApprovals()` and preserve the existing hardening path.

## Current review state

What is the next action?

ClawSweeper re-review, maintainer review, and CI.

What is still waiting on author, maintainer, CI, or external proof?

Nothing known from the author side after addressing the ClawSweeper P1 fast-path safety finding. Full Kubernetes smoke can be added if maintainers want cluster-level confirmation before merge.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper P1: the no-persistence fast path now applies the existing exec approvals symlink-parent and destination safety checks before reading, with regression coverage for a symlinked `exec-approvals.json` resolving to `full/off`.

