### PR TITLE
fix(gateway): share approval runtime socket token

### DIFF
--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -364,6 +364,21 @@ describe("gateway tool defaults", () => {
     expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
   });
 
+  it("keeps the local approval runtime token for remote mode without a remote URL", async () => {
+    mocks.configState.value = {
+      gateway: {
+        mode: "remote",
+      },
+    };
+    mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });
+
+    await callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" });
+
+    const call = capturedGatewayCall();
+    expect(call).not.toHaveProperty("deviceIdentity");
+    expect(call.approvalRuntimeToken).toEqual(expect.any(String));
+  });
+
   it("does not send the local approval runtime token to env-selected gateways", async () => {
     process.env.OPENCLAW_GATEWAY_URL = "wss://gateway.example";
     mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -11,6 +11,12 @@ const mocks = vi.hoisted(() => ({
   configState: {
     value: {} as Record<string, unknown>,
   },
+  deviceIdentity: {
+    deviceId: "agent-tool-device",
+    publicKeyPem: "public-key",
+    privateKeyPem: "private-key",
+  },
+  deviceIdentityError: undefined as Error | undefined,
 }));
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: () => mocks.configState.value,
@@ -18,6 +24,14 @@ vi.mock("../../config/config.js", () => ({
 }));
 vi.mock("../../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => mocks.callGateway(...args),
+}));
+vi.mock("../../infra/device-identity.js", () => ({
+  loadOrCreateDeviceIdentity: () => {
+    if (mocks.deviceIdentityError) {
+      throw mocks.deviceIdentityError;
+    }
+    return mocks.deviceIdentity;
+  },
 }));
 
 function capturedGatewayCall(): CallGatewayScopedOptions {
@@ -32,13 +46,16 @@ function capturedGatewayCall(): CallGatewayScopedOptions {
 describe("gateway tool defaults", () => {
   const envSnapshot = {
     openclaw: process.env.OPENCLAW_GATEWAY_TOKEN,
+    gatewayUrl: process.env.OPENCLAW_GATEWAY_URL,
   };
 
   beforeEach(() => {
     mocks.callGateway.mockClear();
+    mocks.deviceIdentityError = undefined;
     mocks.configState.value = {};
     setActivePluginRegistry(createEmptyPluginRegistry());
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_URL;
   });
 
   afterAll(() => {
@@ -47,11 +64,17 @@ describe("gateway tool defaults", () => {
     } else {
       process.env.OPENCLAW_GATEWAY_TOKEN = envSnapshot.openclaw;
     }
+    if (envSnapshot.gatewayUrl === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_URL;
+    } else {
+      process.env.OPENCLAW_GATEWAY_URL = envSnapshot.gatewayUrl;
+    }
   });
 
   it("leaves url undefined so callGateway can use config", () => {
     const opts = resolveGatewayOptions();
     expect(opts.url).toBeUndefined();
+    expect(opts.target).toBe("local");
   });
 
   it("accepts allowlisted gatewayUrl overrides (SSRF hardening)", async () => {
@@ -305,6 +328,72 @@ describe("gateway tool defaults", () => {
     expect(call.method).toBe("exec.approval.resolve");
     expect(call.scopes).toEqual(["operator.approvals"]);
     expect(call.approvalRuntimeToken).toEqual(expect.any(String));
+  });
+
+  it("does not send the local approval runtime token to configured remote gateways", async () => {
+    mocks.configState.value = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example",
+          token: "remote-token",
+        },
+      },
+    };
+    mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });
+
+    await callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" });
+
+    const call = capturedGatewayCall();
+    expect(call.url).toBeUndefined();
+    expect(call.token).toBeUndefined();
+    expect(call).not.toHaveProperty("approvalRuntimeToken");
+  });
+
+  it("does not send the local approval runtime token to env-selected gateways", async () => {
+    process.env.OPENCLAW_GATEWAY_URL = "wss://gateway.example";
+    mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });
+
+    await callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" });
+
+    const call = capturedGatewayCall();
+    expect(call.url).toBeUndefined();
+    expect(call).not.toHaveProperty("approvalRuntimeToken");
+    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+  });
+
+  it("does not send the local approval runtime token to loopback env-selected gateways", async () => {
+    process.env.OPENCLAW_GATEWAY_URL = "ws://127.0.0.1:18789";
+    mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });
+
+    await callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" });
+
+    const call = capturedGatewayCall();
+    expect(call.url).toBeUndefined();
+    expect(call).not.toHaveProperty("approvalRuntimeToken");
+    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+  });
+
+  it("does not send the local approval runtime token to loopback env-selected gateway paths", async () => {
+    process.env.OPENCLAW_GATEWAY_URL = "ws://127.0.0.1:18789/ws";
+    mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });
+
+    await callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" });
+
+    const call = capturedGatewayCall();
+    expect(call.url).toBeUndefined();
+    expect(call).not.toHaveProperty("approvalRuntimeToken");
+    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+  });
+
+  it("fails env-selected approval calls when requester device identity is unavailable", async () => {
+    process.env.OPENCLAW_GATEWAY_URL = "ws://127.0.0.1:18789";
+    mocks.deviceIdentityError = new Error("state directory read-only");
+
+    await expect(
+      callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" }),
+    ).rejects.toThrow("env-selected approval gateway calls require a stable device identity");
+    expect(mocks.callGateway).not.toHaveBeenCalled();
   });
 
   it("does not send the local approval runtime token to gatewayUrl overrides", async () => {

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -16,6 +16,14 @@ const mocks = vi.hoisted(() => ({
     publicKeyPem: "public-key",
     privateKeyPem: "private-key",
   },
+  persistedDeviceIdentity: undefined as
+    | {
+        deviceId: string;
+        publicKeyPem: string;
+        privateKeyPem: string;
+      }
+    | null
+    | undefined,
   deviceIdentityError: undefined as Error | undefined,
 }));
 vi.mock("../../config/config.js", () => ({
@@ -26,6 +34,10 @@ vi.mock("../../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => mocks.callGateway(...args),
 }));
 vi.mock("../../infra/device-identity.js", () => ({
+  loadDeviceIdentityIfPresent: () =>
+    mocks.persistedDeviceIdentity === undefined
+      ? mocks.deviceIdentity
+      : mocks.persistedDeviceIdentity,
   loadOrCreateDeviceIdentity: () => {
     if (mocks.deviceIdentityError) {
       throw mocks.deviceIdentityError;
@@ -52,6 +64,7 @@ describe("gateway tool defaults", () => {
   beforeEach(() => {
     mocks.callGateway.mockClear();
     mocks.deviceIdentityError = undefined;
+    mocks.persistedDeviceIdentity = undefined;
     mocks.configState.value = {};
     setActivePluginRegistry(createEmptyPluginRegistry());
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
@@ -348,6 +361,7 @@ describe("gateway tool defaults", () => {
     expect(call.url).toBeUndefined();
     expect(call.token).toBeUndefined();
     expect(call).not.toHaveProperty("approvalRuntimeToken");
+    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
   });
 
   it("does not send the local approval runtime token to env-selected gateways", async () => {
@@ -392,7 +406,48 @@ describe("gateway tool defaults", () => {
 
     await expect(
       callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" }),
-    ).rejects.toThrow("env-selected approval gateway calls require a stable device identity");
+    ).rejects.toThrow("remote approval gateway calls require a stable device identity");
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("fails remote approval calls when requester device identity is not persisted", async () => {
+    mocks.configState.value = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://127.0.0.1:18789",
+          token: "remote-token",
+        },
+      },
+    };
+    mocks.persistedDeviceIdentity = null;
+    mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });
+
+    await expect(
+      callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" }),
+    ).rejects.toThrow("remote approval gateway calls require a stable device identity");
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("fails remote approval calls when requester device identity readback differs", async () => {
+    mocks.configState.value = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example",
+          token: "remote-token",
+        },
+      },
+    };
+    mocks.persistedDeviceIdentity = {
+      ...mocks.deviceIdentity,
+      deviceId: "other-device",
+    };
+    mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });
+
+    await expect(
+      callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" }),
+    ).rejects.toThrow("remote approval gateway calls require a stable device identity");
     expect(mocks.callGateway).not.toHaveBeenCalled();
   });
 

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -20,6 +20,7 @@ import {
   type OperatorScope,
 } from "../../gateway/method-scopes.js";
 import { getOperatorApprovalRuntimeToken } from "../../gateway/operator-approval-runtime-token.js";
+import { loadOrCreateDeviceIdentity, type DeviceIdentity } from "../../infra/device-identity.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { readPositiveIntegerParam, readStringParam } from "./common.js";
 
@@ -76,13 +77,9 @@ function canonicalizeToolGatewayWsUrl(raw: string): { origin: string; key: strin
   return { origin, key };
 }
 
-function validateGatewayUrlOverrideForAgentTools(params: {
-  cfg: OpenClawConfig;
-  urlOverride: string;
-}): { url: string; target: GatewayOverrideTarget } {
-  const { cfg } = params;
+function resolveLocalGatewayUrlKeys(cfg: OpenClawConfig): Set<string> {
   const port = resolveGatewayPort(cfg);
-  const localAllowed = new Set<string>([
+  return new Set<string>([
     `ws://127.0.0.1:${port}`,
     `wss://127.0.0.1:${port}`,
     `ws://localhost:${port}`,
@@ -90,7 +87,9 @@ function validateGatewayUrlOverrideForAgentTools(params: {
     `ws://[::1]:${port}`,
     `wss://[::1]:${port}`,
   ]);
+}
 
+function resolveConfiguredRemoteGatewayKey(cfg: OpenClawConfig): string | undefined {
   let remoteKey: string | undefined;
   const remoteUrl = normalizeOptionalString(cfg.gateway?.remote?.url) ?? "";
   if (remoteUrl) {
@@ -102,6 +101,28 @@ function validateGatewayUrlOverrideForAgentTools(params: {
       // gatewayUrl overrides need strict validation.
     }
   }
+  return remoteKey;
+}
+
+function resolveDefaultGatewayTarget(params: {
+  cfg: OpenClawConfig;
+  envGatewayUrl?: string;
+}): GatewayOverrideTarget {
+  if (params.envGatewayUrl) {
+    // Match operator-approvals-client: env-selected URLs may be tunnels or other gateways,
+    // so loopback alone must not grant local approval-runtime authority.
+    return "remote";
+  }
+  return params.cfg.gateway?.mode === "remote" ? "remote" : "local";
+}
+
+function validateGatewayUrlOverrideForAgentTools(params: {
+  cfg: OpenClawConfig;
+  urlOverride: string;
+}): { url: string; target: GatewayOverrideTarget } {
+  const { cfg } = params;
+  const localAllowed = resolveLocalGatewayUrlKeys(cfg);
+  const remoteKey = resolveConfiguredRemoteGatewayKey(cfg);
 
   const parsed = canonicalizeToolGatewayWsUrl(params.urlOverride);
   if (localAllowed.has(parsed.key)) {
@@ -110,6 +131,7 @@ function validateGatewayUrlOverrideForAgentTools(params: {
   if (remoteKey && parsed.key === remoteKey) {
     return { url: parsed.origin, target: "remote" };
   }
+  const port = resolveGatewayPort(cfg);
   throw new Error(
     [
       "gatewayUrl override rejected.",
@@ -160,7 +182,14 @@ export function resolveGatewayOptions(opts?: GatewayCallOptions) {
     typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
       ? Math.max(1, Math.floor(opts.timeoutMs))
       : 30_000;
-  return { url: validatedOverride?.url, token, timeoutMs };
+  const envGatewayUrl = trimToUndefined(process.env.OPENCLAW_GATEWAY_URL);
+  const target =
+    validatedOverride?.target ??
+    resolveDefaultGatewayTarget({
+      cfg,
+      envGatewayUrl,
+    });
+  return { url: validatedOverride?.url, token, timeoutMs, target };
 }
 
 const APPROVAL_RUNTIME_METHODS = new Set<string>([
@@ -174,6 +203,7 @@ const APPROVAL_RUNTIME_METHODS = new Set<string>([
 function resolveApprovalRuntimeTokenForGatewayTool(params: {
   method: string;
   opts: GatewayCallOptions;
+  target: GatewayOverrideTarget;
 }): string | undefined {
   if (!APPROVAL_RUNTIME_METHODS.has(params.method)) {
     return undefined;
@@ -183,7 +213,36 @@ function resolveApprovalRuntimeTokenForGatewayTool(params: {
     // caller-supplied gateway URLs.
     return undefined;
   }
+  if (params.target !== "local") {
+    return undefined;
+  }
   return getOperatorApprovalRuntimeToken();
+}
+
+function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
+  method: string;
+  opts: GatewayCallOptions;
+}): DeviceIdentity | undefined {
+  if (!APPROVAL_RUNTIME_METHODS.has(params.method)) {
+    return undefined;
+  }
+  if (trimToUndefined(params.opts.gatewayUrl) !== undefined) {
+    return undefined;
+  }
+  if (trimToUndefined(process.env.OPENCLAW_GATEWAY_URL) === undefined) {
+    return undefined;
+  }
+  try {
+    return loadOrCreateDeviceIdentity();
+  } catch (error) {
+    throw new Error(
+      [
+        "env-selected approval gateway calls require a stable device identity.",
+        "Fix the OpenClaw state directory permissions or unset OPENCLAW_GATEWAY_URL for local approval-runtime calls.",
+      ].join(" "),
+      { cause: error },
+    );
+  }
 }
 
 /**
@@ -199,7 +258,12 @@ export async function callGatewayTool<T = Record<string, unknown>>(
   const scopes = Array.isArray(extra?.scopes)
     ? extra.scopes
     : resolveLeastPrivilegeOperatorScopesForMethod(method, params);
-  const approvalRuntimeToken = resolveApprovalRuntimeTokenForGatewayTool({ method, opts });
+  const approvalRuntimeToken = resolveApprovalRuntimeTokenForGatewayTool({
+    method,
+    opts,
+    target: gateway.target,
+  });
+  const deviceIdentity = resolveApprovalRequesterDeviceIdentityForGatewayTool({ method, opts });
   return await callGateway<T>({
     url: gateway.url,
     token: gateway.token,
@@ -211,6 +275,7 @@ export async function callGatewayTool<T = Record<string, unknown>>(
     clientDisplayName: "agent",
     mode: GATEWAY_CLIENT_MODES.BACKEND,
     ...(approvalRuntimeToken ? { approvalRuntimeToken } : {}),
+    ...(deviceIdentity ? { deviceIdentity } : {}),
     scopes,
   });
 }

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -20,7 +20,11 @@ import {
   type OperatorScope,
 } from "../../gateway/method-scopes.js";
 import { getOperatorApprovalRuntimeToken } from "../../gateway/operator-approval-runtime-token.js";
-import { loadOrCreateDeviceIdentity, type DeviceIdentity } from "../../infra/device-identity.js";
+import {
+  loadDeviceIdentityIfPresent,
+  loadOrCreateDeviceIdentity,
+  type DeviceIdentity,
+} from "../../infra/device-identity.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { readPositiveIntegerParam, readStringParam } from "./common.js";
 
@@ -222,6 +226,7 @@ function resolveApprovalRuntimeTokenForGatewayTool(params: {
 function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
   method: string;
   opts: GatewayCallOptions;
+  target: GatewayOverrideTarget;
 }): DeviceIdentity | undefined {
   if (!APPROVAL_RUNTIME_METHODS.has(params.method)) {
     return undefined;
@@ -229,16 +234,23 @@ function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
   if (trimToUndefined(params.opts.gatewayUrl) !== undefined) {
     return undefined;
   }
-  if (trimToUndefined(process.env.OPENCLAW_GATEWAY_URL) === undefined) {
+  if (params.target !== "remote") {
     return undefined;
   }
   try {
-    return loadOrCreateDeviceIdentity();
+    const identity = loadOrCreateDeviceIdentity();
+    // Remote approval requests are later matched by requester device id.
+    // Reject loadOrCreate's unpersisted fallback so another process can see the same id.
+    const persistedIdentity = loadDeviceIdentityIfPresent();
+    if (persistedIdentity?.deviceId !== identity.deviceId) {
+      throw new Error("device identity is not persisted");
+    }
+    return identity;
   } catch (error) {
     throw new Error(
       [
-        "env-selected approval gateway calls require a stable device identity.",
-        "Fix the OpenClaw state directory permissions or unset OPENCLAW_GATEWAY_URL for local approval-runtime calls.",
+        "remote approval gateway calls require a stable device identity.",
+        "Fix the OpenClaw state directory permissions or use the local approval-runtime gateway.",
       ].join(" "),
       { cause: error },
     );
@@ -263,7 +275,11 @@ export async function callGatewayTool<T = Record<string, unknown>>(
     opts,
     target: gateway.target,
   });
-  const deviceIdentity = resolveApprovalRequesterDeviceIdentityForGatewayTool({ method, opts });
+  const deviceIdentity = resolveApprovalRequesterDeviceIdentityForGatewayTool({
+    method,
+    opts,
+    target: gateway.target,
+  });
   return await callGateway<T>({
     url: gateway.url,
     token: gateway.token,

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -117,7 +117,13 @@ function resolveDefaultGatewayTarget(params: {
     // so loopback alone must not grant local approval-runtime authority.
     return "remote";
   }
-  return params.cfg.gateway?.mode === "remote" ? "remote" : "local";
+  if (
+    params.cfg.gateway?.mode === "remote" &&
+    normalizeOptionalString(params.cfg.gateway.remote?.url)
+  ) {
+    return "remote";
+  }
+  return "local";
 }
 
 function validateGatewayUrlOverrideForAgentTools(params: {

--- a/src/gateway/operator-approval-runtime-token.test.ts
+++ b/src/gateway/operator-approval-runtime-token.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalEnv = {
+  HOME: process.env.HOME,
+  OPENCLAW_HOME: process.env.OPENCLAW_HOME,
+};
+
+const tempHomes: string[] = [];
+
+function useTempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-approval-runtime-"));
+  tempHomes.push(home);
+  process.env.HOME = home;
+  process.env.OPENCLAW_HOME = home;
+  return home;
+}
+
+function execApprovalsPath(home: string): string {
+  return path.join(home, ".openclaw", "exec-approvals.json");
+}
+
+function writeExecApprovalsToken(home: string, token: string): void {
+  fs.mkdirSync(path.join(home, ".openclaw"), { recursive: true });
+  fs.writeFileSync(
+    execApprovalsPath(home),
+    `${JSON.stringify(
+      {
+        version: 1,
+        socket: {
+          path: "~/.openclaw/exec-approvals.sock",
+          token,
+        },
+        agents: {},
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function importRuntimeTokenModule(): Promise<
+  typeof import("./operator-approval-runtime-token.js")
+> {
+  vi.resetModules();
+  return await import("./operator-approval-runtime-token.js");
+}
+
+afterEach(() => {
+  vi.resetModules();
+  if (originalEnv.HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalEnv.HOME;
+  }
+  if (originalEnv.OPENCLAW_HOME === undefined) {
+    delete process.env.OPENCLAW_HOME;
+  } else {
+    process.env.OPENCLAW_HOME = originalEnv.OPENCLAW_HOME;
+  }
+  for (const home of tempHomes.splice(0)) {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+describe("operator approval runtime token", () => {
+  it("derives the shared approval runtime token from the exec approvals socket token", async () => {
+    const home = useTempHome();
+    writeExecApprovalsToken(home, "shared-runtime-token");
+
+    const runtimeToken = await importRuntimeTokenModule();
+    const sharedToken = runtimeToken.getOperatorApprovalRuntimeToken();
+
+    expect(sharedToken).toEqual(expect.any(String));
+    expect(sharedToken).not.toBe("shared-runtime-token");
+    expect(runtimeToken.isOperatorApprovalRuntimeToken(` ${sharedToken} `)).toBe(true);
+    expect(runtimeToken.isOperatorApprovalRuntimeToken("shared-runtime-token")).toBe(false);
+    expect(runtimeToken.isOperatorApprovalRuntimeToken("different-token")).toBe(false);
+  });
+
+  it("does not pin the process fallback once a shared exec approvals token appears", async () => {
+    const home = useTempHome();
+    const runtimeToken = await importRuntimeTokenModule();
+
+    const fallback = runtimeToken.getOperatorApprovalRuntimeToken();
+    writeExecApprovalsToken(home, "late-shared-runtime-token");
+    const sharedToken = runtimeToken.getOperatorApprovalRuntimeToken();
+
+    expect(sharedToken).not.toBe(fallback);
+    expect(sharedToken).not.toBe("late-shared-runtime-token");
+    expect(runtimeToken.isOperatorApprovalRuntimeToken(fallback)).toBe(true);
+    expect(runtimeToken.isOperatorApprovalRuntimeToken(sharedToken)).toBe(true);
+    expect(runtimeToken.isOperatorApprovalRuntimeToken("late-shared-runtime-token")).toBe(false);
+  });
+
+  it("keeps a stable process fallback without creating exec-approvals.json", async () => {
+    const home = useTempHome();
+    const runtimeToken = await importRuntimeTokenModule();
+
+    const first = runtimeToken.getOperatorApprovalRuntimeToken();
+    const second = runtimeToken.getOperatorApprovalRuntimeToken();
+
+    expect(first).toEqual(expect.any(String));
+    expect(second).toBe(first);
+    expect(fs.existsSync(execApprovalsPath(home))).toBe(false);
+  });
+});

--- a/src/gateway/operator-approval-runtime-token.ts
+++ b/src/gateway/operator-approval-runtime-token.ts
@@ -1,15 +1,43 @@
 // Operator approval runtime token.
-// Provides a process-local loopback token for approval helper clients.
-import { randomBytes, timingSafeEqual } from "node:crypto";
+// Uses an existing shared socket token when available, with a process-local fallback.
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { loadExecApprovals } from "../infra/exec-approvals.js";
 
-let approvalRuntimeToken: string | null = null;
+const APPROVAL_RUNTIME_TOKEN_CONTEXT = "openclaw:gateway-approval-runtime-token:v1";
+
+let fallbackApprovalRuntimeToken: string | null = null;
+
+function deriveApprovalRuntimeToken(socketToken: string): string {
+  return createHmac("sha256", socketToken)
+    .update(APPROVAL_RUNTIME_TOKEN_CONTEXT)
+    .digest("base64url");
+}
+
+function readSharedApprovalRuntimeToken(): string | null {
+  const token = loadExecApprovals().socket?.token?.trim();
+  return token ? deriveApprovalRuntimeToken(token) : null;
+}
+
+function tokenMatches(token: string, expected: string | null | undefined): boolean {
+  if (!expected) {
+    return false;
+  }
+  const tokenBytes = Buffer.from(token);
+  const expectedBytes = Buffer.from(expected);
+  // timingSafeEqual requires equal lengths; keep length rejection explicit instead of catching.
+  return tokenBytes.length === expectedBytes.length && timingSafeEqual(tokenBytes, expectedBytes);
+}
 
 /**
- * Returns the process-local token used to authorize loopback operator-approval clients.
+ * Returns the token used to authorize local operator-approval clients.
  */
 export function getOperatorApprovalRuntimeToken(): string {
-  approvalRuntimeToken ??= randomBytes(32).toString("base64url");
-  return approvalRuntimeToken;
+  const sharedToken = readSharedApprovalRuntimeToken();
+  if (sharedToken) {
+    return sharedToken;
+  }
+  fallbackApprovalRuntimeToken ??= randomBytes(32).toString("base64url");
+  return fallbackApprovalRuntimeToken;
 }
 
 /**
@@ -20,9 +48,11 @@ export function isOperatorApprovalRuntimeToken(value: string | null | undefined)
   if (!token) {
     return false;
   }
-  const expected = getOperatorApprovalRuntimeToken();
-  const tokenBytes = Buffer.from(token);
-  const expectedBytes = Buffer.from(expected);
-  // timingSafeEqual requires equal lengths; keep length rejection explicit instead of catching.
-  return tokenBytes.length === expectedBytes.length && timingSafeEqual(tokenBytes, expectedBytes);
+  const sharedToken = readSharedApprovalRuntimeToken();
+  if (tokenMatches(token, sharedToken)) {
+    return true;
+  }
+  const fallbackToken =
+    fallbackApprovalRuntimeToken ?? (sharedToken ? null : getOperatorApprovalRuntimeToken());
+  return tokenMatches(token, fallbackToken);
 }

--- a/src/gateway/operator-approvals-client.test.ts
+++ b/src/gateway/operator-approvals-client.test.ts
@@ -122,7 +122,7 @@ describe("withOperatorApprovalsGatewayClient", () => {
     expect(clientState.stopAndWaitSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps device identity for remote shared-auth approval clients", async () => {
+  it("keeps device identity and omits approval runtime token for remote shared-auth approval clients", async () => {
     bootstrapState.url = "wss://gateway.example/ws";
     bootstrapState.urlSource = "config gateway.remote.url";
 
@@ -130,6 +130,7 @@ describe("withOperatorApprovalsGatewayClient", () => {
 
     expect(clientState.options).not.toHaveProperty("deviceIdentity", null);
     expect(clientState.options?.deviceIdentity).toBeUndefined();
+    expect(clientState.options).not.toHaveProperty("approvalRuntimeToken");
   });
 
   it.each([

--- a/src/gateway/operator-approvals-client.test.ts
+++ b/src/gateway/operator-approvals-client.test.ts
@@ -133,6 +133,16 @@ describe("withOperatorApprovalsGatewayClient", () => {
     expect(clientState.options).not.toHaveProperty("approvalRuntimeToken");
   });
 
+  it("keeps device identity for env loopback approval clients without runtime authority", async () => {
+    bootstrapState.url = "ws://127.0.0.1:18789";
+    bootstrapState.urlSource = "env OPENCLAW_GATEWAY_URL";
+
+    await runOperatorApprovalsGatewayClient();
+
+    expect(clientState.options?.deviceIdentity).toBeUndefined();
+    expect(clientState.options).not.toHaveProperty("approvalRuntimeToken");
+  });
+
   it.each([
     {
       name: "explicit loopback gateway URL overrides",

--- a/src/gateway/operator-approvals-client.ts
+++ b/src/gateway/operator-approvals-client.ts
@@ -1,6 +1,5 @@
 // Gateway operator-approvals client helper.
 // Connects a backend Gateway client scoped to operator approval events.
-import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -11,25 +10,6 @@ import { startGatewayClientWhenEventLoopReady } from "./client-start-readiness.j
 import { GatewayClient, type GatewayClientOptions } from "./client.js";
 import { getOperatorApprovalRuntimeToken } from "./operator-approval-runtime-token.js";
 
-function isLoopbackGatewayUrl(rawUrl: string): boolean {
-  try {
-    const hostname = new URL(rawUrl).hostname.toLowerCase();
-    const unbracketed =
-      hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-    return unbracketed === "localhost" || isLoopbackIpAddress(unbracketed);
-  } catch {
-    return false;
-  }
-}
-
-function shouldOmitOperatorApprovalDeviceIdentity(params: {
-  url: string;
-  token?: string;
-  password?: string;
-}): boolean {
-  return Boolean((params.token || params.password) && isLoopbackGatewayUrl(params.url));
-}
-
 function shouldSendApprovalRuntimeToken(urlSource: string): boolean {
   // This token is process-local authority; loopback alone may be a tunnel or another gateway.
   return (
@@ -38,15 +18,9 @@ function shouldSendApprovalRuntimeToken(urlSource: string): boolean {
 }
 
 function shouldOmitApprovalRuntimeDeviceIdentity(params: {
-  url: string;
-  token?: string;
-  password?: string;
   sendsApprovalRuntimeToken: boolean;
 }): boolean {
-  if (params.sendsApprovalRuntimeToken) {
-    return true;
-  }
-  return shouldOmitOperatorApprovalDeviceIdentity(params);
+  return params.sendsApprovalRuntimeToken;
 }
 
 /** Create a Gateway client authorized for operator approval event handling. */
@@ -84,9 +58,6 @@ export async function createOperatorApprovalsGatewayClient(
     mode: GATEWAY_CLIENT_MODES.BACKEND,
     scopes: ["operator.approvals"],
     deviceIdentity: shouldOmitApprovalRuntimeDeviceIdentity({
-      url: bootstrap.url,
-      token: bootstrap.auth.token,
-      password: bootstrap.auth.password,
       sendsApprovalRuntimeToken,
     })
       ? null

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -158,6 +158,10 @@ function attachGatewayHarness(options: {
   connectNonce: string;
   refreshHealthSnapshot?: GatewayRequestContext["refreshHealthSnapshot"];
   requestOrigin?: string;
+  requestHost?: string;
+  remoteAddr?: string;
+  localAddr?: string;
+  resolvedAuth?: ResolvedGatewayAuth;
   client?: unknown;
   close?: CloseGatewayConnection;
   isClosed?: () => boolean;
@@ -179,7 +183,10 @@ function attachGatewayHarness(options: {
   } as unknown as WebSocket;
   const send = vi.fn();
   let client: unknown = options.client ?? null;
-  const resolvedAuth: ResolvedGatewayAuth = {
+  const requestHost = options.requestHost ?? "127.0.0.1:19001";
+  const remoteAddr = options.remoteAddr ?? "127.0.0.1";
+  const localAddr = options.localAddr ?? "127.0.0.1";
+  const resolvedAuth: ResolvedGatewayAuth = options.resolvedAuth ?? {
     mode: "none",
     allowTailscale: false,
   };
@@ -187,15 +194,15 @@ function attachGatewayHarness(options: {
     socket,
     upgradeReq: {
       headers: {
-        host: "127.0.0.1:19001",
+        host: requestHost,
         ...(options.requestOrigin ? { origin: options.requestOrigin } : {}),
       },
-      socket: { localAddress: "127.0.0.1", remoteAddress: "127.0.0.1" },
+      socket: { localAddress: localAddr, remoteAddress: remoteAddr },
     } as unknown as IncomingMessage,
     connId: options.connId,
-    remoteAddr: "127.0.0.1",
-    localAddr: "127.0.0.1",
-    requestHost: "127.0.0.1:19001",
+    remoteAddr,
+    localAddr,
+    requestHost,
     requestOrigin: options.requestOrigin,
     connectNonce: options.connectNonce,
     getResolvedAuth: () => resolvedAuth,
@@ -491,6 +498,50 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       internal?: { approvalRuntime?: boolean };
     } | null;
     expect(connectedClient?.internal?.approvalRuntime).toBe(true);
+  });
+
+  it("does not trust approval runtime tokens from remote clients", async () => {
+    const refreshHealthSnapshot = vi.fn<GatewayRequestContext["refreshHealthSnapshot"]>(async () =>
+      createHealthSummary(),
+    );
+    const harness = attachGatewayHarness({
+      connId: "conn-remote-approval-runtime-token",
+      connectNonce: "nonce-remote-approval-runtime-token",
+      requestHost: "gateway.example.com:18789",
+      remoteAddr: "203.0.113.50",
+      resolvedAuth: {
+        mode: "token",
+        token: "gateway-token",
+        allowTailscale: false,
+      },
+      refreshHealthSnapshot,
+    });
+
+    harness.sendConnect("connect-remote-approval-runtime-token", {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "gateway-client",
+        version: "dev",
+        platform: "test",
+        mode: "backend",
+      },
+      role: "operator",
+      scopes: ["operator.approvals"],
+      caps: [],
+      auth: {
+        token: "gateway-token",
+        approvalRuntimeToken: getOperatorApprovalRuntimeToken(),
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(harness.socketSend).toHaveBeenCalled();
+    });
+    const connectedClient = harness.client as {
+      internal?: { approvalRuntime?: boolean };
+    } | null;
+    expect(connectedClient?.internal?.approvalRuntime).not.toBe(true);
   });
 });
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1725,6 +1725,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           }
         }
         const isTrustedApprovalRuntime =
+          pairingLocality !== "remote" &&
           scopes.includes(APPROVALS_SCOPE) &&
           connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
           connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND &&


### PR DESCRIPTION
## Summary
- Use the existing `exec-approvals.json` socket token as the approval-runtime token when it exists, so Docker/CLI/separate-process approval clients sharing `OPENCLAW_HOME` can authenticate as the local approval runtime.
- Keep the process-local random token as the fallback when no shared socket token exists, without creating `exec-approvals.json` just to read a token.
- Keep `approvalRuntimeToken` attached only for generated local gateway URL sources, including the existing `gateway.mode=remote` with missing `gateway.remote.url` fallback-local path.
- Omit `approvalRuntimeToken` for env, explicit, and configured remote URL sources even when the host is loopback; those approval calls use stable requester device identity instead.

## Scope split
- Split out from #86771.
- This PR is only shared approval-runtime token selection for Docker/CLI/separate-process approval clients sharing OpenClaw state.
- It does not include stale Discord button UX or the `approval.routeNotice.send` gateway method.

## Real behavior proof
Behavior addressed: A separate approval-runtime process sharing `OPENCLAW_HOME` can authenticate with the existing `exec-approvals.json` socket token and resolve a requester-bound approval. Env/configured remote gateway URL sources omit `approvalRuntimeToken` and cannot resolve requester-bound approvals without normal owner visibility/runtime authority. Env-selected approval request/wait calls keep requester identity. Remote mode without `gateway.remote.url` keeps the existing fallback-local approval-runtime behavior.

Real environment tested: Current PR head `a89cfa1c4234771e0336fa2b5722f20b1f3ed43b` was tested on Blacksmith Testbox through Crabbox, provider `blacksmith-testbox`, id `tbx_01ktkpn7ebxk5nr9tz74qwe5vc`, Actions run `27140908325`. Earlier live two-process smoke proof covered the shared-`OPENCLAW_HOME` runtime handoff on head `1ef8400457`; the current-head delta is the fallback-local target classification fix and its focused regression proof.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- corepack pnpm test src/agents/tools/gateway.test.ts src/gateway/operator-approval-runtime-token.test.ts src/gateway/operator-approvals-client.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts -- --reporter=dot`

Evidence after fix:

```text
provider=blacksmith-testbox id=tbx_01ktkpn7ebxk5nr9tz74qwe5vc sync=delegated auth=blacksmith
GitHub Actions run: https://github.com/openclaw/openclaw/actions/runs/27140908325
[test] starting test/vitest/vitest.gateway.config.ts
Test Files 11 passed (11)
Tests 113 passed (113)
[test] starting test/vitest/vitest.agents.config.ts
Test Files 1 passed (1)
Tests 29 passed (29)
[test] passed 2 Vitest shards in 17.12s
blacksmith run summary sync=delegated command=1m5.014s total=1m15.223s exit=0
```

Observed result after fix: The current-head focused proof covers shared-token derivation, approval-client token omission/preservation rules, server-side remote locality rejection, and the agent-tool fallback-local regression. The new regression asserts `gateway.mode=remote` without `gateway.remote.url` keeps `approvalRuntimeToken` and does not switch to requester `deviceIdentity`.

What was not tested: No Docker Compose smoke was run. The earlier live two-process smoke used two Node processes on one host sharing `OPENCLAW_HOME`; the current-head proof reran the affected gateway and agent shards on Testbox after the fallback-local fix.

## Tests and validation
- `node scripts/run-vitest.mjs src/agents/tools/gateway.test.ts --reporter=dot` — passed; 1 file, 29 tests.
- `node_modules/.bin/oxfmt --check src/agents/tools/gateway.ts src/agents/tools/gateway.test.ts` — passed.
- `git diff --check` — passed.
- Testbox-through-Crabbox focused proof above — passed; 2 shards, 142 tests.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.

## Risk checklist
Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `Yes`

Highest-risk area: approval-runtime authentication for local approval clients sharing OpenClaw state.

Mitigation: Shared-token selection only reads an existing socket token; it does not create the shared file. The approval client attaches the runtime token only for generated local/fallback gateway URL sources; env, explicit, and configured remote URL sources omit it. Env-selected and configured-remote approval calls use stable requester device identity instead of runtime authority, and fail before opening a gateway connection if that identity cannot be loaded.
