### PR TITLE
Policy: add data handling conformance checks

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -19,7 +19,7 @@ instead of creating a separate health gate.
 
 Policy currently manages configured channels, MCP servers, model providers,
 network SSRF posture, ingress/channel access posture, Gateway exposure posture, agent workspace posture,
-OpenClaw config secret provider/auth profile posture, and governed tool
+data-handling posture, OpenClaw config secret provider/auth profile posture, and governed tool
 declarations. For example, IT or a workspace operator can record that Telegram
 is not an approved channel provider, restrict MCP servers and model refs to
 approved entries, require private-network fetch/browser access to remain
@@ -28,7 +28,9 @@ to stay within reviewed bounds, require Gateway bind/auth/HTTP exposure to stay 
 bounds, require agent workspace access and tool denies to stay in a reviewed
 posture, require OpenClaw config SecretRefs to use managed providers, require
 config auth profiles to carry provider/mode metadata, require governed tools to
-carry risk and sensitivity metadata, then use `doctor --lint` as the shared
+carry risk and sensitivity metadata, require sensitive logging redaction, deny
+telemetry content capture, require session retention maintenance, deny session
+transcript memory indexing, then use `doctor --lint` as the shared
 conformance gate.
 
 Use policy when a workspace needs a durable statement such as "these channels
@@ -52,7 +54,7 @@ doctor can report the missing artifact.
 Policy is authored, not generated from the user's current settings. A minimal
 policy for channels, MCP servers, model providers, network posture, ingress/channel access, Gateway
 exposure, agent workspace posture, configured sandbox runtime posture, OpenClaw
