### PR TITLE
fix(codex): arm completion idle watch for stalled binary after rawResponseItem/completed

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5653,6 +5653,43 @@ describe("runCodexAppServerAttempt", () => {
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
+  it("keeps waiting after raw reasoning completes before a visible message call", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+    params.sourceReplyDeliveryMode = "message_tool_only";
+
+    let settled = false;
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 15,
+      turnTerminalIdleTimeoutMs: 500,
+    }).finally(() => {
+      settled = true;
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "raw-reasoning-1", type: "reasoning" },
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(settled).toBe(false);
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
   it("keeps the normal completion idle guard after non-source reasoning completes", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6303,8 +6303,9 @@ describe("runCodexAppServerAttempt", () => {
     params.timeoutMs = 200;
 
     const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 5,
-      turnTerminalIdleTimeoutMs: 15,
+      turnCompletionIdleTimeoutMs: 5,
+      turnAssistantCompletionIdleTimeoutMs: 30,
+      turnTerminalIdleTimeoutMs: 500,
     });
     await vi.waitFor(
       () =>

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5471,6 +5471,111 @@ describe("runCodexAppServerAttempt", () => {
     ).toBe(false);
   });
 
+  it("arms completion idle watch after non-assistant rawResponseItem/completed with no active items", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    let handleRequest:
+      | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: (
+            handler: (request: {
+              id: string;
+              method: string;
+              params?: unknown;
+            }) => Promise<unknown>,
+          ) => {
+            handleRequest = handler;
+            return () => undefined;
+          },
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 5,
+      turnAssistantCompletionIdleTimeoutMs: 500,
+      turnTerminalIdleTimeoutMs: 500,
+    });
+    await vi.waitFor(() => expect(handleRequest).toBeTypeOf("function"), fastWait);
+
+    const toolResult = (await handleRequest?.({
+      id: "request-tool-1",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: null,
+        tool: "message",
+        arguments: { action: "send", text: "already sent" },
+      },
+    })) as { success?: boolean };
+    expect(toolResult.success).toBe(false);
+    // Send a rawResponseItem/completed with type "reasoning" — this does NOT
+    // qualify as postToolRawAssistantCompletionNeedsTerminalGuard (which
+    // requires type=message + role=assistant + text preview).  Before the fix,
+    // this would disarm the completion idle watch via the catch-all disarm
+    // block, leaving only the 30-minute terminal timeout.  After the fix,
+    // rawResponseItemCompletedWithNoActiveItems keeps the 60s (here 5ms)
+    // completion idle watch armed.
+    await notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "reasoning",
+          id: "raw-reasoning-1",
+        },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    const completionWarnCall = warn.mock.calls.find(
+      ([message]) => message === "codex app-server turn idle timed out waiting for completion",
+    );
+    expect(completionWarnCall).toBeDefined();
+    const completionWarnData = completionWarnCall?.[1] as
+      | { lastActivityReason?: string; timeoutMs?: number }
+      | undefined;
+    expect(completionWarnData?.timeoutMs).toBe(5);
+    expect(completionWarnData?.lastActivityReason).toBe("notification:rawResponseItem/completed");
+    // The terminal idle watch (500ms) should NOT have fired — the shorter
+    // completion idle watch (5ms) should catch the stall first.
+    expect(
+      warn.mock.calls.some(
+        ([message]) =>
+          message === "codex app-server turn idle timed out waiting for terminal event",
+      ),
+    ).toBe(false);
+  });
+
   it("releases the session when Codex accepts a turn but never sends progress", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5653,7 +5653,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
-  it("keeps waiting after raw reasoning completes before a visible message call", async () => {
+  it("keeps waiting after reasoning and its raw mirror complete before a visible message call", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(
       path.join(tempDir, "session.jsonl"),
@@ -5670,6 +5670,22 @@ describe("runCodexAppServerAttempt", () => {
       settled = true;
     });
     await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "reasoning-1", type: "reasoning" },
+      },
+    });
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "reasoning-1", type: "reasoning" },
+      },
+    });
     await harness.notify({
       method: "rawResponseItem/completed",
       params: {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2454,6 +2454,7 @@ export async function runCodexAppServerAttempt(
       notification.method === "rawResponseItem/completed" &&
       activeTurnItemIds.size === 0 &&
       activeAppServerTurnRequests === 0 &&
+      !assistantCompletionCanRelease &&
       !postToolRawAssistantCompletionNeedsTerminalGuard;
     const shouldArmPostReasoningSourceReplyWatch =
       isCurrentTurnNotification &&

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2460,6 +2460,10 @@ export async function runCodexAppServerAttempt(
       isReasoningItemCompletionNotification(notification) &&
       activeTurnItemIds.size === 0 &&
       params.sourceReplyDeliveryMode === "message_tool_only";
+    const shouldArmPostRawReasoningSourceReplyWatch =
+      rawResponseItemCompletedWithNoActiveItems &&
+      isRawReasoningCompletionNotification(notification) &&
+      params.sourceReplyDeliveryMode === "message_tool_only";
     const shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem =
       isCurrentTurnNotification &&
       notification.method === "item/completed" &&
@@ -2480,7 +2484,10 @@ export async function runCodexAppServerAttempt(
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
     } else if (postToolRawAssistantCompletionNeedsTerminalGuard) {
       armTurnCompletionIdleWatch({ timeoutMs: postToolRawAssistantCompletionIdleTimeoutMs });
-    } else if (shouldArmPostReasoningSourceReplyWatch) {
+    } else if (
+      shouldArmPostReasoningSourceReplyWatch ||
+      shouldArmPostRawReasoningSourceReplyWatch
+    ) {
       armTurnCompletionIdleWatch({ timeoutMs: CODEX_POST_REASONING_SOURCE_REPLY_IDLE_TIMEOUT_MS });
     } else if (unblockedAssistantCompletionRelease) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
@@ -2511,6 +2518,7 @@ export async function runCodexAppServerAttempt(
       !postToolRawAssistantCompletionNeedsTerminalGuard &&
       !rawResponseItemCompletedWithNoActiveItems &&
       !shouldArmPostReasoningSourceReplyWatch &&
+      !shouldArmPostRawReasoningSourceReplyWatch &&
       !shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem
     ) {
       // The short completion-idle watchdog guards blind gaps after Codex
@@ -5268,6 +5276,14 @@ function isCompletedAssistantNotification(notification: CodexServerNotification)
 
 function isReasoningItemCompletionNotification(notification: CodexServerNotification): boolean {
   if (!isJsonObject(notification.params) || notification.method !== "item/completed") {
+    return false;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  return item ? readString(item, "type") === "reasoning" : false;
+}
+
+function isRawReasoningCompletionNotification(notification: CodexServerNotification): boolean {
+  if (!isJsonObject(notification.params) || notification.method !== "rawResponseItem/completed") {
     return false;
   }
   const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2449,6 +2449,12 @@ export async function runCodexAppServerAttempt(
       turnCrossedToolHandoff &&
       isRawAssistantCompletionNotification(notification) &&
       activeTurnItemIds.size === 0;
+    const rawResponseItemCompletedWithNoActiveItems =
+      isCurrentTurnNotification &&
+      notification.method === "rawResponseItem/completed" &&
+      activeTurnItemIds.size === 0 &&
+      activeAppServerTurnRequests === 0 &&
+      !postToolRawAssistantCompletionNeedsTerminalGuard;
     const shouldArmPostReasoningSourceReplyWatch =
       isCurrentTurnNotification &&
       isReasoningItemCompletionNotification(notification) &&
@@ -2483,6 +2489,8 @@ export async function runCodexAppServerAttempt(
       // bridge then goes quiet, reset the short completion-idle guard from that
       // final completion so the remaining silent-turn gap fails fast.
       armTurnCompletionIdleWatch();
+    } else if (rawResponseItemCompletedWithNoActiveItems) {
+      armTurnCompletionIdleWatch();
     } else if (isCurrentTurnNotification && rawToolOutputCompletion) {
       // Raw OpenAI response streams can report the tool-output handoff without
       // a matching app-server `item/completed`; keep the post-tool guard alive.
@@ -2501,6 +2509,7 @@ export async function runCodexAppServerAttempt(
       !trackedDynamicToolCompletion &&
       !rawToolOutputCompletion &&
       !postToolRawAssistantCompletionNeedsTerminalGuard &&
+      !rawResponseItemCompletedWithNoActiveItems &&
       !shouldArmPostReasoningSourceReplyWatch &&
       !shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem
     ) {


### PR DESCRIPTION
## Summary

- Arm the 60s completion idle watch when `rawResponseItem/completed` arrives with all tracked items completed and no active app-server requests.
- Keep that raw completion state out of the catch-all completion-watch disarm path so a stalled Codex binary is detected in 60s instead of waiting for the terminal idle timeout.
- Preserve the longer `message_tool_only` source-reply guard for raw reasoning completions so valid turns still have time to send the visible message tool call.
- Add regression coverage for the stalled non-assistant raw completion path, Codex's reasoning item + raw mirror source-reply path, and raw assistant release path.

## Root cause

When the Codex binary relays `rawResponseItem/completed` and all tracked items are already complete, the binary should deliver `turn/completed` shortly after. If the binary goes silent before `turn/completed`, current `main` can disarm the completion idle watch because the notification is not a raw assistant completion, not raw tool output, and not the final `item/completed` path. That leaves only the long terminal idle timeout for recovery.

## Changes

`extensions/codex/src/app-server/run-attempt.ts` now treats current-turn `rawResponseItem/completed` with no active items and no active app-server requests as a completion-watch state. It arms the completion idle watch and excludes that notification from the generic disarm block.

For `message_tool_only` turns, raw reasoning completions are routed through the existing post-reasoning source-reply timeout so they do not prematurely hit the short completion idle timeout before Codex can call the visible message tool.

`extensions/codex/src/app-server/run-attempt.test.ts` adds regressions for a `type: "reasoning"` raw completion that should time out promptly in normal mode, and Codex's real reasoning item lifecycle followed by its raw mirror in message-tool-only mode where the turn should keep waiting until `turn/completed` arrives.

## Real behavior proof

Behavior addressed: A real Codex app-server turn can stall after final progress or `rawResponseItem/completed` without delivering `turn/completed`; this patch keeps the 60s completion idle watchdog armed so the user gets timeout/retry feedback instead of a long hang.

Real environment tested: Live OpenClaw gateway running a cherry-picked build containing this fix on 2026-05-27, plus local macOS source checkout with Node/Vitest regression proof.

Exact steps or command run after this patch: Live gateway ran a real user Codex turn on the patched build; locally, `node scripts/run-vitest.mjs --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/run-attempt.test.ts --reporter=verbose --testTimeout=5000 -t "(arms completion idle watch after non-assistant rawResponseItem/completed with no active items|keeps waiting after reasoning and its raw mirror complete before a visible message call|keeps waiting after reasoning completes before a visible message call|releases the session after a raw assistant response item without turn completion)"`.

Evidence after fix: Live log reported `timeoutMs: 60000, idleMs: 60000` with `lastActivityReason: "notification:item/completed"`; stderr diagnostics showed the session had stalled in `state=processing` with `activeWorkKind=model_call` and no recovery before the watchdog fired. The local regressions assert the completion idle timeout fires with `timeoutMs: 5` and `lastActivityReason: "notification:rawResponseItem/completed"`, while the terminal idle timeout does not fire. The companion regressions assert Codex's reasoning item lifecycle plus raw mirror in `message_tool_only` mode does not interrupt after the short completion timeout, and a raw assistant completion still releases through the assistant-output path even when the completion timeout is shorter.

Observed result after fix: The patched live gateway returned timeout feedback after roughly 60s and allowed retry instead of hanging until the long terminal timeout. The regressions catch the specific non-assistant raw completion path from this PR and the source-reply guard edge found during maintainer review.

What was not tested: A deterministic live reproduction of the exact intermittent `type: "reasoning"` `rawResponseItem/completed` stall; the live stall proof covered the same completion-watch recovery behavior, and the targeted regressions cover the exact raw notification shapes plus the raw assistant release path that must remain unchanged.

## Verification

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/run-attempt.test.ts --reporter=verbose --testTimeout=5000 -t "(arms completion idle watch after non-assistant rawResponseItem/completed with no active items|keeps waiting after reasoning and its raw mirror complete before a visible message call|keeps waiting after reasoning completes before a visible message call|releases the session after a raw assistant response item without turn completion)"`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Refs #87071, #86948, #87022, #87070.
