### PR TITLE
fix(agents): correlate pathless read diagnostics

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -24,11 +24,15 @@ function createTestContext(): {
   onBlockReplyFlush: ReturnType<typeof vi.fn>;
   onAgentEvent: ReturnType<typeof vi.fn>;
   onExecutionPhase: ReturnType<typeof vi.fn>;
+  trace: ReturnType<typeof vi.fn>;
+  isEnabled: ReturnType<typeof vi.fn>;
 } {
   const onBlockReplyFlush = vi.fn();
   const onAgentEvent = vi.fn();
   const onExecutionPhase = vi.fn();
   const warn = vi.fn();
+  const trace = vi.fn();
+  const isEnabled = vi.fn(() => false);
   const ctx: ToolHandlerContext = {
     params: {
       runId: "run-test",
@@ -44,6 +48,8 @@ function createTestContext(): {
     hookRunner: undefined,
     log: {
       debug: vi.fn(),
+      trace,
+      isEnabled,
       info: vi.fn(),
       warn,
     },
@@ -79,7 +85,7 @@ function createTestContext(): {
     trimMessagingToolSent: vi.fn(),
   };
 
-  return { ctx, warn, onBlockReplyFlush, onAgentEvent, onExecutionPhase };
+  return { ctx, warn, onBlockReplyFlush, onAgentEvent, onExecutionPhase, trace, isEnabled };
 }
 
 type CapturedAgentEvent = { stream?: string; data?: Record<string, unknown> };
@@ -156,8 +162,55 @@ function requireSingleMessagingTarget(ctx: ToolHandlerContext) {
 }
 
 describe("handleToolExecutionStart read path checks", () => {
+  it("emits trace-only tool start diagnostics when trace logging is enabled", async () => {
+    const { ctx, trace, isEnabled, warn } = createTestContext();
+    isEnabled.mockImplementation((level: string) => level === "trace");
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "write",
+      toolCallId: "tool-trace",
+      args: { path: "notes.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(trace).toHaveBeenCalledTimes(1);
+    expect(trace.mock.calls[0]?.[0]).toBe("embedded run tool start");
+    expect(trace.mock.calls[0]?.[1]).toEqual({
+      event: "embedded_tool_execution_start",
+      tags: ["tool_start", "embedded", "trace"],
+      runId: "run-test",
+      toolName: "write",
+      toolCallId: "tool-trace",
+      argsType: "object",
+      argsKeys: ["path"],
+      sessionKey: "agent:unit-session",
+      sessionId: "session-test-id",
+      agentId: "agent-test-id",
+      requiredParamsMissing: ["content"],
+    });
+  });
+
+  it("does not build trace tool start diagnostics unless trace logging is enabled", async () => {
+    const { ctx, trace, isEnabled } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "write",
+      toolCallId: "tool-trace-disabled",
+      args: { path: "notes.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(isEnabled).toHaveBeenCalledWith("trace");
+    expect(trace).not.toHaveBeenCalled();
+  });
+
   it("does not warn when read tool uses file_path alias", async () => {
-    const { ctx, warn, onBlockReplyFlush, onExecutionPhase } = createTestContext();
+    const { ctx, warn, trace, onBlockReplyFlush, onExecutionPhase } = createTestContext();
 
     const evt: ToolExecutionStartEvent = {
       type: "tool_execution_start",
@@ -176,6 +229,7 @@ describe("handleToolExecutionStart read path checks", () => {
       source: "pi-embedded",
     });
     expect(warn).not.toHaveBeenCalled();
+    expect(trace).not.toHaveBeenCalled();
   });
 
   it("warns when read tool has neither path nor file_path", async () => {
@@ -211,6 +265,22 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(warnMeta?.consoleMessage).toContain("argsType=object");
     expect(warnMeta?.consoleMessage).toContain("read tool called without path");
     expect(warnMeta).not.toHaveProperty("argsPreview");
+  });
+
+  it("bounds string args before adding read warning preview", async () => {
+    const { ctx, warn } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-string-args",
+      args: "x".repeat(500),
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    const warnMeta = warn.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(warnMeta?.argsPreview).toBe(`${"x".repeat(200)}…`);
   });
 
   it("awaits onBlockReplyFlush before continuing tool start processing", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -32,6 +32,9 @@ function createTestContext(): {
   const ctx: ToolHandlerContext = {
     params: {
       runId: "run-test",
+      sessionKey: "agent:unit-session",
+      sessionId: "session-test-id",
+      agentId: "agent-test-id",
       onBlockReplyFlush,
       onAgentEvent,
       onExecutionPhase,
@@ -188,7 +191,26 @@ describe("handleToolExecutionStart read path checks", () => {
     await handleToolExecutionStart(ctx, evt);
 
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(String(warn.mock.calls[0]?.[0] ?? "")).toContain("read tool called without path");
+    const warnMessage = String(warn.mock.calls[0]?.[0] ?? "");
+    const warnMeta = warn.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(warnMessage).toContain("read tool called without path");
+    expect(warnMeta).toBeTypeOf("object");
+    expect(warnMeta?.event).toBe("embedded_read_tool_start_warning");
+    expect(warnMeta?.tags).toEqual(["tool_start", "read", "embedded", "validation"]);
+    expect(warnMeta?.runId).toBe("run-test");
+    expect(warnMeta?.sessionKey).toBe("agent:unit-session");
+    expect(warnMeta?.sessionId).toBe("session-test-id");
+    expect(warnMeta?.agentId).toBe("agent-test-id");
+    expect(warnMeta?.toolCallId).toBe("tool-2");
+    expect(warnMeta?.argsType).toBe("object");
+    expect(warnMeta?.consoleMessage).toContain("runId=run-test");
+    expect(warnMeta?.consoleMessage).toContain("sessionKey=agent:unit-session");
+    expect(warnMeta?.consoleMessage).toContain("sessionId=session-test-id");
+    expect(warnMeta?.consoleMessage).toContain("agentId=agent-test-id");
+    expect(warnMeta?.consoleMessage).toContain("toolCallId=tool-2");
+    expect(warnMeta?.consoleMessage).toContain("argsType=object");
+    expect(warnMeta?.consoleMessage).toContain("read tool called without path");
+    expect(warnMeta).not.toHaveProperty("argsPreview");
   });
 
   it("awaits onBlockReplyFlush before continuing tool start processing", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -210,7 +210,9 @@ describe("handleToolExecutionStart read path checks", () => {
   });
 
   it("does not warn when read tool uses file_path alias", async () => {
-    const { ctx, warn, trace, onBlockReplyFlush, onExecutionPhase } = createTestContext();
+    const { ctx, warn, trace, isEnabled, onBlockReplyFlush, onExecutionPhase } =
+      createTestContext();
+    isEnabled.mockImplementation((level: string) => level === "trace");
 
     const evt: ToolExecutionStartEvent = {
       type: "tool_execution_start",
@@ -229,7 +231,8 @@ describe("handleToolExecutionStart read path checks", () => {
       source: "pi-embedded",
     });
     expect(warn).not.toHaveBeenCalled();
-    expect(trace).not.toHaveBeenCalled();
+    expect(trace).toHaveBeenCalledTimes(1);
+    expect(trace.mock.calls[0]?.[1]).not.toHaveProperty("requiredParamsMissing");
   });
 
   it("warns when read tool has neither path nor file_path", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -76,6 +76,11 @@ const beforeToolCallModuleLoader = createLazyImportLoader<BeforeToolCallModule>(
 );
 const LIVE_EXEC_OUTPUT_MAX_CHARS = 8000;
 const LIVE_EXEC_UPDATE_MIN_INTERVAL_MS = 250;
+const TRACE_REQUIRED_PARAM_GROUPS = {
+  read: [{ keys: ["path", "file_path"], label: "path" }],
+  write: REQUIRED_PARAM_GROUPS.write,
+  edit: REQUIRED_PARAM_GROUPS.edit,
+} satisfies Record<string, readonly RequiredParamGroup[]>;
 
 function isMiddlewareToolResultError(result: unknown): boolean {
   if (!result || typeof result !== "object") {
@@ -109,16 +114,7 @@ function loadBeforeToolCall(): Promise<BeforeToolCallModule> {
 function getRequiredParamGroupsForTool(
   toolName: string,
 ): readonly RequiredParamGroup[] | undefined {
-  if (toolName === "read") {
-    return REQUIRED_PARAM_GROUPS.read;
-  }
-  if (toolName === "write") {
-    return REQUIRED_PARAM_GROUPS.write;
-  }
-  if (toolName === "edit") {
-    return REQUIRED_PARAM_GROUPS.edit;
-  }
-  return undefined;
+  return TRACE_REQUIRED_PARAM_GROUPS[toolName as keyof typeof TRACE_REQUIRED_PARAM_GROUPS];
 }
 
 function collectMissingRequiredParamLabels(toolName: string, args: unknown): string[] {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -29,6 +29,7 @@ import { truncateUtf16Safe } from "../utils.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import { sanitizeForConsole } from "./console-sanitize.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
 import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
@@ -801,10 +802,46 @@ export function handleToolExecutionStart(
             : "";
       const filePath = filePathValue.trim();
       if (!filePath) {
-        const argsPreview = readStringValue(args)?.slice(0, 200);
-        ctx.log.warn(
-          `read tool called without path: toolCallId=${toolCallId} argsType=${typeof args}${argsPreview ? ` argsPreview=${argsPreview}` : ""}`,
-        );
+        const argsType = typeof args;
+        const argsPreview = sanitizeForConsole(readStringValue(args), 200);
+        const safeRunId = sanitizeForConsole(runId) ?? "-";
+        const safeSessionKey = sanitizeForConsole(ctx.params.sessionKey);
+        const safeSessionId = sanitizeForConsole(ctx.params.sessionId);
+        const safeAgentId = sanitizeForConsole(ctx.params.agentId);
+        const consoleMessageParts = [
+          "read tool called without path:",
+          `runId=${safeRunId}`,
+          `toolCallId=${sanitizeForConsole(toolCallId) ?? "tool-call"}`,
+          `argsType=${argsType}`,
+        ];
+        if (safeSessionKey) {
+          consoleMessageParts.push(`sessionKey=${safeSessionKey}`);
+        }
+        if (safeSessionId) {
+          consoleMessageParts.push(`sessionId=${safeSessionId}`);
+        }
+        if (safeAgentId) {
+          consoleMessageParts.push(`agentId=${safeAgentId}`);
+        }
+        if (argsPreview) {
+          consoleMessageParts.push(`argsPreview=${argsPreview}`);
+        }
+        const consoleMessage = consoleMessageParts.join(" ");
+        const message = `read tool called without path: toolCallId=${toolCallId} argsType=${argsType}${
+          argsPreview ? ` argsPreview=${argsPreview}` : ""
+        }`;
+        ctx.log.warn(message, {
+          event: "embedded_read_tool_start_warning",
+          tags: ["tool_start", "read", "embedded", "validation"],
+          runId: ctx.params.runId,
+          toolCallId,
+          argsType,
+          ...(safeSessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+          ...(safeSessionId ? { sessionId: ctx.params.sessionId } : {}),
+          ...(safeAgentId ? { agentId: ctx.params.agentId } : {}),
+          ...(argsPreview ? { argsPreview } : {}),
+          consoleMessage,
+        });
       }
     }
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -53,6 +53,7 @@ import {
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
+import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./pi-tools.params.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 
@@ -104,6 +105,94 @@ function loadMediaParse(): Promise<MediaParseModule> {
 function loadBeforeToolCall(): Promise<BeforeToolCallModule> {
   return beforeToolCallModuleLoader.load();
 }
+
+function getRequiredParamGroupsForTool(
+  toolName: string,
+): readonly RequiredParamGroup[] | undefined {
+  if (toolName === "read") {
+    return REQUIRED_PARAM_GROUPS.read;
+  }
+  if (toolName === "write") {
+    return REQUIRED_PARAM_GROUPS.write;
+  }
+  if (toolName === "edit") {
+    return REQUIRED_PARAM_GROUPS.edit;
+  }
+  return undefined;
+}
+
+function collectMissingRequiredParamLabels(toolName: string, args: unknown): string[] {
+  const groups = getRequiredParamGroupsForTool(toolName);
+  if (!groups?.length) {
+    return [];
+  }
+  const record = args && typeof args === "object" ? (args as Record<string, unknown>) : undefined;
+  if (!record) {
+    return groups.map((group) => group.label ?? group.keys.join(" or "));
+  }
+  return groups
+    .filter((group) => {
+      const satisfied =
+        group.validator?.(record) ??
+        group.keys.some((key) => {
+          const value = record[key];
+          return typeof value === "string" && (group.allowEmpty || value.trim().length > 0);
+        });
+      return !satisfied;
+    })
+    .map((group) => group.label ?? group.keys.join(" or "));
+}
+
+function buildToolExecutionStartTraceMeta(params: {
+  ctx: ToolHandlerContext;
+  toolName: string;
+  toolCallId: string;
+  args: unknown;
+}): Record<string, unknown> {
+  const args = params.args;
+  const argsType = Array.isArray(args) ? "array" : typeof args;
+  const argsKeys =
+    args && typeof args === "object" && !Array.isArray(args)
+      ? Object.keys(args as Record<string, unknown>).toSorted()
+      : undefined;
+  const requiredParamsMissing = collectMissingRequiredParamLabels(params.toolName, args);
+  return {
+    event: "embedded_tool_execution_start",
+    tags: ["tool_start", "embedded", "trace"],
+    runId: params.ctx.params.runId,
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    argsType,
+    ...(argsKeys?.length ? { argsKeys } : {}),
+    ...(params.ctx.params.sessionKey ? { sessionKey: params.ctx.params.sessionKey } : {}),
+    ...(params.ctx.params.sessionId ? { sessionId: params.ctx.params.sessionId } : {}),
+    ...(params.ctx.params.agentId ? { agentId: params.ctx.params.agentId } : {}),
+    ...(requiredParamsMissing.length ? { requiredParamsMissing } : {}),
+  };
+}
+
+function traceToolExecutionStart(params: {
+  ctx: ToolHandlerContext;
+  toolName: string;
+  toolCallId: string;
+  args: unknown;
+}) {
+  if (!params.ctx.log.trace || params.ctx.log.isEnabled?.("trace") !== true) {
+    return;
+  }
+  params.ctx.log.trace(
+    "embedded run tool start",
+    buildToolExecutionStartTraceMeta({
+      ctx: params.ctx,
+      toolName: params.toolName,
+      toolCallId: params.toolCallId,
+      args: params.args,
+    }),
+  );
+}
+
+const TOOL_START_WARNING_PREVIEW_MAX_CHARS = 200;
+const TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS = TOOL_START_WARNING_PREVIEW_MAX_CHARS + 1;
 
 type ToolStartRecord = {
   startTime: number;
@@ -791,6 +880,7 @@ export function handleToolExecutionStart(
     // Track start time and args for after_tool_call hook.
     const startedAt = Date.now();
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: startedAt, args });
+    traceToolExecutionStart({ ctx, toolName, toolCallId, args });
 
     if (toolName === "read") {
       const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
@@ -803,7 +893,11 @@ export function handleToolExecutionStart(
       const filePath = filePathValue.trim();
       if (!filePath) {
         const argsType = typeof args;
-        const argsPreview = sanitizeForConsole(readStringValue(args), 200);
+        const rawArgsPreview = readStringValue(args);
+        const argsPreview = sanitizeForConsole(
+          rawArgsPreview?.slice(0, TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS),
+          TOOL_START_WARNING_PREVIEW_MAX_CHARS,
+        );
         const safeRunId = sanitizeForConsole(runId) ?? "-";
         const safeSessionKey = sanitizeForConsole(ctx.params.sessionKey);
         const safeSessionId = sanitizeForConsole(ctx.params.sessionId);

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -24,6 +24,11 @@ import type { NormalizedUsage } from "./usage.js";
 
 type EmbeddedSubscribeLogger = {
   debug: (message: string, meta?: Record<string, unknown>) => void;
+  trace?: (message: string, meta?: Record<string, unknown>) => void;
+  isEnabled?: (
+    level: "trace" | "debug" | "info" | "warn" | "error" | "fatal",
+    target?: "any" | "console" | "file",
+  ) => boolean;
   info: (message: string, meta?: Record<string, unknown>) => void;
   warn: (message: string, meta?: Record<string, unknown>) => void;
 };


### PR DESCRIPTION
## Summary

- Preserve the existing read-tool missing-path warning and add structured correlation metadata for run, session, agent, tool call, and argument shape.
- Keep the canonical read execution contract unchanged: `path` is still required for execution, and this PR does not add `file`, `filePath`, or other aliases.
- Add focused coverage for the enriched warning and keep the existing `file_path` diagnostic/display no-warning behavior.

## AI assistance disclosure

This PR was implemented with Codex assistance. I reviewed the change and understand the affected embedded tool-start diagnostic path.

## Real behavior proof

Behavior addressed: A `read` tool-start event with no `path` now emits a warning that can be correlated to the run/session/agent instead of only showing the tool call id and argument type.

Real environment tested: Local OpenClaw worktree on Node 22 with repository wrappers, using the production `handleToolExecutionStart` path through `tsx`.

Exact steps or command run after this patch:

```sh
pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts -- --reporter=verbose
pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts
node --import tsx --input-type=module -e '<production handler proof for pathless read and file_path display alias>'
codex review --base origin/main
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm check:changed
```

Evidence after fix:

```text
PATHLESS_WARNING_COUNT=1
{
  "message": "read tool called without path: toolCallId=tool-proof-pathless argsType=object",
  "meta": {
    "event": "embedded_read_tool_start_warning",
    "tags": [
      "tool_start",
      "read",
      "embedded",
      "validation"
    ],
    "runId": "run-proof-64408",
    "toolCallId": "tool-proof-pathless",
    "argsType": "object",
    "sessionKey": "agent:proof-session",
    "sessionId": "session-proof-64408",
    "agentId": "agent-proof-64408",
    "consoleMessage": "read tool called without path: runId=run-proof-64408 toolCallId=tool-proof-pathless argsType=object sessionKey=agent:proof-session sessionId=session-proof-64408 agentId=agent-proof-64408"
  }
}
FILE_PATH_ALIAS_WARNING_COUNT=0
proof_status=0
```

Observed result after fix: The pathless read warning count is exactly one and the warning metadata contains `runId`, `sessionKey`, `sessionId`, `agentId`, `toolCallId`, `argsType`, event, tags, and a sanitized console message. The existing `file_path` diagnostic/display alias still does not trigger the warning.

What was not tested: I did not run a full live model session that causes a provider to emit malformed `read` args, because this patch is limited to the local embedded handler diagnostic path and does not change the caller or tool execution contract.

## Root Cause

`handleToolExecutionStart` already detected a `read` tool-start event without a usable path, but the warning only included `toolCallId` and `argsType`. The runtime context already had the correlation data needed to identify the run/session/agent, but the warning did not include it.

## Dependency contract

`@earendil-works/pi-coding-agent@0.75.5` defines the read tool input schema as canonical `path` plus optional `offset` and `limit`. OpenClaw mirrors that execution contract in `src/agents/pi-tools.params.ts` and `src/agents/pi-tools.read.ts`, and existing tests reject alias-only read execution params. This PR preserves that contract and only improves the warning emitted by the pre-execution embedded subscription handler.

## Regression Test Plan

- `src/agents/pi-embedded-subscribe.handlers.tools.test.ts` now verifies the pathless read warning metadata and sanitized console message.
- The existing test that accepts `file_path` for this diagnostic/display path remains in place.

## Security Impact

Low. The patch adds structured diagnostic fields that are already run/session identifiers in process context. The console message and string argument preview use the existing console sanitizer. It does not print credentials or expand tool argument logging for object payloads.

## Human Verification

I checked the related issue/PR history, dependency read-tool schema, OpenClaw wrapper contract, diff scope, focused tests, formatting, changed checks, Codex review, and a local production-handler proof before preparing this PR.

## CODEOWNERS / owner review

The touched files are under `src/agents/`. `.github/CODEOWNERS` has secops-specific entries for auth/sandbox/secret-sensitive agent paths, but no explicit owner entry matching these two files. No special CODEOWNERS owner appears required beyond normal maintainer review.

## Changelog

No contributor changelog edit. This is a diagnostic fix and OpenClaw maintainer workflow can decide whether to add a changelog entry while landing.

## Review conversations

- Issue #64408 is open and has no linked closing PR.
- Exact open PR search for `64408` found no open PR.
- Closed PRs and related issues showed prior alias-only approaches were rejected or blocked because the execution contract requires canonical `path`.
- Related duplicate #79581 points back to #64408 and supports adding correlation before repairing the eventual caller.

## Risks

- The real source of malformed `read({})` calls still needs a follow-up once correlated logs identify it.
- More warning metadata means slightly larger log records for this already-warning-only path.

## Behavior tradeoffs

- The warning becomes more actionable without hiding or suppressing the malformed call.
- This leaves the current display-only `file_path` behavior intact in the embedded tool-start handler.

## Scope boundaries

- No read execution aliases were added.
- No startup migration, provider behavior, model prompting, or tool schema behavior changed.
- No docs, changelog, dependency, or package metadata changed.

## Validation

```text
pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts -- --reporter=verbose
Test Files  1 passed (1)
Tests       41 passed (41)

pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts
passed

codex review --base origin/main
passed, no findings

OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm check:changed
passed
```
