### PR TITLE
fix(sessions): recover empty preflight compaction

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -110,7 +110,7 @@ openclaw sessions cleanup --json
 - `--dry-run`: preview how many entries would be pruned/capped without writing.
   - In text mode, dry-run prints a per-session action table (`Action`, `Key`, `Age`, `Model`, `Flags`) so you can see what would be kept vs removed.
 - `--enforce`: apply maintenance even when `session.maintenance.mode` is `warn`.
-- `--fix-missing`: remove entries whose transcript files are missing, even if they would not normally age/count out yet.
+- `--fix-missing`: remove entries whose transcript files are missing or header-only/empty, even if they would not normally age/count out yet.
 - `--fix-dm-scope`: when `session.dmScope` is `main`, retire stale peer-keyed direct-DM rows left behind by earlier `per-peer`, `per-channel-peer`, or `per-account-channel-peer` routing. Use `--dry-run` first; applying the cleanup removes those rows from `sessions.json` and preserves their transcripts as deleted archives.
 - `--active-key <key>`: protect a specific active key from disk-budget eviction. Durable external conversation pointers, such as group sessions and thread-scoped chat sessions, are also kept by age/count/disk-budget maintenance.
 - `--agent <id>`: run cleanup for one configured agent store.

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -976,6 +976,123 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("prefers zero compaction tokensAfter over CLI cache usage", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-zero-compaction-with-usage";
+      const sessionId = "test-zero-compaction-with-usage-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 1_794_391,
+          totalTokensFresh: true,
+          inputTokens: 20,
+          outputTokens: 10_855,
+          cacheRead: 1_761_324,
+          cacheWrite: 33_047,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "claude-cli",
+        defaultModel: "claude-opus-4-7",
+        result: {
+          meta: {
+            durationMs: 500,
+            agentMeta: {
+              sessionId,
+              provider: "claude-cli",
+              model: "claude-opus-4-7",
+              usage: {
+                input: 20,
+                output: 10_855,
+                cacheRead: 1_761_324,
+                cacheWrite: 33_047,
+              },
+              lastCallUsage: {
+                input: 20,
+                output: 10_855,
+                cacheRead: 1_761_324,
+                cacheWrite: 33_047,
+              },
+              compactionCount: 1,
+              compactionTokensAfter: 0,
+            },
+          },
+        } as EmbeddedAgentRunResult,
+      });
+
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(0);
+      expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
+      expect(sessionStore[sessionKey]?.inputTokens).toBeUndefined();
+      expect(sessionStore[sessionKey]?.outputTokens).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cacheRead).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cacheWrite).toBeUndefined();
+    });
+  });
+
+  it("prefers fresh usage over positive compaction tokensAfter", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-positive-compaction-with-usage";
+      const sessionId = "test-positive-compaction-with-usage-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 180_000,
+          totalTokensFresh: true,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+        result: {
+          meta: {
+            durationMs: 500,
+            agentMeta: {
+              sessionId,
+              provider: "openai",
+              model: "gpt-5.5",
+              usage: {
+                input: 100_000,
+                output: 3_000,
+                cacheRead: 20_000,
+              },
+              lastCallUsage: {
+                input: 91_000,
+                output: 1_000,
+                cacheRead: 4_000,
+              },
+              compactionCount: 1,
+              compactionTokensAfter: 80_000,
+            },
+          },
+        } as EmbeddedAgentRunResult,
+      });
+
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(120_000);
+      expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
+      expect(sessionStore[sessionKey]?.inputTokens).toBe(100_000);
+      expect(sessionStore[sessionKey]?.outputTokens).toBe(3_000);
+      expect(sessionStore[sessionKey]?.cacheRead).toBe(20_000);
+    });
+  });
+
   it("accepts zero compaction tokensAfter when provider usage is unavailable", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;
@@ -987,6 +1104,29 @@ describe("updateSessionStoreAfterAgentRun", () => {
           updatedAt: 1,
           totalTokens: 12_000,
           totalTokensFresh: true,
+          inputTokens: 20,
+          outputTokens: 10_855,
+          cacheRead: 1_761_324,
+          cacheWrite: 33_047,
+          contextBudgetStatus: {
+            schemaVersion: 1,
+            source: "pre-prompt-estimate",
+            updatedAt: 1,
+            provider: "claude-cli",
+            model: "claude-opus-4-7",
+            route: "compact_only",
+            shouldCompact: true,
+            estimatedPromptTokens: 1_794_391,
+            contextTokenBudget: 1_048_576,
+            promptBudgetBeforeReserve: 1_044_480,
+            reserveTokens: 4_096,
+            effectiveReserveTokens: 4_096,
+            remainingPromptBudgetTokens: 0,
+            overflowTokens: 749_911,
+            toolResultReducibleChars: 0,
+            messageCount: 0,
+            unwindowedMessageCount: 0,
+          },
         },
       };
       await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
@@ -1016,6 +1156,11 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(sessionStore[sessionKey]?.totalTokens).toBe(0);
       expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
       expect(sessionStore[sessionKey]?.compactionCount).toBe(1);
+      expect(sessionStore[sessionKey]?.inputTokens).toBeUndefined();
+      expect(sessionStore[sessionKey]?.outputTokens).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cacheRead).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cacheWrite).toBeUndefined();
+      expect(sessionStore[sessionKey]?.contextBudgetStatus).toBeUndefined();
     });
   });
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -976,7 +976,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
-  it("prefers zero compaction tokensAfter over CLI cache usage", async () => {
+  it("prefers fresh CLI usage over zero compaction tokensAfter", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;
       const sessionKey = "agent:main:explicit:test-zero-compaction-with-usage";
@@ -1029,12 +1029,12 @@ describe("updateSessionStoreAfterAgentRun", () => {
         } as EmbeddedAgentRunResult,
       });
 
-      expect(sessionStore[sessionKey]?.totalTokens).toBe(0);
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(1_794_391);
       expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
-      expect(sessionStore[sessionKey]?.inputTokens).toBeUndefined();
-      expect(sessionStore[sessionKey]?.outputTokens).toBeUndefined();
-      expect(sessionStore[sessionKey]?.cacheRead).toBeUndefined();
-      expect(sessionStore[sessionKey]?.cacheWrite).toBeUndefined();
+      expect(sessionStore[sessionKey]?.inputTokens).toBe(20);
+      expect(sessionStore[sessionKey]?.outputTokens).toBe(10_855);
+      expect(sessionStore[sessionKey]?.cacheRead).toBe(1_761_324);
+      expect(sessionStore[sessionKey]?.cacheWrite).toBe(33_047);
     });
   });
 

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -216,8 +216,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
     next.outputTokens = output;
     const hasUsageTotalTokens =
       typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0;
