### PR TITLE
fix(gateway): route approval notices with approvals scope

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -76,6 +76,7 @@ describe("method scope resolution", () => {
     ["exec.approvals.set", ["operator.admin"]],
     ["exec.approvals.node.get", ["operator.admin"]],
     ["exec.approvals.node.set", ["operator.admin"]],
+    ["approval.routeNotice.send", ["operator.approvals"]],
   ])("resolves least-privilege scopes for %s", (method, expected) => {
     expect(resolveLeastPrivilegeOperatorScopesForMethod(method)).toEqual(expected);
   });
@@ -290,18 +291,20 @@ describe("operator scope authorization", () => {
     });
   });
 
-  it.each(["exec.approval.get", "exec.approval.list", "exec.approval.resolve"])(
-    "requires approvals scope for %s",
-    (method) => {
-      expect(authorizeOperatorScopesForMethod(method, ["operator.write"])).toEqual({
-        allowed: false,
-        missingScope: "operator.approvals",
-      });
-      expect(authorizeOperatorScopesForMethod(method, ["operator.approvals"])).toEqual({
-        allowed: true,
-      });
-    },
-  );
+  it.each([
+    "approval.routeNotice.send",
+    "exec.approval.get",
+    "exec.approval.list",
+    "exec.approval.resolve",
+  ])("requires approvals scope for %s", (method) => {
+    expect(authorizeOperatorScopesForMethod(method, ["operator.write"])).toEqual({
+      allowed: false,
+      missingScope: "operator.approvals",
+    });
+    expect(authorizeOperatorScopesForMethod(method, ["operator.approvals"])).toEqual({
+      allowed: true,
+    });
+  });
 
   it.each([
     "exec.approvals.get",

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -183,6 +183,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "system-presence", scope: "operator.read" },
   { name: "system-event", scope: "operator.admin" },
   { name: "message.action", scope: "operator.write" },
+  { name: "approval.routeNotice.send", scope: "operator.approvals", advertise: false },
   { name: "send", scope: "operator.write" },
   { name: "agent", scope: "operator.write" },
   { name: "agent.identity.get", scope: "operator.read" },

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -515,7 +515,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
     loadHandlers: loadRestartHandlers,
   }),
   ...createLazyCoreHandlers({
-    methods: ["message.action", "send", "poll"],
+    methods: ["message.action", "approval.routeNotice.send", "send", "poll"],
     loadHandlers: loadSendHandlers,
   }),
   ...createLazyCoreHandlers({

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -3,6 +3,7 @@ import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { ExecApprovalManager } from "../exec-approval-manager.js";
 import type { GatewayRequestContext } from "./types.js";
 
 type ResolveOutboundTarget = typeof import("../../infra/outbound/targets.js").resolveOutboundTarget;
@@ -122,10 +123,11 @@ async function loadSendHandlersForTest() {
   ({ sendHandlers } = await import("./send.js"));
 }
 
-const makeContext = (): GatewayRequestContext =>
+const makeContext = (overrides?: Partial<GatewayRequestContext>): GatewayRequestContext =>
   ({
     dedupe: new Map(),
     getRuntimeConfig: () => ({}),
+    ...overrides,
   }) as unknown as GatewayRequestContext;
 
 async function runSend(params: Record<string, unknown>) {
@@ -134,7 +136,11 @@ async function runSend(params: Record<string, unknown>) {
 
 async function runSendWithClient(
   params: Record<string, unknown>,
-  client?: { connect?: { scopes?: string[] } } | null,
+  client?: {
+    connId?: string;
+    connect?: { scopes?: string[]; device?: { id: string }; client?: { id: string } };
+    internal?: { approvalRuntime?: boolean };
+  } | null,
 ) {
   const respond = vi.fn();
   await sendHandlers.send({
@@ -146,6 +152,61 @@ async function runSendWithClient(
     isWebchatConnect: () => false,
   });
   return { respond };
+}
+
+async function runApprovalRouteNoticeSend(
+  params: Record<string, unknown>,
+  client?: {
+    connId?: string;
+    connect?: { scopes?: string[]; device?: { id: string }; client?: { id: string } };
+    internal?: { approvalRuntime?: boolean };
+  } | null,
+  context = makeContext(),
+) {
+  const respond = vi.fn();
+  await sendHandlers["approval.routeNotice.send"]({
+    params: params as never,
+    respond,
+    context,
+    req: { type: "req", id: "1", method: "approval.routeNotice.send" },
+    client: (client ?? null) as never,
+    isWebchatConnect: () => false,
+  });
+  return { respond };
+}
+
+function createApprovalRouteNoticeContext(params?: {
+  id?: string;
+  turnSourceChannel?: string | null;
+  turnSourceTo?: string | null;
+  turnSourceAccountId?: string | null;
+  turnSourceThreadId?: string | number | null;
+  allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
+  requestedByDeviceId?: string | null;
+  requestedByConnId?: string | null;
+  requestedByClientId?: string | null;
+}) {
+  const id = params?.id ?? "req-1";
+  const manager = new ExecApprovalManager();
+  const record = manager.create(
+    {
+      command: "echo hi",
+      turnSourceChannel:
+        params?.turnSourceChannel === undefined ? "discord" : params.turnSourceChannel,
+      turnSourceTo: params?.turnSourceTo === undefined ? "channel:C1" : params.turnSourceTo,
+      turnSourceAccountId:
+        params?.turnSourceAccountId === undefined ? "default" : params.turnSourceAccountId,
+      turnSourceThreadId: params?.turnSourceThreadId ?? undefined,
+      allowedDecisions: params?.allowedDecisions,
+    },
+    60_000,
+    id,
+  );
+  record.requestedByDeviceId = params?.requestedByDeviceId ?? null;
+  record.requestedByConnId = params?.requestedByConnId ?? null;
+  record.requestedByClientId = params?.requestedByClientId ?? null;
+  void manager.register(record, 60_000);
+  return makeContext({ execApprovalManager: manager });
 }
 
 async function runPoll(params: Record<string, unknown>) {
@@ -584,6 +645,320 @@ describe("gateway send mirroring", () => {
 
     expect(deliveryCall()?.channel).toBe("slack");
     expect(deliveryCall()?.gatewayClientScopes).toEqual([]);
+  });
+
+  it("lets approval runtimes send derived route notices without operator.write", async () => {
+    mockDeliverySuccess("m-approval-route-notice");
+    const context = createApprovalRouteNoticeContext({
+      id: "req-1",
+      turnSourceChannel: "discord",
+      turnSourceTo: "channel:C1",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "12345",
+    });
+
+    const { respond } = await runApprovalRouteNoticeSend(
+      {
+        approvalId: "req-1",
+        approvalKind: "exec",
+        target: {
+          channel: "discord",
+          to: "channel:C1",
+          accountId: "default",
+          threadId: "12345",
+        },
+        notice: {
+          kind: "routed-elsewhere",
+          destinations: ["Discord DMs"],
+        },
+      },
+      {
+        connect: { scopes: ["operator.approvals"] },
+        internal: { approvalRuntime: true },
+      },
+      context,
+    );
+
+    expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "channel:C1",
+        accountId: "default",
+        mode: "explicit",
+      }),
+    );
+    expect(deliveryCall()?.channel).toBe("discord");
+    expect(deliveryCall()?.payloads).toEqual([
+      {
+        text: "Approval required. I sent the approval request to Discord DMs, not this chat.",
+        mediaUrl: undefined,
+        mediaUrls: undefined,
+      },
+    ]);
+    expect(deliveryCall()?.threadId).toBe("12345");
+    expect(deliveryCall()?.gatewayClientScopes).toEqual(["operator.approvals"]);
+    expect(firstRespondCall(respond)?.[0]).toBe(true);
+  });
+
+  it("rejects route notices from ordinary approval clients", async () => {
+    mockDeliverySuccess("m-ordinary-route-notice");
+
+    const { respond } = await runApprovalRouteNoticeSend(
+      {
+        approvalId: "req-ordinary",
+        approvalKind: "exec",
+        target: {
+          channel: "discord",
+          to: "channel:C1",
+        },
+        notice: {
+          kind: "routed-elsewhere",
+          destinations: ["Discord DMs"],
+        },
+      },
+      { connect: { scopes: ["operator.approvals"] } },
+      createApprovalRouteNoticeContext({ id: "req-ordinary" }),
+    );
+
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(false);
+    expect(response?.[2]?.message).toBe("unknown or expired approval route notice");
+  });
+
+  it("rejects route notices for approvals requested by the caller", async () => {
+    mockDeliverySuccess("m-self-requested-route-notice");
+
+    const { respond } = await runApprovalRouteNoticeSend(
+      {
+        approvalId: "req-self-requested",
+        approvalKind: "exec",
+        target: {
+          channel: "discord",
+          to: "channel:C1",
+        },
+        notice: {
+          kind: "routed-elsewhere",
+          destinations: ["Discord DMs"],
+        },
+      },
+      {
+        connId: "conn-requester",
+        connect: {
+          scopes: ["operator.approvals"],
+          client: { id: "gateway-client" },
+        },
+        internal: { approvalRuntime: true },
+      },
+      createApprovalRouteNoticeContext({
+        id: "req-self-requested",
+        requestedByConnId: "conn-requester",
+        requestedByClientId: "gateway-client",
+      }),
+    );
+
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(false);
+    expect(response?.[2]?.message).toBe("unknown or expired approval route notice");
+  });
+
+  it("preserves coordinator-provided fallback route notice targets when server-derived", async () => {
+    mockDeliverySuccess("m-approval-route-fallback-notice");
+    mocks.getChannelPlugin.mockReturnValue({
+      actions: { handleAction: true },
+      approvalCapability: {
+        native: {
+          describeDeliveryCapabilities: () => ({
+            enabled: true,
+            preferredSurface: "approver-dm",
+            supportsOriginSurface: true,
+            supportsApproverDmSurface: true,
+            notifyOriginWhenDmOnly: true,
+          }),
+          resolveOriginTarget: async () => ({ to: "channel:C2", threadId: "67890" }),
+        },
+      },
+      outbound: { sendPoll: mocks.sendPoll },
+    });
+
+    const { respond } = await runApprovalRouteNoticeSend(
+      {
+        approvalId: "req-fallback",
+        approvalKind: "exec",
+        target: {
+          channel: "discord",
+          to: "channel:C2",
+          accountId: "default",
+          threadId: "67890",
+        },
+        notice: {
+          kind: "routed-elsewhere",
+          destinations: ["Discord DMs"],
+        },
+      },
+      {
+        connect: { scopes: ["operator.approvals"] },
+        internal: { approvalRuntime: true },
+      },
+      createApprovalRouteNoticeContext({
+        id: "req-fallback",
+        turnSourceChannel: null,
+        turnSourceTo: null,
+        turnSourceAccountId: null,
+        turnSourceThreadId: null,
+      }),
+    );
+
+    expect(deliveryCall()?.channel).toBe("discord");
+    expect(deliveryCall()?.to).toBe("resolved");
+    expect(deliveryCall()?.accountId).toBe("default");
+    expect(deliveryCall()?.threadId).toBe("67890");
+    expect(firstRespondCall(respond)?.[0]).toBe(true);
+  });
+
+  it("rejects caller-provided route notice targets without a server-derived origin", async () => {
+    mockDeliverySuccess("m-unverified-route-notice");
+
+    const { respond } = await runApprovalRouteNoticeSend(
+      {
+        approvalId: "req-unverified",
+        approvalKind: "exec",
+        target: {
+          channel: "discord",
+          to: "channel:C2",
+          accountId: "default",
+          threadId: "67890",
+        },
+        notice: {
+          kind: "routed-elsewhere",
+          destinations: ["Discord DMs"],
+        },
+      },
+      {
+        connect: { scopes: ["operator.approvals"] },
+        internal: { approvalRuntime: true },
+      },
+      createApprovalRouteNoticeContext({
+        id: "req-unverified",
+        turnSourceChannel: null,
+        turnSourceTo: null,
+        turnSourceAccountId: null,
+        turnSourceThreadId: null,
+      }),
+    );
+
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(false);
+    expect(response?.[2]?.message).toBe("approval route notice target unavailable");
+  });
+
+  it("rejects approval route notices for resolved approval ids", async () => {
+    mockDeliverySuccess("m-resolved-route-notice");
+    const manager = new ExecApprovalManager();
+    const record = manager.create(
+      {
+        command: "echo hi",
+        turnSourceChannel: "discord",
+        turnSourceTo: "channel:C1",
+      },
+      60_000,
+      "req-resolved",
+    );
+    void manager.register(record, 60_000);
+    manager.resolve("req-resolved", "allow-once");
+
+    const { respond } = await runApprovalRouteNoticeSend(
+      {
+        approvalId: "req-resolved",
+        approvalKind: "exec",
+        target: {
+          channel: "discord",
+          to: "channel:C1",
+        },
+        notice: {
+          kind: "routed-elsewhere",
+          destinations: ["Discord DMs"],
+        },
+      },
+      {
+        connect: { scopes: ["operator.approvals"] },
+        internal: { approvalRuntime: true },
+      },
+      makeContext({ execApprovalManager: manager }),
+    );
+
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(false);
+    expect(response?.[2]?.message).toBe("unknown or expired approval route notice");
+  });
+
+  it("rejects approval route notices with generic send payload fields", async () => {
+    mockDeliverySuccess("m-rejected-route-notice-media");
+
+    const { respond } = await runApprovalRouteNoticeSend(
+      {
+        approvalId: "req-extra",
+        approvalKind: "exec",
+        target: {
+          channel: "discord",
+          to: "channel:C1",
+        },
+        notice: {
+          kind: "routed-elsewhere",
+          destinations: ["Discord DMs"],
+        },
+        message: "Approval required.",
+      },
+      {
+        connect: { scopes: ["operator.approvals"] },
+        internal: { approvalRuntime: true },
+      },
+      createApprovalRouteNoticeContext({ id: "req-extra" }),
+    );
+
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(false);
+    expect(response?.[2]?.message).toBe("invalid approval route notice request");
+  });
+
+  it("builds delivery-failed route notice text from the approval snapshot", async () => {
+    mockDeliverySuccess("m-delivery-failed-route-notice");
+
+    const { respond } = await runApprovalRouteNoticeSend(
+      {
+        approvalId: "deadbeef-1234-4567-89ab-cdef01234567",
+        approvalKind: "exec",
+        target: {
+          channel: "discord",
+          to: "channel:C1",
+        },
+        notice: { kind: "delivery-failed" },
+      },
+      {
+        connect: { scopes: ["operator.approvals"] },
+        internal: { approvalRuntime: true },
+      },
+      createApprovalRouteNoticeContext({
+        id: "deadbeef-1234-4567-89ab-cdef01234567",
+        allowedDecisions: ["allow-once", "deny"],
+      }),
+    );
+
+    expect(deliveryCall()?.payloads).toEqual([
+      {
+        text:
+          "Approval required. I could not deliver the native approval request.\n" +
+          "Reply with: /approve deadbeef allow-once|deny\n" +
+          "If the short code is ambiguous, use the full id in /approve.",
+        mediaUrl: undefined,
+        mediaUrls: undefined,
+      },
+    ]);
+    expect(firstRespondCall(respond)?.[0]).toBe(true);
   });
 
   it("rejects empty sends when neither text nor media is present", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -5,6 +5,13 @@ import { dispatchChannelMessageAction } from "../../channels/plugins/message-act
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveChannelNativeApprovalDeliveryPlan } from "../../infra/approval-native-delivery.js";
+import {
+  resolveApprovalDeliveryFailedNoticeText,
+  resolveApprovalRoutedElsewhereNoticeText,
+} from "../../infra/approval-native-route-notice.js";
+import { resolveApprovalRequestSessionTarget } from "../../infra/exec-approval-session-target.js";
+import type { ExecApprovalRequest } from "../../infra/exec-approvals.js";
 import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import {
@@ -20,6 +27,7 @@ import { mirrorDeliveredSourceReplyToTranscript } from "../../infra/outbound/sou
 import { maybeResolveIdLikeTarget } from "../../infra/outbound/target-resolver.js";
 import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { extractToolPayload } from "../../infra/outbound/tool-payload.js";
+import type { PluginApprovalRequest } from "../../infra/plugin-approvals.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { normalizePollInput } from "../../polls.js";
@@ -29,7 +37,8 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "../../shared/string-coerce.js";
-import { ADMIN_SCOPE } from "../operator-scopes.js";
+import type { ExecApprovalRecord } from "../exec-approval-manager.js";
+import { ADMIN_SCOPE, APPROVALS_SCOPE } from "../operator-scopes.js";
 import {
   ErrorCodes,
   errorShape,
@@ -39,7 +48,13 @@ import {
   validateSendParams,
 } from "../protocol/index.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
+import { isApprovalDecision, isApprovalRecordVisibleToClient } from "./approval-shared.js";
+import type {
+  GatewayClient,
+  GatewayRequestContext,
+  GatewayRequestHandlers,
+  RespondFn,
+} from "./types.js";
 
 type InflightResult = {
   ok: boolean;
@@ -52,6 +67,9 @@ const inflightByContext = new WeakMap<
   GatewayRequestContext,
   Map<string, Promise<InflightResult>>
 >();
+const MAX_ROUTE_NOTICE_DESTINATIONS = 4;
+const MAX_ROUTE_NOTICE_DESTINATION_LENGTH = 48;
+const ROUTE_NOTICE_DESTINATION_LABEL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 ._#@()/-]*$/;
 
 const getInflightMap = (context: GatewayRequestContext) => {
   let inflight = inflightByContext.get(context);
@@ -288,6 +306,364 @@ async function mirrorDeliveredSourceReplyToTranscriptBestEffort(params: {
   }
 }
 
+type GatewaySendRequest = {
+  to: string;
+  message?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  asVoice?: boolean;
+  gifPlayback?: boolean;
+  channel?: string;
+  accountId?: string;
+  agentId?: string;
+  replyToId?: string;
+  threadId?: string;
+  forceDocument?: boolean;
+  silent?: boolean;
+  parseMode?: "HTML";
+  sessionKey?: string;
+  idempotencyKey: string;
+};
+
+type ApprovalRouteNoticeSpec =
+  | {
+      kind: "routed-elsewhere";
+      destinations: string[];
+    }
+  | {
+      kind: "delivery-failed";
+    };
+
+type ApprovalRouteNoticeTarget = {
+  channel: string;
+  to: string;
+  accountId?: string;
+  threadId?: string;
+};
+
+type ApprovalRouteNoticeRequest = {
+  approvalId: string;
+  approvalKind: "exec" | "plugin";
+  target?: ApprovalRouteNoticeTarget;
+  notice: ApprovalRouteNoticeSpec;
+};
+
+type ApprovalRequestLike = ExecApprovalRequest | PluginApprovalRequest;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const allowed = new Set(keys);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function normalizeRouteNoticeThreadId(value?: string | number | null): string | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+  return normalizeOptionalString(value);
+}
+
+function normalizeRouteNoticeDestinationList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized: string[] = [];
+  for (const entry of value) {
+    const label = normalizeOptionalString(entry);
+    if (
+      !label ||
+      label.length > MAX_ROUTE_NOTICE_DESTINATION_LENGTH ||
+      /[\r\n\t]/.test(label) ||
+      !ROUTE_NOTICE_DESTINATION_LABEL_PATTERN.test(label)
+    ) {
+      continue;
+    }
+    if (!normalized.includes(label)) {
+      normalized.push(label);
+    }
+    if (normalized.length >= MAX_ROUTE_NOTICE_DESTINATIONS) {
+      break;
+    }
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function parseApprovalRouteNoticeTarget(value: unknown): ApprovalRouteNoticeTarget | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value) || !hasOnlyKeys(value, ["channel", "to", "accountId", "threadId"])) {
+    return undefined;
+  }
+  const channel = normalizeOptionalString(value.channel);
+  const to = normalizeOptionalString(value.to);
+  if (!channel || !to) {
+    return undefined;
+  }
+  return {
+    channel,
+    to,
+    accountId: normalizeOptionalString(value.accountId),
+    threadId: normalizeRouteNoticeThreadId(value.threadId as string | number | null | undefined),
+  };
+}
+
+function parseApprovalRouteNoticeRequest(value: unknown): ApprovalRouteNoticeRequest | null {
+  if (!isRecord(value) || !hasOnlyKeys(value, ["approvalId", "approvalKind", "target", "notice"])) {
+    return null;
+  }
+  const approvalId = normalizeOptionalString(value.approvalId);
+  const approvalKind = normalizeOptionalString(value.approvalKind);
+  const notice = value.notice;
+  if (
+    !approvalId ||
+    (approvalKind !== "exec" && approvalKind !== "plugin") ||
+    !isRecord(notice) ||
+    typeof notice.kind !== "string"
+  ) {
+    return null;
+  }
+  const target = parseApprovalRouteNoticeTarget(value.target);
+  if (value.target !== undefined && !target) {
+    return null;
+  }
+  if (notice.kind === "routed-elsewhere") {
+    if (!hasOnlyKeys(notice, ["kind", "destinations"])) {
+      return null;
+    }
+    const destinations = normalizeRouteNoticeDestinationList(notice.destinations);
+    return destinations
+      ? {
+          approvalId,
+          approvalKind,
+          target,
+          notice: { kind: "routed-elsewhere", destinations },
+        }
+      : null;
+  }
+  if (notice.kind === "delivery-failed") {
+    if (!hasOnlyKeys(notice, ["kind"])) {
+      return null;
+    }
+    return {
+      approvalId,
+      approvalKind,
+      target,
+      notice: { kind: "delivery-failed" },
+    };
+  }
+  return null;
+}
+
+function approvalRequestFromSnapshot(params: {
+  approvalId: string;
+  snapshot: {
+    request: unknown;
+    createdAtMs: number;
+    expiresAtMs: number;
+  };
+}): ApprovalRequestLike {
+  return {
+    id: params.approvalId,
+    request: params.snapshot.request as ApprovalRequestLike["request"],
+    createdAtMs: params.snapshot.createdAtMs,
+    expiresAtMs: params.snapshot.expiresAtMs,
+  } as ApprovalRequestLike;
+}
+
+function resolveApprovalRouteNoticeTarget(params: {
+  cfg: OpenClawConfig;
+  request: ApprovalRequestLike;
+}): ApprovalRouteNoticeTarget | null {
+  const directChannel = normalizeOptionalString(params.request.request.turnSourceChannel);
+  const directTo = normalizeOptionalString(params.request.request.turnSourceTo);
+  if (directChannel && directTo) {
+    return {
+      channel: directChannel,
+      to: directTo,
+      accountId: normalizeOptionalString(params.request.request.turnSourceAccountId),
+      threadId: normalizeRouteNoticeThreadId(params.request.request.turnSourceThreadId),
+    };
+  }
+
+  const sessionTarget = resolveApprovalRequestSessionTarget({
+    cfg: params.cfg,
+    request: params.request,
+  });
+  const sessionChannel = normalizeOptionalString(sessionTarget?.channel);
+  const sessionTo = normalizeOptionalString(sessionTarget?.to);
+  return sessionChannel && sessionTo
+    ? {
+        channel: sessionChannel,
+        to: sessionTo,
+        accountId: normalizeOptionalString(sessionTarget?.accountId),
+        threadId: normalizeRouteNoticeThreadId(sessionTarget?.threadId),
+      }
+    : null;
+}
+
+async function resolveApprovalRouteNoticeNativeTarget(params: {
+  cfg: OpenClawConfig;
+  routeNotice: ApprovalRouteNoticeRequest;
+  request: ApprovalRequestLike;
+}): Promise<ApprovalRouteNoticeTarget | null> {
+  const channelInput = normalizeOptionalString(params.routeNotice.target?.channel);
+  const channel = channelInput ? normalizeChannelId(channelInput) : null;
+  if (!channel) {
+    return null;
+  }
+  const accountId = normalizeOptionalString(params.routeNotice.target?.accountId);
+  const plugin = resolveOutboundChannelPlugin({ channel, cfg: params.cfg });
+  const nativeAdapter = plugin?.approvalCapability?.native;
+  if (!nativeAdapter) {
+    return null;
+  }
+  const deliveryPlan = await resolveChannelNativeApprovalDeliveryPlan({
+    cfg: params.cfg,
+    accountId,
+    approvalKind: params.routeNotice.approvalKind,
+    request: params.request,
+    adapter: nativeAdapter,
+  });
+  const originTarget = deliveryPlan.originTarget;
+  const to = normalizeOptionalString(originTarget?.to);
+  return to
+    ? {
+        channel,
+        to,
+        accountId,
+        threadId: normalizeRouteNoticeThreadId(originTarget?.threadId),
+      }
+    : null;
+}
+
+function approvalRouteNoticeTargetsMatch(params: {
+  cfg: OpenClawConfig;
+  snapshotTarget: ApprovalRouteNoticeTarget;
+  nativeTarget: ApprovalRouteNoticeTarget;
+}): boolean {
+  if (params.snapshotTarget.channel !== params.nativeTarget.channel) {
+    return false;
+  }
+  if (
+    params.nativeTarget.accountId !== undefined &&
+    params.snapshotTarget.accountId !== undefined &&
+    params.snapshotTarget.accountId !== params.nativeTarget.accountId
+  ) {
+    return false;
+  }
+  const snapshotTarget = resolveGatewayOutboundTarget({
+    channel: params.snapshotTarget.channel,
+    to: params.snapshotTarget.to,
+    cfg: params.cfg,
+    accountId: params.snapshotTarget.accountId,
+  });
+  const nativeTarget = resolveGatewayOutboundTarget({
+    channel: params.nativeTarget.channel,
+    to: params.nativeTarget.to,
+    cfg: params.cfg,
+    accountId: params.nativeTarget.accountId,
+  });
+  if (snapshotTarget.ok && nativeTarget.ok) {
+    return snapshotTarget.to === nativeTarget.to;
+  }
+  return params.snapshotTarget.to === params.nativeTarget.to;
+}
+
+function mergeApprovalRouteNoticeTargets(params: {
+  cfg: OpenClawConfig;
+  snapshotTarget: ApprovalRouteNoticeTarget | null;
+  nativeTarget: ApprovalRouteNoticeTarget | null;
+}): ApprovalRouteNoticeTarget | null {
+  if (!params.snapshotTarget) {
+    return params.nativeTarget;
+  }
+  if (
+    !params.nativeTarget ||
+    !approvalRouteNoticeTargetsMatch({
+      cfg: params.cfg,
+      snapshotTarget: params.snapshotTarget,
+      nativeTarget: params.nativeTarget,
+    })
+  ) {
+    return params.snapshotTarget;
+  }
+  return {
+    ...params.snapshotTarget,
+    accountId: params.snapshotTarget.accountId ?? params.nativeTarget.accountId,
+    threadId: params.snapshotTarget.threadId ?? params.nativeTarget.threadId,
+  };
+}
+
+function isTrustedApprovalRouteNoticeClient(client: GatewayClient | null | undefined): boolean {
+  return (
+    client?.internal?.approvalRuntime === true &&
+    Array.isArray(client.connect?.scopes) &&
+    client.connect.scopes.includes(APPROVALS_SCOPE)
+  );
+}
+
+function sameApprovalIdentity(a: string | null | undefined, b: string | null | undefined): boolean {
+  const left = normalizeOptionalString(a);
+  const right = normalizeOptionalString(b);
+  return Boolean(left && right && left === right);
+}
+
+function isApprovalRecordRequestedByClient(params: {
+  record: {
+    requestedByConnId?: string | null;
+    requestedByDeviceId?: string | null;
+  };
+  client: GatewayClient | null | undefined;
+}): boolean {
+  // Client ids describe roles such as "gateway-client"; only connection and
+  // device ids identify a concrete requester instance for this self-check.
+  return (
+    sameApprovalIdentity(params.record.requestedByConnId, params.client?.connId) ||
+    sameApprovalIdentity(params.record.requestedByDeviceId, params.client?.connect?.device?.id)
+  );
+}
+
+function canClientSendApprovalRouteNotice(params: {
+  record: ExecApprovalRecord<unknown>;
+  client: GatewayClient | null | undefined;
+}): boolean {
+  return (
+    isTrustedApprovalRouteNoticeClient(params.client) &&
+    isApprovalRecordVisibleToClient({
+      record: params.record,
+      client: params.client ?? null,
+    }) &&
+    !isApprovalRecordRequestedByClient(params)
+  );
+}
+
+function readAllowedApprovalDecisions(request: ApprovalRequestLike): string[] | undefined {
+  const raw = request.request.allowedDecisions;
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const decisions = raw.filter(isApprovalDecision);
+  return decisions.length > 0 ? decisions : undefined;
+}
+
+function buildApprovalRouteNoticeText(params: {
+  routeNotice: ApprovalRouteNoticeRequest;
+  request: ApprovalRequestLike;
+}): string | null {
+  if (params.routeNotice.notice.kind === "routed-elsewhere") {
+    return resolveApprovalRoutedElsewhereNoticeText(params.routeNotice.notice.destinations);
+  }
+  return resolveApprovalDeliveryFailedNoticeText({
+    approvalId: params.routeNotice.approvalId,
+    approvalKind: params.routeNotice.approvalKind,
+    allowedDecisions: readAllowedApprovalDecisions(params.request),
+  });
+}
+
 const sourceReplyTranscriptMirrorQueues = new Map<string, Promise<void>>();
 
 function resolveSourceReplyTranscriptMirrorQueueKey(
@@ -317,6 +693,203 @@ function scheduleDeliveredSourceReplyTranscriptMirror(params: {
     })
     .catch(() => undefined);
   return queued;
+}
+
+async function handleGatewaySendRequest(params: {
+  request: GatewaySendRequest;
+  respond: RespondFn;
+  context: GatewayRequestContext;
+  client: GatewayClient | null | undefined;
+}): Promise<void> {
+  const { request, respond, context, client } = params;
+  const idem = request.idempotencyKey;
+  const dedupeKey = `send:${idem}`;
+  const inflight = resolveGatewayInflightMap({ context, dedupeKey });
+  if (inflight.kind === "cached") {
+    respond(inflight.cached.ok, inflight.cached.payload, inflight.cached.error, {
+      cached: true,
+    });
+    return;
+  }
+  if (inflight.kind === "inflight") {
+    const result = await inflight.inflight;
+    const meta = result.meta ? { ...result.meta, cached: true } : { cached: true };
+    respond(result.ok, result.payload, result.error, meta);
+    return;
+  }
+  const inflightMap = inflight.inflightMap;
+  const to = normalizeOptionalString(request.to) ?? "";
+  const message = normalizeOptionalString(request.message) ?? "";
+  const mediaUrl = normalizeOptionalString(request.mediaUrl);
+  const mediaUrls = Array.isArray(request.mediaUrls)
+    ? request.mediaUrls
+        .map((entry) => normalizeOptionalString(entry))
+        .filter((entry): entry is string => Boolean(entry))
+    : undefined;
+  if (!message && !mediaUrl && (mediaUrls?.length ?? 0) === 0) {
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, "invalid send params: text or media is required"),
+    );
+    return;
+  }
+  const accountId = normalizeOptionalString(request.accountId);
+  const replyToId = normalizeOptionalString(request.replyToId);
+  const threadId = normalizeOptionalString(request.threadId);
+
+  const work = (async (): Promise<InflightResult> => {
+    const resolvedChannel = await resolveRequestedChannel({
+      requestChannel: request.channel,
+      unsupportedMessage: (input) => `unsupported channel: ${input}`,
+      context,
+      rejectWebchatAsInternalOnly: true,
+    });
+    if ("error" in resolvedChannel) {
+      return { ok: false, error: resolvedChannel.error };
+    }
+    const { cfg, channel } = resolvedChannel;
+    const outboundChannel = channel;
+    const plugin = resolveOutboundChannelPlugin({ channel, cfg });
+    if (!plugin) {
+      return {
+        ok: false,
+        error: errorShape(ErrorCodes.INVALID_REQUEST, `unsupported channel: ${channel}`),
+      };
+    }
+
+    try {
+      const resolvedTarget = resolveGatewayOutboundTarget({
+        channel: outboundChannel,
+        to,
+        cfg,
+        accountId,
+      });
+      if (!resolvedTarget.ok) {
+        return {
+          ok: false,
+          error: resolvedTarget.error,
+          meta: { channel },
+        };
+      }
+      const idLikeTarget = await maybeResolveIdLikeTarget({
+        cfg,
+        channel,
+        input: resolvedTarget.to,
+        accountId,
+      });
+      const deliveryTarget = idLikeTarget?.to ?? resolvedTarget.to;
+      const outboundDeps = context.deps ? createOutboundSendDeps(context.deps) : undefined;
+      const outboundPayloads = [
+        {
+          text: message,
+          mediaUrl,
+          mediaUrls,
+          ...(request.asVoice === true ? { audioAsVoice: true } : {}),
+        },
+      ];
+      const outboundPayloadPlan = createOutboundPayloadPlan(outboundPayloads);
+      const mirrorProjection = projectOutboundPayloadPlanForMirror(outboundPayloadPlan);
+      const mirrorText = mirrorProjection.text;
+      const mirrorMediaUrls = mirrorProjection.mediaUrls;
+      const providedSessionKey = normalizeOptionalLowercaseString(request.sessionKey);
+      const explicitAgentId = normalizeOptionalString(request.agentId);
+      const sessionAgentId = providedSessionKey
+        ? resolveSessionAgentId({ sessionKey: providedSessionKey, config: cfg })
+        : undefined;
+      const defaultAgentId = resolveSessionAgentId({ config: cfg });
+      const effectiveAgentId = explicitAgentId ?? sessionAgentId ?? defaultAgentId;
+      const derivedRoute = await resolveOutboundSessionRoute({
+        cfg,
+        channel,
+        agentId: effectiveAgentId,
+        accountId,
+        target: deliveryTarget,
+        currentSessionKey: providedSessionKey,
+        resolvedTarget: idLikeTarget,
+        replyToId,
+        threadId,
+      });
+      const providedSessionBaseKey =
+        parseThreadSessionSuffix(providedSessionKey).baseSessionKey ?? providedSessionKey;
+      const shouldUseDerivedThreadSessionKey =
+        channel === "slack" &&
+        !!providedSessionKey &&
+        !!normalizeOptionalString(derivedRoute?.threadId) &&
+        normalizeOptionalLowercaseString(derivedRoute?.baseSessionKey) ===
+          normalizeOptionalLowercaseString(providedSessionBaseKey) &&
+        normalizeOptionalLowercaseString(derivedRoute?.sessionKey) !== providedSessionKey;
+      const outboundRoute = derivedRoute
+        ? providedSessionKey
+          ? shouldUseDerivedThreadSessionKey
+            ? {
+                ...derivedRoute,
+                baseSessionKey: derivedRoute.baseSessionKey ?? providedSessionKey,
+              }
+            : {
+                ...derivedRoute,
+                sessionKey: providedSessionKey,
+                baseSessionKey: providedSessionKey,
+              }
+          : derivedRoute
+        : null;
+      if (outboundRoute) {
+        await ensureOutboundSessionEntry({
+          cfg,
+          channel,
+          accountId,
+          route: outboundRoute,
+        });
+      }
+      const outboundSessionKey = outboundRoute?.sessionKey ?? providedSessionKey;
+      const outboundSession = buildOutboundSessionContext({
+        cfg,
+        agentId: effectiveAgentId,
+        sessionKey: outboundSessionKey,
+        conversationType: outboundRoute?.chatType,
+      });
+      const send = await sendDurableMessageBatch({
+        cfg,
+        channel: outboundChannel,
+        to: deliveryTarget,
+        accountId,
+        payloads: outboundPayloads,
+        replyToId: replyToId ?? null,
+        session: outboundSession,
+        gifPlayback: request.gifPlayback,
+        forceDocument: request.forceDocument,
+        threadId: outboundRoute?.threadId ?? threadId ?? null,
+        deps: outboundDeps,
+        gatewayClientScopes: client?.connect?.scopes ?? [],
+        silent: request.silent,
+        formatting: request.parseMode ? { parseMode: request.parseMode } : undefined,
+        mirror: outboundSessionKey
+          ? {
+              sessionKey: outboundSessionKey,
+              agentId: effectiveAgentId,
+              text: mirrorText || message,
+              mediaUrls: mirrorMediaUrls.length > 0 ? mirrorMediaUrls : undefined,
+              idempotencyKey: idem,
+            }
+          : undefined,
+      });
+      if (send.status === "failed" || send.status === "partial_failed") {
+        throw send.error;
+      }
+      const results = send.status === "sent" ? send.results : [];
+
+      const result = results.at(-1);
+      if (!result) {
+        throw new Error("No delivery result");
+      }
+      const payload = buildGatewayDeliveryPayload({ runId: idem, channel, result });
+      return createGatewayInflightSuccess({ context, dedupeKey, payload, channel });
+    } catch (err) {
+      return createGatewayInflightUnavailableFailure({ context, dedupeKey, channel, err });
+    }
+  })();
+
+  await runGatewayInflightWork({ inflightMap, dedupeKey, work, respond });
 }
 
 export const sendHandlers: GatewayRequestHandlers = {
@@ -452,6 +1025,78 @@ export const sendHandlers: GatewayRequestHandlers = {
 
     await runGatewayInflightWork({ inflightMap, dedupeKey, work, respond });
   },
+  "approval.routeNotice.send": async ({ params, respond, context, client }) => {
+    const routeNotice = parseApprovalRouteNoticeRequest(params);
+    if (!routeNotice) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid approval route notice request"),
+      );
+      return;
+    }
+    const manager =
+      routeNotice.approvalKind === "plugin"
+        ? context.pluginApprovalManager
+        : context.execApprovalManager;
+    const snapshot = manager?.getSnapshot(routeNotice.approvalId);
+    if (
+      !snapshot ||
+      snapshot.resolvedAtMs !== undefined ||
+      !canClientSendApprovalRouteNotice({
+        record: snapshot,
+        client,
+      })
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "unknown or expired approval route notice"),
+      );
+      return;
+    }
+    const cfg = context.getRuntimeConfig();
+    const approvalRequest = approvalRequestFromSnapshot({
+      approvalId: routeNotice.approvalId,
+      snapshot,
+    });
+    const snapshotTarget = resolveApprovalRouteNoticeTarget({ cfg, request: approvalRequest });
+    const nativeTarget = await resolveApprovalRouteNoticeNativeTarget({
+      cfg,
+      routeNotice,
+      request: approvalRequest,
+    });
+    const target = mergeApprovalRouteNoticeTargets({
+      cfg,
+      snapshotTarget,
+      nativeTarget,
+    });
+    const message = buildApprovalRouteNoticeText({
+      routeNotice,
+      request: approvalRequest,
+    });
+    if (!target || !message) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "approval route notice target unavailable"),
+      );
+      return;
+    }
+    await handleGatewaySendRequest({
+      request: {
+        channel: target.channel,
+        to: target.to,
+        accountId: target.accountId,
+        threadId: target.threadId,
+        message,
+        idempotencyKey: `approval-route-notice:${routeNotice.approvalId}`,
+      },
+      respond,
+      context,
+      client,
+    });
+  },
   send: async ({ params, respond, context, client }) => {
     const p = params;
     if (!validateSendParams(p)) {
@@ -465,212 +1110,12 @@ export const sendHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const request = p as {
-      to: string;
-      message?: string;
-      mediaUrl?: string;
-      mediaUrls?: string[];
-      asVoice?: boolean;
-      gifPlayback?: boolean;
-      channel?: string;
-      accountId?: string;
-      agentId?: string;
-      replyToId?: string;
-      threadId?: string;
-      forceDocument?: boolean;
-      silent?: boolean;
-      parseMode?: "HTML";
-      sessionKey?: string;
-      idempotencyKey: string;
-    };
-    const idem = request.idempotencyKey;
-    const dedupeKey = `send:${idem}`;
-    const inflight = resolveGatewayInflightMap({ context, dedupeKey });
-    if (inflight.kind === "cached") {
-      respond(inflight.cached.ok, inflight.cached.payload, inflight.cached.error, {
-        cached: true,
-      });
-      return;
-    }
-    if (inflight.kind === "inflight") {
-      const result = await inflight.inflight;
-      const meta = result.meta ? { ...result.meta, cached: true } : { cached: true };
-      respond(result.ok, result.payload, result.error, meta);
-      return;
-    }
-    const inflightMap = inflight.inflightMap;
-    const to = normalizeOptionalString(request.to) ?? "";
-    const message = normalizeOptionalString(request.message) ?? "";
-    const mediaUrl = normalizeOptionalString(request.mediaUrl);
-    const mediaUrls = Array.isArray(request.mediaUrls)
-      ? request.mediaUrls
-          .map((entry) => normalizeOptionalString(entry))
-          .filter((entry): entry is string => Boolean(entry))
-      : undefined;
-    if (!message && !mediaUrl && (mediaUrls?.length ?? 0) === 0) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid send params: text or media is required"),
-      );
-      return;
-    }
-    const accountId = normalizeOptionalString(request.accountId);
-    const replyToId = normalizeOptionalString(request.replyToId);
-    const threadId = normalizeOptionalString(request.threadId);
-
-    const work = (async (): Promise<InflightResult> => {
-      const resolvedChannel = await resolveRequestedChannel({
-        requestChannel: request.channel,
-        unsupportedMessage: (input) => `unsupported channel: ${input}`,
-        context,
-        rejectWebchatAsInternalOnly: true,
-      });
-      if ("error" in resolvedChannel) {
-        return { ok: false, error: resolvedChannel.error };
-      }
-      const { cfg, channel } = resolvedChannel;
-      const outboundChannel = channel;
-      const plugin = resolveOutboundChannelPlugin({ channel, cfg });
-      if (!plugin) {
-        return {
-          ok: false,
-          error: errorShape(ErrorCodes.INVALID_REQUEST, `unsupported channel: ${channel}`),
-        };
-      }
-
-      try {
-        const resolvedTarget = resolveGatewayOutboundTarget({
-          channel: outboundChannel,
-          to,
-          cfg,
-          accountId,
-        });
-        if (!resolvedTarget.ok) {
-          return {
-            ok: false,
-            error: resolvedTarget.error,
-            meta: { channel },
-          };
-        }
-        const idLikeTarget = await maybeResolveIdLikeTarget({
-          cfg,
-          channel,
-          input: resolvedTarget.to,
-          accountId,
-        });
-        const deliveryTarget = idLikeTarget?.to ?? resolvedTarget.to;
-        const outboundDeps = context.deps ? createOutboundSendDeps(context.deps) : undefined;
-        const outboundPayloads = [
-          {
-            text: message,
-            mediaUrl,
-            mediaUrls,
-            ...(request.asVoice === true ? { audioAsVoice: true } : {}),
-          },
-        ];
-        const outboundPayloadPlan = createOutboundPayloadPlan(outboundPayloads);
-        const mirrorProjection = projectOutboundPayloadPlanForMirror(outboundPayloadPlan);
-        const mirrorText = mirrorProjection.text;
-        const mirrorMediaUrls = mirrorProjection.mediaUrls;
-        const providedSessionKey = normalizeOptionalLowercaseString(request.sessionKey);
-        const explicitAgentId = normalizeOptionalString(request.agentId);
-        const sessionAgentId = providedSessionKey
-          ? resolveSessionAgentId({ sessionKey: providedSessionKey, config: cfg })
-          : undefined;
-        const defaultAgentId = resolveSessionAgentId({ config: cfg });
-        const effectiveAgentId = explicitAgentId ?? sessionAgentId ?? defaultAgentId;
-        const derivedRoute = await resolveOutboundSessionRoute({
-          cfg,
-          channel,
-          agentId: effectiveAgentId,
-          accountId,
-          target: deliveryTarget,
-          currentSessionKey: providedSessionKey,
-          resolvedTarget: idLikeTarget,
-          replyToId,
-          threadId,
-        });
-        const providedSessionBaseKey =
-          parseThreadSessionSuffix(providedSessionKey).baseSessionKey ?? providedSessionKey;
-        const shouldUseDerivedThreadSessionKey =
-          channel === "slack" &&
-          !!providedSessionKey &&
-          !!normalizeOptionalString(derivedRoute?.threadId) &&
-          normalizeOptionalLowercaseString(derivedRoute?.baseSessionKey) ===
-            normalizeOptionalLowercaseString(providedSessionBaseKey) &&
-          normalizeOptionalLowercaseString(derivedRoute?.sessionKey) !== providedSessionKey;
-        const outboundRoute = derivedRoute
-          ? providedSessionKey
-            ? shouldUseDerivedThreadSessionKey
-              ? {
-                  ...derivedRoute,
-                  baseSessionKey: derivedRoute.baseSessionKey ?? providedSessionKey,
-                }
-              : {
-                  ...derivedRoute,
-                  sessionKey: providedSessionKey,
-                  baseSessionKey: providedSessionKey,
-                }
-            : derivedRoute
-          : null;
-        if (outboundRoute) {
-          await ensureOutboundSessionEntry({
-            cfg,
-            channel,
-            accountId,
-            route: outboundRoute,
-          });
-        }
-        const outboundSessionKey = outboundRoute?.sessionKey ?? providedSessionKey;
-        const outboundSession = buildOutboundSessionContext({
-          cfg,
-          agentId: effectiveAgentId,
-          sessionKey: outboundSessionKey,
-          conversationType: outboundRoute?.chatType,
-        });
-        const send = await sendDurableMessageBatch({
-          cfg,
-          channel: outboundChannel,
-          to: deliveryTarget,
-          accountId,
-          payloads: outboundPayloads,
-          replyToId: replyToId ?? null,
-          session: outboundSession,
-          gifPlayback: request.gifPlayback,
-          forceDocument: request.forceDocument,
-          threadId: outboundRoute?.threadId ?? threadId ?? null,
-          deps: outboundDeps,
-          gatewayClientScopes: client?.connect?.scopes ?? [],
-          silent: request.silent,
-          formatting: request.parseMode ? { parseMode: request.parseMode } : undefined,
-          mirror: outboundSessionKey
-            ? {
-                sessionKey: outboundSessionKey,
-                agentId: effectiveAgentId,
-                text: mirrorText || message,
-                mediaUrls: mirrorMediaUrls.length > 0 ? mirrorMediaUrls : undefined,
-                idempotencyKey: idem,
-              }
-            : undefined,
-        });
-        if (send.status === "failed" || send.status === "partial_failed") {
-          throw send.error;
-        }
-        const results = send.status === "sent" ? send.results : [];
-
-        const result = results.at(-1);
-        if (!result) {
-          throw new Error("No delivery result");
-        }
-        const payload = buildGatewayDeliveryPayload({ runId: idem, channel, result });
-        return createGatewayInflightSuccess({ context, dedupeKey, payload, channel });
-      } catch (err) {
-        return createGatewayInflightUnavailableFailure({ context, dedupeKey, channel, err });
-      }
-    })();
-
-    await runGatewayInflightWork({ inflightMap, dedupeKey, work, respond });
+    await handleGatewaySendRequest({
+      request: p as GatewaySendRequest,
+      respond,
+      context,
+      client,
+    });
   },
   poll: async ({ params, respond, context, client }) => {
     const p = params;

--- a/src/infra/approval-native-route-coordinator.test.ts
+++ b/src/infra/approval-native-route-coordinator.test.ts
@@ -117,13 +117,19 @@ describe("createApprovalNativeRouteReporter", () => {
       ],
     });
 
