### PR TITLE
fix(crabbox): prefer Azure for Windows targets

### DIFF
--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -44,7 +44,9 @@ pnpm crabbox:run -- --help | sed -n '1,120p'
 - OpenClaw scripts prefer `../crabbox/bin/crabbox` when present. The user PATH
   shim can be stale.
 - Check `.crabbox.yaml` for direct-provider defaults. Omitting `--provider`
-  means brokered AWS today.
+  means brokered AWS for normal Linux/macOS paths; the wrapper selects Azure
+  for unqualified Windows/WSL2 runs when the local Crabbox binary advertises
+  Azure.
 - The brokered AWS default is a Linux developer image in `eu-west-1`; the repo
   config pins hot `eu-west-1a/b/c` placement so Fast Snapshot Restore can apply.
   If warmup drifts well past the minute-scale path, verify image promotion,
@@ -82,18 +84,16 @@ Use these only when the task needs an existing non-Linux host. OpenClaw broad
 Linux validation uses the repo Crabbox config unless a provider is explicitly
 requested.
 
-Native brokered Windows is available for Windows-specific proof. Use the AWS
-developer image in `us-west-2` on demand; it has the expected OpenClaw developer
-toolchain and Docker image cache. Keep broad Linux gates on Linux/Testbox unless
-the bug is Windows-specific:
+Native brokered Windows is available for Windows-specific proof. Prefer Azure
+for Windows/WSL2 when the subscription has quota or credits and the local
+Crabbox binary advertises Azure. Keep broad Linux gates on Linux/Testbox unless
+the bug is Windows-specific, and only force AWS when the operator asks for the
+older AWS developer image/cache path or Azure is unavailable:
 
 ```sh
-../crabbox/bin/crabbox warmup \
-  --provider aws \
+pnpm crabbox:warmup -- \
   --target windows \
-  --windows-mode normal \
-  --region us-west-2 \
-  --market on-demand \
+  --windows-mode wsl2 \
   --timing-json
 ```
 

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -195,11 +195,15 @@ function gitOutput(commandArgs) {
   };
 }
 
