### PR TITLE
fix(ui): scope usage requests by agent filter

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2393,7 +2393,7 @@ public struct SessionsUsageParams: Codable, Sendable {
     public init(
         key: String?,
         agentid: String? = nil,
-        agentscope: String?,
+        agentscope: String? = nil,
         startdate: String?,
         enddate: String?,
         mode: AnyCodable?,

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2379,6 +2379,7 @@ public struct SessionsCompactParams: Codable, Sendable {
 public struct SessionsUsageParams: Codable, Sendable {
     public let key: String?
     public let agentid: String?
+    public let agentscope: String?
     public let startdate: String?
     public let enddate: String?
     public let mode: AnyCodable?
@@ -2392,6 +2393,7 @@ public struct SessionsUsageParams: Codable, Sendable {
     public init(
         key: String?,
         agentid: String? = nil,
+        agentscope: String?,
         startdate: String?,
         enddate: String?,
         mode: AnyCodable?,
@@ -2404,6 +2406,7 @@ public struct SessionsUsageParams: Codable, Sendable {
     {
         self.key = key
         self.agentid = agentid
+        self.agentscope = agentscope
         self.startdate = startdate
         self.enddate = enddate
         self.mode = mode
@@ -2418,6 +2421,7 @@ public struct SessionsUsageParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case key
         case agentid = "agentId"
+        case agentscope = "agentScope"
         case startdate = "startDate"
         case enddate = "endDate"
         case mode

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -347,9 +347,11 @@ enumeration of `src/gateway/server-methods/*.ts`.
     - `models.list` returns the runtime-allowed model catalog. Pass `{ "view": "configured" }` for picker-sized configured models (`agents.defaults.models` first, then `models.providers.*.models`), or `{ "view": "all" }` for the full catalog.
     - `usage.status` returns provider usage windows/remaining quota summaries.
     - `usage.cost` returns aggregated cost usage summaries for a date range.
+      Pass `agentId` for one agent, or `agentScope: "all"` to aggregate configured agents.
     - `doctor.memory.status` returns vector-memory / cached embedding readiness for the active default agent workspace. Pass `{ "probe": true }` or `{ "deep": true }` only when the caller explicitly wants a live embedding provider ping.
     - `doctor.memory.remHarness` returns a bounded, read-only REM harness preview for remote control-plane clients. It can include workspace paths, memory snippets, rendered grounded markdown, and deep promotion candidates, so callers need `operator.read`.
-    - `sessions.usage` returns per-session usage summaries.
+    - `sessions.usage` returns per-session usage summaries. Pass `agentId` for one
+      agent, or `agentScope: "all"` to list configured agents together.
     - `sessions.usage.timeseries` returns timeseries usage for one session.
     - `sessions.usage.logs` returns usage log entries for one session.
 

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -42,7 +42,7 @@ const STRICT_LITERAL_STRUCTS = new Set([
 
 const DEFAULTED_OPTIONAL_INIT_PARAMS: Record<string, Set<string>> = {
   SessionsAbortParams: new Set(["agentId"]),
-  SessionsUsageParams: new Set(["agentId"]),
+  SessionsUsageParams: new Set(["agentId", "agentScope"]),
   ArtifactsListParams: new Set(["agentId"]),
   ArtifactsGetParams: new Set(["agentId"]),
   ArtifactsDownloadParams: new Set(["agentId"]),

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -358,6 +358,8 @@ export const SessionsUsageParamsSchema = Type.Object(
     key: Type.Optional(NonEmptyString),
     /** Agent scope for list-style usage queries. */
     agentId: Type.Optional(NonEmptyString),
+    /** Explicit all-agent scope for list-style usage queries. */
+    agentScope: Type.Optional(Type.Literal("all")),
     /** Start date for range filter (YYYY-MM-DD). */
     startDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
     /** End date for range filter (YYYY-MM-DD). */

--- a/src/gateway/server-methods/usage.cost-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.cost-usage-cache.test.ts
@@ -86,14 +86,14 @@ describe("costUsageCache bounded growth", () => {
     // oldest-first, never the newest.
     const lastStartMs = Date.UTC(2026, 0, 1) + (ITERATIONS - 1) * DAY_MS;
     const lastEndMs = lastStartMs + ((ITERATIONS - 1) % 3 === 0 ? DAY_MS : 7 * DAY_MS) - 1;
-    const lastCacheKey = `__all__:${lastStartMs}-${lastEndMs}`;
+    const lastCacheKey = `agent:__default__:${lastStartMs}-${lastEndMs}`;
     expect(testApi.costUsageCache.has(lastCacheKey)).toBe(true);
 
     // Tertiary: the oldest entry must have been evicted once the cap was
     // exceeded. Pre-fix all 600 entries remain and this fails too.
     const firstStartMs = Date.UTC(2026, 0, 1);
     const firstEndMs = firstStartMs + DAY_MS - 1;
-    const firstCacheKey = `__all__:${firstStartMs}-${firstEndMs}`;
+    const firstCacheKey = `agent:__default__:${firstStartMs}-${firstEndMs}`;
     expect(testApi.costUsageCache.has(firstCacheKey)).toBe(false);
   });
 
@@ -125,7 +125,7 @@ describe("costUsageCache bounded growth", () => {
     });
     await Promise.resolve();
 
-    expect(testApi.costUsageCache.has("__all__:1-2")).toBe(true);
+    expect(testApi.costUsageCache.has("agent:__default__:1-2")).toBe(true);
     expect(mocks.loadCostUsageSummaryFromCache).toHaveBeenCalledTimes(257);
     void inFlight.catch(() => {});
     void repeated.catch(() => {});

--- a/src/gateway/server-methods/usage.cost-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.cost-usage-cache.test.ts
@@ -86,14 +86,14 @@ describe("costUsageCache bounded growth", () => {
     // oldest-first, never the newest.
     const lastStartMs = Date.UTC(2026, 0, 1) + (ITERATIONS - 1) * DAY_MS;
     const lastEndMs = lastStartMs + ((ITERATIONS - 1) % 3 === 0 ? DAY_MS : 7 * DAY_MS) - 1;
-    const lastCacheKey = `${lastStartMs}-${lastEndMs}`;
+    const lastCacheKey = `__all__:${lastStartMs}-${lastEndMs}`;
     expect(testApi.costUsageCache.has(lastCacheKey)).toBe(true);
 
     // Tertiary: the oldest entry must have been evicted once the cap was
     // exceeded. Pre-fix all 600 entries remain and this fails too.
     const firstStartMs = Date.UTC(2026, 0, 1);
     const firstEndMs = firstStartMs + DAY_MS - 1;
-    const firstCacheKey = `${firstStartMs}-${firstEndMs}`;
+    const firstCacheKey = `__all__:${firstStartMs}-${firstEndMs}`;
     expect(testApi.costUsageCache.has(firstCacheKey)).toBe(false);
   });
 
@@ -125,7 +125,7 @@ describe("costUsageCache bounded growth", () => {
     });
     await Promise.resolve();
 
-    expect(testApi.costUsageCache.has("1-2")).toBe(true);
+    expect(testApi.costUsageCache.has("__all__:1-2")).toBe(true);
     expect(mocks.loadCostUsageSummaryFromCache).toHaveBeenCalledTimes(257);
     void inFlight.catch(() => {});
     void repeated.catch(() => {});

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -194,6 +194,45 @@ describe("sessions.usage", () => {
     expect(sessions[0].agentId).toBe("main");
   });
 
+  it("uses explicit all-agent scope for list-style usage queries", async () => {
+    const respond = await runSessionsUsage({ ...BASE_USAGE_RANGE, agentScope: "all" });
+
+    expect(vi.mocked(loadCombinedSessionStoreForGateway)).toHaveBeenCalledWith(
+      TEST_RUNTIME_CONFIG,
+      {},
+    );
+    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
+    expect(
+      vi
+        .mocked(discoverAllSessions)
+        .mock.calls.map((call) => (call[0] as { agentId?: string }).agentId),
+    ).toEqual(["main", "opus"]);
+
+    const sessions = expectSuccessfulSessionsUsage(respond);
+    expect(sessions.map((session) => session.key)).toEqual([
+      "agent:opus:s-opus",
+      "agent:main:s-main",
+    ]);
+    expect(sessions.map((session) => session.agentId)).toEqual(["opus", "main"]);
+  });
+
+  it("rejects all-agent scope with a specific agent or key", async () => {
+    const withAgent = await runSessionsUsage({
+      ...BASE_USAGE_RANGE,
+      agentId: "opus",
+      agentScope: "all",
+    });
+    const withKey = await runSessionsUsage({
+      ...BASE_USAGE_RANGE,
+      key: "agent:opus:s-opus",
+      agentScope: "all",
+    });
+
+    expect(mockArg(withAgent, 0, 0)).toBe(false);
+    expect(mockArg(withKey, 0, 0)).toBe(false);
+    expect(vi.mocked(discoverAllSessions)).not.toHaveBeenCalled();
+  });
+
   it("uses the requested agent for list-style usage queries", async () => {
     const respond = await runSessionsUsage({ ...BASE_USAGE_RANGE, agentId: "opus" });
 

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
 });
 
 import { loadCostUsageSummaryFromCache } from "../../infra/session-cost-usage.js";
-import { testApi } from "./usage.js";
+import { testApi, usageHandlers } from "./usage.js";
 
 describe("gateway usage helpers", () => {
   const dayMs = 24 * 60 * 60 * 1000;
@@ -159,6 +159,52 @@ describe("gateway usage helpers", () => {
     expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(loadCostUsageSummaryFromCache).mock.calls.at(0)?.[0]?.refreshMode).toBe(
       "background",
+    );
+  });
+
+  it("keeps cost usage cache entries scoped by agentId", async () => {
+    const config = {} as OpenClawConfig;
+
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+      agentId: "main",
+    });
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+      agentId: "research",
+    });
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+      agentId: "research",
+    });
+
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(loadCostUsageSummaryFromCache).mock.calls.at(0)?.[0]).toMatchObject({
+      agentId: "main",
+    });
+    expect(vi.mocked(loadCostUsageSummaryFromCache).mock.calls.at(1)?.[0]).toMatchObject({
+      agentId: "research",
+    });
+  });
+
+  it("passes usage.cost agentId through to the cost summary loader", async () => {
+    const respond = vi.fn();
+
+    await usageHandlers["usage.cost"]({
+      respond,
+      params: { startDate: "2026-02-01", endDate: "2026-02-02", agentId: "research" },
+      context: { getRuntimeConfig: () => ({}) },
+    } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
+
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "research" }),
     );
   });
 });

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -12,7 +12,19 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
       startDate: "2026-02-01",
       endDate: "2026-02-02",
       daily: [],
-      totals: { totalTokens: 1, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalCost: 0 },
+      totals: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 1,
+        totalCost: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+      },
     })),
   };
 });
