### PR TITLE
test(media): isolate generation provider registry mocks

### DIFF
--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
-import { getImageGenerationProvider, listImageGenerationProviders } from "./provider-registry.js";
 
 const resolvePluginCapabilityProvidersMock = vi.hoisted(() =>
   vi.fn<() => ImageGenerationProviderPlugin[]>(() => []),
@@ -26,21 +25,33 @@ function createProvider(
   };
 }
 
-function requireImageProvider(id: string): ImageGenerationProviderPlugin {
-  const provider = getImageGenerationProvider(id);
+type ImageProviderRegistry = typeof import("./provider-registry.js");
+
+function requireImageProvider(
+  registry: ImageProviderRegistry,
+  id: string,
+): ImageGenerationProviderPlugin {
+  const provider = registry.getImageGenerationProvider(id);
   if (!provider) {
     throw new Error(`expected image generation provider ${id}`);
   }
   return provider;
 }
 
+async function loadProviderRegistry(): Promise<ImageProviderRegistry> {
+  vi.resetModules();
+  return await import("./provider-registry.js");
+}
+
 describe("image-generation provider registry", () => {
   beforeEach(() => {
+    vi.resetModules();
     resolvePluginCapabilityProvidersMock.mockReset();
     resolvePluginCapabilityProvidersMock.mockReturnValue([]);
   });
 
-  it("delegates provider resolution to the capability provider boundary", () => {
+  it("delegates provider resolution to the capability provider boundary", async () => {
+    const { listImageGenerationProviders } = await loadProviderRegistry();
     const cfg = {} as OpenClawConfig;
 
     expect(listImageGenerationProviders(cfg)).toStrictEqual([]);
@@ -50,8 +61,9 @@ describe("image-generation provider registry", () => {
     });
   });
 
-  it("uses active plugin providers without loading from disk", () => {
+  it("uses active plugin providers without loading from disk", async () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([createProvider({ id: "custom-image" })]);
+    const { getImageGenerationProvider } = await loadProviderRegistry();
 
     const provider = getImageGenerationProvider("custom-image");
 
@@ -62,15 +74,17 @@ describe("image-generation provider registry", () => {
     });
   });
 
-  it("ignores prototype-like provider ids and aliases", () => {
+  it("ignores prototype-like provider ids and aliases", async () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([
       createProvider({ id: "__proto__", aliases: ["constructor", "prototype"] }),
       createProvider({ id: "safe-image", aliases: ["safe-alias", "constructor"] }),
     ]);
+    const registry = await loadProviderRegistry();
+    const { getImageGenerationProvider, listImageGenerationProviders } = registry;
 
     expect(listImageGenerationProviders().map((provider) => provider.id)).toEqual(["safe-image"]);
     expect(getImageGenerationProvider("__proto__")).toBeUndefined();
     expect(getImageGenerationProvider("constructor")).toBeUndefined();
-    expect(requireImageProvider("safe-alias").id).toBe("safe-image");
+    expect(requireImageProvider(registry, "safe-alias").id).toBe("safe-image");
   });
 });

--- a/src/video-generation/provider-registry.test.ts
+++ b/src/video-generation/provider-registry.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
-import { getVideoGenerationProvider, listVideoGenerationProviders } from "./provider-registry.js";
 
 const resolvePluginCapabilityProvidersMock = vi.hoisted(() =>
   vi.fn<() => VideoGenerationProviderPlugin[]>(() => []),
@@ -22,21 +21,34 @@ function createProvider(
   };
 }
 
-function requireVideoProvider(id: string): VideoGenerationProviderPlugin {
-  const provider = getVideoGenerationProvider(id);
+type VideoProviderRegistry = typeof import("./provider-registry.js");
+
+function requireVideoProvider(
+  registry: VideoProviderRegistry,
+  id: string,
+): VideoGenerationProviderPlugin {
+  const provider = registry.getVideoGenerationProvider(id);
   if (!provider) {
     throw new Error(`expected video generation provider ${id}`);
   }
   return provider;
 }
 
+async function loadProviderRegistry(): Promise<VideoProviderRegistry> {
+  vi.resetModules();
+  return await import("./provider-registry.js");
+}
+
 describe("video-generation provider registry", () => {
   beforeEach(() => {
+    vi.resetModules();
     resolvePluginCapabilityProvidersMock.mockReset();
     resolvePluginCapabilityProvidersMock.mockReturnValue([]);
   });
 
-  it("delegates provider resolution to the capability provider boundary", () => {
+  it("delegates provider resolution to the capability provider boundary", async () => {
+    const { listVideoGenerationProviders } = await loadProviderRegistry();
+
     expect(listVideoGenerationProviders()).toStrictEqual([]);
     expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
       key: "videoGenerationProviders",
@@ -44,8 +56,9 @@ describe("video-generation provider registry", () => {
     });
   });
 
-  it("uses active plugin providers without loading from disk", () => {
+  it("uses active plugin providers without loading from disk", async () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([createProvider({ id: "custom-video" })]);
+    const { getVideoGenerationProvider } = await loadProviderRegistry();
 
     const provider = getVideoGenerationProvider("custom-video");
 
@@ -56,15 +69,17 @@ describe("video-generation provider registry", () => {
     });
   });
 
-  it("ignores prototype-like provider ids and aliases", () => {
+  it("ignores prototype-like provider ids and aliases", async () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([
       createProvider({ id: "__proto__", aliases: ["constructor", "prototype"] }),
       createProvider({ id: "safe-video", aliases: ["safe-alias", "constructor"] }),
     ]);
+    const registry = await loadProviderRegistry();
+    const { getVideoGenerationProvider, listVideoGenerationProviders } = registry;
 
     expect(listVideoGenerationProviders().map((provider) => provider.id)).toEqual(["safe-video"]);
     expect(getVideoGenerationProvider("__proto__")).toBeUndefined();
     expect(getVideoGenerationProvider("constructor")).toBeUndefined();
-    expect(requireVideoProvider("safe-alias").id).toBe("safe-video");
+    expect(requireVideoProvider(registry, "safe-alias").id).toBe("safe-video");
   });
 });


### PR DESCRIPTION
## Summary

- Load image/video provider registries dynamically inside their tests after `vi.resetModules()`.
- Keeps the mocked `capability-provider-runtime` boundary active when `unit-fast` runs with `isolate: false` and other tests have already imported the real registry modules.

Refs 1c8a11265ba4ebb3613a3b1cb555f7fb048459b5.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts --configLoader runner src/video-generation/runtime.test.ts src/image-generation/provider-registry.test.ts src/video-generation/provider-registry.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts --configLoader runner src/image-generation/runtime.test.ts src/video-generation/runtime.test.ts src/image-generation/provider-registry.test.ts src/video-generation/provider-registry.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: `checks-node-core-fast` on `main` failed because provider-registry tests expected mocked capability providers but received real image/video provider registries after non-isolated module reuse.
Real environment tested: local source checkout on `origin/main` with the `unit-fast` Vitest config.
Exact steps or command run after this patch: ran the failing provider-registry tests together with image/video runtime tests under `test/vitest/vitest.unit-fast.config.ts`.
Evidence after fix: both targeted non-isolated unit-fast commands passed.
Observed result after fix: the provider-registry tests resolve their mocked capability-provider boundary even when related runtime tests preload registry modules in the same shard.
What was not tested: full `checks-node-core-fast` was not rerun locally; CI should cover the complete shard.
