### PR TITLE
fix(gateway): drain probe client close

### DIFF
--- a/src/gateway/probe.close-drain.test.ts
+++ b/src/gateway/probe.close-drain.test.ts
@@ -23,9 +23,13 @@ function rawWsDataToString(data: RawData): string {
 }
 
 function activeClientSocketsToPort(port: number): Socket[] {
+  // Node has no public active-handle API; this regression must prove the probe
+  // promise does not resolve while the client-side socket handle is still live.
+  // oxlint-disable no-underscore-dangle
   const handles =
     (process as typeof process & { _getActiveHandles?: () => unknown[] })._getActiveHandles?.() ??
     [];
+  // oxlint-enable no-underscore-dangle
   return handles.filter(
     (handle): handle is Socket => handle instanceof Socket && handle.remotePort === port,
   );

--- a/src/gateway/probe.close-drain.test.ts
+++ b/src/gateway/probe.close-drain.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs/promises";
+import { type AddressInfo, Socket } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { type RawData, WebSocketServer } from "ws";
+import { probeGateway } from "./probe.js";
+import { PROTOCOL_VERSION } from "./protocol/index.js";
+
+const tempRoots: string[] = [];
+
+function rawWsDataToString(data: RawData): string {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString("utf8");
+  }
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  return Buffer.from(data).toString("utf8");
+}
+
+function activeClientSocketsToPort(port: number): Socket[] {
+  const handles =
+    (process as typeof process & { _getActiveHandles?: () => unknown[] })._getActiveHandles?.() ??
+    [];
+  return handles.filter(
+    (handle): handle is Socket => handle instanceof Socket && handle.remotePort === port,
+  );
+}
+
+async function createTempStateDir(): Promise<string> {
+  const tempRoot = await fs.mkdtemp(path.join(tmpdir(), "openclaw-probe-close-drain-"));
+  tempRoots.push(tempRoot);
+  return tempRoot;
+}
+
+describe("probeGateway close drain", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it("waits for the real WebSocket client socket to close before resolving", async () => {
+    const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    let sawConnect = false;
+
+    wss.on("connection", (ws) => {
+      ws.send(
+        JSON.stringify({
+          type: "event",
+          event: "connect.challenge",
+          payload: { nonce: "test-nonce" },
+        }),
+      );
+      ws.on("message", (raw) => {
+        const frame = JSON.parse(rawWsDataToString(raw)) as {
+          id?: string;
+          method?: string;
+          type?: string;
+        };
+        if (frame.type !== "req" || frame.method !== "connect" || !frame.id) {
+          return;
+        }
+        sawConnect = true;
+        ws.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: true,
+            payload: {
+              type: "hello-ok",
+              protocol: PROTOCOL_VERSION,
+              server: { version: "test", connId: "conn-test" },
+              features: { methods: [], events: ["connect.challenge"] },
+              snapshot: {},
+              auth: { role: "operator", scopes: ["operator.read"] },
+              policy: {
+                maxPayload: 1_000_000,
+                maxBufferedBytes: 1_000_000,
+                tickIntervalMs: 60_000,
+              },
+            },
+          }),
+        );
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve) => wss.once("listening", resolve));
+      const port = (wss.address() as AddressInfo).port;
+
+      const result = await probeGateway({
+        url: `ws://127.0.0.1:${port}`,
+        auth: { token: "secret" },
+        timeoutMs: 1_000,
+        includeDetails: false,
+        env: { ...process.env, OPENCLAW_STATE_DIR: await createTempStateDir() },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(sawConnect).toBe(true);
+      expect(activeClientSocketsToPort(port)).toHaveLength(0);
+    } finally {
+      for (const client of wss.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        wss.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -20,6 +20,10 @@ const gatewayClientState = vi.hoisted(() => ({
     reason: "scope-upgrade",
     requestId: "req-123",
   } as Record<string, unknown> | null,
+  stopCalls: 0,
+  stopAndWaitCalls: [] as Array<{ timeoutMs?: number } | undefined>,
+  stopAndWaitMode: "resolve" as "resolve" | "defer" | "reject",
+  resolveStopAndWait: null as (() => void) | null,
 }));
 
 const deviceIdentityState = vi.hoisted(() => ({
@@ -114,7 +118,21 @@ class MockGatewayClient {
       .catch(() => {});
   }
 
-  stop(): void {}
+  stop(): void {
+    gatewayClientState.stopCalls += 1;
+  }
+
+  async stopAndWait(opts?: { timeoutMs?: number }): Promise<void> {
+    gatewayClientState.stopAndWaitCalls.push(opts);
+    if (gatewayClientState.stopAndWaitMode === "reject") {
+      throw new Error("close drain failed");
+    }
+    if (gatewayClientState.stopAndWaitMode === "defer") {
+      await new Promise<void>((resolve) => {
+        gatewayClientState.resolveStopAndWait = resolve;
+      });
+    }
+  }
 
   async request(method: string): Promise<unknown> {
     gatewayClientState.requests.push(method);
@@ -231,6 +249,10 @@ describe("probeGateway", () => {
       reason: "scope-upgrade",
       requestId: "req-123",
     };
+    gatewayClientState.stopCalls = 0;
+    gatewayClientState.stopAndWaitCalls = [];
+    gatewayClientState.stopAndWaitMode = "resolve";
+    gatewayClientState.resolveStopAndWait = null;
     eventLoopReadyState.calls = [];
     eventLoopReadyState.result = {
       ready: true,
@@ -473,6 +495,50 @@ describe("probeGateway", () => {
     });
     expectProbeAuthFields(result, { capability: "pairing_pending" });
     expect(gatewayClientState.requests).toStrictEqual([]);
+  });
+
+  it("waits for gateway client close drain before resolving", async () => {
+    gatewayClientState.stopAndWaitMode = "defer";
+
+    const probePromise = probeGateway({
+      url: nextProbeUrl("close-drain"),
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      includeDetails: false,
+    });
+    let resolved = false;
+    void probePromise.then(() => {
+      resolved = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(gatewayClientState.stopAndWaitCalls).toHaveLength(1);
+    });
+    expect(gatewayClientState.stopAndWaitCalls[0]).toEqual({ timeoutMs: 1_000 });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    gatewayClientState.resolveStopAndWait?.();
+    const result = await probePromise;
+
+    expect(result.ok).toBe(true);
+    expect(resolved).toBe(true);
+    expect(gatewayClientState.stopCalls).toBe(0);
+  });
+
+  it("falls back to stop when close drain fails", async () => {
+    gatewayClientState.stopAndWaitMode = "reject";
+
+    const result = await probeGateway({
+      url: nextProbeUrl("close-drain-fallback"),
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      includeDetails: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(gatewayClientState.stopAndWaitCalls).toHaveLength(1);
+    expect(gatewayClientState.stopCalls).toBe(1);
   });
 
   it("reports write-capable auth when hello-ok scopes include operator.write", async () => {

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -65,6 +65,7 @@ const DEVICE_IDENTITY_REQUIRED_CLOSE_CODE = 1008;
 const DEVICE_IDENTITY_REQUIRED_CLOSE_REASON = "device identity required";
 const DEVICE_REQUIRED_PROBE_FAILURE_THRESHOLD = 3;
 const DEVICE_REQUIRED_PROBE_TTL_MS = 5 * 60_000;
+const PROBE_CLIENT_STOP_TIMEOUT_MS = 1_000;
 
 type DeviceRequiredProbeCacheEntry = {
   failures: number;
@@ -299,20 +300,26 @@ export async function probeGateway(opts: {
       settled = true;
       startAbort.abort();
       clearProbeTimer();
-      client.stop();
-      if (result.ok) {
-        clearDeviceRequiredProbeFailures(cacheKey);
-      } else if (cacheEligible && isDeviceIdentityRequiredClose(result.close)) {
-        noteDeviceRequiredProbeFailure(cacheKey, Date.now());
-      }
-      const { connectErrorDetails: resultConnectErrorDetails, ...rest } = result;
-      resolve({
-        url: opts.url,
-        ...rest,
-        ...(resultConnectErrorDetails != null
-          ? { connectErrorDetails: resultConnectErrorDetails }
-          : {}),
-      });
+      void (async () => {
+        try {
+          await client.stopAndWait({ timeoutMs: PROBE_CLIENT_STOP_TIMEOUT_MS });
+        } catch {
+          client.stop();
+        }
+        if (result.ok) {
+          clearDeviceRequiredProbeFailures(cacheKey);
+        } else if (cacheEligible && isDeviceIdentityRequiredClose(result.close)) {
+          noteDeviceRequiredProbeFailure(cacheKey, Date.now());
+        }
+        const { connectErrorDetails: resultConnectErrorDetails, ...rest } = result;
+        resolve({
+          url: opts.url,
+          ...rest,
+          ...(resultConnectErrorDetails != null
+            ? { connectErrorDetails: resultConnectErrorDetails }
+            : {}),
+        });
+      })();
     };
     const settleProbe = (params: {
       ok: boolean;


### PR DESCRIPTION
## Real behavior proof
Behavior addressed: `probeGateway()` no longer resolves immediately after requesting WebSocket close; it waits for the client socket teardown path before returning to short-lived CLI callers.

Real environment tested: Local macOS checkout with a real in-process WebSocket server and the real `probeGateway()` / `GatewayClient` implementation. The server completed the normal connect challenge and `hello-ok` handshake; the proof then checked for client sockets still connected to the probe server after `probeGateway()` resolved.

Exact steps or command run after this patch:
```
node --import tsx --input-type=module <<'EOF'
import net from 'node:net';
import { WebSocketServer } from 'ws';
import { probeGateway } from './src/gateway/probe.ts';

const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
let sawConnect = false;
wss.on('connection', (ws) => {
  ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: { nonce: 'proof-nonce' } }));
  ws.on('message', (raw) => {
    const frame = JSON.parse(String(raw));
    if (frame.type === 'req' && frame.method === 'connect') {
      sawConnect = true;
      ws.send(JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: { type: 'hello-ok', protocol: 1, server: { version: 'proof', connId: 'conn-proof' }, features: { methods: [], events: [] }, snapshot: {}, auth: { role: 'operator', scopes: ['operator.read'] }, policy: { maxPayload: 1000000, maxBufferedBytes: 1000000, tickIntervalMs: 30000 } } }));
    }
  });
});
await new Promise((resolve) => wss.once('listening', resolve));
const { port } = wss.address();
const result = await probeGateway({ url: `ws://127.0.0.1:${port}`, timeoutMs: 1000, includeDetails: false, env: process.env });
const clientSocketsToServer = process._getActiveHandles().filter((h) => h instanceof net.Socket && h.remotePort === port);
console.log(`probeOk=${result.ok}`);
console.log(`sawConnect=${sawConnect}`);
console.log(`activeClientSocketsToServerAfterProbe=${clientSocketsToServer.length}`);
console.log(`serverVersion=${result.server?.version}`);
wss.close();
EOF
```

Evidence after fix:
```
probeOk=true
sawConnect=true
activeClientSocketsToServerAfterProbe=0
serverVersion=proof
```

Observed result after fix: The probe completed successfully and no active client socket to the probed gateway remained after the promise resolved.

What was not tested: A reporter-sized production CLI hang; this proof uses a local WebSocket server to exercise the same client/probe teardown path deterministically. Full `pnpm check:changed` was not run because `blacksmith-testbox` could not warm up with `blacksmith` missing on PATH.

## Summary
- wait for bounded gateway client close-drain before resolving `probeGateway()`
- fall back to `stop()` if ordered close-drain fails
- add probe regression coverage for teardown ordering and fallback cleanup

## Verification
- `node scripts/run-vitest.mjs src/gateway/probe.test.ts src/gateway/client.test.ts src/commands/gateway-status.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/gateway/probe.ts src/gateway/probe.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json --base upstream/main`

Closes #87210

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
