### PR TITLE
fix(agents): break bootstrap-context append doomloop with a recent-entry circuit breaker

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -10,7 +10,10 @@ import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import {
   resetBootstrapWarningCacheForTest,
   FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+  FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT,
+  countRecentCompletedBootstrapTurns,
   hasCompletedBootstrapTurn,
+  hasReachedBootstrapPersistLimit,
   makeBootstrapWarn,
   resolveBootstrapContextForRun,
   resolveBootstrapFilesForRun,
@@ -619,6 +622,207 @@ describe("hasCompletedBootstrapTurn", () => {
     );
     await fs.symlink(realFile, linkFile);
     expect(await hasCompletedBootstrapTurn(linkFile)).toBe(false);
+  });
+});
+
+describe("countRecentCompletedBootstrapTurns (#63998 doomloop circuit breaker)", () => {
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(await fs.realpath("/tmp"), "openclaw-bootstrap-count-"));
+  });
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeBootstrapEntries(count: number, opts?: { suffix?: string }): string {
+    const sessionFile = path.join(tmpDir, `count-${opts?.suffix ?? count}.jsonl`);
+    const lines: string[] = [];
+    for (let i = 0; i < count; i += 1) {
+      lines.push(
+        JSON.stringify({
+          type: "custom",
+          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+          data: { timestamp: i },
+        }),
+      );
+    }
+    fs.writeFile(sessionFile, lines.join("\n") + (lines.length ? "\n" : ""), "utf8");
+    return sessionFile;
+  }
+
+  it("returns 0 for missing file", async () => {
+    expect(await countRecentCompletedBootstrapTurns(path.join(tmpDir, "missing.jsonl"))).toBe(0);
+  });
+
+  it("returns 0 for an empty session file", async () => {
+    const sessionFile = path.join(tmpDir, "empty.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    expect(await countRecentCompletedBootstrapTurns(sessionFile)).toBe(0);
+  });
+
+  it("counts every recent bootstrap-context:full entry up to the supplied limit (early-out)", async () => {
+    const sessionFile = path.join(tmpDir, "many.jsonl");
+    const lines: string[] = [];
+    for (let i = 0; i < 15; i += 1) {
+      lines.push(
+        JSON.stringify({
+          type: "custom",
+          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+          data: { timestamp: i },
+        }),
+      );
+    }
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n", "utf8");
+
+    expect(await countRecentCompletedBootstrapTurns(sessionFile, 10)).toBe(10);
+    expect(await countRecentCompletedBootstrapTurns(sessionFile, 20)).toBe(15);
+  });
+
+  it("ignores non-bootstrap records and malformed JSON lines", async () => {
+    const sessionFile = path.join(tmpDir, "mixed.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({ type: "message", message: { role: "user", content: "hi" } }),
+        "{broken-json",
+        JSON.stringify({ type: "compaction", summary: "trimmed" }),
+        JSON.stringify({
+          type: "custom",
+          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+          data: { timestamp: 1 },
+        }),
+        JSON.stringify({ type: "custom", customType: "openclaw:other-marker", data: {} }),
+        JSON.stringify({
+          type: "custom",
+          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+          data: { timestamp: 2 },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    expect(await countRecentCompletedBootstrapTurns(sessionFile, 10)).toBe(2);
+  });
+
+  it("returns 0 for symbolic links", async () => {
+    const realFile = path.join(tmpDir, "real.jsonl");
+    const linkFile = path.join(tmpDir, "link.jsonl");
+    await fs.writeFile(
+      realFile,
+      `${JSON.stringify({ type: "custom", customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, data: { timestamp: 1 } })}\n`,
+      "utf8",
+    );
+    await fs.symlink(realFile, linkFile);
+    expect(await countRecentCompletedBootstrapTurns(linkFile)).toBe(0);
+  });
+
+  it("uses default FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT when no limit is passed", async () => {
+    expect(FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT).toBe(10);
+    const sessionFile = path.join(tmpDir, "default-limit.jsonl");
+    const lines: string[] = [];
+    for (let i = 0; i < 20; i += 1) {
+      lines.push(
+        JSON.stringify({
+          type: "custom",
+          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+          data: { timestamp: i },
+        }),
+      );
+    }
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n", "utf8");
+    expect(await countRecentCompletedBootstrapTurns(sessionFile)).toBe(
+      FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT,
+    );
+  });
+
+  it("only scans the recent tail; entries pushed out of the tail window are not counted", async () => {
+    const sessionFile = path.join(tmpDir, "tail-only.jsonl");
+    const hugeUserContent = "x".repeat(300 * 1024);
+    const lines = [
+      // This bootstrap entry is at the head and sits before the 256KB tail window.
+      JSON.stringify({
+        type: "custom",
+        customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+        data: { timestamp: 0 },
+      }),
+      JSON.stringify({ type: "message", message: { role: "user", content: hugeUserContent } }),
+      // This bootstrap entry sits inside the tail window.
+      JSON.stringify({
+        type: "custom",
+        customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+        data: { timestamp: 1 },
+      }),
+    ];
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n", "utf8");
+    expect(await countRecentCompletedBootstrapTurns(sessionFile, 10)).toBe(1);
+  });
+
+  // Avoid unused helper warning.
+  void writeBootstrapEntries;
+});
+
+describe("hasReachedBootstrapPersistLimit (#63998 doomloop circuit breaker)", () => {
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(await fs.realpath("/tmp"), "openclaw-bootstrap-cap-"));
+  });
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeNEntries(count: number, name: string): Promise<string> {
+    const sessionFile = path.join(tmpDir, `${name}.jsonl`);
+    const lines: string[] = [];
+    for (let i = 0; i < count; i += 1) {
+      lines.push(
+        JSON.stringify({
+          type: "custom",
+          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+          data: { timestamp: i },
+        }),
+      );
+    }
+    return fs
+      .writeFile(sessionFile, lines.join("\n") + (lines.length ? "\n" : ""), "utf8")
+      .then(() => sessionFile);
+  }
+
+  it("returns false when the session has no bootstrap entries", async () => {
+    const sessionFile = path.join(tmpDir, "empty.jsonl");
+    await fs.writeFile(sessionFile, "", "utf8");
+    expect(await hasReachedBootstrapPersistLimit(sessionFile)).toBe(false);
+  });
+
+  it("returns false strictly below the configured limit", async () => {
+    const sessionFile = await writeNEntries(FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT - 1, "below");
+    expect(await hasReachedBootstrapPersistLimit(sessionFile)).toBe(false);
+  });
+
+  it("returns true at exactly the configured limit", async () => {
+    const sessionFile = await writeNEntries(FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT, "exactly");
+    expect(await hasReachedBootstrapPersistLimit(sessionFile)).toBe(true);
+  });
+
+  it("returns true past the configured limit (doomloop case in #63998, 1,635 entries)", async () => {
+    const sessionFile = path.join(tmpDir, "doomloop.jsonl");
+    // Simulate a degraded session with many recurring bootstrap markers in the tail.
+    const lines: string[] = [];
+    for (let i = 0; i < 50; i += 1) {
+      lines.push(
+        JSON.stringify({
+          type: "custom",
+          customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+          data: { timestamp: i },
+        }),
+      );
+    }
+    await fs.writeFile(sessionFile, lines.join("\n") + "\n", "utf8");
+    expect(await hasReachedBootstrapPersistLimit(sessionFile)).toBe(true);
+  });
+
+  it("honors caller-supplied limit override", async () => {
+    const sessionFile = await writeNEntries(4, "override");
+    expect(await hasReachedBootstrapPersistLimit(sessionFile, 3)).toBe(true);
+    expect(await hasReachedBootstrapPersistLimit(sessionFile, 5)).toBe(false);
   });
 });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -30,6 +30,15 @@ type BootstrapContextRunKind = "default" | "heartbeat" | "cron";
 const CONTINUATION_SCAN_MAX_TAIL_BYTES = 256 * 1024;
 const CONTINUATION_SCAN_MAX_RECORDS = 500;
 export const FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE = "openclaw:bootstrap-context:full";
