### PR TITLE
fix(cli): validate timeout and banner TTY state

### DIFF
--- a/src/cli/banner.test.ts
+++ b/src/cli/banner.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatCliBannerLine } from "./banner.js";
 
 const readCliBannerTaglineModeMock = vi.hoisted(() => vi.fn());
+const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 
 vi.mock("./banner-config-lite.js", () => ({
   parseTaglineMode: (value: unknown) =>
@@ -13,6 +14,27 @@ beforeEach(() => {
   readCliBannerTaglineModeMock.mockReset();
   readCliBannerTaglineModeMock.mockReturnValue(undefined);
 });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (stdoutIsTtyDescriptor) {
+    Object.defineProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+  } else {
+    delete (process.stdout as { isTTY?: boolean }).isTTY;
+  }
+});
+
+async function importFreshBannerModule() {
+  vi.resetModules();
+  return await import("./banner.js");
+}
+
+function setStdoutIsTty(value: boolean) {
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value,
+  });
+}
 
 describe("formatCliBannerLine", () => {
   it("hides tagline text when cli.banner.taglineMode is off", () => {
@@ -70,5 +92,43 @@ describe("formatCliBannerLine", () => {
     });
 
     expect(line).toBe("OpenClaw 2026.3.7 (abc1234)");
+  });
+});
+
+describe("emitCliBanner", () => {
+  it("uses injected non-TTY state before writing to stdout", async () => {
+    const { emitCliBanner, hasEmittedCliBanner } = await importFreshBannerModule();
+    setStdoutIsTty(true);
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    emitCliBanner("2026.3.7", {
+      argv: ["node", "openclaw"],
+      commit: "abc1234",
+      isTty: false,
+      mode: "off",
+      richTty: false,
+    });
+
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(hasEmittedCliBanner()).toBe(false);
+  });
+
+  it("allows injected TTY state to emit when stdout lacks isTTY", async () => {
+    const { emitCliBanner, hasEmittedCliBanner } = await importFreshBannerModule();
+    setStdoutIsTty(false);
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    emitCliBanner("2026.3.7", {
+      argv: ["node", "openclaw"],
+      commit: "abc1234",
+      env: { LANG: "en_US.UTF-8" },
+      isTty: true,
+      mode: "off",
+      platform: "darwin",
+      richTty: false,
+    });
+
+    expect(writeSpy).toHaveBeenCalledWith("\n🦞 OpenClaw 2026.3.7 (abc1234)\n\n");
+    expect(hasEmittedCliBanner()).toBe(true);
   });
 });

--- a/src/cli/banner.ts
+++ b/src/cli/banner.ts
@@ -174,7 +174,8 @@ export function emitCliBanner(version: string, options: BannerOptions = {}) {
     return;
   }
   const argv = options.argv ?? process.argv;
