### PR TITLE
fix(compaction): route OpenAI compaction through Codex OAuth when Codex runtime is active

### DIFF
--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -214,13 +214,13 @@ describe("OpenAI Codex routing policy", () => {
     ).toBe("openai-codex");
   });
 
-  it("keeps OpenAI compaction on OpenAI when only direct API-key auth is implied", () => {
+  it("routes OpenAI compaction through Codex OAuth when Codex runtime is active", () => {
     expect(
       resolveOpenAICompactionRuntimeProvider({
         provider: "openai",
         harnessRuntime: "codex",
       }),
-    ).toBe("openai");
+    ).toBe("openai-codex");
   });
 
   it("does not route non-OpenAI providers when runtime is codex", () => {

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -92,25 +92,6 @@ function configuredOpenAIAuthOrderStartsWithCodexProfile(config: OpenClawConfig 
   return hasOpenAICodexAuthProfileOverride(firstProfile);
 }
 
-function configuredOpenAICodexAuthProfileExists(config: OpenClawConfig | undefined): boolean {
-  if (!openAIProviderUsesCodexRuntimeByDefault({ provider: OPENAI_PROVIDER_ID, config })) {
-    return false;
-  }
-  const configuredCodexOrder = findNormalizedProviderValue(
-    config?.auth?.order,
-    OPENAI_CODEX_PROVIDER_ID,
-  );
-  if (
-    configuredCodexOrder?.some(
-      (profileId) => typeof profileId === "string" && profileId.trim().length > 0,
-    ) === true
-  ) {
-    return true;
-  }
-  return Object.values(config?.auth?.profiles ?? {}).some(
-    (profile) => normalizeProviderId(profile?.provider ?? "") === OPENAI_CODEX_PROVIDER_ID,
-  );
-}
 
 export function shouldRouteOpenAIPiThroughCodexAuthProvider(params: {
   provider: string;

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -230,12 +230,7 @@ export function resolveOpenAICompactionRuntimeProvider(params: {
   if (!isOpenAIProvider(params.provider)) {
     return params.provider;
   }
-  if (
-    runtime === "codex" &&
-    (hasOpenAICodexAuthProfileOverride(params.authProfileId) ||
-      configuredOpenAIAuthOrderStartsWithCodexProfile(params.config) ||
-      configuredOpenAICodexAuthProfileExists(params.config))
-  ) {
+  if (runtime === "codex") {
     return OPENAI_CODEX_PROVIDER_ID;
   }
   return runtime === "pi" &&

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -587,7 +587,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     expect(mockCallArg(resolveModelMock, 0, 1)).toBe("gpt-5.5");
   });
 
-  it("preserves direct OpenAI API-key compaction when no Codex auth is configured", async () => {
+  it("routes compaction through Codex OAuth when Codex runtime is active even without explicit Codex auth", async () => {
     resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "codex" });
     resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
       model: { provider, api: "responses", id: modelId, input: [] },
@@ -614,7 +614,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(mockCallArg(resolveModelMock)).toBe("openai");
+    expect(mockCallArg(resolveModelMock)).toBe("openai-codex");
     expect(mockCallArg(resolveModelMock, 0, 1)).toBe("gpt-5.5");
   });
 


### PR DESCRIPTION
## Summary

When compaction is triggered for a Codex OAuth user, the compaction runtime provider resolution falls back to direct OpenAI provider if no explicit Codex auth profile is configured in config files. This causes a "Missing API key for OpenAI" error for users who authenticate solely via Codex OAuth.

## Root cause

`resolveOpenAICompactionRuntimeProvider` requires explicit Codex auth profile configuration (via `config.auth.order`, `config.auth.profiles`, or `authProfileId` override) before routing compaction through the Codex OAuth provider, even when the runtime is already resolved as `codex`.

Many Codex OAuth users authenticate via the Codex app-server OAuth flow (`openclaw codex login`) without adding explicit auth profiles to their config. The runtime being `codex` already indicates that the Codex plugin is active — the extra auth profile check is unnecessary.

## Fix

When `runtime === "codex"`, always return `OPENAI_CODEX_PROVIDER_ID` ("openai-codex"). This is consistent with how `resolveSelectedOpenAIPiRuntimeProvider` already handles the same case.

## Testing

- Updated `resolveOpenAICompactionRuntimeProvider` test: `harnessRuntime: "codex"` without auth config now expects `"openai-codex"` instead of `"openai"`

Fixes #86820