### PR TITLE
fix(discord): deliver same-session channel replies

### DIFF
--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -54,12 +54,28 @@ type ResetAwareSessionStore = AcpSessionStore & {
   markFresh: (sessionKey: string) => void;
 };
 
+type OpenClawLeaseSessionMetadata = {
+  openclawLeaseId: string;
+  openclawGatewayInstanceId: string;
+};
+
 function withOpenClawManagedTurnTimeout<T extends object>(input: T): T & { timeoutMs: 0 } {
   // OpenClaw owns ACP turn deadlines. acpx treats timeout after partial agent
   // output as a completed turn, which can mark background work done early.
   return {
     ...input,
     timeoutMs: 0,
+  };
+}
+
+function withOpenClawLeaseSessionMetadata<T extends object>(
+  record: T,
+  metadata: OpenClawLeaseSessionMetadata,
+): T & OpenClawLeaseSessionMetadata {
+  return {
+    ...record,
+    openclawLeaseId: metadata.openclawLeaseId,
+    openclawGatewayInstanceId: metadata.openclawGatewayInstanceId,
   };
 }
 
@@ -234,11 +250,10 @@ function createResetAwareSessionStore(
       if (!lease) {
         return record;
       }
-      return {
-        ...(record as Record<string, unknown>),
+      return withOpenClawLeaseSessionMetadata(record, {
         openclawLeaseId: lease.leaseId,
         openclawGatewayInstanceId: lease.gatewayInstanceId,
-      } as unknown as AcpLoadedSessionRecord;
+      });
     },
     async save(record: AcpSessionRecord): Promise<void> {
       let recordToSave = record;
@@ -266,14 +281,18 @@ function createResetAwareSessionStore(
           state: "open",
         };
         await params.leaseStore.save(lease);
-        recordToSave = {
-          ...(record as Record<string, unknown>),
-          // ACPX uses agentCommand as reuse identity. Lease metadata belongs to
-          // our sidecar record, so keep the persisted command stable.
-          agentCommand: stableAgentCommand,
-          openclawLeaseId: launch.leaseId,
-          openclawGatewayInstanceId: launch.gatewayInstanceId,
-        } as unknown as AcpSessionRecord;
+        recordToSave = withOpenClawLeaseSessionMetadata(
+          {
+            ...record,
+            // ACPX uses agentCommand as reuse identity. Lease metadata belongs to
+            // our sidecar record, so keep the persisted command stable.
+            agentCommand: stableAgentCommand,
+          },
+          {
+            openclawLeaseId: launch.leaseId,
+            openclawGatewayInstanceId: launch.gatewayInstanceId,
+          },
+        );
       }
       await baseStore.save(recordToSave);
       if (sessionName) {

--- a/extensions/codex/src/command-account.ts
+++ b/extensions/codex/src/command-account.ts
@@ -224,12 +224,12 @@ function resolveActiveProfileId(params: {
   const lastGood = [
     params.store.lastGood?.[OPENAI_PROVIDER_ID],
     params.store.lastGood?.[OPENAI_CODEX_PROVIDER_ID],
-  ].find((profileId): profileId is string => {
-    if (!profileId) {
-      return false;
-    }
-    return params.order.includes(profileId) && isActiveProfileCandidate(params, profileId);
-  });
+  ].find(
+    (profileId): profileId is string =>
+      typeof profileId === "string" &&
+      params.order.includes(profileId) &&
+      isActiveProfileCandidate(params, profileId),
+  );
   if (lastGood) {
     return lastGood;
   }

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -660,8 +660,7 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
     reason: "rate_limit" | "billing" | "auth_permanent";
     cfg?: OpenClawConfig;
   }): Promise<void> {
-    vi.useFakeTimers();
-    vi.setSystemTime(params.now);
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(params.now);
     try {
       await markAuthProfileFailure({
         store: params.store,
@@ -670,7 +669,7 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
         cfg: params.cfg,
       });
     } finally {
-      vi.useRealTimers();
+      dateNowSpy.mockRestore();
     }
   }
 
