### PR TITLE
fix(ui): scope usage filters by agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI: pass the selected Usage page `agent:` filter to usage session and cost requests, and seed the agent filter from configured agents so non-main agent usage can be loaded again. (#87132) Thanks @hpfan.
 - Memory/security: reject prompt-like text submitted through the explicit `memory_store` tool before embedding or storage, matching the existing auto-capture prompt-injection filter. (#87142)
 - Gateway/security: enable the default auth rate limiter for remote non-browser and HTTP gateway auth failures when `gateway.auth.rateLimit` is unset, while preserving the loopback exemption. (#87148)
 - Prompt hardening: route untrusted group prompt metadata through sanitized untrusted structured context while preserving trusted operator-configured group system prompts and aligning the plugin SDK docs/test helpers. (#87144)

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -161,4 +161,31 @@ describe("gateway usage helpers", () => {
       "background",
     );
   });
+
+  it("loadCostUsageSummaryCached keeps agent-scoped summaries in separate cache entries", async () => {
+    const config = {} as OpenClawConfig;
+
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+      agentId: "main",
+    });
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+      agentId: "ops",
+    });
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+      agentId: "ops",
+    });
+
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(loadCostUsageSummaryFromCache).mock.calls[0]?.[0]?.agentId).toBe("main");
+    expect(vi.mocked(loadCostUsageSummaryFromCache).mock.calls[1]?.[0]?.agentId).toBe("ops");
+  });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -720,8 +720,9 @@ async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
   config: OpenClawConfig;
