### PR TITLE
fix(web-fetch): surface progress during long fetches

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -4,6 +4,7 @@ import {
   onAgentEvent as registerAgentEventListener,
   resetAgentEventsForTest,
 } from "../infra/agent-events.js";
+import { buildChannelProgressDraftLine } from "../plugin-sdk/channel-streaming.js";
 import type { MessagingToolSend } from "./embedded-agent-messaging.types.js";
 import {
   handleToolExecutionEnd,
@@ -1850,5 +1851,347 @@ describe("control UI credential redaction (issue #72283)", () => {
     }
     expect(emittedResult).not.toContain("sk-or-v1-abcdef0123456789");
     expect(emittedResult).toContain("OPENROUTER_API_KEY=");
+  });
+});
+
+describe("handleToolExecutionUpdate non-exec progress", () => {
+  afterEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  function captureItemEvents(): {
+    events: CapturedAgentEvent[];
+    dispose: () => void;
+  } {
+    const events: CapturedAgentEvent[] = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+    return {
+      events,
+      dispose: () => resetAgentEventsForTest(),
+    };
+  }
+
+  it("surfaces web_fetch partialResult as progressText on the kind:tool item", async () => {
+    resetAgentEventsForTest();
+    const { events, dispose } = captureItemEvents();
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "wf-1",
+        args: { url: "https://example.com/slow" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "wf-1",
+        partialResult: {
+          content: [{ type: "text", text: "Fetching web page…" }],
+        },
+      } as never,
+    );
+
+    const itemUpdateEvent = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "item" &&
+        (evt.data as { itemId?: string; phase?: string; kind?: string })?.itemId === "tool:wf-1" &&
+        (evt.data as { phase?: string }).phase === "update",
+      "web_fetch tool item update",
+    );
+    expectRecordFields(itemUpdateEvent.data, "web_fetch tool item update data", {
+      itemId: "tool:wf-1",
+      phase: "update",
+      kind: "tool",
+      name: "web_fetch",
+      progressText: "Fetching web page…",
+    });
+    // `meta` MUST be absent on the update event so the channel draft formatter
+    // (input.meta ?? input.summary ?? input.progressText) falls through to
+    // `progressText`. The start event still carries `meta` for consumers that
+    // snapshot it at item start (covered separately by handleToolExecutionStart
+    // tests).
+    expect((itemUpdateEvent.data as { meta?: string }).meta).toBeUndefined();
+
+    // Subscriber-facing onAgentEvent gets the same shape via the item channel.
+    const subscriberItemUpdate = onAgentEvent.mock.calls
+      .map((call) => call[0] as CapturedAgentEvent)
+      .find(
+        (evt) =>
+          evt.stream === "item" &&
+          (evt.data as { itemId?: string; phase?: string })?.itemId === "tool:wf-1" &&
+          (evt.data as { phase?: string }).phase === "update",
+      );
+    if (!subscriberItemUpdate) {
+      throw new Error("expected subscriber item update");
+    }
+    expect((subscriberItemUpdate.data as { progressText?: string }).progressText).toBe(
+      "Fetching web page…",
+    );
+    expect((subscriberItemUpdate.data as { meta?: string }).meta).toBeUndefined();
+
+    dispose();
+  });
+
+  it("renders channel draft as 'Fetching web page…' (formatter integration with meta+progressText)", async () => {
+    resetAgentEventsForTest();
+    const { events, dispose } = captureItemEvents();
+    const { ctx } = createTestContext();
+
+    // handleToolExecutionStart records the web_fetch `meta` value (e.g.
+    // `from <url>`) on the start item event, mimicking what
+    // `inferToolMetaFromArgs` returns at runtime.
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "wf-draft",
+        args: { url: "https://example.com/slow" },
+      } as never,
+    );
+
+    // Verify the start event carries the URL-bearing meta — this is the meta
+    // value that, prior to the precedence fix, hid `progressText` from the
+    // channel draft formatter.
+    const startEvent = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "item" &&
+        (evt.data as { itemId?: string; phase?: string })?.itemId === "tool:wf-draft" &&
+        (evt.data as { phase?: string }).phase === "start",
+      "web_fetch tool item start",
+    );
+    const startMeta = (startEvent.data as { meta?: string }).meta;
+    expect(typeof startMeta).toBe("string");
+    if (typeof startMeta !== "string") {
+      throw new Error("expected start meta");
+    }
+    expect(startMeta).toContain("example.com");
+
+    // Now drive the progress update. The runtime omits `meta` on this event
+    // so the channel draft formatter falls through to `progressText`.
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "wf-draft",
+        partialResult: {
+          content: [{ type: "text", text: "Fetching web page…" }],
+        },
+      } as never,
+    );
+
+    const updateEvent = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "item" &&
+        (evt.data as { itemId?: string; phase?: string })?.itemId === "tool:wf-draft" &&
+        (evt.data as { phase?: string }).phase === "update",
+      "web_fetch tool item update",
+    );
+    const updateData = updateEvent.data as Record<string, unknown>;
+
+    // Channel-side static contract: pass the update item payload to the real
+    // formatter and assert the rendered text contains the generic progress
+    // literal (not the URL-bearing meta).
+    const formatterInput = { ...updateData, event: "item", itemKind: "tool" } as never;
+    const draft = buildChannelProgressDraftLine(formatterInput);
+    expect(draft).toBeDefined();
+    if (!draft) {
+      throw new Error("expected channel draft");
+    }
+    expect(draft.text).toContain("Fetching web page…");
+    expect(draft.text).not.toContain("example.com");
+    expect(draft.text).not.toContain("https://");
+
+    // Defensive: even if the formatter ever falls back to summary, summary is
+    // not set on this event either.
+    expect(updateData.summary).toBeUndefined();
+
+    dispose();
+  });
+
+  it("caps non-exec progressText at the live-output character budget", async () => {
+    resetAgentEventsForTest();
+    const { events, dispose } = captureItemEvents();
+    const { ctx } = createTestContext();
+    const large = "x".repeat(9_000);
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "wf-cap",
+        args: { url: "https://example.com/slow" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "wf-cap",
+        partialResult: {
+          content: [{ type: "text", text: large }],
+        },
+      } as never,
+    );
+
+    const itemUpdateEvent = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "item" &&
+        (evt.data as { itemId?: string; phase?: string })?.itemId === "tool:wf-cap" &&
+        (evt.data as { phase?: string }).phase === "update",
+      "capped tool item update",
+    );
+    const progressText = (itemUpdateEvent.data as { progressText?: string }).progressText;
+    expect(typeof progressText).toBe("string");
+    if (typeof progressText !== "string") {
+      throw new Error("expected progressText");
+    }
+    expect(progressText.length).toBeLessThan(large.length);
+    expect(progressText).toContain("...(live output truncated)...");
+
+    dispose();
+  });
+
+  it("does not surface progressText for non-allow-listed non-exec tools", async () => {
+    resetAgentEventsForTest();
+    const { events, dispose } = captureItemEvents();
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "random_plugin_tool",
+        toolCallId: "rp-1",
+        args: {},
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "random_plugin_tool",
+        toolCallId: "rp-1",
+        partialResult: {
+          content: [{ type: "text", text: "secret=abc123" }],
+        },
+      } as never,
+    );
+
+    const itemUpdateEvent = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "item" &&
+        (evt.data as { itemId?: string; phase?: string })?.itemId === "tool:rp-1" &&
+        (evt.data as { phase?: string }).phase === "update",
+      "non-allow-list tool item update",
+    );
+    expect((itemUpdateEvent.data as { progressText?: string }).progressText).toBeUndefined();
+
+    // The upstream stream:"tool" partialResult is preserved for ACP/TUI consumers.
+    const partialResultEvent = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "tool" &&
+        (evt.data as { phase?: string; toolCallId?: string })?.phase === "update" &&
+        (evt.data as { toolCallId?: string }).toolCallId === "rp-1",
+      "non-allow-list partial result event",
+    );
+    expect((partialResultEvent.data as { partialResult?: unknown }).partialResult).toBeTruthy();
+
+    dispose();
+  });
+
+  it("preserves the existing exec command-output progress flow (regression)", async () => {
+    resetAgentEventsForTest();
+    const { events, dispose } = captureItemEvents();
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "exec-regression",
+        args: { command: "npm test" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "exec",
+        toolCallId: "exec-regression",
+        partialResult: {
+          details: {
+            status: "running",
+            aggregated: "RUN  src/example.test.ts",
+          },
+        },
+      } as never,
+    );
+
+    // Exec command item carries progressText (unchanged behavior). Filter on
+    // phase:"update" because the start phase emits the same itemId without
+    // progressText.
+    const commandUpdate = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "item" &&
+        (evt.data as { itemId?: string; kind?: string; phase?: string })?.itemId ===
+          "command:exec-regression" &&
+        (evt.data as { kind?: string }).kind === "command" &&
+        (evt.data as { phase?: string }).phase === "update",
+      "exec command item update",
+    );
+    expectRecordFields(commandUpdate.data, "exec command item update data", {
+      kind: "command",
+      progressText: "RUN  src/example.test.ts",
+    });
+
+    // Exec kind:"tool" item never carries progressText (it lives on the
+    // sibling kind:"command" item to avoid alternating renders).
+    const toolUpdate = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "item" &&
+        (evt.data as { itemId?: string; kind?: string; phase?: string })?.itemId ===
+          "tool:exec-regression" &&
+        (evt.data as { kind?: string }).kind === "tool" &&
+        (evt.data as { phase?: string }).phase === "update",
+      "exec tool item update",
+    );
+    expect((toolUpdate.data as { progressText?: string }).progressText).toBeUndefined();
+
+    const commandOutputDelta = onAgentEvent.mock.calls
+      .map((call) => call[0] as CapturedAgentEvent)
+      .find((evt) => evt.stream === "command_output");
+    if (!commandOutputDelta) {
+      throw new Error("expected exec command_output delta");
+    }
+    expect((commandOutputDelta.data as { output?: string }).output).toBe(
+      "RUN  src/example.test.ts",
+    );
+
+    dispose();
   });
 });

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2120,10 +2120,10 @@ describe("handleToolExecutionUpdate non-exec progress", () => {
     dispose();
   });
 
