### PR TITLE
fix: restore shared CI replay and Windows Node setup

### DIFF
--- a/.github/actions/setup-pnpm-store-cache/ensure-node.sh
+++ b/.github/actions/setup-pnpm-store-cache/ensure-node.sh
@@ -26,12 +26,19 @@ openclaw_active_node_version() {
   node -p 'process.versions.node' 2>/dev/null || true
 }
 
+openclaw_to_shell_path() {
+  local input_path="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$input_path" 2>/dev/null || printf '%s' "$input_path"
+    return
+  fi
+  printf '%s' "$input_path"
+}
+
 openclaw_prepend_node_bin() {
   local node_bin_dir="$1"
-  local shell_node_bin_dir="$node_bin_dir"
-  if command -v cygpath >/dev/null 2>&1; then
-    shell_node_bin_dir="$(cygpath -u "$node_bin_dir" 2>/dev/null || printf '%s' "$node_bin_dir")"
-  fi
+  local shell_node_bin_dir
+  shell_node_bin_dir="$(openclaw_to_shell_path "$node_bin_dir")"
   export PATH="$shell_node_bin_dir:$PATH"
   if [[ -n "${GITHUB_PATH:-}" ]]; then
     local github_node_bin_dir="$shell_node_bin_dir"
@@ -57,6 +64,7 @@ openclaw_find_toolcache_node() {
     "/Users/runner/hostedtoolcache" \
     "/c/hostedtoolcache/windows"
   do
+    root="$(openclaw_to_shell_path "$root")"
     if [[ -d "$root/node" ]]; then
       roots+=("$root/node")
     elif [[ "$(basename "$root")" == "node" && -d "$root" ]]; then

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -782,6 +782,7 @@ export async function sanitizeSessionHistory(params: {
     !isOpenAIResponsesApi && policy.repairToolUseResultPairing
       ? sanitizeToolUseResultPairing(sanitizedToolIds, {
           erroredAssistantResultPolicy: "drop",
+          markRepairedLegacyToolResultsAsError: allowProviderOwnedThinkingReplay,
         })
       : sanitizedToolIds;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -24,6 +24,11 @@ type RawToolCallBlock = {
   arguments?: unknown;
 };
 
+type ToolCallLike = {
+  id: string;
+  name?: string;
+};
+
 const RAW_TOOL_CALL_BLOCK_TYPES = new Set([
   "toolCall",
   "toolUse",
@@ -193,6 +198,7 @@ type ErroredAssistantResultPolicy = "preserve" | "drop";
 
 type ToolUseResultPairingOptions = {
   erroredAssistantResultPolicy?: ErroredAssistantResultPolicy;
+  markRepairedLegacyToolResultsAsError?: boolean;
   missingToolResultText?: string;
 };
 
@@ -219,6 +225,7 @@ export function stripToolResultDetails(messages: AgentMessage[]): AgentMessage[]
 function collectFollowingToolResults(
   messages: AgentMessage[],
   index: number,
+  toolCalls: ToolCallLike[] = [],
 ): { ids: Set<string>; displaced: boolean } {
   const ids = new Set<string>();
   let sawNonToolResult = false;
@@ -233,7 +240,14 @@ function collectFollowingToolResults(
       break;
     }
     if (message.role === "toolResult") {
-      const resultIds = extractToolResultIds(message);
+      const toolResult = message as Extract<AgentMessage, { role: "toolResult" }>;
+      const resultIds = extractToolResultIds(toolResult);
+      if (resultIds.length === 0) {
+        const legacyResult = normalizeLegacyToolResultId(toolResult, toolCalls);
+        if (legacyResult) {
+          resultIds.push(legacyResult.toolCallId);
+        }
+      }
       for (const id of resultIds) {
         ids.add(id);
       }
@@ -243,6 +257,36 @@ function collectFollowingToolResults(
     sawNonToolResult = true;
   }
   return { ids, displaced };
+}
+
+function normalizeLegacyToolResultId(
+  message: Extract<AgentMessage, { role: "toolResult" }>,
+  toolCalls: ToolCallLike[],
+  options?: { markAsError?: boolean },
+): (Extract<AgentMessage, { role: "toolResult" }> & { toolCallId: string }) | null {
+  if (extractToolResultId(message)) {
+    return null;
+  }
+
+  const resultToolName =
+    normalizeOptionalString((message as { toolName?: unknown }).toolName) ??
+    normalizeOptionalString((message as { name?: unknown }).name);
+  const candidates = resultToolName
+    ? toolCalls.filter((toolCall) => normalizeOptionalString(toolCall.name) === resultToolName)
+    : toolCalls.length === 1
+      ? toolCalls
+      : [];
+  const candidate = candidates.length === 1 ? candidates[0] : undefined;
+  if (!candidate) {
+    return null;
+  }
+
+  const normalized = normalizeToolResultName(message, candidate.name);
+  return {
+    ...normalized,
+    toolCallId: candidate.id,
+    ...(options?.markAsError ? { isError: true } : {}),
+  } as Extract<AgentMessage, { role: "toolResult" }> & { toolCallId: string };
 }
 
 function repairToolCallInputs(
@@ -280,7 +324,11 @@ function repairToolCallInputs(
       // valid and already has a real tool result. Otherwise drop the
       // whole assistant turn rather than mutating provider-owned content.
       const replaySafeToolCalls = extractToolCallsFromAssistant(msg);
-      const followingToolResults = collectFollowingToolResults(messages, index);
+      const followingToolResults = collectFollowingToolResults(
+        messages,
+        index,
+        replaySafeToolCalls,
+      );
       if (
         isReplaySafeThinkingAssistantTurn(msg.content, allowedToolNames) &&
         replaySafeToolCalls.every(
@@ -514,6 +562,23 @@ export function repairToolUseResultPairing(
             spanResultsById.set(id, normalizedToolResult);
           }
           continue;
+        }
+        if (!id) {
+          const normalizedToolResult = normalizeLegacyToolResultId(toolResult, toolCalls, {
+            markAsError: options?.markRepairedLegacyToolResultsAsError === true,
+          });
+          if (normalizedToolResult && toolCallIds.has(normalizedToolResult.toolCallId)) {
+            if (seenToolResultIds.has(normalizedToolResult.toolCallId)) {
+              droppedDuplicateCount += 1;
+              changed = true;
+              continue;
+            }
+            if (!spanResultsById.has(normalizedToolResult.toolCallId)) {
+              spanResultsById.set(normalizedToolResult.toolCallId, normalizedToolResult);
+            }
+            changed = true;
+            continue;
+          }
         }
       }
 

--- a/test/scripts/setup-pnpm-store-cache-ensure-node.test.ts
+++ b/test/scripts/setup-pnpm-store-cache-ensure-node.test.ts
@@ -146,6 +146,49 @@ exit 1
     }
   });
 
+  it("normalizes Windows RUNNER_TOOL_CACHE before probing Git Bash paths", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-ensure-node-"));
+    try {
+      const activeBin = join(root, "active", "bin");
+      writeFakeNode(activeBin, "22.19.0");
+      const toolcacheRoot = join(root, "hostedtoolcache", "windows");
+      const toolcacheBin = join(toolcacheRoot, "node", "24.15.0", "x64");
+      const toolcacheNode = writeFakeNode(toolcacheBin, "24.15.0");
+      const helperBin = join(root, "helpers");
+      mkdirSync(helperBin, { recursive: true });
+      const cygpath = join(helperBin, "cygpath");
+      writeFileSync(
+        cygpath,
+        `#!/usr/bin/env bash
+if [[ "$1" == "-u" && "$2" == "C:\\\\hostedtoolcache\\\\windows" ]]; then
+  echo "${toolcacheRoot}"
+  exit 0
+fi
+if [[ "$1" == "-u" && "$2" == "C:\\\\hostedtoolcache\\\\windows\\\\node\\\\24.15.0\\\\x64" ]]; then
+  echo "${toolcacheBin}"
+  exit 0
+fi
+if [[ "$1" == "-w" ]]; then
+  echo "C:\\\\hostedtoolcache\\\\windows\\\\node\\\\24.15.0\\\\x64"
+  exit 0
+fi
+printf '%s' "$2"
+`,
+      );
+      chmodSync(cygpath, 0o755);
+      const result = runEnsureNode(root, "24.x", {
+        PATH: `${helperBin}:${activeBin}:${process.env.PATH ?? ""}`,
+        RUNNER_TOOL_CACHE: "C:\\hostedtoolcache\\windows",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(`Using Node 24.15.0 from ${toolcacheNode}`);
+      expect(result.stdout).toContain(`${toolcacheNode}\n24.15.0`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("repairs PATH from the container-mounted GitHub Actions toolcache", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-ensure-node-"));
     try {


### PR DESCRIPTION
## Summary
- Fix Windows Git Bash Node activation by normalizing toolcache roots before probing and prepending paths, so `openclaw_ensure_node 24.x` can select the Node 24 toolcache over an active Node 22.
- Repair idless legacy tool results for replay-safe signed-thinking Anthropic turns without mutating the signed assistant content, and mark those repaired legacy results as errors for signed-thinking replay validation.

## Verification
- `node scripts/run-vitest.mjs test/scripts/setup-pnpm-store-cache-ensure-node.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner.sanitize-session-history.test.ts -t 'preserves signed thinking turns while repairing legacy tool-result pairing for anthropic'`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- `node scripts/run-vitest.mjs src/agents/session-transcript-repair.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts -t 'preserves sessions_spawn attachment payloads on replay|preserves signed thinking tool calls by repairing missing sibling results'`
- `git diff --check`

## Real behavior proof
Behavior addressed: Shared CI failures in Windows Node setup and Anthropic signed-thinking replay repair.
Real environment tested: Local OpenClaw checkout on macOS with repo Vitest wrapper and simulated Windows Git Bash/toolcache paths.
Exact steps or command run after this patch: The commands listed in Verification.
Evidence after fix: The Windows setup-node regression test selects fake Node 24 from the simulated Windows toolcache while active Node is 22.19.0; the targeted signed-thinking sanitizer test now preserves the assistant/toolResult span and repairs the idless result as `isError: true`.
Observed result after fix: All listed verification commands passed.
What was not tested: A live GitHub Actions Windows runner rerun; CI should provide that proof on this PR.


## Regression provenance
- ref 03ae999a1ac2c26aee47a13e0b6448b95c573871
- ref ef86d8c95c2362f5404ae156cdba26cfffe3d323
- ref 4e45b11983c8f20a9264821fe2dfa03c121a752f