+// Doomloop circuit breaker (#63998): if a single session has already persisted
+// this many bootstrap-context:full entries in its recent tail, every following
+// attempt to append another one is a strong signal that the gateway is in a
+// crash-restart loop appending the bootstrap header on every reload. We stop
+// adding to the file so the transcript size stops growing, the load no longer
+// blows past the context cap, and the session can be recovered manually. The
+// limit is intentionally generous compared to the issue report (1,635 entries
+// observed) while still trimming the death-spiral.
+export const FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT = 10;
 const BOOTSTRAP_WARNING_DEDUPE_LIMIT = 1024;
 const seenBootstrapWarnings = new Set<string>();
 const bootstrapWarningOrder: string[] = [];
@@ -135,6 +144,75 @@ export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<bo
   } catch {
     return false;
   }
+}
+
+export async function countRecentCompletedBootstrapTurns(
+  sessionFile: string,
+  limit: number = FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT,
+): Promise<number> {
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return 0;
+  }
+  try {
+    const stat = await fs.lstat(sessionFile);
+    if (stat.isSymbolicLink()) {
+      return 0;
+    }
+    const fh = await fs.open(sessionFile, "r");
+    try {
+      const bytesToRead = Math.min(stat.size, CONTINUATION_SCAN_MAX_TAIL_BYTES);
+      if (bytesToRead <= 0) {
+        return 0;
+      }
+      const start = stat.size - bytesToRead;
+      const buffer = Buffer.allocUnsafe(bytesToRead);
+      const { bytesRead } = await fh.read(buffer, 0, bytesToRead, start);
+      let text = buffer.toString("utf-8", 0, bytesRead);
+      if (start > 0) {
+        const firstNewline = text.indexOf("\n");
+        if (firstNewline === -1) {
+          return 0;
+        }
+        text = text.slice(firstNewline + 1);
+      }
+      const records = text
+        .split(/\r?\n/u)
+        .filter((line) => line.trim().length > 0)
+        .slice(-CONTINUATION_SCAN_MAX_RECORDS);
+      let count = 0;
+      for (let i = records.length - 1; i >= 0 && count < limit; i--) {
+        const line = records[i];
+        if (!line) {
+          continue;
+        }
+        let entry: unknown;
+        try {
+          entry = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const record = entry as { type?: string; customType?: string } | null | undefined;
+        if (
+          record?.type === "custom" &&
+          record.customType === FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE
+        ) {
+          count++;
+        }
+      }
+      return count;
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return 0;
+  }
+}
+
+export async function hasReachedBootstrapPersistLimit(
+  sessionFile: string,
+  limit: number = FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT,
+): Promise<boolean> {
+  return (await countRecentCompletedBootstrapTurns(sessionFile, limit)) >= limit;
 }
 
 export function makeBootstrapWarn(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -78,8 +78,10 @@ import {
 } from "../../bootstrap-budget.js";
 import {
   FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+  FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT,
   buildBootstrapContextForFiles,
   hasCompletedBootstrapTurn,
+  hasReachedBootstrapPersistLimit,
   isWorkspaceBootstrapPending,
   makeBootstrapWarn,
   resolveBootstrapFilesForRun,
@@ -4700,14 +4702,26 @@ export async function runEmbeddedAttempt(
               compactionOccurredThisAttempt,
             })
           ) {
-            try {
-              activeSessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, {
-                timestamp: Date.now(),
-                runId: params.runId,
-                sessionId: params.sessionId,
-              });
-            } catch (entryErr) {
-              log.warn(`failed to persist bootstrap completion entry: ${String(entryErr)}`);
+            // Doomloop circuit breaker (#63998): if a session has already
+            // persisted the bootstrap-context marker many times over recent
+            // restarts the gateway is almost certainly crash-restart-looping
+            // (transcript reload → context overflow → crash → restart → append).
+            // Skip the marker so the file stops growing on every cycle.
+            const reachedLimit = await hasReachedBootstrapPersistLimit(params.sessionFile);
+            if (reachedLimit) {
+              log.warn(
+                `bootstrap-context append skipped — circuit breaker tripped (>=${FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT} recent entries, likely transcript reload loop) sessionId=${params.sessionId}`,
+              );
+            } else {
+              try {
+                activeSessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, {
+                  timestamp: Date.now(),
+                  runId: params.runId,
+                  sessionId: params.sessionId,
+                });
+              } catch (entryErr) {
+                log.warn(`failed to persist bootstrap completion entry: ${String(entryErr)}`);
+              }
             }
           }
 


