### PR TITLE
fix: repair local approval resolution

### DIFF
--- a/src/gateway/operator-approvals-client.e2e.test.ts
+++ b/src/gateway/operator-approvals-client.e2e.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { captureEnv } from "../test-utils/env.js";
+import { ADMIN_SCOPE, APPROVALS_SCOPE } from "./method-scopes.js";
+import { withOperatorApprovalsGatewayClient } from "./operator-approvals-client.js";
+import { startGatewayServer } from "./server.js";
+import {
+  connectGatewayClient,
+  disconnectGatewayClient,
+  getFreeGatewayPort,
+} from "./test-helpers.e2e.js";
+
+const TEST_ENV_KEYS = [
+  "HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_GATEWAY_PORT",
+];
+
+type Cleanup = () => Promise<void> | void;
+
+async function requestExecApproval(params: {
+  requester: Awaited<ReturnType<typeof connectGatewayClient>>;
+  id: string;
+}): Promise<void> {
+  await expect(
+    params.requester.request("exec.approval.request", {
+      id: params.id,
+      command: "printf smoke",
+      cwd: "/tmp",
+      host: "local",
+      ask: "always",
+      twoPhase: true,
+      timeoutMs: 60_000,
+    }),
+  ).resolves.toMatchObject({
+    status: "accepted",
+    id: params.id,
+  });
+}
+
+describe("operator approval gateway client runtime token source", () => {
+  const cleanup: Cleanup[] = [];
+
+  afterEach(async () => {
+    for (const step of cleanup.splice(0).toReversed()) {
+      await step();
+    }
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    clearSessionStoreCacheForTest();
+  });
+
+  it("uses runtime authority only for generated local gateway URLs", async () => {
+    const envSnapshot = captureEnv(TEST_ENV_KEYS);
+    cleanup.push(() => envSnapshot.restore());
+
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-approval-client-e2e-"));
+    cleanup.push(() => fs.rm(tempHome, { recursive: true, force: true, maxRetries: 5 }));
+
+    const stateDir = path.join(tempHome, ".openclaw");
+    await fs.mkdir(stateDir, { recursive: true });
+    process.env.HOME = tempHome;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const port = await getFreeGatewayPort();
+    const token = "approval-client-e2e-token";
+    const url = `ws://127.0.0.1:${port}`;
+    process.env.OPENCLAW_GATEWAY_PORT = String(port);
+
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token },
+      controlUiEnabled: false,
+      deferStartupSidecars: true,
+    });
+    cleanup.push(() => server.close());
+
+    const admin = await connectGatewayClient({
+      url,
+      token,
+      clientDisplayName: "approval admin",
+      scopes: [ADMIN_SCOPE],
+      timeoutMs: 60_000,
+    });
+    cleanup.push(() => disconnectGatewayClient(admin));
+
+    const requester = await connectGatewayClient({
+      url,
+      token,
+      clientDisplayName: "approval requester",
+      scopes: [APPROVALS_SCOPE],
+      timeoutMs: 60_000,
+    });
+    cleanup.push(() => disconnectGatewayClient(requester));
+
+    const localConfig = {
+      gateway: {
+        port,
+        auth: { mode: "token", token },
+      },
+    } satisfies OpenClawConfig;
+
+    await requestExecApproval({ requester, id: "local-source-approval" });
+    await withOperatorApprovalsGatewayClient(
+      {
+        config: localConfig,
+        clientDisplayName: "local source approval resolver",
+      },
+      async (client) => {
+        await client.request(
+          "exec.approval.resolve",
+          { id: "local-source-approval", decision: "allow-once" },
+          { timeoutMs: 10_000 },
+        );
+      },
+    );
+
+    const remoteLoopbackConfig = {
+      gateway: {
+        mode: "remote",
+        remote: { url },
+        auth: { mode: "token", token },
+      },
+    } satisfies OpenClawConfig;
+
+    await requestExecApproval({ requester, id: "remote-loopback-approval" });
+    await expect(
+      withOperatorApprovalsGatewayClient(
+        {
+          config: remoteLoopbackConfig,
+          clientDisplayName: "remote loopback approval resolver",
+        },
+        async (client) => {
+          await client.request(
+            "exec.approval.resolve",
+            { id: "remote-loopback-approval", decision: "allow-once" },
+            { timeoutMs: 10_000 },
+          );
+        },
+      ),
+    ).rejects.toMatchObject({
+      gatewayCode: "INVALID_REQUEST",
+      details: { reason: "APPROVAL_NOT_FOUND" },
+    });
+
+    await admin.request(
+      "exec.approval.resolve",
+      { id: "remote-loopback-approval", decision: "deny" },
+      { timeoutMs: 10_000 },
+    );
+  }, 120_000);
+});

