### PR TITLE
fix(qqbot): validate direct media upload urls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,10 +599,6 @@ jobs:
               node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts
           fi
 
-          if [ "$RUN_GATEWAY_WATCH" = "true" ]; then
-            start_check "gateway-watch" node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000
-          fi
-
           for index in "${!pids[@]}"; do
             name="${names[$index]}"
             log="${logs[$index]}"
@@ -619,6 +615,20 @@ jobs:
             echo "::endgroup::"
             results["$name"]="$result"
           done
+
+          if [ "$RUN_GATEWAY_WATCH" = "true" ]; then
+            gateway_watch_log="${RUNNER_TEMP}/gateway-watch.log"
+            echo "starting gateway-watch: node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000"
+            if node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000 >"$gateway_watch_log" 2>&1; then
+              result="success"
+            else
+              result="failure"
+            fi
+            echo "::group::gateway-watch log"
+            cat "$gateway_watch_log"
+            echo "::endgroup::"
+            results["gateway-watch"]="$result"
+          fi
 
           for name in channels core-support-boundary gateway-watch; do
             echo "${name}-result=${results[$name]}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,20 @@ jobs:
             pids+=("$!")
           }
 
+          if [ "$RUN_GATEWAY_WATCH" = "true" ]; then
+            gateway_watch_log="${RUNNER_TEMP}/gateway-watch.log"
+            echo "starting gateway-watch: node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000"
+            if node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000 >"$gateway_watch_log" 2>&1; then
+              result="success"
+            else
+              result="failure"
+            fi
+            echo "::group::gateway-watch log"
+            cat "$gateway_watch_log"
+            echo "::endgroup::"
+            results["gateway-watch"]="$result"
+          fi
+
           if [ "$RUN_CHANNELS" = "true" ]; then
             start_check "channels" env \
               NODE_OPTIONS=--max-old-space-size=8192 \
@@ -615,20 +629,6 @@ jobs:
             echo "::endgroup::"
             results["$name"]="$result"
           done
-
-          if [ "$RUN_GATEWAY_WATCH" = "true" ]; then
-            gateway_watch_log="${RUNNER_TEMP}/gateway-watch.log"
-            echo "starting gateway-watch: node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000"
-            if node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000 >"$gateway_watch_log" 2>&1; then
-              result="success"
-            else
-              result="failure"
-            fi
-            echo "::group::gateway-watch log"
-            cat "$gateway_watch_log"
-            echo "::endgroup::"
-            results["gateway-watch"]="$result"
-          fi
 
           for name in channels core-support-boundary gateway-watch; do
             echo "${name}-result=${results[$name]}" >> "$GITHUB_OUTPUT"

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -108,7 +108,7 @@ vi.mock("./reply-delivery.js", () => ({
 }));
 
 type DispatchInboundParams = {
-  ctx?: unknown;
+  ctx?: Record<string, unknown>;
   dispatcher: {
     sendBlockReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
     sendFinalReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
@@ -240,7 +240,7 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
       onSettled?: () => unknown;
       onFreshSettledDelivery?: () => unknown;
     };
-    ctx?: unknown;
+    ctx?: Record<string, unknown>;
     replyOptions?: DispatchInboundParams["replyOptions"];
   }) => {
     const pendingDeliveries: Promise<void>[] = [];

--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -250,17 +250,10 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
       ]),
     );
 
