### PR TITLE
fix(telegram): protect against accidental command menu clearing (#66958)

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -349,4 +349,69 @@ describe("bot-native-command-menu", () => {
       "Telegram rejected 10 commands (BOT_COMMANDS_TOO_MUCH); retrying with 8.",
     );
   });
+
+  it("skips sync when commands are empty but native is not explicitly disabled (#66958)", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+    const accountId = `test-empty-protect-${Date.now()}`;
+
+    // When nativeDisabledExplicit is false (default) and commands are empty,
+    // we should skip sync and log a warning instead of clearing the menu.
+    syncTelegramMenuCommands({
+      bot: {
+        api: { deleteMyCommands, setMyCommands },
+      } as unknown as Parameters<typeof syncTelegramMenuCommands>[0]["bot"],
+      runtime: {
+        log: runtimeLog,
+        error: vi.fn(),
+        exit: vi.fn(),
+      } as Parameters<typeof syncTelegramMenuCommands>[0]["runtime"],
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+      nativeDisabledExplicit: false,
+    });
+
+    // Wait a tick for the async sync function
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // deleteMyCommands and setMyCommands should NOT be called
+    expect(deleteMyCommands).not.toHaveBeenCalled();
+    expect(setMyCommands).not.toHaveBeenCalled();
+    // Should log a warning about the transient issue
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("command registration skipped because the resolved command list is empty"),
+    );
+  });
+
+  it("clears menu when commands are empty and native is explicitly disabled (#66958)", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+    const accountId = `test-empty-disabled-${Date.now()}`;
+
+    // When nativeDisabledExplicit is true and commands are empty,
+    // we should proceed to clear the menu as intended.
+    syncTelegramMenuCommands({
+      bot: {
+        api: { deleteMyCommands, setMyCommands },
+      } as unknown as Parameters<typeof syncTelegramMenuCommands>[0]["bot"],
+      runtime: {
+        log: runtimeLog,
+        error: vi.fn(),
+        exit: vi.fn(),
+      } as Parameters<typeof syncTelegramMenuCommands>[0]["runtime"],
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+      nativeDisabledExplicit: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(deleteMyCommands).toHaveBeenCalled();
+    });
+
+    expect(setMyCommands).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -373,16 +373,16 @@ describe("bot-native-command-menu", () => {
       nativeDisabledExplicit: false,
     });
 
-    // Wait a tick for the async sync function
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Wait for the log call to confirm the early-return path executed
+    await vi.waitFor(() => {
+      expect(runtimeLog).toHaveBeenCalledWith(
+        expect.stringContaining("command registration skipped because the resolved command list is empty"),
+      );
+    });
 
     // deleteMyCommands and setMyCommands should NOT be called
     expect(deleteMyCommands).not.toHaveBeenCalled();
     expect(setMyCommands).not.toHaveBeenCalled();
-    // Should log a warning about the transient issue
-    expect(runtimeLog).toHaveBeenCalledWith(
-      expect.stringContaining("command registration skipped because the resolved command list is empty"),
-    );
   });
 
   it("clears menu when commands are empty and native is explicitly disabled (#66958)", async () => {

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -238,8 +238,9 @@ export function syncTelegramMenuCommands(params: {
   commandsToRegister: TelegramMenuCommand[];
   accountId?: string;
   botIdentity?: string;
+  nativeDisabledExplicit?: boolean;
 }): void {
-  const { bot, runtime, commandsToRegister, accountId, botIdentity } = params;
+  const { bot, runtime, commandsToRegister, accountId, botIdentity, nativeDisabledExplicit } = params;
   const sync = async () => {
     // Skip sync if the command list hasn't changed since the last successful
     // sync. This prevents hitting Telegram's 429 rate limit when the gateway
@@ -249,6 +250,20 @@ export function syncTelegramMenuCommands(params: {
     const cachedHash = readCachedCommandHash(accountId, botIdentity);
     if (cachedHash === currentHash) {
       logVerbose("telegram: command menu unchanged; skipping sync");
+      return;
+    }
+
+    // Protect against accidentally clearing the command menu when commands
+    // are enabled but the runtime resolution produces an empty list.
+    // This can happen due to race conditions during startup or plugin loading.
+    // See: openclaw/openclaw#66958
+    if (commandsToRegister.length === 0 && !nativeDisabledExplicit) {
+      runtime.log?.(
+        "telegram: command registration skipped because the resolved command list is empty, " +
+          "but native commands are not explicitly disabled. " +
+          "This may indicate a transient runtime resolution issue. " +
+          "If you intend to clear the menu, set channels.telegram.commands.native to false."
+      );
       return;
     }
 

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -238,9 +238,14 @@ export function syncTelegramMenuCommands(params: {
   commandsToRegister: TelegramMenuCommand[];
   accountId?: string;
   botIdentity?: string;
+  /**
+   * When true, the caller explicitly intends to disable native commands.
+   * When false/undefined, empty command lists are treated as transient errors
+   * rather than intentional clearing (fixes #66958).
+   */
   nativeDisabledExplicit?: boolean;
 }): void {
-  const { bot, runtime, commandsToRegister, accountId, botIdentity, nativeDisabledExplicit } = params;
+  const { bot, runtime, commandsToRegister, accountId, botIdentity, nativeDisabledExplicit = false } = params;
   const sync = async () => {
     // Skip sync if the command list hasn't changed since the last successful
     // sync. This prevents hitting Telegram's 429 rate limit when the gateway
@@ -256,6 +261,8 @@ export function syncTelegramMenuCommands(params: {
     // Protect against accidentally clearing the command menu when commands
     // are enabled but the runtime resolution produces an empty list.
     // This can happen due to race conditions during startup or plugin loading.
+    // Default nativeDisabledExplicit to false means we protect against
+    // accidental clearing unless the caller explicitly opts out.
     // See: openclaw/openclaw#66958
     if (commandsToRegister.length === 0 && !nativeDisabledExplicit) {
       runtime.log?.(

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -607,6 +607,7 @@ export const registerTelegramNativeCommands = ({
     commandsToRegister,
     accountId,
     botIdentity: opts.token,
+    nativeDisabledExplicit,
   });
 
   const resolveCommandRuntimeContext = async (params: {


### PR DESCRIPTION
## Summary

Fixes #66958 - Telegram native command menu can be cleared on startup because runtime command registration resolves to an empty list.

## Problem

When `commands.native` is set to `"auto"` or `true`, the Telegram bot's native command menu was being cleared on startup. This happened because:

1. The runtime native-command resolution path (`listNativeCommandSpecsForConfig`) sometimes produces an empty `commandsToRegister` list during startup
2. When the list is empty, `syncTelegramMenuCommands` calls `deleteMyCommands()` and caches the empty-list hash
3. This causes the bot menu to be cleared and remain missing across restarts

## Root Cause

The issue is a race condition during startup where:
- Plugin registration may not be complete when command resolution runs
- The command registry cache may be stale or empty
- There's no protection against accidentally clearing the menu when commands are enabled but resolution fails

## Solution

This PR adds a protective check in `syncTelegramMenuCommands` that:

1. **Skips sync** when `commandsToRegister` is empty but native commands are **not explicitly disabled**
2. **Logs a warning** to help diagnose transient runtime resolution issues
3. **Only clears the menu** when `nativeDisabledExplicit` is `true` (user explicitly set `commands.native: false`)

### Changes

- `extensions/telegram/src/bot-native-command-menu.ts`:
  - Add `nativeDisabledExplicit` parameter to `syncTelegramMenuCommands`
  - Add protective check before calling `deleteMyCommands`
  - Log informative warning when skipping sync due to empty command list

- `extensions/telegram/src/bot-native-commands.ts`:
  - Pass `nativeDisabledExplicit` to `syncTelegramMenuCommands`

- `extensions/telegram/src/bot-native-command-menu.test.ts`:
  - Add test: "skips sync when commands are empty but native is not explicitly disabled"
  - Add test: "clears menu when commands are empty and native is explicitly disabled"

## Testing

Two new test cases verify:
1. When `nativeDisabledExplicit: false` and commands are empty, sync is skipped and no API calls are made
2. When `nativeDisabledExplicit: true` and commands are empty, the menu is cleared as intended

## Impact

- **Severity**: Medium-High (affects user experience, but not data loss)
- **Scope**: All Telegram users with `commands.native: "auto"` or `true`
- **Regression Risk**: Low (only adds protection, doesn't change normal behavior)

## Checklist

- [x] Code follows project style guidelines
- [x] Added tests for new behavior
- [x] All existing tests pass
- [x] Commit message follows conventional commits format
- [x] Fixes #66958