### PR TITLE
fix(memory): salvage qmd search JSON after nonzero exit

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1857,7 +1857,7 @@ describe("QmdMemoryManager", () => {
               },
             ]),
           );
-          child.stderr.emit("data", "ggml-metal-device.m:612");
+          child.stderr.emit("data", "ggml-metal-device.m:612 assertion failed");
           child.closeWith(134);
         });
         return child;
@@ -1914,6 +1914,44 @@ describe("QmdMemoryManager", () => {
     await expect(
       manager.search("router glacier backup", { sessionKey: "agent:main:slack:dm:u123" }),
     ).rejects.toThrow(/qmd query router glacier backup .* failed \(code 134\): not json/);
+    await manager.close();
+  });
+
+  it("does not use qmd query JSON from a non-crash search failure", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        queueMicrotask(() => {
+          child.stdout.emit("data", "[]");
+          child.stderr.emit("data", "SQLITE_BUSY: database is locked");
+          child.closeWith(2);
+        });
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+
+    await expect(
+      manager.search("router glacier backup", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).rejects.toThrow(/SQLITE_BUSY: database is locked/);
+    expect(logWarnMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("using captured search results"),
+    );
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1847,6 +1847,7 @@ describe("QmdMemoryManager", () => {
       if (args[0] === "query") {
         const child = createMockChild({ autoClose: false });
         queueMicrotask(() => {
+          child.stdout.emit("data", "initializing qmd reranker\n");
           child.stdout.emit(
             "data",
             JSON.stringify(

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1952,7 +1952,11 @@ describe("QmdMemoryManager", () => {
         if (collection === "memory-root-main" && !missingCollectionSeen) {
           missingCollectionSeen = true;
           const child = createMockChild({ autoClose: false });
-          emitAndClose(child, "stderr", "Collection not found: memory-root-main", 1);
+          queueMicrotask(() => {
+            child.stdout.emit("data", "[]");
+            child.stderr.emit("data", "Collection not found: memory-root-main");
+            child.closeWith(1);
+          });
           return child;
         }
         if (collection === "memory-root-main") {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1829,6 +1829,94 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("uses valid qmd query JSON captured before a non-zero exit", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        queueMicrotask(() => {
+          child.stdout.emit(
+            "data",
+            JSON.stringify([
+              {
+                file: "qmd://workspace-main/notes/welcome.md",
+                score: 0.93,
+                snippet: "@@ -7,1\nrouter glacier backup",
+              },
+            ]),
+          );
+          child.stderr.emit("data", "ggml-metal-device.m:612");
+          child.closeWith(134);
+        });
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+
+    await expect(
+      manager.search("router glacier backup", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toEqual([
+      {
+        path: "notes/welcome.md",
+        startLine: 7,
+        endLine: 7,
+        score: 0.93,
+        snippet: "@@ -7,1\nrouter glacier backup",
+        source: "memory",
+      },
+    ]);
+    expectMockMessageContains(
+      logWarnMock,
+      "qmd query exited non-zero after producing valid JSON; using captured search results (code 134)",
+    );
+    await manager.close();
+  });
+
+  it("keeps invalid qmd query stdout failed after a non-zero exit", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "not json", 134);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+
+    await expect(
+      manager.search("router glacier backup", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).rejects.toThrow(/qmd query router glacier backup .* failed \(code 134\): not json/);
+    await manager.close();
+  });
+
   it("repairs missing managed collections and retries search once", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1849,13 +1849,17 @@ describe("QmdMemoryManager", () => {
         queueMicrotask(() => {
           child.stdout.emit(
             "data",
-            JSON.stringify([
-              {
-                file: "qmd://workspace-main/notes/welcome.md",
-                score: 0.93,
-                snippet: "@@ -7,1\nrouter glacier backup",
-              },
-            ]),
+            JSON.stringify(
+              [
+                {
+                  file: "qmd://workspace-main/notes/welcome.md",
+                  score: 0.93,
+                  snippet: "@@ -7,1\nrouter glacier backup",
+                },
+              ],
+              null,
+              2,
+            ),
           );
           child.stderr.emit("data", "ggml-metal-device.m:612 assertion failed");
           child.closeWith(134);

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1924,7 +1924,12 @@ export class QmdMemoryManager implements MemorySearchManager {
     err: unknown,
     command: "query" | "search" | "vsearch",
   ): QmdQueryResult[] | null {
-    if (!isCliCommandError(err) || !hasQmdJsonArrayPayload(err.stdout)) {
+    if (
+      !isCliCommandError(err) ||
+      this.isMissingCollectionSearchError(err) ||
+      this.isUnsupportedQmdOptionError(err) ||
+      !hasQmdJsonArrayPayload(err.stdout)
+    ) {
       return null;
     }
     try {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1928,8 +1928,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.isMissingCollectionSearchError(err) ||
       this.isUnsupportedQmdOptionError(err) ||
       this.isSqliteBusyError(err) ||
-      !isQmdNativeAbortAfterOutput(err) ||
-      !err.stdout.trim().startsWith("[")
+      !isQmdNativeAbortAfterOutput(err)
     ) {
       return null;
     }

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1928,6 +1928,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       !isCliCommandError(err) ||
       this.isMissingCollectionSearchError(err) ||
       this.isUnsupportedQmdOptionError(err) ||
+      this.isSqliteBusyError(err) ||
+      !isQmdNativeAbortAfterOutput(err) ||
       !hasQmdJsonArrayPayload(err.stdout)
     ) {
       return null;
@@ -3198,6 +3200,25 @@ function formatQmdSearchExit(err: { code: number | null; signal: NodeJS.Signals 
     return `signal ${err.signal ?? "unknown"}`;
   }
   return `code ${err.code}`;
+}
+
+function isQmdNativeAbortAfterOutput(err: {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+}): boolean {
+  const aborted = err.code === 134 || err.signal === "SIGABRT";
+  if (!aborted) {
+    return false;
+  }
+  const stderr = normalizeLowercaseStringOrEmpty(err.stderr);
+  return (
+    stderr.includes("ggml-metal") ||
+    stderr.includes("node-llama-cpp") ||
+    stderr.includes("llama.cpp") ||
+    stderr.includes("abort trap") ||
+    stderr.includes("assertion failed")
+  );
 }
 
 function hasQmdJsonArrayPayload(raw: string): boolean {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -23,7 +23,6 @@ import {
   deriveQmdScopeChannel,
   deriveQmdScopeChatType,
   isQmdScopeAllowed,
-  isCliCommandError,
   listSessionFilesForAgent,
   parseQmdQueryJson,
   resolveCliSpawnInvocation,
@@ -1925,7 +1924,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     command: "query" | "search" | "vsearch",
   ): QmdQueryResult[] | null {
     if (
-      !isCliCommandError(err) ||
+      !isQmdCliCommandError(err) ||
       this.isMissingCollectionSearchError(err) ||
       this.isUnsupportedQmdOptionError(err) ||
       this.isSqliteBusyError(err) ||
@@ -3200,6 +3199,29 @@ function formatQmdSearchExit(err: { code: number | null; signal: NodeJS.Signals 
     return `signal ${err.signal ?? "unknown"}`;
   }
   return `code ${err.code}`;
+}
+
+function isQmdCliCommandError(err: unknown): err is {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+} {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const candidate = err as {
+    code?: unknown;
+    signal?: unknown;
+    stdout?: unknown;
+    stderr?: unknown;
+  };
+  return (
+    (typeof candidate.code === "number" || candidate.code === null) &&
+    (typeof candidate.signal === "string" || candidate.signal === null) &&
+    typeof candidate.stdout === "string" &&
+    typeof candidate.stderr === "string"
+  );
 }
 
 function isQmdNativeAbortAfterOutput(err: {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -23,6 +23,7 @@ import {
   deriveQmdScopeChannel,
   deriveQmdScopeChatType,
   isQmdScopeAllowed,
+  isCliCommandError,
   listSessionFilesForAgent,
   parseQmdQueryJson,
   resolveCliSpawnInvocation,
@@ -1198,8 +1199,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         }
         const args = this.buildSearchArgs(qmdSearchCommand, trimmed, limit);
         args.push(...this.buildCollectionFilterArgs(collectionGroups[0] ?? collectionNames));
-        const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
-        return parseQmdQueryJson(result.stdout, result.stderr);
+        return await this.runQmdSearch(args, qmdSearchCommand);
       } catch (err) {
         if (allowMissingCollectionRepair && this.isMissingCollectionSearchError(err)) {
           throw err;
@@ -1228,10 +1228,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             fallbackArgs.push(
               ...this.buildCollectionFilterArgs(collectionGroups[0] ?? collectionNames),
             );
-            const fallback = await this.runQmd(fallbackArgs, {
-              timeoutMs: this.qmd.limits.timeoutMs,
-            });
-            return parseQmdQueryJson(fallback.stdout, fallback.stderr);
+            return await this.runQmdSearch(fallbackArgs, "query");
           } catch (fallbackErr) {
             log.warn(`qmd query fallback failed: ${String(fallbackErr)}`);
             throw fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
@@ -1905,6 +1902,40 @@ export class QmdMemoryManager implements MemorySearchManager {
       // Large `qmd update` runs can easily exceed the output cap; keep only stderr.
       discardStdout: opts?.discardOutput,
     });
+  }
+
+  private async runQmdSearch(
+    args: string[],
+    command: "query" | "search" | "vsearch",
+  ): Promise<QmdQueryResult[]> {
+    try {
+      const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
+      return parseQmdQueryJson(result.stdout, result.stderr);
+    } catch (err) {
+      const recovered = this.parseFailedQmdSearchJson(err, command);
+      if (recovered) {
+        return recovered;
+      }
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  private parseFailedQmdSearchJson(
+    err: unknown,
+    command: "query" | "search" | "vsearch",
+  ): QmdQueryResult[] | null {
+    if (!isCliCommandError(err) || !hasQmdJsonArrayPayload(err.stdout)) {
+      return null;
+    }
+    try {
+      const parsed = parseQmdQueryJson(err.stdout, err.stderr);
+      log.warn(
+        `qmd ${command} exited non-zero after producing valid JSON; using captured search results (${formatQmdSearchExit(err)})`,
+      );
+      return parsed;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -2986,8 +3017,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     for (const collectionNames of collectionGroups) {
       const args = this.buildSearchArgs(command, query, limit);
       args.push(...this.buildCollectionFilterArgs(collectionNames));
-      const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
-      const parsed = parseQmdQueryJson(result.stdout, result.stderr);
+      const parsed = await this.runQmdSearch(args, command);
       for (const entry of parsed) {
         const defaultCollection = collectionNames.length === 1 ? collectionNames[0] : undefined;
         const normalizedHints = this.normalizeDocHints({
@@ -3156,4 +3186,16 @@ function resolveQmdManagerRuntimeConfig(
 
 function normalizeQmdSemanticQuery(query: string): string {
   return query.replace(/(\w)-(?=\w)/g, "$1 ");
+}
+
+function formatQmdSearchExit(err: { code: number | null; signal: NodeJS.Signals | null }): string {
+  if (err.code === null) {
+    return `signal ${err.signal ?? "unknown"}`;
+  }
+  return `code ${err.code}`;
+}
+
+function hasQmdJsonArrayPayload(raw: string): boolean {
+  const trimmed = raw.trim();
+  return trimmed.startsWith("[]") || trimmed.startsWith("[{") || /\n\s*\[(?:\]|\{)/.test(trimmed);
 }

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1929,7 +1929,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.isUnsupportedQmdOptionError(err) ||
       this.isSqliteBusyError(err) ||
       !isQmdNativeAbortAfterOutput(err) ||
-      !hasQmdJsonArrayPayload(err.stdout)
+      !err.stdout.trim().startsWith("[")
     ) {
       return null;
     }
@@ -3241,9 +3241,4 @@ function isQmdNativeAbortAfterOutput(err: {
     stderr.includes("abort trap") ||
     stderr.includes("assertion failed")
   );
-}
-
-function hasQmdJsonArrayPayload(raw: string): boolean {
-  const trimmed = raw.trim();
-  return trimmed.startsWith("[]") || trimmed.startsWith("[{") || /\n\s*\[(?:\]|\{)/.test(trimmed);
 }

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -25,11 +25,9 @@ export {
 } from "./host/qmd-scope.js";
 export {
   checkQmdBinaryAvailability,
-  isCliCommandError,
   resolveCliSpawnInvocation,
   resolveQmdBinaryUnavailableReason,
   runCliCommand,
-  type CliCommandError,
   type QmdBinaryAvailability,
   type QmdBinaryUnavailable,
   type QmdBinaryUnavailableReason,

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -25,9 +25,11 @@ export {
 } from "./host/qmd-scope.js";
 export {
   checkQmdBinaryAvailability,
+  isCliCommandError,
   resolveCliSpawnInvocation,
   resolveQmdBinaryUnavailableReason,
   runCliCommand,
+  type CliCommandError,
   type QmdBinaryAvailability,
   type QmdBinaryUnavailable,
   type QmdBinaryUnavailableReason,

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -16,7 +16,6 @@ vi.mock("node:child_process", async () => {
 
 import {
   checkQmdBinaryAvailability,
-  isCliCommandError,
   resolveCliSpawnInvocation,
   resolveQmdBinaryUnavailableReason,
   runCliCommand,
@@ -224,14 +223,17 @@ describe("runCliCommand", () => {
       });
       throw new Error("expected runCliCommand to reject");
     } catch (err) {
-      expect(isCliCommandError(err)).toBe(true);
-      if (!isCliCommandError(err)) {
+      expect(err).toBeInstanceOf(Error);
+      if (!(err instanceof Error)) {
         throw err;
       }
-      expect(err.code).toBe(134);
-      expect(err.signal).toBeNull();
-      expect(err.stdout).toBe('[{"docid":"abc","score":0.93}]');
-      expect(err.stderr).toBe("ggml-metal-device.m:612");
+      expect(err.name).toBe("CliCommandError");
+      expect(err).toMatchObject({
+        code: 134,
+        signal: null,
+        stdout: '[{"docid":"abc","score":0.93}]',
+        stderr: "ggml-metal-device.m:612",
+      });
       expect(err.message).toContain("qmd query test failed (code 134)");
     }
   });

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -16,16 +16,26 @@ vi.mock("node:child_process", async () => {
 
 import {
   checkQmdBinaryAvailability,
+  isCliCommandError,
   resolveCliSpawnInvocation,
   resolveQmdBinaryUnavailableReason,
+  runCliCommand,
   type QmdBinaryAvailability,
 } from "./qmd-process.js";
 
 function createMockChild() {
   const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
     kill: ReturnType<typeof vi.fn>;
+    closeWith: (code?: number | null, signal?: NodeJS.Signals | null) => void;
   };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
   child.kill = vi.fn();
+  child.closeWith = (code: number | null = 0, signal: NodeJS.Signals | null = null) => {
+    child.emit("close", code, signal);
+  };
   return child;
 }
 
@@ -189,5 +199,86 @@ describe("checkQmdBinaryAvailability", () => {
     await expect(
       checkQmdBinaryAvailability({ command: "qmd", env: process.env, cwd: tempDir }),
     ).resolves.toEqual({ available: false, reason: "binary", error: "spawn qmd ENOENT" });
+  });
+});
+
+describe("runCliCommand", () => {
+  it("keeps stdout and stderr on non-zero exits", async () => {
+    const child = createMockChild();
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        child.stdout.emit("data", '[{"docid":"abc","score":0.93}]');
+        child.stderr.emit("data", "ggml-metal-device.m:612");
+        child.closeWith(134);
+      });
+      return child;
+    });
+
+    try {
+      await runCliCommand({
+        commandSummary: "qmd query test",
+        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+        env: process.env,
+        cwd: tempDir,
+        maxOutputChars: 10_000,
+      });
+      throw new Error("expected runCliCommand to reject");
+    } catch (err) {
+      expect(isCliCommandError(err)).toBe(true);
+      if (!isCliCommandError(err)) {
+        throw err;
+      }
+      expect(err.code).toBe(134);
+      expect(err.signal).toBeNull();
+      expect(err.stdout).toBe('[{"docid":"abc","score":0.93}]');
+      expect(err.stderr).toBe("ggml-metal-device.m:612");
+      expect(err.message).toContain("qmd query test failed (code 134)");
+    }
+  });
+
+  it("records signal-only command failures", async () => {
+    const child = createMockChild();
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        child.stdout.emit("data", "[]");
+        child.closeWith(null, "SIGABRT");
+      });
+      return child;
+    });
+
+    await expect(
+      runCliCommand({
+        commandSummary: "qmd query test",
+        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+        env: process.env,
+        cwd: tempDir,
+        maxOutputChars: 10_000,
+      }),
+    ).rejects.toMatchObject({
+      code: null,
+      signal: "SIGABRT",
+      stdout: "[]",
+    });
+  });
+
+  it("does not expose truncated output as a recoverable command failure", async () => {
+    const child = createMockChild();
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        child.stdout.emit("data", "too much output");
+        child.closeWith(1);
+      });
+      return child;
+    });
+
+    await expect(
+      runCliCommand({
+        commandSummary: "qmd query test",
+        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+        env: process.env,
+        cwd: tempDir,
+        maxOutputChars: 4,
+      }),
+    ).rejects.toThrow(/produced too much output/);
   });
 });

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -219,7 +219,7 @@ export async function runCliCommand(params: {
   });
 }
 
-export class CliCommandError extends Error {
+class CliCommandError extends Error {
   readonly code: number | null;
   readonly signal: NodeJS.Signals | null;
   readonly stdout: string;
@@ -241,7 +241,7 @@ export class CliCommandError extends Error {
   }
 }
 
-export function isCliCommandError(err: unknown): err is CliCommandError {
+function isCliCommandError(err: unknown): err is CliCommandError {
   return err instanceof CliCommandError;
 }
 

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -241,10 +241,6 @@ class CliCommandError extends Error {
   }
 }
 
-function isCliCommandError(err: unknown): err is CliCommandError {
-  return err instanceof CliCommandError;
-}
-
 function formatCliCommandFailureMessage(params: {
   commandSummary: string;
   code: number | null;

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -9,6 +9,32 @@ export type CliSpawnInvocation = {
   windowsHide?: boolean;
 };
 
+export class CliCommandError extends Error {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(params: {
+    commandSummary: string;
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    stdout: string;
+    stderr: string;
+  }) {
+    super(formatCliCommandFailureMessage(params));
+    this.name = "CliCommandError";
+    this.code = params.code;
+    this.signal = params.signal;
+    this.stdout = params.stdout;
+    this.stderr = params.stderr;
+  }
+}
+
+export function isCliCommandError(err: unknown): err is CliCommandError {
+  return err instanceof CliCommandError;
+}
+
 export type QmdBinaryUnavailableReason = "binary" | "workspace-cwd";
 
 export type QmdBinaryUnavailable = {
@@ -190,7 +216,7 @@ export async function runCliCommand(params: {
       }
       reject(err);
     });
-    child.on("close", (code) => {
+    child.on("close", (code, signal) => {
       if (timer) {
         clearTimeout(timer);
       }
@@ -205,10 +231,30 @@ export async function runCliCommand(params: {
       if (code === 0) {
         resolve({ stdout, stderr });
       } else {
-        reject(new Error(`${params.commandSummary} failed (code ${code}): ${stderr || stdout}`));
+        reject(
+          new CliCommandError({
+            commandSummary: params.commandSummary,
+            code,
+            signal,
+            stdout,
+            stderr,
+          }),
+        );
       }
     });
   });
+}
+
+function formatCliCommandFailureMessage(params: {
+  commandSummary: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}): string {
+  const exit =
+    params.code === null ? `signal ${params.signal ?? "unknown"}` : `code ${String(params.code)}`;
+  return `${params.commandSummary} failed (${exit}): ${params.stderr || params.stdout}`;
 }
 
 function appendOutputWithCap(

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -9,32 +9,6 @@ export type CliSpawnInvocation = {
   windowsHide?: boolean;
 };
 
-export class CliCommandError extends Error {
-  readonly code: number | null;
-  readonly signal: NodeJS.Signals | null;
-  readonly stdout: string;
-  readonly stderr: string;
-
-  constructor(params: {
-    commandSummary: string;
-    code: number | null;
-    signal: NodeJS.Signals | null;
-    stdout: string;
-    stderr: string;
-  }) {
-    super(formatCliCommandFailureMessage(params));
-    this.name = "CliCommandError";
-    this.code = params.code;
-    this.signal = params.signal;
-    this.stdout = params.stdout;
-    this.stderr = params.stderr;
-  }
-}
-
-export function isCliCommandError(err: unknown): err is CliCommandError {
-  return err instanceof CliCommandError;
-}
-
 export type QmdBinaryUnavailableReason = "binary" | "workspace-cwd";
 
 export type QmdBinaryUnavailable = {
@@ -235,7 +209,7 @@ export async function runCliCommand(params: {
           new CliCommandError({
             commandSummary: params.commandSummary,
             code,
-            signal,
+            signal: signal ?? null,
             stdout,
             stderr,
           }),
@@ -243,6 +217,32 @@ export async function runCliCommand(params: {
       }
     });
   });
+}
+
+export class CliCommandError extends Error {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(params: {
+    commandSummary: string;
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    stdout: string;
+    stderr: string;
+  }) {
+    super(formatCliCommandFailureMessage(params));
+    this.name = "CliCommandError";
+    this.code = params.code;
+    this.signal = params.signal;
+    this.stdout = params.stdout;
+    this.stderr = params.stderr;
+  }
+}
+
+export function isCliCommandError(err: unknown): err is CliCommandError {
+  return err instanceof CliCommandError;
 }
 
 function formatCliCommandFailureMessage(params: {


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`). AI-assisted.

## Summary

QMD can print good search results and then crash while shutting down on Apple Silicon.
OpenClaw was treating that late crash as a full search failure and throwing away the results.
This change keeps failed subprocess output available and lets the QMD search path use it only when stdout contains valid QMD search JSON.

Fixes #85217

## What Changed

The process helper now reports failed command output in a structured way.
The QMD manager uses that extra detail only for direct search commands, so update, embed, status, timeout, truncated output, and invalid JSON failures still fail closed.

- Added `CliCommandError` with exit code, signal, stdout, and stderr.
- Exported the typed error guard through the memory host QMD SDK surface.
- Routed direct QMD search parsing through a helper that can recover valid JSON from non-zero QMD exits.
- Added a strict JSON-array guard so log prefixes like `[qmd]` are not treated as recoverable search results.
- Added regression tests for captured stdout/stderr, signal exits, truncated output, recovered query results, and invalid failed stdout.

## Testing

I tested the focused OpenClaw paths and also reproduced the live QMD crash locally on Apple Silicon.
The patched live-helper smoke could not run because direct TS import hit an unrelated local package export issue before executing the helper, so the after-fix behavior is covered by targeted regression tests.

- `pnpm install --frozen-lockfile` - passed
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/qmd-process.test.ts packages/memory-host-sdk/src/host/qmd-query-parser.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts extensions/memory-core/src/memory/search-manager.test.ts` - passed, 4 files, 160 tests
- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/qmd-manager.ts packages/memory-host-sdk/src/host/qmd-process.ts packages/memory-host-sdk/src/engine-qmd.ts packages/memory-host-sdk/src/host/qmd-process.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts` - passed
- `git diff --check` - passed

## Real behavior proof

Behavior addressed: QMD search output produced before a non-zero subprocess exit should not be discarded when the stdout is valid QMD search JSON.

Real environment tested: local macOS Apple Silicon, Darwin 25.4.0 arm64, Node v24.16.0, `@tobilu/qmd@2.5.1`, isolated QMD home/cache under `/tmp/openclaw-85217-qmd-repro`, plus OpenClaw targeted mocked regression tests.

Exact steps or command run after this patch: Ran an isolated QMD collection with two markdown files, embedded it, then ran `qmd query "router glacier backup" --json -n 5 -c reprodocs` through `npm exec --yes @tobilu/qmd@2.5.1`. Ran the focused OpenClaw Vitest command listed above after applying this patch.

Evidence after fix: The live QMD command exited `134`, wrote 601 stdout chars, wrote valid JSON with 2 parsed results and top score `0.93`, and stderr contained `ggml-metal-device.m:612: GGML_ASSERT([rsets->data count] == 0) failed`. The focused OpenClaw regression tests passed and prove the patched manager returns captured QMD search JSON after a non-zero exit while invalid or truncated output still fails.

Observed result after fix: OpenClaw's QMD search path now accepts valid JSON search results from the typed failed subprocess output and logs a warning instead of falling back to an empty builtin index. Non-search commands and invalid failed output are still treated as failures.

What was not tested: A full OpenClaw CLI/gateway search against live QMD after the patch was not completed because direct local TS import hit an unrelated `@earendil-works/pi-ai` package export error before the patched helper could run. CI and Codex review are still pending on this PR.

## Risks

The main risk is accidentally hiding real QMD failures.
The recovery is intentionally narrow to reduce that risk.

- Only typed subprocess failures from direct QMD search commands are recoverable.
- The recovered stdout must contain a JSON array payload that `parseQmdQueryJson` accepts.
- Truncated output is rejected before recovery.
- Maintenance commands are not routed through this recovery helper.


