### PR TITLE
fix(agents): wrap hook-injected system context with boundary markers

### DIFF
--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { wrapHookSystemContext } from "./prompt-compaction-hook-helpers.js";
+
+describe("wrapHookSystemContext", () => {
+  test("wraps a non-empty segment with boundary markers", () => {
+    const result = wrapHookSystemContext("## My Custom Rules\n\nFoo bar baz.");
+    expect(result).toBe("---\n## My Custom Rules\n\nFoo bar baz.\n---");
+  });
+
+  test("returns undefined for undefined input", () => {
+    expect(wrapHookSystemContext(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined for an empty string", () => {
+    expect(wrapHookSystemContext("")).toBeUndefined();
+  });
+
+  test("wraps a single-line segment", () => {
+    const result = wrapHookSystemContext("Rule: always format output.");
+    expect(result).toBe("---\nRule: always format output.\n---");
+  });
+
+  test("preserves leading and trailing whitespace within the segment", () => {
+    const segment = "\n\n## Top\n\n\n";
+    const result = wrapHookSystemContext(segment);
+    expect(result).toBe("---\n\n\n## Top\n\n\n\n---");
+  });
+});

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -52,6 +52,18 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
     promptBuildResult,
     legacyResult,
   });
+  const wrappedPrependSystemContext = wrapHookSystemContext(
+    joinPresentTextSegments([
+      promptBuildResult?.prependSystemContext,
+      legacyResult?.prependSystemContext,
+    ]),
+  );
+  const wrappedAppendSystemContext = wrapHookSystemContext(
+    joinPresentTextSegments([
+      promptBuildResult?.appendSystemContext,
+      legacyResult?.appendSystemContext,
+    ]),
+  );
   return {
     prompt:
       joinPresentTextSegments([
@@ -61,13 +73,19 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
       ]) ?? params.prompt,
     developerInstructions:
       joinPresentTextSegments([
-        promptBuildResult?.prependSystemContext,
-        legacyResult?.prependSystemContext,
+        wrappedPrependSystemContext,
         systemPrompt,
-        promptBuildResult?.appendSystemContext,
-        legacyResult?.appendSystemContext,
+        wrappedAppendSystemContext,
       ]) ?? systemPrompt,
   };
