### PR TITLE
fix: harden CLI and gateway help paths

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -96,6 +96,16 @@ describe("argv helpers", () => {
       expected: ["node", "openclaw", "plugins", "list", "--help"],
     },
     {
+      name: "unknown plugin command group help target",
+      argv: ["node", "openclaw", "external-plugin", "help", "inspect"],
+      expected: ["node", "openclaw", "external-plugin", "inspect", "--help"],
+    },
+    {
+      name: "unknown plugin command group help target help flag",
+      argv: ["node", "openclaw", "external-plugin", "help", "inspect", "--help"],
+      expected: ["node", "openclaw", "external-plugin", "inspect", "--help"],
+    },
+    {
       name: "extra help positionals remain untouched",
       argv: ["node", "openclaw", "backup", "help", "missing", "extra", "--help"],
       expected: ["node", "openclaw", "backup", "help", "missing", "extra", "--help"],

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -151,6 +151,21 @@ describe("argv helpers", () => {
       argv: ["node", "openclaw", "help", "--help"],
       expected: ["node", "openclaw", "help", "--help"],
     },
+    {
+      name: "nested root help target",
+      argv: ["node", "openclaw", "help", "plugins", "list"],
+      expected: ["node", "openclaw", "plugins", "list", "--help"],
+    },
+    {
+      name: "nested root help target with help flag",
+      argv: ["node", "openclaw", "help", "plugins", "list", "--help"],
+      expected: ["node", "openclaw", "plugins", "list", "--help"],
+    },
+    {
+      name: "nested root help target with trailing root option",
+      argv: ["node", "openclaw", "help", "memory", "status", "--no-color"],
+      expected: ["node", "openclaw", "--no-color", "memory", "status", "--help"],
+    },
   ])("normalizes root help targets: $name", ({ argv, expected }) => {
     expect(normalizeRootHelpTargetArgv(argv)).toEqual(expected);
   });

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -14,6 +14,7 @@ import {
   isRootHelpInvocation,
   isRootVersionInvocation,
   normalizeGeneratedHelpCommandArgv,
+  normalizeRootHelpTargetArgv,
   shouldMigrateState,
   shouldMigrateStateFromPath,
 } from "./argv.js";
@@ -122,6 +123,36 @@ describe("argv helpers", () => {
     },
   ])("normalizes generated help commands: $name", ({ argv, expected }) => {
     expect(normalizeGeneratedHelpCommandArgv(argv)).toEqual(expected);
+  });
+
+  it.each([
+    {
+      name: "root help target",
+      argv: ["node", "openclaw", "help", "plugins"],
+      expected: ["node", "openclaw", "plugins", "--help"],
+    },
+    {
+      name: "root help target with help flag",
+      argv: ["node", "openclaw", "help", "plugins", "--help"],
+      expected: ["node", "openclaw", "plugins", "--help"],
+    },
+    {
+      name: "root option before help target",
+      argv: ["node", "openclaw", "--profile", "work", "help", "memory"],
+      expected: ["node", "openclaw", "--profile", "work", "memory", "--help"],
+    },
+    {
+      name: "bare root help remains untouched",
+      argv: ["node", "openclaw", "help"],
+      expected: ["node", "openclaw", "help"],
+    },
+    {
+      name: "root help self-help remains untouched",
+      argv: ["node", "openclaw", "help", "--help"],
+      expected: ["node", "openclaw", "help", "--help"],
+    },
+  ])("normalizes root help targets: $name", ({ argv, expected }) => {
+    expect(normalizeRootHelpTargetArgv(argv)).toEqual(expected);
   });
 
   it.each([

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -106,6 +106,11 @@ describe("argv helpers", () => {
       expected: ["node", "openclaw", "external-plugin", "inspect", "--help"],
     },
     {
+      name: "generated help target with trailing root option",
+      argv: ["node", "openclaw", "memory", "help", "status", "--no-color"],
+      expected: ["node", "openclaw", "--no-color", "memory", "status", "--help"],
+    },
+    {
       name: "extra help positionals remain untouched",
       argv: ["node", "openclaw", "backup", "help", "missing", "extra", "--help"],
       expected: ["node", "openclaw", "backup", "help", "missing", "extra", "--help"],

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -13,6 +13,7 @@ import {
   isHelpOrVersionInvocation,
   isRootHelpInvocation,
   isRootVersionInvocation,
+  normalizeGeneratedHelpCommandArgv,
   shouldMigrateState,
   shouldMigrateStateFromPath,
 } from "./argv.js";
@@ -66,6 +67,36 @@ describe("argv helpers", () => {
     },
   ])("detects help/version flags: $name", ({ argv, expected }) => {
     expect(hasHelpOrVersion(argv)).toBe(expected);
+  });
+
+  it.each([
+    {
+      name: "known command group help command help flag",
+      argv: ["node", "openclaw", "backup", "help", "--help"],
+      expected: ["node", "openclaw", "backup", "help"],
+    },
+    {
+      name: "known command group help command short help flag",
+      argv: ["node", "openclaw", "--profile", "work", "backup", "help", "-h"],
+      expected: ["node", "openclaw", "--profile", "work", "backup", "help"],
+    },
+    {
+      name: "leaf positional help remains untouched",
+      argv: ["node", "openclaw", "docs", "help", "--help"],
+      expected: ["node", "openclaw", "docs", "help", "--help"],
+    },
+    {
+      name: "extra help positionals remain untouched",
+      argv: ["node", "openclaw", "backup", "help", "missing", "extra", "--help"],
+      expected: ["node", "openclaw", "backup", "help", "missing", "extra", "--help"],
+    },
+    {
+      name: "terminator help flag remains untouched",
+      argv: ["node", "openclaw", "backup", "help", "--", "--help"],
+      expected: ["node", "openclaw", "backup", "help", "--", "--help"],
+    },
+  ])("normalizes generated help commands: $name", ({ argv, expected }) => {
+    expect(normalizeGeneratedHelpCommandArgv(argv)).toEqual(expected);
   });
 
   it.each([

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -86,6 +86,16 @@ describe("argv helpers", () => {
       expected: ["node", "openclaw", "docs", "help", "--help"],
     },
     {
+      name: "known command group help target",
+      argv: ["node", "openclaw", "plugins", "help", "list"],
+      expected: ["node", "openclaw", "plugins", "list", "--help"],
+    },
+    {
+      name: "known command group help target help flag",
+      argv: ["node", "openclaw", "plugins", "help", "list", "--help"],
+      expected: ["node", "openclaw", "plugins", "list", "--help"],
+    },
+    {
       name: "extra help positionals remain untouched",
       argv: ["node", "openclaw", "backup", "help", "missing", "extra", "--help"],
       expected: ["node", "openclaw", "backup", "help", "missing", "extra", "--help"],

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -195,7 +195,7 @@ export function normalizeGeneratedHelpCommandArgv(argv: string[]): string[] {
   if (
     !primary ||
     secondary?.value !== "help" ||
-    !ROOT_COMMANDS_WITH_SUBCOMMANDS.has(primary.value)
+    (KNOWN_ROOT_COMMANDS.has(primary.value) && !ROOT_COMMANDS_WITH_SUBCOMMANDS.has(primary.value))
   ) {
     return argv;
   }

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -165,6 +165,48 @@ export function isRootHelpInvocation(argv: string[]): boolean {
   return isRootInvocationForFlags(argv, HELP_FLAGS);
 }
 
+export function normalizeGeneratedHelpCommandArgv(argv: string[]): string[] {
+  const positionals: Array<{ value: string; index: number }> = [];
+  let helpFlagIndex: number | null = null;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      break;
+    }
+    if (positionals.length === 0) {
+      const consumed = consumeRootOptionToken(argv, index);
+      if (consumed > 0) {
+        index += consumed - 1;
+        continue;
+      }
+    }
+    if (HELP_FLAGS.has(arg)) {
+      helpFlagIndex = index;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      return argv;
+    }
+    positionals.push({ value: arg, index });
+  }
+
+  const [primary, secondary] = positionals;
+  if (
+    !primary ||
+    secondary?.value !== "help" ||
+    !ROOT_COMMANDS_WITH_SUBCOMMANDS.has(primary.value)
+  ) {
+    return argv;
+  }
+
+  if (positionals.length === 2 && helpFlagIndex === secondary.index + 1) {
+    return argv.toSpliced(helpFlagIndex, 1);
+  }
+
+  return argv;
+}
+
 export function getFlagValue(argv: string[], name: string): string | null | undefined {
   const args = argv.slice(2);
   for (let i = 0; i < args.length; i += 1) {

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -215,6 +215,45 @@ export function normalizeGeneratedHelpCommandArgv(argv: string[]): string[] {
   return [argv[0], argv[1], ...rootOptions, primary.value, target.value, "--help"];
 }
 
+export function normalizeRootHelpTargetArgv(argv: string[]): string[] {
+  const positionals: Array<{ value: string; index: number }> = [];
+  const rootOptions: string[] = [];
+  let helpFlagIndex: number | null = null;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      break;
+    }
+    const consumed = consumeRootOptionToken(argv, index);
+    if (consumed > 0) {
+      rootOptions.push(...argv.slice(index, index + consumed));
+      index += consumed - 1;
+      continue;
+    }
+    if (HELP_FLAGS.has(arg)) {
+      helpFlagIndex = index;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      return argv;
+    }
+    positionals.push({ value: arg, index });
+  }
+
+  const [help, target] = positionals;
+  if (
+    help?.value !== "help" ||
+    !target ||
+    positionals.length !== 2 ||
+    (helpFlagIndex !== null && helpFlagIndex !== target.index + 1)
+  ) {
+    return argv;
+  }
+
+  return [argv[0], argv[1], ...rootOptions, target.value, "--help"];
+}
+
 export function getFlagValue(argv: string[], name: string): string | null | undefined {
   const args = argv.slice(2);
   for (let i = 0; i < args.length; i += 1) {

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -167,6 +167,7 @@ export function isRootHelpInvocation(argv: string[]): boolean {
 
 export function normalizeGeneratedHelpCommandArgv(argv: string[]): string[] {
   const positionals: Array<{ value: string; index: number }> = [];
+  const rootOptions: string[] = [];
   let helpFlagIndex: number | null = null;
 
   for (let index = 2; index < argv.length; index += 1) {
@@ -174,12 +175,11 @@ export function normalizeGeneratedHelpCommandArgv(argv: string[]): string[] {
     if (!arg || arg === FLAG_TERMINATOR) {
       break;
     }
-    if (positionals.length === 0) {
-      const consumed = consumeRootOptionToken(argv, index);
-      if (consumed > 0) {
-        index += consumed - 1;
-        continue;
-      }
+    const consumed = consumeRootOptionToken(argv, index);
+    if (consumed > 0) {
+      rootOptions.push(...argv.slice(index, index + consumed));
+      index += consumed - 1;
+      continue;
     }
     if (HELP_FLAGS.has(arg)) {
       helpFlagIndex = index;
@@ -212,8 +212,7 @@ export function normalizeGeneratedHelpCommandArgv(argv: string[]): string[] {
     return argv;
   }
 
-  const normalized = argv.toSpliced(secondary.index, 1);
-  return helpFlagIndex === null ? [...normalized, "--help"] : normalized;
+  return [argv[0], argv[1], ...rootOptions, primary.value, target.value, "--help"];
 }
 
 export function getFlagValue(argv: string[], name: string): string | null | undefined {

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -245,13 +245,13 @@ export function normalizeRootHelpTargetArgv(argv: string[]): string[] {
   if (
     help?.value !== "help" ||
     !target ||
-    positionals.length !== 2 ||
-    (helpFlagIndex !== null && helpFlagIndex !== target.index + 1)
+    (helpFlagIndex !== null && helpFlagIndex !== positionals.at(-1)!.index + 1)
   ) {
     return argv;
   }
 
-  return [argv[0], argv[1], ...rootOptions, target.value, "--help"];
+  const targetPath = positionals.slice(1).map((positional) => positional.value);
+  return [argv[0], argv[1], ...rootOptions, ...targetPath, "--help"];
 }
 
 export function getFlagValue(argv: string[], name: string): string | null | undefined {

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -191,7 +191,7 @@ export function normalizeGeneratedHelpCommandArgv(argv: string[]): string[] {
     positionals.push({ value: arg, index });
   }
 
-  const [primary, secondary] = positionals;
+  const [primary, secondary, target] = positionals;
   if (
     !primary ||
     secondary?.value !== "help" ||
@@ -204,7 +204,16 @@ export function normalizeGeneratedHelpCommandArgv(argv: string[]): string[] {
     return argv.toSpliced(helpFlagIndex, 1);
   }
 
-  return argv;
+  if (
+    !target ||
+    positionals.length !== 3 ||
+    (helpFlagIndex !== null && helpFlagIndex !== target.index + 1)
+  ) {
+    return argv;
+  }
+
+  const normalized = argv.toSpliced(secondary.index, 1);
+  return helpFlagIndex === null ? [...normalized, "--help"] : normalized;
 }
 
 export function getFlagValue(argv: string[], name: string): string | null | undefined {

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -393,6 +393,14 @@ describe("gateway-cli coverage", () => {
     expect(runtimeErrors.join("\n")).toContain("Gateway call failed:");
   });
 
+  it("validates gateway call timeout before opening a transport", async () => {
+    callGateway.mockClear();
+    await expectGatewayExit(["gateway", "call", "health", "--timeout", "nope", "--json"]);
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("Invalid --timeout");
+  });
+
   it("validates gateway ports and handles force/start errors", async () => {
     // Invalid port
     await expectGatewayExit(["gateway", "--port", "0", "--token", "test-token"]);

--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../gateway/protocol/client-info.js";
+import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import { withProgress } from "../progress.js";
 
 export type GatewayRpcOpts = {
@@ -13,6 +14,8 @@ export type GatewayRpcOpts = {
   expectFinal?: boolean;
   json?: boolean;
 };
+
+const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 10_000;
 
 export const gatewayCallOpts = (cmd: Command) =>
   cmd
@@ -39,7 +42,7 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
         method,
         params,
         expectFinal: Boolean(opts.expectFinal),
-        timeoutMs: Number(opts.timeout ?? 10_000),
+        timeoutMs: parseTimeoutMsWithFallback(opts.timeout, DEFAULT_GATEWAY_RPC_TIMEOUT_MS),
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
       }),

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -43,7 +43,16 @@ const EXAMPLES = [
   ],
 ] as const;
 
-export function configureProgramHelp(program: Command, ctx: ProgramContext) {
+export function configureProgramHelp(
+  program: Command,
+  ctx: ProgramContext,
+  options?: { commandsWithSubcommands?: ReadonlySet<string> },
+) {
+  const commandsWithSubcommands = new Set([
+    ...ROOT_COMMANDS_WITH_SUBCOMMANDS,
+    ...(options?.commandsWithSubcommands ?? []),
+  ]);
+
   program
     .name(CLI_NAME)
     .description("")
@@ -77,7 +86,7 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     optionTerm: (option) => theme.option(option.flags),
     subcommandTerm: (cmd) => {
       const isRootCommand = cmd.parent === program;
-      const hasSubcommands = isRootCommand && ROOT_COMMANDS_WITH_SUBCOMMANDS.has(cmd.name());
+      const hasSubcommands = isRootCommand && commandsWithSubcommands.has(cmd.name());
       return theme.command(hasSubcommands ? `${cmd.name()} *` : cmd.name());
     },
   });

--- a/src/cli/program/root-help.test.ts
+++ b/src/cli/program/root-help.test.ts
@@ -80,6 +80,7 @@ describe("root help", () => {
     expect(text).toContain("status");
     expect(text).toContain("config");
     expect(text).toContain("matrix");
+    expect(text).toContain("matrix *");
     expect(text).toContain("Matrix channel utilities");
   });
 

--- a/src/cli/program/root-help.ts
+++ b/src/cli/program/root-help.ts
@@ -19,19 +19,28 @@ export type RootHelpRenderOptions = Pick<PluginLoadOptions, "pluginSdkResolution
 
 async function buildRootHelpProgram(renderOptions?: RootHelpRenderOptions): Promise<Command> {
   const program = new Command();
-  configureProgramHelp(program, {
-    programVersion: VERSION,
-    channelOptions: [],
-    messageChannelOptions: "",
-    agentChannelOptions: "",
-  });
-
   const pluginDescriptors =
     renderOptions?.includePluginDescriptors === true || renderOptions?.config
       ? await getPluginCliCommandDescriptors(renderOptions.config, renderOptions.env, {
           pluginSdkResolution: renderOptions.pluginSdkResolution,
         })
       : [];
+  configureProgramHelp(
+    program,
+    {
+      programVersion: VERSION,
+      channelOptions: [],
+      messageChannelOptions: "",
+      agentChannelOptions: "",
+    },
+    {
+      commandsWithSubcommands: new Set(
+        pluginDescriptors
+          .filter((descriptor) => descriptor.hasSubcommands)
+          .map((descriptor) => descriptor.name),
+      ),
+    },
+  );
 
   addCommandDescriptorsToProgram(
     program,

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -12,7 +12,7 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
-import { normalizeGeneratedHelpCommandArgv } from "./argv.js";
+import { normalizeGeneratedHelpCommandArgv, normalizeRootHelpTargetArgv } from "./argv.js";
 import {
   isReservedNonPluginCommandRoot,
   shouldRegisterPrimaryCommandOnly,
@@ -484,7 +484,7 @@ export async function runCli(argv: string[] = process.argv) {
     }
     return;
   }
-  let normalizedArgv = parsedProfile.argv;
+  let normalizedArgv = normalizeRootHelpTargetArgv(parsedProfile.argv);
   const normalizedInvocation = resolveCliArgvInvocation(normalizedArgv);
   const isHelpOrVersionInvocation = normalizedInvocation.hasHelpOrVersion;
   startupTrace.mark("argv");

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -12,6 +12,7 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
+import { normalizeGeneratedHelpCommandArgv } from "./argv.js";
 import {
   isReservedNonPluginCommandRoot,
   shouldRegisterPrimaryCommandOnly,
@@ -804,7 +805,7 @@ export async function runCli(argv: string[] = process.argv) {
         process.exit(1);
       });
 
-      const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
+      const parseArgv = normalizeGeneratedHelpCommandArgv(rewriteUpdateFlagArgv(normalizedArgv));
       const invocation = resolveCliArgvInvocation(parseArgv);
       // Register the primary command (builtin or subcli) so help and command parsing
       // are correct even with lazy command registration.

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -697,6 +697,7 @@ describe("skills cli commands", () => {
     expect(defaultRuntime.writeStdout).toHaveBeenCalledTimes(1);
     expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
     expect(defaultRuntime.log).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
     expect(runtimeErrors).toStrictEqual([]);
     expect(runtimeStdout).toHaveLength(1);
 

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -79,7 +79,6 @@ async function runSkillsAction(
   try {
     const report = await loadSkillsStatusReport(options);
     defaultRuntime.writeStdout(render(report));
-    defaultRuntime.exit(0);
   } catch (err) {
     defaultRuntime.error(String(err));
     defaultRuntime.exit(1);

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -319,6 +319,23 @@ describe("registerPluginCliCommands", () => {
     });
   });
 
+  it("keeps root-help descriptor load failures quiet", async () => {
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as unknown as typeof process.stderr.write);
+    mocks.loadOpenClawPluginCliRegistry.mockImplementationOnce((options: { logger?: unknown }) => {
+      const logger = options.logger as { error?: (message: string) => void };
+      logger.error?.("[plugins] stale failed to load from /tmp/stale: boom");
+      throw new Error("boom");
+    });
+
+    await expect(
+      getPluginCliCommandDescriptors({ plugins: { entries: { stale: {} } } } as OpenClawConfig),
+    ).resolves.toEqual([]);
+
+    expect(stderrWrite).not.toHaveBeenCalled();
+  });
+
   it("keeps runtime CLI command registration on the full plugin loader for legacy channel plugins", async () => {
     const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
     mocks.applyPluginAutoEnable.mockReturnValue({

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -8,7 +8,7 @@ import {
   type PluginCliLoaderOptions,
 } from "./cli-registry-loader.js";
 import { registerPluginCliCommandGroups } from "./register-plugin-cli-command-groups.js";
-import type { OpenClawPluginCliCommandDescriptor } from "./types.js";
+import type { OpenClawPluginCliCommandDescriptor, PluginLogger } from "./types.js";
 
 type PluginCliRegistrationMode = "eager" | "lazy";
 
@@ -34,6 +34,13 @@ interface ProgramWithEntriesCache {
 const logger = createPluginCliLogger();
 const loaderOptionIds = new WeakMap<object, number>();
 let nextLoaderOptionId = 1;
+
+const quietDescriptorLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} satisfies PluginLogger;
 
 function stableJsonKey(value: unknown): string {
   if (value === undefined) {
@@ -81,7 +88,7 @@ export async function getPluginCliCommandDescriptors(
   env?: NodeJS.ProcessEnv,
   loaderOptions?: PluginCliLoaderOptions,
 ): Promise<OpenClawPluginCliCommandDescriptor[]> {
-  return loadPluginCliDescriptors({ cfg, env, loaderOptions });
+  return loadPluginCliDescriptors({ cfg, env, loaderOptions, logger: quietDescriptorLogger });
 }
 
 export async function registerPluginCliCommands(


### PR DESCRIPTION
## Summary

- Fixes root help/plugin descriptor discovery so stale plugin descriptor load failures stay quiet and plugin command groups render with the `*` subcommand marker.
- Normalizes CLI help spellings across generated help commands, plugin-owned command groups, root `help <target>` paths, nested help targets, and trailing root options.
- Fixes large `skills list --json` output truncation and rejects invalid `gateway call --timeout` values before opening the gateway transport.

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git fetch origin main && git rebase origin/main`
- `git diff --check origin/main...HEAD`
- `pnpm test src/cli/argv.test.ts src/cli/run-main.exit.test.ts src/cli/gateway-cli.coverage.test.ts src/cli/skills-cli.commands.test.ts src/plugins/cli.test.ts src/cli/program/root-help.test.ts -- --reporter=verbose`
- `pnpm test:changed`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json $(git diff --name-only origin/main...HEAD | tr '\n' ' ')`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: CLI/gateway help routing, root-help descriptor rendering, skills JSON stdout completion, and gateway RPC timeout validation.

Real environment tested: local macOS checkout, real installed OpenClaw state, rebased onto latest `origin/main`.

Exact steps or command run after this patch: built and probed `node dist/index.js` help/JSON/gateway cases during the live sweep, then reran the focused tests and changed-test lane listed above after rebasing.

Evidence after fix: generated/root/plugin help cases returned rc=0 with stdout help and empty stderr; `skills list --json` parsed repeatedly with the full 115-skill payload; `gateway call health --timeout nope/0/-1 --json` now fails before transport with `Invalid --timeout`.

Observed result after fix: focused tests passed, `test:changed` passed, scoped lint over changed files passed, and autoreview returned no accepted/actionable findings.

What was not tested: `pnpm check:changed` still fails on an unrelated latest-main lint issue in `src/acp/control-plane/manager.test.ts` (`no-unnecessary-boolean-literal-compare`); this branch does not touch that file.
