### PR TITLE
fix(cli): add Windows stack-size respawn

### DIFF
--- a/src/cli/windows-argv.test.ts
+++ b/src/cli/windows-argv.test.ts
@@ -47,6 +47,28 @@ describe("normalizeWindowsArgv", () => {
     }
   });
 
+  it("preserves non-launcher positionals containing node.exe after a duplicated launcher", () => {
+    const platform = mockProcessPlatform("win32");
+    try {
+      expect(
+        normalizeWindowsArgv([
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+          "debug node.exe-wrapper startup",
+          "--verbose",
+        ]),
+      ).toEqual([
+        "C:\\Program Files\\nodejs\\node.exe",
+        "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+        "debug node.exe-wrapper startup",
+        "--verbose",
+      ]);
+    } finally {
+      platform.mockRestore();
+    }
+  });
+
   it("preserves exact node.exe option values outside the launcher prefix", () => {
     const platform = mockProcessPlatform("win32");
     try {

--- a/src/cli/windows-argv.ts
+++ b/src/cli/windows-argv.ts
@@ -1,7 +1,14 @@
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
-export function normalizeWindowsArgv(argv: string[]): string[] {
-  if (process.platform !== "win32") {
+export function normalizeWindowsArgv(
+  argv: string[],
+  options: {
+    platform?: NodeJS.Platform;
+    execPath?: string;
+  } = {},
+): string[] {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
     return argv;
   }
   if (argv.length < 2) {
@@ -27,7 +34,7 @@ export function normalizeWindowsArgv(argv: string[]): string[] {
     normalizeArg(value).replace(/^\\\\\\?\\/, "");
   const basename = (value: string): string => value.split(/[\\/]/).pop() ?? value;
 
-  const execPath = normalizeCandidate(process.execPath);
+  const execPath = normalizeCandidate(options.execPath ?? process.execPath);
   const execPathLower = normalizeLowercaseStringOrEmpty(execPath);
   const execBase = normalizeLowercaseStringOrEmpty(basename(execPath));
   const isExecPath = (value: string | undefined): boolean => {

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -45,6 +45,7 @@ describe("buildCliRespawnPlan", () => {
       env: {},
       execArgv: [],
       autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+      platform: "linux",
     });
 
     const respawnPlan = expectCliRespawnPlan(plan);
@@ -63,6 +64,7 @@ describe("buildCliRespawnPlan", () => {
         env: {},
         execArgv: [],
         autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+        platform: "linux",
       });
 
       const respawnPlan = expectCliRespawnPlan(plan);
@@ -80,6 +82,7 @@ describe("buildCliRespawnPlan", () => {
         env: { [OPENCLAW_NODE_EXTRA_CA_CERTS_READY]: "1" },
         execArgv: [],
         autoNodeExtraCaCerts: undefined,
+        platform: "linux",
       }),
     ).toBeNull();
   });
@@ -90,6 +93,7 @@ describe("buildCliRespawnPlan", () => {
       env: { NODE_EXTRA_CA_CERTS: "/custom/ca.pem" },
       execArgv: [],
       autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+      platform: "linux",
     });
 
     const respawnPlan = expectCliRespawnPlan(plan);
@@ -106,20 +110,83 @@ describe("buildCliRespawnPlan", () => {
         },
         execArgv: [EXPERIMENTAL_WARNING_FLAG],
         autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+        platform: "linux",
       }),
     ).toBeNull();
   });
 
-  it("does not respawn on Windows", () => {
+  it("adds a larger V8 stack size on Windows", () => {
+    const plan = buildCliRespawnPlan({
+      argv: [
+        "node",
+        "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs",
+        "dashboard",
+      ],
+      env: {},
+      execArgv: [],
+      autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+      platform: "win32",
+    });
+
+    const respawnPlan = expectCliRespawnPlan(plan);
+    expect(respawnPlan.argv).toEqual([
+      "--stack-size=8192",
+      "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs",
+      "dashboard",
+    ]);
+    expect(respawnPlan.env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    expect(respawnPlan.env[OPENCLAW_NODE_EXTRA_CA_CERTS_READY]).toBeUndefined();
+    expect(respawnPlan.env[OPENCLAW_NODE_OPTIONS_READY]).toBeUndefined();
+  });
+
+  it("normalizes duplicated Windows node.exe argv before respawning", () => {
+    const scriptPath =
+      "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs";
+    const plan = buildCliRespawnPlan({
+      argv: [
+        "C:\\Program Files\\nodejs\\node.exe",
+        "C:\\Program Files\\nodejs\\node.exe",
+        scriptPath,
+        "node.exe",
+        "dashboard",
+        "--no-open",
+      ],
+      env: {},
+      execArgv: [],
+      execPath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+
+    const respawnPlan = expectCliRespawnPlan(plan);
+    expect(respawnPlan.argv).toEqual(["--stack-size=8192", scriptPath, "dashboard", "--no-open"]);
+  });
+
+  it("does not respawn on Windows when stack size is already configured", () => {
     expect(
       buildCliRespawnPlan({
         argv: [
           "node",
           "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs",
-          "onboard",
+          "dashboard",
         ],
         env: {},
-        execArgv: [],
+        execArgv: ["--stack-size=16384"],
+        autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+        platform: "win32",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not respawn on Windows when underscore stack size spelling is already configured", () => {
+    expect(
+      buildCliRespawnPlan({
+        argv: [
+          "node",
+          "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs",
+          "dashboard",
+        ],
+        env: {},
+        execArgv: ["--stack_size=16384"],
         autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
         platform: "win32",
       }),

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -5,12 +5,14 @@ import {
   shouldSkipRespawnForArgv,
   shouldSkipStartupEnvironmentRespawnForArgv,
 } from "./cli/respawn-policy.js";
+import { normalizeWindowsArgv } from "./cli/windows-argv.js";
 import { isTruthyEnvValue } from "./infra/env.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 
 export const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
 export const OPENCLAW_NODE_OPTIONS_READY = "OPENCLAW_NODE_OPTIONS_READY";
 export const OPENCLAW_NODE_EXTRA_CA_CERTS_READY = "OPENCLAW_NODE_EXTRA_CA_CERTS_READY";
+const WINDOWS_STACK_SIZE_FLAG = "--stack-size=8192";
 const CLI_RESPAWN_SIGNAL_EXIT_GRACE_MS = 1_000;
 const CLI_RESPAWN_SIGNAL_FORCE_KILL_GRACE_MS = 1_000;
 
@@ -58,6 +60,16 @@ function hasExperimentalWarningSuppressed(
   return execArgv.some((arg) => arg === EXPERIMENTAL_WARNING_FLAG || arg === "--no-warnings");
 }
 
+function hasStackSizeConfigured(execArgv: string[]): boolean {
+  return execArgv.some(
+    (arg) =>
+      arg === "--stack-size" ||
+      arg.startsWith("--stack-size=") ||
+      arg === "--stack_size" ||
+      arg.startsWith("--stack_size="),
+  );
+}
+
 export function buildCliRespawnPlan(
   params: {
     argv?: string[];
@@ -73,21 +85,36 @@ export function buildCliRespawnPlan(
   const execArgv = params.execArgv ?? process.execArgv;
   const execPath = params.execPath ?? process.execPath;
   const platform = params.platform ?? process.platform;
+  const normalizedArgv =
+    platform === "win32" ? normalizeWindowsArgv(argv, { platform, execPath }) : argv;
 
   if (
-    shouldSkipStartupEnvironmentRespawnForArgv(argv) ||
+    shouldSkipStartupEnvironmentRespawnForArgv(normalizedArgv) ||
     isTruthyEnvValue(env.OPENCLAW_NO_RESPAWN)
   ) {
-    return null;
-  }
-
-  if (platform === "win32") {
     return null;
   }
 
   const childEnv: NodeJS.ProcessEnv = { ...env };
   const childExecArgv = [...execArgv];
   let needsRespawn = false;
+
+  if (platform === "win32") {
+    if (!hasStackSizeConfigured(childExecArgv)) {
+      childExecArgv.unshift(WINDOWS_STACK_SIZE_FLAG);
+      needsRespawn = true;
+    }
+
+    if (!needsRespawn) {
+      return null;
+    }
+
+    return {
+      command: resolveCliRespawnCommand({ execPath, platform }),
+      argv: [...childExecArgv, ...normalizedArgv.slice(1)],
+      env: childEnv,
+    };
+  }
 
   const autoNodeExtraCaCerts =
     params.autoNodeExtraCaCerts ??


### PR DESCRIPTION
## Summary
- add a Windows-only CLI respawn with `--stack-size=8192` for stack-heavy startup paths
- normalize duplicated Windows `node.exe` launcher argv before respawn handoff
- preserve non-launcher argv values containing `node.exe` and recognize both `--stack-size` and `--stack_size` as already configured

Supersedes #86307. Fixes #62055. Thanks @giodl73-repo for the original fix.

## Verification
- `node --v8-options | rg -n "stack-size|stack_size"`
- `node --stack-size=8192 -e "console.log('ok')"`
- `node --stack_size=8192 -e "console.log('ok')"`
- `pnpm format:check src/cli/windows-argv.ts src/cli/windows-argv.test.ts src/entry.respawn.ts src/entry.respawn.test.ts`
- `node scripts/run-vitest.mjs src/entry.respawn.test.ts src/cli/windows-argv.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `pnpm check:changed` via Testbox `tbx_01ksjzf06pcgx29qrctjrn4rhr`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/26473172664

Behavior addressed: Windows CLI startup can crash on large module graphs because the default V8 stack is too small.
Real environment tested: local Node accepted both stack-size spellings; Testbox ran the changed gate on the staged patch.
Exact steps or command run after this patch: focused Vitest, format check, autoreview, and `pnpm check:changed` as listed above.
Evidence after fix: respawn plan tests cover Windows stack-size insertion, duplicate launcher cleanup, existing stack-size guards, and non-launcher `node.exe` argv preservation.
Observed result after fix: all focused tests and the changed gate passed.
What was not tested: live Windows packaged CLI startup; this patch is validated with unit coverage and Node flag contract checks.
