### PR TITLE
fix(usage): treat MiniMax current_interval_usage_count as used, not remaining

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -55,7 +55,7 @@ describe("fetchMinimaxUsage", () => {
     });
 
     const result = await fetchMinimaxUsage("key", 5000, mockFetch, { baseUrl });
-    expect(result.windows).toEqual([{ label: "5h", usedPercent: 2, resetAt: undefined }]);
+    expect(result.windows).toEqual([{ label: "5h", usedPercent: 98, resetAt: undefined }]);
   });
 
   it.each([
@@ -153,11 +153,11 @@ describe("fetchMinimaxUsage", () => {
       },
     },
     {
-      name: "treats MiniMax current_interval_usage_count as remaining quota (not consumed)",
+      name: "treats MiniMax current_interval_usage_count as used (consumed) quota",
       payload: {
         data: {
           current_interval_total_count: 100,
-          current_interval_usage_count: 98,
+          current_interval_usage_count: 2,
           plan_name: "Coding Plan",
         },
       },
@@ -208,7 +208,7 @@ describe("fetchMinimaxUsage", () => {
             {
               model_name: "MiniMax-M*",
               current_interval_total_count: 600,
-              current_interval_usage_count: 595,
+              current_interval_usage_count: 5,
               start_time: 1_774_180_800_000,
               end_time: 1_774_195_200_000,
             },
@@ -240,7 +240,7 @@ describe("fetchMinimaxUsage", () => {
             {
               model_name: "video-01",
               current_interval_total_count: 200,
-              current_interval_usage_count: 150,
+              current_interval_usage_count: 50,
               start_time: 1_774_180_800_000,
               end_time: 1_774_195_200_000,
             },

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -79,6 +79,12 @@ const USED_KEYS = [
   "prompts_used",
   "promptsUsed",
   "consumed",
+  // MiniMax token_plan/remains endpoint returns these as used (consumed) counts,
+  // not remaining. See https://github.com/openclaw/openclaw/issues/86885
+  "current_interval_usage_count",
+  "currentIntervalUsageCount",
+  "current_weekly_usage_count",
+  "currentWeeklyUsageCount",
 ] as const;
 
 const TOTAL_KEYS = [
@@ -144,12 +150,6 @@ const REMAINING_KEYS = [
   "prompts_left",
   "promptsLeft",
   "left",
-  // MiniMax usage endpoints misname these: values are remaining quota, not consumed.
-  // See https://github.com/MiniMax-AI/MiniMax-M2/issues/99
-  "current_interval_usage_count",
-  "currentIntervalUsageCount",
-  "current_weekly_usage_count",
-  "currentWeeklyUsageCount",
 ] as const;
 
 const PLAN_KEYS = ["plan", "plan_name", "planName", "product", "tier"] as const;


### PR DESCRIPTION
## Problem

MiniMax portal usage tracker shows **0% left** even when the user has ~98% of their quota remaining.

**Issue:** #86885 
**Related:** #52335, #81156

### Root cause

The /v1/token_plan/remains endpoint returns current_interval_usage_count and current_weekly_usage_count as **consumed (used) counts**, not remaining quota. 

Previously these four keys lived in REMAINING_KEYS, so the gateway computed:


Example from #86885:
- current_interval_total_count: 1500
- current_interval_usage_count: 1473 (actual **used** ~27, remaining ~1473)
- Old logic: remaining = 1473 → used = 1500 - 1473 = 27 → usedPercent = 1.8% ✅
- But when current_interval_usage_count is small (actual used ~27), old logic: remaining = 27 → used = 1473 → usedPercent = 98.2% → **"0% left"** ❌

Issue #81156 independently confirmed the same endpoint returns used counts, not remaining.

## Fix

Move current_interval_usage_count, currentIntervalUsageCount, current_weekly_usage_count, currentWeeklyUsageCount from REMAINING_KEYS to USED_KEYS.

Now the count-derived path naturally computes:


## Test updates

- Updated existing tests to reflect the new semantics (used counts, not remaining).
- No new logic paths added; existing unit-test coverage preserved.

## Checklist

- [x] I have read the Contributing Guide
- [x] This PR targets main
- [x] This is a bug fix, not a breaking change

---

**Closing this PR** after further investigation. Issue #86885 contains live API evidence showing `current_interval_usage_count` from the `v1/coding_plan/remains` endpoint is **remaining** (1473), not consumed. The correct fix is the opposite direction — keeping these keys in `REMAINING_KEYS`. Will follow up on #86885 with the correct approach.