### PR TITLE
fix(ui): bypass service worker for top-level navigations

### DIFF
--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -49,6 +49,14 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  // Skip top-level navigations so the browser can handle HTTP auth
+  // challenges natively — WWW-Authenticate dialogs are bypassed when the
+  // response comes from a service worker, breaking reverse-proxy setups
+  // with basic/digest auth in front of the gateway.
+  if (event.request.mode === "navigate") {
+    return;
+  }
+
   // Skip non-UI routes — API, RPC, and plugin routes should never be cached.
   if (
     url.pathname.startsWith("/api/") ||


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**
The Control UI service worker intercepts top-level navigation requests in its network-first branch and forwards the response back to the page via `event.respondWith()`. When the network returns a `401 Unauthorized` with `WWW-Authenticate`, the browser's native credentials dialog does **not** fire — per the Fetch/HTML spec, only responses delivered straight from the network trigger the HTTP auth challenge UI. Responses traversing a service worker are treated as opaque application responses.

This is invisible in Gateway-direct setups (where auth happens inside the SPA), but breaks every reverse-proxy deployment where an HTTP auth layer (basic, digest, negotiate) sits in front of the gateway (Caddy, Traefik, nginx, Pomerium, etc.). On a full browser restart the browser clears its HTTP-auth memory cache; the next navigation goes through the SW, the SW forwards a network 401 back, the dialog never opens, and the user sees a bare `401 Unauthorized` page. The only recovery is to clear the site data (which also unregisters the SW), then re-authenticate from scratch.

**Why does this matter now?**
Reverse-proxy-fronted deployments are explicitly supported (`gateway.auth.mode: "trusted-proxy"`; see #71669 and #53274 for context on bypass policies for these setups), and #85939 already tracks side-effects of the SW caching policy. With `controlUi.dangerouslyDisableDeviceAuth: true`, the operator has explicitly delegated authentication to the reverse proxy — but the SW still silently breaks the browser-native handoff.

**What is the intended outcome?**
- On every fresh navigation (full reload or browser restart) the browser handles the 401 + `WWW-Authenticate` directly and shows the credentials prompt.
- Once basic_auth is filled, the browser caches the credentials in its per-process HTTP-auth memory and attaches them automatically to subsequent XHR/fetch; the SW takes over again for sub-resources (cache-first for `/assets/*`, network-first for everything else).
- All other SW responsibilities (precaching, cache versioning, push notifications, asset caching, `/api/` `/rpc` `/plugins/` bypass) are unchanged.

**What is intentionally out of scope?**
- Offline-first navigation of the app shell. The SPA cannot function without network anyway (every API/RPC/plugin call already short-circuits the SW), so an offline shell would render but not work. Losing offline shell load is an acceptable trade-off.
- Any change to gateway-side auth, token routing, `control-ui-config` endpoints, or session/scope handling.
- Any change to the `/api/`, `/rpc`, `/plugins/`, or `/assets/` SW branches.

**What does success look like?**
- On a reverse-proxy deployment with `controlUi.dangerouslyDisableDeviceAuth: true` plus an HTTP basic_auth layer, closing the browser and reopening triggers the basic_auth dialog on first visit instead of a bare 401 page.
- No regression for Gateway-direct deployments (the only behavioral change is for top-level navigations, which always need fresh network data anyway since `/api/` and `/rpc` are already excluded from caching).

**What should reviewers focus on?**
- The 4-line guard inserted right after the GET / same-origin guard in `ui/public/sw.js` (`event.request.mode === "navigate"` → early return).
- Whether the offline-shell trade-off is acceptable, or whether maintainers prefer a narrower variant (only skip navigation when the response is 401). The 401-conditional variant is non-trivial because once the SW has called `fetch` and received the response, returning it via `respondWith` already poisons the auth-UI handoff — it requires re-issuing the request outside the SW via a cache-busting redirect or `clients.matchAll() + client.navigate()`.

## Linked context

Tracks #87268 (defect filed separately so it stays trackable independently of this PR's review outcome; ClawSweeper review on that issue concurs the bug is source-reproducible on current `main` / `v2026.5.26` and points back to this PR as the active fix path).

Related #85939 #71669 #53274

This PR was not maintainer-requested; it was surfaced while diagnosing a Caddy + `dangerouslyDisableDeviceAuth: true` deployment.

## Real behavior proof

- **Behavior or issue addressed**: bare `401 Unauthorized` page (no credentials dialog) on full browser restart for OpenClaw Control UI hosted behind an HTTP basic_auth reverse proxy.
- **Real environment tested**:
  - OpenClaw `2026.5.22` gateway, `gateway.auth.mode: "trusted-proxy"`, `controlUi.dangerouslyDisableDeviceAuth: true`, loopback bind on port 18789.
  - Reverse proxy: Caddy 2.11.3 with `basic_auth` + `reverse_proxy` injecting `X-Forwarded-User: admin`.
  - Browser: Firefox (latest stable, normal profile).
- **Reproduction (without the patch)**:
  1. Open Control UI URL, complete basic_auth in the browser, complete the SPA's own first-time setup if any, confirm the UI is working.
  2. Close every Firefox window/process (`pgrep -a firefox` returns nothing).
  3. Reopen Firefox, navigate to the same Control UI URL.
  4. Observed: bare `401 Unauthorized` page with no credentials dialog. Firefox DevTools Network tab shows a single request `GET <host>/openclaw/overview`, **Transferred: service worker**, **Status: 401**.
  5. Recovery requires clearing the site data (cookies + storage + SW registration), which wipes any persisted Control UI state.
- **Control case**: same reproduction in a Firefox private window — works correctly even after restarting Firefox (private windows don't keep a persisted SW). Confirms the SW is the differentiator.
- **Exact code path observed**: `ui/public/sw.js` falls into the `else` branch (network-first) at line 76 for the navigation `GET /openclaw/overview`, calls `fetch(event.request)`, receives the Caddy `401 WWW-Authenticate: Basic realm="restricted"` response, and returns it via `event.respondWith()`. Per [MDN: Using Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers) and Fetch spec, responses delivered through a service worker do not trigger the browser's HTTP authentication challenge UI.
- **Exact steps or command run after this patch**:
  1. Build the patched SW: `pnpm ui:build` — emits `dist/control-ui/sw.js` containing the new `if (event.request.mode === "navigate") return;` early-return.
  2. Swap the rebuilt `sw.js` onto the served gateway (same reverse-proxy deployment as the repro).
  3. Fully close Firefox: `pkill -TERM firefox && sleep 2 && pgrep -a firefox` returns empty.
  4. Reopen Firefox, navigate to the same Control UI URL with DevTools open (Network tab, "Persist Logs" enabled).
  5. Observe the credentials dialog firing and capture the navigation request entry in DevTools.
- **Evidence after fix**:

  Firefox DevTools network capture of the navigation request after applying the patch (domain redacted), retrieved from a fresh browser session on the same Caddy `basic_auth` reverse-proxy deployment. The capture shows the request hitting the network (no service-worker layer) and the `401 WWW-Authenticate: Basic realm="restricted"` response reaching the browser, which then fires the native auth dialog.

  <img width="2082" height="1119" alt="Firefox DevTools network capture after fix" src="https://github.com/user-attachments/assets/019d9ac0-8c22-4f73-b7b5-dc840db225c5" />

  Response headers copied from DevTools → Copy Response Headers:
  ```
  HTTP/2 401
  alt-svc: h3=":443"; ma=2592000
  server: Caddy
  www-authenticate: Basic realm="restricted"
  content-length: 0
  date: Tue, 26 May 2026 23:49:03 GMT
  X-Firefox-Spdy: h2
  ```
- **Observed result after fix**: live end-to-end verification on the same reverse-proxy deployment.
  - Rebuilt `dist/control-ui/sw.js` swapped onto the served gateway, Firefox fully closed (`pgrep -a firefox` empty), reopened, navigated to the Control UI URL.
  - Basic_auth credentials dialog appears on first visit — exactly as on the pre-SW baseline.
  - DevTools Network tab on the 401 navigation request shows **Transferred: `NS_BINDING_CANCELLED_OLD_LOAD`** (no longer `service worker`) — a Firefox-internal marker that the original load was cancelled when the browser auto-retried with the `Authorization` header after the dialog was filled. The fact that the load made it onto the network (rather than being SW-served) is the load-bearing signal here.
  - After typing credentials, the SPA loads normally; sub-resource SW branches remain active (`/assets/*` cache-first, etc.) — no regression on day-to-day usage.
- **What was not tested**: behavior under Chromium/Safari (verification was limited to Firefox latest stable). The patched branch matches the Fetch-spec contract, so a cross-browser regression would be a user-agent spec deviation rather than a defect introduced by this patch.
- **Proof limitations or environment constraints**: live verification was exercised against Caddy `basic_auth` only; digest and negotiate were not exercised, but they follow the same Fetch-spec auth-challenge codepath (response delivered straight from network triggers the UA's auth UI), so the same fix should apply.

## Tests and validation

Commands run from the root of this repo, against this branch:
- `pnpm exec oxfmt --check --threads=1 ui/public/sw.js` → *All matched files use the correct format.*
- `pnpm test ui/src/ui/service-worker-cache.test.ts` → 1 file, 1 test passed.
- `pnpm test ui/src/ui/service-worker-cache.test.ts ui/src/ui/app-native-bridge.test.ts ui/src/ui/app-chat.test.ts` → 2 files, 62 tests passed (sanity check on adjacent UI surfaces that mention `navigate`).
- `pnpm ui:build` → success, 420ms; emitted `dist/control-ui/sw.js` contains the new `if (event.request.mode === "navigate") return;` branch.

No new automated test was added. The behavior under change is browser-spec coupling (HTTP auth-challenge UI ↔ network-direct responses) and is not faithfully testable in vitest without a real navigation context. A test stub that asserted "the code short-circuits on `mode === 'navigate'`" would be a tautology of the diff. Happy to add a Playwright/e2e probe if maintainers point at the preferred harness.

**What failed before this fix**: see *Real behavior proof* — bare 401 after browser restart on basic_auth reverse-proxy deployment.

## Risk checklist

- **User-visible behavior change?** `Yes` — top-level navigations are no longer served by the SW. On a fresh navigation without network, the browser will now show its standard offline page instead of a SW-served shell. The SPA cannot operate without network anyway (every API route is excluded from caching), so the previously-cached offline shell was a deceptive UX.
- **Config, environment, or migration behavior change?** `No`. No config surfaces added, removed, or changed.
- **Security / auth / secrets / network / tool-execution behavior change?** `Yes` (positive direction). HTTP auth challenges from reverse proxies now correctly traverse to the browser's native auth UI. No new auth surface is added; token/password modes inside the SPA are unaffected. No new external network call. No new tool execution path.
- **Highest-risk area**: users who rely on opening the Control UI offline (e.g. as an installed PWA) will see a browser error page instead of the cached shell. Given the SPA cannot make any RPC call offline, this is a UX regression on the offline shell only.
- **Mitigation**: documented in the inline code comment and in this PR description. The `./` precache stays in place; only the dispatcher branch that *serves* it for navigations is removed. If maintainers want to keep offline shell render, a refinement is possible: in the `navigate` branch, attempt `fetch` first, and only if the response succeeds and is non-auth-challenge serve from SW; on a 401 fall back via `clients.matchAll() + client.navigate()` with a cache-buster to re-issue the request outside the SW. Happy to iterate.

## Current review state

- **Next action**: maintainer review.
- **Still waiting on**: maintainer review.
- **Bot/reviewer comments addressed**: real-behavior-proof gate — restructured the *Real behavior proof* section so the required `Exact steps or command run after this patch`, `Evidence after fix`, and `Observed result after fix` field labels are recognised by `real-behavior-proof-check.mjs`; embedded the Firefox DevTools screenshot inside the `Evidence after fix` field (previously a sibling `## Proof screenshot` section the gate did not see).