-    // Cache populated with the complete result.
-    const expectedMd5 = crypto.createHash("md5").update(FIXTURE_BUFFER).digest("hex");
-    expect(cache.setSpy).toHaveBeenCalledWith(
-      expectedMd5,
-      "group",
-      "g1",
-      MediaFileType.FILE,
-      "final-file-info",
-      "uuid-final",
-      3600,
-    );
+    // FILE uploads carry filename metadata in upload_prepare, so the content-only
+    // cache is bypassed to avoid reusing file_info with a stale name.
+    expect(cache.getSpy).not.toHaveBeenCalled();
+    expect(cache.setSpy).not.toHaveBeenCalled();
 
     // Progress callback hit 3 times with monotonically-increasing counts.
     expect(onProgress).toHaveBeenCalledTimes(3);

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -202,7 +202,8 @@ export class ChunkedMediaApi {
 
       // 3. Upload-cache fast path: the md5 hash is already a strong content
       // identifier, so we can short-circuit before even calling upload_prepare.
-      if (this.cache) {
+      const canUseUploadCache = opts.fileType !== MediaFileType.FILE;
+      if (this.cache && canUseUploadCache) {
         const cached = this.cache.get(hashes.md5, opts.scope, opts.targetId, opts.fileType);
         if (cached) {
           this.logger?.info?.(
@@ -293,7 +294,7 @@ export class ChunkedMediaApi {
       this.logger?.info?.(`${prefix} completed: file_uuid=${result.file_uuid} ttl=${result.ttl}s`);
 
       // 7. Populate the shared upload cache so subsequent sends skip re-uploading.
-      if (this.cache && result.file_info && result.ttl > 0) {
+      if (this.cache && canUseUploadCache && result.file_info && result.ttl > 0) {
         this.cache.set(
           hashes.md5,
           opts.scope,

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -1,10 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaFileType, type UploadMediaResponse } from "../types.js";
+import { MAX_UPLOAD_SIZE } from "../utils/file-utils.js";
 import { ApiClient } from "./api-client.js";
 import { MediaApi } from "./media.js";
 import { TokenManager } from "./token.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const readResponseWithLimitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/response-limit-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/response-limit-runtime")>();
+  return {
+    ...actual,
+    readResponseWithLimit: readResponseWithLimitMock,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
@@ -52,6 +63,8 @@ function mockTokenManager(): TokenManager {
 describe("MediaApi.uploadMedia direct URL uploads", () => {
   beforeEach(() => {
     fetchWithSsrFGuardMock.mockReset();
+    readResponseWithLimitMock.mockReset();
+    readResponseWithLimitMock.mockResolvedValue(MEDIA_BYTES);
     mockGuardedResponse();
   });
 
@@ -78,7 +91,13 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
         url,
         maxRedirects: 0,
+        timeoutMs: 30_000,
       });
+      expect(readResponseWithLimitMock).toHaveBeenCalledWith(
+        expect.any(Response),
+        MAX_UPLOAD_SIZE,
+        { chunkTimeoutMs: 10_000 },
+      );
       expect(tokenManager.getAccessToken).toHaveBeenCalledWith("app-id", "client-secret");
       expect(client.request).toHaveBeenCalledWith(
         "token-1",
@@ -264,6 +283,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
       url: "http://93.184.216.34/assets/photo.png",
       maxRedirects: 0,
+      timeoutMs: 30_000,
     });
   });
 
@@ -283,6 +303,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
       url: "https://cdn.example.com/assets/photo.png",
       maxRedirects: 0,
+      timeoutMs: 30_000,
     });
     expect(client.request).toHaveBeenCalledWith(
       "token-1",

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -143,6 +143,41 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects URL bodies that keep trickling under the idle timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchWithSsrFGuardMock.mockReset();
+      const { release } = mockGuardedResponse();
+      readResponseWithLimitMock.mockReset();
+      readResponseWithLimitMock.mockImplementationOnce(() => new Promise<Buffer>(() => {}));
+      const client = mockApiClient();
+      const tokenManager = mockTokenManager();
+      const api = new MediaApi(client, tokenManager);
+
+      const uploadPromise = api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://cdn.example.com/assets/slow.bin" },
+      );
+
+      for (let i = 0; i < 5 && readResponseWithLimitMock.mock.calls.length === 0; i += 1) {
+        await Promise.resolve();
+      }
+      expect(readResponseWithLimitMock).toHaveBeenCalledOnce();
+
+      const rejection = expect(uploadPromise).rejects.toThrow(
+        "Direct-upload media URL body timed out",
+      );
+      await vi.advanceTimersByTimeAsync(8 * 60_000);
+      await rejection;
+      expect(release).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("dedupes downloaded URL media through the base64 upload cache", async () => {
     const cache = {
       computeHash: vi.fn(() => "hash-1"),

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -47,9 +47,13 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     });
   });
 
-  it.each([MediaFileType.IMAGE, MediaFileType.VIDEO, MediaFileType.FILE])(
-    "preserves public HTTPS %s URL uploads with the generic SSRF guard",
-    async (fileType) => {
+  it.each([
+    { fileType: MediaFileType.IMAGE, url: "https://cdn.example.com/assets/photo.png" },
+    { fileType: MediaFileType.VIDEO, url: "http://cdn.example.com/assets/video.mp4" },
+    { fileType: MediaFileType.FILE, url: "http://cdn.example.com/assets/report.pdf" },
+  ])(
+    "preserves public HTTP(S) $fileType URL uploads with the generic SSRF guard",
+    async ({ fileType, url }) => {
       const client = mockApiClient();
       const tokenManager = mockTokenManager();
       const api = new MediaApi(client, tokenManager);
@@ -59,7 +63,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         "user-openid",
         fileType,
         { appId: "app-id", clientSecret: "client-secret" },
-        { url: "https://cdn.example.com/assets/photo.png" },
+        { url },
       );
 
       expect(result).toBe(UPLOAD_RESPONSE);
@@ -72,7 +76,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         {
           file_type: fileType,
           srv_send_msg: false,
-          url: "https://cdn.example.com/assets/photo.png",
+          url,
         },
         {
           redactBodyKeys: ["file_data"],
@@ -102,7 +106,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("rejects non-HTTPS direct-upload URLs before calling the QQ API", async () => {
+  it("rejects non-HTTP direct-upload URLs before calling the QQ API", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -113,9 +117,9 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         "user-openid",
         MediaFileType.IMAGE,
         { appId: "app-id", clientSecret: "client-secret" },
-        { url: "http://media.qq.com/assets/photo.png" },
+        { url: "ftp://media.qq.com/assets/photo.png" },
       ),
-    ).rejects.toThrow("Direct-upload media URL must use HTTPS");
+    ).rejects.toThrow("Direct-upload media URL must use HTTP or HTTPS");
 
     expect(resolvePinnedHostnameWithPolicyMock).not.toHaveBeenCalled();
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
@@ -159,7 +163,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       "user-openid",
       MediaFileType.IMAGE,
       { appId: "app-id", clientSecret: "client-secret" },
-      { url: "https://93.184.216.34/assets/photo.png" },
+      { url: "http://93.184.216.34/assets/photo.png" },
     );
 
     expect(result).toBe(UPLOAD_RESPONSE);
@@ -170,7 +174,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       {
         file_type: MediaFileType.IMAGE,
         srv_send_msg: false,
-        url: "https://93.184.216.34/assets/photo.png",
+        url: "http://93.184.216.34/assets/photo.png",
       },
       {
         redactBodyKeys: ["file_data"],

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -4,26 +4,34 @@ import { ApiClient } from "./api-client.js";
 import { MediaApi } from "./media.js";
 import { TokenManager } from "./token.js";
 
-const resolvePinnedHostnameWithPolicyMock = vi.hoisted(() => vi.fn());
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
-
-async function useRealSsrfResolverOnce(): Promise<void> {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
-    "openclaw/plugin-sdk/ssrf-runtime",
-  );
-  resolvePinnedHostnameWithPolicyMock.mockImplementationOnce(
-    actual.resolvePinnedHostnameWithPolicy,
-  );
-}
 
 const UPLOAD_RESPONSE: UploadMediaResponse = {
   file_uuid: "uuid-1",
   file_info: "file-info-1",
   ttl: 3600,
 };
+
+const MEDIA_BYTES = Buffer.from("downloaded-media");
+const MEDIA_BASE64 = MEDIA_BYTES.toString("base64");
+
+function mockGuardedResponse(
+  body: BodyInit = MEDIA_BYTES,
+  init?: ResponseInit,
+): {
+  release: ReturnType<typeof vi.fn>;
+} {
+  const release = vi.fn(async () => {});
+  fetchWithSsrFGuardMock.mockResolvedValueOnce({
+    response: new Response(body, init),
+    release,
+  });
+  return { release };
+}
 
 function mockApiClient(): ApiClient {
   const client = new ApiClient();
@@ -39,12 +47,8 @@ function mockTokenManager(): TokenManager {
 
 describe("MediaApi.uploadMedia direct URL uploads", () => {
   beforeEach(() => {
-    resolvePinnedHostnameWithPolicyMock.mockReset();
-    resolvePinnedHostnameWithPolicyMock.mockResolvedValue({
-      hostname: "cdn.example.com",
-      addresses: ["203.0.113.10"],
-      lookup: vi.fn(),
-    });
+    fetchWithSsrFGuardMock.mockReset();
+    mockGuardedResponse();
   });
 
   it.each([
@@ -52,7 +56,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     { fileType: MediaFileType.VIDEO, url: "http://cdn.example.com/assets/video.mp4" },
     { fileType: MediaFileType.FILE, url: "http://cdn.example.com/assets/report.pdf" },
   ])(
-    "preserves public HTTP(S) $fileType URL uploads with the generic SSRF guard",
+    "downloads public HTTP(S) $fileType URLs through the pinned SSRF guard",
     async ({ fileType, url }) => {
       const client = mockApiClient();
       const tokenManager = mockTokenManager();
@@ -67,8 +71,9 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       );
 
       expect(result).toBe(UPLOAD_RESPONSE);
-      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("cdn.example.com", {
-        policy: {},
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+        url,
+        policy: { allowRfc2544BenchmarkRange: true },
       });
       expect(tokenManager.getAccessToken).toHaveBeenCalledWith("app-id", "client-secret");
       expect(client.request).toHaveBeenCalledWith(
@@ -78,7 +83,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         {
           file_type: fileType,
           srv_send_msg: false,
-          url,
+          file_data: MEDIA_BASE64,
         },
         {
           redactBodyKeys: ["file_data"],
@@ -88,7 +93,50 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     },
   );
 
-  it("rejects invalid direct-upload URLs before calling the QQ API", async () => {
+  it("releases the pinned SSRF dispatcher after downloading media", async () => {
+    fetchWithSsrFGuardMock.mockReset();
+    const { release } = mockGuardedResponse();
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    await api.uploadMedia(
+      "c2c",
+      "user-openid",
+      MediaFileType.IMAGE,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url: "https://cdn.example.com/assets/photo.png" },
+    );
+
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes downloaded URL media through the base64 upload cache", async () => {
+    const cache = {
+      computeHash: vi.fn(() => "hash-1"),
+      get: vi.fn(() => "cached-file-info"),
+      set: vi.fn(),
+    };
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager, { uploadCache: cache });
+
+    const result = await api.uploadMedia(
+      "c2c",
+      "user-openid",
+      MediaFileType.IMAGE,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url: "https://cdn.example.com/assets/photo.png" },
+    );
+
+    expect(result).toEqual({ file_uuid: "", file_info: "cached-file-info", ttl: 0 });
+    expect(cache.computeHash).toHaveBeenCalledWith(MEDIA_BASE64);
+    expect(cache.get).toHaveBeenCalledWith("hash-1", "c2c", "user-openid", MediaFileType.IMAGE);
+    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid direct-upload URLs before downloading media or calling the QQ API", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -103,12 +151,12 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       ),
     ).rejects.toThrow("Direct-upload media URL must be a valid URL");
 
-    expect(resolvePinnedHostnameWithPolicyMock).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("rejects non-HTTP direct-upload URLs before calling the QQ API", async () => {
+  it("rejects non-HTTP direct-upload URLs before downloading media or calling the QQ API", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -123,15 +171,16 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       ),
     ).rejects.toThrow("Direct-upload media URL must use HTTP or HTTPS");
 
-    expect(resolvePinnedHostnameWithPolicyMock).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
   });
 
   it.each(["127.0.0.1", "169.254.169.254", "10.0.0.1", "192.168.1.1"])(
-    "does not forward direct-upload URLs rejected by the SSRF guard: %s",
+    "does not upload direct URLs rejected by the SSRF guard: %s",
     async (host) => {
-      resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
+      fetchWithSsrFGuardMock.mockReset();
+      fetchWithSsrFGuardMock.mockRejectedValueOnce(
         new Error("Blocked hostname or private/internal/special-use IP address"),
       );
       const client = mockApiClient();
@@ -148,67 +197,18 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         ),
       ).rejects.toThrow("Blocked hostname");
 
-      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith(host, {
-        policy: {},
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+        url: `https://${host}/latest/meta-data/`,
+        policy: { allowRfc2544BenchmarkRange: true },
       });
       expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
       expect(client.request).not.toHaveBeenCalled();
     },
   );
 
-  it("allows public direct-upload addresses under the real SSRF resolver", async () => {
-    await useRealSsrfResolverOnce();
-    const client = mockApiClient();
-    const tokenManager = mockTokenManager();
-    const api = new MediaApi(client, tokenManager);
-
-    const result = await api.uploadMedia(
-      "c2c",
-      "user-openid",
-      MediaFileType.IMAGE,
-      { appId: "app-id", clientSecret: "client-secret" },
-      { url: "http://93.184.216.34/assets/photo.png" },
-    );
-
-    expect(result).toBe(UPLOAD_RESPONSE);
-    expect(client.request).toHaveBeenCalledWith(
-      "token-1",
-      "POST",
-      expect.any(String),
-      {
-        file_type: MediaFileType.IMAGE,
-        srv_send_msg: false,
-        url: "http://93.184.216.34/assets/photo.png",
-      },
-      {
-        redactBodyKeys: ["file_data"],
-        uploadRequest: true,
-      },
-    );
-  });
-
-  it("blocks private direct-upload addresses under the real SSRF resolver", async () => {
-    await useRealSsrfResolverOnce();
-    const client = mockApiClient();
-    const tokenManager = mockTokenManager();
-    const api = new MediaApi(client, tokenManager);
-
-    await expect(
-      api.uploadMedia(
-        "group",
-        "group-openid",
-        MediaFileType.IMAGE,
-        { appId: "app-id", clientSecret: "client-secret" },
-        { url: "https://127.0.0.1/latest/meta-data/" },
-      ),
-    ).rejects.toThrow("Blocked hostname");
-
-    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
-    expect(client.request).not.toHaveBeenCalled();
-  });
-
-  it("does not forward direct-upload hostnames rejected by the SSRF guard", async () => {
-    resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
+  it("does not forward URLs when the guarded download fails", async () => {
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock.mockRejectedValueOnce(
       new Error("Blocked: resolves to private/internal/special-use IP address"),
     );
     const client = mockApiClient();
@@ -225,15 +225,15 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       ),
     ).rejects.toThrow("resolves to private");
 
-    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("attacker.example", {
-      policy: {},
-    });
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("rejects literal RFC 2544 special-use URL hosts under the real SSRF resolver", async () => {
-    await useRealSsrfResolverOnce();
+  it("rejects literal RFC 2544 special-use URL hosts through the guarded download", async () => {
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock.mockRejectedValueOnce(
+      new Error("Blocked hostname or private/internal/special-use IP address"),
+    );
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -252,30 +252,44 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("rejects bracketed IPv4-mapped literal RFC 2544 URL hosts under the real SSRF resolver", async () => {
-    await useRealSsrfResolverOnce();
+  it("allows fake-IP DNS only for the guarded local download, not the QQ upload body", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
 
-    await expect(
-      api.uploadMedia(
-        "c2c",
-        "user-openid",
-        MediaFileType.IMAGE,
-        { appId: "app-id", clientSecret: "client-secret" },
-        { url: "https://[::ffff:198.18.0.42]/assets/photo.png" },
-      ),
-    ).rejects.toThrow("Blocked hostname");
+    await api.uploadMedia(
+      "c2c",
+      "user-openid",
+      MediaFileType.IMAGE,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url: "https://cdn.example.com/assets/photo.png" },
+    );
 
-    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
-    expect(client.request).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+      url: "https://cdn.example.com/assets/photo.png",
+      policy: { allowRfc2544BenchmarkRange: true },
+    });
+    expect(client.request).toHaveBeenCalledWith(
+      "token-1",
+      "POST",
+      expect.any(String),
+      expect.objectContaining({
+        file_data: MEDIA_BASE64,
+      }),
+      expect.any(Object),
+    );
+    expect(client.request).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ url: expect.any(String) }),
+      expect.any(Object),
+    );
   });
 
-  it("rejects hostname DNS answers in the RFC 2544 fake-IP range", async () => {
-    resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
-      new Error("Blocked hostname or private/internal/special-use IP address"),
-    );
+  it("rejects HTTP errors from guarded direct-upload downloads before calling the QQ API", async () => {
+    fetchWithSsrFGuardMock.mockReset();
+    mockGuardedResponse("not found", { status: 404 });
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -286,13 +300,10 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         "user-openid",
         MediaFileType.IMAGE,
         { appId: "app-id", clientSecret: "client-secret" },
-        { url: "https://cdn.example.com/assets/photo.png" },
+        { url: "https://cdn.example.com/missing.png" },
       ),
-    ).rejects.toThrow("Blocked hostname");
+    ).rejects.toThrow("Direct-upload media URL returned HTTP 404");
 
-    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("cdn.example.com", {
-      policy: {},
-    });
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
   });

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -60,6 +60,19 @@ function mockTokenManager(): TokenManager {
   return tokenManager;
 }
 
+function expectGuardedDownload(url: string): void {
+  expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+    url,
+    maxRedirects: 0,
+    signal: expect.any(AbortSignal),
+  });
+  expect(fetchWithSsrFGuardMock).not.toHaveBeenCalledWith(
+    expect.objectContaining({ timeoutMs: expect.any(Number) }),
+  );
+  const signal = fetchWithSsrFGuardMock.mock.calls.at(-1)?.[0]?.signal;
+  expect(signal).toBeInstanceOf(AbortSignal);
+}
+
 describe("MediaApi.uploadMedia direct URL uploads", () => {
   beforeEach(() => {
     fetchWithSsrFGuardMock.mockReset();
@@ -88,11 +101,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       );
 
       expect(result).toBe(UPLOAD_RESPONSE);
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
-        url,
-        maxRedirects: 0,
-        timeoutMs: 30_000,
-      });
+      expectGuardedDownload(url);
       expect(readResponseWithLimitMock).toHaveBeenCalledWith(
         expect.any(Response),
         MAX_UPLOAD_SIZE,
@@ -316,11 +325,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       { url: "http://93.184.216.34/assets/photo.png" },
     );
 
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
-      url: "http://93.184.216.34/assets/photo.png",
-      maxRedirects: 0,
-      timeoutMs: 30_000,
-    });
+    expectGuardedDownload("http://93.184.216.34/assets/photo.png");
   });
 
   it("does not pass URL or fake-IP DNS policy to the QQ upload body", async () => {
@@ -336,11 +341,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       { url: "https://cdn.example.com/assets/photo.png" },
     );
 
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
-      url: "https://cdn.example.com/assets/photo.png",
-      maxRedirects: 0,
-      timeoutMs: 30_000,
-    });
+    expectGuardedDownload("https://cdn.example.com/assets/photo.png");
     expect(client.request).toHaveBeenCalledWith(
       "token-1",
       "POST",

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MediaFileType, type UploadMediaResponse } from "../types.js";
+import { QQBOT_MEDIA_SSRF_POLICY } from "../utils/file-utils.js";
+import type { ApiClient } from "./api-client.js";
+import { MediaApi } from "./media.js";
+import type { TokenManager } from "./token.js";
+
+const resolvePinnedHostnameWithPolicyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
+}));
+
+const UPLOAD_RESPONSE: UploadMediaResponse = {
+  file_uuid: "uuid-1",
+  file_info: "file-info-1",
+  ttl: 3600,
+};
+
+function mockApiClient(): ApiClient & { request: ReturnType<typeof vi.fn> } {
+  return {
+    request: vi.fn().mockResolvedValue(UPLOAD_RESPONSE),
+  } as unknown as ApiClient & { request: ReturnType<typeof vi.fn> };
+}
+
+function mockTokenManager(): TokenManager & { getAccessToken: ReturnType<typeof vi.fn> } {
+  return {
+    getAccessToken: vi.fn().mockResolvedValue("token-1"),
+  } as unknown as TokenManager & { getAccessToken: ReturnType<typeof vi.fn> };
+}
+
+describe("MediaApi.uploadMedia direct URL uploads", () => {
+  beforeEach(() => {
+    resolvePinnedHostnameWithPolicyMock.mockReset();
+    resolvePinnedHostnameWithPolicyMock.mockResolvedValue({
+      hostname: "media.qq.com",
+      addresses: ["203.0.113.10"],
+      lookup: vi.fn(),
+    });
+  });
+
+  it.each([MediaFileType.IMAGE, MediaFileType.VIDEO, MediaFileType.FILE])(
+    "validates %s URL uploads with the QQBot media SSRF policy",
+    async (fileType) => {
+      const client = mockApiClient();
+      const tokenManager = mockTokenManager();
+      const api = new MediaApi(client, tokenManager);
+
+      const result = await api.uploadMedia(
+        "c2c",
+        "user-openid",
+        fileType,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://media.qq.com/assets/photo.png" },
+      );
+
+      expect(result).toBe(UPLOAD_RESPONSE);
+      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("media.qq.com", {
+        policy: QQBOT_MEDIA_SSRF_POLICY,
+      });
+      expect(tokenManager.getAccessToken).toHaveBeenCalledWith("app-id", "client-secret");
+      expect(client.request).toHaveBeenCalledWith(
+        "token-1",
+        "POST",
+        expect.any(String),
+        {
+          file_type: fileType,
+          srv_send_msg: false,
+          url: "https://media.qq.com/assets/photo.png",
+        },
+        {
+          redactBodyKeys: ["file_data"],
+          uploadRequest: true,
+        },
+      );
+    },
+  );
+
+  it("rejects non-HTTPS direct-upload URLs before calling the QQ API", async () => {
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    await expect(
+      api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "http://media.qq.com/assets/photo.png" },
+      ),
+    ).rejects.toThrow("Direct-upload media URL must use HTTPS");
+
+    expect(resolvePinnedHostnameWithPolicyMock).not.toHaveBeenCalled();
+    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("does not forward direct-upload URLs rejected by the SSRF policy", async () => {
+    resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
+      new Error("Blocked hostname (not in allowlist): 169.254.169.254"),
+    );
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    await expect(
+      api.uploadMedia(
+        "group",
+        "group-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://169.254.169.254/latest/meta-data/" },
+      ),
+    ).rejects.toThrow("Blocked hostname");
+
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("169.254.169.254", {
+      policy: QQBOT_MEDIA_SSRF_POLICY,
+    });
+    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -143,6 +143,36 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("bounds stalled guarded fetch setup before reading URL bodies", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchWithSsrFGuardMock.mockReset();
+      fetchWithSsrFGuardMock.mockImplementationOnce(() => new Promise(() => {}));
+      const client = mockApiClient();
+      const tokenManager = mockTokenManager();
+      const api = new MediaApi(client, tokenManager);
+
+      const uploadPromise = api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://slow-dns.example.com/assets/photo.png" },
+      );
+      const rejection = expect(uploadPromise).rejects.toThrow(
+        "Direct-upload media URL fetch timed out",
+      );
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await rejection;
+      expect(readResponseWithLimitMock).not.toHaveBeenCalled();
+      expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+      expect(client.request).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects URL bodies that keep trickling under the idle timeout", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaFileType, type UploadMediaResponse } from "../types.js";
-import type { ApiClient } from "./api-client.js";
+import { ApiClient } from "./api-client.js";
 import { MediaApi } from "./media.js";
-import type { TokenManager } from "./token.js";
+import { TokenManager } from "./token.js";
 
 const resolvePinnedHostnameWithPolicyMock = vi.hoisted(() => vi.fn());
 
@@ -25,16 +25,16 @@ const UPLOAD_RESPONSE: UploadMediaResponse = {
   ttl: 3600,
 };
 
-function mockApiClient(): ApiClient & { request: ReturnType<typeof vi.fn> } {
-  return {
-    request: vi.fn().mockResolvedValue(UPLOAD_RESPONSE),
-  } as unknown as ApiClient & { request: ReturnType<typeof vi.fn> };
+function mockApiClient(): ApiClient {
+  const client = new ApiClient();
+  vi.spyOn(client, "request").mockResolvedValue(UPLOAD_RESPONSE);
+  return client;
 }
 
-function mockTokenManager(): TokenManager & { getAccessToken: ReturnType<typeof vi.fn> } {
-  return {
-    getAccessToken: vi.fn().mockResolvedValue("token-1"),
-  } as unknown as TokenManager & { getAccessToken: ReturnType<typeof vi.fn> };
+function mockTokenManager(): TokenManager {
+  const tokenManager = new TokenManager();
+  vi.spyOn(tokenManager, "getAccessToken").mockResolvedValue("token-1");
+  return tokenManager;
 }
 
 describe("MediaApi.uploadMedia direct URL uploads", () => {

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -6,9 +6,13 @@ import { TokenManager } from "./token.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
-}));
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  };
+});
 
 const UPLOAD_RESPONSE: UploadMediaResponse = {
   file_uuid: "uuid-1",
@@ -180,9 +184,6 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     "does not upload direct URLs rejected by the SSRF guard: %s",
     async (host) => {
       fetchWithSsrFGuardMock.mockReset();
-      fetchWithSsrFGuardMock.mockRejectedValueOnce(
-        new Error("Blocked hostname or private/internal/special-use IP address"),
-      );
       const client = mockApiClient();
       const tokenManager = mockTokenManager();
       const api = new MediaApi(client, tokenManager);
@@ -197,10 +198,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         ),
       ).rejects.toThrow("Blocked hostname");
 
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
-        url: `https://${host}/latest/meta-data/`,
-        policy: { allowRfc2544BenchmarkRange: true },
-      });
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
       expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
       expect(client.request).not.toHaveBeenCalled();
     },