-    expect(requestGateway).toHaveBeenCalledWith("send", {
-      channel: "slack",
-      to: "channel:C123",
-      accountId: "default",
-      threadId: "1712345678.123456",
-      message: "Approval required. I sent the approval request to Slack DMs, not this chat.",
-      idempotencyKey: "approval-route-notice:approval-1",
+    expect(requestGateway).toHaveBeenCalledWith("approval.routeNotice.send", {
+      approvalId: "approval-1",
+      approvalKind: "exec",
+      target: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "default",
+        threadId: "1712345678.123456",
+      },
+      notice: {
+        kind: "routed-elsewhere",
+        destinations: ["Slack DMs"],
+      },
     });
     expect(lateRuntimeGateway).not.toHaveBeenCalled();
   });
@@ -209,13 +215,19 @@ describe("createApprovalNativeRouteReporter", () => {
       ],
     });
 
-    expect(originGateway).toHaveBeenCalledWith("send", {
-      channel: "slack",
-      to: "channel:C123",
-      accountId: "work-a",
-      threadId: undefined,
-      message: "Approval required. I sent the approval request to Slack DMs, not this chat.",
-      idempotencyKey: "approval-route-notice:approval-2",
+    expect(originGateway).toHaveBeenCalledWith("approval.routeNotice.send", {
+      approvalId: "approval-2",
+      approvalKind: "exec",
+      target: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "work-a",
+        threadId: undefined,
+      },
+      notice: {
+        kind: "routed-elsewhere",
+        destinations: ["Slack DMs"],
+      },
     });
     expect(otherGateway).not.toHaveBeenCalled();
   });
