### PR TITLE
fix(plugin-sdk): use Function.name to find onDiagnosticEvent export

### DIFF
--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -362,10 +362,13 @@ function normalizeDiagnosticEventsModule(mod) {
   if (typeof mod.onDiagnosticEvent === "function") {
     return mod;
   }
-  if (typeof mod.r === "function") {
+  const fn = Object.values(mod).find(
+    (v) => typeof v === "function" && v.name === "onDiagnosticEvent",
+  );
+  if (fn) {
     return {
       ...mod,
-      onDiagnosticEvent: mod.r,
+      onDiagnosticEvent: fn,
     };
   }
   return mod;

--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -147,14 +147,55 @@ function onDiagnosticEventFromSharedState(listener) {
   };
 }
 
+function snapshotDiagnosticListeners(state) {
+  return state && state.listeners instanceof Set ? new Set(state.listeners) : null;
+}
+
+function removeAddedDiagnosticListeners(beforeListeners) {
+  const state = getDiagnosticEventsState(false);
+  if (!state || !(state.listeners instanceof Set)) {
+    return;
+  }
+  if (!beforeListeners) {
+    state.listeners.clear();
+    return;
+  }
+  for (const listener of state.listeners) {
+    if (!beforeListeners.has(listener)) {
+      state.listeners.delete(listener);
+    }
+  }
+}
+
+function trySubscribeDiagnosticEvents(diagnosticEvents, listener, beforeListeners) {
+  try {
+    const unsubscribe = diagnosticEvents.onDiagnosticEvent(listener);
+    if (typeof unsubscribe === "function") {
+      return unsubscribe;
+    }
+  } catch {
+    // Fall back to shared state if a stale dist chunk exposes a broken wrapper.
+  }
+  removeAddedDiagnosticListeners(beforeListeners);
+  return null;
+}
+
 function onDiagnosticEvent(listener) {
   const beforeState = getDiagnosticEventsState(false);
+  const beforeListeners = snapshotDiagnosticListeners(beforeState);
   const beforeSize = beforeState?.listeners?.size;
   const diagnosticEvents = loadDiagnosticEventsModule();
   if (!diagnosticEvents || typeof diagnosticEvents.onDiagnosticEvent !== "function") {
     return onDiagnosticEventFromSharedState(listener);
   }
-  const unsubscribeDiagnosticEvents = diagnosticEvents.onDiagnosticEvent(listener);
+  const unsubscribeDiagnosticEvents = trySubscribeDiagnosticEvents(
+    diagnosticEvents,
+    listener,
+    beforeListeners,
+  );
+  if (!unsubscribeDiagnosticEvents) {
+    return onDiagnosticEventFromSharedState(listener);
+  }
   const afterState = getDiagnosticEventsState(false);
   if (afterState && afterState.listeners.size > (beforeSize ?? 0)) {
     return unsubscribeDiagnosticEvents;
@@ -163,8 +204,11 @@ function onDiagnosticEvent(listener) {
   // diagnostic module in a separate graph from the active core emitter.
   const unsubscribeSharedState = onDiagnosticEventFromSharedState(listener);
   return () => {
-    unsubscribeDiagnosticEvents();
-    unsubscribeSharedState();
+    try {
+      unsubscribeDiagnosticEvents();
+    } finally {
+      unsubscribeSharedState();
+    }
   };
 }
 

--- a/src/plugins/contracts/plugin-sdk-root-alias.test.ts
+++ b/src/plugins/contracts/plugin-sdk-root-alias.test.ts
@@ -525,6 +525,36 @@ describe("plugin-sdk root alias", () => {
     );
   });
 
+  it("resolves the diagnostic event export by function name when dist aliases shift", () => {
+    let subscribeCount = 0;
+    let unsubscribeCount = 0;
+    const lazyModule = loadRootAliasWithStubs({
+      aliasPath: createDistAliasPath(),
+      distEntries: ["diagnostic-events-W3Hz61fI.js"],
+      monolithicExports: {
+        r: function emitFailoverEvent(): void {
+          throw new Error("wrong diagnostic event alias selected");
+        },
+        u: function onDiagnosticEvent(_listener: () => void): () => void {
+          subscribeCount += 1;
+          return () => {
+            unsubscribeCount += 1;
+          };
+        },
+      },
+    });
+
+    const unsubscribe = (
+      lazyModule.moduleExports.onDiagnosticEvent as (
+        listener: (event: { type: string }) => void,
+      ) => () => void
+    )(() => undefined);
+    unsubscribe();
+
+    expect(subscribeCount).toBe(1);
+    expect(unsubscribeCount).toBe(1);
+  });
+
   it("bridges diagnostic listeners through shared process state when the lazy module is isolated", () => {
     const seen: string[] = [];
     const lazyModule = loadDiagnosticEventsAlias(["diagnostic-events-W3Hz61fI.js"]);

--- a/src/plugins/contracts/plugin-sdk-root-alias.test.ts
+++ b/src/plugins/contracts/plugin-sdk-root-alias.test.ts
@@ -11,6 +11,7 @@ const rootSdk = require(rootAliasPath) as Record<string, unknown>;
 const rootAliasSource = fs.readFileSync(rootAliasPath, "utf-8");
 const compatPath = fileURLToPath(new URL("../../plugin-sdk/compat.ts", import.meta.url));
 const packageJsonPath = fileURLToPath(new URL("../../../package.json", import.meta.url));
+const diagnosticEventsStateKey = Symbol.for("openclaw.diagnosticEvents.state.v1");
 const legacyRootExportNames = [
   "registerContextEngine",
   "buildMemorySystemPromptAddition",
@@ -34,6 +35,10 @@ type EmptySchema = {
         success: false;
         error: { issues: Array<{ path: Array<string | number>; message: string }> };
       };
+};
+
+type DiagnosticEventsStateFixture = {
+  listeners: Set<(event: { type: string }, metadata: { trusted: boolean }) => void>;
 };
 
 function requirePropertyDescriptor(
@@ -181,6 +186,56 @@ function loadDiagnosticEventsAlias(distEntries: string[]) {
       slowHelper: (): string => "loaded",
     },
   });
+}
+
+function ensureDiagnosticEventsStateFixture(
+  context: Record<PropertyKey, unknown>,
+): DiagnosticEventsStateFixture {
+  const existing = context[diagnosticEventsStateKey] as DiagnosticEventsStateFixture | undefined;
+  if (existing) {
+    return existing;
+  }
+  const state = vm.runInNewContext(
+    `({
+      marker: Symbol.for("openclaw.diagnosticEvents.state.v1"),
+      enabled: true,
+      seq: 0,
+      listeners: new Set(),
+      dispatchDepth: 0,
+      asyncQueue: [],
+      asyncDrainScheduled: false,
+      asyncDroppedEvents: 0,
+      asyncDroppedTrustedEvents: 0,
+      asyncDroppedUntrustedEvents: 0,
+      asyncDroppedPriorityEvents: 0,
+    })`,
+    context,
+  ) as DiagnosticEventsStateFixture;
+  Object.defineProperty(context, diagnosticEventsStateKey, {
+    configurable: true,
+    enumerable: false,
+    value: state,
+    writable: false,
+  });
+  return state;
+}
+
+function requireDiagnosticEventsStateFixture(
+  lazyModule: ReturnType<typeof loadRootAliasWithStubs>,
+): DiagnosticEventsStateFixture {
+  const state = lazyModule.globalContext[diagnosticEventsStateKey] as
+    | DiagnosticEventsStateFixture
+    | undefined;
+  if (!state) {
+    throw new Error("expected diagnostic events state fixture");
+  }
+  return state;
+}
+
+function emitFixtureDiagnosticEvent(state: DiagnosticEventsStateFixture): void {
+  for (const registered of state.listeners) {
+    registered({ type: "model.usage" }, { trusted: false });
+  }
 }
 
 function expectDiagnosticEventAccessor(lazyModule: ReturnType<typeof loadRootAliasWithStubs>) {
@@ -553,6 +608,106 @@ describe("plugin-sdk root alias", () => {
 
     expect(subscribeCount).toBe(1);
     expect(unsubscribeCount).toBe(1);
+  });
+
+  it("falls back and removes stale diagnostic listeners when the dist subscription is invalid", () => {
+    const seen: string[] = [];
+    let lazyModule!: ReturnType<typeof loadRootAliasWithStubs>;
+    const preexistingListener = (): void => undefined;
+    lazyModule = loadRootAliasWithStubs({
+      aliasPath: createDistAliasPath(),
+      distEntries: ["diagnostic-events-W3Hz61fI.js"],
+      monolithicExports: {
+        onDiagnosticEvent(listener: (event: { type: string }) => void): undefined {
+          const state = ensureDiagnosticEventsStateFixture(lazyModule.globalContext);
+          state.listeners.add((event, metadata) => {
+            if (!metadata.trusted) {
+              listener(event);
+            }
+          });
+          return undefined;
+        },
+      },
+    });
+    const state = ensureDiagnosticEventsStateFixture(lazyModule.globalContext);
+    state.listeners.add(preexistingListener);
+
+    const unsubscribe = (
+      lazyModule.moduleExports.onDiagnosticEvent as (
+        listener: (event: { type: string }) => void,
+      ) => () => void
+    )((event) => {
+      seen.push(event.type);
+    });
+
+    expect(state.listeners.size).toBe(2);
+    expect(state.listeners.has(preexistingListener)).toBe(true);
+    emitFixtureDiagnosticEvent(state);
+    unsubscribe();
+
+    expect(seen).toEqual(["model.usage"]);
+    expect(state.listeners.size).toBe(1);
+    expect(state.listeners.has(preexistingListener)).toBe(true);
+  });
+
+  it("falls back to shared diagnostic state when the dist subscription throws", () => {
+    const seen: string[] = [];
+    let subscribeCount = 0;
+    const lazyModule = loadRootAliasWithStubs({
+      aliasPath: createDistAliasPath(),
+      distEntries: ["diagnostic-events-W3Hz61fI.js"],
+      monolithicExports: {
+        onDiagnosticEvent(): never {
+          subscribeCount += 1;
+          throw new Error("stale diagnostic subscription");
+        },
+      },
+    });
+
+    const unsubscribe = (
+      lazyModule.moduleExports.onDiagnosticEvent as (
+        listener: (event: { type: string }) => void,
+      ) => () => void
+    )((event) => {
+      seen.push(event.type);
+    });
+    const state = requireDiagnosticEventsStateFixture(lazyModule);
+
+    expect(subscribeCount).toBe(1);
+    expect(state.listeners.size).toBe(1);
+    emitFixtureDiagnosticEvent(state);
+    unsubscribe();
+
+    expect(seen).toEqual(["model.usage"]);
+    expect(state.listeners.size).toBe(0);
+  });
+
+  it("removes the shared-state fallback listener when diagnostic cleanup throws", () => {
+    let diagnosticUnsubscribeCount = 0;
+    const lazyModule = loadRootAliasWithStubs({
+      aliasPath: createDistAliasPath(),
+      distEntries: ["diagnostic-events-W3Hz61fI.js"],
+      monolithicExports: {
+        onDiagnosticEvent(): () => void {
+          return () => {
+            diagnosticUnsubscribeCount += 1;
+            throw new Error("diagnostic cleanup failed");
+          };
+        },
+      },
+    });
+
+    const unsubscribe = (
+      lazyModule.moduleExports.onDiagnosticEvent as (
+        listener: (event: { type: string }) => void,
+      ) => () => void
+    )(() => undefined);
+    const state = requireDiagnosticEventsStateFixture(lazyModule);
+
+    expect(state.listeners.size).toBe(1);
+    expect(() => unsubscribe()).toThrow("diagnostic cleanup failed");
+    expect(diagnosticUnsubscribeCount).toBe(1);
+    expect(state.listeners.size).toBe(0);
   });
 
   it("bridges diagnostic listeners through shared process state when the lazy module is isolated", () => {


### PR DESCRIPTION
## Problem

Plugins that import `onDiagnosticEvent` from `openclaw/plugin-sdk` can fail during gateway stop/restart after a bundled build reshuffles minified export aliases.

`src/plugin-sdk/root-alias.cjs` was treating the dist diagnostic-events export named `r` as `onDiagnosticEvent`. In `2026.5.25-beta.1`, that alias points at `emitFailoverEvent`, while the real `onDiagnosticEvent` export is another letter. A plugin can still receive events through the shared-state fallback, but the combined unsubscribe closure later calls a non-function and crashes with:

```text
TypeError: unsubscribeDiagnosticEvents is not a function
```

## Change and value

This PR stops depending on one fragile minified export letter. When a dist diagnostic-events chunk lacks the public `onDiagnosticEvent` property, the root alias now selects the function whose retained JavaScript function name is `onDiagnosticEvent`.

The root alias also treats stale or malformed diagnostic-event modules as stale dist state: if subscribing throws or returns a non-callable cleanup, it removes any listener that attempt added and falls back to the shared diagnostic-events state. If the diagnostic cleanup later throws, the shared fallback listener is still removed in `finally`.

That keeps the shipped root SDK alias stable across bundler alias reshuffles without adding a new public API, config flag, package export, or plugin-facing migration step.

## Who is affected, and who is not

Affected:

- External plugins that subscribe to diagnostic events through `openclaw/plugin-sdk`.
- Operators restarting a gateway with one of those plugins enabled.
- Future builds where the bundler assigns `onDiagnosticEvent` to any letter other than `r`.

Not affected:

- The plugin SDK public export list and package subpaths.
- Diagnostic event filtering rules for trusted internal events or `log.record` events.
- Existing source fallback and hashed dist chunk selection behavior.

## Why now

The alias mapping already changed in the current beta line, so this is not a hypothetical future minifier risk. The reported failure is tied to a real plugin/runtime path and can recur whenever dist chunk aliases change again.

Fixes #87082

## Implementation

- Keep the direct `mod.onDiagnosticEvent` path unchanged.
- Replace the hardcoded `mod.r` fallback with a scan for a function whose `.name` is `onDiagnosticEvent`.
- Validate the diagnostic subscription result before trusting it as an unsubscribe callback.
- Remove listeners added by a stale/invalid diagnostic module before falling back to shared state.
- Use `finally` so shared-state fallback cleanup still runs if diagnostic cleanup throws.
- Add regression tests for the broken beta-style mapping, invalid subscription return, thrown subscription, and cleanup-throw fallback removal.

## Verification

- `node --check src/plugin-sdk/root-alias.cjs`
- `pnpm exec oxfmt --check src/plugin-sdk/root-alias.cjs src/plugins/contracts/plugin-sdk-root-alias.test.ts`
- `git diff --check origin/main...HEAD`
- GitHub Actions on refreshed head `8da195379c284711f597c7477fa1ca79096b4d5b`: `Real behavior proof`, `build-artifacts`, `checks-node-agentic-plugin-sdk`, `check-test-types`, `check-lint`, `check-guards`, `check-prod-types`, and the previously red `checks-node-agentic-control-plane-runtime` shard passed.
- Packaged-dist proof below, using the actual `dist-runtime-build` artifact emitted by GitHub Actions for head `8da195379c284711f597c7477fa1ca79096b4d5b`.
- Direct VM proof below, using the actual `src/plugin-sdk/root-alias.cjs` source from PR head and a stubbed built diagnostic-events chunk with the reported alias shape plus stale-module cleanup variants.
- Attempted local `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-root-alias.test.ts` twice, including a single-worker verbose run; the local Vitest runner remained CPU-bound with no output and was stopped. GitHub PR CI covers the committed plugin SDK contract shard.
- Independent Claude and Codex review gates completed with no merge-blocking findings.

AI assistance: this PR has Claude/Codex-assisted commits; the proof above was run after the patch.

## Real behavior proof

- Behavior or issue addressed: The plugin SDK root alias no longer treats minified dist export `r` as `onDiagnosticEvent` when `r` is actually `emitFailoverEvent`; subscribing and then unsubscribing through `openclaw/plugin-sdk` stays callable and does not throw `TypeError: unsubscribeDiagnosticEvents is not a function`. Stale diagnostic modules that throw, return invalid cleanup, or throw during cleanup no longer leave shared fallback listeners behind.
- Real environment tested: GitHub Actions `dist-runtime-build` artifact from run `26483496866`, artifact id `7229369403`, artifact digest `sha256:4991d002f57b76e2bd33ff451e27e95954bb51626dd5e0896701f8853888061c`, built from PR head `8da195379c284711f597c7477fa1ca79096b4d5b`; then extracted and exercised locally with Node `v26.1.0` on Linux/WSL.
- Exact steps or command run after this patch: Downloaded the CI `dist-runtime-build` artifact for run `26483496866`, extracted `dist/plugin-sdk/root-alias.cjs`, `dist/diagnostic-events-CNGydBWO.js`, and its dependency chunk, then required the emitted root alias in production mode. The proof inspected the actual emitted export line, confirmed `r` is `emitFailoverEvent` and `u` is `onDiagnosticEvent`, subscribed through the emitted root alias, delivered one diagnostic event through the real shared listener set, and unsubscribed.
- Evidence after fix: Terminal output from the exact-head packaged-dist proof:

```text
artifact-head=8da195379c284711f597c7477fa1ca79096b4d5b
artifact=dist-runtime-build run=26483496866 id=7229369403 digest=sha256:4991d002f57b76e2bd33ff451e27e95954bb51626dd5e0896701f8853888061c
chunk=dist/diagnostic-events-CNGydBWO.js
export-r=emitFailoverEvent
export-onDiagnosticEvent=u
unsubscribe-type=function
listener-counts=0->1->0
received=model.usage
```

- Observed result after fix: The actual emitted CI dist chunk has the broken beta-style alias shape (`r` is `emitFailoverEvent`, `u` is `onDiagnosticEvent`), and the emitted root alias still returns a callable unsubscribe. The listener set grows from 0 to 1 on subscribe, receives a `model.usage` diagnostic event, and returns to 0 after unsubscribe.
- Additional regression proof: Terminal output from a source-level old-vs-new harness:

```text
old-hardcoded-r: unsubscribe=function
old-hardcoded-r: failed TypeError: unsubscribeDiagnosticEvents is not a function
current-function-name: unsubscribe=function
current-function-name: subscribe=1 unsubscribe=1
invalid-return: unsubscribe=function
invalid-return: seen=model.usage listeners=0
throwing-subscribe: unsubscribe=function
throwing-subscribe: seen=model.usage listeners=0
cleanup-throws: unsubscribe=function
cleanup-throws: failed Error: diagnostic cleanup failed
cleanup-throws: diagnostic=1 listeners=0
```

- Observed result in regression proof: The old hardcoded alias path reproduces the reported unsubscribe crash, while the patched root alias selects the named `onDiagnosticEvent` function, subscribes once, returns a callable unsubscribe closure, and unsubscribes once without throwing. Invalid and throwing subscription paths fall back to shared diagnostic state and leave zero listeners after unsubscribe. If diagnostic cleanup itself throws, the error still propagates but the shared fallback listener count returns to zero.
- What was not tested: No known changed-path proof gap remains for the alias-selection and stale-module cleanup behavior. I did not mutate the shared local OpenClaw gateway by installing the third-party observability plugin; the exact-head packaged-dist proof exercises the emitted root alias and actual emitted diagnostic-events chunk, and GitHub CI covers the committed contract regression tests.