-config secret provider/auth profile posture, and tool metadata looks like this:
+data-handling posture, config secret provider/auth profile posture, and tool metadata looks like this:
 
 ```jsonc
 {
@@ -118,6 +120,20 @@ config secret provider/auth profile posture, and tool metadata looks like this:
       "denyTools": ["exec", "process", "write", "edit", "apply_patch"],
     },
   },
+  "dataHandling": {
+    "sensitiveLogging": {
+      "requireRedaction": true,
+    },
+    "telemetry": {
+      "denyContentCapture": true,
+    },
+    "retention": {
+      "requireSessionMaintenance": true,
+    },
+    "memory": {
+      "denySessionTranscriptIndexing": true,
+    },
+  },
   "secrets": {
     "requireManagedProviders": true,
     "denySources": ["exec"],
@@ -155,7 +171,8 @@ when a concrete rule is present. OpenClaw reads current `channels.*` settings
 `mcp.servers.*`, `models.providers.*`, selected agent model refs, network SSRF
 settings, direct-message session scope, channel DM policy, channel group policy,
 channel/group mention gates, Gateway bind/auth/Control UI/Tailscale/remote/HTTP
-posture, OpenClaw config agent sandbox workspace access and tool deny posture, config secret
+posture, OpenClaw config agent sandbox workspace access and tool deny posture,
+data-handling config posture, config secret
 provider and SecretRef provenance, config auth profile metadata, configured
 global/per-agent tool posture, and `TOOLS.md` declarations as evidence, then
 reports observed state that does not conform. If a policy denies non-loopback
@@ -176,6 +193,11 @@ runtime. Secret evidence records
 provider/source posture and SecretRef metadata, never raw secret values. Policy
 does not read or attest per-agent credential stores such as `auth-profiles.json`;
 those stores remain owned by the existing auth and credential flows.
+Data-handling evidence is config-level posture only: it checks configured
+redaction mode, telemetry content-capture toggles, session maintenance mode, and
+session-transcript memory indexing settings. It does not inspect raw logs,
+telemetry exports, transcript contents, memory files, or prove that no personal
+data or secrets exist.
 
 ### Policy rule reference
 
@@ -194,7 +216,8 @@ its own finding against the same observed config.
 
 Use `scopes.<scopeName>` when one set of agents or channels needs stricter
 policy than the top-level baseline. Agent-scoped sections use `agentIds`, which
-supports `tools.*`, `agents.workspace.*`, and `sandbox.*`. Channel-scoped
+supports `tools.*`, `agents.workspace.*`, `sandbox.*`, and
+`dataHandling.memory.*`. Channel-scoped
 ingress uses `channelIds`, which supports `ingress.channels.*`. Unsupported
 sections are rejected instead of being ignored. If an `agentIds` entry is not
 present in `agents.list[]`, OpenClaw evaluates the scoped rule against inherited
@@ -232,6 +255,11 @@ global/default posture for that runtime agent id.
       "sandbox": {
         "requireMode": ["all"],
         "allowBackends": ["docker"],
+      },
+      "dataHandling": {
+        "memory": {
+          "denySessionTranscriptIndexing": true,
+        },
       },
     },
     "shell-sandbox": {
@@ -274,10 +302,10 @@ groups where those fields cannot be observed.
 Top-level `ingress.session.requireDmScope` remains global because
 `session.dmScope` is not channel-attributable evidence.
 
-| Selector     | Supported sections                         | Use when                                          |
-| ------------ | ------------------------------------------ | ------------------------------------------------- |
-| `agentIds`   | `tools`, `agents.workspace`, and `sandbox` | One or more runtime agents need stricter rules.   |
-| `channelIds` | `ingress.channels`                         | One or more channels need stricter ingress rules. |
+| Selector     | Supported sections                                                | Use when                                          |
+| ------------ | ----------------------------------------------------------------- | ------------------------------------------------- |
+| `agentIds`   | `tools`, `agents.workspace`, `sandbox`, and `dataHandling.memory` | One or more runtime agents need stricter rules.   |
+| `channelIds` | `ingress.channels`                                                | One or more channels need stricter ingress rules. |
 
 Every scope present in `policy.jsonc` must be valid and enforceable.
 
@@ -353,6 +381,15 @@ Every scope present in `policy.jsonc` must be valid and enforceable.
 Policy treats missing `sandbox.mode` as the implicit default `off`, so
 `sandbox.requireMode` reports a fresh or unconfigured sandbox as outside an
 allowlist such as `["all"]`.
+
+#### Data Handling
+
+| Policy field                                        | Observed state                                                                       | Use when                                                               |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| `dataHandling.sensitiveLogging.requireRedaction`    | `logging.redactSensitive`                                                            | Set to `true` to reject `logging.redactSensitive: "off"`.              |
+| `dataHandling.telemetry.denyContentCapture`         | `diagnostics.otel.captureContent`                                                    | Set to `true` to reject telemetry content capture.                     |
+| `dataHandling.retention.requireSessionMaintenance`  | `session.maintenance.mode`                                                           | Set to `true` to require effective session maintenance mode `enforce`. |
+| `dataHandling.memory.denySessionTranscriptIndexing` | `memory.qmd.sessions.enabled` and `agents.*.memorySearch.experimental.sessionMemory` | Set to `true` to reject session transcript indexing into memory.       |
 
 #### Secrets
 
@@ -674,63 +711,67 @@ choose a different interval.
 
 Policy currently verifies:
 
-| Check id                                          | Finding                                                                           |
-| ------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `policy/policy-jsonc-missing`                     | Policy is enabled but `policy.jsonc` is missing.                                  |
-| `policy/policy-jsonc-invalid`                     | Policy cannot be parsed or contains malformed rule entries.                       |
-| `policy/policy-hash-mismatch`                     | Policy does not match configured `expectedHash`.                                  |
-| `policy/attestation-hash-mismatch`                | Current policy evidence no longer matches the accepted attestation.               |
-| `policy/policy-conformance-invalid`               | A baseline or checked policy file has invalid comparison syntax.                  |
-| `policy/policy-conformance-missing`               | A checked policy file is missing a rule required by the baseline policy file.     |
-| `policy/policy-conformance-weaker`                | A checked policy file has a weaker value than the baseline policy file.           |
-| `policy/channels-denied-provider`                 | An enabled channel matches a channel deny rule.                                   |
-| `policy/mcp-denied-server`                        | A configured MCP server is denied by policy.                                      |
-| `policy/mcp-unapproved-server`                    | A configured MCP server is outside the allowlist.                                 |
-| `policy/models-denied-provider`                   | A configured model provider or model ref uses a denied provider.                  |
-| `policy/models-unapproved-provider`               | A configured model provider or model ref is outside the allowlist.                |
-| `policy/network-private-access-enabled`           | A private-network SSRF escape hatch is enabled when policy denies it.             |
-| `policy/ingress-dm-policy-unapproved`             | A channel DM policy is outside the policy allowlist.                              |
-| `policy/ingress-dm-scope-unapproved`              | `session.dmScope` does not match the policy-required DM isolation scope.          |
-| `policy/ingress-open-groups-denied`               | A channel group policy is `open` while policy denies open group ingress.          |
-| `policy/ingress-group-mention-required`           | A channel or group entry disables mention gates while policy requires them.       |
-| `policy/gateway-non-loopback-bind`                | Gateway bind posture permits non-loopback exposure when policy denies it.         |
-| `policy/gateway-auth-disabled`                    | Gateway authentication is disabled when policy requires auth.                     |
-| `policy/gateway-rate-limit-missing`               | Gateway auth rate-limit posture is not explicit when policy requires it.          |
-| `policy/gateway-control-ui-insecure`              | Gateway Control UI insecure exposure toggles are enabled.                         |
-| `policy/gateway-tailscale-funnel`                 | Gateway Tailscale Funnel exposure is enabled when policy denies it.               |
-| `policy/gateway-remote-enabled`                   | Gateway remote mode is active when policy denies it.                              |
-| `policy/gateway-http-endpoint-enabled`            | A Gateway HTTP API endpoint is enabled while denied by policy.                    |
-| `policy/gateway-http-url-fetch-unrestricted`      | Gateway HTTP URL-fetch input lacks a required URL allowlist.                      |
-| `policy/agents-workspace-access-denied`           | Agent sandbox mode or workspace access is outside the policy allowlist.           |
-| `policy/agents-tool-not-denied`                   | An agent or default config does not deny a tool required by policy.               |
-| `policy/tools-profile-unapproved`                 | A configured global or per-agent tool profile is outside the allowlist.           |
-| `policy/tools-fs-workspace-only-required`         | Filesystem tools are not configured with workspace-only path posture.             |
-| `policy/tools-exec-security-unapproved`           | Exec security mode is outside the policy allowlist.                               |
-| `policy/tools-exec-ask-unapproved`                | Exec ask mode is outside the policy allowlist.                                    |
-| `policy/tools-exec-host-unapproved`               | Exec host routing is outside the policy allowlist.                                |
-| `policy/tools-elevated-enabled`                   | Elevated tool mode is enabled when policy denies it.                              |
-| `policy/tools-also-allow-missing`                 | A configured `alsoAllow` list is missing an entry required by policy.             |
-| `policy/tools-also-allow-unexpected`              | A configured `alsoAllow` list includes an entry not expected by policy.           |
-| `policy/tools-required-deny-missing`              | A global or per-agent tool deny list does not include a required denied tool.     |
-| `policy/sandbox-mode-unapproved`                  | Sandbox mode is outside the policy allowlist.                                     |
-| `policy/sandbox-backend-unapproved`               | Sandbox backend is outside the policy allowlist.                                  |
-| `policy/sandbox-container-posture-unobservable`   | A container posture rule is enabled for a backend that cannot observe it.         |
-| `policy/sandbox-container-host-network-denied`    | A container-backed sandbox or browser uses host network mode.                     |
-| `policy/sandbox-container-namespace-join-denied`  | A container-backed sandbox or browser joins another container namespace.          |
-| `policy/sandbox-container-mount-mode-required`    | A container-backed sandbox or browser mount is not read-only.                     |
-| `policy/sandbox-container-runtime-socket-mount`   | A container-backed sandbox or browser mount exposes the container runtime socket. |
-| `policy/sandbox-container-unconfined-profile`     | Container sandbox profile is unconfined when policy denies it.                    |
-| `policy/sandbox-browser-cdp-source-range-missing` | Sandbox browser CDP source range is missing when policy requires one.             |
-| `policy/secrets-unmanaged-provider`               | A config SecretRef references a provider not declared under `secrets.providers`.  |
-| `policy/secrets-denied-provider-source`           | A config secret provider or SecretRef uses a source denied by policy.             |
-| `policy/secrets-insecure-provider`                | A secret provider opts into insecure posture when policy denies it.               |
-| `policy/auth-profile-invalid-metadata`            | A config auth profile is missing valid provider or mode metadata.                 |
-| `policy/auth-profile-unapproved-mode`             | A config auth profile mode is outside the policy allowlist.                       |
-| `policy/tools-missing-risk-level`                 | A governed tool declaration is missing risk metadata.                             |
-| `policy/tools-unknown-risk-level`                 | A governed tool declaration uses an unknown risk value.                           |
-| `policy/tools-missing-sensitivity-token`          | A governed tool declaration is missing sensitivity metadata.                      |
-| `policy/tools-missing-owner`                      | A governed tool declaration is missing owner metadata.                            |
-| `policy/tools-unknown-sensitivity-token`          | A governed tool declaration uses an unknown sensitivity value.                    |
+| Check id                                                 | Finding                                                                           |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `policy/policy-jsonc-missing`                            | Policy is enabled but `policy.jsonc` is missing.                                  |
+| `policy/policy-jsonc-invalid`                            | Policy cannot be parsed or contains malformed rule entries.                       |
+| `policy/policy-hash-mismatch`                            | Policy does not match configured `expectedHash`.                                  |
+| `policy/attestation-hash-mismatch`                       | Current policy evidence no longer matches the accepted attestation.               |
+| `policy/policy-conformance-invalid`                      | A baseline or checked policy file has invalid comparison syntax.                  |
+| `policy/policy-conformance-missing`                      | A checked policy file is missing a rule required by the baseline policy file.     |
+| `policy/policy-conformance-weaker`                       | A checked policy file has a weaker value than the baseline policy file.           |
+| `policy/channels-denied-provider`                        | An enabled channel matches a channel deny rule.                                   |
+| `policy/mcp-denied-server`                               | A configured MCP server is denied by policy.                                      |
+| `policy/mcp-unapproved-server`                           | A configured MCP server is outside the allowlist.                                 |
+| `policy/models-denied-provider`                          | A configured model provider or model ref uses a denied provider.                  |
+| `policy/models-unapproved-provider`                      | A configured model provider or model ref is outside the allowlist.                |
+| `policy/network-private-access-enabled`                  | A private-network SSRF escape hatch is enabled when policy denies it.             |
+| `policy/ingress-dm-policy-unapproved`                    | A channel DM policy is outside the policy allowlist.                              |
+| `policy/ingress-dm-scope-unapproved`                     | `session.dmScope` does not match the policy-required DM isolation scope.          |
+| `policy/ingress-open-groups-denied`                      | A channel group policy is `open` while policy denies open group ingress.          |
+| `policy/ingress-group-mention-required`                  | A channel or group entry disables mention gates while policy requires them.       |
+| `policy/gateway-non-loopback-bind`                       | Gateway bind posture permits non-loopback exposure when policy denies it.         |
+| `policy/gateway-auth-disabled`                           | Gateway authentication is disabled when policy requires auth.                     |
+| `policy/gateway-rate-limit-missing`                      | Gateway auth rate-limit posture is not explicit when policy requires it.          |
+| `policy/gateway-control-ui-insecure`                     | Gateway Control UI insecure exposure toggles are enabled.                         |
+| `policy/gateway-tailscale-funnel`                        | Gateway Tailscale Funnel exposure is enabled when policy denies it.               |
+| `policy/gateway-remote-enabled`                          | Gateway remote mode is active when policy denies it.                              |
+| `policy/gateway-http-endpoint-enabled`                   | A Gateway HTTP API endpoint is enabled while denied by policy.                    |
+| `policy/gateway-http-url-fetch-unrestricted`             | Gateway HTTP URL-fetch input lacks a required URL allowlist.                      |
+| `policy/agents-workspace-access-denied`                  | Agent sandbox mode or workspace access is outside the policy allowlist.           |
+| `policy/agents-tool-not-denied`                          | An agent or default config does not deny a tool required by policy.               |
+| `policy/tools-profile-unapproved`                        | A configured global or per-agent tool profile is outside the allowlist.           |
+| `policy/tools-fs-workspace-only-required`                | Filesystem tools are not configured with workspace-only path posture.             |
+| `policy/tools-exec-security-unapproved`                  | Exec security mode is outside the policy allowlist.                               |
+| `policy/tools-exec-ask-unapproved`                       | Exec ask mode is outside the policy allowlist.                                    |
+| `policy/tools-exec-host-unapproved`                      | Exec host routing is outside the policy allowlist.                                |
+| `policy/tools-elevated-enabled`                          | Elevated tool mode is enabled when policy denies it.                              |
+| `policy/tools-also-allow-missing`                        | A configured `alsoAllow` list is missing an entry required by policy.             |
+| `policy/tools-also-allow-unexpected`                     | A configured `alsoAllow` list includes an entry not expected by policy.           |
+| `policy/tools-required-deny-missing`                     | A global or per-agent tool deny list does not include a required denied tool.     |
+| `policy/sandbox-mode-unapproved`                         | Sandbox mode is outside the policy allowlist.                                     |
+| `policy/sandbox-backend-unapproved`                      | Sandbox backend is outside the policy allowlist.                                  |
+| `policy/sandbox-container-posture-unobservable`          | A container posture rule is enabled for a backend that cannot observe it.         |
+| `policy/sandbox-container-host-network-denied`           | A container-backed sandbox or browser uses host network mode.                     |
+| `policy/sandbox-container-namespace-join-denied`         | A container-backed sandbox or browser joins another container namespace.          |
+| `policy/sandbox-container-mount-mode-required`           | A container-backed sandbox or browser mount is not read-only.                     |
+| `policy/sandbox-container-runtime-socket-mount`          | A container-backed sandbox or browser mount exposes the container runtime socket. |
+| `policy/sandbox-container-unconfined-profile`            | Container sandbox profile is unconfined when policy denies it.                    |
+| `policy/sandbox-browser-cdp-source-range-missing`        | Sandbox browser CDP source range is missing when policy requires one.             |
+| `policy/data-handling-redaction-disabled`                | Sensitive logging redaction is disabled when policy requires it.                  |
+| `policy/data-handling-telemetry-content-capture`         | Telemetry content capture is enabled when policy denies it.                       |
+| `policy/data-handling-session-retention-not-enforced`    | Session retention maintenance is not enforced when policy requires it.            |
+| `policy/data-handling-session-transcript-memory-enabled` | Session transcript memory indexing is enabled when policy denies it.              |
+| `policy/secrets-unmanaged-provider`                      | A config SecretRef references a provider not declared under `secrets.providers`.  |
+| `policy/secrets-denied-provider-source`                  | A config secret provider or SecretRef uses a source denied by policy.             |
+| `policy/secrets-insecure-provider`                       | A secret provider opts into insecure posture when policy denies it.               |
+| `policy/auth-profile-invalid-metadata`                   | A config auth profile is missing valid provider or mode metadata.                 |
+| `policy/auth-profile-unapproved-mode`                    | A config auth profile mode is outside the policy allowlist.                       |
+| `policy/tools-missing-risk-level`                        | A governed tool declaration is missing risk metadata.                             |
+| `policy/tools-unknown-risk-level`                        | A governed tool declaration uses an unknown risk value.                           |
+| `policy/tools-missing-sensitivity-token`                 | A governed tool declaration is missing sensitivity metadata.                      |
+| `policy/tools-missing-owner`                             | A governed tool declaration is missing owner metadata.                            |
+| `policy/tools-unknown-sensitivity-token`                 | A governed tool declaration uses an unknown sensitivity value.                    |
 
 Policy findings can include both `target` and `requirement`. `target` is the
 observed workspace thing that does not conform. `requirement` is the authored

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -110,8 +110,8 @@ writes.
 ## Session maintenance
 
 OpenClaw automatically bounds session storage over time. By default, it runs
-in `warn` mode (reports what would be cleaned). Set `session.maintenance.mode`
-to `"enforce"` for automatic cleanup:
+in `enforce` mode and applies cleanup during maintenance. Set
+`session.maintenance.mode` to `"warn"` to report what would be cleaned without mutating the store/files:
 
 ```json5
 {

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1272,7 +1272,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
     resetTriggers: ["/new", "/reset"],
     store: "~/.openclaw/agents/{agentId}/sessions/sessions.json",
     maintenance: {
-      mode: "warn", // warn | enforce
+      mode: "enforce", // enforce (default) | warn
       pruneAfter: "30d",
       maxEntries: 500,
       resetArchiveRetention: "30d", // duration or false
@@ -1311,7 +1311,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
 - **`agentToAgent.maxPingPongTurns`**: maximum reply-back turns between agents during agent-to-agent exchanges (integer, range: `0`-`20`, default: `5`). `0` disables ping-pong chaining.
 - **`sendPolicy`**: match by `channel`, `chatType` (`direct|group|channel`, with legacy `dm` alias), `keyPrefix`, or `rawKeyPrefix`. First deny wins.
 - **`maintenance`**: session-store cleanup + retention controls.
-  - `mode`: `warn` emits warnings only; `enforce` applies cleanup.
+  - `mode`: `enforce` applies cleanup and is the default; `warn` emits warnings only.
   - `pruneAfter`: age cutoff for stale entries (default `30d`).
   - `maxEntries`: maximum number of entries in `sessions.json` (default `500`). Runtime writes batch cleanup with a small high-water buffer for production-sized caps; `openclaw sessions cleanup --enforce` applies the cap immediately.
   - `rotateBytes`: deprecated and ignored; `openclaw doctor --fix` removes it from older configs.

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -27,7 +27,7 @@ settings and governed workspace declarations. Policy currently covers channel
 conformance, governed tool metadata, MCP server posture, model-provider posture,
 private-network access posture, Gateway exposure posture, agent workspace/tool
 posture, configured global/per-agent tool posture, configured sandbox runtime
-posture, ingress/channel access posture, and OpenClaw config secret
+posture, ingress/channel access posture, data-handling posture, and OpenClaw config secret
 provider/auth profile posture.
 
 Policy stores authored requirements in `policy.jsonc`, observes existing
@@ -55,9 +55,16 @@ and require sandbox browser CDP source ranges.
 These checks observe config conformance only; they do not read runtime approval
 state, inspect live containers, or add runtime enforcement.
 
+Data-handling rules can require sensitive logging redaction, deny telemetry
+content capture, require session retention maintenance, and deny session
+transcript memory indexing. These checks observe config conformance only; they
+do not inspect raw logs, telemetry exports, transcripts, memory files, secrets,
+or personal data.
+
 Named policy scopes under `scopes.<scopeName>` can add stricter normal policy
 sections for the selector they list. `agentIds` supports `tools`,
-`agents.workspace`, and `sandbox`; `channelIds` supports `ingress.channels`.
+`agents.workspace`, `sandbox`, and `dataHandling.memory`; `channelIds` supports
+`ingress.channels`.
 Runtime agent ids that are not explicitly listed in `agents.list[]` are checked
 against inherited global/default posture rather than silently passing with no
 evidence. Every scope present in `policy.jsonc` must be valid and enforceable

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -78,7 +78,7 @@ OpenClaw resolves these via `src/config/sessions.ts`.
 
 Session persistence has automatic maintenance controls (`session.maintenance`) for `sessions.json`, transcript artifacts, and trajectory sidecars:
 
-- `mode`: `warn` (default) or `enforce`
+- `mode`: `enforce` (default) or `warn`
 - `pruneAfter`: stale-entry age cutoff (default `30d`)
 - `maxEntries`: cap entries in `sessions.json` (default `500`)
 - `resetArchiveRetention`: retention for `*.reset.<timestamp>` transcript archives (default: same as `pruneAfter`; `false` disables cleanup)

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -7308,7 +7308,7 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
-  it("treats omitted session maintenance mode as warn for retention conformance", async () => {
+  it("treats omitted session maintenance mode as enforce for retention conformance", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
@@ -7334,18 +7334,12 @@ describe("registerPolicyDoctorChecks", () => {
         expect.objectContaining({
           kind: "sessionRetentionMode",
           source: "oc://openclaw.config/session/maintenance/mode",
-          value: "warn",
+          value: "enforce",
           explicit: false,
         }),
       ]),
     );
-    expect(result.findings).toEqual([
-      expect.objectContaining({
-        checkId: "policy/data-handling-session-retention-not-enforced",
-        ocPath: "oc://openclaw.config/session/maintenance/mode",
-        requirement: "oc://policy.jsonc/dataHandling/retention/requireSessionMaintenance",
-      }),
-    ]);
+    expect(result.findings).toEqual([]);
   });
 
   it("does not treat disabled telemetry capture subkeys as content capture", async () => {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -7308,6 +7308,46 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
+  it("treats omitted session maintenance mode as warn for retention conformance", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      session: {},
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        dataHandling: {
+          retention: { requireSessionMaintenance: true },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(evidence.dataHandling).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "sessionRetentionMode",
+          source: "oc://openclaw.config/session/maintenance/mode",
+          value: "warn",
+          explicit: false,
+        }),
+      ]),
+    );
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/data-handling-session-retention-not-enforced",
+        ocPath: "oc://openclaw.config/session/maintenance/mode",
+        requirement: "oc://policy.jsonc/dataHandling/retention/requireSessionMaintenance",
+      }),
+    ]);
+  });
+
   it("does not treat disabled telemetry capture subkeys as content capture", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -243,6 +243,11 @@ describe("registerPolicyDoctorChecks", () => {
         strictness: "requires-true",
         selectors: ["channelIds"],
       },
+      {
+        path: "dataHandling.memory.denySessionTranscriptIndexing",
+        strictness: "requires-true",
+        selectors: ["agentIds"],
+      },
     ]);
   });
 
