### PR TITLE
feat(feishu): include reply context in comment auto replies

### DIFF
--- a/extensions/feishu/src/comment-dispatcher.test.ts
+++ b/extensions/feishu/src/comment-dispatcher.test.ts
@@ -158,6 +158,10 @@ describe("createFeishuCommentReplyDispatcher", () => {
       comment_id: "comment_1",
       content: "hello world",
       is_whole_comment: false,
+      auto_reply_context: {
+        refer_reply_id: "reply_1",
+        ai_reply_source_type: 2,
+      },
     });
     expect(cleanup).not.toHaveBeenCalled();
 

--- a/extensions/feishu/src/comment-dispatcher.ts
+++ b/extensions/feishu/src/comment-dispatcher.ts
@@ -9,7 +9,7 @@ import {
 } from "./comment-dispatcher-runtime-api.js";
 import { createCommentTypingReactionLifecycle } from "./comment-reaction.js";
 import type { CommentFileType } from "./comment-target.js";
-import { deliverCommentThreadText } from "./drive.js";
+import { deliverCommentThreadText, type FeishuCommentAutoReplyContext } from "./drive.js";
 import { getFeishuRuntime } from "./runtime.js";
 
 type CreateFeishuCommentReplyDispatcherParams = {
@@ -53,6 +53,9 @@ export function createFeishuCommentReplyDispatcher(
     accountId: params.accountId,
     runtime: params.runtime,
   });
+  const autoReplyContext: FeishuCommentAutoReplyContext | undefined = params.replyId?.trim()
+    ? { refer_reply_id: params.replyId.trim(), ai_reply_source_type: 2 }
+    : undefined;
 
   const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     core.channel.reply.createReplyDispatcherWithTyping({
@@ -83,6 +86,7 @@ export function createFeishuCommentReplyDispatcher(
             comment_id: params.commentId,
             content: chunk,
             is_whole_comment: params.isWholeComment,
+            ...(autoReplyContext ? { auto_reply_context: autoReplyContext } : {}),
           });
         }
       },

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -646,6 +646,7 @@ describe("registerFeishuDriveTools", () => {
           },
         ],
       },
