### PR TITLE
fix(ollama): normalize greedy top_p

### DIFF
--- a/extensions/ollama/ollama.live.test.ts
+++ b/extensions/ollama/ollama.live.test.ts
@@ -258,7 +258,7 @@ describe.skipIf(!LIVE)("ollama live", () => {
     expect(events.map((event) => (event as { type?: string }).type)).toContain("done");
     expect(payload?.model).toBe(CHAT_MODEL);
     expect(payload?.options?.num_ctx).toBe(4096);
-    expect(payload?.options?.top_p).toBe(0.9);
+    expect(payload?.options?.top_p).toBe(1);
     expect(payload?.think).toBe(false);
     expect(payload?.keep_alive).toBe("5m");
     const properties = payload?.tools?.[0]?.function?.parameters?.properties;

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -2319,6 +2319,117 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
+  it("sets top_p=1 for native Ollama greedy sampling requests", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: {
+            params: {
+              num_ctx: 4096,
+              top_p: 0.9,
+              thinking: false,
+            },
+          },
+          options: { temperature: 0 },
+        });
+
+        const events = await collectStreamEvents(stream);
+        expect(events.at(-1)?.type).toBe("done");
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          options: {
+            temperature?: number;
+            top_p?: number;
+          };
+        };
+        expect(requestBody.options.temperature).toBe(0);
+        expect(requestBody.options.top_p).toBe(1);
+      },
+    );
+  });
+
+  it("sets top_p=1 for native Ollama greedy requests without configured top_p", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: {
+            params: {
+              num_ctx: 4096,
+              thinking: false,
+            },
+          },
+          options: { temperature: 0 },
+        });
+
+        const events = await collectStreamEvents(stream);
+        expect(events.at(-1)?.type).toBe("done");
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          options: {
+            temperature?: number;
+            top_p?: number;
+          };
+        };
+        expect(requestBody.options.temperature).toBe(0);
+        expect(requestBody.options.top_p).toBe(1);
+      },
+    );
+  });
+
+  it("preserves configured top_p for native Ollama non-greedy sampling requests", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: {
+            params: {
+              top_p: 0.9,
+            },
+          },
+          options: { temperature: 0.2 },
+        });
+
+        const events = await collectStreamEvents(stream);
+        expect(events.at(-1)?.type).toBe("done");
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          options: {
+            temperature?: number;
+            top_p?: number;
+          };
+        };
+        expect(requestBody.options.temperature).toBe(0.2);
+        expect(requestBody.options.top_p).toBe(0.9);
+      },
+    );
+  });
+
   it("omits num_ctx when the model has no params.num_ctx and no catalog window", async () => {
     await withMockNdjsonFetch(
       [

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -343,6 +343,18 @@ function resolveOllamaModelOptions(model: ProviderRuntimeModel): Record<string, 
   return options;
 }
 
+function normalizeOllamaGreedySamplingOptions(options: Record<string, unknown>): void {
+  if (options.temperature !== 0) {
+    return;
+  }
+  if (
+    options.top_p === undefined ||
+    (typeof options.top_p === "number" && Number.isFinite(options.top_p) && options.top_p !== 1)
+  ) {
+    options.top_p = 1;
+  }
+}
+
 function resolveOllamaTopLevelParams(
   model: ProviderRuntimeModel,
 ): Record<string, unknown> | undefined {
@@ -1098,6 +1110,7 @@ export function createOllamaStreamFn(
         if (typeof options?.maxTokens === "number") {
           ollamaOptions.num_predict = options.maxTokens;
         }
+        normalizeOllamaGreedySamplingOptions(ollamaOptions);
 
         const body = buildOllamaChatRequest({
           modelId: model.id,


### PR DESCRIPTION
## Summary

- Normalize native Ollama chat requests so greedy sampling (`temperature: 0`) sends `top_p: 1` instead of the default `0.9`.
- Keep non-greedy requests unchanged, so other Ollama models and custom sampling configs still preserve their configured `top_p`.
- Update the Ollama live payload expectation to match the greedy request contract.

## Split notes

- Current PR: narrow Ollama greedy-sampling payload normalization plus focused request-payload tests.
- Later QA follow-up: QA Lab mock suite still has unrelated failures in subagent fallback, WebChat direct reply, media generation, memory dreaming, thinking visibility, Skill Workshop, plugin hook sentinel, Codex read wording, runtime inventory drift, and Control UI browser provisioning.
- Later infrastructure follow-up: Windows Crabbox proof is blocked by native/WSL2 hydration/runner support, not by this Ollama patch.

## Verification

- `node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts` passed locally: 97 tests.
- `git diff --check origin/main...HEAD` passed.
- AWS Crabbox `run_aec8b962ea6c`, lease `cbx_b2bd5d09e92d`: targeted QA Lab failed-scenario rerun completed with `--allow-failures`; `pnpm check:changed` passed in the same run.
- AWS Crabbox `run_3bf6828dc9d2`, lease `cbx_f1927a040100`: live Ollama Cloud smoke passed for `ministral-3:3b` and `gemma4:31b` with 3 passed / 1 skipped each.
- AWS Crabbox `run_2788e6c0cab5`, lease `cbx_1db542844178`: Kitchen Sink RPC passed; QA Lab mock full suite finished 101 passed / 11 failed.
- Autoreview: clean, no accepted/actionable findings.

## Real behavior proof

Behavior addressed: Hosted Ollama native chat rejects greedy sampling when `temperature: 0` is paired with `top_p` below 1; native Ollama requests now normalize that combination to `top_p: 1`.

Real environment tested: AWS Crabbox Linux plus hosted Ollama Cloud API, including `ministral-3:3b` and `gemma4:31b`.

Exact steps or command run after this patch: `OPENCLAW_LIVE_OLLAMA_MODEL=ministral-3:3b node scripts/test-live.mjs extensions/ollama/ollama.live.test.ts --reporter=verbose`; `OPENCLAW_LIVE_OLLAMA_MODEL=gemma4:31b node scripts/test-live.mjs extensions/ollama/ollama.live.test.ts --reporter=verbose`; `pnpm check:changed` via Crabbox; targeted QA Lab failed-scenario rerun via `pnpm openclaw qa suite --allow-failures --provider-mode mock-openai --concurrency 1`.

Evidence after fix: Live Ollama Cloud smoke passed for both tested models; the changed gate passed; focused stream runtime tests passed locally.

Observed result after fix: Greedy native Ollama payloads now send `top_p: 1`; non-greedy payloads still preserve configured `top_p`.

What was not tested: Embeddings remain skipped in the live Ollama test because that is a separate opt-in contract. Windows product proof was attempted but blocked by Crabbox Windows hydration/runner support.