+}
+
+export function wrapHookSystemContext(segment: string | undefined): string | undefined {
+  if (!segment) {
+    return undefined;
+  }
+  const marker = "---";
+  return `${marker}\n${segment}\n${marker}`;
 }
 
 function resolvePromptBuildSystemPrompt(params: {


### PR DESCRIPTION
## Summary

Plugin-emitted `appendSystemContext` / `prependSystemContext` from `before_prompt_build` is joined with the main system prompt (containing workspace files) using only a blank-line separator. When the injected block uses the same Markdown heading level as subsections of the preceding workspace file, the model attributes injected rules to that file instead of recognizing them as plugin-originated.

This change wraps each hook system-context segment with a stable `---` boundary marker at the shared harness composition layer so every plugin gets the boundary for free.

Closes #87045.

## Change Type
- [x] Bug fix
- [x] Test

## Scope
- [x] Agents / harness

## Linked Issue
- Closes #87045

## Real behavior proof

**Behavior or issue addressed**: When a plugin returns `appendSystemContext: "## My Custom Rules\n\nFoo bar baz."` and the system prompt ends with a Codex workspace file that uses H2/H3 Markdown, the model attributes the injected rules to the preceding workspace file because there is only blank-line separation between them.

**Real environment tested**: macOS 26.5 arm64, Node v22.22.0, upstream main @ 8fa5ecb8

**Exact steps or command run after this patch**:

1. Run the full prompt-compaction-hook-helpers test suite:
   ```
   node scripts/run-vitest.mjs run src/agents/harness/prompt-compaction-hook-helpers.test.ts
   ```

2. Run existing affected test suites for regression:
   ```
   node scripts/run-vitest.mjs run src/agents/harness/lifecycle-hook-helpers.test.ts src/plugins/hooks.phase-hooks.test.ts src/agents/cli-runner/prepare.test.ts
   ```

3. Drift proof — revert the src patch and confirm new tests fail:
   ```
   git stash push -- src/agents/harness/prompt-compaction-hook-helpers.ts
   node scripts/run-vitest.mjs run src/agents/harness/prompt-compaction-hook-helpers.test.ts
   // 10 tests fail (wrapHookSystemContext not exported)
   git stash pop
   ```

4. Restore and confirm all pass.

5. Format and lint:
   ```
   npx oxfmt --check src/agents/harness/prompt-compaction-hook-helpers.ts src/agents/harness/prompt-compaction-hook-helpers.test.ts
   npx oxlint src/agents/harness/prompt-compaction-hook-helpers.ts src/agents/harness/prompt-compaction-hook-helpers.test.ts
   ```

**Evidence after fix**:

$ node scripts/run-vitest.mjs run src/agents/harness/prompt-compaction-hook-helpers.test.ts

 RUN  v4.1.7

 ✓  agents-core  prompt-compaction-hook-helpers.test.ts (5 tests) 17ms
 ✓  agents-support  prompt-compaction-hook-helpers.test.ts (5 tests) 16ms

 Test Files  2 passed (2)
      Tests  10 passed (10)

// Existing tests: 89/89 pass — no regression
$ node scripts/run-vitest.mjs run src/agents/harness/lifecycle-hook-helpers.test.ts src/plugins/hooks.phase-hooks.test.ts src/agents/cli-runner/prepare.test.ts

 Test Files  5 passed (5)
      Tests  89 passed (89)

// Drift proof: revert src, tests fail
$ git stash push -- src/agents/harness/prompt-compaction-hook-helpers.ts
$ node scripts/run-vitest.mjs run src/agents/harness/prompt-compaction-hook-helpers.test.ts

 ❯  agents-core  prompt-compaction-hook-helpers.test.ts (5 tests | 5 failed)
 ❯  agents-support  prompt-compaction-hook-helpers.test.ts (5 tests | 5 failed)
// All 10 fail — wrapHookSystemContext not exported

// Restore: back to 10/10
$ git stash pop
$ node scripts/run-vitest.mjs run src/agents/harness/prompt-compaction-hook-helpers.test.ts

 Test Files  2 passed (2)
      Tests  10 passed (10)

// Format + lint clean
$ npx oxfmt --check ... && npx oxlint ...
All matched files use the correct format.
Found 0 warnings and 0 errors.

**Observed result after fix**:

With the patch applied, the composed `developerInstructions` wraps plugin-emitted hook context with `---` boundary markers:

Before (current main):
```
prepend hook content

[workspace file H2 section]
...
append hook content
```

After (with this patch):
```
---
prepend hook content
---

[workspace file H2 section]
...

---
append hook content
---
```

The `---` horizontal-rule markers clearly separate plugin-injected context from Workspace file content, so the model no longer misattributes injected rules to the preceding file.

**What was not tested**:

- Live model smoke to verify the attribution fix end-to-end (requires Codex OAuth credentials)
- CLI-specific `prepare.ts` path, which composes system context through a different code path not affected by this change

## Root Cause

`resolvePromptBuildDeveloperInstructions` in `src/agents/harness/prompt-compaction-hook-helpers.ts` joins `prependSystemContext`, `systemPrompt`, and `appendSystemContext` with `\n\n` separators via `joinPresentTextSegments`. The `systemPrompt` may contain Codex workspace files with Markdown H2/H3 sections, but no closing marker separates workspace content from the following hook context. An injected H2 section from `appendSystemContext` becomes visually indistinguishable from a subsection of the preceding workspace file.

Fix: wrap each hook system-context segment with `---` boundary markers before joining, so every plugin automatically gets a clear separation from workspace file content.

## Regression Test Plan

- New `src/agents/harness/prompt-compaction-hook-helpers.test.ts` with 5 focused cases for `wrapHookSystemContext`:
  - Wraps non-empty segment with `---` markers
  - Returns undefined for undefined input
  - Returns undefined for empty string
  - Wraps single-line segments
  - Preserves leading/trailing whitespace within the segment
- Existing tests in `lifecycle-hook-helpers.test.ts`, `hooks.phase-hooks.test.ts`, and `cli-runner/prepare.test.ts` pass unchanged (89/89)
- The CLI runner `prepare.ts` path is unaffected (it composes system context through a different code path)

## User-visible / Behavior Changes

Plugin authors who use `appendSystemContext` or `prependSystemContext` in `before_prompt_build` hooks will now have their emitted content wrapped with `---` boundary markers when injected into the system prompt. This prevents the model from misattributing hook-emitted rules to workspace files that happen to precede the injected context.

## Scope boundary

- Only changes the shared harness composition layer in `src/agents/harness/prompt-compaction-hook-helpers.ts`
- Does not change the `joinPresentTextSegments` helper itself (it remains a generic join utility)
- Does not change the CLI runner path (`cli-runner/prepare.ts`)
- Does not change the hook merge layer (`hooks.phase-hooks.ts`)
