### PR TITLE
Harden final extraction after unclosed reasoning tags

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -796,6 +796,16 @@ describe("extractAssistantVisibleText", () => {
     expect(extractAssistantVisibleText(msg)).toBe("Legacy answer");
   });
 
+  it("sanitizes malformed unclosed reasoning around a final block in legacy unphased text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "<think>reasoning <final>Done.</final> trailing" }],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantVisibleText(msg)).toBe("Done.");
+  });
+
   it("does not pull unphased legacy text into final_answer extraction when phased blocks are present", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -842,6 +842,12 @@ describe("sanitizeAssistantVisibleText", () => {
     );
   });
 
+  it("prefers a well-formed final block over malformed unclosed reasoning", () => {
+    expect(sanitizeAssistantVisibleText("<think>reasoning <final>VISIBLE</final> trailing")).toBe(
+      "VISIBLE",
+    );
+  });
+
   it("keeps unclosed trailing reasoning hidden when visible text already exists", () => {
     expect(sanitizeAssistantVisibleText("Visible prefix <think>private reasoning tail")).toBe(
       "Visible prefix",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -63,6 +63,34 @@ describe("stripReasoningTagsFromText", () => {
     ] as const)("$name", (testCase) => {
       expectStrippedCase(testCase);
     });
+
+    it.each([
+      {
+        name: "recovers final content from unclosed think",
+        input: "<think>reasoning <final>VISIBLE</final>",
+        expected: "VISIBLE",
+      },
+      {
+        name: "recovers final content from unclosed thinking",
+        input: "<thinking>reasoning <final>VISIBLE</final>",
+        expected: "VISIBLE",
+      },
+      {
+        name: "drops trailing text outside the final block",
+        input: "<think>reasoning <final>VISIBLE</final> trailing",
+        expected: "VISIBLE",
+      },
+      {
+        name: "preserves the existing fallback when no final block exists",
+        input: "<think>reasoning only",
+        expected: "reasoning only",
+      },
+    ] as const)("$name", (testCase) => {
+      expectStrippedCase({
+        ...testCase,
+        opts: { mode: "strict" },
+      });
+    });
   });
 
   describe("code block preservation (issue #3952)", () => {
@@ -326,6 +354,15 @@ describe("stripReasoningTagsFromText", () => {
     { input: "C <final>2</final> D", expected: "C 2 D" },
     { input: "E <think>x</think> F", expected: "E  F" },
   ] as const)("does not leak regex state across repeated calls: %j", (testCase) => {
+    expectStrippedCase(testCase);
+  });
+
+  it.each([
+    { input: "<final>VISIBLE</final>", expected: "VISIBLE" },
+    { input: "<think>hidden</think><final>VISIBLE</final>", expected: "VISIBLE" },
+    { input: "plain answer", expected: "plain answer" },
+    { input: "plain <final>answer</final>", expected: "plain answer" },
+  ] as const)("preserves clean visible extraction behavior: %j", (testCase) => {
     expectStrippedCase(testCase);
   });
 });

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -17,6 +17,78 @@ function applyTrim(value: string, mode: ReasoningTagTrim): string {
   return value.trim();
 }
 
+function findFirstUnclosedReasoningContentIndex(text: string): number | undefined {
+  const codeRegions = findCodeRegions(text);
+  THINKING_TAG_RE.lastIndex = 0;
+  let thinkingDepth = 0;
+  let firstUnclosedContentIndex: number | undefined;
+
+  for (const match of text.matchAll(THINKING_TAG_RE)) {
+    const idx = match.index ?? 0;
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+
+    const isClose = match[1] === "/";
+    if (thinkingDepth === 0) {
+      if (isClose) {
+        continue;
+      }
+      thinkingDepth = 1;
+      firstUnclosedContentIndex = idx + match[0].length;
+      continue;
+    }
+
+    if (isClose) {
+      thinkingDepth -= 1;
+      if (thinkingDepth === 0) {
+        firstUnclosedContentIndex = undefined;
+      }
+    } else {
+      thinkingDepth += 1;
+    }
+  }
+
+  return thinkingDepth > 0 ? firstUnclosedContentIndex : undefined;
+}
+
+function extractWellFormedFinalContentAfterIndex(params: {
+  text: string;
+  minIndex: number;
+  trimMode: ReasoningTagTrim;
+}): string | undefined {
+  const codeRegions = findCodeRegions(params.text);
+  let result = "";
+  let inFinal = false;
+  let finalContentStart = 0;
+  let foundClosedFinal = false;
+
+  for (const match of findFinalTagMatches(params.text)) {
+    const idx = match.index;
+    if (idx < params.minIndex || isInsideCode(idx, codeRegions) || match.isSelfClosing) {
+      continue;
+    }
+
+    if (!inFinal && !match.isClose) {
+      inFinal = true;
+      finalContentStart = idx + match.text.length;
+      continue;
+    }
+
+    if (inFinal && match.isClose) {
+      result += params.text.slice(finalContentStart, idx);
+      inFinal = false;
+      foundClosedFinal = true;
+    }
+  }
+
+  if (!foundClosedFinal) {
+    return undefined;
+  }
+
+  return applyTrim(result, params.trimMode);
+}
+
 export function hasOrphanReasoningCloseBoundary(params: {
   before: string;
   after: string;
@@ -49,6 +121,9 @@ export function stripReasoningTagsFromText(
   if (matches.length === 0 && !hasThinkingTag) {
     return text;
   }
+  const sourceFirstUnclosedContentIndex = hasThinkingTag
+    ? findFirstUnclosedReasoningContentIndex(text)
+    : undefined;
   if (matches.length > 0) {
     const finalMatches: Array<{ start: number; length: number; inCode: boolean }> = [];
     const preCodeRegions = findCodeRegions(cleaned);
@@ -125,6 +200,16 @@ export function stripReasoningTagsFromText(
     firstUnclosedContentIndex !== undefined &&
     cleaned.trim()
   ) {
+    if (sourceFirstUnclosedContentIndex !== undefined) {
+      const finalContent = extractWellFormedFinalContentAfterIndex({
+        text,
+        minIndex: sourceFirstUnclosedContentIndex,
+        trimMode,
+      });
+      if (finalContent !== undefined) {
+        return finalContent;
+      }
+    }
     return applyTrim(cleaned.slice(firstUnclosedContentIndex), trimMode);
   }
 


### PR DESCRIPTION
## Problem

Provider raw text can contain malformed reasoning markup such as an unclosed `<think>` or `<thinking>` block followed by a well-formed `<final>...</final>` block.

The current delivery sanitizer strips the tag text first, then uses the existing unclosed reasoning fallback when the visible result would otherwise be empty. In that malformed shape, reasoning prose before the final block can be preserved in user-visible output.

## Fix

Before the existing unclosed reasoning fallback, detect whether a well-formed `<final>...</final>` block appears after the unclosed reasoning opening tag. When it does, use only the final block content as the visible answer.

The existing fallback remains unchanged when no well-formed final block exists, so malformed local-model replies like `<think>visible answer` still recover their answer text instead of becoming empty.

## Tests

- malformed unclosed `<think>` followed by `<final>VISIBLE</final>`
- malformed unclosed `<thinking>` alias followed by `<final>VISIBLE</final>`
- trailing text after the final block is dropped from visible output
- existing unclosed reasoning fallback is preserved when no final block exists
- clean `<final>...</final>` behavior is preserved
- closed `<think>...</think><final>...</final>` behavior is preserved
- plain answer behavior is preserved
- legacy unphased embedded assistant visible extraction path is covered

## Verification

- `node scripts/test-projects.mjs src/shared/text/reasoning-tags.test.ts src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-utils.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/shared/text/reasoning-tags.ts src/shared/text/reasoning-tags.test.ts src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-utils.test.ts`
- `git diff --check`
