### PR TITLE
fix(reply): reduce visible reply delivery latency

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -58,6 +58,7 @@ import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-event
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { logSessionTurnCreated } from "../../logging/diagnostic.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -110,6 +111,7 @@ import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 import { createReplyMediaContext } from "./reply-media-paths.runtime.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
+import { isReplyProfilerEnabled } from "./reply-timing-tracker.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
 // Maximum number of LiveSessionModelSwitchError retries before surfacing a
@@ -117,6 +119,148 @@ import type { TypingSignaler } from "./typing-mode.js";
 // selection keeps conflicting with fallback model choices.
 // See: https://github.com/openclaw/openclaw/issues/58348
 export const MAX_LIVE_SWITCH_RETRIES = 2;
+
+type AgentTurnTimingSpan = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+type AgentTurnTimingSummary = {
+  totalMs: number;
+  spans: AgentTurnTimingSpan[];
+};
+
+const agentTurnTimingLog = createSubsystemLogger("auto-reply/agent-turn-timing");
+const AGENT_TURN_TIMING_WARN_TOTAL_MS = 1_000;
+const AGENT_TURN_TIMING_WARN_STAGE_MS = 500;
+
+function createAgentTurnTimingTracker(options: { profilerEnabled?: boolean } = {}): {
+  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
+  measureSync: <T>(name: string, run: () => T) => T;
+  logIfSlow: (params: {
+    runId: string;
+    sessionId?: string;
+    sessionKey?: string;
+    outcome: "completed" | "error";
+    error?: string;
+  }) => void;
+  logMilestoneIfSlow: (params: {
+    runId: string;
+    sessionId?: string;
+    sessionKey?: string;
+    milestone: string;
+  }) => void;
+} {
+  if (!options.profilerEnabled) {
+    // This tracker wraps the agent-turn hot path. Without an explicit profiler
+    // flag, keep every wrapper pass-through so normal turns avoid Date.now and
+    // span-array work entirely.
+    return {
+      async measure(_name, run) {
+        return await run();
+      },
+      measureSync(_name, run) {
+        return run();
+      },
+      logIfSlow() {},
+      logMilestoneIfSlow() {},
+    };
+  }
+
+  const startedAt = Date.now();
+  let didLog = false;
+  const spans: AgentTurnTimingSpan[] = [];
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  const record = (name: string, spanStartedAt: number) => {
+    spans.push({
+      name,
+      durationMs: toMs(Date.now() - spanStartedAt),
+      elapsedMs: toMs(Date.now() - startedAt),
+    });
+  };
+  const snapshot = (): AgentTurnTimingSummary => ({
+    totalMs: toMs(Date.now() - startedAt),
+    spans: spans.slice(),
+  });
+  const shouldLog = (summary: AgentTurnTimingSummary) =>
+    summary.totalMs >= AGENT_TURN_TIMING_WARN_TOTAL_MS ||
+    summary.spans.some((span) => span.durationMs >= AGENT_TURN_TIMING_WARN_STAGE_MS);
+  const formatSpans = (summary: AgentTurnTimingSummary) =>
+    summary.spans.length > 0
+      ? summary.spans
+          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+          .join(",")
+      : "none";
+  return {
+    async measure(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return await run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    measureSync(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    logIfSlow(params) {
+      if (didLog) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      didLog = true;
+      agentTurnTimingLog.warn(
+        `agent turn timings runId=${params.runId} sessionId=${
+          params.sessionId ?? "unknown"
+        } sessionKey=${params.sessionKey ?? "unknown"} outcome=${params.outcome} totalMs=${
+          summary.totalMs
+        } stages=${formatSpans(summary)}${params.error ? ` error="${params.error}"` : ""}`,
+        {
+          runId: params.runId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          outcome: params.outcome,
+          error: params.error,
+          totalMs: summary.totalMs,
+          spans: summary.spans,
+        },
+      );
+    },
+    logMilestoneIfSlow(params) {
+      if (!options.profilerEnabled) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      agentTurnTimingLog.warn(
+        `agent turn milestone runId=${params.runId} sessionId=${
+          params.sessionId ?? "unknown"
+        } sessionKey=${params.sessionKey ?? "unknown"} milestone=${params.milestone} totalMs=${
+          summary.totalMs
+        } stages=${formatSpans(summary)}`,
+        {
+          runId: params.runId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          milestone: params.milestone,
+          totalMs: summary.totalMs,
+          spans: summary.spans,
+        },
+      );
+    },
+  };
+}
 
 function readApprovalScopeValue(value: unknown): "turn" | "session" | undefined {
   return value === "turn" || value === "session" ? value : undefined;
@@ -1326,6 +1470,9 @@ export async function runAgentTurnWithFallback(params: {
   };
 
   const runId = params.opts?.runId ?? crypto.randomUUID();
+  const agentTurnTiming = createAgentTurnTimingTracker({
+    profilerEnabled: isReplyProfilerEnabled({ config: runtimeConfig }),
+  });
   if (isDiagnosticsEnabled(runtimeConfig)) {
     logSessionTurnCreated({
       runId,
@@ -1341,26 +1488,30 @@ export async function runAgentTurnWithFallback(params: {
   }
   const replyMediaContext =
     params.replyMediaContext ??
-    createReplyMediaContext({
+    agentTurnTiming.measureSync("reply_media_context", () =>
+      createReplyMediaContext({
+        cfg: runtimeConfig,
+        sessionKey: params.sessionKey,
+        workspaceDir: params.followupRun.run.workspaceDir,
+        messageProvider: params.followupRun.run.messageProvider,
+        accountId: params.followupRun.originatingAccountId ?? params.followupRun.run.agentAccountId,
+        groupId: params.followupRun.run.groupId,
+        groupChannel: params.followupRun.run.groupChannel,
+        groupSpace: params.followupRun.run.groupSpace,
+        requesterSenderId: params.followupRun.run.senderId,
+        requesterSenderName: params.followupRun.run.senderName,
+        requesterSenderUsername: params.followupRun.run.senderUsername,
+        requesterSenderE164: params.followupRun.run.senderE164,
+      }),
+    );
+  const currentTurnImages = await agentTurnTiming.measure("current_turn_images", () =>
+    resolveCurrentTurnImages({
+      ctx: params.sessionCtx,
       cfg: runtimeConfig,
-      sessionKey: params.sessionKey,
-      workspaceDir: params.followupRun.run.workspaceDir,
-      messageProvider: params.followupRun.run.messageProvider,
-      accountId: params.followupRun.originatingAccountId ?? params.followupRun.run.agentAccountId,
-      groupId: params.followupRun.run.groupId,
-      groupChannel: params.followupRun.run.groupChannel,
-      groupSpace: params.followupRun.run.groupSpace,
-      requesterSenderId: params.followupRun.run.senderId,
-      requesterSenderName: params.followupRun.run.senderName,
-      requesterSenderUsername: params.followupRun.run.senderUsername,
-      requesterSenderE164: params.followupRun.run.senderE164,
-    });
-  const currentTurnImages = await resolveCurrentTurnImages({
-    ctx: params.sessionCtx,
-    cfg: runtimeConfig,
-    images: params.followupRun.images ?? params.opts?.images,
-    imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
-  });
+      images: params.followupRun.images ?? params.opts?.images,
+      imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
+    }),
+  );
   let didNotifyAgentRunStart = false;
   const notifyAgentRunStart = () => {
     if (didNotifyAgentRunStart) {
@@ -1714,632 +1865,683 @@ export async function runAgentTurnWithFallback(params: {
       const runLane = CommandLane.Main;
       let queuedUserMessagePersistedAcrossFallback = false;
       let assistantErrorPersistedAcrossFallback = false;
-      const fallbackResult = await runWithModelFallback<EmbeddedAgentRunResult>({
-        ...resolveModelFallbackOptions(effectiveRun, runtimeConfig),
+      // Profiler-only milestone: it separates fallback setup from the actual
+      // model run without adding extra live logs/snapshots to normal turns.
+      agentTurnTiming.logMilestoneIfSlow({
         runId,
         sessionId: params.followupRun.run.sessionId,
-        lane: runLane,
-        resolveAgentHarnessRuntimeOverride: (provider) =>
-          resolveSessionRuntimeOverrideForProvider({
-            provider,
-            entry: params.getActiveSessionEntry(),
-          }),
-        prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
-          await ensureSelectedAgentHarnessPlugin({
-            config: runtimeConfig,
-            provider,
-            modelId: model,
-            agentId: params.followupRun.run.agentId,
-            sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
-            agentHarnessRuntimeOverride,
-            workspaceDir: params.followupRun.run.workspaceDir,
-          });
-        },
-        onFallbackStep: (step) => {
-          emitModelFallbackStepLifecycle({
-            runId,
-            sessionKey: params.sessionKey,
-            step,
-          });
-        },
-        classifyResult: async ({ result, provider, model }) => {
-          const classification = outcomePlan.classifyRunResult({
-            result,
-            provider,
-            model,
-            hasDirectlySentBlockReply: directlySentBlockKeys.size > 0,
-            hasBlockReplyPipelineOutput: Boolean(
-              blockReplyPipeline?.hasBuffered() || blockReplyPipeline?.didStream(),
-            ),
-          });
-          if (classification) {
-            await rollbackClassifiedFallbackCandidateSelection(provider, model);
-          }
-          return classification;
-        },
-        run: async (provider, model, runOptions) => {
-          attemptedRuntimeProvider = provider;
-          attemptedRuntimeModel = model;
-          const suppressQueuedUserPersistenceForCandidate =
-            (params.followupRun.run.suppressNextUserMessagePersistence ?? false) ||
-            queuedUserMessagePersistedAcrossFallback;
-          const suppressAssistantErrorPersistenceForCandidate =
-            assistantErrorPersistedAcrossFallback;
-          const candidateRun = resolveRunForFallbackCandidate(provider, model);
-          const activeProbe = effectiveRun.autoFallbackPrimaryProbe;
-          if (activeProbe && provider === activeProbe.provider && model === activeProbe.model) {
-            markAutoFallbackPrimaryProbe({
-              probe: activeProbe,
-              sessionKey: params.sessionKey,
-            });
-          }
-          // Notify that model selection is complete (including after fallback).
-          // This allows responsePrefix template interpolation with the actual model.
-          params.opts?.onModelSelected?.({
-            provider,
-            model,
-            thinkLevel: params.followupRun.run.thinkLevel,
-          });
-          let rollbackFallbackCandidateSelection: (() => Promise<void>) | undefined;
-          try {
-            rollbackFallbackCandidateSelection = await persistFallbackCandidateSelection(
+        sessionKey: params.sessionKey,
+        milestone: "before_model_fallback",
+      });
+      const fallbackResult = await agentTurnTiming.measure("model_fallback", () =>
+        runWithModelFallback<EmbeddedAgentRunResult>({
+          ...resolveModelFallbackOptions(effectiveRun, runtimeConfig),
+          runId,
+          sessionId: params.followupRun.run.sessionId,
+          lane: runLane,
+          resolveAgentHarnessRuntimeOverride: (provider) =>
+            resolveSessionRuntimeOverrideForProvider({
               provider,
-              model,
-              candidateRun,
-            );
-            if (rollbackFallbackCandidateSelection) {
-              pendingFallbackCandidateRollback = {
-                provider,
-                model,
-                rollback: rollbackFallbackCandidateSelection,
-              };
-            }
-          } catch (error) {
-            logVerbose(
-              `failed to persist fallback candidate selection (non-fatal): ${String(error)}`,
-            );
-          }
-
-          const sessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
-            provider,
-            entry: params.getActiveSessionEntry(),
-          });
-          const selectedAuthProfile = resolveRunAuthProfile(candidateRun, provider, {
-            config: runtimeConfig,
-          });
-          const cliExecutionProvider =
-            sessionRuntimeOverride === "pi"
-              ? provider
-              : ((sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, runtimeConfig)
-                  ? sessionRuntimeOverride
-                  : undefined) ??
-                resolveCliRuntimeExecutionProvider({
-                  provider,
-                  cfg: runtimeConfig,
-                  agentId: params.followupRun.run.agentId,
-                  modelId: model,
-                  authProfileId: selectedAuthProfile.authProfileId,
-                }) ??
-                provider);
-
-          if (isCliProvider(cliExecutionProvider, runtimeConfig)) {
-            const isRoomEventCliRun = params.followupRun.currentInboundEventKind === "room_event";
-            const cliSessionBinding = isRoomEventCliRun
-              ? undefined
-              : getCliSessionBinding(params.getActiveSessionEntry(), cliExecutionProvider);
-            const authProfile = resolveRunAuthProfile(candidateRun, cliExecutionProvider, {
-              config: runtimeConfig,
-            });
-            const hookMessageProvider = resolveOriginMessageProvider({
-              originatingChannel: params.followupRun.originatingChannel,
-              provider: params.sessionCtx.Provider,
-            });
-            const result = await runCliAgentWithLifecycle({
-              runId,
-              provider: cliExecutionProvider,
-              onAgentRunStart: notifyAgentRunStart,
-              suppressAssistantBridge: params.followupRun.run.silentExpected,
-              onAssistantText: async (text) => {
-                const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
-                if (textForTyping === undefined || !params.opts?.onPartialReply) {
-                  return;
-                }
-                await params.opts.onPartialReply({ text: textForTyping });
-              },
-              onReasoningText: async (text) => {
-                await params.opts?.onReasoningStream?.({ text });
-              },
-              onErrorBeforeLifecycle: async () => {
-                if (!rollbackFallbackCandidateSelection) {
-                  return;
-                }
-                try {
-                  await rollbackFallbackCandidateSelection();
-                  clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                } catch (rollbackError) {
-                  logVerbose(
-                    `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                  );
-                }
-              },
-              runParams: {
-                sessionId: params.followupRun.run.sessionId,
-                sessionKey: params.sessionKey,
-                agentId: params.followupRun.run.agentId,
-                trigger: params.isHeartbeat ? "heartbeat" : "user",
-                sessionFile: params.followupRun.run.sessionFile,
-                workspaceDir: params.followupRun.run.workspaceDir,
+              entry: params.getActiveSessionEntry(),
+            }),
+          prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
+            await agentTurnTiming.measure("fallback_prepare_harness", () =>
+              ensureSelectedAgentHarnessPlugin({
                 config: runtimeConfig,
-                prompt: params.commandBody,
-                transcriptPrompt: params.transcriptCommandBody,
-                currentInboundEventKind: params.followupRun.currentInboundEventKind,
-                currentInboundContext: params.followupRun.currentInboundContext,
-                inputProvenance: params.followupRun.run.inputProvenance,
-                provider: cliExecutionProvider,
-                model,
-                thinkLevel: params.followupRun.run.thinkLevel,
-                timeoutMs: params.followupRun.run.timeoutMs,
-                runId,
-                lane: runLane,
-                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
-                silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
-                extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
-                ownerNumbers: params.followupRun.run.ownerNumbers,
-                cliSessionId: cliSessionBinding?.sessionId,
-                cliSessionBinding,
-                authProfileId: authProfile.authProfileId,
-                bootstrapPromptWarningSignaturesSeen,
-                bootstrapPromptWarningSignature:
-                  bootstrapPromptWarningSignaturesSeen[
-                    bootstrapPromptWarningSignaturesSeen.length - 1
-                  ],
-                images: currentTurnImages.images,
-                imageOrder: currentTurnImages.imageOrder,
-                skillsSnapshot: params.followupRun.run.skillsSnapshot,
-                messageChannel: params.followupRun.originatingChannel ?? undefined,
-                messageProvider: hookMessageProvider,
-                agentAccountId: params.followupRun.run.agentAccountId,
-                senderIsOwner: params.followupRun.run.senderIsOwner,
-                disableTools: params.opts?.disableTools,
-                abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
-                replyOperation: params.replyOperation,
-              },
-              transformResult: (rawResult) =>
-                isRoomEventCliRun && rawResult.meta.agentMeta
-                  ? (() => {
-                      const { cliSessionBinding: _cliSessionBinding, ...agentMeta } =
-                        rawResult.meta.agentMeta;
-                      return {
-                        ...rawResult,
-                        meta: {
-                          ...rawResult.meta,
-                          agentMeta: {
-                            ...agentMeta,
-                            sessionId: "",
-                          },
-                        },
-                      };
-                    })()
-                  : rawResult,
-            });
-            bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-              result.meta?.systemPromptReport,
-            );
-            return result;
-          }
-          const { embeddedContext, senderContext, runBaseParams } = buildEmbeddedRunExecutionParams(
-            {
-              run: candidateRun,
-              sessionCtx: params.sessionCtx,
-              hasRepliedRef: params.opts?.hasRepliedRef,
-              provider,
-              runId,
-              allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
-              model,
-            },
-          );
-          const agentHarnessPolicy = sessionRuntimeOverride
-            ? ({ runtime: sessionRuntimeOverride, runtimeSource: "model" } as const)
-            : resolveAgentHarnessPolicy({
                 provider,
                 modelId: model,
-                config: runtimeConfig,
                 agentId: params.followupRun.run.agentId,
                 sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
-              });
-          const embeddedRunProvider = resolveOpenAIRuntimeProviderForPi({
-            provider,
-            harnessRuntime: agentHarnessPolicy.runtime,
-            authProfileProvider: runBaseParams.authProfileId?.split(":", 1)[0],
-            authProfileId: runBaseParams.authProfileId,
-            config: runtimeConfig,
-            workspaceDir: params.followupRun.run.workspaceDir,
-          });
-          const embeddedRunHarnessOverride =
-            sessionRuntimeOverride ??
-            (agentHarnessPolicy.runtime === "pi" && embeddedRunProvider !== provider
-              ? "pi"
-              : undefined);
-          return (async () => {
-            let attemptCompactionCount = 0;
-            const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
+                agentHarnessRuntimeOverride,
+                workspaceDir: params.followupRun.run.workspaceDir,
+              }),
+            );
+          },
+          onFallbackStep: (step) => {
+            emitModelFallbackStepLifecycle({
               runId,
               sessionKey: params.sessionKey,
+              step,
             });
+          },
+          classifyResult: async ({ result, provider, model }) => {
+            const classification = outcomePlan.classifyRunResult({
+              result,
+              provider,
+              model,
+              hasDirectlySentBlockReply: directlySentBlockKeys.size > 0,
+              hasBlockReplyPipelineOutput: Boolean(
+                blockReplyPipeline?.hasBuffered() || blockReplyPipeline?.didStream(),
+              ),
+            });
+            if (classification) {
+              await rollbackClassifiedFallbackCandidateSelection(provider, model);
+            }
+            return classification;
+          },
+          run: async (provider, model, runOptions) => {
+            attemptedRuntimeProvider = provider;
+            attemptedRuntimeModel = model;
+            const suppressQueuedUserPersistenceForCandidate =
+              (params.followupRun.run.suppressNextUserMessagePersistence ?? false) ||
+              queuedUserMessagePersistedAcrossFallback;
+            const suppressAssistantErrorPersistenceForCandidate =
+              assistantErrorPersistedAcrossFallback;
+            const candidateRun = resolveRunForFallbackCandidate(provider, model);
+            const activeProbe = effectiveRun.autoFallbackPrimaryProbe;
+            if (activeProbe && provider === activeProbe.provider && model === activeProbe.model) {
+              markAutoFallbackPrimaryProbe({
+                probe: activeProbe,
+                sessionKey: params.sessionKey,
+              });
+            }
+            // Notify that model selection is complete (including after fallback).
+            // This allows responsePrefix template interpolation with the actual model.
+            params.opts?.onModelSelected?.({
+              provider,
+              model,
+              thinkLevel: params.followupRun.run.thinkLevel,
+            });
+            let rollbackFallbackCandidateSelection: (() => Promise<void>) | undefined;
             try {
-              const result = await runEmbeddedPiAgent({
-                ...embeddedContext,
-                allowGatewaySubagentBinding: true,
-                trigger: params.isHeartbeat ? "heartbeat" : "user",
-                groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
-                groupChannel:
-                  normalizeOptionalString(params.sessionCtx.GroupChannel) ??
-                  normalizeOptionalString(params.sessionCtx.GroupSubject),
-                groupSpace: normalizeOptionalString(params.sessionCtx.GroupSpace),
-                ...senderContext,
-                ...runBaseParams,
-                provider: embeddedRunProvider,
-                agentHarnessId: embeddedRunHarnessOverride,
-                agentHarnessRuntimeOverride: embeddedRunHarnessOverride,
-                sandboxSessionKey: params.runtimePolicySessionKey,
-                prompt: params.commandBody,
-                transcriptPrompt: params.transcriptCommandBody,
-                currentInboundEventKind: params.followupRun.currentInboundEventKind,
-                currentInboundContext: params.followupRun.currentInboundContext,
-                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
-                forceMessageTool:
-                  params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only",
-                silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
-                suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
-                onUserMessagePersisted: () => {
-                  queuedUserMessagePersistedAcrossFallback = true;
-                },
-                suppressTranscriptOnlyAssistantPersistence:
-                  params.followupRun.run.suppressTranscriptOnlyAssistantPersistence,
-                suppressAssistantErrorPersistence: suppressAssistantErrorPersistenceForCandidate,
-                onAssistantErrorMessagePersisted: () => {
-                  assistantErrorPersistedAcrossFallback = true;
-                },
-                toolResultFormat: (() => {
-                  const channel = resolveMessageChannel(
-                    params.sessionCtx.Surface,
-                    params.sessionCtx.Provider,
-                  );
-                  if (!channel) {
-                    return "markdown";
-                  }
-                  return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
-                })(),
-                toolProgressDetail: params.toolProgressDetail,
-                suppressToolErrorWarnings:
-                  params.opts?.shouldSuppressToolErrorWarnings ??
-                  params.opts?.suppressToolErrorWarnings,
-                disableTools: params.opts?.disableTools,
-                enableHeartbeatTool: params.opts?.enableHeartbeatTool,
-                forceHeartbeatTool: params.opts?.forceHeartbeatTool,
-                bootstrapContextMode: params.opts?.bootstrapContextMode,
-                bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
-                images: currentTurnImages.images,
-                imageOrder: currentTurnImages.imageOrder,
-                abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
-                replyOperation: params.replyOperation,
-                blockReplyBreak: params.resolvedBlockStreamingBreak,
-                blockReplyChunking: params.blockReplyChunking,
-                onPartialReply: async (payload) => {
-                  const textForTyping = await handlePartialForTyping(payload);
-                  if (!params.opts?.onPartialReply || textForTyping === undefined) {
-                    return;
-                  }
-                  await params.opts.onPartialReply({
-                    text: textForTyping,
-                    mediaUrls: payload.mediaUrls,
-                  });
-                },
-                onAssistantMessageStart: async () => {
-                  await params.typingSignals.signalMessageStart();
-                  await params.opts?.onAssistantMessageStart?.();
-                },
-                onReasoningStream:
-                  params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
-                    ? async (payload) => {
-                        if (params.followupRun.run.silentExpected) {
-                          return;
-                        }
-                        await params.typingSignals.signalReasoningDelta();
-                        await params.opts?.onReasoningStream?.({
-                          text: payload.text,
-                          mediaUrls: payload.mediaUrls,
-                        });
-                      }
-                    : undefined,
-                onReasoningEnd: params.opts?.onReasoningEnd,
-                onAgentEvent: async (evt) => {
-                  lifecycleBackstop.note(evt);
-                  // Signal run start only after the embedded agent emits real activity.
-                  const hasLifecyclePhase =
-                    evt.stream === "lifecycle" && typeof evt.data.phase === "string";
-                  if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
-                    notifyAgentRunStart();
-                  }
-                  // Trigger typing when tools start executing.
-                  // Must await to ensure typing indicator starts before tool summaries are emitted.
-                  if (evt.stream === "tool") {
-                    const phase = readStringValue(evt.data.phase) ?? "";
-                    const name = readStringValue(evt.data.name);
-                    const toolCallId = readStringValue(evt.data.toolCallId) ?? "";
-                    const args =
-                      evt.data.args && typeof evt.data.args === "object"
-                        ? (evt.data.args as Record<string, unknown>)
-                        : undefined;
-                    if (
-                      sourceRepliesAreToolOnly &&
-                      toolCallId &&
-                      name &&
-                      (phase === "start" || phase === "update") &&
-                      args &&
-                      isMessagingToolSendAction(name, args)
-                    ) {
-                      messageToolOnlyDeliveryToolCallIds.add(toolCallId);
-                    }
-                    if (shouldSuppressProgressAfterMessageToolDelivery()) {
+              rollbackFallbackCandidateSelection = await agentTurnTiming.measure(
+                "fallback_persist_selection",
+                () => persistFallbackCandidateSelection(provider, model, candidateRun),
+              );
+              if (rollbackFallbackCandidateSelection) {
+                pendingFallbackCandidateRollback = {
+                  provider,
+                  model,
+                  rollback: rollbackFallbackCandidateSelection,
+                };
+              }
+            } catch (error) {
+              logVerbose(
+                `failed to persist fallback candidate selection (non-fatal): ${String(error)}`,
+              );
+            }
+
+            const { sessionRuntimeOverride, cliExecutionProvider } = agentTurnTiming.measureSync(
+              "fallback_resolve_runtime",
+              () => {
+                const resolvedSessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
+                  provider,
+                  entry: params.getActiveSessionEntry(),
+                });
+                const resolvedSelectedAuthProfile = resolveRunAuthProfile(candidateRun, provider, {
+                  config: runtimeConfig,
+                });
+                const resolvedCliExecutionProvider =
+                  resolvedSessionRuntimeOverride === "pi"
+                    ? provider
+                    : ((resolvedSessionRuntimeOverride &&
+                      isCliProvider(resolvedSessionRuntimeOverride, runtimeConfig)
+                        ? resolvedSessionRuntimeOverride
+                        : undefined) ??
+                      resolveCliRuntimeExecutionProvider({
+                        provider,
+                        cfg: runtimeConfig,
+                        agentId: params.followupRun.run.agentId,
+                        modelId: model,
+                        authProfileId: resolvedSelectedAuthProfile.authProfileId,
+                      }) ??
+                      provider);
+                return {
+                  sessionRuntimeOverride: resolvedSessionRuntimeOverride,
+                  cliExecutionProvider: resolvedCliExecutionProvider,
+                };
+              },
+            );
+
+            if (isCliProvider(cliExecutionProvider, runtimeConfig)) {
+              const isRoomEventCliRun = params.followupRun.currentInboundEventKind === "room_event";
+              const cliSessionBinding = isRoomEventCliRun
+                ? undefined
+                : getCliSessionBinding(params.getActiveSessionEntry(), cliExecutionProvider);
+              const authProfile = resolveRunAuthProfile(candidateRun, cliExecutionProvider, {
+                config: runtimeConfig,
+              });
+              const hookMessageProvider = resolveOriginMessageProvider({
+                originatingChannel: params.followupRun.originatingChannel,
+                provider: params.sessionCtx.Provider,
+              });
+              const result = await agentTurnTiming.measure("cli_run", () =>
+                runCliAgentWithLifecycle({
+                  runId,
+                  provider: cliExecutionProvider,
+                  onAgentRunStart: notifyAgentRunStart,
+                  suppressAssistantBridge: params.followupRun.run.silentExpected,
+                  onAssistantText: async (text) => {
+                    const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
+                    if (textForTyping === undefined || !params.opts?.onPartialReply) {
                       return;
                     }
-                    if (phase === "start" || phase === "update") {
-                      const toolStartProgressPromise = params.opts?.onToolStart?.({
-                        name,
-                        phase,
-                        args,
-                        detailMode: params.toolProgressDetail,
-                      });
-                      await Promise.all([
-                        params.typingSignals.signalToolStart(),
-                        toolStartProgressPromise,
-                      ]);
+                    await params.opts.onPartialReply({ text: textForTyping });
+                  },
+                  onReasoningText: async (text) => {
+                    await params.opts?.onReasoningStream?.({ text });
+                  },
+                  onErrorBeforeLifecycle: async () => {
+                    if (!rollbackFallbackCandidateSelection) {
+                      return;
                     }
-                  }
-                  const suppressItemChannelProgress =
-                    evt.stream === "item" &&
-                    evt.data.suppressChannelProgress === true &&
-                    Boolean(params.opts?.onToolStart);
-                  const itemPhase = evt.stream === "item" ? readStringValue(evt.data.phase) : "";
-                  const itemName = evt.stream === "item" ? readStringValue(evt.data.name) : "";
-                  const itemStatus = evt.stream === "item" ? readStringValue(evt.data.status) : "";
-                  const itemToolCallId =
-                    evt.stream === "item" ? (readStringValue(evt.data.toolCallId) ?? "") : "";
-                  const completedMessageToolDelivery =
-                    sourceRepliesAreToolOnly &&
-                    itemPhase === "end" &&
-                    itemStatus === "completed" &&
-                    itemToolCallId.length > 0 &&
-                    messageToolOnlyDeliveryToolCallIds.has(itemToolCallId);
-                  const suppressProgressAfterMessageToolDelivery =
-                    shouldSuppressProgressAfterMessageToolDelivery();
-                  if (completedMessageToolDelivery) {
-                    messageToolOnlyDeliveryToolCallIds.delete(itemToolCallId);
-                    messageToolOnlyDeliveryCompleted = true;
-                  }
-                  if (
-                    evt.stream === "item" &&
-                    !suppressItemChannelProgress &&
-                    (!suppressProgressAfterMessageToolDelivery || completedMessageToolDelivery)
-                  ) {
-                    await params.opts?.onItemEvent?.({
-                      itemId: readStringValue(evt.data.itemId),
-                      kind: readStringValue(evt.data.kind),
-                      title: readStringValue(evt.data.title),
-                      name: itemName,
-                      phase: itemPhase,
-                      status: itemStatus,
-                      summary: readStringValue(evt.data.summary),
-                      progressText: readStringValue(evt.data.progressText),
-                      meta: readStringValue(evt.data.meta),
-                      approvalId: readStringValue(evt.data.approvalId),
-                      approvalSlug: readStringValue(evt.data.approvalSlug),
-                    });
-                  }
-                  if (evt.stream === "plan" && !shouldSuppressProgressAfterMessageToolDelivery()) {
-                    await params.opts?.onPlanUpdate?.({
-                      phase: readStringValue(evt.data.phase),
-                      title: readStringValue(evt.data.title),
-                      explanation: readStringValue(evt.data.explanation),
-                      steps: Array.isArray(evt.data.steps)
-                        ? evt.data.steps.filter((step): step is string => typeof step === "string")
-                        : undefined,
-                      source: readStringValue(evt.data.source),
-                    });
-                  }
-                  if (
-                    evt.stream === "approval" &&
-                    !shouldSuppressProgressAfterMessageToolDelivery()
-                  ) {
-                    await params.opts?.onApprovalEvent?.({
-                      phase: readStringValue(evt.data.phase),
-                      kind: readStringValue(evt.data.kind),
-                      status: readStringValue(evt.data.status),
-                      title: readStringValue(evt.data.title),
-                      itemId: readStringValue(evt.data.itemId),
-                      toolCallId: readStringValue(evt.data.toolCallId),
-                      approvalId: readStringValue(evt.data.approvalId),
-                      approvalSlug: readStringValue(evt.data.approvalSlug),
-                      command: readStringValue(evt.data.command),
-                      host: readStringValue(evt.data.host),
-                      reason: readStringValue(evt.data.reason),
-                      scope: readApprovalScopeValue(evt.data.scope),
-                      message: readStringValue(evt.data.message),
-                    });
-                  }
-                  if (
-                    evt.stream === "command_output" &&
-                    !shouldSuppressProgressAfterMessageToolDelivery()
-                  ) {
-                    await params.opts?.onCommandOutput?.({
-                      itemId: readStringValue(evt.data.itemId),
-                      phase: readStringValue(evt.data.phase),
-                      title: readStringValue(evt.data.title),
-                      toolCallId: readStringValue(evt.data.toolCallId),
-                      name: readStringValue(evt.data.name),
-                      output: readStringValue(evt.data.output),
-                      status: readStringValue(evt.data.status),
-                      exitCode:
-                        typeof evt.data.exitCode === "number" || evt.data.exitCode === null
-                          ? evt.data.exitCode
-                          : undefined,
-                      durationMs:
-                        typeof evt.data.durationMs === "number" ? evt.data.durationMs : undefined,
-                      cwd: readStringValue(evt.data.cwd),
-                    });
-                  }
-                  if (evt.stream === "patch" && !shouldSuppressProgressAfterMessageToolDelivery()) {
-                    await params.opts?.onPatchSummary?.({
-                      itemId: readStringValue(evt.data.itemId),
-                      phase: readStringValue(evt.data.phase),
-                      title: readStringValue(evt.data.title),
-                      toolCallId: readStringValue(evt.data.toolCallId),
-                      name: readStringValue(evt.data.name),
-                      added: Array.isArray(evt.data.added)
-                        ? evt.data.added.filter(
-                            (entry): entry is string => typeof entry === "string",
-                          )
-                        : undefined,
-                      modified: Array.isArray(evt.data.modified)
-                        ? evt.data.modified.filter(
-                            (entry): entry is string => typeof entry === "string",
-                          )
-                        : undefined,
-                      deleted: Array.isArray(evt.data.deleted)
-                        ? evt.data.deleted.filter(
-                            (entry): entry is string => typeof entry === "string",
-                          )
-                        : undefined,
-                      summary: readStringValue(evt.data.summary),
-                    });
-                  }
-                  // Track auto-compaction and notify higher layers.
-                  if (evt.stream === "compaction") {
-                    const phase = readStringValue(evt.data.phase) ?? "";
-                    const hookMessages = readCompactionHookMessages(evt.data.messages);
-                    if (phase === "start") {
-                      // Keep custom compaction callbacks active, but gate the
-                      // fallback user-facing notice behind explicit opt-in.
-                      if (params.opts?.onCompactionStart) {
-                        await params.opts.onCompactionStart();
-                      }
-                      if (hookMessages.length > 0) {
-                        await sendCompactionHookMessages(hookMessages);
-                      } else if (
-                        !params.opts?.onCompactionStart &&
-                        shouldNotifyUserAboutCompaction
-                      ) {
-                        // Send directly via opts.onBlockReply (bypassing the
-                        // pipeline) so the notice does not cause final payloads
-                        // to be discarded on non-streaming model paths.
-                        await sendCompactionNotice("start");
-                      }
+                    try {
+                      await rollbackFallbackCandidateSelection();
+                      clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
+                    } catch (rollbackError) {
+                      logVerbose(
+                        `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
+                      );
                     }
-                    if (phase === "end") {
-                      const completed = evt.data?.completed === true;
-                      if (completed) {
-                        attemptCompactionCount += 1;
-                        if (params.opts?.onCompactionEnd) {
-                          await params.opts.onCompactionEnd();
-                        }
-                        if (hookMessages.length > 0) {
-                          await sendCompactionHookMessages(hookMessages);
-                        } else if (
-                          !params.opts?.onCompactionEnd &&
-                          shouldNotifyUserAboutCompaction
-                        ) {
-                          await sendCompactionNotice("end");
-                        }
-                      } else if (hookMessages.length > 0) {
-                        await sendCompactionHookMessages(hookMessages);
-                      } else if (shouldNotifyUserAboutCompaction) {
-                        await sendCompactionNotice("incomplete");
-                      }
-                    }
-                  }
-                },
-                // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
-                // even when regular block streaming is disabled. The handler sends directly
-                // via opts.onBlockReply when the pipeline isn't available.
-                onBlockReply: blockReplyHandler,
-                onBlockReplyFlush:
-                  params.blockStreamingEnabled && blockReplyPipeline
-                    ? async () => {
-                        await blockReplyPipeline.flush({ force: true });
-                      }
-                    : undefined,
-                shouldEmitToolResult: params.shouldEmitToolResult,
-                shouldEmitToolOutput: params.shouldEmitToolOutput,
-                bootstrapPromptWarningSignaturesSeen,
-                bootstrapPromptWarningSignature:
-                  bootstrapPromptWarningSignaturesSeen[
-                    bootstrapPromptWarningSignaturesSeen.length - 1
-                  ],
-                onToolResult: onToolResult
-                  ? (() => {
-                      // Serialize tool result delivery to preserve message ordering.
-                      // Without this, concurrent tool callbacks race through typing signals
-                      // and message sends, causing out-of-order delivery to the user.
-                      // See: https://github.com/openclaw/openclaw/issues/11044
-                      let toolResultChain: Promise<void> = Promise.resolve();
-                      return (payload: ReplyPayload) => {
-                        toolResultChain = toolResultChain
-                          .then(async () => {
-                            const { text, skip } = normalizeStreamingText(payload);
-                            if (skip) {
-                              return;
-                            }
-                            if (text !== undefined) {
-                              await params.typingSignals.signalTextDelta(text);
-                            }
-                            await onToolResult({
-                              ...payload,
-                              text,
-                            });
-                          })
-                          .catch((err) => {
-                            // Keep chain healthy after an error so later tool results still deliver.
-                            logVerbose(`tool result delivery failed: ${String(err)}`);
-                          });
-                        const task = toolResultChain.finally(() => {
-                          params.pendingToolTasks.delete(task);
-                        });
-                        params.pendingToolTasks.add(task);
-                      };
-                    })()
-                  : undefined,
-              });
+                  },
+                  runParams: {
+                    sessionId: params.followupRun.run.sessionId,
+                    sessionKey: params.sessionKey,
+                    agentId: params.followupRun.run.agentId,
+                    trigger: params.isHeartbeat ? "heartbeat" : "user",
+                    sessionFile: params.followupRun.run.sessionFile,
+                    workspaceDir: params.followupRun.run.workspaceDir,
+                    config: runtimeConfig,
+                    prompt: params.commandBody,
+                    transcriptPrompt: params.transcriptCommandBody,
+                    currentInboundEventKind: params.followupRun.currentInboundEventKind,
+                    currentInboundContext: params.followupRun.currentInboundContext,
+                    inputProvenance: params.followupRun.run.inputProvenance,
+                    provider: cliExecutionProvider,
+                    model,
+                    thinkLevel: params.followupRun.run.thinkLevel,
+                    timeoutMs: params.followupRun.run.timeoutMs,
+                    runId,
+                    lane: runLane,
+                    extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                    sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
+                    silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
+                    extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
+                    ownerNumbers: params.followupRun.run.ownerNumbers,
+                    cliSessionId: cliSessionBinding?.sessionId,
+                    cliSessionBinding,
+                    authProfileId: authProfile.authProfileId,
+                    bootstrapPromptWarningSignaturesSeen,
+                    bootstrapPromptWarningSignature:
+                      bootstrapPromptWarningSignaturesSeen[
+                        bootstrapPromptWarningSignaturesSeen.length - 1
+                      ],
+                    images: currentTurnImages.images,
+                    imageOrder: currentTurnImages.imageOrder,
+                    skillsSnapshot: params.followupRun.run.skillsSnapshot,
+                    messageChannel: params.followupRun.originatingChannel ?? undefined,
+                    messageProvider: hookMessageProvider,
+                    agentAccountId: params.followupRun.run.agentAccountId,
+                    senderIsOwner: params.followupRun.run.senderIsOwner,
+                    disableTools: params.opts?.disableTools,
+                    abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
+                    replyOperation: params.replyOperation,
+                  },
+                  transformResult: (rawResult) =>
+                    isRoomEventCliRun && rawResult.meta.agentMeta
+                      ? (() => {
+                          const { cliSessionBinding: _cliSessionBinding, ...agentMeta } =
+                            rawResult.meta.agentMeta;
+                          return {
+                            ...rawResult,
+                            meta: {
+                              ...rawResult.meta,
+                              agentMeta: {
+                                ...agentMeta,
+                                sessionId: "",
+                              },
+                            },
+                          };
+                        })()
+                      : rawResult,
+                }),
+              );
               bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                 result.meta?.systemPromptReport,
               );
-              lifecycleBackstop.emit("end", result);
-              const resultCompactionCount = Math.max(
-                0,
-                result.meta?.agentMeta?.compactionCount ?? 0,
-              );
-              attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
               return result;
-            } catch (err) {
-              if (rollbackFallbackCandidateSelection) {
-                try {
-                  await rollbackFallbackCandidateSelection();
-                  clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                } catch (rollbackError) {
-                  logVerbose(
-                    `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                  );
-                }
-              }
-              lifecycleBackstop.emit("error", err);
-              throw err;
-            } finally {
-              autoCompactionCount += attemptCompactionCount;
             }
-          })();
-        },
+            const { embeddedContext, senderContext, runBaseParams } =
+              buildEmbeddedRunExecutionParams({
+                run: candidateRun,
+                sessionCtx: params.sessionCtx,
+                hasRepliedRef: params.opts?.hasRepliedRef,
+                provider,
+                runId,
+                allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+                model,
+              });
+            const agentHarnessPolicy = sessionRuntimeOverride
+              ? ({ runtime: sessionRuntimeOverride, runtimeSource: "model" } as const)
+              : resolveAgentHarnessPolicy({
+                  provider,
+                  modelId: model,
+                  config: runtimeConfig,
+                  agentId: params.followupRun.run.agentId,
+                  sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
+                });
+            const embeddedRunProvider = resolveOpenAIRuntimeProviderForPi({
+              provider,
+              harnessRuntime: agentHarnessPolicy.runtime,
+              authProfileProvider: runBaseParams.authProfileId?.split(":", 1)[0],
+              authProfileId: runBaseParams.authProfileId,
+              config: runtimeConfig,
+              workspaceDir: params.followupRun.run.workspaceDir,
+            });
+            const embeddedRunHarnessOverride =
+              sessionRuntimeOverride ??
+              (agentHarnessPolicy.runtime === "pi" && embeddedRunProvider !== provider
+                ? "pi"
+                : undefined);
+            return (async () => {
+              let attemptCompactionCount = 0;
+              const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
+                runId,
+                sessionKey: params.sessionKey,
+              });
+              try {
+                // Profiler-only milestone: it exposes time spent before Codex
+                // dispatch while leaving the regular embedded run path inert.
+                agentTurnTiming.logMilestoneIfSlow({
+                  runId,
+                  sessionId: params.followupRun.run.sessionId,
+                  sessionKey: params.sessionKey,
+                  milestone: "before_embedded_run",
+                });
+                const result = await agentTurnTiming.measure("embedded_run", () =>
+                  runEmbeddedPiAgent({
+                    ...embeddedContext,
+                    allowGatewaySubagentBinding: true,
+                    trigger: params.isHeartbeat ? "heartbeat" : "user",
+                    groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
+                    groupChannel:
+                      normalizeOptionalString(params.sessionCtx.GroupChannel) ??
+                      normalizeOptionalString(params.sessionCtx.GroupSubject),
+                    groupSpace: normalizeOptionalString(params.sessionCtx.GroupSpace),
+                    ...senderContext,
+                    ...runBaseParams,
+                    provider: embeddedRunProvider,
+                    agentHarnessId: embeddedRunHarnessOverride,
+                    agentHarnessRuntimeOverride: embeddedRunHarnessOverride,
+                    sandboxSessionKey: params.runtimePolicySessionKey,
+                    prompt: params.commandBody,
+                    transcriptPrompt: params.transcriptCommandBody,
+                    currentInboundEventKind: params.followupRun.currentInboundEventKind,
+                    currentInboundContext: params.followupRun.currentInboundContext,
+                    extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                    sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
+                    forceMessageTool:
+                      params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only",
+                    silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
+                    suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
+                    onUserMessagePersisted: () => {
+                      queuedUserMessagePersistedAcrossFallback = true;
+                    },
+                    suppressTranscriptOnlyAssistantPersistence:
+                      params.followupRun.run.suppressTranscriptOnlyAssistantPersistence,
+                    suppressAssistantErrorPersistence:
+                      suppressAssistantErrorPersistenceForCandidate,
+                    onAssistantErrorMessagePersisted: () => {
+                      assistantErrorPersistedAcrossFallback = true;
+                    },
+                    toolResultFormat: (() => {
+                      const channel = resolveMessageChannel(
+                        params.sessionCtx.Surface,
+                        params.sessionCtx.Provider,
+                      );
+                      if (!channel) {
+                        return "markdown";
+                      }
+                      return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
+                    })(),
+                    toolProgressDetail: params.toolProgressDetail,
+                    suppressToolErrorWarnings:
+                      params.opts?.shouldSuppressToolErrorWarnings ??
+                      params.opts?.suppressToolErrorWarnings,
+                    disableTools: params.opts?.disableTools,
+                    enableHeartbeatTool: params.opts?.enableHeartbeatTool,
+                    forceHeartbeatTool: params.opts?.forceHeartbeatTool,
+                    bootstrapContextMode: params.opts?.bootstrapContextMode,
+                    bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
+                    images: currentTurnImages.images,
+                    imageOrder: currentTurnImages.imageOrder,
+                    abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
+                    replyOperation: params.replyOperation,
+                    blockReplyBreak: params.resolvedBlockStreamingBreak,
+                    blockReplyChunking: params.blockReplyChunking,
+                    onPartialReply: async (payload) => {
+                      const textForTyping = await handlePartialForTyping(payload);
+                      if (!params.opts?.onPartialReply || textForTyping === undefined) {
+                        return;
+                      }
+                      await params.opts.onPartialReply({
+                        text: textForTyping,
+                        mediaUrls: payload.mediaUrls,
+                      });
+                    },
+                    onAssistantMessageStart: async () => {
+                      await params.typingSignals.signalMessageStart();
+                      await params.opts?.onAssistantMessageStart?.();
+                    },
+                    onReasoningStream:
+                      params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
+                        ? async (payload) => {
+                            if (params.followupRun.run.silentExpected) {
+                              return;
+                            }
+                            await params.typingSignals.signalReasoningDelta();
+                            await params.opts?.onReasoningStream?.({
+                              text: payload.text,
+                              mediaUrls: payload.mediaUrls,
+                            });
+                          }
+                        : undefined,
+                    onReasoningEnd: params.opts?.onReasoningEnd,
+                    onAgentEvent: async (evt) => {
+                      lifecycleBackstop.note(evt);
+                      // Signal run start only after the embedded agent emits real activity.
+                      const hasLifecyclePhase =
+                        evt.stream === "lifecycle" && typeof evt.data.phase === "string";
+                      if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
+                        notifyAgentRunStart();
+                      }
+                      // Trigger typing when tools start executing.
+                      // Must await to ensure typing indicator starts before tool summaries are emitted.
+                      if (evt.stream === "tool") {
+                        const phase = readStringValue(evt.data.phase) ?? "";
+                        const name = readStringValue(evt.data.name);
+                        const toolCallId = readStringValue(evt.data.toolCallId) ?? "";
+                        const args =
+                          evt.data.args && typeof evt.data.args === "object"
+                            ? (evt.data.args as Record<string, unknown>)
+                            : undefined;
+                        if (
+                          sourceRepliesAreToolOnly &&
+                          toolCallId &&
+                          name &&
+                          (phase === "start" || phase === "update") &&
+                          args &&
+                          isMessagingToolSendAction(name, args)
+                        ) {
+                          messageToolOnlyDeliveryToolCallIds.add(toolCallId);
+                        }
+                        if (shouldSuppressProgressAfterMessageToolDelivery()) {
+                          return;
+                        }
+                        if (phase === "start" || phase === "update") {
+                          const toolStartProgressPromise = params.opts?.onToolStart?.({
+                            name,
+                            phase,
+                            args,
+                            detailMode: params.toolProgressDetail,
+                          });
+                          await Promise.all([
+                            params.typingSignals.signalToolStart(),
+                            toolStartProgressPromise,
+                          ]);
+                        }
+                      }
+                      const suppressItemChannelProgress =
+                        evt.stream === "item" &&
+                        evt.data.suppressChannelProgress === true &&
+                        Boolean(params.opts?.onToolStart);
+                      const itemPhase =
+                        evt.stream === "item" ? readStringValue(evt.data.phase) : "";
+                      const itemName = evt.stream === "item" ? readStringValue(evt.data.name) : "";
+                      const itemStatus =
+                        evt.stream === "item" ? readStringValue(evt.data.status) : "";
+                      const itemToolCallId =
+                        evt.stream === "item" ? (readStringValue(evt.data.toolCallId) ?? "") : "";
+                      const completedMessageToolDelivery =
+                        sourceRepliesAreToolOnly &&
+                        itemPhase === "end" &&
+                        itemStatus === "completed" &&
+                        itemToolCallId.length > 0 &&
+                        messageToolOnlyDeliveryToolCallIds.has(itemToolCallId);
+                      const suppressProgressAfterMessageToolDelivery =
+                        shouldSuppressProgressAfterMessageToolDelivery();
+                      if (completedMessageToolDelivery) {
+                        messageToolOnlyDeliveryToolCallIds.delete(itemToolCallId);
+                        messageToolOnlyDeliveryCompleted = true;
+                      }
+                      if (
+                        evt.stream === "item" &&
+                        !suppressItemChannelProgress &&
+                        (!suppressProgressAfterMessageToolDelivery || completedMessageToolDelivery)
+                      ) {
+                        await params.opts?.onItemEvent?.({
+                          itemId: readStringValue(evt.data.itemId),
+                          kind: readStringValue(evt.data.kind),
+                          title: readStringValue(evt.data.title),
+                          name: itemName,
+                          phase: itemPhase,
+                          status: itemStatus,
+                          summary: readStringValue(evt.data.summary),
+                          progressText: readStringValue(evt.data.progressText),
+                          meta: readStringValue(evt.data.meta),
+                          approvalId: readStringValue(evt.data.approvalId),
+                          approvalSlug: readStringValue(evt.data.approvalSlug),
+                        });
+                      }
+                      if (
+                        evt.stream === "plan" &&
+                        !shouldSuppressProgressAfterMessageToolDelivery()
+                      ) {
+                        await params.opts?.onPlanUpdate?.({
+                          phase: readStringValue(evt.data.phase),
+                          title: readStringValue(evt.data.title),
+                          explanation: readStringValue(evt.data.explanation),
+                          steps: Array.isArray(evt.data.steps)
+                            ? evt.data.steps.filter(
+                                (step): step is string => typeof step === "string",
+                              )
+                            : undefined,
+                          source: readStringValue(evt.data.source),
+                        });
+                      }
+                      if (
+                        evt.stream === "approval" &&
+                        !shouldSuppressProgressAfterMessageToolDelivery()
+                      ) {
+                        await params.opts?.onApprovalEvent?.({
+                          phase: readStringValue(evt.data.phase),
+                          kind: readStringValue(evt.data.kind),
+                          status: readStringValue(evt.data.status),
+                          title: readStringValue(evt.data.title),
+                          itemId: readStringValue(evt.data.itemId),
+                          toolCallId: readStringValue(evt.data.toolCallId),
+                          approvalId: readStringValue(evt.data.approvalId),
+                          approvalSlug: readStringValue(evt.data.approvalSlug),
+                          command: readStringValue(evt.data.command),
+                          host: readStringValue(evt.data.host),
+                          reason: readStringValue(evt.data.reason),
+                          scope: readApprovalScopeValue(evt.data.scope),
+                          message: readStringValue(evt.data.message),
+                        });
+                      }
+                      if (
+                        evt.stream === "command_output" &&
+                        !shouldSuppressProgressAfterMessageToolDelivery()
+                      ) {
+                        await params.opts?.onCommandOutput?.({
+                          itemId: readStringValue(evt.data.itemId),
+                          phase: readStringValue(evt.data.phase),
+                          title: readStringValue(evt.data.title),
+                          toolCallId: readStringValue(evt.data.toolCallId),
+                          name: readStringValue(evt.data.name),
+                          output: readStringValue(evt.data.output),
+                          status: readStringValue(evt.data.status),
+                          exitCode:
+                            typeof evt.data.exitCode === "number" || evt.data.exitCode === null
+                              ? evt.data.exitCode
+                              : undefined,
+                          durationMs:
+                            typeof evt.data.durationMs === "number"
+                              ? evt.data.durationMs
+                              : undefined,
+                          cwd: readStringValue(evt.data.cwd),
+                        });
+                      }
+                      if (
+                        evt.stream === "patch" &&
+                        !shouldSuppressProgressAfterMessageToolDelivery()
+                      ) {
+                        await params.opts?.onPatchSummary?.({
+                          itemId: readStringValue(evt.data.itemId),
+                          phase: readStringValue(evt.data.phase),
+                          title: readStringValue(evt.data.title),
+                          toolCallId: readStringValue(evt.data.toolCallId),
+                          name: readStringValue(evt.data.name),
+                          added: Array.isArray(evt.data.added)
+                            ? evt.data.added.filter(
+                                (entry): entry is string => typeof entry === "string",
+                              )
+                            : undefined,
+                          modified: Array.isArray(evt.data.modified)
+                            ? evt.data.modified.filter(
+                                (entry): entry is string => typeof entry === "string",
+                              )
+                            : undefined,
+                          deleted: Array.isArray(evt.data.deleted)
+                            ? evt.data.deleted.filter(
+                                (entry): entry is string => typeof entry === "string",
+                              )
+                            : undefined,
+                          summary: readStringValue(evt.data.summary),
+                        });
+                      }
+                      // Track auto-compaction and notify higher layers.
+                      if (evt.stream === "compaction") {
+                        const phase = readStringValue(evt.data.phase) ?? "";
+                        const hookMessages = readCompactionHookMessages(evt.data.messages);
+                        if (phase === "start") {
+                          // Keep custom compaction callbacks active, but gate the
+                          // fallback user-facing notice behind explicit opt-in.
+                          if (params.opts?.onCompactionStart) {
+                            await params.opts.onCompactionStart();
+                          }
+                          if (hookMessages.length > 0) {
+                            await sendCompactionHookMessages(hookMessages);
+                          } else if (
+                            !params.opts?.onCompactionStart &&
+                            shouldNotifyUserAboutCompaction
+                          ) {
+                            // Send directly via opts.onBlockReply (bypassing the
+                            // pipeline) so the notice does not cause final payloads
+                            // to be discarded on non-streaming model paths.
+                            await sendCompactionNotice("start");
+                          }
+                        }
+                        if (phase === "end") {
+                          const completed = evt.data?.completed === true;
+                          if (completed) {
+                            attemptCompactionCount += 1;
+                            if (params.opts?.onCompactionEnd) {
+                              await params.opts.onCompactionEnd();
+                            }
+                            if (hookMessages.length > 0) {
+                              await sendCompactionHookMessages(hookMessages);
+                            } else if (
+                              !params.opts?.onCompactionEnd &&
+                              shouldNotifyUserAboutCompaction
+                            ) {
+                              await sendCompactionNotice("end");
+                            }
+                          } else if (hookMessages.length > 0) {
+                            await sendCompactionHookMessages(hookMessages);
+                          } else if (shouldNotifyUserAboutCompaction) {
+                            await sendCompactionNotice("incomplete");
+                          }
+                        }
+                      }
+                    },
+                    // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
+                    // even when regular block streaming is disabled. The handler sends directly
+                    // via opts.onBlockReply when the pipeline isn't available.
+                    onBlockReply: blockReplyHandler,
+                    onBlockReplyFlush:
+                      params.blockStreamingEnabled && blockReplyPipeline
+                        ? async () => {
+                            await blockReplyPipeline.flush({ force: true });
+                          }
+                        : undefined,
+                    shouldEmitToolResult: params.shouldEmitToolResult,
+                    shouldEmitToolOutput: params.shouldEmitToolOutput,
+                    bootstrapPromptWarningSignaturesSeen,
+                    bootstrapPromptWarningSignature:
+                      bootstrapPromptWarningSignaturesSeen[
+                        bootstrapPromptWarningSignaturesSeen.length - 1
+                      ],
+                    onToolResult: onToolResult
+                      ? (() => {
+                          // Serialize tool result delivery to preserve message ordering.
+                          // Without this, concurrent tool callbacks race through typing signals
+                          // and message sends, causing out-of-order delivery to the user.
+                          // See: https://github.com/openclaw/openclaw/issues/11044
+                          let toolResultChain: Promise<void> = Promise.resolve();
+                          return (payload: ReplyPayload) => {
+                            toolResultChain = toolResultChain
+                              .then(async () => {
+                                const { text, skip } = normalizeStreamingText(payload);
+                                if (skip) {
+                                  return;
+                                }
+                                if (text !== undefined) {
+                                  await params.typingSignals.signalTextDelta(text);
+                                }
+                                await onToolResult({
+                                  ...payload,
+                                  text,
+                                });
+                              })
+                              .catch((err) => {
+                                // Keep chain healthy after an error so later tool results still deliver.
+                                logVerbose(`tool result delivery failed: ${String(err)}`);
+                              });
+                            const task = toolResultChain.finally(() => {
+                              params.pendingToolTasks.delete(task);
+                            });
+                            params.pendingToolTasks.add(task);
+                          };
+                        })()
+                      : undefined,
+                  }),
+                );
+                bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                  result.meta?.systemPromptReport,
+                );
+                lifecycleBackstop.emit("end", result);
+                const resultCompactionCount = Math.max(
+                  0,
+                  result.meta?.agentMeta?.compactionCount ?? 0,
+                );
+                attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
+                return result;
+              } catch (err) {
+                if (rollbackFallbackCandidateSelection) {
+                  try {
+                    await rollbackFallbackCandidateSelection();
+                    clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
+                  } catch (rollbackError) {
+                    logVerbose(
+                      `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
+                    );
+                  }
+                }
+                lifecycleBackstop.emit("error", err);
+                throw err;
+              } finally {
+                autoCompactionCount += attemptCompactionCount;
+              }
+            })();
+          },
+        }),
+      );
+      agentTurnTiming.logIfSlow({
+        runId,
+        sessionId: params.followupRun.run.sessionId,
+        sessionKey: params.sessionKey,
+        outcome: "completed",
       });
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
@@ -2446,6 +2648,13 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
       const message = formatErrorMessage(err);
+      agentTurnTiming.logIfSlow({
+        runId,
+        sessionId: params.followupRun.run.sessionId,
+        sessionKey: params.sessionKey,
+        outcome: "error",
+        error: message,
+      });
       const isBilling = isFallbackSummaryError(err)
         ? hasBillingAttemptSummary(err)
         : isBillingErrorMessage(message);

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -240,7 +240,7 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(coordinator.getRoutedCounts().block).toBe(0);
   });
 
-  it("waits for direct block dispatcher delivery before resolving block delivery", async () => {
+  it("does not wait for direct block dispatcher delivery before resolving block delivery", async () => {
     const delivered: unknown[] = [];
     let releaseDelivery: (() => void) | undefined;
     let markDeliveryStarted: (() => void) | undefined;
@@ -276,13 +276,68 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     });
 
     await deliveryStarted;
+    await Promise.resolve();
 
     expect(delivered).toEqual([{ text: "hello" }]);
-    expect(deliverySettled).toBe(false);
+    expect(deliverySettled).toBe(true);
 
     releaseDelivery?.();
     await expect(deliveryPromise).resolves.toBe(true);
     expect(deliverySettled).toBe(true);
+    await dispatcher.waitForIdle();
+  });
+
+  it("waits for pending direct block delivery before resolving tool delivery", async () => {
+    const delivered: unknown[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "visiblechat",
+        Surface: "visiblechat",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+    });
+
+    await expect(coordinator.deliver("block", { text: "hello" }, { skipTts: true })).resolves.toBe(
+      true,
+    );
+    await deliveryStarted;
+
+    let toolDeliverySettled = false;
+    const toolDeliveryPromise = coordinator
+      .deliver("tool", { text: "tool result" }, { skipTts: true })
+      .then((result) => {
+        toolDeliverySettled = true;
+        return result;
+      });
+
+    await Promise.resolve();
+
+    expect(delivered).toEqual([{ text: "hello" }]);
+    expect(toolDeliverySettled).toBe(false);
+
+    releaseDelivery?.();
+    await expect(toolDeliveryPromise).resolves.toBe(true);
+    expect(toolDeliverySettled).toBe(true);
+    expect(delivered).toEqual([{ text: "hello" }, { text: "tool result" }]);
   });
 
   it("stops waiting for direct block delivery when the ACP dispatch aborts", async () => {

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -234,11 +234,23 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     },
     toolMessageByCallId: new Map(),
   };
+  let hasPendingDirectBlockReplyDelivery = false;
+  const waitForPendingDirectBlockReplyDelivery = async () => {
+    if (!hasPendingDirectBlockReplyDelivery) {
+      return;
+    }
+    // ACP direct block replies should not block the common visible-reply path.
+    // Defer the idle wait until a later tool delivery would otherwise overtake
+    // that block reply in user-visible ordering.
+    hasPendingDirectBlockReplyDelivery = false;
+    await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
+  };
   const settleDirectVisibleText = async () => {
     if (state.settledDirectVisibleText || state.queuedDirectVisibleTextDeliveries === 0) {
       return;
     }
     state.settledDirectVisibleText = true;
+    hasPendingDirectBlockReplyDelivery = false;
     await params.dispatcher.waitForIdle();
     const failedCounts = params.dispatcher.getFailedCounts();
     const failedVisibleCount = failedCounts.block + failedCounts.final;
@@ -440,6 +452,10 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       return true;
     }
 
+    if (kind === "tool") {
+      await waitForPendingDirectBlockReplyDelivery();
+    }
+
     const tracksVisibleText = await shouldTreatDeliveredTextAsVisible({
       channel: directChannel,
       kind,
@@ -462,7 +478,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       state.failedVisibleTextDelivery = true;
     }
     if (kind === "block" && delivered) {
-      await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
+      hasPendingDirectBlockReplyDelivery = true;
     }
     return delivered;
   };

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4738,6 +4738,78 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).not.toHaveBeenCalled();
   });
 
