### PR TITLE
Fix Claude CLI duplicate skills prompt

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -161,13 +161,13 @@ told us OpenClaw-style Claude CLI usage is allowed again, so OpenClaw treats
 a new policy.
 </Note>
 
-The bundled Anthropic `claude-cli` backend receives the OpenClaw skills snapshot
-two ways: the compact OpenClaw skills catalog in the appended system prompt, and
-a temporary Claude Code plugin passed with `--plugin-dir`. The plugin contains
-only the eligible skills for that agent/session, so Claude Code's native skill
-resolver sees the same filtered set that OpenClaw would otherwise advertise in
-the prompt. Skill env/API key overrides are still applied by OpenClaw to the
-child process environment for the run.
+The bundled Anthropic `claude-cli` backend prefers Claude Code's native skill
+resolver for OpenClaw skills. When at least one selected skill can be
+materialized, OpenClaw passes a temporary Claude Code plugin with `--plugin-dir`
+and omits the duplicate OpenClaw skills catalog from the appended system prompt.
+If no plugin skill can be prepared, OpenClaw keeps the prompt catalog as a
+fallback. Skill env/API key overrides are still applied by OpenClaw to the child
+process environment for the run.
 
 Claude CLI also has its own noninteractive permission mode. OpenClaw maps that
 to the existing exec policy instead of adding Claude-specific policy config.

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1455,6 +1455,164 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("omits Claude CLI prompt skills when the native skills plugin can carry them", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const skillDir = path.join(dir, "skills", "weather");
+    fs.mkdirSync(skillDir, { recursive: true });
+    const skillFilePath = path.join(skillDir, "SKILL.md");
+    fs.writeFileSync(
+      skillFilePath,
+      [
+        "---",
+        "name: weather",
+        "description: Use weather tools for forecasts.",
+        "---",
+        "",
+        "Read forecast data before replying.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            pluginId: "anthropic",
+            bundleMcp: false,
+            config: {
+              command: "claude",
+              args: ["--print"],
+              output: "jsonl",
+              input: "stdin",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-claude-plugin-skills-prompt",
+        config: createCliBackendConfig({ systemPromptOverride: null }),
+        skillsSnapshot: {
+          prompt: [
+            "<available_skills>",
+            "  <skill>",
+            "    <name>weather</name>",
+            "    <description>Use weather tools for forecasts.</description>",
+            `    <location>${skillFilePath}</location>`,
+            "  </skill>",
+            "</available_skills>",
+          ].join("\n"),
+          skills: [{ name: "weather" }],
+          resolvedSkills: [
+            {
+              name: "weather",
+              description: "Use weather tools for forecasts.",
+              filePath: skillFilePath,
+              baseDir: skillDir,
+              source: "test",
+              sourceInfo: {
+                path: skillDir,
+                source: "test",
+                scope: "project",
+                origin: "top-level",
+                baseDir: skillDir,
+              },
+              disableModelInvocation: false,
+            },
+          ],
+        },
+      });
+
+      expect(context.systemPrompt).not.toContain("<available_skills>");
+      expect(context.systemPrompt).not.toContain("<name>weather</name>");
+      expect(context.systemPromptReport.skills.promptChars).toBe(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps Claude CLI prompt skills when plugin skills are unavailable", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const missingSkillFilePath = path.join(dir, "skills", "missing", "SKILL.md");
+
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            pluginId: "anthropic",
+            bundleMcp: false,
+            config: {
+              command: "claude",
+              args: ["--print"],
+              output: "jsonl",
+              input: "stdin",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-claude-plugin-skills-prompt-fallback",
+        config: createCliBackendConfig({ systemPromptOverride: null }),
+        skillsSnapshot: {
+          prompt: [
+            "<available_skills>",
+            "  <skill>",
+            "    <name>weather</name>",
+            "    <description>Use weather tools for forecasts.</description>",
+            `    <location>${missingSkillFilePath}</location>`,
+            "  </skill>",
+            "</available_skills>",
+          ].join("\n"),
+          skills: [{ name: "weather" }],
+          resolvedSkills: [
+            {
+              name: "weather",
+              description: "Use weather tools for forecasts.",
+              filePath: missingSkillFilePath,
+              baseDir: path.dirname(missingSkillFilePath),
+              source: "test",
+              sourceInfo: {
+                path: path.dirname(missingSkillFilePath),
+                source: "test",
+                scope: "project",
+                origin: "top-level",
+                baseDir: path.dirname(missingSkillFilePath),
+              },
+              disableModelInvocation: false,
+            },
+          ],
+        },
+      });
+
+      expect(context.systemPrompt).toContain("<available_skills>");
+      expect(context.systemPrompt).toContain("<name>weather</name>");
+      expect(context.systemPromptReport.skills.promptChars).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not probe the transcript for non-claude-cli providers", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { getRuntimeConfig } from "../../config/config.js";
 import {
   assertContextEngineHostSupport,
@@ -53,7 +54,7 @@ import { resolveAttemptPrependSystemContext } from "../pi-embedded-runner/run/at
 import { composeSystemPromptWithHookContext } from "../pi-embedded-runner/run/attempt.thread-helpers.js";
 import { buildCurrentInboundPrompt } from "../pi-embedded-runner/run/runtime-context-prompt.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
-import { resolveSkillsPromptForRun } from "../skills.js";
+import { resolveSkillsPromptForRun, type SkillSnapshot } from "../skills.js";
 import { resolveSystemPromptOverride } from "../system-prompt-override.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt } from "../system-prompt.js";
@@ -118,6 +119,23 @@ export function shouldSkipLocalCliCredentialEpoch(params: {
     params.authProfileId &&
     params.authCredential &&
     params.preparedExecution,
+  );
+}
+
+function claudeCliSkillsPluginCanCarryPrompt(params: {
+  provider: string;
+  skillsSnapshot?: SkillSnapshot;
+}): boolean {
+  if (!isClaudeCliProvider(params.provider)) {
+    return false;
+  }
+  return (
+    params.skillsSnapshot?.resolvedSkills?.some(
+      (skill) =>
+        Boolean(skill.name?.trim()) &&
+        Boolean(skill.filePath?.trim()) &&
+        fs.existsSync(skill.filePath),
+    ) ?? false
   );
 }
 
@@ -403,6 +421,12 @@ export async function prepareCliRunContext(
     config: params.config,
     agentId: sessionAgentId,
   });
+  const systemPromptSkillsPrompt = claudeCliSkillsPluginCanCarryPrompt({
+    provider: params.provider,
+    skillsSnapshot: params.skillsSnapshot,
+  })
+    ? ""
+    : skillsPrompt;
   const builtSystemPrompt =
     resolveSystemPromptOverride({
       config: params.config,
@@ -419,7 +443,7 @@ export async function prepareCliRunContext(
       heartbeatPrompt,
       docsPath: openClawReferences.docsPath ?? undefined,
       sourcePath: openClawReferences.sourcePath ?? undefined,
-      skillsPrompt,
+      skillsPrompt: systemPromptSkillsPrompt,
       tools: promptTools,
       contextFiles,
       modelDisplay,
@@ -529,7 +553,7 @@ export async function prepareCliRunContext(
     systemPrompt,
     bootstrapFiles,
     injectedFiles: contextFiles,
-    skillsPrompt,
+    skillsPrompt: systemPromptSkillsPrompt,
     tools: promptTools,
     currentTurn: {
       ...(params.currentInboundEventKind ? { kind: params.currentInboundEventKind } : {}),


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Prevents Claude CLI runs from receiving the same OpenClaw skills catalog through both the appended system prompt and Claude Code native skill plugin.
- Keeps the OpenClaw prompt catalog as a fallback when no selected skill file can be materialized into the Claude plugin.
- Updates Claude CLI backend docs so they describe the plugin-first behavior instead of two-way delivery.

Why does this matter now?

- Issue #87063 reports Claude CLI sessions growing toward context exhaustion because the selected skill catalog is duplicated every turn.

What is the intended outcome?

- Claude CLI uses one authoritative skill exposure path when the native plugin can carry selected skills, reducing static prompt overhead while preserving fallback behavior.

What is intentionally out of scope?

- Prompt caching changes.
- The already-fixed CLI runtime alias harness selection path.
- Clawpatch's unrelated qa-channel SSRF finding outside the touched files.

What does success look like?

- Claude CLI prepared system prompts omit `<available_skills>` when the native plugin has at least one materializable skill.
- Claude CLI prepared system prompts keep `<available_skills>` when plugin skill files are unavailable.
- Non-Claude providers keep existing prompt behavior.

What should reviewers focus on?

- Whether `prepareCliRunContext` is the right layer to suppress the duplicate prompt catalog while preserving fallback behavior.
- Whether checking for an existing selected skill file is sufficient to avoid suppressing the fallback when plugin materialization cannot happen.

## Linked context

Which issue does this close?

Closes #87063

Which issues, PRs, or discussions are related?

Related #87063

Was this requested by a maintainer or owner?

- Created from the Astra/Vector P1 automation queue for issue #87063.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Claude CLI duplicate skill catalog injection in the prepared system prompt when a native Claude skills plugin can carry selected OpenClaw skills.
- Real environment tested: macOS local checkout at `/Users/miya/Desktop/openclaw-issue-87063`, Claude Code `2.1.150`, OpenClaw CLI runner loaded through `node --import tsx`, temporary OpenClaw state/session/skill directory under `/tmp`.
- Exact steps or command run after this patch: ran OpenClaw's real `prepareCliRunContext` + `runPreparedCliAgent` path with provider `claude-cli`, model `sonnet`, a real temporary `skills/weather/SKILL.md`, and CLI backend logging enabled. The run invoked the installed `claude` binary and returned a live Claude response.
- Evidence after fix (redacted copied terminal output from the OpenClaw Claude CLI run):

```text
PREPARED_PROMPT_PROOF {"skillFileExists":true,"systemPromptHasAvailableSkills":false,"systemPromptHasWeatherSkill":false,"skillsPromptChars":0}
[agent/cli-backend] cli exec: provider=claude-cli model=sonnet promptChars=44 trigger=unknown useResume=false session=none resumeSession=none reuse=none historyPrompt=none
[agent/cli-backend] cli argv: claude --print --output-format text --no-session-persistence --setting-sources user --permission-mode bypassPermissions --strict-mcp-config --mcp-config /Users/miya/.openclaw/tmp/openclaw-cli-mcp-REDACTED/mcp.json --plugin-dir /tmp/openclaw/openclaw-claude-skills-REDACTED/openclaw-skills --model sonnet --append-system-prompt-file /private/tmp/openclaw/openclaw-cli-system-prompt-REDACTED/system-prompt.md <prompt:44 chars>
[agent/cli-backend] cli env auth: host=none child=none cleared=none
[agent/cli-backend] cli env mcp: token=*** sessionKey=<empty> agentId=main accountId=<empty> messageChannel=<empty>
[agent/cli-backend] cli stdout:
OPENCLAW_CLAUDE_LIVE_PROOF_OK
CLAUDE_RESULT_TEXT "OPENCLAW_CLAUDE_LIVE_PROOF_OK"
```

- Observed result after fix: with an existing selected skill file that can be carried by the Claude plugin, OpenClaw prepared a Claude CLI prompt with no `<available_skills>` block, invoked Claude with `--plugin-dir .../openclaw-skills`, and received the expected live Claude response.
- What was not tested: prompt-cache behavior changes; they are outside this PR.
- Proof limitations or environment constraints: the live run proves plugin-first invocation and prompt suppression for a minimal selected skill. It does not measure the reporter's full 30-skill token count.
- Before evidence (optional but encouraged): issue #87063 includes ClawSweeper source reproduction showing `prepareCliRunContext` placed the skills prompt in the CLI system prompt while `execute.ts` also prepared the Claude skills plugin.

## Tests and validation

Which commands did you run?

- Live OpenClaw Claude CLI runner proof described above
- `node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts`
- `node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts src/agents/cli-runner/prepare.test.ts src/agents/harness/selection.test.ts src/agents/skills/compact-format.test.ts`
- `git diff --check`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- Clawpatch: `doctor`, `status`, `init`, `map`, `review`, `report` via OpenClaw tools

What regression coverage was added or updated?

- Added Claude CLI prepare coverage for plugin-carried skills suppressing the prompt catalog.
- Added fallback coverage for missing plugin skill files keeping the prompt catalog.

What failed before this fix, if known?

- The new suppression test would have failed because the Claude CLI system prompt still included `<available_skills>` even when selected skills were also available to the Claude plugin.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Claude CLI sessions should receive a smaller appended system prompt when native plugin skills are available.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Suppressing too much prompt skill metadata if the native Claude plugin cannot actually materialize skills.

How is that risk mitigated?

- Suppression now requires a Claude CLI provider and at least one resolved skill with an existing skill file; missing skill-file coverage verifies the prompt fallback remains active. The live Claude CLI proof confirms the plugin-first path invokes Claude with `--plugin-dir` while omitting prompt skills.

## Current review state

What is the next action?

- ClawSweeper re-review, CI, and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Live Claude CLI proof has been added. One CI check (`check-test-types`) is failing in files outside this PR (`src/commands/docs.test.ts`, `src/plugins/runtime/runtime-registry-loader.test.ts`) and may need maintainer/baseline handling if rerun does not clear it.

Which bot or reviewer comments were addressed?

- Addressed ClawSweeper's request for real Claude CLI proof showing `--plugin-dir` and `<available_skills>` absent from the prepared prompt.

AI-assisted: yes, implemented by OpenClaw Vector.