### PR TITLE
fix(status): show explicit fast mode state

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -671,7 +671,7 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("· pi");
   });
 
-  it("hides fast mode when disabled", () => {
+  it("shows fast mode when disabled", () => {
     const text = buildStatusMessage({
       agent: {
         model: "anthropic/claude-opus-4-6",
@@ -685,7 +685,7 @@ describe("buildStatusMessage", () => {
       queue: { mode: "collect", depth: 0 },
     });
 
-    expect(normalizeTestText(text)).not.toContain("Fast");
+    expect(normalizeTestText(text)).toContain("Fast: off");
   });
 
   it("shows configured text verbosity for the active model", () => {

--- a/src/status/status-labels.ts
+++ b/src/status/status-labels.ts
@@ -1,6 +1,1 @@
-export const formatFastModeLabel = (enabled: boolean): string | null => {
-  if (!enabled) {
-    return null;
-  }
-  return "Fast";
-};
+export const formatFastModeLabel = (enabled: boolean): string => `Fast: ${enabled ? "on" : "off"}`;

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -3,10 +3,10 @@ import { formatFastModeLabel } from "./status-labels.js";
 
 describe("formatFastModeLabel", () => {
   it("shows fast mode when enabled", () => {
-    expect(formatFastModeLabel(true)).toBe("Fast");
+    expect(formatFastModeLabel(true)).toBe("Fast: on");
   });
 
-  it("hides fast mode when disabled", () => {
-    expect(formatFastModeLabel(false)).toBeNull();
+  it("shows fast mode when disabled", () => {
+    expect(formatFastModeLabel(false)).toBe("Fast: off");
   });
 });


### PR DESCRIPTION

<img width="1346" height="584" alt="Screenshot 2026-05-26 at 19 06 31" src="https://github.com/user-attachments/assets/cd4c2414-5597-41d0-806c-67c116c221ff" />


## Summary
- show fast mode status as explicit on/off text
- keep a visible label when fast mode is disabled

## Testing
- Not run (per instruction).