### PR TITLE
fix(cli): bound local CLI lifetime after completion and finite timeout

### DIFF
--- a/src/cli/local-agent-lifetime.test.ts
+++ b/src/cli/local-agent-lifetime.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  armLocalAgentHardTimeout,
+  resolveLocalAgentHardTimeoutPlan,
+} from "./local-agent-lifetime.js";
+
+const agentLocalArgv = (...args: string[]) => ["node", "openclaw", "agent", "--local", ...args];
+
+describe("resolveLocalAgentHardTimeoutPlan", () => {
+  it("ignores non-agent and help invocations", () => {
+    expect(resolveLocalAgentHardTimeoutPlan({ argv: ["node", "openclaw", "status"] })).toBeNull();
+    expect(
+      resolveLocalAgentHardTimeoutPlan({ argv: ["node", "openclaw", "agent", "--help"] }),
+    ).toBeNull();
+  });
+
+  it("ignores agent runs that are not local", () => {
+    expect(
+      resolveLocalAgentHardTimeoutPlan({ argv: ["node", "openclaw", "agent", "--timeout", "2"] }),
+    ).toBeNull();
+  });
+
+  it("uses explicit timeout seconds plus grace", () => {
+    expect(resolveLocalAgentHardTimeoutPlan({ argv: agentLocalArgv("--timeout", "2") })).toEqual({
+      timeoutMs: 32_000,
+      timeoutSeconds: 2,
+    });
+  });
+
+  it("treats explicit zero as no hard timeout", () => {
+    expect(resolveLocalAgentHardTimeoutPlan({ argv: agentLocalArgv("--timeout", "0") })).toBeNull();
+  });
+
+  it("does not arm the wall-clock timer when timeout is omitted", () => {
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: agentLocalArgv(),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("armLocalAgentHardTimeout", () => {
+  it("exits 124 and reports the resolved timeout when the hard timer fires", () => {
+    const unref = vi.fn();
+    let callback: (() => void) | undefined;
+    const setTimeout = vi.fn((cb: () => void, timeoutMs: number) => {
+      callback = cb;
+      expect(timeoutMs).toBe(31_000);
+      return { unref };
+    });
+    const write = vi.fn();
+    const exit = vi.fn();
+
+    armLocalAgentHardTimeout({
+      argv: agentLocalArgv("--timeout=1"),
+      setTimeout: setTimeout as never,
+      stderr: { write } as never,
+      exit,
+    });
+
+    expect(unref).toHaveBeenCalledOnce();
+    expect(callback).toBeDefined();
+
+    callback?.();
+
+    expect(write).toHaveBeenCalledWith("local agent command timed out after 1s plus 30s grace\n");
+    expect(exit).toHaveBeenCalledWith(124);
+  });
+});

--- a/src/cli/local-agent-lifetime.test.ts
+++ b/src/cli/local-agent-lifetime.test.ts
@@ -231,7 +231,10 @@ describe("exitAfterLocalAgentCompletion", () => {
           resolveHook = resolve;
         }),
     );
-    const setTimeout = vi.fn((_cb: () => void, _timeoutMs: number) => ({ unref: vi.fn() }));
+    const forceKillUnref = vi.fn();
+    const setTimeout = vi.fn((_cb: () => void, _timeoutMs: number) => ({
+      unref: forceKillUnref,
+    }));
     const clearTimeout = vi.fn();
     const kill = vi.fn();
     const exit = vi.fn(() => {
@@ -252,21 +255,25 @@ describe("exitAfterLocalAgentCompletion", () => {
     });
 
     await vi.waitFor(() => expect(hook).toHaveBeenCalledOnce());
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 3);
+    expect(forceKillUnref).toHaveBeenCalledOnce();
+    const killCallback = setTimeout.mock.calls.find(([, timeoutMs]) => timeoutMs === 3)?.[0];
+    killCallback?.();
+    expect(kill).toHaveBeenCalledWith(12345, "SIGKILL");
     expect(exit).not.toHaveBeenCalled();
 
     resolveHook?.();
     await expect(result).rejects.toThrow("exit");
 
     expect(exit).toHaveBeenCalledWith(process.exitCode ?? 0);
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 3);
-    const killCallback = setTimeout.mock.calls.find(([, timeoutMs]) => timeoutMs === 3)?.[0];
-    killCallback?.();
-    expect(kill).toHaveBeenCalledWith(12345, "SIGKILL");
   });
 
   it("still exits when the optional otel pre-exit hook rejects", async () => {
     const hook = vi.fn(() => Promise.reject(new Error("flush failed")));
-    const setTimeout = vi.fn((_cb: () => void, _timeoutMs: number) => ({ unref: vi.fn() }));
+    const forceKillUnref = vi.fn();
+    const setTimeout = vi.fn((_cb: () => void, _timeoutMs: number) => ({
+      unref: forceKillUnref,
+    }));
     const exit = vi.fn(() => {
       throw new Error("exit");
     });
@@ -288,5 +295,6 @@ describe("exitAfterLocalAgentCompletion", () => {
     expect(hook).toHaveBeenCalledOnce();
     expect(exit).toHaveBeenCalledWith(process.exitCode ?? 0);
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 3);
+    expect(forceKillUnref).toHaveBeenCalledOnce();
   });
 });

--- a/src/cli/local-agent-lifetime.test.ts
+++ b/src/cli/local-agent-lifetime.test.ts
@@ -172,6 +172,8 @@ describe("armLocalAgentHardTimeout", () => {
 });
 
 describe("exitAfterLocalAgentCompletion", () => {
+  const otelPreExitSymbol = Symbol.for("openclaw.otel.preExit");
+
   it("does nothing outside local agent runs", async () => {
     const stdout = { write: vi.fn() };
     const stderr = { write: vi.fn() };
@@ -219,5 +221,72 @@ describe("exitAfterLocalAgentCompletion", () => {
     await expect(result).rejects.toThrow("exit");
     expect(exit).toHaveBeenCalledWith(process.exitCode ?? 0);
     expect(clearTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for an optional otel pre-exit hook before forcing exit", async () => {
+    let resolveHook: (() => void) | undefined;
+    const hook = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveHook = resolve;
+        }),
+    );
+    const setTimeout = vi.fn((_cb: () => void, _timeoutMs: number) => ({ unref: vi.fn() }));
+    const clearTimeout = vi.fn();
+    const kill = vi.fn();
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    });
+
+    const result = exitAfterLocalAgentCompletion({
+      argv: agentLocalArgv(),
+      globalObject: { [otelPreExitSymbol]: hook },
+      stdout: { write: vi.fn(), destroyed: true } as never,
+      stderr: { write: vi.fn(), destroyed: true } as never,
+      setTimeout: setTimeout as never,
+      clearTimeout: clearTimeout as never,
+      exit: exit as never,
+      kill,
+      pid: 12345,
+      forceKillTimeoutMs: 3,
+    });
+
+    await vi.waitFor(() => expect(hook).toHaveBeenCalledOnce());
+    expect(exit).not.toHaveBeenCalled();
+
+    resolveHook?.();
+    await expect(result).rejects.toThrow("exit");
+
+    expect(exit).toHaveBeenCalledWith(process.exitCode ?? 0);
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 3);
+    const killCallback = setTimeout.mock.calls.find(([, timeoutMs]) => timeoutMs === 3)?.[0];
+    killCallback?.();
+    expect(kill).toHaveBeenCalledWith(12345, "SIGKILL");
+  });
+
+  it("still exits when the optional otel pre-exit hook rejects", async () => {
+    const hook = vi.fn(() => Promise.reject(new Error("flush failed")));
+    const setTimeout = vi.fn((_cb: () => void, _timeoutMs: number) => ({ unref: vi.fn() }));
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    });
+
+    await expect(
+      exitAfterLocalAgentCompletion({
+        argv: agentLocalArgv(),
+        globalObject: { [otelPreExitSymbol]: hook },
+        stdout: { write: vi.fn(), destroyed: true } as never,
+        stderr: { write: vi.fn(), destroyed: true } as never,
+        setTimeout: setTimeout as never,
+        clearTimeout: vi.fn() as never,
+        exit: exit as never,
+        kill: vi.fn(),
+        forceKillTimeoutMs: 3,
+      }),
+    ).rejects.toThrow("exit");
+
+    expect(hook).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(process.exitCode ?? 0);
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 3);
   });
 });

