### PR TITLE
fix(cli): avoid duplicate Claude skills prompt

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -490,6 +490,12 @@ describe("runCliAgent spawn path", () => {
     supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
       const input = (args[0] ?? {}) as { argv?: string[] };
       pluginDir = requireArgAfter(input.argv, "--plugin-dir");
+      const systemPromptFile = requireArgAfter(input.argv, "--append-system-prompt-file");
+      const systemPrompt = await fs.readFile(systemPromptFile, "utf-8");
+      expect(systemPrompt).toContain("You are a helpful assistant.");
+      expect(systemPrompt).not.toContain("## Skills");
+      expect(systemPrompt).not.toContain("<available_skills>");
+      expect(systemPrompt).not.toContain("Use weather tools for forecasts.");
       const manifest = JSON.parse(
         await fs.readFile(path.join(pluginDir, ".claude-plugin", "plugin.json"), "utf-8"),
       ) as { name?: string; skills?: string };
@@ -517,8 +523,19 @@ describe("runCliAgent spawn path", () => {
           model: "sonnet",
           runId: "run-claude-skills-plugin",
           workspaceDir,
+          backend: {
+            systemPromptFileArg: "--append-system-prompt-file",
+          },
           skillsSnapshot: {
-            prompt: "",
+            prompt: [
+              "<available_skills>",
+              "  <skill>",
+              "    <name>weather</name>",
+              "    <description>Use weather tools for forecasts.</description>",
+              `    <location>${path.join(skillDir, "SKILL.md")}</location>`,
+              "  </skill>",
+              "</available_skills>",
+            ].join("\n"),
             skills: [{ name: "weather" }],
             resolvedSkills: [
               {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -62,6 +62,7 @@ function buildPreparedCliRunContext(params: {
   model: string;
   runId: string;
   prompt?: string;
+  systemPrompt?: string;
   sessionId?: string;
   sessionKey?: string;
   sessionEntry?: PreparedCliRunContext["params"]["sessionEntry"];
@@ -139,7 +140,7 @@ function buildPreparedCliRunContext(params: {
     contextEngineConfig: {},
     modelId: params.model,
     normalizedModel: params.model,
-    systemPrompt: "You are a helpful assistant.",
+    systemPrompt: params.systemPrompt ?? "You are a helpful assistant.",
     systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
     bootstrapPromptWarningLines: [],
     authEpochVersion: 2,
@@ -493,6 +494,8 @@ describe("runCliAgent spawn path", () => {
       const systemPromptFile = requireArgAfter(input.argv, "--append-system-prompt-file");
       const systemPrompt = await fs.readFile(systemPromptFile, "utf-8");
       expect(systemPrompt).toContain("You are a helpful assistant.");
+      expect(systemPrompt).toContain("## Memory");
+      expect(systemPrompt).toContain("Keep memories.");
       expect(systemPrompt).not.toContain("## Skills");
       expect(systemPrompt).not.toContain("<available_skills>");
       expect(systemPrompt).not.toContain("Use weather tools for forecasts.");
@@ -523,6 +526,21 @@ describe("runCliAgent spawn path", () => {
           model: "sonnet",
           runId: "run-claude-skills-plugin",
           workspaceDir,
+          systemPrompt: [
+            "You are a helpful assistant.",
+            "",
+            "## Skills",
+            "Scan <available_skills> before replying.",
+            "<available_skills>",
+            "  <skill>",
+            "    <name>weather</name>",
+            "    <description>Use weather tools for forecasts.</description>",
+            "  </skill>",
+            "</available_skills>",
+            "",
+            "## Memory",
+            "Keep memories.",
+          ].join("\n"),
           backend: {
             systemPromptFileArg: "--append-system-prompt-file",
           },

--- a/src/agents/cli-runner/claude-skills-system-prompt.test.ts
+++ b/src/agents/cli-runner/claude-skills-system-prompt.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { stripOpenClawSkillsPromptSection } from "./claude-skills-system-prompt.js";
+
+describe("stripOpenClawSkillsPromptSection", () => {
+  it("removes only the OpenClaw skills section from a CLI system prompt", () => {
+    const prompt = [
+      "You are a personal assistant running inside OpenClaw.",
+      "",
+      "## Tooling",
+      "No OpenClaw tool list is injected.",
+      "",
+      "## Skills",
+      "Scan <available_skills> before replying.",
+      "<available_skills>",
+      "<skill><name>weather</name></skill>",
+      "</available_skills>",
+      "",
+      "## Memory",
+      "Remember useful facts.",
+    ].join("\n");
+
+    expect(stripOpenClawSkillsPromptSection(prompt)).toBe(
+      [
+        "You are a personal assistant running inside OpenClaw.",
+        "",
+        "## Tooling",
+        "No OpenClaw tool list is injected.",
+        "",
+        "## Memory",
+        "Remember useful facts.",
+      ].join("\n"),
+    );
+  });
+
+  it("leaves prompts without an OpenClaw skills section unchanged", () => {
+    const prompt = "## Tooling\nNo tools.\n\n## Memory\nRemember facts.";
+    expect(stripOpenClawSkillsPromptSection(prompt)).toBe(prompt);
+  });
+});

--- a/src/agents/cli-runner/claude-skills-system-prompt.ts
+++ b/src/agents/cli-runner/claude-skills-system-prompt.ts
@@ -1,0 +1,23 @@
+const SKILLS_SECTION_HEADING = "## Skills";
+const NEXT_SECTION_RE = /\n##\s+/g;
+
+export function stripOpenClawSkillsPromptSection(systemPrompt: string): string {
+  const start = systemPrompt.indexOf(SKILLS_SECTION_HEADING);
+  if (start < 0) {
+    return systemPrompt;
+  }
+
+  NEXT_SECTION_RE.lastIndex = start + SKILLS_SECTION_HEADING.length;
+  const nextSection = NEXT_SECTION_RE.exec(systemPrompt);
+  const end = nextSection?.index ?? systemPrompt.length;
+  const before = systemPrompt.slice(0, start).replace(/\n+$/u, "");
+  const after = systemPrompt.slice(end).replace(/^\n+/u, "");
+
+  if (!before) {
+    return after;
+  }
+  if (!after) {
+    return before;
+  }
+  return `${before}\n\n${after}`;
+}

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -24,6 +24,7 @@ import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { applySkillEnvOverridesFromSnapshot } from "../skills.js";
 import { runClaudeLiveSessionTurn, shouldUseClaudeLiveSession } from "./claude-live-session.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
+import { stripOpenClawSkillsPromptSection } from "./claude-skills-system-prompt.js";
 import {
   buildCliSupervisorScopeKey,
   buildCliArgs,
@@ -279,10 +280,18 @@ export async function executePreparedCliRun(
   const useResume = Boolean(
     cliSessionIdToUse && resolvedSessionId && backend.resumeArgs && backend.resumeArgs.length > 0,
   );
+  const claudeSkillsPlugin = await prepareClaudeCliSkillsPlugin({
+    backendId: context.backendResolved.id,
+    skillsSnapshot: params.skillsSnapshot,
+  });
+  const systemPromptForRun =
+    claudeSkillsPlugin.args.length > 0
+      ? stripOpenClawSkillsPromptSection(context.systemPrompt)
+      : context.systemPrompt;
   const systemPromptArg = resolveSystemPromptUsage({
     backend,
     isNewSession: isNew,
-    systemPrompt: context.systemPrompt,
+    systemPrompt: systemPromptForRun,
   });
   const systemPromptFile =
     systemPromptArg && (!useResume || backend.systemPromptWhen === "always")
@@ -322,10 +331,6 @@ export async function executePreparedCliRun(
   const resolvedArgs = useResume
     ? baseArgs.map((entry) => entry.replaceAll("{sessionId}", resolvedSessionId ?? ""))
     : baseArgs;
-  const claudeSkillsPlugin = await prepareClaudeCliSkillsPlugin({
-    backendId: context.backendResolved.id,
-    skillsSnapshot: params.skillsSnapshot,
-  });
   let claudeSkillsPluginCleanupOwned = false;
   const baseArgsWithSkills =
     claudeSkillsPlugin.args.length > 0


### PR DESCRIPTION
Fixes #87063.

## Summary
- Strips OpenClaw's generated `## Skills` catalog from Claude CLI system prompt files when the same skills are passed through a Claude session plugin.
- Keeps the fallback system prompt behavior unchanged when no Claude skills plugin is prepared.
- Adds helper coverage and a spawn-path assertion that the following system prompt sections are preserved.

## Real behavior proof
- **Behavior or issue addressed**: Claude CLI sessions no longer receive the same OpenClaw skills catalog both in the system prompt file and in the session plugin.
- **Real environment tested**: Local OpenClaw source checkout on Linux at PR head `73fb15fc090975320957e08565112023c8e9bd9f`, with workspace dependencies installed.
- **Exact steps or command run after this patch**:
```bash
pnpm exec tsx -e "import { stripOpenClawSkillsPromptSection } from './src/agents/cli-runner/claude-skills-system-prompt.ts'; const input = ['A', '', '## Skills', '<available_skills>', 'weather', '</available_skills>', '', '## Memory', 'B'].join('\n'); const out = stripOpenClawSkillsPromptSection(input); if (out !== 'A\n\n## Memory\nB') throw new Error(JSON.stringify(out)); console.log(out);"
```
- **Observed result after fix**: The actual helper removes the generated skills section and preserves the following memory section, matching the Claude plugin dedupe path added by this PR.
- **What was not tested**: A live Claude CLI process invocation; the proof above exercises the actual OpenClaw prompt-stripping code, and the PR adds spawn-path coverage for the plugin argument plus prompt-file contents.
- **Evidence after fix**: Terminal output from the patched OpenClaw checkout:
> A
>
> ## Memory
> B

## Supplemental checks
- `node scripts/run-oxlint-shards.mjs --threads=8`
- `git diff --check origin/main...HEAD`