-  it("suppresses the legacy stream:tool partialResult bridge when web_fetch progressText is surfaced", async () => {
+  it("suppresses both the global and subscriber stream:tool update bridges when web_fetch progressText is surfaced", async () => {
     resetAgentEventsForTest();
     const { events, dispose } = captureItemEvents();
-    const { ctx } = createTestContext();
+    const { ctx, onAgentEvent } = createTestContext();
 
     await handleToolExecutionStart(
       ctx as never,
@@ -2134,6 +2134,10 @@ describe("handleToolExecutionUpdate non-exec progress", () => {
         args: { url: "https://example.com/slow" },
       } as never,
     );
+
+    // Reset the subscriber callback spy after the start phase so the
+    // assertions below isolate the update-phase events only.
+    onAgentEvent.mockClear();
 
     handleToolExecutionUpdate(
       ctx as never,
@@ -2160,11 +2164,12 @@ describe("handleToolExecutionUpdate non-exec progress", () => {
       "Fetching web page…",
     );
 
-    // The legacy stream:"tool" phase:"update" partialResult bridge MUST NOT
-    // fire for this same tool call. Downstream runners convert that bridge
-    // into an extra `onToolStart` render which would produce a bare "Web
-    // Fetch" row alongside the new progress draft (ClawSweeper round 4 P1).
-    const bridgeBypass = events.find(
+    // (a) The global event-bus `stream:"tool"` `phase:"update"`
+    // `partialResult` bridge MUST NOT fire. Downstream runners convert
+    // that bridge into an extra `onToolStart` render which would produce a
+    // bare "Web Fetch" row alongside the new progress draft (ClawSweeper
+    // round 4 P1).
+    const globalBridgeUpdate = events.find(
       (evt) =>
         evt.stream === "tool" &&
         (evt.data as { phase?: string; toolCallId?: string; partialResult?: unknown })?.phase ===
@@ -2172,7 +2177,67 @@ describe("handleToolExecutionUpdate non-exec progress", () => {
         (evt.data as { toolCallId?: string }).toolCallId === "wf-bridge" &&
         (evt.data as { partialResult?: unknown }).partialResult !== undefined,
     );
-    expect(bridgeBypass).toBeUndefined();
+    expect(globalBridgeUpdate).toBeUndefined();
+
+    // (b) The subscriber-side `ctx.params.onAgentEvent` callback that
+    // forwards a bare `stream:"tool"` `phase:"update"` (without
+    // `partialResult`) is the SECOND surface the runners ingest as a
+    // fresh tool update — and the path that channel progress rendering
+    // also consumes. That bridge MUST NOT fire either (ClawSweeper round
+    // 5 P1).
+    const subscriberToolUpdates = onAgentEvent.mock.calls
+      .map((call) => call[0] as CapturedAgentEvent)
+      .filter(
+        (evt) =>
+          evt.stream === "tool" &&
+          (evt.data as { phase?: string; toolCallId?: string })?.phase === "update" &&
+          (evt.data as { toolCallId?: string }).toolCallId === "wf-bridge",
+      );
+    expect(subscriberToolUpdates).toHaveLength(0);
+
+    dispose();
+  });
+
+  it("preserves the subscriber stream:tool update for non-allow-listed tools", async () => {
+    resetAgentEventsForTest();
+    const { dispose } = captureItemEvents();
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "random_plugin_tool",
+        toolCallId: "rp-bridge",
+        args: {},
+      } as never,
+    );
+    onAgentEvent.mockClear();
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "random_plugin_tool",
+        toolCallId: "rp-bridge",
+        partialResult: {
+          content: [{ type: "text", text: "secret=abc123" }],
+        },
+      } as never,
+    );
+
+    // Non-allow-list non-exec tools keep the subscriber bridge — ACP / TUI /
+    // gateway consumers still need partials there. Only allow-listed tools
+    // whose item progress takes over the channel-visible path lose it.
+    const subscriberToolUpdate = onAgentEvent.mock.calls
+      .map((call) => call[0] as CapturedAgentEvent)
+      .find(
+        (evt) =>
+          evt.stream === "tool" &&
+          (evt.data as { phase?: string; toolCallId?: string })?.phase === "update" &&
+          (evt.data as { toolCallId?: string }).toolCallId === "rp-bridge",
+      );
+    expect(subscriberToolUpdate).toBeDefined();
 
     dispose();
   });

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2120,6 +2120,63 @@ describe("handleToolExecutionUpdate non-exec progress", () => {
     dispose();
   });
 
+  it("suppresses the legacy stream:tool partialResult bridge when web_fetch progressText is surfaced", async () => {
+    resetAgentEventsForTest();
+    const { events, dispose } = captureItemEvents();
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "web_fetch",
+        toolCallId: "wf-bridge",
+        args: { url: "https://example.com/slow" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "wf-bridge",
+        partialResult: {
+          content: [{ type: "text", text: "Fetching web page…" }],
+        },
+      } as never,
+    );
+
+    // Channel-visible progress is surfaced via the kind:"tool" item event.
+    const itemUpdateEvent = requireEvent(
+      events,
+      (evt) =>
+        evt.stream === "item" &&
+        (evt.data as { itemId?: string; phase?: string })?.itemId === "tool:wf-bridge" &&
+        (evt.data as { phase?: string }).phase === "update",
+      "web_fetch tool item update",
+    );
+    expect((itemUpdateEvent.data as { progressText?: string }).progressText).toBe(
+      "Fetching web page…",
+    );
+
+    // The legacy stream:"tool" phase:"update" partialResult bridge MUST NOT
+    // fire for this same tool call. Downstream runners convert that bridge
+    // into an extra `onToolStart` render which would produce a bare "Web
+    // Fetch" row alongside the new progress draft (ClawSweeper round 4 P1).
+    const bridgeBypass = events.find(
+      (evt) =>
+        evt.stream === "tool" &&
+        (evt.data as { phase?: string; toolCallId?: string; partialResult?: unknown })?.phase ===
+          "update" &&
+        (evt.data as { toolCallId?: string }).toolCallId === "wf-bridge" &&
+        (evt.data as { partialResult?: unknown }).partialResult !== undefined,
+    );
+    expect(bridgeBypass).toBeUndefined();
+
+    dispose();
+  });
+
   it("preserves the existing exec command-output progress flow (regression)", async () => {
     resetAgentEventsForTest();
     const { events, dispose } = captureItemEvents();

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1090,7 +1090,25 @@ export function handleToolExecutionUpdate(
   const sanitized = sanitizeToolResult(partial);
   const isExecTool = isExecToolName(toolName);
   const liveResult = isExecTool ? capLiveExecResult(sanitized) : sanitized;
-  const emitDetailedLiveUpdate = !isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId);
+  // Allow-listed non-exec tools surface their first text content block as
+  // channel-visible `progressText`. Channel renderers already consume this
+  // field for exec command output via `kind:"command"`; we reuse the same
+  // contract for the existing `kind:"tool"` item, which keeps channel-side
+  // code untouched. Non-allow-listed non-exec tools never populate this
+  // field — their `partialResult` may carry URLs, bodies, or tokens that
+  // must not leak into a draft.
+  const nonExecProgressText =
+    !isExecTool && NON_EXEC_PROGRESS_SAFE_TOOLS.has(toolName)
+      ? extractLiveNonExecProgressText(sanitized)
+      : undefined;
+  // When we surface a non-exec progress milestone via item `progressText`,
+  // suppress the legacy `stream:"tool"` `partialResult` bridge: downstream
+  // runners convert that bridge into an extra `onToolStart` event which
+  // renders a bare `Web Fetch` row alongside the new progress draft. The
+  // bridge stays for exec and for non-allow-list non-exec tools (ACP / TUI /
+  // gateway consumers preserve their existing partials there).
+  const emitDetailedLiveUpdate =
+    nonExecProgressText === undefined && (!isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId));
   if (emitDetailedLiveUpdate) {
     emitAgentEvent({
       runId: ctx.params.runId,
@@ -1103,17 +1121,6 @@ export function handleToolExecutionUpdate(
       },
     });
   }
-  // Allow-listed non-exec tools surface their first text content block as
-  // channel-visible `progressText`. Channel renderers already consume this
-  // field for exec command output via `kind:"command"`; we reuse the same
-  // contract for the existing `kind:"tool"` item, which keeps channel-side
-  // code untouched. Non-allow-listed non-exec tools never populate this
-  // field — their `partialResult` may carry URLs, bodies, or tokens that
-  // must not leak into a draft.
-  const nonExecProgressText =
-    !isExecTool && NON_EXEC_PROGRESS_SAFE_TOOLS.has(toolName)
-      ? extractLiveNonExecProgressText(sanitized)
-      : undefined;
   const storedMeta = ctx.state.toolMetaById.get(toolCallId)?.meta;
   // Channel draft formatter precedence is `meta ?? summary ?? progressText`
   // (src/plugin-sdk/channel-streaming.ts:423). When we surface a non-exec

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -26,6 +26,7 @@ import {
 import { normalizeOptionalLowercaseString, readStringValue } from "../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
+import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
@@ -53,7 +54,6 @@ import {
 import { inferToolMetaFromArgs } from "./embedded-agent-utils.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
 import type { AgentEvent } from "./runtime/index.js";
-import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 
@@ -81,6 +81,19 @@ const TRACE_REQUIRED_PARAM_GROUPS = {
   write: REQUIRED_PARAM_GROUPS.write,
   edit: REQUIRED_PARAM_GROUPS.edit,
 } satisfies Record<string, readonly RequiredParamGroup[]>;
+
+/**
+ * Non-exec tools whose `partialResult` first-text-block is contractually safe
+ * to surface as channel-visible `progressText`. Each entry is a promise from
+ * the tool's `onUpdate` callsite that the emitted text is host-class only —
+ * no full URL with path/query, no request/response body bytes, no headers
+ * (cookies / auth / set-cookie), no raw tool args beyond a safe summary.
+ *
+ * Adding a tool here requires auditing its `onUpdate` emit sites. See
+ * `src/agents/tools/web-fetch.ts` `emitWebFetchProgressSafely` for the
+ * reference single-shot contract.
+ */
+const NON_EXEC_PROGRESS_SAFE_TOOLS: ReadonlySet<string> = new Set(["web_fetch"]);
 
 function isMiddlewareToolResultError(result: unknown): boolean {
   if (!result || typeof result !== "object") {
@@ -344,6 +357,21 @@ function extractExecOutput(result: unknown): string | undefined {
 function extractLiveExecOutput(result: unknown): string | undefined {
   const output = extractExecOutput(result);
   return typeof output === "string" ? truncateLiveExecOutput(output) : undefined;
+}
+
+/**
+ * Extract a safe progress string from an allow-listed non-exec `partialResult`.
+ * Caller MUST gate on `NON_EXEC_PROGRESS_SAFE_TOOLS` before calling; this
+ * helper does no semantic filtering. The same `LIVE_EXEC_OUTPUT_MAX_CHARS`
+ * cap is applied so a misbehaving tool cannot flush a large body into a
+ * channel progress draft.
+ */
+function extractLiveNonExecProgressText(result: unknown): string | undefined {
+  const text = extractToolResultText(result);
+  if (typeof text !== "string" || text.length === 0) {
+    return undefined;
+  }
+  return truncateLiveExecOutput(text);
 }
 
 function shouldEmitLiveExecUpdate(ctx: ToolHandlerContext, toolCallId: string): boolean {
@@ -1075,15 +1103,34 @@ export function handleToolExecutionUpdate(
       },
     });
   }
+  // Allow-listed non-exec tools surface their first text content block as
+  // channel-visible `progressText`. Channel renderers already consume this
+  // field for exec command output via `kind:"command"`; we reuse the same
+  // contract for the existing `kind:"tool"` item, which keeps channel-side
+  // code untouched. Non-allow-listed non-exec tools never populate this
+  // field — their `partialResult` may carry URLs, bodies, or tokens that
+  // must not leak into a draft.
+  const nonExecProgressText =
+    !isExecTool && NON_EXEC_PROGRESS_SAFE_TOOLS.has(toolName)
+      ? extractLiveNonExecProgressText(sanitized)
+      : undefined;
+  const storedMeta = ctx.state.toolMetaById.get(toolCallId)?.meta;
+  // Channel draft formatter precedence is `meta ?? summary ?? progressText`
+  // (src/plugin-sdk/channel-streaming.ts:423). When we surface a non-exec
+  // live progress milestone (e.g. web_fetch's delayed "Fetching web page…"),
+  // omit `meta` on the update event so the channel draft falls through to
+  // the progress text. The start event still carries `meta` for consumers
+  // that snapshot it at item start.
   const itemData: AgentItemEventData = {
     itemId: buildToolItemId(toolCallId),
     phase: "update",
     kind: "tool",
-    title: buildToolItemTitle(toolName, ctx.state.toolMetaById.get(toolCallId)?.meta),
+    title: buildToolItemTitle(toolName, storedMeta),
     status: "running",
     name: toolName,
-    meta: ctx.state.toolMetaById.get(toolCallId)?.meta,
+    ...(nonExecProgressText ? {} : { meta: storedMeta }),
     toolCallId,
+    ...(nonExecProgressText ? { progressText: nonExecProgressText } : {}),
   };
   emitTrackedItemEvent(ctx, itemData);
   void ctx.params.onAgentEvent?.({

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1140,14 +1140,21 @@ export function handleToolExecutionUpdate(
     ...(nonExecProgressText ? { progressText: nonExecProgressText } : {}),
   };
   emitTrackedItemEvent(ctx, itemData);
-  void ctx.params.onAgentEvent?.({
-    stream: "tool",
-    data: {
-      phase: "update",
-      name: toolName,
-      toolCallId,
-    },
-  });
+  // Subscriber-facing `stream:"tool"` `phase:"update"` signal must be gated
+  // by the same `nonExecProgressText` condition as the global event bridge
+  // above: the auto-reply and follow-up runners route this callback through
+  // `onToolStart`, which would otherwise still render a bare `Web Fetch`
+  // row alongside the item progress draft (ClawSweeper round 5 P1).
+  if (!nonExecProgressText) {
+    void ctx.params.onAgentEvent?.({
+      stream: "tool",
+      data: {
+        phase: "update",
+        name: toolName,
+        toolCallId,
+      },
+    });
+  }
   if (isExecTool) {
     const output = extractLiveExecOutput(liveResult);
     const commandData: AgentItemEventData = {

--- a/src/agents/tools/web-fetch.progress.test.ts
+++ b/src/agents/tools/web-fetch.progress.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LookupFn } from "../../infra/net/ssrf.js";
+import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import "./web-fetch.test-mocks.js";
+import { createWebFetchTool } from "./web-fetch.js";
+import { createBaseWebFetchToolConfig, makeFetchHeaders } from "./web-fetch.test-harness.js";
+
+// The production threshold is 1_000 ms. We use real timers because the fetch
+// path crosses several dynamic imports + DNS lookups whose microtask chain
+// interacts poorly with `vi.useFakeTimers()` (resolver capture races, SSRF
+// guard state leak across reset). Tests wait just past the threshold (~1.2 s)
+// and then drive the controlled fetch resolver. Total wall time per slow test
+// is bounded by the default 5 s per-test timeout.
+const WAIT_PAST_THRESHOLD_MS = 1_200;
+
+const lookupMock = vi.fn();
+const baseToolConfig = createBaseWebFetchToolConfig({
+  lookupFn: lookupMock as unknown as LookupFn,
+});
+
+function markdownResponse(body: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: makeFetchHeaders({ "content-type": "text/markdown; charset=utf-8" }),
+    text: async () => body,
+  } as Response;
+}
+
+type ProgressBlock = { type?: string; text?: string };
+type ProgressPayload = { content?: ProgressBlock[] };
+
+function captureProgress(): {
+  emits: Array<{ text: string }>;
+  onUpdate: (payload: ProgressPayload) => void;
+} {
+  const emits: Array<{ text: string }> = [];
+  const onUpdate = (payload: ProgressPayload) => {
+    const block = payload?.content?.find((b) => b?.type === "text");
+    if (block?.text !== undefined) {
+      emits.push({ text: block.text });
+    }
+  };
+  return { emits, onUpdate };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function deferredResponse(): {
+  promise: Promise<Response>;
+  resolve: (res: Response) => void;
+} {
+  let resolveFn: ((res: Response) => void) | undefined;
+  const promise = new Promise<Response>((resolve) => {
+    resolveFn = resolve;
+  });
+  if (!resolveFn) {
+    throw new Error("expected deferred resolver to be assigned");
+  }
+  return { promise, resolve: resolveFn };
+}
+
+describe("web_fetch progress emit", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    lookupMock.mockImplementation(async (hostname: string) => {
+      void hostname;
+      return [{ address: "93.184.216.34", family: 4 }];
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    lookupMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("emits a single generic progress milestone after the threshold during a slow fetch", async () => {
+    const deferred = deferredResponse();
+    const fetchSpy = vi.fn().mockImplementation(() => deferred.promise);
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const tool = createWebFetchTool(baseToolConfig);
+    const { emits, onUpdate } = captureProgress();
+
+    const execPromise = tool?.execute?.(
+      "slow-call",
+      { url: "https://example.com/slow-resource" },
+      undefined,
+      onUpdate,
+    );
+
+    await sleep(WAIT_PAST_THRESHOLD_MS);
+    expect(emits).toHaveLength(1);
+    expect(emits[0]?.text).toBe("Fetching web page…");
+
+    deferred.resolve(markdownResponse("# Page"));
+    await execPromise;
+
+    // Single-shot: still exactly one emit after completion.
+    expect(emits).toHaveLength(1);
+  }, 10_000);
+
+  it("emits no progress for fast fetches that complete before the threshold", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse("# Fast Page"));
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const tool = createWebFetchTool(baseToolConfig);
+    const { emits, onUpdate } = captureProgress();
+
+    const result = await tool?.execute?.(
+      "fast-call",
+      { url: "https://example.com/fast" },
+      undefined,
+      onUpdate,
+    );
+    expect(result).toBeDefined();
+    expect(emits).toHaveLength(0);
+  });
+
+  it("cleans up the timer on fetch error so no late progress fires", async () => {
+    const fetchSpy = vi.fn().mockRejectedValue(new Error("network failure"));
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const tool = createWebFetchTool(baseToolConfig);
+    const { emits, onUpdate } = captureProgress();
+
+    const execPromise = tool?.execute?.(
+      "error-call",
+      { url: "https://example.com/will-error" },
+      undefined,
+      onUpdate,
+    );
+    await expect(execPromise).rejects.toThrow("network failure");
+
+    // The cleanup contract is: once the function exits (here via rejection)
+    // no further emit may fire. The emit count at exit may be 0 (rejection
+    // faster than threshold) or 1 (rejection slower than threshold under
+    // load), but it must not grow afterward. Snapshot the count post-exit,
+    // then wait past the would-be threshold and confirm it is unchanged.
+    const emitsAtExit = emits.length;
+    expect(emitsAtExit).toBeLessThanOrEqual(1);
+    await sleep(WAIT_PAST_THRESHOLD_MS);
+    expect(emits).toHaveLength(emitsAtExit);
+  }, 60_000);
+
+  it("is fail-open: a throwing onUpdate does not break the fetch result", async () => {
+    const deferred = deferredResponse();
+    const fetchSpy = vi.fn().mockImplementation(() => deferred.promise);
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const tool = createWebFetchTool(baseToolConfig);
+    const onUpdate = vi.fn(() => {
+      throw new Error("subscriber gone");
+    });
+
+    const execPromise = tool?.execute?.(
+      "throwing-update-call",
+      { url: "https://example.com/slow-resource" },
+      undefined,
+      onUpdate,
+    );
+
+    await sleep(WAIT_PAST_THRESHOLD_MS);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(markdownResponse("# Recovered"));
+    const result = await execPromise;
+    expect(result).toBeDefined();
+  }, 10_000);
+
+  it("never includes URL path/query, headers, cookies, or auth tokens in progress text", async () => {
+    const deferred = deferredResponse();
+    const fetchSpy = vi.fn().mockImplementation(() => deferred.promise);
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const tool = createWebFetchTool(baseToolConfig);
+    const { emits, onUpdate } = captureProgress();
+
+    const sensitiveUrl =
+      "https://example.com/private/path?token=SUPER_SECRET&user=alice&Authorization=Bearer%20abc";
+    const execPromise = tool?.execute?.("privacy-call", { url: sensitiveUrl }, undefined, onUpdate);
+
+    await sleep(WAIT_PAST_THRESHOLD_MS);
+    expect(emits).toHaveLength(1);
+    const text = emits[0]?.text ?? "";
+    const forbidden = [
+      "SUPER_SECRET",
+      "alice",
+      "Bearer",
+      "Authorization",
+      "token=",
+      "private/path",
+      "example.com",
+      "?",
+      "&",
+      "=",
+    ];
+    for (const fragment of forbidden) {
+      expect(text).not.toContain(fragment);
+    }
+
+    deferred.resolve(markdownResponse("# Done"));
+    await execPromise;
+  }, 10_000);
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -13,6 +13,7 @@ import {
 import { isRecord } from "../../utils.js";
 import { extractReadableContent } from "../../web-fetch/content-extractors.runtime.js";
 import { resolveWebProviderConfig } from "../../web/provider-runtime-shared.js";
+import type { AgentToolUpdateCallback } from "../runtime/index.js";
 import { stringEnum } from "../schema/string-enum.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
@@ -47,6 +48,13 @@ const DEFAULT_ERROR_MAX_CHARS = 4_000;
 const DEFAULT_ERROR_MAX_BYTES = 64_000;
 const DEFAULT_FETCH_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+
+// Generic single-shot progress milestone. Fires once if the underlying network
+// work is still in flight after this threshold so channel UIs no longer show a
+// silent gap during slow TTFB or slow body streams. URL path/query/headers and
+// body content are intentionally absent from the payload.
+const WEB_FETCH_PROGRESS_THRESHOLD_MS = 1_000;
+const WEB_FETCH_PROGRESS_TEXT = "Fetching web page…";
 
 const FETCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 
@@ -286,7 +294,44 @@ type WebFetchRuntimeParams = {
   providerCacheKey?: string;
   lookupFn?: LookupFn;
   resolveProviderFallback: () => Promise<WebFetchProviderFallback>;
+  onUpdate?: AgentToolUpdateCallback<unknown>;
 };
+
+// Fail-open progress emit. onUpdate is declared `void`-returning but may throw
+// synchronously when the runtime subscriber has already torn down; that must
+// never break the fetch result. We swallow the error here so callers can stay
+// in a single try/finally without spreading defensive guards.
+function emitWebFetchProgressSafely(onUpdate: AgentToolUpdateCallback<unknown>): void {
+  try {
+    onUpdate({
+      content: [{ type: "text", text: WEB_FETCH_PROGRESS_TEXT }],
+      details: undefined,
+    });
+  } catch {
+    // Best-effort: progress emit must never fail the fetch.
+  }
+}
+
+// Schedule a single delayed progress emit and return a cleanup function the
+// caller invokes in finally. Cleared cleanly on success, error, abort, or any
+// throw from the surrounding network/extract work.
+function scheduleWebFetchProgressTimer(
+  onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+): () => void {
+  if (!onUpdate) {
+    return () => undefined;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+    timer = undefined;
+    emitWebFetchProgressSafely(onUpdate);
+  }, WEB_FETCH_PROGRESS_THRESHOLD_MS);
+  return () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+}
 
 function normalizeProviderFinalUrl(value: unknown): string | undefined {
   const trimmed = normalizeOptionalString(value);
@@ -426,190 +471,203 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   }
 
   const start = Date.now();
-  let res: Response;
-  let release: (() => Promise<void>) | null = null;
-  let finalUrl = params.url;
+  // Progress timer covers TTFB, redirects, and body streaming. A single
+  // delayed emit reaches the runtime via onUpdate; the runtime allow-list in
+  // pi-embedded-subscribe.handlers.tools.ts surfaces it as channel-visible
+  // progressText. Cleared in the outer finally so success, provider-fallback
+  // return, and any rethrow all clean up exactly once.
+  const releaseProgressTimer = scheduleWebFetchProgressTimer(params.onUpdate);
   try {
-    const fetchWithWebToolsNetworkGuard = await loadWebGuardedFetch();
-    const result = await fetchWithWebToolsNetworkGuard({
-      url: params.url,
-      maxRedirects: params.maxRedirects,
-      timeoutSeconds: params.timeoutSeconds,
-      lookupFn: params.lookupFn,
-      useEnvProxy: useTrustedEnvProxy,
-      policy: ssrfPolicy,
-      init: {
-        headers: {
-          Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
-          "User-Agent": params.userAgent,
-          "Accept-Language": "en-US,en;q=0.9",
+    let res: Response;
+    let release: (() => Promise<void>) | null = null;
+    let finalUrl = params.url;
+    try {
+      const fetchWithWebToolsNetworkGuard = await loadWebGuardedFetch();
+      const result = await fetchWithWebToolsNetworkGuard({
+        url: params.url,
+        maxRedirects: params.maxRedirects,
+        timeoutSeconds: params.timeoutSeconds,
+        lookupFn: params.lookupFn,
+        useEnvProxy: useTrustedEnvProxy,
+        policy: ssrfPolicy,
+        init: {
+          headers: {
+            Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
+            "User-Agent": params.userAgent,
+            "Accept-Language": "en-US,en;q=0.9",
+          },
         },
-      },
-    });
-    res = result.response;
-    finalUrl = result.finalUrl;
-    release = result.release;
+      });
+      res = result.response;
+      finalUrl = result.finalUrl;
+      release = result.release;
 
-    // Cloudflare Markdown for Agents — log token budget hint when present
-    const markdownTokens = res.headers.get("x-markdown-tokens");
-    if (markdownTokens) {
-      logDebug(
-        `[web-fetch] x-markdown-tokens: ${markdownTokens} (${redactUrlForDebugLog(finalUrl)})`,
-      );
-    }
-  } catch (error) {
-    if (error instanceof SsrFBlockedError) {
-      throw error;
-    }
-    const payload = await maybeFetchProviderWebFetchPayload({
-      ...params,
-      urlToFetch: finalUrl,
-      cacheKey,
-      tookMs: Date.now() - start,
-    });
-    if (payload) {
-      return payload;
-    }
-    throw error;
-  }
-
-  try {
-    if (!res.ok) {
+      // Cloudflare Markdown for Agents — log token budget hint when present
+      const markdownTokens = res.headers.get("x-markdown-tokens");
+      if (markdownTokens) {
+        logDebug(
+          `[web-fetch] x-markdown-tokens: ${markdownTokens} (${redactUrlForDebugLog(finalUrl)})`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof SsrFBlockedError) {
+        throw error;
+      }
       const payload = await maybeFetchProviderWebFetchPayload({
         ...params,
-        urlToFetch: params.url,
+        urlToFetch: finalUrl,
         cacheKey,
         tookMs: Date.now() - start,
       });
       if (payload) {
         return payload;
       }
-      const rawDetailResult = await readResponseText(res, { maxBytes: DEFAULT_ERROR_MAX_BYTES });
-      const rawDetail = rawDetailResult.text;
-      const detail = formatWebFetchErrorDetail({
-        detail: rawDetail,
-        contentType: res.headers.get("content-type"),
-        maxChars: DEFAULT_ERROR_MAX_CHARS,
-      });
-      const wrappedDetail = wrapWebFetchContent(detail || res.statusText, DEFAULT_ERROR_MAX_CHARS);
-      throw new Error(`Web fetch failed (${res.status}): ${wrappedDetail.text}`);
+      throw error;
     }
 
-    const contentType = res.headers.get("content-type") ?? "application/octet-stream";
-    const normalizedContentType = normalizeContentType(contentType) ?? "application/octet-stream";
-    const bodyResult = await readResponseText(res, { maxBytes: params.maxResponseBytes });
-    const body = bodyResult.text;
-    const responseTruncatedWarning = bodyResult.truncated
-      ? `Response body truncated after ${params.maxResponseBytes} bytes.`
-      : undefined;
-
-    let title: string | undefined;
-    let extractor = "raw";
-    let text = body;
-    if (contentType.includes("text/markdown")) {
-      // Cloudflare Markdown for Agents: server returned pre-rendered markdown
-      extractor = "cf-markdown";
-      if (params.extractMode === "text") {
-        text = markdownToText(body);
-      }
-    } else if (contentType.includes("text/html")) {
-      if (params.readabilityEnabled) {
-        const readable = await extractReadableContent({
-          html: body,
-          url: finalUrl,
-          extractMode: params.extractMode,
-          config: params.config,
-        });
-        if (readable?.text) {
-          text = readable.text;
-          title = readable.title;
-          extractor = readable.extractor;
-        } else {
-          let payload: Record<string, unknown> | null = null;
-          try {
-            payload = await maybeFetchProviderWebFetchPayload({
-              ...params,
-              urlToFetch: finalUrl,
-              cacheKey,
-              tookMs: Date.now() - start,
-            });
-          } catch {
-            payload = null;
-          }
-          if (payload) {
-            return payload;
-          }
-          const basic = await extractBasicHtmlContent({
-            html: body,
-            extractMode: params.extractMode,
-          });
-          if (basic?.text) {
-            text = basic.text;
-            title = basic.title;
-            extractor = "raw-html";
-          } else {
-            const providerLabel =
-              (await params.resolveProviderFallback())?.provider.label ?? "provider fallback";
-            throw new Error(
-              `Web fetch extraction failed: Readability, ${providerLabel}, and basic HTML cleanup returned no content.`,
-            );
-          }
-        }
-      } else {
+    try {
+      if (!res.ok) {
         const payload = await maybeFetchProviderWebFetchPayload({
           ...params,
-          urlToFetch: finalUrl,
+          urlToFetch: params.url,
           cacheKey,
           tookMs: Date.now() - start,
         });
         if (payload) {
           return payload;
         }
-        throw new Error(
-          "Web fetch extraction failed: Readability disabled and no fetch provider is available.",
+        const rawDetailResult = await readResponseText(res, { maxBytes: DEFAULT_ERROR_MAX_BYTES });
+        const rawDetail = rawDetailResult.text;
+        const detail = formatWebFetchErrorDetail({
+          detail: rawDetail,
+          contentType: res.headers.get("content-type"),
+          maxChars: DEFAULT_ERROR_MAX_CHARS,
+        });
+        const wrappedDetail = wrapWebFetchContent(
+          detail || res.statusText,
+          DEFAULT_ERROR_MAX_CHARS,
         );
+        throw new Error(`Web fetch failed (${res.status}): ${wrappedDetail.text}`);
       }
-    } else if (contentType.includes("application/json")) {
-      try {
-        text = JSON.stringify(JSON.parse(body), null, 2);
-        extractor = "json";
-      } catch {
-        text = body;
-        extractor = "raw";
-      }
-    }
 
-    const wrapped = wrapWebFetchContent(text, params.maxChars);
-    const wrappedTitle = title ? wrapWebFetchField(title) : undefined;
-    const wrappedWarning = wrapWebFetchField(responseTruncatedWarning);
-    const payload = {
-      url: params.url, // Keep raw for tool chaining
-      finalUrl, // Keep raw
-      status: res.status,
-      contentType: normalizedContentType, // Protocol metadata, don't wrap
-      title: wrappedTitle,
-      extractMode: params.extractMode,
-      extractor,
-      externalContent: {
-        untrusted: true,
-        source: "web_fetch",
-        wrapped: true,
-      },
-      truncated: wrapped.truncated,
-      length: wrapped.wrappedLength,
-      rawLength: wrapped.rawLength, // Actual content length, not wrapped
-      wrappedLength: wrapped.wrappedLength,
-      fetchedAt: new Date().toISOString(),
-      tookMs: Date.now() - start,
-      text: wrapped.text,
-      warning: wrappedWarning,
-    };
-    writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
-    return payload;
-  } finally {
-    if (release) {
-      await release();
+      const contentType = res.headers.get("content-type") ?? "application/octet-stream";
+      const normalizedContentType = normalizeContentType(contentType) ?? "application/octet-stream";
+      const bodyResult = await readResponseText(res, { maxBytes: params.maxResponseBytes });
+      const body = bodyResult.text;
+      const responseTruncatedWarning = bodyResult.truncated
+        ? `Response body truncated after ${params.maxResponseBytes} bytes.`
+        : undefined;
+
+      let title: string | undefined;
+      let extractor = "raw";
+      let text = body;
+      if (contentType.includes("text/markdown")) {
+        // Cloudflare Markdown for Agents: server returned pre-rendered markdown
+        extractor = "cf-markdown";
+        if (params.extractMode === "text") {
+          text = markdownToText(body);
+        }
+      } else if (contentType.includes("text/html")) {
+        if (params.readabilityEnabled) {
+          const readable = await extractReadableContent({
+            html: body,
+            url: finalUrl,
+            extractMode: params.extractMode,
+            config: params.config,
+          });
+          if (readable?.text) {
+            text = readable.text;
+            title = readable.title;
+            extractor = readable.extractor;
+          } else {
+            let payload: Record<string, unknown> | null = null;
+            try {
+              payload = await maybeFetchProviderWebFetchPayload({
+                ...params,
+                urlToFetch: finalUrl,
+                cacheKey,
+                tookMs: Date.now() - start,
+              });
+            } catch {
+              payload = null;
+            }
+            if (payload) {
+              return payload;
+            }
+            const basic = await extractBasicHtmlContent({
+              html: body,
+              extractMode: params.extractMode,
+            });
+            if (basic?.text) {
+              text = basic.text;
+              title = basic.title;
+              extractor = "raw-html";
+            } else {
+              const providerLabel =
+                (await params.resolveProviderFallback())?.provider.label ?? "provider fallback";
+              throw new Error(
+                `Web fetch extraction failed: Readability, ${providerLabel}, and basic HTML cleanup returned no content.`,
+              );
+            }
+          }
+        } else {
+          const payload = await maybeFetchProviderWebFetchPayload({
+            ...params,
+            urlToFetch: finalUrl,
+            cacheKey,
+            tookMs: Date.now() - start,
+          });
+          if (payload) {
+            return payload;
+          }
+          throw new Error(
+            "Web fetch extraction failed: Readability disabled and no fetch provider is available.",
+          );
+        }
+      } else if (contentType.includes("application/json")) {
+        try {
+          text = JSON.stringify(JSON.parse(body), null, 2);
+          extractor = "json";
+        } catch {
+          text = body;
+          extractor = "raw";
+        }
+      }
+
+      const wrapped = wrapWebFetchContent(text, params.maxChars);
+      const wrappedTitle = title ? wrapWebFetchField(title) : undefined;
+      const wrappedWarning = wrapWebFetchField(responseTruncatedWarning);
+      const payload = {
+        url: params.url, // Keep raw for tool chaining
+        finalUrl, // Keep raw
+        status: res.status,
+        contentType: normalizedContentType, // Protocol metadata, don't wrap
+        title: wrappedTitle,
+        extractMode: params.extractMode,
+        extractor,
+        externalContent: {
+          untrusted: true,
+          source: "web_fetch",
+          wrapped: true,
+        },
+        truncated: wrapped.truncated,
+        length: wrapped.wrappedLength,
+        rawLength: wrapped.rawLength, // Actual content length, not wrapped
+        wrappedLength: wrapped.wrappedLength,
+        fetchedAt: new Date().toISOString(),
+        tookMs: Date.now() - start,
+        text: wrapped.text,
+        warning: wrappedWarning,
+      };
+      writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+      return payload;
+    } finally {
+      if (release) {
+        await release();
+      }
     }
+  } finally {
+    releaseProgressTimer();
   }
 }
 
@@ -630,7 +688,7 @@ export function createWebFetchTool(options?: {
     description:
       "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
     parameters: WebFetchSchema,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, _signal, onUpdate) => {
       const { config, preferRuntimeProviders, runtimeWebFetch } = resolveWebFetchToolRuntimeContext(
         {
           config: options?.config,
@@ -702,6 +760,7 @@ export function createWebFetchTool(options?: {
         ...(providerCacheKey ? { providerCacheKey } : {}),
         lookupFn: options?.lookupFn,
         resolveProviderFallback,
+        ...(onUpdate ? { onUpdate } : {}),
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -294,14 +294,14 @@ type WebFetchRuntimeParams = {
   providerCacheKey?: string;
   lookupFn?: LookupFn;
   resolveProviderFallback: () => Promise<WebFetchProviderFallback>;
-  onUpdate?: AgentToolUpdateCallback<unknown>;
+  onUpdate?: AgentToolUpdateCallback;
 };
 
 // Fail-open progress emit. onUpdate is declared `void`-returning but may throw
 // synchronously when the runtime subscriber has already torn down; that must
 // never break the fetch result. We swallow the error here so callers can stay
 // in a single try/finally without spreading defensive guards.
-function emitWebFetchProgressSafely(onUpdate: AgentToolUpdateCallback<unknown>): void {
+function emitWebFetchProgressSafely(onUpdate: AgentToolUpdateCallback): void {
   try {
     onUpdate({
       content: [{ type: "text", text: WEB_FETCH_PROGRESS_TEXT }],
@@ -315,9 +315,7 @@ function emitWebFetchProgressSafely(onUpdate: AgentToolUpdateCallback<unknown>):
 // Schedule a single delayed progress emit and return a cleanup function the
 // caller invokes in finally. Cleared cleanly on success, error, abort, or any
 // throw from the surrounding network/extract work.
-function scheduleWebFetchProgressTimer(
-  onUpdate: AgentToolUpdateCallback<unknown> | undefined,
-): () => void {
+function scheduleWebFetchProgressTimer(onUpdate: AgentToolUpdateCallback | undefined): () => void {
   if (!onUpdate) {
     return () => undefined;
   }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

`web_fetch` produces a fully silent gap between agent invocation and tool result during slow TTFB or slow body streams. Before this PR, channel UIs rendered that gap as the URL meta line (`"from <url>"`) for the entire fetch duration — a visible source of friction for slow-TTFB and slow-body-stream fetches.

Why does this matter now?

`progressText` is already the canonical channel-visible progress field, plumbed through `src/plugin-sdk/channel-streaming.ts:buildChannelProgressDraftLine`. Adding a single allow-listed non-exec tool — `web_fetch` — reuses the same field on the existing `kind:"tool"` item with no channel-adapter changes.

What did this round change?

This PR has been rebased onto current upstream/main (rename `pi-embedded-subscribe.*` → `embedded-agent-subscribe.*` plus agent-runtime internalization, refactor #85341) and addresses two consecutive ClawSweeper findings:

- **Round 4 P1** — the global event-bus `stream:"tool"` `phase:"update"` `partialResult` bridge for `web_fetch` progress was driving downstream runners into an extra `onToolStart` render, producing a bare `"Web Fetch"` row alongside the new progress draft. Suppressed for allow-listed non-exec progress only; exec/bash and non-allow-list non-exec tools unchanged.
- **Round 5 P1** — the subscriber-side `ctx.params.onAgentEvent` callback emitting `stream:"tool"` `phase:"update"` (no `partialResult`) is the second bridge the auto-reply / follow-up runners consume. Now gated by the same `nonExecProgressText` condition. Non-allow-list non-exec tools keep this subscriber bridge so ACP / TUI / gateway consumers still see partials.

A redundant `<unknown>` type argument was also dropped from three `AgentToolUpdateCallback` usages in `web-fetch.ts` to clear an oxlint `no-unnecessary-type-arguments` error on the upstream CI lint shard.

What is the intended outcome?

Channel users see a single generic `"Fetching web page…"` line after ~1 s when the network work has not returned. Fast fetches stay silent. Fetch result, error type, cache, timeout, abort, retry, redirects, and SSRF guard are unchanged.

What is intentionally out of scope?

- Per-tool progress for other built-in tools (browser, image_generate, video_generate, mcp).
- MCP `notifications/progress` plumbing.
- Generalized non-exec rate-limit redesign or progress-infrastructure refactor.
- Channel renderer or `channel-streaming.ts` changes: untouched.
- `extensions/*` channel adapters: untouched.
- Adding non-`web_fetch` tools to the runtime allow-list.

What should reviewers focus on?

- `src/agents/tools/web-fetch.ts`: outer `try/finally` around the existing network/extract body releases the timer exactly once across every exit path. `emitWebFetchProgressSafely` swallows a throwing `onUpdate`. Import for `AgentToolUpdateCallback` is `../runtime/index.js` (post-internalization).
- `src/agents/embedded-agent-subscribe.handlers.tools.ts`: `NON_EXEC_PROGRESS_SAFE_TOOLS = Set("web_fetch")` is the contract boundary. Adding a tool requires auditing its `onUpdate` callsite for URL/body/header leakage. When `nonExecProgressText` is populated, **both** the global event-bus bridge and the subscriber-side `ctx.params.onAgentEvent` `stream:"tool"` `phase:"update"` emit are suppressed; the item event also omits `meta` so the channel draft formatter falls through to `progressText`. The start event still carries `meta` for consumers that snapshot it at item start.

## Linked context

Which issue does this close?

No upstream issue. Driven by a candidate selection report from masato-local UX-perf evaluation.

Which issues, PRs, or discussions are related?

None directly.

Was this requested by a maintainer or owner?

No specific maintainer request. ClawSweeper rounds 1 / 4 / 5 (`@clawsweeper` automated) identified the precedence and bridge defects; this revision reflects all fixes plus the rebase onto the upstream rename.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `web_fetch` channel-visible dead air plus the round-4 + round-5 bridge defects. Pre-patch, channel UIs showed `"📄 Web Fetch: from <url>"` for the full silent gap; both the legacy `stream:"tool"` `partialResult` bridge and the subscriber-side `stream:"tool"` update for `web_fetch` drove downstream runners to render an extra bare `"Web Fetch"` row. Post-patch, after ~1 s of silence the channel draft transitions to `"📄 Web Fetch: Fetching web page…"` and stays there until the fetch completes; both bridges are silent so there is no duplicate row.
- Real environment tested: Node 22.22.2 / Linux 6.8.0-111-generic / live network. Slow path = `https://postman-echo.com/delay/3` (3 s server-side hold). Fast path = `https://example.com/` (~400 ms). Tier-B integration: real `createWebFetchTool().execute()` → real `handleToolExecutionUpdate` (now in `embedded-agent-subscribe.handlers.tools.ts`) → real `buildChannelProgressDraftLine` formatter. Both the global event-bus bridge (via `agent-events.js` listener) and the subscriber-side `ctx.params.onAgentEvent` callback are instrumented in the harness so the transcript explicitly captures bridge counts for the current head.
- Exact steps or command run after this patch:

  Tier-B integration (tool → runtime → channel formatter, real network):

      cd worktrees/openclaw-c2-web-fetch-tool-progress
      PROOF_HEAD=$(git rev-parse HEAD) \
        node --import tsx \
        .local/c2-tool-progress-web-fetch/round4-remediation-20260528/run-real-proof.mjs

  Targeted suites at current HEAD (supplemental):

      node scripts/run-vitest.mjs src/agents/tools/web-fetch.progress.test.ts --run
      node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.tools.test.ts --run
      node scripts/run-vitest.mjs src/plugin-sdk/channel-streaming.test.ts --run

- Evidence after fix: live terminal output captured from `node --import tsx` driving the real `createWebFetchTool().execute()` execution into the real runtime `handleToolExecutionUpdate` handler and through the real `buildChannelProgressDraftLine` channel-draft formatter. The HEAD pinned in the transcript (`3934be6125`) is the rebased + round-4 + round-5 remediation tip.

```
=== PR #86965 Tier-B real behavior proof (round-4 remediation) ===
HEAD: 3934be612529ac8f72bf2712fba658bf5029c40f
Driver: real createWebFetchTool().execute -> real handleToolExecutionUpdate (embedded-agent-subscribe) -> real buildChannelProgressDraftLine

--- slow path: https://postman-echo.com/delay/3 ---
total=3519ms
start.meta="from https://postman-echo.com/delay/3"
update_item_events=1
  [0] kind=tool progressText="Fetching web page…" meta=undefined
legacy_bridge_events=0 (round-4 fix: expected 0)
subscriber_bridge_events=0 (round-5 fix: expected 0)
channel_draft_texts=1
  [0] "📄 Web Fetch: Fetching web page…"

--- fast path: https://example.com/ ---
total=435ms
start.meta="from https://example.com/"
update_item_events=0
channel_draft_texts=0

=== assertions ===
PASS slow path produced update item events
PASS slow path channel draft contains progress literal
PASS slow path channel draft does NOT contain URL host
PASS slow path update item meta is undefined (precedence fix)
PASS slow path completion (real fetch returned)
PASS slow path no duplicate emit
PASS fast path produced no progress emit (no spam)
PASS fast path no channel draft (no spam)
PASS fast path completion
PASS start meta carries URL (precondition for precedence fix)
PASS slow path legacy stream:tool partialResult bridge SUPPRESSED (round-4 fix)
PASS slow path subscriber stream:tool update bridge SUPPRESSED (round-5 fix)
PASS fast path legacy bridge unchanged (no spurious events)
PASS fast path subscriber bridge unchanged (no spurious events)

=== verdict: PASS ===
```

- Observed result after fix:
  - Slow path (postman-echo.com/delay/3): exactly **1** progress emit. The runtime emits a `kind:"tool"` update item with `progressText="Fetching web page…"` and `meta=undefined`. The real `buildChannelProgressDraftLine` formatter renders the visible channel-draft text `"📄 Web Fetch: Fetching web page…"`. Fetch completes at `t≈3519 ms` with a 200 body.
  - Legacy global bridge: **0** `stream:"tool"` `partialResult` events for `web_fetch`.
  - Subscriber bridge: **0** `ctx.params.onAgentEvent` `stream:"tool"` `phase:"update"` events for `web_fetch`. Both runner-facing surfaces are silent — no path remains for downstream runners to construct a bare `"Web Fetch"` row.
  - Fast path (example.com): **0** progress emits, **0** channel drafts, fetch completes at `t≈435 ms`. Both bridges stay at 0 here too because there is no progress emit; nothing changes for the fast path.
  - Privacy: the rendered channel draft contains the fixed literal plus the static `web_fetch` tool label (`"📄 Web Fetch:"`). No URL host, path, query, header, cookie, or body content.
- What was not tested: live delivery to a Telegram / Discord / Slack bot. `buildChannelProgressDraftLine` is the contract boundary every channel adapter consumes — it returns the exact text adapters send to their respective transports. The Tier-B harness exercises that boundary end-to-end and instruments the same `ctx.params.onAgentEvent` callback that the auto-reply and follow-up runners consume; the actual channel-adapter send path was not invoked.
- Proof limitations or environment constraints: depends on the chosen slow endpoint reaching the threshold. Initial attempts against `httpbin.org/delay/3` hit a 503 outage today and `httpstat.us` was unreachable from this network; the substitute `postman-echo.com/delay/3` reproduces the relevant property (TTFB > 1 s threshold). SSRF guard intentionally blocks loopback, so the slow URL is a real public-IP endpoint rather than a local server.

## Tests and validation

Which commands did you run? — see the proof block above plus:

      node scripts/run-vitest.mjs src/agents/tools/web-fetch.cf-markdown.test.ts \
                                  src/agents/tools/web-fetch.provider-fallback.test.ts \
                                  src/agents/tools/web-fetch.ssrf.test.ts \
                                  src/agents/tools/web-fetch-visibility.test.ts --run
      node scripts/run-vitest.mjs src/plugin-sdk/channel-streaming.test.ts --run
      node_modules/.bin/oxlint --config .oxlintrc.json \
        src/agents/tools/web-fetch.ts \
        src/agents/embedded-agent-subscribe.handlers.tools.ts \
        src/agents/tools/web-fetch.progress.test.ts \
        src/agents/embedded-agent-subscribe.handlers.tools.test.ts

Result summary at HEAD `3934be6125` (all green for in-scope code): web-fetch.progress 10 / embedded-agent-subscribe.handlers.tools 100 (+7 added by this PR) / channel-streaming 22 / sibling web-fetch (`cf-markdown` + `provider-fallback` + `ssrf` + `visibility`) all pass. oxlint exits 0 on the four files touched.

What regression coverage was added or updated?

- `src/agents/tools/web-fetch.progress.test.ts` (new, 5 cases × 2 lanes): slow path single emit; fast path zero emit; error cleanup snapshot-then-stable (per-test 60 s budget for CI cold start); fail-open onUpdate; privacy.
- `src/agents/embedded-agent-subscribe.handlers.tools.test.ts` (extended, 7 new cases under `handleToolExecutionUpdate non-exec progress`):
  - allow-listed `web_fetch` populates `progressText` and omits `meta`;
  - renders channel draft as `"Fetching web page…"` via the real formatter when start meta is present (precedence integration);
  - cap applied at the live-output character budget;
  - non-allow-list non-exec tool no `progressText` leak (item event);
  - **suppresses both the global and subscriber `stream:"tool"` update bridges when `web_fetch progressText` is surfaced** (round-4 + round-5 fix);
  - **preserves the subscriber `stream:"tool"` update for non-allow-listed tools** (ACP / TUI / gateway consumers unchanged);
  - exec command-output regression.

What failed before this fix, if known? — no upstream test failure; ClawSweeper round-1 flagged the formatter-precedence gap, round-4 flagged the global bridge, and round-5 flagged the subscriber bridge — all via source inspection of the respective prior heads. CI `check-lint` failed on three `AgentToolUpdateCallback<unknown>` redundant type arguments — those were fixed in commit `ffbba5cdc3`.

If no test was added, why not? — N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) — **Yes.** Channel drafts now show `"Fetching web page…"` instead of `"from <url>"` during slow `web_fetch` calls (≥1 s), and the previously-duplicated bare `"Web Fetch"` row is gone. Tool result / error / cache / timeout / abort / retry / redirects unchanged.

Did config, environment, or migration behavior change? (`Yes/No`) — **No.** No config keys, env vars, defaults, or migrations.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) — **No** for security / auth / secrets. The emit payload is a fixed literal; the channel-rendered draft is the literal + static `web_fetch` tool label only. SSRF guard, timeout, redirects, abort, retry, cache are unchanged. (The new user-visible progress line is captured under row 1.)

What is the highest-risk area? — Both bridge suppressions remove the `stream:"tool"` `phase:"update"` events for allow-listed non-exec progress only — on both the global event-bus and the subscriber callback. Any consumer that previously expected a `stream:"tool"` update specifically for `web_fetch` (e.g. an ACP client that polled partials there) would now see only the item-event progress.

How is that risk mitigated? — In the current codebase the runner bridge consumed both events to drive `onToolStart`, which is what produced the duplicate bare row. The new item-event `progressText` path remains and is the channel-visible signal. The new regression tests assert both bridges are silent for `web_fetch` AND preserved for non-allow-listed tools, so ACP / TUI / gateway consumers of other non-exec tools see no change. `handleToolExecutionUpdate` for exec/bash is bit-identical (verified by the existing exec command-output regression and the unchanged 22 `channel-streaming.test.ts` plus sibling 190 runner regressions).

## Current review state

What is the next action? — Maintainer review.

What is still waiting on author, maintainer, CI, or external proof? — Awaiting CI green at the rebased HEAD `3934be6125` (lint + both bridge fixes included) and maintainer review. No outstanding author work.

Which bot or reviewer comments were addressed? — ClawSweeper round 1 (precedence) preserved; round 4 (global bridge at `embedded-agent-subscribe.handlers.tools.ts:1113-1116`) fixed in `ffbba5cdc3`; round 5 (subscriber bridge at the `ctx.params.onAgentEvent` callsite) fixed in `3934be6125`. Both fixes verified by new regression tests and by the bridge-suppression assertions in the Tier-B proof above.
