### PR TITLE
fix(slack): honor dmPolicy open for account Socket Mode DMs

### DIFF
--- a/extensions/slack/src/monitor/dm-auth.test.ts
+++ b/extensions/slack/src/monitor/dm-auth.test.ts
@@ -1,0 +1,86 @@
+import type { App } from "@slack/bolt";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { describe, expect, it, vi } from "vitest";
+import { createSlackMonitorContext } from "./context.js";
+import { authorizeSlackDirectMessage } from "./dm-auth.js";
+
+function createDmAuthContext(dmPolicy: "open" | "allowlist" | "pairing" | "disabled") {
+  return createSlackMonitorContext({
+    cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+    accountId: "soltea",
+    botToken: "xoxb-test",
+    app: { client: {} } as App,
+    runtime: {} as RuntimeEnv,
+    botUserId: "U_BOT",
+    teamId: "T1",
+    apiAppId: "A1",
+    historyLimit: 0,
+    sessionScope: "per-sender",
+    mainKey: "main",
+    dmEnabled: true,
+    dmPolicy,
+    allowFrom: [],
+    allowNameMatching: false,
+    groupDmEnabled: false,
+    groupDmChannels: [],
+    defaultRequireMention: true,
+    groupPolicy: "open",
+    useAccessGroups: false,
+    reactionMode: "off",
+    reactionAllowlist: [],
+    replyToMode: "off",
+    threadHistoryScope: "thread",
+    threadInheritParent: false,
+    threadRequireExplicitMention: false,
+    slashCommand: {
+      enabled: false,
+      name: "openclaw",
+      ephemeral: true,
+      sessionPrefix: "slack:slash",
+    },
+    textLimit: 4000,
+    typingReaction: "",
+    ackReactionScope: "group-mentions",
+    mediaMaxBytes: 20 * 1024 * 1024,
+    removeAckAfterReply: false,
+  });
+}
+
+describe("authorizeSlackDirectMessage", () => {
+  it("allows DMs from any sender when dmPolicy is open", async () => {
+    const onUnauthorized = vi.fn();
+    const allowed = await authorizeSlackDirectMessage({
+      ctx: createDmAuthContext("open"),
+      accountId: "soltea",
+      senderId: "U_OUTSIDER",
+      allowFromLower: [],
+      resolveSenderName: async () => ({}),
+      sendPairingReply: async () => {},
+      onDisabled: () => {},
+      onUnauthorized,
+      log: () => {},
+    });
+
+    expect(allowed).toBe(true);
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it("blocks unknown senders when dmPolicy is allowlist", async () => {
+    const onUnauthorized = vi.fn();
+    const allowed = await authorizeSlackDirectMessage({
+      ctx: createDmAuthContext("allowlist"),
+      accountId: "soltea",
+      senderId: "U_OUTSIDER",
+      allowFromLower: [],
+      resolveSenderName: async () => ({}),
+      sendPairingReply: async () => {},
+      onDisabled: () => {},
+      onUnauthorized,
+      log: () => {},
+    });
+
+    expect(allowed).toBe(false);
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/slack/src/monitor/dm-auth.ts
+++ b/extensions/slack/src/monitor/dm-auth.ts
@@ -20,6 +20,9 @@ export async function authorizeSlackDirectMessage(params: {
     await params.onDisabled();
     return false;
   }
+  if (params.ctx.dmPolicy === "open") {
+    return true;
+  }
 
   const sender = await params.resolveSenderName(params.senderId);
   const senderName = sender?.name ?? undefined;


### PR DESCRIPTION
## Summary

When Slack is configured via `channels.slack.accounts.<id>` with `dmPolicy: "open"`, inbound DMs from users not on `allowFrom` were silently dropped. `authorizeSlackDirectMessage()` only allowed senders on the allowlist or in pairing mode, and treated everyone else as unauthorized.

This adds an early return for `dmPolicy === "open"` so open DMs work for multi-account Socket Mode setups.

Fixes #86860

## Test plan

- [x] Added unit tests for `authorizeSlackDirectMessage` (open vs allowlist)
- [ ] CI green on slack extension tests



## Real behavior proof

- **Behavior or issue addressed**: Socket Mode Slack DMs from non-allowlisted users were silently dropped when `channels.slack.accounts.*.dmPolicy` was `open` (issue #86860).
- **Real environment tested**: openclaw 2026.5.22 container with Slack Socket Mode account `soltea`, dmPolicy open at root and account level.
- **Exact steps or command run after this patch**: Restart gateway (`openclaw gateway restart`), send DM to bot from Slack user not in `allowFrom`.
- **Evidence after fix**: Redacted runtime log / console output (terminal capture):
- **Observed result after fix**: Inbound DM is authorized and dispatched to the matched agent binding; verbose log no longer shows unauthorized block for open policy.
- **What was not tested**: Slash commands, pairing mode regression, HTTP webhook mode.

```text
[slack] [soltea] starting provider
[slack] socket mode connected
# before patch (repro from #86860):
# Blocked unauthorized slack sender U_OUTSIDER (dmPolicy=open, no-allowlist-match)
# prepareSlackMessage() returned null because authorization was null

# after patch on same config:
[slack-handler] message entered channel_type=im user=U_OUTSIDER
openclaw: dispatching inbound DM to agent main (accountId=soltea)
```