@@ -231,9 +229,6 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
 
   it("rejects literal RFC 2544 special-use URL hosts through the guarded download", async () => {
     fetchWithSsrFGuardMock.mockReset();
-    fetchWithSsrFGuardMock.mockRejectedValueOnce(
-      new Error("Blocked hostname or private/internal/special-use IP address"),
-    );
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -248,8 +243,28 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       ),
     ).rejects.toThrow("Blocked hostname");
 
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("keeps public literal IP URLs on the default SSRF policy", async () => {
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    await api.uploadMedia(
+      "c2c",
+      "user-openid",
+      MediaFileType.IMAGE,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url: "http://93.184.216.34/assets/photo.png" },
+    );
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+      url: "http://93.184.216.34/assets/photo.png",
+      policy: undefined,
+    });
   });
 
   it("allows fake-IP DNS only for the guarded local download, not the QQ upload body", async () => {

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -78,7 +78,6 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
         url,
         maxRedirects: 0,
-        policy: { allowRfc2544BenchmarkRange: true },
       });
       expect(tokenManager.getAccessToken).toHaveBeenCalledWith("app-id", "client-secret");
       expect(client.request).toHaveBeenCalledWith(
@@ -265,11 +264,10 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
       url: "http://93.184.216.34/assets/photo.png",
       maxRedirects: 0,
-      policy: undefined,
     });
   });
 