@@ -549,6 +554,10 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/sandbox-container-runtime-socket-mount",
       "policy/sandbox-container-unconfined-profile",
       "policy/sandbox-browser-cdp-source-range-missing",
+      "policy/data-handling-redaction-disabled",
+      "policy/data-handling-telemetry-content-capture",
+      "policy/data-handling-session-retention-not-enforced",
+      "policy/data-handling-session-transcript-memory-enabled",
       "policy/secrets-unmanaged-provider",
       "policy/secrets-denied-provider-source",
       "policy/secrets-insecure-provider",
@@ -1126,6 +1135,7 @@ describe("registerPolicyDoctorChecks", () => {
           includeIngress: false,
           includeGatewayExposure: false,
           includeAgentWorkspace: false,
+          includeDataHandling: false,
           includeToolPosture: false,
           includeSandboxPosture: false,
           includeSecrets: false,
@@ -1159,6 +1169,7 @@ describe("registerPolicyDoctorChecks", () => {
           includeIngress: false,
           includeGatewayExposure: false,
           includeAgentWorkspace: false,
+          includeDataHandling: false,
           includeToolPosture: false,
           includeSandboxPosture: false,
           includeSecrets: false,
@@ -1204,6 +1215,7 @@ describe("registerPolicyDoctorChecks", () => {
           includeIngress: false,
           includeGatewayExposure: false,
           includeAgentWorkspace: false,
+          includeDataHandling: false,
           includeToolPosture: false,
           includeSandboxPosture: false,
           includeSecrets: false,
@@ -1235,6 +1247,7 @@ describe("registerPolicyDoctorChecks", () => {
       includeIngress: false,
       includeGatewayExposure: false,
       includeAgentWorkspace: false,
+      includeDataHandling: false,
       includeToolPosture: false,
       includeSandboxPosture: false,
       includeSecrets: false,
@@ -1243,6 +1256,7 @@ describe("registerPolicyDoctorChecks", () => {
     expect(evidence).not.toHaveProperty("ingress");
     expect(evidence).not.toHaveProperty("gatewayExposure");
     expect(evidence).not.toHaveProperty("agentWorkspace");
+    expect(evidence).not.toHaveProperty("dataHandling");
     expect(evidence).not.toHaveProperty("sandboxPosture");
     expect(evidence).not.toHaveProperty("secrets");
     expect(evidence).not.toHaveProperty("authProfiles");
@@ -7213,6 +7227,370 @@ describe("registerPolicyDoctorChecks", () => {
         severity: "error",
         ocPath: "oc://openclaw.config/auth/profiles/oauth",
         requirement: "oc://policy.jsonc/auth/profiles/allowModes",
+      }),
+    ]);
+  });
+
+  it("reports data-handling conformance findings from config posture", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      logging: { redactSensitive: "off" },
+      diagnostics: { otel: { enabled: true, captureContent: { enabled: true, toolInputs: true } } },
+      session: { maintenance: { mode: "warn" } },
+      memory: { backend: "qmd", qmd: { sessions: { enabled: true } } },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        dataHandling: {
+          sensitiveLogging: { requireRedaction: true },
+          telemetry: { denyContentCapture: true },
+          retention: { requireSessionMaintenance: true },
+          memory: { denySessionTranscriptIndexing: true },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(evidence.dataHandling).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "sensitiveLoggingRedaction",
+          source: "oc://openclaw.config/logging/redactSensitive",
+          value: false,
+        }),
+        expect.objectContaining({
+          kind: "telemetryContentCapture",
+          source: "oc://openclaw.config/diagnostics/otel/captureContent",
+          value: true,
+        }),
+        expect.objectContaining({
+          kind: "sessionRetentionMode",
+          source: "oc://openclaw.config/session/maintenance/mode",
+          value: "warn",
+        }),
+        expect.objectContaining({
+          kind: "memorySessionTranscriptIndexing",
+          source: "oc://openclaw.config/memory/qmd/sessions/enabled",
+          value: true,
+        }),
+      ]),
+    );
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/data-handling-redaction-disabled",
+          ocPath: "oc://openclaw.config/logging/redactSensitive",
+          requirement: "oc://policy.jsonc/dataHandling/sensitiveLogging/requireRedaction",
+        }),
+        expect.objectContaining({
+          checkId: "policy/data-handling-telemetry-content-capture",
+          ocPath: "oc://openclaw.config/diagnostics/otel/captureContent",
+          requirement: "oc://policy.jsonc/dataHandling/telemetry/denyContentCapture",
+        }),
+        expect.objectContaining({
+          checkId: "policy/data-handling-session-retention-not-enforced",
+          ocPath: "oc://openclaw.config/session/maintenance/mode",
+          requirement: "oc://policy.jsonc/dataHandling/retention/requireSessionMaintenance",
+        }),
+        expect.objectContaining({
+          checkId: "policy/data-handling-session-transcript-memory-enabled",
+          ocPath: "oc://openclaw.config/memory/qmd/sessions/enabled",
+          requirement: "oc://policy.jsonc/dataHandling/memory/denySessionTranscriptIndexing",
+        }),
+      ]),
+    );
+  });
+
+  it("does not treat disabled telemetry capture subkeys as content capture", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      diagnostics: { otel: { captureContent: { toolInputs: true } } },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ dataHandling: { telemetry: { denyContentCapture: true } } }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("does not report inert telemetry capture config", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      diagnostics: {
+        enabled: false,
+        otel: { enabled: true, captureContent: true },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ dataHandling: { telemetry: { denyContentCapture: true } } }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("reports OTEL log body content capture without trace export", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      diagnostics: {
+        otel: { enabled: true, traces: false, logs: true, captureContent: true },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ dataHandling: { telemetry: { denyContentCapture: true } } }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/data-handling-telemetry-content-capture",
+        ocPath: "oc://openclaw.config/diagnostics/otel/captureContent",
+      }),
+    ]);
+  });
+
+  it("does not treat trace-only content capture subkeys as log body capture", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      diagnostics: {
+        otel: {
+          enabled: true,
+          traces: false,
+          logs: true,
+          captureContent: { enabled: true, toolInputs: true },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ dataHandling: { telemetry: { denyContentCapture: true } } }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("supports agent-scoped session transcript memory conformance", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      agents: {
+        defaults: {
+          memorySearch: { experimental: { sessionMemory: true }, sources: ["memory", "sessions"] },
+        },
+        list: [
+          { id: "sebby" },
+          { id: "buddy", memorySearch: { experimental: { sessionMemory: false } } },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        scopes: {
+          restricted: {
+            agentIds: ["sebby"],
+            dataHandling: { memory: { denySessionTranscriptIndexing: true } },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/data-handling-session-transcript-memory-enabled",
+        ocPath: "oc://openclaw.config/agents/defaults/memorySearch/experimental/sessionMemory",
+        requirement:
+          "oc://policy.jsonc/scopes/restricted/dataHandling/memory/denySessionTranscriptIndexing",
+      }),
+    ]);
+  });
+
+  it("applies agent-scoped data-handling memory claims to inherited default posture", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      agents: {
+        defaults: {
+          memorySearch: { experimental: { sessionMemory: true }, sources: ["sessions"] },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        scopes: {
+          restricted: {
+            agentIds: ["release"],
+            dataHandling: { memory: { denySessionTranscriptIndexing: true } },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/data-handling-session-transcript-memory-enabled",
+        ocPath: "oc://openclaw.config/agents/defaults/memorySearch/experimental/sessionMemory",
+        requirement:
+          "oc://policy.jsonc/scopes/restricted/dataHandling/memory/denySessionTranscriptIndexing",
+      }),
+    ]);
+  });
+
+  it("does not report inert memory transcript indexing config", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      memory: { qmd: { sessions: { enabled: true } } },
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: false,
+            experimental: { sessionMemory: true },
+            sources: ["sessions"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        dataHandling: { memory: { denySessionTranscriptIndexing: true } },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("reports malformed data-handling policy sections", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        dataHandling: {
+          sensitiveLogging: true,
+          memory: [],
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/dataHandling/sensitiveLogging",
+        }),
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/dataHandling/memory",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects scoped data-handling rules that cannot be agent-scoped", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        scopes: {
+          restricted: {
+            agentIds: ["sebby"],
+            dataHandling: { telemetry: { denyContentCapture: true } },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/policy-jsonc-invalid",
+        target: "oc://policy.jsonc/scopes/restricted/dataHandling/telemetry",
+      }),
+    ]);
+  });
+
+  it("rejects malformed scoped data-handling memory rules", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        scopes: {
+          restricted: {
+            agentIds: ["sebby"],
+            dataHandling: { memory: { denySessionTranscriptIndexing: "true" } },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/policy-jsonc-invalid",
+        target:
+          "oc://policy.jsonc/scopes/restricted/dataHandling/memory/denySessionTranscriptIndexing",
       }),
     ]);
   });

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -15,6 +15,7 @@ import {
   policyDocumentHash,
   type PolicyAuthProfileEvidence,
   type PolicyAgentWorkspaceEvidence,
+  type PolicyDataHandlingEvidence,
   type PolicyEvidence,
   type PolicyIngressEvidence,
   type PolicySandboxPostureEvidence,
@@ -72,6 +73,12 @@ const CHECK_IDS = {
   policySandboxContainerRuntimeSocketMount: "policy/sandbox-container-runtime-socket-mount",
   policySandboxContainerUnconfinedProfile: "policy/sandbox-container-unconfined-profile",
   policySandboxBrowserCdpSourceRangeMissing: "policy/sandbox-browser-cdp-source-range-missing",
+  policyDataHandlingRedactionDisabled: "policy/data-handling-redaction-disabled",
+  policyDataHandlingTelemetryContentCapture: "policy/data-handling-telemetry-content-capture",
+  policyDataHandlingSessionRetentionNotEnforced:
+    "policy/data-handling-session-retention-not-enforced",
+  policyDataHandlingSessionTranscriptMemory:
+    "policy/data-handling-session-transcript-memory-enabled",
   policySecretsUnmanagedProvider: "policy/secrets-unmanaged-provider",
   policySecretsDeniedProviderSource: "policy/secrets-denied-provider-source",
   policySecretsInsecureProvider: "policy/secrets-insecure-provider",
@@ -127,6 +134,10 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policySandboxContainerRuntimeSocketMount,
   CHECK_IDS.policySandboxContainerUnconfinedProfile,
   CHECK_IDS.policySandboxBrowserCdpSourceRangeMissing,
+  CHECK_IDS.policyDataHandlingRedactionDisabled,
+  CHECK_IDS.policyDataHandlingTelemetryContentCapture,
+  CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced,
+  CHECK_IDS.policyDataHandlingSessionTranscriptMemory,
   CHECK_IDS.policySecretsUnmanagedProvider,
   CHECK_IDS.policySecretsDeniedProviderSource,
   CHECK_IDS.policySecretsInsecureProvider,
@@ -446,6 +457,31 @@ export const POLICY_RULE_METADATA = [
     scopeSelectors: ["channelIds"],
   },
   {
+    policyPath: ["dataHandling", "sensitiveLogging", "requireRedaction"],
+    strictness: "requires-true",
+    valueType: "boolean",
+    checkIds: [CHECK_IDS.policyDataHandlingRedactionDisabled],
+  },
+  {
+    policyPath: ["dataHandling", "telemetry", "denyContentCapture"],
+    strictness: "requires-true",
+    valueType: "boolean",
+    checkIds: [CHECK_IDS.policyDataHandlingTelemetryContentCapture],
+  },
+  {
+    policyPath: ["dataHandling", "retention", "requireSessionMaintenance"],
+    strictness: "requires-true",
+    valueType: "boolean",
+    checkIds: [CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced],
+  },
+  {
+    policyPath: ["dataHandling", "memory", "denySessionTranscriptIndexing"],
+    strictness: "requires-true",
+    valueType: "boolean",
+    checkIds: [CHECK_IDS.policyDataHandlingSessionTranscriptMemory],
+    scopeSelectors: ["agentIds"],
+  },
+  {
     policyPath: ["secrets", "requireManagedProviders"],
     strictness: "requires-true",
     valueType: "boolean",
@@ -573,6 +609,10 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policySandboxContainerRuntimeSocketMountCheck);
   registerHealthCheck(policySandboxContainerUnconfinedProfileCheck);
   registerHealthCheck(policySandboxBrowserCdpSourceRangeMissingCheck);
+  registerHealthCheck(policyDataHandlingRedactionDisabledCheck);
+  registerHealthCheck(policyDataHandlingTelemetryContentCaptureCheck);
+  registerHealthCheck(policyDataHandlingSessionRetentionNotEnforcedCheck);
+  registerHealthCheck(policyDataHandlingSessionTranscriptMemoryCheck);
   registerHealthCheck(policySecretsUnmanagedProviderCheck);
   registerHealthCheck(policySecretsDeniedProviderSourceCheck);
   registerHealthCheck(policySecretsInsecureProviderCheck);
@@ -1072,6 +1112,58 @@ const policySandboxBrowserCdpSourceRangeMissingCheck: HealthCheck = {
   },
 };
 
+const policyDataHandlingRedactionDisabledCheck: HealthCheck = {
+  id: CHECK_IDS.policyDataHandlingRedactionDisabled,
+  kind: "plugin",
+  description: "Sensitive logging redaction remains enabled when policy requires it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(
+      await evaluatePolicy(ctx),
+      CHECK_IDS.policyDataHandlingRedactionDisabled,
+    );
+  },
+};
+
+const policyDataHandlingTelemetryContentCaptureCheck: HealthCheck = {
+  id: CHECK_IDS.policyDataHandlingTelemetryContentCapture,
+  kind: "plugin",
+  description: "Telemetry content capture remains disabled when policy denies it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(
+      await evaluatePolicy(ctx),
+      CHECK_IDS.policyDataHandlingTelemetryContentCapture,
+    );
+  },
+};
+
+const policyDataHandlingSessionRetentionNotEnforcedCheck: HealthCheck = {
+  id: CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced,
+  kind: "plugin",
+  description: "Session retention maintenance is enforced when policy requires it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(
+      await evaluatePolicy(ctx),
+      CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced,
+    );
+  },
+};
+
+const policyDataHandlingSessionTranscriptMemoryCheck: HealthCheck = {
+  id: CHECK_IDS.policyDataHandlingSessionTranscriptMemory,
+  kind: "plugin",
+  description: "Session transcript memory indexing remains disabled when policy denies it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(
+      await evaluatePolicy(ctx),
+      CHECK_IDS.policyDataHandlingSessionTranscriptMemory,
+    );
+  },
+};
+
 const policySecretsUnmanagedProviderCheck: HealthCheck = {
   id: CHECK_IDS.policySecretsUnmanagedProvider,
   kind: "plugin",
@@ -1275,6 +1367,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   const includeIngress = policyHasIngressRules(policy);
   const includeGatewayExposure = policyHasGatewayRules(policy);
   const includeAgentWorkspace = policyHasAgentWorkspaceRules(policy);
+  const includeDataHandling = policyHasDataHandlingRules(policy);
   const includeSandboxPosture = policyHasSandboxPostureRules(policy);
   if (requiredMetadata.size > 0) {
     const toolsFile = await readWorkspaceFile(ctx, "TOOLS.md");
@@ -1283,6 +1376,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
       includeIngress,
       includeGatewayExposure,
       includeAgentWorkspace,
+      includeDataHandling,
       includeToolPosture: policyHasToolPostureRules(policy),
       includeSandboxPosture,
       includeSecrets,
@@ -1293,6 +1387,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
       includeIngress,
       includeGatewayExposure,
       includeAgentWorkspace,
+      includeDataHandling,
       includeToolPosture: policyHasToolPostureRules(policy),
       includeSandboxPosture,
       includeSecrets,
@@ -1310,6 +1405,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     ...agentWorkspaceFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...toolPostureFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...sandboxPostureFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
+    ...dataHandlingFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...secretAuthProvenanceFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...authMetadataRequirementFindings,
     ...metadataRequirementFindings,
@@ -1583,6 +1679,16 @@ export function policyContainerShapeFindings(
         `oc://${policyDocName}/mcp`,
         `${policyPath} mcp must be an object.`,
         `Fix ${policyPath} so mcp is an object.`,
+      ),
+    ];
+  }
+  if (policy.dataHandling !== undefined && !isRecord(policy.dataHandling)) {
+    return [
+      policyShapeFinding(
+        policyPath,
+        `oc://${policyDocName}/dataHandling`,
+        `${policyPath} dataHandling must be an object.`,
+        `Fix ${policyPath} so dataHandling is an object.`,
       ),
     ];
   }
