### PR TITLE
fix(reply): defer context compaction safely

### DIFF
--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -101,6 +101,7 @@ async function deferOwningContextEngineBudgetCompaction(params: {
   contextEngineRuntimeContext: ContextEngineRuntimeContext;
 }): Promise<EmbeddedPiCompactResult> {
   let deferredScheduled = false;
+  let deferredScheduleFailure: unknown;
   try {
     await runContextEngineMaintenance({
       contextEngine: params.contextEngine,
@@ -114,6 +115,9 @@ async function deferOwningContextEngineBudgetCompaction(params: {
       onDeferredMaintenance: () => {
         deferredScheduled = true;
       },
+      onDeferredMaintenanceFailure: (error) => {
+        deferredScheduleFailure = error;
+      },
     });
   } catch (err) {
     log.warn("failed to defer context-engine budget compaction", {
@@ -121,11 +125,12 @@ async function deferOwningContextEngineBudgetCompaction(params: {
     });
   }
 
-  if (!deferredScheduled) {
+  if (!deferredScheduled || deferredScheduleFailure) {
     await disposeContextEngine(params.contextEngine);
     log.warn(
       `[compaction] failed to schedule context-engine-owned budget compaction background maintenance ` +
-        `(sessionKey=${params.compactParams.sessionKey ?? params.compactParams.sessionId})`,
+        `(sessionKey=${params.compactParams.sessionKey ?? params.compactParams.sessionId}` +
+        `${deferredScheduleFailure ? ` error=${formatErrorMessage(deferredScheduleFailure)}` : ""})`,
     );
     return {
       ok: false,

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
@@ -3,6 +3,7 @@ import type { ContextEngineRuntimeContext } from "../../context-engine/types.js"
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import {
   enqueueCommandInLane,
+  markGatewayDraining,
   resetCommandQueueStateForTest,
 } from "../../process/command-queue.js";
 import * as commandQueueModule from "../../process/command-queue.js";
@@ -954,6 +955,143 @@ describe("runContextEngineMaintenance", () => {
         "maintain:second",
         "dispose:second",
       ]);
+    });
+  });
+
+  it("reports deferred maintenance schedule failure while gateway is draining", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-draining-", async () => {
+      resetCommandQueueStateForTest();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+
+      const sessionKey = "agent:main:session-draining";
+      const maintain = vi.fn(async () => ({
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+      }));
+      const onDeferredMaintenance = vi.fn();
+      const onDeferredMaintenanceFailure = vi.fn();
+      const backgroundEngine = {
+        info: {
+          id: "test",
+          name: "Test Engine",
+          turnMaintenanceMode: "background" as const,
+        },
+        ingest: async () => ({ ingested: true }),
+        assemble: async ({ messages }: { messages: unknown[] }) => ({
+          messages,
+          estimatedTokens: 0,
+        }),
+        compact: async () => ({ ok: true, compacted: false }),
+        maintain,
+      } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+
+      markGatewayDraining();
+      const result = await runContextEngineMaintenance({
+        contextEngine: backgroundEngine,
+        sessionId: "session-draining",
+        sessionKey,
+        sessionFile: "/tmp/session-draining.jsonl",
+        reason: "turn",
+        onDeferredMaintenance,
+        onDeferredMaintenanceFailure,
+      });
+
+      expect(result).toBeUndefined();
+      expect(onDeferredMaintenance).not.toHaveBeenCalled();
+      expect(onDeferredMaintenanceFailure).toHaveBeenCalledOnce();
+      expect(onDeferredMaintenanceFailure.mock.calls[0]?.[0]).toHaveProperty(
+        "name",
+        "GatewayDrainingError",
+      );
+      expect(maintain).not.toHaveBeenCalled();
+      const tasks = listTasksForOwnerKey(sessionKey).filter(
+        (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+      );
+      expect(tasks).toEqual([]);
+    });
+  });
+
+  it("rejects coalesced deferred maintenance requests while gateway is draining", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-draining-coalesced-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+
+        const sessionKey = "agent:main:session-draining-coalesced";
+        let releaseMaintenance: (() => void) | undefined;
+        const maintain = vi.fn(async () => {
+          await new Promise<void>((resolve) => {
+            releaseMaintenance = resolve;
+          });
+          return {
+            changed: false,
+            bytesFreed: 0,
+            rewrittenEntries: 0,
+          };
+        });
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const firstDeferred: Promise<void>[] = [];
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-draining-coalesced",
+          sessionKey,
+          sessionFile: "/tmp/session-draining-coalesced.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            firstDeferred.push(promise);
+          },
+        });
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+
+        const onDeferredMaintenance = vi.fn();
+        const onDeferredMaintenanceFailure = vi.fn();
+        markGatewayDraining();
+        const result = await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-draining-coalesced",
+          sessionKey,
+          sessionFile: "/tmp/session-draining-coalesced.jsonl",
+          reason: "turn",
+          onDeferredMaintenance,
+          onDeferredMaintenanceFailure,
+        });
+
+        expect(result).toBeUndefined();
+        expect(onDeferredMaintenance).not.toHaveBeenCalled();
+        expect(onDeferredMaintenanceFailure).toHaveBeenCalledOnce();
+        expect(onDeferredMaintenanceFailure.mock.calls[0]?.[0]).toHaveProperty(
+          "name",
+          "GatewayDrainingError",
+        );
+        expect(maintain).toHaveBeenCalledTimes(1);
+
+        if (!releaseMaintenance) {
+          throw new Error("Expected maintenance release callback to be initialized");
+        }
+        releaseMaintenance();
+        await firstDeferred[0];
+      } finally {
+        resetCommandQueueStateForTest();
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -8,7 +8,12 @@ import type {
 } from "../../context-engine/types.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { enqueueCommandInLane, getQueueSize } from "../../process/command-queue.js";
+import {
+  enqueueCommandInLane,
+  GatewayDrainingError,
+  getQueueSize,
+  isGatewayDraining,
+} from "../../process/command-queue.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   completeTaskRunByRunId,
@@ -51,6 +56,7 @@ type DeferredTurnMaintenanceScheduleParams = {
   agentId?: string;
   config?: OpenClawConfig;
   disposeContextEngineAfterMaintenance?: boolean;
+  onScheduleFailure?: (error: unknown) => void;
 };
 
 type DeferredTurnMaintenanceRunState = {
@@ -560,6 +566,11 @@ function scheduleDeferredTurnMaintenance(
   if (!sessionKey) {
     return undefined;
   }
+  if (isGatewayDraining()) {
+    params.onScheduleFailure?.(new GatewayDrainingError());
+    return undefined;
+  }
+
   const activeRun = activeDeferredTurnMaintenanceRuns.get(sessionKey);
   if (activeRun) {
     const supersededParams = activeRun.rerunRequested ? activeRun.latestParams : undefined;
@@ -632,6 +643,7 @@ function scheduleDeferredTurnMaintenance(
   let state!: DeferredTurnMaintenanceRunState;
   const trackedPromise = runPromise
     .catch((err) => {
+      params.onScheduleFailure?.(err);
       markDeferredTurnMaintenanceTaskScheduleFailure({
         sessionKey,
         taskId: task.taskId,
@@ -681,6 +693,7 @@ export async function runContextEngineMaintenance(params: {
   agentId?: string;
   executionMode?: "foreground" | "background";
   onDeferredMaintenance?: (promise: Promise<void>) => void;
+  onDeferredMaintenanceFailure?: (error: unknown) => void;
   config?: OpenClawConfig;
   disposeDeferredContextEngineAfterMaintenance?: boolean;
 }): Promise<ContextEngineMaintenanceResult | undefined> {
@@ -706,6 +719,7 @@ export async function runContextEngineMaintenance(params: {
         agentId: params.agentId,
         config: params.config,
         disposeContextEngineAfterMaintenance: params.disposeDeferredContextEngineAfterMaintenance,
+        onScheduleFailure: params.onDeferredMaintenanceFailure,
       });
       if (deferred) {
         params.onDeferredMaintenance?.(deferred);

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -404,6 +404,10 @@ export function markGatewayDraining(): void {
   getQueueState().gatewayDraining = true;
 }
 
+export function isGatewayDraining(): boolean {
+  return getQueueState().gatewayDraining;
+}
+
 export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
   const cleaned = normalizeLane(lane);
   const state = getLaneState(cleaned);


### PR DESCRIPTION
## Summary

This extracts the context-compaction defer path from #85941 into a focused PR.

- defer context-engine-owned budget compaction to background maintenance instead of blocking reply startup
- keep successful compaction no-ops compatible with plugin-authored free-form reasons
- share the explicit deferred-compaction sentinel between the compaction queue and reply preflight handling
- add coverage for deferred maintenance, compaction hooks, no-op compatibility, and task-flow persistence
- keep the original contributor commit author: Keshav's Bot <keshavbotagent@gmail.com>

Split from #85941 so the compaction behavior and compatibility surface can be reviewed independently. Thanks @keshavbotagent for the original work.

## Verification

- `git diff --check origin/main...origin/codex/split-85941-compaction-defer`
- `pnpm test src/auto-reply/reply/agent-runner-memory.test.ts` on the grouped source branch before this split: 34 passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` on the grouped source branch before this split: clean

## Real behavior proof

Behavior addressed: reply preflight no longer aborts on successful plugin/context-engine compaction no-ops with free-form reasons, while the explicit deferred-compaction sentinel still fails the required preflight path.
Real environment tested: local source checkout on fresh `origin/main` split branch plus grouped source branch before extraction.
Exact steps or command run after this patch: `git diff --check origin/main...origin/codex/split-85941-compaction-defer`; grouped source proof ran `pnpm test src/auto-reply/reply/agent-runner-memory.test.ts` and autoreview.
Evidence after fix: split branch cherry-picked cleanly onto current `origin/main`; whitespace/conflict sanity passed; grouped source branch regression test passed and autoreview reported no accepted/actionable findings.
Observed result after fix: no diff-check errors; compaction no-op regression passed in the focused test before split; commit author preserved as Keshav's Bot <keshavbotagent@gmail.com>.
What was not tested: the full compaction test matrix and live context-engine/plugin compaction were not rerun after the split; CI should run the normal PR gates.
