### PR TITLE
fix(telegram): refine typing and progress drafts

### DIFF
--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -24,10 +24,12 @@ type BuildTelegramMessageContextForTestParams = {
   options?: BuildTelegramMessageContextParams["options"];
   cfg?: Record<string, unknown>;
   accountId?: string;
+  dmPolicy?: BuildTelegramMessageContextParams["dmPolicy"];
   historyLimit?: number;
   groupHistories?: Map<string, import("openclaw/plugin-sdk/reply-history").HistoryEntry[]>;
   ackReactionScope?: BuildTelegramMessageContextParams["ackReactionScope"];
   botApi?: Record<string, unknown>;
+  sendChatActionHandler?: BuildTelegramMessageContextParams["sendChatActionHandler"];
   runtime?: BuildTelegramMessageContextParams["runtime"];
   sessionRuntime?: BuildTelegramMessageContextParams["sessionRuntime"] | null;
   resolveGroupActivation?: BuildTelegramMessageContextParams["resolveGroupActivation"];
@@ -127,7 +129,7 @@ export async function buildTelegramMessageContextForTest(
     account: { accountId: params.accountId ?? "default" } as never,
     historyLimit: params.historyLimit ?? 0,
     groupHistories: params.groupHistories ?? new Map(),
-    dmPolicy: "open",
+    dmPolicy: params.dmPolicy ?? "open",
     allowFrom: ["*"],
     groupAllowFrom: [],
     ackReactionScope: params.ackReactionScope ?? "off",
@@ -140,7 +142,7 @@ export async function buildTelegramMessageContextForTest(
         groupConfig: { requireMention: false },
         topicConfig: undefined,
       })),
