### PR TITLE
WIP: fix macOS CLI password argv exposure

### DIFF
--- a/apps/macos/Sources/OpenClawMacCLI/CLIArgParsingSupport.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/CLIArgParsingSupport.swift
@@ -7,3 +7,94 @@ enum CLIArgParsingSupport {
         return args[index].trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
+
+enum CLISecretInputError: Error, CustomStringConvertible {
+    case missingValue(String)
+    case mutuallyExclusive(String)
+    case unreadableFile(String)
+
+    var description: String {
+        switch self {
+        case let .missingValue(flag):
+            return "\(flag) requires a value"
+        case let .mutuallyExclusive(name):
+            return "only one \(name) input flag may be used"
+        case let .unreadableFile(path):
+            return "could not read secret file: \(path)"
+        }
+    }
+}
+
+enum CLISecretInput: Equatable {
+    case inline(String)
+    case stdin
+    case file(String)
+    case environment(String)
+
+    func resolve() throws -> String? {
+        switch self {
+        case let .inline(value):
+            return value.trimmingCharacters(in: .whitespacesAndNewlines)
+        case .stdin:
+            let data = FileHandle.standardInput.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        case let .file(path):
+            do {
+                let expandedPath = NSString(string: path).expandingTildeInPath
+                return try String(contentsOfFile: expandedPath, encoding: .utf8)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            } catch {
+                throw CLISecretInputError.unreadableFile(path)
+            }
+        case let .environment(name):
+            return ProcessInfo.processInfo.environment[name]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+}
+
+struct CLISecretInputParser {
+    private(set) var value: CLISecretInput?
+    private let name: String
+
+    init(name: String) {
+        self.name = name
+    }
+
+    mutating func set(_ next: CLISecretInput) throws {
+        if value != nil {
+            throw CLISecretInputError.mutuallyExclusive(name)
+        }
+        value = next
+    }
+
+    mutating func parseInline(_ args: [String], index: inout Int, flag: String) throws {
+        guard let raw = CLIArgParsingSupport.nextValue(args, index: &index) else {
+            throw CLISecretInputError.missingValue(flag)
+        }
+        try set(.inline(raw))
+    }
+
+    mutating func parseFile(_ args: [String], index: inout Int, flag: String) throws {
+        guard let path = CLIArgParsingSupport.nextValue(args, index: &index) else {
+            throw CLISecretInputError.missingValue(flag)
+        }
+        try set(.file(path))
+    }
+
+    mutating func parseEnvironment(_ args: [String], index: inout Int, flag: String) throws {
+        guard let name = CLIArgParsingSupport.nextValue(args, index: &index) else {
+            throw CLISecretInputError.missingValue(flag)
+        }
+        try set(.environment(name))
+    }
+
+    mutating func parseStdin() throws {
+        try set(.stdin)
+    }
+
+    func resolve() throws -> String? {
+        guard let value else { return nil }
+        return try value.resolve()
+    }
+}

--- a/apps/macos/Sources/OpenClawMacCLI/CLIArgParsingSupport.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/CLIArgParsingSupport.swift
@@ -8,9 +8,11 @@ enum CLIArgParsingSupport {
     }
 }
 
-enum CLISecretInputError: Error, CustomStringConvertible {
+enum CLISecretInputError: Error, CustomStringConvertible, LocalizedError, Equatable {
     case missingValue(String)
     case mutuallyExclusive(String)
+    case emptyValue(String)
+    case missingEnvironment(String)
     case unreadableFile(String)
 
     var description: String {
@@ -19,10 +21,16 @@ enum CLISecretInputError: Error, CustomStringConvertible {
             return "\(flag) requires a value"
         case let .mutuallyExclusive(name):
             return "only one \(name) input flag may be used"
+        case let .emptyValue(source):
+            return "\(source) did not provide a non-empty secret"
+        case let .missingEnvironment(name):
+            return "environment variable \(name) is not set"
         case let .unreadableFile(path):
             return "could not read secret file: \(path)"
         }
     }
+
+    var errorDescription: String? { description }
 }
 
 enum CLISecretInput: Equatable {
@@ -37,19 +45,42 @@ enum CLISecretInput: Equatable {
             return value.trimmingCharacters(in: .whitespacesAndNewlines)
         case .stdin:
             let data = FileHandle.standardInput.readDataToEndOfFile()
-            return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let value = String(data: data, encoding: .utf8) else {
+                throw CLISecretInputError.emptyValue("--password-stdin")
+            }
+            return try nonEmptySecret(value, source: "--password-stdin")
         case let .file(path):
+            let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedPath.isEmpty else {
+                throw CLISecretInputError.missingValue("--password-file")
+            }
             do {
-                let expandedPath = NSString(string: path).expandingTildeInPath
-                return try String(contentsOfFile: expandedPath, encoding: .utf8)
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let expandedPath = NSString(string: trimmedPath).expandingTildeInPath
+                let value = try String(contentsOfFile: expandedPath, encoding: .utf8)
+                return try nonEmptySecret(value, source: "--password-file")
+            } catch let error as CLISecretInputError {
+                throw error
             } catch {
-                throw CLISecretInputError.unreadableFile(path)
+                throw CLISecretInputError.unreadableFile(trimmedPath)
             }
         case let .environment(name):
-            return ProcessInfo.processInfo.environment[name]?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedName.isEmpty else {
+                throw CLISecretInputError.missingValue("--password-env")
+            }
+            guard let value = ProcessInfo.processInfo.environment[trimmedName] else {
+                throw CLISecretInputError.missingEnvironment(trimmedName)
+            }
+            return try nonEmptySecret(value, source: "--password-env \(trimmedName)")
         }
+    }
+
+    private func nonEmptySecret(_ value: String, source: String) throws -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw CLISecretInputError.emptyValue(source)
+        }
+        return trimmed
     }
 }
 

