### PR TITLE
Skip QMD memory search when scope denies

### DIFF
--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -114,6 +114,10 @@ export function getMemorySearchManagerMockCalls(): number {
   return getMemorySearchManagerMock.mock.calls.length;
 }
 
+export function getMemorySearchMockCalls(): number {
+  return stubManager.search.mock.calls.length;
+}
+
 export function getMemorySearchManagerMockConfigs(): unknown[] {
   return getMemorySearchManagerMock.mock.calls.map(([params]) => params.cfg);
 }

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -266,7 +266,7 @@ describe("QmdMemoryManager", () => {
     spawnMock.mockImplementation(() => createMockChild());
     watchMock.mockClear();
     withFileLockMock.mockClear();
-    logWarnMock.mockClear();
+    logDebugMock.mockClear();
     logDebugMock.mockClear();
     logInfoMock.mockClear();
     tmpRoot = path.join(fixtureRoot, `case-${fixtureCount++}`);
@@ -4201,8 +4201,8 @@ describe("QmdMemoryManager", () => {
     ).resolves.toStrictEqual([]);
 
     expect(spawnMock.mock.calls.length).toBe(beforeCalls);
-    expectMockMessageContains(logWarnMock, "qmd search denied by scope");
-    expectMockMessageContains(logWarnMock, "chatType=channel");
+    expectMockMessageContains(logDebugMock, "qmd search skipped_by_scope");
+    expectMockMessageContains(logDebugMock, "chatType=channel");
 
     await manager.close();
   });

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2682,8 +2682,8 @@ export class QmdMemoryManager implements MemorySearchManager {
     const channel = deriveQmdScopeChannel(sessionKey) ?? "unknown";
     const chatType = deriveQmdScopeChatType(sessionKey) ?? "unknown";
     const key = sessionKey?.trim() || "<none>";
-    log.warn(
-      `qmd search denied by scope (channel=${channel}, chatType=${chatType}, session=${key})`,
+    log.debug(
+      `qmd search skipped_by_scope (channel=${channel}, chatType=${chatType}, session=${key})`,
     );
   }
 

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -3,6 +3,7 @@ import {
   getMemorySearchManagerMockCalls,
   getMemorySearchManagerMockConfigs,
   getMemorySearchManagerMockParams,
+  getMemorySearchMockCalls,
   resetMemoryToolMockState,
   setMemoryBackend,
   setMemorySearchImpl,
@@ -226,6 +227,74 @@ describe("memory_search unavailable payloads", () => {
     expect(details.debug?.fallback).toBe("unsupported-search-flags");
     expect(details.debug?.hits).toBe(1);
     expect(details.debug?.searchMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("skips qmd memory manager resolution when session scope denies search", async () => {
+    setMemoryBackend("qmd");
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        memory: {
+          backend: "qmd",
+          qmd: {
+            scope: {
+              default: "deny",
+              rules: [{ action: "allow", match: { chatType: "direct" } }],
+            },
+          },
+        },
+      },
+      agentSessionKey: "agent:main:slack:channel:c123",
+    });
+
+    const result = await tool.execute("scope-denied", { query: "prior work" });
+
+    expect(result.details).toMatchObject({
+      results: [],
+      debug: {
+        backend: "qmd",
+        skipped: "skipped_by_scope",
+        channel: "slack",
+        chatType: "channel",
+        sessionKey: "agent:main:slack:channel:c123",
+        searchMs: 0,
+        hits: 0,
+      },
+    });
+    expect(getMemorySearchManagerMockCalls()).toBe(0);
+    expect(getMemorySearchMockCalls()).toBe(0);
+  });
+
+  it("uses qmd memory manager when session scope allows search", async () => {
+    setMemoryBackend("qmd");
+    setMemorySearchImpl(async () => [
+      {
+        path: "MEMORY.md",
+        startLine: 1,
+        endLine: 1,
+        score: 0.9,
+        snippet: "prior work",
+        source: "memory",
+      },
+    ]);
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        memory: {
+          backend: "qmd",
+          qmd: {
+            scope: {
+              default: "deny",
+              rules: [{ action: "allow", match: { chatType: "direct" } }],
+            },
+          },
+        },
+      },
+      agentSessionKey: "agent:main:slack:dm:u123",
+    });
+
+    await tool.execute("scope-allowed", { query: "prior work" });
+
+    expect(getMemorySearchManagerMockCalls()).toBe(1);
+    expect(getMemorySearchMockCalls()).toBe(1);
   });
 });
 

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -1,4 +1,10 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import {
+  deriveQmdScopeChannel,
+  deriveQmdScopeChatType,
+  isQmdScopeAllowed,
+} from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   asToolParamsRecord,
@@ -36,6 +42,8 @@ import {
   MemorySearchSchema,
   searchMemoryCorpusSupplements,
 } from "./tools.shared.js";
+
+const log = createSubsystemLogger("memory");
 
 type MemorySearchToolResult =
   | (MemorySearchResult & { corpus: MemorySource })