-    const useCompactionSnapshot =
-      compactionTokensAfter !== undefined && (compactionTokensAfter === 0 || !hasUsageTotalTokens);
+    const useCompactionSnapshot = compactionTokensAfter !== undefined && !hasUsageTotalTokens;
     if (useCompactionSnapshot) {
       next.totalTokens = compactionTokensAfter;
       next.totalTokensFresh = true;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -214,18 +214,29 @@ export async function updateSessionStoreAfterAgentRun(params: {
     );
     next.inputTokens = input;
     next.outputTokens = output;
-    if (typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0) {
-      next.totalTokens = totalTokens;
-      next.totalTokensFresh = true;
-    } else if (compactionTokensAfter !== undefined) {
+    const hasUsageTotalTokens =
+      typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0;
+    const useCompactionSnapshot =
+      compactionTokensAfter !== undefined && (compactionTokensAfter === 0 || !hasUsageTotalTokens);
+    if (useCompactionSnapshot) {
       next.totalTokens = compactionTokensAfter;
+      next.totalTokensFresh = true;
+      next.inputTokens = undefined;
+      next.outputTokens = undefined;
+      next.cacheRead = undefined;
+      next.cacheWrite = undefined;
+      next.contextBudgetStatus = undefined;
+    } else if (hasUsageTotalTokens) {
+      next.totalTokens = totalTokens;
       next.totalTokensFresh = true;
     } else {
       next.totalTokens = undefined;
       next.totalTokensFresh = false;
     }
-    next.cacheRead = usage.cacheRead ?? 0;
-    next.cacheWrite = usage.cacheWrite ?? 0;
+    if (!useCompactionSnapshot) {
+      next.cacheRead = usage.cacheRead ?? 0;
+      next.cacheWrite = usage.cacheWrite ?? 0;
+    }
     // Snapshot cost like tokens (runEstimatedCostUsd is already computed from
     // cumulative run usage, so assign directly instead of accumulating).
     // Fixes #69347: cost was inflated 1x-72x by accumulating on every persist.
@@ -235,6 +246,11 @@ export async function updateSessionStoreAfterAgentRun(params: {
   } else if (compactionTokensAfter !== undefined && !preserveUserFacingRunState) {
     next.totalTokens = compactionTokensAfter;
     next.totalTokensFresh = true;
+    next.inputTokens = undefined;
+    next.outputTokens = undefined;
+    next.cacheRead = undefined;
+    next.cacheWrite = undefined;
+    next.contextBudgetStatus = undefined;
   } else if (
     !preserveUserFacingRunState &&
     typeof entry.totalTokens === "number" &&

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -527,6 +527,43 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     ),
   }));
 
+  vi.doMock("../cli-backends.js", async () => {
+    const actual = await vi.importActual<typeof import("../cli-backends.js")>("../cli-backends.js");
+    const claudeBinding = {
+      provider: "anthropic",
+      runtime: "claude-cli",
+      pluginId: "anthropic",
+    };
+    return {
+      ...actual,
+      listCliRuntimeModelBackendBindings: vi.fn((params?: unknown) => [
+        claudeBinding,
+        ...actual
+          .listCliRuntimeModelBackendBindings(
+            params as Parameters<typeof actual.listCliRuntimeModelBackendBindings>[0],
+          )
+          .filter(
+            (binding) =>
+              binding.provider !== claudeBinding.provider ||
+              binding.runtime !== claudeBinding.runtime,
+          ),
+      ]),
+      listCliRuntimeProviderIds: vi.fn(() => ["claude-cli"]),
+      resolveCliRuntimeModelBackendBinding: vi.fn(
+        (params: { provider?: string; runtime?: string }) =>
+          params.provider === claudeBinding.provider && params.runtime === claudeBinding.runtime
+            ? claudeBinding
+            : actual.resolveCliRuntimeModelBackendBinding(params),
+      ),
+      isCliRuntimeModelBackendForProvider: vi.fn(
+        (params: { provider?: string; runtime?: string }) =>
+          params.provider === claudeBinding.provider && params.runtime === claudeBinding.runtime
+            ? true
+            : actual.isCliRuntimeModelBackendForProvider(params),
+      ),
+    };
+  });
+
   vi.doMock("../workspace-run.js", () => ({
     resolveRunWorkspaceDir: vi.fn((params: { workspaceDir: string }) => ({
       workspaceDir: params.workspaceDir,

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -529,6 +529,8 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("../cli-backends.js", async () => {
     const actual = await vi.importActual<typeof import("../cli-backends.js")>("../cli-backends.js");
+    type ResolveBindingParams = Parameters<typeof actual.resolveCliRuntimeModelBackendBinding>[0];
+    type ProviderCheckParams = Parameters<typeof actual.isCliRuntimeModelBackendForProvider>[0];
     const claudeBinding = {
       provider: "anthropic",
       runtime: "claude-cli",
@@ -549,17 +551,15 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
           ),
       ]),
       listCliRuntimeProviderIds: vi.fn(() => ["claude-cli"]),
-      resolveCliRuntimeModelBackendBinding: vi.fn(
-        (params: { provider?: string; runtime?: string }) =>
-          params.provider === claudeBinding.provider && params.runtime === claudeBinding.runtime
-            ? claudeBinding
-            : actual.resolveCliRuntimeModelBackendBinding(params),
+      resolveCliRuntimeModelBackendBinding: vi.fn((params: ResolveBindingParams) =>
+        params.provider === claudeBinding.provider && params.runtime === claudeBinding.runtime
+          ? claudeBinding
+          : actual.resolveCliRuntimeModelBackendBinding(params),
       ),
-      isCliRuntimeModelBackendForProvider: vi.fn(
-        (params: { provider?: string; runtime?: string }) =>
-          params.provider === claudeBinding.provider && params.runtime === claudeBinding.runtime
-            ? true
-            : actual.isCliRuntimeModelBackendForProvider(params),
+      isCliRuntimeModelBackendForProvider: vi.fn((params: ProviderCheckParams) =>
+        params.provider === claudeBinding.provider && params.runtime === claudeBinding.runtime
+          ? true
+          : actual.isCliRuntimeModelBackendForProvider(params),
       ),
     };
   });

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -33,6 +33,12 @@ type MockCompactionResult =
       compacted: false;
       reason: string;
       result?: undefined;
+    }
+  | {
+      ok: true;
+      compacted: false;
+      reason: string;
+      result?: undefined;
     };
 
 export const mockedGlobalHookRunner = {

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1873,7 +1873,7 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
       expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
       expect(result.meta.error).toBeUndefined();
-      expect(result.meta.agentMeta?.compactionTokensAfter).toBe(0);
+      expect(result.meta.agentMeta?.compactionTokensAfter).toBeUndefined();
       const stored = JSON.parse(await fs.readFile(storePath, "utf8"))["test-key"];
       expect(stored.totalTokens).toBe(0);
       expect(stored.totalTokensFresh).toBe(true);

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentHarness } from "../harness/types.js";
 import type { AgentInternalEvent } from "../internal-events.js";
@@ -475,6 +478,9 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
         },
         agents: {
           defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
             models: {
               "anthropic/test-model": { agentRuntime: { id: "claude-cli" } },
             },
@@ -1800,6 +1806,44 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
   });
 
   it("recovers preflight compaction when stale tokens point at an empty transcript", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-empty-preflight-"));
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "test-key": {
+          sessionId: "test-session",
+          updatedAt: 1,
+          totalTokens: 1_500_000,
+          totalTokensFresh: true,
+          inputTokens: 20,
+          outputTokens: 10_855,
+          cacheRead: 1_761_324,
+          cacheWrite: 33_047,
+          contextBudgetStatus: {
+            schemaVersion: 1,
+            source: "pre-prompt-estimate",
+            updatedAt: 1,
+            provider: "claude-cli",
+            model: "claude-opus-4-7",
+            route: "compact_only",
+            shouldCompact: true,
+            estimatedPromptTokens: 1_794_391,
+            contextTokenBudget: 1_048_576,
+            promptBudgetBeforeReserve: 1_044_480,
+            reserveTokens: 4_096,
+            effectiveReserveTokens: 4_096,
+            remainingPromptBudgetTokens: 0,
+            overflowTokens: 749_911,
+            toolResultReducibleChars: 0,
+            messageCount: 0,
+            unwindowedMessageCount: 0,
+          },
+        },
+      }),
+      "utf8",
+    );
+
     mockedRunEmbeddedAttempt
       .mockResolvedValueOnce(
         makeAttemptResult({
@@ -1816,12 +1860,31 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       reason: "no real conversation messages",
     });
 
-    const result = await runEmbeddedAgent(overflowBaseRunParams);
+    try {
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        config: {
+          session: {
+            store: storePath,
+          },
+        } as RunEmbeddedAgentParams["config"],
+      });
 
-    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(result.meta.error).toBeUndefined();
-    expect(result.meta.agentMeta?.compactionTokensAfter).toBe(0);
+      expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+      expect(result.meta.error).toBeUndefined();
+      expect(result.meta.agentMeta?.compactionTokensAfter).toBe(0);
+      const stored = JSON.parse(await fs.readFile(storePath, "utf8"))["test-key"];
+      expect(stored.totalTokens).toBe(0);
+      expect(stored.totalTokensFresh).toBe(true);
+      expect(stored.inputTokens).toBeUndefined();
+      expect(stored.outputTokens).toBeUndefined();
+      expect(stored.cacheRead).toBeUndefined();
+      expect(stored.cacheWrite).toBeUndefined();
+      expect(stored.contextBudgetStatus).toBeUndefined();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("passes observed overflow token counts into compaction when providers report them", async () => {

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1816,7 +1816,7 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       reason: "no real conversation messages",
     });
 
-    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+    const result = await runEmbeddedAgent(overflowBaseRunParams);
 
     expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1799,6 +1799,31 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     expect(result.meta.agentMeta?.compactionTokensAfter).toBe(80_000);
   });
 