+  agentId?: string;
 }): Promise<CostUsageSummary> {
-  const cacheKey = `${params.startMs}-${params.endMs}`;
+  const cacheKey = `${params.agentId ?? "__default__"}:${params.startMs}-${params.endMs}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (
@@ -745,6 +746,7 @@ async function loadCostUsageSummaryCached(params: {
     startMs: params.startMs,
     endMs: params.endMs,
     config: params.config,
+    agentId: params.agentId,
     requestRefresh: true,
     refreshMode: "background",
   })
@@ -832,7 +834,13 @@ export const usageHandlers: GatewayRequestHandlers = {
       mode: params?.mode,
       utcOffset: params?.utcOffset,
     });
-    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
+    const requestedAgentId = normalizeOptionalString(params?.agentId);
+    const summary = await loadCostUsageSummaryCached({
+      startMs,
+      endMs,
+      config,
+      agentId: requestedAgentId ? normalizeAgentId(requestedAgentId) : undefined,
+    });
     respond(true, summary, undefined);
   },
   "sessions.usage": async ({ respond, params, context }) => {

--- a/ui/src/ui/app-render-usage-tab.ts
+++ b/ui/src/ui/app-render-usage-tab.ts
@@ -50,6 +50,7 @@ export function renderUsageTab(state: AppViewState) {
       loading: state.usageLoading,
       error: state.usageError,
       sessions: state.usageResult?.sessions ?? [],
+      configuredAgentIds: state.agentsList?.agents.map((agent) => agent.id) ?? [],
       sessionsLimitReached: (state.usageResult?.sessions?.length ?? 0) >= 1000,
       totals: state.usageResult?.totals ?? null,
       aggregates: state.usageResult?.aggregates ?? null,
@@ -167,6 +168,7 @@ export function renderUsageTab(state: AppViewState) {
             state.usageQueryDebounceTimer = null;
           }
           state.usageQuery = state.usageQueryDraft;
+          void loadUsage(state);
         },
         onClearQuery: () => {
           if (state.usageQueryDebounceTimer) {
@@ -175,6 +177,7 @@ export function renderUsageTab(state: AppViewState) {
           }
           state.usageQueryDraft = "";
           state.usageQuery = "";
+          void loadUsage(state);
         },
         onSelectDay: (day, shiftKey) => {
           if (shiftKey && state.usageSelectedDays.length > 0) {

--- a/ui/src/ui/controllers/usage.node.test.ts
+++ b/ui/src/ui/controllers/usage.node.test.ts
@@ -29,6 +29,7 @@ function createState(request: RequestFn, overrides: Partial<UsageState> = {}): U
     usageTimeSeriesCursorEnd: null,
     usageSessionLogs: null,
     usageSessionLogsLoading: false,
+    usageQuery: "",
     usageTimeZone: "local",
     ...overrides,
   };
@@ -98,6 +99,39 @@ describe("usage controller date interpretation params", () => {
       endDate: "2026-02-16",
       mode: "utc",
     });
+  });
+
+  it("passes a single exact agent query token to sessions.usage", async () => {
+    const request = vi.fn(async () => ({}));
+    const state = createState(request, {
+      usageQuery: "agent:Ops label:build",
+      usageTimeZone: "utc",
+    });
+
+    await loadUsage(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentId: "ops",
+      mode: "utc",
+      groupBy: "family",
+      includeHistorical: true,
+      limit: 1000,
+      includeContextWeight: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "usage.cost", {
+      startDate: "2026-02-16",
+      endDate: "2026-02-16",
+      agentId: "ops",
+      mode: "utc",
+    });
+  });
+
+  it("does not send agentId for wildcard or ambiguous agent query tokens", () => {
+    expect(testApi.resolveUsageAgentIdFromQuery("agent:ops")).toBe("ops");
+    expect(testApi.resolveUsageAgentIdFromQuery("agent:op*")).toBeUndefined();
+    expect(testApi.resolveUsageAgentIdFromQuery("agent:ops agent:main")).toBeUndefined();
   });
 
   it("captures useful error strings in loadUsage", async () => {

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -1,7 +1,9 @@
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
+import { normalizeAgentId } from "../session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type { SessionsUsageResult, CostUsageSummary, SessionUsageTimeSeries } from "../types.ts";
+import { extractQueryTerms } from "../usage-helpers.ts";
 import type { SessionLogEntry } from "../views/usage.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -26,6 +28,7 @@ export type UsageState = {
   usageTimeSeriesCursorEnd: number | null;
   usageSessionLogs: SessionLogEntry[] | null;
   usageSessionLogsLoading: boolean;
+  usageQuery: string;
   usageTimeZone: "local" | "utc";
   settings?: { gatewayUrl?: string };
 };
@@ -170,6 +173,20 @@ const buildDateInterpretationParams = (timeZone: "local" | "utc") => {
   };
 };
 
+function resolveUsageAgentIdFromQuery(query: string): string | undefined {
+  const agentTerms = extractQueryTerms(query).filter(
+    (term) => normalizeLowercaseStringOrEmpty(term.key) === "agent",
+  );
+  if (agentTerms.length !== 1) {
+    return undefined;
+  }
+  const value = agentTerms[0]?.value.trim();
+  if (!value || value.includes("*") || value.includes("?")) {
+    return undefined;
+  }
+  return normalizeAgentId(value);
+}
+
 function toErrorMessage(err: unknown): string {
   if (typeof err === "string") {
     return err;
@@ -213,6 +230,7 @@ export async function loadUsage(
   try {
     const startDate = overrides?.startDate ?? state.usageStartDate;
     const endDate = overrides?.endDate ?? state.usageEndDate;
+    const requestedAgentId = resolveUsageAgentIdFromQuery(state.usageQuery);
     const runUsageRequests = (includeDateInterpretation: boolean, includeUsageScope: boolean) => {
       const dateInterpretation = includeDateInterpretation
         ? buildDateInterpretationParams(state.usageTimeZone)
@@ -227,6 +245,7 @@ export async function loadUsage(
         client.request("sessions.usage", {
           startDate,
           endDate,
+          ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
           ...dateInterpretation,
           ...usageScopeParams,
           limit: 1000, // Cap at 1000 sessions
@@ -235,6 +254,7 @@ export async function loadUsage(
         client.request("usage.cost", {
           startDate,
           endDate,
+          ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
           ...dateInterpretation,
         }),
       ]);
@@ -292,6 +312,7 @@ export const testApi = {
   rememberLegacyDateInterpretation,
   shouldSendLegacyUsageScopeParams,
   rememberLegacyUsageScopeParams,
+  resolveUsageAgentIdFromQuery,
   resetLegacyUsageDateParamsCache: () => {
     legacyUsageDateParamsCache = null;
     legacyUsageScopeParamsCache = null;

--- a/ui/src/ui/views/usage.test.ts
+++ b/ui/src/ui/views/usage.test.ts
@@ -112,4 +112,37 @@ describe("renderUsage", () => {
     expect(container.querySelector(".usage-page-title")).toBeNull();
     expect(container.querySelector(".usage-header")).not.toBeNull();
   });
+
+  it("shows configured agents in the agent filter before their sessions are loaded", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderUsage(
+        createUsageProps({
+          data: {
+            loading: false,
+            error: null,
+            sessions: [
+              {
+                key: "agent:main:main",
+                agentId: "main",
+                usage: { totalTokens: 1, totalCost: 0 },
+              } as never,
+            ],
+            configuredAgentIds: ["main", "ops"],
+            sessionsLimitReached: false,
+            totals: null,
+            aggregates: null,
+            costDaily: [],
+            cacheStatus: undefined,
+          },
+        }),
+      ),
+      container,
+    );
+
+    const agentFilter = container.querySelector(".usage-filter-select");
+    expect(agentFilter?.textContent).toContain("main");
+    expect(agentFilter?.textContent).toContain("ops");
+  });
 });

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -204,7 +204,10 @@ export function renderUsage(props: UsageProps) {
     }
     return Array.from(set);
   };
-  const agentOptions = unique(sortedSessions.map((s) => s.agentId)).slice(0, 12);
+  const agentOptions = unique([
+    ...(data.configuredAgentIds ?? []),
+    ...sortedSessions.map((s) => s.agentId),
+  ]).slice(0, 12);
   const channelOptions = unique(sortedSessions.map((s) => s.channel)).slice(0, 12);
   const providerOptions = unique([
     ...sortedSessions.map((s) => s.modelProvider),

--- a/ui/src/ui/views/usageTypes.ts
+++ b/ui/src/ui/views/usageTypes.ts
@@ -27,6 +27,7 @@ export type UsageDataState = {
   loading: boolean;
   error: string | null;
   sessions: UsageSessionEntry[];
+  configuredAgentIds?: string[];
   sessionsLimitReached: boolean; // True if 1000 session cap was hit
   totals: UsageTotals | null;
   aggregates: UsageAggregates | null;


### PR DESCRIPTION
## Summary

- Fixes the Control UI Usage page regression where applying an `agent:` filter only narrowed the already-loaded client-side sessions, while the backend continued defaulting usage discovery to the main agent.
- Sends a single exact `agent:` query token as `agentId` to both `sessions.usage` and `usage.cost`, so session rows, totals, daily charts, and CSV/JSON exports stay on the same agent scope.
- Seeds the Usage page agent filter from configured `agents.list` entries before non-main sessions are loaded, so users can select non-main agents instead of needing to type the token by hand.
- Intentionally out of scope: multi-agent OR filtering; the existing query language treats repeated filter tokens as conjunctive, so this keeps the server scope to one exact agent token.
- Reviewers should focus on the `usage.cost` agent-aware cache key and the query-token-to-RPC scoping behavior.

## Linked context

Closes #87132

Related #81386

Was this requested by a maintainer or owner?

No direct maintainer request; #87132 is a source-proven, queueable regression.

## Real behavior proof (required for external PRs)

Behavior addressed: Control UI Usage page non-main agent filtering after `sessions.usage` began defaulting omitted `agentId` to the default agent.
Real environment tested: Local OpenClaw checkout at commit 092e14fd3f on macOS; mocked gateway/client tests plus changed gate.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/controllers/usage.node.test.ts ui/src/ui/views/usage.test.ts src/gateway/server-methods/usage.test.ts`; `pnpm check:changed`.
Evidence after fix: Added regression assertions that `agent:Ops` sends `agentId: "ops"` to both `sessions.usage` and `usage.cost`; added view coverage that configured agent `ops` appears in the Usage agent filter before an ops session is loaded; added gateway coverage that cost usage cache entries are separated by `agentId`.
Observed result after fix: Focused Vitest command exited 0; `pnpm check:changed` exited 0 after rebase onto latest `origin/main`.
What was not tested: A live browser session against a running multi-agent Gateway with real transcript data.
Proof limitations or environment constraints: This contributor checkout has READ permission on `openclaw/openclaw`, so the branch is pushed from fork `yelog/openclaw-1`; live multi-agent UI proof was not run in this pass.
Before evidence (optional but encouraged): Issue #87132 documents the pre-fix request payload omission and the backend default-to-main behavior from current source.

## Tests and validation

Commands run:

- `node scripts/run-vitest.mjs ui/src/ui/controllers/usage.node.test.ts ui/src/ui/views/usage.test.ts src/gateway/server-methods/usage.test.ts`
- `pnpm check:changed`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added or updated:

- UI usage controller verifies exact `agent:` query tokens scope both usage RPCs.
- UI usage view verifies configured agents populate the agent filter even before matching sessions are loaded.
- Gateway usage helper verifies agent-scoped cost summaries use separate in-memory cache entries.

What failed before this fix, if known?

The Web UI did not send `agentId` in `sessions.usage`; after #81386, the gateway defaulted omitted list-style usage queries to the default agent, hiding non-main sessions from the Usage page agent filter.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Keeping session usage and daily cost usage scoped consistently when a UI query contains one exact `agent:` token.

How is that risk mitigated?

The frontend sends the same normalized agent scope to both usage RPCs, and the gateway cost cache includes `agentId` in its cache key before delegating to the already agent-aware cost summary loader.

## Current review state

What is the next action?

Maintainer review, CI, and ideally live multi-agent Control UI proof.

What is still waiting on author, maintainer, CI, or external proof?

CI and live UI proof are still pending.

Which bot or reviewer comments were addressed?

Local autoreview first reported that `usage.cost` remained unscoped; this patch now scopes `usage.cost` and separates its cache by `agentId`. A follow-up autoreview attempt was blocked by the Codex usage limit after the fix, so no clean second autoreview result is available.
