### PR TITLE
fix(status): surface systemd gateway hygiene

### DIFF
--- a/src/commands/doctor-format.test.ts
+++ b/src/commands/doctor-format.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildGatewayRuntimeHints } from "./doctor-format.js";
+
+describe("buildGatewayRuntimeHints", () => {
+  it("surfaces suspicious systemd cgroup hygiene with inspection commands", () => {
+    expect(
+      buildGatewayRuntimeHints(
+        {
+          status: "running",
+          pid: 1234,
+          systemd: {
+            unit: "openclaw-gateway.service",
+            killMode: "process",
+            tasksCurrent: 807,
+            memoryCurrent: 11_918_534_246,
+          },
+        },
+        { platform: "linux", env: {} },
+      ),
+    ).toEqual([
+      "Systemd cgroup hygiene looks elevated: cgroup hygiene: KillMode=process, tasks=807, memory=11.1GiB.",
+      "This usually means old helper or browser processes may still be attached to the gateway service.",
+      "Run: systemctl --user show openclaw-gateway.service -p KillMode -p TasksCurrent -p MemoryCurrent -p MainPID",
+      "Run: systemd-cgls --user-unit openclaw-gateway.service",
+      "After reviewing service settings, run: openclaw gateway restart",
+    ]);
+  });
+
+  it("does not warn for normal systemd cgroup metrics", () => {
+    expect(
+      buildGatewayRuntimeHints(
+        {
+          status: "running",
+          pid: 1234,
+          systemd: {
+            unit: "openclaw-gateway.service",
+            killMode: "control-group",
+            tasksCurrent: 7,
+            memoryCurrent: 132_120_576,
+          },
+        },
+        { platform: "linux", env: {} },
+      ),
+    ).toEqual([]);
+  });
+});

--- a/src/commands/doctor-format.ts
+++ b/src/commands/doctor-format.ts
@@ -7,7 +7,11 @@ import {
 import { resolveDaemonContainerContext } from "../daemon/container-context.js";
 import { formatRuntimeStatus } from "../daemon/runtime-format.js";
 import { buildPlatformRuntimeLogHints } from "../daemon/runtime-hints.js";
-import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
+import {
+  getSystemdCgroupHygieneSummary,
+  isSystemdCgroupHygieneRisk,
+  type GatewayServiceRuntime,
+} from "../daemon/service-runtime.js";
 import {
   isSystemdUnavailableDetail,
   renderSystemdUnavailableHints,
@@ -94,6 +98,20 @@ export function buildGatewayRuntimeHints(
         windowsTaskName: resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE),
       }),
     );
