### PR TITLE
fix(daemon): keep Windows Scheduled Task running on battery power (#59299)

### DIFF
--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -8,10 +8,28 @@ import { auditGatewayServiceConfig, SERVICE_AUDIT_CODES } from "./service-audit.
 
 const schtasksCalls: string[][] = [];
 const schtasksResponses: { code: number; stdout: string; stderr: string }[] = [];
+// Captures the XML payload at /Create /XML time before the production code's
+// `finally` block deletes the temp file. Indexed by the position in
+// `schtasksCalls` so individual tests can pin which create-call they assert on.
+const xmlPayloadCaptures: Array<{ index: number; xml: string }> = [];
 
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: async (argv: string[]) => {
+    const index = schtasksCalls.length;
     schtasksCalls.push(argv);
+    const xmlFlagPos = argv.indexOf("/XML");
+    if (xmlFlagPos !== -1) {
+      const xmlPath = argv[xmlFlagPos + 1];
+      if (typeof xmlPath === "string") {
+        try {
+          const raw = await fs.readFile(xmlPath);
+          // Strip the UTF-16 LE BOM and decode for readable assertions.
+          xmlPayloadCaptures.push({ index, xml: raw.slice(2).toString("utf16le") });
+        } catch {
+          // Mock cannot block production cleanup; tests assert via captured payloads.
+        }
+      }
+    }
     return schtasksResponses.shift() ?? { code: 0, stdout: "", stderr: "" };
   },
 }));
