### PR TITLE
fix(harness): wrap plugin-injected system context with boundary marker (#87045)

### DIFF
--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression test for #87045: plugin-injected system context lacked a
+ * boundary marker, so a workspace-files block followed by an
+ * `appendSystemContext` block produced Markdown headings the model
+ * attributed back to the last workspace file (e.g. `TOOLS.md`).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../../plugins/hooks.test-helpers.js";
+import { resolveAgentHarnessBeforePromptBuildResult } from "./prompt-compaction-hook-helpers.js";
+
+const PLUGIN_BOUNDARY = "[plugin-injected context — not a workspace file]";
+
+afterEach(() => {
+  resetGlobalHookRunner();
+});
+
+function makeCtx() {
+  return {
+    runId: "run-1",
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    workspaceDir: "/workspace",
+  } as never;
+}
+
+describe("resolveAgentHarnessBeforePromptBuildResult", () => {
+  it("wraps plugin-emitted system-context segments with a boundary marker", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_prompt_build",
+          handler: () => ({
+            appendSystemContext: "## My Custom Rules\n\nFoo bar baz.",
+            prependSystemContext: "## Prep Rules\n\nQux quux.",
+          }),
+        },
+      ]) as never,
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "user prompt",
+      developerInstructions: "### /workspace/TOOLS.md\n\n## Formato por Canal\n\nbody.",
+      messages: [],
+      ctx: makeCtx(),
+    });
+
+    const before = result.developerInstructions.indexOf("## Prep Rules");
+    const between = result.developerInstructions.indexOf("### /workspace/TOOLS.md");
+    const after = result.developerInstructions.indexOf("## My Custom Rules");
+    expect(before).toBeGreaterThanOrEqual(0);
+    expect(between).toBeGreaterThan(before);
+    expect(after).toBeGreaterThan(between);
+
+    // Boundary marker must appear immediately around each plugin segment, not
+    // around the workspace-files block itself.
+    const boundaryCount = result.developerInstructions.split(PLUGIN_BOUNDARY).length - 1;
+    // 2 plugin segments × 2 boundary occurrences (open + close) = 4.
+    expect(boundaryCount).toBe(4);
+
+    // The boundary must sit *between* the workspace files and the appended
+    // plugin context so the heading hierarchy is reset.
+    const boundaryBeforeAppend = result.developerInstructions.lastIndexOf(PLUGIN_BOUNDARY, after);
+    expect(boundaryBeforeAppend).toBeGreaterThan(between);
+    expect(boundaryBeforeAppend).toBeLessThan(after);
+  });
+
+  it("leaves prompt and system prompt untouched when no plugin segments are returned", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_prompt_build",
+          handler: () => ({}),
+        },
+      ]) as never,
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "user prompt",
+      developerInstructions: "system",
+      messages: [],
+      ctx: makeCtx(),
+    });
+
+    expect(result.developerInstructions).toBe("system");
+    expect(result.developerInstructions.includes(PLUGIN_BOUNDARY)).toBe(false);
+    expect(result.prompt).toBe("user prompt");
+  });
+});

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -10,6 +10,22 @@ import { buildAgentHookContext, type AgentHarnessHookContext } from "./hook-cont
 
 const log = createSubsystemLogger("agents/harness");
 
+/**
+ * Wraps a plugin-emitted system-prompt segment with a stable boundary so the
+ * model cannot continue the heading hierarchy of an adjacent block. See
+ * issue #87045: without a boundary, an injected `## My Custom Rules` block
+ * appended after a workspace-files block was attributed to the last
+ * workspace file (e.g. `TOOLS.md`).
+ */
+const PLUGIN_SYSTEM_CONTEXT_BOUNDARY = "\n---\n[plugin-injected context — not a workspace file]\n";
+
+function wrapPluginSystemContext(segment: string | undefined): string | undefined {
+  if (typeof segment !== "string" || segment.trim().length === 0) {
+    return undefined;
+  }
+  return `${PLUGIN_SYSTEM_CONTEXT_BOUNDARY}\n${segment.trim()}\n${PLUGIN_SYSTEM_CONTEXT_BOUNDARY}`;
+}
+
 export type AgentHarnessPromptBuildResult = {
   prompt: string;
   developerInstructions: string;
@@ -61,11 +77,11 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
       ]) ?? params.prompt,
     developerInstructions:
       joinPresentTextSegments([
-        promptBuildResult?.prependSystemContext,
-        legacyResult?.prependSystemContext,
+        wrapPluginSystemContext(promptBuildResult?.prependSystemContext),
+        wrapPluginSystemContext(legacyResult?.prependSystemContext),
         systemPrompt,
-        promptBuildResult?.appendSystemContext,
-        legacyResult?.appendSystemContext,
+        wrapPluginSystemContext(promptBuildResult?.appendSystemContext),
+        wrapPluginSystemContext(legacyResult?.appendSystemContext),
       ]) ?? systemPrompt,
   };
 }


### PR DESCRIPTION
Closes #87045.

### Problem
When a plugin returns `prependSystemContext` / `appendSystemContext` from `before_prompt_build`, the harness concatenated each segment into the developer instructions with only a `\n\n` separator. The Codex workspace-files block also emits no closing marker, so an injected `## My Custom Rules` block placed after a workspace file (e.g. `TOOLS.md`) was parsed by the model as another sub-section of that file. The reporter verified the model citing `TOOLS.md` for content that lived entirely inside the plugin-emitted block.

### Fix
`src/agents/harness/prompt-compaction-hook-helpers.ts` now wraps each plugin-emitted system-context segment with a stable boundary marker:

```
\n---\n[plugin-injected context — not a workspace file]\n
```

`---` breaks Markdown heading continuity, and the inline note tells the model the block is operator-injected, not part of the workspace catalog. Empty / whitespace-only segments still collapse to `undefined`, so the no-plugin code path is unchanged.

### Regression test
`src/agents/harness/prompt-compaction-hook-helpers.test.ts` registers a `before_prompt_build` hook returning both prepend and append segments and asserts the boundary appears around each plugin segment and between the workspace files and the appended block. A second test confirms the no-plugin path leaves the developer instructions and prompt untouched.

Verified the regression test fails on `main` and passes with the fix.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts \
  src/agents/harness/prompt-compaction-hook-helpers.test.ts
# 2 passed
```