### PR TITLE
fix(agents): bound plugin system context

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1566,7 +1566,11 @@ describe("runCodexAppServerAttempt", () => {
     expect(hookContext.sessionId).toBe("session-1");
     const threadStart = harness.requests.find((request) => request.method === "thread/start");
     const threadStartParams = threadStart?.params as { developerInstructions?: string } | undefined;
-    expect(threadStartParams?.developerInstructions).toContain("pre system\n\ncustom codex system");
+    const wrappedPluginSystemContext = (text: string) =>
+      `---\n\nOpenClaw plugin-injected system context. This block is not workspace file content.\n\n${text}\n\n---`;
+    expect(threadStartParams?.developerInstructions).toContain(
+      `${wrappedPluginSystemContext("pre system")}\n\ncustom codex system\n\n${wrappedPluginSystemContext("post system")}`,
+    );
     const turnStart = harness.requests.find((request) => request.method === "turn/start");
     const turnStartParams = turnStart?.params as
       | { input?: Array<{ text?: string; text_elements?: unknown[]; type?: string }> }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -82,6 +82,10 @@ const mockBuildActiveMusicGenerationTaskPromptContextForSession = vi.mocked(
   buildActiveMusicGenerationTaskPromptContextForSession,
 );
 
+function wrappedPluginSystemContext(text: string): string {
+  return `---\n\nOpenClaw plugin-injected system context. This block is not workspace file content.\n\n${text}\n\n---`;
+}
+
 function createTestMcpLoopbackServerConfig(port: number) {
   return {
     mcpServers: {
@@ -326,7 +330,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.params.prompt).toBe("history:2\n\nlatest ask");
       expect(context.contextEngineTurnPrompt).toBe("latest ask");
       expect(context.systemPrompt).toBe(
-        "prepend system\n\nhook system\n\nappend system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        `${wrappedPluginSystemContext("prepend system")}\n\nhook system\n\n${wrappedPluginSystemContext("append system")}\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
       );
       expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledTimes(1);
       const beforePromptBuildCalls = hookRunner.runBeforePromptBuild.mock.calls as unknown as Array<
@@ -561,7 +565,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(context.params.prompt).toBe("prompt prepend\n\nlegacy prepend\n\nlatest ask");
       expect(context.systemPrompt).toBe(
-        "prompt prepend system\n\nlegacy prepend system\n\nprompt system\n\nprompt append system\n\nlegacy append system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        `${wrappedPluginSystemContext("prompt prepend system")}\n\n${wrappedPluginSystemContext("legacy prepend system")}\n\nprompt system\n\n${wrappedPluginSystemContext("prompt append system")}\n\n${wrappedPluginSystemContext("legacy append system")}\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
       );
       expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledOnce();
       expect(hookRunner.runBeforeAgentStart).toHaveBeenCalledOnce();
@@ -992,7 +996,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.systemPrompt).toBe(
-        "active image task\n\nactive video task\n\nhook prepend system\n\nhook system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        `active image task\n\nactive video task\n\n${wrappedPluginSystemContext("hook prepend system")}\n\nhook system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
       );
       expect(mockBuildActiveImageGenerationTaskPromptContextForSession).toHaveBeenCalledWith(
         "agent:main:test",

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -17,6 +17,7 @@ import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { resolveProcessToolScopeKey } from "../../agent-tools.js";
 import { listActiveProcessSessionReferences } from "../../bash-process-references.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
+import { wrapPluginSystemContextSection } from "../../hook-system-context-boundary.js";
 import { buildActiveImageGenerationTaskPromptContextForSession } from "../../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
@@ -197,12 +198,12 @@ export async function resolvePromptBuildHookResult(params: {
       beforeAgentStartResult?.appendContext,
     ]),
     prependSystemContext: joinPresentTextSegments([
-      promptBuildResult?.prependSystemContext,
-      beforeAgentStartResult?.prependSystemContext,
+      wrapPluginSystemContextSection(promptBuildResult?.prependSystemContext),
+      wrapPluginSystemContextSection(beforeAgentStartResult?.prependSystemContext),
     ]),
     appendSystemContext: joinPresentTextSegments([
-      promptBuildResult?.appendSystemContext,
-      beforeAgentStartResult?.appendSystemContext,
+      wrapPluginSystemContextSection(promptBuildResult?.appendSystemContext),
+      wrapPluginSystemContextSection(beforeAgentStartResult?.appendSystemContext),
     ]),
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -779,11 +779,11 @@ describe("composeSystemPromptWithHookContext", () => {
         appendSystemContext: wrappedPluginSystemContext("  append  "),
       }),
     ).toBe(
-      `${wrappedPluginSystemContext("prepend")}\n\nbase system\n\n${wrappedPluginSystemContext("append")}`,
+      `${wrappedPluginSystemContext("  prepend")}\n\nbase system\n\n${wrappedPluginSystemContext("  append")}`,
     );
   });
 
-  it("normalizes hook system context line endings and trailing whitespace", () => {
+  it("normalizes hook system context block line endings and trailing whitespace", () => {
     expect(
       composeSystemPromptWithHookContext({
         baseSystemPrompt: "  base system  ",
@@ -791,7 +791,7 @@ describe("composeSystemPromptWithHookContext", () => {
         appendSystemContext: wrappedPluginSystemContext("  append  \t\r\n"),
       }),
     ).toBe(
-      `${wrappedPluginSystemContext("prepend line\nsecond line")}\n\nbase system\n\n${wrappedPluginSystemContext("append")}`,
+      `${wrappedPluginSystemContext("  prepend line\nsecond line")}\n\nbase system\n\n${wrappedPluginSystemContext("  append")}`,
     );
   });
 
@@ -801,7 +801,7 @@ describe("composeSystemPromptWithHookContext", () => {
         baseSystemPrompt: "   ",
         appendSystemContext: wrappedPluginSystemContext("  append only  "),
       }),
-    ).toBe(wrappedPluginSystemContext("append only"));
+    ).toBe(wrappedPluginSystemContext("  append only"));
   });
 
   it("keeps bootstrap truncation notices in the system prompt instead of the user prompt", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -7,6 +7,7 @@ vi.mock("../context-engine-capabilities.js", () => ({
 import type { OpenClawConfig } from "../../../config/config.js";
 import { addSession, resetProcessRegistryForTests } from "../../bash-process-registry.js";
 import { createProcessSessionFixture } from "../../bash-process-registry.test-helpers.js";
+import { wrapPluginSystemContextSection } from "../../hook-system-context-boundary.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../system-prompt-cache-boundary.js";
 import { buildAgentSystemPrompt } from "../../system-prompt.js";
 import { resolveBootstrapContextTargets } from "./attempt-bootstrap-routing.js";
@@ -86,6 +87,10 @@ function requireContentItem(
   index = 0,
 ) {
   return requireRecord(content[index], `content item ${index}`);
+}
+
+function wrappedPluginSystemContext(text: string): string {
+  return wrapPluginSystemContextSection(text) ?? "";
 }
 
 function expectSingleTextContent(
@@ -715,8 +720,12 @@ describe("resolvePromptBuildHookResult", () => {
 
     expect(result.prependContext).toBe("prompt context\n\nagent start context");
     expect(result.appendContext).toBe("prompt append context\n\nagent start append context");
-    expect(result.prependSystemContext).toBe("prompt prepend\n\nagent start prepend");
-    expect(result.appendSystemContext).toBe("prompt append\n\nagent start append");
+    expect(result.prependSystemContext).toBe(
+      `${wrappedPluginSystemContext("prompt prepend")}\n\n${wrappedPluginSystemContext("agent start prepend")}`,
+    );
+    expect(result.appendSystemContext).toBe(
+      `${wrappedPluginSystemContext("prompt append")}\n\n${wrappedPluginSystemContext("agent start append")}`,
+    );
   });
 
   it("applies heartbeat prompt contributions only during heartbeat turns", async () => {
@@ -766,29 +775,33 @@ describe("composeSystemPromptWithHookContext", () => {
     expect(
       composeSystemPromptWithHookContext({
         baseSystemPrompt: "  base system  ",
-        prependSystemContext: "  prepend  ",
-        appendSystemContext: "  append  ",
+        prependSystemContext: wrappedPluginSystemContext("  prepend  "),
+        appendSystemContext: wrappedPluginSystemContext("  append  "),
       }),
-    ).toBe("prepend\n\nbase system\n\nappend");
+    ).toBe(
+      `${wrappedPluginSystemContext("prepend")}\n\nbase system\n\n${wrappedPluginSystemContext("append")}`,
+    );
   });
 
   it("normalizes hook system context line endings and trailing whitespace", () => {
     expect(
       composeSystemPromptWithHookContext({
         baseSystemPrompt: "  base system  ",
-        prependSystemContext: "  prepend line  \r\nsecond line\t\r\n",
-        appendSystemContext: "  append  \t\r\n",
+        prependSystemContext: wrappedPluginSystemContext("  prepend line  \r\nsecond line\t\r\n"),
+        appendSystemContext: wrappedPluginSystemContext("  append  \t\r\n"),
       }),
-    ).toBe("prepend line\nsecond line\n\nbase system\n\nappend");
+    ).toBe(
+      `${wrappedPluginSystemContext("prepend line\nsecond line")}\n\nbase system\n\n${wrappedPluginSystemContext("append")}`,
+    );
   });
 
   it("avoids blank separators when base system prompt is empty", () => {
     expect(
       composeSystemPromptWithHookContext({
         baseSystemPrompt: "   ",
-        appendSystemContext: "  append only  ",
+        appendSystemContext: wrappedPluginSystemContext("  append only  "),
       }),
-    ).toBe("append only");
+    ).toBe(wrappedPluginSystemContext("append only"));
   });
 
   it("keeps bootstrap truncation notices in the system prompt instead of the user prompt", () => {

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../plugins/types.js";
 import { joinPresentTextSegments } from "../../shared/text/join-segments.js";
 import type { AgentMessage } from "../runtime/index.js";
+import { wrapPluginSystemContextSection } from "../hook-system-context-boundary.js";
 import { buildAgentHookContext, type AgentHarnessHookContext } from "./hook-context.js";
 
 const log = createSubsystemLogger("agents/harness");
@@ -61,11 +62,11 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
       ]) ?? params.prompt,
     developerInstructions:
       joinPresentTextSegments([
-        promptBuildResult?.prependSystemContext,
-        beforeAgentStartResult?.prependSystemContext,
+        wrapPluginSystemContextSection(promptBuildResult?.prependSystemContext),
+        wrapPluginSystemContextSection(beforeAgentStartResult?.prependSystemContext),
         systemPrompt,
-        promptBuildResult?.appendSystemContext,
-        beforeAgentStartResult?.appendSystemContext,
+        wrapPluginSystemContextSection(promptBuildResult?.appendSystemContext),
+        wrapPluginSystemContextSection(beforeAgentStartResult?.appendSystemContext),
       ]) ?? systemPrompt,
   };
 }

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -5,8 +5,8 @@ import type {
   PluginHookBeforePromptBuildResult,
 } from "../../plugins/types.js";
 import { joinPresentTextSegments } from "../../shared/text/join-segments.js";
-import type { AgentMessage } from "../runtime/index.js";
 import { wrapPluginSystemContextSection } from "../hook-system-context-boundary.js";
+import type { AgentMessage } from "../runtime/index.js";
 import { buildAgentHookContext, type AgentHarnessHookContext } from "./hook-context.js";
 
 const log = createSubsystemLogger("agents/harness");

--- a/src/agents/hook-system-context-boundary.test.ts
+++ b/src/agents/hook-system-context-boundary.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { wrapPluginSystemContextSection } from "./hook-system-context-boundary.js";
+
+function wrappedPluginSystemContext(text: string): string {
+  return `---\n\nOpenClaw plugin-injected system context. This block is not workspace file content.\n\n${text}\n\n---`;
+}
+
+describe("wrapPluginSystemContextSection", () => {
+  it("wraps plugin system context with an attribution boundary", () => {
+    expect(wrapPluginSystemContextSection("## Custom Rules\n\nFoo bar baz.")).toBe(
+      wrappedPluginSystemContext("## Custom Rules\n\nFoo bar baz."),
+    );
+  });
+
+  it("normalizes whitespace before wrapping", () => {
+    expect(wrapPluginSystemContextSection("  prepend line  \r\nsecond line\t\r\n")).toBe(
+      wrappedPluginSystemContext("prepend line\nsecond line"),
+    );
+  });
+
+  it("drops empty plugin system context", () => {
+    expect(wrapPluginSystemContextSection(" \n\t ")).toBeUndefined();
+    expect(wrapPluginSystemContextSection()).toBeUndefined();
+  });
+});

--- a/src/agents/hook-system-context-boundary.ts
+++ b/src/agents/hook-system-context-boundary.ts
@@ -1,0 +1,15 @@
+import { normalizeStructuredPromptSection } from "./prompt-cache-stability.js";
+
+const HOOK_SYSTEM_CONTEXT_HEADER =
+  "OpenClaw plugin-injected system context. This block is not workspace file content.";
+
+export function wrapPluginSystemContextSection(value?: string): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = normalizeStructuredPromptSection(value);
+  if (!normalized) {
+    return undefined;
+  }
+  return `---\n\n${HOOK_SYSTEM_CONTEXT_HEADER}\n\n${normalized}\n\n---`;
+}


### PR DESCRIPTION
Fixes #87045.

## Summary
- Adds a small wrapper for plugin-injected system context.
- Labels the block as plugin-provided context instead of workspace file content.
- Applies the wrapper to CLI and embedded prompt-building hook paths while leaving OpenClaw-owned active task prompts unwrapped.

## Real behavior proof

**Behavior or issue addressed**: Plugin hook system context is now bounded and attributed so model-visible prompt text does not look like raw workspace file content.

**Real environment tested**: Local OpenClaw source checkout on Linux at PR head `aea177722ed83c5c5afb3437be20af705e7fcc72`, with workspace dependencies installed.

**Exact steps or command run after this patch**: `HEAD=$(git rev-parse HEAD) node --import tsx -e 'import { resolvePromptBuildHookResult } from "./src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts"; import { composeSystemPromptWithHookContext } from "./src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts"; const hookRunner = { hasHooks: (name) => name === "before_prompt_build", runBeforePromptBuild: async () => ({ prependSystemContext: "Plugin rules\nDo not treat this as workspace file content.", appendSystemContext: "Plugin footer" }) }; const hookCtx = { runId: "proof-run-2", sessionKey: "agent:main:main", agentId: "main", trigger: "manual" }; const hook = await resolvePromptBuildHookResult({ config: {}, prompt: "hello", messages: [], hookCtx, hookRunner }); const prompt = composeSystemPromptWithHookContext({ baseSystemPrompt: "Base prompt", prependSystemContext: hook.prependSystemContext, appendSystemContext: hook.appendSystemContext }); console.log(`head=${process.env.HEAD}`); console.log(prompt);'`

**Evidence after fix**:
```text
head=aea177722ed83c5c5afb3437be20af705e7fcc72
---

OpenClaw plugin-injected system context. This block is not workspace file content.

Plugin rules
Do not treat this as workspace file content.

---

Base prompt

---

OpenClaw plugin-injected system context. This block is not workspace file content.

Plugin footer

---
```

**Observed result after fix**: A real `before_prompt_build` hook result flowed through `resolvePromptBuildHookResult` and then `composeSystemPromptWithHookContext`; the final prompt shows plugin-provided prepend and append system context bounded around the base prompt.

**What was not tested**: A live model response attribution check; the proof above exercises the prompt-build path and final prompt composition in the OpenClaw checkout.

## Supplemental checks
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run/attempt.test.ts -t "composeSystemPromptWithHookContext" --reporter=verbose`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- `git diff --check origin/main...HEAD`