@@ -1909,6 +2015,7 @@ function scopedPolicyShapeFinding(
     }
     if (
       (overlay.agents !== undefined ||
+        overlay.dataHandling !== undefined ||
         overlay.tools !== undefined ||
         overlay.sandbox !== undefined) &&
       !hasAgentIds
@@ -1917,7 +2024,7 @@ function scopedPolicyShapeFinding(
         params.policyPath,
         `oc://${params.policyDocName}/${targetPrefix}`,
         `${params.policyPath} scopes.${scopeName} uses agent-scoped sections without agentIds.`,
-        `List agentIds for agents.workspace, tools, or sandbox policy sections.`,
+        `List agentIds for agents.workspace, dataHandling.memory, tools, or sandbox policy sections.`,
       );
     }
     const unsupportedKey = Object.keys(overlay).find(
@@ -1925,6 +2032,7 @@ function scopedPolicyShapeFinding(
         key !== "agentIds" &&
         key !== "channelIds" &&
         key !== "agents" &&
+        key !== "dataHandling" &&
         key !== "tools" &&
         key !== "sandbox" &&
         key !== "ingress",
@@ -1934,8 +2042,27 @@ function scopedPolicyShapeFinding(
         params.policyPath,
         `oc://${params.policyDocName}/${targetPrefix}/${ocPathSegment(unsupportedKey)}`,
         `${params.policyPath} scopes.${scopeName}.${unsupportedKey} is not a supported scoped policy section.`,
-        `Use agentIds with agents.workspace, tools, or sandbox, and channelIds with ingress.channels.`,
+        `Use agentIds with agents.workspace, dataHandling.memory, tools, or sandbox, and channelIds with ingress.channels.`,
       );
+    }
+    if (overlay.dataHandling !== undefined && !isRecord(overlay.dataHandling)) {
+      return policyShapeFinding(
+        params.policyPath,
+        `oc://${params.policyDocName}/${targetPrefix}/dataHandling`,
+        `${params.policyPath} scopes.${scopeName}.dataHandling must be an object.`,
+        `Fix ${params.policyPath} so the scoped dataHandling policy section is an object.`,
+      );
+    }
+    if (isRecord(overlay.dataHandling)) {
+      const scopedDataHandlingFinding = scopedDataHandlingPolicyShapeFinding(overlay.dataHandling, {
+        policyPath: params.policyPath,
+        policyDocName: params.policyDocName,
+        targetPrefix,
+        scopeName,
+      });
+      if (scopedDataHandlingFinding !== undefined) {
+        return scopedDataHandlingFinding;
+      }
     }
     if (overlay.agents !== undefined && !isRecord(overlay.agents)) {
       return policyShapeFinding(
@@ -2008,6 +2135,60 @@ function scopedPolicyShapeFinding(
     policyPath: params.policyPath,
     policy: params.policy,
   });
+}
+
+function scopedDataHandlingPolicyShapeFinding(
+  dataHandling: Record<string, unknown>,
+  params: {
+    readonly policyPath: string;
+    readonly policyDocName: string;
+    readonly targetPrefix: string;
+    readonly scopeName: string;
+  },
+): HealthFinding | undefined {
+  const unsupportedKey = Object.keys(dataHandling).find((key) => key !== "memory");
+  if (unsupportedKey !== undefined) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/${params.targetPrefix}/dataHandling/${ocPathSegment(unsupportedKey)}`,
+      `${params.policyPath} scopes.${params.scopeName}.dataHandling.${unsupportedKey} is not a supported scoped policy section.`,
+      `Move global data-handling rules to top-level dataHandling, or use dataHandling.memory with agentIds.`,
+    );
+  }
+  if (dataHandling.memory !== undefined && !isRecord(dataHandling.memory)) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/${params.targetPrefix}/dataHandling/memory`,
+      `${params.policyPath} scopes.${params.scopeName}.dataHandling.memory must be an object.`,
+      `Fix ${params.policyPath} so the scoped dataHandling.memory policy section is an object.`,
+    );
+  }
+  if (!isRecord(dataHandling.memory)) {
+    return undefined;
+  }
+  const unsupportedMemoryKey = Object.keys(dataHandling.memory).find(
+    (key) => key !== "denySessionTranscriptIndexing",
+  );
+  if (unsupportedMemoryKey !== undefined) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/${params.targetPrefix}/dataHandling/memory/${ocPathSegment(unsupportedMemoryKey)}`,
+      `${params.policyPath} scopes.${params.scopeName}.dataHandling.memory.${unsupportedMemoryKey} is not a supported scoped policy rule.`,
+      `Use dataHandling.memory.denySessionTranscriptIndexing or remove the unsupported rule.`,
+    );
+  }
+  if (
+    dataHandling.memory.denySessionTranscriptIndexing !== undefined &&
+    typeof dataHandling.memory.denySessionTranscriptIndexing !== "boolean"
+  ) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/${params.targetPrefix}/dataHandling/memory/denySessionTranscriptIndexing`,
+      `${params.policyPath} scopes.${params.scopeName}.dataHandling.memory.denySessionTranscriptIndexing must be a boolean.`,
+      `Set dataHandling.memory.denySessionTranscriptIndexing to true or false.`,
+    );
+  }
+  return undefined;
 }
 
 function scopedSelectorShapeFinding(
@@ -4418,6 +4599,285 @@ function secretAuthProvenanceFindings(
   ];
 }
 
