### PR TITLE
docs(codex): clarify report-mode plugin approvals

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -98,6 +98,18 @@ OpenClaw can mirror selected events, but it cannot rewrite the native Codex
 thread unless Codex exposes that operation through app-server or native hook
 callbacks.
 
+Codex app-server report-mode `PreToolUse` events are fail-closed for plugin
+approval requests. If an OpenClaw `before_tool_call` hook returns
+`requireApproval` while the native payload sets report approval mode
+(`openclaw_approval_mode` is `"report"`), OpenClaw does not open an
+interactive plugin approval prompt. The relay reports the requirement back to
+Codex as a denied `PreToolUse` response using the approval title or
+description as the deny reason. Plugins that need a
+human decision on this path should return `block` with explicit retry or
+out-of-band approval instructions. Codex `PermissionRequest` events are a
+separate approval path and can still route through OpenClaw approvals when the
+runtime is configured for that bridge.
+
 Codex app-server item notifications also provide async `after_tool_call`
 observations for native tool completions that are not already covered by the
 native `PostToolUse` relay. These observations are for telemetry and plugin

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -211,6 +211,9 @@ Hook guard behavior for typed lifecycle hooks:
 - `params` rewrites the tool parameters for execution.
 - `requireApproval` pauses the agent run and asks the user through plugin
   approvals. The `/approve` command can approve both exec and plugin approvals.
+  In Codex app-server report-mode native `PreToolUse` relays, this is reported
+  back to Codex as a denied tool call instead of opening an interactive plugin
+  approval prompt; see [Codex harness runtime](/plugins/codex-harness-runtime#hook-boundaries).
 - A lower-priority `block: true` can still block after a higher-priority hook
   requested approval.
 - `onResolution` receives the resolved approval decision - `allow-once`,


### PR DESCRIPTION
## Summary

- Document that Codex app-server report-mode `PreToolUse` plugin approval requirements fail closed as denied tool calls instead of opening interactive plugin approval prompts.
- Cross-link the general plugin hook `requireApproval` docs to the Codex harness runtime boundary.

Fixes #86777

## Real behavior proof

- **Behavior addressed**: Plugin authors could read the generic `requireApproval` docs and expect an interactive OpenClaw approval prompt even on Codex-native app-server report-mode `PreToolUse` hooks.
- **Real environment tested**: Repository checkout `/root/projects/openclaw-codex-report-docs`, PR head `3e79956434`, base `origin/main`, changed files `docs/plugins/codex-harness-runtime.md` and `docs/plugins/hooks.md`.
- **Exact steps or command run after this patch**: Inspected source and tests with `rg`; reviewed the docs diff; ran `git diff --check`; ran `node scripts/check-docs-mdx.mjs docs/plugins/codex-harness-runtime.md docs/plugins/hooks.md`; ran `pnpm docs:list`; attempted `node scripts/docs-link-audit.mjs --anchors docs/plugins/codex-harness-runtime.md docs/plugins/hooks.md`.
- **Evidence after fix**: Copied live terminal output from the patched checkout:

```text
src/agents/harness/native-hook-relay.ts:1489:  return payload.openclaw_approval_mode === "report" ? "report" : undefined;
src/agents/harness/native-hook-relay.test.ts:1158:  it("reports synthetic app-server PreToolUse approval requirements without opening plugin approvals", async () => {
src/agents/harness/native-hook-relay.test.ts:1182:        openclaw_approval_mode: "report",
src/agents/pi-tools.before-tool-call.ts:798:      if (args.approvalMode === "report") {
src/agents/pi-tools.before-tool-call.ts:864:      if (args.approvalMode === "report") {
docs/plugins/codex-harness-runtime.md:101:Codex app-server report-mode `PreToolUse` events are fail-closed for plugin
docs/plugins/codex-harness-runtime.md:104:(`openclaw_approval_mode` is `"report"`), OpenClaw does not open an
docs/plugins/hooks.md:214:  In Codex app-server report-mode native `PreToolUse` relays, this is reported
Docs MDX check passed (2 files, 180ms).
```

The docs diff adds the report-mode boundary to `docs/plugins/codex-harness-runtime.md` and cross-links it from `docs/plugins/hooks.md`. `git diff --check`, targeted MDX check, and `pnpm docs:list` passed.
- **Observed result after fix**: The docs now tell plugin authors that report-mode native `PreToolUse` `requireApproval` is reported back to Codex as a denied tool call rather than opening an interactive plugin approval prompt.
- **What was not tested**: `docs-link-audit` could not complete locally because Mintlify link-rot failed to import `react` from its pnpm-isolated dependency path. The changed link targets an existing page and anchor in the same docs tree.

## Verification

- `git diff --check`
- `node scripts/check-docs-mdx.mjs docs/plugins/codex-harness-runtime.md docs/plugins/hooks.md`
- `pnpm docs:list`
