### PR TITLE
[codex] fix Codex budget native compaction trigger

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -214,9 +214,17 @@ history, search, `/new`, `/reset`, and future model or harness switching.
 
 Explicit compaction requests, such as `/compact` or a plugin-requested manual
 compact operation, start native Codex compaction with `thread/compact/start`.
+OpenClaw also starts native Codex compaction for the `budget` preflight trigger
+used by `agents.defaults.compaction.maxActiveTranscriptBytes`, because that
+trigger protects the local channel transcript mirror from growing without a
+native cleanup request. Other automatic triggers remain Codex-owned and are not
+started by OpenClaw.
+
 OpenClaw returns after starting that native operation. It does not wait for
 completion, impose a separate OpenClaw timeout, restart the shared Codex
 app-server, or record the operation as an OpenClaw-completed compaction.
+Operators debugging oversized transcript behavior can search gateway logs for
+`started codex app-server compaction` with `trigger: "budget"`.
 
 When a context engine requests Codex thread-bootstrap projection, OpenClaw
 projects tool-call names and ids, input shapes, and redacted tool-result content

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -354,7 +354,9 @@ OpenClaw also enforces a safety floor for embedded runs:
   string such as `"20mb"` to run local compaction before a turn when the active
   transcript gets large. This guard is active only when
   `truncateAfterCompaction` is also enabled. Leave it unset or set `0` to
-  disable.
+  disable. For Codex harness sessions, this preflight starts native Codex
+  compaction with `thread/compact/start` rather than replacing Codex compaction
+  with an OpenClaw summarizer.
 - When `agents.defaults.compaction.truncateAfterCompaction` is enabled,
   OpenClaw rotates the active transcript to a compacted successor JSONL after
   compaction. Branch/restore checkpoint actions use that compacted successor;

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -126,7 +126,7 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(details.pending).toBe(true);
   });
 
