### PR TITLE
Fix embedded session file ownership race

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -20,6 +20,7 @@ export {
   queueEmbeddedPiMessage,
   queueEmbeddedPiMessage as queueEmbeddedAgentMessage,
   queueEmbeddedPiMessageWithOutcome,
+  resolveActiveEmbeddedRunSessionIdBySessionFile,
   resolveActiveEmbeddedRunSessionId,
   resolveActiveEmbeddedRunSessionId as resolveActiveEmbeddedAgentRunSessionId,
   waitForEmbeddedPiRunEnd,

--- a/src/agents/pi-embedded-runner/run-state.ts
+++ b/src/agents/pi-embedded-runner/run-state.ts
@@ -49,6 +49,7 @@ const embeddedRunState = resolveGlobalSingleton(EMBEDDED_RUN_STATE_KEY, () => ({
   activeRuns: new Map<string, EmbeddedPiQueueHandle>(),
   snapshots: new Map<string, ActiveEmbeddedRunSnapshot>(),
   sessionIdsByKey: new Map<string, string>(),
+  sessionIdsByFile: new Map<string, string>(),
   waiters: new Map<string, Set<EmbeddedRunWaiter>>(),
   modelSwitchRequests: new Map<string, EmbeddedRunModelSwitchRequest>(),
 }));
@@ -62,6 +63,9 @@ export const ACTIVE_EMBEDDED_RUN_SNAPSHOTS =
 export const ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY =
   embeddedRunState.sessionIdsByKey ??
   (embeddedRunState.sessionIdsByKey = new Map<string, string>());
+export const ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE =
+  embeddedRunState.sessionIdsByFile ??
+  (embeddedRunState.sessionIdsByFile = new Map<string, string>());
 export const EMBEDDED_RUN_WAITERS =
   embeddedRunState.waiters ??
   (embeddedRunState.waiters = new Map<string, Set<EmbeddedRunWaiter>>());
@@ -93,6 +97,7 @@ export function listActiveEmbeddedRunSessionIds(): string[] {
     ...new Set([
       ...ACTIVE_EMBEDDED_RUNS.keys(),
       ...ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.values(),
+      ...ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.values(),
       ...listActiveReplyRunSessionIds(),
     ]),
   ].toSorted((a, b) => a.localeCompare(b));

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -14,11 +14,13 @@ import {
   resetSessionWriteLockStateForTest,
 } from "../../session-write-lock.js";
 import {
+  acquireEmbeddedAttemptSessionFileOwner,
   createEmbeddedAttemptSessionLockController,
   EmbeddedAttemptSessionTakeoverError,
   installPromptSubmissionLockRelease,
   installSessionEventWriteLock,
   installSessionExternalHookWriteLock,
+  resetEmbeddedAttemptSessionFileOwnersForTest,
 } from "./attempt.session-lock.js";
 
 const lockOptions = {
@@ -31,6 +33,7 @@ const lockOptions = {
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  resetEmbeddedAttemptSessionFileOwnersForTest();
   resetSessionWriteLockStateForTest();
   for (const dir of tempDirs.splice(0)) {
     await fs.rm(dir, { recursive: true, force: true });
@@ -46,6 +49,50 @@ async function createTempSessionFile(): Promise<string> {
 }
 
 describe("embedded attempt session lock lifecycle", () => {
+  it("serializes embedded attempts that share a session file owner", async () => {
+    const sessionFile = await createTempSessionFile();
+    const firstOwner = await acquireEmbeddedAttemptSessionFileOwner({ sessionFile });
+
+    let secondOwnerAcquired = false;
+    const secondOwnerPromise = acquireEmbeddedAttemptSessionFileOwner({ sessionFile }).then(
+      (owner) => {
+        secondOwnerAcquired = true;
+        return owner;
+      },
+    );
+
+    await Promise.resolve();
+    expect(secondOwnerAcquired).toBe(false);
+
+    firstOwner.release();
+    const secondOwner = await secondOwnerPromise;
+    expect(secondOwnerAcquired).toBe(true);
+    secondOwner.release();
+  });
+
+  it("uses the same embedded attempt owner for symlinked session file paths", async () => {
+    const sessionFile = await createTempSessionFile();
+    const symlinkFile = path.join(path.dirname(sessionFile), "session-link.jsonl");
+    await fs.symlink(sessionFile, symlinkFile);
+    const firstOwner = await acquireEmbeddedAttemptSessionFileOwner({ sessionFile });
+
+    let symlinkOwnerAcquired = false;
+    const symlinkOwnerPromise = acquireEmbeddedAttemptSessionFileOwner({
+      sessionFile: symlinkFile,
+    }).then((owner) => {
+      symlinkOwnerAcquired = true;
+      return owner;
+    });
+
+    await Promise.resolve();
+    expect(symlinkOwnerAcquired).toBe(false);
+
+    firstOwner.release();
+    const symlinkOwner = await symlinkOwnerPromise;
+    expect(symlinkOwnerAcquired).toBe(true);
+    symlinkOwner.release();
+  });
+
   it("releases the coarse attempt lock before prompt submission and reacquires for cleanup", async () => {
     const releases: string[] = [];
     const acquireSessionWriteLock = vi
@@ -874,7 +921,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releaseForPrompt).toHaveBeenCalledTimes(1);
     expect(reacquireAfterPrompt).toHaveBeenCalledTimes(1);
     expect(streamFn).toHaveBeenCalledWith("model", "context");
-    expect(events).toEqual(["drain", "release", "stream", "reacquire"]);
+    expect(events).toEqual(["drain", "release", "stream", "drain", "reacquire"]);
   });
 
   it("rewraps provider stream submission after the stream function is rebuilt", async () => {
@@ -921,17 +968,19 @@ describe("embedded attempt session lock lifecycle", () => {
 
     expect(firstStreamFn).toHaveBeenCalledTimes(1);
     expect(secondStreamFn).toHaveBeenCalledTimes(1);
-    expect(waitForSessionEvents).toHaveBeenCalledTimes(2);
+    expect(waitForSessionEvents).toHaveBeenCalledTimes(4);
     expect(releaseForPrompt).toHaveBeenCalledTimes(2);
     expect(reacquireAfterPrompt).toHaveBeenCalledTimes(2);
     expect(events).toEqual([
       "drain",
       "release",
       "first-stream",
+      "drain",
       "reacquire",
       "drain",
       "release",
       "second-stream",
+      "drain",
       "reacquire",
     ]);
   });

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -1,12 +1,13 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { statSync } from "node:fs";
 import fs from "node:fs/promises";
-import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { withOwnedSessionTranscriptWrites } from "../../../config/sessions/transcript-write-context.js";
+import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
 import { normalizeStringEntries } from "../../../shared/string-normalization.js";
 import { isSessionWriteLockTimeoutError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
+import { resolveEmbeddedSessionFileKey } from "../session-file-key.js";
 
 type SessionLock = Awaited<ReturnType<typeof acquireSessionWriteLock>>;
 type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
@@ -403,7 +404,156 @@ const trustedSessionFileStates = new Map<string, TrustedSessionFileState>();
 let ownedSessionFileWriteGeneration = 0;
 
 function resolveSessionFileFenceKey(sessionFile: string): string {
-  return path.resolve(sessionFile);
+  return resolveEmbeddedSessionFileKey(sessionFile);
+}
+
+type SessionFileOwnerWaiter = {
+  resolve: () => void;
+  reject: (error: unknown) => void;
+  timer?: NodeJS.Timeout;
+  abortListener?: () => void;
+  signal?: AbortSignal;
+};
+
+type SessionFileOwnerEntry = {
+  ownerId: symbol;
+  waiters: Set<SessionFileOwnerWaiter>;
+};
+
+type SessionFileOwnerState = {
+  owners: Map<string, SessionFileOwnerEntry>;
+};
+
+const EMBEDDED_ATTEMPT_SESSION_FILE_OWNER_STATE_KEY = Symbol.for(
+  "openclaw.embeddedAttemptSessionFileOwnerState",
+);
+
+const sessionFileOwnerState = resolveGlobalSingleton(
+  EMBEDDED_ATTEMPT_SESSION_FILE_OWNER_STATE_KEY,
+  (): SessionFileOwnerState => ({
+    owners: new Map<string, SessionFileOwnerEntry>(),
+  }),
+);
+
+export type EmbeddedAttemptSessionFileOwner = {
+  sessionFileKey: string;
+  release(): void;
+};
+
+export class EmbeddedAttemptSessionFileOwnerTimeoutError extends Error {
+  constructor(sessionFile: string, timeoutMs: number) {
+    super(`timed out waiting for embedded session file owner after ${timeoutMs}ms: ${sessionFile}`);
+    this.name = "EmbeddedAttemptSessionFileOwnerTimeoutError";
+  }
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
+}
+
+function waitForSessionFileOwnerRelease(params: {
+  sessionFile: string;
+  entry: SessionFileOwnerEntry;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (params.signal?.aborted) {
+    return Promise.reject(abortReason(params.signal) ?? new Error("operation aborted"));
+  }
+  return new Promise<void>((resolve, reject) => {
+    const waiter: SessionFileOwnerWaiter = {
+      resolve,
+      reject,
+      signal: params.signal,
+    };
+    const cleanup = () => {
+      params.entry.waiters.delete(waiter);
+      if (waiter.timer) {
+        clearTimeout(waiter.timer);
+      }
+      if (waiter.signal && waiter.abortListener) {
+        waiter.signal.removeEventListener("abort", waiter.abortListener);
+      }
+    };
+    waiter.resolve = () => {
+      cleanup();
+      resolve();
+    };
+    waiter.reject = (error) => {
+      cleanup();
+      reject(error);
+    };
+    if (params.timeoutMs !== undefined && Number.isFinite(params.timeoutMs)) {
+      waiter.timer = setTimeout(
+        () => {
+          waiter.reject(
+            new EmbeddedAttemptSessionFileOwnerTimeoutError(
+              params.sessionFile,
+              params.timeoutMs ?? 0,
+            ),
+          );
+        },
+        Math.max(1, Math.floor(params.timeoutMs)),
+      );
+      waiter.timer.unref?.();
+    }
+    if (params.signal) {
+      waiter.abortListener = () => {
+        waiter.reject(abortReason(params.signal!) ?? new Error("operation aborted"));
+      };
+      params.signal.addEventListener("abort", waiter.abortListener, { once: true });
+    }
+    params.entry.waiters.add(waiter);
+  });
+}
+
+export async function acquireEmbeddedAttemptSessionFileOwner(params: {
+  sessionFile: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}): Promise<EmbeddedAttemptSessionFileOwner> {
+  const sessionFileKey = resolveEmbeddedSessionFileKey(params.sessionFile);
+  const ownerId = Symbol(sessionFileKey);
+  while (true) {
+    if (params.signal?.aborted) {
+      throw abortReason(params.signal) ?? new Error("operation aborted");
+    }
+    const entry = sessionFileOwnerState.owners.get(sessionFileKey);
+    if (!entry) {
+      sessionFileOwnerState.owners.set(sessionFileKey, {
+        ownerId,
+        waiters: new Set(),
+      });
+      return {
+        sessionFileKey,
+        release() {
+          const current = sessionFileOwnerState.owners.get(sessionFileKey);
+          if (!current || current.ownerId !== ownerId) {
+            return;
+          }
+          sessionFileOwnerState.owners.delete(sessionFileKey);
+          for (const waiter of current.waiters) {
+            waiter.resolve();
+          }
+        },
+      };
+    }
+    await waitForSessionFileOwnerRelease({
+      sessionFile: params.sessionFile,
+      entry,
+      timeoutMs: params.timeoutMs,
+      signal: params.signal,
+    });
+  }
+}
+
+export function resetEmbeddedAttemptSessionFileOwnersForTest(): void {
+  for (const entry of sessionFileOwnerState.owners.values()) {
+    for (const waiter of entry.waiters) {
+      waiter.reject(new Error("embedded attempt session file owners reset"));
+    }
+  }
+  sessionFileOwnerState.owners.clear();
 }
 
 function recordOwnedSessionFileWrite(
@@ -924,6 +1074,7 @@ export function installPromptSubmissionLockRelease(params: {
       }
       return await originalStreamFn(...args);
     } finally {
+      await params.waitForSessionEvents(params.session);
       await params.reacquireAfterPrompt();
     }
   };

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -451,6 +451,10 @@ function abortReason(signal: AbortSignal): unknown {
   return "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
 }
 
+function abortOwnerWaitReason(signal: AbortSignal): unknown {
+  return abortReason(signal) ?? new Error("operation aborted", { cause: signal });
+}
+
 function waitForSessionFileOwnerRelease(params: {
   sessionFile: string;
   entry: SessionFileOwnerEntry;
@@ -458,7 +462,7 @@ function waitForSessionFileOwnerRelease(params: {
   signal?: AbortSignal;
 }): Promise<void> {
   if (params.signal?.aborted) {
-    return Promise.reject(abortReason(params.signal) ?? new Error("operation aborted"));
+    return Promise.reject(abortOwnerWaitReason(params.signal));
   }
   return new Promise<void>((resolve, reject) => {
     const waiter: SessionFileOwnerWaiter = {
@@ -499,7 +503,7 @@ function waitForSessionFileOwnerRelease(params: {
     }
     if (params.signal) {
       waiter.abortListener = () => {
-        waiter.reject(abortReason(params.signal!) ?? new Error("operation aborted"));
+        waiter.reject(abortOwnerWaitReason(params.signal!));
       };
       params.signal.addEventListener("abort", waiter.abortListener, { once: true });
     }
@@ -516,7 +520,7 @@ export async function acquireEmbeddedAttemptSessionFileOwner(params: {
   const ownerId = Symbol(sessionFileKey);
   while (true) {
     if (params.signal?.aborted) {
-      throw abortReason(params.signal) ?? new Error("operation aborted");
+      throw abortOwnerWaitReason(params.signal);
     }
     const entry = sessionFileOwnerState.owners.get(sessionFileKey);
     if (!entry) {
@@ -550,7 +554,11 @@ export async function acquireEmbeddedAttemptSessionFileOwner(params: {
 export function resetEmbeddedAttemptSessionFileOwnersForTest(): void {
   for (const entry of sessionFileOwnerState.owners.values()) {
     for (const waiter of entry.waiters) {
-      waiter.reject(new Error("embedded attempt session file owners reset"));
+      waiter.reject(
+        new Error("embedded attempt session file owners reset", {
+          cause: "resetEmbeddedAttemptSessionFileOwnersForTest",
+        }),
+      );
     }
   }
   sessionFileOwnerState.owners.clear();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -249,6 +249,7 @@ import {
   clearActiveEmbeddedRun,
   type EmbeddedPiQueueHandle,
   setActiveEmbeddedRun,
+  updateActiveEmbeddedRunSessionFile,
   updateActiveEmbeddedRunSnapshot,
 } from "../runs.js";
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
@@ -339,7 +340,9 @@ import {
   shouldInjectHeartbeatPrompt,
 } from "./attempt.prompt-helpers.js";
 import {
+  acquireEmbeddedAttemptSessionFileOwner,
   EmbeddedAttemptSessionTakeoverError,
+  type EmbeddedAttemptSessionFileOwner,
   createEmbeddedAttemptSessionLockController,
   installPromptSubmissionLockRelease,
   installSessionExternalHookWriteLock,
@@ -1344,6 +1347,7 @@ export async function runEmbeddedAttempt(
   let beforeAgentRunBlockedBy: string | undefined;
   // Releases the eager session lock if post-prompt code exits before cleanup.
   let releaseRetainedSessionLock: (() => Promise<void>) | undefined;
+  let retainedSessionFileOwner: EmbeddedAttemptSessionFileOwner | undefined;
   let bundleMcpRuntime: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
   let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
   let toolSearchCatalogRef: ToolSearchCatalogRef | undefined;
@@ -2279,6 +2283,11 @@ export async function runEmbeddedAttempt(
       compactionTimeoutMs,
     });
     await throwIfAttemptAbortSignalFiredAfterPrepCleanup();
+    retainedSessionFileOwner = await acquireEmbeddedAttemptSessionFileOwner({
+      sessionFile: params.sessionFile,
+      timeoutMs: sessionWriteLockOptions.maxHoldMs,
+      signal: params.abortSignal,
+    });
     const sessionLockController = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
       lockOptions: {
@@ -3493,7 +3502,12 @@ export async function runEmbeddedAttempt(
           onBeforeLifecycleTerminal: () => {
             // Clear embedded-run activity before emitting terminal lifecycle events so
             // post-completion cleanup does not observe a logically finished run as active.
-            clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
+            clearActiveEmbeddedRun(
+              params.sessionId,
+              queueHandle,
+              params.sessionKey,
+              params.sessionFile,
+            );
           },
           enforceFinalTag: params.enforceFinalTag,
           silentExpected: params.silentExpected,
@@ -3609,7 +3623,7 @@ export async function runEmbeddedAttempt(
       if (params.replyOperation) {
         params.replyOperation.attachBackend(queueHandle);
       }
-      setActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
+      setActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey, params.sessionFile);
 
       let abortWarnTimer: NodeJS.Timeout | undefined;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
@@ -4732,6 +4746,7 @@ export async function runEmbeddedAttempt(
               if (rotation.rotated) {
                 sessionIdUsed = rotation.sessionId ?? sessionIdUsed;
                 sessionFileUsed = rotation.sessionFile ?? sessionFileUsed;
+                updateActiveEmbeddedRunSessionFile(params.sessionId, sessionFileUsed);
                 log.info(
                   `[compaction] rotated active transcript after automatic compaction ` +
                     `(sessionKey=${params.sessionKey ?? params.sessionId})`,
@@ -4805,7 +4820,12 @@ export async function runEmbeddedAttempt(
         if (params.replyOperation) {
           params.replyOperation.detachBackend(queueHandle);
         }
-        clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
+        clearActiveEmbeddedRun(
+          params.sessionId,
+          queueHandle,
+          params.sessionKey,
+          params.sessionFile,
+        );
       }
 
       const toolMetasNormalized = toolMetas
@@ -5260,6 +5280,8 @@ export async function runEmbeddedAttempt(
         `failed to release retained session lock on attempt teardown: runId=${params.runId} ${String(releaseErr)}`,
       );
     }
+    retainedSessionFileOwner?.release();
+    retainedSessionFileOwner = undefined;
     emitDiagnosticRunCompleted?.(
       aborted ? "aborted" : "error",
       promptError ?? new Error("run exited before diagnostic completion"),

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -7,6 +7,11 @@ import {
   testing as replyRunTesting,
   createReplyOperation,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { setDiagnosticsEnabledForProcess } from "../../infra/diagnostic-events.js";
+import {
+  getDiagnosticSessionState,
+  resetDiagnosticSessionStateForTest,
+} from "../../logging/diagnostic-session-state.js";
 import { diagnosticLogger } from "../../logging/diagnostic.js";
 import {
   testing,
@@ -24,6 +29,7 @@ import {
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
+  updateActiveEmbeddedRunSessionFile,
   waitForActiveEmbeddedRuns,
 } from "./runs.js";
 
@@ -51,6 +57,8 @@ describe("pi-embedded runner run registry", () => {
   afterEach(() => {
     testing.resetActiveEmbeddedRuns();
     replyRunTesting.resetReplyRunRegistry();
+    resetDiagnosticSessionStateForTest();
+    setDiagnosticsEnabledForProcess(false);
     vi.restoreAllMocks();
   });
 
@@ -105,6 +113,27 @@ describe("pi-embedded runner run registry", () => {
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("records active run session files in diagnostic state for heartbeat recovery", () => {
+    setDiagnosticsEnabledForProcess(true);
+    const sessionFile = "/tmp/openclaw-run-registry-session.jsonl";
+    const handle = createRunHandle();
+
+    setActiveEmbeddedRun("session-file-diagnostics", handle, "agent:main:visible", sessionFile);
+
+    expect(getDiagnosticSessionState({ sessionId: "session-file-diagnostics" }).sessionFile).toBe(
+      sessionFile,
+    );
+
+    updateActiveEmbeddedRunSessionFile(
+      "session-file-diagnostics",
+      "/tmp/openclaw-run-registry-rotated.jsonl",
+    );
+
+    expect(getDiagnosticSessionState({ sessionId: "session-file-diagnostics" }).sessionFile).toBe(
+      "/tmp/openclaw-run-registry-rotated.jsonl",
+    );
   });
 
   it("passes steering options to active embedded runs", () => {

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -1,10 +1,13 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { diagnosticLogger } from "../../logging/diagnostic.js";
 import {
   testing as replyRunTesting,
   createReplyOperation,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { diagnosticLogger } from "../../logging/diagnostic.js";
 import {
   testing,
   abortAndDrainEmbeddedPiRun,
@@ -18,6 +21,7 @@ import {
   queueEmbeddedPiMessageWithOutcomeAsync,
   requestEmbeddedRunModelSwitch,
   resolveActiveEmbeddedRunHandleSessionId,
+  resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
   waitForActiveEmbeddedRuns,
@@ -79,6 +83,28 @@ describe("pi-embedded runner run registry", () => {
     expect(aborted).toBe(true);
     expect(abortA).toHaveBeenCalledTimes(1);
     expect(abortB).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves active embedded runs by canonical session file", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-run-registry-"));
+    try {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      const symlinkFile = path.join(tempDir, "session-link.jsonl");
+      await fs.writeFile(sessionFile, '{"type":"session"}\n', "utf8");
+      await fs.symlink(sessionFile, symlinkFile);
+      const handle = createRunHandle();
+
+      setActiveEmbeddedRun("session-file-run", handle, "agent:main:visible", sessionFile);
+
+      expect(resolveActiveEmbeddedRunHandleSessionIdBySessionFile(symlinkFile)).toBe(
+        "session-file-run",
+      );
+
+      clearActiveEmbeddedRun("session-file-run", handle, "agent:main:visible", sessionFile);
+      expect(resolveActiveEmbeddedRunHandleSessionIdBySessionFile(symlinkFile)).toBeUndefined();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("passes steering options to active embedded runs", () => {

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -16,6 +16,7 @@ import {
   diagnosticLogger as diag,
   logMessageQueued,
   logSessionStateChange,
+  updateDiagnosticSessionFile,
 } from "../../logging/diagnostic.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
@@ -589,6 +590,7 @@ export function setActiveEmbeddedRun(
   logSessionStateChange({
     sessionId,
     sessionKey,
+    sessionFile,
     state: "processing",
     reason: wasActive ? "run_replaced" : "run_started",
   });
@@ -617,6 +619,7 @@ export function updateActiveEmbeddedRunSessionFile(
   }
   clearActiveRunSessionFiles(sessionId);
   setActiveRunSessionFile(sessionFile, sessionId);
+  updateDiagnosticSessionFile({ sessionId, sessionFile });
 }
 
 export function clearActiveEmbeddedRun(
@@ -635,7 +638,13 @@ export function clearActiveEmbeddedRun(
     EMBEDDED_RUN_MODEL_SWITCH_REQUESTS.delete(sessionId);
     clearActiveRunSessionKeys(sessionId, sessionKey);
     clearActiveRunSessionFiles(sessionId, sessionFile);
-    logSessionStateChange({ sessionId, sessionKey, state: "idle", reason: "run_completed" });
+    logSessionStateChange({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      state: "idle",
+      reason: "run_completed",
+    });
     markDiagnosticEmbeddedRunEnded({ sessionId, sessionKey });
     if (!sessionId.startsWith("probe-")) {
       diag.debug(`run cleared: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -20,6 +20,7 @@ import {
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   ACTIVE_EMBEDDED_RUNS,
+  ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE,
   ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY,
   ACTIVE_EMBEDDED_RUN_SNAPSHOTS,
   EMBEDDED_RUN_MODEL_SWITCH_REQUESTS,
@@ -31,6 +32,7 @@ import {
   type EmbeddedRunModelSwitchRequest,
   type EmbeddedRunWaiter,
 } from "./run-state.js";
+import { resolveEmbeddedSessionFileKey } from "./session-file-key.js";
 
 export {
   getActiveEmbeddedRunCount,
@@ -119,6 +121,31 @@ function clearActiveRunSessionKeys(sessionId: string, sessionKey?: string): void
   for (const [key, activeSessionId] of ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY) {
     if (activeSessionId === sessionId) {
       ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.delete(key);
+    }
+  }
+}
+
+function setActiveRunSessionFile(sessionFile: string | undefined, sessionId: string): void {
+  if (!sessionFile?.trim()) {
+    return;
+  }
+  ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.set(
+    resolveEmbeddedSessionFileKey(sessionFile),
+    sessionId,
+  );
+}
+
+function clearActiveRunSessionFiles(sessionId: string, sessionFile?: string): void {
+  const normalizedSessionFile = sessionFile?.trim();
+  if (normalizedSessionFile) {
+    const sessionFileKey = resolveEmbeddedSessionFileKey(normalizedSessionFile);
+    if (ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.get(sessionFileKey) === sessionId) {
+      ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.delete(sessionFileKey);
+    }
+  }
+  for (const [sessionFileKey, activeSessionId] of ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE) {
+    if (activeSessionId === sessionId) {
+      ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.delete(sessionFileKey);
     }
   }
 }
@@ -366,6 +393,18 @@ export function resolveActiveEmbeddedRunHandleSessionId(sessionKey: string): str
   return ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.get(normalizedSessionKey);
 }
 
+export function resolveActiveEmbeddedRunHandleSessionIdBySessionFile(
+  sessionFile: string,
+): string | undefined {
+  const normalizedSessionFile = sessionFile.trim();
+  if (!normalizedSessionFile) {
+    return undefined;
+  }
+  return ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.get(
+    resolveEmbeddedSessionFileKey(normalizedSessionFile),
+  );
+}
+
 export function resolveActiveEmbeddedRunSessionId(sessionKey: string): string | undefined {
   const normalizedSessionKey = sessionKey.trim();
   if (!normalizedSessionKey) {
@@ -375,6 +414,12 @@ export function resolveActiveEmbeddedRunSessionId(sessionKey: string): string | 
     resolveActiveReplyRunSessionId(normalizedSessionKey) ??
     ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.get(normalizedSessionKey)
   );
+}
+
+export function resolveActiveEmbeddedRunSessionIdBySessionFile(
+  sessionFile: string,
+): string | undefined {
+  return resolveActiveEmbeddedRunHandleSessionIdBySessionFile(sessionFile);
 }
 
 export function getActiveEmbeddedRunSnapshot(
@@ -534,10 +579,13 @@ export function setActiveEmbeddedRun(
   sessionId: string,
   handle: EmbeddedPiQueueHandle,
   sessionKey?: string,
+  sessionFile?: string,
 ) {
   const wasActive = ACTIVE_EMBEDDED_RUNS.has(sessionId);
   ACTIVE_EMBEDDED_RUNS.set(sessionId, handle);
   setActiveRunSessionKey(sessionKey, sessionId);
+  clearActiveRunSessionFiles(sessionId);
+  setActiveRunSessionFile(sessionFile, sessionId);
   logSessionStateChange({
     sessionId,
     sessionKey,
@@ -560,10 +608,22 @@ export function updateActiveEmbeddedRunSnapshot(
   ACTIVE_EMBEDDED_RUN_SNAPSHOTS.set(sessionId, snapshot);
 }
 
+export function updateActiveEmbeddedRunSessionFile(
+  sessionId: string,
+  sessionFile: string | undefined,
+): void {
+  if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
+    return;
+  }
+  clearActiveRunSessionFiles(sessionId);
+  setActiveRunSessionFile(sessionFile, sessionId);
+}
+
 export function clearActiveEmbeddedRun(
   sessionId: string,
   handle: EmbeddedPiQueueHandle,
   sessionKey?: string,
+  sessionFile?: string,
 ) {
   const activeHandle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
   if (activeHandle === undefined) {
@@ -574,6 +634,7 @@ export function clearActiveEmbeddedRun(
     ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
     EMBEDDED_RUN_MODEL_SWITCH_REQUESTS.delete(sessionId);
     clearActiveRunSessionKeys(sessionId, sessionKey);
+    clearActiveRunSessionFiles(sessionId, sessionFile);
     logSessionStateChange({ sessionId, sessionKey, state: "idle", reason: "run_completed" });
     markDiagnosticEmbeddedRunEnded({ sessionId, sessionKey });
     if (!sessionId.startsWith("probe-")) {
@@ -596,6 +657,7 @@ export function forceClearEmbeddedPiRun(
     ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
     EMBEDDED_RUN_MODEL_SWITCH_REQUESTS.delete(sessionId);
     clearActiveRunSessionKeys(sessionId, sessionKey);
+    clearActiveRunSessionFiles(sessionId);
     logSessionStateChange({ sessionId, sessionKey, state: "idle", reason });
     markDiagnosticEmbeddedRunEnded({ sessionId, sessionKey });
     notifyEmbeddedRunEnded(sessionId);
@@ -617,6 +679,7 @@ export const testing = {
     ACTIVE_EMBEDDED_RUNS.clear();
     ACTIVE_EMBEDDED_RUN_SNAPSHOTS.clear();
     ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.clear();
+    ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.clear();
     EMBEDDED_RUN_MODEL_SWITCH_REQUESTS.clear();
   },
 };

--- a/src/agents/pi-embedded-runner/session-file-key.ts
+++ b/src/agents/pi-embedded-runner/session-file-key.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function resolveEmbeddedSessionFileKey(sessionFile: string): string {
+  const resolvedSessionFile = path.resolve(sessionFile);
+  const realpathSync = fs.realpathSync.native ?? fs.realpathSync;
+  try {
+    return realpathSync(resolvedSessionFile);
+  } catch {
+    // New transcript files often do not exist yet. Canonicalize the existing
+    // parent so aliases still collapse before the first write creates the file.
+  }
+  const sessionDir = path.dirname(resolvedSessionFile);
+  try {
+    return path.join(realpathSync(sessionDir), path.basename(resolvedSessionFile));
+  } catch {
+    return resolvedSessionFile;
+  }
+}

--- a/src/agents/pi-embedded.runtime.ts
+++ b/src/agents/pi-embedded.runtime.ts
@@ -4,6 +4,7 @@ export {
   isEmbeddedPiRunActive,
   isEmbeddedPiRunStreaming,
   resolveActiveEmbeddedRunSessionId,
+  resolveActiveEmbeddedRunSessionIdBySessionFile,
   runEmbeddedPiAgent,
   resolveEmbeddedSessionLane,
   waitForEmbeddedPiRunEnd,

--- a/src/agents/pi-embedded.ts
+++ b/src/agents/pi-embedded.ts
@@ -23,6 +23,7 @@ export {
   queueEmbeddedPiMessageWithOutcome,
   resolveActiveEmbeddedAgentRunSessionId,
   resolveActiveEmbeddedRunSessionId,
+  resolveActiveEmbeddedRunSessionIdBySessionFile,
   resolveEmbeddedSessionLane,
   runEmbeddedAgent,
   runEmbeddedPiAgent,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../agents/pi-embedded.runtime.js", () => ({
   isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
   isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
   resolveActiveEmbeddedRunSessionId: vi.fn().mockReturnValue(undefined),
+  resolveActiveEmbeddedRunSessionIdBySessionFile: vi.fn().mockReturnValue(undefined),
   resolveEmbeddedSessionLane: vi.fn().mockReturnValue("session:session-key"),
   waitForEmbeddedPiRunEnd: vi.fn().mockResolvedValue(true),
 }));

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -950,12 +950,15 @@ export async function runPreparedReply(
   const piRuntime = useFastReplyRuntime
     ? null
     : await traceRunPhase("reply.load_pi_runtime", () => loadPiEmbeddedRuntime());
+  const resolveActiveEmbeddedSessionId = (sessionFile = preparedSessionState.sessionFile) =>
+    piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey) ??
+    piRuntime?.resolveActiveEmbeddedRunSessionIdBySessionFile?.(sessionFile);
   const sessionLaneKey = piRuntime
     ? piRuntime.resolveEmbeddedSessionLane(sessionKey ?? sessionIdFinal)
     : undefined;
   const laneSize = sessionLaneKey ? getQueueSize(sessionLaneKey) : 0;
   const activeRunQueueMode = effectiveResetTriggered ? "interrupt" : resolvedQueue.mode;
-  const rawActiveSessionIdForInterrupt = piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey);
+  const rawActiveSessionIdForInterrupt = resolveActiveEmbeddedSessionId();
   const activeSessionIdForInterrupt = isOwnPreDispatchOperationSession(
     rawActiveSessionIdForInterrupt,
   )
@@ -1045,11 +1048,11 @@ export async function runPreparedReply(
   const resolveActiveReplyOperationSessionId = () =>
     sessionKey ? resolveActiveReplyRunSessionId(sessionKey) : undefined;
   const resolveActiveQueueSessionId = () =>
-    piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey) ??
+    resolveActiveEmbeddedSessionId() ??
     resolveActiveReplyOperationSessionId() ??
     preparedSessionState.sessionId;
   const resolveQueueBusyState = () => {
-    const embeddedActiveSessionId = piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey);
+    const embeddedActiveSessionId = resolveActiveEmbeddedSessionId();
     const replyOperationActiveSessionId = resolveActiveReplyOperationSessionId();
     const activeSessionId =
       embeddedActiveSessionId ?? replyOperationActiveSessionId ?? preparedSessionState.sessionId;
@@ -1317,7 +1320,8 @@ export async function runPreparedReply(
     isRunActive: () => {
       const latestSessionState = resolvePreparedSessionState();
       const latestActiveSessionId =
-        piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey) ?? latestSessionState.sessionId;
+        resolveActiveEmbeddedSessionId(latestSessionState.sessionFile) ??
+        latestSessionState.sessionId;
       return piRuntime?.isEmbeddedPiRunActive(latestActiveSessionId) ?? false;
     },
     isStreaming,

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -23,6 +23,7 @@ export type DiagnosticSessionRecoveryNoopReason = "no_active_work";
 export type StuckSessionRecoveryRequest = {
   sessionId?: string;
   sessionKey?: string;
+  sessionFile?: string;
   ageMs: number;
   queueDepth?: number;
   allowActiveAbort?: boolean;

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -3,6 +3,7 @@ export type SessionStateValue = "idle" | "processing" | "waiting";
 export type SessionState = {
   sessionId?: string;
   sessionKey?: string;
+  sessionFile?: string;
   lastActivity: number;
   generation?: number;
   lastStuckWarnAgeMs?: number;
@@ -28,6 +29,7 @@ export type ToolCallRecord = {
 export type SessionRef = {
   sessionId?: string;
   sessionKey?: string;
+  sessionFile?: string;
 };
 
 export const diagnosticSessionStates = new Map<string, SessionState>();
@@ -99,6 +101,9 @@ function mergeSessionState(target: SessionState, source: SessionState): void {
     sessionStatePriority(source.state) > sessionStatePriority(target.state);
   target.sessionId ??= source.sessionId;
   target.sessionKey ??= source.sessionKey;
+  if (source.sessionFile && (sourceIsNewer || !target.sessionFile)) {
+    target.sessionFile = source.sessionFile;
+  }
   if (sourceIsNewer || sourceIsSameAgeAndMoreActive) {
     target.state = source.state;
   }
@@ -154,11 +159,15 @@ export function getDiagnosticSessionState(ref: SessionRef): SessionState {
     if (ref.sessionKey) {
       existing.sessionKey = ref.sessionKey;
     }
+    if (ref.sessionFile) {
+      existing.sessionFile = ref.sessionFile;
+    }
     return existing;
   }
   const created: SessionState = {
     sessionId: ref.sessionId,
     sessionKey: ref.sessionKey,
+    sessionFile: ref.sessionFile,
     lastActivity: Date.now(),
     generation: 0,
     state: "idle",

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
 import {
+  testing as embeddedRunTesting,
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "../agents/pi-embedded-runner/runs.js";
+import {
   testing as replyRunTesting,
   createReplyOperation,
 } from "../auto-reply/reply/reply-run-registry.js";
@@ -22,6 +27,7 @@ function delay(ms: number): Promise<"blocked"> {
 describe("stuck session recovery integration", () => {
   afterEach(() => {
     recoveryTesting.resetRecoveriesInFlight();
+    embeddedRunTesting.resetActiveEmbeddedRuns();
     replyRunTesting.resetReplyRunRegistry();
     resetCommandQueueStateForTest();
   });
@@ -56,6 +62,50 @@ describe("stuck session recovery integration", () => {
     expect(getQueueSize(lane)).toBe(2);
 
     operation.complete();
+    expect(resetCommandLane(lane)).toBe(1);
+    await expect(queued).resolves.toBe("drained");
+  });
+
+  it("does not reset sibling-key lane work while the same session file has an active embedded run", async () => {
+    const activeSessionKey = "agent:main:visible";
+    const fallbackSessionKey = "agent:main:fallback";
+    const activeSessionId = "active-session-file-run";
+    const fallbackSessionId = "fallback-session-file-run";
+    const sessionFile = "/tmp/openclaw-diagnostic-shared-session.jsonl";
+    const lane = resolveEmbeddedSessionLane(fallbackSessionKey);
+    const handle = {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {},
+    };
+
+    setActiveEmbeddedRun(activeSessionId, handle, activeSessionKey, sessionFile);
+    void enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+    const queued = enqueueCommandInLane(lane, async () => "drained", {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: fallbackSessionId,
+      sessionKey: fallbackSessionKey,
+      sessionFile,
+      ageMs: 180_000,
+      queueDepth: 1,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "observe_only",
+      reason: "active_embedded_run",
+      activeSessionId,
+    });
+    await expect(Promise.race([queued, delay(100)])).resolves.toBe("blocked");
+    expect(getQueueSize(lane)).toBe(2);
+
+    clearActiveEmbeddedRun(activeSessionId, handle, activeSessionKey, sessionFile);
     expect(resetCommandLane(lane)).toBe(1);
     await expect(queued).resolves.toBe("drained");
   });

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -11,7 +11,9 @@ const mocks = vi.hoisted(() => ({
   getCommandLaneSnapshot: vi.fn(),
   resetCommandLane: vi.fn(),
   resolveActiveEmbeddedRunSessionId: vi.fn(),
+  resolveActiveEmbeddedRunSessionIdBySessionFile: vi.fn(),
   resolveActiveEmbeddedRunHandleSessionId: vi.fn(),
+  resolveActiveEmbeddedRunHandleSessionIdBySessionFile: vi.fn(),
   resolveEmbeddedSessionLane: vi.fn((key: string) => `session:${key}`),
   waitForEmbeddedPiRunEnd: vi.fn(),
   getDiagnosticSessionActivitySnapshot: vi.fn(),
@@ -44,7 +46,11 @@ vi.mock("../agents/pi-embedded-runner/runs.js", () => ({
   isEmbeddedPiRunActive: mocks.isEmbeddedPiRunActive,
   isEmbeddedPiRunHandleActive: mocks.isEmbeddedPiRunHandleActive,
   resolveActiveEmbeddedRunSessionId: mocks.resolveActiveEmbeddedRunSessionId,
+  resolveActiveEmbeddedRunSessionIdBySessionFile:
+    mocks.resolveActiveEmbeddedRunSessionIdBySessionFile,
   resolveActiveEmbeddedRunHandleSessionId: mocks.resolveActiveEmbeddedRunHandleSessionId,
+  resolveActiveEmbeddedRunHandleSessionIdBySessionFile:
+    mocks.resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
   waitForEmbeddedPiRunEnd: mocks.waitForEmbeddedPiRunEnd,
 }));
 
@@ -87,7 +93,9 @@ function resetMocks() {
   });
   mocks.resetCommandLane.mockReset();
   mocks.resolveActiveEmbeddedRunSessionId.mockReset();
+  mocks.resolveActiveEmbeddedRunSessionIdBySessionFile.mockReset();
   mocks.resolveActiveEmbeddedRunHandleSessionId.mockReset();
+  mocks.resolveActiveEmbeddedRunHandleSessionIdBySessionFile.mockReset();
   mocks.resolveEmbeddedSessionLane.mockClear();
   mocks.waitForEmbeddedPiRunEnd.mockReset();
   mocks.getDiagnosticSessionActivitySnapshot.mockReset();
@@ -128,6 +136,28 @@ describe("stuck session recovery", () => {
       "stuck session recovery skipped: sessionId=session-1 sessionKey=agent:main:main age=180s queueDepth=1 activeSessionId=session-1",
       "stuck session recovery outcome: status=skipped action=observe_only sessionId=session-1 sessionKey=agent:main:main activeSessionId=session-1 activeWorkKind=embedded_run reason=active_embedded_run",
     ]);
+  });
+
+  it("does not release a sibling-key lane while the same session file has an active run", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionIdBySessionFile.mockReturnValue("session-file-run");
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "sibling-session",
+      sessionKey: "agent:main:fallback",
+      sessionFile: "/tmp/openclaw-shared-session.jsonl",
+      ageMs: 180_000,
+      queueDepth: 1,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "observe_only",
+      reason: "active_embedded_run",
+      activeSessionId: "session-file-run",
+    });
+    expect(mocks.abortEmbeddedPiRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
   it("reclaims a stale active embedded run with queued work and no forward progress (#85639)", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -4,7 +4,9 @@ import {
   isEmbeddedPiRunActive,
   isEmbeddedPiRunHandleActive,
   resolveActiveEmbeddedRunSessionId,
+  resolveActiveEmbeddedRunSessionIdBySessionFile,
   resolveActiveEmbeddedRunHandleSessionId,
+  resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
 } from "../agents/pi-embedded-runner/runs.js";
 import { getCommandLaneSnapshot, resetCommandLane } from "../process/command-queue.js";
 import { getDiagnosticSessionActivitySnapshot } from "./diagnostic-run-activity.js";
@@ -126,12 +128,22 @@ export async function recoverStuckDiagnosticSession(
       params.sessionId && isEmbeddedPiRunHandleActive(params.sessionId)
         ? params.sessionId
         : undefined;
+    const fileActiveSessionId = params.sessionFile
+      ? resolveActiveEmbeddedRunHandleSessionIdBySessionFile(params.sessionFile)
+      : undefined;
     let activeSessionId = params.sessionKey
-      ? (resolveActiveEmbeddedRunHandleSessionId(params.sessionKey) ?? fallbackActiveSessionId)
-      : fallbackActiveSessionId;
+      ? (resolveActiveEmbeddedRunHandleSessionId(params.sessionKey) ??
+        fileActiveSessionId ??
+        fallbackActiveSessionId)
+      : (fileActiveSessionId ?? fallbackActiveSessionId);
+    const fileActiveWorkSessionId = params.sessionFile
+      ? resolveActiveEmbeddedRunSessionIdBySessionFile(params.sessionFile)
+      : undefined;
     const activeWorkSessionId = params.sessionKey
-      ? (resolveActiveEmbeddedRunSessionId(params.sessionKey) ?? params.sessionId)
-      : params.sessionId;
+      ? (resolveActiveEmbeddedRunSessionId(params.sessionKey) ??
+        fileActiveWorkSessionId ??
+        params.sessionId)
+      : (fileActiveWorkSessionId ?? params.sessionId);
     const laneKey = params.sessionKey?.trim() || params.sessionId?.trim();
     const sessionLane = laneKey ? resolveEmbeddedSessionLane(laneKey) : null;
     let aborted = false;

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -385,6 +385,34 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("threads session files from heartbeat state into stuck-session recovery", () => {
+    const recoverStuckSession = vi.fn();
+    const sessionFile = "/tmp/openclaw-heartbeat-session.jsonl";
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs: 30_000,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({
+      sessionId: "s1",
+      sessionKey: "main",
+      sessionFile,
+      state: "processing",
+    });
+    vi.advanceTimersByTime(61_000);
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", sessionFile, queueDepth: 0 },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
   it("does not warn while a processing session continues reporting progress", () => {
     const events: DiagnosticEventPayload[] = [];
     const unsubscribe = onDiagnosticEvent((event) => {
@@ -880,14 +908,25 @@ describe("stuck session diagnostics threshold", () => {
       },
       { recoverStuckSession },
     );
-    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    logSessionStateChange({
+      sessionId: "s1",
+      sessionKey: "main",
+      sessionFile: "/tmp/openclaw-active-abort-session.jsonl",
+      state: "processing",
+    });
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 
     vi.advanceTimersByTime(61_000);
 
     expectRecoveryCall(
       recoverStuckSession,
-      { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+      {
+        sessionId: "s1",
+        sessionKey: "main",
+        sessionFile: "/tmp/openclaw-active-abort-session.jsonl",
+        queueDepth: 0,
+        allowActiveAbort: true,
+      },
       ["ageMs", "stateGeneration"],
     );
   });

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -897,6 +897,15 @@ export function logSessionStateChange(
   markActivity();
 }
 
+export function updateDiagnosticSessionFile(params: SessionRef) {
+  if (!areDiagnosticsEnabledForProcess()) {
+    return;
+  }
+  const state = getDiagnosticSessionState(params);
+  state.sessionFile = params.sessionFile?.trim() || undefined;
+  markActivity();
+}
+
 export function markDiagnosticSessionProgress(params: SessionRef) {
   if (!areDiagnosticsEnabledForProcess()) {
     return;
@@ -1262,6 +1271,7 @@ export function startDiagnosticHeartbeat(
             request: {
               sessionId: state.sessionId,
               sessionKey: state.sessionKey,
+              sessionFile: state.sessionFile,
               ageMs: attentionAgeMs,
               queueDepth: state.queueDepth,
               expectedState: state.state,
@@ -1284,6 +1294,7 @@ export function startDiagnosticHeartbeat(
             request: {
               sessionId: state.sessionId,
               sessionKey: state.sessionKey,
+              sessionFile: state.sessionFile,
               ageMs: attentionAgeMs,
               queueDepth: state.queueDepth,
               allowActiveAbort: true,


### PR DESCRIPTION
## Summary
- serialize embedded attempts by canonical session file so sibling session keys cannot open overlapping prompt windows on the same transcript
- add session-file active-run indexing for reply admission, interrupt handling, stuck-session recovery, and production diagnostic heartbeat recovery requests
- drain queued transcript events before reacquiring the prompt lock and add regressions for owner, symlink, registry, heartbeat, and recovery paths

Fixes #85913.

## Verification
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings
- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts src/agents/pi-embedded-runner/runs.test.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts` - 8 files, 275 tests passed
- AWS Crabbox `run_3a67455a592e`, provider `aws`, lease `cbx_8c50f1cc49d4`, type `c7a.8xlarge`: source-level heartbeat proof passed and emitted `OPENCLAW_85913_HEARTBEAT_FIX_PROOF`

## Real behavior proof
Behavior addressed: Same-process embedded runs that resolve to the same physical transcript file are serialized by session-file owner, and sibling/fallback-key recovery now observes active same-file runs from both direct recovery and production diagnostic heartbeat recovery paths.

Real environment tested: AWS Crabbox Linux, provider `aws`, lease `cbx_8c50f1cc49d4`, run `run_3a67455a592e`, Node `v24.16.0`, synced branch patch.

Exact steps or command run after this patch: Source-level proof registered an active embedded run with a canonical session file, verified diagnostic state retained that file, verified sibling-key stuck recovery skipped because that same session file had an active embedded run, then aged a processing diagnostic state and let the real heartbeat interval request recovery.

Evidence after fix: Crabbox proof emitted `OPENCLAW_85913_HEARTBEAT_FIX_PROOF {"status":"fixed","recordedFile":"/tmp/openclaw-85913-heartbeat-proof.jsonl","siblingRecovery":{"status":"skipped","reason":"active_embedded_run","activeSessionId":"openclaw-85913-active-session"},"heartbeatRequest":{"sessionId":"openclaw-85913-heartbeat-session","sessionKey":"agent:main:openclaw-85913-heartbeat","sessionFile":"/tmp/openclaw-85913-heartbeat-proof.jsonl"}}`.

Observed result after fix: The active run's transcript path was retained in diagnostic state, same-file sibling recovery returned `status=skipped`, `reason=active_embedded_run`, and the production heartbeat recovery request carried the same `sessionFile` into recovery.

What was not tested: A real Telegram bot roundtrip was not rerun for this update because the fix is in the shared embedded runner/session ownership and diagnostic recovery paths, and the AWS proof exercises the reported same-file race plus the highest-risk heartbeat sibling recovery path without live channel credentials.
