### PR TITLE
fix(exec): canonicalize bound vs requested node selectors before rejecting host=node (#87213)

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for #87213: `exec host=node` rejected requests when the
+ * bound node and the requested node referred to the same physical node
+ * via different supported selector forms (e.g. canonical id vs. display
+ * name). The pre-fix guard compared raw selector text before resolving
+ * either side through the node resolver.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const listNodesMock = vi.hoisted(() => vi.fn());
+const resolveNodeIdFromListMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./tools/nodes-utils.js", () => ({
+  listNodes: listNodesMock,
+  resolveNodeIdFromList: resolveNodeIdFromListMock,
+}));
+
+vi.mock("./tools/gateway.js", () => ({
+  callGatewayTool: vi.fn(),
+}));
+
+let resolveNodeExecutionTarget: typeof import("./bash-tools.exec-host-node-phases.js").resolveNodeExecutionTarget;
+
+const NODES = [
+  {
+    nodeId: "node-canonical-abc123",
+    nodeName: "home-wsl-debian",
+    platform: "linux",
+    connected: true,
+    commands: ["system.run"],
+  },
+  {
+    nodeId: "node-other-xyz",
+    nodeName: "other-host",
+    platform: "linux",
+    connected: true,
+    commands: ["system.run"],
+  },
+];
+
+function makeParams(overrides: Record<string, unknown>) {
+  return {
+    command: "echo hi",
+    workdir: undefined,
+    env: {},
+    security: "full" as const,
+    ask: "off" as const,
+    defaultTimeoutSec: 30,
+    approvalRunningNoticeMs: 0,
+    warnings: [],
+    ...overrides,
+  } as never;
+}
+
+beforeEach(async () => {
+  listNodesMock.mockReset();
+  resolveNodeIdFromListMock.mockReset();
+  listNodesMock.mockResolvedValue(NODES);
+  ({ resolveNodeExecutionTarget } = await import("./bash-tools.exec-host-node-phases.js"));
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("resolveNodeExecutionTarget bound vs requested selector canonicalization", () => {
+  it("allows the request when bound id and requested display name resolve to the same node", async () => {
+    resolveNodeIdFromListMock.mockImplementation((_nodes: unknown, query: string | undefined) => {
+      if (query === "node-canonical-abc123" || query === "home-wsl-debian") {
+        return "node-canonical-abc123";
+      }
+      throw new Error(`unknown node ${query}`);
+    });
+
+    const target = await resolveNodeExecutionTarget(
+      makeParams({
+        boundNode: "node-canonical-abc123",
+        requestedNode: "home-wsl-debian",
+      }),
+    );
+    expect(target.nodeId).toBe("node-canonical-abc123");
+  });
+
+  it("still rejects when bound and requested selectors resolve to different nodes", async () => {
+    resolveNodeIdFromListMock.mockImplementation((_nodes: unknown, query: string | undefined) => {
+      if (query === "node-canonical-abc123") return "node-canonical-abc123";
+      if (query === "other-node") return "node-other-xyz";
+      throw new Error(`unknown node ${query}`);
+    });
+
+    await expect(
+      resolveNodeExecutionTarget(
+        makeParams({
+          boundNode: "node-canonical-abc123",
+          requestedNode: "other-node",
+        }),
+      ),
+    ).rejects.toThrow(/exec node not allowed/);
+  });
+});

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -96,11 +96,33 @@ export function formatNodeRunToolResult(params: {
 export async function resolveNodeExecutionTarget(
   params: ExecuteNodeHostCommandParams,
 ): Promise<NodeExecutionTarget> {
+  const nodes = await listNodes({});
   if (params.boundNode && params.requestedNode && params.boundNode !== params.requestedNode) {
-    throw new Error(`exec node not allowed (bound to ${params.boundNode})`);
+    // Compare canonical node ids first — the raw selectors may be different
+    // supported forms (full id, display name, IP, id prefix) for the same
+    // physical node. Fall back to literal mismatch if either selector fails
+    // to resolve, so the previous error still surfaces in that case.
+    let boundCanonical: string | null = null;
+    let requestedCanonical: string | null = null;
+    try {
+      boundCanonical = resolveNodeIdFromList(nodes, params.boundNode);
+    } catch {
+      boundCanonical = null;
+    }
+    try {
+      requestedCanonical = resolveNodeIdFromList(nodes, params.requestedNode);
+    } catch {
+      requestedCanonical = null;
+    }
+    if (
+      boundCanonical === null ||
+      requestedCanonical === null ||
+      boundCanonical !== requestedCanonical
+    ) {
+      throw new Error(`exec node not allowed (bound to ${params.boundNode})`);
+    }
   }
   const nodeQuery = params.boundNode || params.requestedNode;
-  const nodes = await listNodes({});
   if (nodes.length === 0) {
     throw new Error(
       "exec host=node requires a paired node (none available). This requires a companion app or node host.",


### PR DESCRIPTION
Closes #87213.

### Problem
`exec host=node` rejected a valid request when `tools.exec.node` (the bound node) and the call's `node` parameter referred to the **same physical node** via different supported selector forms — for example a canonical full node id configured as the bound node, and a display name like `home-wsl-debian` passed at call time. The pre-fix guard compared raw selector text before resolving either side through the shared node resolver:

```ts
if (params.boundNode && params.requestedNode && params.boundNode !== params.requestedNode) {
  throw new Error(`exec node not allowed (bound to ${params.boundNode})`);
}
```

### Fix
Resolve both selectors through `resolveNodeIdFromList` first; only throw `exec node not allowed (bound to <id>)` when either selector fails to resolve, or the two canonical ids differ. The existing rejection behaviour for genuinely different nodes is preserved, and so are all other downstream checks (paired/connected/system.run capability).

### Regression test
`src/agents/bash-tools.exec-host-node-phases.test.ts` covers both paths:
- bound id + requested display name resolving to the same node → call is allowed (now passes).
- bound id + a different node selector resolving to a different canonical id → still throws `exec node not allowed`.

Verified the new test fails on `main` and passes with the fix.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts \
  src/agents/bash-tools.exec-host-node-phases.test.ts
# 2 passed
```