### PR TITLE
fix(plugins): resolve openclaw/plugin-sdk/<subpath> imports without root-alias.cjs fall-through (AI-assisted)

### DIFF
--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -126,15 +126,19 @@ describe("tryNativeRequireJavaScriptModule", () => {
     ).toEqual({ ok: false });
   });
 
-  it("resolves alias subpaths relative to file-valued alias targets", () => {
+  it("resolves scoped plugin-sdk subpaths via exact alias entries supplied by the scoped backfill", () => {
+    // Production flow: `resolvePluginSdkScopedAliasMap` adds the scoped
+    // alias as an exact entry, so the native require can find it without
+    // needing prefix fallback through the file-valued root alias.
     const dir = makeTempDir();
     const pluginSdkDir = path.join(dir, "plugin-sdk");
     fs.mkdirSync(pluginSdkDir, { recursive: true });
     const modulePath = path.join(dir, "plugin.cjs");
     const rootAliasPath = path.join(pluginSdkDir, "root-alias.cjs");
+    const taskRuntimePath = path.join(pluginSdkDir, "agent-harness-task-runtime.js");
     fs.writeFileSync(rootAliasPath, "module.exports = {};\n", "utf8");
     fs.writeFileSync(
-      path.join(pluginSdkDir, "agent-harness-task-runtime.js"),
+      taskRuntimePath,
       'module.exports = { marker: "task-runtime" };\n',
       "utf8",
     );
@@ -148,10 +152,49 @@ describe("tryNativeRequireJavaScriptModule", () => {
       allowWindows: true,
       aliasMap: {
         "openclaw/plugin-sdk": rootAliasPath,
+        "openclaw/plugin-sdk/agent-harness-task-runtime": taskRuntimePath,
       },
     });
 
     expect(result).toEqual({ ok: true, moduleExport: { marker: "task-runtime" } });
+  });
+
+  it("does not resolve subpaths via prefix fallback against a file-valued root alias", () => {
+    // P2-1 regression: when only the file-valued `openclaw/plugin-sdk` root
+    // alias is present, sibling files on disk MUST NOT be reachable via
+    // prefix matching. The scoped alias map (which honors private-subpath
+    // gating) is the single source of truth for which subpaths are
+    // resolvable. Without this, private subpaths like
+    // `codex-native-task-runtime` could be loaded by untrusted plugins just
+    // because the dist artifact happens to exist next to root-alias.cjs.
+    const dir = makeTempDir();
+    const pluginSdkDir = path.join(dir, "plugin-sdk");
+    fs.mkdirSync(pluginSdkDir, { recursive: true });
+    const rootAliasPath = path.join(pluginSdkDir, "root-alias.cjs");
+    fs.writeFileSync(rootAliasPath, "module.exports = {};\n", "utf8");
+    fs.writeFileSync(
+      path.join(pluginSdkDir, "codex-native-task-runtime.js"),
+      'module.exports = { private: true };\n',
+      "utf8",
+    );
+    const modulePath = path.join(dir, "plugin.cjs");
+    fs.writeFileSync(
+      modulePath,
+      'module.exports = require("openclaw/plugin-sdk/codex-native-task-runtime");\n',
+      "utf8",
+    );
+
+    const result = tryNativeRequireJavaScriptModule(modulePath, {
+      allowWindows: true,
+      fallbackOnMissingDependency: true,
+      aliasMap: {
+        // Only the file-valued root alias. No scoped entry for the private
+        // subpath - so resolution must NOT succeed via prefix matching.
+        "openclaw/plugin-sdk": rootAliasPath,
+      },
+    });
+
+    expect(result).toEqual({ ok: false });
   });
 
   it("uses the longest alias prefix when resolving native require subpaths", () => {
@@ -236,11 +279,11 @@ describe("tryNativeRequireJavaScriptModule", () => {
   });
 
   it("re-throws non-MODULE_NOT_FOUND errors raised during subpath alias resolution", () => {
+    // Use a DIRECTORY-VALUED alias to exercise the prefix-resolution path
+    // (file-valued targets are intentionally excluded from prefix matching).
     const dir = makeTempDir();
-    const pluginSdkDir = path.join(dir, "plugin-sdk");
+    const pluginSdkDir = path.join(dir, "plugin-sdk-dir");
     fs.mkdirSync(pluginSdkDir, { recursive: true });
-    const rootAliasPath = path.join(pluginSdkDir, "root-alias.cjs");
-    fs.writeFileSync(rootAliasPath, "module.exports = {};\n", "utf8");
 
     const moduleWithResolver = Module as typeof Module & {
       _resolveFilename?: (
@@ -266,7 +309,7 @@ describe("tryNativeRequireJavaScriptModule", () => {
     try {
       expect(() =>
         withNativeRequireAliases(
-          { "openclaw/plugin-sdk": rootAliasPath },
+          { "openclaw/plugin-sdk": pluginSdkDir },
           () => testRequire("openclaw/plugin-sdk/throw-trigger"),
         ),
       ).toThrow("permission denied");

--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -1,13 +1,16 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   isJavaScriptModulePath,
   tryNativeRequireJavaScriptModule,
+  withNativeRequireAliases,
 } from "./native-module-require.js";
 
 const tempDirs: string[] = [];
+const testRequire = createRequire(import.meta.url);
 
 function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-native-require-"));
@@ -118,6 +121,86 @@ describe("tryNativeRequireJavaScriptModule", () => {
       tryNativeRequireJavaScriptModule(modulePath, {
         allowWindows: true,
         fallbackOnNativeError: true,
+      }),
+    ).toEqual({ ok: false });
+  });
+
+  it("resolves alias subpaths relative to file-valued alias targets", () => {
+    const dir = makeTempDir();
+    const pluginSdkDir = path.join(dir, "plugin-sdk");
+    fs.mkdirSync(pluginSdkDir, { recursive: true });
+    const modulePath = path.join(dir, "plugin.cjs");
+    const rootAliasPath = path.join(pluginSdkDir, "root-alias.cjs");
+    fs.writeFileSync(rootAliasPath, "module.exports = {};\n", "utf8");
+    fs.writeFileSync(
+      path.join(pluginSdkDir, "agent-harness-task-runtime.js"),
+      'module.exports = { marker: "task-runtime" };\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      modulePath,
+      'module.exports = require("openclaw/plugin-sdk/agent-harness-task-runtime");\n',
+      "utf8",
+    );
+
+    const result = tryNativeRequireJavaScriptModule(modulePath, {
+      allowWindows: true,
+      aliasMap: {
+        "openclaw/plugin-sdk": rootAliasPath,
+      },
+    });
+
+    expect(result).toEqual({ ok: true, moduleExport: { marker: "task-runtime" } });
+  });
+
+  it("uses the longest alias prefix when resolving native require subpaths", () => {
+    const dir = makeTempDir();
+    const shortAliasDir = path.join(dir, "short");
+    const longAliasDir = path.join(dir, "long");
+    fs.mkdirSync(path.join(shortAliasDir, "nested"), { recursive: true });
+    fs.mkdirSync(longAliasDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(shortAliasDir, "nested", "runtime.js"),
+      'module.exports = { marker: "short" };\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(longAliasDir, "runtime.js"),
+      'module.exports = { marker: "long" };\n',
+      "utf8",
+    );
+
+    const loaded = withNativeRequireAliases(
+      {
+        "openclaw/plugin-sdk": shortAliasDir,
+        "openclaw/plugin-sdk/nested": longAliasDir,
+      },
+      () => testRequire("openclaw/plugin-sdk/nested/runtime"),
+    );
+
+    expect(loaded).toEqual({ marker: "long" });
+  });
+
+  it("falls back to the original resolver when a prefix alias cannot resolve the subpath", () => {
+    const dir = makeTempDir();
+    const pluginSdkDir = path.join(dir, "plugin-sdk");
+    fs.mkdirSync(pluginSdkDir, { recursive: true });
+    const modulePath = path.join(dir, "plugin.cjs");
+    const rootAliasPath = path.join(pluginSdkDir, "root-alias.cjs");
+    fs.writeFileSync(rootAliasPath, "module.exports = {};\n", "utf8");
+    fs.writeFileSync(
+      modulePath,
+      'module.exports = require("openclaw/plugin-sdk/missing-runtime");\n',
+      "utf8",
+    );
+
+    expect(
+      tryNativeRequireJavaScriptModule(modulePath, {
+        allowWindows: true,
+        aliasMap: {
+          "openclaw/plugin-sdk": rootAliasPath,
+        },
+        fallbackOnMissingDependency: true,
       }),
     ).toEqual({ ok: false });
   });

--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import Module from "node:module";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
@@ -203,6 +204,75 @@ describe("tryNativeRequireJavaScriptModule", () => {
         fallbackOnMissingDependency: true,
       }),
     ).toEqual({ ok: false });
+  });
+
+  it("resolves alias subpaths when the alias target is a directory whose name contains a dot", () => {
+    // Regression guard for the prior `path.extname(aliasTarget)` heuristic: a
+    // versioned directory like `plugin-sdk.v2` is a directory, not a file, and
+    // suffix resolution must happen INSIDE it, not under its parent.
+    const dir = makeTempDir();
+    const pluginSdkDir = path.join(dir, "plugin-sdk.v2");
+    fs.mkdirSync(pluginSdkDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginSdkDir, "runtime.js"),
+      'module.exports = { marker: "versioned-dir" };\n',
+      "utf8",
+    );
+    const modulePath = path.join(dir, "plugin.cjs");
+    fs.writeFileSync(
+      modulePath,
+      'module.exports = require("openclaw/plugin-sdk/runtime");\n',
+      "utf8",
+    );
+
+    const result = tryNativeRequireJavaScriptModule(modulePath, {
+      allowWindows: true,
+      aliasMap: {
+        "openclaw/plugin-sdk": pluginSdkDir,
+      },
+    });
+
+    expect(result).toEqual({ ok: true, moduleExport: { marker: "versioned-dir" } });
+  });
+
+  it("re-throws non-MODULE_NOT_FOUND errors raised during subpath alias resolution", () => {
+    const dir = makeTempDir();
+    const pluginSdkDir = path.join(dir, "plugin-sdk");
+    fs.mkdirSync(pluginSdkDir, { recursive: true });
+    const rootAliasPath = path.join(pluginSdkDir, "root-alias.cjs");
+    fs.writeFileSync(rootAliasPath, "module.exports = {};\n", "utf8");
+
+    const moduleWithResolver = Module as typeof Module & {
+      _resolveFilename?: (
+        request: string,
+        parent: NodeJS.Module | undefined,
+        isMain: boolean,
+        options?: { paths?: string[] },
+      ) => string;
+    };
+    const originalResolveFilename = moduleWithResolver._resolveFilename;
+    if (!originalResolveFilename) {
+      throw new Error("Module._resolveFilename is not patchable in this environment");
+    }
+    moduleWithResolver._resolveFilename = ((request, parent, isMain, options) => {
+      if (typeof request === "string" && request.endsWith("throw-trigger")) {
+        const error = new Error("permission denied") as Error & { code?: string };
+        error.code = "EACCES";
+        throw error;
+      }
+      return originalResolveFilename(request, parent, isMain, options);
+    }) as typeof originalResolveFilename;
+
+    try {
+      expect(() =>
+        withNativeRequireAliases(
+          { "openclaw/plugin-sdk": rootAliasPath },
+          () => testRequire("openclaw/plugin-sdk/throw-trigger"),
+        ),
+      ).toThrow("permission denied");
+    } finally {
+      moduleWithResolver._resolveFilename = originalResolveFilename;
+    }
   });
 });
 

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { createRequire } from "node:module";
 import Module from "node:module";
 import path from "node:path";
@@ -80,6 +81,28 @@ function requireWithOptionalAliases(
   return withNativeRequireAliases(aliasMap, () => nodeRequire(modulePath));
 }
 
+// Memoized file-vs-directory probe for alias targets. We need this to decide
+// whether to use `dirname(aliasTarget)` (file target) or `aliasTarget` itself
+// (directory target) as the base for suffix resolution. A pure `path.extname`
+// heuristic is wrong for directories whose last segment contains a dot
+// (e.g. `dist/plugin-sdk.v2`), so we prefer a real `statSync` and only fall
+// back to the extension check when the target cannot be stat'd.
+const aliasTargetIsFileCache = new Map<string, boolean>();
+function isFileValuedAliasTarget(aliasTarget: string): boolean {
+  const cached = aliasTargetIsFileCache.get(aliasTarget);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let isFile: boolean;
+  try {
+    isFile = fs.statSync(aliasTarget).isFile();
+  } catch {
+    isFile = path.extname(aliasTarget) !== "";
+  }
+  aliasTargetIsFileCache.set(aliasTarget, isFile);
+  return isFile;
+}
+
 function resolveAliasSubpathTarget(params: {
   aliasTarget: string;
   remainder: string;
@@ -89,12 +112,16 @@ function resolveAliasSubpathTarget(params: {
   originalResolveFilename: ResolveFilename;
 }): string | null {
   const { aliasTarget, isMain, options, originalResolveFilename, parent, remainder } = params;
-  const basePath = path.extname(aliasTarget) ? path.dirname(aliasTarget) : aliasTarget;
+  const basePath = isFileValuedAliasTarget(aliasTarget) ? path.dirname(aliasTarget) : aliasTarget;
   const targetPath = path.resolve(basePath, remainder);
   try {
     return originalResolveFilename(targetPath, parent, isMain, options);
-  } catch {
-    return null;
+  } catch (error) {
+    const code = (error as { code?: unknown } | null)?.code;
+    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
+      return null;
+    }
+    throw error;
   }
 }
 

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -80,6 +80,52 @@ function requireWithOptionalAliases(
   return withNativeRequireAliases(aliasMap, () => nodeRequire(modulePath));
 }
 
+function resolveAliasSubpathTarget(params: {
+  aliasTarget: string;
+  remainder: string;
+  parent: NodeJS.Module | undefined;
+  isMain: boolean;
+  options?: { paths?: string[] };
+  originalResolveFilename: ResolveFilename;
+}): string | null {
+  const { aliasTarget, isMain, options, originalResolveFilename, parent, remainder } = params;
+  const basePath = path.extname(aliasTarget) ? path.dirname(aliasTarget) : aliasTarget;
+  const targetPath = path.resolve(basePath, remainder);
+  try {
+    return originalResolveFilename(targetPath, parent, isMain, options);
+  } catch {
+    return null;
+  }
+}
+
+function resolveNativeRequireAlias(
+  request: string,
+  aliasMap: Record<string, string>,
+  parent: NodeJS.Module | undefined,
+  isMain: boolean,
+  options: { paths?: string[] } | undefined,
+  originalResolveFilename: ResolveFilename,
+): string | null {
+  const exactTarget = aliasMap[request];
+  if (exactTarget) {
+    return exactTarget;
+  }
+  const prefix = Object.keys(aliasMap)
+    .filter((key) => request.startsWith(`${key}/`))
+    .toSorted((left, right) => right.length - left.length)[0];
+  if (!prefix) {
+    return null;
+  }
+  return resolveAliasSubpathTarget({
+    aliasTarget: aliasMap[prefix],
+    remainder: request.slice(prefix.length + 1),
+    parent,
+    isMain,
+    options,
+    originalResolveFilename,
+  });
+}
+
 export function withNativeRequireAliases<T>(
   aliasMap: Record<string, string> | undefined,
   run: () => T,
@@ -89,7 +135,14 @@ export function withNativeRequireAliases<T>(
   }
   const originalResolveFilename = moduleWithResolver["_resolveFilename"];
   moduleWithResolver["_resolveFilename"] = ((request, parent, isMain, options) => {
-    const aliasTarget = aliasMap[request];
+    const aliasTarget = resolveNativeRequireAlias(
+      request,
+      aliasMap,
+      parent,
+      isMain,
+      options,
+      originalResolveFilename,
+    );
     if (aliasTarget) {
       return aliasTarget;
     }

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -137,14 +137,24 @@ function resolveNativeRequireAlias(
   if (exactTarget) {
     return exactTarget;
   }
+  // Restrict prefix-based subpath fallback to alias targets that are
+  // DIRECTORIES. A file-valued root alias (e.g. `openclaw/plugin-sdk` ->
+  // `dist/plugin-sdk/root-alias.cjs`) intentionally does NOT expose every
+  // sibling file in its containing directory; the scoped alias map governs
+  // which subpaths are reachable, including private-subpath gating. Using
+  // prefix matching against a file target to resolve arbitrary siblings
+  // would bypass that gate. Public subpaths must already be present as
+  // exact entries in the alias map via the scoped backfill.
   const prefix = Object.keys(aliasMap)
-    .filter((key) => request.startsWith(`${key}/`))
+    .filter(
+      (key) => request.startsWith(`${key}/`) && !isFileValuedAliasTarget(aliasMap[key] ?? ""),
+    )
     .toSorted((left, right) => right.length - left.length)[0];
   if (!prefix) {
     return null;
   }
   return resolveAliasSubpathTarget({
-    aliasTarget: aliasMap[prefix],
+    aliasTarget: aliasMap[prefix] ?? "",
     remainder: request.slice(prefix.length + 1),
     parent,
     isMain,

--- a/src/plugins/plugin-module-loader-cache.test.ts
+++ b/src/plugins/plugin-module-loader-cache.test.ts
@@ -431,11 +431,15 @@ describe("getCachedPluginModuleLoader", () => {
     >(import.meta.url, "./plugin-module-loader-cache.js?scope=native-require-fastpath");
 
     const cache = new Map();
+    const aliasMap = {
+      "openclaw/plugin-sdk": "/repo/dist/plugin-sdk/root-alias.cjs",
+    };
     const loader = getCachedPluginModuleLoader({
       cache,
       modulePath: "/repo/dist/extensions/demo/api.js",
       importerUrl: "file:///repo/src/plugins/public-surface-loader.ts",
       loaderFilename: "file:///repo/src/plugins/public-surface-loader.ts",
+      aliasMap,
       createLoader: asPluginModuleLoaderFactory(createJiti),
     });
 
@@ -447,6 +451,7 @@ describe("getCachedPluginModuleLoader", () => {
     expect(fromSourceTransformer).not.toHaveBeenCalled();
     // allowWindows must be passed so the native fast path works on Windows too.
     expectNativeOptions(nativeStub, "/repo/dist/extensions/demo/api.js");
+    expect(callArg(nativeStub, 0, 1, "native options")).toMatchObject({ aliasMap });
     expectStats(getPluginModuleLoaderStats(), {
       calls: 1,
       nativeHits: 1,

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -714,6 +714,33 @@ describe("plugin sdk alias helpers", () => {
     expect(aliases["@openclaw/plugin-sdk/agent-harness-task-runtime"]).toBeUndefined();
   });
 
+  it("does not backfill openclaw/plugin-sdk/index (root-export dist artifact)", () => {
+    // P2-2 regression: `dist/plugin-sdk/index.js` is the dist artifact for
+    // the package's root `./plugin-sdk` export, not a scoped subpath. The
+    // package.json contract only exposes `openclaw/plugin-sdk` for it, so
+    // backfilling `openclaw/plugin-sdk/index` would synthesize a subpath
+    // that does not exist in `package.json#exports` and would break for
+    // plugins loaded against the published package.
+    const fixture = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
+      },
+    });
+    fs.writeFileSync(
+      path.join(fixture.root, "dist", "plugin-sdk", "core.js"),
+      "export const core = true;\n",
+      "utf-8",
+    );
+    // dist/plugin-sdk/index.js already exists from the fixture (default
+    // distFile). Confirm the backfill does NOT publish it as a scoped alias.
+    const aliases = resolvePluginSdkScopedAliasMap({
+      modulePath: path.join(fixture.root, "dist", "plugins", "loader.js"),
+    });
+
+    expect(aliases["openclaw/plugin-sdk/index"]).toBeUndefined();
+    expect(aliases["@openclaw/plugin-sdk/index"]).toBeUndefined();
+  });
+
   it("does NOT backfill private dist plugin-sdk artifacts for untrusted callers", () => {
     const fixture = createPluginSdkAliasFixture({
       packageExports: {

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -714,6 +714,46 @@ describe("plugin sdk alias helpers", () => {
     expect(aliases["@openclaw/plugin-sdk/agent-harness-task-runtime"]).toBeUndefined();
   });
 
+  it("backfills to source artifact when pluginSdkResolution=src and src exists", () => {
+    // P2-3 regression: when source mode is requested and a subpath is
+    // missing from package.json#exports but present in BOTH src and dist,
+    // the backfill must respect the src-first resolution order. Otherwise
+    // source-mode dev/test loaders would silently run stale built code for
+    // the same stale-export case this patch is meant to handle.
+    const fixture = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
+      },
+    });
+    fs.writeFileSync(
+      path.join(fixture.root, "dist", "plugin-sdk", "core.js"),
+      "export const core = true;\n",
+      "utf-8",
+    );
+    const srcTaskRuntimePath = path.join(
+      fixture.root,
+      "src",
+      "plugin-sdk",
+      "agent-harness-task-runtime.ts",
+    );
+    const distTaskRuntimePath = path.join(
+      fixture.root,
+      "dist",
+      "plugin-sdk",
+      "agent-harness-task-runtime.js",
+    );
+    fs.writeFileSync(srcTaskRuntimePath, 'export const marker = "src";\n', "utf-8");
+    fs.writeFileSync(distTaskRuntimePath, 'export const marker = "dist";\n', "utf-8");
+
+    const aliases = resolvePluginSdkScopedAliasMap({
+      modulePath: path.join(fixture.root, "extensions", "demo", "index.ts"),
+      pluginSdkResolution: "src",
+    });
+
+    expect(aliases["openclaw/plugin-sdk/agent-harness-task-runtime"]).toBe(srcTaskRuntimePath);
+    expect(aliases["@openclaw/plugin-sdk/agent-harness-task-runtime"]).toBe(srcTaskRuntimePath);
+  });
+
   it("does not backfill openclaw/plugin-sdk/index (root-export dist artifact)", () => {
     // P2-2 regression: `dist/plugin-sdk/index.js` is the dist artifact for
     // the package's root `./plugin-sdk` export, not a scoped subpath. The

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -670,7 +670,7 @@ describe("plugin sdk alias helpers", () => {
     fs.writeFileSync(corePath, "export const core = true;\n", "utf-8");
     fs.writeFileSync(
       taskRuntimePath,
-      'import "./agent-harness-task-runtime-missing-chunk.js";\nexport const marker = true;\n',
+      "export const marker = true;\n",
       "utf-8",
     );
     const aliases = resolvePluginSdkScopedAliasMap({
@@ -682,6 +682,78 @@ describe("plugin sdk alias helpers", () => {
     );
     expect(aliases["openclaw/plugin-sdk/agent-harness-task-runtime"]).toBe(taskRuntimePath);
     expect(aliases["@openclaw/plugin-sdk/agent-harness-task-runtime"]).toBe(taskRuntimePath);
+    // The package-level fall-through that caused the original bug appended the
+    // subpath under the file-valued root alias target. Confirm no alias value
+    // ever points inside `root-alias.cjs/<subpath>`.
+    for (const aliasValue of Object.values(aliases)) {
+      expect(aliasValue).not.toMatch(/root-alias\.cjs[\\/]/);
+    }
+  });
+
+  it("does not backfill dist plugin-sdk artifacts whose transitive relative imports are missing", () => {
+    const fixture = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
+      },
+    });
+    fs.writeFileSync(
+      path.join(fixture.root, "dist", "plugin-sdk", "core.js"),
+      "export const core = true;\n",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(fixture.root, "dist", "plugin-sdk", "agent-harness-task-runtime.js"),
+      'import { x } from "./agent-harness-task-runtime-missing-chunk.js";\nexport const marker = x;\n',
+      "utf-8",
+    );
+    const aliases = resolvePluginSdkScopedAliasMap({
+      modulePath: path.join(fixture.root, "dist", "plugins", "loader.js"),
+    });
+
+    expect(aliases["openclaw/plugin-sdk/agent-harness-task-runtime"]).toBeUndefined();
+    expect(aliases["@openclaw/plugin-sdk/agent-harness-task-runtime"]).toBeUndefined();
+  });
+
+  it("does NOT backfill private dist plugin-sdk artifacts for untrusted callers", () => {
+    const fixture = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
+      },
+    });
+    fs.writeFileSync(
+      path.join(fixture.root, "dist", "plugin-sdk", "core.js"),
+      "export const core = true;\n",
+      "utf-8",
+    );
+    // Drop a private subpath artifact in dist. Its scoped alias must NOT be
+    // exposed to an untrusted loader path when private QA mode is disabled.
+    fs.writeFileSync(
+      path.join(fixture.root, "dist", "plugin-sdk", "codex-native-task-runtime.js"),
+      "export const marker = true;\n",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(fixture.root, "dist", "plugin-sdk", "ssrf-runtime-internal.js"),
+      "export const marker = true;\n",
+      "utf-8",
+    );
+
+    const aliases = withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: undefined }, () =>
+      resolvePluginSdkScopedAliasMap({
+        modulePath: path.join(
+          fixture.root,
+          "dist",
+          "extensions",
+          "demo",
+          "index.js",
+        ),
+      }),
+    );
+
+    expect(aliases["openclaw/plugin-sdk/codex-native-task-runtime"]).toBeUndefined();
+    expect(aliases["@openclaw/plugin-sdk/codex-native-task-runtime"]).toBeUndefined();
+    expect(aliases["openclaw/plugin-sdk/ssrf-runtime-internal"]).toBeUndefined();
+    expect(aliases["@openclaw/plugin-sdk/ssrf-runtime-internal"]).toBeUndefined();
   });
 
   it("adds non-QA private Codex helper subpaths only for trusted Codex plugins", () => {

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -21,6 +21,7 @@ import {
   resolveExtensionApiAlias,
   resolvePluginRuntimeModulePath,
   resolvePluginSdkAliasFile,
+  resolvePluginSdkScopedAliasMap,
   shouldPreferNativeModuleLoad,
 } from "./sdk-alias.js";
 import {
@@ -651,6 +652,36 @@ describe("plugin sdk alias helpers", () => {
       }),
     );
     expect(subpaths).toEqual(["core", "qa-channel", "qa-channel-protocol", "qa-lab", "qa-runtime"]);
+  });
+
+  it("backfills scoped aliases for real dist plugin-sdk artifacts even when exports are stale", () => {
+    const fixture = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
+      },
+    });
+    const corePath = path.join(fixture.root, "dist", "plugin-sdk", "core.js");
+    const taskRuntimePath = path.join(
+      fixture.root,
+      "dist",
+      "plugin-sdk",
+      "agent-harness-task-runtime.js",
+    );
+    fs.writeFileSync(corePath, "export const core = true;\n", "utf-8");
+    fs.writeFileSync(
+      taskRuntimePath,
+      'import "./agent-harness-task-runtime-missing-chunk.js";\nexport const marker = true;\n',
+      "utf-8",
+    );
+    const aliases = resolvePluginSdkScopedAliasMap({
+      modulePath: path.join(fixture.root, "dist", "plugins", "loader.js"),
+    });
+
+    expect(fs.realpathSync(aliases["openclaw/plugin-sdk/core"] ?? "")).toBe(
+      fs.realpathSync(corePath),
+    );
+    expect(aliases["openclaw/plugin-sdk/agent-harness-task-runtime"]).toBe(taskRuntimePath);
+    expect(aliases["@openclaw/plugin-sdk/agent-harness-task-runtime"]).toBe(taskRuntimePath);
   });
 
   it("adds non-QA private Codex helper subpaths only for trusted Codex plugins", () => {

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -632,6 +632,15 @@ function hasPluginSdkSubpathArtifact(packageRoot: string, subpath: string) {
   );
 }
 
+// `dist/plugin-sdk/index.js` is the dist artifact for the package's root
+// `./plugin-sdk` export, not a scoped subpath. The package contract only
+// exposes `openclaw/plugin-sdk` for it, so backfilling
+// `openclaw/plugin-sdk/index` here would synthesize a subpath that does
+// not exist in `package.json#exports` and would break for plugins that
+// load against the published package rather than the OpenClaw aliasing
+// loader.
+const PLUGIN_SDK_ROOT_DIST_BASENAME = "index";
+
 function listDistPluginSdkArtifactSubpaths(packageRoot: string): Set<string> {
   try {
     const distPluginSdkDir = path.join(packageRoot, "dist", "plugin-sdk");
@@ -640,7 +649,11 @@ function listDistPluginSdkArtifactSubpaths(packageRoot: string): Set<string> {
         .readdirSync(distPluginSdkDir, { withFileTypes: true })
         .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
         .map((entry) => entry.name.slice(0, -".js".length))
-        .filter((subpath) => isSafePluginSdkSubpathSegment(subpath)),
+        .filter(
+          (subpath) =>
+            isSafePluginSdkSubpathSegment(subpath) &&
+            subpath !== PLUGIN_SDK_ROOT_DIST_BASENAME,
+        ),
     );
   } catch {
     return new Set();

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -641,6 +641,42 @@ function hasPluginSdkSubpathArtifact(packageRoot: string, subpath: string) {
 // loader.
 const PLUGIN_SDK_ROOT_DIST_BASENAME = "index";
 
+function resolveBackfillablePluginSdkSubpathTarget(params: {
+  packageRoot: string;
+  subpath: string;
+  orderedKinds: readonly PluginSdkAliasCandidateKind[];
+}): string | null {
+  for (const kind of params.orderedKinds) {
+    if (kind === "src") {
+      for (const ext of PLUGIN_SDK_SOURCE_CANDIDATE_EXTENSIONS) {
+        const candidate = path.join(
+          params.packageRoot,
+          "src",
+          "plugin-sdk",
+          `${params.subpath}${ext}`,
+        );
+        if (fs.existsSync(candidate)) {
+          return candidate;
+        }
+      }
+      continue;
+    }
+    const candidate = path.join(
+      params.packageRoot,
+      "dist",
+      "plugin-sdk",
+      `${params.subpath}.js`,
+    );
+    // Mirror the health check used by the primary alias loop so we never
+    // publish a backfilled alias for an artifact whose transitive relative
+    // dependencies are missing on disk.
+    if (isUsableDistPluginSdkArtifact(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 function listDistPluginSdkArtifactSubpaths(packageRoot: string): Set<string> {
   try {
     const distPluginSdkDir = path.join(packageRoot, "dist", "plugin-sdk");
@@ -779,12 +815,17 @@ export function resolvePluginSdkScopedAliasMap(
       if (!isBackfillableDistPluginSdkArtifactSubpath({ packageRoot, modulePath, subpath })) {
         continue;
       }
-      const candidate = path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`);
-      // Mirror the health check used by the primary alias loop so we never
-      // publish a backfilled alias for an artifact whose transitive relative
-      // dependencies are missing on disk. Doing otherwise would just swap one
-      // runtime failure for another instead of failing fast in the loader.
-      if (!isUsableDistPluginSdkArtifact(candidate)) {
+      // Honor the same src/dist resolution order the primary loop uses
+      // (orderedKinds). When src is preferred and a src artifact exists,
+      // backfilling to dist would silently make source-mode dev/test
+      // loaders run stale built SDK code for the same stale-export case
+      // this patch is meant to handle.
+      const candidate = resolveBackfillablePluginSdkSubpathTarget({
+        packageRoot,
+        subpath,
+        orderedKinds,
+      });
+      if (!candidate) {
         continue;
       }
       for (const packageName of PLUGIN_SDK_PACKAGE_NAMES) {

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -606,7 +606,12 @@ function shouldIncludePrivateLocalOnlyPluginSdkSubpath(params: {
   );
 }
 
-function shouldBackfillDistPluginSdkArtifactSubpath(params: {
+// Backfill is default-allow for any non-private dist plugin-sdk subpath:
+// returns true when the subpath is not in the private list at all, or when
+// it IS private but the caller has trusted owner / private QA CLI access.
+// Callers MUST still gate on `isUsableDistPluginSdkArtifact` so we never
+// publish a scoped alias for a broken dist file.
+function isBackfillableDistPluginSdkArtifactSubpath(params: {
   packageRoot: string;
   modulePath: string;
   subpath: string;
@@ -758,10 +763,17 @@ export function resolvePluginSdkScopedAliasMap(
       if (Object.prototype.hasOwnProperty.call(aliasMap, `openclaw/plugin-sdk/${subpath}`)) {
         continue;
       }
-      if (!shouldBackfillDistPluginSdkArtifactSubpath({ packageRoot, modulePath, subpath })) {
+      if (!isBackfillableDistPluginSdkArtifactSubpath({ packageRoot, modulePath, subpath })) {
         continue;
       }
       const candidate = path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`);
+      // Mirror the health check used by the primary alias loop so we never
+      // publish a backfilled alias for an artifact whose transitive relative
+      // dependencies are missing on disk. Doing otherwise would just swap one
+      // runtime failure for another instead of failing fast in the loader.
+      if (!isUsableDistPluginSdkArtifact(candidate)) {
+        continue;
+      }
       for (const packageName of PLUGIN_SDK_PACKAGE_NAMES) {
         aliasMap[`${packageName}/${subpath}`] = candidate;
       }

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -606,6 +606,17 @@ function shouldIncludePrivateLocalOnlyPluginSdkSubpath(params: {
   );
 }
 
+function shouldBackfillDistPluginSdkArtifactSubpath(params: {
+  packageRoot: string;
+  modulePath: string;
+  subpath: string;
+}) {
+  if (!readPrivateLocalOnlyPluginSdkSubpaths(params.packageRoot).includes(params.subpath)) {
+    return true;
+  }
+  return shouldIncludePrivateLocalOnlyPluginSdkSubpath(params);
+}
+
 function hasPluginSdkSubpathArtifact(packageRoot: string, subpath: string) {
   const distPath = path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`);
   if (isUsableDistPluginSdkArtifact(distPath)) {
@@ -739,6 +750,20 @@ export function resolvePluginSdkScopedAliasMap(
       }
       if (Object.prototype.hasOwnProperty.call(aliasMap, `openclaw/plugin-sdk/${subpath}`)) {
         break;
+      }
+    }
+  }
+  if (distPluginSdkArtifacts.size > 0) {
+    for (const subpath of distPluginSdkArtifacts) {
+      if (Object.prototype.hasOwnProperty.call(aliasMap, `openclaw/plugin-sdk/${subpath}`)) {
+        continue;
+      }
+      if (!shouldBackfillDistPluginSdkArtifactSubpath({ packageRoot, modulePath, subpath })) {
+        continue;
+      }
+      const candidate = path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`);
+      for (const packageName of PLUGIN_SDK_PACKAGE_NAMES) {
+        aliasMap[`${packageName}/${subpath}`] = candidate;
       }
     }
   }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Imports like `openclaw/plugin-sdk/agent-harness-task-runtime` could fall through to `dist/plugin-sdk/root-alias.cjs/agent-harness-task-runtime` (a nested-under-a-file path that does not exist), breaking Codex/OpenClaw harness startup whenever a scoped subpath was not present as an exact entry in the loader alias map.

Why does this matter now?

- The fall-through breaks the agent harness boot path and any plugin that imports `openclaw/plugin-sdk/<subpath>` for a subpath the alias map has not enumerated. The bug surfaces silently as a `MODULE_NOT_FOUND` rooted under `root-alias.cjs/...`, which is confusing to debug.

What is the intended outcome?

- `resolvePluginSdkScopedAliasMap` backfills scoped entries for real `dist/plugin-sdk/*.js` artifacts even when `package.json#exports` is stale, gated by `isUsableDistPluginSdkArtifact` (no broken artifacts) and `isBackfillableDistPluginSdkArtifactSubpath` (private SDK subpath gating preserved). `dist/plugin-sdk/index.js` is excluded since it's the root export, not a scoped subpath. Backfill honors `pluginSdkResolution` (src vs dist).
- `withNativeRequireAliases` resolves subpaths against the longest matching prefix, but **only when the alias target is a directory**. File-valued targets (e.g. the package-level `openclaw/plugin-sdk -> root-alias.cjs`) must match exactly via the scoped alias map; prefix fallback against a file target would bypass the same private-subpath gates the scoped map enforces. Suffix resolution uses `fs.statSync` for the file-vs-dir decision (falls back to `path.extname` if stat fails) and only swallows `MODULE_NOT_FOUND`/`ERR_MODULE_NOT_FOUND` errors.

What is intentionally out of scope?

- Changes to `package.json#exports` and the SDK package contract itself. The scoped backfill is a runtime safety net; the canonical export list still drives the contract.
- The pre-existing TypeScript error in `src/secrets/config-io.ts` (unrelated to this fix).

What does success look like?

- Plugins requiring `openclaw/plugin-sdk/<subpath>` resolve to the correct file. Private SDK subpaths remain inaccessible to untrusted callers. No alias value ever points inside `root-alias.cjs/<subpath>`. Source-mode dev/test loaders run src artifacts when src is preferred.

What should reviewers focus on?

- The native-require longest-prefix policy in `src/plugins/native-module-require.ts` (file-valued targets are excluded from prefix matching).
- The `orderedKinds`-aware backfill helper `resolveBackfillablePluginSdkSubpathTarget` in `src/plugins/sdk-alias.ts` and the `index`/private gating around `listDistPluginSdkArtifactSubpaths`.

## Linked context

Closes #

Related #

Was this requested by a maintainer or owner? No (proactive fix).

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: file-valued root alias subpath fall-through producing `root-alias.cjs/<subpath>` paths and missing scoped aliases for stale `package.json#exports`.
- Real environment tested: vitest unit suite (91 tests across the three touched test files) + three scoped boundary lint scripts + `codex review --base origin/main` (final pass reports "No actionable regressions were identified").
- Exact steps or commands run after this patch:
    - `node scripts/run-vitest.mjs run src/plugins/sdk-alias.test.ts src/plugins/native-module-require.test.ts src/plugins/plugin-module-loader-cache.test.ts`
    - `npm run lint:plugins:plugin-sdk-subpaths-exported`
    - `npm run lint:extensions:no-plugin-sdk-internal`
    - `npm run lint:plugins:no-monolithic-plugin-sdk-entry-imports`
    - `codex review --base origin/main`
- Evidence after fix:
    - `RUN  v4.1.7 ... ✓ sdk-alias.test.ts (60 tests) ... ✓ native-module-require.test.ts (15 tests) ... ✓ plugin-module-loader-cache.test.ts (16 tests). Test Files 3 passed (3). Tests 91 passed (91).`
    - Lint output: `OK: all referenced openclaw/plugin-sdk/<subpath> imports are exported.` / `No extension plugin-sdk boundary violations found. Baseline matches (0 entries).` / `OK: bundled plugin source files use scoped plugin-sdk subpaths (4358 checked).`
    - Codex review final pass: `No actionable regressions were identified in the changed plugin SDK alias and native require paths.`
- Observed result after fix: Scoped alias map exposes `openclaw/plugin-sdk/agent-harness-task-runtime -> dist/plugin-sdk/agent-harness-task-runtime.js` directly; `openclaw/plugin-sdk/index` is never published; private SDK subpaths (`codex-native-task-runtime`, `ssrf-runtime-internal`) remain undefined for untrusted modulePaths; `pluginSdkResolution: "src"` resolves to the src artifact when present.
- What was not tested: full end-to-end Codex/OpenClaw harness boot on a real install (this sandbox does not have a fully built openclaw runtime to exercise the harness against live transports). Full `pnpm build && pnpm check && pnpm test` was not run because `pnpm` is not installed in this environment.
- Proof limitations or environment constraints: this PR was authored in a sandboxed agent environment (macOS, Node 25.8, npm 11.11, no pnpm, no real OpenClaw deploy). Maintainers/ClawSweeper should treat real-install verification as the next gate.
- Before evidence (optional but encouraged): the original failure mode is documented in commit `cbb2968` and reproduced in `src/plugins/native-module-require.test.ts` (resolves scoped plugin-sdk subpaths via exact alias entries ... + does not resolve subpaths via prefix fallback against a file-valued root alias).

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs run src/plugins/sdk-alias.test.ts src/plugins/native-module-require.test.ts src/plugins/plugin-module-loader-cache.test.ts` — PASS (91/91)
- `npm run lint:plugins:plugin-sdk-subpaths-exported` — PASS
- `npm run lint:extensions:no-plugin-sdk-internal` — PASS
- `npm run lint:plugins:no-monolithic-plugin-sdk-entry-imports` — PASS
- `codex review --base origin/main` — three passes, final pass clean
- `NODE_OPTIONS="--max-old-space-size=12288" node_modules/.bin/tsc --noEmit --project tsconfig.json` — only pre-existing unrelated error in `src/secrets/config-io.ts`

What regression coverage was added or updated?

- `src/plugins/sdk-alias.test.ts`: backfill respects exports staleness; private subpath gating preserved (`codex-native-task-runtime`, `ssrf-runtime-internal`); broken artifacts (`isUsableDistPluginSdkArtifact`-flagged) are skipped; `openclaw/plugin-sdk/index` is never published; backfill resolves to src when `pluginSdkResolution: "src"`; no alias value points inside `root-alias.cjs/<subpath>`.
- `src/plugins/native-module-require.test.ts`: longest-prefix only engages for directory-valued targets; exact-match scoped subpath alias works; file-valued root alias does NOT prefix-resolve to siblings (P2-1 gating regression); directory targets whose names contain a dot (e.g. `plugin-sdk.v2`) resolve correctly; non-`MODULE_NOT_FOUND` errors propagate; missing subpath under file-valued root alias still falls back to original resolver cleanly.

What failed before this fix, if known?

- `tryNativeRequireJavaScriptModule(..., aliasMap: { "openclaw/plugin-sdk": rootAliasPath })` against `require("openclaw/plugin-sdk/agent-harness-task-runtime")` would fail with `MODULE_NOT_FOUND` rooted under `root-alias.cjs/agent-harness-task-runtime`.

If no test was added, why not? N/A — 6 new regression tests added across both test files.

## Risk checklist

Did user-visible behavior change? `Yes` — plugins relying on `openclaw/plugin-sdk/<subpath>` now resolve correctly; the file-valued-prefix native-require fallback (added in cbb2968 but never shipped to main) is intentionally restricted to directory-valued targets.

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `Yes (defense-in-depth)` — private SDK subpath gating (codex-native-task-runtime, codex-mcp-projection, ssrf-runtime-internal) is now reliably enforced for native-require resolution; the prior fallback could have bypassed it under contrived conditions.

What is the highest-risk area? `src/plugins/native-module-require.ts` `_resolveFilename` patching. It runs hot during every plugin require under `withNativeRequireAliases`. The new `isFileValuedAliasTarget` cache is module-scope; bounded by alias map size.

How is that risk mitigated? Memoized stat probe with `path.extname` fallback, narrow MODULE_NOT_FOUND catch, comprehensive test coverage (15 tests), and `codex review` cross-check.

## Current review state

What is the next action? Maintainer review + real-OpenClaw-install proof from someone with access.

What is still waiting on author, maintainer, CI, or external proof?

- External: real-environment harness boot verification (see Proof limitations).
- CI: full `pnpm build && pnpm check && pnpm test` will run on the PR; could not be run locally due to missing `pnpm`.

Which bot or reviewer comments were addressed?

- Internal Opus pre-submission review: gated backfill on `isUsableDistPluginSdkArtifact`, added private-gating regression test, narrowed error catch in `resolveAliasSubpathTarget`, fs.statSync file-vs-dir probe, renamed helper to `isBackfillableDistPluginSdkArtifactSubpath`, added Windows-dot-dir + re-throw + end-to-end regression tests.
- Codex review pass #1: restricted native-require prefix-based fallback to directory-valued alias targets (private-gating bypass fix); excluded `openclaw/plugin-sdk/index` from backfill.
- Codex review pass #2: `resolveBackfillablePluginSdkSubpathTarget` now walks `orderedKinds` so source-mode loaders no longer resolve backfilled subpaths to stale dist artifacts.
- Codex review pass #3: clean.

---

AI-assisted: this PR was authored with [Oz](https://warp.dev/oz). All four commits are signed with the `Co-Authored-By: Oz <oz-agent@warp.dev>` trailer. Codex was run locally three times against `origin/main` per CONTRIBUTING.md guidance for AI-assisted PRs.

_Conversation: https://app.warp.dev/conversation/2d289493-3706-484b-8d65-da0e5ce2cd46_
_Run: https://oz.warp.dev/runs/019e66cf-cb04-7a54-8475-3409158dff6b_

_This PR was generated with [Oz](https://warp.dev/oz)._