--- a/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
@@ -21,6 +21,7 @@ struct ConfigureRemoteOptions {
 
     static func parse(_ args: [String]) throws -> ConfigureRemoteOptions {
         var opts = ConfigureRemoteOptions()
+        var passwordInput = CLISecretInputParser(name: "password")
         var i = 0
         while i < args.count {
             let arg = args[i]
@@ -40,7 +41,13 @@ struct ConfigureRemoteOptions {
             case "--token":
                 opts.token = CLIArgParsingSupport.nextValue(args, index: &i)
             case "--password":
-                opts.password = CLIArgParsingSupport.nextValue(args, index: &i)
+                try passwordInput.parseInline(args, index: &i, flag: arg)
+            case "--password-stdin":
+                try passwordInput.parseStdin()
+            case "--password-file":
+                try passwordInput.parseFile(args, index: &i, flag: arg)
+            case "--password-env":
+                try passwordInput.parseEnvironment(args, index: &i, flag: arg)
             case "--identity":
                 opts.identity = CLIArgParsingSupport.nextValue(args, index: &i)
             case "--project-root":
@@ -52,6 +59,7 @@ struct ConfigureRemoteOptions {
             }
             i += 1
         }
+        opts.password = try passwordInput.resolve()
         return opts
     }
 }
@@ -77,9 +85,11 @@ func runConfigureRemote(_ args: [String]) {
 
             Usage:
               openclaw-mac configure-remote --ssh-target <user@host[:port]> [--local-port <port>]
-                                          [--remote-port <port>] [--token <token>] [--password <password>]
+                                          [--remote-port <port>] [--token <token>] [--password-stdin]
+                                          [--password-file <path>] [--password-env <name>] [--password <password>]
                                           [--identity <path>] [--project-root <path>] [--cli-path <path>] [--json]
               openclaw-mac configure-remote --direct-url <ws://host:port|wss://host> [--token <token>]
+                                          [--password-stdin] [--password-file <path>] [--password-env <name>]
                                           [--password <password>] [--project-root <path>] [--cli-path <path>] [--json]
 
             Options:
@@ -88,7 +98,10 @@ func runConfigureRemote(_ args: [String]) {
               --local-port <p>    Local tunnel port for the mac app/UI. Default: 18789.
               --remote-port <p>   Gateway port on the remote host. Default: 18789.
               --token <token>     Remote gateway token.
-              --password <pw>     Remote gateway password.
+              --password-stdin    Read remote gateway password from stdin.
+              --password-file <p>  Read remote gateway password from a file.
+              --password-env <n>   Read remote gateway password from an environment variable.
+              --password <pw>     Remote gateway password; warning: exposes the value in process listings and shell history.
               --identity <path>   SSH identity file.
               --project-root <p>  Remote OpenClaw checkout for CLI commands.
               --cli-path <path>   Remote openclaw executable or entrypoint.

--- a/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
@@ -19,49 +19,59 @@ struct ConnectOptions {
     var scopesAreExplicit: Bool = false
     var help: Bool = false
 
-    static func parse(_ args: [String]) -> ConnectOptions {
+    static func parse(_ args: [String]) throws -> ConnectOptions {
         var opts = ConnectOptions()
-        let flagHandlers: [String: (inout ConnectOptions) -> Void] = [
-            "-h": { $0.help = true },
-            "--help": { $0.help = true },
-            "--json": { $0.json = true },
-            "--probe": { $0.probe = true },
-        ]
-        let valueHandlers: [String: (inout ConnectOptions, String) -> Void] = [
-            "--url": { $0.url = $1 },
-            "--token": { $0.token = $1 },
-            "--password": { $0.password = $1 },
-            "--mode": { $0.mode = $1 },
-            "--timeout": { opts, raw in
-                if let parsed = Int(raw.trimmingCharacters(in: .whitespacesAndNewlines)) {
-                    opts.timeoutMs = max(250, parsed)
-                }
-            },
-            "--client-id": { $0.clientId = $1 },
-            "--client-mode": { $0.clientMode = $1 },
-            "--display-name": { $0.displayName = $1 },
-            "--role": { $0.role = $1 },
-            "--scopes": { opts, raw in
-                opts.scopes = raw.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                    .filter { !$0.isEmpty }
-                opts.scopesAreExplicit = true
-            },
-        ]
+        var passwordInput = CLISecretInputParser(name: "password")
         var i = 0
         while i < args.count {
             let arg = args[i]
-            if let handler = flagHandlers[arg] {
-                handler(&opts)
-                i += 1
-                continue
-            }
-            if let handler = valueHandlers[arg], let value = CLIArgParsingSupport.nextValue(args, index: &i) {
-                handler(&opts, value)
-                i += 1
-                continue
+            switch arg {
+            case "-h", "--help":
+                opts.help = true
+            case "--json":
+                opts.json = true
+            case "--probe":
+                opts.probe = true
+            case "--url":
+                opts.url = CLIArgParsingSupport.nextValue(args, index: &i)
+            case "--token":
+                opts.token = CLIArgParsingSupport.nextValue(args, index: &i)
+            case "--password":
+                try passwordInput.parseInline(args, index: &i, flag: arg)
+            case "--password-stdin":
+                try passwordInput.parseStdin()
+            case "--password-file":
+                try passwordInput.parseFile(args, index: &i, flag: arg)
+            case "--password-env":
+                try passwordInput.parseEnvironment(args, index: &i, flag: arg)
+            case "--mode":
+                opts.mode = CLIArgParsingSupport.nextValue(args, index: &i)
+            case "--timeout":
+                if let raw = CLIArgParsingSupport.nextValue(args, index: &i),
+                   let parsed = Int(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+                {
+                    opts.timeoutMs = max(250, parsed)
+                }
+            case "--client-id":
+                opts.clientId = CLIArgParsingSupport.nextValue(args, index: &i) ?? opts.clientId
+            case "--client-mode":
+                opts.clientMode = CLIArgParsingSupport.nextValue(args, index: &i) ?? opts.clientMode
+            case "--display-name":
+                opts.displayName = CLIArgParsingSupport.nextValue(args, index: &i)
+            case "--role":
+                opts.role = CLIArgParsingSupport.nextValue(args, index: &i) ?? opts.role
+            case "--scopes":
+                if let raw = CLIArgParsingSupport.nextValue(args, index: &i) {
+                    opts.scopes = raw.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                        .filter { !$0.isEmpty }
+                    opts.scopesAreExplicit = true
+                }
+            default:
+                break
             }
             i += 1
         }
+        opts.password = try passwordInput.resolve()
         return opts
     }
 }
@@ -92,31 +102,41 @@ actor SnapshotStore {
 }
 
 func runConnect(_ args: [String]) async {
-    let opts = ConnectOptions.parse(args)
+    let opts: ConnectOptions
+    do {
+        opts = try ConnectOptions.parse(args)
+    } catch {
+        fputs("connect: \(error)\n", stderr)
+        exit(1)
+    }
     if opts.help {
         print("""
         openclaw-mac connect
 
         Usage:
-          openclaw-mac connect [--url <ws://host:port>] [--token <token>] [--password <password>]
+          openclaw-mac connect [--url <ws://host:port>] [--token <token>] [--password-stdin]
+                               [--password-file <path>] [--password-env <name>] [--password <password>]
                                [--mode <local|remote>] [--timeout <ms>] [--probe] [--json]
                                [--client-id <id>] [--client-mode <mode>] [--display-name <name>]
                                [--role <role>] [--scopes <a,b,c>]
 
         Options:
-          --url <url>        Gateway WebSocket URL (overrides config)
-          --token <token>    Gateway token (if required)
-          --password <pw>    Gateway password (if required)
-          --mode <mode>      Resolve from config: local|remote (default: config or local)
-          --timeout <ms>     Request timeout (default: 15000)
-          --probe            Force a fresh health probe
-          --json             Emit JSON
-          --client-id <id>   Override client id (default: openclaw-macos)
-          --client-mode <m>  Override client mode (default: ui)
-          --display-name <n> Override display name
-          --role <role>      Override role (default: operator)
-          --scopes <a,b,c>   Override scopes list
-          -h, --help         Show help
+          --url <url>             Gateway WebSocket URL (overrides config)
+          --token <token>         Gateway token (if required)
+          --password-stdin        Read gateway password from stdin
+          --password-file <path>  Read gateway password from a file
+          --password-env <name>   Read gateway password from an environment variable
+          --password <pw>         Gateway password; warning: exposes the value in process listings and shell history
+          --mode <mode>           Resolve from config: local|remote (default: config or local)
+          --timeout <ms>          Request timeout (default: 15000)
+          --probe                 Force a fresh health probe
+          --json                  Emit JSON
+          --client-id <id>        Override client id (default: openclaw-macos)
+          --client-mode <m>       Override client mode (default: ui)
+          --display-name <n>      Override display name
+          --role <role>           Override role (default: operator)
+          --scopes <a,b,c>        Override scopes list
+          -h, --help              Show help
         """)
         return
     }

--- a/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
@@ -12,8 +12,9 @@ struct WizardCliOptions {
     var json: Bool = false
     var help: Bool = false
 
-    static func parse(_ args: [String]) -> WizardCliOptions {
+    static func parse(_ args: [String]) throws -> WizardCliOptions {
         var opts = WizardCliOptions()
+        var passwordInput = CLISecretInputParser(name: "password")
         var i = 0
         while i < args.count {
             let arg = args[i]
@@ -27,7 +28,13 @@ struct WizardCliOptions {
             case "--token":
                 opts.token = CLIArgParsingSupport.nextValue(args, index: &i)
             case "--password":
-                opts.password = CLIArgParsingSupport.nextValue(args, index: &i)
+                try passwordInput.parseInline(args, index: &i, flag: arg)
+            case "--password-stdin":
+                try passwordInput.parseStdin()
+            case "--password-file":
+                try passwordInput.parseFile(args, index: &i, flag: arg)
+            case "--password-env":
+                try passwordInput.parseEnvironment(args, index: &i, flag: arg)
             case "--mode":
                 if let value = CLIArgParsingSupport.nextValue(args, index: &i) {
                     opts.mode = value
@@ -39,6 +46,7 @@ struct WizardCliOptions {
             }
             i += 1
         }
+        opts.password = try passwordInput.resolve()
         return opts
     }
 }
@@ -62,19 +70,29 @@ enum WizardCliError: Error, CustomStringConvertible {
 }
 
 func runWizardCommand(_ args: [String]) async {
-    let opts = WizardCliOptions.parse(args)
+    let opts: WizardCliOptions
+    do {
+        opts = try WizardCliOptions.parse(args)
+    } catch {
+        fputs("wizard: \(error)\n", stderr)
+        exit(1)
+    }
     if opts.help {
         print("""
         openclaw-mac wizard
 
         Usage:
-          openclaw-mac wizard [--url <ws://host:port>] [--token <token>] [--password <password>]
+          openclaw-mac wizard [--url <ws://host:port>] [--token <token>] [--password-stdin]
+                              [--password-file <path>] [--password-env <name>] [--password <password>]
                               [--mode <local|remote>] [--workspace <path>] [--json]
 
         Options:
           --url <url>        Gateway WebSocket URL (overrides config)
           --token <token>    Gateway token (if required)
-          --password <pw>    Gateway password (if required)
+          --password-stdin   Read gateway password from stdin
+          --password-file <p> Read gateway password from a file
+          --password-env <n>  Read gateway password from an environment variable
+          --password <pw>    Gateway password; warning: exposes the value in process listings and shell history
           --mode <mode>      Wizard mode (local|remote). Default: local
           --workspace <path> Wizard workspace override
           --json             Print raw wizard responses

--- a/apps/macos/Tests/OpenClawIPCTests/MacCLISecretInputTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacCLISecretInputTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import OpenClawMacCLI
+
+@Suite(.serialized)
+struct MacCLISecretInputTests {
+    @Test func `connect parses password file`() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-cli-password-\(UUID().uuidString)")
+        try "file-secret\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let opts = try ConnectOptions.parse(["--password-file", fileURL.path])
+
+        #expect(opts.password == "file-secret")
+    }
+
+    @Test func `configure remote parses password file`() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-cli-configure-password-\(UUID().uuidString)")
+        try "remote-secret\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let opts = try ConfigureRemoteOptions.parse([
+            "--ssh-target", "alice@gateway.example",
+            "--password-file", fileURL.path,
+        ])
+
+        #expect(opts.password == "remote-secret")
+    }
+
+    @Test func `wizard parses password file`() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-cli-wizard-password-\(UUID().uuidString)")
+        try "wizard-secret\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let opts = try WizardCliOptions.parse(["--password-file", fileURL.path])
+
+        #expect(opts.password == "wizard-secret")
+    }
+
+    @Test func `safe password input rejects empty files instead of falling back`() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-cli-empty-password-\(UUID().uuidString)")
+        try "\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        #expect(throws: CLISecretInputError.self) {
+            _ = try ConnectOptions.parse(["--password-file", fileURL.path])
+        }
+
+        #expect(throws: CLISecretInputError.self) {
+            _ = try ConfigureRemoteOptions.parse([
+                "--ssh-target", "alice@gateway.example",
+                "--password-file", fileURL.path,
+            ])
+        }
+
+        #expect(throws: CLISecretInputError.self) {
+            _ = try WizardCliOptions.parse(["--password-file", fileURL.path])
+        }
+    }
+
+    @Test func `safe password input rejects missing env instead of falling back`() throws {
+        let envName = "OPENCLAW_TEST_MISSING_PASSWORD_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+
+        #expect(throws: CLISecretInputError.self) {
+            _ = try ConnectOptions.parse(["--password-env", envName])
+        }
+
+        #expect(throws: CLISecretInputError.self) {
+            _ = try ConfigureRemoteOptions.parse([
+                "--ssh-target", "alice@gateway.example",
+                "--password-env", envName,
+            ])
+        }
+
+        #expect(throws: CLISecretInputError.self) {
+            _ = try WizardCliOptions.parse(["--password-env", envName])
+        }
+    }
+
+    @Test func `password inputs are mutually exclusive`() throws {
+        #expect(throws: CLISecretInputError.self) {
+            _ = try ConnectOptions.parse([
+                "--password", "inline-secret",
+                "--password-file", "/tmp/secret",
+            ])
+        }
+
+        #expect(throws: CLISecretInputError.self) {
+            _ = try ConfigureRemoteOptions.parse([
+                "--ssh-target", "alice@gateway.example",
+                "--password-file", "/tmp/secret",
+                "--password-env", "OPENCLAW_PASSWORD",
+            ])
+        }
+
+        #expect(throws: CLISecretInputError.self) {
+            _ = try WizardCliOptions.parse([
+                "--password-env", "OPENCLAW_PASSWORD",
+                "--password-stdin",
+            ])
+        }
+    }
+
+    @Test func `legacy inline empty password preserves fallback compatibility`() throws {
+        let opts = try ConnectOptions.parse(["--password", ""])
+
+        #expect(opts.password == "")
+    }
+}


### PR DESCRIPTION
Fixes #83880

## Summary

Draft PR for the macOS CLI credential exposure issue.

Current draft state:
- Adds shared macOS CLI secret input parsing for `--password-stdin`, `--password-file`, and `--password-env`.
- Wires the safe password input contract into `openclaw-mac connect`.
- Keeps legacy `--password` for compatibility, but documents that it exposes the value in process listings and shell history.

Still pending before ready-for-review:
- Wire the same safe password input contract into `configure-remote`.
- Wire the same safe password input contract into `wizard`.
- Add focused Swift parser tests for safe password inputs and mutual exclusion.
- Run the macOS CLI test lane.

## Security scope

This is intended to avoid requiring gateway passwords to be supplied as command-line argv values, where they can appear in process listings and shell history.

## Verification

Not yet run. Draft opened from the updated fork branch so the remaining work can continue against the current 2026.5.26 upstream line.