@@ -269,16 +281,16 @@ describe("createApprovalNativeRouteReporter", () => {
       deliveredTargets: [],
     });
 
-    expect(requestGateway).toHaveBeenCalledWith("send", {
-      channel: "discord",
-      to: "channel:C123",
-      accountId: "default",
-      threadId: undefined,
-      message:
-        "Approval required. I could not deliver the native approval request.\n" +
-        "Reply with: /approve deadbeef allow-once|deny\n" +
-        "If the short code is ambiguous, use the full id in /approve.",
-      idempotencyKey: "approval-route-notice:deadbeef-1234-4567-89ab-cdef01234567",
+    expect(requestGateway).toHaveBeenCalledWith("approval.routeNotice.send", {
+      approvalId: "deadbeef-1234-4567-89ab-cdef01234567",
+      approvalKind: "exec",
+      target: {
+        channel: "discord",
+        to: "channel:C123",
+        accountId: "default",
+        threadId: undefined,
+      },
+      notice: { kind: "delivery-failed" },
     });
   });
 });

--- a/src/infra/approval-native-route-coordinator.ts
+++ b/src/infra/approval-native-route-coordinator.ts
@@ -6,11 +6,7 @@ import type {
   ChannelApprovalNativeDeliveryPlan,
   ChannelApprovalNativePlannedTarget,
 } from "./approval-native-delivery.js";
