### PR TITLE
fix(config): narrow profiled tool section doctor repair

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { OpenClawConfig } from "../../../config/types.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
 
@@ -90,6 +91,712 @@ describe("legacy silent reply config migrate", () => {
       "Removed agents.defaults.silentReplyRewrite",
       "Removed surfaces.telegram.silentReplyRewrite",
     ]);
+  });
+});
+
+describe("profile configured tool section migrate", () => {
+  it("adds explicit global alsoAllow grants for configured tool sections under profiles", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["read", "write"],
+        exec: { security: "allowlist" },
+        fs: { workspaceOnly: true },
+      },
+    });
+
+    expect(res.config?.tools?.alsoAllow).toEqual(["read", "write", "exec", "process", "edit"]);
+    expect(res.changes).toContain(
+      'Added tools.alsoAllow entries (exec, process, edit) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("adds explicit agent alsoAllow grants for configured tool sections under profiles", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              profile: "messaging",
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("does not change profiled tool sections when explicit grants already cover them", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process", "read", "write", "edit"],
+        exec: { security: "allowlist" },
+        fs: { workspaceOnly: true },
+      },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
+  it("adds missing grants to allow when an allowlist already exists", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["message"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools).not.toHaveProperty("alsoAllow");
+    expect(res.changes).toContain(
+      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
+    );
+    expect(res.changes).toContain(
+      'Added tools.allow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("sets profile full when an existing allowlist already contains configured section grants", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["message", "exec", "process"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.changes).toEqual([
+      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
+    ]);
+  });
+
+  it("narrows broad allowlists before making them authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["*"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.allow).toContain("message");
+    expect(res.config?.tools?.allow).toContain("exec");
+    expect(res.config?.tools?.allow).toContain("process");
+    expect(res.config?.tools?.allow).not.toContain("*");
+    expect(res.config?.tools?.allow).not.toContain("read");
+    expect(res.changes).toContain(
+      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+    );
+  });
+
+  it("concretizes profile-bound glob allowlists before making them authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["sessions_*"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.allow).toEqual([
+      "sessions_list",
+      "sessions_history",
+      "sessions_send",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.tools?.allow).not.toContain("session_status");
+    expect(res.config?.tools?.allow).not.toContain("sessions_*");
+  });
+
+  it("preserves plugin allow entries when making profiles authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["gmail_search"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.allow).toEqual(["gmail_search", "exec", "process"]);
+  });
+
+  it("adds missing allow grants even when the selected profile already covers them", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "coding",
+        allow: ["message"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.changes).toContain(
+      'Added tools.allow entries (exec, process) for configured tool sections under profile "coding".',
+    );
+  });
+
+  it("drops allow entries blocked by the original profile before making them authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["message", "web_search"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.allow).not.toContain("web_search");
+    expect(res.changes).toContain(
+      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+    );
+  });
+
+  it("adds provider-scoped alsoAllow grants for configured tool sections under profiles", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("sets provider profile full when provider allow already contains configured section grants", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+            allow: ["message", "exec", "process"],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
+    expect(res.changes).toContain(
+      'Set tools.byProvider.openai.profile to "full" so tools.byProvider.openai.allow controls configured tool sections directly.',
+    );
+  });
+
+  it("narrows broad provider allowlists before making them authoritative", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+            allow: ["group:openclaw"],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
+    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("message");
+    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("exec");
+    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("process");
+    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("group:openclaw");
+    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("read");
+    expect(res.changes).toContain(
+      'Replaced tools.byProvider.openai.allow entries with profile "messaging" grants plus configured tool sections.',
+    );
+  });
+
+  it("drops provider allow entries blocked by the original profile", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+            allow: ["message", "web_search"],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
+    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("web_search");
+    expect(res.changes).toContain(
+      'Replaced tools.byProvider.openai.allow entries with profile "messaging" grants plus configured tool sections.',
+    );
+  });
+
+  it("updates restrictive provider allowlists that inherit the active profile", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        byProvider: {
+          openai: {
+            allow: ["message"],
+          },
+        },
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.tools?.byProvider?.openai).not.toHaveProperty("profile");
+    expect(res.changes).toContain(
+      'Added tools.byProvider.openai.allow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("does not use parent alsoAllow as provider profile alsoAllow", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process"],
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.byProvider?.openai?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("adds agent grants when configured sections inherit the global profile", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("does not grant global configured sections to an agent-owned profile", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        exec: { security: "allowlist" },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              profile: "messaging",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
+    expect(res.changes).not.toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("preserves inherited alsoAllow when creating an agent override", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        exec: { security: "allowlist" },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              fs: { workspaceOnly: true },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual([
+      "exec",
+      "process",
+      "read",
+      "write",
+      "edit",
+    ]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process, read, write, edit) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("overrides an inherited profile when an agent allowlist already exists", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              allow: ["message"],
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
+    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
+    expect(res.changes).toContain(
+      'Set agents.list.0.tools.profile to "full" so agents.list.0.tools.allow controls configured tool sections directly.',
+    );
+  });
+
+  it("adds agent allow grants even when inherited alsoAllow already covers them", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process"],
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              allow: ["message"],
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
+    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
+  });
+
+  it("respects an explicit empty agent alsoAllow override", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process"],
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              alsoAllow: [],
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("adds agent allow grants for globally configured sections", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        exec: { security: "allowlist" },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              allow: ["message"],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
+    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+  });
+
+  it("adds agent provider-scoped grants for configured tool sections under profiles", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+              byProvider: {
+                openai: {
+                  profile: "messaging",
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
+      "exec",
+      "process",
+    ]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("adds agent provider-scoped grants for globally configured tool sections", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              byProvider: {
+                openai: {
+                  profile: "messaging",
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
+      "exec",
+      "process",
+    ]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+  });
+
+  it("inherits provider profiles through model-scoped provider overrides", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              byProvider: {
+                "openai/gpt-5": {
+                  allow: ["message"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.profile).toBe(
+      "full",
+    );
+  });
+
+  it("materializes inherited provider profile grants for agent configured sections", () => {
+    const raw = {
+      tools: {
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+            },
+          },
+        ],
+      },
+    };
+    const res = migrateLegacyConfigForTest(raw);
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
+      "exec",
+      "process",
+    ]);
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).toContain("agents.list");
+  });
+
+  it("adds provider-wide inherited grants even when a model override is also repaired", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+              byProvider: {
+                "openai/gpt-5": {
+                  allow: ["message"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
+      "exec",
+      "process",
+    ]);
+  });
+
+  it("prefers canonical inherited provider policy keys when materializing grants", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        byProvider: {
+          modelstudio: {
+            profile: "coding",
+          },
+          qwen: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: { security: "allowlist" },
+              byProvider: {
+                "qwen/qwen-plus": {
+                  allow: ["message"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["qwen/qwen-plus"]?.allow).toEqual([
+      "message",
+      "exec",
+      "process",
+    ]);
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["qwen/qwen-plus"]?.profile).toBe(
+      "full",
+    );
+    expect(res.changes).toContain(
+      'Added agents.list.0.tools.byProvider.qwen/qwen-plus.allow entries (exec, process) for configured tool sections under profile "messaging".',
+    );
   });
 });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -95,58 +95,34 @@ describe("legacy silent reply config migrate", () => {
 });
 
 describe("profile configured tool section migrate", () => {
-  it("adds explicit global alsoAllow grants for configured tool sections under profiles", () => {
-    const res = migrateLegacyConfigForTest({
+  it("does not add grants when configured sections are the only signal", () => {
+    const raw = {
       tools: {
         profile: "messaging",
         alsoAllow: ["read", "write"],
         exec: { security: "allowlist" },
         fs: { workspaceOnly: true },
       },
-    });
-
-    expect(res.config?.tools?.alsoAllow).toEqual(["read", "write", "exec", "process", "edit"]);
-    expect(res.changes).toContain(
-      'Added tools.alsoAllow entries (exec, process, edit) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("adds explicit agent alsoAllow grants for configured tool sections under profiles", () => {
-    const res = migrateLegacyConfigForTest({
       agents: {
         list: [
           {
             id: "sage",
             tools: {
-              profile: "messaging",
               exec: { security: "allowlist" },
             },
           },
         ],
       },
-    });
-
-    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
-    expect(res.changes).toContain(
-      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("does not change profiled tool sections when explicit grants already cover them", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        alsoAllow: ["exec", "process", "read", "write", "edit"],
-        exec: { security: "allowlist" },
-        fs: { workspaceOnly: true },
-      },
-    });
+    };
+    const res = migrateLegacyConfigForTest(raw);
 
     expect(res.config).toBeNull();
     expect(res.changes).toEqual([]);
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).not.toContain("tools");
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).not.toContain("agents.list");
   });
 
-  it("adds missing grants to allow when an allowlist already exists", () => {
+  it("does not add missing grants to an unrelated allowlist", () => {
     const res = migrateLegacyConfigForTest({
       tools: {
         profile: "messaging",
@@ -155,18 +131,11 @@ describe("profile configured tool section migrate", () => {
       },
     });
 
-    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
-    expect(res.config?.tools?.profile).toBe("full");
-    expect(res.config?.tools).not.toHaveProperty("alsoAllow");
-    expect(res.changes).toContain(
-      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
-    );
-    expect(res.changes).toContain(
-      'Added tools.allow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
   });
 
-  it("sets profile full when an existing allowlist already contains configured section grants", () => {
+  it("sets profile full when an allowlist already contains configured-section grants", () => {
     const res = migrateLegacyConfigForTest({
       tools: {
         profile: "messaging",
@@ -177,10 +146,43 @@ describe("profile configured tool section migrate", () => {
 
     expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
     expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools).not.toHaveProperty("alsoAllow");
     expect(res.changes).toEqual([
-      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
-      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
+      'Replaced tools.allow entries with profile "messaging" grants plus explicit configured-section grants.',
+      'Set tools.profile to "full" so tools.allow controls explicit configured-section grants directly.',
     ]);
+  });
+
+  it("merges same-scope alsoAllow when it contains explicit configured-section grants", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["message"],
+        alsoAllow: ["exec"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["message", "exec"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools).not.toHaveProperty("alsoAllow");
+    expect(res.changes).toContain("Merged tools.alsoAllow into tools.allow.");
+    expect(res.config?.tools?.allow).not.toContain("process");
+  });
+
+  it("repairs configured-section grants held in allow when alsoAllow is also present", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        profile: "messaging",
+        allow: ["message", "exec", "process"],
+        alsoAllow: ["browser"],
+        exec: { security: "allowlist" },
+      },
+    });
+
+    expect(res.config?.tools?.allow).toEqual(["message", "browser", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools).not.toHaveProperty("alsoAllow");
   });
 
   it("narrows broad allowlists before making them authoritative", () => {
@@ -199,33 +201,19 @@ describe("profile configured tool section migrate", () => {
     expect(res.config?.tools?.allow).not.toContain("*");
     expect(res.config?.tools?.allow).not.toContain("read");
     expect(res.changes).toContain(
-      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+      'Replaced tools.allow entries with profile "messaging" grants plus explicit configured-section grants.',
     );
   });
 
-  it("concretizes profile-bound glob allowlists before making them authoritative", () => {
-    const res = migrateLegacyConfigForTest({
+  it("does not treat unrelated globs or plugin allow entries as configured-section grants", () => {
+    const glob = migrateLegacyConfigForTest({
       tools: {
         profile: "messaging",
         allow: ["sessions_*"],
         exec: { security: "allowlist" },
       },
     });
-
-    expect(res.config?.tools?.profile).toBe("full");
-    expect(res.config?.tools?.allow).toEqual([
-      "sessions_list",
-      "sessions_history",
-      "sessions_send",
-      "exec",
-      "process",
-    ]);
-    expect(res.config?.tools?.allow).not.toContain("session_status");
-    expect(res.config?.tools?.allow).not.toContain("sessions_*");
-  });
-
-  it("preserves plugin allow entries when making profiles authoritative", () => {
-    const res = migrateLegacyConfigForTest({
+    const plugin = migrateLegacyConfigForTest({
       tools: {
         profile: "messaging",
         allow: ["gmail_search"],
@@ -233,180 +221,11 @@ describe("profile configured tool section migrate", () => {
       },
     });
 
-    expect(res.config?.tools?.profile).toBe("full");
-    expect(res.config?.tools?.allow).toEqual(["gmail_search", "exec", "process"]);
+    expect(glob.config).toBeNull();
+    expect(plugin.config).toBeNull();
   });
 
-  it("adds missing allow grants even when the selected profile already covers them", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "coding",
-        allow: ["message"],
-        exec: { security: "allowlist" },
-      },
-    });
-
-    expect(res.config?.tools?.allow).toEqual(["exec", "process"]);
-    expect(res.config?.tools?.profile).toBe("full");
-    expect(res.changes).toContain(
-      'Added tools.allow entries (exec, process) for configured tool sections under profile "coding".',
-    );
-  });
-
-  it("drops allow entries blocked by the original profile before making them authoritative", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        allow: ["message", "web_search"],
-        exec: { security: "allowlist" },
-      },
-    });
-
-    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
-    expect(res.config?.tools?.profile).toBe("full");
-    expect(res.config?.tools?.allow).not.toContain("web_search");
-    expect(res.changes).toContain(
-      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
-    );
-  });
-
-  it("adds provider-scoped alsoAllow grants for configured tool sections under profiles", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        exec: { security: "allowlist" },
-        byProvider: {
-          openai: {
-            profile: "messaging",
-          },
-        },
-      },
-    });
-
-    expect(res.config?.tools?.byProvider?.openai?.alsoAllow).toEqual(["exec", "process"]);
-    expect(res.changes).toContain(
-      'Added tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("sets provider profile full when provider allow already contains configured section grants", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        exec: { security: "allowlist" },
-        byProvider: {
-          openai: {
-            profile: "messaging",
-            allow: ["message", "exec", "process"],
-          },
-        },
-      },
-    });
-
-    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
-      "message",
-      "exec",
-      "process",
-    ]);
-    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
-    expect(res.changes).toContain(
-      'Set tools.byProvider.openai.profile to "full" so tools.byProvider.openai.allow controls configured tool sections directly.',
-    );
-  });
-
-  it("narrows broad provider allowlists before making them authoritative", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        exec: { security: "allowlist" },
-        byProvider: {
-          openai: {
-            profile: "messaging",
-            allow: ["group:openclaw"],
-          },
-        },
-      },
-    });
-
-    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
-    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("message");
-    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("exec");
-    expect(res.config?.tools?.byProvider?.openai?.allow).toContain("process");
-    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("group:openclaw");
-    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("read");
-    expect(res.changes).toContain(
-      'Replaced tools.byProvider.openai.allow entries with profile "messaging" grants plus configured tool sections.',
-    );
-  });
-
-  it("drops provider allow entries blocked by the original profile", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        exec: { security: "allowlist" },
-        byProvider: {
-          openai: {
-            profile: "messaging",
-            allow: ["message", "web_search"],
-          },
-        },
-      },
-    });
-
-    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
-      "message",
-      "exec",
-      "process",
-    ]);
-    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
-    expect(res.config?.tools?.byProvider?.openai?.allow).not.toContain("web_search");
-    expect(res.changes).toContain(
-      'Replaced tools.byProvider.openai.allow entries with profile "messaging" grants plus configured tool sections.',
-    );
-  });
-
-  it("updates restrictive provider allowlists that inherit the active profile", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        byProvider: {
-          openai: {
-            allow: ["message"],
-          },
-        },
-        exec: { security: "allowlist" },
-      },
-    });
-
-    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
-    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual([
-      "message",
-      "exec",
-      "process",
-    ]);
-    expect(res.config?.tools?.byProvider?.openai).not.toHaveProperty("profile");
-    expect(res.changes).toContain(
-      'Added tools.byProvider.openai.allow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("does not use parent alsoAllow as provider profile alsoAllow", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        alsoAllow: ["exec", "process"],
-        byProvider: {
-          openai: {
-            profile: "messaging",
-          },
-        },
-        exec: { security: "allowlist" },
-      },
-    });
-
-    expect(res.config?.tools?.byProvider?.openai?.alsoAllow).toEqual(["exec", "process"]);
-    expect(res.changes).toContain(
-      'Added tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("adds agent grants when configured sections inherit the global profile", () => {
+  it("repairs agent allowlists with explicit configured-section grants under an inherited profile", () => {
     const res = migrateLegacyConfigForTest({
       tools: {
         profile: "messaging",
@@ -416,86 +235,7 @@ describe("profile configured tool section migrate", () => {
           {
             id: "sage",
             tools: {
-              exec: { security: "allowlist" },
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
-    expect(res.changes).toContain(
-      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("does not grant global configured sections to an agent-owned profile", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        exec: { security: "allowlist" },
-      },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              profile: "messaging",
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
-    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
-    expect(res.changes).not.toContain(
-      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("preserves inherited alsoAllow when creating an agent override", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        exec: { security: "allowlist" },
-      },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              fs: { workspaceOnly: true },
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.tools?.alsoAllow).toEqual(["exec", "process"]);
-    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual([
-      "exec",
-      "process",
-      "read",
-      "write",
-      "edit",
-    ]);
-    expect(res.changes).toContain(
-      'Added agents.list.0.tools.alsoAllow entries (exec, process, read, write, edit) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("overrides an inherited profile when an agent allowlist already exists", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-      },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              allow: ["message"],
+              allow: ["message", "exec", "process"],
               exec: { security: "allowlist" },
             },
           },
@@ -504,193 +244,13 @@ describe("profile configured tool section migrate", () => {
     });
 
     expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
-    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
-      "message",
-      "exec",
-      "process",
-    ]);
-    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
-    expect(res.changes).toContain(
-      'Set agents.list.0.tools.profile to "full" so agents.list.0.tools.allow controls configured tool sections directly.',
-    );
+    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual(["message", "exec", "process"]);
   });
 
-  it("adds agent allow grants even when inherited alsoAllow already covers them", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        alsoAllow: ["exec", "process"],
-      },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              allow: ["message"],
-              exec: { security: "allowlist" },
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
-    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
-      "message",
-      "exec",
-      "process",
-    ]);
-    expect(res.config?.agents?.list?.[0]?.tools).not.toHaveProperty("alsoAllow");
-  });
-
-  it("respects an explicit empty agent alsoAllow override", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        alsoAllow: ["exec", "process"],
-      },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              alsoAllow: [],
-              exec: { security: "allowlist" },
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.agents?.list?.[0]?.tools?.alsoAllow).toEqual(["exec", "process"]);
-    expect(res.changes).toContain(
-      'Added agents.list.0.tools.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("adds agent allow grants for globally configured sections", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        profile: "messaging",
-        exec: { security: "allowlist" },
-      },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              allow: ["message"],
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.agents?.list?.[0]?.tools?.profile).toBe("full");
-    expect(res.config?.agents?.list?.[0]?.tools?.allow).toEqual([
-      "message",
-      "exec",
-      "process",
-    ]);
-  });
-
-  it("adds agent provider-scoped grants for configured tool sections under profiles", () => {
-    const res = migrateLegacyConfigForTest({
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              exec: { security: "allowlist" },
-              byProvider: {
-                openai: {
-                  profile: "messaging",
-                },
-              },
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
-      "exec",
-      "process",
-    ]);
-    expect(res.changes).toContain(
-      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("adds agent provider-scoped grants for globally configured tool sections", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        exec: { security: "allowlist" },
-      },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              byProvider: {
-                openai: {
-                  profile: "messaging",
-                },
-              },
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
-      "exec",
-      "process",
-    ]);
-    expect(res.changes).toContain(
-      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-  });
-
-  it("inherits provider profiles through model-scoped provider overrides", () => {
-    const res = migrateLegacyConfigForTest({
-      tools: {
-        exec: { security: "allowlist" },
-        byProvider: {
-          openai: {
-            profile: "messaging",
-          },
-        },
-      },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              byProvider: {
-                "openai/gpt-5": {
-                  allow: ["message"],
-                },
-              },
-            },
-          },
-        ],
-      },
-    });
-
-    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.allow).toEqual([
-      "message",
-      "exec",
-      "process",
-    ]);
-    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.profile).toBe(
-      "full",
-    );
-  });
-
-  it("materializes inherited provider profile grants for agent configured sections", () => {
+  it("does not materialize provider grants when no provider grant intent is explicit", () => {
     const raw = {
       tools: {
+        exec: { security: "allowlist" },
         byProvider: {
           openai: {
             profile: "messaging",
@@ -710,60 +270,54 @@ describe("profile configured tool section migrate", () => {
     };
     const res = migrateLegacyConfigForTest(raw);
 
-    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
-      "exec",
-      "process",
-    ]);
-    expect(res.changes).toContain(
-      'Added agents.list.0.tools.byProvider.openai.alsoAllow entries (exec, process) for configured tool sections under profile "messaging".',
-    );
-    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).toContain("agents.list");
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).not.toContain("agents.list");
   });
 
-  it("adds provider-wide inherited grants even when a model override is also repaired", () => {
-    const res = migrateLegacyConfigForTest({
+  it("does not report inherited top-level profile provider allowlists as fixable", () => {
+    const raw = {
       tools: {
+        profile: "messaging",
+        exec: { security: "allowlist" },
         byProvider: {
           openai: {
-            profile: "messaging",
+            allow: ["message", "exec", "process"],
           },
         },
       },
-      agents: {
-        list: [
-          {
-            id: "sage",
-            tools: {
-              exec: { security: "allowlist" },
-              byProvider: {
-                "openai/gpt-5": {
-                  allow: ["message"],
-                },
-              },
-            },
+    };
+    const res = migrateLegacyConfigForTest(raw);
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).not.toContain("tools");
+  });
+
+  it("sets provider profile full when provider allow already contains configured-section grants", () => {
+    const res = migrateLegacyConfigForTest({
+      tools: {
+        exec: { security: "allowlist" },
+        byProvider: {
+          openai: {
+            profile: "messaging",
+            allow: ["message", "exec", "process"],
           },
-        ],
+        },
       },
     });
 
-    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["openai/gpt-5"]?.allow).toEqual([
-      "message",
-      "exec",
-      "process",
-    ]);
-    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.openai?.alsoAllow).toEqual([
-      "exec",
-      "process",
-    ]);
+    expect(res.config?.tools?.byProvider?.openai?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.byProvider?.openai?.profile).toBe("full");
+    expect(res.changes).toContain(
+      'Set tools.byProvider.openai.profile to "full" so tools.byProvider.openai.allow controls explicit configured-section grants directly.',
+    );
   });
 
-  it("prefers canonical inherited provider policy keys when materializing grants", () => {
+  it("repairs model-scoped provider allowlists with inherited provider profiles", () => {
     const res = migrateLegacyConfigForTest({
       tools: {
         byProvider: {
-          modelstudio: {
-            profile: "coding",
-          },
           qwen: {
             profile: "messaging",
           },
@@ -777,7 +331,7 @@ describe("profile configured tool section migrate", () => {
               exec: { security: "allowlist" },
               byProvider: {
                 "qwen/qwen-plus": {
-                  allow: ["message"],
+                  allow: ["message", "exec", "process"],
                 },
               },
             },
@@ -794,8 +348,17 @@ describe("profile configured tool section migrate", () => {
     expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["qwen/qwen-plus"]?.profile).toBe(
       "full",
     );
-    expect(res.changes).toContain(
-      'Added agents.list.0.tools.byProvider.qwen/qwen-plus.allow entries (exec, process) for configured tool sections under profile "messaging".',
+  });
+
+  it("ignores blocked inherited provider keys while resolving provider repairs", () => {
+    const raw = JSON.parse(
+      '{"tools":{"byProvider":{"__proto__":{"profile":"messaging"},"qwen":{"profile":"messaging"}}},"agents":{"list":[{"id":"sage","tools":{"exec":{"security":"allowlist"},"byProvider":{"qwen/qwen-plus":{"allow":["message","exec","process"]}}}}]}}',
+    );
+    const res = migrateLegacyConfigForTest(raw);
+
+    expect(Object.prototype).not.toHaveProperty("profile");
+    expect(res.config?.agents?.list?.[0]?.tools?.byProvider?.["qwen/qwen-plus"]?.profile).toBe(
+      "full",
     );
   });
 });

--- a/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
@@ -6,6 +6,7 @@ describe("legacy config migrate validation", () => {
   let partialValidationResult: ReturnType<typeof migrateLegacyConfig>;
   let agentModelTimeoutResult: ReturnType<typeof migrateLegacyConfig>;
   let modelThinkingFormatResult: ReturnType<typeof migrateLegacyConfig>;
+  let profileConfiguredToolAllowResult: ReturnType<typeof migrateLegacyConfig>;
 
   beforeAll(() => {
     groupChatRoutingResult = migrateLegacyConfig({
@@ -89,6 +90,13 @@ describe("legacy config migrate validation", () => {
         },
       },
     });
+    profileConfiguredToolAllowResult = migrateLegacyConfig({
+      tools: {
+        profile: "messaging",
+        allow: ["message"],
+        exec: { security: "allowlist" },
+      },
+    });
   });
 
   it("returns valid migrated config for legacy group chat routing drift", () => {
@@ -167,5 +175,19 @@ describe("legacy config migrate validation", () => {
     expect(res.config?.models?.providers?.bailian?.models?.[1]?.compat).toEqual({
       thinkingFormat: "qwen",
     });
+  });
+
+  it("returns valid config when migrating profiled tool sections with an existing allowlist", () => {
+    const res = profileConfiguredToolAllowResult;
+
+    expect(res.partiallyValid).toBeUndefined();
+    expect(res.config?.tools?.allow).toEqual(["message", "exec", "process"]);
+    expect(res.config?.tools?.profile).toBe("full");
+    expect(res.config?.tools?.alsoAllow).toBeUndefined();
+    expect(res.changes).toStrictEqual([
+      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
+      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
+      'Added tools.allow entries (exec, process) for configured tool sections under profile "messaging".',
+    ]);
   });
 });

--- a/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
@@ -93,7 +93,7 @@ describe("legacy config migrate validation", () => {
     profileConfiguredToolAllowResult = migrateLegacyConfig({
       tools: {
         profile: "messaging",
-        allow: ["message"],
+        allow: ["message", "exec", "process"],
         exec: { security: "allowlist" },
       },
     });
@@ -185,9 +185,8 @@ describe("legacy config migrate validation", () => {
     expect(res.config?.tools?.profile).toBe("full");
     expect(res.config?.tools?.alsoAllow).toBeUndefined();
     expect(res.changes).toStrictEqual([
-      'Replaced tools.allow entries with profile "messaging" grants plus configured tool sections.',
-      'Set tools.profile to "full" so tools.allow controls configured tool sections directly.',
-      'Added tools.allow entries (exec, process) for configured tool sections under profile "messaging".',
+      'Replaced tools.allow entries with profile "messaging" grants plus explicit configured-section grants.',
+      'Set tools.profile to "full" so tools.allow controls explicit configured-section grants directly.',
     ]);
   });
 });

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -1,5 +1,9 @@
 import { listLegacyRuntimeModelProviderAliases } from "../../../agents/model-runtime-aliases.js";
 import { normalizeProviderId } from "../../../agents/provider-id.js";
+import { isKnownCoreToolId } from "../../../agents/tool-catalog.js";
+import { isToolAllowedByPolicyName } from "../../../agents/tool-policy-match.js";
+import { expandToolGroups, mergeAlsoAllowPolicy } from "../../../agents/tool-policy.js";
+import { resolveToolProfilePolicy } from "../../../agents/tool-policy-shared.js";
 import {
   defineLegacyConfigMigration,
   ensureRecord,
@@ -9,6 +13,7 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { isBlockedObjectKey } from "../../../config/prototype-keys.js";
+import { uniqueStrings } from "../../../shared/string-normalization.js";
 
 const AGENT_HEARTBEAT_KEYS = new Set([
   "every",
@@ -120,6 +125,39 @@ const IGNORED_AGENT_MODEL_TIMEOUT_RULES: LegacyConfigRule[] = [
     message:
       'agents.list[].model.timeoutMs and agents.list[].subagents.model.timeoutMs are ignored; agent model config only selects primary/fallback models. Run "openclaw doctor --fix" to remove them.',
     match: (value) => hasAgentListModelTimeout(value),
+  },
+];
+
+const PROFILE_CONFIGURED_TOOL_SECTION_RULES: LegacyConfigRule[] = [
+  {
+    path: ["tools"],
+    message:
+      'tools.profile no longer implicitly grants configured tools.exec/tools.fs sections; add explicit tool grants or run "openclaw doctor --fix".',
+    match: (value) => toolProfileConfiguredSectionsNeedAlsoAllow(value),
+  },
+  {
+    path: ["agents", "list"],
+    message:
+      'agents.list[].tools.profile no longer implicitly grants configured tools.exec/tools.fs sections; add explicit tool grants or run "openclaw doctor --fix".',
+    match: (value, root) => {
+      const globalTools = getRecord(root.tools);
+      const inheritedProfile =
+        typeof globalTools?.profile === "string" ? globalTools.profile : undefined;
+      const inheritedAlsoAllow = readToolPolicyGrantList(globalTools, "alsoAllow");
+      return (
+        Array.isArray(value) &&
+        value.some((agent) => {
+          const agentTools = getRecord(getRecord(agent)?.tools);
+          return toolProfileConfiguredSectionsNeedAlsoAllow(
+            agentTools,
+              inheritedProfile,
+              inheritedAlsoAllow,
+              collectEffectiveConfiguredToolSectionGrants(globalTools, agentTools),
+              getRecord(globalTools?.byProvider),
+            );
+          })
+      );
+    },
   },
 ];
 
@@ -472,7 +510,609 @@ function removeLegacySilentReplyConfig(raw: Record<string, unknown>, changes: st
   }
 }
 
+const CONFIGURED_TOOL_SECTION_GRANTS = [
+  { key: "exec", grants: ["exec", "process"] },
+  { key: "fs", grants: ["read", "write", "edit"] },
+] as const;
+
+function readToolPolicyGrantList(value: unknown, key: "allow" | "alsoAllow"): string[] {
+  return readOwnToolPolicyGrantList(value, key) ?? [];
+}
+
+function readOwnToolPolicyGrantList(
+  value: unknown,
+  key: "allow" | "alsoAllow",
+): string[] | undefined {
+  const tools = getRecord(value);
+  return Array.isArray(tools?.[key])
+    ? tools[key].filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+}
+
+function resolveToolProfileForMigration(
+  tools: Record<string, unknown>,
+  inheritedProfile?: string,
+): string | undefined {
+  return typeof tools.profile === "string" ? tools.profile : inheritedProfile;
+}
+
+function missingProfileConfiguredSectionGrants(params: {
+  value: unknown;
+  inheritedProfile?: string;
+  inheritedAlsoAllow?: string[];
+  configuredGrants?: string[];
+}): string[] {
+  const tools = getRecord(params.value);
+  if (!tools) {
+    return [];
+  }
+  const profile = resolveToolProfileForMigration(tools, params.inheritedProfile);
+  if (!profile) {
+    return [];
+  }
+  const explicitAlsoAllow = readOwnToolPolicyGrantList(tools, "alsoAllow");
+  const ownAllow = readToolPolicyGrantList(tools, "allow");
+  const configuredGrants = params.configuredGrants ?? collectConfiguredToolSectionGrants(tools);
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(profile),
+    explicitAlsoAllow ?? params.inheritedAlsoAllow ?? [],
+  );
+  return uniqueStrings(
+    configuredGrants.filter((toolName) =>
+      ownAllow.length > 0
+        ? !isToolAllowedByPolicyName(toolName, { allow: ownAllow })
+        : !isToolAllowedByPolicyName(toolName, profilePolicy),
+    ),
+  );
+}
+
+function toolProfileConfiguredSectionsNeedAlsoAllow(
+  value: unknown,
+  inheritedProfile?: string,
+  inheritedAlsoAllow?: string[],
+  configuredGrantsOverride?: string[],
+  inheritedByProvider?: Record<string, unknown> | null,
+): boolean {
+  const tools = getRecord(value);
+  if (!tools) {
+    return false;
+  }
+  const configuredGrants = configuredGrantsOverride ?? collectConfiguredToolSectionGrants(tools);
+  return (
+    scopeToolProfileConfiguredSectionsNeedMigration({
+      value,
+      inheritedProfile,
+      inheritedAlsoAllow,
+      configuredGrants,
+    }) ||
+    byProviderToolProfilesNeedConfiguredSectionMigration(
+      tools,
+      configuredGrants,
+      resolveToolProfileForMigration(tools, inheritedProfile),
+      readOwnToolPolicyGrantList(tools, "alsoAllow") ?? inheritedAlsoAllow,
+      inheritedByProvider,
+    )
+  );
+}
+
+function collectConfiguredToolSectionGrants(tools: Record<string, unknown>): string[] {
+  const grants: string[] = [];
+  for (const section of CONFIGURED_TOOL_SECTION_GRANTS) {
+    if (getRecord(tools[section.key])) {
+      grants.push(...section.grants);
+    }
+  }
+  return uniqueStrings(grants);
+}
+
+function collectEffectiveConfiguredToolSectionGrants(
+  inheritedTools: Record<string, unknown> | null | undefined,
+  tools: Record<string, unknown> | null | undefined,
+): string[] {
+  const includeInheritedSections = typeof tools?.profile !== "string";
+  return uniqueStrings([
+    ...(includeInheritedSections && inheritedTools
+      ? collectConfiguredToolSectionGrants(inheritedTools)
+      : []),
+    ...(tools ? collectConfiguredToolSectionGrants(tools) : []),
+  ]);
+}
+
+function toolProfileAllowRequiresFull(params: {
+  value: unknown;
+  inheritedProfile?: string;
+  inheritedAlsoAllow?: string[];
+  configuredGrants: string[];
+}): boolean {
+  const tools = getRecord(params.value);
+  if (!tools) {
+    return false;
+  }
+  const profile = resolveToolProfileForMigration(tools, params.inheritedProfile);
+  if (!profile || profile === "full") {
+    return false;
+  }
+  const ownAllow = readToolPolicyGrantList(tools, "allow");
+  if (ownAllow.length === 0) {
+    return false;
+  }
+  const explicitAlsoAllow = readOwnToolPolicyGrantList(tools, "alsoAllow");
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(profile),
+    explicitAlsoAllow ?? params.inheritedAlsoAllow ?? [],
+  );
+  return params.configuredGrants.some(
+    (toolName) =>
+      isToolAllowedByPolicyName(toolName, { allow: ownAllow }) &&
+      !isToolAllowedByPolicyName(toolName, profilePolicy),
+  );
+}
+
+function resolveProfileBoundAllowGrants(params: {
+  tools: Record<string, unknown>;
+  profile: string;
+  allow: string[];
+  inheritedAlsoAllow?: string[];
+  configuredGrants: string[];
+}): string[] {
+  const explicitAlsoAllow = readOwnToolPolicyGrantList(params.tools, "alsoAllow");
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(params.profile),
+    explicitAlsoAllow ?? params.inheritedAlsoAllow ?? [],
+  );
+  const profileAllow = expandToolGroups(profilePolicy?.allow);
+  const coreAllow = profileAllow.includes("*")
+    ? expandToolGroups(params.allow)
+    : profileAllow.filter((toolName) =>
+        isToolAllowedByPolicyName(toolName, { allow: params.allow }),
+      );
+  const pluginAllow = expandToolGroups(params.allow).filter((entry) => {
+    if (entry === "*" || isKnownCoreToolId(entry)) {
+      return false;
+    }
+    return !profileAllow.some((toolName) => isToolAllowedByPolicyName(toolName, { allow: [entry] }));
+  });
+  return uniqueStrings([
+    ...coreAllow,
+    ...pluginAllow,
+    ...params.configuredGrants,
+  ]);
+}
+
+function scopeToolProfileConfiguredSectionsNeedMigration(params: {
+  value: unknown;
+  inheritedProfile?: string;
+  inheritedAlsoAllow?: string[];
+  configuredGrants: string[];
+}): boolean {
+  return (
+    missingProfileConfiguredSectionGrants(params).length > 0 ||
+    toolProfileAllowRequiresFull(params)
+  );
+}
+
+function byProviderToolProfilesNeedConfiguredSectionMigration(
+  tools: Record<string, unknown>,
+  configuredGrants: string[],
+  inheritedProfile?: string,
+  inheritedAlsoAllow?: string[],
+  inheritedByProvider?: Record<string, unknown> | null,
+): boolean {
+  const byProvider = getRecord(tools.byProvider);
+  const ownProviderNeedsMigration = Boolean(
+    byProvider &&
+      Object.entries(byProvider).some(([providerKey, policy]) => {
+        const inheritedProviderPolicy = resolveInheritedProviderPolicy(
+          inheritedByProvider,
+          providerKey,
+        );
+        const inheritedProviderProfile =
+          typeof inheritedProviderPolicy?.profile === "string"
+            ? inheritedProviderPolicy.profile
+            : undefined;
+        return scopeToolProfileConfiguredSectionsNeedMigration({
+          value: policy,
+          inheritedProfile: inheritedProviderProfile ?? inheritedProfile,
+          inheritedAlsoAllow:
+            readOwnToolPolicyGrantList(inheritedProviderPolicy, "alsoAllow") ??
+            inheritedAlsoAllow,
+          configuredGrants,
+        });
+      }),
+  );
+  if (ownProviderNeedsMigration) {
+    return true;
+  }
+  const localConfiguredGrants = collectConfiguredToolSectionGrants(tools);
+  if (localConfiguredGrants.length === 0) {
+    return false;
+  }
+  const handledProviders = new Set(
+    Object.keys(byProvider ?? {}).map((providerKey) => normalizeToolProviderPolicyKey(providerKey)),
+  );
+  return listInheritedProviderPoliciesWithProfiles(inheritedByProvider).some(
+    (inheritedProvider) =>
+      !handledProviders.has(inheritedProvider.normalizedKey) &&
+      scopeToolProfileConfiguredSectionsNeedMigration({
+        value: {},
+        inheritedProfile: inheritedProvider.profile,
+        inheritedAlsoAllow: readOwnToolPolicyGrantList(inheritedProvider.policy, "alsoAllow"),
+        configuredGrants: localConfiguredGrants,
+      }),
+  );
+}
+
+function addProfileConfiguredSectionGrants(
+  value: unknown,
+  pathLabel: string,
+  changes: string[],
+  inheritedProfile?: string,
+  inheritedAlsoAllow?: string[],
+  configuredGrantsOverride?: string[],
+): void {
+  const tools = getRecord(value);
+  if (!tools) {
+    return;
+  }
+  const profile = resolveToolProfileForMigration(tools, inheritedProfile);
+  if (!profile) {
+    return;
+  }
+  const configuredGrants = configuredGrantsOverride ?? collectConfiguredToolSectionGrants(tools);
+  const missing = missingProfileConfiguredSectionGrants({
+    value: tools,
+    inheritedProfile,
+    inheritedAlsoAllow,
+    configuredGrants,
+  });
+  const allow = readToolPolicyGrantList(tools, "allow");
+  const grantKey = allow.length > 0 ? "allow" : "alsoAllow";
+  const needsProfileFull =
+    grantKey === "allow" &&
+    profile !== "full" &&
+    (missing.length > 0 ||
+      toolProfileAllowRequiresFull({
+        value: tools,
+        inheritedProfile,
+        inheritedAlsoAllow,
+        configuredGrants,
+      }));
+  if (missing.length === 0 && !needsProfileFull) {
+    return;
+  }
+  if (needsProfileFull) {
+    tools.allow = resolveProfileBoundAllowGrants({
+      tools,
+      profile,
+      allow,
+      inheritedAlsoAllow,
+      configuredGrants,
+    });
+    changes.push(
+      `Replaced ${pathLabel}.allow entries with profile "${profile}" grants plus configured tool sections.`,
+    );
+  } else if (missing.length > 0) {
+    const ownGrants = readOwnToolPolicyGrantList(tools, grantKey);
+    tools[grantKey] = uniqueStrings([
+      ...(grantKey === "alsoAllow" && ownGrants === undefined ? (inheritedAlsoAllow ?? []) : []),
+      ...(ownGrants ?? []),
+      ...missing,
+    ]);
+  }
+  if (needsProfileFull) {
+    tools.profile = "full";
+    changes.push(
+      `Set ${pathLabel}.profile to "full" so ${pathLabel}.allow controls configured tool sections directly.`,
+    );
+  }
+  if (missing.length > 0) {
+    changes.push(
+      `Added ${pathLabel}.${grantKey} entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
+    );
+  }
+}
+
+function addByProviderProfileConfiguredSectionGrants(
+  value: unknown,
+  pathLabel: string,
+  changes: string[],
+  configuredGrantsOverride?: string[],
+  inheritedProfile?: string,
+  inheritedByProvider?: Record<string, unknown> | null,
+): void {
+  const tools = getRecord(value);
+  if (!tools) {
+    return;
+  }
+  const configuredGrants = configuredGrantsOverride ?? collectConfiguredToolSectionGrants(tools);
+  if (configuredGrants.length === 0) {
+    return;
+  }
+  const byProvider = getRecord(tools.byProvider);
+  const handledProviders = new Set<string>();
+  for (const [providerKey, providerPolicy] of Object.entries(byProvider ?? {})) {
+    if (isBlockedObjectKey(providerKey)) {
+      continue;
+    }
+    addHandledProviderPolicyKey(handledProviders, providerKey);
+    const inheritedProviderPolicy = resolveInheritedProviderPolicy(
+      inheritedByProvider,
+      providerKey,
+    );
+    const ownsProviderProfile = typeof getRecord(providerPolicy)?.profile === "string";
+    const inheritedProviderProfile =
+      typeof inheritedProviderPolicy?.profile === "string" ? inheritedProviderPolicy.profile : undefined;
+    const providerInheritedProfile =
+      inheritedProviderProfile ?? inheritedProfile;
+    const providerInheritedAlsoAllow = readOwnToolPolicyGrantList(
+      inheritedProviderPolicy,
+      "alsoAllow",
+    );
+    addProfileConfiguredSectionGrantsWithConfiguredGrants(
+      providerPolicy,
+      `${pathLabel}.byProvider.${providerKey}`,
+      changes,
+      configuredGrants,
+      providerInheritedProfile,
+      providerInheritedAlsoAllow,
+      ownsProviderProfile || Boolean(inheritedProviderProfile),
+    );
+  }
+  const localConfiguredGrants = collectConfiguredToolSectionGrants(tools);
+  if (localConfiguredGrants.length === 0) {
+    return;
+  }
+  for (const inheritedProvider of listInheritedProviderPoliciesWithProfiles(inheritedByProvider)) {
+    if (handledProviders.has(inheritedProvider.normalizedKey)) {
+      continue;
+    }
+    const providerPolicy: Record<string, unknown> = {};
+    const changeCount = changes.length;
+    addProfileConfiguredSectionGrantsWithConfiguredGrants(
+      providerPolicy,
+      `${pathLabel}.byProvider.${inheritedProvider.key}`,
+      changes,
+      localConfiguredGrants,
+      inheritedProvider.profile,
+      readOwnToolPolicyGrantList(inheritedProvider.policy, "alsoAllow"),
+    );
+    if (changes.length > changeCount) {
+      if (!getRecord(tools.byProvider)) {
+        tools.byProvider = {};
+      }
+      getRecord(tools.byProvider)![inheritedProvider.key] = providerPolicy;
+      addHandledProviderPolicyKey(handledProviders, inheritedProvider.normalizedKey);
+    }
+  }
+}
+
+function addHandledProviderPolicyKey(handledProviders: Set<string>, providerKey: string): void {
+  handledProviders.add(normalizeToolProviderPolicyKey(providerKey));
+}
+
+function normalizeToolProviderPolicyKey(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  const slashIndex = normalized.indexOf("/");
+  if (slashIndex <= 0) {
+    return normalizeProviderId(normalized);
+  }
+  const provider = normalizeProviderId(normalized.slice(0, slashIndex));
+  const modelId = normalized.slice(slashIndex + 1);
+  return modelId ? `${provider}/${modelId}` : provider;
+}
+
+function isCanonicalToolProviderPolicyKey(value: string): boolean {
+  return value.trim().toLowerCase() === normalizeToolProviderPolicyKey(value);
+}
+
+function buildInheritedProviderPolicyLookup(
+  inheritedByProvider: Record<string, unknown> | null | undefined,
+): Map<
+  string,
+  {
+    key: string;
+    policy: Record<string, unknown>;
+    canonical: boolean;
+  }
+> {
+  const lookup = new Map<
+    string,
+    {
+      key: string;
+      policy: Record<string, unknown>;
+      canonical: boolean;
+    }
+  >();
+  for (const [key, value] of Object.entries(inheritedByProvider ?? {})) {
+    const policy = getRecord(value);
+    if (!policy) {
+      continue;
+    }
+    const normalized = normalizeToolProviderPolicyKey(key);
+    if (!normalized) {
+      continue;
+    }
+    const canonical = isCanonicalToolProviderPolicyKey(key);
+    const existing = lookup.get(normalized);
+    if (!existing || (canonical && !existing.canonical)) {
+      lookup.set(normalized, { key, policy, canonical });
+    }
+  }
+  return lookup;
+}
+
+function resolveInheritedProviderPolicy(
+  inheritedByProvider: Record<string, unknown> | null | undefined,
+  providerKey: string,
+): Record<string, unknown> | null {
+  const lookup = buildInheritedProviderPolicyLookup(inheritedByProvider);
+  const normalized = normalizeToolProviderPolicyKey(providerKey);
+  const slashIndex = normalized.indexOf("/");
+  const candidates = slashIndex > 0 ? [normalized, normalized.slice(0, slashIndex)] : [normalized];
+  for (const candidate of candidates) {
+    const match = lookup.get(candidate);
+    if (match) {
+      return match.policy;
+    }
+  }
+  return null;
+}
+
+function listInheritedProviderPoliciesWithProfiles(
+  inheritedByProvider: Record<string, unknown> | null | undefined,
+): Array<{
+  key: string;
+  normalizedKey: string;
+  policy: Record<string, unknown>;
+  profile: string;
+}> {
+  const entries: Array<{
+    key: string;
+    normalizedKey: string;
+    policy: Record<string, unknown>;
+    profile: string;
+  }> = [];
+  for (const [normalizedKey, match] of buildInheritedProviderPolicyLookup(inheritedByProvider)) {
+    if (typeof match.policy.profile !== "string") {
+      continue;
+    }
+    entries.push({
+      key: match.key,
+      normalizedKey,
+      policy: match.policy,
+      profile: match.policy.profile,
+    });
+  }
+  return entries;
+}
+
+function addProfileConfiguredSectionGrantsWithConfiguredGrants(
+  value: unknown,
+  pathLabel: string,
+  changes: string[],
+  configuredGrants: string[],
+  inheritedProfile?: string,
+  inheritedAlsoAllow?: string[],
+  materializeProfile = true,
+): void {
+  const tools = getRecord(value);
+  if (!tools) {
+    return;
+  }
+  const profile = resolveToolProfileForMigration(tools, inheritedProfile);
+  if (!profile) {
+    return;
+  }
+  const missing = missingProfileConfiguredSectionGrants({
+    value: tools,
+    inheritedProfile,
+    inheritedAlsoAllow,
+    configuredGrants,
+  });
+  const allow = readToolPolicyGrantList(tools, "allow");
+  const grantKey = allow.length > 0 ? "allow" : "alsoAllow";
+  if (!materializeProfile) {
+    if (allow.length === 0 || missing.length === 0) {
+      return;
+    }
+    tools.allow = uniqueStrings([...allow, ...missing]);
+    changes.push(
+      `Added ${pathLabel}.allow entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
+    );
+    return;
+  }
+  const needsProfileFull =
+    grantKey === "allow" &&
+    profile !== "full" &&
+    (missing.length > 0 ||
+      toolProfileAllowRequiresFull({
+        value: tools,
+        inheritedProfile,
+        inheritedAlsoAllow,
+        configuredGrants,
+      }));
+  if (missing.length === 0 && !needsProfileFull) {
+    return;
+  }
+  if (needsProfileFull) {
+    tools.allow = resolveProfileBoundAllowGrants({
+      tools,
+      profile,
+      allow,
+      inheritedAlsoAllow,
+      configuredGrants,
+    });
+    changes.push(
+      `Replaced ${pathLabel}.allow entries with profile "${profile}" grants plus configured tool sections.`,
+    );
+  } else if (missing.length > 0) {
+    const ownGrants = readOwnToolPolicyGrantList(tools, grantKey);
+    tools[grantKey] = uniqueStrings([
+      ...(grantKey === "alsoAllow" && ownGrants === undefined ? (inheritedAlsoAllow ?? []) : []),
+      ...(ownGrants ?? []),
+      ...missing,
+    ]);
+  }
+  if (needsProfileFull) {
+    tools.profile = "full";
+    changes.push(
+      `Set ${pathLabel}.profile to "full" so ${pathLabel}.allow controls configured tool sections directly.`,
+    );
+  }
+  if (missing.length > 0) {
+    changes.push(
+      `Added ${pathLabel}.${grantKey} entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
+    );
+  }
+}
+
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "tools.profile-configured-sections-alsoAllow",
+    describe: "Add explicit tool grants for configured tool sections under profiles",
+    legacyRules: PROFILE_CONFIGURED_TOOL_SECTION_RULES,
+    apply: (raw, changes) => {
+      const globalTools = getRecord(raw.tools);
+      const inheritedProfile =
+        typeof globalTools?.profile === "string" ? globalTools.profile : undefined;
+      const inheritedAlsoAllow = readToolPolicyGrantList(globalTools, "alsoAllow");
+      addProfileConfiguredSectionGrants(raw.tools, "tools", changes);
+      addByProviderProfileConfiguredSectionGrants(
+        raw.tools,
+        "tools",
+        changes,
+        undefined,
+        inheritedProfile,
+      );
+      const agents = getRecord(raw.agents);
+      if (!Array.isArray(agents?.list)) {
+        return;
+      }
+      for (const [index, agent] of agents.list.entries()) {
+        const agentTools = getRecord(getRecord(agent)?.tools);
+        const configuredGrants = collectEffectiveConfiguredToolSectionGrants(
+          globalTools,
+          agentTools,
+        );
+        addProfileConfiguredSectionGrants(
+          agentTools,
+          `agents.list.${index}.tools`,
+          changes,
+          inheritedProfile,
+          inheritedAlsoAllow,
+          configuredGrants,
+        );
+        addByProviderProfileConfiguredSectionGrants(
+          agentTools,
+          `agents.list.${index}.tools`,
+          changes,
+          configuredGrants,
+          resolveToolProfileForMigration(agentTools ?? {}, inheritedProfile),
+          getRecord(globalTools?.byProvider),
+        );
+      }
+    },
+  }),
   defineLegacyConfigMigration({
     id: "silentReplyRewrite-removed",
     describe: "Remove legacy silent reply rewrite and direct-chat silent reply config",

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -2,8 +2,8 @@ import { listLegacyRuntimeModelProviderAliases } from "../../../agents/model-run
 import { normalizeProviderId } from "../../../agents/provider-id.js";
 import { isKnownCoreToolId } from "../../../agents/tool-catalog.js";
 import { isToolAllowedByPolicyName } from "../../../agents/tool-policy-match.js";
-import { expandToolGroups, mergeAlsoAllowPolicy } from "../../../agents/tool-policy.js";
 import { resolveToolProfilePolicy } from "../../../agents/tool-policy-shared.js";
+import { expandToolGroups, mergeAlsoAllowPolicy } from "../../../agents/tool-policy.js";
 import {
   defineLegacyConfigMigration,
   ensureRecord,
@@ -132,13 +132,13 @@ const PROFILE_CONFIGURED_TOOL_SECTION_RULES: LegacyConfigRule[] = [
   {
     path: ["tools"],
     message:
-      'tools.profile no longer implicitly grants configured tools.exec/tools.fs sections; add explicit tool grants or run "openclaw doctor --fix".',
-    match: (value) => toolProfileConfiguredSectionsNeedAlsoAllow(value),
+      'tools.profile filters explicit configured-section tool grants; run "openclaw doctor --fix" to rewrite the explicit grants into a valid allowlist.',
+    match: (value) => toolProfileConfiguredSectionsNeedExplicitRepair(value),
   },
   {
     path: ["agents", "list"],
     message:
-      'agents.list[].tools.profile no longer implicitly grants configured tools.exec/tools.fs sections; add explicit tool grants or run "openclaw doctor --fix".',
+      'agents.list[].tools.profile filters explicit configured-section tool grants; run "openclaw doctor --fix" to rewrite the explicit grants into a valid allowlist.',
     match: (value, root) => {
       const globalTools = getRecord(root.tools);
       const inheritedProfile =
@@ -148,14 +148,14 @@ const PROFILE_CONFIGURED_TOOL_SECTION_RULES: LegacyConfigRule[] = [
         Array.isArray(value) &&
         value.some((agent) => {
           const agentTools = getRecord(getRecord(agent)?.tools);
-          return toolProfileConfiguredSectionsNeedAlsoAllow(
+          return toolProfileConfiguredSectionsNeedExplicitRepair(
             agentTools,
-              inheritedProfile,
-              inheritedAlsoAllow,
-              collectEffectiveConfiguredToolSectionGrants(globalTools, agentTools),
-              getRecord(globalTools?.byProvider),
-            );
-          })
+            inheritedProfile,
+            inheritedAlsoAllow,
+            collectEffectiveConfiguredToolSectionGrants(globalTools, agentTools),
+            getRecord(globalTools?.byProvider),
+          );
+        })
       );
     },
   },
@@ -536,37 +536,45 @@ function resolveToolProfileForMigration(
   return typeof tools.profile === "string" ? tools.profile : inheritedProfile;
 }
 
-function missingProfileConfiguredSectionGrants(params: {
+function collectProfileConfiguredSectionRepairGrants(params: {
   value: unknown;
   inheritedProfile?: string;
   inheritedAlsoAllow?: string[];
-  configuredGrants?: string[];
+  configuredGrants: string[];
 }): string[] {
   const tools = getRecord(params.value);
   if (!tools) {
     return [];
   }
   const profile = resolveToolProfileForMigration(tools, params.inheritedProfile);
-  if (!profile) {
+  if (!profile || profile === "full") {
+    return [];
+  }
+  const ownAllow = readToolPolicyGrantList(tools, "allow");
+  if (ownAllow.length === 0) {
     return [];
   }
   const explicitAlsoAllow = readOwnToolPolicyGrantList(tools, "alsoAllow");
-  const ownAllow = readToolPolicyGrantList(tools, "allow");
-  const configuredGrants = params.configuredGrants ?? collectConfiguredToolSectionGrants(tools);
+  const explicitPolicy = {
+    allow: uniqueStrings([...ownAllow, ...(explicitAlsoAllow ?? [])]),
+  };
   const profilePolicy = mergeAlsoAllowPolicy(
     resolveToolProfilePolicy(profile),
     explicitAlsoAllow ?? params.inheritedAlsoAllow ?? [],
   );
   return uniqueStrings(
-    configuredGrants.filter((toolName) =>
-      ownAllow.length > 0
-        ? !isToolAllowedByPolicyName(toolName, { allow: ownAllow })
-        : !isToolAllowedByPolicyName(toolName, profilePolicy),
+    params.configuredGrants.filter(
+      (toolName) =>
+        isToolAllowedByPolicyName(toolName, explicitPolicy) &&
+        (!isToolAllowedByPolicyName(toolName, profilePolicy) ||
+          (explicitAlsoAllow
+            ? isToolAllowedByPolicyName(toolName, { allow: explicitAlsoAllow })
+            : false)),
     ),
   );
 }
 
-function toolProfileConfiguredSectionsNeedAlsoAllow(
+function toolProfileConfiguredSectionsNeedExplicitRepair(
   value: unknown,
   inheritedProfile?: string,
   inheritedAlsoAllow?: string[],
@@ -588,7 +596,6 @@ function toolProfileConfiguredSectionsNeedAlsoAllow(
     byProviderToolProfilesNeedConfiguredSectionMigration(
       tools,
       configuredGrants,
-      resolveToolProfileForMigration(tools, inheritedProfile),
       readOwnToolPolicyGrantList(tools, "alsoAllow") ?? inheritedAlsoAllow,
       inheritedByProvider,
     )
@@ -624,28 +631,7 @@ function toolProfileAllowRequiresFull(params: {
   inheritedAlsoAllow?: string[];
   configuredGrants: string[];
 }): boolean {
-  const tools = getRecord(params.value);
-  if (!tools) {
-    return false;
-  }
-  const profile = resolveToolProfileForMigration(tools, params.inheritedProfile);
-  if (!profile || profile === "full") {
-    return false;
-  }
-  const ownAllow = readToolPolicyGrantList(tools, "allow");
-  if (ownAllow.length === 0) {
-    return false;
-  }
-  const explicitAlsoAllow = readOwnToolPolicyGrantList(tools, "alsoAllow");
-  const profilePolicy = mergeAlsoAllowPolicy(
-    resolveToolProfilePolicy(profile),
-    explicitAlsoAllow ?? params.inheritedAlsoAllow ?? [],
-  );
-  return params.configuredGrants.some(
-    (toolName) =>
-      isToolAllowedByPolicyName(toolName, { allow: ownAllow }) &&
-      !isToolAllowedByPolicyName(toolName, profilePolicy),
-  );
+  return collectProfileConfiguredSectionRepairGrants(params).length > 0;
 }
 
 function resolveProfileBoundAllowGrants(params: {
@@ -670,13 +656,11 @@ function resolveProfileBoundAllowGrants(params: {
     if (entry === "*" || isKnownCoreToolId(entry)) {
       return false;
     }
-    return !profileAllow.some((toolName) => isToolAllowedByPolicyName(toolName, { allow: [entry] }));
+    return !profileAllow.some((toolName) =>
+      isToolAllowedByPolicyName(toolName, { allow: [entry] }),
+    );
   });
-  return uniqueStrings([
-    ...coreAllow,
-    ...pluginAllow,
-    ...params.configuredGrants,
-  ]);
+  return uniqueStrings([...coreAllow, ...pluginAllow, ...params.configuredGrants]);
 }
 
 function scopeToolProfileConfiguredSectionsNeedMigration(params: {
@@ -685,40 +669,40 @@ function scopeToolProfileConfiguredSectionsNeedMigration(params: {
   inheritedAlsoAllow?: string[];
   configuredGrants: string[];
 }): boolean {
-  return (
-    missingProfileConfiguredSectionGrants(params).length > 0 ||
-    toolProfileAllowRequiresFull(params)
-  );
+  return toolProfileAllowRequiresFull(params);
 }
 
 function byProviderToolProfilesNeedConfiguredSectionMigration(
   tools: Record<string, unknown>,
   configuredGrants: string[],
-  inheritedProfile?: string,
   inheritedAlsoAllow?: string[],
   inheritedByProvider?: Record<string, unknown> | null,
 ): boolean {
   const byProvider = getRecord(tools.byProvider);
   const ownProviderNeedsMigration = Boolean(
     byProvider &&
-      Object.entries(byProvider).some(([providerKey, policy]) => {
-        const inheritedProviderPolicy = resolveInheritedProviderPolicy(
-          inheritedByProvider,
-          providerKey,
-        );
-        const inheritedProviderProfile =
-          typeof inheritedProviderPolicy?.profile === "string"
-            ? inheritedProviderPolicy.profile
-            : undefined;
-        return scopeToolProfileConfiguredSectionsNeedMigration({
-          value: policy,
-          inheritedProfile: inheritedProviderProfile ?? inheritedProfile,
-          inheritedAlsoAllow:
-            readOwnToolPolicyGrantList(inheritedProviderPolicy, "alsoAllow") ??
-            inheritedAlsoAllow,
-          configuredGrants,
-        });
-      }),
+    Object.entries(byProvider).some(([providerKey, policy]) => {
+      const inheritedProviderPolicy = resolveInheritedProviderPolicy(
+        inheritedByProvider,
+        providerKey,
+      );
+      const inheritedProviderProfile =
+        typeof inheritedProviderPolicy?.profile === "string"
+          ? inheritedProviderPolicy.profile
+          : undefined;
+      const hasProviderProfile =
+        typeof getRecord(policy)?.profile === "string" || Boolean(inheritedProviderProfile);
+      if (!hasProviderProfile) {
+        return false;
+      }
+      return scopeToolProfileConfiguredSectionsNeedMigration({
+        value: policy,
+        inheritedProfile: inheritedProviderProfile,
+        inheritedAlsoAllow:
+          readOwnToolPolicyGrantList(inheritedProviderPolicy, "alsoAllow") ?? inheritedAlsoAllow,
+        configuredGrants,
+      });
+    }),
   );
   if (ownProviderNeedsMigration) {
     return true;
@@ -759,57 +743,35 @@ function addProfileConfiguredSectionGrants(
     return;
   }
   const configuredGrants = configuredGrantsOverride ?? collectConfiguredToolSectionGrants(tools);
-  const missing = missingProfileConfiguredSectionGrants({
+  const repairGrants = collectProfileConfiguredSectionRepairGrants({
     value: tools,
     inheritedProfile,
     inheritedAlsoAllow,
     configuredGrants,
   });
   const allow = readToolPolicyGrantList(tools, "allow");
-  const grantKey = allow.length > 0 ? "allow" : "alsoAllow";
-  const needsProfileFull =
-    grantKey === "allow" &&
-    profile !== "full" &&
-    (missing.length > 0 ||
-      toolProfileAllowRequiresFull({
-        value: tools,
-        inheritedProfile,
-        inheritedAlsoAllow,
-        configuredGrants,
-      }));
-  if (missing.length === 0 && !needsProfileFull) {
+  if (repairGrants.length === 0 || allow.length === 0 || profile === "full") {
     return;
   }
-  if (needsProfileFull) {
-    tools.allow = resolveProfileBoundAllowGrants({
-      tools,
-      profile,
-      allow,
-      inheritedAlsoAllow,
-      configuredGrants,
-    });
-    changes.push(
-      `Replaced ${pathLabel}.allow entries with profile "${profile}" grants plus configured tool sections.`,
-    );
-  } else if (missing.length > 0) {
-    const ownGrants = readOwnToolPolicyGrantList(tools, grantKey);
-    tools[grantKey] = uniqueStrings([
-      ...(grantKey === "alsoAllow" && ownGrants === undefined ? (inheritedAlsoAllow ?? []) : []),
-      ...(ownGrants ?? []),
-      ...missing,
-    ]);
+  const ownAlsoAllow = readOwnToolPolicyGrantList(tools, "alsoAllow");
+  tools.allow = resolveProfileBoundAllowGrants({
+    tools,
+    profile,
+    allow: uniqueStrings([...allow, ...(ownAlsoAllow ?? [])]),
+    inheritedAlsoAllow,
+    configuredGrants: repairGrants,
+  });
+  changes.push(
+    `Replaced ${pathLabel}.allow entries with profile "${profile}" grants plus explicit configured-section grants.`,
+  );
+  if (ownAlsoAllow) {
+    delete tools.alsoAllow;
+    changes.push(`Merged ${pathLabel}.alsoAllow into ${pathLabel}.allow.`);
   }
-  if (needsProfileFull) {
-    tools.profile = "full";
-    changes.push(
-      `Set ${pathLabel}.profile to "full" so ${pathLabel}.allow controls configured tool sections directly.`,
-    );
-  }
-  if (missing.length > 0) {
-    changes.push(
-      `Added ${pathLabel}.${grantKey} entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
-    );
-  }
+  tools.profile = "full";
+  changes.push(
+    `Set ${pathLabel}.profile to "full" so ${pathLabel}.allow controls explicit configured-section grants directly.`,
+  );
 }
 
 function addByProviderProfileConfiguredSectionGrants(
@@ -841,9 +803,10 @@ function addByProviderProfileConfiguredSectionGrants(
     );
     const ownsProviderProfile = typeof getRecord(providerPolicy)?.profile === "string";
     const inheritedProviderProfile =
-      typeof inheritedProviderPolicy?.profile === "string" ? inheritedProviderPolicy.profile : undefined;
-    const providerInheritedProfile =
-      inheritedProviderProfile ?? inheritedProfile;
+      typeof inheritedProviderPolicy?.profile === "string"
+        ? inheritedProviderPolicy.profile
+        : undefined;
+    const providerInheritedProfile = inheritedProviderProfile ?? inheritedProfile;
     const providerInheritedAlsoAllow = readOwnToolPolicyGrantList(
       inheritedProviderPolicy,
       "alsoAllow",
@@ -924,6 +887,9 @@ function buildInheritedProviderPolicyLookup(
     }
   >();
   for (const [key, value] of Object.entries(inheritedByProvider ?? {})) {
+    if (isBlockedObjectKey(key)) {
+      continue;
+    }
     const policy = getRecord(value);
     if (!policy) {
       continue;
@@ -1003,65 +969,38 @@ function addProfileConfiguredSectionGrantsWithConfiguredGrants(
   if (!profile) {
     return;
   }
-  const missing = missingProfileConfiguredSectionGrants({
+  if (!materializeProfile) {
+    return;
+  }
+  const repairGrants = collectProfileConfiguredSectionRepairGrants({
     value: tools,
     inheritedProfile,
     inheritedAlsoAllow,
     configuredGrants,
   });
   const allow = readToolPolicyGrantList(tools, "allow");
-  const grantKey = allow.length > 0 ? "allow" : "alsoAllow";
-  if (!materializeProfile) {
-    if (allow.length === 0 || missing.length === 0) {
-      return;
-    }
-    tools.allow = uniqueStrings([...allow, ...missing]);
-    changes.push(
-      `Added ${pathLabel}.allow entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
-    );
+  if (repairGrants.length === 0 || allow.length === 0 || profile === "full") {
     return;
   }
-  const needsProfileFull =
-    grantKey === "allow" &&
-    profile !== "full" &&
-    (missing.length > 0 ||
-      toolProfileAllowRequiresFull({
-        value: tools,
-        inheritedProfile,
-        inheritedAlsoAllow,
-        configuredGrants,
-      }));
-  if (missing.length === 0 && !needsProfileFull) {
-    return;
+  const ownAlsoAllow = readOwnToolPolicyGrantList(tools, "alsoAllow");
+  tools.allow = resolveProfileBoundAllowGrants({
+    tools,
+    profile,
+    allow: uniqueStrings([...allow, ...(ownAlsoAllow ?? [])]),
+    inheritedAlsoAllow,
+    configuredGrants: repairGrants,
+  });
+  changes.push(
+    `Replaced ${pathLabel}.allow entries with profile "${profile}" grants plus explicit configured-section grants.`,
+  );
+  if (ownAlsoAllow) {
+    delete tools.alsoAllow;
+    changes.push(`Merged ${pathLabel}.alsoAllow into ${pathLabel}.allow.`);
   }
-  if (needsProfileFull) {
-    tools.allow = resolveProfileBoundAllowGrants({
-      tools,
-      profile,
-      allow,
-      inheritedAlsoAllow,
-      configuredGrants,
-    });
-    changes.push(
-      `Replaced ${pathLabel}.allow entries with profile "${profile}" grants plus configured tool sections.`,
-    );
-  } else if (missing.length > 0) {
-    const ownGrants = readOwnToolPolicyGrantList(tools, grantKey);
-    tools[grantKey] = uniqueStrings([
-      ...(grantKey === "alsoAllow" && ownGrants === undefined ? (inheritedAlsoAllow ?? []) : []),
-      ...(ownGrants ?? []),
-      ...missing,
-    ]);
-  }
-  if (needsProfileFull) {
+  if (materializeProfile) {
     tools.profile = "full";
     changes.push(
-      `Set ${pathLabel}.profile to "full" so ${pathLabel}.allow controls configured tool sections directly.`,
-    );
-  }
-  if (missing.length > 0) {
-    changes.push(
-      `Added ${pathLabel}.${grantKey} entries (${missing.join(", ")}) for configured tool sections under profile "${profile}".`,
+      `Set ${pathLabel}.profile to "full" so ${pathLabel}.allow controls explicit configured-section grants directly.`,
     );
   }
 }
@@ -1069,7 +1008,7 @@ function addProfileConfiguredSectionGrantsWithConfiguredGrants(
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS: LegacyConfigMigrationSpec[] = [
   defineLegacyConfigMigration({
     id: "tools.profile-configured-sections-alsoAllow",
-    describe: "Add explicit tool grants for configured tool sections under profiles",
+    describe: "Repair explicit configured-section tool grants filtered by profiles",
     legacyRules: PROFILE_CONFIGURED_TOOL_SECTION_RULES,
     apply: (raw, changes) => {
       const globalTools = getRecord(raw.tools);

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -7,6 +7,7 @@ import {
   collectDoctorPreviewNotes,
   collectChannelBoundMessageToolPolicyWarnings,
   collectDoctorPreviewWarnings,
+  collectProfileConfiguredToolSectionWarnings,
   collectVisibleReplyToolPolicyWarnings,
 } from "./preview-warnings.js";
 
@@ -476,6 +477,201 @@ describe("doctor preview warnings", () => {
       "channels.telegram: channel is configured, but plugins.enabled=false blocks channel plugins globally.",
     );
     expect(warnings.join("\n")).not.toContain("stale plugin reference");
+  });
+
+  it("warns without suggesting fix when configured tool sections need explicit profile grants", async () => {
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        tools: {
+          profile: "messaging",
+          exec: {
+            security: "allowlist",
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    const warning = expectSingleWarningContaining(warnings, 'tools.profile is "messaging"');
+    expect(warning).toContain("tools.exec is configured");
+    expect(warning).toContain('tools.alsoAllow: ["exec", "process"]');
+    expect(warning).not.toContain("doctor --fix");
+  });
+
+  it("does not suggest alsoAllow when configured section warnings already have allow", () => {
+    const warnings = collectProfileConfiguredToolSectionWarnings({
+      tools: {
+        profile: "messaging",
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              allow: ["message"],
+              exec: {
+                security: "allowlist",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(warnings, "agents.list[0].tools.profile");
+    expect(warning).toContain("Add these grants to agents.list[0].tools.allow");
+    expect(warning).toContain('set agents.list[0].tools.profile to "full"');
+    expect(warning).not.toContain("agents.list[0].tools.alsoAllow");
+  });
+
+  it("warns when an agent tool section inherits a restrictive provider profile", () => {
+    const warnings = collectProfileConfiguredToolSectionWarnings({
+      tools: {
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: {
+                security: "allowlist",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.byProvider.openai.profile is "messaging"',
+    );
+    expect(warning).toContain("agents.list[0].tools.exec is configured");
+    expect(warning).toContain(
+      'agents.list[0].tools.byProvider.openai.alsoAllow: ["exec", "process"]',
+    );
+  });
+
+  it("uses inherited provider alsoAllow for agent provider profile warnings", () => {
+    const warnings = collectProfileConfiguredToolSectionWarnings({
+      tools: {
+        byProvider: {
+          openai: {
+            alsoAllow: ["exec", "process"],
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: {
+                security: "allowlist",
+              },
+              byProvider: {
+                "openai/gpt-5": {
+                  profile: "messaging",
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("uses model-scoped agent provider overrides for inherited provider warnings", () => {
+    const warnings = collectProfileConfiguredToolSectionWarnings({
+      tools: {
+        byProvider: {
+          openai: {
+            profile: "messaging",
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            model: {
+              primary: "openai/gpt-5",
+            },
+            tools: {
+              exec: {
+                security: "allowlist",
+              },
+              byProvider: {
+                "openai/gpt-5": {
+                  alsoAllow: ["exec", "process"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("treats empty provider alsoAllow as an explicit inherited-profile override", () => {
+    const warnings = collectProfileConfiguredToolSectionWarnings({
+      tools: {
+        byProvider: {
+          openai: {
+            profile: "messaging",
+            alsoAllow: ["exec", "process"],
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "sage",
+            tools: {
+              exec: {
+                security: "allowlist",
+              },
+              byProvider: {
+                openai: {
+                  alsoAllow: [],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'tools.byProvider.openai.profile is "messaging"',
+    );
+    expect(warning).toContain(
+      'agents.list[0].tools.byProvider.openai.alsoAllow: ["exec", "process"]',
+    );
+  });
+
+  it("does not warn for configured tool sections already granted by explicit alsoAllow", () => {
+    const warnings = collectProfileConfiguredToolSectionWarnings({
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["exec", "process"],
+        exec: {
+          security: "allowlist",
+        },
+      },
+    });
+
+    expect(warnings).toStrictEqual([]);
   });
 
   it("does not warn when default group visible replies are automatic", () => {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -460,12 +460,12 @@ function collectProfileConfiguredToolSectionScopeWarnings(params: {
     : params.inheritedAlsoAllow;
   const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), alsoAllow);
   const uncoveredEntries = configuredEntries
-    .map((entry) => ({
-      ...entry,
-      grants: entry.grants.filter(
+    .map((entry) => {
+      const grants = entry.grants.filter(
         (toolName) => !isToolAllowedByPolicyName(toolName, profilePolicy),
-      ),
-    }))
+      );
+      return { grants, label: entry.label };
+    })
     .filter((entry) => entry.grants.length > 0);
   if (uncoveredEntries.length === 0) {
     return [];

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -3,7 +3,10 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../../agents/defaults.js";
 import { parseModelRef } from "../../../agents/model-selection-normalize.js";
 import { normalizeProviderId } from "../../../agents/provider-id.js";
 import { pickSandboxToolPolicy } from "../../../agents/sandbox-tool-policy.js";
-import { isToolAllowedByPolicies } from "../../../agents/tool-policy-match.js";
+import {
+  isToolAllowedByPolicies,
+  isToolAllowedByPolicyName,
+} from "../../../agents/tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../../agents/tool-policy.js";
 import { resolveAgentModelPrimaryValue } from "../../../config/model-input.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
@@ -370,6 +373,386 @@ export function collectChannelBoundMessageToolPolicyWarnings(cfg: OpenClawConfig
   });
 }
 
+const PROFILE_CONFIGURED_TOOL_SECTIONS = [
+  { key: "exec", label: "tools.exec", grants: ["exec", "process"] },
+  { key: "fs", label: "tools.fs", grants: ["read", "write", "edit"] },
+] as const;
+
+type ConfiguredToolSectionGrantEntry = {
+  label: string;
+  grants: string[];
+};
+
+function collectConfiguredToolSectionGrantEntries(params: {
+  tools?: Record<string, unknown> | null;
+  pathLabel: string;
+}): ConfiguredToolSectionGrantEntry[] {
+  const entries: ConfiguredToolSectionGrantEntry[] = [];
+  for (const section of PROFILE_CONFIGURED_TOOL_SECTIONS) {
+    if (hasRecord(params.tools?.[section.key])) {
+      entries.push({
+        label: `${params.pathLabel}.${section.key}`,
+        grants: [...section.grants],
+      });
+    }
+  }
+  return entries;
+}
+
+function formatQuotedList(values: string[]): string {
+  return values.map((value) => `"${value}"`).join(", ");
+}
+
+function hasNonEmptyStringList(value: unknown): value is string[] {
+  return Array.isArray(value) && value.some((entry) => typeof entry === "string");
+}
+
+function readPreviewStringList(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+}
+
+function formatProfileConfiguredSectionGrantAdvice(params: {
+  pathLabel: string;
+  grants: string[];
+  hasAllow: boolean;
+  provider?: boolean;
+}): string {
+  const providerSuffix = params.provider ? " for that provider" : "";
+  if (params.hasAllow) {
+    return `Add these grants to ${params.pathLabel}.allow and set ${params.pathLabel}.profile to "full" if these tools should be available${providerSuffix}.`;
+  }
+  return `Add ${params.pathLabel}.alsoAllow: [${formatQuotedList(
+    params.grants,
+  )}] if these tools should be available${providerSuffix}.`;
+}
+
+function collectProfileConfiguredToolSectionScopeWarnings(params: {
+  tools?: Record<string, unknown> | null;
+  inheritedTools?: Record<string, unknown> | null;
+  pathLabel: string;
+  inheritedPathLabel?: string;
+  includeInheritedSections?: boolean;
+  inheritedProfile?: string;
+  inheritedAlsoAllow?: string[];
+}): string[] {
+  const tools = params.tools;
+  const profile =
+    (typeof tools?.profile === "string" ? tools.profile : undefined) ?? params.inheritedProfile;
+  if (!profile) {
+    return [];
+  }
+  const configuredEntries = [
+    ...(params.includeInheritedSections && params.inheritedTools && params.inheritedPathLabel
+      ? collectConfiguredToolSectionGrantEntries({
+          tools: params.inheritedTools,
+          pathLabel: params.inheritedPathLabel,
+        })
+      : []),
+    ...collectConfiguredToolSectionGrantEntries({ tools, pathLabel: params.pathLabel }),
+  ];
+  if (configuredEntries.length === 0) {
+    return [];
+  }
+  const alsoAllow = Array.isArray(tools?.alsoAllow)
+    ? tools.alsoAllow.filter((entry): entry is string => typeof entry === "string")
+    : params.inheritedAlsoAllow;
+  const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), alsoAllow);
+  const uncoveredEntries = configuredEntries
+    .map((entry) => ({
+      ...entry,
+      grants: entry.grants.filter(
+        (toolName) => !isToolAllowedByPolicyName(toolName, profilePolicy),
+      ),
+    }))
+    .filter((entry) => entry.grants.length > 0);
+  if (uncoveredEntries.length === 0) {
+    return [];
+  }
+  const uncoveredGrants = [...new Set(uncoveredEntries.flatMap((entry) => entry.grants))];
+  const advice = formatProfileConfiguredSectionGrantAdvice({
+    pathLabel: params.pathLabel,
+    grants: uncoveredGrants,
+    hasAllow: hasNonEmptyStringList(tools?.allow),
+  });
+  return [
+    `- ${params.pathLabel}.profile is "${profile}" and ${uncoveredEntries
+      .map((entry) => entry.label)
+      .join(
+        " / ",
+      )} is configured, but configured sections no longer widen the active profile. ${advice}`,
+  ];
+}
+
+function collectByProviderConfiguredToolSectionWarnings(params: {
+  tools?: Record<string, unknown> | null;
+  inheritedTools?: Record<string, unknown> | null;
+  pathLabel: string;
+  configuredEntries: ConfiguredToolSectionGrantEntry[];
+}): string[] {
+  const byProvider = hasRecord(params.tools?.byProvider) ? params.tools.byProvider : undefined;
+  if (!byProvider || params.configuredEntries.length === 0) {
+    return [];
+  }
+  const inheritedByProvider = hasRecord(params.inheritedTools?.byProvider)
+    ? params.inheritedTools.byProvider
+    : undefined;
+  return Object.entries(byProvider).flatMap(([providerKey, policyValue]) => {
+    const policy = hasRecord(policyValue) ? policyValue : undefined;
+    if (!policy) {
+      return [];
+    }
+    const profile = typeof policy.profile === "string" ? policy.profile : undefined;
+    if (!profile) {
+      return [];
+    }
+    const inheritedPolicy = resolveInheritedProviderPolicyForPreview(
+      inheritedByProvider,
+      providerKey,
+    );
+    const alsoAllow =
+      readPreviewStringList(policy.alsoAllow) ?? readPreviewStringList(inheritedPolicy?.alsoAllow);
+    const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), alsoAllow);
+    const uncoveredEntries = params.configuredEntries
+      .map((entry) => ({
+        ...entry,
+        grants: entry.grants.filter(
+          (toolName) => !isToolAllowedByPolicyName(toolName, profilePolicy),
+        ),
+      }))
+      .filter((entry) => entry.grants.length > 0);
+    if (uncoveredEntries.length === 0) {
+      return [];
+    }
+    const providerPath = `${params.pathLabel}.byProvider.${providerKey}`;
+    const uncoveredGrants = [...new Set(uncoveredEntries.flatMap((entry) => entry.grants))];
+    const advice = formatProfileConfiguredSectionGrantAdvice({
+      pathLabel: providerPath,
+      grants: uncoveredGrants,
+      hasAllow: hasNonEmptyStringList(policy.allow),
+      provider: true,
+    });
+    return [
+      `- ${providerPath}.profile is "${profile}" and ${uncoveredEntries
+        .map((entry) => entry.label)
+        .join(
+          " / ",
+        )} is configured, but configured sections no longer widen the provider profile. ${advice}`,
+    ];
+  });
+}
+
+function resolveInheritedProviderPolicyForPreview(
+  inheritedByProvider: Record<string, unknown> | undefined,
+  providerKey: string,
+): ToolPolicyConfig | undefined {
+  if (!inheritedByProvider) {
+    return undefined;
+  }
+  const normalized = normalizeProviderPolicyKey(providerKey);
+  const slashIndex = normalized.indexOf("/");
+  const modelProvider = slashIndex > 0 ? normalized.slice(0, slashIndex) : normalized;
+  const modelId = slashIndex > 0 ? normalized.slice(slashIndex + 1) : "";
+  const policy = resolveProviderToolPolicy({
+    byProvider: inheritedByProvider as Record<string, ToolPolicyConfig>,
+    modelProvider,
+    modelId,
+  });
+  return policy && hasRecord(policy) ? policy : undefined;
+}
+
+function resolveProviderPolicyEntryForPreview(params: {
+  byProvider?: Record<string, unknown>;
+  modelProvider?: string;
+  modelId?: string;
+}): { key: string; policy: Record<string, unknown> } | undefined {
+  if (!params.byProvider || !params.modelProvider) {
+    return undefined;
+  }
+  const lookup = new Map<
+    string,
+    { key: string; policy: Record<string, unknown>; canonical: boolean }
+  >();
+  for (const [key, value] of Object.entries(params.byProvider)) {
+    const policy = hasRecord(value) ? value : undefined;
+    if (!policy) {
+      continue;
+    }
+    const normalized = normalizeProviderPolicyKey(key);
+    if (!normalized) {
+      continue;
+    }
+    const canonical = isCanonicalProviderPolicyKey(key);
+    const existing = lookup.get(normalized);
+    if (!existing || (canonical && !existing.canonical)) {
+      lookup.set(normalized, { key, policy, canonical });
+    }
+  }
+  const provider = normalizeProviderPolicyKey(params.modelProvider);
+  const modelId = normalizeLowercaseStringOrEmpty(params.modelId);
+  const candidates = [...(modelId ? [`${provider}/${modelId}`] : []), provider];
+  for (const candidate of candidates) {
+    const match = lookup.get(candidate);
+    if (match) {
+      return { key: match.key, policy: match.policy };
+    }
+  }
+  return undefined;
+}
+
+function collectInheritedByProviderConfiguredToolSectionWarnings(params: {
+  inheritedTools?: Record<string, unknown> | null;
+  inheritedPathLabel: string;
+  overridingTools?: Record<string, unknown> | null;
+  overridingPathLabel: string;
+  configuredEntries: ConfiguredToolSectionGrantEntry[];
+  modelProvider?: string;
+  modelId?: string;
+}): string[] {
+  const inheritedByProvider = hasRecord(params.inheritedTools?.byProvider)
+    ? params.inheritedTools.byProvider
+    : undefined;
+  if (!inheritedByProvider || params.configuredEntries.length === 0) {
+    return [];
+  }
+  const overridingByProvider = hasRecord(params.overridingTools?.byProvider)
+    ? params.overridingTools.byProvider
+    : undefined;
+  const inheritedEntryForModel = resolveProviderPolicyEntryForPreview({
+    byProvider: inheritedByProvider,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+  });
+  return Object.entries(inheritedByProvider).flatMap(([providerKey, policyValue]) => {
+    if (params.modelProvider && inheritedEntryForModel?.key !== providerKey) {
+      return [];
+    }
+    const inheritedPolicy = hasRecord(policyValue) ? policyValue : undefined;
+    if (!inheritedPolicy) {
+      return [];
+    }
+    const profile =
+      typeof inheritedPolicy.profile === "string" ? inheritedPolicy.profile : undefined;
+    if (!profile) {
+      return [];
+    }
+    const overridingEntry =
+      resolveProviderPolicyEntryForPreview({
+        byProvider: overridingByProvider,
+        modelProvider: params.modelProvider,
+        modelId: params.modelId,
+      }) ??
+      (hasRecord(overridingByProvider?.[providerKey])
+        ? { key: providerKey, policy: overridingByProvider[providerKey] }
+        : undefined);
+    const overridingPolicy = overridingEntry?.policy;
+    if (typeof overridingPolicy?.profile === "string") {
+      return [];
+    }
+    const alsoAllow =
+      readPreviewStringList(overridingPolicy?.alsoAllow) ??
+      readPreviewStringList(inheritedPolicy.alsoAllow);
+    const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), alsoAllow);
+    const uncoveredEntries = params.configuredEntries
+      .map((entry) => ({
+        ...entry,
+        grants: entry.grants.filter(
+          (toolName) => !isToolAllowedByPolicyName(toolName, profilePolicy),
+        ),
+      }))
+      .filter((entry) => entry.grants.length > 0);
+    if (uncoveredEntries.length === 0) {
+      return [];
+    }
+    const overridePath = `${params.overridingPathLabel}.byProvider.${
+      overridingEntry?.key ?? providerKey
+    }`;
+    const inheritedPath = `${params.inheritedPathLabel}.byProvider.${providerKey}`;
+    const uncoveredGrants = [...new Set(uncoveredEntries.flatMap((entry) => entry.grants))];
+    const advice = formatProfileConfiguredSectionGrantAdvice({
+      pathLabel: overridePath,
+      grants: uncoveredGrants,
+      hasAllow: hasNonEmptyStringList(overridingPolicy?.allow),
+      provider: true,
+    });
+    return [
+      `- ${inheritedPath}.profile is "${profile}" and ${uncoveredEntries
+        .map((entry) => entry.label)
+        .join(
+          " / ",
+        )} is configured, but configured sections no longer widen the inherited provider profile. ${advice}`,
+    ];
+  });
+}
+
+export function collectProfileConfiguredToolSectionWarnings(cfg: OpenClawConfig): string[] {
+  const warnings: string[] = [];
+  const globalTools = hasRecord(cfg.tools) ? cfg.tools : undefined;
+  const globalAlsoAllow = Array.isArray(globalTools?.alsoAllow)
+    ? globalTools.alsoAllow.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+  const globalProfile = typeof globalTools?.profile === "string" ? globalTools.profile : undefined;
+  const globalConfiguredEntries = collectConfiguredToolSectionGrantEntries({
+    tools: globalTools,
+    pathLabel: "tools",
+  });
+
+  warnings.push(
+    ...collectProfileConfiguredToolSectionScopeWarnings({
+      tools: globalTools,
+      pathLabel: "tools",
+    }),
+    ...collectByProviderConfiguredToolSectionWarnings({
+      tools: globalTools,
+      pathLabel: "tools",
+      configuredEntries: globalConfiguredEntries,
+    }),
+  );
+
+  listAgentRecords(cfg).forEach((agent, index) => {
+    const agentTools = hasRecord(agent.tools) ? agent.tools : undefined;
+    const agentId = typeof agent.id === "string" ? agent.id : undefined;
+    const agentConfig = agentId ? resolveAgentConfig(cfg, agentId) : undefined;
+    const modelRef = resolvePrimaryModelRef(cfg, agentConfig?.model);
+    const agentPath = `agents.list[${index}].tools`;
+    const includeInheritedSections =
+      agentTools !== undefined && typeof agentTools.profile !== "string";
+    const ownAgentConfiguredEntries = collectConfiguredToolSectionGrantEntries({
+      tools: agentTools,
+      pathLabel: agentPath,
+    });
+    const agentConfiguredEntries = [...globalConfiguredEntries, ...ownAgentConfiguredEntries];
+    warnings.push(
+      ...collectProfileConfiguredToolSectionScopeWarnings({
+        tools: agentTools,
+        inheritedTools: globalTools,
+        pathLabel: agentPath,
+        inheritedPathLabel: "tools",
+        includeInheritedSections,
+        inheritedProfile: globalProfile,
+        inheritedAlsoAllow: globalAlsoAllow,
+      }),
+      ...collectByProviderConfiguredToolSectionWarnings({
+        tools: agentTools,
+        inheritedTools: globalTools,
+        pathLabel: agentPath,
+        configuredEntries: agentConfiguredEntries,
+      }),
+      ...collectInheritedByProviderConfiguredToolSectionWarnings({
+        inheritedTools: globalTools,
+        inheritedPathLabel: "tools",
+        overridingTools: agentTools,
+        overridingPathLabel: agentPath,
+        configuredEntries: ownAgentConfiguredEntries,
+        modelProvider: modelRef.provider,
+        modelId: modelRef.model,
+      }),
+    );
+  });
+  return warnings;
+}
+
 export type DoctorPreviewNotes = {
   infoNotes: string[];
   warningNotes: string[];
@@ -388,6 +771,7 @@ export async function collectDoctorPreviewNotes(params: {
 
   warnings.push(...collectVisibleReplyToolPolicyWarnings(params.cfg));
   warnings.push(...collectChannelBoundMessageToolPolicyWarnings(params.cfg));
+  warnings.push(...collectProfileConfiguredToolSectionWarnings(params.cfg));
 
   const channelPluginRuntime =
     hasChannelConfig && hasExplicitChannelPluginBlockerConfig(params.cfg)


### PR DESCRIPTION
## Summary

- Replaces the closed #86931 doctor migration with a narrower repair: `doctor --fix` only rewrites configured-section tool grants when the grant intent is already explicit but filtered by profile or invalid representation.
- Adds warning-only doctor preview guidance for ambiguous configured `tools.exec` / `tools.fs` sections, including global, agent, provider, inherited provider, and model-scoped provider cases.
- Adds regression coverage for avoiding accidental permission widening while still repairing explicit grants.

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local` → clean, no accepted/actionable findings.
- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs run src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts src/commands/doctor/shared/preview-warnings.test.ts` → 3 files passed, 107 tests passed.
- `pnpm tsgo:core:test` → passed.
- `node --import tsx -e '<direct migration and warning repro>'` → passed; missing grant intent stays warning-only and explicit grants rewrite without adding new grants.
- `git diff --check` → passed.

## Real behavior proof

Behavior addressed: `openclaw doctor --fix` no longer infers permission widening from configured `tools.exec` / `tools.fs`; ambiguous cases warn with explicit user-initiated grant guidance.

Real environment tested: local OpenClaw source checkout on Node/TS runtime paths, using focused doctor migration tests plus a direct `migrateLegacyConfig` and `collectProfileConfiguredToolSectionWarnings` repro.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts src/commands/doctor/shared/preview-warnings.test.ts`; `pnpm tsgo:core:test`; direct `node --import tsx -e` repro for warning-only missing intent and explicit-grant rewrite.

Evidence after fix: focused tests pass; type lane passes; direct repro reports `regression repro passed: missing intent is warning-only; explicit grants rewrite without adding new grants`.

Observed result after fix: missing configured-section grants are not auto-added, explicit ineffective grants are rewritten to schema-valid/effective representation, and doctor preview guidance does not suggest invalid `allow` plus `alsoAllow` combinations.

What was not tested: packaged install or live user config mutation on a real installed OpenClaw home; broad CI is expected to cover the wider repository lanes.
