### PR TITLE
fix(codex): keep attempt watchdog for queued terminal turns

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -9365,6 +9365,65 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("keeps the attempt watchdog armed when terminal projection wedges", async () => {
+    const harness = createStartedThreadHarness();
+    vi.spyOn(CodexAppServerEventProjector.prototype, "handleNotification").mockImplementation(
+      async () => new Promise(() => undefined),
+    );
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 120;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 5,
+      turnTerminalIdleTimeoutMs: 5,
+    });
+    await harness.waitForMethod("turn/start");
+
+    void harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+
+    const result = await Promise.race([
+      run,
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error("attempt watchdog did not release queued terminal turn")),
+          1_000,
+        );
+      }),
+    ]);
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    expect(
+      warn.mock.calls.some(
+        ([message]) => message === "codex app-server turn idle timed out waiting for progress",
+      ),
+    ).toBe(true);
+    expect(
+      warn.mock.calls.some(
+        ([message]) =>
+          message === "codex app-server turn idle timed out waiting for terminal event",
+      ),
+    ).toBe(false);
+    expect(
+      warn.mock.calls.some(
+        ([message]) => message === "codex app-server turn idle timed out waiting for completion",
+      ),
+    ).toBe(false);
+  });
+
   it("routes Computer Use MCP elicitations through the native bridge", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1980,6 +1980,8 @@ export async function runCodexAppServerAttempt(
   };
 
   const fireTurnAttemptIdleTimeout = () => {
+    // terminalTurnNotificationQueued only suppresses short idle guards; a
+    // wedged notification queue still needs the full attempt timeout backstop.
     if (completed || runAbortController.signal.aborted || !turnAttemptIdleWatchArmed) {
       return;
     }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Keeps the Codex app-server full attempt watchdog armed after a terminal turn notification has been queued.
- Prevents a wedged notification queue or projector from leaving the run stuck indefinitely after short idle guards are suppressed.

Why does this matter now?

- This addresses a reviewer finding that the queued-terminal guard could remove the final timeout backstop for post-turn binary silence.

What is the intended outcome?

- `terminalTurnNotificationQueued` suppresses only short completion/terminal idle false positives.
- `params.timeoutMs` remains the full-attempt backstop until the run is actually completed.

What is intentionally out of scope?

- No changes to app-server notification ordering, projector behavior, or terminal-turn completion semantics.

What does success look like?

- A queued terminal notification that wedges before `finally` still aborts via the attempt watchdog instead of hanging the session lane.

What should reviewers focus on?

- The invariant around `terminalTurnNotificationQueued`: it should not be added to `fireTurnAttemptIdleTimeout`.

## Linked context

Which issue does this close?

- None.

Which issues, PRs, or discussions are related?

- Related maintainer review comment: keep the attempt watchdog as the queued-terminal backstop.

Was this requested by a maintainer or owner?

- Yes, requested from maintainer review follow-up in chat.

## Real behavior proof (required for external PRs)

- Behavior addressed: queued terminal notifications no longer disable the full attempt watchdog when projection/dispatch wedges.
- Real environment tested: local OpenClaw checkout plus delegated Blacksmith Testbox changed gate.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/codex/src/app-server/run-attempt.test.ts --testNamePattern "keeps the attempt watchdog armed"`; `OPENCLAW_TESTBOX=1 pnpm check:changed`.
- Evidence after fix: targeted Vitest passed: `1 passed | 232 skipped`; Testbox `tbx_01kskyg44ej461k574jee8ffjc` completed with exit `0`.
- Observed result after fix: the regression wedges terminal projection and the run still aborts through `turn_progress_idle_timeout`; completion and terminal idle timeout warnings remain suppressed.
- What was not tested: live Codex binary session with an actual wedged projector/queue.
- Proof limitations or environment constraints: the wedge is mocked to make the post-terminal queue failure deterministic.
- Before evidence: reviewer identified that adding `terminalTurnNotificationQueued` to the attempt watchdog path would allow an indefinite hang.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/run-attempt.test.ts --testNamePattern "keeps the attempt watchdog armed"`
- `OPENCLAW_TESTBOX=1 pnpm check:changed`

What regression coverage was added or updated?

- Added a Codex app-server run-attempt regression that queues `turn/completed`, wedges projector notification handling, and verifies the full attempt watchdog releases the run.

What failed before this fix, if known?

- The reviewed patch shape could let the queued-terminal flag suppress the only remaining watchdog after completion and terminal idle guards were already suppressed.

If no test was added, why not?

- N/A; regression test added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Timeout behavior for Codex app-server turns after terminal notifications are received.

How is that risk mitigated?

- The change preserves existing short idle suppression and adds a focused regression for the wedged queued-terminal case.

## Current review state

What is the next action?

- Review the watchdog invariant and regression.

What is still waiting on author, maintainer, CI, or external proof?

- CI on this PR.

Which bot or reviewer comments were addressed?

- Addressed the reviewer comment: keep the attempt watchdog as the queued-terminal backstop.