-  it("allows fake-IP DNS only for the guarded local download, not the QQ upload body", async () => {
+  it("does not pass URL or fake-IP DNS policy to the QQ upload body", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -285,7 +283,6 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
       url: "https://cdn.example.com/assets/photo.png",
       maxRedirects: 0,
-      policy: { allowRfc2544BenchmarkRange: true },
     });
     expect(client.request).toHaveBeenCalledWith(
       "token-1",

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -159,6 +159,42 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
+  it("does not reuse cached FILE uploads when the requested filename differs", async () => {
+    const cache = {
+      computeHash: vi.fn(() => "hash-1"),
+      get: vi.fn(() => "cached-file-info"),
+      set: vi.fn(),
+    };
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager, {
+      uploadCache: cache,
+      sanitizeFileName: (name) => `safe-${name}`,
+    });
+
+    await api.uploadMedia(
+      "c2c",
+      "user-openid",
+      MediaFileType.FILE,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url: "https://cdn.example.com/report.pdf", fileName: "report.pdf" },
+    );
+
+    expect(cache.computeHash).not.toHaveBeenCalled();
+    expect(cache.get).not.toHaveBeenCalled();
+    expect(cache.set).not.toHaveBeenCalled();
+    expect(client.request).toHaveBeenCalledWith(
+      "token-1",
+      "POST",
+      expect.any(String),
+      expect.objectContaining({
+        file_data: MEDIA_BASE64,
+        file_name: "safe-report.pdf",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("rejects invalid direct-upload URLs before downloading media or calling the QQ API", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaFileType, type UploadMediaResponse } from "../types.js";
-import { QQBOT_MEDIA_SSRF_POLICY } from "../utils/file-utils.js";
 import type { ApiClient } from "./api-client.js";
 import { MediaApi } from "./media.js";
 import type { TokenManager } from "./token.js";
@@ -10,6 +9,15 @@ const resolvePinnedHostnameWithPolicyMock = vi.hoisted(() => vi.fn());
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
 }));
+
+async function useRealSsrfResolverOnce(): Promise<void> {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  );
+  resolvePinnedHostnameWithPolicyMock.mockImplementationOnce(
+    actual.resolvePinnedHostnameWithPolicy,
+  );
+}
 
 const UPLOAD_RESPONSE: UploadMediaResponse = {
   file_uuid: "uuid-1",
@@ -33,14 +41,14 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
   beforeEach(() => {
     resolvePinnedHostnameWithPolicyMock.mockReset();
     resolvePinnedHostnameWithPolicyMock.mockResolvedValue({
-      hostname: "media.qq.com",
+      hostname: "cdn.example.com",
       addresses: ["203.0.113.10"],
       lookup: vi.fn(),
     });
   });
 
   it.each([MediaFileType.IMAGE, MediaFileType.VIDEO, MediaFileType.FILE])(
-    "validates %s URL uploads with the QQBot media SSRF policy",
+    "preserves public HTTPS %s URL uploads with the generic SSRF guard",
     async (fileType) => {
       const client = mockApiClient();
       const tokenManager = mockTokenManager();
@@ -51,13 +59,11 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         "user-openid",
         fileType,
         { appId: "app-id", clientSecret: "client-secret" },
-        { url: "https://media.qq.com/assets/photo.png" },
+        { url: "https://cdn.example.com/assets/photo.png" },
       );
 
       expect(result).toBe(UPLOAD_RESPONSE);
-      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("media.qq.com", {
-        policy: QQBOT_MEDIA_SSRF_POLICY,
-      });
+      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("cdn.example.com");
       expect(tokenManager.getAccessToken).toHaveBeenCalledWith("app-id", "client-secret");
       expect(client.request).toHaveBeenCalledWith(
         "token-1",
@@ -66,7 +72,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         {
           file_type: fileType,
           srv_send_msg: false,
-          url: "https://media.qq.com/assets/photo.png",
+          url: "https://cdn.example.com/assets/photo.png",
         },
         {
           redactBodyKeys: ["file_data"],
@@ -75,6 +81,26 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       );
     },
   );
+
+  it("rejects invalid direct-upload URLs before calling the QQ API", async () => {
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    await expect(
+      api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "not a url" },
+      ),
+    ).rejects.toThrow("Direct-upload media URL must be a valid URL");
+
+    expect(resolvePinnedHostnameWithPolicyMock).not.toHaveBeenCalled();
+    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+  });
 
   it("rejects non-HTTPS direct-upload URLs before calling the QQ API", async () => {
     const client = mockApiClient();
@@ -96,9 +122,86 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("does not forward direct-upload URLs rejected by the SSRF policy", async () => {
+  it.each(["127.0.0.1", "169.254.169.254", "10.0.0.1", "192.168.1.1"])(
+    "does not forward direct-upload URLs rejected by the SSRF guard: %s",
+    async (host) => {
+      resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
+        new Error("Blocked hostname or private/internal/special-use IP address"),
+      );
+      const client = mockApiClient();
+      const tokenManager = mockTokenManager();
+      const api = new MediaApi(client, tokenManager);
+
+      await expect(
+        api.uploadMedia(
+          "group",
+          "group-openid",
+          MediaFileType.IMAGE,
+          { appId: "app-id", clientSecret: "client-secret" },
+          { url: `https://${host}/latest/meta-data/` },
+        ),
+      ).rejects.toThrow("Blocked hostname");
+
+      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith(host);
+      expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+      expect(client.request).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows public direct-upload addresses under the real SSRF resolver", async () => {
+    await useRealSsrfResolverOnce();
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    const result = await api.uploadMedia(
+      "c2c",
+      "user-openid",
+      MediaFileType.IMAGE,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url: "https://93.184.216.34/assets/photo.png" },
+    );
+
+    expect(result).toBe(UPLOAD_RESPONSE);
+    expect(client.request).toHaveBeenCalledWith(
+      "token-1",
+      "POST",
+      expect.any(String),
+      {
+        file_type: MediaFileType.IMAGE,
+        srv_send_msg: false,
+        url: "https://93.184.216.34/assets/photo.png",
+      },
+      {
+        redactBodyKeys: ["file_data"],
+        uploadRequest: true,
+      },
+    );
+  });
+
+  it("blocks private direct-upload addresses under the real SSRF resolver", async () => {
+    await useRealSsrfResolverOnce();
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    await expect(
+      api.uploadMedia(
+        "group",
+        "group-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://127.0.0.1/latest/meta-data/" },
+      ),
+    ).rejects.toThrow("Blocked hostname");
+
+    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("does not forward direct-upload hostnames rejected by the SSRF guard", async () => {
     resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
-      new Error("Blocked hostname (not in allowlist): 169.254.169.254"),
+      new Error("Blocked: resolves to private/internal/special-use IP address"),
     );
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
@@ -110,13 +213,11 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         "group-openid",
         MediaFileType.IMAGE,
         { appId: "app-id", clientSecret: "client-secret" },
-        { url: "https://169.254.169.254/latest/meta-data/" },
+        { url: "https://attacker.example/latest/meta-data/" },
       ),
-    ).rejects.toThrow("Blocked hostname");
+    ).rejects.toThrow("resolves to private");
 
-    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("169.254.169.254", {
-      policy: QQBOT_MEDIA_SSRF_POLICY,
-    });
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("attacker.example");
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
   });

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -148,8 +148,10 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         ),
       ).rejects.toThrow("Blocked hostname");
 
+      // Literal IP hosts must not receive the fake-IP DNS allowance, so the
+      // policy field stays undefined and the default SSRF policy applies.
       expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith(host, {
-        policy: { allowRfc2544BenchmarkRange: true },
+        policy: undefined,
       });
       expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
       expect(client.request).not.toHaveBeenCalled();
