### PR TITLE
fix: strip invalid thinking signatures for all anthropic-messages sessions

### DIFF
--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -727,12 +727,13 @@ export async function sanitizeSessionHistory(params: {
       ...resolveImageSanitizationLimits(params.config),
     },
   );
+  const isAnthropicMessagesTransport = isAnthropicApi(params.modelApi);
   // Some recovery paths supply a narrow policy with preserveSignatures disabled.
   // Native signed-thinking providers still cannot replay missing/blank
   // signatures once the assistant turn is no longer latest in the outbound
   // request.
   const validatedThinkingSignatures =
-    signedThinkingProvider || policy.preserveSignatures
+    signedThinkingProvider || policy.preserveSignatures || isAnthropicMessagesTransport
       ? stripInvalidThinkingSignatures(sanitizedImages, {
           preserveLatestAssistant: params.preserveLatestAssistantThinking ?? true,
         })


### PR DESCRIPTION
## Summary

Fixes issue where thinking blocks with empty/blank signatures are persisted to session transcripts when using the direct `anthropic-messages` transport (i.e., the standard Anthropic API, not Bedrock). On subsequent turns, the empty signature causes the API to reject the request.

## Root Cause

The `stripInvalidThinkingSignatures` function was only called when `providerRequiresSignedThinking()` returned `true` (for `anthropic`, `amazon-bedrock`, `anthropic-vertex`). The standard `anthropic-messages` transport path uses `isAnthropicApi()` to identify the transport type but was not included in the signature-stripping guard. This is the same class of bug that was fixed for Bedrock in #70054.

## Fix

Extend the signature-stripping guard in `replay-history.ts` to also cover sessions using the `anthropic-messages` transport (`modelApi === "anthropic-messages"`). This ensures that any session using the Anthropic Messages API — regardless of provider — has empty/invalid thinking signatures stripped before replay.

## Validation

- `node_modules/.bin/tsc --noEmit` passes (type-check)
- `node_modules/.bin/vitest run src/agents/pi-embedded-runner/thinking.test.ts --reporter=dot` (unit tests for `stripInvalidThinkingSignatures`)
- `node_modules/.bin/vitest run src/agents/pi-embedded-runner.sanitize-session-history.test.ts --reporter=dot` (replay sanitization tests)

Closes #86886