### PR TITLE
fix(hooks): include media metadata in toPluginMessageReceivedEvent

### DIFF
--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -40,6 +40,7 @@ function makeInboundCtx(overrides: Partial<FinalizedMsgContext> = {}): Finalized
     MessageThreadId: 42,
     MediaPath: "/tmp/audio.ogg",
     MediaType: "audio/ogg",
+    MediaUrl: "https://cdn.example.com/audio.ogg",
     GroupSubject: "ops",
     GroupChannel: "ops-room",
     GroupSpace: "guild-1",
@@ -112,6 +113,8 @@ describe("message hook mappers", () => {
         MediaType: undefined,
         MediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
         MediaTypes: ["image/jpeg", "image/jpeg"],
+        MediaUrl: "https://cdn.example.com/tree.jpg",
+        MediaUrls: ["https://cdn.example.com/tree.jpg", "https://cdn.example.com/ramp.jpg"],
       }),
     );
 
@@ -119,6 +122,11 @@ describe("message hook mappers", () => {
     expect(canonical.mediaType).toBe("image/jpeg");
     expect(canonical.mediaPaths).toEqual(["/tmp/tree.jpg", "/tmp/ramp.jpg"]);
     expect(canonical.mediaTypes).toEqual(["image/jpeg", "image/jpeg"]);
+    expect(canonical.mediaUrl).toBe("https://cdn.example.com/tree.jpg");
+    expect(canonical.mediaUrls).toEqual([
+      "https://cdn.example.com/tree.jpg",
+      "https://cdn.example.com/ramp.jpg",
+    ]);
     expect(toPluginInboundClaimEvent(canonical)).toEqual(
       expect.objectContaining({
         metadata: expect.objectContaining({
@@ -126,6 +134,8 @@ describe("message hook mappers", () => {
           mediaType: "image/jpeg",
           mediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
           mediaTypes: ["image/jpeg", "image/jpeg"],
+          mediaUrl: "https://cdn.example.com/tree.jpg",
+          mediaUrls: ["https://cdn.example.com/tree.jpg", "https://cdn.example.com/ramp.jpg"],
         }),
       }),
     );
@@ -147,6 +157,9 @@ describe("message hook mappers", () => {
         messageId: "msg-1",
         senderName: "User One",
         threadId: 42,
+        mediaPath: "/tmp/audio.ogg",
+        mediaType: "audio/ogg",
+        mediaUrl: "https://cdn.example.com/audio.ogg",
       }),
     });
     expect(toInternalMessageReceivedContext(canonical)).toEqual({

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -42,6 +42,8 @@ export type CanonicalInboundMessageHookContext = {
   mediaType?: string;
   mediaPaths?: string[];
   mediaTypes?: string[];
+  mediaUrl?: string;
+  mediaUrls?: string[];
   originatingChannel?: string;
   originatingTo?: string;
   guildId?: string;
@@ -125,6 +127,12 @@ export function deriveInboundMessageHookContext(
     mediaType: ctx.MediaType ?? mediaTypes?.[0],
     mediaPaths,
     mediaTypes,
+    mediaUrl: ctx.MediaUrl,
+    mediaUrls: Array.isArray(ctx.MediaUrls)
+      ? ctx.MediaUrls.filter(
+          (value): value is string => typeof value === "string" && value.length > 0,
+        )
+      : undefined,
     originatingChannel: ctx.OriginatingChannel,
     originatingTo: ctx.OriginatingTo,
     guildId: ctx.GroupSpace,
@@ -263,6 +271,8 @@ export function toPluginInboundClaimEvent(
       mediaType: canonical.mediaType,
       mediaPaths: canonical.mediaPaths,
       mediaTypes: canonical.mediaTypes,
+      mediaUrl: canonical.mediaUrl,
+      mediaUrls: canonical.mediaUrls,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
       groupId: canonical.groupId,
@@ -289,6 +299,12 @@ export function toPluginMessageReceivedEvent(
       senderName: canonical.senderName,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
+      mediaPath: canonical.mediaPath,
+      mediaType: canonical.mediaType,
+      mediaPaths: canonical.mediaPaths,
+      mediaTypes: canonical.mediaTypes,
+      mediaUrl: canonical.mediaUrl,
+      mediaUrls: canonical.mediaUrls,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
     },


### PR DESCRIPTION
## Summary

ClawSweeper review identified that the original fix only included `mediaPath`/`mediaType`/`mediaPaths`/`mediaTypes` but omitted `mediaUrl` and `mediaUrls`, which are available in `FinalizedMsgContext` and needed by plugins handling URL-based media references.

**Key change**: Added `mediaUrl` and `mediaUrls` fields to `CanonicalInboundMessageHookContext`, `deriveInboundMessageHookContext`, `toPluginInboundClaimEvent`, and `toPluginMessageReceivedEvent`.

## Changes
- `src/hooks/message-hook-mappers.ts`: Add mediaUrl/mediaUrls to type, derive function, and both event mappers
- `src/hooks/message-hook-mappers.test.ts`: Add test coverage for all six media metadata fields