### PR TITLE
fix(onboard): preserve configured default model

### DIFF
--- a/src/commands/onboard-auth.config-shared.test.ts
+++ b/src/commands/onboard-auth.config-shared.test.ts
@@ -282,6 +282,46 @@ describe("onboard auth provider config merges", () => {
     expect(next.agents?.defaults?.model).toEqual({ primary: "custom/model-z" });
   });
 
+  it("does not let default-model presets replace an existing default model", () => {
+    const next = applyProviderConfigWithDefaultModelPreset(
+      {
+        agents: {
+          defaults: {
+            models: {
+              "claude-max-proxy/claude-opus-4-7": {},
+              "claude-max-proxy/claude-sonnet-4-6": {},
+            },
+            model: {
+              primary: "claude-max-proxy/claude-opus-4-7",
+              fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+            },
+          },
+        },
+      },
+      {
+        providerId: "moonshot",
+        api: "openai-completions",
+        baseUrl: "https://api.moonshot.cn/v1",
+        defaultModel: makeModel("kimi-k2.6"),
+        aliases: [{ modelRef: "moonshot/kimi-k2.6", alias: "Kimi" }],
+        primaryModelRef: "moonshot/kimi-k2.6",
+      },
+    );
+
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "claude-max-proxy/claude-opus-4-7",
+      fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+    });
+    expect(next.agents?.defaults?.models).toEqual({
+      "claude-max-proxy/claude-opus-4-7": {},
+      "claude-max-proxy/claude-sonnet-4-6": {},
+      "moonshot/kimi-k2.6": { alias: "Kimi" },
+    });
+    expect(next.models?.providers?.moonshot?.models?.map((model) => model.id)).toEqual([
+      "kimi-k2.6",
+    ]);
+  });
+
   it("applies catalog presets with alias and merged catalog models", () => {
     const next = applyProviderConfigWithModelCatalogPreset(
       {
@@ -313,5 +353,37 @@ describe("onboard auth provider config merges", () => {
       alias: "Catalog Alias",
     });
     expect(next.agents?.defaults?.model).toEqual({ primary: "custom/model-b" });
+  });
+
+  it("does not let catalog presets replace an existing default model", () => {
+    const next = applyProviderConfigWithModelCatalogPreset(
+      {
+        agents: {
+          defaults: {
+            models: {
+              "custom-existing/model-a": {},
+            },
+            model: {
+              primary: "custom-existing/model-a",
+            },
+          },
+        },
+      },
+      {
+        providerId: "custom",
+        api: "openai-completions",
+        baseUrl: "https://example.com/v1",
+        catalogModels: [makeModel("model-b")],
+        aliases: [{ modelRef: "custom/model-b", alias: "Catalog Alias" }],
+        primaryModelRef: "custom/model-b",
+      },
+    );
+
+    expect(next.agents?.defaults?.model).toEqual({ primary: "custom-existing/model-a" });
+    expect(next.agents?.defaults?.models).toEqual({
+      "custom-existing/model-a": {},
+      "custom/model-b": { alias: "Catalog Alias" },
+    });
+    expect(next.models?.providers?.custom?.models?.map((model) => model.id)).toEqual(["model-b"]);
   });
 });

--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -53,6 +53,10 @@ function extractAgentDefaultModelFallbacks(model: unknown): string[] | undefined
   return Array.isArray(fallbacks) ? fallbacks.map((value) => String(value)) : undefined;
 }
 
+function hasAgentDefaultModelPrimary(cfg: OpenClawConfig): boolean {
+  return resolvePrimaryStringValue(cfg.agents?.defaults?.model) !== undefined;
+}
+
 function normalizeAgentModelAliasEntry(entry: AgentModelAliasEntry): {
   modelRef: string;
   alias?: string;
@@ -404,7 +408,9 @@ export function applyProviderConfigWithDefaultModelPreset(
     defaultModelId: params.defaultModelId,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? hasAgentDefaultModelPrimary(cfg)
+      ? next
+      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
     : next;
 }
 
@@ -446,7 +452,9 @@ export function applyProviderConfigWithDefaultModelsPreset(
     defaultModelId: params.defaultModelId,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? hasAgentDefaultModelPrimary(cfg)
+      ? next
+      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
     : next;
 }
 
@@ -518,7 +526,9 @@ export function applyProviderConfigWithModelCatalogPreset(
     catalogModels: params.catalogModels,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? hasAgentDefaultModelPrimary(cfg)
+      ? next
+      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
     : next;
 }
 


### PR DESCRIPTION
Fixes #75720

## Summary
- Keep an existing `agents.defaults.model.primary` when provider preset appliers run during auth onboarding/update flows.
- Continue merging provider models, catalog entries, and aliases so the provider is still usable after onboarding.
- Add regression coverage for both default-model presets and catalog presets preserving an existing configured default model.

## Scope
- No config schema changes.
- No new public config API.
- No plugin SDK surface additions.
- No merge performed.

## Validation
- `node scripts/run-vitest.mjs src/commands/onboard-auth.config-shared.test.ts --reporter=dot` - 1 file, 13 tests passed
- `./node_modules/.bin/oxfmt --check src/plugin-sdk/provider-onboard.ts src/commands/onboard-auth.config-shared.test.ts`
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-onboard.ts src/commands/onboard-auth.config-shared.test.ts`
- `git diff --check origin/main...HEAD`
- `git diff --check`

## Real Behavior Proof
Head: `4153502f777ca1a76862d28ab9aaf68c2d84d04d`
Environment: WSL Ubuntu, Node `v22.22.3`.

I exercised the real provider-onboard config merge path used by provider onboarding/update helpers:
- existing config started with `agents.defaults.model.primary = claude-max-proxy/claude-opus-4-7` and fallback `claude-max-proxy/claude-sonnet-4-6`
- ran `applyZaiConfig(existingConfig)`, which uses the catalog preset path with a `primaryModelRef`
- ran `applyProviderConfigWithDefaultModelPreset(existingConfig, moonshotPreset)`, which uses the default-model preset path with a `primaryModelRef`
- ran `applyZaiConfig({})` for fresh-config behavior

Observed result:
- existing primary remained `claude-max-proxy/claude-opus-4-7`
- existing fallbacks remained `[claude-max-proxy/claude-sonnet-4-6]`
- Z.ai provider model was still added to `agents.defaults.models`
- Moonshot provider model was still added to `agents.defaults.models`
- fresh config still seeded the provider default: `zai/glm-5.1`

Terminal output:

```json
{
  "existingPrimaryAfterZai": "claude-max-proxy/claude-opus-4-7",
  "existingFallbacksAfterZai": [
    "claude-max-proxy/claude-sonnet-4-6"
  ],
  "zaiModelAdded": true,
  "freshPrimaryAfterZai": "zai/glm-5.1",
  "defaultModelPresetPrimary": "claude-max-proxy/claude-opus-4-7",
  "defaultModelPresetAdded": true
}
```