### PR TITLE
fix(reply): queue visible turns behind active replies

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -231,7 +231,9 @@ async function startAgentRun(params: {
       } catch (err) {
         const queueSummary =
           formatEmbeddedPiQueueFailureSummary(queueOutcome) ?? "active run queue rejected";
-        throw new Error(`${queueSummary}; fallback_failed error=${formatErrorMessage(err)}`);
+        throw new Error(`${queueSummary}; fallback_failed error=${formatErrorMessage(err)}`, {
+          cause: err,
+        });
       }
     }
     const response = await params.callGateway<{ runId: string }>({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -84,6 +84,7 @@ import { buildReplyPromptEnvelope, buildReplyPromptEnvelopeBase } from "./prompt
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings-runtime.js";
 import {
+  REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
   abortReplyRunBySessionId,
   isReplyRunActiveForSessionId,
   isReplyRunStreamingForSessionId,
@@ -1106,7 +1107,7 @@ export async function runPreparedReply(
       },
       waitForActiveRunEnd: (activeRunSessionId) =>
         isReplyRunActiveForSessionId(activeRunSessionId)
-          ? waitForReplyRunEndBySessionId(activeRunSessionId)
+          ? waitForReplyRunEndBySessionId(activeRunSessionId, REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS)
           : (piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined)),
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -110,6 +110,8 @@ const replyRunState = resolveGlobalSingleton<ReplyRunState>(REPLY_RUN_STATE_KEY,
   waitersByKey: new Map<string, Set<ReplyRunWaiter>>(),
 }));
 
