### PR TITLE
fix(gateway): drain probe WebSocket close before settling result (#87210)

### DIFF
--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -4,6 +4,9 @@ const gatewayClientState = vi.hoisted(() => ({
   options: null as Record<string, unknown> | null,
   requests: [] as string[],
   startCalls: 0,
+  stopCalls: 0,
+  stopAndWaitCalls: 0,
+  stopAndWaitArgs: [] as Array<unknown>,
   startMode: "hello" as "hello" | "close" | "connect-error-close" | "startup-retry-then-hello",
   close: { code: 1008, reason: "pairing required" },
   helloAuth: {
@@ -114,7 +117,14 @@ class MockGatewayClient {
       .catch(() => {});
   }
 
-  stop(): void {}
+  stop(): void {
+    gatewayClientState.stopCalls += 1;
+  }
+
+  async stopAndWait(opts?: { timeoutMs?: number }): Promise<void> {
+    gatewayClientState.stopAndWaitCalls += 1;
+    gatewayClientState.stopAndWaitArgs.push(opts);
+  }
 
   async request(method: string): Promise<unknown> {
     gatewayClientState.requests.push(method);
@@ -220,6 +230,9 @@ describe("probeGateway", () => {
     gatewayClientState.options = null;
     gatewayClientState.requests = [];
     gatewayClientState.startCalls = 0;
+    gatewayClientState.stopCalls = 0;
+    gatewayClientState.stopAndWaitCalls = 0;
+    gatewayClientState.stopAndWaitArgs = [];
     gatewayClientState.close = { code: 1008, reason: "pairing required" };
     gatewayClientState.helloAuth = {
       role: "operator",
@@ -315,6 +328,23 @@ describe("probeGateway", () => {
       version: "2026.4.24",
       connId: "conn-test",
     });
+  });
+
+  it("drains gateway WebSocket close via stopAndWait so the CLI exits promptly (#87210)", async () => {
+    await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+    });
+    // settle() must use stopAndWait so the socket close is drained before the
+    // probe promise resolves. The raw client.stop() should not run on the
+    // happy path because it leaves an unreferenced WebSocket handle that has
+    // historically kept the Node process alive past the printed status
+    // output.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(gatewayClientState.stopAndWaitCalls).toBeGreaterThanOrEqual(1);
+    expect(gatewayClientState.stopAndWaitArgs[0]).toEqual({ timeoutMs: 500 });
+    expect(gatewayClientState.stopCalls).toBe(0);
   });
 
   it("loads probe identity and cached device auth from the provided env", async () => {

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -56,6 +56,10 @@ export type GatewayProbeResult = {
 };
 
 export const MIN_PROBE_TIMEOUT_MS = 250;
+// Bound how long settle() waits for the probe's WebSocket close to drain so a
+// wedged gateway cannot delay CLI exit indefinitely after status output
+// (issue #87210).
+export const PROBE_STOP_DRAIN_TIMEOUT_MS = 500;
 export const MAX_TIMER_DELAY_MS = MAX_SAFE_TIMEOUT_DELAY_MS;
 const PAIRING_REQUIRED_PATTERN = /\bpairing required\b/i;
 const OPERATOR_READ_SCOPE = "operator.read";
@@ -299,7 +303,15 @@ export async function probeGateway(opts: {
       settled = true;
       startAbort.abort();
       clearProbeTimer();
-      client.stop();
+      // Drain the WebSocket close before resolving so the CLI process can
+      // exit promptly instead of holding an active socket handle past the
+      // last rendered line (issue #87210). Bound the wait so a wedged
+      // gateway cannot delay status output indefinitely.
+      void client.stopAndWait({ timeoutMs: PROBE_STOP_DRAIN_TIMEOUT_MS }).catch(() => {
+        try {
+          client.stop();
+        } catch {}
+      });
       if (result.ok) {
         clearDeviceRequiredProbeFailures(cacheKey);
       } else if (cacheEligible && isDeviceIdentityRequiredClose(result.close)) {


### PR DESCRIPTION
Closes #87210.

### Problem
`openclaw gateway status` (and any other short-lived CLI command going through `probeGateway`) could fail to exit promptly: `settle()` invoked `client.stop()` fire-and-forget and resolved while the WebSocket close handshake was still in flight. The dangling socket kept the Node event loop alive past the rendered status output until something external killed the process.

### Fix
Switch `settle()` to `client.stopAndWait({ timeoutMs: 500 })` so the probe promise only resolves after the close handshake drains. The wait is bounded by a new `PROBE_STOP_DRAIN_TIMEOUT_MS = 500` constant so a wedged gateway cannot delay status output indefinitely; on timeout (or any unexpected rejection) we fall back to the original fire-and-forget `client.stop()`, so behaviour for never-handshaking probes is unchanged.

### Regression test
`src/gateway/probe.test.ts` asserts that the happy path goes through `stopAndWait({ timeoutMs: 500 })` and that the raw `client.stop()` shortcut is not used when `stopAndWait` is available.