+  it("does not run plugin-owned binding delivery when the caller already aborted", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: { handled: true, reply: { text: "should not send" } },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-aborted-1",
+      targetSessionKey: "plugin-binding:codex:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1481858418548412579",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/workspace/openclaw-app-server",
+        data: {
+          kind: "codex-app-server-session",
+          version: 1,
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/workspace/openclaw",
+        },
+      },
+    } satisfies SessionBindingRecord);
+    const abortController = new AbortController();
+    abortController.abort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "discord:channel:1481858418548412579",
+      To: "discord:channel:1481858418548412579",
+      AccountId: "default",
+      SenderId: "user-9",
+      SenderUsername: "ada",
+      CommandAuthorized: true,
+      WasMentioned: false,
+      CommandBody: "who are you",
+      RawBody: "who are you",
+      Body: "who are you",
+      MessageSid: "msg-claim-plugin-aborted-1",
+      SessionKey: "agent:main:discord:channel:1481858418548412579",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "should not run" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyOptions: { abortSignal: abortController.signal },
+      replyResolver,
+    });
+
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(sessionBindingMocks.touch).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runInboundClaimForPluginOutcome).not.toHaveBeenCalled();
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("lets authorized plugin-owned binding commands fall through to command processing", async () => {
     setNoAbort();
     expect(
@@ -5706,7 +5778,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(callOrder).toEqual(["queued:The answer is 42", "dispatch:The answer is 42"]);
   });
 
-  it("waits for same-channel block dispatcher delivery before resolving block replies", async () => {
+  it("does not wait for same-channel block dispatcher delivery before resolving block replies", async () => {
     setNoAbort();
     const ctx = buildTestCtx({ Provider: "whatsapp" });
     const delivered: ReplyPayload[] = [];
@@ -5739,10 +5811,10 @@ describe("dispatchReplyFromConfig", () => {
       await deliveryStarted;
 
       expect(delivered).toEqual([{ text: "before tool" }]);
-      expect(blockReplySettled).toBe(false);
+      await blockReplyPromise;
+      expect(blockReplySettled).toBe(true);
 
       releaseDelivery?.();
-      await blockReplyPromise;
       return undefined;
     };
 
@@ -5754,6 +5826,177 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(blockReplySettled).toBe(true);
+    await dispatcher.waitForIdle();
+  });
+
+  it("waits for pending same-channel block delivery before completing block-only dispatch", async () => {
+    setNoAbort();
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const delivered: ReplyPayload[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "only block" });
+      return undefined;
+    };
+
+    let dispatchSettled = false;
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    }).then((result) => {
+      dispatchSettled = true;
+      return result;
+    });
+
+    await deliveryStarted;
+
+    expect(delivered).toEqual([{ text: "only block" }]);
+    expect(dispatchSettled).toBe(false);
+
+    releaseDelivery?.();
+    await dispatchPromise;
+
+    expect(dispatchSettled).toBe(true);
+  });
+
+  it("waits for pending same-channel block delivery before forwarding tool progress", async () => {
+    setNoAbort();
+    const cfg = {
+      agents: { defaults: { verboseDefault: "on" } },
+    } as const satisfies OpenClawConfig;
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const delivered: ReplyPayload[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const onToolStart = vi.fn();
+    let toolProgressSettled = false;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "before tool" });
+      const toolProgressPromise = Promise.resolve(opts?.onToolStart?.({ name: "lookup" })).then(
+        () => {
+          toolProgressSettled = true;
+        },
+      );
+
+      await deliveryStarted;
+
+      expect(delivered).toEqual([{ text: "before tool" }]);
+      expect(onToolStart).not.toHaveBeenCalled();
+      expect(toolProgressSettled).toBe(false);
+
+      releaseDelivery?.();
+      await toolProgressPromise;
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onToolStart },
+    });
+
+    expect(toolProgressSettled).toBe(true);
+    expect(onToolStart).toHaveBeenCalledWith({ name: "lookup" });
+  });
+
+  it("does not synthesize tool-start capability while ordering item progress", async () => {
+    setNoAbort();
+    const cfg = {
+      agents: { defaults: { verboseDefault: "on" } },
+    } as const satisfies OpenClawConfig;
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const delivered: ReplyPayload[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const onItemEvent = vi.fn();
+    let itemProgressSettled = false;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "before item" });
+      expect(opts?.onToolStart).toBeUndefined();
+      const itemProgressPromise = Promise.resolve(
+        opts?.onItemEvent?.({ itemId: "1", kind: "tool", progressText: "running" }),
+      ).then(() => {
+        itemProgressSettled = true;
+      });
+
+      await deliveryStarted;
+
+      expect(delivered).toEqual([{ text: "before item" }]);
+      expect(onItemEvent).not.toHaveBeenCalled();
+      expect(itemProgressSettled).toBe(false);
+
+      releaseDelivery?.();
+      await itemProgressPromise;
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onItemEvent },
+    });
+
+    expect(itemProgressSettled).toBe(true);
+    expect(onItemEvent).toHaveBeenCalledWith({
+      itemId: "1",
+      kind: "tool",
+      progressText: "running",
+    });
   });
 
   it("forwards payload metadata into onBlockReplyQueued context", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -61,6 +61,7 @@ import {
   markDiagnosticSessionProgress,
 } from "../../logging/diagnostic.js";
 import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycle.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { matchPluginCommand } from "../../plugins/commands.js";
 import {
   buildPluginBindingDeclinedText,
@@ -131,6 +132,7 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
 import { replyRunRegistry, type ReplyOperation } from "./reply-run-registry.js";
+import { isReplyProfilerEnabled } from "./reply-timing-tracker.js";
 import { admitReplyTurn, resolveReplyTurnKind } from "./reply-turn-admission.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveReplyRoutingDecision } from "./routing-policy.js";
@@ -783,6 +785,102 @@ function createAbortAwareDispatcher(params: {
   return dispatcher;
 }
 
+type ReplyHotPathTimingSpan = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+type ReplyHotPathTimingSummary = {
+  totalMs: number;
+  spans: ReplyHotPathTimingSpan[];
+};
+
+const replyHotPathTimingLog = createSubsystemLogger("auto-reply/reply-timing");
+const REPLY_HOT_PATH_TIMING_WARN_TOTAL_MS = 1_000;
+const REPLY_HOT_PATH_TIMING_WARN_STAGE_MS = 500;
+
+function createReplyHotPathTimingTracker(options: { profilerEnabled?: boolean } = {}): {
+  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
+  logIfSlow: (params: {
+    channel: string;
+    messageId?: number | string;
+    sessionKey?: string;
+    outcome: "completed" | "skipped" | "error";
+    reason?: string;
+  }) => void;
+} {
+  if (!options.profilerEnabled) {
+    // This slow-path splitter was added for latency investigation. Keep it
+    // inert in normal production dispatches so only explicit profiler runs pay
+    // the Date.now/span allocation cost.
+    return {
+      async measure(_name, run) {
+        return await run();
+      },
+      logIfSlow() {},
+    };
+  }
+
+  const startedAt = Date.now();
+  let didLog = false;
+  const spans: ReplyHotPathTimingSpan[] = [];
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  const snapshot = (): ReplyHotPathTimingSummary => ({
+    totalMs: toMs(Date.now() - startedAt),
+    spans: spans.slice(),
+  });
+  const shouldLog = (summary: ReplyHotPathTimingSummary) =>
+    summary.totalMs >= REPLY_HOT_PATH_TIMING_WARN_TOTAL_MS ||
+    summary.spans.some((span) => span.durationMs >= REPLY_HOT_PATH_TIMING_WARN_STAGE_MS);
+  const formatSpans = (summary: ReplyHotPathTimingSummary) =>
+    summary.spans.length > 0
+      ? summary.spans
+          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+          .join(",")
+      : "none";
+  return {
+    async measure(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return await run();
+      } finally {
+        spans.push({
+          name,
+          durationMs: toMs(Date.now() - spanStartedAt),
+          elapsedMs: toMs(Date.now() - startedAt),
+        });
+      }
+    },
+    logIfSlow(params) {
+      if (didLog) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      didLog = true;
+      replyHotPathTimingLog.warn(
+        `reply hot path timings channel=${params.channel} messageId=${
+          params.messageId ?? "unknown"
+        } sessionKey=${params.sessionKey ?? "unknown"} outcome=${params.outcome} totalMs=${
+          summary.totalMs
+        } stages=${formatSpans(summary)}${params.reason ? ` reason=${params.reason}` : ""}`,
+        {
+          channel: params.channel,
+          messageId: params.messageId,
+          sessionKey: params.sessionKey,
+          outcome: params.outcome,
+          reason: params.reason,
+          totalMs: summary.totalMs,
+          spans: summary.spans,
+        },
+      );
+    },
+  };
+}
+
 export type {
   DispatchFromConfigParams,
   DispatchFromConfigResult,
@@ -822,12 +920,17 @@ export async function dispatchReplyFromConfig(
     hasSessionKey: Boolean(sessionKey),
     hasRunId: typeof params.replyOptions?.runId === "string",
   };
+  const replyHotPathTiming = createReplyHotPathTimingTracker({
+    profilerEnabled: isReplyProfilerEnabled({ config: cfg }),
+  });
   const traceReplyPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
-    measureDiagnosticsTimelineSpan(name, run, {
-      phase: "agent-turn",
-      config: cfg,
-      attributes: traceAttributes,
-    });
+    replyHotPathTiming.measure(name, () =>
+      measureDiagnosticsTimelineSpan(name, run, {
+        phase: "agent-turn",
+        config: cfg,
+        attributes: traceAttributes,
+      }),
+    );
   let agentDispatchStartedAt = 0;
 
   const recordProcessed = (
@@ -837,6 +940,15 @@ export async function dispatchReplyFromConfig(
       error?: string;
     },
   ) => {
+    if (diagnosticsEnabled) {
+      replyHotPathTiming.logIfSlow({
+        channel,
+        messageId,
+        sessionKey,
+        outcome,
+        reason: opts?.reason,
+      });
+    }
     messageLifecycle.markProcessed(outcome, opts);
   };
 
@@ -1432,6 +1544,16 @@ export async function dispatchReplyFromConfig(
       counts: dispatcher.getQueuedCounts(),
     });
   };
+  const finishReplyOperationAbortedDispatch = (): DispatchFromConfigResult => {
+    commitInboundDedupeIfClaimed();
+    recordProcessed("completed", { reason: "reply_operation_aborted" });
+    markIdle("message_completed");
+    completeDispatchReplyOperation();
+    return attachSourceReplyDeliveryMode({
+      queuedFinal: false,
+      counts: dispatcher.getQueuedCounts(),
+    });
+  };
 
   let pluginFallbackReason:
     | "plugin-bound-fallback-missing-plugin"
@@ -1439,6 +1561,9 @@ export async function dispatchReplyFromConfig(
     | undefined;
 
   if (pluginOwnedBinding) {
+    if (isPreDispatchOperationAborted()) {
+      return finishReplyOperationAbortedDispatch();
+    }
     touchConversationBindingRecord(pluginOwnedBinding.bindingId);
     if (shouldBypassPluginOwnedBindingForCommand(ctx)) {
       logVerbose(
@@ -2012,6 +2137,17 @@ export async function dispatchReplyFromConfig(
     const onPatchSummaryFromReplyOptions = params.replyOptions?.onPatchSummary;
     const allowSuppressedSourceProgressCallbacks =
       params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed === true;
+    let hasPendingDirectBlockReplyDelivery = false;
+    const waitForPendingDirectBlockReplyDelivery = async (abortSignal?: AbortSignal) => {
+      if (!hasPendingDirectBlockReplyDelivery) {
+        return;
+      }
+      // Direct block replies are queued asynchronously so lightweight replies do
+      // not wait for dispatcher idle. Flush only before later tool/progress
+      // callbacks and final completion where external ordering is visible.
+      hasPendingDirectBlockReplyDelivery = false;
+      await waitForReplyDispatcherIdle(dispatcher, abortSignal);
+    };
     const shouldForwardProgressCallback = (options?: {
       forwardWhenSourceDeliverySuppressed?: boolean;
       requiresToolSummaryVisibility?: boolean;
@@ -2031,9 +2167,10 @@ export async function dispatchReplyFromConfig(
         forwardWhenSourceDeliverySuppressed?: boolean;
         requiresToolSummaryVisibility?: boolean;
         onForward?: (...args: Args) => void;
+        waitForDirectBlockReplyDelivery?: boolean;
       },
     ): ((...args: Args) => Promise<void>) | undefined => {
-      if (!callback && (!suppressAutomaticSourceDelivery || !canTrackSession)) {
+      if (!callback) {
         return undefined;
       }
       return async (...args: Args) => {
@@ -2041,6 +2178,12 @@ export async function dispatchReplyFromConfig(
           return;
         }
         markProgress();
+        if (options?.waitForDirectBlockReplyDelivery) {
+          await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+          if (isDispatchOperationAborted()) {
+            return;
+          }
+        }
         if (shouldForwardProgressCallback(options)) {
           options?.onForward?.(...args);
           await callback?.(...args);
@@ -2077,10 +2220,12 @@ export async function dispatchReplyFromConfig(
             onToolStart: wrapProgressCallback(params.replyOptions?.onToolStart, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onItemEvent: wrapProgressCallback(params.replyOptions?.onItemEvent, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
               onForward: (payload) => {
                 if (hasFailedProgressStatus(payload)) {
                   markVisibleToolErrorProgress();
@@ -2090,6 +2235,7 @@ export async function dispatchReplyFromConfig(
             onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
               onForward: (payload) => {
                 if (hasFailedProgressStatus(payload)) {
                   markVisibleToolErrorProgress();
@@ -2099,14 +2245,20 @@ export async function dispatchReplyFromConfig(
             onCompactionStart: wrapProgressCallback(params.replyOptions?.onCompactionStart, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onCompactionEnd: wrapProgressCallback(params.replyOptions?.onCompactionEnd, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onToolResult: (payload: ReplyPayload) => {
               markProgress();
               const run = async () => {
+                if (isDispatchOperationAborted()) {
+                  return;
+                }
+                await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
                 if (isDispatchOperationAborted()) {
                   return;
                 }
@@ -2171,6 +2323,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2193,6 +2349,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2223,6 +2383,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2329,7 +2493,7 @@ export async function dispatchReplyFromConfig(
                   markInboundDedupeReplayUnsafe();
                   const delivered = dispatcher.sendBlockReply(normalizedPayload);
                   if (delivered) {
-                    await waitForReplyDispatcherIdle(dispatcher, context?.abortSignal);
+                    hasPendingDirectBlockReplyDelivery = true;
                   }
                 }
               };
@@ -2461,6 +2625,7 @@ export async function dispatchReplyFromConfig(
         accumulatedBlockTtsText.trim()
       ) {
         try {
+          await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
           throwIfDispatchOperationAborted();
           const ttsSyntheticReply = await maybeApplyTtsToReplyPayload({
             payload: { text: accumulatedBlockTtsText },
@@ -2520,6 +2685,7 @@ export async function dispatchReplyFromConfig(
       }
     }
 
+    await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
     const counts = dispatcher.getQueuedCounts();
     counts.final += routedFinalCount;
     commitInboundDedupeIfClaimed();
@@ -2537,14 +2703,7 @@ export async function dispatchReplyFromConfig(
     });
   } catch (err) {
     if (isDispatchReplyOperationAbortedError(err)) {
-      commitInboundDedupeIfClaimed();
-      recordProcessed("completed", { reason: "reply_operation_aborted" });
-      markIdle("message_completed");
-      completeDispatchReplyOperation();
-      return attachSourceReplyDeliveryMode({
-        queuedFinal: false,
-        counts: dispatcher.getQueuedCounts(),
-      });
+      return finishReplyOperationAbortedDispatch();
     }
     if (inboundDedupeClaim.status === "claimed") {
       if (inboundDedupeReplayUnsafe) {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -15,6 +15,7 @@ import { type OpenClawConfig, getRuntimeConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { defaultRuntime } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -47,6 +48,7 @@ import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
 import { createFastTestModelSelectionState, createModelSelectionState } from "./model-selection.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 import { initSessionState } from "./session.js";
 import {
   isStaleHeartbeatAutoFallbackOverride,
@@ -89,6 +91,8 @@ const mediaUnderstandingApplyRuntimeLoader = createLazyImportLoader(
 const linkUnderstandingApplyRuntimeLoader = createLazyImportLoader(
   () => import("../../link-understanding/apply.runtime.js"),
 );
+
+const replyResolverTimingLog = createSubsystemLogger("auto-reply/reply-resolver-timing");
 const commandsCoreRuntimeLoader = createLazyImportLoader(
   () => import("./commands-core.runtime.js"),
 );
@@ -214,45 +218,85 @@ export async function getReplyFromConfig(
     isFastTestEnv,
     configOverride,
   });
-  const useFastTestBootstrap = shouldUseReplyFastTestBootstrap({
-    isFastTestEnv,
-    configOverride,
-  });
-  const useFastTestRuntime = shouldUseReplyFastTestRuntime({
-    cfg,
-    isFastTestEnv,
-  });
-  const finalized = finalizeInboundContext(ctx);
-  const targetSessionKey = resolveCommandTurnTargetSessionKey(finalized);
-  const agentSessionKey = targetSessionKey || finalized.SessionKey;
-  const traceAttributes = {
+  // Profiler spans stay inert unless diagnostics enable `profiler` or
+  // `reply.profiler`, so normal replies do not pay per-stage Date.now/array
+  // bookkeeping while we can still split resolver costs on demand.
+  const resolverTiming = createReplyTimingTracker({ log: replyResolverTimingLog, config: cfg });
+  const useFastTestBootstrap = resolverTiming.measureSync("reply.resolve_fast_test_bootstrap", () =>
+    shouldUseReplyFastTestBootstrap({
+      isFastTestEnv,
+      configOverride,
+    }),
+  );
+  const useFastTestRuntime = resolverTiming.measureSync("reply.resolve_fast_test_runtime", () =>
+    shouldUseReplyFastTestRuntime({
+      cfg,
+      isFastTestEnv,
+    }),
+  );
+  const finalized = resolverTiming.measureSync("reply.finalize_context", () =>
+    finalizeInboundContext(ctx),
+  );
+  const { agentSessionKey, agentId } = resolverTiming.measureSync(
+    "reply.resolve_agent_scope",
+    () => {
+      const targetSessionKey = resolveCommandTurnTargetSessionKey(finalized);
+      const resolvedAgentSessionKey = targetSessionKey || finalized.SessionKey;
+      return {
+        agentSessionKey: resolvedAgentSessionKey,
+        agentId: resolveSessionAgentId({
+          sessionKey: resolvedAgentSessionKey,
+          config: cfg,
+        }),
+      };
+    },
+  );
+  const traceAttributes = resolverTiming.measureSync("reply.resolve_trace_context", () => ({
     surface: normalizeOptionalString(finalized.Surface ?? finalized.Provider) ?? "unknown",
     hasSessionKey: Boolean(agentSessionKey),
     isHeartbeat: opts?.isHeartbeat === true,
     hasMedia: hasInboundMedia(finalized),
-  };
-  const traceGetReplyPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
-    measureDiagnosticsTimelineSpan(name, run, {
-      phase: "agent-turn",
-      config: cfg,
-      attributes: traceAttributes,
+  }));
+  const messageId = finalized.MessageSid ?? finalized.MessageSidFirst ?? finalized.MessageSidLast;
+  let resolverTimingSessionKey = agentSessionKey;
+  const logResolverTiming = (outcome: string, reason?: string, error?: string) =>
+    resolverTiming.logIfSlow({
+      message: `reply resolver timings surface=${traceAttributes.surface} messageId=${
+        messageId ?? "unknown"
+      } sessionKey=${resolverTimingSessionKey ?? "unknown"} agentId=${agentId}`,
+      outcome,
+      reason,
+      error,
+      details: {
+        surface: traceAttributes.surface,
+        messageId,
+        sessionKey: resolverTimingSessionKey,
+        agentId,
+      },
     });
-  const agentId = resolveSessionAgentId({
-    sessionKey: agentSessionKey,
-    config: cfg,
-  });
-  const mergedSkillFilter = mergeSkillFilters(
-    opts?.skillFilter,
-    resolveAgentSkillsFilter(cfg, agentId),
+  const traceGetReplyPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
+    resolverTiming.measure(name, () =>
+      measureDiagnosticsTimelineSpan(name, run, {
+        phase: "agent-turn",
+        config: cfg,
+        attributes: traceAttributes,
+      }),
+    );
+  const mergedSkillFilter = resolverTiming.measureSync("reply.resolve_skill_filter", () =>
+    mergeSkillFilters(opts?.skillFilter, resolveAgentSkillsFilter(cfg, agentId)),
   );
   const resolvedOpts =
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
   const agentCfg = cfg.agents?.defaults;
   const sessionCfg = cfg.session;
-  const { defaultProvider, defaultModel, aliasIndex } = resolveDefaultModel({
-    cfg,
-    agentId,
-  });
+  const { defaultProvider, defaultModel, aliasIndex } = resolverTiming.measureSync(
+    "reply.resolve_default_model",
+    () =>
+      resolveDefaultModel({
+        cfg,
+        agentId,
+      }),
+  );
   let provider = defaultProvider;
   let model = defaultModel;
   let hasResolvedHeartbeatModelOverride = false;
@@ -277,22 +321,34 @@ export async function getReplyFromConfig(
     }
   }
 
-  const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
-  const workspaceDirForNativeCommand = workspaceDirRaw;
-  const agentDir = resolveAgentDir(cfg, agentId);
-  const timeoutMs = resolveAgentTimeoutMs({ cfg, overrideSeconds: opts?.timeoutOverrideSeconds });
-  const configuredTypingSeconds =
-    agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
-  const typingIntervalSeconds =
-    typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
-  const typing = createTypingController({
-    onReplyStart: opts?.onReplyStart,
-    onCleanup: opts?.onTypingCleanup,
-    typingIntervalSeconds,
-    silentToken: SILENT_REPLY_TOKEN,
-    log: defaultRuntime.log,
+  const { workspaceDirRaw, workspaceDirForNativeCommand, agentDir, timeoutMs } =
+    resolverTiming.measureSync("reply.resolve_workspace_agent_dir", () => {
+      const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
+      return {
+        workspaceDirRaw,
+        workspaceDirForNativeCommand: workspaceDirRaw,
+        agentDir: resolveAgentDir(cfg, agentId),
+        timeoutMs: resolveAgentTimeoutMs({
+          cfg,
+          overrideSeconds: opts?.timeoutOverrideSeconds,
+        }),
+      };
+    });
+  const typing = resolverTiming.measureSync("reply.create_typing_controller", () => {
+    const configuredTypingSeconds =
+      agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
+    const typingIntervalSeconds =
+      typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
+    const controller = createTypingController({
+      onReplyStart: opts?.onReplyStart,
+      onCleanup: opts?.onTypingCleanup,
+      typingIntervalSeconds,
+      silentToken: SILENT_REPLY_TOKEN,
+      log: defaultRuntime.log,
+    });
+    opts?.onTypingController?.(controller);
+    return controller;
   });
-  opts?.onTypingController?.(typing);
 
   const nativeSlashCommandFastReply = await traceGetReplyPhase(
     "reply.native_slash_command_fast_path",
@@ -316,6 +372,7 @@ export async function getReplyFromConfig(
       }),
   );
   if (nativeSlashCommandFastReply.handled) {
+    logResolverTiming("completed", "native_slash_command_fast_path");
     return nativeSlashCommandFastReply.reply;
   }
 
@@ -390,6 +447,7 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
+  resolverTimingSessionKey = sessionKey ?? resolverTimingSessionKey;
 
   if (sessionEntry?.pendingFinalDelivery && sessionEntry.pendingFinalDeliveryText) {
     const text = sanitizePendingFinalDeliveryText(sessionEntry.pendingFinalDeliveryText);
@@ -455,6 +513,7 @@ export async function getReplyFromConfig(
             }),
           });
         }
+        logResolverTiming("completed", "pending_final_delivery_replay");
         return { text: replayText };
       }
     }
@@ -579,7 +638,8 @@ export async function getReplyFromConfig(
       triggerBodyNormalized,
       commandAuthorized,
     });
-    return await traceGetReplyPhase("reply.run_prepared_reply", () =>
+    logResolverTiming("milestone", "before_fast_directive_prepared_reply");
+    const fastReplyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
       runPreparedReply({
         ctx,
         sessionCtx,
@@ -636,6 +696,8 @@ export async function getReplyFromConfig(
         autoFallbackPrimaryProbe,
       }),
     );
+    logResolverTiming("completed", "fast_directive_prepared_reply");
+    return fastReplyResult;
   }
 
   const directiveResult = await traceGetReplyPhase("reply.resolve_directives", () =>
@@ -671,6 +733,7 @@ export async function getReplyFromConfig(
     }),
   );
   if (directiveResult.kind === "reply") {
+    logResolverTiming("completed", "directive_reply");
     return directiveResult.reply;
   }
 
@@ -771,6 +834,7 @@ export async function getReplyFromConfig(
   );
   if (inlineActionResult.kind === "reply") {
     await maybeEmitMissingResetHooks();
+    logResolverTiming("completed", "inline_action_reply");
     return inlineActionResult.reply;
   }
   await maybeEmitMissingResetHooks();
@@ -862,6 +926,7 @@ export async function getReplyFromConfig(
         ),
       );
       if (hookResult?.handled) {
+        logResolverTiming("completed", "before_agent_reply_hook");
         return hookResult.reply ?? { text: SILENT_REPLY_TOKEN };
       }
     }
@@ -884,7 +949,8 @@ export async function getReplyFromConfig(
     );
   }
 
-  return await traceGetReplyPhase("reply.run_prepared_reply", () =>
+  logResolverTiming("milestone", "before_run_prepared_reply");
+  const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
     runPreparedReply({
       ctx,
       sessionCtx,
@@ -931,4 +997,6 @@ export async function getReplyFromConfig(
       autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
     }),
   );
+  logResolverTiming("completed", "prepared_reply");
+  return replyResult;
 }

--- a/src/auto-reply/reply/reply-timing-tracker.test.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createReplyTimingTracker, isReplyProfilerEnabled } from "./reply-timing-tracker.js";
+
+describe("isReplyProfilerEnabled", () => {
+  it("matches global and reply profiler diagnostic flags", () => {
+    const cfg = { diagnostics: { flags: ["reply.profiler"] } } as OpenClawConfig;
+    expect(isReplyProfilerEnabled({ config: cfg, env: {} as NodeJS.ProcessEnv })).toBe(true);
+    expect(
+      isReplyProfilerEnabled({
+        env: { OPENCLAW_DIAGNOSTICS: "profiler" } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("createReplyTimingTracker", () => {
+  it("is a pass-through tracker unless the profiler flag is enabled", async () => {
+    const warn = vi.fn();
+    const tracker = createReplyTimingTracker({ log: { warn } });
+
+    expect(tracker.measureSync("sync", () => 42)).toBe(42);
+    await expect(tracker.measure("async", async () => "ok")).resolves.toBe("ok");
+    tracker.logIfSlow({ message: "reply timings" });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("records and logs spans when the profiler flag is enabled", () => {
+    const warn = vi.fn();
+    const tracker = createReplyTimingTracker({
+      log: { warn },
+      env: { OPENCLAW_DIAGNOSTICS: "reply.profiler" } as NodeJS.ProcessEnv,
+      totalWarnMs: 0,
+      stageWarnMs: 0,
+    });
+
+    expect(tracker.measureSync("sync", () => 7)).toBe(7);
+    tracker.logIfSlow({ message: "reply timings", outcome: "completed" });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain("stages=sync:");
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      outcome: "completed",
+      spans: [expect.objectContaining({ name: "sync" })],
+    });
+  });
+});

--- a/src/auto-reply/reply/reply-timing-tracker.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.ts
@@ -1,0 +1,141 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
+
+type ReplyTimingSpan = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+type ReplyTimingSummary = {
+  totalMs: number;
+  spans: ReplyTimingSpan[];
+};
+
+type ReplyTimingLogger = {
+  warn: (message: string, details?: Record<string, unknown>) => void;
+};
+
+type ReplyTimingTracker = {
+  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
+  measureSync: <T>(name: string, run: () => T) => T;
+  logIfSlow: (params: {
+    message: string;
+    outcome?: string;
+    reason?: string;
+    error?: string;
+    details?: Record<string, unknown>;
+  }) => void;
+};
+
+const DEFAULT_TIMING_WARN_TOTAL_MS = 1_000;
+const DEFAULT_TIMING_WARN_STAGE_MS = 500;
+
+export function isReplyProfilerEnabled(params?: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const cfg = params?.config;
+  const env = params?.env ?? process.env;
+  return (
+    isDiagnosticFlagEnabled("profiler", cfg, env) ||
+    isDiagnosticFlagEnabled("reply.profiler", cfg, env)
+  );
+}
+
+export function createReplyTimingTracker(params: {
+  log: ReplyTimingLogger;
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  enabled?: boolean;
+  totalWarnMs?: number;
+  stageWarnMs?: number;
+}): ReplyTimingTracker {
+  const enabled =
+    params.enabled ?? isReplyProfilerEnabled({ config: params.config, env: params.env });
+  if (!enabled) {
+    // Normal production turns use pass-through wrappers so added profiling
+    // calls do not allocate spans or call Date.now on the hot reply path.
+    return {
+      async measure(_name, run) {
+        return await run();
+      },
+      measureSync(_name, run) {
+        return run();
+      },
+      logIfSlow() {},
+    };
+  }
+
+  const startedAt = Date.now();
+  const spans: ReplyTimingSpan[] = [];
+  let didLog = false;
+  const totalWarnMs = params.totalWarnMs ?? DEFAULT_TIMING_WARN_TOTAL_MS;
+  const stageWarnMs = params.stageWarnMs ?? DEFAULT_TIMING_WARN_STAGE_MS;
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  const record = (name: string, spanStartedAt: number) => {
+    spans.push({
+      name,
+      durationMs: toMs(Date.now() - spanStartedAt),
+      elapsedMs: toMs(Date.now() - startedAt),
+    });
+  };
+  const snapshot = (): ReplyTimingSummary => ({
+    totalMs: toMs(Date.now() - startedAt),
+    spans: spans.slice(),
+  });
+  const shouldLog = (summary: ReplyTimingSummary) =>
+    summary.totalMs >= totalWarnMs || summary.spans.some((span) => span.durationMs >= stageWarnMs);
+  const formatSpans = (summary: ReplyTimingSummary) =>
+    summary.spans.length > 0
+      ? summary.spans
+          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+          .join(",")
+      : "none";
+
+  return {
+    async measure(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return await run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    measureSync(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    logIfSlow(logParams) {
+      if (didLog) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      didLog = true;
+      const suffix = [
+        `totalMs=${summary.totalMs}`,
+        `stages=${formatSpans(summary)}`,
+        logParams.outcome ? `outcome=${logParams.outcome}` : undefined,
+        logParams.reason ? `reason=${logParams.reason}` : undefined,
+        logParams.error ? `error="${logParams.error}"` : undefined,
+      ]
+        .filter(Boolean)
+        .join(" ");
+      params.log.warn(`${logParams.message} ${suffix}`, {
+        ...logParams.details,
+        outcome: logParams.outcome,
+        reason: logParams.reason,
+        error: logParams.error,
+        totalMs: summary.totalMs,
+        spans: summary.spans,
+      });
+    },
+  };
+}

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -133,6 +133,24 @@ describe("startGatewayMaintenanceTimers", () => {
     stopMaintenanceTimers(timers);
   });
 
+  it("refreshes automatic health snapshots without live channel probes", async () => {
+    vi.useFakeTimers();
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    deps.refreshGatewayHealthSnapshot = vi.fn(async () => ({ ok: true }) as HealthSummary);
+
+    const timers = startGatewayMaintenanceTimers(deps);
+
+    expect(deps.refreshGatewayHealthSnapshot).toHaveBeenCalledWith({ probe: false });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deps.refreshGatewayHealthSnapshot).toHaveBeenCalledTimes(2);
+    expect(deps.refreshGatewayHealthSnapshot).toHaveBeenLastCalledWith({ probe: false });
+
+    stopMaintenanceTimers(timers);
+  });
+
   it("skips overlapping media cleanup runs", async () => {
     vi.useFakeTimers();
     let resolveCleanup = () => {};

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -72,16 +72,17 @@ export function startGatewayMaintenanceTimers(params: {
     params.nodeSendToAllSubscribed("tick", payload);
   }, TICK_INTERVAL_MS);
 
-  // periodic health refresh to keep cached snapshot warm
+  // Keep cached health warm without request-time live channel probes. Explicit
+  // status/doctor probe paths still pass probe=true when the operator asks.
   const healthInterval = setInterval(() => {
     void params
-      .refreshGatewayHealthSnapshot({ probe: true })
+      .refreshGatewayHealthSnapshot({ probe: false })
       .catch((err) => params.logHealth.error(`refresh failed: ${formatError(err)}`));
   }, HEALTH_REFRESH_INTERVAL_MS);
 
   // Prime cache so first client gets a snapshot without waiting.
   void params
-    .refreshGatewayHealthSnapshot({ probe: true })
+    .refreshGatewayHealthSnapshot({ probe: false })
     .catch((err) => params.logHealth.error(`initial refresh failed: ${formatError(err)}`));
 
   // dedupe cache cleanup

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -199,6 +199,13 @@ function deliveryCall(index = 0): Record<string, any> | undefined {
   return calls[index]?.[0];
 }
 
+function appendTranscriptCall(index = 0): Record<string, any> | undefined {
+  const calls = mocks.appendAssistantMessageToSessionTranscript.mock.calls as unknown as Array<
+    [Record<string, any>]
+  >;
+  return calls[index]?.[0];
+}
+
 function firstRespondCall(respond: ReturnType<typeof vi.fn>) {
   const calls = respond.mock.calls as unknown as Array<
     [
@@ -1453,6 +1460,178 @@ describe("gateway send mirroring", () => {
       idempotencyKey: "idem-caption-source-message-action",
       config: {},
     });
+  });
+
+  it("waits for source transcript mirroring before responding to message.action", async () => {
+    const telegramPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram async source send transcript mirror test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async () => jsonResult({ ok: true, messageId: "tg-async-1" }),
+      },
+    };
+    const mirrorDeferred = createDeferred<{ ok: boolean; sessionFile: string }>();
+    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+      "send-test-source-message-action-async-mirror",
+    );
+    mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
+      jsonResult({ ok: true, messageId: "tg-async-1" }),
+    );
+    mocks.appendAssistantMessageToSessionTranscript.mockReturnValueOnce(mirrorDeferred.promise);
+
+    const respond = vi.fn();
+    const request = sendHandlers["message.action"]({
+      params: {
+        channel: "telegram",
+        action: "send",
+        params: {
+          to: "chat-123",
+          message: "visible media caption",
+        },
+        sessionKey: "agent:main:telegram:direct:chat-123",
+        agentId: "main",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "chat-123",
+        },
+        idempotencyKey: "idem-async-source-message-action",
+      } as never,
+      respond,
+      context: makeContext(),
+      req: { type: "req", id: "1", method: "message.action" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+    });
+    expect(respond).not.toHaveBeenCalled();
+
+    mirrorDeferred.resolve({ ok: true, sessionFile: "x" });
+    await request;
+
+    expect(firstRespondCall(respond)[0]).toBe(true);
+  });
+
+  it("preserves source transcript mirror order before message.action responses", async () => {
+    const telegramPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram ordered async source send transcript mirror test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async () => jsonResult({ ok: true, messageId: "tg-ordered" }),
+      },
+    };
+    const firstMirrorDeferred = createDeferred<{ ok: boolean; sessionFile: string }>();
+    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+      "send-test-source-message-action-ordered-async-mirror",
+    );
+    mocks.dispatchChannelMessageAction.mockResolvedValue(
+      jsonResult({ ok: true, messageId: "tg-ordered" }),
+    );
+    mocks.appendAssistantMessageToSessionTranscript
+      .mockReturnValueOnce(firstMirrorDeferred.promise)
+      .mockResolvedValueOnce({ ok: true, sessionFile: "x" });
+
+    const firstRespond = vi.fn();
+    const secondRespond = vi.fn();
+    const first = sendHandlers["message.action"]({
+      params: {
+        channel: "telegram",
+        action: "send",
+        params: {
+          to: "chat-123",
+          message: "first visible reply",
+        },
+        sessionKey: "agent:main:telegram:direct:chat-123",
+        agentId: "main",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "chat-123",
+        },
+        idempotencyKey: "idem-ordered-source-message-action-1",
+      } as never,
+      respond: firstRespond,
+      context: makeContext(),
+      req: { type: "req", id: "1", method: "message.action" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+    await vi.waitFor(() => {
+      expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+    });
+    const second = sendHandlers["message.action"]({
+      params: {
+        channel: "telegram",
+        action: "send",
+        params: {
+          to: "chat-123",
+          message: "second visible reply",
+        },
+        sessionKey: "agent:main:telegram:direct:chat-123",
+        agentId: "main",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "chat-123",
+        },
+        idempotencyKey: "idem-ordered-source-message-action-2",
+      } as never,
+      respond: secondRespond,
+      context: makeContext(),
+      req: { type: "req", id: "2", method: "message.action" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+    expect(firstRespond).not.toHaveBeenCalled();
+    expect(secondRespond).not.toHaveBeenCalled();
+    expect(appendTranscriptCall(0)).toEqual(
+      expect.objectContaining({ text: "first visible reply" }),
+    );
+
+    firstMirrorDeferred.resolve({ ok: true, sessionFile: "x" });
+    await first;
+    await second;
+
+    expect(firstRespondCall(firstRespond)[0]).toBe(true);
+    expect(firstRespondCall(secondRespond)[0]).toBe(true);
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(2);
+    expect(appendTranscriptCall(1)).toEqual(
+      expect.objectContaining({ text: "second visible reply" }),
+    );
   });
 
   it("mirrors presentation-only source-conversation message.action sends", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -288,6 +288,37 @@ async function mirrorDeliveredSourceReplyToTranscriptBestEffort(params: {
   }
 }
 
+const sourceReplyTranscriptMirrorQueues = new Map<string, Promise<void>>();
+
+function resolveSourceReplyTranscriptMirrorQueueKey(
+  mirror: Parameters<typeof mirrorDeliveredSourceReplyToTranscript>[0],
+): string {
+  return mirror.sessionKey?.trim() || "__global__";
+}
+
+function scheduleDeliveredSourceReplyTranscriptMirror(params: {
+  context: GatewayRequestContext;
+  mirror: Parameters<typeof mirrorDeliveredSourceReplyToTranscript>[0];
+}): Promise<void> {
+  const queueKey = resolveSourceReplyTranscriptMirrorQueueKey(params.mirror);
+  const previous = sourceReplyTranscriptMirrorQueues.get(queueKey);
+  // Queue per session so current-conversation source replies are visible before
+  // a following turn can read the transcript.
+  const queued = (async () => {
+    await previous?.catch(() => undefined);
+    await mirrorDeliveredSourceReplyToTranscriptBestEffort(params);
+  })();
+  sourceReplyTranscriptMirrorQueues.set(queueKey, queued);
+  void queued
+    .finally(() => {
+      if (sourceReplyTranscriptMirrorQueues.get(queueKey) === queued) {
+        sourceReplyTranscriptMirrorQueues.delete(queueKey);
+      }
+    })
+    .catch(() => undefined);
+  return queued;
+}
+
 export const sendHandlers: GatewayRequestHandlers = {
   "message.action": async ({ params, respond, context, client }) => {
     const p = params;
@@ -399,7 +430,7 @@ export const sendHandlers: GatewayRequestHandlers = {
         const agentId =
           normalizeOptionalString(request.agentId) ??
           (sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined);
-        await mirrorDeliveredSourceReplyToTranscriptBestEffort({
+        await scheduleDeliveredSourceReplyTranscriptMirror({
           context,
           mirror: {
             action: request.action,

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -224,7 +224,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     expect(hello.ok).toBe(true);
 
     await vi.waitFor(() => {
-      expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: true });
+      expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: false });
     });
     resolveRefresh?.();
   });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1776,7 +1776,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           presence: snapshot.presence.length,
           stateVersion: snapshot.stateVersion.presence,
         });
-        void refreshHealthSnapshot({ probe: true }).catch((err) =>
+        // Post-connect refresh only needs a cached/config snapshot for UI state;
+        // live channel probes here pulled slow Discord/Telegram HTTP checks into
+        // reply-adjacent websocket handshakes.
+        void refreshHealthSnapshot({ probe: false }).catch((err) =>
           logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
         );
         return;

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -250,6 +250,78 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     });
   });
 
+  it("returns requests-in-flight when another session for the same agent has an active reply run", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      const listActiveReplyRunSessionKeys = vi.fn(() => [
+        "agent:main:telegram:group:-1003966283270:topic:547",
+      ]);
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: vi.fn((_lane?: string) => 0),
+          listActiveReplyRunSessionKeys,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+      expect(listActiveReplyRunSessionKeys).toHaveBeenCalledOnce();
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("ignores unscoped active reply runs when checking same-agent heartbeat work", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      const listActiveReplyRunSessionKeys = vi.fn(() => ["legacy-session-key"]);
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: vi.fn((_lane?: string) => 0),
+          listActiveReplyRunSessionKeys,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("ran");
+      expect(listActiveReplyRunSessionKeys).toHaveBeenCalledOnce();
+      expect(replySpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("does not defer immediate heartbeat wakes for another active session", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      const listActiveReplyRunSessionKeys = vi.fn(() => [
+        "agent:main:telegram:group:-1003966283270:topic:547",
+      ]);
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        intent: "immediate",
+        deps: {
+          getQueueSize: vi.fn((_lane?: string) => 0),
+          listActiveReplyRunSessionKeys,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledOnce();
+    });
+  });
+
   it("does not defer on a recent heartbeat ack pending final delivery", async () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -36,7 +36,10 @@ import {
 } from "../auto-reply/heartbeat.js";
 import { replaceGenericExternalRunFailureText } from "../auto-reply/reply/agent-runner-failure-copy.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
-import { replyRunRegistry } from "../auto-reply/reply/reply-run-registry.js";
+import {
+  listActiveReplyRunSessionKeys,
+  replyRunRegistry,
+} from "../auto-reply/reply/reply-run-registry.js";
 import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
@@ -148,6 +151,7 @@ export type HeartbeatDeps = OutboundSendDeps &
     getQueueSize?: (lane?: string) => number;
     getCommandLaneSnapshots?: () => readonly CommandLaneSnapshot[];
     isReplyRunActive?: (sessionKey: string) => boolean;
+    listActiveReplyRunSessionKeys?: () => readonly string[];
     nowMs?: () => number;
   };
 
@@ -219,6 +223,17 @@ function hasAgentOptInBusyLaneWork(
   getSnapshots: () => readonly CommandLaneSnapshot[],
 ): boolean {
   return hasQueuedWorkInLaneSnapshots(getSnapshots(), (lane) => laneBelongsToAgent(lane, agentId));
+}
+
+function hasActiveReplyRunForAgent(
+  agentId: string,
+  listSessionKeys: () => readonly string[],
+): boolean {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  return listSessionKeys().some((sessionKey) => {
+    const parsed = parseAgentSessionKey(sessionKey);
+    return parsed ? normalizeAgentId(parsed.agentId) === normalizedAgentId : false;
+  });
 }
 
 function resolveHeartbeatChannelPlugin(channel: string): ChannelPlugin | undefined {
@@ -1343,6 +1358,21 @@ export async function runHeartbeatOnce(opts: {
       durationMs: Date.now() - startedAt,
     });
     return { status: "skipped", reason: HEARTBEAT_SKIP_LANES_BUSY };
+  }
+
+  const shouldHonorActiveReplyRuns = opts.intent !== "immediate" && opts.intent !== "manual";
+  const listActiveReplyRuns =
+    opts.deps?.listActiveReplyRunSessionKeys ?? listActiveReplyRunSessionKeys;
+  // Scheduled heartbeats are background work, so defer them when any session on
+  // the same agent is already replying; immediate/manual wakes keep their
+  // existing semantics for explicit user/system actions.
+  if (shouldHonorActiveReplyRuns && hasActiveReplyRunForAgent(agentId, listActiveReplyRuns)) {
+    emitHeartbeatEvent({
+      status: "skipped",
+      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+      durationMs: Date.now() - startedAt,
+    });
+    return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
   }
 
   // Phase 2: Stronger heartbeat deferral while a final delivery replay is pending.


### PR DESCRIPTION
## Summary

This extracts the reply-delivery latency work from #85941 into a focused PR.

- reduce visible reply send latency by moving delivery and follow-up scheduling onto narrower reply phases
- add reply timing tracking for delivery/dispatch diagnostics
- update ACP delivery, config dispatch, gateway send, gateway maintenance, and heartbeat busy-lane behavior around active replies
- add focused coverage for dispatch timing, gateway send behavior, and heartbeat lane skipping
- keep the original contributor commit author: Keshav's Bot <keshavbotagent@gmail.com>

Split from #85941 so the largest and riskiest reply pipeline change can be reviewed on its own. Thanks @keshavbotagent for the original work.

## Verification

- `git diff --check origin/main...origin/codex/split-85941-reply-latency`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` on the grouped source branch before this split: clean

## Real behavior proof

Behavior addressed: visible reply delivery work is separated from slower follow-up/maintenance phases so user-facing replies can be sent earlier.
Real environment tested: local source checkout on fresh `origin/main` split branch plus grouped source branch before extraction.
Exact steps or command run after this patch: `git diff --check origin/main...origin/codex/split-85941-reply-latency`; grouped source proof ran autoreview.
Evidence after fix: split branch cherry-picked cleanly onto current `origin/main`; whitespace/conflict sanity passed; grouped source branch autoreview reported no accepted/actionable findings.
Observed result after fix: no diff-check errors; commit author preserved as Keshav's Bot <keshavbotagent@gmail.com>.
What was not tested: focused reply-delivery Vitest, gateway E2E, and live reply timing were not rerun after the split; CI should run the normal PR gates.