--- a/src/gateway/operator-approvals-client.e2e.test.ts
+++ b/src/gateway/operator-approvals-client.e2e.test.ts
@@ -19,7 +19,9 @@ const TEST_ENV_KEYS = [
   "HOME",
   "OPENCLAW_STATE_DIR",
   "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_URL",
   "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_GATEWAY_PASSWORD",
   "OPENCLAW_GATEWAY_PORT",
 ];
 
@@ -60,6 +62,10 @@ describe("operator approval gateway client runtime token source", () => {
   it("uses runtime authority only for generated local gateway URLs", async () => {
     const envSnapshot = captureEnv(TEST_ENV_KEYS);
     cleanup.push(() => envSnapshot.restore());
+    delete process.env.OPENCLAW_CONFIG_PATH;
+    delete process.env.OPENCLAW_GATEWAY_URL;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
 
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-approval-client-e2e-"));
     cleanup.push(() => fs.rm(tempHome, { recursive: true, force: true, maxRetries: 5 }));

--- a/src/gateway/operator-approvals-client.test.ts
+++ b/src/gateway/operator-approvals-client.test.ts
@@ -11,6 +11,7 @@ const clientState = vi.hoisted(() => ({
 
 const bootstrapState = vi.hoisted(() => ({
   url: "ws://127.0.0.1:18789",
+  urlSource: "local loopback",
   auth: { token: "secret" as string | undefined, password: undefined as string | undefined },
 }));
 
@@ -56,6 +57,7 @@ class MockGatewayClient {
 vi.mock("./client-bootstrap.js", () => ({
   resolveGatewayClientBootstrap: vi.fn(async () => ({
     url: bootstrapState.url,
+    urlSource: bootstrapState.urlSource,
     auth: bootstrapState.auth,
   })),
 }));
@@ -75,6 +77,7 @@ describe("withOperatorApprovalsGatewayClient", () => {
     clientState.stopSpy.mockReset();
     clientState.stopAndWaitSpy.mockReset().mockResolvedValue(undefined);
     bootstrapState.url = "ws://127.0.0.1:18789";
+    bootstrapState.urlSource = "local loopback";
     bootstrapState.auth = { token: "secret", password: undefined };
   });
 
@@ -104,6 +107,7 @@ describe("withOperatorApprovalsGatewayClient", () => {
 
   it("keeps device identity for remote shared-auth approval clients", async () => {
     bootstrapState.url = "wss://gateway.example/ws";
+    bootstrapState.urlSource = "config gateway.remote.url";
 
     await withOperatorApprovalsGatewayClient(
       {
@@ -117,7 +121,9 @@ describe("withOperatorApprovalsGatewayClient", () => {
     expect(clientState.options?.deviceIdentity).toBeUndefined();
   });
 
-  it("keeps approval runtime token for loopback explicit gateway URL overrides", async () => {
+  it("omits approval runtime token for explicit loopback gateway URL overrides", async () => {
+    bootstrapState.urlSource = "cli --url";
+
     await withOperatorApprovalsGatewayClient(
       {
         config: {} as never,
@@ -127,11 +133,12 @@ describe("withOperatorApprovalsGatewayClient", () => {
       async () => undefined,
     );
 
-    expect(typeof clientState.options?.approvalRuntimeToken).toBe("string");
+    expect(clientState.options).not.toHaveProperty("approvalRuntimeToken");
   });
 
   it("omits approval runtime token for remote explicit gateway URL overrides", async () => {
     bootstrapState.url = "wss://gateway.example/ws";
+    bootstrapState.urlSource = "cli --url";
 
     await withOperatorApprovalsGatewayClient(
       {
@@ -143,6 +150,51 @@ describe("withOperatorApprovalsGatewayClient", () => {
     );
 
     expect(clientState.options).not.toHaveProperty("approvalRuntimeToken");
+  });
+
+  it("omits approval runtime token for configured remote loopback gateway URLs", async () => {
+    bootstrapState.url = "ws://127.0.0.1:18789";
+    bootstrapState.urlSource = "config gateway.remote.url";
+
+    await withOperatorApprovalsGatewayClient(
+      {
+        config: {} as never,
+        clientDisplayName: "Matrix approval (@owner:example.org)",
+      },
+      async () => undefined,
+    );
+
+    expect(clientState.options).not.toHaveProperty("approvalRuntimeToken");
+  });
+
+  it("omits approval runtime token for env loopback gateway URL overrides", async () => {
+    bootstrapState.url = "ws://127.0.0.1:18789";
+    bootstrapState.urlSource = "env OPENCLAW_GATEWAY_URL";
+
+    await withOperatorApprovalsGatewayClient(
+      {
+        config: {} as never,
+        clientDisplayName: "Matrix approval (@owner:example.org)",
+      },
+      async () => undefined,
+    );
+
+    expect(clientState.options).not.toHaveProperty("approvalRuntimeToken");
+  });
+
+  it("keeps approval runtime token for local fallback gateway URLs", async () => {
+    bootstrapState.url = "ws://127.0.0.1:18789";
+    bootstrapState.urlSource = "missing gateway.remote.url (fallback local)";
+
+    await withOperatorApprovalsGatewayClient(
+      {
+        config: {} as never,
+        clientDisplayName: "Matrix approval (@owner:example.org)",
+      },
+      async () => undefined,
+    );
+
+    expect(typeof clientState.options?.approvalRuntimeToken).toBe("string");
   });
 
   it("keeps device identity for loopback approval clients without shared auth", async () => {

--- a/src/gateway/operator-approvals-client.ts
+++ b/src/gateway/operator-approvals-client.ts
@@ -25,6 +25,13 @@ function shouldOmitOperatorApprovalDeviceIdentity(params: {
   return Boolean((params.token || params.password) && isLoopbackGatewayUrl(params.url));
 }
 
+function shouldSendApprovalRuntimeToken(urlSource: string): boolean {
+  // This token is process-local authority; loopback alone may be a tunnel or another gateway.
+  return (
+    urlSource === "local loopback" || urlSource === "missing gateway.remote.url (fallback local)"
+  );
+}
+
 export async function createOperatorApprovalsGatewayClient(
   params: Pick<
     GatewayClientOptions,
@@ -44,13 +51,12 @@ export async function createOperatorApprovalsGatewayClient(
     gatewayUrl: params.gatewayUrl,
     env: process.env,
   });
-  const shouldSendApprovalRuntimeToken = !params.gatewayUrl || isLoopbackGatewayUrl(bootstrap.url);
 
   return new GatewayClient({
     url: bootstrap.url,
     token: bootstrap.auth.token,
     password: bootstrap.auth.password,
-    ...(shouldSendApprovalRuntimeToken
+    ...(shouldSendApprovalRuntimeToken(bootstrap.urlSource)
       ? { approvalRuntimeToken: getOperatorApprovalRuntimeToken() }
       : {}),
     preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,


### PR DESCRIPTION
Summary
- Follow-up to #86771: reworks approval runtime token forwarding so authority follows the gateway URL source, not whether the URL host is loopback.
- Keeps the token for generated local gateway targets and local fallback targets; omits it for CLI, env, and configured remote URLs, including loopback SSH-tunnel URLs.
- Adds focused mocked coverage plus a real Gateway e2e that proves generated-local resolution succeeds and configured-loopback remote resolution is not promoted.

Verification
- autoreview: clean, no accepted/actionable findings.
- Local: pnpm exec oxfmt --check src/gateway/operator-approvals-client.ts src/gateway/operator-approvals-client.test.ts src/gateway/operator-approvals-client.e2e.test.ts extensions/discord/src/monitor/exec-approvals.ts extensions/discord/src/monitor/exec-approvals.test.ts
- Local: git diff --check origin/main...HEAD
- Crabbox AWS run run_c36357c075dc on cbx_79c88d07570f: node scripts/run-vitest.mjs run src/gateway/operator-approvals-client.test.ts src/gateway/operator-approvals-client.e2e.test.ts src/agents/tools/gateway.test.ts extensions/discord/src/monitor/exec-approvals.test.ts --reporter=dot --pool=forks --no-file-parallelism --testTimeout=120000
- Crabbox AWS run run_c36357c075dc on cbx_79c88d07570f: pnpm exec oxfmt --check src/gateway/operator-approvals-client.ts src/gateway/operator-approvals-client.test.ts src/gateway/operator-approvals-client.e2e.test.ts extensions/discord/src/monitor/exec-approvals.ts extensions/discord/src/monitor/exec-approvals.test.ts

Behavior addressed: approval resolution from local channel/plugin surfaces keeps same-process runtime authority, while configured or override loopback gateway URLs are treated as remote/tunnel targets and do not receive the process-local approval runtime token.
Real environment tested: Crabbox AWS Linux c7a.8xlarge, Node v24.16.0, pnpm 11.2.2, real loopback Gateway server in src/gateway/operator-approvals-client.e2e.test.ts.
Exact steps or command run after this patch: node scripts/run-vitest.mjs run src/gateway/operator-approvals-client.test.ts src/gateway/operator-approvals-client.e2e.test.ts src/agents/tools/gateway.test.ts extensions/discord/src/monitor/exec-approvals.test.ts --reporter=dot --pool=forks --no-file-parallelism --testTimeout=120000
Evidence after fix: 5 test files passed, 68 tests passed; formatter check passed on all touched files.
Observed result after fix: default generated local gateway resolution succeeds with runtime authority; configured loopback remote URL resolution is rejected as approval not found without runtime authority.
What was not tested: full repository check suite and live Discord click against Discord API.

Keeps contributor credit from @fuller-stack-dev.