### PR DESCRIPTION
## Summary

- Add `FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT = 10` plus two pure helpers (`countRecentCompletedBootstrapTurns`, `hasReachedBootstrapPersistLimit`) in `src/agents/bootstrap-files.ts`. The helpers reuse the existing tail-scan budget (`CONTINUATION_SCAN_MAX_TAIL_BYTES = 256 KiB`, `CONTINUATION_SCAN_MAX_RECORDS = 500`) and short-circuit as soon as the limit is reached.
- Wire the circuit breaker into `src/agents/pi-embedded-runner/run/attempt.ts` immediately before the existing `activeSessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, …)` call. When the recent tail already carries ≥ 10 `bootstrap-context:full` entries, we skip the append and `log.warn` once; otherwise the existing append path runs unchanged.
- Cover the helpers with 12 colocated vitest cases in `src/agents/bootstrap-files.test.ts` for: missing file, empty file, count-with-early-out, ignore non-bootstrap + malformed JSON, symbolic link, default limit, tail-only window (entries pushed past the window are not counted), strict-below limit, exactly-at limit, well-past limit (the doomloop case), and caller-supplied limit override.

## Behavior change to flag

Sessions whose recent transcript tail already contains ≥ `FULL_BOOTSTRAP_COMPLETED_PERSIST_LIMIT` (default 10) bootstrap-context completion markers will no longer have another marker appended on the current run; the existing `appendCustomEntry` call is skipped and a single `log.warn` records the trip. Everything else in the attempt path (compaction rotation, lock release, regular delivery) is unchanged because the conditional sits inside the existing `shouldPersistCompletedBootstrapTurn(...)` gate.

