### PR TITLE
fix: avoid gateway daemon repair on protocol mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
+- **Gateway doctor protocol mismatch:** keep `openclaw doctor` from mutating the local Gateway service when a live Gateway closes with a protocol mismatch, while still showing diagnostics for the stale process. (#87205) Thanks @rifachnia.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.
 - **LM Studio embedding preload:** honor model- and provider-level context-window limits when preloading embedding models, preventing avoidable GPU out-of-memory failures. (#100750) Thanks @zak-li, @ZOOWH, and @hxz398.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
-- **Gateway doctor protocol mismatch:** keep `openclaw doctor` from mutating the local Gateway service when a live Gateway closes with a protocol mismatch, while still showing diagnostics for the stale process. (#87205) Thanks @rifachnia.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.
 - **LM Studio embedding preload:** honor model- and provider-level context-window limits when preloading embedding models, preventing avoidable GPU out-of-memory failures. (#100750) Thanks @zak-li, @ZOOWH, and @hxz398.

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -799,4 +799,27 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(service.restart).not.toHaveBeenCalled();
     // The restart prompt was shown but user declined (createPrompter returned false for it).
   });
+
+  it("skips repair flow when protocolMismatch is true", async () => {
+    setPlatform("linux");
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter: createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options: { repair: true, nonInteractive: true },
+      }),
+      options: { deep: false, repair: true, nonInteractive: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+      protocolMismatch: true,
+    });
+
+    // Service diagnostics still run (isLoaded is called), but the
+    // dead-gateway restart/install flow is skipped.
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(service.install).not.toHaveBeenCalled();
+    expect(healthCommand).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -800,8 +800,15 @@ describe("maybeRepairGatewayDaemon", () => {
     // The restart prompt was shown but user declined (createPrompter returned false for it).
   });
 
-  it("skips repair flow when protocolMismatch is true", async () => {
+  it("runs read-only diagnostics and skips repair mutations when protocolMismatch is true", async () => {
     setPlatform("linux");
+    const listeners = [{ pid: 12_345, command: "node" }];
+    inspectPortUsage.mockResolvedValueOnce({
+      port: 18789,
+      status: "busy",
+      listeners,
+      hints: ["Port 18789 is already in use."],
+    });
 
     await maybeRepairGatewayDaemon({
       cfg: { gateway: {} },
@@ -816,10 +823,19 @@ describe("maybeRepairGatewayDaemon", () => {
       protocolMismatch: true,
     });
 
-    // Service diagnostics still run (isLoaded is called), but the
-    // dead-gateway restart/install flow is skipped.
+    expect(service.isLoaded).toHaveBeenCalled();
+    expect(service.readRuntime).toHaveBeenCalled();
+    expect(inspectPortUsage).toHaveBeenCalledWith(18789);
+    expect(formatPortDiagnostics).toHaveBeenCalledWith({
+      port: 18789,
+      status: "busy",
+      listeners,
+      hints: ["Port 18789 is already in use."],
+    });
+    expect(note).toHaveBeenCalledWith("Port 18789 is already in use.", "Gateway port");
     expect(service.restart).not.toHaveBeenCalled();
     expect(service.install).not.toHaveBeenCalled();
+    expect(service.stage).not.toHaveBeenCalled();
     expect(healthCommand).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -192,6 +192,7 @@ export async function maybeRepairGatewayDaemon(params: {
   gatewayDetailsMessage: string;
   healthOk: boolean;
   healthSkipped?: boolean;
+  protocolMismatch?: boolean;
 }) {
   if (params.healthOk) {
     await maybeReportEstablishedGatewayClients({
@@ -235,6 +236,33 @@ export async function maybeRepairGatewayDaemon(params: {
     if (handoff) {
       note(formatGatewayRestartHandoffDiagnostic(handoff), "Gateway");
     }
+  }
+
+  // Protocol mismatch comes from a live Gateway transport close, not a dead daemon.
+  // Keep read-only diagnostics, but do not bootstrap, install, start, or restart service state.
+  if (params.protocolMismatch) {
+    noteGatewayRuntime(serviceRuntime, process.env);
+    if (params.cfg.gateway?.mode !== "remote") {
+      const port = resolveGatewayPort(params.cfg, process.env);
+      const diagnostics = await inspectPortUsage(port);
+      await maybeReportEstablishedGatewayClients({
+        cfg: params.cfg,
+        deep: params.options.deep ?? false,
+        port,
+      });
+      if (
+        diagnostics.status === "busy" &&
+        !isExpectedGatewayListeners(diagnostics.listeners, diagnostics.port)
+      ) {
+        note(formatPortDiagnostics(diagnostics).join("\n"), "Gateway port");
+      } else if (loaded && serviceRuntime?.status === "running") {
+        const lastError = await readLastGatewayErrorLine(process.env);
+        if (lastError) {
+          note(`Last gateway error: ${lastError}`, "Gateway");
+        }
+      }
+    }
+    return;
   }
 
   if (isLocalDarwinGateway) {

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -145,6 +145,31 @@ describe("checkGatewayHealth", () => {
     expect(note).not.toHaveBeenCalledWith("Gateway not running.", "Gateway");
   });
 
+  it("returns protocolMismatch only for typed protocol mismatch closes", async () => {
+    const error = Object.assign(new Error("gateway closed (1002): protocol mismatch"), {
+      kind: "closed",
+      reason: "protocol mismatch",
+    });
+    callGateway.mockRejectedValueOnce(error);
+    isGatewayTransportError.mockImplementation((value) => value === error);
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    const result = await checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 });
+
+    expect(result).toEqual({
+      authenticated: false,
+      healthOk: false,
+      protocolMismatch: true,
+      status: undefined,
+    });
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway is running but speaks an incompatible protocol"),
+      "Gateway protocol mismatch",
+    );
+    expect(note).not.toHaveBeenCalledWith("Gateway not running.", expect.anything());
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
   it("reports credentials-required when status RPC auth blocks a reachable gateway", async () => {
     callGateway.mockRejectedValueOnce(new Error());
     isGatewayCredentialsRequiredError.mockReturnValueOnce(true);

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -136,8 +136,9 @@ describe("checkGatewayHealth", () => {
     isGatewayTransportError.mockImplementation((value) => value === error);
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
-    await checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 });
+    const result = await checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 });
 
+    expect(result).toEqual({ authenticated: false, healthOk: false, status: undefined });
     expect(note).toHaveBeenCalledWith(
       "Gateway connect failed: gateway closed (1008): protocol version mismatch",
       "Gateway",
@@ -168,6 +169,19 @@ describe("checkGatewayHealth", () => {
     );
     expect(note).not.toHaveBeenCalledWith("Gateway not running.", expect.anything());
     expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("does not infer protocolMismatch from untyped close text", async () => {
+    callGateway.mockRejectedValueOnce(new Error("gateway closed (1002): protocol mismatch"));
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    const result = await checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 });
+
+    expect(result).toEqual({ authenticated: false, healthOk: false, status: undefined });
+    expect(note).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "Gateway protocol mismatch",
+    );
   });
 
   it("reports credentials-required when status RPC auth blocks a reachable gateway", async () => {

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -7,6 +7,7 @@ import {
   buildGatewayProbeConnectionDetails,
   callGateway,
   isGatewayCredentialsRequiredError,
+  isGatewayTransportError,
 } from "../gateway/call.js";
 import { isGatewaySecretRefUnavailableError } from "../gateway/credentials.js";
 import type { DoctorMemoryStatusPayload } from "../gateway/server-methods/doctor.js";
@@ -43,6 +44,12 @@ function isGatewayHealthAuthUnavailableError(error: unknown): boolean {
   return isGatewayCredentialsRequiredError(error) || isGatewaySecretRefUnavailableError(error);
 }
 
+function isGatewayProtocolMismatchClose(err: unknown): boolean {
+  return (
+    isGatewayTransportError(err) && err.kind === "closed" && err.reason === "protocol mismatch"
+  );
+}
+
 function noteCliGatewayVersionSkew(status: StatusSummary | undefined): void {
   const gatewayVersion = status?.runtimeVersion?.trim();
   if (!gatewayVersion || gatewayVersion === VERSION) {
@@ -68,10 +75,16 @@ export async function checkGatewayHealth(params: {
   runtime: RuntimeEnv;
   cfg: OpenClawConfig;
   timeoutMs?: number;
-}): Promise<{ healthOk: boolean; authenticated: boolean; status?: StatusSummary }> {
+}): Promise<{
+  healthOk: boolean;
+  authenticated: boolean;
+  protocolMismatch?: boolean;
+  status?: StatusSummary;
+}> {
   const timeoutMs =
     typeof params.timeoutMs === "number" && params.timeoutMs > 0 ? params.timeoutMs : 10_000;
   let healthOk = false;
+  let protocolMismatch = false;
   let status: StatusSummary | undefined;
   try {
     status = await callGateway<StatusSummary>({
@@ -127,7 +140,15 @@ export async function checkGatewayHealth(params: {
       }
     }
     const message = String(err);
-    if (message.includes("gateway closed")) {
+    if (isGatewayProtocolMismatchClose(err)) {
+      protocolMismatch = true;
+      const gatewayDetails = buildGatewayConnectionDetails({ config: params.cfg });
+      note(
+        "Gateway is running but speaks an incompatible protocol.\nStop the stale gateway and restart it with the current build.",
+        "Gateway protocol mismatch",
+      );
+      note(gatewayDetails.message, "Gateway connection");
+    } else if (message.includes("gateway closed")) {
       const gatewayDetails = buildGatewayConnectionDetails({ config: params.cfg });
       const closedDiagnostic = formatGatewayClosedDiagnostic(err);
       if (closedDiagnostic) {
@@ -141,7 +162,12 @@ export async function checkGatewayHealth(params: {
     }
   }
 
-  return { healthOk, authenticated: false, status };
+  return {
+    healthOk,
+    authenticated: false,
+    ...(protocolMismatch ? { protocolMismatch } : {}),
+    status,
+  };
 }
 
 /** Probes gateway memory readiness without forcing deep embedding checks. */

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1459,6 +1459,34 @@ describe("doctor health contributions", () => {
     );
   });
 
+  it("forwards Gateway protocol mismatch to daemon repair", async () => {
+    const contribution = requireDoctorContribution("doctor:gateway-daemon");
+    const ctx = {
+      cfg: {},
+      gatewayDetails: { message: "gateway details" },
+      healthOk: false,
+      protocolMismatch: true,
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: { nonInteractive: true },
+    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.maybeRepairGatewayDaemon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: ctx.cfg,
+        runtime: ctx.runtime,
+        prompter: ctx.prompter,
+        options: ctx.options,
+        gatewayDetailsMessage: "gateway details",
+        healthOk: false,
+        protocolMismatch: true,
+      }),
+    );
+  });
+
   it("keeps implemented core health checks owned by ordered doctor contributions", async () => {
     const coreIds = CORE_HEALTH_CHECKS.map((check) => check.id);
     const contributionIds = resolveDoctorHealthContributions().flatMap(

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -45,6 +45,7 @@ export type DoctorHealthFlowContext = {
   healthOk?: boolean;
   gatewayHealthAuthenticated?: boolean;
   gatewayHealthSkipped?: boolean;
+  protocolMismatch?: boolean;
   gatewayStatus?: import("../commands/status.types.js").StatusSummary;
   gatewayMemoryProbe?: Awaited<ReturnType<typeof probeGatewayMemoryStatus>>;
   postInstallDoctorResult?: UpdatePostInstallDoctorResult;
@@ -1128,7 +1129,7 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
   }
   const { checkGatewayHealth, probeGatewayMemoryStatus } =
     await import("../commands/doctor-gateway-health.js");
-  const { healthOk, authenticated, status } = await checkGatewayHealth({
+  const { healthOk, authenticated, protocolMismatch, status } = await checkGatewayHealth({
     runtime: ctx.runtime,
     cfg: ctx.cfg,
     timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
@@ -1136,6 +1137,7 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
   ctx.gatewayHealthSkipped = false;
   ctx.healthOk = healthOk;
   ctx.gatewayHealthAuthenticated = authenticated;
+  ctx.protocolMismatch = protocolMismatch;
   ctx.gatewayStatus = status;
   ctx.gatewayMemoryProbe = authenticated
     ? await probeGatewayMemoryStatus({
@@ -1252,6 +1254,7 @@ async function runGatewayDaemonHealth(ctx: DoctorHealthFlowContext): Promise<voi
     // doctor --fix restart services only because probing would require exec.
     healthOk: ctx.healthOk ?? false,
     healthSkipped: ctx.gatewayHealthSkipped === true,
+    protocolMismatch: ctx.protocolMismatch ?? false,
   });
 }
 


### PR DESCRIPTION
## Summary

* Detect protocol mismatch explicitly during doctor gateway health checks
* Avoid treating incompatible running gateways as dead/stale gateways
* Skip daemon repair flow for protocol mismatch states
* Add regression coverage for protocol mismatch handling and repair skipping

Related #87156

## Real behavior proof

Behavior addressed:

* Protocol mismatch previously propagated as `healthOk=false`, causing `openclaw doctor` to treat a running gateway as dead/stale and enter daemon repair flow.

Real environment tested:

* Native Windows 11
* Git/source checkout
* Existing gateway service on port 18789
* Startup-folder fallback runtime active

Exact steps or command run after this patch:

```bash
openclaw gateway status
npm run openclaw -- doctor --deep
```

Evidence after fix:

* `gateway status` still reported:

  * `Connectivity probe: failed`
  * `protocol mismatch`
* but `doctor --deep`:

  * completed successfully
  * no longer printed `Gateway not running`
  * did not trigger daemon repair/reinstall flow

Observed result:

* Protocol mismatch is now treated as an incompatibility state instead of a dead gateway state.

Not tested:

* Scheduled Task migration flows
* Automatic gateway restart after update
* Non-Windows environments

## Tests

```bash
npm test -- src/commands/doctor-gateway-health.test.ts src/commands/doctor-gateway-daemon-flow.test.ts

npm run typecheck

npm run lint
```

Regression coverage added:

* protocol mismatch health classification
* skipping daemon repair flow during protocol mismatch

Validation result:

* targeted protocol mismatch tests pass
* oxlint clean
* no new typecheck errors in touched files
* one unrelated existing Windows test failure remains (`/tmp/` hardcoded handoff env expectation)
