### PR TITLE
fix(media): resolve inbound media refs consistently

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -353,6 +353,36 @@ describe("modelSupportsImages", () => {
 });
 
 describe("loadImageFromRef", () => {
+  it("hydrates managed inbound media URIs before workspace path resolution", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-image-uri-"));
+    const workspaceDir = path.join(stateDir, "workspace-agent");
+    const inboundDir = path.join(stateDir, "media", "inbound");
+    const mediaId = "telegram-photo.png";
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(inboundDir, { recursive: true });
+    await fs.writeFile(path.join(inboundDir, mediaId), Buffer.from(TINY_PNG_BASE64, "base64"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    try {
+      const image = await loadImageFromRef(
+        {
+          raw: `media://inbound/${mediaId}`,
+          type: "media-uri",
+          resolved: `media://inbound/${mediaId}`,
+        },
+        workspaceDir,
+        { workspaceOnly: true },
+      );
+
+      expect(image?.type).toBe("image");
+      expect(image?.mimeType).toBe("image/png");
+      expect(image?.data).toBe(TINY_PNG_BASE64);
+    } finally {
+      vi.unstubAllEnvs();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("allows sandbox-validated host paths outside default media roots", async () => {
     const homeDir = os.homedir();
     await fs.mkdir(homeDir, { recursive: true });

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../../infra/local-file-access.js";
+import { resolveMediaReferenceLocalPath } from "../../../media/media-reference.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import { loadWebMedia } from "../../../media/web-media.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
@@ -435,6 +436,10 @@ export async function loadImageFromRef(
 ): Promise<ImageContent | null> {
   try {
     let targetPath = ref.resolved;
+
+    if (!options?.sandbox) {
+      targetPath = await resolveMediaReferenceLocalPath(targetPath);
+    }
 
     // Resolve paths relative to sandbox or workspace as needed
     if (options?.sandbox) {

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -854,7 +854,7 @@ export function createImageTool(options?: {
         // shared image registry here, so fail gracefully instead of attempting to
         // `fs.readFile("image:0")` and producing a noisy ENOENT.
         const refInfo = classifyMediaReferenceSource(normalizedRef);
-        const { isDataUrl, isFileUrl, isHttpUrl } = refInfo;
+        const { isDataUrl, isFileUrl, isHttpUrl, isMediaStoreUrl } = refInfo;
         if (refInfo.hasUnsupportedScheme) {
           return {
             content: [
@@ -888,6 +888,7 @@ export function createImageTool(options?: {
             !isDataUrl &&
             !isFileUrl &&
             !isHttpUrl &&
+            !isMediaStoreUrl &&
             !refInfo.looksLikeWindowsDrivePath &&
             !isAbsolute(normalizedRef) &&
             options?.workspaceDir


### PR DESCRIPTION
## Summary
- Resolve native prompt-image media refs through the managed media reference helper before workspace path resolution.
- Keep direct image tool `media://inbound/...` refs as media-store URIs so `loadWebMedia` hydrates the managed inbound file instead of constructing `workspace/media:/inbound/...`.
- Add regression coverage for native loader managed inbound URI hydration.

## Verification
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/images.test.ts src/agents/tools/image-tool.test.ts src/media/media-reference.test.ts src/media/web-media.test.ts`
- real local managed-media proof command shown below

## Real behavior proof
Behavior addressed: Telegram/channel inbound images saved under the managed media store and referenced as `media://inbound/<id>` now load in both native prompt-image loading and the direct image understanding tool instead of being workspace-resolved as `media:/inbound` paths.
Real environment tested: local macOS checkout, Node/tsx runtime, real temporary `OPENCLAW_STATE_DIR/media/inbound/proof-image.png`, and a real temporary workspace plus agent directory.
Exact steps or command run after this patch: created a temp `OPENCLAW_STATE_DIR`, wrote a 1x1 PNG to `media/inbound/proof-image.png`, called `loadImageFromRef()` with `media://inbound/proof-image.png` and `workspaceOnly: true`, then executed the real `image` tool with a stubbed provider so the tool still loaded the image through production media loading.
Evidence after fix: copied terminal output from the local proof command:
```text
native_load type=image mime=image/png bytes=91
tool_result text=tool-ok mime=image/png bytes=91
tool_loaded_bytes=91
```
Observed result after fix: both native prompt-image loading and the direct image tool loaded the real managed inbound PNG bytes from `media://inbound/proof-image.png`; the targeted Vitest suite also passed 6 test files and 295 tests after the rebase.
What was not tested: live Telegram delivery was not exercised in this local proof; the managed media-store filesystem path and direct/native agent image-loading behavior were verified with real local files.

Fixes #87024.

If this PR is squash/reworked, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