+  it("recovers preflight compaction when stale tokens point at an empty transcript", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: makeOverflowError(),
+          promptErrorSource: "precheck",
+          preflightRecovery: { route: "compact_only" },
+          assistantTexts: [],
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "no real conversation messages",
+    });
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.meta.error).toBeUndefined();
+    expect(result.meta.agentMeta?.compactionTokensAfter).toBe(0);
+  });
+
   it("passes observed overflow token counts into compaction when providers report them", async () => {
     const overflowError = new Error(
       '400 {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 277403 tokens > 200000 maximum"}}',

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1850,6 +1850,25 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
           promptError: makeOverflowError(),
           promptErrorSource: "precheck",
           preflightRecovery: { route: "compact_only" },
+          contextBudgetStatus: {
+            schemaVersion: 1,
+            source: "pre-prompt-estimate",
+            updatedAt: 1,
+            provider: "claude-cli",
+            model: "claude-opus-4-7",
+            route: "compact_only",
+            shouldCompact: true,
+            estimatedPromptTokens: 1_794_391,
+            contextTokenBudget: 1_048_576,
+            promptBudgetBeforeReserve: 1_044_480,
+            reserveTokens: 4_096,
+            effectiveReserveTokens: 4_096,
+            remainingPromptBudgetTokens: 0,
+            overflowTokens: 749_911,
+            toolResultReducibleChars: 0,
+            messageCount: 0,
+            unwindowedMessageCount: 0,
+          },
           assistantTexts: [],
         }),
       )
@@ -1874,6 +1893,7 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
       expect(result.meta.error).toBeUndefined();
       expect(result.meta.agentMeta?.compactionTokensAfter).toBeUndefined();
+      expect(result.meta.agentMeta?.contextBudgetStatus).toBeUndefined();
       const stored = JSON.parse(await fs.readFile(storePath, "utf8"))["test-key"];
       expect(stored.totalTokens).toBe(0);
       expect(stored.totalTokensFresh).toBe(true);

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { resolveStorePath, updateSessionStoreEntry } from "../../config/sessions.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import {
   resolveContextEngine,
