### PR TITLE
fix(codex): synthesize failed tool.result for orphan tool.call (#86808)

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1558,6 +1558,81 @@ describe("CodexAppServerEventProjector", () => {
     ).toHaveLength(1);
   });
 
+  it("fails closed and synthesizes a result when a native tool call never completes", async () => {
+    const trajectoryRecorder = {
+      filePath: "trajectory.jsonl",
+      recordEvent: vi.fn(),
+      flush: vi.fn(async () => undefined),
+    };
+    const projector = await createProjector(await createParams(), { trajectoryRecorder });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-denied",
+          command: "/bin/zsh -lc 'python3 tools/topic_scout_daily.py --deliver-report'",
+          cwd: "/Users/sompisjunsui/.openclaw/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "agentMessage",
+          id: "msg-denied",
+          text: "SYSTEM_RUN_DENIED topic-scout-daily did not run the owned wrapper",
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(String(result.promptError)).toContain("SYSTEM_RUN_DENIED");
+    expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    expect(toolResultMessage.role).toBe("toolResult");
+    expect(toolResultMessage.toolCallId).toBe("cmd-denied");
+    expect(toolResultMessage.toolName).toBe("bash");
+    expect(toolResultMessage.isError).toBe(true);
+    const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
+    expect(JSON.stringify(toolResultContent)).toContain("without a matching tool.result");
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith("tool.call", {
+      threadId: THREAD_ID,
+      turnId: TURN_ID,
+      itemId: "cmd-denied",
+      toolCallId: "cmd-denied",
+      name: "bash",
+      arguments: {
+        command: "/bin/zsh -lc 'python3 tools/topic_scout_daily.py --deliver-report'",
+        cwd: "/Users/sompisjunsui/.openclaw/workspace",
+      },
+    });
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith("tool.result", {
+      threadId: THREAD_ID,
+      turnId: TURN_ID,
+      itemId: "cmd-denied",
+      toolCallId: "cmd-denied",
+      name: "bash",
+      status: "failed",
+      isError: true,
+      result: { status: "failed", reason: "missing_tool_result" },
+      output: expect.stringContaining("SYSTEM_RUN_DENIED"),
+    });
+  });
+
   it("does not synthesize completed progress for running turn completion snapshots", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({ ...(await createParams()), onAgentEvent });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -102,6 +102,8 @@ const CODEX_PROMPT_TOTAL_INPUT_KEYS = [
 
 const MAX_TOOL_OUTPUT_DELTA_MESSAGES_PER_ITEM = 20;
 const TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS = 12_000;
+const MISSING_TOOL_RESULT_ERROR =
+  "SYSTEM_RUN_DENIED: OpenClaw recorded a tool.call without a matching tool.result before the Codex turn completed; treating the turn as failed.";
 const TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES = new Set([
   "message",
   "messages",
@@ -160,6 +162,9 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptMessages: AgentMessage[] = [];
   private readonly toolTranscriptCallIds = new Set<string>();
   private readonly toolTranscriptResultIds = new Set<string>();
+  private readonly toolTranscriptNamesById = new Map<string, string>();
+  private readonly toolTrajectoryCallIds = new Set<string>();
+  private readonly toolTrajectoryResultIds = new Set<string>();
   private readonly transcriptToolProgressCallIds = new Set<string>();
   private lastNativeToolError: EmbeddedRunAttemptResult["lastToolError"];
   private readonly nativeGeneratedMediaUrls = new Set<string>();
@@ -171,6 +176,7 @@ export class CodexAppServerEventProjector {
   private completedTurn: CodexTurn | undefined;
   private promptError: unknown;
   private promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
+  private synthesizedMissingToolResultError: string | null = null;
   private aborted = false;
   private tokenUsage: ReturnType<typeof normalizeUsage>;
   private guardianReviewCount = 0;
@@ -265,6 +271,7 @@ export class CodexAppServerEventProjector {
     toolTelemetry: CodexAppServerToolTelemetry,
     options?: { yieldDetected?: boolean },
   ): EmbeddedRunAttemptResult {
+    this.synthesizeMissingToolResults();
     const assistantTexts = this.collectAssistantTexts();
     const reasoningText = collectTextValues(this.reasoningTextByItem).join("\n\n");
     const planText = collectTextValues(this.planTextByItem).join("\n\n");
@@ -311,6 +318,7 @@ export class CodexAppServerEventProjector {
     const turnFailed = this.completedTurn?.status === "failed";
     const promptError =
       this.promptError ??
+      this.synthesizedMissingToolResultError ??
       (turnFailed ? (this.completedTurn?.error?.message ?? "codex app-server turn failed") : null);
     const agentHarnessResultClassification = classifyAgentHarnessTerminalOutcome({
       assistantTexts,
@@ -1002,6 +1010,7 @@ export class CodexAppServerEventProjector {
     status: ReturnType<typeof itemStatus>;
   }): void {
     if (params.phase === "start") {
+      this.toolTrajectoryCallIds.add(params.item.id);
       this.options.trajectoryRecorder?.recordEvent("tool.call", {
         threadId: this.threadId,
         turnId: this.turnId,
@@ -1012,6 +1021,7 @@ export class CodexAppServerEventProjector {
       });
       return;
     }
+    this.toolTrajectoryResultIds.add(params.item.id);
     const toolResult = itemToolResult(params.item).result;
     const output = itemOutputText(params.item, this.toolResultOutputTextByItem);
     this.options.trajectoryRecorder?.recordEvent("tool.result", {
@@ -1274,6 +1284,7 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.toolTranscriptCallIds.add(params.id);
+    this.toolTranscriptNamesById.set(params.id, params.name);
     this.toolTranscriptArgumentsById.set(params.id, params.arguments);
     if (!shouldEmitTranscriptToolProgress(params.name, params.arguments)) {
       this.transcriptToolProgressSuppressedIds.add(params.id);
@@ -1287,6 +1298,45 @@ export class CodexAppServerEventProjector {
         `${this.turnId}:tool:${params.id}:call`,
       ),
     );
+  }
+
+  private synthesizeMissingToolResults(): void {
+    const missingIds = [...this.toolTranscriptCallIds].filter(
+      (id) => !this.toolTranscriptResultIds.has(id),
+    );
+    if (missingIds.length === 0) {
+      return;
+    }
+    for (const id of missingIds) {
+      const name = this.toolTranscriptNamesById.get(id) ?? "tool";
+      const text = `${MISSING_TOOL_RESULT_ERROR} toolCallId=${id}; toolName=${name}`;
+      this.recordToolTranscriptResult({
+        id,
+        name,
+        text,
+        isError: true,
+      });
+      if (this.toolTrajectoryCallIds.has(id) && !this.toolTrajectoryResultIds.has(id)) {
+        this.toolTrajectoryResultIds.add(id);
+        this.options.trajectoryRecorder?.recordEvent("tool.result", {
+          threadId: this.threadId,
+          turnId: this.turnId,
+          itemId: id,
+          toolCallId: id,
+          name,
+          status: "failed",
+          isError: true,
+          result: { status: "failed", reason: "missing_tool_result" },
+          output: text,
+        });
+      }
+    }
+    if (!this.synthesizedMissingToolResultError) {
+      this.synthesizedMissingToolResultError =
+        missingIds.length === 1
+          ? MISSING_TOOL_RESULT_ERROR
+          : `${MISSING_TOOL_RESULT_ERROR} missingToolResultCount=${missingIds.length}`;
+    }
   }
 
   private recordToolTranscriptResult(params: ToolTranscriptResultInput): void {


### PR DESCRIPTION
Closes #86808.

### Problem
When a Codex app-server turn ended after persisting a `tool.call` but before the matching `tool.result` (denied auto-approval, interrupted sandbox, runtime crash), the projector mirrored the call into the OpenClaw transcript and trajectory but never emitted a terminal result. The downstream invariant **every persisted tool.call has exactly one terminal tool.result** broke; the session resumed with an orphan tool call and the next prompt was rejected with `SYSTEM_RUN_DENIED`.

### Fix
`CodexAppServerEventProjector` now:
- Tracks transcript tool-call ids by tool name (`toolTranscriptNamesById`).
- Tracks which call ids were recorded into the trajectory (`toolTrajectoryCallIds` / `toolTrajectoryResultIds`).
- On `buildResult`, synthesizes a `status: "failed", reason: "missing_tool_result"` trajectory event **and** a mirrored `toolResult` message for every call id without a terminal result.
- Bubbles a synthetic `SYSTEM_RUN_DENIED` `promptError` so the attempt is classified as failed instead of silently swallowed.

### Regression test
`extensions/codex/src/app-server/event-projector.test.ts` — *fails closed and synthesizes a result when a native tool call never completes*:

- emits `item/started` for a `commandExecution` (no completion event),
- finishes with `turn/completed` and an `agentMessage`,
- asserts `promptError`, the synthesized `toolResult` message shape (`toolCallId`, `toolName=bash`, `isError=true`, error text), and the synthesized trajectory `tool.result` event.

Verified the test fails on `main` (`expected 'null' to contain 'SYSTEM_RUN_DENIED'`) and passes with the fix.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts \
  extensions/codex/src/app-server/event-projector.test.ts
# 70 passed
```

### Notes
- No behaviour change when every `tool.call` already has a result (synthesize loop is a no-op).
- The synthetic trajectory event uses `status: "failed"`, `result: { status: "failed", reason: "missing_tool_result" }`, mirroring how the runtime would describe a denied tool today.