### PR TITLE
Avoid profile cooldowns for provider overloads

### DIFF
--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -209,7 +209,7 @@ describe("markAuthProfileFailure", () => {
       expect(reloaded.usageStats?.["anthropic:default"]?.cooldownUntil).toBe(firstCooldownUntil);
     });
   });
-  it("records overloaded failures in the cooldown bucket", async () => {
+  it("records overloaded failures without making the profile unusable", async () => {
     await withAuthProfileStore(async ({ agentDir, store }) => {
       await markAuthProfileFailure({
         store,
@@ -219,7 +219,8 @@ describe("markAuthProfileFailure", () => {
       });
 
       const stats = store.usageStats?.["anthropic:default"];
-      expect(typeof stats?.cooldownUntil).toBe("number");
+      expect(stats?.cooldownUntil).toBeUndefined();
+      expect(stats?.cooldownReason).toBe("overloaded");
       expect(stats?.disabledUntil).toBeUndefined();
       expect(stats?.disabledReason).toBeUndefined();
       expect(stats?.failureCounts?.overloaded).toBe(1);

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -602,14 +602,18 @@ function computeNextProfileUsageStats(params: {
     });
     updatedStats.disabledReason = disabledFailureReason;
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
-    // Keep active cooldown windows immutable so retries within the window
-    // cannot push recovery further out.
-    updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
-      existingUntil: params.existing.cooldownUntil,
-      now: params.now,
-      recomputedUntil: params.now + backoffMs,
-    });
+    if (params.reason === "overloaded") {
+      updatedStats.cooldownUntil = undefined;
+    } else {
+      const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+      // Keep active cooldown windows immutable so retries within the window
+      // cannot push recovery further out.
+      updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
+        existingUntil: params.existing.cooldownUntil,
+        now: params.now,
+        recomputedUntil: params.now + backoffMs,
+      });
+    }
     // Update cooldown metadata based on whether the window is still active
     // and whether the same or a different model is failing.
     const existingCooldownActive =

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -458,7 +458,7 @@ describe("runWithModelFallback + runEmbeddedPiAgent failover behavior", () => {
     });
   });
 
-  it("falls back across providers after overloaded primary failure and persists transient cooldown", async () => {
+  it("falls back across providers after overloaded primary failure without persisting cooldown", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);
       mockPrimaryOverloadedThenFallbackSuccess();
@@ -476,7 +476,7 @@ describe("runWithModelFallback + runEmbeddedPiAgent failover behavior", () => {
       expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
 
       const usageStats = await readUsageStats(agentDir);
-      expect(typeof usageStats["openai:p1"]?.cooldownUntil).toBe("number");
+      expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
       expectFailureCount(usageStats, "openai:p1", "overloaded", 1);
       expect(typeof usageStats["groq:p1"]?.lastUsed).toBe("number");
 
@@ -610,7 +610,7 @@ describe("runWithModelFallback + runEmbeddedPiAgent failover behavior", () => {
     });
   });
 
-  it("persists overloaded cooldown across turns while still allowing one probe and fallback", async () => {
+  it("does not let overloaded failures skip later turns", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);
       mockPrimaryOverloadedThenFallbackSuccess();
@@ -641,7 +641,7 @@ describe("runWithModelFallback + runEmbeddedPiAgent failover behavior", () => {
       expectOpenAiThenGroqAttemptOrder({ expectOpenAiAuthProfileId: "openai:p1" });
 
       const usageStats = await readUsageStats(agentDir);
-      expect(typeof usageStats["openai:p1"]?.cooldownUntil).toBe("number");
+      expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
       expectFailureCount(usageStats, "openai:p1", "overloaded", 2);
       expect(computeBackoffMock).not.toHaveBeenCalled();
       expect(sleepWithAbortMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary\n- Record provider overloaded failures without setting auth-profile cooldownUntil\n- Preserve cooldown/disable behavior for rate-limit, auth, and billing failures\n- Update fallback and auth-profile tests for repeated overload attempts\n\n## Testing\n- node scripts/test-projects.mjs src/agents/auth-profiles.markauthprofilefailure.test.ts src/agents/model-fallback.run-embedded.e2e.test.ts