### PR TITLE
fix(memory): reject invalid CLI numeric options

### DIFF
--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -212,6 +212,40 @@ describe("memory cli", () => {
     await program.parseAsync(["memory", ...args], { from: "user" });
   }
 
+  it("rejects invalid memory search numeric options before running the command", async () => {
+    const program = new Command();
+    program.name("test");
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: () => {},
+    });
+    registerMemoryCli(program);
+
+    await expect(
+      program.parseAsync(["memory", "search", "hello", "--max-results", "nope"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("--max-results must be a finite number.");
+    expect(getMemorySearchManager).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid memory promote numeric options before running the command", async () => {
+    const program = new Command();
+    program.name("test");
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: () => {},
+    });
+    registerMemoryCli(program);
+
+    await expect(
+      program.parseAsync(["memory", "promote", "--limit", "Infinity"], { from: "user" }),
+    ).rejects.toThrow("--limit must be a finite number.");
+    expect(getMemorySearchManager).not.toHaveBeenCalled();
+  });
+
   function captureHelpOutput(command: Command | undefined) {
     let output = "";
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -1,4 +1,4 @@
-import { InvalidArgumentError, type Command } from "commander";
+import type { Command } from "commander";
 import {
   formatDocsLink,
   formatHelpExamples,
@@ -68,7 +68,7 @@ async function runMemoryRemBackfill(opts: MemoryRemBackfillOptions) {
 function parseMemoryCliNumberOption(value: string, flag: string): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) {
-    throw new InvalidArgumentError(`${flag} must be a finite number.`);
+    throw new Error(`${flag} must be a finite number.`);
   }
   return parsed;
 }

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -65,10 +65,19 @@ async function runMemoryRemBackfill(opts: MemoryRemBackfillOptions) {
   await runtime.runMemoryRemBackfill(opts);
 }
 
+function invalidCliArgument(message: string): Error & { code: string; exitCode: number } {
+  const error = new Error(message) as Error & { code: string; exitCode: number };
+  error.name = "InvalidArgumentError";
+  // Commander recognizes parser failures by code; keep the import type-only for bundled plugin deps.
+  error.code = "commander.invalidArgument";
+  error.exitCode = 1;
+  return error;
+}
+
 function parseMemoryCliNumberOption(value: string, flag: string): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) {
-    throw new Error(`${flag} must be a finite number.`);
+    throw invalidCliArgument(`${flag} must be a finite number.`);
   }
   return parsed;
 }

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import {
   formatDocsLink,
   formatHelpExamples,
@@ -63,6 +63,14 @@ async function runMemoryRemHarness(opts: MemoryRemHarnessOptions) {
 async function runMemoryRemBackfill(opts: MemoryRemBackfillOptions) {
   const runtime = await loadMemoryCliRuntime();
   await runtime.runMemoryRemBackfill(opts);
+}
+
+function parseMemoryCliNumberOption(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new InvalidArgumentError(`${flag} must be a finite number.`);
+  }
+  return parsed;
 }
 
 export function registerMemoryCli(program: Command) {
@@ -142,8 +150,12 @@ export function registerMemoryCli(program: Command) {
     .argument("[query]", "Search query")
     .option("--query <text>", "Search query (alternative to positional argument)")
     .option("--agent <id>", "Agent id (default: default agent)")
-    .option("--max-results <n>", "Max results", (value: string) => Number(value))
-    .option("--min-score <n>", "Minimum score", (value: string) => Number(value))
+    .option("--max-results <n>", "Max results", (value: string) =>
+      parseMemoryCliNumberOption(value, "--max-results"),
+    )
+    .option("--min-score <n>", "Minimum score", (value: string) =>
+      parseMemoryCliNumberOption(value, "--min-score"),
+    )
     .option("--json", "Print JSON")
     .action(async (queryArg: string | undefined, opts: MemorySearchCommandOptions) => {
       await runMemorySearch(queryArg, opts);
@@ -153,21 +165,23 @@ export function registerMemoryCli(program: Command) {
     .command("promote")
     .description("Rank short-term recalls and optionally append top entries to MEMORY.md")
     .option("--agent <id>", "Agent id (default: default agent)")
-    .option("--limit <n>", "Max candidates", (value: string) => Number(value))
+    .option("--limit <n>", "Max candidates", (value: string) =>
+      parseMemoryCliNumberOption(value, "--limit"),
+    )
     .option(
       "--min-score <n>",
       `Minimum weighted score (default: ${DEFAULT_PROMOTION_MIN_SCORE})`,
-      (value: string) => Number(value),
+      (value: string) => parseMemoryCliNumberOption(value, "--min-score"),
     )
     .option(
       "--min-recall-count <n>",
       `Minimum recall count (default: ${DEFAULT_PROMOTION_MIN_RECALL_COUNT})`,
-      (value: string) => Number(value),
+      (value: string) => parseMemoryCliNumberOption(value, "--min-recall-count"),
     )
     .option(
       "--min-unique-queries <n>",
       `Minimum distinct query count (default: ${DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES})`,
-      (value: string) => Number(value),
+      (value: string) => parseMemoryCliNumberOption(value, "--min-unique-queries"),
     )
     .option("--apply", "Append selected candidates to MEMORY.md", false)
     .option("--include-promoted", "Include already promoted candidates", false)

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -172,6 +172,42 @@ describe("memory-wiki cli", () => {
     );
   });
 
+  it("rejects apply confidence values outside the documented range", async () => {
+    const { config } = await createCliVault();
+    const program = new Command();
+    program.name("test");
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: () => {},
+    });
+    registerWikiCli(program, config);
+
+    await expect(
+      program.parseAsync(
+        [
+          "wiki",
+          "apply",
+          "synthesis",
+          "CLI Alpha",
+          "--body",
+          "Alpha from CLI.",
+          "--source-id",
+          "source.alpha",
+          "--confidence",
+          "Infinity",
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("--confidence must be a number between 0 and 1.");
+
+    await expect(
+      program.parseAsync(["wiki", "apply", "metadata", "entity.alpha", "--confidence", "1.5"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("--confidence must be a number between 0 and 1.");
+  });
+
   it("registers apply metadata and preserves the page body", async () => {
     const { rootDir, config } = await createCliVault();
     const targetPath = path.join(rootDir, "entities", "alpha.md");

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
 import {
   isRecord,
@@ -431,14 +431,20 @@ function addWikiSearchConfigOptions<T extends Command>(command: T): T {
     );
 }
 
+function parseWikiConfidenceOption(value: string): number {
+  const confidence = Number(value);
+  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    throw new InvalidArgumentError("--confidence must be a number between 0 and 1.");
+  }
+  return confidence;
+}
+
 function addWikiApplyMutationOptions<T extends Command>(command: T): T {
   return command
     .option("--source-id <id>", "Source id", collectCliValues)
     .option("--contradiction <text>", "Contradiction note", collectCliValues)
     .option("--question <text>", "Open question", collectCliValues)
-    .option("--confidence <n>", "Confidence score between 0 and 1", (value: string) =>
-      Number(value),
-    )
+    .option("--confidence <n>", "Confidence score between 0 and 1", parseWikiConfidenceOption)
     .option("--status <status>", "Page status");
 }
 

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -431,10 +431,19 @@ function addWikiSearchConfigOptions<T extends Command>(command: T): T {
     );
 }
 
+function invalidCliArgument(message: string): Error & { code: string; exitCode: number } {
+  const error = new Error(message) as Error & { code: string; exitCode: number };
+  error.name = "InvalidArgumentError";
+  // Commander recognizes parser failures by code; keep the import type-only for bundled plugin deps.
+  error.code = "commander.invalidArgument";
+  error.exitCode = 1;
+  return error;
+}
+
 function parseWikiConfidenceOption(value: string): number {
   const confidence = Number(value);
   if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
-    throw new Error("--confidence must be a number between 0 and 1.");
+    throw invalidCliArgument("--confidence must be a number between 0 and 1.");
   }
   return confidence;
 }

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { InvalidArgumentError, type Command } from "commander";
+import type { Command } from "commander";
 import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
 import {
   isRecord,
@@ -434,7 +434,7 @@ function addWikiSearchConfigOptions<T extends Command>(command: T): T {
 function parseWikiConfidenceOption(value: string): number {
   const confidence = Number(value);
   if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
-    throw new InvalidArgumentError("--confidence must be a number between 0 and 1.");
+    throw new Error("--confidence must be a number between 0 and 1.");
   }
   return confidence;
 }


### PR DESCRIPTION
## Summary
- Reject non-finite memory CLI numeric options before command runtime for `memory search` and `memory promote`.
- Enforce `wiki apply --confidence` as a finite 0..1 value before metadata mutation.
- Preserve Commander parse-error UX without importing `commander` at bundled plugin runtime.

## Verification
Behavior addressed: invalid memory/wiki numeric CLI inputs now fail in Commander parsing before command actions run.
Real environment tested: local checkout, Node/Vitest through repo wrapper, CLI via `pnpm openclaw`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts extensions/memory-wiki/src/cli.test.ts`; `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/cli.ts extensions/memory-core/src/cli.test.ts extensions/memory-wiki/src/cli.ts extensions/memory-wiki/src/cli.test.ts`; `git diff --check`; `pnpm openclaw memory search hello --max-results nope --json`; `pnpm openclaw wiki apply synthesis CLIProof --body proof --source-id source.alpha --confidence 1.5 --json`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.
Evidence after fix: focused Vitest passed 2 files / 68 tests; oxfmt and `git diff --check` passed; autoreview reported no accepted/actionable findings.
Observed result after fix: `memory search --max-results nope` exits 1 with `option '--max-results <n>' argument 'nope' is invalid. --max-results must be a finite number.`; `wiki apply ... --confidence 1.5` exits 1 with `option '--confidence <n>' argument '1.5' is invalid. --confidence must be a number between 0 and 1.`
What was not tested: full CI locally; GitHub CI is running on the pushed branch.
