### PR TITLE
test(cli): add banner emission reset helper

### DIFF
--- a/src/cli/banner.test.ts
+++ b/src/cli/banner.test.ts
@@ -131,4 +131,29 @@ describe("emitCliBanner", () => {
     expect(writeSpy).toHaveBeenCalledWith("\n🦞 OpenClaw 2026.3.7 (abc1234)\n\n");
     expect(hasEmittedCliBanner()).toBe(true);
   });
+
+  it("can reset banner emission state for same-module tests", async () => {
+    const { emitCliBanner, hasEmittedCliBanner, testing } = await importFreshBannerModule();
+    setStdoutIsTty(true);
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const options = {
+      argv: ["node", "openclaw"],
+      commit: "abc1234",
+      env: { LANG: "en_US.UTF-8" },
+      isTty: true,
+      mode: "off" as const,
+      platform: "darwin" as const,
+      richTty: false,
+    };
+
+    emitCliBanner("2026.3.7", options);
+    expect(hasEmittedCliBanner()).toBe(true);
+
+    testing.resetBannerEmittedForTests();
+    expect(hasEmittedCliBanner()).toBe(false);
+
+    emitCliBanner("2026.3.7", options);
+    expect(writeSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/cli/banner.ts
+++ b/src/cli/banner.ts
@@ -192,3 +192,10 @@ export function emitCliBanner(version: string, options: BannerOptions = {}) {
 export function hasEmittedCliBanner(): boolean {
   return bannerEmitted;
 }
+
+export const testing = {
+  resetBannerEmittedForTests(): void {
+    bannerEmitted = false;
+  },
+};
+export { testing as __testing };


### PR DESCRIPTION
Summary:
- Add a CLI banner testing reset helper for the module-level emission guard.
- Cover same-module reset/re-emit behavior in banner tests.

Fixes #83903

## Real behavior proof
Behavior addressed: CLI banner module state can now be reset in the same loaded module instance, so tests that emit the banner can clear the one-shot guard and emit again.
Real environment tested: Local OpenClaw source checkout on macOS, Node 24.14.0, dependencies installed with pnpm install --frozen-lockfile.
Exact steps or command run after this patch: node --import tsx -e "const writes=[]; const originalWrite=process.stdout.write.bind(process.stdout); process.stdout.write=(chunk)=>{writes.push(String(chunk)); return true;}; Object.defineProperty(process.stdout,'isTTY',{configurable:true,value:true}); const {emitCliBanner,hasEmittedCliBanner,testing}=await import('./src/cli/banner.ts'); const options={argv:['node','openclaw'],commit:'abc1234',env:{LANG:'en_US.UTF-8'},isTty:true,mode:'off',platform:'darwin',richTty:false}; emitCliBanner('2026.3.7',options); if(!hasEmittedCliBanner()) throw new Error('banner was not marked emitted'); testing.resetBannerEmittedForTests(); if(hasEmittedCliBanner()) throw new Error('banner reset did not clear state'); emitCliBanner('2026.3.7',options); if(writes.length!==2) throw new Error('expected two writes after reset, got '+writes.length); process.stdout.write=originalWrite; console.log('ad hoc banner reset check passed');"
Evidence after fix: Console output from the real source checkout:
```
ad hoc banner reset check passed
```
Observed result after fix: The first emit set hasEmittedCliBanner() to true, resetBannerEmittedForTests() cleared it to false, and a second emit produced a second stdout write in the same module instance.
What was not tested: A packaged OpenClaw install was not launched; this PR only exposes a test reset helper and does not change production CLI banner emission behavior.

Verification:
- pnpm install --frozen-lockfile
- CI=true OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/banner.test.ts src/cli/channel-options.test.ts
- pnpm exec oxfmt --check --threads=1 src/cli/banner.ts src/cli/banner.test.ts
- git diff --check
