### PR TITLE
fix(codex): prevent false idle timeouts under notification queue delay

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1979,7 +1979,12 @@ export async function runCodexAppServerAttempt(
   };
 
   const fireTurnAttemptIdleTimeout = () => {
-    if (completed || runAbortController.signal.aborted || !turnAttemptIdleWatchArmed) {
+    if (
+      completed ||
+      terminalTurnNotificationQueued ||
+      runAbortController.signal.aborted ||
+      !turnAttemptIdleWatchArmed
+    ) {
       return;
     }
     const idleMs = Math.max(0, Date.now() - turnAttemptLastProgressAt);
@@ -2014,6 +2019,7 @@ export async function runCodexAppServerAttempt(
   const fireTurnCompletionIdleTimeout = () => {
     if (
       completed ||
+      terminalTurnNotificationQueued ||
       runAbortController.signal.aborted ||
       !turnCompletionIdleWatchArmed ||
       activeAppServerTurnRequests > 0
@@ -2053,6 +2059,7 @@ export async function runCodexAppServerAttempt(
   const fireTurnTerminalIdleTimeout = () => {
     if (
       completed ||
+      terminalTurnNotificationQueued ||
       runAbortController.signal.aborted ||
       !turnTerminalIdleWatchArmed ||
       activeAppServerTurnRequests > 0
@@ -2580,6 +2587,17 @@ export async function runCodexAppServerAttempt(
     }
     if (isTerminalTurnNotificationForTurn(notification, turnId)) {
       terminalTurnNotificationQueued = true;
+    }
+    // Touch idle-watch timestamps at receive time (not just at process time)
+    // so that the completion-idle timer sees live binary I/O even when the
+    // notification queue is backed up behind setImmediate yields under heavy
+    // event-loop load.  See openclaw/openclaw#86948.
+    if (correlation.matchesActiveTurn !== false) {
+      const now = Date.now();
+      turnCompletionLastActivityAt = now;
+      turnCompletionLastActivityReason = `notification:${notification.method}`;
+      turnAttemptLastProgressAt = now;
+      turnAttemptLastProgressReason = `notification:${notification.method}`;
     }
     notificationQueue = notificationQueue.then(
       () => handleNotification(notification),


### PR DESCRIPTION
## Summary

- Check `terminalTurnNotificationQueued` in all three idle timeout handlers so they don't fire when `turn/completed` is already queued but not yet processed
- Touch `turnCompletionLastActivityAt` / `turnAttemptLastProgressAt` at enqueue time in `enqueueNotification`, not just at process time

Companion to #87022 — that PR bounds the fallout (client retirement, failover policy) when a timeout fires; this PR prevents the false timeout from firing in the first place.

## Root cause

`waitForCodexNotificationDispatchTurn()` yields via `setImmediate` (introduced in `ea16a5e9e1` / #82333). Under event-loop saturation, `turn/completed` sits in the notification queue past the 60s idle threshold. The idle timer checks process-time timestamps, but the notification hasn't been processed yet — only enqueued. The `terminalTurnNotificationQueued` flag (added in `4cbf616d30`) already marks this at enqueue time, but the idle timeout handlers don't check it.

## Changes

**`extensions/codex/src/app-server/run-attempt.ts`:**

1. `fireTurnAttemptIdleTimeout`: add `terminalTurnNotificationQueued` to guard condition
2. `fireTurnCompletionIdleTimeout`: add `terminalTurnNotificationQueued` to guard condition
3. `fireTurnTerminalIdleTimeout`: add `terminalTurnNotificationQueued` to guard condition
4. `enqueueNotification`: touch `turnCompletionLastActivityAt` and `turnAttemptLastProgressAt` at receive time for notifications matching the active turn, so the idle timer sees live binary I/O even when the queue is backed up

## Real behavior proof

**Before (on `5a7d5c6def`, includes #87022):** Two false idle timeouts in 25 minutes, TUI channel, `openai/gpt-5.5`:

```
22:46:34 [WARN] codex app-server turn idle timed out waiting for completion
22:46:34 [WARN] codex app-server client retired after timed-out turn
23:07:37 [WARN] codex app-server turn idle timed out waiting for completion
23:07:37 [WARN] codex app-server client retired after timed-out turn
```

Monitor CSV (pre-fix):
```
timestamp  cpu_pct  total_fds  tcp_fds  tcp_established  event_loop_warn
23:59:12   102.7    81         5        3                0
23:59:19   103.7    81         5        3                0
23:59:25   105.8    81         5        3                0
23:59:58   145.9    90         6        3                0
00:00:37   187.9    89         6        3                0
```

**After (fix applied, gateway restarted at 23:56):** Turn ran 4m 38s+ past the 60s threshold, zero false timeouts:

```
timestamp  cpu_pct  total_fds  tcp_fds  tcp_established  event_loop_warn
00:01:17   0.2      89         6        3                0
00:02:10   0.1      89         6        3                0
00:03:09   0.1      89         6        3                0
00:04:08   0.1      89         6        3                0
00:05:07   0.2      89         6        3                0
00:06:06   0.3      89         6        3                0
```

Zero timeouts, CPU 0.1–1.4%, fds stable at 89–90, TCP stable at 6–7.

## Separate issue noted

During post-fix testing, a **genuine** binary stall was observed — the codex binary stops sending notifications after `rawResponseItem/completed` and `turn/completed` never arrives (377s+). This fix correctly does NOT suppress that timeout, since `terminalTurnNotificationQueued` is never set when `turn/completed` genuinely never arrives. Filed separately.

Refs #86948, #87022.
cc @steipete @Peetiegonzalez