+export const REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS = 15_000;
+
 export class ReplyRunAlreadyActiveError extends Error {
   constructor(sessionKey: string) {
     super(`Reply run already active for ${sessionKey}`);
@@ -440,7 +442,6 @@ export const replyRunRegistry: ReplyRunRegistry = {
     return true;
   },
   waitForIdle(sessionKey, timeoutMs, opts) {
-    const effectiveTimeoutMs = timeoutMs ?? 15_000;
     const normalizedSessionKey = normalizeOptionalString(sessionKey);
     if (!normalizedSessionKey || !replyRunState.activeRunsByKey.has(normalizedSessionKey)) {
       return Promise.resolve(true);
@@ -471,8 +472,8 @@ export const replyRunRegistry: ReplyRunRegistry = {
           resolve(ended);
         },
       };
-      if (Number.isFinite(effectiveTimeoutMs)) {
-        waiter.timer = setTimeout(() => waiter.finish(false), Math.max(100, effectiveTimeoutMs));
+      if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs)) {
+        waiter.timer = setTimeout(() => waiter.finish(false), Math.max(100, timeoutMs));
       }
       if (opts?.signal) {
         abortHandler = () => waiter.finish(false);
@@ -543,7 +544,7 @@ export function forceClearReplyRunBySessionId(sessionId: string, cause?: unknown
 
 export function waitForReplyRunEndBySessionId(
   sessionId: string,
-  timeoutMs = 15_000,
+  timeoutMs: number,
 ): Promise<boolean> {
   const waitKey = resolveReplyRunWaitKey(sessionId);
   if (!waitKey) {

--- a/src/auto-reply/reply/reply-turn-admission.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createReplyOperation, testing } from "./reply-run-registry.js";
 import { admitReplyTurn } from "./reply-turn-admission.js";
 
@@ -36,6 +36,74 @@ describe("reply turn admission", () => {
     if (result.status === "owned") {
       expect(result.operation.sessionId).toBe("active-session");
       result.operation.complete();
+    }
+  });
+
+  it("does not apply cleanup settle timeout to visible turn admission", async () => {
+    vi.useFakeTimers();
+    try {
+      const active = createReplyOperation({
+        sessionKey: "agent:main:discord:channel:42",
+        sessionId: "active-session",
+        resetTriggered: false,
+      });
+      active.setPhase("running");
+
+      const admitted = admitReplyTurn({
+        sessionKey: "agent:main:discord:channel:42",
+        sessionId: "waiting-session",
+        kind: "visible",
+        resetTriggered: false,
+      });
+
+      let settled = false;
+      void admitted.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(settled).toBe(false);
+
+      active.complete();
+      const result = await admitted;
+      expect(result.status).toBe("owned");
+      if (result.status === "owned") {
+        result.operation.complete();
+      }
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the cleanup settle timeout for queued follow-up retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const active = createReplyOperation({
+        sessionKey: "agent:main:discord:channel:42",
+        sessionId: "active-session",
+        resetTriggered: false,
+      });
+      active.setPhase("running");
+
+      const admitted = admitReplyTurn({
+        sessionKey: "agent:main:discord:channel:42",
+        sessionId: "queued-session",
+        kind: "queued_followup",
+        resetTriggered: false,
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(admitted).resolves.toMatchObject({
+        status: "skipped",
+        reason: "active-run",
+        activeOperation: active,
+      });
+      active.complete();
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
     }
   });
 

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -1,5 +1,6 @@
 import {
   createReplyOperation,
+  REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
   replyRunRegistry,
   ReplyRunAlreadyActiveError,
   type ReplyOperation,
@@ -54,7 +55,10 @@ export async function admitReplyTurn(params: {
       if (params.waitForActive === false) {
         return { status: "skipped", reason: "active-run", activeOperation };
       }
-      const ended = await replyRunRegistry.waitForIdle(params.sessionKey, params.waitTimeoutMs, {
+      const waitTimeoutMs =
+        params.waitTimeoutMs ??
+        (params.kind === "queued_followup" ? REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS : undefined);
+      const ended = await replyRunRegistry.waitForIdle(params.sessionKey, waitTimeoutMs, {
         signal: params.upstreamAbortSignal,
       });
       if (!ended) {


### PR DESCRIPTION
## Summary
- Remove the hidden 15s default from the low-level reply-run idle wait so visible user turns no longer inherit cleanup-settle behavior.
- Keep the 15s timeout explicit for cleanup/retry paths: queued follow-up admission and interrupt/reset active-run settling.
- Add core reply-admission regressions that prove visible turns wait past 15s while queued follow-ups still defer/retry after the cleanup settle timeout.

## Verification
- `pnpm -s exec oxfmt src/auto-reply/reply/reply-run-registry.ts src/auto-reply/reply/reply-turn-admission.ts src/auto-reply/reply/reply-turn-admission.test.ts src/auto-reply/reply/get-reply-run.ts src/agents/tools/sessions-send-tool.ts`
- `pnpm -s exec oxlint src/auto-reply/reply/reply-run-registry.ts src/auto-reply/reply/reply-turn-admission.ts src/auto-reply/reply/reply-turn-admission.test.ts src/auto-reply/reply/get-reply-run.ts src/agents/tools/sessions-send-tool.ts`
- `git diff --check`
- `pnpm -s tsgo:core:test`
- `pnpm -s tsgo:core`
- `pnpm lint --threads=8`
- `fnm exec --using v24.15.0 -- pnpm -s exec tsx -e '...'`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real Behavior Proof
Behavior addressed: Visible user turns arriving while a same-session reply operation is active should wait for that operation to clear instead of being skipped by the reply-run registry's cleanup-settle timeout.

Real environment tested: Local OpenClaw source checkout on Node 24.15.0, against PR head `cba103871a493fc1db922bce519d7824400d967c`.

Exact steps or command run after this patch: Ran a terminal probe with Node 24.15.0 against the patched OpenClaw source checkout. The probe created an active reply operation, admitted a visible turn for the same session key, confirmed no `15_000` timer was scheduled and the turn stayed pending, completed the active operation, then confirmed the visible turn was admitted with the active session id. The same terminal probe admitted a queued follow-up and confirmed it still schedules the explicit `15_000` retry/defer timeout.

Evidence after fix: Terminal output from the OpenClaw source checkout:

```text
$ fnm exec --using v24.15.0 -- pnpm -s exec tsx -e '...'
visible waits without 15s; queued followup keeps 15s retry timeout
```

Observed result after fix: The visible reply admission remained pending while the active reply operation was running, scheduled no `15_000` cleanup timer, then became owned after the active operation completed. The queued follow-up path still scheduled the `15_000` retry timeout and returned `skipped active-run`, so a stuck active run does not wedge the follow-up drain.

What was not tested: I did not force a deployed Telegram message to wait behind a deliberately held active operation. The changed core admission behavior was exercised directly in a local OpenClaw source checkout.