-    sendChatActionHandler: { sendChatAction: vi.fn() } as never,
+    sendChatActionHandler: params.sendChatActionHandler ?? ({ sendChatAction: vi.fn() } as never),
   });
 }
 

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -109,6 +109,7 @@ export type TelegramMessageContext = {
   sendTyping: () => Promise<void>;
   sendRecordVoice: () => Promise<void>;
   sendChatActionHandler: BuildTelegramMessageContextParams["sendChatActionHandler"];
+  initialTypingCueSent?: boolean;
   ackReactionPromise: Promise<boolean> | null;
   reactionApi: TelegramReactionApi | null;
   removeAckAfterReply: boolean;
@@ -368,6 +369,7 @@ export const buildTelegramMessageContext = async ({
   ) {
     return null;
   }
+  let initialTypingCueSent = false;
   const ensureConfiguredBindingReady = async (): Promise<boolean> => {
     if (!configuredBinding) {
       return true;
@@ -478,6 +480,15 @@ export const buildTelegramMessageContext = async ({
 
   if (!(await ensureConfiguredBindingReady())) {
     return null;
+  }
+
+  // Direct chats are now reply-eligible; send the first typing cue before
+  // expensive context/session construction without showing typing for dropped turns.
+  if (!isGroup) {
+    initialTypingCueSent = true;
+    void sendTyping().catch((err) => {
+      logVerbose(`telegram early direct typing cue failed for chat ${chatId}: ${String(err)}`);
+    });
   }
 
   const { ctxPayload, skillFilter, turn } = await buildTelegramInboundContextPayload({
@@ -643,6 +654,7 @@ export const buildTelegramMessageContext = async ({
     sendTyping,
     sendRecordVoice,
     sendChatActionHandler,
+    initialTypingCueSent,
     ackReactionPromise,
     reactionApi,
     removeAckAfterReply,

--- a/extensions/telegram/src/bot-message-context.typing.test.ts
+++ b/extensions/telegram/src/bot-message-context.typing.test.ts
@@ -1,0 +1,80 @@
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import { describe, expect, it, vi } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+import type { TelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
+
+function createSendChatActionHandler(
+  sendChatAction = vi.fn(async () => undefined),
+): TelegramSendChatActionHandler & { sendChatAction: typeof sendChatAction } {
+  return {
+    sendChatAction,
+    isSuspended: () => false,
+    reset: () => undefined,
+  };
+}
+
+describe("buildTelegramMessageContext typing", () => {
+  it("sends direct typing after body resolution and before session context construction", async () => {
+    const buildInboundContext = vi.fn(buildChannelInboundEventContext);
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          from: { id: 42, first_name: "Pat" },
+          text: "hello",
+        },
+        sendChatActionHandler,
+        sessionRuntime: {
+          buildChannelInboundEventContext: buildInboundContext,
+        },
+      }),
+    ).resolves.not.toBeNull();
+
+    expect(sendChatActionHandler.sendChatAction).toHaveBeenCalledWith(42, "typing", undefined);
+    expect(sendChatActionHandler.sendChatAction.mock.invocationCallOrder[0]).toBeLessThan(
+      buildInboundContext.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not send direct typing when there is no replyable body", async () => {
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          from: { id: 42, first_name: "Pat" },
+          text: undefined,
+        },
+        sendChatActionHandler,
+      }),
+    ).resolves.toBeNull();
+
+    expect(sendChatActionHandler.sendChatAction).not.toHaveBeenCalled();
+  });
+
+  it("does not send early direct typing before DM access passes", async () => {
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          from: { id: 42, first_name: "Pat" },
+          text: "hello",
+        },
+        cfg: {
+          agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+          channels: { telegram: { dmPolicy: "disabled", allowFrom: [] } },
+          messages: { groupChat: { mentionPatterns: [] } },
+        },
+        dmPolicy: "disabled",
+        sendChatActionHandler,
+      }),
+    ).resolves.toBeNull();
+
+    expect(sendChatActionHandler.sendChatAction).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1981,6 +1981,35 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("does not stream text-only tool results into progress drafts", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver(
+          { text: "stdout line one\nstdout line two" },
+          { kind: "tool" },
+        );
+        await replyOptions?.onItemEvent?.({ kind: "search", progressText: "docs lookup" });
+        return { queuedFinal: false };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).not.toHaveBeenCalledWith(
+      expect.stringContaining("stdout line one"),
+    );
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith(
+      "Shelling\n\n`🛠️ Exec`\n`🔎 Web Search: docs lookup`",
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("does not restart progress drafts after final answer delivery", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1752,18 +1752,27 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.noteReasoningHint();
                       }
                       if (segment.lane === "answer" && info.kind === "tool") {
-                        if (
-                          nativeToolProgressDraft &&
-                          canUseNativeToolProgressDraft({
-                            payload: effectivePayload,
-                            reply,
-                            buttons: telegramButtons,
-                          })
-                        ) {
+                        const canRepresentAsTransientProgress = canUseNativeToolProgressDraft({
+                          payload: effectivePayload,
+                          reply,
+                          buttons: telegramButtons,
+                        });
+                        if (nativeToolProgressDraft && canRepresentAsTransientProgress) {
                           if (await pushStreamToolProgress(segment.update.text)) {
                             blockDelivered = true;
                             continue;
                           }
+                        }
+                        if (
+                          canRepresentAsTransientProgress &&
+                          streamMode === "progress" &&
+                          answerLane.stream
+                        ) {
+                          // Progress-mode streams render tool status in the
+                          // live draft. Do not also emit text-only tool output
+                          // as answer text, or simple commands duplicate and
+                          // restart the progress draft.
+                          continue;
                         }
                         await prepareAnswerLaneForToolProgress();
                       }

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -160,7 +160,10 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
           (options?.ingressBuffer ? ` buffer=${options.ingressBuffer}` : ""),
       );
     }
-    if (context.ctxPayload.InboundEventKind !== "room_event") {
+    if (
+      context.ctxPayload.InboundEventKind !== "room_event" &&
+      context.initialTypingCueSent !== true
+    ) {
       void context.sendTyping().catch((err) => {
         logVerbose(`telegram early typing cue failed for chat ${context.chatId}: ${String(err)}`);
       });


### PR DESCRIPTION
## Summary

This extracts the Telegram-only typing/progress-draft part of #85941 into a focused PR.

- preserve Telegram typing context when dispatching progress and final replies
- add coverage for typing context behavior and progress draft dispatch
- keep the original contributor commit author: Keshav's Bot <keshavbotagent@gmail.com>

Split from #85941 so the Telegram surface can be reviewed and landed independently. Thanks @keshavbotagent for the original work.

## Verification

- `git diff --check origin/main...origin/codex/split-85941-telegram-progress`

## Real behavior proof

Behavior addressed: Telegram progress and reply dispatch now preserve the typing context expected by the Telegram plugin path.
Real environment tested: local source checkout on fresh `origin/main` split branch.
Exact steps or command run after this patch: `git diff --check origin/main...origin/codex/split-85941-telegram-progress`.
Evidence after fix: split branch cherry-picked cleanly onto current `origin/main`; whitespace/conflict sanity passed.
Observed result after fix: no diff-check errors; commit author preserved as Keshav's Bot <keshavbotagent@gmail.com>.
What was not tested: focused Telegram Vitest and live Telegram delivery were not rerun after the split; CI should run the normal PR gates.
