### PR TITLE
fix(channels): preserve direct native progress callbacks

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2053,6 +2053,59 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("suppresses direct native progress callbacks when send policy denies delivery", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sendPolicy: "deny",
+      verboseLevel: "off",
+    };
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      From: "telegram:123",
+      SessionKey: "agent:main:telegram:dm:123",
+    });
+    const onToolStart = vi.fn();
+    const onItemEvent = vi.fn();
+    const onCommandOutput = vi.fn();
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolStart?.({ name: "exec", phase: "start" });
+      await opts?.onItemEvent?.({ itemId: "1", kind: "tool", progressText: "running exec" });
+      await opts?.onCommandOutput?.({ phase: "end", name: "exec", status: "ok", exitCode: 0 });
+      await opts?.onToolResult?.({ text: "exec: ok" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+        suppressDefaultToolProgressMessages: true,
+        allowProgressCallbacksWhenSourceDeliverySuppressed: true,
+        onToolStart,
+        onItemEvent,
+        onCommandOutput,
+      },
+    });
+
+    expect(onToolStart).not.toHaveBeenCalled();
+    expect(onItemEvent).not.toHaveBeenCalled();
+    expect(onCommandOutput).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("normalizes tool-result media before delivery and drops blocked file URLs", async () => {
     setNoAbort();
     replyMediaPathMocks.createReplyMediaPathNormalizer.mockReturnValue(

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1945,7 +1945,7 @@ describe("dispatchReplyFromConfig", () => {
       await opts?.onPatchSummary?.({ phase: "end", summary: "1 modified" });
       await opts?.onCompactionStart?.();
       await opts?.onCompactionEnd?.();
-      await opts?.onToolResult?.({ text: "🔧 exec: ok" });
+      await opts?.onToolResult?.({ text: "exec: ok" });
       return { text: "done" } satisfies ReplyPayload;
     };
 
@@ -1990,6 +1990,67 @@ describe("dispatchReplyFromConfig", () => {
     expect(event.shouldSendToolSummaries).toBe(false);
     shouldSendToolSummaries = true;
     expect(event.shouldSendToolSummaries).toBe(true);
+  });
+
+  it("forwards direct native progress callbacks while verbose is off", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "off",
+    };
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      From: "telegram:123",
+      SessionKey: "agent:main:telegram:dm:123",
+    });
+    const onToolStart = vi.fn();
+    const onItemEvent = vi.fn();
+    const onCommandOutput = vi.fn();
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolStart?.({ name: "exec", phase: "start" });
+      await opts?.onItemEvent?.({ itemId: "1", kind: "tool", progressText: "running exec" });
+      await opts?.onCommandOutput?.({ phase: "end", name: "exec", status: "ok", exitCode: 0 });
+      await opts?.onToolResult?.({ text: "🔧 exec: ok" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+        suppressDefaultToolProgressMessages: true,
+        allowProgressCallbacksWhenSourceDeliverySuppressed: true,
+        onToolStart,
+        onItemEvent,
+        onCommandOutput,
+      },
+    });
+
+    expect(onToolStart).toHaveBeenCalledWith({ name: "exec", phase: "start" });
+    expect(onItemEvent).toHaveBeenCalledWith({
+      itemId: "1",
+      kind: "tool",
+      progressText: "running exec",
+    });
+    expect(onCommandOutput).toHaveBeenCalledWith({
+      phase: "end",
+      name: "exec",
+      status: "ok",
+      exitCode: 0,
+    });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
   it("normalizes tool-result media before delivery and drops blocked file URLs", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2032,6 +2032,7 @@ export async function dispatchReplyFromConfig(
       return (
         !suppressAutomaticSourceDelivery ||
         (allowSuppressedSourceProgressCallbacks &&
+          !sendPolicyDenied &&
           options?.forwardWhenSourceDeliverySuppressed === true)
       );
     };

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2012,11 +2012,21 @@ export async function dispatchReplyFromConfig(
     const onPatchSummaryFromReplyOptions = params.replyOptions?.onPatchSummary;
     const allowSuppressedSourceProgressCallbacks =
       params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed === true;
+    const shouldAllowQuietDirectNativeProgressCallbacks = (options?: {
+      requiresToolSummaryVisibility?: boolean;
+    }) =>
+      options?.requiresToolSummaryVisibility === true &&
+      params.replyOptions?.suppressDefaultToolProgressMessages === true &&
+      chatType === "direct";
     const shouldForwardProgressCallback = (options?: {
       forwardWhenSourceDeliverySuppressed?: boolean;
       requiresToolSummaryVisibility?: boolean;
     }) => {
-      if (options?.requiresToolSummaryVisibility === true && !shouldSendToolSummaries()) {
+      if (
+        options?.requiresToolSummaryVisibility === true &&
+        !shouldSendToolSummaries() &&
+        !shouldAllowQuietDirectNativeProgressCallbacks(options)
+      ) {
         return false;
       }
       return (


### PR DESCRIPTION
## Summary

Fixes a Telegram DM regression introduced by `45fbf2d81a` / #85488 where Codex app-server turns stopped creating channel-native progress drafts when `/verbose` is off.

The regression came from tying progress callback forwarding to tool-summary visibility. That is correct for default verbose text summaries, but too broad for direct-message channel UI: Telegram progress drafts need `onToolStart` / item / command-output callbacks even when the final source reply is suppressed and visible text summaries are disabled.

This keeps the `/verbose` gate for groups and normal verbose summaries, while allowing quiet direct-channel native progress callbacks when:

- chat type is direct
- default tool progress messages are suppressed
- the callback was otherwise gated only by tool-summary visibility

## Real behavior proof

**Behavior or issue addressed:** Telegram DM progress drafts for Codex app-server tool turns disappeared after `45fbf2d81a0e6955d977bc4b1c7d29458c2894d0` / #85488 when `/verbose` was off, despite `streaming.mode=progress` and `progress.toolProgress=true`.

**Real environment tested:** Isolated OpenClaw source worktree `/tmp/openclaw-pr-progress-fix`, temp OpenClaw config/state, non-prod Telegram bot `@vanechka_intern_bot`, MTProto user observer, Codex app-server runtime with `openai/gpt-5.5`. Production gateway/config were not touched.

**Exact steps or command run after this patch:**

```text
OPENCLAW_QA_TELEGRAM_SUT_BOT_KEY=vanechka_intern_bot \
REPRO_TOOL_PROGRESS=true \
REPRO_PROGRESS_MAX_LINES=8 \
REPRO_PROGRESS_ONLY=true \
REPRO_ARTIFACT_DIR=/root/.openclaw/workspace-tolik/tmp/openclaw-bisect/pr-fix-smoke-3 \
REPRO_GATEWAY_PORT=19888 \
REPRO_TIMEOUT_MS=150000 \
python3 /root/.openclaw/workspace-tolik/tmp/openclaw-bisect/telegram_codex_progress_dm_repro.py /tmp/openclaw-pr-progress-fix
```

**Evidence after fix:** Copied live output from the isolated Telegram DM observer:

```json
{
  "ok": true,
  "artifactDir": "/root/.openclaw/workspace-tolik/tmp/openclaw-bisect/pr-fix-smoke-3",
  "sawProgress": true,
  "timeline": [
    {
      "text": "Working\n\n🛠️ print text (workspace), 'printf PROGRESS_BISECT_OK'"
    }
  ]
}
```

**Observed result after fix:** The observer saw a real visible Telegram progress draft before terminal completion. Controlled bisect had identified `45fbf2d81a` as first bad and disproved the originally suspected Codex runtime commits.

**What was not tested:** Other channels were not manually smoke-tested. The changed branch is direct chat only; group `/verbose` behavior remains covered by existing tests and the new unit test asserts quiet direct callbacks without restoring default text tool summaries.

## Tests

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts
pnpm tsgo:core:test
python3 /root/.openclaw/workspace-tolik/tmp/openclaw-bisect/telegram_codex_progress_dm_repro.py /tmp/openclaw-pr-progress-fix
```