### PR TITLE
fix(agents): resolve inbound media read refs

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -18,6 +18,7 @@ import { hasEncodedFileUrlSeparator, trySafeFileURLToPath } from "../infra/local
 import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
+  resolveInboundMediaReference,
   resolveMediaReferenceSandboxPath,
 } from "../media/media-reference.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
@@ -67,6 +68,14 @@ type ReadTruncationDetails = {
   outputLines: number;
   firstLineExceedsLimit: boolean;
 };
+
+async function tryResolveInboundMediaReference(source: string) {
+  try {
+    return await resolveInboundMediaReference(source);
+  } catch {
+    return null;
+  }
+}
 
 const OFFSET_BEYOND_EOF_RE = /^Offset \d+ is beyond end of file \(\d+ lines total\)$/;
 const READ_CONTINUATION_NOTICE_RE =
@@ -755,6 +764,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
     containerWorkdir?: string;
     pathParamKeys?: readonly string[];
     normalizeGuardedPathParams?: boolean;
+    allowManagedInboundMediaReferences?: boolean;
   },
 ): AnyAgentTool {
   const pathParamKeys =
@@ -776,6 +786,14 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (filePath !== rawFilePath && record) {
           normalizedRecord ??= { ...record };
           normalizedRecord[key] = filePath;
+        }
+        if (options?.allowManagedInboundMediaReferences) {
+          const mediaReference = await tryResolveInboundMediaReference(filePath);
+          if (mediaReference) {
+            normalizedRecord ??= { ...record };
+            normalizedRecord[key] = mediaReference.physicalPath;
+            continue;
+          }
         }
         let guardedRoot = root;
         let workspaceMapping: ReturnType<typeof mapContainerPathToRoot> | undefined;
@@ -888,20 +906,30 @@ export function createOpenClawReadTool(
         ? stripMalformedXmlArgValueSuffixFromKeys(record, ["path"])
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.read, base.name);
+      const readArgs = normalizedRecord ? { ...normalizedRecord } : {};
+      const originalFilePath =
+        typeof normalizedRecord?.path === "string" ? normalizedRecord.path : "<unknown>";
+      if (typeof normalizedRecord?.path === "string") {
+        const mediaReference = await tryResolveInboundMediaReference(normalizedRecord.path);
+        if (mediaReference) {
+          readArgs.path = mediaReference.physicalPath;
+        }
+      }
       const result = await executeReadWithAdaptivePaging({
         base,
         toolCallId,
-        args: normalizedRecord ?? {},
+        args: readArgs,
         signal,
         maxBytes: resolveAdaptiveReadMaxBytes(options),
       });
-      const filePath =
-        typeof normalizedRecord?.path === "string" ? normalizedRecord.path : "<unknown>";
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
-      const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
+      const normalizedResult = await normalizeReadImageResult(
+        strippedDetailsResult,
+        originalFilePath,
+      );
       return sanitizeToolResultImages(
         normalizedResult,
-        `read:${filePath}`,
+        `read:${originalFilePath}`,
         options?.imageSanitization,
       );
     },

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -772,6 +772,7 @@ export function createOpenClawCodingTools(options?: {
           workspaceOnly
             ? wrapToolWorkspaceRootGuardWithOptions(wrapped, codingRoot, {
                 additionalRoots: skillReadRoots,
+                allowManagedInboundMediaReferences: true,
               })
             : wrapped,
         );

--- a/src/agents/agent-tools.workspace-paths.test.ts
+++ b/src/agents/agent-tools.workspace-paths.test.ts
@@ -118,6 +118,62 @@ describe("workspace path resolution", () => {
     });
   });
 
