### PR TITLE
fix(diagnostics): flush OTel trace batches

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -53,6 +53,7 @@ const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const traceExporterCtor = vi.hoisted(() => vi.fn());
 const metricExporterCtor = vi.hoisted(() => vi.fn());
 const logExporterCtor = vi.hoisted(() => vi.fn());
+const spanProcessorCtor = vi.hoisted(() => vi.fn());
 const unhandledRejectionHandlerState = vi.hoisted(() => {
   let handlers: Array<(reason: unknown) => boolean> = [];
   return {
@@ -136,6 +137,9 @@ vi.mock("@opentelemetry/sdk-metrics", () => ({
 }));
 
 vi.mock("@opentelemetry/sdk-trace-base", () => ({
+  BatchSpanProcessor: function BatchSpanProcessor(exporter?: unknown, options?: unknown) {
+    spanProcessorCtor(exporter, options);
+  },
   ParentBasedSampler: function ParentBasedSampler() {},
   TraceIdRatioBasedSampler: function TraceIdRatioBasedSampler() {},
 }));
@@ -259,6 +263,10 @@ function mockCallArg(mock: { mock: { calls: unknown[][] } }, argIndex: number, c
 
 function firstExporterOptions(mock: { mock: { calls: unknown[][] } }): { url?: string } {
   return mockCallArg(mock, 0) as { url?: string };
+}
+
+function firstSpanProcessorOptions(): { scheduledDelayMillis?: number } {
+  return mockCallArg(spanProcessorCtor, 1) as { scheduledDelayMillis?: number };
 }
 
 function firstSetSpanContext(): Record<string, unknown> {
@@ -390,6 +398,7 @@ describe("diagnostics-otel service", () => {
     traceExporterCtor.mockClear();
     metricExporterCtor.mockClear();
     logExporterCtor.mockClear();
+    spanProcessorCtor.mockClear();
     unhandledRejectionHandlerState.reset();
     unhandledRejectionHandlerState.register.mockClear();
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
@@ -1192,6 +1201,18 @@ describe("diagnostics-otel service", () => {
 
     const options = firstExporterOptions(traceExporterCtor);
     expect(options.url).toBe("https://collector.example.com/v1/Traces");
+    await service.stop?.(ctx);
+  });
+
+  test("applies flush interval to trace batching", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createTraceOnlyContext(OTEL_TEST_ENDPOINT);
+    ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
+
+    await service.start(ctx);
+
+    expect(spanProcessorCtor).toHaveBeenCalledTimes(1);
+    expect(firstSpanProcessorOptions().scheduledDelayMillis).toBe(1000);
     await service.stop?.(ctx);
   });
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -14,7 +14,11 @@ import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
-import { ParentBasedSampler, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-base";
+import {
+  BatchSpanProcessor,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+} from "@opentelemetry/sdk-trace-base";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import {
   ATTR_GEN_AI_INPUT_MESSAGES,
@@ -1167,6 +1171,14 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               ...(headers ? { headers } : {}),
             })
           : undefined;
+        const spanProcessors =
+          traceExporter && typeof otel.flushIntervalMs === "number"
+            ? [
+                new BatchSpanProcessor(traceExporter, {
+                  scheduledDelayMillis: Math.max(1000, otel.flushIntervalMs),
+                }),
+              ]
+            : undefined;
 
         const metricExporter = metricsEnabled
           ? new OTLPMetricExporter({
@@ -1186,7 +1198,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
         sdk = new NodeSDK({
           resource,
-          ...(traceExporter ? { traceExporter } : {}),
+          ...(spanProcessors ? { spanProcessors } : traceExporter ? { traceExporter } : {}),
           ...(metricReader ? { metricReader } : {}),
           ...(sampleRate !== undefined
             ? {

--- a/scripts/qa-otel-smoke.ts
+++ b/scripts/qa-otel-smoke.ts
@@ -923,6 +923,47 @@ function isLatestGenAiModelCallSpan(span: CapturedSpan): boolean {
   );
 }
 
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasRequiredSmokeSignals(receiver: ReturnType<typeof startLocalOtlpReceiver>): boolean {
+  const spanNames = new Set(receiver.capturedSpans.map((span) => span.name));
+  const metricNames = new Set(receiver.capturedMetrics.map((metric) => metric.name));
+  return (
+    REQUIRED_SPAN_NAMES.every((name) => spanNames.has(name)) &&
+    receiver.capturedSpans.some(isLatestGenAiModelCallSpan) &&
+    REQUIRED_METRIC_NAMES.every((name) => metricNames.has(name)) &&
+    receiver.capturedLogRecords.length > 0 &&
+    ["traces", "metrics", "logs"].every((signal) =>
+      receiver.capturedRequests.some((request) => request.signal === signal)
+    )
+  );
+}
+
+async function waitForExpectedTelemetry(
+  receiver: ReturnType<typeof startLocalOtlpReceiver>,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (hasRequiredSmokeSignals(receiver)) {
+      return;
+    }
+    await delay(250);
+  }
+}
+
+function formatBoundedList(values: readonly string[], maxItems: number): string {
+  if (values.length === 0) {
+    return "(none)";
+  }
+  const visible = values.slice(0, maxItems);
+  const suffix =
+    values.length > visible.length ? `, ... (${values.length - visible.length} more)` : "";
+  return `${visible.join(", ")}${suffix}`;
+}
+
 function assertSmoke(params: {
   childExitCode: number;
   disallowedBodyNeedles: string[];
@@ -1075,7 +1116,11 @@ async function main() {
     child.stdout?.on("data", (chunk) => process.stdout.write(chunk));
     child.stderr?.on("data", (chunk) => process.stderr.write(chunk));
     childExitCode = await waitForChild(child);
-    await new Promise((resolve) => setTimeout(resolve, 3000));
+    if (childExitCode === 0) {
+      await waitForExpectedTelemetry(receiver, 15_000);
+    } else {
+      await delay(3000);
+    }
   } finally {
     try {
       await collector?.close();
@@ -1136,6 +1181,20 @@ async function main() {
     for (const failure of assertion.failures) {
       process.stderr.write(`qa-otel-smoke: ${failure}\n`);
     }
+    process.stderr.write(
+      `qa-otel-smoke: captured request counts traces=${assertion.signalRequestCounts.traces} ` +
+        `metrics=${assertion.signalRequestCounts.metrics} logs=${assertion.signalRequestCounts.logs}\n`,
+    );
+    process.stderr.write(
+      `qa-otel-smoke: captured decoded counts spans=${receiver.capturedSpans.length} ` +
+        `metrics=${receiver.capturedMetrics.length} logs=${receiver.capturedLogRecords.length}\n`,
+    );
+    process.stderr.write(
+      `qa-otel-smoke: captured span names: ${formatBoundedList(assertion.spanNames, 40)}\n`,
+    );
+    process.stderr.write(
+      `qa-otel-smoke: captured metric names: ${formatBoundedList(assertion.metricNames, 40)}\n`,
+    );
     for (const [signal, contexts] of Object.entries(assertion.leakContexts)) {
       for (const context of contexts ?? []) {
         process.stderr.write(`qa-otel-smoke: ${signal} leak context: ${context}\n`);


### PR DESCRIPTION
## Summary

- Apply `diagnostics.otel.flushIntervalMs` to OTel trace batching by installing a `BatchSpanProcessor` when trace export is enabled.
- Keep the existing `traceExporter` NodeSDK path when no flush interval is configured.
- Make `scripts/qa-otel-smoke.ts` wait for required telemetry after a successful QA run and print bounded request/span/metric diagnostics on failures.

## Verification

- `git diff --check`
- AWS Crabbox Linux/Docker baseline before fix: `run_e750e8713d26`, `provider=aws`, `lease=cbx_e1f116c5b3c5`; in-process OTel smoke, Docker collector OTel smoke, and Prometheus smoke passed.
- AWS Crabbox Windows baseline reproduced the bug: `run_4dca7ba8900c`, `provider=aws`, `lease=cbx_9bbd4144eba2`; focused diagnostics/logging tests passed, but native Windows OTel smoke missed late lifecycle/model spans.
- AWS Crabbox Windows diagnostic rerun: `run_54d283057cf1`, `provider=aws`, `lease=cbx_be55a96281a7`; captured trace/metric/log requests, with metrics/logs present but trace spans limited to early diagnostic phase spans.
- AWS Crabbox Windows fixed proof: `run_49c567500e69`, `provider=aws`, `lease=cbx_811cf3deac91`; `pnpm test:serial extensions/diagnostics-otel/src/service.test.ts`, in-process OTel smoke, and `pnpm qa:prometheus:smoke` passed.
- AWS Crabbox Linux/Docker fixed proof: `run_befc0a4fbb09`, `provider=aws`, `lease=cbx_9a3fe01a5ab2`; diagnostics-otel service test, in-process OTel smoke, Docker collector OTel smoke, and Prometheus smoke passed.
- AWS Crabbox macOS fixed proof: `run_8b1bb01e9164`, `provider=aws`, `lease=cbx_62818701aecf`; diagnostics/logging/Prometheus service tests and in-process OTel smoke passed. Docker was not installed on the macOS image.
- AWS Crabbox final changed gate after rebase: `run_1c41fd57c70d`, `provider=aws`, `lease=cbx_d772b91f0478`; `pnpm check:changed` passed.
- Autoreview: `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings.

## Real behavior proof

Behavior addressed: short-lived Windows/QA diagnostics runs can lose late OTel trace spans even when `diagnostics.otel.flushIntervalMs` is configured.

Real environment tested: AWS Crabbox Linux, native Windows, and macOS runners; Linux and Windows Docker/Prometheus smoke where Docker was available.

Exact steps or command run after this patch: `pnpm test:serial extensions/diagnostics-otel/src/service.test.ts`, `node --import tsx scripts/qa-otel-smoke.ts`, `node --import tsx scripts/qa-otel-smoke.ts --collector docker`, `pnpm qa:prometheus:smoke`, and `pnpm check:changed` on Crabbox runners.

Evidence after fix: Windows OTel smoke passed with spans=17 metrics=56 logs=14 traces=4 metricRequests=26 logRequests=6; Linux collector smoke passed with spans=18 metrics=28 logs=14 traces=3 metricRequests=6 logRequests=5; macOS in-process smoke passed with spans=18 metrics=24 logs=14 traces=3 metricRequests=6 logRequests=4.

Observed result after fix: required OTel lifecycle/model spans are exported before QA cleanup on Windows, while Linux Docker collector and Prometheus smoke remain green.

What was not tested: macOS Docker collector and Prometheus container smoke, because the AWS macOS image reported `docker: command not found`; macOS Prometheus coverage used the focused service test.