+      extra: '{"refer_reply_id":"reply_ambient_1","ai_reply_source_type":2}',
     });
     const cleanupRequest = mockCallArg<{
       client?: unknown;
@@ -722,6 +723,7 @@ describe("registerFeishuDriveTools", () => {
     expect(request.data).toEqual({
       file_type: "docx",
       reply_elements: [{ type: "text", text: "ambient top-level comment" }],
+      extra: '{"refer_reply_id":"reply_ambient_1","ai_reply_source_type":2}',
     });
     const cleanupRequest = mockCallArg<{
       client?: unknown;
@@ -921,6 +923,71 @@ describe("registerFeishuDriveTools", () => {
       },
     });
     expect(firstLogMessage(infoSpy)).toContain("whole-comment compatibility path");
+    const details = result.details as {
+      comment_id?: string;
+      delivery_mode?: string;
+      success?: boolean;
+    };
+    expect(details.success).toBe(true);
+    expect(details.comment_id).toBe("c2");
+    expect(details.delivery_mode).toBe("add_comment");
+  });
+
+  it("adds auto-reply extra when a whole-document event reply uses add_comment compatibility", async () => {
+    const registerTool = vi.fn();
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({
+      agentAccountId: undefined,
+      deliveryContext: {
+        channel: "feishu",
+        to: "comment:docx:doc_1:c1",
+        threadId: "1778586476090009089",
+      },
+    });
+
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ comment_id: "c1", is_whole: true }],
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { comment_id: "c2" },
+      });
+
+    const result = await tool.execute("call-whole-event", {
+      action: "reply_comment",
+      content: "whole comment follow-up",
+    });
+
+    expectRequestCall(requestMock, 1, {
+      method: "POST",
+      url: "/open-apis/drive/v1/files/doc_1/new_comments",
+      data: {
+        file_type: "docx",
+        reply_elements: [{ type: "text", text: "whole comment follow-up" }],
+        extra: '{"refer_reply_id":1778586476090009089,"ai_reply_source_type":2}',
+      },
+    });
     const details = result.details as {
       comment_id?: string;
       delivery_mode?: string;

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -116,6 +116,43 @@ type FeishuDriveToolContext = {
 };
 
 const FEISHU_DRIVE_REQUEST_TIMEOUT_MS = 30_000;
+const FEISHU_AI_REPLY_SOURCE_TYPE = 2;
+
+export type FeishuCommentAutoReplyContext = {
+  refer_reply_id: string;
+  ai_reply_source_type: 2;
+};
+
+function createFeishuCommentAutoReplyContext(
+  replyId: string | number | undefined,
+): FeishuCommentAutoReplyContext | undefined {
+  const normalized = typeof replyId === "number" ? String(replyId) : replyId?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return {
+    refer_reply_id: normalized,
+    ai_reply_source_type: FEISHU_AI_REPLY_SOURCE_TYPE,
+  };
+}
+
+function buildFeishuCommentAutoReplyExtra(
+  context: FeishuCommentAutoReplyContext | undefined,
+): string | undefined {
+  if (!context) {
+    return undefined;
+  }
+  const referReplyId = context.refer_reply_id.trim();
+  if (!referReplyId) {
+    return undefined;
+  }
+  const referReplyIdLiteral = /^(?:0|[1-9]\d*)$/u.test(referReplyId)
+    ? referReplyId
+    : JSON.stringify(referReplyId);
+  // `extra` is itself a JSON string. Preserve int64 reply ids as JSON digits
+  // without converting them to JS numbers.
+  return `{"refer_reply_id":${referReplyIdLiteral},"ai_reply_source_type":${context.ai_reply_source_type}}`;
+}
 
 function getDriveInternalClient(client: Lark.Client): FeishuDriveInternalClient {
   return client as FeishuDriveInternalClient;
@@ -209,6 +246,37 @@ function applyAmbientCommentDefaults<
     file_type: params.file_type ?? ambient.fileType,
     comment_id: params.comment_id?.trim() || ambient.commentId,
   };
+}
+
+function resolveAmbientCommentAutoReplyContext(
+  params: {
+    file_token?: string;
+    file_type?: CommentFileType;
+    comment_id?: string;
+  },
+  context: FeishuDriveToolContext | undefined,
+): FeishuCommentAutoReplyContext | undefined {
+  const ambient = resolveAmbientCommentTarget(context);
+  if (!ambient) {
+    return undefined;
+  }
+  const referReplyId = createFeishuCommentAutoReplyContext(context?.deliveryContext?.threadId);
+  if (!referReplyId) {
+    return undefined;
+  }
+  const fileToken = params.file_token?.trim();
+  if (fileToken && fileToken !== ambient.fileToken) {
+    return undefined;
+  }
+  const fileType = params.file_type;
+  if (fileType && fileType !== ambient.fileType) {
+    return undefined;
+  }
+  const commentId = params.comment_id?.trim();
+  if (commentId && commentId !== ambient.commentId) {
+    return undefined;
+  }
+  return referReplyId;
 }
 
 function applyAddCommentAmbientDefaults<
@@ -528,11 +596,13 @@ async function addComment(
     file_type: "doc" | "docx";
     content: string;
     block_id?: string;
+    auto_reply_context?: FeishuCommentAutoReplyContext;
   },
 ): Promise<{ success: true } & Record<string, unknown>> {
   if (params.block_id?.trim() && params.file_type !== "docx") {
     throw new Error("block_id is only supported for docx comments");
   }
+  const extra = buildFeishuCommentAutoReplyExtra(params.auto_reply_context);
   const response = assertDriveApiSuccess(
     await requestDriveApi<FeishuDriveApiResponse<Record<string, unknown>>>({
       client,
@@ -542,6 +612,7 @@ async function addComment(
         file_type: params.file_type,
         reply_elements: buildReplyElements(params.content),
         ...(params.block_id?.trim() ? { anchor: { block_id: params.block_id.trim() } } : {}),
+        ...(extra ? { extra } : {}),
       },
     }),
   );
@@ -586,12 +657,14 @@ export async function replyComment(
     file_type: CommentFileType;
     comment_id: string;
     content: string;
+    auto_reply_context?: FeishuCommentAutoReplyContext;
   },
 ): Promise<{ success: true; reply_id?: string } & Record<string, unknown>> {
   const url = `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments/${encodeURIComponent(
     params.comment_id,
   )}/replies`;
   const query = { file_type: params.file_type };
+  const extra = buildFeishuCommentAutoReplyExtra(params.auto_reply_context);
   try {
     const response = await requestDriveApi<FeishuDriveApiResponse<Record<string, unknown>>>({
       client,
@@ -609,6 +682,7 @@ export async function replyComment(
             },
           ],
         },
+        ...(extra ? { extra } : {}),
       },
     });
     if (response.code === 0) {
@@ -657,6 +731,7 @@ export async function deliverCommentThreadText(
     comment_id: string;
     content: string;
     is_whole_comment?: boolean;
+    auto_reply_context?: FeishuCommentAutoReplyContext;
   },
 ): Promise<
   | ({ success: true; reply_id?: string } & Record<string, unknown> & {
@@ -697,6 +772,7 @@ export async function deliverCommentThreadText(
         file_token: params.file_token,
         file_type: wholeCommentFileType,
         content: params.content,
+        auto_reply_context: params.auto_reply_context,
       })),
     };
   }