@@ -220,6 +221,40 @@ function isNoRealConversationCompactionNoop(params: {
     params.compacted === false &&
     params.reason === NO_REAL_CONVERSATION_MESSAGES_REASON
   );
+}
+
+async function resetNoRealConversationTokenSnapshot(params: {
+  config?: RunEmbeddedAgentParams["config"];
+  sessionKey?: string;
+  agentId?: string;
+}): Promise<void> {
+  if (!params.sessionKey) {
+    return;
+  }
+  const storePath = resolveStorePath(params.config?.session?.store, { agentId: params.agentId });
+  try {
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey: params.sessionKey,
+      skipMaintenance: true,
+      takeCacheOwnership: true,
+      update: async () => ({
+        totalTokens: 0,
+        totalTokensFresh: true,
+        inputTokens: undefined,
+        outputTokens: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+        contextBudgetStatus: undefined,
+        updatedAt: Date.now(),
+      }),
+    });
+  } catch (err) {
+    log.warn(
+      `[context-overflow-precheck] failed to reset stale context snapshot for ` +
+        `${params.sessionKey}: ${String(err)}`,
+    );
+  }
 }
 
 function resolveAttemptDispatchApiKey(params: {
@@ -2129,6 +2164,11 @@ export async function runEmbeddedAgent(
               await runOwnsCompactionAfterHook("overflow recovery", compactResult);
               if (preflightRecovery && isNoRealConversationCompactionNoop(compactResult)) {
                 lastCompactionTokensAfter = 0;
+                await resetNoRealConversationTokenSnapshot({
+                  config: params.config,
+                  sessionKey: params.sessionKey,
+                  agentId: sessionAgentId,
+                });
                 log.info(
                   `[context-overflow-precheck] stale token state had no real conversation messages for ` +
                     `${provider}/${modelId}; resetting the context snapshot and retrying prompt`,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2163,7 +2163,7 @@ export async function runEmbeddedAgent(
               }
               await runOwnsCompactionAfterHook("overflow recovery", compactResult);
               if (preflightRecovery && isNoRealConversationCompactionNoop(compactResult)) {
-                lastCompactionTokensAfter = 0;
+                lastCompactionTokensAfter = undefined;
                 await resetNoRealConversationTokenSnapshot({
                   config: params.config,
                   sessionKey: params.sessionKey,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -207,7 +207,20 @@ const MID_TURN_PRECHECK_CONTINUATION_PROMPT =
   "Continue from the current transcript after the latest tool result. Do not repeat the original user request, and do not rerun completed tools unless the transcript shows they are still needed.";
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
+const NO_REAL_CONVERSATION_MESSAGES_REASON = "no real conversation messages";
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
+
+function isNoRealConversationCompactionNoop(params: {
+  ok?: boolean;
+  compacted?: boolean;
+  reason?: string;
+}): boolean {
+  return (
+    params.ok === true &&
+    params.compacted === false &&
+    params.reason === NO_REAL_CONVERSATION_MESSAGES_REASON
+  );
+}
 
 function resolveAttemptDispatchApiKey(params: {
   apiKeyInfo: ApiKeyInfo | null;
@@ -2114,6 +2127,17 @@ export async function runEmbeddedAgent(
                 };
               }
               await runOwnsCompactionAfterHook("overflow recovery", compactResult);
+              if (preflightRecovery && isNoRealConversationCompactionNoop(compactResult)) {
+                lastCompactionTokensAfter = 0;
+                log.info(
+                  `[context-overflow-precheck] stale token state had no real conversation messages for ` +
+                    `${provider}/${modelId}; resetting the context snapshot and retrying prompt`,
+                );
+                if (preflightRecovery.source === "mid-turn") {
+                  continueFromCurrentTranscript();
+                }
+                continue;
+              }
               if (compactResult.compacted) {
                 adoptCompactionTranscript(compactResult);
                 if (

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2164,6 +2164,7 @@ export async function runEmbeddedAgent(
               await runOwnsCompactionAfterHook("overflow recovery", compactResult);
               if (preflightRecovery && isNoRealConversationCompactionNoop(compactResult)) {
                 lastCompactionTokensAfter = undefined;
+                lastContextBudgetStatus = undefined;
                 await resetNoRealConversationTokenSnapshot({
                   config: params.config,
                   sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1627,6 +1627,7 @@ export async function runReplyAgent(params: {
       cfg,
       usage,
       lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
+      compactionTokensAfter: runResult.meta?.agentMeta?.compactionTokensAfter,
       promptTokens,
       usageIsContextSnapshot: usedCliProvider ? true : undefined,
       isHeartbeat,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -987,6 +987,7 @@ export function createFollowupRunner(params: {
           cfg: runtimeConfig,
           usage,
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
+          compactionTokensAfter: runResult.meta?.agentMeta?.compactionTokensAfter,
           promptTokens,
           isHeartbeat: opts?.isHeartbeat === true,
           preserveUserFacingSessionModelState: preserveUserFacingSessionState,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -51,6 +51,11 @@ function resolveNonNegativeNumber(value: number | undefined): number | undefined
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
+function resolveNonNegativeTokenCount(value: number | undefined): number | undefined {
+  const resolved = resolveNonNegativeNumber(value);
+  return resolved === undefined ? undefined : Math.floor(resolved);
+}
+
 function estimateSessionRunCostUsd(params: {
   cfg: OpenClawConfig;
   usage?: NormalizedUsage;
@@ -89,6 +94,7 @@ export async function persistSessionUsageUpdate(params: {
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;
   cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
+  compactionTokensAfter?: number;
   preserveFreshTotalTokensOnStaleUsage?: boolean;
   preserveUserFacingSessionModelState?: boolean;
   logLabel?: string;
@@ -107,8 +113,13 @@ export async function persistSessionUsageUpdate(params: {
     params.promptTokens > 0;
   const hasFreshContextSnapshot =
     Boolean(params.lastCallUsage) || hasPromptTokens || params.usageIsContextSnapshot === true;
+  const compactionTokensAfter = resolveNonNegativeTokenCount(params.compactionTokensAfter);
+  const hasCompactionSnapshot = compactionTokensAfter !== undefined;
+  const useCompactionSnapshot =
+    compactionTokensAfter !== undefined &&
+    (compactionTokensAfter === 0 || !hasFreshContextSnapshot);
 
-  if (hasUsage || hasFreshContextSnapshot) {
+  if (hasUsage || hasFreshContextSnapshot || hasCompactionSnapshot) {
     try {
       await updateSessionStoreEntry({
         storePath,
@@ -130,13 +141,15 @@ export async function persistSessionUsageUpdate(params: {
             params.lastCallUsage ??
             (params.usageIsContextSnapshot === true ? params.usage : undefined);
           const totalTokens =
-            hasFreshContextSnapshot && !preserveUserFacingRunState
-              ? deriveSessionTotalTokens({
-                  usage: usageForContext,
-                  contextTokens: resolvedContextTokens,
-                  promptTokens: params.promptTokens,
-                })
-              : undefined;
+            !preserveUserFacingRunState && useCompactionSnapshot
+              ? compactionTokensAfter
+              : hasFreshContextSnapshot && !preserveUserFacingRunState
+                ? deriveSessionTotalTokens({
+                    usage: usageForContext,
+                    contextTokens: resolvedContextTokens,
+                    promptTokens: params.promptTokens,
+                  })
+                : undefined;
           const runEstimatedCostUsd = preserveUserFacingRunState
             ? undefined
             : estimateSessionRunCostUsd({
@@ -167,13 +180,20 @@ export async function persistSessionUsageUpdate(params: {
             patch.cacheRead = cacheUsage?.cacheRead ?? 0;
             patch.cacheWrite = cacheUsage?.cacheWrite ?? 0;
           }
+          if (useCompactionSnapshot && !preserveUserFacingRunState) {
+            patch.inputTokens = undefined;
+            patch.outputTokens = undefined;
+            patch.cacheRead = undefined;
+            patch.cacheWrite = undefined;
+            patch.contextBudgetStatus = undefined;
+          }
           // Snapshot cost like tokens (runEstimatedCostUsd is already computed from
           // cumulative run usage, so assign directly instead of accumulating).
           // Fixes #69347: cost was inflated 1x-72x by accumulating on every persist.
           if (runEstimatedCostUsd !== undefined) {
             patch.estimatedCostUsd = runEstimatedCostUsd;
           }
-          if (hasFreshContextSnapshot && !preserveUserFacingRunState) {
+          if ((hasFreshContextSnapshot || hasCompactionSnapshot) && !preserveUserFacingRunState) {
             patch.totalTokens = totalTokens;
             patch.totalTokensFresh = true;
           } else if (

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -115,9 +115,6 @@ export async function persistSessionUsageUpdate(params: {
     Boolean(params.lastCallUsage) || hasPromptTokens || params.usageIsContextSnapshot === true;
   const compactionTokensAfter = resolveNonNegativeTokenCount(params.compactionTokensAfter);
   const hasCompactionSnapshot = compactionTokensAfter !== undefined;
-  const useCompactionSnapshot =
-    compactionTokensAfter !== undefined &&
-    (compactionTokensAfter === 0 || !hasFreshContextSnapshot);
 
   if (hasUsage || hasFreshContextSnapshot || hasCompactionSnapshot) {
     try {
@@ -140,16 +137,23 @@ export async function persistSessionUsageUpdate(params: {
           const usageForContext =
             params.lastCallUsage ??
             (params.usageIsContextSnapshot === true ? params.usage : undefined);
-          const totalTokens =
-            !preserveUserFacingRunState && useCompactionSnapshot
-              ? compactionTokensAfter
-              : hasFreshContextSnapshot && !preserveUserFacingRunState
-                ? deriveSessionTotalTokens({
-                    usage: usageForContext,
-                    contextTokens: resolvedContextTokens,
-                    promptTokens: params.promptTokens,
-                  })
-                : undefined;
+          const usageTotalTokens =
+            hasFreshContextSnapshot && !preserveUserFacingRunState
+              ? deriveSessionTotalTokens({
+                  usage: usageForContext,
+                  contextTokens: resolvedContextTokens,
+                  promptTokens: params.promptTokens,
+                })
+              : undefined;
+          const hasPositiveUsageTotal =
+            typeof usageTotalTokens === "number" &&
+            Number.isFinite(usageTotalTokens) &&
+            usageTotalTokens > 0;
+          const useCompactionSnapshot =
+            !preserveUserFacingRunState &&
+            compactionTokensAfter !== undefined &&
+            (compactionTokensAfter === 0 || !hasPositiveUsageTotal);
+          const totalTokens = useCompactionSnapshot ? compactionTokensAfter : usageTotalTokens;
           const runEstimatedCostUsd = preserveUserFacingRunState
             ? undefined
             : estimateSessionRunCostUsd({

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -152,7 +152,7 @@ export async function persistSessionUsageUpdate(params: {
           const useCompactionSnapshot =
             !preserveUserFacingRunState &&
             compactionTokensAfter !== undefined &&
-            (compactionTokensAfter === 0 || !hasPositiveUsageTotal);
+            !hasPositiveUsageTotal;
           const totalTokens = useCompactionSnapshot ? compactionTokensAfter : usageTotalTokens;
           const runEstimatedCostUsd = preserveUserFacingRunState
             ? undefined

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3236,6 +3236,96 @@ describe("persistSessionUsageUpdate", () => {
     });
   });
 
+  it("prefers zero compactionTokensAfter over CLI cache usage", async () => {
+    const storePath = await createStorePath("openclaw-usage-compaction-reset-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        totalTokens: 1_794_391,
+        totalTokensFresh: true,
+        inputTokens: 20,
+        outputTokens: 10_855,
+        cacheRead: 1_761_324,
+        cacheWrite: 33_047,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "claude-cli",
+          model: "claude-opus-4-7",
+          route: "compact_only",
+          shouldCompact: true,
+          estimatedPromptTokens: 1_794_391,
+          contextTokenBudget: 1_048_576,
+          promptBudgetBeforeReserve: 1_044_480,
+          reserveTokens: 4_096,
+          effectiveReserveTokens: 4_096,
+          remainingPromptBudgetTokens: 0,
+          overflowTokens: 749_911,
+          toolResultReducibleChars: 0,
+          messageCount: 0,
+          unwindowedMessageCount: 0,
+        },
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { input: 20, output: 10_855, cacheRead: 1_761_324, cacheWrite: 33_047 },
+      lastCallUsage: { input: 20, output: 10_855, cacheRead: 1_761_324, cacheWrite: 33_047 },
+      usageIsContextSnapshot: true,
+      providerUsed: "claude-cli",
+      contextTokensUsed: 1_048_576,
+      compactionTokensAfter: 0,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].totalTokens).toBe(0);
+    expect(stored[sessionKey].totalTokensFresh).toBe(true);
+    expect(stored[sessionKey].inputTokens).toBeUndefined();
+    expect(stored[sessionKey].outputTokens).toBeUndefined();
+    expect(stored[sessionKey].cacheRead).toBeUndefined();
+    expect(stored[sessionKey].cacheWrite).toBeUndefined();
+    expect(stored[sessionKey].contextBudgetStatus).toBeUndefined();
+  });
+
+  it("prefers fresh lastCallUsage over positive compactionTokensAfter", async () => {
+    const storePath = await createStorePath("openclaw-usage-compaction-positive-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        totalTokens: 180_000,
+        totalTokensFresh: true,
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { input: 100_000, output: 3_000, cacheRead: 20_000 },
+      lastCallUsage: { input: 91_000, output: 1_000, cacheRead: 4_000 },
+      providerUsed: "openai",
+      contextTokensUsed: 200_000,
+      compactionTokensAfter: 80_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].totalTokens).toBe(95_000);
+    expect(stored[sessionKey].totalTokensFresh).toBe(true);
+    expect(stored[sessionKey].inputTokens).toBe(100_000);
+    expect(stored[sessionKey].outputTokens).toBe(3_000);
+    expect(stored[sessionKey].cacheRead).toBe(4_000);
+  });
+
   it("persists totalTokens from promptTokens when usage is unavailable", async () => {
     const storePath = await createStorePath("openclaw-usage-");
     const sessionKey = "main";

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3236,7 +3236,7 @@ describe("persistSessionUsageUpdate", () => {
     });
   });
 
-  it("prefers zero compactionTokensAfter over CLI cache usage", async () => {
+  it("prefers fresh final usage over zero compactionTokensAfter", async () => {
     const storePath = await createStorePath("openclaw-usage-compaction-reset-");
     const sessionKey = "main";
     await seedSessionStore({
@@ -3251,25 +3251,6 @@ describe("persistSessionUsageUpdate", () => {
         outputTokens: 10_855,
         cacheRead: 1_761_324,
         cacheWrite: 33_047,
-        contextBudgetStatus: {
-          schemaVersion: 1,
-          source: "pre-prompt-estimate",
-          updatedAt: 1,
-          provider: "claude-cli",
-          model: "claude-opus-4-7",
-          route: "compact_only",
-          shouldCompact: true,
-          estimatedPromptTokens: 1_794_391,
-          contextTokenBudget: 1_048_576,
-          promptBudgetBeforeReserve: 1_044_480,
-          reserveTokens: 4_096,
-          effectiveReserveTokens: 4_096,
-          remainingPromptBudgetTokens: 0,
-          overflowTokens: 749_911,
-          toolResultReducibleChars: 0,
-          messageCount: 0,
-          unwindowedMessageCount: 0,
-        },
       },
     });
 
@@ -3285,13 +3266,12 @@ describe("persistSessionUsageUpdate", () => {
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
-    expect(stored[sessionKey].totalTokens).toBe(0);
+    expect(stored[sessionKey].totalTokens).toBe(1_794_391);
     expect(stored[sessionKey].totalTokensFresh).toBe(true);
-    expect(stored[sessionKey].inputTokens).toBeUndefined();
-    expect(stored[sessionKey].outputTokens).toBeUndefined();
-    expect(stored[sessionKey].cacheRead).toBeUndefined();
-    expect(stored[sessionKey].cacheWrite).toBeUndefined();
-    expect(stored[sessionKey].contextBudgetStatus).toBeUndefined();
+    expect(stored[sessionKey].inputTokens).toBe(20);
+    expect(stored[sessionKey].outputTokens).toBe(10_855);
+    expect(stored[sessionKey].cacheRead).toBe(1_761_324);
+    expect(stored[sessionKey].cacheWrite).toBe(33_047);
   });
 
   it("prefers fresh lastCallUsage over positive compactionTokensAfter", async () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3326,6 +3326,60 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored[sessionKey].cacheRead).toBe(4_000);
   });
 
+  it("uses positive compactionTokensAfter when final usage has no prompt total", async () => {
+    const storePath = await createStorePath("openclaw-usage-compaction-fallback-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        totalTokens: 180_000,
+        totalTokensFresh: true,
+        inputTokens: 5_000,
+        outputTokens: 2_000,
+        cacheRead: 50_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "claude-cli",
+          model: "claude-opus-4-7",
+          route: "compact_only",
+          shouldCompact: true,
+          estimatedPromptTokens: 180_000,
+          contextTokenBudget: 1_048_576,
+          promptBudgetBeforeReserve: 1_044_480,
+          reserveTokens: 4_096,
+          effectiveReserveTokens: 4_096,
+          remainingPromptBudgetTokens: 864_480,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 0,
+          unwindowedMessageCount: 0,
+        },
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { output: 125 },
+      lastCallUsage: { output: 125 },
+      providerUsed: "claude-cli",
+      compactionTokensAfter: 80_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].totalTokens).toBe(80_000);
+    expect(stored[sessionKey].totalTokensFresh).toBe(true);
+    expect(stored[sessionKey].inputTokens).toBeUndefined();
+    expect(stored[sessionKey].outputTokens).toBeUndefined();
+    expect(stored[sessionKey].cacheRead).toBeUndefined();
+    expect(stored[sessionKey].contextBudgetStatus).toBeUndefined();
+  });
+
   it("persists totalTokens from promptTokens when usage is unavailable", async () => {
     const storePath = await createStorePath("openclaw-usage-");
     const sessionKey = "main";

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -97,22 +97,33 @@ export type SessionsCleanupRunResult = {
 
 const EMPTY_TRANSCRIPT_MAX_BYTES = 4096;
 
+function isTranscriptMessageRole(role: unknown): boolean {
+  return (
+    role === "user" ||
+    role === "assistant" ||
+    role === "tool" ||
+    role === "toolResult" ||
+    role === "system"
+  );
+}
+
 function isTranscriptMessageRecord(entry: unknown): boolean {
   if (!entry || typeof entry !== "object") {
     return false;
   }
-  const record = entry as { role?: unknown; type?: unknown };
+  const record = entry as { message?: unknown; role?: unknown; type?: unknown };
   if (record.type === "message") {
     return true;
   }
-  return (
+  if (
     record.type === undefined &&
-    (record.role === "user" ||
-      record.role === "assistant" ||
-      record.role === "tool" ||
-      record.role === "toolResult" ||
-      record.role === "system")
-  );
+    record.message &&
+    typeof record.message === "object" &&
+    isTranscriptMessageRole((record.message as { role?: unknown }).role)
+  ) {
+    return true;
+  }
+  return record.type === undefined && isTranscriptMessageRole(record.role);
 }
 
 function transcriptHasNoMessageRecords(transcriptPath: string): boolean {

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -95,6 +95,44 @@ export type SessionsCleanupRunResult = {
   appliedSummaries: SessionCleanupSummary[];
 };
 
+const EMPTY_TRANSCRIPT_MAX_BYTES = 4096;
+
+function transcriptHasNoMessageRecords(transcriptPath: string): boolean {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(transcriptPath);
+  } catch {
+    return false;
+  }
+  if (!stat.isFile() || stat.size > EMPTY_TRANSCRIPT_MAX_BYTES) {
+    return false;
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(transcriptPath, "utf-8");
+  } catch {
+    return false;
+  }
+
+  const lines = raw.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+  if (lines.length === 0) {
+    return true;
+  }
+  for (const line of lines) {
+    let entry: unknown;
+    try {
+      entry = JSON.parse(line) as unknown;
+    } catch {
+      return false;
+    }
+    if (entry && typeof entry === "object" && (entry as { type?: unknown }).type === "message") {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function resolveSessionCleanupAction(params: {
   key: string;
   missingKeys: Set<string>;
@@ -220,7 +258,11 @@ function pruneMissingTranscriptEntries(params: {
     } catch {
       // Malformed legacy rows cannot resolve a transcript path; --fix-missing prunes them.
     }
-    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    if (
+      !transcriptPath ||
+      !fs.existsSync(transcriptPath) ||
+      transcriptHasNoMessageRecords(transcriptPath)
+    ) {
       delete params.store[key];
       removed += 1;
       params.onPruned?.(key);

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -97,6 +97,24 @@ export type SessionsCleanupRunResult = {
 
 const EMPTY_TRANSCRIPT_MAX_BYTES = 4096;
 
+function isTranscriptMessageRecord(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const record = entry as { role?: unknown; type?: unknown };
+  if (record.type === "message") {
+    return true;
+  }
+  return (
+    record.type === undefined &&
+    (record.role === "user" ||
+      record.role === "assistant" ||
+      record.role === "tool" ||
+      record.role === "toolResult" ||
+      record.role === "system")
+  );
+}
+
 function transcriptHasNoMessageRecords(transcriptPath: string): boolean {
   let stat: fs.Stats;
   try {
@@ -126,7 +144,7 @@ function transcriptHasNoMessageRecords(transcriptPath: string): boolean {
     } catch {
       return false;
     }
-    if (entry && typeof entry === "object" && (entry as { type?: unknown }).type === "message") {
+    if (isTranscriptMessageRecord(entry)) {
       return false;
     }
   }

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -331,6 +331,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     const emptyPresentTranscript = path.join(testDir, "empty-present.jsonl");
     const headerOnlyPresentTranscript = path.join(testDir, "header-only-present.jsonl");
     const userOnlyPresentTranscript = path.join(testDir, "user-only-present.jsonl");
+    const legacyRolePresentTranscript = path.join(testDir, "legacy-role-present.jsonl");
     await fs.writeFile(
       storePath,
       JSON.stringify(
@@ -360,6 +361,7 @@ describe("Integration: saveSessionStore with pruning", () => {
           "empty-present": { sessionId: "empty-present", updatedAt: now },
           "header-only-present": { sessionId: "header-only-present", updatedAt: now },
           "user-only-present": { sessionId: "user-only-present", updatedAt: now },
+          "legacy-role-present": { sessionId: "legacy-role-present", updatedAt: now },
         } satisfies Record<string, SessionEntry>,
         null,
         2,
@@ -379,6 +381,11 @@ describe("Integration: saveSessionStore with pruning", () => {
       '{"type":"session","id":"user-only-present"}\n{"type":"message","message":{"role":"user","content":"hello"}}\n',
       "utf-8",
     );
+    await fs.writeFile(
+      legacyRolePresentTranscript,
+      '{"role":"user","content":"legacy transcript row"}\n',
+      "utf-8",
+    );
 
     const dryRun = await runSessionsCleanup({
       cfg: {},
@@ -387,8 +394,8 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
     const preview = dryRun.previewResults[0];
     expect(preview?.summary.missing).toBe(5);
-    expect(preview?.summary.beforeCount).toBe(9);
-    expect(preview?.summary.afterCount).toBe(4);
+    expect(preview?.summary.beforeCount).toBe(10);
+    expect(preview?.summary.afterCount).toBe(5);
     expect(preview?.missingKeys.has("invalid-no-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-bad-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-missing-relative-file")).toBe(true);
@@ -397,6 +404,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(preview?.missingKeys.has("agent:main:metadata")).toBe(false);
     expect(preview?.missingKeys.has("legacy-present-invalid-id")).toBe(false);
     expect(preview?.missingKeys.has("user-only-present")).toBe(false);
+    expect(preview?.missingKeys.has("legacy-role-present")).toBe(false);
     const rawAfterDryRun = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
       unknown
@@ -410,19 +418,21 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
 
     expect(applied.appliedSummaries[0]?.missing).toBe(5);
-    expect(applied.appliedSummaries[0]?.afterCount).toBe(4);
+    expect(applied.appliedSummaries[0]?.afterCount).toBe(5);
     const persisted = loadSessionStore(storePath, { skipCache: true });
     expect(Object.keys(persisted)).toEqual([
       "agent:main:metadata",
       "legacy-present-invalid-id",
       "valid-present",
       "user-only-present",
+      "legacy-role-present",
     ]);
     expect(persisted["agent:main:metadata"]).toMatchObject({ groupActivation: "always" });
     expect(persisted["agent:main:metadata"]?.sessionId).toBeUndefined();
     expect(persisted["legacy-present-invalid-id"]?.sessionId).toBe("agent:main:main");
     await expectPathExists(validTranscript);
     await expectPathExists(legacyPresentTranscript);
+    await expectPathExists(legacyRolePresentTranscript);
     await expectPathExists(userOnlyPresentTranscript);
   });
 

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -328,6 +328,9 @@ describe("Integration: saveSessionStore with pruning", () => {
     const now = Date.now();
     const validTranscript = path.join(testDir, "valid-present.jsonl");
     const legacyPresentTranscript = path.join(testDir, "legacy-present.jsonl");
+    const emptyPresentTranscript = path.join(testDir, "empty-present.jsonl");
+    const headerOnlyPresentTranscript = path.join(testDir, "header-only-present.jsonl");
+    const userOnlyPresentTranscript = path.join(testDir, "user-only-present.jsonl");
     await fs.writeFile(
       storePath,
       JSON.stringify(
@@ -354,6 +357,9 @@ describe("Integration: saveSessionStore with pruning", () => {
             updatedAt: now,
           },
           "valid-present": { sessionId: "valid-present", updatedAt: now },
+          "empty-present": { sessionId: "empty-present", updatedAt: now },
+          "header-only-present": { sessionId: "header-only-present", updatedAt: now },
+          "user-only-present": { sessionId: "user-only-present", updatedAt: now },
         } satisfies Record<string, SessionEntry>,
         null,
         2,
@@ -362,6 +368,17 @@ describe("Integration: saveSessionStore with pruning", () => {
     );
     await fs.writeFile(validTranscript, "valid", "utf-8");
     await fs.writeFile(legacyPresentTranscript, "legacy", "utf-8");
+    await fs.writeFile(emptyPresentTranscript, "", "utf-8");
+    await fs.writeFile(
+      headerOnlyPresentTranscript,
+      '{"type":"session","id":"header-only-present","cwd":"/tmp"}\n',
+      "utf-8",
+    );
+    await fs.writeFile(
+      userOnlyPresentTranscript,
+      '{"type":"session","id":"user-only-present"}\n{"type":"message","message":{"role":"user","content":"hello"}}\n',
+      "utf-8",
+    );
 
     const dryRun = await runSessionsCleanup({
       cfg: {},
@@ -369,14 +386,17 @@ describe("Integration: saveSessionStore with pruning", () => {
       targets: [{ agentId: "main", storePath }],
     });
     const preview = dryRun.previewResults[0];
-    expect(preview?.summary.missing).toBe(3);
-    expect(preview?.summary.beforeCount).toBe(6);
-    expect(preview?.summary.afterCount).toBe(3);
+    expect(preview?.summary.missing).toBe(5);
+    expect(preview?.summary.beforeCount).toBe(9);
+    expect(preview?.summary.afterCount).toBe(4);
     expect(preview?.missingKeys.has("invalid-no-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-bad-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-missing-relative-file")).toBe(true);
+    expect(preview?.missingKeys.has("empty-present")).toBe(true);
+    expect(preview?.missingKeys.has("header-only-present")).toBe(true);
     expect(preview?.missingKeys.has("agent:main:metadata")).toBe(false);
     expect(preview?.missingKeys.has("legacy-present-invalid-id")).toBe(false);
+    expect(preview?.missingKeys.has("user-only-present")).toBe(false);
     const rawAfterDryRun = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
       unknown
@@ -389,19 +409,21 @@ describe("Integration: saveSessionStore with pruning", () => {
       targets: [{ agentId: "main", storePath }],
     });
 
-    expect(applied.appliedSummaries[0]?.missing).toBe(3);
-    expect(applied.appliedSummaries[0]?.afterCount).toBe(3);
+    expect(applied.appliedSummaries[0]?.missing).toBe(5);
+    expect(applied.appliedSummaries[0]?.afterCount).toBe(4);
     const persisted = loadSessionStore(storePath, { skipCache: true });
     expect(Object.keys(persisted)).toEqual([
       "agent:main:metadata",
       "legacy-present-invalid-id",
       "valid-present",
+      "user-only-present",
     ]);
     expect(persisted["agent:main:metadata"]).toMatchObject({ groupActivation: "always" });
     expect(persisted["agent:main:metadata"]?.sessionId).toBeUndefined();
     expect(persisted["legacy-present-invalid-id"]?.sessionId).toBe("agent:main:main");
     await expectPathExists(validTranscript);
     await expectPathExists(legacyPresentTranscript);
+    await expectPathExists(userOnlyPresentTranscript);
   });
 
   it("sessions cleanup previews stale direct DM rows after dmScope returns to main", async () => {

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -332,6 +332,10 @@ describe("Integration: saveSessionStore with pruning", () => {
     const headerOnlyPresentTranscript = path.join(testDir, "header-only-present.jsonl");
     const userOnlyPresentTranscript = path.join(testDir, "user-only-present.jsonl");
     const legacyRolePresentTranscript = path.join(testDir, "legacy-role-present.jsonl");
+    const legacyNestedRolePresentTranscript = path.join(
+      testDir,
+      "legacy-nested-role-present.jsonl",
+    );
     await fs.writeFile(
       storePath,
       JSON.stringify(
@@ -362,6 +366,10 @@ describe("Integration: saveSessionStore with pruning", () => {
           "header-only-present": { sessionId: "header-only-present", updatedAt: now },
           "user-only-present": { sessionId: "user-only-present", updatedAt: now },
           "legacy-role-present": { sessionId: "legacy-role-present", updatedAt: now },
+          "legacy-nested-role-present": {
+            sessionId: "legacy-nested-role-present",
+            updatedAt: now,
+          },
         } satisfies Record<string, SessionEntry>,
         null,
         2,
@@ -386,6 +394,11 @@ describe("Integration: saveSessionStore with pruning", () => {
       '{"role":"user","content":"legacy transcript row"}\n',
       "utf-8",
     );
+    await fs.writeFile(
+      legacyNestedRolePresentTranscript,
+      '{"message":{"role":"user","content":"legacy nested transcript row"}}\n',
+      "utf-8",
+    );
 
     const dryRun = await runSessionsCleanup({
       cfg: {},
@@ -394,8 +407,8 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
     const preview = dryRun.previewResults[0];
     expect(preview?.summary.missing).toBe(5);
-    expect(preview?.summary.beforeCount).toBe(10);
-    expect(preview?.summary.afterCount).toBe(5);
+    expect(preview?.summary.beforeCount).toBe(11);
+    expect(preview?.summary.afterCount).toBe(6);
     expect(preview?.missingKeys.has("invalid-no-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-bad-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-missing-relative-file")).toBe(true);
@@ -405,6 +418,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(preview?.missingKeys.has("legacy-present-invalid-id")).toBe(false);
     expect(preview?.missingKeys.has("user-only-present")).toBe(false);
     expect(preview?.missingKeys.has("legacy-role-present")).toBe(false);
+    expect(preview?.missingKeys.has("legacy-nested-role-present")).toBe(false);
     const rawAfterDryRun = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
       unknown
@@ -418,7 +432,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
 
     expect(applied.appliedSummaries[0]?.missing).toBe(5);
-    expect(applied.appliedSummaries[0]?.afterCount).toBe(5);
+    expect(applied.appliedSummaries[0]?.afterCount).toBe(6);
     const persisted = loadSessionStore(storePath, { skipCache: true });
     expect(Object.keys(persisted)).toEqual([
       "agent:main:metadata",
@@ -426,6 +440,7 @@ describe("Integration: saveSessionStore with pruning", () => {
       "valid-present",
       "user-only-present",
       "legacy-role-present",
+      "legacy-nested-role-present",
     ]);
     expect(persisted["agent:main:metadata"]).toMatchObject({ groupActivation: "always" });
     expect(persisted["agent:main:metadata"]?.sessionId).toBeUndefined();
@@ -433,6 +448,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     await expectPathExists(validTranscript);
     await expectPathExists(legacyPresentTranscript);
     await expectPathExists(legacyRolePresentTranscript);
+    await expectPathExists(legacyNestedRolePresentTranscript);
     await expectPathExists(userOnlyPresentTranscript);
   });
 


### PR DESCRIPTION
## Summary
- Treat the specific preflight compaction result `ok: true`, `compacted: false`, `reason: no real conversation messages` as stale session token metadata instead of a hard compaction failure.
- Reset the context snapshot to 0 and retry the prompt so an empty/header-only transcript can self-heal on the next inbound message.
- Extend `openclaw sessions cleanup --fix-missing` to prune empty or header-only transcript rows, while preserving both typed message transcripts and legacy role-only transcript rows.
- Document the repair behavior.

## Verification
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.test.ts src/agents/embedded-agent-runner/run.empty-error-retry.test.ts src/agents/command/session-store.test.ts src/config/sessions/store.pruning.integration.test.ts src/gateway/server.sessions.store-rpc.test.ts extensions/discord/src/monitor/message-handler.preflight.test.ts`
- real local cleanup proof command shown below

## Real behavior proof
Behavior addressed: an over-budget session entry with an empty/header-only transcript no longer bounces every message after preflight compaction returns `no real conversation messages`; cleanup also repairs the empty-present transcript case without deleting message-bearing transcripts.

Real environment tested: local macOS checkout, Node/tsx runtime, real temporary `sessions.json`, and real transcript files covering empty, header-only, typed-message, and legacy role-only JSONL shapes.

Exact steps or command run after this patch: created a temporary `sessions.json` with `empty-present`, `header-only-present`, `typed-message-present`, and `legacy-role-present` rows; wrote matching JSONL transcripts on disk; ran `runSessionsCleanup(... fixMissing: true ...)` in dry-run and apply modes; reran the focused embedded-runner, session-store, gateway session RPC, cleanup, and Discord preflight suites listed above.

Evidence after fix: copied terminal output from the local cleanup proof command:
```text
dry_run missing=2 after=2 emptyFlagged=true headerFlagged=true typedMessagePreserved=true legacyRolePreserved=true
applied missing=2 remainingKeys=legacy-role-present,typed-message-present
remainingFiles typed=true legacy=true empty=true header=true
```

Observed result after fix: `--fix-missing` detects the empty and header-only stale-token rows before mutating, then removes only those store rows when applied. It preserves both a modern `type: "message"` transcript and a legacy `role: "user"` transcript, which also fixes the failed `sessions.compact` CI shard where a valid legacy transcript was being pruned before compaction. The runner regression still passes, showing `no real conversation messages` preflight compaction retries instead of surfacing an error with `compactionTokensAfter: 0`.

What was not tested: a live Discord account reproduction was not forced; the core state-machine deadlock, cleanup repair path, legacy transcript preservation, gateway compact RPC path, and Discord preflight surface were verified locally with deterministic runner/gateway tests and real temp session-store files.

Fixes #87016.

If this PR is squash/reworked, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>