### PR TITLE
Fix chat image history media rewrite

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -150,6 +150,21 @@ type TranscriptAppendResult = {
   error?: string;
 };
 
+export const testing = {
+  async rewriteChatSendUserTurnMediaPathsForTest(params: {
+    transcriptPath: string;
+    sessionKey: string;
+    message: string;
+    savedImages: Array<{ id: string; path: string; size?: number; contentType?: string }>;
+    cfg: OpenClawConfig;
+  }): Promise<unknown> {
+    return await rewriteChatSendUserTurnMediaPaths({
+      ...params,
+      savedImages: params.savedImages as SavedMedia[],
+    });
+  },
+};
+
 type AbortOrigin = "rpc" | "stop-command";
 
 type AbortedPartialSnapshot = {
@@ -1098,6 +1113,41 @@ function extractTranscriptUserText(content: unknown): string | undefined {
   return textBlocks.length > 0 ? textBlocks.join("") : undefined;
 }
 
+function isTranscriptImageContentBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "image" || type === "input_image";
+}
+
+function transcriptContentHasImageBlocks(content: unknown): boolean {
+  return Array.isArray(content) && content.some(isTranscriptImageContentBlock);
+}
+
+function stripTranscriptImageContentBlocks(content: unknown): unknown {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  return content.filter((block) => !isTranscriptImageContentBlock(block));
+}
+
+function transcriptUserTextMatchesChatSend(content: unknown, message: string): boolean {
+  const text = extractTranscriptUserText(content);
+  if (text === undefined) {
+    return false;
+  }
+  if (text === message) {
+    return true;
+  }
+  const trimmedMessage = message.trim();
+  return (
+    trimmedMessage.length > 0 &&
+    transcriptContentHasImageBlocks(content) &&
+    text.includes(trimmedMessage)
+  );
+}
+
 async function rewriteChatSendUserTurnMediaPaths(params: {
   transcriptPath: string;
   sessionKey: string;
@@ -1125,7 +1175,10 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
     ) {
       return false;
     }
-    return extractTranscriptUserText((message as { content?: unknown }).content) === params.message;
+    return transcriptUserTextMatchesChatSend(
+      (message as { content?: unknown }).content,
+      params.message,
+    );
   });
   const targetMessage = target?.record.message as Record<string, unknown> | undefined;
   if (!target || !target.id || !targetMessage) {
@@ -1133,9 +1186,10 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
   }
   const rewrittenMessage = {
     ...targetMessage,
+    content: stripTranscriptImageContentBlocks(targetMessage.content),
     ...mediaFields,
   };
-  await rewriteTranscriptEntriesInSessionFile({
+  return await rewriteTranscriptEntriesInSessionFile({
     sessionFile: params.transcriptPath,
     sessionKey: params.sessionKey,
     config: params.cfg,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -907,6 +907,78 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.send rewrites metadata-wrapped image user turns to media paths", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      const { readSessionTranscriptIndex } = await import("./session-transcript-index.fs.js");
+      const { testing: chatTesting } = await import("./server-methods/chat.js");
+      const prompt = "Add these items to my pantry. 2 of each";
+      const hugeInlineImageData = "i".repeat(120_000);
+      const transcriptPath = path.join(sessionDir, "sess-main.jsonl");
+
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "sess-main",
+          timestamp: new Date().toISOString(),
+          cwd: sessionDir,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "metadata-wrapped-image-user-turn",
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: `Sender (untrusted metadata):\n\`\`\`json\n{"label":"ClawHome (openclaw-ios)"}\n\`\`\`\n${prompt}`,
+              },
+              {
+                type: "image",
+                mimeType: "image/png",
+                data: hugeInlineImageData,
+              },
+            ],
+          },
+        }),
+      ]);
+
+      const result = await chatTesting.rewriteChatSendUserTurnMediaPathsForTest({
+        transcriptPath,
+        sessionKey: "main",
+        message: prompt,
+        savedImages: [
+          {
+            id: "image-1",
+            path: "/tmp/openclaw-media/inbound/image-1.png",
+            size: 1024,
+            contentType: "image/png",
+          },
+        ],
+        cfg: {},
+      });
+      expect(result).toMatchObject({
+        changed: true,
+        bytesFreed: expect.any(Number),
+        rewrittenEntries: 1,
+      });
+
+      const transcript = await fs.readFile(transcriptPath, "utf-8");
+      expect(transcript).toContain("MediaPaths");
+      const index = await readSessionTranscriptIndex(transcriptPath);
+      const activeMessages = index?.entries.map((entry) => entry.record.message) ?? [];
+      const activeSerialized = JSON.stringify(activeMessages);
+      expect(activeSerialized).toContain("MediaPaths");
+      expect(activeSerialized).toContain(prompt);
+      expect(activeSerialized).not.toContain(hugeInlineImageData.slice(0, 128));
+    } finally {
+      await fs.rm(sessionDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
   test("chat.history hard-caps single oversized nested payloads", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const historyMaxBytes = 64 * 1024;


### PR DESCRIPTION
## Summary
- match metadata-wrapped chat.send image user turns when rewriting transcript media paths
- strip inline image content blocks from the active rewritten transcript turn so chat.history uses managed MediaPaths instead of oversized inline payloads
- add a regression covering ClawHome-style sender metadata around image uploads

## Tests
- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.chat.gateway-server-chat-b.test.ts