### PR TITLE
fix(anthropic): send bare direct model ids

### DIFF
--- a/scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs
+++ b/scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs
@@ -33,7 +33,7 @@ export function createJsonlRequestTailer(filePath, options = {}) {
       return JSON.parse(line);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`invalid app-server JSONL at ${filePath}: ${message}`);
+      throw new Error(`invalid app-server JSONL at ${filePath}: ${message}`, { cause: error });
     }
   }
 

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -206,6 +206,38 @@ describe("anthropic transport stream", () => {
     );
   });
 
+  it("strips the provider prefix from direct Anthropic request model ids", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({ id: "anthropic/claude-sonnet-4-6" }),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("keeps slash-bearing model ids for Anthropic-compatible proxy providers", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4-6",
+        baseUrl: "https://openrouter.ai/api/anthropic",
+      }),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-or-test",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload.model).toBe("anthropic/claude-sonnet-4-6");
+  });
+
   it("bypasses the OpenAI SSE sanitizer for Kimi Anthropic thinking streams", async () => {
     const model = makeAnthropicTransportModel({
       id: "kimi-for-coding",

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -238,6 +238,23 @@ describe("anthropic transport stream", () => {
     expect(latestAnthropicRequest().payload.model).toBe("anthropic/claude-sonnet-4-6");
   });
 
+  it("keeps slash-bearing model ids for configured Anthropic-compatible endpoints", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "anthropic/claude-sonnet-4-6",
+        baseUrl: "https://anthropic-proxy.internal",
+      }),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload.model).toBe("anthropic/claude-sonnet-4-6");
+  });
+
   it("bypasses the OpenAI SSE sanitizer for Kimi Anthropic thinking streams", async () => {
     const model = makeAnthropicTransportModel({
       id: "kimi-for-coding",

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -72,10 +72,7 @@ type AnthropicMessagesClient = {
 };
 
 function resolveAnthropicRequestModelId(model: AnthropicTransportModel): string {
-  if (
-    normalizeLowercaseStringOrEmpty(model.provider) === "anthropic" &&
-    /^anthropic\//i.test(model.id)
-  ) {
+  if (isDirectAnthropicModel(model) && /^anthropic\//i.test(model.id)) {
     return model.id.replace(/^anthropic\//i, "");
   }
   return model.id;

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -71,6 +71,16 @@ type AnthropicMessagesClient = {
   };
 };
 
+function resolveAnthropicRequestModelId(model: AnthropicTransportModel): string {
+  if (
+    normalizeLowercaseStringOrEmpty(model.provider) === "anthropic" &&
+    /^anthropic\//i.test(model.id)
+  ) {
+    return model.id.replace(/^anthropic\//i, "");
+  }
+  return model.id;
+}
+
 type TransportContentBlock =
   | { type: "text"; text: string; index?: number }
   | {
@@ -794,7 +804,7 @@ function buildAnthropicParams(
     enableCacheControl: true,
   });
   const params: Record<string, unknown> = {
-    model: model.id,
+    model: resolveAnthropicRequestModelId(model),
     messages: ensureNonEmptyAnthropicMessages(
       convertAnthropicMessages(context.messages, model, isOAuthToken, {
         allowReasoningContentReplay: supportsReasoningContentReplay(model),


### PR DESCRIPTION
Closes #87181

## Summary
- strip an `anthropic/` prefix from final direct Anthropic Messages payload model ids
- keep slash-bearing model ids unchanged for Anthropic-compatible proxy/custom endpoints
- add transport regression coverage for both direct Anthropic and proxy cases

## Verification
- `timeout 60s fnm exec --using 24.15.0 -- node --import tsx --input-type=module ...` captured the direct transport payload before network handoff and captured a custom endpoint request with a local HTTP server
- `pnpm exec oxfmt --check --threads=1 src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts`
- `node scripts/run-oxlint.mjs src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts`
- `git diff --check temp/landpr-87227...HEAD && git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base temp/landpr-87227`

## Real behavior proof
- Behavior addressed: Direct Anthropic requests no longer send provider-qualified model ids like `anthropic/claude-sonnet-4-6` in the `/v1/messages` JSON body, while Anthropic-compatible custom endpoints keep slash-bearing model ids unchanged.
- Real environment tested: Local macOS checkout with the real Anthropic Messages transport. The direct Anthropic path was captured from the real transport payload before network handoff, and the custom endpoint path was captured through a local HTTP server receiving the actual `/v1/messages` request body.
- Exact steps or command run after this patch:

```sh
timeout 60s fnm exec --using 24.15.0 -- node --import tsx --input-type=module <<'EOF'
import http from 'node:http';
import { createAnthropicMessagesTransportStreamFn } from './src/agents/anthropic-transport-stream.ts';
import { attachModelProviderRequestTransport } from './src/agents/provider-request-config.ts';

const streamFn = createAnthropicMessagesTransportStreamFn();
const directModel = {
  id: 'anthropic/claude-sonnet-4-6',
  name: 'Claude Sonnet 4.6',
  api: 'anthropic-messages',
  provider: 'anthropic',
  input: ['text'],
  reasoning: true,
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
  contextWindow: 200000,
  maxTokens: 8192,
};
let directPayloadModel;
try {
  await (await Promise.resolve(streamFn(directModel, {
    messages: [{ role: 'user', content: 'ping' }],
  }, {
    apiKey: 'sk-ant-redacted',
    onPayload: (params) => {
      directPayloadModel = params.model;
      throw new Error('capture-complete');
    },
  }))).result();
} catch (error) {
  if (!String(error?.message ?? error).includes('capture-complete')) {
    throw error;
  }
}

const captured = [];
const server = http.createServer((req, res) => {
  let body = '';
  req.setEncoding('utf8');
  req.on('data', (chunk) => { body += chunk; });
  req.on('end', () => {
    captured.push({ url: req.url, body: JSON.parse(body) });
    res.writeHead(200, { 'content-type': 'text/event-stream' });
    res.end('data: {"type":"message_start","message":{"id":"msg_1","model":"anthropic/claude-sonnet-4-6","usage":{"input_tokens":1,"output_tokens":0}}}\n\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}\n\ndata: {"type":"message_stop"}\n\n');
  });
});
await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
const { port } = server.address();
const customModel = attachModelProviderRequestTransport({
  ...directModel,
  baseUrl: `http://127.0.0.1:${port}`,
}, { proxy: { mode: 'env-proxy' } });
await (await Promise.resolve(streamFn(customModel, {
  messages: [{ role: 'user', content: 'pong' }],
}, { apiKey: 'sk-ant-redacted' }))).result();
server.closeAllConnections?.();
server.close();
console.log(`directPayloadModel=${directPayloadModel}`);
console.log(`customRequestUrl=${captured[0].url}`);
console.log(`customPayloadModel=${captured[0].body.model}`);
console.log(`customPayloadKeepsProviderPrefix=${String(captured[0].body.model).startsWith('anthropic/')}`);
EOF
```

- Evidence after fix:

```text
directPayloadModel=claude-sonnet-4-6
customRequestUrl=/v1/messages
customPayloadModel=anthropic/claude-sonnet-4-6
customPayloadKeepsProviderPrefix=true
```

- Observed result after fix: The direct Anthropic transport payload used the bare Claude model id, and the custom Anthropic-compatible endpoint received the original slash-bearing model id.
- What was not tested: Live Anthropic API submission, to avoid requiring or exposing a real API key. Local Vitest for this file spun in this checkout, so regression-test execution is left to CI.

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