@@ -203,6 +215,34 @@ describe("gateway usage helpers", () => {
     } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
 
     expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "research" }),
+    );
+  });
+
+  it("passes usage.cost all-agent scope through to all configured agent loaders", async () => {
+    const respond = vi.fn();
+
+    await usageHandlers["usage.cost"]({
+      respond,
+      params: { startDate: "2026-02-01", endDate: "2026-02-02", agentScope: "all" },
+      context: {
+        getRuntimeConfig: () => ({
+          agents: { list: [{ id: "main" }, { id: "research" }] },
+        }),
+      },
+    } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        totals: expect.objectContaining({ totalTokens: 2 }),
+      }),
+      undefined,
+    );
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main" }),
+    );
     expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "research" }),
     );

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadProviderUsageSummary } from "../../infra/provider-usage.js";
 import type {
   CostUsageSummary,
+  CostUsageTotals,
   SessionCostSummary,
   SessionDailyModelUsage,
   SessionMessageCounts,
@@ -72,6 +73,36 @@ type CostUsageCacheEntry = {
 };
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
+
+function createEmptyCostUsageTotals(): CostUsageTotals {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    totalCost: 0,
+    inputCost: 0,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+  };
+}
+
+function addCostUsageTotals(target: CostUsageTotals, source: CostUsageTotals): void {
+  target.input += source.input;
+  target.output += source.output;
+  target.cacheRead += source.cacheRead;
+  target.cacheWrite += source.cacheWrite;
+  target.totalTokens += source.totalTokens;
+  target.totalCost += source.totalCost;
+  target.inputCost += source.inputCost;
+  target.outputCost += source.outputCost;
+  target.cacheReadCost += source.cacheReadCost;
+  target.cacheWriteCost += source.cacheWriteCost;
+  target.missingCostEntries += source.missingCostEntries;
+}
 
 function findCostUsageCacheEvictionKey(): string | undefined {
   for (const [key, entry] of costUsageCache) {
@@ -721,8 +752,9 @@ async function loadCostUsageSummaryCached(params: {
   endMs: number;
   config: OpenClawConfig;
   agentId?: string;
+  agentScope?: "all";
 }): Promise<CostUsageSummary> {
-  const cacheKey = `${params.agentId ?? "__all__"}:${params.startMs}-${params.endMs}`;
+  const cacheKey = `${params.agentScope === "all" ? "all" : `agent:${params.agentId ?? "__default__"}`}:${params.startMs}-${params.endMs}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (
@@ -742,14 +774,22 @@ async function loadCostUsageSummaryCached(params: {
   }
 
   const entry: CostUsageCacheEntry = cached ?? {};
-  const inFlight = loadCostUsageSummaryFromCache({
-    startMs: params.startMs,
-    endMs: params.endMs,
-    config: params.config,
-    agentId: params.agentId,
-    requestRefresh: true,
-    refreshMode: "background",
-  })
+  const inFlight = (
+    params.agentScope === "all"
+      ? loadAllAgentCostUsageSummary({
+          startMs: params.startMs,
+          endMs: params.endMs,
+          config: params.config,
+        })
+      : loadCostUsageSummaryFromCache({
+          startMs: params.startMs,
+          endMs: params.endMs,
+          config: params.config,
+          agentId: params.agentId,
+          requestRefresh: true,
+          refreshMode: "background",
+        })
+  )
     .then((summary) => {
       setCostUsageCache(cacheKey, {
         summary,
@@ -778,6 +818,56 @@ async function loadCostUsageSummaryCached(params: {
     return entry.summary;
   }
   return await inFlight;
+}
+
+async function loadAllAgentCostUsageSummary(params: {
+  startMs: number;
+  endMs: number;
+  config: OpenClawConfig;
+}): Promise<CostUsageSummary> {
+  const agentIds = listAgentsForGateway(params.config).agents.map((agent) =>
+    normalizeAgentId(agent.id),
+  );
+  const summaries = await Promise.all(
+    agentIds.map((agentId) =>
+      loadCostUsageSummaryFromCache({
+        startMs: params.startMs,
+        endMs: params.endMs,
+        config: params.config,
+        agentId,
+        requestRefresh: true,
+        refreshMode: "background",
+      }),
+    ),
+  );
+  const dailyByDate = new Map<string, CostUsageTotals & { date: string }>();
+  const totals = createEmptyCostUsageTotals();
+  let cacheStatus: UsageCacheStatus | undefined;
+  let updatedAt = 0;
+  let days = 0;
+  for (const summary of summaries) {
+    updatedAt = Math.max(updatedAt, summary.updatedAt);
+    days = Math.max(days, summary.days);
+    addCostUsageTotals(totals, summary.totals);
+    if (summary.cacheStatus) {
+      cacheStatus = mergeUsageCacheStatus(cacheStatus, summary.cacheStatus);
+    }
+    for (const day of summary.daily) {
+      const entry = dailyByDate.get(day.date) ?? {
+        date: day.date,
+        ...createEmptyCostUsageTotals(),
+      };
+      addCostUsageTotals(entry, day);
+      dailyByDate.set(day.date, entry);
+    }
+  }
+  return {
+    updatedAt,
+    days,
+    daily: Array.from(dailyByDate.values()).toSorted((a, b) => a.date.localeCompare(b.date)),
+    totals,
+    ...(cacheStatus ? { cacheStatus } : {}),
+  };
 }
 
 function mergeUsageCacheStatus(
@@ -835,7 +925,14 @@ export const usageHandlers: GatewayRequestHandlers = {
       utcOffset: params?.utcOffset,
     });
     const agentId = normalizeOptionalString(params?.agentId);
-    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config, agentId });
+    const agentScope = params?.agentScope === "all" && !agentId ? "all" : undefined;
+    const summary = await loadCostUsageSummaryCached({
+      startMs,
+      endMs,
+      config,
+      agentId,
+      agentScope,
+    });
     respond(true, summary, undefined);
   },
   "sessions.usage": async ({ respond, params, context }) => {
@@ -864,6 +961,18 @@ export const usageHandlers: GatewayRequestHandlers = {
     const includeContextWeight = p.includeContextWeight ?? false;
     const specificKey = normalizeOptionalString(p.key) ?? null;
     const requestedAgentId = normalizeOptionalString(p.agentId);
+    const requestedAllAgents = p.agentScope === "all";
+    if (requestedAllAgents && (requestedAgentId || specificKey)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "agentScope=all cannot be combined with key or agentId",
+        ),
+      );
+      return;
+    }
     const specificKeyAgentId = specificKey ? parseAgentSessionKey(specificKey)?.agentId : undefined;
     if (
       requestedAgentId &&
@@ -877,21 +986,22 @@ export const usageHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const effectiveAgentId = normalizeAgentId(
-      requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config),
-    );
+    const effectiveAgentId = requestedAllAgents
+      ? undefined
+      : normalizeAgentId(requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config));
     const groupingMode: UsageGroupingMode =
       p.groupBy === "family" || p.includeHistorical === true ? "family" : "instance";
 
     // Load session store for named sessions
-    const { storePath, store } = loadCombinedSessionStoreForGateway(config, {
-      agentId: effectiveAgentId,
-    });
-    const scopedStore = filterSessionStoreByAgent({
-      config,
-      store,
-      agentId: effectiveAgentId,
-    });
+    const sessionStoreOpts = effectiveAgentId ? { agentId: effectiveAgentId } : {};
+    const { storePath, store } = loadCombinedSessionStoreForGateway(config, sessionStoreOpts);
+    const scopedStore = effectiveAgentId
+      ? filterSessionStoreByAgent({
+          config,
+          store,
+          agentId: effectiveAgentId,
+        })
+      : store;
     const now = Date.now();
 
     const mergedEntries: MergedEntry[] = [];
@@ -900,11 +1010,12 @@ export const usageHandlers: GatewayRequestHandlers = {
     if (specificKey) {
       const scopedSpecificKey = resolveStoredSessionKeyForAgentStore({
         cfg: config,
-        agentId: effectiveAgentId,
+        agentId: effectiveAgentId ?? resolveDefaultAgentId(config),
         sessionKey: specificKey,
       });
       const scopedParsed = parseAgentSessionKey(scopedSpecificKey);
-      const agentIdFromKey = scopedParsed?.agentId ?? effectiveAgentId;
+      const agentIdFromKey =
+        scopedParsed?.agentId ?? effectiveAgentId ?? resolveDefaultAgentId(config);
       const keyRest = scopedParsed?.rest ?? specificKey;
 
       // Prefer the store entry when available, even if the caller provides a discovered key
@@ -972,7 +1083,7 @@ export const usageHandlers: GatewayRequestHandlers = {
       // Full discovery for list view
       const discoveredSessions = await discoverAllSessionsForUsage({
         config,
-        agentId: effectiveAgentId,
+        ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
         startMs,
         endMs,
       });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -720,8 +720,9 @@ async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
   config: OpenClawConfig;
+  agentId?: string;
 }): Promise<CostUsageSummary> {
-  const cacheKey = `${params.startMs}-${params.endMs}`;
+  const cacheKey = `${params.agentId ?? "__all__"}:${params.startMs}-${params.endMs}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (
@@ -745,6 +746,7 @@ async function loadCostUsageSummaryCached(params: {
     startMs: params.startMs,
     endMs: params.endMs,
     config: params.config,
+    agentId: params.agentId,
     requestRefresh: true,
     refreshMode: "background",
   })
@@ -832,7 +834,8 @@ export const usageHandlers: GatewayRequestHandlers = {
       mode: params?.mode,
       utcOffset: params?.utcOffset,
     });
-    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
+    const agentId = normalizeOptionalString(params?.agentId);
+    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config, agentId });
     respond(true, summary, undefined);
   },
   "sessions.usage": async ({ respond, params, context }) => {

--- a/ui/src/ui/app-render-usage-tab.test.ts
+++ b/ui/src/ui/app-render-usage-tab.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderUsageTab } from "./app-render-usage-tab.ts";
+import type { AppViewState } from "./app-view-state.ts";
+
+const loadUsageMock = vi.hoisted(() => vi.fn(async () => {}));
+const renderUsageMock = vi.hoisted(() => vi.fn(() => null));
+
+vi.mock("./controllers/usage.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./controllers/usage.ts")>();
+  return {
+    ...actual,
+    loadUsage: loadUsageMock,
+  };
+});
+
+vi.mock("./views/usage.ts", () => ({
+  renderUsage: renderUsageMock,
+}));
+
+function createState(overrides: Partial<AppViewState> = {}): AppViewState {
+  return {
+    tab: "usage",
+    usageLoading: false,
+    usageError: null,
+    usageResult: null,
+    usageCostSummary: null,
+    usageStartDate: "2026-02-16",
+    usageEndDate: "2026-02-16",
+    usageScope: "family",
+    usageSelectedSessions: [],
+    usageSelectedDays: [],
+    usageSelectedHours: [],
+    usageQuery: "",
+    usageQueryDraft: "",
+    usageQueryDebounceTimer: null,
+    usageTimeZone: "local",
+    agentsList: {
+      defaultId: "main",
+      mainKey: "agent:main:main",
+      agents: [{ id: "main" }, { id: "research" }],
+    },
+    ...overrides,
+  } as unknown as AppViewState;
+}
+
+describe("renderUsageTab", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes configured agents to the usage view", () => {
+    renderUsageTab(createState());
+
+    expect(renderUsageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ agents: ["main", "research"] }),
+      }),
+    );
+  });
+
+  it("reloads usage when applying a query changes the server-side agent scope", () => {
+    const state = createState({ usageQuery: "", usageQueryDraft: "agent:research " });
+
+    renderUsageTab(state);
+    renderUsageMock.mock.calls[0]?.[0].callbacks.filters.onApplyQuery();
+
+    expect(state.usageQuery).toBe("agent:research ");
+    expect(loadUsageMock).toHaveBeenCalledWith(state);
+  });
+});

