### PR TITLE
fix(agent-runner): classify "no real conversation messages" as compaction skip (#87016)

### DIFF
--- a/src/agents/pi-embedded-runner/compact-reasons.test.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.test.ts
@@ -34,6 +34,16 @@ describe("classifyCompactionReason", () => {
     );
   });
 
+  it('classifies "no real conversation messages" as a skip-like reason (#87016)', () => {
+    // Empty transcript / stale token counter desync: preflight compaction
+    // would otherwise throw a generic failure for every subsequent inbound
+    // message, leaving the session permanently wedged. Treat as a skip so
+    // the runner continues with the fresh session.
+    expect(classifyCompactionReason("no real conversation messages")).toBe(
+      "no_compactable_entries",
+    );
+  });
+
   it('classifies "already under target" as below threshold', () => {
     expect(classifyCompactionReason("already under target")).toBe("below_threshold");
   });

--- a/src/agents/pi-embedded-runner/compact-reasons.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.ts
@@ -26,7 +26,7 @@ export function classifyCompactionReason(reason?: string): string {
   if (!text) {
     return "unknown";
   }
-  if (text.includes("nothing to compact")) {
+  if (text.includes("nothing to compact") || text.includes("no real conversation messages")) {
     return "no_compactable_entries";
   }
   // Backends use both phrases for the same harmless state: the transcript is


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Embedded agent sessions (Discord/group channels especially) could enter a permanent deadlock where every inbound message bounces with `Preflight compaction required but failed: no real conversation messages`. Issue #87016 documents recurring deadlocks on a steady-state Discord channel (4+ in 36h).
- Root cause is state desync: `sessions.json` carries a large stale `totalTokens` so preflight compaction triggers, but the on-disk transcript is a header-only `.jsonl` so the context engine returns `{ ok: true, compacted: false, reason: "no real conversation messages" }`. The runner's skip-reason allow-list does not recognise that phrasing, so it throws and the same bounce repeats on every subsequent message.

Why does this matter now?

- It's a P1 / impact:message-loss / impact:session-state bug — once a channel is wedged the bot drops every message until manual intervention.

What is the intended outcome?

- Treat the "no real conversation messages" outcome the same way "nothing to compact" is already treated: a benign skip. The reply continues against the fresh session instead of surfacing a generic compaction failure for every inbound message.

What is intentionally out of scope?

- The deeper trigger (fallback-turn transcripts not getting appended to the outer `.jsonl`) and `sessions cleanup --fix-empty` — the issue lists those as fixes 2 and 3. This PR only ships the small, safe stop-the-bleed fix listed as #1 in the issue.
- Resetting the persisted `totalTokens` on this path. The skip already keeps the session usable; a separate change can prune the stale counter.

What does success look like?

- Once a session reaches the empty-transcript / stale-token-counter state, the next inbound message goes through normally instead of throwing. No new behaviour when the transcript actually does have real messages.

What should reviewers focus on?

- That `classifyCompactionReason` change does not accidentally widen the meaning of `no_compactable_entries` (the substring is specific enough that other paths won't collide).
- That `isPreflightCompactionSkipReason` already includes `no_compactable_entries`, so the runner returns `entry ?? params.sessionEntry` without further plumbing changes.

## Linked context

Closes #87016

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: preflight-compaction deadlock from #87016.
- Real environment tested: local OpenClaw checkout, unit tests under `vitest`.
- Exact steps or command run after this patch:
  - `pnpm vitest run src/agents/pi-embedded-runner/compact-reasons.test.ts`
- Evidence after fix:
  ```
  Test Files  1 passed (1)
       Tests  12 passed (12)
  ```
- Before evidence (same test, on `main`):
  ```
  AssertionError: expected 'unknown' to be 'no_compactable_entries'
   ❯ src/agents/pi-embedded-runner/compact-reasons.test.ts:42:71
  Test Files  1 failed (1)
       Tests  1 failed | 11 passed (12)
  ```
- Observed result after fix: classification returns `no_compactable_entries`, which `isPreflightCompactionSkipReason` already maps to a skip, so the runner returns the existing session entry instead of throwing.
- What was not tested: a full live Discord embedded-agent loop. The deadlock is probabilistic (depends on `empty_response` from the primary model on a fresh session), so I leaned on the unit-level regression + the explicit log/reason string from the issue.
- Proof limitations or environment constraints: hard to reliably re-trigger the underlying empty-jsonl path on demand; the existing `isPreflightCompactionSkipReason` already returns `entry ?? params.sessionEntry` on the corresponding classification, so the runner-level behaviour is exercised indirectly via the classification test.

## Tests and validation

Which commands did you run?

- `pnpm vitest run src/agents/pi-embedded-runner/compact-reasons.test.ts`

What regression coverage was added or updated?

- New case in `compact-reasons.test.ts`: `classifies "no real conversation messages" as a skip-like reason (#87016)`. The test fails on `main` and passes with this patch.

What failed before this fix, if known?

- Every subsequent inbound message after the empty-transcript desync, with the literal log line quoted in the issue.

If no test was added, why not?

- Test added.

## Risk checklist

Did user-visible behavior change? (`Yes`) — previously-wedged sessions resume processing messages.
Did config, environment, or migration behavior change? (`No`)
Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?

- Misclassifying a future compaction-engine response that happens to include the substring `no real conversation messages` in an error path that *should* surface to the user.

How is that risk mitigated?

- Only the success-path branch (`result?.ok === true`, `result.compacted === false`) is affected. Hard failures (`!result?.ok`) still throw through the existing branches. The substring is specific enough that the only known producer is the "skip — empty transcript" path called out by the issue.

## Current review state

What is the next action?

- Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Maintainer review / CI.