@@ -19,6 +37,7 @@ vi.mock("./schtasks-exec.js", () => ({
 beforeEach(() => {
   schtasksCalls.length = 0;
   schtasksResponses.length = 0;
+  xmlPayloadCaptures.length = 0;
 });
 
 describe("installScheduledTask", () => {
@@ -135,7 +154,15 @@ describe("installScheduledTask", () => {
       expect(schtasksCalls[0]).toEqual(["/Query"]);
       expect(schtasksCalls[1]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
       expect(schtasksCalls[2]?.[0]).toBe("/Change");
-      expect(schtasksCalls[3]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+      // Battery-flag XML re-apply runs between /Change and /Run on upgrades.
+      expect(schtasksCalls[3]?.slice(0, 5)).toEqual([
+        "/Create",
+        "/F",
+        "/TN",
+        "OpenClaw Gateway",
+        "/XML",
+      ]);
+      expect(schtasksCalls[4]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
     });
   });
 
@@ -197,22 +224,16 @@ describe("installScheduledTask", () => {
       const launcher = await fs.readFile(launcherPath, "utf8");
 
       expectInitialTaskQueries();
-      expect(schtasksCalls[2]).toEqual([
+      // `/Create /XML` argv shape: ["/Create", "/F", "/TN", "<name>", "/XML", "<path>", "/RU", "<user>", "/NP"].
+      // The XML payload is what carries the SC, RL, TR, and battery settings now.
+      expect(schtasksCalls[2]?.slice(0, 5)).toEqual([
         "/Create",
         "/F",
-        "/SC",
-        "ONLOGON",
-        "/RL",
-        "LIMITED",
         "/TN",
         "OpenClaw Gateway",
-        "/TR",
-        expect.stringContaining("gateway.vbs"),
-        "/RU",
-        "WORKSTATION\\alice",
-        "/NP",
-        "/IT",
+        "/XML",
       ]);
+      expect(schtasksCalls[2]?.slice(6)).toEqual(["/RU", "WORKSTATION\\alice", "/NP"]);
       expect(launcher).toContain("WScript.Shell");
       expect(launcher).toContain(scriptPath);
       expect(launcher).toContain(`Run """${scriptPath}""", 0, False`);
@@ -220,9 +241,77 @@ describe("installScheduledTask", () => {
     });
   });
 
+  it("creates the Scheduled Task via XML with battery start/continue enabled (#59299)", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+
+      await installDefaultGatewayTask({
+        ...env,
+        USERDOMAIN: "WORKSTATION",
+        USERNAME: "alice",
+      });
+
+      // `/Create` must use `/XML <path>` so battery flags can be set; the
+      // CLI flag form (`/SC ONLOGON /RL LIMITED /TR ...`) cannot express
+      // `DisallowStartIfOnBatteries`/`StopIfGoingOnBatteries`.
+      const createCall = schtasksCalls[2];
+      expect(createCall?.[0]).toBe("/Create");
+      expect(createCall).toContain("/XML");
+
+      const captured = xmlPayloadCaptures.find((entry) => entry.index === 2);
+      expect(captured).toBeDefined();
+      const xml = captured?.xml ?? "";
+      expect(xml).toContain("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>");
+      expect(xml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
+      // Preserve the prior CLI semantics: ONLOGON trigger, LeastPrivilege, exec action.
+      expect(xml).toContain("<LogonTrigger>");
+      expect(xml).toContain("<RunLevel>LeastPrivilege</RunLevel>");
+      expect(xml).toContain("<UserId>WORKSTATION\\alice</UserId>");
+      expect(xml).toContain("<Exec>");
+    });
+  });
+
+  it("re-applies the XML on /Change so upgraded tasks adopt battery flags (#59299)", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      // /Query yes, /Query /TN yes, /Change ok, /Create /XML ok (upgrade), /Run ok.
+      schtasksResponses.push(
+        okSchtasksResponse,
+        okSchtasksResponse,
+        okSchtasksResponse,
+        okSchtasksResponse,
+        okSchtasksResponse,
+      );
+
+      await installDefaultGatewayTask(env);
+
+      expectInitialTaskQueries();
+      expect(schtasksCalls[2]?.[0]).toBe("/Change");
+      expect(schtasksCalls[3]?.slice(0, 5)).toEqual([
+        "/Create",
+        "/F",
+        "/TN",
+        "OpenClaw Gateway",
+        "/XML",
+      ]);
+      const upgradeCapture = xmlPayloadCaptures.find((entry) => entry.index === 3);
+      expect(upgradeCapture).toBeDefined();
+      const upgradeXml = upgradeCapture?.xml ?? "";
+      expect(upgradeXml).toContain("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>");
+      expect(upgradeXml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
+      expectTaskRunCall(4);
+    });
+  });
+
   it("updates existing tasks to use the hidden launcher when requested", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(okSchtasksResponse, okSchtasksResponse, okSchtasksResponse);
+      // /Query, /Query /TN, /Change (TR-only), /Create /XML (upgrade re-apply), /Run.
+      schtasksResponses.push(
+        okSchtasksResponse,
+        okSchtasksResponse,
+        okSchtasksResponse,
+        okSchtasksResponse,
+        okSchtasksResponse,
+      );
 
       const { scriptPath } = await installDefaultGatewayTask({
         ...env,
@@ -241,7 +330,15 @@ describe("installScheduledTask", () => {
         expect.stringContaining("gateway.vbs"),
       ]);
       expect(schtasksCalls[2]?.[4]).toContain(launcherPath);
-      expectTaskRunCall(3);
+      // Upgrade XML re-apply runs after /Change so older tasks pick up battery flags.
+      expect(schtasksCalls[3]?.slice(0, 5)).toEqual([
+        "/Create",
+        "/F",
+        "/TN",
+        "OpenClaw Gateway",
+        "/XML",
+      ]);
+      expectTaskRunCall(4);
     });
   });
 
@@ -260,7 +357,9 @@ describe("installScheduledTask", () => {
 
   it("throws when /Run fails after updating an existing task", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
+      // /Query, /Query /TN, /Change, /Create XML upgrade re-apply, /Run (fails).
       schtasksResponses.push(
+        okSchtasksResponse,
         okSchtasksResponse,
         okSchtasksResponse,
         okSchtasksResponse,
@@ -273,7 +372,8 @@ describe("installScheduledTask", () => {
 
       expectInitialTaskQueries();
       expect(schtasksCalls[2]?.[0]).toBe("/Change");
-      expectTaskRunCall(3);
+      expect(schtasksCalls[3]?.[0]).toBe("/Create");
+      expectTaskRunCall(4);
     });
   });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { isGatewayArgv } from "../infra/gateway-process-argv.js";
 import { findVerifiedGatewayListenerPidsOnPortSync } from "../infra/gateway-processes.js";
@@ -97,6 +98,93 @@ function quoteSchtasksArg(value: string): string {
     return value;
   }
   return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+// XML 1.0 text-node escape for Task Scheduler payloads. `<Command>`, `<Arguments>`,
+// `<Description>`, and `<UserId>` accept any literal user/script path, so the
+// only characters that need encoding are XML structural ones. CR/LF are already
+// rejected upstream in `assertNoCmdLineBreak`.
+function escapeXmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// Task Scheduler XML payload for `schtasks /Create /XML`. We switched off the
+// CLI flag form to set `<DisallowStartIfOnBatteries>` and `<StopIfGoingOnBatteries>`
+// to `false`, which the `schtasks /Create` and `/Change` CLI surfaces do not
+// expose. The CLI default leaves both at `true`, which kills the Gateway task
+// when a laptop unplugs from AC power (#59299). The rest of the XML mirrors
+// the prior CLI flags: ONLOGON trigger, LeastPrivilege run level, single-instance
+// policy, no idle restrictions, and the same `<Exec>` action wired to the
+// existing `gateway.cmd` / `gateway.vbs` launcher.
+function buildScheduledTaskXml(params: {
+  taskDescription: string;
+  taskUser: string | null;
+  launchPath: string;
+}): string {
+  const description = escapeXmlText(params.taskDescription);
+  const command = escapeXmlText(params.launchPath);
+  const principalLogon = params.taskUser
+    ? `\n      <UserId>${escapeXmlText(params.taskUser)}</UserId>\n      <LogonType>InteractiveToken</LogonType>`
+    : "\n      <GroupId>S-1-5-32-545</GroupId>";
+  const triggerUser = params.taskUser
+    ? `\n      <UserId>${escapeXmlText(params.taskUser)}</UserId>`
+    : "";
+  return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>${description}</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>${triggerUser}
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">${principalLogon}
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${command}</Command>
+    </Exec>
+  </Actions>
+</Task>`;
+}
+
+async function writeTaskXmlTempFile(xml: string): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-task-xml-"));
+  const xmlPath = path.join(tmpDir, "task.xml");
+  // schtasks /XML expects UTF-16 LE with BOM; Node's "utf16le" Buffer plus a
+  // manual FFFE BOM matches what Task Scheduler import accepts on all locales.
+  const bom = Buffer.from([0xff, 0xfe]);
+  const body = Buffer.from(xml, "utf16le");
+  await fs.writeFile(xmlPath, Buffer.concat([bom, body]));
+  return xmlPath;
 }
 
 function resolveTaskUser(env: GatewayServiceEnv): string | null {
@@ -688,6 +776,8 @@ async function updateExistingScheduledTask(params: {
   taskName: string;
   quotedLaunchPath: string;
   scriptPath: string;
+  taskLaunchPath: string;
+  description?: string;
 }): Promise<boolean> {
   if (!(await isRegisteredScheduledTask(params.env))) {
     return false;
@@ -701,6 +791,23 @@ async function updateExistingScheduledTask(params: {
   ]);
   if (change.code !== 0) {
     return false;
+  }
+  // Re-apply the full XML on top of the `/Change` so tasks installed by older
+  // versions inherit the `<DisallowStartIfOnBatteries>false</...>` and
+  // `<StopIfGoingOnBatteries>false</...>` flags on upgrade (#59299). Best
+  // effort: a non-zero result here leaves the existing settings in place, so
+  // upgraders keep the prior buggy defaults rather than losing the task.
+  const upgradeXmlPath = await writeTaskXmlTempFile(
+    buildScheduledTaskXml({
+      taskDescription: params.description ?? "OpenClaw Gateway",
+      taskUser: resolveTaskUser(params.env),
+      launchPath: params.taskLaunchPath,
+    }),
+  );
+  try {
+    await execSchtasks(["/Create", "/F", "/TN", params.taskName, "/XML", upgradeXmlPath]);
+  } finally {
+    await fs.rm(path.dirname(upgradeXmlPath), { recursive: true, force: true }).catch(() => {});
   }
   await runScheduledTaskOrThrow({
     taskName: params.taskName,
@@ -882,25 +989,31 @@ async function activateScheduledTask(params: {
     return;
   }
 
-  const baseArgs = [
-    "/Create",
-    "/F",
-    "/SC",
-    "ONLOGON",
-    "/RL",
-    "LIMITED",
-    "/TN",
-    taskName,
-    "/TR",
-    quotedLaunchPath,
-  ];
   const taskUser = resolveTaskUser(params.env);
-  const taskUserArgs = taskUser ? ["/RU", taskUser, "/NP", "/IT"] : [];
-  let create = await execSchtasks(
-    taskUserArgs.length > 0 ? [...baseArgs, ...taskUserArgs] : baseArgs,
+  // Use `schtasks /Create /XML` so the task carries explicit
+  // `DisallowStartIfOnBatteries=false` and `StopIfGoingOnBatteries=false`
+  // settings. The CLI flag form (`/Create /SC ONLOGON ...`) cannot set those
+  // flags and inherits the Task Scheduler defaults (both true), which kills
+  // the Gateway when a laptop unplugs from AC power (#59299).
+  const xmlPath = await writeTaskXmlTempFile(
+    buildScheduledTaskXml({
+      taskDescription,
+      taskUser,
+      launchPath: params.taskLaunchPath,
+    }),
   );
-  if (create.code !== 0 && taskUser) {
-    create = await execSchtasks(baseArgs);
+  let create: Awaited<ReturnType<typeof execSchtasks>>;
+  try {
+    const xmlArgs = ["/Create", "/F", "/TN", taskName, "/XML", xmlPath];
+    const xmlArgsWithUser = taskUser ? [...xmlArgs, "/RU", taskUser, "/NP"] : xmlArgs;
+    create = await execSchtasks(xmlArgsWithUser);
+    if (create.code !== 0 && taskUser) {
+      // Retry without the elevated `/RU` form, matching the pre-XML behavior
+      // for accounts whose service password cannot be stored.
+      create = await execSchtasks(xmlArgs);
+    }
+  } finally {
+    await fs.rm(path.dirname(xmlPath), { recursive: true, force: true }).catch(() => {});
   }
   if (create.code !== 0) {
     const detail = create.stderr || create.stdout;


### PR DESCRIPTION
## Summary

On Windows, the Gateway daemon crashes (or rather is killed by Task Scheduler) every single time the laptop switches from AC to battery power. Reporter on Windows 10 22H2 documented a 100% failure rate over OpenClaw versions 2026.2.x–2026.4.1 (#59299). This change updates the Windows Scheduled Task install/update path to set `<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>` and `<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>` so the Gateway task starts and continues running on battery power. Existing tasks installed by older versions inherit the new battery flags on the next gateway install/refresh.

## Root Cause

- `src/daemon/schtasks.ts:activateScheduledTask` used `schtasks /Create` with CLI flags (`/SC ONLOGON /RL LIMITED /TR ...`). The CLI flag surface of `schtasks /Create` cannot set `<DisallowStartIfOnBatteries>` or `<StopIfGoingOnBatteries>` — those are XML-only settings.
- When those flags are not explicitly set, Task Scheduler defaults both to `true` (per the Microsoft Task Scheduler settings schema). Default `true` for both means the task is prevented from starting on battery and is killed mid-run when AC power is lost.
- Execution path: `installScheduledTask` → `activateScheduledTask` → `execSchtasks(["/Create", "/F", "/SC", "ONLOGON", ...])` → resulting task has `StopIfGoingOnBatteries=true` → unplugging AC stops the Gateway.

## Changes

- `src/daemon/schtasks.ts`:
  - Add `buildScheduledTaskXml()` that emits a Task Scheduler XML payload mirroring the prior CLI flags (ONLOGON trigger, LeastPrivilege run level, `InteractiveToken` logon when a `taskUser` is resolved, single-instance policy, no idle restrictions, exec action wired to the existing `gateway.cmd`/`gateway.vbs` launcher) and explicitly sets `<DisallowStartIfOnBatteries>false</...>` and `<StopIfGoingOnBatteries>false</...>`.
  - Add `writeTaskXmlTempFile()` that writes UTF-16 LE with BOM (what `schtasks /XML` expects on all locales) and returns the temp path; the temp dir is cleaned up in a `finally` block.
  - Replace the `schtasks /Create <CLI flags>` call in `activateScheduledTask()` with `schtasks /Create /F /TN <name> /XML <tempfile> [/RU <user> /NP]`. The same `taskUser` retry-without-`/RU` fallback is preserved.
  - Re-apply the XML in `updateExistingScheduledTask()` right after the existing `/Change /TR` call so users upgrading from older versions adopt the battery flags on the next gateway install/refresh, rather than having to fully uninstall and reinstall. The re-apply is best-effort: a non-zero result leaves the existing settings in place instead of removing the task.
- `src/daemon/schtasks.install.test.ts`:
  - Capture `/XML` payload contents at mock time (before the production `finally` block deletes the temp file) via a new `xmlPayloadCaptures` array.
  - Update existing tests that pinned the prior CLI argv shape to the new `/XML` argv shape.
  - Add 2 new regression tests: one that pins `<DisallowStartIfOnBatteries>false</...>` and `<StopIfGoingOnBatteries>false</...>` on fresh `/Create`, and one that pins the upgrade-path XML re-apply.

## Reproduction (before fix)

Source-reproducible on the install path (live Windows AC-to-battery proof requires hardware that is not present in this checkout):

~~~text
# Inspect the generated `schtasks /Create` argv on current main:
src/daemon/schtasks.ts:885-896 (baseArgs)
  ["/Create", "/F", "/SC", "ONLOGON", "/RL", "LIMITED", "/TN", <name>, "/TR", <launcher>]
# No `/XML` and no battery flags -> Task Scheduler defaults
# DisallowStartIfOnBatteries=true, StopIfGoingOnBatteries=true.
# Effect on Windows: task is killed the moment AC is unplugged.
~~~

## Verification (after fix)

~~~text
node scripts/run-vitest.mjs src/daemon/schtasks.install.test.ts
  ...
  ✓ creates the Scheduled Task via XML with battery start/continue enabled (#59299) 12ms
  ✓ re-applies the XML on /Change so upgraded tasks adopt battery flags (#59299) 8ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
~~~

~~~text
node scripts/run-vitest.mjs src/daemon/schtasks.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks-exec.test.ts
 Test Files  4 passed (4)
      Tests  54 passed (54)
~~~

~~~text
pnpm tsgo:core  (EXIT=0)
~~~

## Test

- `node scripts/run-vitest.mjs src/daemon/schtasks.install.test.ts` — 12 passed (incl. 2 new battery-flag regression tests)
- `node scripts/run-vitest.mjs src/daemon/schtasks.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks-exec.test.ts` — 54 passed (sibling daemon coverage)
- `pnpm tsgo:core` — passed

## Notes

- Scope: smallest XML-based repair that can set the two battery flags. CLI-only `/Create` and `/Change` cannot set these settings on any current `schtasks.exe` build, so XML is the only mechanism available without taking a PowerShell dependency.
- Preserved unchanged:
  - Startup-folder fallback when `/Create` is denied or times out (the same `shouldFallbackToStartupEntry` branch still runs on `/Create /XML` failures)
  - Hidden launcher (`.vbs`) selection via `OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER`
  - `quoteSchtasksArg` quoting strategy for the script launch path
  - `/Change` update path: still updates `/TR` first; XML re-apply is best-effort and never removes the task
  - All `runScheduledTaskOrThrow` and fallback launch behavior downstream
- This follows clawsweeper's direction on #59299: *"Land a narrow Windows Scheduled Task settings repair that lets the Gateway task start and continue on battery while preserving the current Startup-folder fallback, hidden launcher, quoting, and update behavior."*
- This is a narrower replacement for #68149 (full PowerShell `Register-ScheduledTask` rewrite) which clawsweeper flagged as not a ready closing fix.

## Real behavior proof

- Behavior addressed: Windows Gateway Scheduled Task no longer dies when the laptop unplugs from AC power; the task is also allowed to start while already on battery.
- Real environment tested: Unit-level proof against the schtasks argv mock that backs the existing install/update test surface. A live macOS Parallels / Windows laptop AC-to-battery proof is not part of this PR — see *What was not tested* below.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/daemon/schtasks.install.test.ts`
  - `node scripts/run-vitest.mjs src/daemon/schtasks.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks-exec.test.ts`
  - `pnpm tsgo:core`
- Evidence after fix: 12/12 install tests and 54/54 sibling tests pass; the new regression test reads the generated XML payload via the mock-capture array and asserts both `<DisallowStartIfOnBatteries>false</...>` and `<StopIfGoingOnBatteries>false</...>` are present, plus that the prior `<LogonTrigger>`, `<RunLevel>LeastPrivilege</RunLevel>`, `<UserId>...</UserId>`, and `<Exec>` semantics are preserved.
- Observed result after fix: `schtasks /Create /XML <tempfile>` argv shape lands the task with battery start/continue allowed; the upgrade `/Change` path additionally re-applies the XML so existing installs adopt the new flags.
- What was not tested: live Windows hardware AC-to-battery unplug. The fix is source-reproducible from the Task Scheduler XML schema documented by Microsoft and the existing test surface, but a live battery test is still useful before announcing the fix.

Closes #59299