--- a/ui/src/ui/app-render-usage-tab.test.ts
+++ b/ui/src/ui/app-render-usage-tab.test.ts
@@ -29,6 +29,7 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
     usageStartDate: "2026-02-16",
     usageEndDate: "2026-02-16",
     usageScope: "family",
+    usageAgentId: null,
     usageSelectedSessions: [],
     usageSelectedDays: [],
     usageSelectedHours: [],
@@ -60,8 +61,8 @@ describe("renderUsageTab", () => {
     );
   });
 
-  it("reloads usage when applying a query changes the server-side agent scope", () => {
-    const state = createState({ usageQuery: "", usageQueryDraft: "agent:research " });
+  it("reloads usage when selecting an agent scope", () => {
+    const state = createState();
 
     renderUsageTab(state);
     expect(renderUsageMock).toHaveBeenCalled();
@@ -69,9 +70,9 @@ describe("renderUsageTab", () => {
     if (!props) {
       throw new Error("expected renderUsage props");
     }
-    props.callbacks.filters.onApplyQuery();
+    props.callbacks.filters.onAgentChange("research");
 
-    expect(state.usageQuery).toBe("agent:research ");
+    expect(state.usageAgentId).toBe("research");
     expect(loadUsageMock).toHaveBeenCalledWith(state);
   });
 });

--- a/ui/src/ui/app-render-usage-tab.test.ts
+++ b/ui/src/ui/app-render-usage-tab.test.ts
@@ -2,9 +2,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import type { UsageProps } from "./views/usageTypes.ts";
 
 const loadUsageMock = vi.hoisted(() => vi.fn(async () => {}));
-const renderUsageMock = vi.hoisted(() => vi.fn(() => null));
+const renderUsageMock = vi.hoisted(() => vi.fn((_props: UsageProps) => null));
 
 vi.mock("./controllers/usage.ts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./controllers/usage.ts")>();
@@ -63,7 +64,12 @@ describe("renderUsageTab", () => {
     const state = createState({ usageQuery: "", usageQueryDraft: "agent:research " });
 
     renderUsageTab(state);
-    renderUsageMock.mock.calls[0]?.[0].callbacks.filters.onApplyQuery();
+    expect(renderUsageMock).toHaveBeenCalled();
+    const props = renderUsageMock.mock.calls[0]?.[0];
+    if (!props) {
+      throw new Error("expected renderUsage props");
+    }
+    props.callbacks.filters.onApplyQuery();
 
     expect(state.usageQuery).toBe("agent:research ");
     expect(loadUsageMock).toHaveBeenCalledWith(state);

--- a/ui/src/ui/app-render-usage-tab.ts
+++ b/ui/src/ui/app-render-usage-tab.ts
@@ -1,12 +1,7 @@
 import { nothing } from "lit";
 import type { AppViewState } from "./app-view-state.ts";
 import type { UsageState } from "./controllers/usage.ts";
-import {
-  loadUsage,
-  loadSessionTimeSeries,
-  loadSessionLogs,
-  resolveUsageAgentIdFromQuery,
-} from "./controllers/usage.ts";
+import { loadUsage, loadSessionTimeSeries, loadSessionLogs } from "./controllers/usage.ts";
 import { renderUsage } from "./views/usage.ts";
 
 type UsageCacheStatus = NonNullable<NonNullable<UsageState["usageResult"]>["cacheStatus"]>;
@@ -72,6 +67,7 @@ export function renderUsageTab(state: AppViewState) {
       selectedSessions: state.usageSelectedSessions,
       selectedDays: state.usageSelectedDays,
       selectedHours: state.usageSelectedHours,
+      agentId: state.usageAgentId,
       query: state.usageQuery,
       queryDraft: state.usageQueryDraft,
       timeZone: state.usageTimeZone,
@@ -129,6 +125,15 @@ export function renderUsageTab(state: AppViewState) {
           state.usageSessionLogs = null;
           void loadUsage(state);
         },
+        onAgentChange: (agentId) => {
+          state.usageAgentId = agentId;
+          state.usageSelectedDays = [];
+          state.usageSelectedHours = [];
+          state.usageSelectedSessions = [];
+          state.usageTimeSeries = null;
+          state.usageSessionLogs = null;
+          void loadUsage(state);
+        },
         onRefresh: () => loadUsage(state),
         onTimeZoneChange: (zone) => {
           state.usageTimeZone = zone;
@@ -162,37 +167,25 @@ export function renderUsageTab(state: AppViewState) {
           if (state.usageQueryDebounceTimer) {
             window.clearTimeout(state.usageQueryDebounceTimer);
           }
-          const previousAgentId = resolveUsageAgentIdFromQuery(state.usageQuery);
           state.usageQueryDebounceTimer = window.setTimeout(() => {
             state.usageQuery = state.usageQueryDraft;
             state.usageQueryDebounceTimer = null;
-            if (resolveUsageAgentIdFromQuery(state.usageQuery) !== previousAgentId) {
-              void loadUsage(state);
-            }
           }, 250);
         },
         onApplyQuery: () => {
-          const previousAgentId = resolveUsageAgentIdFromQuery(state.usageQuery);
           if (state.usageQueryDebounceTimer) {
             window.clearTimeout(state.usageQueryDebounceTimer);
             state.usageQueryDebounceTimer = null;
           }
           state.usageQuery = state.usageQueryDraft;
-          if (resolveUsageAgentIdFromQuery(state.usageQuery) !== previousAgentId) {
-            void loadUsage(state);
-          }
         },
         onClearQuery: () => {
-          const previousAgentId = resolveUsageAgentIdFromQuery(state.usageQuery);
           if (state.usageQueryDebounceTimer) {
             window.clearTimeout(state.usageQueryDebounceTimer);
             state.usageQueryDebounceTimer = null;
           }
           state.usageQueryDraft = "";
           state.usageQuery = "";
-          if (previousAgentId) {
-            void loadUsage(state);
-          }
         },
         onSelectDay: (day, shiftKey) => {
           if (shiftKey && state.usageSelectedDays.length > 0) {

--- a/ui/src/ui/app-render-usage-tab.ts
+++ b/ui/src/ui/app-render-usage-tab.ts
@@ -1,7 +1,12 @@
 import { nothing } from "lit";
 import type { AppViewState } from "./app-view-state.ts";
 import type { UsageState } from "./controllers/usage.ts";
-import { loadUsage, loadSessionTimeSeries, loadSessionLogs } from "./controllers/usage.ts";
+import {
+  loadUsage,
+  loadSessionTimeSeries,
+  loadSessionLogs,
+  resolveUsageAgentIdFromQuery,
+} from "./controllers/usage.ts";
 import { renderUsage } from "./views/usage.ts";
 
 type UsageCacheStatus = NonNullable<NonNullable<UsageState["usageResult"]>["cacheStatus"]>;
@@ -50,6 +55,7 @@ export function renderUsageTab(state: AppViewState) {
       loading: state.usageLoading,
       error: state.usageError,
       sessions: state.usageResult?.sessions ?? [],
+      agents: state.agentsList?.agents.map((entry) => entry.id).filter(Boolean) ?? [],
       sessionsLimitReached: (state.usageResult?.sessions?.length ?? 0) >= 1000,
       totals: state.usageResult?.totals ?? null,
       aggregates: state.usageResult?.aggregates ?? null,
@@ -156,25 +162,37 @@ export function renderUsageTab(state: AppViewState) {
           if (state.usageQueryDebounceTimer) {
             window.clearTimeout(state.usageQueryDebounceTimer);
           }
+          const previousAgentId = resolveUsageAgentIdFromQuery(state.usageQuery);
           state.usageQueryDebounceTimer = window.setTimeout(() => {
             state.usageQuery = state.usageQueryDraft;
             state.usageQueryDebounceTimer = null;
+            if (resolveUsageAgentIdFromQuery(state.usageQuery) !== previousAgentId) {
+              void loadUsage(state);
+            }
           }, 250);
         },
         onApplyQuery: () => {
+          const previousAgentId = resolveUsageAgentIdFromQuery(state.usageQuery);
           if (state.usageQueryDebounceTimer) {
             window.clearTimeout(state.usageQueryDebounceTimer);
             state.usageQueryDebounceTimer = null;
           }
           state.usageQuery = state.usageQueryDraft;
+          if (resolveUsageAgentIdFromQuery(state.usageQuery) !== previousAgentId) {
+            void loadUsage(state);
+          }
         },
         onClearQuery: () => {
+          const previousAgentId = resolveUsageAgentIdFromQuery(state.usageQuery);
           if (state.usageQueryDebounceTimer) {
             window.clearTimeout(state.usageQueryDebounceTimer);
             state.usageQueryDebounceTimer = null;
           }
           state.usageQueryDraft = "";
           state.usageQuery = "";
+          if (previousAgentId) {
+            void loadUsage(state);
+          }
         },
         onSelectDay: (day, shiftKey) => {
           if (shiftKey && state.usageSelectedDays.length > 0) {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -322,6 +322,7 @@ export type AppViewState = {
   usageStartDate: string;
   usageEndDate: string;
   usageScope: "instance" | "family";
+  usageAgentId: string | null;
   usageSelectedSessions: string[];
   usageSelectedDays: string[];
   usageSelectedHours: number[];

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -472,6 +472,7 @@ export class OpenClawApp extends LitElement {
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
   })();
   @state() usageScope: "instance" | "family" = "family";
+  @state() usageAgentId: string | null = null;
   @state() usageSelectedSessions: string[] = [];
   @state() usageSelectedDays: string[] = [];
   @state() usageSelectedHours: number[] = [];

--- a/ui/src/ui/controllers/usage.node.test.ts
+++ b/ui/src/ui/controllers/usage.node.test.ts
@@ -101,7 +101,7 @@ describe("usage controller date interpretation params", () => {
     });
   });
 
-  it("passes a single selected agent query as sessions.usage agentId", async () => {
+  it("passes a single selected agent query as sessions and cost agentId", async () => {
     const request = vi.fn(async () => ({}));
     const state = createState(request, {
       usageQuery: "provider:openai agent:research ",
@@ -119,6 +119,12 @@ describe("usage controller date interpretation params", () => {
       includeHistorical: true,
       limit: 1000,
       includeContextWeight: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "usage.cost", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentId: "research",
+      mode: "utc",
     });
   });
 
@@ -300,6 +306,12 @@ describe("usage controller date interpretation params", () => {
       limit: 1000,
       includeContextWeight: true,
     });
+    expect(request).toHaveBeenNthCalledWith(2, "usage.cost", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentId: "research",
+      mode: "utc",
+    });
     expect(request).toHaveBeenNthCalledWith(3, "sessions.usage", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
@@ -308,6 +320,11 @@ describe("usage controller date interpretation params", () => {
       includeHistorical: true,
       limit: 1000,
       includeContextWeight: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(4, "usage.cost", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      mode: "utc",
     });
 
     await loadUsage(state);
@@ -320,6 +337,11 @@ describe("usage controller date interpretation params", () => {
       includeHistorical: true,
       limit: 1000,
       includeContextWeight: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(6, "usage.cost", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      mode: "utc",
     });
 
     testApi.resetLegacyUsageDateParamsCache();

--- a/ui/src/ui/controllers/usage.node.test.ts
+++ b/ui/src/ui/controllers/usage.node.test.ts
@@ -21,6 +21,7 @@ function createState(request: RequestFn, overrides: Partial<UsageState> = {}): U
     usageStartDate: "2026-02-16",
     usageEndDate: "2026-02-16",
     usageScope: "family",
+    usageQuery: "",
     usageSelectedSessions: [],
     usageSelectedDays: [],
     usageTimeSeries: null,
@@ -98,6 +99,33 @@ describe("usage controller date interpretation params", () => {
       endDate: "2026-02-16",
       mode: "utc",
     });
+  });
+
+  it("passes a single selected agent query as sessions.usage agentId", async () => {
+    const request = vi.fn(async () => ({}));
+    const state = createState(request, {
+      usageQuery: "provider:openai agent:research ",
+      usageTimeZone: "utc",
+    });
+
+    await loadUsage(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentId: "research",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+  });
+
+  it("does not send agentId for multiple or globbed agent query filters", () => {
+    expect(testApi.resolveUsageAgentIdFromQuery("agent:research agent:main")).toBeUndefined();
+    expect(testApi.resolveUsageAgentIdFromQuery("agent:research*")).toBeUndefined();
+    expect(testApi.resolveUsageAgentIdFromQuery("agent:research channel:slack")).toBe("research");
   });
 
   it("captures useful error strings in loadUsage", async () => {

--- a/ui/src/ui/controllers/usage.node.test.ts
+++ b/ui/src/ui/controllers/usage.node.test.ts
@@ -21,6 +21,7 @@ function createState(request: RequestFn, overrides: Partial<UsageState> = {}): U
     usageStartDate: "2026-02-16",
     usageEndDate: "2026-02-16",
     usageScope: "family",
+    usageAgentId: null,
     usageQuery: "",
     usageSelectedSessions: [],
     usageSelectedDays: [],
@@ -39,6 +40,7 @@ function expectSpecificTimezoneCalls(request: ReturnType<typeof vi.fn>, startCal
   expect(request).toHaveBeenNthCalledWith(startCall, "sessions.usage", {
     startDate: "2026-02-16",
     endDate: "2026-02-16",
+    agentScope: "all",
     mode: "specific",
     utcOffset: "UTC+5:30",
     groupBy: "family",
@@ -49,6 +51,7 @@ function expectSpecificTimezoneCalls(request: ReturnType<typeof vi.fn>, startCal
   expect(request).toHaveBeenNthCalledWith(startCall + 1, "usage.cost", {
     startDate: "2026-02-16",
     endDate: "2026-02-16",
+    agentScope: "all",
     mode: "specific",
     utcOffset: "UTC+5:30",
   });
@@ -88,6 +91,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
       mode: "utc",
       groupBy: "family",
       includeHistorical: true,
@@ -97,14 +101,41 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(2, "usage.cost", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
       mode: "utc",
     });
   });
 
-  it("passes a single selected agent query as sessions and cost agentId", async () => {
+  it("requests all-agent sessions and costs by default", async () => {
     const request = vi.fn(async () => ({}));
     const state = createState(request, {
-      usageQuery: "provider:openai agent:research ",
+      usageTimeZone: "utc",
+    });
+
+    await loadUsage(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentScope: "all",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "usage.cost", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentScope: "all",
+      mode: "utc",
+    });
+  });
+
+  it("passes selected agent as sessions and cost agentId", async () => {
+    const request = vi.fn(async () => ({}));
+    const state = createState(request, {
+      usageAgentId: "research",
       usageTimeZone: "utc",
     });
 
@@ -126,12 +157,6 @@ describe("usage controller date interpretation params", () => {
       agentId: "research",
       mode: "utc",
     });
-  });
-
-  it("does not send agentId for multiple or globbed agent query filters", () => {
-    expect(testApi.resolveUsageAgentIdFromQuery("agent:research agent:main")).toBeUndefined();
-    expect(testApi.resolveUsageAgentIdFromQuery("agent:research*")).toBeUndefined();
-    expect(testApi.resolveUsageAgentIdFromQuery("agent:research channel:slack")).toBe("research");
   });
 
   it("captures useful error strings in loadUsage", async () => {
@@ -178,6 +203,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(3, "sessions.usage", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
       groupBy: "family",
       includeHistorical: true,
       limit: 1000,
@@ -186,6 +212,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(4, "usage.cost", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
     });
 
     // Subsequent loads for the same gateway should skip mode/utcOffset immediately.
@@ -194,6 +221,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(5, "sessions.usage", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
       groupBy: "family",
       includeHistorical: true,
       limit: 1000,
@@ -202,6 +230,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(6, "usage.cost", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
     });
 
     // Persisted flag should survive cache resets (simulating app reload).
@@ -240,6 +269,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(3, "sessions.usage", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
       mode: "specific",
       utcOffset: "UTC+5:30",
       limit: 1000,
@@ -248,6 +278,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(4, "usage.cost", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
       mode: "specific",
       utcOffset: "UTC+5:30",
     });
@@ -258,6 +289,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(5, "sessions.usage", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
       mode: "specific",
       utcOffset: "UTC+5:30",
       limit: 1000,
@@ -266,6 +298,7 @@ describe("usage controller date interpretation params", () => {
     expect(request).toHaveBeenNthCalledWith(6, "usage.cost", {
       startDate: "2026-02-16",
       endDate: "2026-02-16",
+      agentScope: "all",
       mode: "specific",
       utcOffset: "UTC+5:30",
     });
@@ -290,7 +323,7 @@ describe("usage controller date interpretation params", () => {
 
     const state = createState(request, {
       settings: { gatewayUrl: "ws://127.0.0.1:18789" },
-      usageQuery: "agent:research",
+      usageAgentId: "research",
       usageTimeZone: "utc",
     });
 
@@ -346,6 +379,68 @@ describe("usage controller date interpretation params", () => {
 
     testApi.resetLegacyUsageDateParamsCache();
     expect(testApi.shouldSendLegacyUsageAgentParams(state)).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back and remembers compatibility when sessions.usage rejects agentScope", async () => {
+    const storage = createStorageMock();
+    vi.stubGlobal("localStorage", storage as unknown as Storage);
+
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "sessions.usage") {
+        const record = (params ?? {}) as Record<string, unknown>;
+        if ("agentScope" in record) {
+          throw new Error(
+            "invalid sessions.usage params: at root: unexpected property 'agentScope'",
+          );
+        }
+        return { sessions: [] };
+      }
+      return {};
+    });
+
+    const state = createState(request, {
+      settings: { gatewayUrl: "ws://127.0.0.1:18789" },
+      usageTimeZone: "utc",
+    });
+
+    await loadUsage(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentScope: "all",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+
+    await loadUsage(state);
+
+    expect(request).toHaveBeenNthCalledWith(5, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+
+    testApi.resetLegacyUsageDateParamsCache();
+    expect(testApi.shouldSendLegacyUsageAgentScope(state)).toBe(false);
 
     vi.unstubAllGlobals();
   });

--- a/ui/src/ui/controllers/usage.node.test.ts
+++ b/ui/src/ui/controllers/usage.node.test.ts
@@ -267,6 +267,67 @@ describe("usage controller date interpretation params", () => {
     vi.unstubAllGlobals();
   });
 
+  it("falls back and remembers compatibility when sessions.usage rejects agentId", async () => {
+    const storage = createStorageMock();
+    vi.stubGlobal("localStorage", storage as unknown as Storage);
+
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "sessions.usage") {
+        const record = (params ?? {}) as Record<string, unknown>;
+        if ("agentId" in record) {
+          throw new Error("invalid sessions.usage params: at root: unexpected property 'agentId'");
+        }
+        return { sessions: [] };
+      }
+      return {};
+    });
+
+    const state = createState(request, {
+      settings: { gatewayUrl: "ws://127.0.0.1:18789" },
+      usageQuery: "agent:research",
+      usageTimeZone: "utc",
+    });
+
+    await loadUsage(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentId: "research",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+
+    await loadUsage(state);
+
+    expect(request).toHaveBeenNthCalledWith(5, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+
+    testApi.resetLegacyUsageDateParamsCache();
+    expect(testApi.shouldSendLegacyUsageAgentParams(state)).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
   it("keeps optional loaders resilient when requests fail", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.usage.timeseries" || method === "sessions.usage.logs") {

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -2,6 +2,7 @@ import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type { SessionsUsageResult, CostUsageSummary, SessionUsageTimeSeries } from "../types.ts";
+import { extractQueryTerms } from "../usage-helpers.ts";
 import type { SessionLogEntry } from "../views/usage.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -18,6 +19,7 @@ export type UsageState = {
   usageStartDate: string;
   usageEndDate: string;
   usageScope: "instance" | "family";
+  usageQuery: string;
   usageSelectedSessions: string[];
   usageSelectedDays: string[];
   usageTimeSeries: SessionUsageTimeSeries | null;
@@ -170,6 +172,14 @@ const buildDateInterpretationParams = (timeZone: "local" | "utc") => {
   };
 };
 
+export function resolveUsageAgentIdFromQuery(query: string): string | undefined {
+  const agentValues = extractQueryTerms(query)
+    .filter((term) => normalizeLowercaseStringOrEmpty(term.key) === "agent")
+    .map((term) => term.value.trim())
+    .filter((value) => value.length > 0 && !value.includes("*") && !value.includes("?"));
+  return new Set(agentValues).size === 1 ? agentValues[0] : undefined;
+}
+
 function toErrorMessage(err: unknown): string {
   if (typeof err === "string") {
     return err;
@@ -213,6 +223,7 @@ export async function loadUsage(
   try {
     const startDate = overrides?.startDate ?? state.usageStartDate;
     const endDate = overrides?.endDate ?? state.usageEndDate;
+    const agentId = resolveUsageAgentIdFromQuery(state.usageQuery);
     const runUsageRequests = (includeDateInterpretation: boolean, includeUsageScope: boolean) => {
       const dateInterpretation = includeDateInterpretation
         ? buildDateInterpretationParams(state.usageTimeZone)
@@ -227,6 +238,7 @@ export async function loadUsage(
         client.request("sessions.usage", {
           startDate,
           endDate,
+          ...(agentId ? { agentId } : undefined),
           ...dateInterpretation,
           ...usageScopeParams,
           limit: 1000, // Cap at 1000 sessions
@@ -287,6 +299,7 @@ export const testApi = {
   toErrorMessage,
   isLegacyDateInterpretationUnsupportedError,
   isLegacyUsageScopeUnsupportedError,
+  resolveUsageAgentIdFromQuery,
   normalizeGatewayCompatibilityKey,
   shouldSendLegacyDateInterpretation,
   rememberLegacyDateInterpretation,

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -283,6 +283,7 @@ export async function loadUsage(
         client.request("usage.cost", {
           startDate,
           endDate,
+          ...(includeAgentScope && agentId ? { agentId } : undefined),
           ...dateInterpretation,
         }),
       ]);

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -2,7 +2,6 @@ import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type { SessionsUsageResult, CostUsageSummary, SessionUsageTimeSeries } from "../types.ts";
-import { extractQueryTerms } from "../usage-helpers.ts";
 import type { SessionLogEntry } from "../views/usage.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -19,6 +18,7 @@ export type UsageState = {
   usageStartDate: string;
   usageEndDate: string;
   usageScope: "instance" | "family";
+  usageAgentId: string | null;
   usageQuery: string;
   usageSelectedSessions: string[];
   usageSelectedDays: string[];
@@ -35,17 +35,20 @@ export type UsageState = {
 const LEGACY_USAGE_DATE_PARAMS_STORAGE_KEY = "openclaw.control.usage.date-params.v1";
 const LEGACY_USAGE_SCOPE_PARAMS_STORAGE_KEY = "openclaw.control.usage.scope-params.v1";
 const LEGACY_USAGE_AGENT_PARAMS_STORAGE_KEY = "openclaw.control.usage.agent-params.v1";
+const LEGACY_USAGE_AGENT_SCOPE_STORAGE_KEY = "openclaw.control.usage.agent-scope.v1";
 const LEGACY_USAGE_DATE_PARAMS_MODE_RE = /unexpected property ['"]mode['"]/i;
 const LEGACY_USAGE_DATE_PARAMS_OFFSET_RE = /unexpected property ['"]utcoffset['"]/i;
 const LEGACY_USAGE_SCOPE_PARAMS_GROUP_BY_RE = /unexpected property ['"]groupby['"]/i;
 const LEGACY_USAGE_SCOPE_PARAMS_INCLUDE_HISTORICAL_RE =
   /unexpected property ['"]includehistorical['"]/i;
 const LEGACY_USAGE_AGENT_PARAMS_AGENT_ID_RE = /unexpected property ['"]agentid['"]/i;
+const LEGACY_USAGE_AGENT_SCOPE_RE = /unexpected property ['"]agentscope['"]/i;
 const LEGACY_USAGE_DATE_PARAMS_INVALID_RE = /invalid sessions\.usage params/i;
 
 let legacyUsageDateParamsCache: Set<string> | null = null;
 let legacyUsageScopeParamsCache: Set<string> | null = null;
 let legacyUsageAgentParamsCache: Set<string> | null = null;
+let legacyUsageAgentScopeCache: Set<string> | null = null;
 
 function loadLegacyGatewayParamCache(storageKey: string): Set<string> {
   const raw = getSafeLocalStorage()?.getItem(storageKey);
@@ -105,6 +108,13 @@ function getLegacyUsageAgentParamsCache(): Set<string> {
   return legacyUsageAgentParamsCache;
 }
 
+function getLegacyUsageAgentScopeCache(): Set<string> {
+  if (!legacyUsageAgentScopeCache) {
+    legacyUsageAgentScopeCache = loadLegacyGatewayParamCache(LEGACY_USAGE_AGENT_SCOPE_STORAGE_KEY);
+  }
+  return legacyUsageAgentScopeCache;
+}
+
 function normalizeGatewayCompatibilityKey(gatewayUrl?: string): string {
   const trimmed = gatewayUrl?.trim();
   if (!trimmed) {
@@ -155,6 +165,18 @@ function rememberLegacyUsageAgentParams(state: UsageState) {
   persistLegacyGatewayParamCache(LEGACY_USAGE_AGENT_PARAMS_STORAGE_KEY, cache);
 }
 
+function shouldSendLegacyUsageAgentScope(state: UsageState): boolean {
+  return !getLegacyUsageAgentScopeCache().has(
+    normalizeGatewayCompatibilityKey(state.settings?.gatewayUrl),
+  );
+}
+
+function rememberLegacyUsageAgentScope(state: UsageState) {
+  const cache = getLegacyUsageAgentScopeCache();
+  cache.add(normalizeGatewayCompatibilityKey(state.settings?.gatewayUrl));
+  persistLegacyGatewayParamCache(LEGACY_USAGE_AGENT_SCOPE_STORAGE_KEY, cache);
+}
+
 function isLegacyDateInterpretationUnsupportedError(err: unknown): boolean {
   const message = toErrorMessage(err);
   return (
@@ -181,6 +203,13 @@ function isLegacyUsageAgentUnsupportedError(err: unknown): boolean {
   );
 }
 
+function isLegacyUsageAgentScopeUnsupportedError(err: unknown): boolean {
+  const message = toErrorMessage(err);
+  return (
+    LEGACY_USAGE_DATE_PARAMS_INVALID_RE.test(message) && LEGACY_USAGE_AGENT_SCOPE_RE.test(message)
+  );
+}
+
 const formatUtcOffset = (timezoneOffsetMinutes: number): string => {
   // `Date#getTimezoneOffset()` is minutes to add to local time to reach UTC.
   // Convert to UTC±H[:MM] where positive means east of UTC.
@@ -203,14 +232,6 @@ const buildDateInterpretationParams = (timeZone: "local" | "utc") => {
     utcOffset: formatUtcOffset(new Date().getTimezoneOffset()),
   };
 };
-
-export function resolveUsageAgentIdFromQuery(query: string): string | undefined {
-  const agentValues = extractQueryTerms(query)
-    .filter((term) => normalizeLowercaseStringOrEmpty(term.key) === "agent")
-    .map((term) => term.value.trim())
-    .filter((value) => value.length > 0 && !value.includes("*") && !value.includes("?"));
-  return new Set(agentValues).size === 1 ? agentValues[0] : undefined;
-}
 
 function toErrorMessage(err: unknown): string {
   if (typeof err === "string") {
@@ -255,11 +276,12 @@ export async function loadUsage(
   try {
     const startDate = overrides?.startDate ?? state.usageStartDate;
     const endDate = overrides?.endDate ?? state.usageEndDate;
-    const agentId = resolveUsageAgentIdFromQuery(state.usageQuery);
+    const agentId = normalizeLowercaseStringOrEmpty(state.usageAgentId ?? "") || undefined;
     const runUsageRequests = (
       includeDateInterpretation: boolean,
       includeUsageScope: boolean,
       includeAgentScope: boolean,
+      includeAllAgentScope: boolean,
     ) => {
       const dateInterpretation = includeDateInterpretation
         ? buildDateInterpretationParams(state.usageTimeZone)
@@ -270,11 +292,18 @@ export async function loadUsage(
             includeHistorical: state.usageScope === "family",
           }
         : undefined;
+      const agentScopeParams = agentId
+        ? includeAgentScope
+          ? { agentId }
+          : undefined
+        : includeAllAgentScope
+          ? { agentScope: "all" as const }
+          : undefined;
       return Promise.all([
         client.request("sessions.usage", {
           startDate,
           endDate,
-          ...(includeAgentScope && agentId ? { agentId } : undefined),
+          ...agentScopeParams,
           ...dateInterpretation,
           ...usageScopeParams,
           limit: 1000, // Cap at 1000 sessions
@@ -283,7 +312,7 @@ export async function loadUsage(
         client.request("usage.cost", {
           startDate,
           endDate,
-          ...(includeAgentScope && agentId ? { agentId } : undefined),
+          ...agentScopeParams,
           ...dateInterpretation,
         }),
       ]);
@@ -292,12 +321,14 @@ export async function loadUsage(
     let includeDateInterpretation = shouldSendLegacyDateInterpretation(state);
     let includeUsageScope = shouldSendLegacyUsageScopeParams(state);
     let includeAgentScope = Boolean(agentId) && shouldSendLegacyUsageAgentParams(state);
+    let includeAllAgentScope = !agentId && shouldSendLegacyUsageAgentScope(state);
     while (true) {
       try {
         const [sessionsRes, costRes] = await runUsageRequests(
           includeDateInterpretation,
           includeUsageScope,
           includeAgentScope,
+          includeAllAgentScope,
         );
         applyUsageResults(state, sessionsRes, costRes);
         break;
@@ -307,6 +338,13 @@ export async function loadUsage(
           // Remember this per gateway and retry with client-side filtering only.
           rememberLegacyUsageAgentParams(state);
           includeAgentScope = false;
+          continue;
+        }
+        if (includeAllAgentScope && isLegacyUsageAgentScopeUnsupportedError(err)) {
+          // Older gateways reject explicit all-agent usage scope. Retrying without
+          // it keeps pre-agent-scope gateways usable while current gateways prove all-agent intent.
+          rememberLegacyUsageAgentScope(state);
+          includeAllAgentScope = false;
           continue;
         }
         if (includeUsageScope && isLegacyUsageScopeUnsupportedError(err)) {
@@ -346,7 +384,7 @@ export const testApi = {
   isLegacyDateInterpretationUnsupportedError,
   isLegacyUsageScopeUnsupportedError,
   isLegacyUsageAgentUnsupportedError,
-  resolveUsageAgentIdFromQuery,
+  isLegacyUsageAgentScopeUnsupportedError,
   normalizeGatewayCompatibilityKey,
   shouldSendLegacyDateInterpretation,
   rememberLegacyDateInterpretation,
@@ -354,10 +392,13 @@ export const testApi = {
   rememberLegacyUsageScopeParams,
   shouldSendLegacyUsageAgentParams,
   rememberLegacyUsageAgentParams,
+  shouldSendLegacyUsageAgentScope,
+  rememberLegacyUsageAgentScope,
   resetLegacyUsageDateParamsCache: () => {
     legacyUsageDateParamsCache = null;
     legacyUsageScopeParamsCache = null;
     legacyUsageAgentParamsCache = null;
+    legacyUsageAgentScopeCache = null;
   },
 };
 export { testApi as __test };

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -34,15 +34,18 @@ export type UsageState = {
 
 const LEGACY_USAGE_DATE_PARAMS_STORAGE_KEY = "openclaw.control.usage.date-params.v1";
 const LEGACY_USAGE_SCOPE_PARAMS_STORAGE_KEY = "openclaw.control.usage.scope-params.v1";
+const LEGACY_USAGE_AGENT_PARAMS_STORAGE_KEY = "openclaw.control.usage.agent-params.v1";
 const LEGACY_USAGE_DATE_PARAMS_MODE_RE = /unexpected property ['"]mode['"]/i;
 const LEGACY_USAGE_DATE_PARAMS_OFFSET_RE = /unexpected property ['"]utcoffset['"]/i;
 const LEGACY_USAGE_SCOPE_PARAMS_GROUP_BY_RE = /unexpected property ['"]groupby['"]/i;
 const LEGACY_USAGE_SCOPE_PARAMS_INCLUDE_HISTORICAL_RE =
   /unexpected property ['"]includehistorical['"]/i;
+const LEGACY_USAGE_AGENT_PARAMS_AGENT_ID_RE = /unexpected property ['"]agentid['"]/i;
 const LEGACY_USAGE_DATE_PARAMS_INVALID_RE = /invalid sessions\.usage params/i;
 
 let legacyUsageDateParamsCache: Set<string> | null = null;
 let legacyUsageScopeParamsCache: Set<string> | null = null;
+let legacyUsageAgentParamsCache: Set<string> | null = null;
 
 function loadLegacyGatewayParamCache(storageKey: string): Set<string> {
   const raw = getSafeLocalStorage()?.getItem(storageKey);
@@ -93,6 +96,15 @@ function getLegacyUsageScopeParamsCache(): Set<string> {
   return legacyUsageScopeParamsCache;
 }
 
+function getLegacyUsageAgentParamsCache(): Set<string> {
+  if (!legacyUsageAgentParamsCache) {
+    legacyUsageAgentParamsCache = loadLegacyGatewayParamCache(
+      LEGACY_USAGE_AGENT_PARAMS_STORAGE_KEY,
+    );
+  }
+  return legacyUsageAgentParamsCache;
+}
+
 function normalizeGatewayCompatibilityKey(gatewayUrl?: string): string {
   const trimmed = gatewayUrl?.trim();
   if (!trimmed) {
@@ -131,6 +143,18 @@ function rememberLegacyUsageScopeParams(state: UsageState) {
   persistLegacyGatewayParamCache(LEGACY_USAGE_SCOPE_PARAMS_STORAGE_KEY, cache);
 }
 
+function shouldSendLegacyUsageAgentParams(state: UsageState): boolean {
+  return !getLegacyUsageAgentParamsCache().has(
+    normalizeGatewayCompatibilityKey(state.settings?.gatewayUrl),
+  );
+}
+
+function rememberLegacyUsageAgentParams(state: UsageState) {
+  const cache = getLegacyUsageAgentParamsCache();
+  cache.add(normalizeGatewayCompatibilityKey(state.settings?.gatewayUrl));
+  persistLegacyGatewayParamCache(LEGACY_USAGE_AGENT_PARAMS_STORAGE_KEY, cache);
+}
+
 function isLegacyDateInterpretationUnsupportedError(err: unknown): boolean {
   const message = toErrorMessage(err);
   return (
@@ -146,6 +170,14 @@ function isLegacyUsageScopeUnsupportedError(err: unknown): boolean {
     LEGACY_USAGE_DATE_PARAMS_INVALID_RE.test(message) &&
     (LEGACY_USAGE_SCOPE_PARAMS_GROUP_BY_RE.test(message) ||
       LEGACY_USAGE_SCOPE_PARAMS_INCLUDE_HISTORICAL_RE.test(message))
+  );
+}
+
+function isLegacyUsageAgentUnsupportedError(err: unknown): boolean {
+  const message = toErrorMessage(err);
+  return (
+    LEGACY_USAGE_DATE_PARAMS_INVALID_RE.test(message) &&
+    LEGACY_USAGE_AGENT_PARAMS_AGENT_ID_RE.test(message)
   );
 }
 
@@ -224,7 +256,11 @@ export async function loadUsage(
     const startDate = overrides?.startDate ?? state.usageStartDate;
     const endDate = overrides?.endDate ?? state.usageEndDate;
     const agentId = resolveUsageAgentIdFromQuery(state.usageQuery);
-    const runUsageRequests = (includeDateInterpretation: boolean, includeUsageScope: boolean) => {
+    const runUsageRequests = (
+      includeDateInterpretation: boolean,
+      includeUsageScope: boolean,
+      includeAgentScope: boolean,
+    ) => {
       const dateInterpretation = includeDateInterpretation
         ? buildDateInterpretationParams(state.usageTimeZone)
         : undefined;
@@ -238,7 +274,7 @@ export async function loadUsage(
         client.request("sessions.usage", {
           startDate,
           endDate,
-          ...(agentId ? { agentId } : undefined),
+          ...(includeAgentScope && agentId ? { agentId } : undefined),
           ...dateInterpretation,
           ...usageScopeParams,
           limit: 1000, // Cap at 1000 sessions
@@ -254,15 +290,24 @@ export async function loadUsage(
 
     let includeDateInterpretation = shouldSendLegacyDateInterpretation(state);
     let includeUsageScope = shouldSendLegacyUsageScopeParams(state);
+    let includeAgentScope = Boolean(agentId) && shouldSendLegacyUsageAgentParams(state);
     while (true) {
       try {
         const [sessionsRes, costRes] = await runUsageRequests(
           includeDateInterpretation,
           includeUsageScope,
+          includeAgentScope,
         );
         applyUsageResults(state, sessionsRes, costRes);
         break;
       } catch (err) {
+        if (includeAgentScope && isLegacyUsageAgentUnsupportedError(err)) {
+          // Older gateways reject `agentId` in `sessions.usage`.
+          // Remember this per gateway and retry with client-side filtering only.
+          rememberLegacyUsageAgentParams(state);
+          includeAgentScope = false;
+          continue;
+        }
         if (includeUsageScope && isLegacyUsageScopeUnsupportedError(err)) {
           // Older gateways reject `groupBy`/`includeHistorical` in `sessions.usage`.
           // Remember this per gateway and retry with instance-compatible params.
@@ -299,15 +344,19 @@ export const testApi = {
   toErrorMessage,
   isLegacyDateInterpretationUnsupportedError,
   isLegacyUsageScopeUnsupportedError,
+  isLegacyUsageAgentUnsupportedError,
   resolveUsageAgentIdFromQuery,
   normalizeGatewayCompatibilityKey,
   shouldSendLegacyDateInterpretation,
   rememberLegacyDateInterpretation,
   shouldSendLegacyUsageScopeParams,
   rememberLegacyUsageScopeParams,
+  shouldSendLegacyUsageAgentParams,
+  rememberLegacyUsageAgentParams,
   resetLegacyUsageDateParamsCache: () => {
     legacyUsageDateParamsCache = null;
     legacyUsageScopeParamsCache = null;
+    legacyUsageAgentParamsCache = null;
   },
 };
 export { testApi as __test };

--- a/ui/src/ui/views/usage.test.ts
+++ b/ui/src/ui/views/usage.test.ts
@@ -13,6 +13,7 @@ function createUsageProps(overrides: Partial<UsageProps> = {}): UsageProps {
       loading: false,
       error: null,
       sessions: [],
+      agents: [],
       sessionsLimitReached: false,
       totals: null,
       aggregates: null,
@@ -111,5 +112,34 @@ describe("renderUsage", () => {
     expect(container.querySelector(".usage-page-header")).toBeNull();
     expect(container.querySelector(".usage-page-title")).toBeNull();
     expect(container.querySelector(".usage-header")).not.toBeNull();
+  });
+
+  it("shows configured agents in the agent filter even before their usage sessions load", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderUsage(
+        createUsageProps({
+          data: {
+            ...createUsageProps().data,
+            agents: ["main", "research"],
+            sessions: [
+              {
+                key: "agent:main:main",
+                agentId: "main",
+                lastUpdated: Date.now(),
+                usage: null,
+              } as UsageProps["data"]["sessions"][number],
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    const agentFilter = container.querySelector(".usage-filter-select");
+
+    expect(agentFilter?.textContent).toContain("main");
+    expect(agentFilter?.textContent).toContain("research");
   });
 });

--- a/ui/src/ui/views/usage.test.ts
+++ b/ui/src/ui/views/usage.test.ts
@@ -27,6 +27,7 @@ function createUsageProps(overrides: Partial<UsageProps> = {}): UsageProps {
       selectedSessions: [],
       selectedDays: [],
       selectedHours: [],
+      agentId: null,
       query: "",
       queryDraft: "",
       timeZone: "local",
@@ -64,6 +65,7 @@ function createUsageProps(overrides: Partial<UsageProps> = {}): UsageProps {
         onStartDateChange: noop,
         onEndDateChange: noop,
         onScopeChange: noop,
+        onAgentChange: noop,
         onRefresh: noop,
         onTimeZoneChange: noop,
         onToggleHeaderPinned: noop,
@@ -141,5 +143,48 @@ describe("renderUsage", () => {
 
     expect(agentFilter?.textContent).toContain("main");
     expect(agentFilter?.textContent).toContain("research");
+  });
+
+  it("filters visible sessions when an agent scope is selected", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderUsage(
+        createUsageProps({
+          data: {
+            ...createUsageProps().data,
+            agents: ["main", "research"],
+            sessions: [
+              {
+                key: "agent:main:main",
+                agentId: "main",
+                lastUpdated: Date.now(),
+                usage: {
+                  totalTokens: 10,
+                  totalCost: 0,
+                } as UsageProps["data"]["sessions"][number]["usage"],
+              } as UsageProps["data"]["sessions"][number],
+              {
+                key: "agent:research:main",
+                agentId: "research",
+                lastUpdated: Date.now(),
+                usage: {
+                  totalTokens: 20,
+                  totalCost: 0,
+                } as UsageProps["data"]["sessions"][number]["usage"],
+              } as UsageProps["data"]["sessions"][number],
+            ],
+          },
+          filters: {
+            ...createUsageProps().filters,
+            agentId: "research",
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("agent:research:main");
+    expect(container.textContent).not.toContain("agent:main:main");
   });
 });

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -204,7 +204,10 @@ export function renderUsage(props: UsageProps) {
     }
     return Array.from(set);
   };
-  const agentOptions = unique(sortedSessions.map((s) => s.agentId)).slice(0, 12);
+  const agentOptions = unique([...data.agents, ...sortedSessions.map((s) => s.agentId)]).slice(
+    0,
+    12,
+  );
   const channelOptions = unique(sortedSessions.map((s) => s.channel)).slice(0, 12);
   const providerOptions = unique([
     ...sortedSessions.map((s) => s.modelProvider),

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -155,10 +155,16 @@ export function renderUsage(props: UsageProps) {
     return valB - valA;
   });
 
+  const agentScopedSessions = filters.agentId
+    ? sortedSessions.filter(
+        (s) => normalizeQueryText(s.agentId ?? "") === normalizeQueryText(filters.agentId ?? ""),
+      )
+    : sortedSessions;
+
   // Filter sessions by selected days
   const dayFilteredSessions =
     filters.selectedDays.length > 0
-      ? sortedSessions.filter((s) => {
+      ? agentScopedSessions.filter((s) => {
           if (s.usage?.activityDates?.length) {
             return s.usage.activityDates.some((d) => filters.selectedDays.includes(d));
           }
@@ -169,7 +175,7 @@ export function renderUsage(props: UsageProps) {
           const sessionDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
           return filters.selectedDays.includes(sessionDate);
         })
-      : sortedSessions;
+      : agentScopedSessions;
 
   const hourFilteredSessions =
     filters.selectedHours.length > 0
@@ -184,7 +190,7 @@ export function renderUsage(props: UsageProps) {
   const queryWarnings = queryResult.warnings;
   const querySuggestions = buildQuerySuggestions(
     filters.queryDraft,
-    sortedSessions,
+    agentScopedSessions,
     data.aggregates,
   );
   const queryTerms = extractQueryTerms(filters.query);
@@ -208,14 +214,14 @@ export function renderUsage(props: UsageProps) {
     0,
     12,
   );
-  const channelOptions = unique(sortedSessions.map((s) => s.channel)).slice(0, 12);
+  const channelOptions = unique(agentScopedSessions.map((s) => s.channel)).slice(0, 12);
   const providerOptions = unique([
-    ...sortedSessions.map((s) => s.modelProvider),
-    ...sortedSessions.map((s) => s.providerOverride),
+    ...agentScopedSessions.map((s) => s.modelProvider),
+    ...agentScopedSessions.map((s) => s.providerOverride),
     ...(data.aggregates?.byProvider.map((entry) => entry.provider) ?? []),
   ]).slice(0, 12);
   const modelOptions = unique([
-    ...sortedSessions.map((s) => s.model),
+    ...agentScopedSessions.map((s) => s.model),
     ...(data.aggregates?.byModel.map((entry) => entry.model) ?? []),
   ]).slice(0, 12);
   const toolOptions = unique(data.aggregates?.tools.tools.map((tool) => tool.name) ?? []).slice(
@@ -247,7 +253,7 @@ export function renderUsage(props: UsageProps) {
   // Compute display totals and count based on filters
   let displayTotals: UsageTotals | null;
   let displaySessionCount: number;
-  const totalSessions = sortedSessions.length;
+  const totalSessions = agentScopedSessions.length;
 
   if (filters.selectedSessions.length > 0) {
     // Sessions selected - compute totals from selected sessions
@@ -266,6 +272,9 @@ export function renderUsage(props: UsageProps) {
   } else if (hasQuery) {
     displayTotals = computeSessionTotals(filteredSessions);
     displaySessionCount = filteredSessions.length;
+  } else if (filters.agentId) {
+    displayTotals = computeSessionTotals(agentScopedSessions);
+    displaySessionCount = totalSessions;
   } else {
     // No filters - show all
     displayTotals = data.totals;
@@ -412,6 +421,35 @@ export function renderUsage(props: UsageProps) {
                     }}
                   />
                   <span>${value}</span>
+                </label>
+              `;
+            })}
+          </div>
+        </div>
+      </details>
+    `;
+  };
+  const renderAgentScopeSelect = () => {
+    const selected = filters.agentId ?? "";
+    return html`
+      <details class="usage-filter-select">
+        <summary>
+          <span>${t("usage.filters.agent")}</span>
+          <span class="usage-filter-badge">${selected || t("usage.filters.all")}</span>
+        </summary>
+        <div class="usage-filter-popover">
+          <div class="usage-filter-options">
+            ${["", ...agentOptions].map((value) => {
+              const checked = selected === value;
+              return html`
+                <label class="usage-filter-option">
+                  <input
+                    type="radio"
+                    name="usage-agent-scope"
+                    .checked=${checked}
+                    @change=${() => filterActions.onAgentChange(value || null)}
+                  />
+                  <span>${value || t("usage.filters.all")}</span>
                 </label>
               `;
             })}
@@ -672,7 +710,7 @@ export function renderUsage(props: UsageProps) {
             </div>
           </div>
           <div class="usage-filter-row">
-            ${renderFilterSelect("agent", t("usage.filters.agent"), agentOptions)}
+            ${renderAgentScopeSelect()}
             ${renderFilterSelect("channel", t("usage.filters.channel"), channelOptions)}
             ${renderFilterSelect("provider", t("usage.filters.provider"), providerOptions)}
             ${renderFilterSelect("model", t("usage.filters.model"), modelOptions)}

--- a/ui/src/ui/views/usageTypes.ts
+++ b/ui/src/ui/views/usageTypes.ts
@@ -42,6 +42,7 @@ export type UsageFilterState = {
   selectedSessions: string[]; // Support multiple session selection
   selectedDays: string[]; // Support multiple day selection
   selectedHours: number[]; // Support multiple hour selection
+  agentId: string | null;
   query: string;
   queryDraft: string;
   timeZone: "local" | "utc";
@@ -82,6 +83,7 @@ export type UsageCallbacks = {
     onStartDateChange: (date: string) => void;
     onEndDateChange: (date: string) => void;
     onScopeChange: (scope: "instance" | "family") => void;
+    onAgentChange: (agentId: string | null) => void;
     onRefresh: () => void;
     onTimeZoneChange: (zone: "local" | "utc") => void;
     onToggleHeaderPinned: () => void;

--- a/ui/src/ui/views/usageTypes.ts
+++ b/ui/src/ui/views/usageTypes.ts
@@ -27,6 +27,7 @@ export type UsageDataState = {
   loading: boolean;
   error: string | null;
   sessions: UsageSessionEntry[];
+  agents: string[];
   sessionsLimitReached: boolean; // True if 1000 session cap was hit
   totals: UsageTotals | null;
   aggregates: UsageAggregates | null;


### PR DESCRIPTION
Fixes #87132.

## Summary
- replace query-token agent scoping with an explicit Usage agent scope selector
- request all configured agents by default with `agentScope: "all"`, while selected agents still use `agentId`
- merge all-agent `usage.cost` summaries across configured agents and keep scoped cache entries separate
- keep legacy gateway fallbacks for `agentId` and `agentScope`, with generated protocol/docs updates

## Verification
- `node scripts/run-vitest.mjs ui/src/ui/controllers/usage.node.test.ts ui/src/ui/app-render-usage-tab.test.ts ui/src/ui/views/usage.test.ts --reporter=dot` (18 tests passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.cost-usage-cache.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts --reporter=dot` (34 tests passed)
- `pnpm check:test-types`
- `pnpm protocol:check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/protocol/schema/sessions.ts src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.cost-usage-cache.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts ui/src/ui/controllers/usage.ts ui/src/ui/controllers/usage.node.test.ts ui/src/ui/app.ts ui/src/ui/app-view-state.ts ui/src/ui/app-render-usage-tab.ts ui/src/ui/app-render-usage-tab.test.ts ui/src/ui/views/usage.ts ui/src/ui/views/usage.test.ts ui/src/ui/views/usageTypes.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit d67156a3c5 --thinking low --no-web-search`

## Real behavior proof

**Behavior addressed**: The Usage page needed a real agent scope, not a query-string side effect. Default Usage now asks the gateway for all configured agents, selected agents use `agentId`, and the gateway can aggregate all-agent cost totals instead of silently falling back to the default agent.

**Real environment tested**: Local OpenClaw checkout on branch `pr-87222`, using the Control UI usage tests, gateway usage method tests, generated gateway protocol check, and test typecheck.

**Exact steps or command run after this patch**: Ran the verification commands listed above after the final fixup commit.

**Evidence after fix**: UI usage tests passed 18/18, gateway usage tests passed 34/34, `pnpm check:test-types` passed, `pnpm protocol:check` passed with generated Swift protocol output staged, targeted oxlint returned success, `git diff --check` returned clean, and the narrowed autoreview reported no accepted/actionable findings on the Swift compatibility fix.

**Observed result after fix**: With no selected agent, the UI sends `agentScope: "all"` to `sessions.usage` and `usage.cost`. With a selected agent, both requests send that `agentId`. The gateway lists sessions across configured agents for explicit all-agent scope, rejects conflicting all-agent plus specific-agent/key requests, aggregates cost totals by date across configured agents, and keeps cost cache entries separated by all/default/specific-agent scope.

**What was not tested**: I did not run a live browser against a multi-agent gateway. A local `pnpm build` attempt was stopped after `tsdown` stayed quiet for about 15 minutes; CI will cover the full build lane. A Testbox `pnpm check:changed` run exited `255` without actionable logs.





