### PR TITLE
docs(backup): describe manual restore flow

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -31,7 +31,7 @@ openclaw backup sqlite restore ~/Backups/openclaw-sqlite/<snapshot-id> --target 
 Archive `create` and `verify`, plus SQLite `create`, `list`, `verify`, and
 `restore`, accept `--json` for one machine-readable result on stdout.
 
-OpenClaw does not currently provide an `openclaw backup restore` command. Restore is a manual copy-back flow guided by the embedded `manifest.json`. See [Restore from an archive](#restore-from-an-archive).
+OpenClaw does not currently provide an `openclaw backup restore` command. Follow [Restore a full archive](/install/backups#restore-a-full-archive) for the manual, manifest-driven copy-back flow.
 
 ## Notes
 
@@ -125,93 +125,6 @@ For a partial backup in that situation, rerun with `--no-include-workspace`: it 
 
 `--only-config` also works when the config is malformed, since it does not parse the config for workspace discovery.
 
-## Restore from an archive
-
-OpenClaw does not currently provide an `openclaw backup restore` command. Archives are plain `.tar.gz` files, and the embedded `manifest.json` records the source paths and archive paths needed for a manual restore.
-
-Start only from an archive you created or otherwise trust. `openclaw backup verify` checks archive structure and payload layout, but it does not authenticate the archive or make untrusted content safe.
-
-### Inspect and stage the archive
-
-Verify the archive before extracting it, then extract into a private temporary directory. The block sets `set -euo pipefail` so a failed `openclaw backup verify` stops the script before any extraction:
-
-```bash
-set -euo pipefail
-
-ARCHIVE=./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz
-
-openclaw backup verify "$ARCHIVE"
-
-restore_dir="$(mktemp -d -t openclaw-restore.XXXXXX)"
-trap 'rm -rf "$restore_dir"' EXIT
-
-tar -xzf "$ARCHIVE" -C "$restore_dir"
-manifest_path="$(find "$restore_dir" -mindepth 2 -maxdepth 2 -name manifest.json -print -quit)"
-test -n "$manifest_path"
-cat "$manifest_path"
-```
-
-Treat the restore directory as sensitive. It may contain credentials, auth profiles, sessions, and workspace data from the archive. Remove it when you are done inspecting or restoring; the `trap` in the example handles cleanup when the shell exits.
-
-The manifest reports `archiveRoot`, `paths.stateDir`, `paths.configPath`, `paths.oauthDir`, `paths.workspaceDirs`, and an `assets[]` list. Each asset includes its `kind`, original `sourcePath`, and `archivePath` inside the tarball. Use those manifest fields as the source of truth before copying anything back.
-
-Do not derive the archive root from the `.tar.gz` filename. `openclaw backup create --output` can write to a custom filename while the embedded `archiveRoot` remains timestamp-derived.
-
-### Archive layout
-
-The archive stores the manifest and payload under one root directory:
-
-```text
-<archive-root>/manifest.json
-<archive-root>/payload/posix/<absolute-source-path-without-leading-slash>/...
-<archive-root>/payload/windows/<DRIVE>/<rest>/...
-<archive-root>/payload/relative/<relative-source-path>/...
-```
-
-For example, a POSIX source path like `/home/alex/.openclaw` is stored under `<archive-root>/payload/posix/home/alex/.openclaw`. The manifest asset's `archivePath` contains the exact path to copy from, so prefer that over reconstructing paths by hand.
-
-### Restore selected paths
-
-Before overwriting a live install:
-
-- Stop the Gateway and any node hosts that use the files you are restoring.
-- Make a fresh backup of the current state, or move the current directories aside.
-- Restore the smallest set of paths needed, such as only the config asset for a config rollback.
-- Use `manifest.json` to map each asset's `archivePath` to the target path you want to restore.
-- Restart OpenClaw and run `openclaw doctor` after the restore.
-
-For example, to restore the state asset into the current user's default state directory:
-
-```bash
-set -euo pipefail
-
-state_archive_path="$(
-  node -e 'const fs = require("node:fs"); const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(manifest.assets.find((asset) => asset.kind === "state")?.archivePath ?? "");' "$manifest_path"
-)"
-test -n "$state_archive_path"
-
-state_target="$HOME/.openclaw"
-state_backup="$HOME/.openclaw.pre-restore.$(date +%s)"
-
-openclaw gateway stop
-
-if [ -e "$state_target" ]; then
-  mv "$state_target" "$state_backup"
-fi
-mkdir -p "$state_target"
-cp -a "$restore_dir/$state_archive_path"/. "$state_target"/
-
-openclaw doctor
-openclaw gateway start
-openclaw status
-```
-
-For a same-machine restore, the manifest `sourcePath` values are usually the intended targets. For a new machine or different home directory, choose the new target paths first, then copy only the matching asset payloads into those locations.
-
-For a full local restore, the usual targets are the state directory, active config file, credentials directory, and any workspace directories listed in the manifest. Do not restore onto a running service.
-
-Before a full restore, review [What gets backed up](#what-gets-backed-up): archives intentionally omit volatile files, plugin dependency trees, and installer-managed runtime roots such as state-local `tmp/`. Recreate those artifacts after restore.
-
 ## Size and performance
 
 OpenClaw does not enforce a built-in maximum backup size or per-file size limit. An archive write that produces no data for five minutes fails and removes its partial temporary file instead of hanging indefinitely. Practical limits otherwise come from:
@@ -229,3 +142,4 @@ Large workspaces are usually the main driver of archive size. Use `--no-include-
 
 - [CLI reference](/cli)
 - [Migrating an OpenClaw install](/install/migrating)
+- [Restore a full archive](/install/backups#restore-a-full-archive)

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -181,16 +181,23 @@ Before overwriting a live install:
 For example, to restore the state asset into the current user's default state directory:
 
 ```bash
+set -euo pipefail
+
 state_archive_path="$(
   node -e 'const fs = require("node:fs"); const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(manifest.assets.find((asset) => asset.kind === "state")?.archivePath ?? "");' "$manifest_path"
 )"
 test -n "$state_archive_path"
 
+state_target="$HOME/.openclaw"
+state_backup="$HOME/.openclaw.pre-restore.$(date +%s)"
+
 openclaw gateway stop
 
-mv "$HOME/.openclaw" "$HOME/.openclaw.pre-restore.$(date +%s)" 2>/dev/null || true
-mkdir -p "$HOME/.openclaw"
-cp -a "$restore_dir/$state_archive_path"/. "$HOME/.openclaw"/
+if [ -e "$state_target" ]; then
+  mv "$state_target" "$state_backup"
+fi
+mkdir -p "$state_target"
+cp -a "$restore_dir/$state_archive_path"/. "$state_target"/
 
 openclaw doctor
 openclaw gateway start

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -4,6 +4,7 @@ read_when:
   - You want a first-class backup archive for local OpenClaw state
   - You need a compact, verified snapshot of one OpenClaw SQLite database
   - You want to preview which paths would be included before reset or uninstall
+  - You want to restore from a `.tar.gz` archive previously created by `openclaw backup`
 title: "Backup"
 ---
 
@@ -29,6 +30,8 @@ openclaw backup sqlite restore ~/Backups/openclaw-sqlite/<snapshot-id> --target 
 
 Archive `create` and `verify`, plus SQLite `create`, `list`, `verify`, and
 `restore`, accept `--json` for one machine-readable result on stdout.
+
+OpenClaw does not currently provide an `openclaw backup restore` command. Restore is a manual copy-back flow guided by the embedded `manifest.json`. See [Restore from an archive](#restore-from-an-archive).
 
 ## Notes
 
@@ -122,6 +125,84 @@ For a partial backup in that situation, rerun with `--no-include-workspace`: it 
 
 `--only-config` also works when the config is malformed, since it does not parse the config for workspace discovery.
 
+## Restore from an archive
+
+OpenClaw does not currently provide an `openclaw backup restore` command. Archives are plain `.tar.gz` files, and the embedded `manifest.json` records the source paths and archive paths needed for a manual restore.
+
+Start only from an archive you created or otherwise trust. `openclaw backup verify` checks archive structure and payload layout, but it does not authenticate the archive or make untrusted content safe.
+
+### Inspect and stage the archive
+
+Verify the archive before extracting it, then extract into a private temporary directory:
+
+```bash
+ARCHIVE=./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz
+
+openclaw backup verify "$ARCHIVE"
+
+restore_dir="$(mktemp -d -t openclaw-restore.XXXXXX)"
+trap 'rm -rf "$restore_dir"' EXIT
+
+tar -xzf "$ARCHIVE" -C "$restore_dir"
+manifest_path="$(find "$restore_dir" -mindepth 2 -maxdepth 2 -name manifest.json -print -quit)"
+test -n "$manifest_path"
+cat "$manifest_path"
+```
+
+Treat the restore directory as sensitive. It may contain credentials, auth profiles, sessions, and workspace data from the archive. Remove it when you are done inspecting or restoring; the `trap` in the example handles cleanup when the shell exits.
+
+The manifest reports `archiveRoot`, `paths.stateDir`, `paths.configPath`, `paths.oauthDir`, `paths.workspaceDirs`, and an `assets[]` list. Each asset includes its `kind`, original `sourcePath`, and `archivePath` inside the tarball. Use those manifest fields as the source of truth before copying anything back.
+
+Do not derive the archive root from the `.tar.gz` filename. `openclaw backup create --output` can write to a custom filename while the embedded `archiveRoot` remains timestamp-derived.
+
+### Archive layout
+
+The archive stores the manifest and payload under one root directory:
+
+```text
+<archive-root>/manifest.json
+<archive-root>/payload/posix/<absolute-source-path-without-leading-slash>/...
+<archive-root>/payload/windows/<DRIVE>/<rest>/...
+<archive-root>/payload/relative/<relative-source-path>/...
+```
+
+For example, a POSIX source path like `/home/alex/.openclaw` is stored under `<archive-root>/payload/posix/home/alex/.openclaw`. The manifest asset's `archivePath` contains the exact path to copy from, so prefer that over reconstructing paths by hand.
+
+### Restore selected paths
+
+Before overwriting a live install:
+
+- Stop the Gateway and any node hosts that use the files you are restoring.
+- Make a fresh backup of the current state, or move the current directories aside.
+- Restore the smallest set of paths needed, such as only the config asset for a config rollback.
+- Use `manifest.json` to map each asset's `archivePath` to the target path you want to restore.
+- Restart OpenClaw and run `openclaw doctor` after the restore.
+
+For example, to restore the state asset into the current user's default state directory:
+
+```bash
+state_archive_path="$(
+  node -e 'const fs = require("node:fs"); const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(manifest.assets.find((asset) => asset.kind === "state")?.archivePath ?? "");' "$manifest_path"
+)"
+test -n "$state_archive_path"
+
+openclaw gateway stop
+
+mv "$HOME/.openclaw" "$HOME/.openclaw.pre-restore.$(date +%s)" 2>/dev/null || true
+mkdir -p "$HOME/.openclaw"
+cp -a "$restore_dir/$state_archive_path"/. "$HOME/.openclaw"/
+
+openclaw doctor
+openclaw gateway start
+openclaw status
+```
+
+For a same-machine restore, the manifest `sourcePath` values are usually the intended targets. For a new machine or different home directory, choose the new target paths first, then copy only the matching asset payloads into those locations.
+
+For a full local restore, the usual targets are the state directory, active config file, credentials directory, and any workspace directories listed in the manifest. Do not restore onto a running service.
+
+Installed plugin source and manifest files are restored from the state directory's `extensions/` tree, but nested `node_modules/` dependency trees are not included in backups. If a restored plugin reports missing dependencies, run `openclaw plugins update <id>` or reinstall it with `openclaw plugins install <spec> --force`.
+
 ## Size and performance
 
 OpenClaw does not enforce a built-in maximum backup size or per-file size limit. An archive write that produces no data for five minutes fails and removes its partial temporary file instead of hanging indefinitely. Practical limits otherwise come from:
@@ -138,3 +219,4 @@ Large workspaces are usually the main driver of archive size. Use `--no-include-
 ## Related
 
 - [CLI reference](/cli)
+- [Migrating an OpenClaw install](/install/migrating)

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -210,7 +210,7 @@ For a same-machine restore, the manifest `sourcePath` values are usually the int
 
 For a full local restore, the usual targets are the state directory, active config file, credentials directory, and any workspace directories listed in the manifest. Do not restore onto a running service.
 
-Installed plugin source and manifest files are restored from the state directory's `extensions/` tree, but nested `node_modules/` dependency trees are not included in backups. If a restored plugin reports missing dependencies, run `openclaw plugins update <id>` or reinstall it with `openclaw plugins install <spec> --force`.
+Before a full restore, review [What gets backed up](#what-gets-backed-up): archives intentionally omit volatile files, plugin dependency trees, and installer-managed runtime roots such as state-local `tmp/`. Recreate those artifacts after restore.
 
 ## Size and performance
 

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -133,9 +133,11 @@ Start only from an archive you created or otherwise trust. `openclaw backup veri
 
 ### Inspect and stage the archive
 
-Verify the archive before extracting it, then extract into a private temporary directory:
+Verify the archive before extracting it, then extract into a private temporary directory. The block sets `set -euo pipefail` so a failed `openclaw backup verify` stops the script before any extraction:
 
 ```bash
+set -euo pipefail
+
 ARCHIVE=./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz
 
 openclaw backup verify "$ARCHIVE"

--- a/docs/install/backups.md
+++ b/docs/install/backups.md
@@ -140,19 +140,106 @@ encryption rules.
 
 ## Restore
 
-Restore is deliberately explicit; nothing overwrites a live database in
-place:
+Restore is deliberately explicit; nothing overwrites live state in place.
 
-1. Stop the Gateway.
-2. For archives: extract into a staging directory and follow the
-   `manifest.json` source-to-archive mapping to put files back; see
-   [Updating](/install/updating#rollback) for the rollback workflow.
-3. For snapshots: `openclaw backup sqlite restore <snapshot-directory>
---target <new-database-path>` writes a re-verified database to a fresh
-   target. Move it into place while the Gateway is stopped.
-4. For Litestream: `litestream restore` writes a fresh database file; move it
-   into place the same way.
-5. Start the Gateway and check `openclaw health` and `openclaw doctor`.
+### Restore a full archive
+
+Start only from an archive you created or otherwise trust. `openclaw backup
+verify` checks archive structure and payload layout, but it does not
+authenticate the archive or make untrusted content safe.
+
+Before a full restore, review [What gets backed
+up](/cli/backup#what-gets-backed-up). Archives intentionally omit volatile
+files, plugin dependency trees, and installer-managed runtime roots such as
+state-local `tmp/`. Recreate those artifacts after restore.
+
+Verify before extracting, then stage the archive in a private temporary
+directory:
+
+```bash
+set -euo pipefail
+
+ARCHIVE=./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz
+
+openclaw backup verify "$ARCHIVE"
+
+restore_dir="$(mktemp -d -t openclaw-restore.XXXXXX)"
+trap 'rm -rf "$restore_dir"' EXIT
+
+tar -xzf "$ARCHIVE" -C "$restore_dir"
+manifest_path="$(find "$restore_dir" -mindepth 2 -maxdepth 2 -name manifest.json -print -quit)"
+test -n "$manifest_path"
+cat "$manifest_path"
+```
+
+Treat the staging directory as sensitive. It can contain credentials, auth
+profiles, sessions, and workspace data. The `trap` removes it when the shell
+exits.
+
+The manifest records `archiveRoot`, the original paths under `paths`, and an
+`assets[]` list. Each asset includes its `kind`, original `sourcePath`, and
+`archivePath` inside the tarball. Use those fields as the source of truth; do
+not derive the archive root from the archive filename.
+
+The archive layout is:
+
+```text
+<archive-root>/manifest.json
+<archive-root>/payload/posix/<absolute-source-path-without-leading-slash>/...
+<archive-root>/payload/windows/<DRIVE>/<rest>/...
+<archive-root>/payload/relative/<relative-source-path>/...
+```
+
+Before copying files back, stop the Gateway and any node hosts that use them.
+Make a fresh backup of the current state or move the current directories
+aside. Restore the smallest set of assets needed.
+
+For example, this restores the state asset to the current user's default
+state directory. The target stays absent until `cp -a` creates it, preserving
+the staged directory's mode and metadata:
+
+```bash
+set -euo pipefail
+
+state_archive_path="$(
+  node -e 'const fs = require("node:fs"); const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(manifest.assets.find((asset) => asset.kind === "state")?.archivePath ?? "");' "$manifest_path"
+)"
+test -n "$state_archive_path"
+
+state_source="$restore_dir/$state_archive_path"
+state_target="$HOME/.openclaw"
+state_backup="$HOME/.openclaw.pre-restore.$(date +%s)"
+
+test -d "$state_source"
+openclaw gateway stop
+
+if [ -e "$state_target" ] || [ -L "$state_target" ]; then
+  mv "$state_target" "$state_backup"
+fi
+test ! -e "$state_target"
+test ! -L "$state_target"
+cp -a "$state_source" "$state_target"
+
+openclaw doctor
+openclaw gateway start
+openclaw health
+openclaw status
+```
+
+For a same-machine restore, the manifest `sourcePath` values are usually the
+intended targets. On a new machine or under a different home directory,
+choose the new targets first, then copy only the matching asset payloads.
+Typical full-restore targets are the state directory, active config file,
+credentials directory, and workspace directories. See
+[Updating](/install/updating#rollback) for the rollback workflow.
+
+### Restore a database
+
+For a snapshot, `openclaw backup sqlite restore <snapshot-directory> --target
+<new-database-path>` writes a re-verified database to a fresh target. For
+Litestream, `litestream restore` writes a fresh database file. Move either
+result into place while the Gateway is stopped, then start the Gateway and
+check `openclaw health` and `openclaw doctor`.
 
 After restoring onto a different OpenClaw version, preflight the database
 first with `openclaw database preflight`; see


### PR DESCRIPTION
Closes #77849

## What Problem This Solves

OpenClaw can create and verify full `.tar.gz` backups, but it does not currently provide a first-class archive restore command. Operators had no documented path for safely inspecting a trusted archive, mapping its manifest assets back to target paths, or restoring the smallest necessary state.

## Why This Change Was Made

This adds a manual, manifest-driven restore runbook to the existing Backups guide and keeps the backup CLI page as the concise command reference. It preserves the current product boundary—archive restore remains an explicit offline operator procedure—and calls out trust, private staging, cleanup, omitted artifacts, and same-machine/new-machine considerations.

## User Impact

Operators can now restore selected payloads from a trusted OpenClaw backup without guessing the archive root or treating structural verification as archive authentication. The guide verifies before extraction, fails closed in its shell examples, keeps sensitive staging private, and points to post-restore doctor/plugin follow-up.

## Evidence

Exact PR head: `4dc4080ad886bce4560bd6fff19b951675c44ccb`

- Rebased the contributor commits onto upstream `main` at `1672d78d17d48e80942319954d7e5d3411488ff6`.
- Reconciled the same-file drift from #122250 without broadening runtime scope. Both target documentation blobs remained unchanged on live `main`, so no additional rebase was needed.
- Addressed the exact-head ClawSweeper ownership finding by moving the detailed archive runbook to `docs/install/backups.md`; `docs/cli/backup.md` now links to the canonical guide.
- The copy-back example keeps the target absent until `cp -a` creates it, preserving the staged directory mode and metadata.
- `git diff --check` passed with no output.
- Both `bash` restore examples passed `bash -n` syntax validation.
- `pnpm docs:list --headings` parsed `/install/backups` with `Restore`, `Restore a full archive`, and `Restore a database`.
- `node scripts/check-docs-mdx.mjs docs/install/backups.md docs/cli/backup.md` passed for both files.
- `pnpm docs:check-links` checked 6,448 internal links with 0 broken.
- No generated navigation/map or updating-guide files changed.

No live restore was performed because this is documentation for the existing manual procedure, not a new restore implementation.

<!-- Punchcard-Session: calm-cedar-workshop-by -->
