### PR TITLE
fix(brave): hide legacy web-search config using defineProperty

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -98,6 +98,25 @@ function resolveConfiguredBraveCredential(config: unknown): unknown {
   );
 }
 
+const LEGACY_WEB_SEARCH_PROVIDER_KEYS = new Set([
+  "brave",
+  "duckduckgo",
+  "exa",
+  "firecrawl",
+  "gemini",
+  "grok",
+  "kimi",
+  "minimax",
+  "ollama",
+  "perplexity",
+  "searxng",
+  "tavily",
+]);
+
+function isLegacyWebSearchProviderKey(key: string): boolean {
+  return LEGACY_WEB_SEARCH_PROVIDER_KEYS.has(key);
+}
+
 function mergeScopedSearchConfig(
   searchConfig: Record<string, unknown> | undefined,
   key: string,
@@ -109,13 +128,22 @@ function mergeScopedSearchConfig(
   }
 
   const currentScoped = isRecord(searchConfig?.[key]) ? searchConfig?.[key] : {};
-  const next: Record<string, unknown> = {
-    ...searchConfig,
-    [key]: {
+  const next: Record<string, unknown> = { ...searchConfig };
+  const existingDescriptor = searchConfig
+    ? Object.getOwnPropertyDescriptor(searchConfig, key)
+    : undefined;
+  const shouldHideRuntimeInjectedLegacyShape =
+    isLegacyWebSearchProviderKey(key) && existingDescriptor === undefined;
+
+  Object.defineProperty(next, key, {
+    value: {
       ...currentScoped,
       ...pluginConfig,
     },
-  };
+    enumerable: !shouldHideRuntimeInjectedLegacyShape,
+    configurable: true,
+    writable: true,
+  });
 
   if (options?.mirrorApiKeyToTopLevel && pluginConfig.apiKey !== undefined) {
     next.apiKey = pluginConfig.apiKey;

--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -4,7 +4,10 @@ import type {
   WebSearchProviderPlugin,
   WebSearchProviderToolDefinition,
 } from "openclaw/plugin-sdk/provider-web-search";
-import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-config-contract";
+import {
+  createWebSearchProviderContractFields,
+  mergeScopedSearchConfig,
+} from "openclaw/plugin-sdk/provider-web-search-config-contract";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const BRAVE_CREDENTIAL_PATH = "plugins.entries.brave.config.webSearch.apiKey";
@@ -96,60 +99,6 @@ function resolveConfiguredBraveCredential(config: unknown): unknown {
     resolveProviderWebSearchPluginConfig(config, "brave")?.apiKey ??
     resolveLegacyTopLevelBraveCredential(config)?.value
   );
-}
-
-const LEGACY_WEB_SEARCH_PROVIDER_KEYS = new Set([
-  "brave",
-  "duckduckgo",
-  "exa",
-  "firecrawl",
-  "gemini",
-  "grok",
-  "kimi",
-  "minimax",
-  "ollama",
-  "perplexity",
-  "searxng",
-  "tavily",
-]);
-
-function isLegacyWebSearchProviderKey(key: string): boolean {
-  return LEGACY_WEB_SEARCH_PROVIDER_KEYS.has(key);
-}
-
-function mergeScopedSearchConfig(
-  searchConfig: Record<string, unknown> | undefined,
-  key: string,
-  pluginConfig: Record<string, unknown> | undefined,
-  options?: { mirrorApiKeyToTopLevel?: boolean },
-): Record<string, unknown> | undefined {
-  if (!pluginConfig) {
-    return searchConfig;
-  }
-
-  const currentScoped = isRecord(searchConfig?.[key]) ? searchConfig?.[key] : {};
-  const next: Record<string, unknown> = { ...searchConfig };
-  const existingDescriptor = searchConfig
-    ? Object.getOwnPropertyDescriptor(searchConfig, key)
-    : undefined;
-  const shouldHideRuntimeInjectedLegacyShape =
-    isLegacyWebSearchProviderKey(key) && existingDescriptor === undefined;
-
-  Object.defineProperty(next, key, {
-    value: {
-      ...currentScoped,
-      ...pluginConfig,
-    },
-    enumerable: !shouldHideRuntimeInjectedLegacyShape,
-    configurable: true,
-    writable: true,
-  });
-
-  if (options?.mirrorApiKeyToTopLevel && pluginConfig.apiKey !== undefined) {
-    next.apiKey = pluginConfig.apiKey;
-  }
-
-  return next;
 }
 
 function resolveBraveMode(searchConfig?: Record<string, unknown>): "web" | "llm-context" {


### PR DESCRIPTION
## Summary

Refactor brave web-search provider to use the shared `mergeScopedSearchConfig` from plugin SDK instead of a local inline copy. This removes the duplicated legacy provider key list, delegating to the single canonical implementation from PR #86818.

**Problem**: PR #86818 fixed the shared module to hide legacy provider config using `Object.defineProperty` with `enumerable: false`. Brave had its own inline copy using plain spread, causing the crash-loop.

**Fix**: Delete the entire inline copy. Import from `openclaw/plugin-sdk/provider-web-search-config-contract`.

## Real behavior proof

Behavior addressed: Brave web-search provider now uses shared SDK helper which correctly hides runtime-injected legacy provider config keys as non-enumerable while keeping them readable by provider code.

Real environment tested: Node v22.22.0, Linux (local checkout on PR-head branch fix/87191-mergeScopedSearchConfig-crash).

Exact steps or command run after this patch:
```bash
npx tsx scripts/brave-proof-sdk.mjs
```

Evidence after fix:
```console
$ npx tsx scripts/brave-proof-sdk.mjs
=== Real behavior proof: SDK mergeScopedSearchConfig ===

Test 1 - Runtime-injected legacy "brave":
  enumerable: false
  value.apiKey: test-key
  JSON.stringify hides brave: true
  brave is still readable: true

Test 2 - User-authored "brave" (existing descriptor):
  enumerable: true
  value.apiKey: new-key

Test 3 - Non-legacy provider "custom-provider":
  enumerable: true

=== All tests passed ===
```

Observed result after fix: Runtime-injected legacy "brave" key is non-enumerable (hidden from JSON.stringify and validation) but still readable by provider code. User-authored brave config keeps enumerable=true. Non-legacy keys are enumerable.

What was not tested: Full gateway container startup with real Brave web-search requests.

## Changes

extensions/brave/src/brave-web-search-provider.ts: +4 / -55

## Related

Issue: #87191
Related PRs: #86818, #86779