-import {
-  describeApprovalDeliveryDestination,
-  resolveApprovalDeliveryFailedNoticeText,
-  resolveApprovalRoutedElsewhereNoticeText,
-} from "./approval-native-route-notice.js";
+import { describeApprovalDeliveryDestination } from "./approval-native-route-notice.js";
 import { buildChannelApprovalNativeTargetKey } from "./approval-native-target-key.js";
 import type { ChannelApprovalKind } from "./approval-types.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
@@ -58,6 +54,25 @@ type RouteNoticeTarget = {
   accountId?: string | null;
   threadId?: string | number | null;
 };
+
+type RouteNoticeGatewayPayload =
+  | {
+      approvalId: string;
+      approvalKind: ChannelApprovalKind;
+      target: RouteNoticeTarget;
+      notice: {
+        kind: "delivery-failed";
+      };
+    }
+  | {
+      approvalId: string;
+      approvalKind: ChannelApprovalKind;
+      target: RouteNoticeTarget;
+      notice: {
+        kind: "routed-elsewhere";
+        destinations: string[];
+      };
+    };
 
 const activeApprovalRouteRuntimes = new Map<string, ApprovalRouteRuntimeRecord>();
 const pendingApprovalRouteNotices = new Map<string, PendingApprovalRouteNotice>();