+function dataHandlingFindings(
+  policy: unknown,
+  policyPath: string,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const shapeFindings = dataHandlingPolicyShapeFindings(policy, policyPath, policyDocName);
+  if (shapeFindings.length > 0) {
+    return shapeFindings;
+  }
+  const findings: HealthFinding[] = [];
+  findings.push(
+    ...dataHandlingFindingsForRule(policy, policyDocName, "dataHandling", evidence, () => true),
+  );
+  for (const target of agentScopedPolicyTargets(policy)) {
+    if (!dataHandlingPolicyHasRules(target.overlay.dataHandling)) {
+      continue;
+    }
+    findings.push(
+      ...dataHandlingFindingsForRule(
+        target.overlay,
+        policyDocName,
+        `scopes/${ocPathSegment(target.scopeName)}/dataHandling`,
+        evidence,
+        (entry) =>
+          entry.kind !== "memorySessionTranscriptIndexing" ||
+          scopedDataHandlingAgentMatches(entry, target.agentId, evidence.dataHandling ?? []),
+      ),
+    );
+  }
+  return findings;
+}
+
+function scopedDataHandlingAgentMatches(
+  entry: PolicyDataHandlingEvidence,
+  policyAgentId: string,
+  entries: readonly PolicyDataHandlingEvidence[],
+): boolean {
+  if (entry.id === "memory-qmd-session-transcripts") {
+    return true;
+  }
+  if (scopedAgentIdMatches(entry.agentId, policyAgentId)) {
+    return true;
+  }
+  return (
+    entry.id === "agents-defaults-memory-session-transcripts" &&
+    !entries.some(
+      (candidate) =>
+        candidate.scope === "agent" &&
+        candidate.kind === entry.kind &&
+        scopedAgentIdMatches(candidate.agentId, policyAgentId),
+    )
+  );
+}
+
+function dataHandlingFindingsForRule(
+  policy: unknown,
+  policyDocName: string,
+  requirementBase: string,
+  evidence: PolicyEvidence,
+  evidenceFilter: (entry: PolicyDataHandlingEvidence) => boolean,
+): readonly HealthFinding[] {
+  const dataHandling = isRecord(policy) ? policy.dataHandling : undefined;
+  if (!isRecord(dataHandling)) {
+    return [];
+  }
+  const findings: HealthFinding[] = [];
+  if (readPolicyBoolean(dataHandling, ["sensitiveLogging", "requireRedaction"]) === true) {
+    findings.push(
+      ...dataHandlingEntries(evidence, "sensitiveLoggingRedaction")
+        .filter(evidenceFilter)
+        .filter((entry) => entry.value !== true)
+        .map((entry) =>
+          dataHandlingFinding(entry, {
+            checkId: CHECK_IDS.policyDataHandlingRedactionDisabled,
+            message: "Sensitive logging redaction is disabled.",
+            requirement: `oc://${policyDocName}/${requirementBase}/sensitiveLogging/requireRedaction`,
+            fixHint: "Set logging.redactSensitive to tools or update policy after review.",
+          }),
+        ),
+    );
+  }
+  if (readPolicyBoolean(dataHandling, ["telemetry", "denyContentCapture"]) === true) {
+    findings.push(
+      ...dataHandlingEntries(evidence, "telemetryContentCapture")
+        .filter(evidenceFilter)
+        .filter((entry) => entry.value === true)
+        .map((entry) =>
+          dataHandlingFinding(entry, {
+            checkId: CHECK_IDS.policyDataHandlingTelemetryContentCapture,
+            message: "Telemetry content capture is enabled.",
+            requirement: `oc://${policyDocName}/${requirementBase}/telemetry/denyContentCapture`,
+            fixHint: "Disable diagnostics.otel.captureContent or update policy after review.",
+          }),
+        ),
+    );
+  }
+  if (readPolicyBoolean(dataHandling, ["retention", "requireSessionMaintenance"]) === true) {
+    findings.push(
+      ...dataHandlingEntries(evidence, "sessionRetentionMode")
+        .filter(evidenceFilter)
+        .filter((entry) => entry.value !== "enforce")
+        .map((entry) =>
+          dataHandlingFinding(entry, {
+            checkId: CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced,
+            message: `Session retention maintenance mode is '${entry.value ?? "unknown"}'.`,
+            requirement: `oc://${policyDocName}/${requirementBase}/retention/requireSessionMaintenance`,
+            fixHint: "Set session.maintenance.mode to enforce or update policy after review.",
+          }),
+        ),
+    );
+  }
+  if (readPolicyBoolean(dataHandling, ["memory", "denySessionTranscriptIndexing"]) === true) {
+    findings.push(
+      ...dataHandlingEntries(evidence, "memorySessionTranscriptIndexing")
+        .filter(evidenceFilter)
+        .filter((entry) => entry.value === true)
+        .map((entry) =>
+          dataHandlingFinding(entry, {
+            checkId: CHECK_IDS.policyDataHandlingSessionTranscriptMemory,
+            message: `${dataHandlingLabel(entry)} enables session transcript memory indexing.`,
+            requirement: `oc://${policyDocName}/${requirementBase}/memory/denySessionTranscriptIndexing`,
+            fixHint:
+              "Disable session transcript memory indexing for the matching config surface or update policy after review.",
+          }),
+        ),
+    );
+  }
+  return findings;
+}
+
+function dataHandlingPolicyShapeFindings(
+  policy: unknown,
+  policyPath: string,
+  policyDocName: string,
+): readonly HealthFinding[] {
+  if (!isRecord(policy)) {
+    return [];
+  }
+  if (!isRecord(policy.dataHandling)) {
+    return [];
+  }
+  return [
+    dataHandlingSectionShapeFinding(policy.dataHandling, {
+      policyPath,
+      policyDocName,
+      propertyPath: "dataHandling.sensitiveLogging",
+      targetPath: "dataHandling/sensitiveLogging",
+      section: "sensitiveLogging",
+    }),
+    dataHandlingSectionShapeFinding(policy.dataHandling, {
+      policyPath,
+      policyDocName,
+      propertyPath: "dataHandling.telemetry",
+      targetPath: "dataHandling/telemetry",
+      section: "telemetry",
+    }),
+    dataHandlingSectionShapeFinding(policy.dataHandling, {
+      policyPath,
+      policyDocName,
+      propertyPath: "dataHandling.retention",
+      targetPath: "dataHandling/retention",
+      section: "retention",
+    }),
+    dataHandlingSectionShapeFinding(policy.dataHandling, {
+      policyPath,
+      policyDocName,
+      propertyPath: "dataHandling.memory",
+      targetPath: "dataHandling/memory",
+      section: "memory",
+    }),
+    dataHandlingBooleanShapeFinding(policy.dataHandling, {
+      policyPath,
+      policyDocName,
+      propertyPath: "dataHandling.sensitiveLogging.requireRedaction",
+      targetPath: "dataHandling/sensitiveLogging/requireRedaction",
+      path: ["sensitiveLogging", "requireRedaction"],
+    }),
+    dataHandlingBooleanShapeFinding(policy.dataHandling, {
+      policyPath,
+      policyDocName,
+      propertyPath: "dataHandling.telemetry.denyContentCapture",
+      targetPath: "dataHandling/telemetry/denyContentCapture",
+      path: ["telemetry", "denyContentCapture"],
+    }),
+    dataHandlingBooleanShapeFinding(policy.dataHandling, {
+      policyPath,
+      policyDocName,
+      propertyPath: "dataHandling.retention.requireSessionMaintenance",
+      targetPath: "dataHandling/retention/requireSessionMaintenance",
+      path: ["retention", "requireSessionMaintenance"],
+    }),
+    dataHandlingBooleanShapeFinding(policy.dataHandling, {
+      policyPath,
+      policyDocName,
+      propertyPath: "dataHandling.memory.denySessionTranscriptIndexing",
+      targetPath: "dataHandling/memory/denySessionTranscriptIndexing",
+      path: ["memory", "denySessionTranscriptIndexing"],
+    }),
+  ].filter((finding): finding is HealthFinding => finding !== undefined);
+}
+
+function dataHandlingSectionShapeFinding(
+  dataHandling: Record<string, unknown>,
+  params: {
+    readonly policyPath: string;
+    readonly policyDocName: string;
+    readonly propertyPath: string;
+    readonly targetPath: string;
+    readonly section: string;
+  },
+): HealthFinding | undefined {
+  const value = dataHandling[params.section];
+  if (value === undefined || isRecord(value)) {
+    return undefined;
+  }
+  return policyShapeFinding(
+    params.policyPath,
+    `oc://${params.policyDocName}/${params.targetPath}`,
+    `${params.policyPath} ${params.propertyPath} must be an object.`,
+    `Fix ${params.propertyPath} so it contains boolean policy rules.`,
+  );
+}
+
+function dataHandlingBooleanShapeFinding(
+  dataHandling: unknown,
+  params: {
+    readonly policyPath: string;
+    readonly policyDocName: string;
+    readonly propertyPath: string;
+    readonly targetPath: string;
+    readonly path: readonly string[];
+  },
+): HealthFinding | undefined {
+  const value = getPolicyPath(dataHandling, params.path);
+  if (value === undefined || typeof value === "boolean") {
+    return undefined;
+  }
+  return policyShapeFinding(
+    params.policyPath,
+    `oc://${params.policyDocName}/${params.targetPath}`,
+    `${params.policyPath} ${params.propertyPath} must be a boolean.`,
+    `Set ${params.propertyPath} to true or false.`,
+  );
+}
+
+function dataHandlingEntries(
+  evidence: PolicyEvidence,
+  kind: PolicyDataHandlingEvidence["kind"],
+): readonly PolicyDataHandlingEvidence[] {
+  return (evidence.dataHandling ?? []).filter((entry) => entry.kind === kind);
+}
+
+function dataHandlingFinding(
+  entry: PolicyDataHandlingEvidence,
+  params: {
+    readonly checkId: (typeof POLICY_CHECK_IDS)[number];
+    readonly message: string;
+    readonly requirement: string;
+    readonly fixHint: string;
+  },
+): HealthFinding {
+  return {
+    checkId: params.checkId,
+    severity: "error",
+    message: params.message,
+    source: "policy",
+    path: "openclaw config",
+    ocPath: entry.source,
+    target: entry.source,
+    requirement: params.requirement,
+    fixHint: params.fixHint,
+  };
+}
+
+function dataHandlingLabel(entry: PolicyDataHandlingEvidence): string {
+  return entry.agentId === undefined ? "Global data handling config" : `agent '${entry.agentId}'`;
+}
+
 function policyHasSecretRules(policy: unknown): boolean {
   if (!isRecord(policy) || !isRecord(policy.secrets)) {
     return false;
@@ -4522,6 +4982,34 @@ function sandboxPosturePolicyHasRules(value: unknown): boolean {
     (containers !== undefined &&
       SANDBOX_CONTAINER_POLICY_RULES.some((rule) => containers[rule.key] !== undefined)) ||
     browser?.requireCdpSourceRange !== undefined
+  );
+}
+
+function policyHasDataHandlingRules(policy: unknown): boolean {
+  if (!isRecord(policy)) {
+    return false;
+  }
+  if (dataHandlingPolicyHasRules(policy.dataHandling)) {
+    return true;
+  }
+  return agentScopedPolicyOverlays(policy).some(([, overlay]) =>
+    dataHandlingPolicyHasRules(overlay.dataHandling),
+  );
+}
+
+function dataHandlingPolicyHasRules(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const dataHandling = value;
+  return (
+    (isRecord(dataHandling.sensitiveLogging) &&
+      dataHandling.sensitiveLogging.requireRedaction !== undefined) ||
+    (isRecord(dataHandling.telemetry) && dataHandling.telemetry.denyContentCapture !== undefined) ||
+    (isRecord(dataHandling.retention) &&
+      dataHandling.retention.requireSessionMaintenance !== undefined) ||
+    (isRecord(dataHandling.memory) &&
+      dataHandling.memory.denySessionTranscriptIndexing !== undefined)
   );
 }
 

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { coerceSecretRef } from "openclaw/plugin-sdk/secret-input";
 import {
   asBoolean as readBoolean,
@@ -48,6 +49,7 @@ export type PolicyEvidence = {
   readonly ingress?: readonly PolicyIngressEvidence[];
   readonly gatewayExposure?: readonly PolicyGatewayExposureEvidence[];
   readonly agentWorkspace?: readonly PolicyAgentWorkspaceEvidence[];
+  readonly dataHandling?: readonly PolicyDataHandlingEvidence[];
   readonly secrets?: readonly PolicySecretEvidence[];
   readonly authProfiles?: readonly PolicyAuthProfileEvidence[];
 };
@@ -206,6 +208,20 @@ export type PolicyAuthProfileEvidence = {
   readonly mode?: string;
 };
 
+export type PolicyDataHandlingEvidence = {
+  readonly id: string;
+  readonly kind:
+    | "memorySessionTranscriptIndexing"
+    | "sensitiveLoggingRedaction"
+    | "sessionRetentionMode"
+    | "telemetryContentCapture";
+  readonly source: string;
+  readonly scope: "global" | "agent";
+  readonly agentId?: string;
+  readonly value?: boolean | string;
+  readonly explicit?: boolean;
+};
+
 type SecretRefEvidence = {
   readonly source: "env" | "file" | "exec";
   readonly provider: string;
@@ -280,6 +296,7 @@ export function collectPolicyEvidence(
     readonly includeIngress?: boolean;
     readonly includeGatewayExposure?: boolean;
     readonly includeAgentWorkspace?: boolean;
+    readonly includeDataHandling?: boolean;
     readonly includeToolPosture?: boolean;
     readonly includeSandboxPosture?: boolean;
     readonly includeSecrets?: boolean;
@@ -293,6 +310,7 @@ export function collectPolicyEvidence(
     readonly includeIngress?: boolean;
     readonly includeGatewayExposure?: boolean;
     readonly includeAgentWorkspace?: boolean;
+    readonly includeDataHandling?: boolean;
     readonly includeToolPosture?: boolean;
     readonly includeSandboxPosture?: boolean;
     readonly includeSecrets?: boolean;
@@ -306,6 +324,7 @@ export function collectPolicyEvidence(
     readonly includeIngress?: boolean;
     readonly includeGatewayExposure?: boolean;
     readonly includeAgentWorkspace?: boolean;
+    readonly includeDataHandling?: boolean;
     readonly includeToolPosture?: boolean;
     readonly includeSandboxPosture?: boolean;
     readonly includeSecrets?: boolean;
@@ -325,6 +344,7 @@ export function collectPolicyEvidence(
     ...(options.includeAgentWorkspace === false
       ? {}
       : { agentWorkspace: scanPolicyAgentWorkspace(cfg) }),
+    ...(options.includeDataHandling === false ? {} : { dataHandling: scanPolicyDataHandling(cfg) }),
     ...(options.includeToolPosture === false ? {} : { toolPosture: scanPolicyToolPosture(cfg) }),
     ...(options.includeSandboxPosture === false
       ? {}
@@ -793,6 +813,202 @@ export function scanPolicyAuthProfiles(
       }
       return entry;
     });
+}
+
+export function scanPolicyDataHandling(
+  cfg: Record<string, unknown>,
+): readonly PolicyDataHandlingEvidence[] {
+  const entries: PolicyDataHandlingEvidence[] = [];
+  const logging = isRecord(cfg.logging) ? cfg.logging : {};
+  entries.push({
+    id: "logging-redaction",
+    kind: "sensitiveLoggingRedaction",
+    source: "oc://openclaw.config/logging/redactSensitive",
+    scope: "global",
+    value: logging.redactSensitive !== "off",
+    explicit: logging.redactSensitive !== undefined,
+  });
+
+  const diagnostics = isRecord(cfg.diagnostics) ? cfg.diagnostics : {};
+  const otel = isRecord(diagnostics.otel) ? diagnostics.otel : {};
+  const otelEnabled = diagnostics.enabled !== false && otel.enabled === true;
+  const tracesEnabled = otelEnabled && otel.traces !== false;
+  const logsEnabled = otelEnabled && otel.logs === true;
+  const captureContent =
+    otelEnabled &&
+    telemetryContentCaptureEnabled(otel.captureContent, {
+      tracesEnabled,
+      logsEnabled,
+    });
+  entries.push({
+    id: "diagnostics-otel-content-capture",
+    kind: "telemetryContentCapture",
+    source: "oc://openclaw.config/diagnostics/otel/captureContent",
+    scope: "global",
+    value: captureContent,
+    explicit: otel.captureContent !== undefined,
+  });
+
+  const session = isRecord(cfg.session) ? cfg.session : {};
+  const maintenance = isRecord(session.maintenance) ? session.maintenance : {};
+  const retentionMode = typeof maintenance.mode === "string" ? maintenance.mode : "enforce";
+  entries.push({
+    id: "session-maintenance-mode",
+    kind: "sessionRetentionMode",
+    source: "oc://openclaw.config/session/maintenance/mode",
+    scope: "global",
+    value: retentionMode,
+    explicit: maintenance.mode !== undefined,
+  });
+
+  pushMemorySessionTranscriptIndexing(entries, cfg);
+  return entries.toSorted((a, b) => a.source.localeCompare(b.source));
+}
+
+function telemetryContentCaptureEnabled(
+  value: unknown,
+  signals: { readonly tracesEnabled: boolean; readonly logsEnabled: boolean },
+): boolean {
+  if (value === true) {
+    return signals.tracesEnabled || signals.logsEnabled;
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (!signals.tracesEnabled) {
+    return false;
+  }
+  if (value.enabled !== true) {
+    return false;
+  }
+  return (
+    value.inputMessages === true ||
+    value.outputMessages === true ||
+    value.toolInputs === true ||
+    value.toolOutputs === true ||
+    value.systemPrompt === true ||
+    value.toolDefinitions === true
+  );
+}
+
+function pushMemorySessionTranscriptIndexing(
+  entries: PolicyDataHandlingEvidence[],
+  cfg: Record<string, unknown>,
+): void {
+  const memory = isRecord(cfg.memory) ? cfg.memory : {};
+  const qmd = isRecord(memory.qmd) ? memory.qmd : {};
+  const qmdSessions = isRecord(qmd.sessions) ? qmd.sessions : {};
+  if (qmdSessions.enabled !== undefined) {
+    entries.push({
+      id: "memory-qmd-session-transcripts",
+      kind: "memorySessionTranscriptIndexing",
+      source: "oc://openclaw.config/memory/qmd/sessions/enabled",
+      scope: "global",
+      value: memory.backend === "qmd" && readBoolean(qmdSessions.enabled) === true,
+      explicit: true,
+    });
+  }
+
+  const agents = isRecord(cfg.agents) ? cfg.agents : {};
+  const defaults = isRecord(agents.defaults) ? agents.defaults : {};
+  const defaultsMemorySearch = isRecord(defaults.memorySearch) ? defaults.memorySearch : {};
+  const defaultSessionMemory = memorySearchSessionTranscriptIndexing(defaultsMemorySearch);
+  if (defaultSessionMemory !== undefined) {
+    entries.push({
+      id: "agents-defaults-memory-session-transcripts",
+      kind: "memorySessionTranscriptIndexing",
+      source: "oc://openclaw.config/agents/defaults/memorySearch/experimental/sessionMemory",
+      scope: "global",
+      value: defaultSessionMemory,
+      explicit: true,
+    });
+  }
+
+  if (!Array.isArray(agents.list)) {
+    return;
+  }
+  agents.list.forEach((rawAgent, index) => {
+    if (!isRecord(rawAgent)) {
+      return;
+    }
+    const agentId =
+      readString(rawAgent.id) ??
+      readString(rawAgent.name) ??
+      readString(rawAgent.slug) ??
+      `agent-${index}`;
+    const memorySearch = isRecord(rawAgent.memorySearch) ? rawAgent.memorySearch : undefined;
+    const agentSessionMemory =
+      memorySearch === undefined
+        ? defaultSessionMemory
+        : memorySearchSessionTranscriptIndexing(memorySearch, defaultsMemorySearch);
+    if (agentSessionMemory === undefined) {
+      return;
+    }
+    const explicit = memorySearchSessionTranscriptIndexingHasLocalConfig(memorySearch);
+    entries.push({
+      id: `${agentId}-memory-session-transcripts`,
+      kind: "memorySessionTranscriptIndexing",
+      source: explicit
+        ? `oc://openclaw.config/agents/list/#${index}/memorySearch/experimental/sessionMemory`
+        : "oc://openclaw.config/agents/defaults/memorySearch/experimental/sessionMemory",
+      scope: "agent",
+      agentId: normalizeAgentId(agentId),
+      value: agentSessionMemory,
+      explicit,
+    });
+  });
+}
+
+function memorySearchSessionTranscriptIndexing(
+  memorySearch: unknown,
+  inheritedMemorySearch?: unknown,
+): boolean | undefined {
+  if (!isRecord(memorySearch)) {
+    return undefined;
+  }
+  const experimental = isRecord(memorySearch.experimental) ? memorySearch.experimental : {};
+  const inherited = isRecord(inheritedMemorySearch) ? inheritedMemorySearch : {};
+  const inheritedExperimental = isRecord(inherited.experimental) ? inherited.experimental : {};
+  const enabled = readBoolean(memorySearch.enabled) ?? readBoolean(inherited.enabled) ?? true;
+  const sessionMemory =
+    readBoolean(experimental.sessionMemory) ?? readBoolean(inheritedExperimental.sessionMemory);
+  const sourcesIncludeSessions =
+    memorySearchSourcesIncludeSessions(memorySearch) ??
+    memorySearchSourcesIncludeSessions(inherited) ??
+    false;
+  if (
+    sessionMemory === undefined &&
+    memorySearchSourcesIncludeSessions(memorySearch) === undefined &&
+    readBoolean(memorySearch.enabled) === undefined
+  ) {
+    return undefined;
+  }
+  if (!enabled) {
+    return false;
+  }
+  return sessionMemory === true && sourcesIncludeSessions;
+}
+
+function memorySearchSessionTranscriptIndexingHasLocalConfig(memorySearch: unknown): boolean {
+  if (!isRecord(memorySearch)) {
+    return false;
+  }
+  const experimental = isRecord(memorySearch.experimental) ? memorySearch.experimental : {};
+  return (
+    readBoolean(memorySearch.enabled) !== undefined ||
+    readBoolean(experimental.sessionMemory) !== undefined ||
+    memorySearchSourcesIncludeSessions(memorySearch) !== undefined
+  );
+}
+
+function memorySearchSourcesIncludeSessions(memorySearch: unknown): boolean | undefined {
+  if (!isRecord(memorySearch) || memorySearch.sources === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(memorySearch.sources)) {
+    return false;
+  }
+  return memorySearch.sources.includes("sessions");
 }
 
 function scanPolicySecretProviders(cfg: Record<string, unknown>): readonly PolicySecretEvidence[] {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -851,7 +851,7 @@ export function scanPolicyDataHandling(
 
   const session = isRecord(cfg.session) ? cfg.session : {};
   const maintenance = isRecord(session.maintenance) ? session.maintenance : {};
-  const retentionMode = typeof maintenance.mode === "string" ? maintenance.mode : "enforce";
+  const retentionMode = typeof maintenance.mode === "string" ? maintenance.mode : "warn";
   entries.push({
     id: "session-maintenance-mode",
     kind: "sessionRetentionMode",

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -851,7 +851,7 @@ export function scanPolicyDataHandling(
 
   const session = isRecord(cfg.session) ? cfg.session : {};
   const maintenance = isRecord(session.maintenance) ? session.maintenance : {};
-  const retentionMode = typeof maintenance.mode === "string" ? maintenance.mode : "warn";
+  const retentionMode = typeof maintenance.mode === "string" ? maintenance.mode : "enforce";
   entries.push({
     id: "session-maintenance-mode",
     kind: "sessionRetentionMode",


### PR DESCRIPTION
## Summary

Adds data-handling policy conformance checks. This is config-level conformance only: Policy observes OpenClaw configuration posture and reports findings when the configured workspace violates the authored policy. It does not inspect user data, transcript contents, credentials, or secret values.

The new `policy.jsonc` syntax is:

```jsonc
{
  "dataHandling": {
    "sensitiveLogging": {
      "requireRedaction": true
    },
    "telemetry": {
      "denyContentCapture": true
    },
    "retention": {
      "requireSessionMaintenance": true
    },
    "memory": {
      "denySessionTranscriptIndexing": true
    }
  },
  "scopes": {
    "restricted-agents": {
      "agentIds": ["analyst"],
      "dataHandling": {
        "memory": {
          "denySessionTranscriptIndexing": true
        }
      }
    }
  }
}
```

## Contract

Supported fields:

| Policy field | Observed state | Use when |
| --- | --- | --- |
| `dataHandling.sensitiveLogging.requireRedaction` | `logging.redactSensitive` | Set to `true` to reject `logging.redactSensitive: "off"`. |
| `dataHandling.telemetry.denyContentCapture` | `diagnostics.otel.captureContent` | Set to `true` to reject telemetry content capture. |
| `dataHandling.retention.requireSessionMaintenance` | `session.maintenance.mode` | Set to `true` to require effective session maintenance mode `enforce`. |
| `dataHandling.memory.denySessionTranscriptIndexing` | `memory.qmd.sessions.enabled` and `agents.*.memorySearch.experimental.sessionMemory` | Set to `true` to reject session transcript indexing into memory. |

`dataHandling.memory.*` can be scoped with `agentIds`; the other data-handling fields remain top-level because their observed state is global workspace configuration rather than per-agent evidence.

New check IDs:

| Check ID | Meaning |
| --- | --- |
| `policy/data-handling-redaction-disabled` | Sensitive logging redaction is disabled when policy requires it. |
| `policy/data-handling-telemetry-content-capture` | Telemetry content capture is enabled when policy denies it. |
| `policy/data-handling-session-retention-not-enforced` | Session retention maintenance is not enforced when policy requires it. |
| `policy/data-handling-session-transcript-memory-enabled` | Session transcript memory indexing is enabled when policy denies it. |

## Usage

```bash
openclaw policy check
openclaw policy check --json
openclaw doctor --lint
```

## Validation

- Focused policy doctor coverage for data-handling findings, data-handling evidence, agent-scoped memory posture, malformed data-handling policy shape, and `policy compare` metadata.
- Policy docs updated with data-handling syntax, scope support, command usage, check IDs, and config-only semantics.