+  it("reads managed inbound media URIs from custom workspaces when workspaceOnly is enabled", async () => {
+    await withTempDir("openclaw-managed-media-", async (rootDir) => {
+      const stateDir = path.join(rootDir, "state");
+      const workspaceDir = path.join(rootDir, "workspace-regi");
+      const inboundDir = path.join(stateDir, "media", "inbound");
+      const inboundId = "telegram-note.txt";
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(inboundDir, { recursive: true });
+      await fs.writeFile(path.join(inboundDir, inboundId), "managed inbound read ok", "utf8");
+
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+      try {
+        const cfg: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
+        const tools = createOpenClawCodingTools({ workspaceDir, config: cfg });
+        const { readTool } = expectReadWriteEditTools(tools);
+
+        const result = await readTool.execute("ws-read-managed-media", {
+          path: `media://inbound/${inboundId}`,
+        });
+
+        expect(getTextContent(result)).toContain("managed inbound read ok");
+        await expect(
+          fs.access(path.join(workspaceDir, "media:", "inbound", inboundId)),
+        ).rejects.toThrow();
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
+
+  it("reads managed inbound media URIs from custom workspaces without workspaceOnly", async () => {
+    await withTempDir("openclaw-managed-media-", async (rootDir) => {
+      const stateDir = path.join(rootDir, "state");
+      const workspaceDir = path.join(rootDir, "workspace-regi");
+      const inboundDir = path.join(stateDir, "media", "inbound");
+      const inboundId = "telegram-note.txt";
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(inboundDir, { recursive: true });
+      await fs.writeFile(path.join(inboundDir, inboundId), "managed inbound read ok", "utf8");
+
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+      try {
+        const tools = createOpenClawCodingTools({ workspaceDir });
+        const { readTool } = expectReadWriteEditTools(tools);
+
+        const result = await readTool.execute("ws-read-managed-media-no-guard", {
+          path: `media://inbound/${inboundId}`,
+        });
+
+        expect(getTextContent(result)).toContain("managed inbound read ok");
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
+
   it("allows deletion edits with empty newText", async () => {
     await withTempDir("openclaw-ws-", async (workspaceDir) => {
       await withTempDir("openclaw-cwd-", async (otherDir) => {


### PR DESCRIPTION
Closes #87203

## Summary
- allow managed inbound media references through the host read workspace guard
- normalize `media://inbound/...` to the validated media-store file path before upstream read execution
- cover custom workspace reads with and without `workspaceOnly`

## Verification
- `node scripts/run-vitest.mjs src/agents/agent-tools.workspace-paths.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts src/media/media-reference.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/agent-tools.read.ts src/agents/agent-tools.ts src/agents/agent-tools.workspace-paths.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json --base upstream/main`

## Real behavior proof
- Behavior addressed: Non-sandbox host read tools now resolve `media://inbound/<id>` against the global OpenClaw media store instead of treating it as a custom-workspace-relative path.
- Real environment tested: Local macOS checkout at PR head `d7ce7eb81c787b4c45e16d1485344a3b97e1c448`, Node `v24.15.0`, dependencies installed from the PR lockfile. The proof used the real upstream `createReadTool`, OpenClaw's real `createOpenClawReadTool`, and the real workspace root guard with `allowManagedInboundMediaReferences: true`. No channel credentials or external media services were used.
- Exact steps or command run after this patch: Created a temporary `OPENCLAW_STATE_DIR` containing a real `state/media/inbound/telegram-note.txt` file, created a separate custom workspace directory named `workspace-regi`, constructed the guarded read tool from the PR code, then executed `readTool.execute("proof-managed-media-current-head", { path: "media://inbound/telegram-note.txt", limit: 4096 })` with the workspace-only guard enabled.
- Evidence after fix: Terminal transcript from the current PR-head worktree:

  ```text
  prHead=d7ce7eb81c787b4c45e16d1485344a3b97e1c448
  node=v24.15.0
  customWorkspace=/private/tmp/openclaw-pr87219-proof-d7ce7eb/workspace-regi
  stateInboundPath=/private/tmp/openclaw-pr87219-proof-d7ce7eb/state/media/inbound/telegram-note.txt
  mediaRef=media://inbound/telegram-note.txt
  workspaceOnlyGuard=enabled
  readLimit=4096
  readContainsManagedContent=true
  workspaceRelativeCorruptionExists=false
  ```

- Observed result after fix: The guarded read tool returned the managed inbound media file contents (`managed inbound read ok`) while `workspaceOnly` protection was active, and no corrupted custom-workspace path like `workspace-regi/media:/inbound/telegram-note.txt` was created or required.
- What was not tested: No Windows runtime execution was run; the path-safe behavior is covered by the added regression tests. No live Telegram or Discord account was used because the fix is in managed inbound media reference resolution before provider-specific transport handling.

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>