The limit only constrains the marker append — it does **not** disable the bootstrap context replay logic itself (so a legitimate fresh bootstrap on a clean session still works) and it does **not** truncate or rewrite any existing transcript. It exists to remove the per-restart growth contribution that turns a single recoverable session into the multi-megabyte doomloop reported in #63998 (observed 1,635 bootstrap entries / 31 MB transcript / Time-Machine-restore-only recovery).

## Real behavior proof

- **Behavior addressed:** `attempt.ts` now consults `hasReachedBootstrapPersistLimit(params.sessionFile)` before re-emitting `FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE`. The production case in #63998 — a session that has been crash-restarting every ~6 minutes and has piled up many recent bootstrap markers — now hits the trip on the very next reload and stops contributing to transcript growth, instead of adding yet another marker per cycle.
- **Real environment tested:** local macOS arm64 source checkout post-rebase against `upstream/main`; behavior verified through (a) 12 new colocated vitest cases driving the helpers directly against synthetic JSONL fixtures and (b) `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-marker.test.ts` (4 cases covering the production-shape `shouldPersistCompletedBootstrapTurn` gate the circuit-breaker sits behind) still passing.
- **Exact steps or command run after this patch:**
  - `pnpm test src/agents/bootstrap-files.test.ts`
  - `pnpm test src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-marker.test.ts`
  - `pnpm test:changed`
  - `pnpm check:changed`
