### PR TITLE
fix(imessage): stage remote media before understanding

### DIFF
--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -50,12 +50,14 @@ registerGetReplyRuntimeOverrides(mocks);
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
 let resolveDefaultModelMock: typeof import("./directive-handling.defaults.js").resolveDefaultModel;
 let runPreparedReplyMock: typeof import("./get-reply-run.js").runPreparedReply;
+let stageSandboxMediaMock: typeof import("./stage-sandbox-media.runtime.js").stageSandboxMedia;
 
 async function loadGetReplyRuntimeForTest() {
   ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
   ({ resolveDefaultModel: resolveDefaultModelMock } =
     await import("./directive-handling.defaults.js"));
   ({ runPreparedReply: runPreparedReplyMock } = await import("./get-reply-run.js"));
+  ({ stageSandboxMedia: stageSandboxMediaMock } = await import("./stage-sandbox-media.runtime.js"));
 }
 
 function emptyAliasIndex() {
@@ -101,6 +103,7 @@ describe("getReplyFromConfig message hooks", () => {
     mocks.initSessionState.mockReset();
     vi.mocked(resolveDefaultModelMock).mockReset();
     vi.mocked(runPreparedReplyMock).mockReset();
+    vi.mocked(stageSandboxMediaMock).mockReset();
     vi.mocked(logVerbose).mockReset();
 
     mocks.applyMediaUnderstanding.mockImplementation(async (...args: unknown[]) => {
@@ -141,6 +144,7 @@ describe("getReplyFromConfig message hooks", () => {
       aliasIndex: emptyAliasIndex(),
     });
     vi.mocked(runPreparedReplyMock).mockResolvedValue({ text: "ok" });
+    vi.mocked(stageSandboxMediaMock).mockResolvedValue({ staged: new Map() });
     mocks.initSessionState.mockResolvedValue(
       createGetReplySessionState({
         sessionKey: "agent:main:telegram:-100123",
@@ -281,6 +285,70 @@ describe("getReplyFromConfig message hooks", () => {
         text: "a tiny dot image",
       }),
     ]);
+    expect(stageSandboxMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("stages remote iMessage media before media understanding", async () => {
+    const order: string[] = [];
+    const remotePath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+    const stagedPath = "/tmp/openclaw-remote-cache/photo.jpg";
+    vi.mocked(stageSandboxMediaMock).mockImplementationOnce(async (params) => {
+      order.push("stage");
+      params.ctx.MediaPath = stagedPath;
+      params.ctx.MediaPaths = [stagedPath];
+      params.ctx.MediaUrl = stagedPath;
+      params.ctx.MediaUrls = [stagedPath];
+      params.sessionCtx.MediaPath = stagedPath;
+      params.sessionCtx.MediaPaths = [stagedPath];
+      params.sessionCtx.MediaUrl = stagedPath;
+      params.sessionCtx.MediaUrls = [stagedPath];
+      return { staged: new Map([[remotePath, stagedPath]]) };
+    });
+    mocks.applyMediaUnderstanding.mockImplementationOnce(async (...args: unknown[]) => {
+      order.push("understand");
+      const { ctx } = args[0] as { ctx: MsgContext };
+      expect(ctx.MediaPath).toBe(stagedPath);
+      expect(ctx.MediaPaths).toEqual([stagedPath]);
+      expect(ctx.MediaUrl).toBe(stagedPath);
+      expect(ctx.MediaUrls).toEqual([stagedPath]);
+      expect(ctx.MediaStaged).toBe(true);
+    });
+
+    await getReplyFromConfig(
+      buildCtx({
+        Provider: "imessage",
+        Surface: "imessage",
+        OriginatingChannel: "imessage",
+        OriginatingTo: "imessage:chat:abc",
+        ChatType: "direct",
+        Body: "please describe this",
+        BodyForAgent: "please describe this",
+        RawBody: "please describe this",
+        CommandBody: "please describe this",
+        BodyForCommands: "please describe this",
+        SessionKey: "agent:main:imessage:direct:user",
+        From: "imessage:user",
+        To: "imessage:chat:abc",
+        MediaPath: remotePath,
+        MediaPaths: [remotePath],
+        MediaUrl: remotePath,
+        MediaUrls: [remotePath],
+        MediaType: "image/jpeg",
+        MediaTypes: ["image/jpeg"],
+        MediaRemoteHost: "user@gateway-host",
+      }),
+      undefined,
+      withFastReplyConfig({}),
+    );
+
+    expect(order).toEqual(["stage", "understand"]);
+    expect(stageSandboxMediaMock).toHaveBeenCalledTimes(1);
+    expect(stageSandboxMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:imessage:direct:user",
+        workspaceDir: "/tmp/workspace",
+      }),
+    );
   });
 
   it("emits only preprocessed when no transcript is produced", async () => {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -187,6 +187,36 @@ async function applyMediaUnderstandingIfNeeded(params: {
   }
 }
 
+async function stageRemoteInboundMediaBeforeUnderstandingIfNeeded(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+  workspaceDir: string;
+}): Promise<boolean> {
+  if (
+    !params.sessionKey ||
+    params.ctx.MediaStaged ||
+    !normalizeOptionalString(params.ctx.MediaRemoteHost) ||
+    !hasInboundMedia(params.ctx)
+  ) {
+    return false;
+  }
+
+  const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
+  const result = await stageSandboxMedia({
+    ctx: params.ctx,
+    sessionCtx: params.ctx,
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    workspaceDir: params.workspaceDir,
+  });
+  if (result.staged.size > 0) {
+    params.ctx.MediaStaged = true;
+    return true;
+  }
+  return false;
+}
+
 async function applyLinkUnderstandingIfNeeded(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
@@ -387,6 +417,20 @@ export async function getReplyFromConfig(
   );
   const workspaceDir = workspace.dir;
 
+  if (
+    !isFastTestEnv &&
+    normalizeOptionalString(finalized.MediaRemoteHost) &&
+    hasInboundMedia(finalized)
+  ) {
+    await traceGetReplyPhase("reply.stage_remote_media_pre_understanding", () =>
+      stageRemoteInboundMediaBeforeUnderstandingIfNeeded({
+        ctx: finalized,
+        cfg,
+        sessionKey: agentSessionKey,
+        workspaceDir,
+      }),
+    );
+  }
   if (!isFastTestEnv && hasInboundMedia(finalized)) {
     await traceGetReplyPhase("reply.apply_media_understanding", () =>
       applyMediaUnderstandingIfNeeded({


### PR DESCRIPTION
## Summary
- stage remote inbound iMessage media before media understanding runs when `MediaRemoteHost` is present
- mark successfully pre-staged media as `MediaStaged` so the later pre-agent staging block does not retry the rewritten cache path
- add regression coverage for the remote iMessage ordering and keep the existing SCP remote-path tests green

## Root cause
The iMessage remote-host path intentionally passes raw remote Mac attachment paths plus `MediaRemoteHost` so `stageSandboxMedia` can SCP-fetch and rewrite them. `getReplyFromConfig` ran media understanding before that staging step, so image analysis saw `/Users/.../Library/Messages/Attachments/...` and rejected it before SCP had a chance to cache the file locally.

## Real behavior proof
- **Behavior or issue addressed:** Remote iMessage image attachments should be fetched into OpenClaw's local remote-cache before media understanding sees the attachment path. The failing behavior was media understanding receiving the raw macOS `/Users/.../Library/Messages/Attachments/...` path.
- **Real environment tested:** Local macOS source checkout of this PR, running the actual OpenClaw `stageSandboxMedia` runtime with `HOME` isolated to a temp OpenClaw setup. The scenario used an iMessage `remoteHost` config, a raw macOS Messages attachment path, and a temporary local `scp` wrapper that copied the remote-path fixture into the destination requested by OpenClaw.
- **Exact steps or command run after this patch:** Ran a one-off `node --import tsx --input-type=module` OpenClaw runtime probe from the PR checkout. The probe created a raw `/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg` attachment, set `MediaRemoteHost=user@gateway-host`, called the real `stageSandboxMedia` implementation with iMessage remote attachment roots, then printed the path that media understanding would receive after the pre-understanding staging step.
- **Evidence after fix:** Copied terminal output from the after-fix runtime probe:

```text
proof scenario: Linux gateway style iMessage remoteHost with raw macOS attachment path
before MediaPath=/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg
stagedCount=1
after MediaPath=/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/tmp.PzNk6ilXYX/.openclaw/media/remote-cache/agent-main-imessage-direct-user-629f8d24/photo.jpg
after MediaPaths=["/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/tmp.PzNk6ilXYX/.openclaw/media/remote-cache/agent-main-imessage-direct-user-629f8d24/photo.jpg"]
sessionCtx MediaPath=/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/tmp.PzNk6ilXYX/.openclaw/media/remote-cache/agent-main-imessage-direct-user-629f8d24/photo.jpg
rewrittenUsesRemoteCache=true
cachedFileBytes=34
mediaUnderstandingInputPath=/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/tmp.PzNk6ilXYX/.openclaw/media/remote-cache/agent-main-imessage-direct-user-629f8d24/photo.jpg
rawRemotePathStillVisibleToUnderstanding=false
```

- **Observed result after fix:** The raw remote Messages path was rewritten to a local OpenClaw `.openclaw/media/remote-cache/.../photo.jpg` path before the handoff. The media-understanding input path was the local cache path, and `rawRemotePathStillVisibleToUnderstanding=false` confirms the failing raw `/Users/...` path no longer reaches the next step.
- **What was not tested:** I did not use a live Apple Messages database or real remote Mac credentials in this public proof. The exercised behavior is the OpenClaw remote-host staging and path rewrite contract that sits between the iMessage monitor and media understanding.

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply.message-hooks.test.ts src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/auto-reply/reply/get-reply.ts src/auto-reply/reply/get-reply.message-hooks.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json --base upstream/main`
- `pnpm check:changed -- --base upstream/main`

Fixes #87089

Attribution note: if maintainers squash or rework this PR, please preserve author attribution or include `Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`.
