### PR TITLE
fix(agents): strip stale invalid Anthropic thinking

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, UserMessage, Usage } from "@earendil-works/pi-ai";
+import type { AssistantMessage, ThinkingContent, UserMessage, Usage } from "@earendil-works/pi-ai";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   expectOpenAIResponsesStrictSanitizeCall,
@@ -1493,6 +1493,34 @@ describe("sanitizeSessionHistory", () => {
       ]);
     },
   );
+
+  it("strips invalid direct Anthropic thinking signatures from prior assistant turns when a user follows up", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("first"),
+      makeAssistantMessage([
+        {
+          type: "thinking",
+          thinking: "empty signature",
+          signature: "",
+        } as unknown as ThinkingContent,
+        { type: "thinking", thinking: "blank signature", thinkingSignature: "   " },
+      ]),
+      makeUserMessage("second"),
+    ]);
+
+    const result = await sanitizeAnthropicHistory({
+      provider: "anthropic",
+      modelApi: "anthropic-messages",
+      messages,
+      modelId: "claude-sonnet-4-6",
+    });
+
+    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
+    ]);
+  });
 
   it.each([
     {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1533,6 +1533,59 @@ describe("sanitizeSessionHistory", () => {
       modelApi: "bedrock-converse-stream",
       label: "bedrock",
     },
+  ])(
+    "preserves active tool-turn thinking signatures for $label even when a tool result follows",
+    async ({ provider, modelApi }) => {
+      setNonGoogleModelApi();
+
+      const messages = castAgentMessages([
+        makeUserMessage("look up the answer"),
+        makeAssistantMessage([
+          {
+            type: "thinking",
+            thinking: "call the tool",
+            signature: "",
+          } as unknown as ThinkingContent,
+          { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+        ]),
+        castAgentMessage({
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "lookup",
+          content: [{ type: "text", text: "42" }],
+          isError: false,
+        }),
+      ]);
+
+      const result = await sanitizeAnthropicHistory({
+        provider,
+        modelApi,
+        messages,
+        modelId: "claude-sonnet-4-6",
+      });
+
+      expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+        {
+          type: "thinking",
+          thinking: "call the tool",
+          signature: "",
+        },
+        { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+      ]);
+    },
+  );
+
+  it.each([
+    {
+      provider: "anthropic",
+      modelApi: "anthropic-messages",
+      label: "anthropic",
+    },
+    {
+      provider: "amazon-bedrock",
+      modelApi: "bedrock-converse-stream",
+      label: "bedrock",
+    },
   ])("strips invalid thinking signatures before $label replay", async ({ provider, modelApi }) => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -727,6 +727,12 @@ export async function sanitizeSessionHistory(params: {
       ...resolveImageSanitizationLimits(params.config),
     },
   );
+  const lastMessage = sanitizedImages[sanitizedImages.length - 1];
+  const preserveLatestAssistantThinking =
+    params.preserveLatestAssistantThinking ??
+    (!!lastMessage &&
+      typeof lastMessage === "object" &&
+      (lastMessage as { role?: unknown }).role === "assistant");
   // Some recovery paths supply a narrow policy with preserveSignatures disabled.
   // Native signed-thinking providers still cannot replay missing/blank
   // signatures once the assistant turn is no longer latest in the outbound
@@ -734,7 +740,7 @@ export async function sanitizeSessionHistory(params: {
   const validatedThinkingSignatures =
     signedThinkingProvider || policy.preserveSignatures
       ? stripInvalidThinkingSignatures(sanitizedImages, {
-          preserveLatestAssistant: params.preserveLatestAssistantThinking ?? true,
+          preserveLatestAssistant: preserveLatestAssistantThinking,
         })
       : sanitizedImages;
   const droppedReasoning = policy.dropReasoningFromHistory

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -50,6 +50,7 @@ import { isZeroUsageEmptyStopAssistantTurn } from "./empty-assistant-turn.js";
 import {
   dropReasoningFromHistory,
   dropThinkingBlocks,
+  shouldPreserveLatestAssistantThinking,
   stripInvalidThinkingSignatures,
 } from "./thinking.js";
 
@@ -727,12 +728,9 @@ export async function sanitizeSessionHistory(params: {
       ...resolveImageSanitizationLimits(params.config),
     },
   );
-  const lastMessage = sanitizedImages[sanitizedImages.length - 1];
   const preserveLatestAssistantThinking =
     params.preserveLatestAssistantThinking ??
-    (!!lastMessage &&
-      typeof lastMessage === "object" &&
-      (lastMessage as { role?: unknown }).role === "assistant");
+    shouldPreserveLatestAssistantThinking(sanitizedImages);
   // Some recovery paths supply a narrow policy with preserveSignatures disabled.
   // Native signed-thinking providers still cannot replay missing/blank
   // signatures once the assistant turn is no longer latest in the outbound

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -261,6 +261,31 @@ function shouldPreserveCurrentToolTurnReasoning(
   return false;
 }
 
+export function shouldPreserveLatestAssistantThinking(messages: AgentMessage[]): boolean {
+  let latestAssistantIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (isAssistantMessageWithContent(messages[index])) {
+      latestAssistantIndex = index;
+      break;
+    }
+  }
+  if (latestAssistantIndex < 0) {
+    return false;
+  }
+  if (latestAssistantIndex === messages.length - 1) {
+    return true;
+  }
+
+  let latestUserIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if ((messages[index] as { role?: unknown })?.role === "user") {
+      latestUserIndex = index;
+      break;
+    }
+  }
+  return shouldPreserveCurrentToolTurnReasoning(messages, latestAssistantIndex, latestUserIndex);
+}
+
 function stripAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
   let touched = false;
   const out: AgentMessage[] = [];


### PR DESCRIPTION
Closes #86886

## Real behavior proof
Behavior addressed: Follow-up turns for direct Anthropic `anthropic-messages` no longer replay prior assistant `thinking` blocks with empty or blank signatures.

Real environment tested: Local macOS checkout of `openclaw/openclaw` on branch `fix/anthropic-empty-thinking-signature-86886`, using the real `sanitizeSessionHistory` implementation. Synthetic transcript shape: `user`, `assistant` with empty/blank thinking signatures, then a new `user` follow-up. Provider/model API: `anthropic` / `anthropic-messages`.

Exact steps or command run after this patch:
```sh
node --import tsx --input-type=module <<'EOF'
const { sanitizeSessionHistory } = await import('./src/agents/pi-embedded-runner/replay-history.ts');
const { OMITTED_ASSISTANT_REASONING_TEXT } = await import('./src/agents/pi-embedded-runner/thinking.ts');

const messages = [
  { role: 'user', content: 'first', timestamp: 1 },
  {
    role: 'assistant',
    provider: 'anthropic',
    api: 'anthropic-messages',
    model: 'claude-sonnet-4-6',
    timestamp: 2,
    stopReason: 'toolUse',
    content: [
      { type: 'thinking', thinking: 'empty signature reasoning', signature: '' },
      { type: 'thinking', thinking: 'blank signature reasoning', thinkingSignature: '   ' },
    ],
  },
  { role: 'user', content: 'follow up', timestamp: 3 },
];
const sessionManager = { getEntries: () => [], appendCustomEntry: () => {} };
const sanitized = await sanitizeSessionHistory({
  messages,
  provider: 'anthropic',
  modelApi: 'anthropic-messages',
  modelId: 'claude-sonnet-4-6',
  sessionManager,
  sessionId: 'proof-empty-thinking-signature',
});
const assistant = sanitized[1];
const content = assistant.content;
const invalidThinkingBlocks = content.filter((block) =>
  block.type === 'thinking' || block.type === 'redacted_thinking'
);
console.log(`provider=anthropic`);
console.log(`modelApi=anthropic-messages`);
console.log(`messageShape=user,assistant(empty-signature-thinking),user`);
console.log(`assistantContentAfter=${JSON.stringify(content)}`);
console.log(`invalidThinkingBlocksAfter=${invalidThinkingBlocks.length}`);
console.log(`usesOmittedReasoningFallback=${content.some((block) => block.type === 'text' && block.text === OMITTED_ASSISTANT_REASONING_TEXT)}`);
console.log(`lastMessageRole=${sanitized.at(-1)?.role}`);
EOF
```

Evidence after fix:
```text
provider=anthropic
modelApi=anthropic-messages
messageShape=user,assistant(empty-signature-thinking),user
assistantContentAfter=[{"type":"text","text":"[assistant reasoning omitted]"}]
invalidThinkingBlocksAfter=0
usesOmittedReasoningFallback=true
lastMessageRole=user
```

Observed result after fix: The prior assistant turn no longer contains any `thinking` or `redacted_thinking` blocks with invalid signatures, and the assistant turn remains replayable because it is replaced with `[assistant reasoning omitted]` instead of being dropped.

What was not tested: Live Anthropic API submission; this proof validates the exact replay-history sanitizer that prepares the outbound `anthropic-messages` request. Full `pnpm check:changed` was not run locally.

## Summary
- treat prior assistant turns as safe to sanitize once a newer user turn exists
- strip empty or blank direct Anthropic thinking signatures before `anthropic-messages` replay
- preserve turn shape with the existing omitted-reasoning fallback when all thinking blocks are removed
- carry current-main CI fixes for the JSONL tailer lint error and Node-watchdog artifact test race

## Verification
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-runner/thinking.test.ts src/agents/transcript-policy.test.ts`
- `node scripts/run-vitest.mjs test/scripts/openclaw-e2e-instance.test.ts`
- `pnpm tsgo:test`
- `pnpm lint --threads=8`
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/replay-history.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs test/scripts/openclaw-e2e-instance.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json --base upstream/main`

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