-  it("skips native app-server compaction for automatic budget triggers", async () => {
+  it("starts native app-server compaction for automatic budget triggers", async () => {
     const fake = createFakeCodexClient();
     setCodexAppServerClientFactoryForTest(async () => fake.client);
     const sessionFile = await writeTestBinding();
@@ -142,16 +142,45 @@ describe("maybeCompactCodexAppServerSession", () => {
       }),
     );
 
+    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBeUndefined();
+    expect(result.result?.tokensBefore).toBe(456);
+    expect(compactDetails(result)).toMatchObject({
+      backend: "codex-app-server",
+      threadId: "thread-1",
+      signal: "thread/compact/start",
+      pending: true,
+    });
+  });
+
+  it("skips native app-server compaction for overflow triggers", async () => {
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+
+    const result = requireCompactResult(
+      await maybeCompactCodexAppServerSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile,
+        workspaceDir: tempDir,
+        trigger: "overflow",
+        currentTokenCount: 654,
+      }),
+    );
+
     expect(fake.request).not.toHaveBeenCalled();
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(false);
     expect(result.reason).toBe("codex app-server owns automatic compaction");
-    expect(result.result?.tokensBefore).toBe(456);
+    expect(result.result?.tokensBefore).toBe(654);
     expect(compactDetails(result)).toMatchObject({
       backend: "codex-app-server",
       skipped: true,
       reason: "non_manual_trigger",
-      trigger: "budget",
+      trigger: "overflow",
     });
   });
 

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -122,7 +122,10 @@ async function compactCodexNativeThread(
   params: CompactEmbeddedPiSessionParams,
   options: { pluginConfig?: unknown; clientFactory?: CodexAppServerClientFactory } = {},
 ): Promise<EmbeddedPiCompactResult | undefined> {
-  if (params.trigger !== "manual") {
+  // The transcript-byte budget preflight is an explicit OpenClaw request to
+  // shrink a large channel mirror; skipping it leaves long-lived Codex sessions
+  // above the configured local transcript guard.
+  if (params.trigger !== "manual" && params.trigger !== "budget") {
     embeddedAgentLog.info("skipping codex app-server compaction for non-manual trigger", {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
@@ -185,6 +188,7 @@ async function compactCodexNativeThread(
     embeddedAgentLog.info("started codex app-server compaction", {
       sessionId: params.sessionId,
       threadId: binding.threadId,
+      trigger: params.trigger ?? "manual",
     });
   } catch (error) {
     if (isCodexThreadNotFoundError(error)) {
@@ -198,6 +202,7 @@ async function compactCodexNativeThread(
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       threadId: binding.threadId,
+      trigger: params.trigger ?? "manual",
       reason: formatCompactionError(error),
     });
     return {


### PR DESCRIPTION
## Summary

- Start Codex native app-server compaction for the `budget` preflight trigger instead of treating it like an unrelated automatic trigger.
- Keep omitted and `overflow` triggers on the existing Codex-owned skip path.
- Document that `agents.defaults.compaction.maxActiveTranscriptBytes` starts native Codex compaction for Codex harness sessions.

## Duplicate check

I checked current `origin/main` plus open PRs/issues before opening this PR. Current `main` still skipped `trigger: "budget"` in `extensions/codex/src/app-server/compact.ts` and had a test pinning that skip in `compact.test.ts`. I did not find an open PR from this fork for this compaction trigger; the only open `Steady-ai` PR was #86716 for Discord delivery accounting. I also inspected nearby compaction/Codex PRs including #81916, #63636, #54585, #86160, #83229, #82856, #86094, and #73092; none made `budget` start native Codex compaction.

## Real behavior proof

Behavior addressed: Codex harness sessions with `agents.defaults.compaction.maxActiveTranscriptBytes` call compaction with `trigger: "budget"`. Current source skipped that trigger before sending `thread/compact/start`, so the local transcript-byte guard could leave long-lived channel mirrors above the configured cleanup threshold.

Real environment tested: OpenClaw source worktree rebased on `origin/main` at `d88681662b`, PR head `47f33748d4`, on WSL Ubuntu 24.04 / Node 22.22.0. The source-runtime probe used the real `maybeCompactCodexAppServerSession` entry point and real Codex session-binding file I/O, with the app-server client boundary instrumented only to capture the outgoing app-server request.

Exact steps or command run after this patch: Ran a `node --import tsx -` source-runtime probe from the PR worktree. The probe wrote a temporary Codex app-server binding, invoked `maybeCompactCodexAppServerSession` once with `trigger: "budget"` and once with `trigger: "overflow"`, then printed the request/result shape. I then ran the focused checks listed in Verification.

Evidence after fix: Copied terminal output from the source-runtime probe:

```text
[agent/embedded] started codex app-server compaction
[agent/embedded] skipping codex app-server compaction for non-manual trigger
{
  "head": "47f33748d4",
  "behavior": "codex budget compaction trigger starts native app-server compaction",
  "budget": {
    "request": {
      "method": "thread/compact/start",
      "params": {
        "threadId": "thread-proof-budget"
      }
    },
    "ok": true,
    "compacted": false,
    "reason": null,
    "signal": "thread/compact/start",
    "pending": true,
    "tokensBefore": 456
  },
  "overflow": {
    "additionalRequests": 0,
    "ok": true,
    "compacted": false,
    "reason": "codex app-server owns automatic compaction",
    "skippedReason": "non_manual_trigger",
    "trigger": "overflow"
  }
}
```

Observed result after fix: Budget preflight compaction now sends `thread/compact/start` and returns the existing pending native-compaction result shape. The overflow trigger sends no additional app-server request and still returns the existing `non_manual_trigger` skip result.

What was not tested: I did not run a live Discord or Telegram gateway replay from this source branch. The live failure was observed in an installed runtime; this PR ports the source-level behavior and locks it with focused Codex extension tests.

## Risk

Low. The change is limited to the Codex app-server compaction trigger gate. It does not wait for native compaction completion, add credentials, change network targets, or replace Codex compaction with OpenClaw summarization.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/compact.test.ts` -> 1 file / 19 tests passed
- `node_modules/.bin/oxfmt --check extensions/codex/src/app-server/compact.ts extensions/codex/src/app-server/compact.test.ts docs/plugins/codex-harness-runtime.md docs/reference/session-management-compaction.md` -> passed
- `git diff --check` -> passed
- `pnpm docs:list` -> passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/compact.ts extensions/codex/src/app-server/compact.test.ts` -> passed
- `node scripts/check-docs-mdx.mjs docs/plugins/codex-harness-runtime.md docs/reference/session-management-compaction.md` -> passed