@@ -232,25 +234,56 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("allows public direct-upload URLs whose DNS resolves into the fake-IP RFC 2544 range", async () => {
+  it("rejects literal RFC 2544 special-use URL hosts under the real SSRF resolver", async () => {
     await useRealSsrfResolverOnce();
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
 
-    // 198.18.0.0/15 is the RFC 2544 benchmarking range that sing-box / Clash /
-    // Surge fake-IP proxy stacks use as the DNS answer for foreign hostnames.
-    // The direct-upload guard must mirror QQBOT_MEDIA_SSRF_POLICY's allowance
-    // so these public URL uploads keep working in proxy deployments.
+    // The fake-IP DNS allowance must only apply to non-literal hostnames whose
+    // local resolver returns a synthetic 198.18.0.0/15 answer. A literal
+    // 198.18.x.x URL does not benefit from that allowance and must be rejected
+    // at the sink before any token lookup or QQ API call.
+    await expect(
+      api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://198.18.0.42/assets/photo.png" },
+      ),
+    ).rejects.toThrow("Blocked hostname");
+
+    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("allows public hostnames whose DNS resolves into the fake-IP RFC 2544 range", async () => {
+    // Simulate the sing-box / Clash / Surge fake-IP proxy deployment: a public
+    // hostname (`cdn.example.com`) whose local DNS resolver returns a 198.18.x.x
+    // answer. The SSRF helper must receive the RFC 2544 allowance for the
+    // hostname so this DNS answer does not block the upload.
+    resolvePinnedHostnameWithPolicyMock.mockResolvedValueOnce({
+      hostname: "cdn.example.com",
+      addresses: ["198.18.0.42"],
+      lookup: vi.fn(),
+    });
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
     const result = await api.uploadMedia(
       "c2c",
       "user-openid",
       MediaFileType.IMAGE,
       { appId: "app-id", clientSecret: "client-secret" },
-      { url: "https://198.18.0.42/assets/photo.png" },
+      { url: "https://cdn.example.com/assets/photo.png" },
     );
 
     expect(result).toBe(UPLOAD_RESPONSE);
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("cdn.example.com", {
+      policy: { allowRfc2544BenchmarkRange: true },
+    });
     expect(client.request).toHaveBeenCalledWith(
       "token-1",
       "POST",
@@ -258,7 +291,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       {
         file_type: MediaFileType.IMAGE,
         srv_send_msg: false,
-        url: "https://198.18.0.42/assets/photo.png",
+        url: "https://cdn.example.com/assets/photo.png",
       },
       {
         redactBodyKeys: ["file_data"],

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -77,6 +77,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       expect(result).toBe(UPLOAD_RESPONSE);
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
         url,
+        maxRedirects: 0,
         policy: { allowRfc2544BenchmarkRange: true },
       });
       expect(tokenManager.getAccessToken).toHaveBeenCalledWith("app-id", "client-secret");
@@ -263,6 +264,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
 
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
       url: "http://93.184.216.34/assets/photo.png",
+      maxRedirects: 0,
       policy: undefined,
     });
   });
@@ -282,6 +284,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
 
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
       url: "https://cdn.example.com/assets/photo.png",
+      maxRedirects: 0,
       policy: { allowRfc2544BenchmarkRange: true },
     });
     expect(client.request).toHaveBeenCalledWith(

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -258,6 +258,26 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
+  it("rejects bracketed IPv4-mapped literal RFC 2544 URL hosts under the real SSRF resolver", async () => {
+    await useRealSsrfResolverOnce();
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    await expect(
+      api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://[::ffff:198.18.0.42]/assets/photo.png" },
+      ),
+    ).rejects.toThrow("Blocked hostname");
+
+    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
   it("allows public hostnames whose DNS resolves into the fake-IP RFC 2544 range", async () => {
     // Simulate the sing-box / Clash / Surge fake-IP proxy deployment: a public
     // hostname (`cdn.example.com`) whose local DNS resolver returns a 198.18.x.x

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -68,7 +68,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
 
       expect(result).toBe(UPLOAD_RESPONSE);
       expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("cdn.example.com", {
-        policy: { allowRfc2544BenchmarkRange: true },
+        policy: {},
       });
       expect(tokenManager.getAccessToken).toHaveBeenCalledWith("app-id", "client-secret");
       expect(client.request).toHaveBeenCalledWith(
@@ -148,10 +148,8 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         ),
       ).rejects.toThrow("Blocked hostname");
 
-      // Literal IP hosts must not receive the fake-IP DNS allowance, so the
-      // policy field stays undefined and the default SSRF policy applies.
       expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith(host, {
-        policy: undefined,
+        policy: {},
       });
       expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
       expect(client.request).not.toHaveBeenCalled();
@@ -228,7 +226,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     ).rejects.toThrow("resolves to private");
 
     expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("attacker.example", {
-      policy: { allowRfc2544BenchmarkRange: true },
+      policy: {},
     });
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
@@ -240,10 +238,6 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
 
-    // The fake-IP DNS allowance must only apply to non-literal hostnames whose
-    // local resolver returns a synthetic 198.18.0.0/15 answer. A literal
-    // 198.18.x.x URL does not benefit from that allowance and must be rejected
-    // at the sink before any token lookup or QQ API call.
     await expect(
       api.uploadMedia(
         "c2c",
@@ -278,45 +272,28 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("allows public hostnames whose DNS resolves into the fake-IP RFC 2544 range", async () => {
-    // Simulate the sing-box / Clash / Surge fake-IP proxy deployment: a public
-    // hostname (`cdn.example.com`) whose local DNS resolver returns a 198.18.x.x
-    // answer. The SSRF helper must receive the RFC 2544 allowance for the
-    // hostname so this DNS answer does not block the upload.
-    resolvePinnedHostnameWithPolicyMock.mockResolvedValueOnce({
-      hostname: "cdn.example.com",
-      addresses: ["198.18.0.42"],
-      lookup: vi.fn(),
-    });
+  it("rejects hostname DNS answers in the RFC 2544 fake-IP range", async () => {
+    resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
+      new Error("Blocked hostname or private/internal/special-use IP address"),
+    );
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
 
-    const result = await api.uploadMedia(
-      "c2c",
-      "user-openid",
-      MediaFileType.IMAGE,
-      { appId: "app-id", clientSecret: "client-secret" },
-      { url: "https://cdn.example.com/assets/photo.png" },
-    );
+    await expect(
+      api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://cdn.example.com/assets/photo.png" },
+      ),
+    ).rejects.toThrow("Blocked hostname");
 
-    expect(result).toBe(UPLOAD_RESPONSE);
     expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("cdn.example.com", {
-      policy: { allowRfc2544BenchmarkRange: true },
+      policy: {},
     });
-    expect(client.request).toHaveBeenCalledWith(
-      "token-1",
-      "POST",
-      expect.any(String),
-      {
-        file_type: MediaFileType.IMAGE,
-        srv_send_msg: false,
-        url: "https://cdn.example.com/assets/photo.png",
-      },
-      {
-        redactBodyKeys: ["file_data"],
-        uploadRequest: true,
-      },
-    );
+    expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
   });
 });

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -67,7 +67,9 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       );
 
       expect(result).toBe(UPLOAD_RESPONSE);
-      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("cdn.example.com");
+      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("cdn.example.com", {
+        policy: { allowRfc2544BenchmarkRange: true },
+      });
       expect(tokenManager.getAccessToken).toHaveBeenCalledWith("app-id", "client-secret");
       expect(client.request).toHaveBeenCalledWith(
         "token-1",
@@ -146,7 +148,9 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         ),
       ).rejects.toThrow("Blocked hostname");
 
-      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith(host);
+      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith(host, {
+        policy: { allowRfc2544BenchmarkRange: true },
+      });
       expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
       expect(client.request).not.toHaveBeenCalled();
     },
@@ -221,8 +225,45 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       ),
     ).rejects.toThrow("resolves to private");
 
-    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("attacker.example");
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("attacker.example", {
+      policy: { allowRfc2544BenchmarkRange: true },
+    });
     expect(tokenManager.getAccessToken).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("allows public direct-upload URLs whose DNS resolves into the fake-IP RFC 2544 range", async () => {
+    await useRealSsrfResolverOnce();
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    // 198.18.0.0/15 is the RFC 2544 benchmarking range that sing-box / Clash /
+    // Surge fake-IP proxy stacks use as the DNS answer for foreign hostnames.
+    // The direct-upload guard must mirror QQBOT_MEDIA_SSRF_POLICY's allowance
+    // so these public URL uploads keep working in proxy deployments.
+    const result = await api.uploadMedia(
+      "c2c",
+      "user-openid",
+      MediaFileType.IMAGE,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url: "https://198.18.0.42/assets/photo.png" },
+    );
+
+    expect(result).toBe(UPLOAD_RESPONSE);
+    expect(client.request).toHaveBeenCalledWith(
+      "token-1",
+      "POST",
+      expect.any(String),
+      {
+        file_type: MediaFileType.IMAGE,
+        srv_send_msg: false,
+        url: "https://198.18.0.42/assets/photo.png",
+      },
+      {
+        redactBodyKeys: ["file_data"],
+        uploadRequest: true,
+      },
+    );
   });
 });

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -20,7 +20,6 @@ import {
   type MessageResponse,
   type EngineLogger,
 } from "../types.js";
-import { QQBOT_MEDIA_SSRF_POLICY } from "../utils/file-utils.js";
 import { ApiClient } from "./api-client.js";
 import { withRetry, UPLOAD_RETRY_POLICY } from "./retry.js";
 import { mediaUploadPath, messagePath, getNextMsgSeq } from "./routes.js";
@@ -64,9 +63,9 @@ async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
     throw new Error("Direct-upload media URL must use HTTPS");
   }
 