@@ -142,6 +150,42 @@ function normalizeActiveMemoryQmdSearchMode(
 
 function isActiveMemorySessionKey(sessionKey?: string): boolean {
   return typeof sessionKey === "string" && sessionKey.includes(":active-memory:");
+}
+
+type QmdSearchScopeDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: "skipped_by_scope";
+      channel: string;
+      chatType: string;
+      sessionKey: string;
+    };
+
+function resolveQmdSearchScopeDecision(params: {
+  backend: string;
+  qmd?: { scope?: Parameters<typeof isQmdScopeAllowed>[0] };
+  sessionKey?: string;
+}): QmdSearchScopeDecision {
+  if (params.backend !== "qmd" || !params.qmd) {
+    return { allowed: true };
+  }
+  if (isQmdScopeAllowed(params.qmd.scope, params.sessionKey)) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    reason: "skipped_by_scope",
+    channel: deriveQmdScopeChannel(params.sessionKey) ?? "unknown",
+    chatType: deriveQmdScopeChatType(params.sessionKey) ?? "unknown",
+    sessionKey: params.sessionKey?.trim() || "<none>",
+  };
+}
+
+function logQmdSearchSkippedByScope(decision: Exclude<QmdSearchScopeDecision, { allowed: true }>) {
+  log.info(
+    `qmd search skipped_by_scope (channel=${decision.channel}, chatType=${decision.chatType}, session=${decision.sessionKey})`,
+  );
 }
 
 function resolveActiveMemoryQmdSearchModeOverride(
@@ -266,7 +310,17 @@ export function createMemorySearchTool(options: {
         const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
         const shouldQueryMemory = requestedCorpus !== "wiki";
         const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
-        const memory = shouldQueryMemory ? await getMemoryManagerContext({ cfg, agentId }) : null;
+        const resolvedMemoryBackend = resolveMemoryBackendConfig({ cfg, agentId });
+        const scopeDecision = shouldQueryMemory
+          ? resolveQmdSearchScopeDecision({
+              ...resolvedMemoryBackend,
+              sessionKey: options.agentSessionKey,
+            })
+          : ({ allowed: true } as const);
+        const shouldOpenMemoryManager = shouldQueryMemory && scopeDecision.allowed;
+        const memory = shouldOpenMemoryManager
+          ? await getMemoryManagerContext({ cfg, agentId })
+          : null;
         if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
           return jsonResult(buildMemorySearchUnavailableResult(memory.error));
         }
@@ -298,11 +352,27 @@ export function createMemorySearchTool(options: {
                 configuredMode?: string;
                 effectiveMode?: string;
                 fallback?: string;
+                skipped?: "skipped_by_scope";
+                channel?: string;
+                chatType?: string;
+                sessionKey?: string;
                 searchMs: number;
                 hits: number;
               }
             | undefined;
-          if (shouldQueryMemory && memory && !("error" in memory)) {
+          if (shouldQueryMemory && !scopeDecision.allowed) {
+            logQmdSearchSkippedByScope(scopeDecision);
+            searchDebug = {
+              backend: "qmd",
+              skipped: scopeDecision.reason,
+              channel: scopeDecision.channel,
+              chatType: scopeDecision.chatType,
+              sessionKey: scopeDecision.sessionKey,
+              searchMs: 0,
+              hits: 0,
+            };
+          }
+          if (shouldOpenMemoryManager && memory && !("error" in memory)) {
             let activeMemory = memory;
             const runtimeDebug: MemorySearchRuntimeDebug[] = [];
             const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
@@ -356,10 +426,12 @@ export function createMemorySearchTool(options: {
             }
             const status = activeMemory.manager.status();
             const decorated = decorateCitations(rawResults, includeCitations);
-            const resolved = resolveMemoryBackendConfig({ cfg, agentId });
             const memoryResults =
               status.backend === "qmd"
-                ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
+                ? clampResultsByInjectedChars(
+                    decorated,
+                    resolvedMemoryBackend.qmd?.limits.maxInjectedChars,
+                  )
                 : decorated;
             surfacedMemoryResults = memoryResults.map((result) => ({
               ...result,


### PR DESCRIPTION
## Summary

- short-circuit QMD-backed `memory_search` when the current session is denied by `memory.qmd.scope`
- return an empty successful result with `debug.skipped = "skipped_by_scope"` instead of opening the memory manager
- keep the QMD manager's own scope guard as defense in depth, but log it as `skipped_by_scope` at debug level instead of a warning-style denial

## Why

Denied QMD memory searches are correctly blocked today, but the request can still reach the QMD manager in channel/thread contexts that are outside scope. This creates noisy `qmd search denied by scope` journal entries and can waste work before the denial is known.

## Validation

- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory-tool-manager-mock.ts extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- `pnpm test extensions/memory-core/src/tools.test.ts`
- `pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts -- -t "logs when qmd scope denies search"`
- `pnpm tsgo:extensions:test`

Note: running the full `extensions/memory-core/src/memory/qmd-manager.test.ts` file on current `origin/main` still shows unrelated pre-existing warning-mock accumulation failures in other tests; the changed scope-denial test passes when targeted.