-  if (!process.stdout.isTTY) {
+  const isTty = options.isTty ?? process.stdout.isTTY;
+  if (!isTty) {
     return;
   }
   if (hasJsonFlag(argv)) {

--- a/src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts
+++ b/src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_EXEC_APPROVAL_TIMEOUT_MS } from "../../infra/exec-approvals.js";
 import { parseTimeoutMs } from "../parse-timeout.js";
-import { callGatewayCli } from "./rpc.js";
+import { callGatewayCli, callNodePairApprovalGatewayCli } from "./rpc.js";
 
 /**
  * Regression test for #12098:
@@ -59,6 +59,29 @@ describe("exec approval transport timeout (#12098)", () => {
     const callOpts = firstGatewayCall();
     expect(callOpts.method).toBe("exec.approval.request");
     expect(callOpts.timeoutMs).toBe(35_000);
+  });
+
+  it("callGatewayCli rejects invalid opts.timeout instead of forwarding NaN", async () => {
+    await expect(
+      callGatewayCli("exec.approval.request", { timeout: "nope" } as never, {
+        timeoutMs: 120_000,
+      }),
+    ).rejects.toThrow("Invalid --timeout");
+
+    expect(callGatewaySpy).not.toHaveBeenCalled();
+  });
+
+  it("callNodePairApprovalGatewayCli rejects invalid opts.timeout instead of forwarding NaN", async () => {
+    await expect(
+      callNodePairApprovalGatewayCli(
+        "node.pair.list",
+        { timeout: "Infinity" } as never,
+        {},
+        { scopes: [] },
+      ),
+    ).rejects.toThrow("Invalid --timeout");
+
+    expect(callGatewaySpy).not.toHaveBeenCalled();
   });
 
   it("fix: overriding transportTimeoutMs gives the approval enough transport time", async () => {

--- a/src/cli/nodes-cli/rpc.runtime.ts
+++ b/src/cli/nodes-cli/rpc.runtime.ts
@@ -1,10 +1,16 @@
 import { callGateway } from "../../gateway/call.js";
 import type { OperatorScope } from "../../gateway/method-scopes.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../gateway/protocol/client-info.js";
+import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import { withProgress } from "../progress.js";
 import type { NodesRpcOpts } from "./types.js";
 
 const NODE_PAIR_APPROVAL_GATEWAY_METHODS = new Set<string>(["node.pair.list", "node.pair.approve"]);
+const DEFAULT_NODES_RPC_TIMEOUT_MS = 10_000;
+
+function resolveNodesTransportTimeoutMs(opts: NodesRpcOpts, overrideMs?: number): number {
+  return overrideMs ?? parseTimeoutMsWithFallback(opts.timeout, DEFAULT_NODES_RPC_TIMEOUT_MS);
+}
 
 export async function callGatewayCliRuntime(
   method: string,
@@ -24,7 +30,7 @@ export async function callGatewayCliRuntime(
         token: opts.token,
         method,
         params,
-        timeoutMs: callOpts?.transportTimeoutMs ?? Number(opts.timeout ?? 10_000),
+        timeoutMs: resolveNodesTransportTimeoutMs(opts, callOpts?.transportTimeoutMs),
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
       }),
@@ -54,7 +60,7 @@ export async function callNodePairApprovalGatewayCliRuntime(
         token: opts.token,
         method,
         params,
-        timeoutMs: callOpts.transportTimeoutMs ?? Number(opts.timeout ?? 10_000),
+        timeoutMs: resolveNodesTransportTimeoutMs(opts, callOpts.transportTimeoutMs),
         clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
         mode: GATEWAY_CLIENT_MODES.BACKEND,
         scopes: callOpts.scopes,


### PR DESCRIPTION
## Summary

- Fixes two clawpatch-reported CLI bugs in a narrow core surface.
- `emitCliBanner` now honors injected TTY state before writing to stdout, so tests and non-standard callers can suppress or force banner emission consistently.
- Nodes RPC transport timeout handling now uses the existing positive-integer timeout parser instead of `Number(...)`, preventing malformed values from reaching gateway calls as `NaN`.
- Adds focused regressions for both banner emission and nodes RPC timeout rejection.

## Linked context

Related: local clawpatch findings `fnd_sig-feat-cli-command-a46daf300c-_54ecc11a3e`, `fnd_sig-feat-cli-command-65b90e46bd-_38d9e559f2`.

## Real behavior proof

Behavior addressed: CLI banner emission ignored injected `isTty`; nodes RPC CLI timeout parsing forwarded invalid values as `NaN`.
Real environment tested: local OpenClaw checkout on macOS, actual `pnpm openclaw` CLI invocation, direct Node runtime import with `tsx`, and focused Vitest via repo wrapper.
Exact steps or command run after this patch: `pnpm openclaw nodes list --timeout nope --json`; `node --import tsx --input-type=module` runtime import of `src/cli/banner.ts` calling `emitCliBanner` with `process.stdout.isTTY=true` and `isTty:false`; `node scripts/run-vitest.mjs src/cli/banner.test.ts src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts`
Evidence after fix: `pnpm openclaw nodes list --timeout nope --json` exited 1 and printed `nodes list failed: Error: Invalid --timeout. Use a positive millisecond value, e.g. --timeout 30000. Received: "nope".`; the banner runtime import printed `stdout.isTTY=true`, `injected.isTty=false`, `writes=0`, `emitted=false`; focused Vitest passed 2 files / 12 tests.
Observed result after fix: actual CLI rejects malformed nodes RPC timeouts before gateway transport; injected non-TTY banner calls do not write or mark the banner emitted; injected TTY calls can emit when stdout lacks `isTTY`; regression tests cover both paths.
What was not tested: full repository check suite.
Proof limitations or environment constraints: the banner proof uses a direct runtime module import because the changed `isTty` override is an internal injection path rather than a user-facing CLI flag.
Before evidence: code inspection showed `emitCliBanner` gated on `process.stdout.isTTY` directly and nodes RPC runtime used `Number(opts.timeout ?? 10_000)`.

## Verification

- `node scripts/run-vitest.mjs src/cli/banner.test.ts src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cli/banner.ts src/cli/banner.test.ts src/cli/nodes-cli/rpc.runtime.ts src/cli/nodes-cli/register.invoke.approval-transport-timeout.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> `autoreview clean: no accepted/actionable findings reported`

## Risk checklist

Did user-visible behavior change? `Yes`, invalid nodes RPC timeout values now fail with the existing timeout error instead of leaking `NaN` into gateway transport behavior.
Did config, environment, or migration behavior change? `No`.
Did security, auth, secrets, network, or tool execution behavior change? `No`.
What is the highest-risk area? CLI callers that accidentally relied on malformed timeout strings silently bypassing transport timeout handling.
How is that risk mitigated? Existing parser/error contract is reused and focused tests cover invalid timeout rejection plus explicit timeout forwarding.

## Current review state

What is the next action? Review and CI.
What is still waiting on author, maintainer, CI, or external proof? GitHub CI on the pushed branch.
Which bot or reviewer comments were addressed? None yet.
