### PR TITLE
fix(macos): default WebChat picker to node-scoped session in remote mode (#59268)

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -351,6 +351,33 @@ actor GatewayConnection {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Session key the chat picker should default to for this paired client.
+    ///
+    /// In remote mode every paired Mac/iOS device defaults to its own
+    /// `node-${deviceId}` session — otherwise multiple paired Macs would share
+    /// the gateway main session and the picker would surface the wrong node's
+    /// chat history and label (#59268). Local mode keeps the snapshot main
+    /// session so the menu app behaves as before.
+    func cachedPreferredDefaultSessionKey() async -> String? {
+        let mode = await MainActor.run { AppStateStore.shared.connectionMode }
+        if mode == .remote {
+            return Self.nodeScopedSessionKey()
+        }
+        return self.cachedMainSessionKey()
+    }
+
+    func preferredDefaultSessionKey(timeoutMs: Double = 15000) async -> String {
+        let mode = await MainActor.run { AppStateStore.shared.connectionMode }
+        if mode == .remote {
+            return Self.nodeScopedSessionKey()
+        }
+        return await self.mainSessionKey(timeoutMs: timeoutMs)
+    }
+
+    static func nodeScopedSessionKey() -> String {
+        "node-\(DeviceIdentityStore.loadOrCreate().deviceId)"
+    }
+
     func cachedGatewayVersion() -> String? {
         guard let snapshot = self.lastSnapshot else { return nil }
         let raw = snapshot.server["version"]?.value as? String

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -104,7 +104,7 @@ final class WebChatManager {
 
     func preferredSessionKey() async -> String {
         if let cachedPreferredSessionKey { return cachedPreferredSessionKey }
-        let key = await GatewayConnection.shared.mainSessionKey()
+        let key = await GatewayConnection.shared.preferredDefaultSessionKey()
         self.cachedPreferredSessionKey = key
         return key
     }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -60,7 +60,9 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             params: params,
             timeoutMs: 15000)
         let decoded = try JSONDecoder().decode(OpenClawChatSessionsListResponse.self, from: data)
-        let mainSessionKey = await GatewayConnection.shared.cachedMainSessionKey()
+        // Remote-paired clients resolve to their own node-scoped session here so
+        // the picker doesn't default every Mac to the shared gateway main (#59268).
+        let mainSessionKey = await GatewayConnection.shared.cachedPreferredDefaultSessionKey()
         let defaults = decoded.defaults.map {
             OpenClawChatSessionsDefaults(
                 modelProvider: $0.modelProvider,

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatMainSessionKeyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatMainSessionKeyTests.swift
@@ -1,7 +1,9 @@
 import Foundation
 import Testing
 @testable import OpenClaw
+import OpenClawKit
 
+@Suite(.serialized)
 struct WebChatMainSessionKeyTests {
     @Test func `config get snapshot main key falls back to main when missing`() throws {
         let json = """
@@ -63,5 +65,32 @@ struct WebChatMainSessionKeyTests {
         """
         let key = try GatewayConnection.mainSessionKey(fromConfigGetData: Data(json.utf8))
         #expect(key == "global")
+    }
+
+    @Test func `node scoped session key embeds device identity`() {
+        let key = GatewayConnection.nodeScopedSessionKey()
+        let deviceId = DeviceIdentityStore.loadOrCreate().deviceId
+        #expect(!deviceId.isEmpty)
+        #expect(key == "node-\(deviceId)")
+    }
+
+    @Test @MainActor func `remote mode resolves preferred default to node scoped key`() async {
+        let previous = AppStateStore.shared.connectionMode
+        AppStateStore.shared.connectionMode = .remote
+        defer { AppStateStore.shared.connectionMode = previous }
+
+        let expected = "node-\(DeviceIdentityStore.loadOrCreate().deviceId)"
+        let cached = await GatewayConnection.shared.cachedPreferredDefaultSessionKey()
+        #expect(cached == expected)
+    }
+
+    @Test @MainActor func `local mode preferred default mirrors cached main session key`() async {
+        let previous = AppStateStore.shared.connectionMode
+        AppStateStore.shared.connectionMode = .local
+        defer { AppStateStore.shared.connectionMode = previous }
+
+        let cachedMain = GatewayConnection.shared.cachedMainSessionKey()
+        let preferred = await GatewayConnection.shared.cachedPreferredDefaultSessionKey()
+        #expect(preferred == cachedMain)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatMainSessionKeyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatMainSessionKeyTests.swift
@@ -89,7 +89,7 @@ struct WebChatMainSessionKeyTests {
         AppStateStore.shared.connectionMode = .local
         defer { AppStateStore.shared.connectionMode = previous }
 
-        let cachedMain = GatewayConnection.shared.cachedMainSessionKey()
+        let cachedMain = await GatewayConnection.shared.cachedMainSessionKey()
         let preferred = await GatewayConnection.shared.cachedPreferredDefaultSessionKey()
         #expect(preferred == cachedMain)
     }


### PR DESCRIPTION
## Summary

Fixes #59268. When two or more macOS apps are paired to the **same remote gateway**, the WebChat picker defaulted every Mac to the shared gateway `main` session. The result was (a) session labels appearing swapped/wrong across devices and (b) chat history leaking between Macs (messages from one Mac visible on another), with no in-app workaround.

The macOS app resolved its default WebChat session through `GatewayConnection.mainSessionKey()` / `cachedMainSessionKey()`, which only ever return the global/main session — there is no per-device scoping. In a remote multi-Mac topology every node therefore collapses onto one shared session id.

### Change

Introduce a node-scoped default for **remote mode only**, keyed off the existing per-device identity:

- `nodeScopedSessionKey()` → `"node-\(DeviceIdentityStore.loadOrCreate().deviceId)"`
- `cachedPreferredDefaultSessionKey()` / `preferredDefaultSessionKey(timeoutMs:)` dispatch on `AppStateStore.connectionMode`: remote → node-scoped key; local → existing `cachedMainSessionKey()` / `mainSessionKey()` (unchanged).
- WebChat entry points (`WebChatManager.preferredSessionKey()`, `MacGatewayChatTransport.listSessions()` picker default) now consume the preferred-default helpers.

This aligns the macOS default with the gateway's existing `node-${nodeId}` convention for node-originated events (`src/gateway/server-node-events.ts`). Local single-Mac behavior is unchanged.

### Scope

Triggering requires remote/gateway mode **and** 2+ Macs paired to one gateway — an uncommon topology, but deterministic (100%) when hit and with no workaround. Single reporter; ClawSweeper rated it P1 / source-repro / clear-fix-shape.

## Verification

Behavior addressed: macOS WebChat picker defaulting all paired Macs to the shared gateway `main` session in remote mode, causing cross-device session/label collision and message leak (#59268).

Real environment tested: Local macOS dev checkout, Swift 6.3 toolchain, `apps/macos` SwiftPM package. A live two-Mac pairing lab was NOT run (see below).

Exact steps or command run after this patch:
```
cd apps/macos && swift test --filter WebChatMainSessionKeyTests --no-parallel
```

Evidence after fix:
```
✔ Test "node scoped session key embeds device identity" passed
✔ Test "remote mode resolves preferred default to node scoped key" passed
✔ Test "local mode preferred default mirrors cached main session key" passed
✔ Test run with 8 tests in 1 suite passed after 0.021 seconds.
```

Observed result after fix: In remote mode, `cachedPreferredDefaultSessionKey()` resolves to `node-<deviceId>` (unique per Mac via `DeviceIdentityStore`); in local mode it mirrors `cachedMainSessionKey()` unchanged. The three behavioral guards above assert exactly the remote/local split that fixes the cross-device collision.

What was not tested: No live two-Mac runtime lab — I did not pair two physical Macs to one gateway and visually confirm picker label / session isolation end to end. The fix is proven at the unit level (key derivation + remote/local dispatch) and by source-level alignment with the gateway node-session convention; the runtime picker/label rendering path was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