+  }
+  if (platform === "linux" && isSystemdCgroupHygieneRisk(runtime.systemd)) {
+    const unit =
+      runtime.systemd?.unit ?? `${resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
+    const summary = getSystemdCgroupHygieneSummary(runtime.systemd);
+    if (summary) {
+      hints.push(
+        `Systemd cgroup hygiene looks elevated: ${summary}.`,
+        "This usually means old helper or browser processes may still be attached to the gateway service.",
+        `Run: systemctl --user show ${unit} -p KillMode -p TasksCurrent -p MemoryCurrent -p MainPID`,
+        `Run: systemd-cgls --user-unit ${unit}`,
+        `After reviewing service settings, run: ${formatCliCommand("openclaw gateway restart", env)}`,
+      );
+    }
   }
   return hints;
 }

--- a/src/commands/status.daemon.test.ts
+++ b/src/commands/status.daemon.test.ts
@@ -42,4 +42,60 @@ describe("status daemon summary", () => {
     expect(summary.layout?.sourceScope).toBe("system");
     expect(summary.layout?.entrypointSourceCheckout).toBe(false);
   });
+
+  it("includes suspicious systemd cgroup hygiene in the service runtime summary", async () => {
+    mocks.readServiceStatusSummary.mockResolvedValueOnce({
+      label: "systemd user",
+      installed: true,
+      loaded: true,
+      managedByOpenClaw: true,
+      externallyManaged: false,
+      loadedText: "enabled",
+      runtime: {
+        status: "running",
+        pid: 1234,
+        systemd: {
+          unit: "openclaw-gateway.service",
+          killMode: "process",
+          tasksCurrent: 807,
+          memoryCurrent: 11_918_534_246,
+        },
+      },
+    });
+
+    const summary = await getDaemonStatusSummary();
+    expect(summary.runtimeShort).toBe(
+      "running (pid 1234, cgroup hygiene: KillMode=process, tasks=807, memory=11.1GiB)",
+    );
+    expect(summary.runtime?.systemd).toEqual({
+      unit: "openclaw-gateway.service",
+      killMode: "process",
+      tasksCurrent: 807,
+      memoryCurrent: 11_918_534_246,
+    });
+  });
+
+  it("keeps normal systemd cgroup metrics out of the short status line", async () => {
+    mocks.readServiceStatusSummary.mockResolvedValueOnce({
+      label: "systemd user",
+      installed: true,
+      loaded: true,
+      managedByOpenClaw: true,
+      externallyManaged: false,
+      loadedText: "enabled",
+      runtime: {
+        status: "running",
+        pid: 1234,
+        systemd: {
+          unit: "openclaw-gateway.service",
+          killMode: "control-group",
+          tasksCurrent: 7,
+          memoryCurrent: 132_120_576,
+        },
+      },
+    });
+
+    const summary = await getDaemonStatusSummary();
+    expect(summary.runtimeShort).toBe("running (pid 1234)");
+  });
 });

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -1,3 +1,4 @@
+import { getSystemdCgroupHygieneSummary } from "../daemon/service-runtime.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
 import { formatRuntimeStatusWithDetails } from "../infra/runtime-status.ts";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -101,6 +102,7 @@ export const formatDaemonRuntimeShort = (runtime?: {
   status?: string;
   pid?: number;
   state?: string;
+  systemd?: { killMode?: string; tasksCurrent?: number; memoryCurrent?: number };
   detail?: string;
   missingUnit?: boolean;
 }) => {
@@ -114,6 +116,10 @@ export const formatDaemonRuntimeShort = (runtime?: {
     normalizeLowercaseStringOrEmpty(detail).includes("could not find service");
   if (detail && !noisyLaunchctlDetail) {
     details.push(detail);
+  }
+  const cgroupSummary = getSystemdCgroupHygieneSummary(runtime.systemd);
+  if (cgroupSummary) {
+    details.push(cgroupSummary);
   }
   return formatRuntimeStatusWithDetails({
     status: runtime.status,

--- a/src/daemon/runtime-format.ts
+++ b/src/daemon/runtime-format.ts
@@ -1,4 +1,5 @@
 import { formatRuntimeStatusWithDetails } from "../infra/runtime-status.ts";
+import { getSystemdCgroupHygieneSummary } from "./service-runtime.js";
 
 type ServiceRuntimeLike = {
   status?: string;
@@ -10,6 +11,7 @@ type ServiceRuntimeLike = {
   lastRunResult?: string;
   lastRunTime?: string;
   detail?: string;
+  systemd?: { killMode?: string; tasksCurrent?: number; memoryCurrent?: number };
 };
 
 const SIGNAL_NAMES_BY_STATUS = new Map<number, string>([
@@ -45,6 +47,10 @@ export function formatRuntimeStatus(runtime: ServiceRuntimeLike | undefined): st
   }
   if (runtime.lastRunTime) {
     details.push(`last run time ${runtime.lastRunTime}`);
+  }
+  const cgroupSummary = getSystemdCgroupHygieneSummary(runtime.systemd);
+  if (cgroupSummary) {
+    details.push(cgroupSummary);
   }
   if (runtime.detail) {
     details.push(runtime.detail);

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -50,6 +50,27 @@ function createGatewayAudit({
   });
 }
 
+async function writeSystemdUnitForAudit(home: string, lines: string[]) {
+  const unitDir = path.join(home, ".config", "systemd", "user");
+  const unitPath = path.join(unitDir, "openclaw-gateway.service");
+  await fs.mkdir(unitDir, { recursive: true });
+  await fs.writeFile(
+    unitPath,
+    [
+      "[Unit]",
+      "Description=OpenClaw Gateway",
+      "[Service]",
+      ...lines,
+      "ExecStart=/usr/bin/node gateway",
+      "",
+      "[Install]",
+      "WantedBy=default.target",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
 function expectTokenAudit(
   audit: Awaited<ReturnType<typeof auditGatewayServiceConfig>>,
   {
@@ -376,6 +397,54 @@ describe("auditGatewayServiceConfig", () => {
       serviceToken: "old-token",
     });
     expectTokenAudit(audit, { embedded: true, mismatch: true });
+  });
+
+  it.each(["process", "none"])(
+    `warns when KillMode is %s in explicit unit file`,
+    async (killMode) => {
+      const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
+      await writeSystemdUnitForAudit(home, [
+        "After=network-online.target",
+        "Wants=network-online.target",
+        "RestartSec=5",
+        `KillMode=${killMode}`,
+      ]);
+
+      const audit = await auditGatewayServiceConfig({
+        env: { HOME: home },
+        platform: "linux",
+        command: {
+          programArguments: ["/usr/bin/node", "gateway"],
+          environment: { PATH: "/usr/bin:/bin" },
+        },
+      });
+      expect(
+        audit.issues.some(
+          (entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone,
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("does not warn when KillMode is control-group", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
+    await writeSystemdUnitForAudit(home, [
+      "After=network-online.target",
+      "Wants=network-online.target",
+      "RestartSec=5",
+      "KillMode=control-group",
+    ]);
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "linux",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(
+      audit.issues.some((entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone),
+    ).toBe(false);
   });
 
   it("flags embedded service token even when it matches config token", async () => {

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
-import { normalizeOptionalString } from "../shared/string-coerce.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 import { normalizeStringEntries, sortUniqueStrings } from "../shared/string-normalization.js";
 import { resolveLaunchAgentPlistPath } from "./launchd.js";
 import { isBunRuntime, isNodeRuntime } from "./runtime-binary.js";
@@ -61,6 +64,7 @@ export const SERVICE_AUDIT_CODES = {
   systemdAfterNetworkOnline: "systemd-after-network-online",
   systemdRestartSec: "systemd-restart-sec",
   systemdWantsNetworkOnline: "systemd-wants-network-online",
+  systemdKillModeProcessOrNone: "systemd-kill-mode-process-or-none",
 } as const;
 
 export function needsNodeRuntimeMigration(issues: ServiceConfigIssue[]): boolean {
@@ -79,10 +83,12 @@ function parseSystemdUnit(content: string): {
   after: Set<string>;
   wants: Set<string>;
   restartSec?: string;
+  killMode?: string;
 } {
   const after = new Set<string>();
   const wants = new Set<string>();
   let restartSec: string | undefined;
+  let killMode: string | undefined;
 
   for (const rawLine of content.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -118,10 +124,12 @@ function parseSystemdUnit(content: string): {
       }
     } else if (key === "RestartSec") {
       restartSec = value;
+    } else if (key === "KillMode") {
+      killMode = value;
     }
   }
 
-  return { after, wants, restartSec };
+  return { after, wants, restartSec, killMode };
 }
 
 function isRestartSecPreferred(value: string | undefined): boolean {
@@ -169,6 +177,16 @@ async function auditSystemdUnit(
       code: SERVICE_AUDIT_CODES.systemdRestartSec,
       message: "RestartSec does not match the recommended 5s",
       detail: unitPath,
+      level: "recommended",
+    });
+  }
+  const killMode = normalizeLowercaseStringOrEmpty(parsed.killMode);
+  if (killMode === "process" || killMode === "none") {
+    issues.push({
+      code: SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone,
+      message:
+        "KillMode is process/none; service child processes can survive gateway stops and restarts.",
+      detail: `${unitPath}: ${killMode}`,
       level: "recommended",
     });
   }

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -1,3 +1,12 @@
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+
+export type GatewayServiceSystemdRuntime = {
+  unit?: string;
+  killMode?: string;
+  tasksCurrent?: number;
+  memoryCurrent?: number;
+};
+
 export type GatewayServiceRuntime = {
   status?: string;
   state?: string;
@@ -11,4 +20,62 @@ export type GatewayServiceRuntime = {
   cachedLabel?: boolean;
   missingUnit?: boolean;
   missingSupervision?: boolean;
+  systemd?: GatewayServiceSystemdRuntime;
 };
+
+export const SYSTEMD_TASKS_CURRENT_WARNING_THRESHOLD = 200;
+export const SYSTEMD_MEMORY_CURRENT_WARNING_BYTES = 2 * 1024 * 1024 * 1024;
+
+export function isRiskySystemdKillMode(value: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(value);
+  return normalized === "process" || normalized === "none";
+}
+
+function formatBytesAsGiB(value: number): string {
+  const gib = value / 1024 / 1024 / 1024;
+  const formatted = gib >= 1 ? gib.toFixed(1).replace(/\.0$/, "") : `${value}B`;
+  return gib >= 1 ? `${formatted}GiB` : formatted;
+}
+
+function describeSystemdCgroupLoadWarnings(runtime?: GatewayServiceSystemdRuntime): string[] {
+  if (!runtime) {
+    return [];
+  }
+  const killMode = runtime?.killMode;
+  if (!isRiskySystemdKillMode(killMode)) {
+    return [];
+  }
+  const details: string[] = [];
+  if (
+    runtime.tasksCurrent !== undefined &&
+    Number.isSafeInteger(runtime.tasksCurrent) &&
+    runtime.tasksCurrent >= SYSTEMD_TASKS_CURRENT_WARNING_THRESHOLD
+  ) {
+    details.push(`tasks=${runtime.tasksCurrent}`);
+  }
+  if (
+    runtime.memoryCurrent !== undefined &&
+    Number.isSafeInteger(runtime.memoryCurrent) &&
+    runtime.memoryCurrent >= SYSTEMD_MEMORY_CURRENT_WARNING_BYTES
+  ) {
+    details.push(`memory=${formatBytesAsGiB(runtime.memoryCurrent)}`);
+  }
+  return details;
+}
+
+export function getSystemdCgroupHygieneSummary(
+  runtime?: GatewayServiceSystemdRuntime,
+): string | null {
+  if (!runtime || !runtime.killMode) {
+    return null;
+  }
+  const details = describeSystemdCgroupLoadWarnings(runtime);
+  if (details.length === 0) {
+    return null;
+  }
+  return `cgroup hygiene: KillMode=${runtime.killMode}, ${details.join(", ")}`;
+}
+
+export function isSystemdCgroupHygieneRisk(runtime?: GatewayServiceSystemdRuntime): boolean {
+  return getSystemdCgroupHygieneSummary(runtime) !== null;
+}

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -29,6 +29,7 @@ import {
   isSystemdUnitActive,
   isSystemdUserServiceAvailable,
   parseSystemdShow,
+  readSystemdServiceRuntime,
   readSystemdServiceExecStart,
   restartSystemdService,
   resolveSystemdUserUnitPath,
@@ -528,6 +529,77 @@ describe("systemd runtime parsing", () => {
       activeState: "inactive",
       subState: "dead",
       execMainCode: "exited",
+    });
+  });
+
+  it("rejects invalid cgroup counters as junk", () => {
+    const output = [
+      "ActiveState=active",
+      "SubState=running",
+      "MainPID=1",
+      "ExecMainStatus=0",
+      "ExecMainCode=running",
+      "KillMode=process",
+      "TasksCurrent=42abc",
+      "MemoryCurrent=11GB",
+    ].join("\n");
+    expect(parseSystemdShow(output)).toEqual({
+      activeState: "active",
+      subState: "running",
+      mainPid: 1,
+      execMainStatus: 0,
+      execMainCode: "running",
+      killMode: "process",
+    });
+  });
+});
+
+describe("readSystemdServiceRuntime", () => {
+  it("surfaces systemd cgroup metrics and KillMode", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(
+          args,
+          "show",
+          GATEWAY_SERVICE,
+          "--no-page",
+          "--property",
+          "Id,ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
+        );
+        cb(
+          null,
+          [
+            "Id=openclaw-gateway.service",
+            "ActiveState=active",
+            "SubState=running",
+            "MainPID=1234",
+            "ExecMainStatus=0",
+            "ExecMainCode=running",
+            "KillMode=process",
+            "TasksCurrent=807",
+            "MemoryCurrent=11918534246",
+          ].join("\n"),
+          "",
+        );
+      });
+    const runtime = await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
+    expect(runtime).toEqual({
+      status: "running",
+      state: "active",
+      subState: "running",
+      pid: 1234,
+      lastExitStatus: 0,
+      lastExitReason: "running",
+      systemd: {
+        unit: "openclaw-gateway.service",
+        killMode: "process",
+        tasksCurrent: 807,
+        memoryCurrent: 11_918_534_246,
+      },
     });
   });
 });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -6,7 +6,11 @@ import { resolveStateDir } from "../config/paths.js";
 import { readStateDirDotEnvVarsFromStateDir } from "../config/state-dir-dotenv.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
-import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
+import {
+  parseStrictInteger,
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
+} from "../infra/parse-finite-number.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import { splitArgsPreservingQuotes } from "./arg-split.js";
@@ -389,6 +393,10 @@ type SystemdServiceInfo = {
   mainPid?: number;
   execMainStatus?: number;
   execMainCode?: string;
+  unit?: string;
+  killMode?: string;
+  tasksCurrent?: number;
+  memoryCurrent?: number;
 };
 
 export function parseSystemdShow(output: string): SystemdServiceInfo {
@@ -419,6 +427,28 @@ export function parseSystemdShow(output: string): SystemdServiceInfo {
   const execMainCode = entries.execmaincode;
   if (execMainCode) {
     info.execMainCode = execMainCode;
+  }
+  const unit = entries.id;
+  if (unit) {
+    info.unit = unit;
+  }
+  const killMode = entries.killmode;
+  if (killMode) {
+    info.killMode = killMode;
+  }
+  const tasksCurrentValue = entries.taskscurrent;
+  if (tasksCurrentValue) {
+    const tasksCurrent = parseStrictNonNegativeInteger(tasksCurrentValue);
+    if (tasksCurrent !== undefined) {
+      info.tasksCurrent = tasksCurrent;
+    }
+  }
+  const memoryCurrentValue = entries.memorycurrent;
+  if (memoryCurrentValue) {
+    const memoryCurrent = parseStrictNonNegativeInteger(memoryCurrentValue);
+    if (memoryCurrent !== undefined) {
+      info.memoryCurrent = memoryCurrent;
+    }
   }
   return info;
 }
@@ -1091,7 +1121,7 @@ export async function readSystemdServiceRuntime(
     unitName,
     "--no-page",
     "--property",
-    "ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",
+    "Id,ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
   ]);
   if (res.code !== 0) {
     const detail = (res.stderr || res.stdout).trim();
@@ -1112,6 +1142,12 @@ export async function readSystemdServiceRuntime(
     pid: parsed.mainPid,
     lastExitStatus: parsed.execMainStatus,
     lastExitReason: parsed.execMainCode,
+    systemd: {
+      unit: parsed.unit ?? unitName,
+      killMode: parsed.killMode,
+      tasksCurrent: parsed.tasksCurrent,
+      memoryCurrent: parsed.memoryCurrent,
+    },
   };
 }
 type LegacySystemdUnit = {


### PR DESCRIPTION
## Summary

- Surface systemd gateway cgroup hygiene in status/doctor by carrying `KillMode`, `TasksCurrent`, and `MemoryCurrent` from `systemctl show`.
- Warn only when risky `KillMode=process`/`none` is paired with elevated task or memory counts, and add doctor inspection commands for the runtime case.
- Add a doctor service audit warning for explicit unit-file `KillMode=process` or `KillMode=none`.

## AI Assistance Disclosure

This PR was implemented with Codex assistance. I reviewed the change and understand the affected systemd gateway status/doctor path.

## Real behavior proof

Behavior addressed: `openclaw status --json --deep` now exposes systemd `KillMode`, `TasksCurrent`, and `MemoryCurrent`, and the short service runtime summary surfaces suspicious cgroup hygiene.

Real environment tested: Linux CLI run from the local OpenClaw checkout with isolated `HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`; `systemctl` was replaced in `PATH` with a deterministic fake so no real user service, credential, or cgroup state was touched.

Exact steps or command run after this patch:

```bash
env PATH="<proof-root>/bin:$PATH" \
  HOME="<proof-root>/home" \
  OPENCLAW_HOME="<proof-root>/home" \
  OPENCLAW_STATE_DIR="<proof-root>/state" \
  OPENCLAW_CONFIG_PATH="<proof-root>/state/openclaw.json" \
  NO_COLOR=1 \
  pnpm openclaw status --json --deep --timeout 1000
```

Evidence after fix:

```json
{
  "gatewayService": {
    "label": "systemd user",
    "installed": true,
    "loaded": true,
    "loadedText": "enabled",
    "runtimeShort": "running (pid 1234, state active, cgroup hygiene: KillMode=process, tasks=807, memory=11.1GiB)",
    "runtime": {
      "status": "running",
      "state": "active",
      "subState": "running",
      "pid": 1234,
      "lastExitStatus": 0,
      "lastExitReason": "running",
      "systemd": {
        "unit": "openclaw-gateway.service",
        "killMode": "process",
        "tasksCurrent": 807,
        "memoryCurrent": 11918534246
      }
    }
  }
}
```

Observed result after fix: status carries the structured systemd runtime fields and prints `cgroup hygiene: KillMode=process, tasks=807, memory=11.1GiB` in `gatewayService.runtimeShort`.

What was not tested: a live systemd cgroup leak or a real gateway restart. The proof intentionally avoids changing the developer machine's user services.

## Root Cause

Current main already generates Linux systemd gateway units with `KillMode=control-group`, but the runtime status path only requested `ActiveState`, `SubState`, `MainPID`, `ExecMainStatus`, and `ExecMainCode`. Existing stale or operator-edited units could still have unsafe `KillMode`, high task count, or high memory use, but OpenClaw dropped those facts before status or doctor could show them.

## Dependency Contract

`systemctl show` is intended for computer-parsable unit properties, and `--property` selects the requested property names. `KillMode` is a systemd service kill setting; `process` only targets the main process while `control-group` keeps child processes in the service lifecycle. `TasksCurrent` and `MemoryCurrent` are systemd unit resource-accounting properties.

## Regression Test Plan

- `src/daemon/systemd.test.ts` covers parsing and the `systemctl show` property request.
- `src/commands/status.daemon.test.ts` covers the status runtime summary and structured systemd runtime fields.
- `src/commands/doctor-format.test.ts` covers the doctor runtime hints and inspection commands.
- `src/daemon/service-audit.test.ts` covers unit-file `KillMode=process`/`none` warnings and the `control-group` non-warning case.

## Security Impact

No secrets or credentials are read or printed by the new logic. The patch only surfaces existing systemd unit properties and local unit-file configuration. No service restart, kill behavior, auth path, or credential storage behavior changes.

## Human Verification

The proof uses isolated local state and a deterministic `systemctl` shim. A human reviewer can reproduce without touching real OpenClaw services or credentials.

## CODEOWNERS / owner review

`.github/CODEOWNERS` has no specific owner rule for `src/daemon/*` or `src/commands/*`; normal maintainer review should be sufficient.

## Changelog

Not edited as a contributor. Maintainers can add a changelog entry during landing if desired.

## Review conversations

No existing open PR was found for issue `50186`. Closed PR searches for the exact issue number also returned no prior PR.

## Risks

The cgroup hygiene thresholds are heuristic. A high task or memory count with risky `KillMode` is a strong diagnostic hint, not proof of leaked children.

## Behavior tradeoffs

The warning requires both risky `KillMode` and elevated cgroup load. That avoids noisy status output for normal `control-group` units and for low-load units, but it means a risky low-load unit is only surfaced by the doctor service audit, not the short runtime line.

## Scope boundaries

This does not change generated unit defaults, restart behavior, service activation, process killing, or migration policy. It preserves existing runtime behavior and adds observability.

## Validation

- `codex review --base origin/main` - no findings.
- `pnpm test src/daemon/systemd.test.ts src/daemon/service-audit.test.ts src/commands/status.daemon.test.ts src/commands/doctor-format.test.ts src/daemon/runtime-format.test.ts -- --reporter=verbose` - passed.
- `pnpm format:check src/daemon/service-runtime.ts src/daemon/systemd.ts src/daemon/service-audit.ts src/daemon/runtime-format.ts src/commands/status.format.ts src/commands/status.daemon.test.ts src/commands/doctor-format.ts src/commands/doctor-format.test.ts src/daemon/systemd.test.ts src/daemon/service-audit.test.ts src/daemon/runtime-format.test.ts` - passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/daemon/service-runtime.ts src/daemon/systemd.ts src/daemon/service-audit.ts src/daemon/runtime-format.ts src/commands/status.format.ts src/commands/status.daemon.test.ts src/commands/doctor-format.ts src/commands/doctor-format.test.ts src/daemon/systemd.test.ts src/daemon/service-audit.test.ts src/daemon/runtime-format.test.ts` - passed.
- `git diff --check` - passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm check:changed` - passed after rebasing onto current `origin/main`.
