### PR TITLE
fix(auto-reply): deliver /compact in room_event via explicit-command bypass; notifyUser independent of internal callbacks (#87107)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4250,8 +4250,9 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
-  it("prefers onCompactionEnd callback over default notice when notifyUser is enabled", async () => {
+  it("fires both notifyUser notices alongside onCompactionStart / onCompactionEnd callbacks (#87107)", async () => {
     const onBlockReply = vi.fn();
+    const onCompactionStart = vi.fn();
     const onCompactionEnd = vi.fn();
     state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
       await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
@@ -4281,7 +4282,7 @@ describe("runAgentTurnWithFallback", () => {
         Provider: "whatsapp",
         MessageSid: "msg",
       } as unknown as TemplateContext,
-      opts: { onBlockReply, onCompactionEnd },
+      opts: { onBlockReply, onCompactionStart, onCompactionEnd },
       typingSignals: createMockTypingSignaler(),
       blockReplyPipeline: null,
       blockStreamingEnabled: false,
@@ -4298,12 +4299,17 @@ describe("runAgentTurnWithFallback", () => {
     });
 
     expect(result.kind).toBe("success");
+    // Internal callbacks (Control UI etc.) and the user-channel notifyUser
+    // notices are independent audiences; both must fire when opted in.
+    expect(onCompactionStart).toHaveBeenCalledTimes(1);
     expect(onCompactionEnd).toHaveBeenCalledTimes(1);
-    // The start notice still fires (no onCompactionStart callback provided),
-    // but the completion notice is suppressed in favor of the callback.
-    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).toHaveBeenCalledTimes(2);
     expectBlockReplyCall(onBlockReply, 0, {
       text: "🧹 Compacting context...",
+      isCompactionNotice: true,
+    });
+    expectBlockReplyCall(onBlockReply, 1, {
+      text: "🧹 Compaction complete",
       isCompactionNotice: true,
     });
   });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2437,17 +2437,18 @@ export async function runAgentTurnWithFallback(params: {
                         const phase = readStringValue(evt.data.phase) ?? "";
                         const hookMessages = readCompactionHookMessages(evt.data.messages);
                         if (phase === "start") {
-                          // Keep custom compaction callbacks active, but gate the
-                          // fallback user-facing notice behind explicit opt-in.
+                          // Three independent audiences: internal callbacks
+                          // (Control UI) fire regardless; hookMessages deliver
+                          // plugin-authored user-channel text (overlap with the
+                          // default notice, so they suppress it); notifyUser is
+                          // the opt-in user-channel notice. Internal callbacks
+                          // must not suppress the user notice — see #87107.
                           if (params.opts?.onCompactionStart) {
                             await params.opts.onCompactionStart();
                           }
                           if (hookMessages.length > 0) {
                             await sendCompactionHookMessages(hookMessages);
-                          } else if (
-                            !params.opts?.onCompactionStart &&
-                            shouldNotifyUserAboutCompaction
-                          ) {
+                          } else if (shouldNotifyUserAboutCompaction) {
                             // Send directly via opts.onBlockReply (bypassing the
                             // pipeline) so the notice does not cause final payloads
                             // to be discarded on non-streaming model paths.
@@ -2463,10 +2464,7 @@ export async function runAgentTurnWithFallback(params: {
                             }
                             if (hookMessages.length > 0) {
                               await sendCompactionHookMessages(hookMessages);
-                            } else if (
-                              !params.opts?.onCompactionEnd &&
-                              shouldNotifyUserAboutCompaction
-                            ) {
+                            } else if (shouldNotifyUserAboutCompaction) {
                               await sendCompactionNotice("end");
                             }
                           } else if (hookMessages.length > 0) {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7547,6 +7547,79 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
   });
 
+  it("delivers marked explicit command terminal replies in room events (#87107)", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const commandReply = setReplyPayloadMetadata(
+      { text: "⚙️ Compacted (76k → 934 tokens)" },
+      { deliverDespiteSourceReplySuppression: true },
+    );
+    const replyResolver = vi.fn(async () => commandReply satisfies ReplyPayload);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      InboundEventKind: "room_event",
+      SessionKey: "test:session",
+      CommandSource: "text",
+      CommandAuthorized: true,
+      CommandBody: "/compact",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(commandReply);
+  });
+
+  it("delivers marked /compact reply in room event when CommandSource is undefined (#87107)", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const commandReply = setReplyPayloadMetadata(
+      { text: "⚙️ Compacted (76k → 934 tokens)" },
+      { deliverDespiteSourceReplySuppression: true },
+    );
+    const replyResolver = vi.fn(async () => commandReply satisfies ReplyPayload);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      InboundEventKind: "room_event",
+      SessionKey: "test:session",
+      CommandAuthorized: true,
+      CommandBody: "/compact",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(commandReply);
+  });
+
   it("mirrors internal source reply payloads into the active transcript", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2702,11 +2702,18 @@ export async function dispatchReplyFromConfig(
     let routedFinalCount = 0;
     let attemptedFinalDelivery = false;
     let finalDeliveryFailed = false;
+    // Explicit command turns (native or authorized text-slash like /compact) are
+    // user-initiated, so a marked terminal reply for the command bypasses
+    // room_event suppression. Ambient marked notices (no CommandTurn) stay
+    // suppressed in room_event. sendPolicy: deny still suppresses everything.
+    // Uses the same helper as the source-reply visibility policy so the bypass
+    // and the policy stay aligned.
+    const explicitCommandTurnCtx = isExplicitSourceReplyCommand(ctx, cfg);
     const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) =>
       suppressAutomaticSourceDelivery &&
-      ctx.InboundEventKind !== "room_event" &&
       !sendPolicyDenied &&
-      getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true;
+      getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true &&
+      (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
     for (const reply of replies) {
       throwIfDispatchOperationAborted();
       // Suppress reasoning payloads from channel delivery — channels using this

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillCommandSpec } from "../../agents/skills.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";
@@ -1130,5 +1131,50 @@ describe("handleInlineActions", () => {
       }),
     );
     expect(toolExecute).toHaveBeenCalled();
+  });
+
+  it("marks command-handler terminal replies with deliverDespiteSourceReplySuppression so they are not dropped under message_tool_only delivery (#87107)", async () => {
+    const typing = createTypingController();
+    handleCommandsMock.mockResolvedValueOnce({
+      shouldContinue: false,
+      reply: { text: "⚙️ Compacted (76k → 934 tokens)" },
+    });
+
+    const ctx = buildTestCtx({
+      Body: "/compact",
+      CommandBody: "/compact",
+    });
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/compact",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/compact",
+          commandBodyNormalized: "/compact",
+        },
+        overrides: {
+          cfg: { commands: { text: true } },
+          allowTextCommands: true,
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("reply");
+    if (result.kind !== "reply") {
+      throw new Error("expected reply");
+    }
+    expect(result.reply).toEqual({ text: "⚙️ Compacted (76k → 934 tokens)" });
+    // Reply must carry deliverDespiteSourceReplySuppression so dispatch-from-config
+    // does not silently `continue` past it when sourceReplyDeliveryMode is
+    // "message_tool_only" (Feishu group / WebChat default).
+    expect(
+      getReplyPayloadMetadata(result.reply as object)?.deliverDespiteSourceReplySuppression,
+    ).toBe(true);
   });
 });

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -12,6 +12,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import {
   listReservedChatSlashCommandNames,
   resolveSkillCommandInvocation,
@@ -126,6 +127,23 @@ export type InlineActionResult =
       abortedLastRun: boolean;
       cleanedBody: string;
     };
+
+// Command / skill-dispatch handlers ("/compact", "/status", tool-not-available
+// errors, etc.) emit system-meta feedback for an explicit user action; they
+// are not assistant source content. Mark them so dispatch-from-config does
+// not silently drop them when sourceReplyDeliveryMode === "message_tool_only"
+// (the default for many channels and group chats). See #87107.
+function markCommandReplyForDelivery(
+  reply: ReplyPayload | ReplyPayload[] | undefined,
+): ReplyPayload | ReplyPayload[] | undefined {
+  if (!reply) {
+    return reply;
+  }
+  if (Array.isArray(reply)) {
+    return reply.map((payload) => markReplyPayloadForSourceSuppressionDelivery(payload));
+  }
+  return markReplyPayloadForSourceSuppressionDelivery(reply);
+}
 
 function extractTextFromToolResult(result: unknown): string | null {
   if (!result || typeof result !== "object") {
@@ -307,7 +325,12 @@ export async function handleInlineActions(params: {
       const tool = authorizedTools.find((candidate) => candidate.name === dispatch.toolName);
       if (!tool) {
         typing.cleanup();
-        return { kind: "reply", reply: { text: `❌ Tool not available: ${dispatch.toolName}` } };
+        return {
+          kind: "reply",
+          reply: markCommandReplyForDelivery({
+            text: `❌ Tool not available: ${dispatch.toolName}`,
+          }),
+        };
       }
 
       const toolCallId = `cmd_${generateSecureToken(8)}`;
@@ -323,16 +346,19 @@ export async function handleInlineActions(params: {
           typing.cleanup();
           return {
             kind: "reply",
-            reply: { text: `❌ Tool call blocked: ${blockedReason}` },
+            reply: markCommandReplyForDelivery({ text: `❌ Tool call blocked: ${blockedReason}` }),
           };
         }
         const text = extractTextFromToolResult(result) ?? "✅ Done.";
         typing.cleanup();
-        return { kind: "reply", reply: { text } };
+        return { kind: "reply", reply: markCommandReplyForDelivery({ text }) };
       } catch (err) {
         const message = formatErrorMessage(err);
         typing.cleanup();
-        return { kind: "reply", reply: { text: `❌ ${message}` } };
+        return {
+          kind: "reply",
+          reply: markCommandReplyForDelivery({ text: `❌ ${message}` }),
+        };
       }
     }
 
@@ -494,7 +520,7 @@ export async function handleInlineActions(params: {
     if (inlineResult.reply) {
       if (!inlineCommand.cleaned) {
         typing.cleanup();
-        return { kind: "reply", reply: inlineResult.reply };
+        return { kind: "reply", reply: markCommandReplyForDelivery(inlineResult.reply) };
       }
       await sendInlineReply(inlineResult.reply);
     }
@@ -558,7 +584,7 @@ export async function handleInlineActions(params: {
   const commandResult = await runCommands(command);
   if (!commandResult.shouldContinue) {
     typing.cleanup();
-    return { kind: "reply", reply: commandResult.reply };
+    return { kind: "reply", reply: markCommandReplyForDelivery(commandResult.reply) };
   }
   if (command.commandBodyNormalized !== commandBodyBeforeRun) {
     cleanedBody = command.commandBodyNormalized;


### PR DESCRIPTION
### Summary

- **Problem**: Issue #87107 reports three silent-delivery failures of `/compact` and compaction notices on OpenClaw 2026.5.22. (a) Authorized `/compact` reply silently dropped on Feishu / WebChat **room_event** channels — reporter's logs show `delivered=true` but no `deliver: sending text chunks` and no Feishu API call. (b) Adjacent: command-handler terminal replies (`/status`, skill-tool blocked / error) silently dropped under `messages.visibleReplies: "message_tool"` configs even on DM. (c) `agents.defaults.compaction.notifyUser: true` notices silently skipped whenever any internal `onCompactionStart` / `onCompactionEnd` callback is registered (e.g. by Control UI).
- **Root Cause**:
  - **(a) room_event bypass too coarse**: `src/auto-reply/reply/dispatch-from-config.ts` rejected `deliverDespiteSourceReplySuppression` for every `ctx.InboundEventKind === "room_event"`, conflating user-initiated command terminal replies with ambient runtime failure notices. The `dispatch-from-config.test.ts` `suppresses marked runtime failure notices for room events` test was protecting ambient privacy but locked the bypass too tight, so the marker had no effect for the exact channels the reporter was using.
  - **(b) command-handler terminal replies missing marker**: `src/auto-reply/reply/get-reply-inline-actions.ts` returned `{ kind: "reply", reply }` for six terminal paths (skill-tool not-available, blocked, success, error, inline-action terminal command reply, top-level terminal command reply) without calling `markReplyPayloadForSourceSuppressionDelivery`, even though peer system-meta replies (model-fallback warning in `agent-runner.ts`, embedded-runner errors in `payloads.ts`) already use the same marker. Result: even after (a), the suppress branch would still drop them.
  - **(c) compaction notice gated on internal-callback absence**: `src/auto-reply/reply/agent-runner-execution.ts` (the `else if` chain introduced by #67830 to de-duplicate between internal callbacks and the default notice) gated the default `notifyUser` notice on the absence of `onCompactionStart` / `onCompactionEnd`. Audited every production `onCompactionEnd` consumer: `extensions/telegram` + `extensions/discord` + `extensions/whatsapp` use reaction-emoji controllers (`setThinking()`), `extensions/feishu` clears a streaming-status line, and `src/agents/pi-embedded-subscribe.handlers.compaction.ts` (the pi-embedded / Control UI implementation) writes a log + reconciles a counter + emits an internal `agent-event`. **None emit user-visible chat text.** The intended de-duplication had no runtime competitor; the gate suppressed the documented `🧹 Compaction complete` notice (per `docs/gateway/config-agents.md`) without anything filling the gap. ClawSweeper review on #87107 also flagged this as source-reproducible against the same doc.
- **Fix**:
  - **(a)** Narrow the `shouldDeliverDespiteSourceReplySuppression` precondition in `src/auto-reply/reply/dispatch-from-config.ts` from "never in room_event" to "in room_event only if the current ctx is an explicit command turn" (`isExplicitSourceReplyCommand(ctx, cfg)` — the same helper the source-reply visibility policy uses; matches native commands, authorized text-slash, and the legacy `CommandAuthorized + CommandBody` fallback via `isExplicitCommandTurnContext`). Ambient marked notices and `sendPolicy: deny` stay suppressed.
  - **(b)** Apply `markReplyPayloadForSourceSuppressionDelivery` at the `src/auto-reply/reply/get-reply-inline-actions.ts` chokepoint via a local helper that wraps every terminal `{ kind: "reply" }` exit. Mirrors the marker pattern already used for the model-fallback and embedded-runner notices.
  - **(c)** Split the `else if` chain in `src/auto-reply/reply/agent-runner-execution.ts` (start / completed-end / non-completed-end branches) so the user-channel notice fires on its documented contract while internal callbacks continue to fire on their own (non-chat-text) channels — reactions, status indicators, agent-events. `hookMessages.length > 0` still suppresses the default notice in the same phase because that IS a real chat-text overlap (plugin-authored user-channel text on the same channel).
- **What changed**:
  - `src/auto-reply/reply/dispatch-from-config.ts` — narrow the bypass predicate via the shared `isExplicitSourceReplyCommand(ctx)` helper from `source-reply-delivery-mode.ts` so the bypass and the visibility policy stay aligned.
  - `src/auto-reply/reply/dispatch-from-config.test.ts` — two new dispatch-level tests: `delivers marked explicit command terminal replies in room events (#87107)` (`CommandSource: "text"` shape) and `delivers marked /compact reply in room event when CommandSource is undefined (#87107)` (legacy `CommandAuthorized: true + CommandBody: "/compact"` shape that `isExplicitSourceReplyCommand` now resolves via the control-command-body fallback); existing ambient-failure room-event test stays as-is.
  - `src/auto-reply/reply/get-reply-inline-actions.ts` — `markCommandReplyForDelivery` local helper around six terminal returns.
  - `src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts` — new test asserting the marker.
  - `src/auto-reply/reply/agent-runner-execution.ts` — split the `else if` chain.
  - `src/auto-reply/reply/agent-runner-execution.test.ts` — rewrote the previously-passing test that locked in the buggy `else if` behavior; new assertions cover both callbacks AND both notices firing.
- **What did NOT change (scope boundary)**:
  - `src/auto-reply/reply/source-reply-delivery-mode.ts` — policy resolver untouched.
  - `src/auto-reply/reply-payload.ts` — marker helper unchanged.
  - The ambient room-event suppression contract (no `CommandTurn` → still suppressed in room_event) is preserved by the existing `suppresses marked runtime failure notices for room events` test, which keeps passing.
  - `sendPolicy: deny` continues to suppress every reply regardless of marker.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config` edits).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/api.ts` / `runtime-api.ts`, registry, or loader edits).

### Reproduction

1. On 2026.5.22, configure `agents.defaults.compaction.notifyUser: true` and accumulate a long conversation (70k+ tokens) so `/compact` produces a non-trivial summary.
2. Send `/compact` from a WebChat / Feishu room-event channel.
3. **Before this PR**: no `/compact` summary appears in the user channel; no compaction start / end notice appears; gateway log shows command was dispatched but no channel adapter send.
4. **After this PR**: `/compact` summary appears (room_event explicit-command bypass); both `🧹 Compacting context…` and `🧹 Compaction complete` notices appear (notifyUser fires independently of internal callbacks).

### Real behavior proof

**Behavior addressed (#87107)**: room_event source-suppression now honors the existing `deliverDespiteSourceReplySuppression` marker for explicit command turns (native or authorized text-slash), command-handler terminal replies from inline-actions now carry that marker, and the compaction `notifyUser` notice is no longer gated on internal-callback absence.

**Real environment tested (Linux, Node 22, real-component tsx harness driving production source modules against origin/main HEAD)**: tsx-resolved imports of production `resolveSourceReplyVisibilityPolicy`, `markReplyPayloadForSourceSuppressionDelivery`, `getReplyPayloadMetadata`, and `isExplicitSourceReplyCommand(ctx, cfg)` (which now routes through `isExplicitCommandTurnContext` and covers the legacy `CommandAuthorized + CommandBody` shape without `CommandSource`). The harness mirrors the post-fix `dispatch-from-config` decision verbatim across six behavior-relevant scenarios.

**Exact steps or command run after this patch**:

1. `node_modules/.bin/tsx /tmp/qmd87107/repro.mts` (real-component policy + marker + command-turn sweep)
2. `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
3. `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/get-reply-inline-actions.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`

**Evidence after fix (verbatim real-component harness output)**:

```text
================ #87107 real-component scenario sweep ================

Drives production resolveSourceReplyVisibilityPolicy,
markReplyPayloadForSourceSuppressionDelivery, and
isExplicitSourceReplyCommand against dispatch-from-config decision after
the #87107 narrow-bypass fix.

--- Feishu DM, authorized /compact (text-slash, authorized=true)
    sourceReplyDeliveryMode  = automatic
    suppressDelivery         = false
    isExplicitSourceReplyCmd = true
    before fix               = delivered
    after  fix               = delivered
    fix helps?               = false  (expected: false)  OK

--- room_event, AUTHORIZED /compact, NO CommandSource (legacy fallback via isControlCommandMessage)
    sourceReplyDeliveryMode  = message_tool_only
    suppressDelivery         = true
    isExplicitSourceReplyCmd = true
    before fix               = silently-dropped
    after  fix               = delivered
    fix helps?               = true  (expected: true)  OK

--- WebChat / Feishu group room_event, AUTHORIZED /compact (text-slash)
    sourceReplyDeliveryMode  = message_tool_only
    suppressDelivery         = true
    isExplicitSourceReplyCmd = true
    before fix               = silently-dropped
    after  fix               = delivered
    fix helps?               = true  (expected: true)  OK

--- room_event AMBIENT marked reply (no CommandTurn — runtime failure notice)
    sourceReplyDeliveryMode  = message_tool_only
    suppressDelivery         = true
    isExplicitSourceReplyCmd = false
    before fix               = silently-dropped
    after  fix               = silently-dropped
    fix helps?               = false  (expected: false)  OK

--- Feishu DM, messages.visibleReplies=message_tool, NON-command reply (skill-tool blocked etc.)
    sourceReplyDeliveryMode  = message_tool_only
    suppressDelivery         = true
    isExplicitSourceReplyCmd = false
    before fix               = silently-dropped
    after  fix               = delivered
    fix helps?               = true  (expected: true)  OK

--- Feishu DM, messages.visibleReplies=message_tool, UNAUTHORIZED /compact text-slash
    sourceReplyDeliveryMode  = message_tool_only
    suppressDelivery         = true
    isExplicitSourceReplyCmd = false
    before fix               = silently-dropped
    after  fix               = delivered
    fix helps?               = true  (expected: true)  OK

================ VERDICT ================
PASS — every scenario matches expectations.
```

**Vitest output for the three touched test files**:

```text
 RUN  v4.1.7 /root/main/openclaw/.worktrees/pr-87107

 Test Files  3 passed (3)
      Tests  336 passed (336)
   Duration  32.88s
```

**Observed result after fix**:
- Authorized `/compact` in `room_event` (Feishu group / WebChat-as-room) moves from `silently-dropped` to `delivered` — the exact branch issue #87107 hits for the reported channels.
- Ambient marked reply (no `CommandTurn`) in `room_event` stays `silently-dropped`, preserving the existing privacy contract pinned by `suppresses marked runtime failure notices for room events`.
- Under `messages.visibleReplies: "message_tool"` configs, marker recovers non-explicit / unauthorized-command paths (adjacent hygiene).
- Authorized `/compact` on DM was already delivered (policy short-circuits to `automatic`) and stays so.
- `compaction.notifyUser: true` with both internal callbacks registered now produces both callbacks AND both user-channel notices (was: 0 notices).

**What was not tested**:
- End-to-end live Feishu / WebChat channel send. The real-component harness drives the production policy + marker + explicit-command-turn predicate end-to-end but does not invoke the channel adapter; touched-surface unit tests cover the dispatch-layer behavior.
- `sendPolicy: deny` semantics were not re-tested in this PR (unchanged).

**Regression tests**:
- `dispatch-from-config.test.ts` → `delivers marked explicit command terminal replies in room events (#87107)` (CommandSource: "text" shape) + `delivers marked /compact reply in room event when CommandSource is undefined (#87107)` (legacy fallback shape) + the preserved `suppresses marked runtime failure notices for room events` (ambient privacy contract).
- `get-reply-inline-actions.skip-when-config-empty.test.ts` → marker presence on terminal command replies.
- `agent-runner-execution.test.ts` → both callbacks + both notices fire when `compaction.notifyUser` is enabled.

### Risk / Mitigation

- **Risk**: Widening the bypass for explicit command turns in `room_event` could leak ambient runtime warnings to group chats. **Mitigation**: the new predicate only matches `isExplicitSourceReplyCommand` (native command or authorized text-slash) — the same helper already used by the source-reply visibility policy, so the bypass and the policy stay aligned; ambient notices (no `CommandTurn`) keep the existing suppression, pinned by `suppresses marked runtime failure notices for room events` which still passes.
- **Risk**: Marker on command-handler replies could mask suppression elsewhere. **Mitigation**: marker is only consulted under `suppressAutomaticSourceDelivery && !sendPolicyDenied`; `sendPolicy: deny` still drops everything regardless of marker.
- **Risk**: Independent `notifyUser` notice could over-notify when a plugin also sends a `hookMessage` for the same phase. **Mitigation**: `hookMessages.length > 0` still suppresses the default notice in that phase (same user channel, one text per phase preserved).
- **Risk**: Rewriting `prefers onCompactionEnd callback over default notice when notifyUser is enabled` (introduced by #67830) could mask a legitimate de-duplication constraint. **Mitigation**: audited every production `onCompactionEnd` consumer in the repo — `extensions/telegram`, `extensions/discord`, `extensions/whatsapp` (reaction emoji), `extensions/feishu` (streaming-status-line clear), `src/agents/pi-embedded-subscribe.handlers.compaction.ts` (log + counter reconcile + internal `agent-event`). None emit user-visible chat text, so there is no chat-text source for the default notice to de-duplicate against. The original `else if` would have removed the only user-channel chat notice; this restores the documented `docs/gateway/config-agents.md` contract.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations
- [x] Sessions / storage

### Linked Issue/PR

Fixes #87107