@@ -722,6 +798,7 @@ export async function deliverCommentThreadText(
           file_token: params.file_token,
           file_type: fallbackFileType,
           content: params.content,
+          auto_reply_context: params.auto_reply_context,
         })),
       };
     }
@@ -792,8 +869,14 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
               }
               case "add_comment": {
                 const resolved = applyAddCommentDefaults(applyAddCommentAmbientDefaults(p, ctx));
+                const autoReplyContext = resolveAmbientCommentAutoReplyContext(resolved, ctx);
                 try {
-                  return jsonToolResult(await addComment(client, resolved));
+                  return jsonToolResult(
+                    await addComment(client, {
+                      ...resolved,
+                      ...(autoReplyContext ? { auto_reply_context: autoReplyContext } : {}),
+                    }),
+                  );
                 } finally {
                   void cleanupAmbientCommentTypingReaction({
                     client: getDriveInternalClient(client),
@@ -806,8 +889,14 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
                   applyAmbientCommentDefaults(p, ctx),
                   "reply_comment",
                 );
+                const autoReplyContext = resolveAmbientCommentAutoReplyContext(resolved, ctx);
                 try {
-                  return jsonToolResult(await deliverCommentThreadText(client, resolved));
+                  return jsonToolResult(
+                    await deliverCommentThreadText(client, {
+                      ...resolved,
+                      ...(autoReplyContext ? { auto_reply_context: autoReplyContext } : {}),
+                    }),
+                  );
                 } finally {
                   void cleanupAmbientCommentTypingReaction({
                     client: getDriveInternalClient(client),

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -937,6 +937,10 @@ describe("feishuOutbound comment-thread routing", () => {
 
     expect(status).toBe("done");
     expect(deliverCommentThreadTextMock).toHaveBeenCalled();
+    expect(commentThreadParams()?.auto_reply_context).toEqual({
+      refer_reply_id: "reply_ambient_1",
+      ai_reply_source_type: 2,
+    });
     const cleanupCall = cleanupReactionCall();
     if (!cleanupCall?.client) {
       throw new Error("Expected cleanup reaction client");

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -25,7 +25,7 @@ import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
-import { deliverCommentThreadText } from "./drive.js";
+import { deliverCommentThreadText, type FeishuCommentAutoReplyContext } from "./drive.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "./outbound-runtime-api.js";
 import { buildFeishuPresentationCardElements } from "./presentation-card.js";
@@ -395,12 +395,16 @@ async function sendCommentThreadReply(params: {
   const account = resolveFeishuAccount({ cfg: params.cfg, accountId: params.accountId });
   const client = createFeishuClient(account);
   const replyId = params.replyId?.trim();
+  const autoReplyContext: FeishuCommentAutoReplyContext | undefined = replyId
+    ? { refer_reply_id: replyId, ai_reply_source_type: 2 }
+    : undefined;
   try {
     const result = await deliverCommentThreadText(client, {
       file_token: target.fileToken,
       file_type: target.fileType,
       comment_id: target.commentId,
       content: params.text,
+      ...(autoReplyContext ? { auto_reply_context: autoReplyContext } : {}),
     });
     return {
       messageId:


### PR DESCRIPTION
## Summary

- Problem: Feishu document comment auto replies did not carry source-reply context into the Drive comment write requests, so the receiving side could not distinguish which original comment reply triggered an automatic follow-up.
- Why it matters: comment auto replies need to remain associated with the triggering reply, including whole-document comments where the visible follow-up is created through the add-comment compatibility path instead of the normal reply-comment path.
- What changed: comment-event dispatch, comment-thread outbound delivery, `reply_comment`, and whole-document `add_comment` compatibility now pass a private auto-reply context into Feishu Drive comment writes. The OpenAPI body now includes `extra` with `refer_reply_id` and `ai_reply_source_type` only for event-triggered comment auto replies.
- What did NOT change (scope boundary): normal Feishu IM handling was not changed; user-invoked `feishu_drive` comment tools do not add this `extra`; this PR only affects Feishu document comment auto-reply delivery paths.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Skills / tool execution
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts

## Root Cause / Regression History

- Root cause: N/A; this is a new Feishu comment auto-reply context field required by the receiving comment write path.
- Missing detection / guardrail: existing tests covered comment delivery but did not assert event-triggered context propagation into the final Drive OpenAPI request body.
- Why this changed now: Feishu document-comment auto replies now need to include their triggering reply context for downstream handling while keeping manual comment tool calls unchanged.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `extensions/feishu/src/comment-dispatcher.test.ts`, `extensions/feishu/src/outbound.test.ts`, `extensions/feishu/src/drive.test.ts`
- Scenario the test should lock in: comment-event dispatch and comment-thread outbound delivery must attach auto-reply context; Drive `reply_comment` and whole-document `add_comment` compatibility must serialize `extra`; direct/manual comment writes must remain unchanged unless the ambient comment auto-reply context is present.

## User-visible / Behavior Changes

- Feishu document comment auto replies now preserve the triggering reply context in the comment write payload.
- Whole-document comment auto replies carry the same context when they create a new whole-document comment through the compatibility path.
- Large Feishu reply IDs are preserved as JSON numeric text inside the `extra` string instead of being converted through JS `Number`.
- Normal Feishu IM behavior is unchanged.
- Manual user requests to add or reply to comments through `feishu_drive` are unchanged unless they are running in the auto-reply comment context.

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No new endpoints; existing Feishu Drive comment write bodies include one additional `extra` field only for auto replies)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Risks and Mitigations

- Risk: adding `extra` to existing Feishu Drive comment write bodies could be rejected if sent broadly.
  - Mitigation: `extra` is only generated from auto-reply comment context and is not added to normal manual Drive comment tool calls.
- Risk: Feishu reply IDs exceed JS safe integer precision.
  - Mitigation: numeric reply IDs are kept as strings in OpenClaw state and serialized directly into the `extra` JSON string as numeric text without `Number(...)` conversion.
- Risk: whole-document comments use the add-comment compatibility path rather than the normal reply-comment OpenAPI.
  - Mitigation: the same auto-reply context is passed through `deliverCommentThreadText` into both normal reply writes and whole-document add-comment fallback writes, with tests for both paths.

## Verification

- `node scripts/run-vitest.mjs extensions/feishu/src/drive.test.ts extensions/feishu/src/comment-dispatcher.test.ts extensions/feishu/src/outbound.test.ts` - 3 files passed, 60 tests passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings.

## Real behavior proof

Behavior addressed: Feishu document comment auto replies now include source reply context on the actual Drive comment write request, including the whole-document add-comment compatibility path.
Real environment tested: Local OpenClaw source checkout using the Feishu channel against a real Feishu document-comment auto-reply flow, after building and restarting the local gateway on May 27, 2026.
Exact steps or command run after this patch: In a real Feishu document, created a comment that triggered OpenClaw's Feishu comment auto-reply path, let the local gateway process the event, and observed the resulting Feishu comment reply in the document.
Evidence after fix: Redacted live output from the Feishu comment auto-reply run: the OpenAPI request body carried `extra` as `{"refer_reply_id":7644471294523673786,"ai_reply_source_type":2}`; Feishu accepted the request and created the automatic comment reply.
Observed result after fix: The real Feishu document showed the automatic reply, and the source reply context was preserved in the accepted Drive comment write payload.
What was not tested: Normal Feishu IM behavior was not re-tested because this PR does not change IM handling. No screenshots or recordings are attached; the proof is the redacted copied live output from the local Feishu verification run.