@@ -156,20 +171,11 @@ function hasPlannedNativeTargets(report: ApprovalRouteReport): boolean {
   return report.deliveryPlan.targets.length > 0;
 }
 
-function readAllowedDecisionStrings(request: ApprovalRequest): string[] | undefined {
-  const allowedDecisions =
-    "allowedDecisions" in request.request ? request.request.allowedDecisions : undefined;
-  if (!Array.isArray(allowedDecisions)) {
-    return undefined;
-  }
-  return allowedDecisions.filter((value): value is string => typeof value === "string");
-}
-
 function resolveApprovalRouteNotice(params: {
   approvalKind: ChannelApprovalKind;
   request: ApprovalRequest;
   reports: readonly ApprovalRouteReport[];
-}): { requestGateway: GatewayRequestFn; target: RouteNoticeTarget; text: string } | null {
+}): { requestGateway: GatewayRequestFn; payload: RouteNoticeGatewayPayload } | null {
   const explicitTarget = resolveRouteNoticeTargetFromRequest(params.request);
   const originChannel = normalizeChannel(
     explicitTarget?.channel ?? params.request.request.turnSourceChannel,
@@ -197,12 +203,12 @@ function resolveApprovalRouteNotice(params: {
       requestGateway:
         params.reports.find((report) => activeApprovalRouteRuntimes.has(report.runtimeId))
           ?.requestGateway ?? params.reports[0].requestGateway,
-      target,
-      text: resolveApprovalDeliveryFailedNoticeText({
+      payload: {
         approvalId: params.request.id,
         approvalKind: params.approvalKind,
-        allowedDecisions: readAllowedDecisionStrings(params.request),
-      }),
+        target,
+        notice: { kind: "delivery-failed" },
+      },
     };
   }
 
@@ -247,8 +253,7 @@ function resolveApprovalRouteNotice(params: {
       }),
     ];
   });
