### PR TITLE
fix(googlechat): don't set replyToId in DM conversations

### DIFF
--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -157,3 +157,90 @@ describe("googlechat monitor bot loop protection", () => {
     expect(runTurn).not.toHaveBeenCalled();
   });
 });
+
+describe("googlechat monitor direct messages", () => {
+  it("omits thread metadata from DM reply context and typing messages", async () => {
+    const runTurn = vi.fn();
+    const buildContext = vi.fn((payload: unknown) => payload);
+    const core = {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "agent-1",
+            accountId: "work",
+            sessionKey: "session-1",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/openclaw-googlechat-test",
+          readSessionUpdatedAt: () => undefined,
+          recordInboundSession: vi.fn(),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn(),
+        },
+        turn: { buildContext, run: runTurn },
+      },
+    } as unknown as GoogleChatCoreRuntime;
+    const runtime = { error: vi.fn(), log: vi.fn() } satisfies GoogleChatRuntimeEnv;
+    const account = {
+      accountId: "work",
+      config: {
+        typingIndicator: "message",
+      },
+      credentialSource: "inline",
+    } as ResolvedGoogleChatAccount;
+    const event = {
+      type: "MESSAGE",
+      eventTime: "2026-03-22T00:00:00.001Z",
+      space: { name: "spaces/DM", type: "DM" },
+      message: {
+        name: "spaces/DM/messages/2",
+        text: "hello",
+        thread: { name: "spaces/DM/threads/thread-1" },
+        sender: { name: "users/alice", displayName: "Alice", type: "HUMAN" },
+      },
+    } satisfies GoogleChatEvent;
+
+    accessMocks.applyGoogleChatInboundAccessPolicy.mockResolvedValue({
+      ok: true,
+      commandAuthorized: undefined,
+      effectiveWasMentioned: undefined,
+      groupBotLoopProtection: undefined,
+      groupSystemPrompt: undefined,
+    });
+    apiMocks.sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/DM/messages/typing",
+    });
+
+    await testing.processMessageWithPipeline({
+      event,
+      account,
+      config: {},
+      runtime,
+      core,
+      mediaMaxMb: 10,
+    });
+
+    expect(buildContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reply: {
+          to: "googlechat:spaces/DM",
+          originatingTo: "googlechat:spaces/DM",
+          replyToId: undefined,
+          replyToIdFull: undefined,
+        },
+      }),
+    );
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/DM",
+      text: "_OpenClaw is typing..._",
+      thread: undefined,
+    });
+    expect(runTurn).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -308,8 +308,8 @@ async function processMessageWithPipeline(params: {
     reply: {
       to: `googlechat:${spaceId}`,
       originatingTo: `googlechat:${spaceId}`,
-      replyToId: message.thread?.name,
-      replyToIdFull: message.thread?.name,
+      replyToId: isGroup ? message.thread?.name : undefined,
+      replyToIdFull: isGroup ? message.thread?.name : undefined,
     },
     message: {
       body,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -279,6 +279,7 @@ async function processMessageWithPipeline(params: {
     body: rawBody,
   });
 
+  const replyThreadName = isGroup ? message.thread?.name : undefined;
   const ctxPayload = core.channel.turn.buildContext({
     channel: "googlechat",
     accountId: route.accountId,
@@ -308,8 +309,8 @@ async function processMessageWithPipeline(params: {
     reply: {
       to: `googlechat:${spaceId}`,
       originatingTo: `googlechat:${spaceId}`,
-      replyToId: isGroup ? message.thread?.name : undefined,
-      replyToIdFull: isGroup ? message.thread?.name : undefined,
+      replyToId: replyThreadName,
+      replyToIdFull: replyThreadName,
     },
     message: {
       body,
@@ -364,7 +365,7 @@ async function processMessageWithPipeline(params: {
         account,
         space: spaceId,
         text: `_${botName} is typing..._`,
-        thread: message.thread?.name,
+        thread: replyThreadName,
       });
       typingMessageName = result?.messageName;
     } catch (err) {


### PR DESCRIPTION
## Problem

In Google Chat DM (Direct Message) conversations, the monitor was setting:

```ts
replyToId: message.thread?.name,
replyToIdFull: message.thread?.name,
```

Google Chat's API rejects thread reply IDs in DMs with a `400 INVALID_ARGUMENT: The request contains an invalid thread resource name` error. This caused agents to silently fail when delivering responses — the model had generated a reply successfully, but the user saw no response.

## Fix

Guard `replyToId` and `replyToIdFull` with `isGroup` (which is already computed in the same scope):

```ts
replyToId: isGroup ? message.thread?.name : undefined,
replyToIdFull: isGroup ? message.thread?.name : undefined,
```

Thread reply IDs are only meaningful (and accepted by Google Chat) in group spaces. In DMs, replies go to the conversation root regardless.

## Reproduction

1. Connect a Google Chat agent to a DM space
2. Have the agent generate a response that uses thread context
3. Observe `400 INVALID_ARGUMENT: The request contains an invalid thread resource name` in logs
4. User sees no response despite the model completing successfully