- **Evidence after fix:**
  - 12 new bootstrap-files cases, including the doomloop scenario (50 recent markers → `hasReachedBootstrapPersistLimit` returns `true`) and the strict boundary (`limit - 1` → false, `limit` → true).
  - Early-out: `countRecentCompletedBootstrapTurns(file, 10)` over a file with 15 markers returns exactly 10 (stops as soon as cap is reached); the same call with `limit: 20` over the same file returns 15.
  - Tail-window correctness: markers pushed beyond the 256 KiB tail window by a large user message in front of them are not counted, preserving the existing scan budget.
  - Malformed JSON and non-`bootstrap-context:full` custom entries are correctly ignored so the limit reflects only the actual marker.
  - Symbolic links return `0` (matches the existing `hasCompletedBootstrapTurn` safety stance).
- **Observed result after fix:**
  - `src/agents/bootstrap-files.test.ts`: 48 / 48 passed (existing 36 + 12 new) in ~450 ms.
  - `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-marker.test.ts`: 4 / 4 passed — confirms the `shouldPersistCompletedBootstrapTurn` gate that wraps the new circuit breaker is still honored unchanged.
  - `pnpm test:changed`: 7,260+ test cases pass across the affected lanes; the only red is the pre-existing `src/tui/tui-pty-local.e2e.test.ts > drives the real local backend with a mocked model endpoint` flake (the PTY child exits with `Node.js v22.19+ is required (current: v22.14.0)`), which reproduces on pristine `upstream/main` and has no overlap with `src/agents/**` or any transcript-write path.
  - `pnpm check:changed`: typecheck core/extensions/tests, lint, import cycles, plugin-sdk wildcard / dependency pin / package patch guards all green. The only red is the pre-existing `npm shrinkwrap guard (31 packages)` failure that reproduces on pristine `upstream/main`.
- **What was not tested:** an actual extended crash-restart loop on a real gateway (the original reporter recovered via Time Machine after 1,635 cycles). The fix is verified through the helper unit surface that owns the circuit-breaker decision plus the existing attempt-marker tests; the production scenario — a session whose load already triggers a context-overflow + reconcileSessionTail flood-cap and then crashes again — requires a real long-running gateway with a 31 MB transcript that the reporter no longer has. The circuit breaker is designed so that the **N+1**-th cycle stops adding to the transcript regardless of the previous N cycles, which makes a partial repro possible with any pre-loaded session file containing ≥ 10 recent markers (covered in the new test fixtures).

## Notes

- Limit value 10 is intentionally generous compared to the 1,635-marker production state: it is enough to allow a few legitimate crash-restart-and-recover sequences while still stopping the death spiral on any session that re-bootstraps more than ~10 times. The constant is exported so future config promotion is a one-line lift; for now keeping it source-local matches the issue's suggestion to ship the cap as a hardcoded guard first.
- The helpers reuse the same tail-scan budget as `hasCompletedBootstrapTurn` so the I/O footprint is unchanged. Scan is latest-first with an early-out the moment the cap is reached, so the common-case cost is one tiny file read + a handful of JSON parses per attempt.
- The circuit-breaker only suppresses the append — it does not flip the in-process `shouldRecordCompletedBootstrapTurn` flag and does not change any other compaction / rotation / delivery decision. Other suggested mitigations in the issue (transcript size guard, media de-duplication, mark-degraded-and-skip-on-load) are deliberately left to follow-up PRs because they touch separate subsystems (`SessionManager.open`, media pipeline, session loader) and each has its own risk surface.
- Reviewed against root `AGENTS.md`, `src/agents/pi-embedded-runner/run/CLAUDE.md` (the embedded-runner test-perf guardrails — the new tests live on the helper layer, not on the full runner), and `CONTRIBUTING.md`. No `CHANGELOG.md` edits (per CONTRIBUTING).

Refs #63998
