### PR TITLE
fix: tighten parser edge cases

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -102,6 +102,17 @@ describe("completion-cli", () => {
     expect(script).not.toContain("'-t,'");
   });
 
+  it("generates valid PowerShell root arrays when commands or options are empty", () => {
+    const commandsOnly = new Command().name("openclaw");
+    commandsOnly.command("status");
+    const optionsOnly = new Command().name("openclaw").option("--json", "JSON output");
+    const empty = new Command().name("openclaw");
+
+    expect(getCompletionScript("powershell", commandsOnly)).toContain("$completions = @('status')");
+    expect(getCompletionScript("powershell", optionsOnly)).toContain("$completions = @('--json')");
+    expect(getCompletionScript("powershell", empty)).toContain("$completions = @()");
+  });
+
   it("generates fish completions for root and nested command contexts", () => {
     const script = getCompletionScript("fish", createCompletionProgram());
 

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -414,6 +414,8 @@ function generateBashSubcommand(cmd: Command): string {
 function generatePowerShellCompletion(program: Command): string {
   const rootCmd = program.name();
   const segments: string[] = [];
+  const formatPowerShellArray = (entries: string[]) =>
+    entries.length > 0 ? `@(${entries.map((entry) => `'${entry}'`).join(",")})` : "@()";
 
   const visit = (cmd: Command, pathSegments: string[]) => {
     const fullPath = pathSegments.join(" ");
@@ -421,12 +423,12 @@ function generatePowerShellCompletion(program: Command): string {
     // Command completion for this level
     const subCommands = cmd.commands.map((c) => c.name());
     const options = cmd.options.map((o) => preferredCompletionFlag(o.flags));
-    const allCompletions = [...subCommands, ...options].map((s) => `'${s}'`).join(",");
+    const allCompletions = formatPowerShellArray([...subCommands, ...options]);
 
-    if (fullPath.length > 0 && allCompletions.length > 0) {
+    if (fullPath.length > 0 && [...subCommands, ...options].length > 0) {
       segments.push(`
             if ($commandPath -eq '${fullPath}') {
-                $completions = @(${allCompletions})
+                $completions = ${allCompletions}
                 $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
                 }
@@ -461,7 +463,10 @@ Register-ArgumentCompleter -Native -CommandName ${rootCmd} -ScriptBlock {
     
     # Root command
     if ($commandPath -eq "") {
-         $completions = @(${program.commands.map((c) => `'${c.name()}'`).join(",")}, ${program.options.map((o) => `'${preferredCompletionFlag(o.flags)}'`).join(",")})
+         $completions = ${formatPowerShellArray([
+           ...program.commands.map((command) => command.name()),
+           ...program.options.map((option) => preferredCompletionFlag(option.flags)),
+         ])}
          $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
          }

--- a/src/commands/models/list.local-url.ts
+++ b/src/commands/models/list.local-url.ts
@@ -8,6 +8,7 @@ export const isLocalBaseUrl = (baseUrl: string) => {
       host === "localhost" ||
       host === "127.0.0.1" ||
       host === "0.0.0.0" ||
+      host === "::" ||
       host === "::1" ||
       host.endsWith(".local")
     );

--- a/src/commands/models/list.local-url.ts
+++ b/src/commands/models/list.local-url.ts
@@ -3,7 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 export const isLocalBaseUrl = (baseUrl: string) => {
   try {
     const url = new URL(baseUrl);
-    const host = normalizeLowercaseStringOrEmpty(url.hostname);
+    const host = normalizeLowercaseStringOrEmpty(url.hostname).replace(/^\[|\]$/g, "");
     return (
       host === "localhost" ||
       host === "127.0.0.1" ||

--- a/src/commands/models/list.model-row.test.ts
+++ b/src/commands/models/list.model-row.test.ts
@@ -41,16 +41,18 @@ describe("toModelRow", () => {
   });
 
   it("marks bracketed IPv6 loopback base URLs as local", () => {
-    const row = toModelRow({
-      model: {
-        ...OPENROUTER_MODEL,
-        provider: "ollama",
-        baseUrl: "http://[::1]:11434/v1",
-      } as never,
-      key: "ollama/llama3.2",
-      tags: [],
-    });
+    for (const baseUrl of ["http://[::1]:11434/v1", "http://[::]:11434/v1"]) {
+      const row = toModelRow({
+        model: {
+          ...OPENROUTER_MODEL,
+          provider: "ollama",
+          baseUrl,
+        } as never,
+        key: "ollama/llama3.2",
+        tags: [],
+      });
 
-    expect(row.local).toBe(true);
+      expect(row.local).toBe(true);
+    }
   });
 });

--- a/src/commands/models/list.model-row.test.ts
+++ b/src/commands/models/list.model-row.test.ts
@@ -39,4 +39,18 @@ describe("toModelRow", () => {
 
     expect(row.available).toBe(true);
   });
+
+  it("marks bracketed IPv6 loopback base URLs as local", () => {
+    const row = toModelRow({
+      model: {
+        ...OPENROUTER_MODEL,
+        provider: "ollama",
+        baseUrl: "http://[::1]:11434/v1",
+      } as never,
+      key: "ollama/llama3.2",
+      tags: [],
+    });
+
+    expect(row.local).toBe(true);
+  });
 });

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -42,26 +42,18 @@ async function runCommandSafe(argv: string[], timeoutMs = 5_000): Promise<Comman
 function parseLsofFieldOutput(output: string): PortListener[] {
   const lines = output.split(/\r?\n/).filter(Boolean);
   const listeners: PortListener[] = [];
-  let current: PortListener = {};
+  let processFields: Pick<PortListener, "pid" | "command"> = {};
   for (const line of lines) {
     if (line.startsWith("p")) {
-      if (current.pid || current.command) {
-        listeners.push(current);
-      }
       const pid = Number.parseInt(line.slice(1), 10);
-      current = Number.isFinite(pid) ? { pid } : {};
+      processFields = Number.isFinite(pid) ? { pid } : {};
     } else if (line.startsWith("c")) {
-      current.command = line.slice(1);
+      processFields.command = line.slice(1);
     } else if (line.startsWith("n")) {
       // TCP 127.0.0.1:18789 (LISTEN)
       // TCP *:18789 (LISTEN)
-      if (!current.address) {
-        current.address = line.slice(1);
-      }
+      listeners.push({ ...processFields, address: line.slice(1) });
     }
-  }
-  if (current.pid || current.command) {
-    listeners.push(current);
   }
   return listeners;
 }

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -58,6 +58,18 @@ function parseLsofFieldOutput(output: string): PortListener[] {
   return listeners;
 }
 
+function dedupePortListeners(listeners: PortListener[]): PortListener[] {
+  const seen = new Set<string>();
+  return listeners.filter((listener) => {
+    const key = `${listener.pid ?? ""}\0${listener.command ?? ""}\0${listener.address ?? ""}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
 function normalizeTcpHost(host: string): string {
   const normalized = host.toLowerCase();
   return normalized.startsWith("::ffff:") ? normalized.slice("::ffff:".length) : normalized;
@@ -378,7 +390,7 @@ async function readUnixListeners(
   const lsof = await resolveLsofCommand();
   const res = await runCommandSafe([lsof, "-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-FpFcn"]);
   if (res.code === 0) {
-    const listeners = parseLsofFieldOutput(res.stdout);
+    const listeners = dedupePortListeners(parseLsofFieldOutput(res.stdout));
     await enrichUnixListenerProcessInfo(listeners);
     return { listeners, detail: res.stdout.trim() || undefined, errors: [] };
   }

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -253,6 +253,57 @@ describeUnix("inspectPortUsage", () => {
     });
   });
 
+  it("reports multiple lsof socket records for one process", async () => {
+    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+      const command = argv[0];
+      if (typeof command !== "string") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (command.includes("lsof")) {
+        return {
+          stdout:
+            "p111\ncnode\n" +
+            "nTCP 127.0.0.1:50123->127.0.0.1:18789 (ESTABLISHED)\n" +
+            "nTCP 127.0.0.1:50124->127.0.0.1:18789 (ESTABLISHED)\n",
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "ps") {
+        if (argv.includes("command=")) {
+          return {
+            stdout: "node /tmp/newer-openclaw/dist/index.js logs --follow\n",
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (argv.includes("user=")) {
+          return { stdout: "tester\n", stderr: "", code: 0 };
+        }
+        if (argv.includes("ppid=")) {
+          return { stdout: "1\n", stderr: "", code: 0 };
+        }
+      }
+      return { stdout: "", stderr: "", code: 1 };
+    });
+
+    const result = await inspectPortConnections(18789);
+
+    expect(result.connections).toHaveLength(2);
+    expect(result.connections).toEqual([
+      expect.objectContaining({
+        pid: 111,
+        direction: "client",
+        address: "TCP 127.0.0.1:50123->127.0.0.1:18789 (ESTABLISHED)",
+      }),
+      expect.objectContaining({
+        pid: 111,
+        direction: "client",
+        address: "TCP 127.0.0.1:50124->127.0.0.1:18789 (ESTABLISHED)",
+      }),
+    ]);
+  });
+
   it("falls back to ss for established gateway client connections", async () => {
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
       const command = argv[0];

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -253,6 +253,46 @@ describeUnix("inspectPortUsage", () => {
     });
   });
 
+  it("deduplicates repeated lsof listener records for one process address", async () => {
+    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+      const command = argv[0];
+      if (typeof command !== "string") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (command.includes("lsof")) {
+        return {
+          stdout: "p111\ncnode\nnTCP *:18789 (LISTEN)\nnTCP *:18789 (LISTEN)\n",
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "ps") {
+        if (argv.includes("command=")) {
+          return {
+            stdout: "node /tmp/openclaw/dist/index.js gateway run\n",
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (argv.includes("user=")) {
+          return { stdout: "tester\n", stderr: "", code: 0 };
+        }
+        if (argv.includes("ppid=")) {
+          return { stdout: "1\n", stderr: "", code: 0 };
+        }
+      }
+      return { stdout: "", stderr: "", code: 1 };
+    });
+
+    const result = await inspectPortUsage(18789);
+
+    expect(result.listeners).toHaveLength(1);
+    expect(result.listeners[0]).toMatchObject({
+      pid: 111,
+      address: "TCP *:18789 (LISTEN)",
+    });
+  });
+
   it("reports multiple lsof socket records for one process", async () => {
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
       const command = argv[0];


### PR DESCRIPTION
## Summary

- Fix PowerShell completion root arrays when a command has only subcommands, only options, or no completions.
- Mark bracketed IPv6 loopback and wildcard model base URLs as local for model list filtering.
- Preserve multiple lsof socket records for one process while deduplicating repeated listener records.

Fixes clawpatch findings:
- fnd_sig-feat-cli-command-5483b047cc-_339eb8a9b4
- fnd_sig-feat-library-035ded0e37-b48b_c7d618db6e
- fnd_sig-feat-library-023fe89a12-d6c0_7bb7725307

## Verification

Behavior addressed: PowerShell completion no longer emits invalid root array syntax for one-sided empty completion sets; `models list --local` treats bracketed IPv6 local URLs as local; lsof parsing returns each socket record without double-counting duplicate listener fds.
Real environment tested: local macOS checkout on branch `fix/clawpatch-parser-bugs`, rebased on current `origin/main`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/completion-cli.test.ts src/commands/models/list.model-row.test.ts src/infra/ports.test.ts`; `pnpm exec oxlint src/cli/completion-cli.ts src/cli/completion-cli.test.ts src/commands/models/list.local-url.ts src/commands/models/list.model-row.test.ts src/infra/ports-inspect.ts src/infra/ports.test.ts`; `clawpatch revalidate --include-dirty` for all three findings before the final review adjustments; `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs src/cli/completion-cli.test.ts src/commands/models/list.model-row.test.ts src/infra/ports.test.ts && pnpm exec oxlint src/cli/completion-cli.ts src/cli/completion-cli.test.ts src/commands/models/list.local-url.ts src/commands/models/list.model-row.test.ts src/infra/ports-inspect.ts src/infra/ports.test.ts"`.
Evidence after fix: focused Vitest passed 3 files / 23 tests; oxlint passed; clawpatch revalidated the three original findings as fixed; autoreview completed clean with no accepted/actionable findings on the rebased branch.
Observed result after fix: targeted regression coverage passes and structured review accepts the branch.
What was not tested: live PowerShell completion execution in a Windows shell; live lsof output from every Unix variant.