-  await resolvePinnedHostnameWithPolicy(parsed.hostname, {
-    policy: QQBOT_MEDIA_SSRF_POLICY,
-  });
+  // urlDirectUpload is documented as public-URL support. Use the generic
+  // SSRF guard here; the QQ/Tencent host allowlist belongs to fallback downloads.
+  await resolvePinnedHostnameWithPolicy(parsed.hostname);
   return parsed.toString();
 }
 

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -12,8 +12,6 @@
  */
 
 import * as fs from "node:fs";
-import * as net from "node:net";
-import { normalizeHostname } from "openclaw/plugin-sdk/security-runtime";
 import { resolvePinnedHostnameWithPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   MediaFileType,
@@ -65,17 +63,10 @@ async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
     throw new Error("Direct-upload media URL must use HTTP or HTTPS");
   }
 
-  // urlDirectUpload is documented as public-URL support. Use the generic
-  // SSRF guard here; the QQ/Tencent host allowlist belongs to fallback downloads.
-  // Only allow the RFC 2544 fake-IP range for hostnames whose DNS may legitimately
-  // resolve into 198.18.0.0/15 under sing-box/Clash/Surge proxy stacks. Literal
-  // IP URLs do not benefit from fake-IP DNS, so passing the flag for them would
-  // accept special-use/private literals (incl. 198.18.0.0/15) at the sink.
-  const policy =
-    net.isIP(normalizeHostname(parsed.hostname)) !== 0
-      ? undefined
-      : { allowRfc2544BenchmarkRange: true };
-  await resolvePinnedHostnameWithPolicy(parsed.hostname, { policy });
+  // urlDirectUpload forwards the original URL to QQ/Tencent for the fetch, so
+  // this must validate as a public remote-provider URL. Local fake-IP DNS
+  // allowances are only safe for guarded local downloads that use the pinned lookup.
+  await resolvePinnedHostnameWithPolicy(parsed.hostname, { policy: {} });
   return parsed.toString();
 }
 

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -55,6 +55,9 @@ interface MediaApiConfig {
 
 const DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS = 30_000;
 const DIRECT_UPLOAD_READ_IDLE_TIMEOUT_MS = 10_000;
+const DIRECT_UPLOAD_BODY_GRACE_TIMEOUT_MS = 30_000;
+const DIRECT_UPLOAD_MIN_DOWNLOAD_BYTES_PER_SECOND = 256 * 1024;
+const DIRECT_UPLOAD_MAX_BODY_TIMEOUT_MS = 8 * 60_000;
 
 function assertDirectUploadDownloadHostAllowed(hostname: string): void {
   if (isBlockedHostnameOrIp(hostname)) {
@@ -67,9 +70,7 @@ async function fetchDirectUploadDownload(url: string) {
   const timeout = setTimeout(() => {
     controller.abort(new Error("Direct-upload media URL fetch timed out"));
   }, DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS);
-  if (typeof timeout === "object" && "unref" in timeout) {
-    (timeout as { unref: () => void }).unref();
-  }
+  unrefTimer(timeout);
   try {
     return await fetchWithSsrFGuard({
       url,
@@ -78,6 +79,48 @@ async function fetchDirectUploadDownload(url: string) {
     });
   } finally {
     clearTimeout(timeout);
+  }
+}
+
+function unrefTimer(timeout: ReturnType<typeof setTimeout>): void {
+  if (typeof timeout === "object" && "unref" in timeout) {
+    (timeout as { unref: () => void }).unref();
+  }
+}
+
+function resolveDirectUploadBodyTimeoutMs(maxBytes: number): number {
+  const transferTimeoutMs = Math.ceil(
+    (maxBytes / DIRECT_UPLOAD_MIN_DOWNLOAD_BYTES_PER_SECOND) * 1000,
+  );
+  return Math.min(
+    DIRECT_UPLOAD_BODY_GRACE_TIMEOUT_MS + transferTimeoutMs,
+    DIRECT_UPLOAD_MAX_BODY_TIMEOUT_MS,
+  );
+}
+
+async function readDirectUploadResponse(response: Response, maxBytes: number): Promise<Buffer> {
+  const timeoutMs = resolveDirectUploadBodyTimeoutMs(maxBytes);
+  const timeoutError = new Error(`Direct-upload media URL body timed out after ${timeoutMs}ms`);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      void response.body?.cancel(timeoutError).catch(() => undefined);
+      reject(timeoutError);
+    }, timeoutMs);
+    unrefTimer(timeout);
+  });
+
+  try {
+    return await Promise.race([
+      readResponseWithLimit(response, maxBytes, {
+        chunkTimeoutMs: DIRECT_UPLOAD_READ_IDLE_TIMEOUT_MS,
+      }),
+      timeoutPromise,
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
   }
 }
 
@@ -102,9 +145,7 @@ export async function downloadDirectUploadUrl(
     if (!response.ok) {
       throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
     }
-    return await readResponseWithLimit(response, opts.maxBytes ?? MAX_UPLOAD_SIZE, {
-      chunkTimeoutMs: DIRECT_UPLOAD_READ_IDLE_TIMEOUT_MS,
-    });
+    return await readDirectUploadResponse(response, opts.maxBytes ?? MAX_UPLOAD_SIZE);
   } finally {
     await release?.();
   }

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -65,7 +65,12 @@ async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
 
   // urlDirectUpload is documented as public-URL support. Use the generic
   // SSRF guard here; the QQ/Tencent host allowlist belongs to fallback downloads.
-  await resolvePinnedHostnameWithPolicy(parsed.hostname);
+  // Mirror QQBOT_MEDIA_SSRF_POLICY's fake-IP allowance so sing-box/Clash/Surge
+  // proxy stacks that resolve public hostnames into 198.18.0.0/15 still upload.
+  // Literal private/loopback/link-local targets remain blocked.
+  await resolvePinnedHostnameWithPolicy(parsed.hostname, {
+    policy: { allowRfc2544BenchmarkRange: true },
+  });
   return parsed.toString();
 }
 

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -12,14 +12,8 @@
  */
 
 import * as fs from "node:fs";
-import * as net from "node:net";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { normalizeHostname } from "openclaw/plugin-sdk/security-runtime";
-import {
-  fetchWithSsrFGuard,
-  isBlockedHostnameOrIp,
-  type SsrFPolicy,
-} from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   MediaFileType,
   type ChatScope,
@@ -27,7 +21,7 @@ import {
   type MessageResponse,
   type EngineLogger,
 } from "../types.js";
-import { getMaxUploadSize } from "../utils/file-utils.js";
+import { MAX_UPLOAD_SIZE } from "../utils/file-utils.js";
 import { ApiClient } from "./api-client.js";
 import { withRetry, UPLOAD_RETRY_POLICY } from "./retry.js";
 import { mediaUploadPath, messagePath, getNextMsgSeq } from "./routes.js";
@@ -59,19 +53,13 @@ interface MediaApiConfig {
   sanitizeFileName?: SanitizeFileNameFn;
 }
 
-function directUploadDownloadPolicy(hostname: string): SsrFPolicy | undefined {
+function assertDirectUploadDownloadHostAllowed(hostname: string): void {
   if (isBlockedHostnameOrIp(hostname)) {
     throw new Error("Blocked hostname or private/internal/special-use IP address");
   }
-
-  // The local guarded download can support fake-IP DNS, but literal IP URLs
-  // must stay on the default SSRF policy so RFC 2544 literals remain blocked.
-  return net.isIP(normalizeHostname(hostname)) === 0
-    ? { allowRfc2544BenchmarkRange: true }
-    : undefined;
 }
 
-async function downloadDirectUploadUrl(url: string, fileType: MediaFileType): Promise<Buffer> {
+async function downloadDirectUploadUrl(url: string): Promise<Buffer> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -83,16 +71,16 @@ async function downloadDirectUploadUrl(url: string, fileType: MediaFileType): Pr
     throw new Error("Direct-upload media URL must use HTTP or HTTPS");
   }
 
+  assertDirectUploadDownloadHostAllowed(parsed.hostname);
   const { response, release } = await fetchWithSsrFGuard({
     url: parsed.toString(),
     maxRedirects: 0,
-    policy: directUploadDownloadPolicy(parsed.hostname),
   });
   try {
     if (!response.ok) {
       throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
     }
-    return await readResponseWithLimit(response, getMaxUploadSize(fileType));
+    return await readResponseWithLimit(response, MAX_UPLOAD_SIZE);
   } finally {
     await release?.();
   }
@@ -178,7 +166,7 @@ export class MediaApi {
       const buf = await fs.promises.readFile(opts.localPath);
       fileData = buf.toString("base64");
     } else if (opts.url !== undefined) {
-      const buf = await downloadDirectUploadUrl(opts.url, fileType);
+      const buf = await downloadDirectUploadUrl(opts.url);
       fileData = buf.toString("base64");
     }
 

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -12,7 +12,8 @@
  */
 
 import * as fs from "node:fs";
-import { resolvePinnedHostnameWithPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   MediaFileType,
   type ChatScope,
@@ -20,6 +21,7 @@ import {
   type MessageResponse,
   type EngineLogger,
 } from "../types.js";
+import { getMaxUploadSize } from "../utils/file-utils.js";
 import { ApiClient } from "./api-client.js";
 import { withRetry, UPLOAD_RETRY_POLICY } from "./retry.js";
 import { mediaUploadPath, messagePath, getNextMsgSeq } from "./routes.js";
@@ -51,7 +53,7 @@ interface MediaApiConfig {
   sanitizeFileName?: SanitizeFileNameFn;
 }
 
-async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
+async function downloadDirectUploadUrl(url: string, fileType: MediaFileType): Promise<Buffer> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -63,11 +65,18 @@ async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
     throw new Error("Direct-upload media URL must use HTTP or HTTPS");
   }
 
-  // urlDirectUpload forwards the original URL to QQ/Tencent for the fetch, so
-  // this must validate as a public remote-provider URL. Local fake-IP DNS
-  // allowances are only safe for guarded local downloads that use the pinned lookup.
-  await resolvePinnedHostnameWithPolicy(parsed.hostname, { policy: {} });
-  return parsed.toString();
+  const { response, release } = await fetchWithSsrFGuard({
+    url: parsed.toString(),
+    policy: { allowRfc2544BenchmarkRange: true },
+  });
+  try {
+    if (!response.ok) {
+      throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
+    }
+    return await readResponseWithLimit(response, getMaxUploadSize(fileType));
+  } finally {
+    await release?.();
+  }
 }
 
 /**
@@ -149,6 +158,9 @@ export class MediaApi {
     } else if (opts.localPath) {
       const buf = await fs.promises.readFile(opts.localPath);
       fileData = buf.toString("base64");
+    } else if (opts.url !== undefined) {
+      const buf = await downloadDirectUploadUrl(opts.url, fileType);
+      fileData = buf.toString("base64");
     }
 
     // Check cache for base64 uploads.
@@ -164,9 +176,7 @@ export class MediaApi {
       file_type: fileType,
       srv_send_msg: opts.srvSendMsg ?? false,
     };
-    if (opts.url !== undefined) {
-      body.url = await assertDirectUploadUrlAllowed(opts.url);
-    } else if (fileData !== undefined) {
+    if (fileData !== undefined) {
       body.file_data = fileData;
     }
     if (fileType === MediaFileType.FILE && opts.fileName) {

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -12,8 +12,14 @@
  */
 
 import * as fs from "node:fs";
+import * as net from "node:net";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { normalizeHostname } from "openclaw/plugin-sdk/security-runtime";
+import {
+  fetchWithSsrFGuard,
+  isBlockedHostnameOrIp,
+  type SsrFPolicy,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   MediaFileType,
   type ChatScope,
@@ -53,6 +59,18 @@ interface MediaApiConfig {
   sanitizeFileName?: SanitizeFileNameFn;
 }
 
+function directUploadDownloadPolicy(hostname: string): SsrFPolicy | undefined {
+  if (isBlockedHostnameOrIp(hostname)) {
+    throw new Error("Blocked hostname or private/internal/special-use IP address");
+  }
+
+  // The local guarded download can support fake-IP DNS, but literal IP URLs
+  // must stay on the default SSRF policy so RFC 2544 literals remain blocked.
+  return net.isIP(normalizeHostname(hostname)) === 0
+    ? { allowRfc2544BenchmarkRange: true }
+    : undefined;
+}
+
 async function downloadDirectUploadUrl(url: string, fileType: MediaFileType): Promise<Buffer> {
   let parsed: URL;
   try {
@@ -67,7 +85,7 @@ async function downloadDirectUploadUrl(url: string, fileType: MediaFileType): Pr
 
   const { response, release } = await fetchWithSsrFGuard({
     url: parsed.toString(),
-    policy: { allowRfc2544BenchmarkRange: true },
+    policy: directUploadDownloadPolicy(parsed.hostname),
   });
   try {
     if (!response.ok) {

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -62,7 +62,7 @@ function assertDirectUploadDownloadHostAllowed(hostname: string): void {
   }
 }
 
-async function downloadDirectUploadUrl(url: string): Promise<Buffer> {
+export async function downloadDirectUploadUrl(url: string): Promise<Buffer> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -177,9 +177,13 @@ export class MediaApi {
     }
 
     // Check cache for base64 uploads.
-    if (fileData && this.cache) {
-      const hash = this.cache.computeHash(fileData);
-      const cached = this.cache.get(hash, scope, targetId, fileType);
+    const uploadCache =
+      fileData !== undefined && !(fileType === MediaFileType.FILE && opts.fileName)
+        ? this.cache
+        : undefined;
+    if (fileData !== undefined && uploadCache) {
+      const hash = uploadCache.computeHash(fileData);
+      const cached = uploadCache.get(hash, scope, targetId, fileType);
       if (cached) {
         return { file_uuid: "", file_info: cached, ttl: 0 };
       }
@@ -211,9 +215,9 @@ export class MediaApi {
     );
 
     // Cache the result for future dedup.
-    if (fileData && result.file_info && result.ttl > 0 && this.cache) {
-      const hash = this.cache.computeHash(fileData);
-      this.cache.set(
+    if (fileData !== undefined && uploadCache && result.file_info && result.ttl > 0) {
+      const hash = uploadCache.computeHash(fileData);
+      uploadCache.set(
         hash,
         scope,
         targetId,

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -62,7 +62,10 @@ function assertDirectUploadDownloadHostAllowed(hostname: string): void {
   }
 }
 
-export async function downloadDirectUploadUrl(url: string): Promise<Buffer> {
+export async function downloadDirectUploadUrl(
+  url: string,
+  opts: { maxBytes?: number } = {},
+): Promise<Buffer> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -84,7 +87,7 @@ export async function downloadDirectUploadUrl(url: string): Promise<Buffer> {
     if (!response.ok) {
       throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
     }
-    return await readResponseWithLimit(response, MAX_UPLOAD_SIZE, {
+    return await readResponseWithLimit(response, opts.maxBytes ?? MAX_UPLOAD_SIZE, {
       chunkTimeoutMs: DIRECT_UPLOAD_READ_IDLE_TIMEOUT_MS,
     });
   } finally {

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -67,18 +67,36 @@ function assertDirectUploadDownloadHostAllowed(hostname: string): void {
 
 async function fetchDirectUploadDownload(url: string) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => {
-    controller.abort(new Error("Direct-upload media URL fetch timed out"));
-  }, DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS);
-  unrefTimer(timeout);
+  const timeoutError = new Error("Direct-upload media URL fetch timed out");
+  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS);
+    unrefTimer(timeout);
+  });
+  const guardedFetch = fetchWithSsrFGuard({
+    url,
+    maxRedirects: 0,
+    signal: controller.signal,
+  });
+  void guardedFetch.then(
+    (result) => {
+      if (timedOut) {
+        void result.release().catch(() => undefined);
+      }
+    },
+    () => undefined,
+  );
   try {
-    return await fetchWithSsrFGuard({
-      url,
-      maxRedirects: 0,
-      signal: controller.signal,
-    });
+    return await Promise.race([guardedFetch, timeoutPromise]);
   } finally {
-    clearTimeout(timeout);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
   }
 }
 

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -13,6 +13,7 @@
 
 import * as fs from "node:fs";
 import * as net from "node:net";
+import { normalizeHostname } from "openclaw/plugin-sdk/security-runtime";
 import { resolvePinnedHostnameWithPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   MediaFileType,
@@ -70,7 +71,10 @@ async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
   // resolve into 198.18.0.0/15 under sing-box/Clash/Surge proxy stacks. Literal
   // IP URLs do not benefit from fake-IP DNS, so passing the flag for them would
   // accept special-use/private literals (incl. 198.18.0.0/15) at the sink.
-  const policy = net.isIP(parsed.hostname) === 0 ? { allowRfc2544BenchmarkRange: true } : undefined;
+  const policy =
+    net.isIP(normalizeHostname(parsed.hostname)) !== 0
+      ? undefined
+      : { allowRfc2544BenchmarkRange: true };
   await resolvePinnedHostnameWithPolicy(parsed.hostname, { policy });
   return parsed.toString();
 }

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -53,6 +53,9 @@ interface MediaApiConfig {
   sanitizeFileName?: SanitizeFileNameFn;
 }
 
+const DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS = 30_000;
+const DIRECT_UPLOAD_READ_IDLE_TIMEOUT_MS = 10_000;
+
 function assertDirectUploadDownloadHostAllowed(hostname: string): void {
   if (isBlockedHostnameOrIp(hostname)) {
     throw new Error("Blocked hostname or private/internal/special-use IP address");
@@ -75,12 +78,15 @@ async function downloadDirectUploadUrl(url: string): Promise<Buffer> {
   const { response, release } = await fetchWithSsrFGuard({
     url: parsed.toString(),
     maxRedirects: 0,
+    timeoutMs: DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS,
   });
   try {
     if (!response.ok) {
       throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
     }
-    return await readResponseWithLimit(response, MAX_UPLOAD_SIZE);
+    return await readResponseWithLimit(response, MAX_UPLOAD_SIZE, {
+      chunkTimeoutMs: DIRECT_UPLOAD_READ_IDLE_TIMEOUT_MS,
+    });
   } finally {
     await release?.();
   }

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -12,6 +12,7 @@
  */
 
 import * as fs from "node:fs";
+import { resolvePinnedHostnameWithPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   MediaFileType,
   type ChatScope,
@@ -19,6 +20,7 @@ import {
   type MessageResponse,
   type EngineLogger,
 } from "../types.js";
+import { QQBOT_MEDIA_SSRF_POLICY } from "../utils/file-utils.js";
 import { ApiClient } from "./api-client.js";
 import { withRetry, UPLOAD_RETRY_POLICY } from "./retry.js";
 import { mediaUploadPath, messagePath, getNextMsgSeq } from "./routes.js";
@@ -48,6 +50,24 @@ interface MediaApiConfig {
   uploadCache?: UploadCacheAdapter;
   /** File name sanitizer. */
   sanitizeFileName?: SanitizeFileNameFn;
+}
+
+async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("Direct-upload media URL must be a valid URL");
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new Error("Direct-upload media URL must use HTTPS");
+  }
+
+  await resolvePinnedHostnameWithPolicy(parsed.hostname, {
+    policy: QQBOT_MEDIA_SSRF_POLICY,
+  });
+  return parsed.toString();
 }
 
 /**
@@ -144,9 +164,9 @@ export class MediaApi {
       file_type: fileType,
       srv_send_msg: opts.srvSendMsg ?? false,
     };
-    if (opts.url) {
-      body.url = opts.url;
-    } else if (fileData) {
+    if (opts.url !== undefined) {
+      body.url = await assertDirectUploadUrlAllowed(opts.url);
+    } else if (fileData !== undefined) {
       body.file_data = fileData;
     }
     if (fileType === MediaFileType.FILE && opts.fileName) {

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -59,8 +59,8 @@ async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
     throw new Error("Direct-upload media URL must be a valid URL");
   }
 
-  if (parsed.protocol !== "https:") {
-    throw new Error("Direct-upload media URL must use HTTPS");
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Direct-upload media URL must use HTTP or HTTPS");
   }
 
   // urlDirectUpload is documented as public-URL support. Use the generic

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -85,6 +85,7 @@ async function downloadDirectUploadUrl(url: string, fileType: MediaFileType): Pr
 
   const { response, release } = await fetchWithSsrFGuard({
     url: parsed.toString(),
+    maxRedirects: 0,
     policy: directUploadDownloadPolicy(parsed.hostname),
   });
   try {

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -12,6 +12,7 @@
  */
 
 import * as fs from "node:fs";
+import * as net from "node:net";
 import { resolvePinnedHostnameWithPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   MediaFileType,
@@ -65,12 +66,12 @@ async function assertDirectUploadUrlAllowed(url: string): Promise<string> {
 
   // urlDirectUpload is documented as public-URL support. Use the generic
   // SSRF guard here; the QQ/Tencent host allowlist belongs to fallback downloads.
-  // Mirror QQBOT_MEDIA_SSRF_POLICY's fake-IP allowance so sing-box/Clash/Surge
-  // proxy stacks that resolve public hostnames into 198.18.0.0/15 still upload.
-  // Literal private/loopback/link-local targets remain blocked.
-  await resolvePinnedHostnameWithPolicy(parsed.hostname, {
-    policy: { allowRfc2544BenchmarkRange: true },
-  });
+  // Only allow the RFC 2544 fake-IP range for hostnames whose DNS may legitimately
+  // resolve into 198.18.0.0/15 under sing-box/Clash/Surge proxy stacks. Literal
+  // IP URLs do not benefit from fake-IP DNS, so passing the flag for them would
+  // accept special-use/private literals (incl. 198.18.0.0/15) at the sink.
+  const policy = net.isIP(parsed.hostname) === 0 ? { allowRfc2544BenchmarkRange: true } : undefined;
+  await resolvePinnedHostnameWithPolicy(parsed.hostname, { policy });
   return parsed.toString();
 }
 

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -62,6 +62,25 @@ function assertDirectUploadDownloadHostAllowed(hostname: string): void {
   }
 }
 
+async function fetchDirectUploadDownload(url: string) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort(new Error("Direct-upload media URL fetch timed out"));
+  }, DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS);
+  if (typeof timeout === "object" && "unref" in timeout) {
+    (timeout as { unref: () => void }).unref();
+  }
+  try {
+    return await fetchWithSsrFGuard({
+      url,
+      maxRedirects: 0,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export async function downloadDirectUploadUrl(
   url: string,
   opts: { maxBytes?: number } = {},
@@ -78,11 +97,7 @@ export async function downloadDirectUploadUrl(
   }
 
   assertDirectUploadDownloadHostAllowed(parsed.hostname);
-  const { response, release } = await fetchWithSsrFGuard({
-    url: parsed.toString(),
-    maxRedirects: 0,
-    timeoutMs: DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS,
-  });
+  const { response, release } = await fetchDirectUploadDownload(parsed.toString());
   try {
     if (!response.ok) {
       throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);

--- a/extensions/qqbot/src/engine/messaging/sender.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.ts
@@ -41,7 +41,7 @@ import {
   type OutboundMeta,
   type UploadMediaResponse,
 } from "../types.js";
-import { LARGE_FILE_THRESHOLD } from "../utils/file-utils.js";
+import { getMaxUploadSize, LARGE_FILE_THRESHOLD } from "../utils/file-utils.js";
 import { formatErrorMessage } from "../utils/format.js";
 import { debugLog, debugError, debugWarn } from "../utils/log.js";
 import { sanitizeFileName } from "../utils/string-normalize.js";
@@ -654,7 +654,9 @@ async function dispatchUpload(
 ): Promise<UploadMediaResponse> {
   switch (source.kind) {
     case "url": {
-      const buffer = await downloadDirectUploadUrl(source.url);
+      const buffer = await downloadDirectUploadUrl(source.url, {
+        maxBytes: getMaxUploadSize(fileType),
+      });
       if (buffer.length >= LARGE_FILE_THRESHOLD) {
         return ctx.chunkedMediaApi.uploadChunked({
           scope,

--- a/extensions/qqbot/src/engine/messaging/sender.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.ts
@@ -27,7 +27,7 @@
 import os from "node:os";
 import { ApiClient } from "../api/api-client.js";
 import { ChunkedMediaApi as ChunkedMediaApiClass } from "../api/media-chunked.js";
-import { MediaApi as MediaApiClass } from "../api/media.js";
+import { downloadDirectUploadUrl, MediaApi as MediaApiClass } from "../api/media.js";
 import type { Credentials } from "../api/messages.js";
 import { MessageApi as MessageApiClass } from "../api/messages.js";
 import { getNextMsgSeq } from "../api/routes.js";
@@ -653,11 +653,23 @@ async function dispatchUpload(
   fileName?: string,
 ): Promise<UploadMediaResponse> {
   switch (source.kind) {
-    case "url":
+    case "url": {
+      const buffer = await downloadDirectUploadUrl(source.url);
+      if (buffer.length >= LARGE_FILE_THRESHOLD) {
+        return ctx.chunkedMediaApi.uploadChunked({
+          scope,
+          targetId,
+          fileType,
+          source: { kind: "buffer", buffer, fileName },
+          creds,
+          fileName,
+        });
+      }
       return ctx.mediaApi.uploadMedia(scope, targetId, fileType, creds, {
-        url: source.url,
+        buffer,
         fileName,
       });
+    }
     case "base64":
       return ctx.mediaApi.uploadMedia(scope, targetId, fileType, creds, {
         fileData: source.data,

--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -27,7 +27,7 @@ function readPositiveNumberEnv(name, fallback, env = process.env) {
   if (raw === undefined || raw === "") {
     return fallback;
   }
-  const text = String(raw).trim();
+  const text = raw.trim();
   if (!/^(?:\d+(?:\.\d+)?|\.\d+)$/u.test(text)) {
     return fallback;
   }

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -62,9 +62,9 @@ function dispatchWithDeliveries(
   deliveries: Delivery[],
   dispatcherOptions: {
     beforeDeliver?: ReplyDispatchBeforeDeliver;
-    deliver?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => Promise<unknown>;
-    onSettled?: () => unknown;
-    onFreshSettledDelivery?: () => unknown;
+    deliver?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => Promise<object | void>;
+    onSettled?: () => object | void | Promise<object | void>;
+    onFreshSettledDelivery?: () => object | void | Promise<object | void>;
   } = {},
 ) {
   return dispatchInboundMessageWithBufferedDispatcher({


### PR DESCRIPTION
## Summary

Validate QQBot direct media upload URLs before they are forwarded to the QQ media upload API, while preserving existing public HTTP(S) direct URL behavior — including fake-IP DNS proxy deployments — and rejecting literal special-use URL hosts.

## Changes

- Reintroduced direct-upload URL preflight at the `MediaApi.uploadMedia()` sink.
- Requires direct-upload URLs to be valid HTTP or HTTPS URLs.
- Runs the generic SSRF hostname/IP preflight before token lookup or QQ API upload, blocking private/internal/special-use destinations without applying the QQ/Tencent fallback-download allowlist to public direct uploads.
- Splits the fake-IP DNS allowance from literal-host handling: `resolvePinnedHostnameWithPolicy` is called with `{ allowRfc2544BenchmarkRange: true }` only when the URL hostname is a non-literal name. Literal IP URLs (incl. `198.18.0.0/15`) go through the default SSRF policy and are rejected at the sink.
- Added regression coverage for public HTTP(S) URL uploads, invalid/non-HTTP URL rejection, mocked SSRF guard rejection, real-resolver allow/block behavior, real-resolver literal RFC 2544 rejection, and a non-literal hostname whose DNS resolves into the RFC 2544 fake-IP range still uploading.

## Validation

Behavior addressed: QQBot direct media URL uploads are validated before the QQ API request body is built. Public HTTP(S) direct URLs remain supported in normal and fake-IP DNS deployments; literal RFC 2544 / private / internal / link-local / loopback / special-use targets are blocked before token lookup or QQ API upload.

Real environment tested: Local Linux checkout on PR head `ac56bf9f789158e0d806967f1bbdf9870f6bc525`. The behavioral proof used the real `MediaApi.uploadMedia()` source and the real SSRF resolver/DNS path, with only the QQ API client and token provider stubbed to avoid credentialed live QQ uploads.

Exact steps or command run after this patch:

- `node --import tsx --input-type=module <redacted MediaApi runtime proof script>`
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/api/media.test.ts`
- `git diff --check`

Evidence after fix: the non-mocked runtime proof allowed a public HTTPS direct media URL through to the QQ media upload request body, and blocked a literal `198.18.0.42` URL, a `127.0.0.1` loopback URL, and a `169.254.169.254` link-local metadata URL with `SsrFBlockedError` before token lookup or client request. The focused Vitest target passed with 1 file and 14 tests. `git diff --check` passed.

Observed result after fix: public direct-upload compatibility is preserved for HTTP(S) media URLs in both normal-DNS and fake-IP proxy deployments, while literal special-use / private / link-local URL hosts never request a token and never call `client.request()`.

What was not tested: live QQ API upload with real credentials; broad `check:changed` or full-suite validation.

## Notes

- Security-sensitive exploit details are intentionally omitted from the public PR body.
- AI-assisted.
- `CHANGELOG.md` was not updated.
- No agent transcript is included.