-  const text = resolveApprovalRoutedElsewhereNoticeText(destinations);
-  if (!text) {
+  if (destinations.length === 0) {
     return null;
   }
 
@@ -261,8 +266,15 @@ function resolveApprovalRouteNotice(params: {
 
   return {
     requestGateway,
-    target,
-    text,
+    payload: {
+      approvalId: params.request.id,
+      approvalKind: params.approvalKind,
+      target,
+      notice: {
+        kind: "routed-elsewhere",
+        destinations,
+      },
+    },
   };
 }
 
@@ -311,14 +323,7 @@ async function maybeFinalizeApprovalRouteNotice(approvalId: string): Promise<voi
   }
 
   try {
-    await notice.requestGateway("send", {
-      channel: notice.target.channel,
-      to: notice.target.to,
-      accountId: notice.target.accountId ?? undefined,
-      threadId: notice.target.threadId ?? undefined,
-      message: notice.text,
-      idempotencyKey: `approval-route-notice:${approvalId}`,
-    });
+    await notice.requestGateway("approval.routeNotice.send", notice.payload);
   } catch {
     // The approval delivery already succeeded; the follow-up notice is best-effort.
   }


### PR DESCRIPTION
## Summary
- Add hidden gateway method `approval.routeNotice.send` scoped to `operator.approvals` instead of routing native approval notices through generic `send` / `operator.write`.
- Have the approval native route coordinator send structured route-notice payloads and let the gateway derive the final notice text and verified origin target server-side.
- Reject route notices from ordinary approval clients, requester-owned approvals, resolved approvals, extra generic send payload fields, or unverified caller-provided targets.

## Scope split
- Split out from #86771.
- This PR is only the least-privilege route-notice gateway method.
- It does not include stale Discord button UX or shared `exec-approvals.json` approval-runtime token support.

## Real behavior proof
Behavior addressed: Approval route notices can be sent by trusted approval-runtime clients with `operator.approvals` without granting broad `operator.write`, while the gateway keeps text and target derivation server-side.

Real environment tested: Local OpenClaw source checkout on this PR head `c6ab81395c`, Node `v24.14.0`, macOS host. The smoke used the real gateway route-notice handler and outbound send pipeline with an in-process Discord outbound adapter registered in the active plugin registry.

Exact steps or command run after this patch: Ran a `pnpm exec tsx` smoke from the repo root that registered a Discord outbound adapter, created a pending exec approval in `ExecApprovalManager`, invoked `sendHandlers["approval.routeNotice.send"]` as a trusted approval runtime with only `operator.approvals`, and observed the outbound delivery call.

Evidence after fix:

```text
$ PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm exec tsx <route-notice-smoke>
SMOKE route_notice_send ok {"responseOk":true,"messageId":"route-notice-smoke-1","deliveredText":"Approval required. I sent the approval request to Discord DMs, not this chat.","deliveredTo":"channel:C1","deliveredThreadId":"thread-1","scopes":["operator.approvals"]}
```

Observed result after fix: The route notice was accepted with `operator.approvals`, delivered to the approval's origin channel/thread, and the delivered text was generated by the gateway from the structured `routed-elsewhere` notice payload.

What was not tested: No live Discord or Slack API send was performed. The smoke proves the gateway method, approval-runtime authorization, server-side notice text, target selection, and outbound pipeline handoff; platform-specific live channel delivery remains covered by the channel integrations.

## Tests and validation
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" node scripts/run-vitest.mjs src/gateway/method-scopes.test.ts src/gateway/server-methods/send.test.ts src/infra/approval-native-route-coordinator.test.ts --reporter=dot` — 6 files, 352 tests passed.
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm exec oxfmt --check --threads=1 src/gateway/method-scopes.test.ts src/gateway/methods/core-descriptors.ts src/gateway/server-methods.ts src/gateway/server-methods/send.test.ts src/gateway/server-methods/send.ts src/infra/approval-native-route-coordinator.test.ts src/infra/approval-native-route-coordinator.ts`
- `git diff --check upstream/main..HEAD`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

## Risk checklist
Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `Yes`

Highest-risk area: gateway method authorization and approval route-notice delivery.

Mitigation: the method is hidden, scoped to `operator.approvals`, requires the internal approval-runtime marker, revalidates the pending approval record, derives text server-side, and verifies/falls back to server-derived origin targets before sending.

