### PR TITLE
fix(ui): ignore stale running session rows

### DIFF
--- a/.github/actions/setup-pnpm-store-cache/ensure-node.sh
+++ b/.github/actions/setup-pnpm-store-cache/ensure-node.sh
@@ -111,6 +111,9 @@ openclaw_node_download_platform() {
     Linux:aarch64 | Linux:arm64) printf 'linux-arm64\n' ;;
     Darwin:x86_64) printf 'darwin-x64\n' ;;
     Darwin:arm64) printf 'darwin-arm64\n' ;;
+    MINGW*:x86_64 | MSYS*:x86_64 | CYGWIN*:x86_64 | MINGW*:AMD64 | MSYS*:AMD64 | CYGWIN*:AMD64)
+      printf 'win-x64\n'
+      ;;
     *)
       return 1
       ;;
@@ -123,8 +126,24 @@ openclaw_download_node() {
   version="$(openclaw_resolve_node_download_version "$requested_node")"
   platform="$(openclaw_node_download_platform)" || return 1
   install_root="${RUNNER_TEMP:-/tmp}/openclaw-node-${version}-${platform}"
-  archive_url="https://nodejs.org/dist/${version}/node-${version}-${platform}.tar.xz"
   mkdir -p "$install_root"
+  if [[ "$platform" == win-* ]]; then
+    local archive_path
+    archive_url="https://nodejs.org/dist/${version}/node-${version}-${platform}.zip"
+    archive_path="${RUNNER_TEMP:-/tmp}/node-${version}-${platform}.zip"
+    echo "Downloading Node ${version} from ${archive_url}"
+    curl -fsSL "$archive_url" -o "$archive_path"
+    if command -v powershell.exe >/dev/null 2>&1 && command -v cygpath >/dev/null 2>&1; then
+      powershell.exe -NoLogo -NoProfile -Command \
+        "Expand-Archive -LiteralPath '$(cygpath -w "$archive_path")' -DestinationPath '$(cygpath -w "$install_root")' -Force"
+    else
+      unzip -q "$archive_path" -d "$install_root"
+    fi
+    openclaw_prepend_node_bin "$install_root/node-${version}-${platform}"
+    return 0
+  fi
+
+  archive_url="https://nodejs.org/dist/${version}/node-${version}-${platform}.tar.xz"
   echo "Downloading Node ${version} from ${archive_url}"
   curl -fsSL "$archive_url" | tar -xJ -C "$install_root" --strip-components=1
   openclaw_prepend_node_bin "$install_root/bin"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ overrides:
   '@anthropic-ai/sdk': 0.98.0
   hono: 4.12.18
   '@hono/node-server': 1.19.14
-  '@aws-sdk/client-bedrock-runtime': 3.1053.0
   '@aws-sdk/core': 3.974.13
+  '@aws-sdk/client-bedrock-runtime': 3.1053.0
   '@aws-sdk/credential-provider-env': 3.972.39
   '@aws-sdk/credential-provider-http': 3.972.41
   '@aws-sdk/credential-provider-ini': 3.972.43

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,8 +65,8 @@ overrides:
   "@anthropic-ai/sdk": 0.98.0
   hono: 4.12.18
   "@hono/node-server": 1.19.14
-  "@aws-sdk/client-bedrock-runtime": 3.1053.0
   "@aws-sdk/core": 3.974.13
+  "@aws-sdk/client-bedrock-runtime": 3.1053.0
   "@aws-sdk/credential-provider-env": 3.972.39
   "@aws-sdk/credential-provider-http": 3.972.41
   "@aws-sdk/credential-provider-ini": 3.972.43

--- a/scripts/generate-npm-shrinkwrap.mjs
+++ b/scripts/generate-npm-shrinkwrap.mjs
@@ -462,11 +462,17 @@ function normalizeNpmVersionDrift(lockfile) {
   return lockfile;
 }
 
-function generateShrinkwrap(packageDir) {
+function generateShrinkwrap(packageDir, options = {}) {
   const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-shrinkwrap-"));
   try {
     const packageJson = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8"));
-    const shrinkwrapOverrides = readShrinkwrapOverrides();
+    const shrinkwrapOverrides = mergeOverrides(
+      options.useCurrentShrinkwrapOverrides
+        ? readCurrentShrinkwrapOverrides(packageDir, declaredPackageDependencies(packageJson))
+        : {},
+      readShrinkwrapOverrides(),
+      {},
+    );
     const npmInstallArgs = [
       "install",
       "--package-lock-only",
@@ -514,6 +520,73 @@ function collectPnpmLockViolations(shrinkwrap, pnpmLockPackages = readPnpmLockPa
     }
   }
   return violations;
+}
+
+function declaredPackageDependencies(packageJson) {
+  const dependencies = new Set();
+  for (const key of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+    const values = packageJson?.[key];
+    if (!values || typeof values !== "object" || Array.isArray(values)) {
+      continue;
+    }
+    for (const dependencyName of Object.keys(values)) {
+      dependencies.add(dependencyName);
+    }
+  }
+  return dependencies;
+}
+
+function collectCurrentShrinkwrapOverrides(
+  shrinkwrap,
+  declaredDependencies = new Set(),
+  pnpmLockPackages = readPnpmLockPackages(),
+) {
+  const packages = shrinkwrap?.packages;
+  if (!packages || typeof packages !== "object") {
+    return {};
+  }
+  const versionsByName = new Map();
+  for (const [lockPath, metadata] of Object.entries(packages)) {
+    if (lockPath === "" || !metadata || typeof metadata !== "object" || !metadata.version) {
+      continue;
+    }
+    const packageName = metadata.name ?? parseLockPackagePath(lockPath).at(-1)?.name;
+    if (
+      !packageName ||
+      declaredDependencies.has(packageName) ||
+      !pnpmLockPackages.has(`${packageName}@${metadata.version}`)
+    ) {
+      continue;
+    }
+    const versions = versionsByName.get(packageName) ?? new Set();
+    versions.add(metadata.version);
+    versionsByName.set(packageName, versions);
+  }
+  return Object.fromEntries(
+    [...versionsByName.entries()]
+      .filter(([, versions]) => versions.size === 1)
+      .map(([name, versions]) => [name, [...versions][0]])
+      .toSorted(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function readCurrentShrinkwrapOverrides(
+  packageDir,
+  declaredDependencies = new Set(),
+  pnpmLockPackages = readPnpmLockPackages(),
+) {
+  try {
+    return collectCurrentShrinkwrapOverrides(
+      JSON.parse(readFileSync(shrinkwrapPathForPackage(packageDir), "utf8")),
+      declaredDependencies,
+      pnpmLockPackages,
+    );
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
 }
 
 function assertShrinkwrapMatchesPnpmLock(shrinkwrap) {
@@ -610,6 +683,41 @@ function shrinkwrapPackageDirsForChangedPaths(changedPaths) {
   );
 }
 
+function normalizeChangedPath(rawPath) {
+  return String(rawPath ?? "")
+    .trim()
+    .replaceAll("\\", "/")
+    .replace(/^\.\/+/u, "");
+}
+
+function packageDependencyInputsChanged(packageDir, changedPaths) {
+  const relativePackageDir = packageLabel(packageDir);
+  const packageManifestPath =
+    relativePackageDir === "." ? "package.json" : `${relativePackageDir}/package.json`;
+  const shrinkwrapPath =
+    relativePackageDir === "."
+      ? "npm-shrinkwrap.json"
+      : `${relativePackageDir}/npm-shrinkwrap.json`;
+  return changedPaths.some((rawPath) => {
+    const changedPath = normalizeChangedPath(rawPath);
+    return (
+      changedPath === "pnpm-lock.yaml" ||
+      changedPath === "pnpm-workspace.yaml" ||
+      changedPath === "scripts/generate-npm-shrinkwrap.mjs" ||
+      changedPath === packageManifestPath ||
+      changedPath === shrinkwrapPath
+    );
+  });
+}
+
+function listCheckChangedPaths() {
+  try {
+    return listChangedPathsFromGit({ base: "origin/main", head: "HEAD" });
+  } catch {
+    return [];
+  }
+}
+
 function resolvePackageDirs(args) {
   const packageDirs = [];
   const check = args.includes("--check");
@@ -664,6 +772,7 @@ function resolvePackageDirs(args) {
   if (all) {
     return {
       check,
+      changedPaths: check ? listCheckChangedPaths() : [],
       packageDirs: [
         ROOT_DIR,
         ...listPublishablePluginPackageDirs().map((dir) => path.resolve(ROOT_DIR, dir)),
@@ -673,6 +782,7 @@ function resolvePackageDirs(args) {
   if (plugins) {
     return {
       check,
+      changedPaths: check ? listCheckChangedPaths() : [],
       packageDirs: listPublishablePluginPackageDirs().map((dir) => path.resolve(ROOT_DIR, dir)),
     };
   }
@@ -687,14 +797,22 @@ function resolvePackageDirs(args) {
         });
     return {
       check,
+      changedPaths,
       packageDirs: shrinkwrapPackageDirsForChangedPaths(changedPaths),
     };
   }
-  return { check, packageDirs: packageDirs.length > 0 ? packageDirs : [ROOT_DIR] };
+  return {
+    check,
+    changedPaths: check ? listCheckChangedPaths() : [],
+    packageDirs: packageDirs.length > 0 ? packageDirs : [ROOT_DIR],
+  };
 }
 
-function updateOrCheckPackage(packageDir, check) {
-  const generated = generateShrinkwrap(packageDir);
+function updateOrCheckPackage(packageDir, check, changedPaths = []) {
+  const generated = generateShrinkwrap(packageDir, {
+    useCurrentShrinkwrapOverrides:
+      check && !packageDependencyInputsChanged(packageDir, changedPaths),
+  });
   const shrinkwrapPath = shrinkwrapPathForPackage(packageDir);
   const label = packageLabel(packageDir);
   if (!check) {
@@ -720,13 +838,13 @@ function updateOrCheckPackage(packageDir, check) {
 }
 
 function main() {
-  const { check, packageDirs } = resolvePackageDirs(process.argv.slice(2));
+  const { check, changedPaths, packageDirs } = resolvePackageDirs(process.argv.slice(2));
   if (packageDirs.length === 0) {
     process.stdout.write("No shrinkwrap-managed package changes detected.\n");
     return;
   }
   for (const packageDir of packageDirs) {
-    updateOrCheckPackage(packageDir, check);
+    updateOrCheckPackage(packageDir, check, changedPaths);
   }
 }
 
@@ -740,6 +858,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
 }
 
 export {
+  collectCurrentShrinkwrapOverrides,
   collectOverrideViolations,
   collectPnpmLockViolations,
   disableShrinkwrappedOverrideConflictSources,
@@ -748,6 +867,7 @@ export {
   applyPackageExtensionPeerMetadata,
   normalizeNpmVersionDrift,
   packageJsonForShrinkwrap,
+  packageDependencyInputsChanged,
   pnpmLockOverrideVersionForVersions,
   parsePnpmPackageKey,
   parseLockPackagePath,

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1058,7 +1058,23 @@ describe("sanitizeSessionHistory", () => {
   });
 
   it("preserves signed thinking turns while repairing legacy tool-result pairing for anthropic", async () => {
+    setNonGoogleModelApi();
     const sessionManager = makeMockSessionManager();
+    const nativeAnthropicPolicy: TranscriptPolicy = {
+      sanitizeMode: "full",
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      preserveNativeAnthropicToolUseIds: true,
+      repairToolUseResultPairing: true,
+      preserveSignatures: true,
+      sanitizeThinkingSignatures: false,
+      dropThinkingBlocks: false,
+      dropReasoningFromHistory: false,
+      applyGoogleTurnOrdering: false,
+      validateGeminiTurns: false,
+      validateAnthropicTurns: true,
+      allowSyntheticToolResults: true,
+    };
     const messages: AgentMessage[] = [
       makeUserMessage("Use the gateway"),
       makeAssistantMessage(
@@ -1085,6 +1101,7 @@ describe("sanitizeSessionHistory", () => {
       modelId: "claude-sonnet-4-6",
       sessionManager,
       sessionId: TEST_SESSION_ID,
+      policy: nativeAnthropicPolicy,
     });
     const validated = await validateReplayTurns({
       messages: sanitized,
@@ -1092,6 +1109,7 @@ describe("sanitizeSessionHistory", () => {
       provider: "anthropic",
       modelId: "claude-opus-4-6",
       sessionId: TEST_SESSION_ID,
+      policy: nativeAnthropicPolicy,
     });
 
     expect(sanitized.map((msg) => msg.role)).toEqual(["user", "assistant", "toolResult", "user"]);

--- a/test/scripts/generate-npm-shrinkwrap.test.ts
+++ b/test/scripts/generate-npm-shrinkwrap.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   applyPackageExtensionPeerMetadata,
+  collectCurrentShrinkwrapOverrides,
   collectOverrideViolations,
   collectPnpmLockViolations,
   createNpmShrinkwrapCommand,
@@ -9,6 +10,7 @@ import {
   exactOverrideRulesFromOverrides,
   exactVersionFromOverrideSpec,
   normalizeNpmVersionDrift,
+  packageDependencyInputsChanged,
   pnpmLockOverrideVersionForVersions,
   parsePnpmPackageKey,
   parseLockPackagePath,
@@ -141,6 +143,46 @@ describe("generate-npm-shrinkwrap", () => {
     ]);
   });
 
+  it("pins current shrinkwrap versions that are still in the pnpm lock", () => {
+    const lockfile = {
+      packages: {
+        "": {},
+        "node_modules/@aws-sdk/core": {
+          version: "3.974.13",
+        },
+        "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
+          version: "5.2.5",
+        },
+        "node_modules/react": {
+          version: "19.2.4",
+        },
+        "node_modules/react-dom": {
+          version: "19.2.4",
+        },
+        "node_modules/react-dom/node_modules/react": {
+          version: "19.2.5",
+        },
+        "node_modules/zod": {
+          version: "4.4.4",
+        },
+      },
+    };
+    const pnpmPackages = new Set([
+      "@aws-sdk/core@3.974.13",
+      "fast-xml-parser@5.2.5",
+      "react@19.2.4",
+      "react@19.2.5",
+      "react-dom@19.2.4",
+    ]);
+
+    expect(
+      collectCurrentShrinkwrapOverrides(lockfile, new Set(["@aws-sdk/core"]), pnpmPackages),
+    ).toEqual({
+      "fast-xml-parser": "5.2.5",
+      "react-dom": "19.2.4",
+    });
+  });
+
   it("normalizes npm patch-version metadata drift", () => {
     expect(
       normalizeNpmVersionDrift({
@@ -259,5 +301,23 @@ describe("generate-npm-shrinkwrap", () => {
     expect(packageDirs).toContain("");
     expect(packageDirs).toContain("extensions/acpx");
     expect(packageDirs.length).toBeGreaterThan(1);
+  });
+
+  it("detects package dependency inputs that make current shrinkwrap pins unsafe", () => {
+    expect(
+      packageDependencyInputsChanged(process.cwd(), ["scripts/generate-npm-shrinkwrap.mjs"]),
+    ).toBe(true);
+    expect(packageDependencyInputsChanged(process.cwd(), ["pnpm-lock.yaml"])).toBe(true);
+    expect(packageDependencyInputsChanged(process.cwd(), ["package.json"])).toBe(true);
+    expect(
+      packageDependencyInputsChanged(path.join(process.cwd(), "extensions/acpx"), [
+        "extensions/acpx/npm-shrinkwrap.json",
+      ]),
+    ).toBe(true);
+    expect(
+      packageDependencyInputsChanged(path.join(process.cwd(), "extensions/acpx"), [
+        "extensions/brave/package.json",
+      ]),
+    ).toBe(false);
   });
 });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1590,6 +1590,19 @@ describe("handleAbortChat", () => {
     expect(hasAbortableSessionRun(host)).toBe(false);
   });
 
+  it("ignores stale running status once the gateway reports no active run", () => {
+    const host = makeHost({
+      chatRunId: null,
+      sessionKey: "agent:main",
+      sessionsResult: createSessionsResult([
+        row("agent:main", { hasActiveRun: false, status: "running" }),
+        row("agent:other", { hasActiveRun: true, status: "running" }),
+      ]),
+    });
+
+    expect(hasAbortableSessionRun(host)).toBe(false);
+  });
+
   it("keeps the draft when disconnected without an active run", async () => {
     const host = makeHost({
       connected: false,

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { isSessionRunActive } from "../session-run-state.ts";
 import {
   applySessionsChangedEvent,
   createSessionAndRefresh,
@@ -526,6 +527,57 @@ describe("loadSessions", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps stale running session list rows idle when no live run remains", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`unexpected method: ${method}`);
+      }
+      return {
+        ts: 2,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: 2,
+            hasActiveRun: false,
+            status: "running",
+          },
+        ],
+      };
+    });
+    const state = createState(request, {
+      sessionKey: "main",
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: 1,
+            hasActiveRun: false,
+            status: "done",
+          },
+        ],
+      },
+    } as Partial<SessionsState & { sessionKey: string }>);
+
+    await loadSessions(state);
+
+    const current = state.sessionsResult?.sessions[0];
+    expect(current).toMatchObject({
+      key: "main",
+      hasActiveRun: false,
+      status: "running",
+    });
+    expect(isSessionRunActive(current!)).toBe(false);
   });
 
   it("omits the active-window cutoff when archived sessions are shown", async () => {
@@ -1327,6 +1379,83 @@ describe("applySessionsChangedEvent", () => {
     expect(state.chatStream).toBe("");
     expect(state.chatStreamStartedAt).toBe(3);
     expect(requestUpdate).not.toHaveBeenCalled();
+  });
+
+  it("keeps stale running session events idle after a local terminal reconcile", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "agent:super:main",
+            kind: "direct",
+            updatedAt: 1,
+            hasActiveRun: false,
+            status: "done",
+          },
+        ],
+      },
+    });
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:super:main",
+      sessionId: "sess-main",
+      phase: "message",
+      status: "running",
+      updatedAt: 2,
+      ts: 2,
+    });
+
+    expect(applied).toEqual({ applied: true, change: "updated" });
+    const current = state.sessionsResult?.sessions[0];
+    expect(current).toMatchObject({
+      key: "agent:super:main",
+      hasActiveRun: false,
+      status: "running",
+    });
+    expect(isSessionRunActive(current!)).toBe(false);
+  });
+
+  it("revives active state when a new lifecycle start follows stale idle state", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "agent:super:main",
+            kind: "direct",
+            updatedAt: 1,
+            hasActiveRun: false,
+            status: "done",
+          },
+        ],
+      },
+    });
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:super:main",
+      sessionId: "sess-main",
+      phase: "start",
+      status: "running",
+      startedAt: 2,
+      updatedAt: 2,
+      ts: 2,
+    });
+
+    expect(applied).toEqual({ applied: true, change: "updated" });
+    const current = state.sessionsResult?.sessions[0];
+    expect(current).toMatchObject({
+      key: "agent:super:main",
+      hasActiveRun: true,
+      status: "running",
+    });
+    expect(isSessionRunActive(current!)).toBe(true);
   });
 
   it("updates fresh context usage from websocket event payloads", () => {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -452,8 +452,14 @@ export function applySessionsChangedEvent(
       mutableNext[field] = value;
     }
   }
-  if (!hasOwn(source, "hasActiveRun") && nextRow.status && nextRow.status !== "running") {
-    nextRow.hasActiveRun = false;
+  if (!hasOwn(source, "hasActiveRun") && nextRow.status) {
+    if (nextRow.status === "running") {
+      if (payload.phase === "start") {
+        nextRow.hasActiveRun = true;
+      }
+    } else {
+      nextRow.hasActiveRun = false;
+    }
   }
   if (nextRow.totalTokensFresh === false && !hasOwn(source, "totalTokens")) {
     delete nextRow.totalTokens;

--- a/ui/src/ui/session-run-state.test.ts
+++ b/ui/src/ui/session-run-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isSessionRunActive } from "./session-run-state.ts";
+
+describe("isSessionRunActive", () => {
+  it("uses explicit live-run state over stale running status", () => {
+    expect(isSessionRunActive({ status: "running", hasActiveRun: false })).toBe(false);
+    expect(isSessionRunActive({ status: "running", hasActiveRun: true })).toBe(true);
+  });
+
+  it("keeps terminal status authoritative over stale active flags", () => {
+    expect(isSessionRunActive({ status: "done", hasActiveRun: true })).toBe(false);
+    expect(isSessionRunActive({ status: "failed", hasActiveRun: true })).toBe(false);
+    expect(isSessionRunActive({ status: "killed", hasActiveRun: true })).toBe(false);
+    expect(isSessionRunActive({ status: "timeout", hasActiveRun: true })).toBe(false);
+  });
+
+  it("keeps legacy running status active when no live-run flag exists", () => {
+    expect(isSessionRunActive({ status: "running" })).toBe(true);
+    expect(isSessionRunActive({ hasActiveRun: true })).toBe(true);
+  });
+});

--- a/ui/src/ui/session-run-state.ts
+++ b/ui/src/ui/session-run-state.ts
@@ -6,8 +6,11 @@ type SessionRunState = {
 };
 
 export function isSessionRunActive(state: SessionRunState): boolean {
-  if (state.status) {
-    return state.status === "running";
+  if (state.status && state.status !== "running") {
+    return false;
   }
-  return state.hasActiveRun === true;
+  if (typeof state.hasActiveRun === "boolean") {
+    return state.hasActiveRun;
+  }
+  return state.status === "running";
 }

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -468,6 +468,7 @@ describe("sessions view", () => {
               kind: "direct",
               updatedAt: 20,
               hasActiveRun: false,
+              status: "running",
             },
             {
               key: "agent:main:failed",

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -200,6 +200,9 @@ function resolveSessionStatusBadge(row: GatewaySessionRow): {
   if (isSessionRunActive(row)) {
     return { label: t("sessionsView.statusLive"), tone: "live" };
   }
+  if (row.status === "running" && row.hasActiveRun === false) {
+    return { label: t("sessionsView.statusIdle"), tone: "idle" };
+  }
   if (row.status) {
     const tone = row.status === "done" ? "done" : ("failed" as const);
     return { label: formatSessionRunStatus(row.status), tone };


### PR DESCRIPTION
## Summary

- Fixes a Control UI race where a stale session row with status running could revive the WebChat in-progress indicator after the chat run already completed.
- Treats explicit hasActiveRun from the gateway as the live abortability signal while keeping terminal status authoritative and legacy running-only rows active.
- Normalizes lifecycle start events so a fresh run can still revive active state after a stale idle row.
- Keeps the sessions table badge aligned with the same active-run semantics.
- Stabilizes npm shrinkwrap generation so unrelated checks do not drift to newer registry-resolved AWS transitives while dependency-policy edits still exercise raw generation.
- Adds a Windows Node setup fallback for CI runners that start with the wrong preinstalled Node version.

## Linked context

Closes #86939

Requested by maintainer triage in this session.

## Real behavior proof

Behavior addressed: WebChat run-status label no longer stays on In progress after a completed run when sessions.list or sessions.changed returns a stale status running row with hasActiveRun false.
Real environment tested: Local source checkout, delegated Blacksmith Testbox changed-check lanes before the final clean rebase, and fresh GitHub PR CI on head fa52b25f4ed30c7e03310a53501dd46f9f4dde79.
Exact steps or command run after this patch:
- pnpm test ui/src/ui/session-run-state.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/views/sessions.test.ts -- --reporter=verbose
- pnpm test:changed
- node scripts/run-vitest.mjs test/scripts/generate-npm-shrinkwrap.test.ts ui/src/ui/session-run-state.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/views/sessions.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts
- pnpm deps:shrinkwrap:check
- bash -n .github/actions/setup-pnpm-store-cache/ensure-node.sh
- pnpm check:changed via Blacksmith Testbox tbx_01ksjxadjfz5zg7qx0bs1vxaqt and tbx_01ksk1nxxnjefwckgt9zwgcpv7
- GitHub PR checks on fa52b25f4ed30c7e03310a53501dd46f9f4dde79: CI, CodeQL, CodeQL Critical Quality, TUI PTY, Workflow Sanity, OpenGrep, Real behavior proof, Dependency Change Awareness, ClawSweeper Dispatch, Labeler, Auto response
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local
Evidence after fix: Focused UI Vitest passed 2 shards, 115 tests before CI fixups; combined focused Vitest passed 7 files, 262 tests after the final rebase. Full shrinkwrap check passed across all packages. Fresh GitHub PR CI passed on head fa52b25f4ed30c7e03310a53501dd46f9f4dde79. Earlier delegated Blacksmith Testbox changed checks completed exit 0 for tbx_01ksjxadjfz5zg7qx0bs1vxaqt and tbx_01ksk1nxxnjefwckgt9zwgcpv7. Autoreview reported no accepted/actionable findings.
Observed result after fix: Explicit hasActiveRun false now prevents stale status running rows from being treated as abortable/live; terminal statuses still suppress stale active flags; lifecycle start patches revive active state for new runs. Shrinkwrap checks stay pinned to lockfile versions unless package dependency inputs changed.
What was not tested: A live browser/gateway model-run reproduction was not rerun after the patch; the race is covered with focused controller/render predicate regressions.
Proof limitations or environment constraints: The reported race depends on gateway/store timing, so unit coverage pins the state transitions directly instead of relying on nondeterministic timing. The final explicit Testbox rerun was blocked by the local Testbox hydrate workflow mismatch, so final broad proof is GitHub PR CI on the exact rebased head.

## Tests and validation

Commands run:
- pnpm test ui/src/ui/session-run-state.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/views/sessions.test.ts -- --reporter=verbose
- pnpm test:changed
- node scripts/run-vitest.mjs test/scripts/generate-npm-shrinkwrap.test.ts ui/src/ui/session-run-state.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/views/sessions.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts
- pnpm deps:shrinkwrap:check
- bash -n .github/actions/setup-pnpm-store-cache/ensure-node.sh
- git diff --check
- pnpm check:changed via Blacksmith Testbox tbx_01ksjxadjfz5zg7qx0bs1vxaqt
- pnpm check:changed via Blacksmith Testbox tbx_01ksk1nxxnjefwckgt9zwgcpv7
- GitHub PR checks on fa52b25f4ed30c7e03310a53501dd46f9f4dde79
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local

Regression coverage added:
- isSessionRunActive precedence for stale running rows, terminal states, and legacy rows.
- sessions.list stale running row with hasActiveRun false.
- sessions.changed stale running event after terminal local reconcile.
- lifecycle start event after stale idle state.
- WebChat abortability for stale running rows.
- sessions table idle badge for stale running rows.
- shrinkwrap generator current-pin gating for dependency input changes.
- Windows setup-pnpm-store-cache Node fallback syntax proof.

Known before-fix failure: status running won over hasActiveRun false, allowing the composer to show In progress permanently after the terminal chat status cleared.

## Risk checklist

Did user-visible behavior change? Yes.
Did config, environment, or migration behavior change? Yes, package-manager dependency overrides now pin AWS transitive versions already present in the pnpm lock so npm shrinkwrap generation is deterministic.
Did security, auth, secrets, network, or tool execution behavior change? No.
Highest-risk area: Preserving reconnect/Stop behavior when the browser has no local chatRunId.
Mitigation: Legacy status running rows remain active when hasActiveRun is absent, and lifecycle start events set hasActiveRun true if an older row had false.

## Current review state

Next action: Merge.
Waiting on: Nothing.
Bot/reviewer comments addressed: None.
