### PR TITLE
test(imessage): cover remote media staging order

### DIFF
--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -106,6 +106,7 @@ describe("getReplyFromConfig message hooks", () => {
     vi.mocked(stageSandboxMediaMock).mockReset();
     vi.mocked(logVerbose).mockReset();
 
+    vi.mocked(stageSandboxMediaMock).mockResolvedValue({ staged: new Map() });
     mocks.applyMediaUnderstanding.mockImplementation(async (...args: unknown[]) => {
       const { ctx } = args[0] as { ctx: MsgContext };
       ctx.Transcript = "voice transcript";
@@ -348,6 +349,63 @@ describe("getReplyFromConfig message hooks", () => {
         sessionKey: "agent:main:imessage:direct:user",
         workspaceDir: "/tmp/workspace",
       }),
+    );
+  });
+
+  it("stages remote inbound media before media understanding", async () => {
+    const remotePath = "/Users/kaien/Library/Messages/Attachments/IMG_0351.jpeg";
+    const stagedPath = "/home/openclaw/.openclaw/media/remote-cache/session/IMG_0351.jpeg";
+    vi.mocked(stageSandboxMediaMock).mockImplementationOnce(async (...args: unknown[]) => {
+      const params = args[0] as { ctx: MsgContext; sessionCtx: MsgContext };
+      expect(params.ctx.MediaRemoteHost).toBe("kaien@nerv");
+      expect(params.ctx.MediaPath).toBe(remotePath);
+      params.ctx.MediaPath = stagedPath;
+      params.ctx.MediaPaths = [stagedPath];
+      params.sessionCtx.MediaPath = stagedPath;
+      params.sessionCtx.MediaPaths = [stagedPath];
+      return { staged: new Map([[remotePath, stagedPath]]) };
+    });
+    mocks.applyMediaUnderstanding.mockImplementationOnce(async (...args: unknown[]) => {
+      const params = args[0] as { ctx: MsgContext };
+      expect(params.ctx.MediaPath).toBe(stagedPath);
+      expect(params.ctx.MediaPaths).toEqual([stagedPath]);
+      params.ctx.Body = "[Image]\nA staged remote image";
+      params.ctx.BodyForAgent = "[Image]\nA staged remote image";
+    });
+
+    await expect(
+      getReplyFromConfig(
+        buildCtx({
+          Provider: "imessage",
+          Surface: "imessage",
+          OriginatingChannel: "imessage",
+          OriginatingTo: "imessage:+15550100",
+          ChatType: "direct",
+          Body: "what is in this photo?",
+          BodyForAgent: "what is in this photo?",
+          RawBody: "what is in this photo?",
+          CommandBody: "what is in this photo?",
+          BodyForCommands: "what is in this photo?",
+          SessionKey: "agent:main:imessage:+15550100",
+          From: "imessage:+15550100",
+          To: "imessage:me",
+          MediaPath: remotePath,
+          MediaPaths: [remotePath],
+          MediaType: "image/jpeg",
+          MediaTypes: ["image/jpeg"],
+          MediaRemoteHost: "kaien@nerv",
+          MediaUrl: undefined,
+          MediaUrls: undefined,
+        }),
+        undefined,
+        withFastReplyConfig({}),
+      ),
+    ).resolves.toEqual({ text: "ok" });
+
+    expect(vi.mocked(stageSandboxMediaMock)).toHaveBeenCalledTimes(1);
+    expect(mocks.applyMediaUnderstanding).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(stageSandboxMediaMock).mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.applyMediaUnderstanding.mock.invocationCallOrder[0] ?? 0,
     );
   });
 


### PR DESCRIPTION
## Summary
- Adds regression coverage for path-only remote iMessage media.
- Verifies remote media is staged before media understanding sees the attachment path.
- Verifies the late staging path is not invoked a second time after the pre-understanding stage succeeds.

## Real behavior proof

**Behavior or issue addressed**: Current `main` stages remote iMessage media before media understanding; this PR adds regression coverage for the path-only remote-media case that used to be easy to miss.

**Real environment tested**: Local OpenClaw source checkout on Linux at PR head `09ba0d041b23ccb7fc5614c82b204a45683bcc8d`, with workspace dependencies installed.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/get-reply.message-hooks.test.ts -t "stages remote inbound media before media understanding" --reporter=verbose`

**Evidence after fix**:
```text
RUN  v4.1.7 /media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-87089

✓ |auto-reply-reply| src/auto-reply/reply/get-reply.message-hooks.test.ts > getReplyFromConfig message hooks > stages remote inbound media before media understanding 14655ms

Test Files  1 passed (1)
Tests  1 passed | 9 skipped (10)
Duration  19.57s
```

**Observed result after fix**: The added path-only remote iMessage regression test executed at the PR head and passed; the test asserts staging happens before media understanding and that the late staging path is not called a second time.

**What was not tested**: A live iMessage gateway transfer on macOS; this PR is scoped to regression coverage for the current OpenClaw reply pipeline behavior.

## Supplemental checks
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/get-reply.message-hooks.test.ts`
- `git diff --check origin/main...HEAD`
