### PR TITLE
fix(agents): keep runtime context before active user turns

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -8483,6 +8483,23 @@ describe("runCodexAppServerAttempt", () => {
     ]);
   });
 
+  it("rejects default queued steering after terminal notification is queued", async () => {
+    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+    );
+    await waitForMethod("turn/start");
+
+    const completed = completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    expect(queueActiveRunMessageForTest("session-1", "too late", { debounceMs: 0 })).toBe(false);
+
+    await completed;
+    await run;
+
+    expect(requests.filter((entry) => entry.method === "turn/steer")).toEqual([]);
+  });
+
   it("batches explicit all-mode steering before sending turn/steer", async () => {
     const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3248,7 +3248,7 @@ export async function runCodexAppServerAttempt(
     kind: "embedded" as const,
     queueMessage: async (text: string, options?: CodexSteeringQueueOptions) =>
       activeSteeringQueue.queue(text, options),
-    isStreaming: () => !completed,
+    isStreaming: () => !completed && !terminalTurnNotificationQueued,
     isCompacting: () => projector?.isCompacting() ?? false,
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     cancel: () => runAbortController.abort("cancelled"),

--- a/scripts/e2e/session-runtime-context-docker-client.ts
+++ b/scripts/e2e/session-runtime-context-docker-client.ts
@@ -7,7 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import {
-  queueRuntimeContextForNextTurn,
+  buildRuntimeContextCustomMessage,
   resolveRuntimeContextPromptParts,
 } from "../../dist/agents/pi-embedded-runner/run/runtime-context-prompt.js";
 
@@ -74,20 +74,8 @@ async function verifyRuntimeContextTranscriptShape(root: string) {
     "runtime context was not extracted",
   );
 
-  await queueRuntimeContextForNextTurn({
-    runtimeContext: promptSubmission.runtimeContext,
-    session: {
-      sendCustomMessage: async (message, options) => {
-        assert(options?.deliverAs === "nextTurn", "runtime context was not queued for next turn");
-        sessionManager.appendCustomMessageEntry(
-          message.customType,
-          message.content,
-          message.display,
-          message.details,
-        );
-      },
-    },
-  });
+  const runtimeContextMessage = buildRuntimeContextCustomMessage(promptSubmission.runtimeContext);
+  assert(runtimeContextMessage, "runtime custom message was not built");
   sessionManager.appendMessage({
     role: "user",
     content: promptSubmission.prompt,
@@ -101,11 +89,14 @@ async function verifyRuntimeContextTranscriptShape(root: string) {
 
   const entries = await readJsonl(sessionFile);
   const customEntry = entries.find((entry) => entry.type === "custom_message");
-  assert(customEntry, "hidden runtime custom message was not persisted");
-  assert(customEntry.customType === "openclaw.runtime-context", "unexpected custom message type");
-  assert(customEntry.display === false, "runtime custom message should be hidden");
+  assert(!customEntry, "runtime custom message should not be persisted without its user turn");
   assert(
-    customEntry.content?.includes("secret docker context"),
+    runtimeContextMessage.customType === "openclaw.runtime-context",
+    "unexpected custom message type",
+  );
+  assert(runtimeContextMessage.display === false, "runtime custom message should be hidden");
+  assert(
+    runtimeContextMessage.content.includes("secret docker context"),
     "runtime custom message lost context",
   );
 

--- a/scripts/e2e/session-runtime-context-docker-client.ts
+++ b/scripts/e2e/session-runtime-context-docker-client.ts
@@ -94,7 +94,7 @@ async function verifyRuntimeContextTranscriptShape(root: string) {
     runtimeContextMessage.customType === "openclaw.runtime-context",
     "unexpected custom message type",
   );
-  assert(runtimeContextMessage.display === false, "runtime custom message should be hidden");
+  assert(!runtimeContextMessage.display, "runtime custom message should be hidden");
   assert(
     runtimeContextMessage.content.includes("secret docker context"),
     "runtime custom message lost context",

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -244,7 +244,7 @@ function isUserMessage(message: unknown): boolean {
   );
 }
 
-/** Removes stale runtime-context custom messages while preserving current-turn context. */
+/** Keeps only current-turn runtime context positioned immediately before the active user. */
 export function stripHistoricalRuntimeContextCustomMessages<T>(messages: T[]): T[] {
   if (!messages.some(isOpenClawRuntimeContextCustomMessage)) {
     return messages;
@@ -253,7 +253,17 @@ export function stripHistoricalRuntimeContextCustomMessages<T>(messages: T[]): T
   if (lastUserIndex === -1) {
     return messages.filter((message) => !isOpenClawRuntimeContextCustomMessage(message));
   }
-  return messages.filter(
-    (message, index) => !isOpenClawRuntimeContextCustomMessage(message) || index > lastUserIndex,
-  );
+  const currentRuntimeContextIndexes = new Set<number>();
+  for (let index = lastUserIndex - 1; index >= 0; index -= 1) {
+    if (!isOpenClawRuntimeContextCustomMessage(messages[index])) {
+      break;
+    }
+    currentRuntimeContextIndexes.add(index);
+  }
+  return messages.filter((message, index) => {
+    if (!isOpenClawRuntimeContextCustomMessage(message)) {
+      return true;
+    }
+    return currentRuntimeContextIndexes.has(index);
+  });
 }

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -344,7 +344,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     ]);
   });
 
-  it("sends transcriptPrompt visibly and queues runtime context as hidden custom context", async () => {
+  it("sends transcriptPrompt visibly and keeps runtime context out of transcript messages", async () => {
     const seen: { prompt?: string; messages?: unknown[]; systemPrompt?: string } = {};
 
     const result = await createContextEngineAttemptRunner({
@@ -385,16 +385,12 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         role: "custom",
         customType: "openclaw.runtime-context",
         display: false,
-        content:
-          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nsecret runtime context\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
       },
     );
-    expect(JSON.stringify(seen.messages)).not.toContain(
-      "OpenClaw runtime context for the immediately preceding user message.",
-    );
-    expect(JSON.stringify(seen.messages)).not.toContain("not user-authored");
     expect(seen.systemPrompt).not.toContain("secret runtime context");
-    expect(seen.systemPrompt).not.toContain("OPENCLAW_INTERNAL_CONTEXT");
+    expect(JSON.stringify(seen.messages)).not.toContain(
+      "visible ask",
+    );
     const trajectoryEvents = (
       await fs.readFile(path.join(tempPaths[0] ?? "", "session.trajectory.jsonl"), "utf8")
     )
@@ -761,7 +757,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     });
   });
 
-  it("keeps before_prompt_build prependContext out of system prompt on transcriptPrompt runs", async () => {
+  it("keeps before_prompt_build prependContext out of post-user transcript messages", async () => {
     const runBeforePromptBuild = vi.fn(async () => ({ prependContext: "dynamic hook context" }));
     hoisted.getGlobalHookRunnerMock.mockReturnValue({
       hasHooks: vi.fn((name: string) => name === "before_prompt_build"),
@@ -802,7 +798,12 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         role: "custom",
         customType: "openclaw.runtime-context",
         display: false,
-        content: "dynamic hook context",
+        content: [
+          "OpenClaw runtime context for the immediately preceding user message.",
+          "This context is runtime-generated, not user-authored. Keep internal details private.",
+          "",
+          "dynamic hook context",
+        ].join("\n"),
       },
     );
   });
@@ -1062,7 +1063,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   });
 
   it("keeps inter-session provenance hidden while submitting the visible prompt", async () => {
-    const seen: { prompt?: string; messages?: unknown[] } = {};
+    const seen: { prompt?: string; messages?: unknown[]; systemPrompt?: string } = {};
 
     const result = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
@@ -1086,6 +1087,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       sessionPrompt: async (session, prompt) => {
         seen.prompt = prompt;
         seen.messages = [...session.messages];
+        seen.systemPrompt = session.agent.state.systemPrompt;
         session.messages = [
           ...session.messages,
           { role: "assistant", content: "done", timestamp: 2 },
@@ -1097,9 +1099,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(result.finalPromptText).toBe("visible ask");
     const runtimeContext = findRecord(
       requireRecords(seen.messages, "seen messages"),
-      (message) => message.customType === "openclaw.runtime-context",
+        (message) => message.customType === "openclaw.runtime-context",
       "runtime context message",
     );
+    expect(seen.systemPrompt).not.toContain("[Inter-session message]");
     expect(runtimeContext.content).toContain("[Inter-session message]");
     expect(runtimeContext.content).toContain("isUser=false");
     expect(runtimeContext.content).not.toContain("visible ask");

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -1077,7 +1077,9 @@ export function createDefaultEmbeddedSession(params?: {
           { role: "custom", timestamp: 1, ...message },
           { role: "assistant", content: "done", timestamp: 2 },
         ];
+        return;
       }
+      session.messages = [...session.messages, { role: "custom", timestamp: 1, ...message }];
     },
     abort: async () => {},
     dispose: () => {},

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -479,6 +479,55 @@ describe("normalizeMessagesForLlmBoundary", () => {
     expect(output.some((item) => item.customType === "other-extension-context")).toBe(true);
   });
 
+  it("keeps overflow retry runtime context immediately before the active user", () => {
+    const rebuiltAfterOverflow = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "old ask" }],
+        timestamp: 0,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "old answer" }],
+        timestamp: 1,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry ask" }],
+        timestamp: 2,
+      },
+    ];
+    const runtimeContext = {
+      role: "custom",
+      customType: "openclaw.runtime-context",
+      content: "retry runtime context",
+      display: false,
+      timestamp: 3,
+    };
+
+    const retryMessages = attemptTesting.insertRuntimeContextMessageForPrompt({
+      message: runtimeContext as Parameters<
+        typeof attemptTesting.insertRuntimeContextMessageForPrompt
+      >[0]["message"],
+      messages: rebuiltAfterOverflow as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    });
+    const retryInput = normalizeMessagesForLlmBoundary(retryMessages) as unknown as Array<
+      Record<string, unknown>
+    >;
+
+    expect(retryInput.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "custom",
+      "user",
+    ]);
+    expect(retryInput[2]).toMatchObject({
+      customType: "openclaw.runtime-context",
+      content: "retry runtime context",
+    });
+    expect(retryInput[3]?.content).toEqual([{ type: "text", text: "retry ask" }]);
+  });
+
   it("keeps only safe blocked metadata at the LLM boundary", () => {
     const input = [
       {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -429,33 +429,43 @@ describe("normalizeMessagesForLlmBoundary", () => {
     expect(input[0]).toHaveProperty("details");
   });
 
-  it("keeps historical runtime-context transcript entries out of the LLM boundary", () => {
+  it("keeps only pre-user current-turn runtime context at the LLM boundary", () => {
     const input = [
       {
-        role: "custom",
-        customType: "openclaw.runtime-context",
-        content: "old secret runtime context",
-        display: false,
+        role: "user",
+        content: [{ type: "text", text: "old ask" }],
         timestamp: 0,
       },
       {
-        role: "user",
-        content: [{ type: "text", text: "visible ask" }],
+        role: "assistant",
+        content: [{ type: "text", text: "old answer" }],
         timestamp: 1,
       },
       {
         role: "custom",
         customType: "openclaw.runtime-context",
-        content: "secret runtime context",
+        content: "current secret runtime context",
         display: false,
         timestamp: 2,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "visible ask" }],
+        timestamp: 3,
+      },
+      {
+        role: "custom",
+        customType: "openclaw.runtime-context",
+        content: "post-user stale runtime context",
+        display: false,
+        timestamp: 4,
       },
       {
         role: "custom",
         customType: "other-extension-context",
         content: "normal custom context",
         display: false,
-        timestamp: 3,
+        timestamp: 5,
       },
     ];
 
@@ -463,9 +473,9 @@ describe("normalizeMessagesForLlmBoundary", () => {
       input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
     ) as unknown as Array<Record<string, unknown>>;
 
-    expect(output).toHaveLength(3);
-    expect(output.some((item) => item.content === "old secret runtime context")).toBe(false);
-    expect(output.some((item) => item.content === "secret runtime context")).toBe(true);
+    expect(output).toHaveLength(5);
+    expect(output.some((item) => item.content === "current secret runtime context")).toBe(true);
+    expect(output.some((item) => item.content === "post-user stale runtime context")).toBe(false);
     expect(output.some((item) => item.customType === "other-extension-context")).toBe(true);
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -528,6 +528,49 @@ describe("normalizeMessagesForLlmBoundary", () => {
     expect(retryInput[3]?.content).toEqual([{ type: "text", text: "retry ask" }]);
   });
 
+  it("keeps prompt-local runtime context before the active user in existing sessions", () => {
+    const promptInput = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "old ask" }],
+        timestamp: 0,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "old answer" }],
+        timestamp: 1,
+      },
+      {
+        role: "custom",
+        customType: "openclaw.runtime-context",
+        content: "current runtime context",
+        display: false,
+        timestamp: 2,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "visible ask" }],
+        timestamp: 3,
+      },
+    ];
+
+    const modelInput = normalizeMessagesForLlmBoundary(
+      promptInput as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<Record<string, unknown>>;
+
+    expect(modelInput.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "custom",
+      "user",
+    ]);
+    expect(modelInput[2]).toMatchObject({
+      customType: "openclaw.runtime-context",
+      content: "current runtime context",
+    });
+    expect(modelInput[3]?.content).toEqual([{ type: "text", text: "visible ask" }]);
+  });
+
   it("keeps only safe blocked metadata at the LLM boundary", () => {
     const input = [
       {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1024,7 +1024,15 @@ function installRuntimeContextMessageForPrompt(params: {
   if (!message) {
     return () => undefined;
   }
-  const install = () => {
+  const installBeforePrompt = () => {
+    if (!session.messages.includes(message)) {
+      session.agent.state.messages = appendRuntimeContextMessageForPrompt({
+        message,
+        messages: session.messages,
+      });
+    }
+  };
+  const installBeforeRetry = () => {
     if (!session.messages.includes(message)) {
       session.agent.state.messages = insertRuntimeContextMessageForPrompt({
         message,
@@ -1032,18 +1040,33 @@ function installRuntimeContextMessageForPrompt(params: {
       });
     }
   };
-  install();
+  installBeforePrompt();
   const agent = session.agent;
-  const originalContinue = Reflect.get(agent, "continue", agent).bind(agent) as () => Promise<void>;
-  agent.continue = function continueWithRuntimeContext(this: typeof agent): Promise<void> {
-    // Pi overflow recovery can rebuild state from the persisted branch before retrying.
-    install();
-    return originalContinue();
-  };
+  const originalContinue = Reflect.get(agent, "continue", agent) as unknown;
+  if (typeof originalContinue === "function") {
+    const continueWithAgent = originalContinue.bind(agent) as () => Promise<void>;
+    agent.continue = function continueWithRuntimeContext(this: typeof agent): Promise<void> {
+      // Pi overflow recovery can rebuild state from the persisted branch before retrying.
+      installBeforeRetry();
+      return continueWithAgent();
+    };
+  }
   return () => {
-    agent.continue = originalContinue;
+    if (typeof originalContinue === "function") {
+      agent.continue = originalContinue as typeof agent.continue;
+    }
     session.agent.state.messages = session.messages.filter((candidate) => candidate !== message);
   };
+}
+
+function appendRuntimeContextMessageForPrompt(params: {
+  message: RuntimeContextCustomMessage;
+  messages: AgentMessage[];
+}): AgentMessage[] {
+  if (params.messages.includes(params.message)) {
+    return params.messages;
+  }
+  return [...params.messages, params.message];
 }
 
 function insertRuntimeContextMessageForPrompt(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -865,6 +865,7 @@ async function cancelQueuedSteeringMessage(
 
 export const testing = {
   cancelQueuedSteeringMessage,
+  insertRuntimeContextMessageForPrompt,
   resolveEmbeddedAttemptSessionWriteLockOptions,
   resolveAttemptStreamAuthProfileId,
   steerAndWaitForTranscriptCommit,
@@ -1025,7 +1026,10 @@ function installRuntimeContextMessageForPrompt(params: {
   }
   const install = () => {
     if (!session.messages.includes(message)) {
-      session.agent.state.messages = [...session.messages, message];
+      session.agent.state.messages = insertRuntimeContextMessageForPrompt({
+        message,
+        messages: session.messages,
+      });
     }
   };
   install();
@@ -1040,6 +1044,24 @@ function installRuntimeContextMessageForPrompt(params: {
     agent.continue = originalContinue;
     session.agent.state.messages = session.messages.filter((candidate) => candidate !== message);
   };
+}
+
+function insertRuntimeContextMessageForPrompt(params: {
+  message: RuntimeContextCustomMessage;
+  messages: AgentMessage[];
+}): AgentMessage[] {
+  if (params.messages.includes(params.message)) {
+    return params.messages;
+  }
+  const activeUserMessageIndex = findActiveUserMessageIndex(params.messages);
+  if (activeUserMessageIndex === -1) {
+    return [...params.messages, params.message];
+  }
+  return [
+    ...params.messages.slice(0, activeUserMessageIndex),
+    params.message,
+    ...params.messages.slice(activeUserMessageIndex),
+  ];
 }
 
 function stripHistoricalInboundMetadataFromUserMessages(messages: AgentMessage[]): AgentMessage[] {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1034,11 +1034,11 @@ function installRuntimeContextMessageForPrompt(params: {
   };
   install();
   const agent = session.agent;
-  const originalContinue = agent.continue;
+  const originalContinue = Reflect.get(agent, "continue", agent).bind(agent) as () => Promise<void>;
   agent.continue = function continueWithRuntimeContext(this: typeof agent): Promise<void> {
     // Pi overflow recovery can rebuild state from the persisted branch before retrying.
     install();
-    return originalContinue.call(this);
+    return originalContinue();
   };
   return () => {
     agent.continue = originalContinue;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1019,36 +1019,26 @@ function installRuntimeContextMessageForPrompt(params: {
   session: AgentSession;
   message?: RuntimeContextCustomMessage;
 }): () => void {
-  if (!params.message) {
+  const { message, session } = params;
+  if (!message) {
     return () => undefined;
   }
   const install = () => {
-    if (!params.session.messages.includes(params.message)) {
-      params.session.agent.state.messages = [...params.session.messages, params.message];
+    if (!session.messages.includes(message)) {
+      session.agent.state.messages = [...session.messages, message];
     }
   };
   install();
-  const agentWithContinue = params.session.agent as typeof params.session.agent & {
-    continue?: (...args: unknown[]) => unknown;
+  const agent = session.agent;
+  const originalContinue = agent.continue;
+  agent.continue = function continueWithRuntimeContext(this: typeof agent): Promise<void> {
+    // Pi overflow recovery can rebuild state from the persisted branch before retrying.
+    install();
+    return originalContinue.call(this);
   };
-  const originalContinue = agentWithContinue.continue;
-  if (originalContinue) {
-    agentWithContinue.continue = function continueWithRuntimeContext(
-      this: typeof params.session.agent,
-      ...args: unknown[]
-    ): unknown {
-      // Pi overflow recovery can rebuild state from the persisted branch before retrying.
-      install();
-      return originalContinue.apply(this, args);
-    };
-  }
   return () => {
-    if (originalContinue) {
-      agentWithContinue.continue = originalContinue;
-    }
-    params.session.agent.state.messages = params.session.messages.filter(
-      (message) => message !== params.message,
-    );
+    agent.continue = originalContinue;
+    session.agent.state.messages = session.messages.filter((candidate) => candidate !== message);
   };
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
+import {
+  createAgentSession,
+  type AgentSession,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
 import { isAcpRuntimeSpawnAvailable } from "../../../acp/runtime/availability.js";
 import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
 import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
@@ -413,8 +417,8 @@ import {
 } from "./preemptive-compaction.js";
 import {
   buildCurrentInboundPrompt,
-  buildRuntimeContextSystemContext,
-  queueRuntimeContextForNextTurn,
+  buildRuntimeContextCustomMessage,
+  type RuntimeContextCustomMessage,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
@@ -997,6 +1001,55 @@ export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): Agent
   const withoutHistoricalInboundMetadata =
     stripHistoricalInboundMetadataFromUserMessages(normalized);
   return stripHistoricalRuntimeContextCustomMessages(withoutHistoricalInboundMetadata);
+}
+
+function normalizeMessagesForCurrentPromptBoundary(params: {
+  messages: AgentMessage[];
+  prompt: string;
+}): AgentMessage[] {
+  const promptMessage = {
+    role: "user" as const,
+    content: [{ type: "text" as const, text: params.prompt }],
+    timestamp: Date.now(),
+  };
+  return normalizeMessagesForLlmBoundary([...params.messages, promptMessage]).slice(0, -1);
+}
+
+function installRuntimeContextMessageForPrompt(params: {
+  session: AgentSession;
+  message?: RuntimeContextCustomMessage;
+}): () => void {
+  if (!params.message) {
+    return () => undefined;
+  }
+  const install = () => {
+    if (!params.session.messages.includes(params.message)) {
+      params.session.agent.state.messages = [...params.session.messages, params.message];
+    }
+  };
+  install();
+  const agentWithContinue = params.session.agent as typeof params.session.agent & {
+    continue?: (...args: unknown[]) => unknown;
+  };
+  const originalContinue = agentWithContinue.continue;
+  if (originalContinue) {
+    agentWithContinue.continue = function continueWithRuntimeContext(
+      this: typeof params.session.agent,
+      ...args: unknown[]
+    ): unknown {
+      // Pi overflow recovery can rebuild state from the persisted branch before retrying.
+      install();
+      return originalContinue.apply(this, args);
+    };
+  }
+  return () => {
+    if (originalContinue) {
+      agentWithContinue.continue = originalContinue;
+    }
+    params.session.agent.state.messages = params.session.messages.filter(
+      (message) => message !== params.message,
+    );
+  };
 }
 
 function stripHistoricalInboundMetadataFromUserMessages(messages: AgentMessage[]): AgentMessage[] {
@@ -4008,12 +4061,15 @@ export async function runEmbeddedAttempt(
           const runtimeContextForHook = promptSubmission.runtimeOnly
             ? undefined
             : promptSubmission.runtimeContext?.trim();
-          const runtimeSystemPromptForHook = runtimeContextForHook
-            ? composeSystemPromptWithHookContext({
-                baseSystemPrompt: systemPromptText,
-                appendSystemContext: buildRuntimeContextSystemContext(runtimeContextForHook),
-              })
-            : undefined;
+          const runtimeContextMessageForCurrentTurn =
+            buildRuntimeContextCustomMessage(runtimeContextForHook);
+          const messagesForCurrentPrompt = runtimeContextMessageForCurrentTurn
+            ? [...activeSession.messages, runtimeContextMessageForCurrentTurn]
+            : activeSession.messages;
+          const hookMessagesForCurrentPrompt = normalizeMessagesForCurrentPromptBoundary({
+            messages: messagesForCurrentPrompt,
+            prompt: promptForModel,
+          });
           if (systemPromptReport) {
             systemPromptReport.currentTurn = {
               ...(params.currentInboundEventKind ? { kind: params.currentInboundEventKind } : {}),
@@ -4023,7 +4079,7 @@ export async function runEmbeddedAttempt(
                 : (runtimeContextForHook?.length ?? 0),
             };
           }
-          const systemPromptForHook = runtimeSystemPromptForHook ?? systemPromptText;
+          const systemPromptForHook = systemPromptText;
 
           const persistBlockedBeforeAgentRun = async (block: {
             message: string;
@@ -4065,9 +4121,7 @@ export async function runEmbeddedAttempt(
           };
 
           if (hookRunner?.hasHooks("before_agent_run")) {
-            const beforeRunMessages = cloneHookMessages(
-              normalizeMessagesForLlmBoundary(activeSession.messages),
-            );
+            const beforeRunMessages = cloneHookMessages(hookMessagesForCurrentPrompt);
             let beforeRunResult:
               | Awaited<ReturnType<NonNullable<typeof hookRunner>["runBeforeAgentRun"]>>
               | undefined;
@@ -4298,9 +4352,7 @@ export async function runEmbeddedAttempt(
                   model: params.modelId,
                   systemPrompt: systemPromptForHook,
                   prompt: promptForModel,
-                  historyMessages: cloneHookMessages(
-                    normalizeMessagesForLlmBoundary(activeSession.messages),
-                  ),
+                  historyMessages: cloneHookMessages(hookMessagesForCurrentPrompt),
                   imagesCount: imageResult.images.length,
                   tools: tools,
                 },
@@ -4323,7 +4375,7 @@ export async function runEmbeddedAttempt(
           const preemptiveCompaction = skipPromptSubmission
             ? null
             : shouldPreemptivelyCompactBeforePrompt({
-                messages: activeSession.messages,
+                messages: messagesForCurrentPrompt,
                 ...(contextEnginePromptAuthority === "preassembly_may_overflow"
                   ? { unwindowedMessages: unwindowedContextEngineMessagesForPrecheck }
                   : {}),
@@ -4459,17 +4511,20 @@ export async function runEmbeddedAttempt(
             if (promptSubmission.runtimeOnly) {
               await promptActiveSession(promptForModel);
             } else {
-              await queueRuntimeContextForNextTurn({
+              const cleanupRuntimeContextMessage = installRuntimeContextMessageForPrompt({
                 session: activeSession,
-                runtimeContext: runtimeContextForHook,
+                message: runtimeContextMessageForCurrentTurn,
               });
-
-              // Only pass images option if there are actually images to pass
-              // This avoids potential issues with models that don't expect the images parameter
-              if (imageResult.images.length > 0) {
-                await promptActiveSession(promptForModel, { images: imageResult.images });
-              } else {
-                await promptActiveSession(promptForModel);
+              try {
+                // Only pass images option if there are actually images to pass
+                // This avoids potential issues with models that don't expect the images parameter
+                if (imageResult.images.length > 0) {
+                  await promptActiveSession(promptForModel, { images: imageResult.images });
+                } else {
+                  await promptActiveSession(promptForModel);
+                }
+              } finally {
+                cleanupRuntimeContextMessage();
               }
             }
           }

--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   buildCurrentInboundPrompt,
   buildCurrentInboundPromptContextPrefix,
+  buildRuntimeContextCustomMessage,
   buildRuntimeContextSystemContext,
-  queueRuntimeContextForNextTurn,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
 
@@ -110,30 +110,19 @@ describe("runtime context prompt submission", () => {
     ).toBe("Conversation context:\n\nvisible ask");
   });
 
-  it("queues runtime context as a hidden next-turn custom message", async () => {
-    const sentMessages: Array<{ content: string }> = [];
-    const sendCustomMessage = vi.fn(async (message: { content: string }) => {
-      sentMessages.push(message);
+  it("builds runtime context as prompt-local custom context before the current user prompt", () => {
+    expect(buildRuntimeContextCustomMessage("secret runtime context")).toMatchObject({
+      role: "custom",
+      customType: "openclaw.runtime-context",
+      content: [
+        "OpenClaw runtime context for the immediately preceding user message.",
+        "This context is runtime-generated, not user-authored. Keep internal details private.",
+        "",
+        "secret runtime context",
+      ].join("\n"),
+      display: false,
+      details: { source: "openclaw-runtime-context" },
     });
-
-    await queueRuntimeContextForNextTurn({
-      session: { sendCustomMessage },
-      runtimeContext: "secret runtime context",
-    });
-
-    expect(sendCustomMessage).toHaveBeenCalledWith(
-      {
-        customType: "openclaw.runtime-context",
-        content: "secret runtime context",
-        display: false,
-        details: { source: "openclaw-runtime-context" },
-      },
-      { deliverAs: "nextTurn" },
-    );
-    expect(sentMessages[0]?.content).not.toContain(
-      "OpenClaw runtime context for the immediately preceding user message.",
-    );
-    expect(sentMessages[0]?.content).not.toContain("not user-authored");
   });
 
   it("labels next-turn runtime context only when used as prompt-local system context", () => {

--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.ts
@@ -9,23 +9,20 @@ export { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE };
 
 const OPENCLAW_RUNTIME_EVENT_USER_PROMPT = "Continue the OpenClaw runtime event.";
 
-type RuntimeContextSession = {
-  sendCustomMessage: (
-    message: {
-      customType: string;
-      content: string;
-      display: boolean;
-      details?: Record<string, unknown>;
-    },
-    options?: { deliverAs?: "nextTurn"; triggerTurn?: boolean },
-  ) => Promise<void>;
-};
-
 type RuntimeContextPromptParts = {
   prompt: string;
   runtimeContext?: string;
   runtimeOnly?: boolean;
   runtimeSystemContext?: string;
+};
+
+export type RuntimeContextCustomMessage = {
+  role: "custom";
+  customType: string;
+  content: string;
+  display: false;
+  details: { source: "openclaw-runtime-context" };
+  timestamp: number;
 };
 
 type EmptyTranscriptMode = "model-prompt" | "runtime-event";
@@ -116,21 +113,19 @@ export function buildRuntimeEventSystemContext(runtimeContext: string): string {
   return buildRuntimeContextMessageContent({ runtimeContext, kind: "runtime-event" });
 }
 
-export async function queueRuntimeContextForNextTurn(params: {
-  session: RuntimeContextSession;
-  runtimeContext?: string;
-}): Promise<void> {
-  const runtimeContext = params.runtimeContext?.trim();
-  if (!runtimeContext) {
-    return;
+export function buildRuntimeContextCustomMessage(
+  runtimeContext: string | undefined,
+): RuntimeContextCustomMessage | undefined {
+  const trimmedRuntimeContext = runtimeContext?.trim();
+  if (!trimmedRuntimeContext) {
+    return undefined;
   }
-  await params.session.sendCustomMessage(
-    {
-      customType: OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
-      content: runtimeContext,
-      display: false,
-      details: { source: "openclaw-runtime-context" },
-    },
-    { deliverAs: "nextTurn" },
-  );
+  return {
+    role: "custom",
+    customType: OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
+    content: buildRuntimeContextSystemContext(trimmedRuntimeContext),
+    display: false,
+    details: { source: "openclaw-runtime-context" },
+    timestamp: Date.now(),
+  };
 }

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -172,6 +172,13 @@
     {
       "count": 1,
       "kind": "html-attribute",
+      "name": "aria-label",
+      "path": "ui/src/ui/chat/grouped-render.ts",
+      "text": "Tool returned an error"
+    },
+    {
+      "count": 1,
+      "kind": "html-attribute",
       "name": "title",
       "path": "ui/src/ui/chat/grouped-render.ts",
       "text": "Delete"
@@ -196,6 +203,13 @@
       "name": "text",
       "path": "ui/src/ui/chat/grouped-render.ts",
       "text": "Context"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/chat/grouped-render.ts",
+      "text": "Error"
     },
     {
       "count": 2,
@@ -305,16 +319,23 @@
     {
       "count": 1,
       "kind": "html-attribute",
+      "name": "aria-label",
+      "path": "ui/src/ui/chat/tool-cards.ts",
+      "text": "Tool returned an error"
+    },
+    {
+      "count": 1,
+      "kind": "html-attribute",
       "name": "title",
       "path": "ui/src/ui/chat/tool-cards.ts",
       "text": "Open in the side panel"
     },
     {
-      "count": 1,
+      "count": 2,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/chat/tool-cards.ts",
-      "text": "Completed"
+      "text": "Error"
     },
     {
       "count": 1,
@@ -331,7 +352,7 @@
       "text": "Tool input"
     },
     {
-      "count": 2,
+      "count": 1,
       "kind": "object-property",
       "name": "label",
       "path": "ui/src/ui/chat/tool-cards.ts",


### PR DESCRIPTION
## Summary

This PR keeps OpenClaw-generated runtime context prompt-local and ordered before the active user turn instead of treating it as next-turn/post-user transcript state.

The change addresses one concrete stale-reply/runtime-context cause that can make an agent answer already-answered or previous user messages: hidden `openclaw.runtime-context` was queued for the next turn, then preserved after the latest user message at the LLM boundary. The branch now builds a hidden runtime-context custom message for the current prompt, installs it only while submitting that prompt, keeps only runtime context immediately before the active user message at the LLM boundary, and removes the temporary message after submission.

This matched my local OpenClaw symptom: agents were repeating questions or acting on already-answered context, similar to the reports below. Testing this branch in my own environment appeared to resolve that behavior.

## Related issues

Addresses the runtime-context/user-precedence slice of:

- #32296
- #86849

Related context, but not claimed as fully closed by this PR:

- #76629
- #84662
- #75726

In particular, this is not a full fix for the Codex native-history growth tracked in #84662. It fixes the embedded-runner runtime-context ordering and lifetime path.

## Root cause

`resolveRuntimeContextPromptParts()` separated hidden runtime context from the visible prompt, but the embedded runner delivered that runtime context through `queueRuntimeContextForNextTurn()`. That made it durable next-turn context rather than prompt-local context for the current user request.

The cleanup filter also preserved runtime-context custom messages after the latest user message, which means stale/post-user runtime context could remain model-visible while the latest user request was no longer the strongest final message.

## Behavior after this patch

- Runtime context is formatted with the normal OpenClaw runtime-context header and notice.
- Runtime context is installed as a hidden custom message only for the active prompt submission.
- LLM-boundary cleanup keeps only runtime context immediately before the active user message.
- Runtime context after the latest user message is treated as stale and stripped.
- The temporary context message is removed after prompt submission, including the retry path that rebuilds session state during Pi overflow recovery.
- Codex app-server steering now rejects default queued steering once a terminal turn notification has been queued, avoiding too-late steering into a completed turn.

## Real behavior proof

- Behavior or issue addressed: Hidden OpenClaw runtime context for the current turn must stay prompt-local, ordered before the active user message, and absent from persisted visible transcript state so stale/post-user runtime context cannot make an agent answer an already-answered or previous user message.
- Real environment tested: Local WSL2 source checkout on branch `fix/runtime-context-user-precedence` at `a72453717e91d72f3504bd2d3c4e6d9f4b8cbaf5`, Node `v24.15.0`, built OpenClaw `dist/` and CLI path. The source checkout is the same local OpenClaw setup where I observed the repeated/stale-reply symptom with Hex.
- Exact steps or command run after this patch:

```text
$ git rev-parse --short HEAD
a72453717e

$ node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts extensions/codex/src/app-server/run-attempt.test.ts

$ git diff --check upstream/main...HEAD
$ node scripts/check-no-conflict-markers.mjs

$ bash scripts/e2e/session-runtime-context-docker.sh
$ npx tsx scripts/e2e/session-runtime-context-docker-client.ts
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal capture from the local OpenClaw checkout after the patch:

```text
$ node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts extensions/codex/src/app-server/run-attempt.test.ts
RUN  v4.1.7 <local source checkout>

Test Files  7 passed (7)
Tests  665 passed (665)
Duration  37.71s

$ git diff --check upstream/main...HEAD
(no output)

$ node scripts/check-no-conflict-markers.mjs
(no output)

$ npx tsx scripts/e2e/session-runtime-context-docker-client.ts
session runtime context Docker E2E passed
```

Additional terminal output from the packaged Docker wrapper before it reached Docker shows the package build and tarball integrity path completed, but the container portion could not run because Docker is not available in this WSL distro:

```text
$ bash scripts/e2e/session-runtime-context-docker.sh
Building Docker image: openclaw-session-runtime-context-e2e
==> Building OpenClaw package artifacts
...
OpenClaw package tarball integrity passed.
==> OpenClaw package tarball check finished in 1s

The command 'docker' could not be found in this WSL 2 distro.
```

- Observed result after fix: The dist/CLI runtime-context harness passed: hidden runtime context was extracted from the visible prompt, built as hidden `openclaw.runtime-context`, kept out of the persisted visible user transcript, and doctor repair removed the affected duplicated runtime-context branch. The focused existing-session regression proves old user + assistant history keeps the temporary runtime-context message immediately before the active prompt at the LLM boundary. The focused retry regression also passes and proves overflow-retry state rebuild places the temporary runtime-context message immediately before the active user before LLM-boundary cleanup.
- What was not tested: No full suite, broad Testbox/Crabbox gate, or live external Discord/Telegram channel proof was run. The Docker container wrapper could not complete because Docker is unavailable in this WSL distro; the same client was run directly against the freshly built local `dist/` instead.
- Proof limitations or environment constraints: The real external-channel symptom was observed in my local OpenClaw operator environment, but I am not attaching raw Discord/channel logs because they include private channel/user/session details. The attached terminal proof is therefore focused on the shipped runtime-context transcript behavior and the regression tests that cover the stale post-user and overflow-retry ordering paths.

## Verification

- `git diff --check upstream/main...HEAD`
- `node scripts/check-no-conflict-markers.mjs`
- `node scripts/run-oxlint.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/run-attempt.ts scripts/e2e/session-runtime-context-docker-client.ts src/agents/internal-runtime-context.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.ts`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY node --import tsx scripts/control-ui-i18n.ts check`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `npx tsx scripts/e2e/session-runtime-context-docker-client.ts`

Result: focused Vitest shard passed, 7 files / 665 tests. The dist/CLI session-runtime-context client passed. Changed-file lint, repo-wide oxlint shards, raw-copy/i18n check without provider credentials, diff whitespace, and conflict-marker checks also passed.



