### PR TITLE
fix(media): resolve inbound image refs before paths

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -353,6 +353,33 @@ describe("modelSupportsImages", () => {
 });
 
 describe("loadImageFromRef", () => {
+  it("loads a media-uri ref from the media store before workspace path handling", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-uri-load-"));
+    const inboundDir = path.join(stateDir, "media", "inbound");
+    const mediaId = "claim-check-native.png";
+    await fs.mkdir(inboundDir, { recursive: true });
+    await fs.writeFile(path.join(inboundDir, mediaId), Buffer.from(TINY_PNG_BASE64, "base64"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    try {
+      const image = await loadImageFromRef(
+        {
+          raw: `media://inbound/${mediaId}`,
+          type: "media-uri",
+          resolved: `media://inbound/${mediaId}`,
+        },
+        path.join(stateDir, "workspace"),
+      );
+
+      expect(image?.type).toBe("image");
+      expect(image?.mimeType).toBe("image/png");
+      expect(image?.data).toBe(TINY_PNG_BASE64);
+    } finally {
+      vi.unstubAllEnvs();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("allows sandbox-validated host paths outside default media roots", async () => {
     const homeDir = os.homedir();
     await fs.mkdir(homeDir, { recursive: true });

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -434,6 +434,19 @@ export async function loadImageFromRef(
   },
 ): Promise<ImageContent | null> {
   try {
+    if (ref.type === "media-uri") {
+      const media = await loadWebMedia(ref.resolved, options?.maxBytes);
+      if (media.kind !== "image") {
+        log.debug(`Native image: not an image file: ${ref.resolved} (got ${media.kind})`);
+        return null;
+      }
+      return {
+        type: "image",
+        data: media.buffer.toString("base64"),
+        mimeType: media.contentType ?? "image/jpeg",
+      };
+    }
+
     let targetPath = ref.resolved;
 
     // Resolve paths relative to sandbox or workspace as needed

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2217,6 +2217,26 @@ describe("image tool managed inbound media", () => {
     });
   });
 
+  it("resolves media://inbound refs before workspace-relative path handling", async () => {
+    await withManagedInboundPng(async ({ mediaId }) => {
+      installImageUnderstandingProviderStubs();
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        await withTempWorkspacePng(async ({ workspaceDir }) => {
+          const tool = createRequiredImageTool({
+            config: createMinimaxImageConfig(),
+            agentDir,
+            workspaceDir,
+            fsPolicy: { workspaceOnly: true },
+          });
+
+          await expectImageToolExecOk(tool, `media://inbound/${mediaId}`);
+          expect(fetch).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });
+
   it("allows managed inbound absolute paths when workspaceOnly is enabled", async () => {
     await withManagedInboundPng(async ({ mediaPath }) => {
       installImageUnderstandingProviderStubs();

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -17,6 +17,7 @@ import { resolveTimeoutMs } from "../../media-understanding/resolve.js";
 import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
+  resolveMediaReferenceLocalPath,
 } from "../../media/media-reference.js";
 import type { ImageCompressionModelPolicy, ImageCompressionPolicy } from "../../media/web-media.js";
 import {
@@ -874,12 +875,16 @@ export function createImageTool(options?: {
           throw new Error("Sandboxed image tool does not allow remote URLs.");
         }
 
+        const mediaReferencePath = isDataUrl
+          ? normalizedRef
+          : await resolveMediaReferenceLocalPath(normalizedRef);
+
         const resolvedImage = (() => {
           if (sandboxConfig) {
-            return normalizedRef;
+            return mediaReferencePath;
           }
-          if (normalizedRef.startsWith("~")) {
-            return resolveUserPath(normalizedRef);
+          if (mediaReferencePath.startsWith("~")) {
+            return resolveUserPath(mediaReferencePath);
           }
           // Resolve relative paths against workspaceDir so agents can reference
           // workspace-relative paths (e.g. "inbox/photo.png") without needing to
@@ -889,12 +894,12 @@ export function createImageTool(options?: {
             !isFileUrl &&
             !isHttpUrl &&
             !refInfo.looksLikeWindowsDrivePath &&
-            !isAbsolute(normalizedRef) &&
+            !isAbsolute(mediaReferencePath) &&
             options?.workspaceDir
           ) {
-            return resolve(options.workspaceDir, normalizedRef);
+            return resolve(options.workspaceDir, mediaReferencePath);
           }
-          return normalizedRef;
+          return mediaReferencePath;
         })();
         const resolvedPathInfo: { resolved: string; rewrittenFrom?: string } = isDataUrl
           ? { resolved: "" }


### PR DESCRIPTION
## Summary

Fixes #87024.

Gateway-offloaded inbound images use `media://inbound/<id>` claim-check refs. Two image-loading paths recognized those refs syntactically, but could still let normal path handling run first:

- direct `image` tool inputs with `workspaceDir` could become broken workspace paths like `/workspace/media:/inbound/<id>`
- native `loadImageFromRef()` could resolve `media://inbound/<id>` against the workspace before `loadWebMedia()` saw the media-store URI

This PR resolves direct tool media references before workspace-relative path handling, and sends native `media-uri` refs directly through `loadWebMedia()`, which already centralizes media-store URI resolution and local media policy checks.

This does not add public config options or plugin surface.

## Related

- Coordinates with/supersedes the partial native-only fix in #85236 by covering both the native loader and direct `image` tool path.

## Proof

```sh
node scripts/run-vitest.mjs src/agents/tools/image-tool.test.ts src/agents/pi-embedded-runner/run/images.test.ts --reporter=dot
# Test Files 4 passed (4)
# Tests 230 passed (230)

node scripts/run-vitest.mjs src/agents/tools/image-tool.test.ts --reporter=dot
# Test Files 2 passed (2)
# Tests 154 passed (154)

node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/images.test.ts --reporter=dot
# Test Files 2 passed (2)
# Tests 76 passed (76)

node scripts/run-vitest.mjs src/media/media-reference.test.ts src/media/web-media.test.ts src/agents/tools/pdf-tool.test.ts --reporter=dot
# Test Files 4 passed (4)
# Tests 107 passed (107)

./node_modules/.bin/oxfmt --check src/agents/tools/image-tool.ts src/agents/tools/image-tool.test.ts src/agents/pi-embedded-runner/run/images.ts src/agents/pi-embedded-runner/run/images.test.ts
# All matched files use the correct format.

./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/tools/image-tool.ts src/agents/tools/image-tool.test.ts src/agents/pi-embedded-runner/run/images.ts src/agents/pi-embedded-runner/run/images.test.ts
# Found 0 warnings and 0 errors.

git diff --check origin/main...HEAD
# passed

git diff --check
# passed

pnpm check:changed
# passed
```