-function configuredProvider() {
+function envProvider() {
   const envProvider = process.env.CRABBOX_PROVIDER?.trim();
   if (envProvider) {
     return envProvider;
   }
+  return "";
+}
+
+function configProvider() {
   try {
     const config = readFileSync(resolve(repoRoot, ".crabbox.yaml"), "utf8");
     const match = config.match(/^provider:\s*([^\s#]+)/m);
@@ -207,6 +211,10 @@ function configuredProvider() {
   } catch {
     return "aws";
   }
+}
+
+function configuredProvider() {
+  return envProvider() || configProvider();
 }
 
 const runValueOptions = new Set([
@@ -389,8 +397,15 @@ function commandProvider(commandArgs) {
   return "";
 }
 
-function selectedProvider(commandArgs) {
-  return commandProvider(commandArgs) || configuredProvider();
+function selectedProvider(commandArgs, advertisedProviders = []) {
+  const explicitProvider = commandProvider(commandArgs);
+  if (explicitProvider) {
+    return explicitProvider;
+  }
+  if (shouldPreferAzureForWindows(commandArgs, advertisedProviders)) {
+    return "azure";
+  }
+  return configuredProvider();
 }
 
 function shouldRequireBrokeredAws(commandArgs, providerName) {
@@ -471,6 +486,28 @@ function commandOptionEnd(commandArgs) {
   }
   const delimiter = commandArgs.indexOf("--");
   return delimiter >= 0 ? delimiter : commandArgs.length;
+}
+
+function shouldPreferAzureForWindows(commandArgs, advertisedProviders = []) {
+  return (
+    ["run", "warmup"].includes(commandArgs[0]) &&
+    isWindowsRemoteTarget(commandArgs) &&
+    !commandProvider(commandArgs) &&
+    !envProvider() &&
+    !hasOption(commandArgs, "--id") &&
+    advertisedProviders.includes("azure")
+  );
+}
+
+function ensureAzureWindowsProvider(commandArgs, providerName, advertisedProviders = []) {
+  if (providerName !== "azure" || !shouldPreferAzureForWindows(commandArgs, advertisedProviders)) {
+    return commandArgs;
+  }
+
+  const optionEnd = commandOptionEnd(commandArgs);
+  const normalizedArgs = [...commandArgs];
+  normalizedArgs.splice(optionEnd, 0, "--provider", "azure");
+  return normalizedArgs;
 }
 
 function ensureAwsMacOnDemandMarket(commandArgs, providerName) {
@@ -1739,9 +1776,12 @@ function isProviderAdvertised(provider, advertisedProviders) {
 
 const providers = parseProvidersFromHelp(help.text);
 const displayBinary = binary === "crabbox" ? "crabbox" : relative(repoRoot, binary);
-const provider = selectedProvider(args);
+const provider = selectedProvider(args, providers);
 const commandProviderValue = commandProvider(args);
-let normalizedArgs = ensureAwsMacOnDemandMarket(args, provider);
+let normalizedArgs = ensureAwsMacOnDemandMarket(
+  ensureAzureWindowsProvider(args, provider, providers),
+  provider,
+);
 
 console.error(
   `[crabbox] bin=${displayBinary} version=${version.text || "unknown"} provider=${provider || "unknown"} providers=${providers.join(",") || "unknown"}`,

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -278,6 +278,8 @@ afterAll(() => {
 });
 
 describe.concurrent("scripts/crabbox-wrapper", () => {
+  const azureProviderHelp =
+    "provider: hetzner, aws, azure, local-container, blacksmith-testbox, or cloudflare\n";
   const advertisedProviderAliasHelp = [
     "provider: hetzner, aws, gcp, local-container, blacksmith-testbox,",
     "  namespace-devbox, runpod, semaphore, cloudflare, railway, exe-dev, or ssh",
@@ -350,6 +352,108 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
       "on-demand",
       "--",
       "echo ok",
+    ]);
+  });
+
+  it("prefers Azure for unqualified Windows runs", () => {
+    const result = runWrapper(azureProviderHelp, [
+      "run",
+      "--target",
+      "windows",
+      "--windows-mode",
+      "wsl2",
+      "--",
+      "corepack",
+      "pnpm",
+      "check:changed",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseFakeCrabboxOutput(result).args).toEqual([
+      "run",
+      "--target",
+      "windows",
+      "--windows-mode",
+      "wsl2",
+      "--provider",
+      "azure",
+      "--",
+      "corepack",
+      "pnpm",
+      "check:changed",
+    ]);
+    expect(result.stderr).toContain("provider=azure");
+  });
+
+  it("keeps explicit provider env overrides for Windows runs", () => {
+    const result = runWrapper(
+      azureProviderHelp,
+      ["run", "--target", "windows", "--", "echo ok"],
+      { env: { CRABBOX_PROVIDER: "aws" } },
+    );
+
+    expect(result.status).toBe(0);
+    expect(parseFakeCrabboxOutput(result).args).toEqual([
+      "run",
+      "--target",
+      "windows",
+      "--",
+      "echo ok",
+    ]);
+    expect(result.stderr).toContain("provider=aws");
+  });
+
+  it("keeps the configured provider for Windows runs when Azure is unavailable", () => {
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--target", "windows", "--", "echo ok"],
+    );
+
+    expect(result.status).toBe(0);
+    expect(parseFakeCrabboxOutput(result).args).toEqual([
+      "run",
+      "--target",
+      "windows",
+      "--",
+      "echo ok",
+    ]);
+    expect(result.stderr).toContain("provider=aws");
+  });
+
+  it("keeps existing Windows lease selections on the configured provider", () => {
+    const result = runWrapper(azureProviderHelp, [
+      "run",
+      "--id",
+      "cbx_existing",
+      "--target",
+      "windows",
+      "--",
+      "echo ok",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(parseFakeCrabboxOutput(result).args).toEqual([
+      "run",
+      "--id",
+      "cbx_existing",
+      "--target",
+      "windows",
+      "--",
+      "echo ok",
+    ]);
+    expect(result.stderr).toContain("provider=aws");
+  });
+
+  it("prefers Azure for unqualified Windows warmups", () => {
+    const result = runWrapper(azureProviderHelp, ["warmup", "--target", "windows"]);
+
+    expect(result.status).toBe(0);
+    expect(parseFakeCrabboxOutput(result).args).toEqual([
+      "warmup",
+      "--target",
+      "windows",
+      "--provider",
+      "azure",
     ]);
   });
 


### PR DESCRIPTION
Summary
- Prefer Azure for unqualified Crabbox Windows/WSL2 run and warmup commands when the selected Crabbox binary advertises Azure.
- Preserve explicit --provider, CRABBOX_PROVIDER, existing --id lease reuse, and older Crabbox binaries that do not advertise Azure.
- Update the repo-local Crabbox skill guidance to prefer Azure for Windows/WSL2 when quota or credits are available.

Verification
- CI=1 node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts --testNamePattern "prefers Azure|keeps explicit provider env|keeps the configured provider|keeps existing Windows lease"
- node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- corepack pnpm check:changed
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Notes
- AI-assisted.