### PR TITLE
fix(gateway): require admin for device role approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram: route `sendMessage` action replies through durable outbound delivery so completed agent responses remain retryable when the gateway send path times out. (#87261) Thanks @mbelinky.
+- Gateway/security: require `operator.admin` for node and other non-operator device-role pairing approvals, including trusted-proxy sessions, while keeping pairing-only approvals available for operator-role requests. (#87146)
 
 ## 2026.5.26
 

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -71,9 +71,10 @@ matching client IPs can be approved before they appear in this list. That policy
 is disabled by default and never applies to operator/browser clients or upgrade
 requests.
 
-Approving a non-operator device role, such as `role: node`, requires
-`operator.admin`. `operator.pairing` is enough for operator-device approvals
-only when the requested operator scopes stay within the caller's own scopes.
+Approving node or other non-operator device roles requires `operator.admin`.
+`operator.pairing` is enough for operator-device approvals only when the
+requested operator scopes stay within the caller's own scopes. See
+[Operator scopes](/gateway/operator-scopes) for the approval-time checks.
 
 ```
 openclaw devices approve

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -70,7 +70,8 @@ When approving a device request:
 
 - A request with no operator role does not need operator token scope approval.
 - A request for a non-operator device role, such as `node`, requires
-  `operator.admin`.
+  `operator.admin`, even when `device.pair.approve` is reachable with
+  `operator.pairing`.
 - A request for `operator.read`, `operator.write`, `operator.approvals`,
   `operator.pairing`, or `operator.talk.secrets` requires the caller to hold
   those scopes, or `operator.admin`.
@@ -79,9 +80,9 @@ When approving a device request:
   token scopes. If that existing token is admin-scoped, approval still requires
   `operator.admin`.
 
-Non-admin sessions can approve operator-device requests only inside their own
-operator scopes. Approving non-operator roles is admin-only even for
-shared-secret or trusted-proxy sessions that can otherwise use
+Non-admin shared-secret and trusted-proxy sessions can approve operator-device
+requests only inside their own declared operator scopes. Approving non-operator
+roles is admin-only even when those sessions can otherwise use
 `operator.pairing`.
 
 For paired-device token sessions, management is also self-scoped unless the

--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -888,7 +888,7 @@ describe("deviceHandlers", () => {
     );
   });
 
-  it("allows non-device operator sessions to approve operator roles within caller scopes", async () => {
+  it("allows shared-auth operator sessions to approve operator roles within caller scopes", async () => {
     getPendingDevicePairingMock.mockResolvedValue({
       requestId: "req-1",
       deviceId: "device-2",
@@ -914,7 +914,7 @@ describe("deviceHandlers", () => {
     const opts = createOptions(
       "device.pair.approve",
       { requestId: "req-1" },
-      { client: createClient(["operator.pairing"]) },
+      { client: createClient(["operator.pairing"], "device-1", { isDeviceTokenAuth: false }) },
     );
 
     await deviceHandlers["device.pair.approve"](opts);
@@ -941,11 +941,11 @@ describe("deviceHandlers", () => {
     );
   });
 
-  it("rejects approving node roles from non-admin shared-auth sessions", async () => {
+  it("rejects approving node roles for the caller device without admin scope", async () => {
     getPendingDevicePairingMock.mockResolvedValue({
       requestId: "req-1",
-      deviceId: "device-2",
-      publicKey: "pk-2",
+      deviceId: " device-1 ",
+      publicKey: "pk-1",
       role: "node",
       roles: ["node"],
       ts: 100,
@@ -953,7 +953,28 @@ describe("deviceHandlers", () => {
     const opts = createOptions(
       "device.pair.approve",
       { requestId: "req-1" },
-      { client: createClient(["operator.pairing"]) },
+      { client: createClient(["operator.pairing"], "device-1", { isDeviceTokenAuth: true }) },
+    );
+
+    await deviceHandlers["device.pair.approve"](opts);
+
+    expect(approveDevicePairingMock).not.toHaveBeenCalled();
+    expectRespondedErrorMessage(opts, "device pairing approval denied");
+  });
+
+  it("rejects approving node roles from non-admin shared-auth sessions", async () => {
+    getPendingDevicePairingMock.mockResolvedValue({
+      requestId: "req-1",
+      deviceId: "device-1",
+      publicKey: "pk-1",
+      role: "node",
+      roles: ["node"],
+      ts: 100,
+    });
+    const opts = createOptions(
+      "device.pair.approve",
+      { requestId: "req-1" },
+      { client: createClient(["operator.pairing"], "device-1", { isDeviceTokenAuth: false }) },
     );
 
     await deviceHandlers["device.pair.approve"](opts);
@@ -990,27 +1011,6 @@ describe("deviceHandlers", () => {
       "device.pair.approve",
       { requestId: "missing" },
       { client: createClient(["operator.pairing"]) },
-    );
-
-    await deviceHandlers["device.pair.approve"](opts);
-
-    expect(approveDevicePairingMock).not.toHaveBeenCalled();
-    expectRespondedErrorMessage(opts, "device pairing approval denied");
-  });
-
-  it("rejects approving node roles for the caller device without admin scope", async () => {
-    getPendingDevicePairingMock.mockResolvedValue({
-      requestId: "req-1",
-      deviceId: " device-1 ",
-      publicKey: "pk-1",
-      role: "node",
-      roles: ["node"],
-      ts: 100,
-    });
-    const opts = createOptions(
-      "device.pair.approve",
-      { requestId: "req-1" },
-      { client: createClient(["operator.pairing"], "device-1", { isDeviceTokenAuth: true }) },
     );
 
     await deviceHandlers["device.pair.approve"](opts);


### PR DESCRIPTION
## Summary

Require non-admin `device.pair.approve` callers to pass the non-operator device-role gate regardless of whether the session was authenticated with a device token or shared auth.

## Changes

- Load the pending pairing request for every non-admin approval attempt.
- Keep the existing cross-device ownership check limited to sessions with a device-token-derived caller device id.
- Add regressions for shared-auth/trusted-proxy-shaped sessions: operator-role approvals still succeed, and node-role approvals are denied before `approveDevicePairing` runs.
- Document that approving node or other non-operator device roles requires `operator.admin`.

## Validation

### Real behavior proof

Behavior addressed: Non-admin pairing-only trusted-proxy/shared-auth callers can no longer approve non-operator device roles through `device.pair.approve`; trusted-proxy callers with `operator.admin` still can.

Real environment tested: Local source checkout on branch `688` at `8b131d444975fd2a01e40894aee49e7ce33df680`, Node `v22.22.2`, pnpm `11.2.2`. The proof started a local Gateway configured with `gateway.auth.mode: "trusted-proxy"`, `gateway.trustedProxies: ["127.0.0.1"]`, `allowLoopback: true`, and WebSocket headers `x-forwarded-user` plus `x-forwarded-proto`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/gateway/trusted-proxy-proof.tmp.test.ts --reporter=verbose`. The temporary proof test opened real Gateway WebSocket sessions with trusted-proxy headers, signed paired device identities, omitted `auth.deviceToken`, submitted `device.pair.approve`, printed the RPC responses below, and was removed after the run so it is not part of the PR diff.

Evidence after fix:

```text
stdout | ../../src/gateway/trusted-proxy-proof.tmp.test.ts > temporary trusted-proxy behavior proof > prints real Gateway WS approval responses
[proof] pairing-only trusted-proxy approve ok=false error=device pairing approval denied paired=no

stdout | ../../src/gateway/trusted-proxy-proof.tmp.test.ts > temporary trusted-proxy behavior proof > prints real Gateway WS approval responses
[proof] admin trusted-proxy approve ok=true payloadRole=node pairedRole=node

Test Files  3 passed (3)
Tests  3 passed (3)
Duration  16.55s
```

Observed result after fix: The pairing-only trusted-proxy session reached the real WS `device.pair.approve` path and was denied with `device pairing approval denied`; the pending node device stayed unpaired. The admin trusted-proxy session reached the same path and approved the node device with `role=node`.

What was not tested: I did not run a packaged install, cross-OS lane, or external production reverse proxy. The proof uses the repository Gateway test harness with a local loopback trusted-proxy configuration and real WebSocket/RPC traffic.

Proof limitations or environment constraints: The proof output is copied terminal output, not a screenshot or video. It redacts private paths and uses synthetic device identities, local ports, and test headers.

### Focused regression proof

`node scripts/run-vitest.mjs run src/gateway/server.device-pair-approve-authz.test.ts --reporter=verbose -t "trusted-proxy"` passed and showed both committed trusted-proxy WS regressions:

```text
✓ ... rejects trusted-proxy non-admin approval for node device roles
✓ ... allows trusted-proxy admin approval for node device roles
Test Files  1 passed (1)
Tests  2 passed | 3 skipped (5)
```

Additional validation already run for this branch:

- `node scripts/run-vitest.mjs src/gateway/server-methods/devices.test.ts src/gateway/server.device-pair-approve-authz.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 docs/cli/devices.md docs/gateway/operator-scopes.md src/gateway/device-authz.test-helpers.ts src/gateway/server-methods/devices.ts src/gateway/server-methods/devices.test.ts src/gateway/server.device-pair-approve-authz.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/device-authz.test-helpers.ts src/gateway/server-methods/devices.ts src/gateway/server-methods/devices.test.ts src/gateway/server.device-pair-approve-authz.test.ts`
- `corepack pnpm docs:list`
- `git diff --check`

## Notes

- AI-assisted by Codex.
- `CHANGELOG.md` was not updated.
- `USER.md` is a local worklog only and is intentionally not part of this PR.