--- a/src/cli/local-agent-lifetime.test.ts
+++ b/src/cli/local-agent-lifetime.test.ts
@@ -4,6 +4,7 @@ import {
   exitAfterLocalAgentCompletion,
   resolveLocalAgentHardTimeoutPlan,
 } from "./local-agent-lifetime.js";
+import { normalizeWindowsArgv } from "./windows-argv.js";
 
 const agentLocalArgv = (...args: string[]) => ["node", "openclaw", "agent", "--local", ...args];
 
@@ -42,6 +43,25 @@ describe("resolveLocalAgentHardTimeoutPlan", () => {
     expect(
       resolveLocalAgentHardTimeoutPlan({
         argv: ["node", "openclaw", "--profile", "dev", "agent", "--local", "--timeout", "2"],
+      }),
+    ).toEqual({
+      timeoutMs: 32_000,
+      timeoutSeconds: 2,
+    });
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: normalizeWindowsArgv(
+          [
+            "openclaw",
+            "C:\\Program Files\\nodejs\\node.exe",
+            "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js",
+            "agent",
+            "--local",
+            "--timeout",
+            "2",
+          ],
+          { platform: "win32", execPath: "C:\\Program Files\\nodejs\\node.exe" },
+        ),
       }),
     ).toEqual({
       timeoutMs: 32_000,
@@ -107,20 +127,28 @@ describe("resolveLocalAgentHardTimeoutPlan", () => {
 });
 
 describe("armLocalAgentHardTimeout", () => {
-  it("exits 124 and reports the resolved timeout when the hard timer fires", () => {
+  it("exits 124 and reports the resolved timeout when the hard timer fires", async () => {
     const unref = vi.fn();
     let callback: (() => void) | undefined;
+    let flushCallback: (() => void) | undefined;
     const setTimeout = vi.fn((cb: () => void, timeoutMs: number) => {
-      callback = cb;
-      expect(timeoutMs).toBe(31_000);
+      if (timeoutMs === 31_000) {
+        callback = cb;
+      } else {
+        expect(timeoutMs).toBe(250);
+      }
       return { unref };
     });
-    const write = vi.fn();
+    const clearTimeout = vi.fn();
+    const write = vi.fn((_chunk: string, cb: () => void) => {
+      flushCallback = cb;
+    });
     const exit = vi.fn();
 
     armLocalAgentHardTimeout({
       argv: agentLocalArgv("--timeout=1"),
       setTimeout: setTimeout as never,
+      clearTimeout: clearTimeout as never,
       stderr: { write } as never,
       exit,
     });
@@ -130,8 +158,16 @@ describe("armLocalAgentHardTimeout", () => {
 
     callback?.();
 
-    expect(write).toHaveBeenCalledWith("local agent command timed out after 1s plus 30s grace\n");
+    expect(write).toHaveBeenCalledWith(
+      "local agent command timed out after 1s plus 30s grace\n",
+      expect.any(Function),
+    );
+    expect(exit).not.toHaveBeenCalled();
+    flushCallback?.();
+    await Promise.resolve();
+
     expect(exit).toHaveBeenCalledWith(124);
+    expect(clearTimeout).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/cli/local-agent-lifetime.test.ts
+++ b/src/cli/local-agent-lifetime.test.ts
@@ -117,6 +117,14 @@ describe("resolveLocalAgentHardTimeoutPlan", () => {
     });
   });
 
+  it("stops parsing agent flags after a value option consumes the flag terminator", () => {
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: agentLocalArgv("--message", "--", "--timeout", "1"),
+      }),
+    ).toBeNull();
+  });
+
   it("does not arm the wall-clock timer when timeout is omitted", () => {
     expect(
       resolveLocalAgentHardTimeoutPlan({

--- a/src/cli/local-agent-lifetime.test.ts
+++ b/src/cli/local-agent-lifetime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   armLocalAgentHardTimeout,
+  exitAfterLocalAgentCompletion,
   resolveLocalAgentHardTimeoutPlan,
 } from "./local-agent-lifetime.js";
 
@@ -11,6 +12,11 @@ describe("resolveLocalAgentHardTimeoutPlan", () => {
     expect(resolveLocalAgentHardTimeoutPlan({ argv: ["node", "openclaw", "status"] })).toBeNull();
     expect(
       resolveLocalAgentHardTimeoutPlan({ argv: ["node", "openclaw", "agent", "--help"] }),
+    ).toBeNull();
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: ["node", "openclaw", "-v", "agent", "--local", "--timeout", "1"],
+      }),
     ).toBeNull();
   });
 
@@ -25,10 +31,70 @@ describe("resolveLocalAgentHardTimeoutPlan", () => {
       timeoutMs: 32_000,
       timeoutSeconds: 2,
     });
+    expect(resolveLocalAgentHardTimeoutPlan({ argv: agentLocalArgv("--timeout=1s") })).toEqual({
+      timeoutMs: 31_000,
+      timeoutSeconds: 1,
+    });
+    expect(resolveLocalAgentHardTimeoutPlan({ argv: agentLocalArgv("--timeout", "1.5") })).toEqual({
+      timeoutMs: 31_000,
+      timeoutSeconds: 1,
+    });
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: ["node", "openclaw", "--profile", "dev", "agent", "--local", "--timeout", "2"],
+      }),
+    ).toEqual({
+      timeoutMs: 32_000,
+      timeoutSeconds: 2,
+    });
+  });
+
+  it("clamps the hard timer to Node's timer-safe maximum", () => {
+    expect(
+      resolveLocalAgentHardTimeoutPlan({ argv: agentLocalArgv("--timeout", "2147484") }),
+    ).toEqual({
+      timeoutMs: 2_147_000_000,
+      timeoutSeconds: 2_147_484,
+    });
+  });
+
+  it("uses the last repeated timeout option", () => {
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: agentLocalArgv("--timeout", "1", "--timeout", "0"),
+      }),
+    ).toBeNull();
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: agentLocalArgv("--timeout", "0", "--timeout", "1"),
+      }),
+    ).toEqual({
+      timeoutMs: 31_000,
+      timeoutSeconds: 1,
+    });
   });
 
   it("treats explicit zero as no hard timeout", () => {
     expect(resolveLocalAgentHardTimeoutPlan({ argv: agentLocalArgv("--timeout", "0") })).toBeNull();
+  });
+
+  it("does not treat option values as help or version requests", () => {
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: agentLocalArgv("--message", "--help", "--timeout", "1"),
+      }),
+    ).toEqual({
+      timeoutMs: 31_000,
+      timeoutSeconds: 1,
+    });
+    expect(
+      resolveLocalAgentHardTimeoutPlan({
+        argv: agentLocalArgv("--message=--version", "--timeout=1"),
+      }),
+    ).toEqual({
+      timeoutMs: 31_000,
+      timeoutSeconds: 1,
+    });
   });
 
   it("does not arm the wall-clock timer when timeout is omitted", () => {
@@ -66,5 +132,56 @@ describe("armLocalAgentHardTimeout", () => {
 
     expect(write).toHaveBeenCalledWith("local agent command timed out after 1s plus 30s grace\n");
     expect(exit).toHaveBeenCalledWith(124);
+  });
+});
+
+describe("exitAfterLocalAgentCompletion", () => {
+  it("does nothing outside local agent runs", async () => {
+    const stdout = { write: vi.fn() };
+    const stderr = { write: vi.fn() };
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    });
+
+    await exitAfterLocalAgentCompletion({
+      argv: ["node", "openclaw", "status"],
+      stdout: stdout as never,
+      stderr: stderr as never,
+      exit: exit as never,
+    });
+
+    expect(stdout.write).not.toHaveBeenCalled();
+    expect(stderr.write).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("flushes stdout and stderr before exiting after local agent completion", async () => {
+    const stdoutCallbacks: Array<() => void> = [];
+    const stderrCallbacks: Array<() => void> = [];
+    const stdout = { write: vi.fn((_chunk: string, cb: () => void) => stdoutCallbacks.push(cb)) };
+    const stderr = { write: vi.fn((_chunk: string, cb: () => void) => stderrCallbacks.push(cb)) };
+    const clearTimeout = vi.fn();
+    const setTimeout = vi.fn(() => ({ unref: vi.fn() }));
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    });
+
+    const result = exitAfterLocalAgentCompletion({
+      argv: agentLocalArgv(),
+      stdout: stdout as never,
+      stderr: stderr as never,
+      setTimeout: setTimeout as never,
+      clearTimeout: clearTimeout as never,
+      exit: exit as never,
+    });
+
+    expect(exit).not.toHaveBeenCalled();
+    stdoutCallbacks[0]?.();
+    expect(exit).not.toHaveBeenCalled();
+    stderrCallbacks[0]?.();
+
+    await expect(result).rejects.toThrow("exit");
+    expect(exit).toHaveBeenCalledWith(process.exitCode ?? 0);
+    expect(clearTimeout).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/cli/local-agent-lifetime.ts
+++ b/src/cli/local-agent-lifetime.ts
@@ -1,7 +1,27 @@
-import { getCommandPathWithRootOptions, getFlagValue, hasHelpOrVersion } from "./argv.js";
+import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-options.js";
 
 const LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS = 30_000;
 const LOCAL_AGENT_HARD_TIMEOUT_GRACE_SECONDS = LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS / 1000;
+const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
+const CLI_COMPLETION_STREAM_DRAIN_TIMEOUT_MS = 250;
+const HELP_OR_VERSION_FLAGS = new Set(["-h", "--help", "-V", "--version"]);
+const AGENT_VALUE_FLAGS = new Set([
+  "-m",
+  "--message",
+  "-t",
+  "--to",
+  "--session-key",
+  "--session-id",
+  "--agent",
+  "--model",
+  "--thinking",
+  "--verbose",
+  "--channel",
+  "--reply-to",
+  "--reply-channel",
+  "--reply-account",
+  "--timeout",
+]);
 
 type LocalAgentHardTimeoutDeps = {
   argv?: string[];
@@ -10,33 +30,125 @@ type LocalAgentHardTimeoutDeps = {
   exit?: (code?: number) => never | void;
 };
 
+type CliCompletionExitDeps = {
+  argv?: string[];
+  stdout?: Pick<NodeJS.WriteStream, "write"> &
+    Partial<Pick<NodeJS.WriteStream, "destroyed" | "writableEnded">>;
+  stderr?: Pick<NodeJS.WriteStream, "write"> &
+    Partial<Pick<NodeJS.WriteStream, "destroyed" | "writableEnded">>;
+  setTimeout?: typeof globalThis.setTimeout;
+  clearTimeout?: typeof globalThis.clearTimeout;
+  exit?: (code?: number) => never;
+  drainTimeoutMs?: number;
+};
+
 type LocalAgentTimeoutPlan = {
   timeoutMs: number;
   timeoutSeconds: number;
 };
 
-function parseExplicitTimeoutSeconds(argv: string[]): number | undefined {
-  const raw = getFlagValue(argv, "--timeout");
-  if (raw === undefined || raw === null || !/^\d+$/u.test(raw)) {
+type ParsedLocalAgentArgs = {
+  hasHelpOrVersion: boolean;
+  hasLocal: boolean;
+  timeoutRaw: string | undefined;
+};
+
+function parseTimeoutSeconds(raw: string | undefined): number | undefined {
+  if (raw === undefined) {
     return undefined;
   }
   const parsed = Number.parseInt(raw, 10);
-  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function resolveHardTimeoutMs(timeoutSeconds: number): number {
+  return Math.min(
+    Math.floor(timeoutSeconds * 1000 + LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS),
+    MAX_TIMER_SAFE_TIMEOUT_MS,
+  );
+}
+
+function splitOptionToken(arg: string): { flag: string; value: string | undefined } {
+  const equalsIndex = arg.indexOf("=");
+  return equalsIndex === -1
+    ? { flag: arg, value: undefined }
+    : { flag: arg.slice(0, equalsIndex), value: arg.slice(equalsIndex + 1) };
+}
+
+function findAgentArgsStart(argv: string[]): number | null {
+  const args = argv.slice(2);
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      break;
+    }
+    if (arg === "-v" || HELP_OR_VERSION_FLAGS.has(arg)) {
+      return null;
+    }
+    const rootConsumed = consumeRootOptionToken(args, index);
+    if (rootConsumed > 0) {
+      index += rootConsumed - 1;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    return arg === "agent" ? index + 3 : null;
+  }
+  return null;
+}
+
+function parseLocalAgentArgs(argv: string[]): ParsedLocalAgentArgs | null {
+  const start = findAgentArgsStart(argv);
+  if (start === null) {
+    return null;
+  }
+
+  const parsed: ParsedLocalAgentArgs = {
+    hasHelpOrVersion: false,
+    hasLocal: false,
+    timeoutRaw: undefined,
+  };
+
+  for (let index = start; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      break;
+    }
+
+    const { flag, value } = splitOptionToken(arg);
+    if (HELP_OR_VERSION_FLAGS.has(flag)) {
+      parsed.hasHelpOrVersion = true;
+      continue;
+    }
+    if (flag === "--local") {
+      parsed.hasLocal = true;
+      continue;
+    }
+    if (!AGENT_VALUE_FLAGS.has(flag)) {
+      continue;
+    }
+    const optionValue = value ?? argv[index + 1];
+    if (flag === "--timeout") {
+      parsed.timeoutRaw = optionValue;
+    }
+    if (value === undefined) {
+      index += 1;
+    }
+  }
+
+  return parsed;
 }
 
 export function resolveLocalAgentHardTimeoutPlan(
   deps: LocalAgentHardTimeoutDeps = {},
 ): LocalAgentTimeoutPlan | null {
   const argv = deps.argv ?? process.argv;
-  const commandPath = getCommandPathWithRootOptions(argv, 1);
-  if (commandPath[0] !== "agent" || hasHelpOrVersion(argv)) {
+  const parsedArgs = parseLocalAgentArgs(argv);
+  if (!parsedArgs || parsedArgs.hasHelpOrVersion || !parsedArgs.hasLocal) {
     return null;
   }
-  const localFlag = getFlagValue(argv, "--local");
-  if (localFlag === undefined) {
-    return null;
-  }
-  const overrideSeconds = parseExplicitTimeoutSeconds(argv);
+  const overrideSeconds = parseTimeoutSeconds(parsedArgs.timeoutRaw);
   if (overrideSeconds === undefined) {
     // Keep omitted --timeout on the existing configured/default agent timeout contract.
     return null;
@@ -45,9 +157,17 @@ export function resolveLocalAgentHardTimeoutPlan(
     return null;
   }
   return {
-    timeoutMs: overrideSeconds * 1000 + LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS,
+    timeoutMs: resolveHardTimeoutMs(overrideSeconds),
     timeoutSeconds: overrideSeconds,
   };
+}
+
+export function shouldForceExitAfterLocalAgentCompletion(
+  deps: Pick<LocalAgentHardTimeoutDeps, "argv"> = {},
+): boolean {
+  const argv = deps.argv ?? process.argv;
+  const parsedArgs = parseLocalAgentArgs(argv);
+  return Boolean(parsedArgs && parsedArgs.hasLocal && !parsedArgs.hasHelpOrVersion);
 }
 
 export function armLocalAgentHardTimeout(deps: LocalAgentHardTimeoutDeps = {}): void {
@@ -71,6 +191,52 @@ export function armLocalAgentHardTimeout(deps: LocalAgentHardTimeoutDeps = {}): 
   timer.unref?.();
 }
 
-export function exitAfterCliCompletion(): never {
-  process.exit(process.exitCode ?? 0);
+function waitForStreamFlush(
+  stream: CliCompletionExitDeps["stdout"],
+  deps: Required<Pick<CliCompletionExitDeps, "setTimeout" | "clearTimeout" | "drainTimeoutMs">>,
+): Promise<void> {
+  if (!stream || stream.destroyed || stream.writableEnded) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let done = false;
+    let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+    const finish = () => {
+      if (done) {
+        return;
+      }
+      done = true;
+      if (timer) {
+        deps.clearTimeout(timer);
+      }
+      resolve();
+    };
+    timer = deps.setTimeout(finish, deps.drainTimeoutMs);
+    timer.unref?.();
+    try {
+      stream.write("", finish);
+    } catch {
+      finish();
+    }
+  });
+}
+
+export async function exitAfterLocalAgentCompletion(
+  deps: CliCompletionExitDeps = {},
+): Promise<void> {
+  if (!shouldForceExitAfterLocalAgentCompletion(deps)) {
+    return;
+  }
+  const drainDeps = {
+    setTimeout: deps.setTimeout ?? globalThis.setTimeout,
+    clearTimeout: deps.clearTimeout ?? globalThis.clearTimeout,
+    drainTimeoutMs: deps.drainTimeoutMs ?? CLI_COMPLETION_STREAM_DRAIN_TIMEOUT_MS,
+  };
+  await Promise.all([
+    waitForStreamFlush(deps.stdout ?? process.stdout, drainDeps),
+    waitForStreamFlush(deps.stderr ?? process.stderr, drainDeps),
+  ]);
+  const exit = deps.exit ?? process.exit.bind(process);
+  exit(process.exitCode ?? 0);
 }

--- a/src/cli/local-agent-lifetime.ts
+++ b/src/cli/local-agent-lifetime.ts
@@ -4,6 +4,8 @@ const LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS = 30_000;
 const LOCAL_AGENT_HARD_TIMEOUT_GRACE_SECONDS = LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS / 1000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
 const CLI_COMPLETION_STREAM_DRAIN_TIMEOUT_MS = 250;
+const CLI_COMPLETION_FORCE_KILL_TIMEOUT_MS = 3_000;
+const OTEL_PRE_EXIT_SYMBOL = Symbol.for("openclaw.otel.preExit");
 const HELP_OR_VERSION_FLAGS = new Set(["-h", "--help", "-V", "--version"]);
 const AGENT_VALUE_FLAGS = new Set([
   "-m",
@@ -35,14 +37,18 @@ type LocalAgentHardTimeoutDeps = {
 
 type CliCompletionExitDeps = {
   argv?: string[];
+  globalObject?: Record<symbol, unknown>;
   stdout?: Pick<NodeJS.WriteStream, "write"> &
     Partial<Pick<NodeJS.WriteStream, "destroyed" | "writableEnded">>;
   stderr?: Pick<NodeJS.WriteStream, "write"> &
     Partial<Pick<NodeJS.WriteStream, "destroyed" | "writableEnded">>;
   setTimeout?: typeof globalThis.setTimeout;
   clearTimeout?: typeof globalThis.clearTimeout;
-  exit?: (code?: number) => never;
+  exit?: (code?: number) => never | void;
+  kill?: (pid: number, signal: NodeJS.Signals) => void;
+  pid?: number;
   drainTimeoutMs?: number;
+  forceKillTimeoutMs?: number;
 };
 
 type LocalAgentTimeoutPlan = {
@@ -248,6 +254,29 @@ function waitForStreamFlush(
   return writeAndFlushStream(stream, "", deps);
 }
 
+async function flushOtelBeforeExit(deps: CliCompletionExitDeps): Promise<void> {
+  const hook = (deps.globalObject ?? (globalThis as Record<symbol, unknown>))[OTEL_PRE_EXIT_SYMBOL];
+  if (typeof hook !== "function") {
+    return;
+  }
+  try {
+    await hook();
+  } catch {}
+}
+
+function exitWithKillFallback(deps: CliCompletionExitDeps): void {
+  const setTimer = deps.setTimeout ?? globalThis.setTimeout;
+  const kill = deps.kill ?? process.kill.bind(process);
+  const exit = deps.exit ?? process.exit.bind(process);
+  const pid = deps.pid ?? process.pid;
+  setTimer(() => {
+    try {
+      kill(pid, "SIGKILL");
+    } catch {}
+  }, deps.forceKillTimeoutMs ?? CLI_COMPLETION_FORCE_KILL_TIMEOUT_MS);
+  exit(process.exitCode ?? 0);
+}
+
 export async function exitAfterLocalAgentCompletion(
   deps: CliCompletionExitDeps = {},
 ): Promise<void> {
@@ -263,6 +292,6 @@ export async function exitAfterLocalAgentCompletion(
     waitForStreamFlush(deps.stdout ?? process.stdout, drainDeps),
     waitForStreamFlush(deps.stderr ?? process.stderr, drainDeps),
   ]);
-  const exit = deps.exit ?? process.exit.bind(process);
-  exit(process.exitCode ?? 0);
+  await flushOtelBeforeExit(deps);
+  exitWithKillFallback(deps);
 }

--- a/src/cli/local-agent-lifetime.ts
+++ b/src/cli/local-agent-lifetime.ts
@@ -264,17 +264,35 @@ async function flushOtelBeforeExit(deps: CliCompletionExitDeps): Promise<void> {
   } catch {}
 }
 
-function exitWithKillFallback(deps: CliCompletionExitDeps): void {
+function armForceKillFallback(deps: CliCompletionExitDeps): void {
   const setTimer = deps.setTimeout ?? globalThis.setTimeout;
   const kill = deps.kill ?? process.kill.bind(process);
-  const exit = deps.exit ?? process.exit.bind(process);
   const pid = deps.pid ?? process.pid;
-  setTimer(() => {
+  const timer = setTimer(() => {
     try {
       kill(pid, "SIGKILL");
     } catch {}
   }, deps.forceKillTimeoutMs ?? CLI_COMPLETION_FORCE_KILL_TIMEOUT_MS);
-  exit(process.exitCode ?? 0);
+  timer.unref?.();
+}
+
+function resolveCurrentExitCode(): number {
+  const code = process.exitCode;
+  if (typeof code === "number" && Number.isFinite(code)) {
+    return code;
+  }
+  if (typeof code === "string") {
+    const parsed = Number.parseInt(code, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+function exitWithCurrentCode(deps: CliCompletionExitDeps): void {
+  const exit = deps.exit ?? process.exit.bind(process);
+  exit(resolveCurrentExitCode());
 }
 
 export async function exitAfterLocalAgentCompletion(
@@ -292,6 +310,7 @@ export async function exitAfterLocalAgentCompletion(
     waitForStreamFlush(deps.stdout ?? process.stdout, drainDeps),
     waitForStreamFlush(deps.stderr ?? process.stderr, drainDeps),
   ]);
+  armForceKillFallback(deps);
   await flushOtelBeforeExit(deps);
-  exitWithKillFallback(deps);
+  exitWithCurrentCode(deps);
 }

--- a/src/cli/local-agent-lifetime.ts
+++ b/src/cli/local-agent-lifetime.ts
@@ -7,6 +7,7 @@ const CLI_COMPLETION_STREAM_DRAIN_TIMEOUT_MS = 250;
 const CLI_COMPLETION_FORCE_KILL_TIMEOUT_MS = 3_000;
 const OTEL_PRE_EXIT_SYMBOL = Symbol.for("openclaw.otel.preExit");
 const HELP_OR_VERSION_FLAGS = new Set(["-h", "--help", "-V", "--version"]);
+// Keep this list aligned with agent command options that consume the next argv token.
 const AGENT_VALUE_FLAGS = new Set([
   "-m",
   "--message",
@@ -144,6 +145,9 @@ function parseLocalAgentArgs(argv: string[]): ParsedLocalAgentArgs | null {
       continue;
     }
     const optionValue = value ?? argv[index + 1];
+    if (optionValue === FLAG_TERMINATOR) {
+      break;
+    }
     if (flag === "--timeout") {
       parsed.timeoutRaw = optionValue;
     }

--- a/src/cli/local-agent-lifetime.ts
+++ b/src/cli/local-agent-lifetime.ts
@@ -26,8 +26,11 @@ const AGENT_VALUE_FLAGS = new Set([
 type LocalAgentHardTimeoutDeps = {
   argv?: string[];
   setTimeout?: typeof globalThis.setTimeout;
-  stderr?: Pick<NodeJS.WriteStream, "write">;
+  clearTimeout?: typeof globalThis.clearTimeout;
+  stderr?: Pick<NodeJS.WriteStream, "write"> &
+    Partial<Pick<NodeJS.WriteStream, "destroyed" | "writableEnded">>;
   exit?: (code?: number) => never | void;
+  drainTimeoutMs?: number;
 };
 
 type CliCompletionExitDeps = {
@@ -51,6 +54,12 @@ type ParsedLocalAgentArgs = {
   hasHelpOrVersion: boolean;
   hasLocal: boolean;
   timeoutRaw: string | undefined;
+};
+
+type StreamFlushDeps = Required<
+  Pick<CliCompletionExitDeps, "setTimeout" | "clearTimeout" | "drainTimeoutMs">
+> & {
+  unrefTimeout?: boolean;
 };
 
 function parseTimeoutSeconds(raw: string | undefined): number | undefined {
@@ -176,24 +185,32 @@ export function armLocalAgentHardTimeout(deps: LocalAgentHardTimeoutDeps = {}): 
     return;
   }
   const setTimer = deps.setTimeout ?? globalThis.setTimeout;
+  const clearTimer = deps.clearTimeout ?? globalThis.clearTimeout;
   const stderr = deps.stderr ?? process.stderr;
   const exit = deps.exit ?? process.exit.bind(process);
   const timer = setTimer(() => {
-    try {
-      stderr.write(
-        `local agent command timed out after ${plan.timeoutSeconds}s plus ${LOCAL_AGENT_HARD_TIMEOUT_GRACE_SECONDS}s grace\n`,
-      );
-    } catch {}
-    try {
-      exit(124);
-    } catch {}
+    void writeAndFlushStream(
+      stderr,
+      `local agent command timed out after ${plan.timeoutSeconds}s plus ${LOCAL_AGENT_HARD_TIMEOUT_GRACE_SECONDS}s grace\n`,
+      {
+        setTimeout: setTimer,
+        clearTimeout: clearTimer,
+        drainTimeoutMs: deps.drainTimeoutMs ?? CLI_COMPLETION_STREAM_DRAIN_TIMEOUT_MS,
+        unrefTimeout: false,
+      },
+    ).then(() => {
+      try {
+        exit(124);
+      } catch {}
+    });
   }, plan.timeoutMs);
   timer.unref?.();
 }
 
-function waitForStreamFlush(
+function writeAndFlushStream(
   stream: CliCompletionExitDeps["stdout"],
-  deps: Required<Pick<CliCompletionExitDeps, "setTimeout" | "clearTimeout" | "drainTimeoutMs">>,
+  chunk: string,
+  deps: StreamFlushDeps,
 ): Promise<void> {
   if (!stream || stream.destroyed || stream.writableEnded) {
     return Promise.resolve();
@@ -213,13 +230,22 @@ function waitForStreamFlush(
       resolve();
     };
     timer = deps.setTimeout(finish, deps.drainTimeoutMs);
-    timer.unref?.();
+    if (deps.unrefTimeout !== false) {
+      timer.unref?.();
+    }
     try {
-      stream.write("", finish);
+      stream.write(chunk, finish);
     } catch {
       finish();
     }
   });
+}
+
+function waitForStreamFlush(
+  stream: CliCompletionExitDeps["stdout"],
+  deps: StreamFlushDeps,
+): Promise<void> {
+  return writeAndFlushStream(stream, "", deps);
 }
 
 export async function exitAfterLocalAgentCompletion(

--- a/src/cli/local-agent-lifetime.ts
+++ b/src/cli/local-agent-lifetime.ts
@@ -1,0 +1,76 @@
+import { getCommandPathWithRootOptions, getFlagValue, hasHelpOrVersion } from "./argv.js";
+
+const LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS = 30_000;
+const LOCAL_AGENT_HARD_TIMEOUT_GRACE_SECONDS = LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS / 1000;
+
+type LocalAgentHardTimeoutDeps = {
+  argv?: string[];
+  setTimeout?: typeof globalThis.setTimeout;
+  stderr?: Pick<NodeJS.WriteStream, "write">;
+  exit?: (code?: number) => never | void;
+};
+
+type LocalAgentTimeoutPlan = {
+  timeoutMs: number;
+  timeoutSeconds: number;
+};
+
+function parseExplicitTimeoutSeconds(argv: string[]): number | undefined {
+  const raw = getFlagValue(argv, "--timeout");
+  if (raw === undefined || raw === null || !/^\d+$/u.test(raw)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+export function resolveLocalAgentHardTimeoutPlan(
+  deps: LocalAgentHardTimeoutDeps = {},
+): LocalAgentTimeoutPlan | null {
+  const argv = deps.argv ?? process.argv;
+  const commandPath = getCommandPathWithRootOptions(argv, 1);
+  if (commandPath[0] !== "agent" || hasHelpOrVersion(argv)) {
+    return null;
+  }
+  const localFlag = getFlagValue(argv, "--local");
+  if (localFlag === undefined) {
+    return null;
+  }
+  const overrideSeconds = parseExplicitTimeoutSeconds(argv);
+  if (overrideSeconds === undefined) {
+    // Keep omitted --timeout on the existing configured/default agent timeout contract.
+    return null;
+  }
+  if (overrideSeconds === 0) {
+    return null;
+  }
+  return {
+    timeoutMs: overrideSeconds * 1000 + LOCAL_AGENT_HARD_TIMEOUT_GRACE_MS,
+    timeoutSeconds: overrideSeconds,
+  };
+}
+
+export function armLocalAgentHardTimeout(deps: LocalAgentHardTimeoutDeps = {}): void {
+  const plan = resolveLocalAgentHardTimeoutPlan(deps);
+  if (!plan) {
+    return;
+  }
+  const setTimer = deps.setTimeout ?? globalThis.setTimeout;
+  const stderr = deps.stderr ?? process.stderr;
+  const exit = deps.exit ?? process.exit.bind(process);
+  const timer = setTimer(() => {
+    try {
+      stderr.write(
+        `local agent command timed out after ${plan.timeoutSeconds}s plus ${LOCAL_AGENT_HARD_TIMEOUT_GRACE_SECONDS}s grace\n`,
+      );
+    } catch {}
+    try {
+      exit(124);
+    } catch {}
+  }, plan.timeoutMs);
+  timer.unref?.();
+}
+
+export function exitAfterCliCompletion(): never {
+  process.exit(process.exitCode ?? 0);
+}

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -150,8 +150,47 @@ if (
       }
       gatewayEntryStartupTrace.mark("argv");
 
+      // Wall-clock safety net for `agent --local`: arm a hard timeout before
+      // CLI entry so hung commands don't live forever. Synchronous argv parsing
+      // only — no async, no config import (breaks subshell contexts).
+      (() => {
+        const a = process.argv;
+        let sub: string | undefined;
+        for (let i = 2; i < a.length; i++) {
+          const v = a[i];
+          if (!v) continue;
+          if (v === "--") break;
+          if (!v.startsWith("-")) { sub = v; break; }
+        }
+        if (sub !== "agent") return;
+        let hasLocal = false;
+        let s: string | undefined;
+        for (let i = 2; i < a.length; i++) {
+          const v = a[i];
+          if (!v) continue;
+          if (v === "--") break;
+          if (v === "-h" || v === "--help" || v === "--version" || v === "-V") return;
+          if (v === "--local" || v.startsWith("--local=")) hasLocal = true;
+          if (v === "--timeout") s = a[i + 1];
+          else if (v.startsWith("--timeout=")) s = v.slice(10);
+        }
+        if (!hasLocal) return;
+        let n = 600;
+        if (s !== undefined) { const p = parseInt(s, 10); if (Number.isFinite(p) && p >= 0) n = p; }
+        if (n === 0) return;
+        const t = setTimeout(() => {
+          try { process.stderr.write(`local agent command timed out after ${n}s plus 30s grace\n`); } catch {}
+          try { process.exit(124); } catch {}
+        }, (n + 30) * 1000);
+        t.unref();
+      })();
+
       if (!tryHandleRootVersionFastPath(process.argv)) {
         await runMainOrRootHelp(process.argv);
+        // Work is done — force exit. Background handles (LCM compaction, otel
+        // exporter, plugin loops) can keep the event loop alive indefinitely.
+        setTimeout(() => { try { process.kill(process.pid, "SIGKILL"); } catch {} }, 3000);
+        process.exit(process.exitCode ?? 0);
       }
     }
   }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -3,7 +3,10 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { getCommandPathWithRootOptions, hasFlag, isRootHelpInvocation } from "./cli/argv.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
-import { armLocalAgentHardTimeout, exitAfterCliCompletion } from "./cli/local-agent-lifetime.js";
+import {
+  armLocalAgentHardTimeout,
+  exitAfterLocalAgentCompletion,
+} from "./cli/local-agent-lifetime.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import type { RootHelpRenderOptions } from "./cli/program/root-help.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
@@ -155,7 +158,7 @@ if (
 
       if (!tryHandleRootVersionFastPath(process.argv)) {
         await runMainOrRootHelp(process.argv);
-        exitAfterCliCompletion();
+        await exitAfterLocalAgentCompletion();
       }
     }
   }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -3,6 +3,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { getCommandPathWithRootOptions, hasFlag, isRootHelpInvocation } from "./cli/argv.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
+import { armLocalAgentHardTimeout, exitAfterCliCompletion } from "./cli/local-agent-lifetime.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import type { RootHelpRenderOptions } from "./cli/program/root-help.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
@@ -150,47 +151,11 @@ if (
       }
       gatewayEntryStartupTrace.mark("argv");
 
-      // Wall-clock safety net for `agent --local`: arm a hard timeout before
-      // CLI entry so hung commands don't live forever. Synchronous argv parsing
-      // only — no async, no config import (breaks subshell contexts).
-      (() => {
-        const a = process.argv;
-        let sub: string | undefined;
-        for (let i = 2; i < a.length; i++) {
-          const v = a[i];
-          if (!v) continue;
-          if (v === "--") break;
-          if (!v.startsWith("-")) { sub = v; break; }
-        }
-        if (sub !== "agent") return;
-        let hasLocal = false;
-        let s: string | undefined;
-        for (let i = 2; i < a.length; i++) {
-          const v = a[i];
-          if (!v) continue;
-          if (v === "--") break;
-          if (v === "-h" || v === "--help" || v === "--version" || v === "-V") return;
-          if (v === "--local" || v.startsWith("--local=")) hasLocal = true;
-          if (v === "--timeout") s = a[i + 1];
-          else if (v.startsWith("--timeout=")) s = v.slice(10);
-        }
-        if (!hasLocal) return;
-        let n = 600;
-        if (s !== undefined) { const p = parseInt(s, 10); if (Number.isFinite(p) && p >= 0) n = p; }
-        if (n === 0) return;
-        const t = setTimeout(() => {
-          try { process.stderr.write(`local agent command timed out after ${n}s plus 30s grace\n`); } catch {}
-          try { process.exit(124); } catch {}
-        }, (n + 30) * 1000);
-        t.unref();
-      })();
+      armLocalAgentHardTimeout();
 
       if (!tryHandleRootVersionFastPath(process.argv)) {
         await runMainOrRootHelp(process.argv);
-        // Work is done — force exit. Background handles (LCM compaction, otel
-        // exporter, plugin loops) can keep the event loop alive indefinitely.
-        setTimeout(() => { try { process.kill(process.pid, "SIGKILL"); } catch {} }, 3000);
-        process.exit(process.exitCode ?? 0);
+        exitAfterCliCompletion();
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,47 @@ if (isMain) {
     process.exit(1);
   });
 
-  void runLegacyCliEntry(process.argv).catch((err) => {
+  // Wall-clock safety net for `agent --local`: arm a hard timeout before
+  // CLI entry so hung commands don't live forever. Synchronous argv parsing
+  // only — no async, no config import (breaks subshell contexts).
+  (() => {
+    const a = process.argv;
+    let sub: string | undefined;
+    for (let i = 2; i < a.length; i++) {
+      const v = a[i];
+      if (!v) continue;
+      if (v === "--") break;
+      if (!v.startsWith("-")) { sub = v; break; }
+    }
+    if (sub !== "agent") return;
+    let hasLocal = false;
+    let s: string | undefined;
+    for (let i = 2; i < a.length; i++) {
+      const v = a[i];
+      if (!v) continue;
+      if (v === "--") break;
+      if (v === "-h" || v === "--help" || v === "--version" || v === "-V") return;
+      if (v === "--local" || v.startsWith("--local=")) hasLocal = true;
+      if (v === "--timeout") s = a[i + 1];
+      else if (v.startsWith("--timeout=")) s = v.slice(10);
+    }
+    if (!hasLocal) return;
+    let n = 600;
+    if (s !== undefined) { const p = parseInt(s, 10); if (Number.isFinite(p) && p >= 0) n = p; }
+    if (n === 0) return;
+    const t = setTimeout(() => {
+      try { process.stderr.write(`local agent command timed out after ${n}s plus 30s grace\n`); } catch {}
+      try { process.exit(124); } catch {}
+    }, (n + 30) * 1000);
+    t.unref();
+  })();
+
+  void runLegacyCliEntry(process.argv).then(() => {
+    // Work is done — force exit. Background handles (LCM compaction, otel
+    // exporter, plugin loops) can keep the event loop alive indefinitely.
+    setTimeout(() => { try { process.kill(process.pid, "SIGKILL"); } catch {} }, 3000);
+    process.exit(process.exitCode ?? 0);
+  }).catch((err) => {
     for (const line of formatCliFailureLines({
       title: "The CLI command failed.",
       error: err,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   armLocalAgentHardTimeout,
   exitAfterLocalAgentCompletion,
 } from "./cli/local-agent-lifetime.js";
+import { normalizeWindowsArgv } from "./cli/windows-argv.js";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
 import { isMainModule } from "./infra/is-main.js";
@@ -89,6 +90,7 @@ if (!isMain) {
 
 if (isMain) {
   const { restoreTerminalState } = await import("./terminal/restore.js");
+  const cliArgv = normalizeWindowsArgv(process.argv);
 
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
@@ -119,11 +121,11 @@ if (isMain) {
     process.exit(1);
   });
 
-  armLocalAgentHardTimeout();
+  armLocalAgentHardTimeout({ argv: cliArgv });
 
-  void runLegacyCliEntry(process.argv)
+  void runLegacyCliEntry(cliArgv)
     .then(() => {
-      return exitAfterLocalAgentCompletion();
+      return exitAfterLocalAgentCompletion({ argv: cliArgv });
     })
     .catch((err) => {
       for (const line of formatCliFailureLines({

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ if (isMain) {
       for (const line of formatCliFailureLines({
         title: "The CLI command failed.",
         error: err,
-        argv: process.argv,
+        argv: cliArgv,
       })) {
         console.error(line);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { formatCliFailureLines } from "./cli/failure-output.js";
-import { armLocalAgentHardTimeout, exitAfterCliCompletion } from "./cli/local-agent-lifetime.js";
+import {
+  armLocalAgentHardTimeout,
+  exitAfterLocalAgentCompletion,
+} from "./cli/local-agent-lifetime.js";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
 import { isMainModule } from "./infra/is-main.js";
@@ -120,7 +123,7 @@ if (isMain) {
 
   void runLegacyCliEntry(process.argv)
     .then(() => {
-      exitAfterCliCompletion();
+      return exitAfterLocalAgentCompletion();
     })
     .catch((err) => {
       for (const line of formatCliFailureLines({

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { formatCliFailureLines } from "./cli/failure-output.js";
+import { armLocalAgentHardTimeout, exitAfterCliCompletion } from "./cli/local-agent-lifetime.js";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
 import { isMainModule } from "./infra/is-main.js";
@@ -115,58 +116,24 @@ if (isMain) {
     process.exit(1);
   });
 
-  // Wall-clock safety net for `agent --local`: arm a hard timeout before
-  // CLI entry so hung commands don't live forever. Synchronous argv parsing
-  // only — no async, no config import (breaks subshell contexts).
-  (() => {
-    const a = process.argv;
-    let sub: string | undefined;
-    for (let i = 2; i < a.length; i++) {
-      const v = a[i];
-      if (!v) continue;
-      if (v === "--") break;
-      if (!v.startsWith("-")) { sub = v; break; }
-    }
-    if (sub !== "agent") return;
-    let hasLocal = false;
-    let s: string | undefined;
-    for (let i = 2; i < a.length; i++) {
-      const v = a[i];
-      if (!v) continue;
-      if (v === "--") break;
-      if (v === "-h" || v === "--help" || v === "--version" || v === "-V") return;
-      if (v === "--local" || v.startsWith("--local=")) hasLocal = true;
-      if (v === "--timeout") s = a[i + 1];
-      else if (v.startsWith("--timeout=")) s = v.slice(10);
-    }
-    if (!hasLocal) return;
-    let n = 600;
-    if (s !== undefined) { const p = parseInt(s, 10); if (Number.isFinite(p) && p >= 0) n = p; }
-    if (n === 0) return;
-    const t = setTimeout(() => {
-      try { process.stderr.write(`local agent command timed out after ${n}s plus 30s grace\n`); } catch {}
-      try { process.exit(124); } catch {}
-    }, (n + 30) * 1000);
-    t.unref();
-  })();
+  armLocalAgentHardTimeout();
 
-  void runLegacyCliEntry(process.argv).then(() => {
-    // Work is done — force exit. Background handles (LCM compaction, otel
-    // exporter, plugin loops) can keep the event loop alive indefinitely.
-    setTimeout(() => { try { process.kill(process.pid, "SIGKILL"); } catch {} }, 3000);
-    process.exit(process.exitCode ?? 0);
-  }).catch((err) => {
-    for (const line of formatCliFailureLines({
-      title: "The CLI command failed.",
-      error: err,
-      argv: process.argv,
-    })) {
-      console.error(line);
-    }
-    for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
-      console.error("[openclaw]", message);
-    }
-    restoreTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
-    process.exit(1);
-  });
+  void runLegacyCliEntry(process.argv)
+    .then(() => {
+      exitAfterCliCompletion();
+    })
+    .catch((err) => {
+      for (const line of formatCliFailureLines({
+        title: "The CLI command failed.",
+        error: err,
+        argv: process.argv,
+      })) {
+        console.error(line);
+      }
+      for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
+        console.error("[openclaw]", message);
+      }
+      restoreTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
## Problem

`openclaw agent --local` can finish the agent turn and still keep the CLI process alive indefinitely. The completed command is visible in stdout, but ref'd background handles can prevent Node from exiting.

PR #70691, merged on 2026-04-23 by @Takhoffman, fixed the gateway WebSocket teardown path by waiting for gateway client shutdown. This PR covers the remaining local-agent CLI lifetime gap where work has completed but non-gateway handles, such as compaction loops, telemetry exporter timers, or plugin loops, still keep the process alive.

## Change and value

This is an availability workaround for `agent --local`, not a full lifecycle cleanup of every background subsystem.

- Adds a local-agent lifetime helper for CLI entry points.
- After a completed `agent --local` command, drains stdout/stderr, calls the optional otel pre-exit hook if registered, then exits with `process.exitCode ?? 0`.
- Arms a 3s SIGKILL fallback before awaiting the otel hook so a hung flush cannot hang the CLI forever.
- Adds a wall-clock hard timeout only when the operator passed an explicit positive `--timeout N`; `--timeout 0` disables it, and omitted `--timeout` does not arm a new hard kill.

The otel contract is intentionally optional:

```ts
globalThis[Symbol.for("openclaw.otel.preExit")]
```

If the hook is absent or from an older plugin, the CLI falls through to immediate forced exit. If the hook rejects, the CLI still exits.

## Who is affected, and who is not

Affected:

- `openclaw agent --local ...` runs where the agent turn completes but ref'd background handles keep the process alive.
- Automation that already supplies `--timeout N` and needs a bounded outer CLI lifetime if the command promise itself never resolves.

Not affected:

- Non-local agent runs.
- Help/version invocations.
- Other CLI subcommands.
- Local-agent runs without explicit `--timeout`; these still get the post-completion forced exit, but no new wall-clock kill is added. That preserves the existing agent timeout contract, including the configured/default agent timeout path.

## Why now

#86264 and #86276 were aimed closer to the root cause, but that route grew into cross-subsystem lifecycle work and async config import hazards. This PR deliberately takes the smaller, easier-to-review path: release the caller once the local agent work is done, while leaving deeper subsystem teardown work to follow-up fixes.

Once the root cause is fixed, this becomes mostly redundant: the post-completion exit fires after successful work, and the wall-clock timer never matters if the promise resolves. The main residual risk is that `process.exit()` bypasses future arbitrary exit-time drains; this PR handles the known telemetry case through the optional pre-exit hook.

## Relationship to related PRs

- #70691 fixed the gateway WebSocket teardown path and is already merged.
- #86264 and #86276 explored broader/root-cause cleanup paths but are not the approach taken here.
- This PR is scoped to local-agent CLI lifetime behavior and keeps the root-cause cleanup concern explicit.

## Verification

- Local, after rebasing onto `main` at `96bd939995873d6e6a24fe7d0e6e7779e669c8ff`:
  - `pnpm exec oxfmt --check src/cli/local-agent-lifetime.ts src/cli/local-agent-lifetime.test.ts src/entry.ts src/index.ts`
  - `timeout 180s pnpm exec vitest run --config test/vitest/vitest.cli.config.ts src/cli/local-agent-lifetime.test.ts --reporter=verbose` (`14 passed`)
  - `pnpm tsgo:core`
- Crabbox/GCP exact-head validation:
  - GCP Spot, `us-east1-b`, `e2-standard-8`
  - Node `v24.15.0`, npm `11.12.1`, pnpm `11.2.2`
  - Base `96bd939995873d6e6a24fe7d0e6e7779e669c8ff`
  - Head `9549c867a64fd87fdb9edba89142c9ce492dae9a`
  - `PR87097_HEAD_VALIDATION=passed`
  - `PR87097_BEHAVIOR_PROOF=passed`
- Post-proof rebase:
  - `main` advanced again while the full proof was running.
  - Rebased onto `ebe09be500c50a2708750d8c51235c2f24a828f4`, producing head `571349c9d155efd86f84fe627d17a1b005b06e6e`.
  - No PR-owned files changed across the rebase; it picked up an upstream lint fix outside this PR.
  - Rechecked direct core oxlint, `oxfmt`, focused Vitest (`14 passed`), and `pnpm tsgo:core` on `571349c9d155efd86f84fe627d17a1b005b06e6e`.
- Review gates:
  - Subagent review: no actionable findings.
  - Claude review: no blocking findings; static argv option-list drift and SIGKILL fallback lifetime were triaged as maintenance/intentional residual risks.
  - Codex review: flagged omitted-timeout hard kill as a concern; triaged as intentional because this PR now preserves the configured/default agent timeout contract unless the operator explicitly passed `--timeout N`.

AI-assisted: yes.

## Real behavior proof

Behavior or issue addressed: `openclaw agent --local` can complete the agent turn and still not exit because a ref'd background handle keeps the Node process alive. The patch forces exit after completed local-agent work, while flushing the optional otel pre-exit hook first.

Real environment tested: Crabbox on GCP Spot `us-east1-b`, `e2-standard-8`; Node `v24.15.0`; npm `11.12.1`; pnpm `11.2.2`; main at proof time `96bd939995873d6e6a24fe7d0e6e7779e669c8ff`; PR head `9549c867a64fd87fdb9edba89142c9ce492dae9a`.

Exact steps or command run after this patch: Built current main and the PR head from fresh shallow checkouts, then ran the real CLI entry point with a ref'd preload handle plus an otel pre-exit hook. The after-patch command was:

```bash
timeout 90s env HOME=/tmp/openclaw-pr87097-proof/after-pr/home OPENCLAW_HOME=/tmp/openclaw-pr87097-proof/after-pr/home/.openclaw OPENCLAW_STATE_DIR=/tmp/openclaw-pr87097-proof/after-pr/state OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr87097-proof/after-pr/state/openclaw.json OPENAI_API_KEY=qa-mock-not-a-real-key NODE_DISABLE_COMPILE_CACHE=1 NODE_OPTIONS=--import=/tmp/openclaw-pr87097-proof/after-pr/openclaw-pr87097-ref-handle-and-otel.mjs OPENCLAW_PR87097_OTEL_PROOF_FILE=/tmp/openclaw-pr87097-proof/after-pr/output/otel-pre-exit.log node /tmp/openclaw-pr87097-proof/after-pr/repo/openclaw.mjs agent --local --agent main --session-id pr87097-after-pr-1779860799 --message Return marker OPENCLAW_PR87097_AFTER_PR_OK --thinking off --json
```

Evidence after fix: Terminal output from the exact-head Crabbox run:

```text
BASE_REF_REQUESTED=96bd939995873d6e6a24fe7d0e6e7779e669c8ff
PATCHED_REF_REQUESTED=9549c867a64fd87fdb9edba89142c9ce492dae9a

===== PR87097 before-main scenario =====
REF=96bd939995873d6e6a24fe7d0e6e7779e669c8ff
OPENCLAW_VERSION=OpenClaw 2026.5.26 (96bd939)
EXIT_CODE=124
ELAPSED_SEC=92
ASSERT_EXIT_CODE=passed expected=124 actual=124
ASSERT_MARKER_IN_AGENT_LOG=passed
ASSERT_MOCK_REQUEST_LOG=passed
ASSERT_OTEL_PRE_EXIT_HOOK=skipped-before-hook-not-called
ASSERT_AGENT_TURN=skipped-timeout-preserved-before-hang
PR87097_before-main_SCENARIO=passed

===== PR87097 after-pr scenario =====
REF=9549c867a64fd87fdb9edba89142c9ce492dae9a
OPENCLAW_VERSION=OpenClaw 2026.5.26 (9549c86)
EXIT_CODE=0
ELAPSED_SEC=14
ASSERT_EXIT_CODE=passed expected=0 actual=0
ASSERT_MARKER_IN_AGENT_LOG=passed
ASSERT_MOCK_REQUEST_LOG=passed
ASSERT_OTEL_PRE_EXIT_HOOK=passed
ASSERT_AGENT_TURN=passed
PR87097_after-pr_SCENARIO=passed

===== PR87097 final exact-head validation =====
VALIDATION_REF=9549c867a64fd87fdb9edba89142c9ce492dae9a
VALIDATION_COMMAND=pnpm exec oxfmt --check src/cli/local-agent-lifetime.ts src/cli/local-agent-lifetime.test.ts src/entry.ts src/index.ts
All matched files use the correct format.
VALIDATION_COMMAND=timeout 180s pnpm exec vitest run --config test/vitest/vitest.cli.config.ts src/cli/local-agent-lifetime.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  14 passed (14)
VALIDATION_COMMAND=pnpm build
VALIDATION_COMMAND=pnpm tsgo:core
PR87097_HEAD_VALIDATION=passed
PR87097_BEHAVIOR_PROOF=passed
run summary sync=0s command=12m41.728s total=12m41.811s sync_skipped=true exit=0
```

Observed result after fix: Current `main` completed the agent turn but did not exit before the outer timeout, so it returned `124` after 92s. The PR head completed the same agent turn, called the otel pre-exit hook, and exited `0` after 14s despite the deliberately ref'd background handle.

What was not tested: No changed-path behavior gap remains for this PR. This proof does not claim to fix every subsystem root handle; it proves the local-agent CLI lifetime workaround and the optional otel pre-exit hook under a real CLI invocation with a ref'd background handle.