@@ -931,7 +930,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
         reason: params.reason ?? "rate_limit",
       });
     } finally {
-      vi.useRealTimers();
+      dateNowSpy.mockRestore();
     }
   }
 

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -912,8 +912,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     reason?: "rate_limit" | "unknown";
     useLock?: boolean;
   }): Promise<void> {
-    vi.useFakeTimers();
-    vi.setSystemTime(params.now);
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(params.now);
     if (params.useLock) {
       storeMocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
         async (lockParams: { updater: (store: AuthProfileStore) => boolean }) => {

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -111,6 +111,46 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(sendParams.threadId).toBeUndefined();
   });
 
+  it("bypasses the announce decider for same-session channel replies", async () => {
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:discord:channel:target-room",
+      displayKey: "agent:main:discord:channel:target-room",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:channel:target-room",
+      requesterChannel: "discord",
+      roundOneReply: "Substantive channel reply",
+    });
+
+    expect(runAgentStep).not.toHaveBeenCalled();
+    const sendCall = requireGatewayCall("send");
+    const sendParams = sendCall.params as Record<string, unknown>;
+    expect(sendParams.channel).toBe("discord");
+    expect(sendParams.to).toBe("channel:target-room");
+    expect(sendParams.message).toBe("Substantive channel reply");
+  });
+
+  it("keeps the announce decider for same-session sends from a different channel", async () => {
+    vi.mocked(runAgentStep).mockResolvedValueOnce("ANNOUNCE_SKIP");
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:discord:channel:target-room",
+      displayKey: "agent:main:discord:channel:target-room",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:channel:target-room",
+      requesterChannel: "webchat",
+      roundOneReply: "Substantive channel reply",
+    });
+
+    expect(runAgentStep).toHaveBeenCalledTimes(1);
+    const stepInput = firstMockArg(vi.mocked(runAgentStep), "agent step");
+    expect(stepInput.message).toBe("Agent-to-agent announce step.");
+    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+  });
+
   it.each([
     {
       source: "deliveryContext.accountId",
@@ -207,7 +247,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
-  it.each(["NO_REPLY", "HEARTBEAT_OK"])(
+  it.each(["NO_REPLY", "HEARTBEAT_OK", "ANNOUNCE_SKIP"])(
     "suppresses exact announce control reply %s before channel delivery",
     async (announceReply) => {
       vi.mocked(runAgentStep).mockResolvedValueOnce(announceReply);

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -131,6 +131,38 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(sendParams.message).toBe("Substantive channel reply");
   });
 
+  it("bypasses the announce decider for delayed same-session channel replies", async () => {
+    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
+      text: "Delayed channel reply",
+      fingerprint: "delayed-channel-reply",
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:discord:channel:target-room",
+      displayKey: "agent:main:discord:channel:target-room",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:channel:target-room",
+      requesterChannel: "discord",
+      waitRunId: "run-delayed-channel",
+    });
+
+    expect(firstMockArg(vi.mocked(waitForAgentRun), "agent run wait").runId).toBe(
+      "run-delayed-channel",
+    );
+    expect(
+      firstMockArg(vi.mocked(readLatestAssistantReplySnapshot), "assistant reply snapshot")
+        .sessionKey,
+    ).toBe("agent:main:discord:channel:target-room");
+    expect(runAgentStep).not.toHaveBeenCalled();
+    const sendCall = requireGatewayCall("send");
+    const sendParams = sendCall.params as Record<string, unknown>;
+    expect(sendParams.channel).toBe("discord");
+    expect(sendParams.to).toBe("channel:target-room");
+    expect(sendParams.message).toBe("Delayed channel reply");
+  });
+
   it("keeps the announce decider for same-session sends from a different channel", async () => {
     vi.mocked(runAgentStep).mockResolvedValueOnce("ANNOUNCE_SKIP");
 

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -145,6 +145,10 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       maxPingPongTurns: 2,
       requesterSessionKey: "agent:main:discord:channel:target-room",
       requesterChannel: "discord",
+      baseline: {
+        text: "Previous channel reply",
+        fingerprint: "previous-channel-reply",
+      },
       waitRunId: "run-delayed-channel",
     });
 
@@ -161,6 +165,34 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(sendParams.channel).toBe("discord");
     expect(sendParams.to).toBe("channel:target-room");
     expect(sendParams.message).toBe("Delayed channel reply");
+  });
+
+  it("does not direct-deliver a delayed same-session reply that matches the baseline", async () => {
+    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
+      text: "Previous channel reply",
+      fingerprint: "previous-channel-reply",
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:discord:channel:target-room",
+      displayKey: "agent:main:discord:channel:target-room",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:channel:target-room",
+      requesterChannel: "discord",
+      baseline: {
+        text: "Previous channel reply",
+        fingerprint: "previous-channel-reply",
+      },
+      waitRunId: "run-delayed-channel",
+    });
+
+    expect(firstMockArg(vi.mocked(waitForAgentRun), "agent run wait").runId).toBe(
+      "run-delayed-channel",
+    );
+    expect(runAgentStep).not.toHaveBeenCalled();
+    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
   it("keeps the announce decider for same-session sends from a different channel", async () => {

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -195,6 +195,30 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
+  it("does not direct-deliver a delayed same-session reply without a baseline", async () => {
+    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
+      text: "Maybe stale channel reply",
+      fingerprint: "maybe-stale-channel-reply",
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:discord:channel:target-room",
+      displayKey: "agent:main:discord:channel:target-room",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:channel:target-room",
+      requesterChannel: "discord",
+      waitRunId: "run-delayed-channel",
+    });
+
+    expect(firstMockArg(vi.mocked(waitForAgentRun), "agent run wait").runId).toBe(
+      "run-delayed-channel",
+    );
+    expect(runAgentStep).not.toHaveBeenCalled();
+    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+  });
+
   it("keeps the announce decider for same-session sends from a different channel", async () => {
     vi.mocked(runAgentStep).mockResolvedValueOnce("ANNOUNCE_SKIP");
 

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -126,6 +126,9 @@ export async function runSessionsSendA2AFlow(params: {
       params.requesterSessionKey === params.targetSessionKey &&
       params.requesterChannel === announceTarget.channel
     ) {
+      if (params.waitRunId && !params.roundOneReply && !params.baseline) {
+        return;
+      }
       await deliverAnnounceReply({
         announceTarget,
         message: latestReply,

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -12,6 +12,7 @@ import {
 import { runAgentStep } from "./agent-step.js";
 import { resolveAnnounceTarget } from "./sessions-announce-target.js";
 import {
+  type AnnounceTarget,
   buildAgentToAgentAnnounceContext,
   buildAgentToAgentReplyContext,
   isAnnounceSkip,
@@ -33,6 +34,38 @@ const defaultSessionsSendA2ADeps = {
 let sessionsSendA2ADeps: {
   callGateway: GatewayCaller;
 } = defaultSessionsSendA2ADeps;
+
+async function deliverAnnounceReply(params: {
+  announceTarget: AnnounceTarget;
+  message: string;
+  runContextId: string;
+}) {
+  const message = params.message.trim();
+  if (!message) {
+    return;
+  }
+  try {
+    await sessionsSendA2ADeps.callGateway({
+      method: "send",
+      params: {
+        to: params.announceTarget.to,
+        message,
+        channel: params.announceTarget.channel,
+        accountId: params.announceTarget.accountId,
+        threadId: params.announceTarget.threadId,
+        idempotencyKey: crypto.randomUUID(),
+      },
+      timeoutMs: 10_000,
+    });
+  } catch (err) {
+    log.warn("sessions_send announce delivery failed", {
+      runId: params.runContextId,
+      channel: params.announceTarget.channel,
+      to: params.announceTarget.to,
+      error: formatErrorMessage(err),
+    });
+  }
+}
 
 export async function runSessionsSendA2AFlow(params: {
   targetSessionKey: string;
@@ -82,6 +115,24 @@ export async function runSessionsSendA2AFlow(params: {
       displayKey: params.displayKey,
     });
     const targetChannel = announceTarget?.channel ?? "unknown";
+
+    // A same-session send is a human-facing source-channel reply, not a true
+    // agent-to-agent announcement. Asking the same session to decide whether to
+    // announce can learn stale ANNOUNCE_SKIP patterns from its own history and
+    // silently drop a normal channel response.
+    if (
+      announceTarget &&
+      params.requesterSessionKey &&
+      params.requesterSessionKey === params.targetSessionKey &&
+      params.requesterChannel === announceTarget.channel
+    ) {
+      await deliverAnnounceReply({
+        announceTarget,
+        message: latestReply,
+        runContextId,
+      });
+      return;
+    }
 
     if (
       params.maxPingPongTurns > 0 &&
@@ -152,27 +203,11 @@ export async function runSessionsSendA2AFlow(params: {
       !isAnnounceSkip(announceReply) &&
       !isNonDeliverableSessionsReply(announceReply)
     ) {
-      try {
-        await sessionsSendA2ADeps.callGateway({
-          method: "send",
-          params: {
-            to: announceTarget.to,
-            message: announceReply.trim(),
-            channel: announceTarget.channel,
-            accountId: announceTarget.accountId,
-            threadId: announceTarget.threadId,
-            idempotencyKey: crypto.randomUUID(),
-          },
-          timeoutMs: 10_000,
-        });
-      } catch (err) {
-        log.warn("sessions_send announce delivery failed", {
-          runId: runContextId,
-          channel: announceTarget.channel,
-          to: announceTarget.to,
-          error: formatErrorMessage(err),
-        });
-      }
+      await deliverAnnounceReply({
+        announceTarget,
+        message: announceReply,
+        runContextId,
+      });
     }
   } catch (err) {
     log.warn("sessions_send announce flow failed", {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -509,18 +509,24 @@ export function createSessionsSendTool(opts?: {
         });
       }
 
+      const requesterSessionKey = opts?.agentSessionKey;
+      const requesterChannel = opts?.agentChannel;
+      const sameSessionA2A = requesterSessionKey === resolvedKey;
+
       // Capture the pre-run assistant snapshot before starting the nested run.
       // Fast in-process test doubles and short-circuit agent paths can finish
       // before we reach the post-run read, which would otherwise make the new
       // reply look like the baseline and hide it from the caller.
+      // Fire-and-forget same-session sends still need this baseline because the
+      // A2A follow-up may deliver directly to the source channel.
       const baselineReply =
-        timeoutSeconds === 0
-          ? undefined
-          : await readLatestAssistantReplySnapshot({
+        timeoutSeconds !== 0 || sameSessionA2A
+          ? await readLatestAssistantReplySnapshot({
               sessionKey: resolvedKey,
               limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
               callGateway: gatewayCall,
-            });
+            })
+          : undefined;
 
       const agentMessageContext = buildAgentToAgentMessageContext({
         requesterSessionKey: opts?.agentSessionKey,
@@ -543,8 +549,6 @@ export function createSessionsSendTool(opts?: {
         extraSystemPrompt: agentMessageContext,
         inputProvenance,
       };
-      const requesterSessionKey = opts?.agentSessionKey;
-      const requesterChannel = opts?.agentChannel;
       const maxPingPongTurns = resolvePingPongTurns(cfg);
 
       // Skip the A2A ping-pong + announce flow when the current caller is the

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -520,13 +520,19 @@ export function createSessionsSendTool(opts?: {
       // Fire-and-forget same-session sends still need this baseline because the
       // A2A follow-up may deliver directly to the source channel.
       const baselineReply =
-        timeoutSeconds !== 0 || sameSessionA2A
+        timeoutSeconds !== 0
           ? await readLatestAssistantReplySnapshot({
               sessionKey: resolvedKey,
               limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
               callGateway: gatewayCall,
             })
-          : undefined;
+          : sameSessionA2A
+            ? await readLatestAssistantReplySnapshot({
+                sessionKey: resolvedKey,
+                limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+                callGateway: gatewayCall,
+              }).catch(() => undefined)
+            : undefined;
 
       const agentMessageContext = buildAgentToAgentMessageContext({
         requesterSessionKey: opts?.agentSessionKey,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -929,6 +929,47 @@ describe("sessions_send gating", () => {
     expect(details.sessionKey).toBe(MAIN_AGENT_SESSION_KEY);
   });
 
+  it("passes a baseline into fire-and-forget same-session A2A delivery", async () => {
+    const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
+    vi.mocked(runSessionsSendA2AFlow).mockClear();
+    const tool = createMainSessionsSendTool();
+    const staleAssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "older reply from a previous run" }],
+      timestamp: 20,
+    };
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+        };
+      }
+      if (request.method === "chat.history") {
+        return { messages: [staleAssistantMessage] };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-fire-and-forget", acceptedAt: 123 };
+      }
+      return {};
+    });
+
+    const result = await tool.execute("call-fire-and-forget-same-session", {
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("accepted");
+    expect(details.sessionKey).toBe(MAIN_AGENT_SESSION_KEY);
+    const flowParams = vi.mocked(runSessionsSendA2AFlow).mock.calls[0]?.[0];
+    expect(flowParams?.waitRunId).toBe("run-fire-and-forget");
+    expect(flowParams?.baseline?.text).toBe("older reply from a previous run");
+  });
+
   it("caps oversized timeoutSeconds before waiting for the target run", async () => {
     const tool = createMainSessionsSendTool();
     const waitTimeouts: unknown[] = [];

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -970,6 +970,42 @@ describe("sessions_send gating", () => {
     expect(flowParams?.baseline?.text).toBe("older reply from a previous run");
   });
 
+  it("accepts fire-and-forget same-session sends when baseline history is unavailable", async () => {
+    const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
+    vi.mocked(runSessionsSendA2AFlow).mockClear();
+    const tool = createMainSessionsSendTool();
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+        };
+      }
+      if (request.method === "chat.history") {
+        throw new Error("history unavailable");
+      }
+      if (request.method === "agent") {
+        return { runId: "run-fire-and-forget", acceptedAt: 123 };
+      }
+      return {};
+    });
+
+    const result = await tool.execute("call-fire-and-forget-history-fail", {
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("accepted");
+    expect(details.sessionKey).toBe(MAIN_AGENT_SESSION_KEY);
+    const flowParams = vi.mocked(runSessionsSendA2AFlow).mock.calls[0]?.[0];
+    expect(flowParams?.waitRunId).toBe("run-fire-and-forget");
+    expect(flowParams?.baseline).toBeUndefined();
+  });
+
   it("caps oversized timeoutSeconds before waiting for the target run", async () => {
     const tool = createMainSessionsSendTool();
     const waitTimeouts: unknown[] = [];

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -375,7 +375,6 @@ function listProposalEntries(params: {
       if (!query) {
         return true;
       }
-      const normalizedSearch = normalizedQuery;
       return [
         proposal.id,
         proposal.title,

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -386,7 +386,9 @@ function listProposalEntries(params: {
         const lower = value.toLowerCase();
         return (
           lower.includes(query) ||
-          (normalizedSearch ? normalizeProposalSearchText(lower).includes(normalizedSearch) : false)
+          (normalizedQuery !== undefined &&
+            normalizedQuery.length > 0 &&
+            normalizeProposalSearchText(lower).includes(normalizedQuery))
         );
       });
     })

--- a/src/commands/doctor/shared/release-configured-plugin-installs.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.ts
@@ -105,7 +105,8 @@ function collectSlotPluginIds(cfg: OpenClawConfig): string[] {
   return ["memory", "contextEngine"]
     .map((key) => normalizeId(slots?.[key]))
     .filter(
-      (pluginId): pluginId is string => pluginId !== null && pluginId.toLowerCase() !== "none",
+      (pluginId): pluginId is string =>
+        typeof pluginId === "string" && pluginId.toLowerCase() !== "none",
     );
 }
 

--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -315,7 +315,7 @@ describe("Session Store Cache", () => {
       throw new Error("Expected cached entry");
     }
     expect(entry?.polluted).toBeUndefined();
-    expect(Object.hasOwn(entry, "__proto__")).toBe(true);
+    expect(Object.hasOwn(entry as SessionEntry, "__proto__")).toBe(true);
     expect(Object.prototype).not.toHaveProperty("polluted");
   });
 

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -421,17 +421,17 @@ function createPreferredProviderMatcher(params: {
     if (cached !== undefined) {
       return cached;
     }
-    const preferredOwners = preferredOwnerPluginIdSet;
+    if (!preferredOwnerPluginIdSet) {
+      entryProviderCache.set(normalizedEntryProvider, false);
+      return false;
+    }
     const value =
-      preferredOwners !== undefined &&
-      Boolean(
-        resolveOwningPluginIdsForProviderRef({
-          provider: normalizedEntryProvider,
-          config: params.cfg,
-          workspaceDir: params.workspaceDir,
-          env: params.env,
-        })?.some((pluginId) => preferredOwners.has(pluginId)),
-      );
+      resolveOwningPluginIdsForProviderRef({
+        provider: normalizedEntryProvider,
+        config: params.cfg,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      })?.some((pluginId) => preferredOwnerPluginIdSet.has(pluginId)) ?? false;
     entryProviderCache.set(normalizedEntryProvider, value);
     return value;
   };

--- a/src/infra/retry.test.ts
+++ b/src/infra/retry.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
-import { MAX_SAFE_TIMEOUT_DELAY_MS } from "../utils/timer-delay.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { resolveRetryConfig, retryAsync } from "./retry.js";
 
 const randomMocks = vi.hoisted(() => ({
@@ -206,12 +205,11 @@ describe("retryAsync", () => {
     vi.useFakeTimers();
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const fn = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce("ok");
-    const scheduledDelayMs = resolveTimerTimeoutMs(MAX_SAFE_TIMEOUT_DELAY_MS, 0, 0);
     try {
       const promise = retryAsync(fn, 2, 3_000_000_000);
-      await vi.advanceTimersByTimeAsync(MAX_SAFE_TIMEOUT_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
       await expect(promise).resolves.toBe("ok");
-      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), scheduledDelayMs);
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     } finally {
       timeoutSpy.mockRestore();
       vi.clearAllTimers();
@@ -228,14 +226,13 @@ describe("retryAsync", () => {
       .mockRejectedValueOnce(new Error("boom-1"))
       .mockRejectedValueOnce(new Error("boom-2"))
       .mockResolvedValueOnce("ok");
-    const scheduledDelayMs = resolveTimerTimeoutMs(MAX_SAFE_TIMEOUT_DELAY_MS, 0, 0);
     try {
       const promise = retryAsync(fn, 3, Number.MAX_VALUE);
-      await vi.advanceTimersByTimeAsync(MAX_SAFE_TIMEOUT_DELAY_MS);
-      await vi.advanceTimersByTimeAsync(MAX_SAFE_TIMEOUT_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
       await expect(promise).resolves.toBe("ok");
-      expect(timeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), scheduledDelayMs);
-      expect(timeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), scheduledDelayMs);
+      expect(timeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      expect(timeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     } finally {
       timeoutSpy.mockRestore();
       vi.clearAllTimers();
@@ -319,8 +316,8 @@ describe("resolveRetryConfig", () => {
       },
       expected: {
         attempts: 3,
-        minDelayMs: MAX_SAFE_TIMEOUT_DELAY_MS,
-        maxDelayMs: MAX_SAFE_TIMEOUT_DELAY_MS,
+        minDelayMs: MAX_TIMER_TIMEOUT_MS,
+        maxDelayMs: MAX_TIMER_TIMEOUT_MS,
         jitter: 0,
       },
     },

--- a/src/infra/retry.ts
+++ b/src/infra/retry.ts
@@ -1,6 +1,6 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { MAX_TIMER_TIMEOUT_MS, resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { sleep } from "../utils.js";
-import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { generateSecureFraction } from "./secure-random.js";
 
 export type RetryConfig = {
@@ -49,9 +49,9 @@ function resolveAttemptCount(value: unknown, fallback: number): number {
 
 function resolveRetryDelayMs(value: number): number {
   if (value === Number.POSITIVE_INFINITY) {
-    return MAX_SAFE_TIMEOUT_DELAY_MS;
+    return MAX_TIMER_TIMEOUT_MS;
   }
-  return resolveSafeTimeoutDelayMs(value, { minMs: 0 });
+  return resolveTimerTimeoutMs(value, 0, 0);
 }
 
 export function resolveRetryConfig(


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes same-session, same-channel Discord guild-channel sessions_send replies being dropped when the async A2A announce decider returns ANNOUNCE_SKIP.
- Keeps true cross-agent announcement routing on the existing announce-decider path.

Why does this matter now?

- Channel-originated sessions can already produce the correct assistant reply, but users never see it when the decider treats it like an agent-to-agent announcement.

What is the intended outcome?

- When a channel session sends to itself from the same channel, the latest assistant reply is delivered directly back to the source channel.
- Cross-session and cross-agent announcements still use the existing decider and ping-pong guard behavior.

What is intentionally out of scope?

- No changes to Discord configuration, provider wiring, or broader A2A announcement policy.
- Production Discord guild delivery is still pending reviewer direction before marking the PR ready.

What does success look like?

- A same-session Discord channel reply sends the substantive assistant response instead of returning ANNOUNCE_SKIP.
- Existing cross-agent announce behavior remains unchanged.

What should reviewers focus on?

- Whether same-session, same-channel source replies are the right boundary for bypassing the announce decider.
- Whether the helper extraction preserves the existing delivery semantics for non-same-session A2A flows.

## Linked context

Which issue does this close?

Closes #87157

Which issues, PRs, or discussions are related?

Related #86723
Related #86725

Was this requested by a maintainer or owner?

- Owner-maintainer follow-up from our investigation of the Discord guild-channel reply path described in #87157.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Same-session Discord guild-channel replies can be generated but skipped by the A2A announce decider before reaching the source channel.
- Real environment tested: pi-claw Linux/aarch64 checkout of this PR branch at 7533df12c2b0cba145fed70ded54eaef3e8a3e93, with dependencies installed from the lockfile.
- Exact steps or command run after this patch: From the pi-claw checkout, ran a tsx live harness that imported this branch's runSessionsSendA2AFlow, used a Discord channel session as both targetSessionKey and requesterSessionKey, set requesterChannel to discord, and delivered through a live connected Discord Gateway.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Redacted live output:
  {
    "proofId": "87179-piclaw-1779867020560",
    "head": "7533df12c2b0cba145fed70ded54eaef3e8a3e93",
    "host": "pi-claw",
    "targetSessionKey": "agent:main:discord:channel:[redacted]",
    "requesterSessionKey": "agent:main:discord:channel:[redacted]",
    "requesterChannel": "discord",
    "sendCall": {
      "channel": "discord",
      "to": "channel:[redacted]",
      "accountId": null,
      "threadId": null,
      "message": "PR #87179 live proof 87179-piclaw-1779867020560: same-session Discord reply delivered from pi-claw using patched branch 7533df12.",
      "idempotencyKeyPresent": true
    },
    "gatewayCallMethods": ["send"],
    "sendResult": {
      "runId": "[redacted]",
      "messageId": "[redacted]",
      "channel": "discord",
      "channelId": "[redacted]"
    },
    "sendError": null
  }
- Discord readback after fix: The live channel read returned the same proof text from the bot account at 2026-05-27T07:30:21.436Z, with the returned message id matching the send result (ids redacted here).
- Observed result after fix: The same-session Discord channel flow delivered the substantive reply directly to the source Discord channel. The live harness took the direct send path and did not convert the reply into ANNOUNCE_SKIP.
- What was not tested: A separate lab Discord bot setup on pi-claw still needs guild/intent completion, so the live delivery used the already-connected Discord Gateway.
- Proof limitations or environment constraints: Discord guild/channel/message ids and internal Gateway URL are redacted from this public PR.
- Before evidence (optional but encouraged): #87157 reports sessions_send returning accepted/pending while logs show ANNOUNCE_SKIP, leaving the Discord channel without the generated reply.

## Tests and validation

Which commands did you run?

- git diff --check
- ./node_modules/.bin/tsx -e "import('./src/agents/tools/sessions-send-tool.a2a.ts').then((mod)=>console.log(typeof mod.runSessionsSendA2AFlow))"
- node --import tsx --input-type=module runtime harness for the same-session Discord channel path
- pi-claw live tsx harness from branch 7533df12 invoking runSessionsSendA2AFlow and delivering to a live Discord channel through the connected Gateway
- CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 timeout 180s node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts --reporter=verbose src/agents/tools/sessions-send-tool.a2a.test.ts

What regression coverage was added or updated?

- Added a regression test covering same-session channel replies bypassing the announce decider and delivering the substantive reply directly.
- Focused agents-tools regression file now completes locally and on pi-claw: 14 tests passed in src/agents/tools/sessions-send-tool.a2a.test.ts. This includes the same-session same-channel bypass, same-session different-channel decider path, and cross-session ANNOUNCE_SKIP suppression path.

What failed before this fix, if known?

- In the issue path, the assistant response was generated but the A2A announcement phase returned ANNOUNCE_SKIP, so the Discord channel never received the reply.

If no test was added, why not?

- A focused regression test was added.

## Risk checklist

Did user-visible behavior change? (Yes/No)

Yes.

Did config, environment, or migration behavior change? (Yes/No)

No.

Did security, auth, secrets, network, or tool execution behavior change? (Yes/No)

No.

What is the highest-risk area?

- Accidentally bypassing the announce-decider for flows that are actually cross-agent announcements.

How is that risk mitigated?

- The bypass is limited to requesterSessionKey == targetSessionKey, requesterChannel == announceTarget.channel, and an existing announce target. Cross-session and same-session different-channel flows still use the existing decider path.
- Focused coverage confirms the same-session same-channel bypass while preserving existing announce target behaviors, including same-session different-channel sends using the decider and cross-session ANNOUNCE_SKIP staying silent.

## Current review state

What is the next action?

- ClawSweeper and maintainer review can now use the added live Discord proof plus the pi-claw focused regression run.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on CI/ClawSweeper for the amended head.
- Waiting on maintainer confirmation that same-session, same-channel source replies are the intended boundary for bypassing the A2A announce decider.

Which bot or reviewer comments were addressed?

- Addressed ClawSweeper feedback by tightening the bypass to same-session same-channel replies, completing the focused sessions-send-tool.a2a regression run, adding explicit ANNOUNCE_SKIP suppression coverage, and updating the PR body with that result.
- Added live Discord/running-Gateway proof from pi-claw for the same-session source-channel delivery path.
