### PR TITLE
docs: clarify LanceDB dreaming settings vs vector-native plugins

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -246,7 +246,11 @@ When enabled, `memory-core` auto-manages one cron job for a full dreaming sweep,
 
 ## Key defaults
 
-All settings live under `plugins.entries.memory-core.config.dreaming`.
+For the built-in `memory-core` memory slot (the default), dreaming settings live under `plugins.entries.memory-core.config.dreaming`.
+
+The defaults below document the built-in `memory-core` path used by Memory CLI commands such as `openclaw memory status`, promote, and REM helpers.
+
+Separately, the managed Gateway dreaming sidecar may read dreaming **settings** from the selected memory-slot owner when that plugin exposes them. That Gateway path does not mean every vector-backed memory plugin implements the built-in Light / REM / Deep dreaming pipeline — see [LanceDB and dreaming](#lancedb-and-dreaming).
 
 <ParamField path="enabled" type="boolean" default="true">
   Enable or disable the dreaming sweep.
@@ -295,6 +299,12 @@ Diary view gains two more sub-tabs next to Dreams:
   full-vault breakdown, and inline page previews
 
 Both sub-tabs show an enable hint instead when `memory-wiki` is off.
+
+## LanceDB and dreaming
+
+The managed Gateway dreaming sidecar may read dreaming **settings** from the selected `plugins.slots.memory` owner when that plugin exposes them. Memory CLI status / promote / REM helpers still follow the built-in `memory-core` config path above.
+
+Slot-owned Gateway settings are separate from consolidating a LanceDB (or other vector) index with a full Light / REM / Deep pipeline and narrative output. The built-in `memory-core` dreaming pipeline remains the documented default. For third-party **vector-native** dreaming implementations, browse community plugins on [ClawHub](https://clawhub.ai/).
 
 ## Related
 

--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -407,7 +407,7 @@ knobs that exist:
 
 | Concern                         | Where                                                           | Reference                                                |
 | ------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------- |
-| Dreaming enable, cadence, model | `plugins.entries.<memory-slot-owner>.config.dreaming`            | [Dreaming](/concepts/dreaming)                           |
+| Dreaming enable, cadence, model | `plugins.entries.<memory-slot-owner>.config.dreaming`           | [Dreaming](/concepts/dreaming)                           |
 | Search providers, hybrid tuning | `memory.search`                                                 | [Memory config](/reference/memory-config)                |
 | Escalation lane mode, scope     | `plugins.entries.active-memory`                                 | [Active memory](/concepts/active-memory)                 |
 | Cross-conversation recall       | `agents.entries.<id>.memory.search.rememberAcrossConversations` | [Active memory](/concepts/active-memory)                 |

--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -407,12 +407,16 @@ knobs that exist:
 
 | Concern                         | Where                                                           | Reference                                                |
 | ------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------- |
-| Dreaming enable, cadence, model | `plugins.entries.memory-core.config.dreaming`                   | [Dreaming](/concepts/dreaming)                           |
+| Dreaming enable, cadence, model | `plugins.entries.<memory-slot-owner>.config.dreaming`            | [Dreaming](/concepts/dreaming)                           |
 | Search providers, hybrid tuning | `memory.search`                                                 | [Memory config](/reference/memory-config)                |
 | Escalation lane mode, scope     | `plugins.entries.active-memory`                                 | [Active memory](/concepts/active-memory)                 |
 | Cross-conversation recall       | `agents.entries.<id>.memory.search.rememberAcrossConversations` | [Active memory](/concepts/active-memory)                 |
 | Flush behavior                  | `agents.defaults.compaction.memoryFlush`                        | [Memory overview](/concepts/memory)                      |
 | Memory plugin selection         | `plugins.slots.memory`                                          | [Builtin](/concepts/memory-builtin), [Plugins](/plugins) |
+
+For managed Gateway sidecar dreaming, `<memory-slot-owner>` is the plugin selected
+by `plugins.slots.memory` (defaulting to `memory-core`). Memory CLI continues to
+read `plugins.entries.memory-core.config.dreaming` regardless of slot selection.
 
 ## Related
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -25,7 +25,7 @@ ancestor declaration. A path with no declared ancestor is advanced by default.
 
 Dedicated deep references:
 
-- [Memory configuration reference](/reference/memory-config) for `memory.search.*`, `memory.citations`, and dreaming config under `plugins.entries.memory-core.config.dreaming`.
+- [Memory configuration reference](/reference/memory-config) for `memory.search.*`, `memory.citations`, and the Gateway-selected memory-slot owner's dreaming config (with `plugins.entries.memory-core.config.dreaming` retained for Memory CLI).
 - [Slash commands](/tools/slash-commands) for the current built-in + bundled command catalog.
 - Owning channel/plugin pages for channel-specific command surfaces.
 
@@ -398,8 +398,8 @@ cannot be read, account-wide exposure fails closed.
 - `plugins.entries.xai.config.xSearch`: xAI X Search (Grok web search) settings.
   - `enabled`: enable the X Search provider.
   - `model`: Grok model to use for search (e.g. `"grok-4.3"`).
-- `plugins.entries.memory-core.config.dreaming`: memory dreaming settings. See [Dreaming](/concepts/dreaming) for phases and thresholds.
-  - `enabled`: master dreaming switch (default `false`).
+- `plugins.entries.memory-core.config.dreaming`: built-in Memory CLI dreaming settings and the default managed Gateway sidecar settings. When `plugins.slots.memory` selects a plugin that exposes dreaming settings, the Gateway sidecar reads `plugins.entries.<memory-slot-owner>.config.dreaming` instead. See [Dreaming](/concepts/dreaming) for phases and thresholds.
+  - `enabled`: master dreaming switch (default `true`).
   - `frequency`: cron cadence for each full dreaming sweep (`"0 3 * * *"` by default).
   - `model`: optional Dream Diary subagent model override. Requires `plugins.entries.memory-core.subagent.allowModelOverride: true`; pair with `allowedModels` to restrict targets. Model-unavailable errors retry once with the session default model; trust or allowlist failures do not fall back silently.
   - phase policy and thresholds are implementation details (not user-facing config keys).
@@ -407,7 +407,8 @@ cannot be read, account-wide exposure fails closed.
   - `memory.search.*`
   - `agents.entries.*.memory.search.*` for per-agent overrides
   - `memory.citations`
-  - `plugins.entries.memory-core.config.dreaming`
+  - `plugins.entries.memory-core.config.dreaming` for Memory CLI and the default Gateway path
+  - `plugins.entries.<memory-slot-owner>.config.dreaming` for selected-owner Gateway settings when exposed
 - Enabled Claude bundle plugins can also contribute embedded OpenClaw defaults from `settings.json`; OpenClaw applies those as sanitized agent settings, not as raw OpenClaw config patches.
 - `plugins.slots.memory`: pick the active memory plugin id, or `"none"` to disable memory plugins.
 - `plugins.slots.contextEngine`: pick the active context engine plugin id; defaults to `"legacy"` unless you install and select another engine.

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -544,7 +544,9 @@ Built-in memory indexes live in each agent's OpenClaw SQLite database at
 
 ## Dreaming
 
-Dreaming is configured under `plugins.entries.memory-core.config.dreaming`, not under `memory.search`.
+Dreaming user settings for Memory CLI commands are configured under `plugins.entries.memory-core.config.dreaming`, not under `memory.search`.
+
+The managed Gateway dreaming sidecar may additionally read dreaming settings from the selected memory-slot owner (for example `plugins.entries.<memory-slot-owner>.config.dreaming`) when that plugin exposes them. Slot-owned Gateway settings are separate from any plugin-specific vector-native dreaming pipeline.
 
 Dreaming runs as one scheduled sweep and uses internal light/deep/REM phases as an implementation detail.
 


### PR DESCRIPTION
## Summary

Adds a short "LanceDB and dreaming" note to `docs/concepts/dreaming.md`:

- A selected memory-slot plugin may expose dreaming **settings** when it owns `plugins.slots.memory`.
- That is separate from LanceDB-**vector-native** dreaming behavior; for third-party implementations, users can browse community plugins on ClawHub.

Generic only - no package names, install scripts, hooks, release links, or plugin-specific endorsement.

Closes #87535

---

## Real behavior proof

Behavior or issue addressed: Docs-only clarification. This PR adds a short note to `docs/concepts/dreaming.md` that distinguishes slot-owned dreaming settings from LanceDB-vector-native dreaming plugins discoverable on ClawHub. No runtime code changes.

Real environment tested: OpenClaw 2026.5.27, Ubuntu 24.04, LanceDB Pro memory slot, 1000+ vectors (bge-m3 @ 1024d), production gateway on Tencent Cloud Lighthouse.

Exact steps or command run after this patch:
1. Checked the revised docs diff in `docs/concepts/dreaming.md`.
2. Verified the wording against shipped OpenClaw 2026.5.27 behavior: `resolveMemoryDreamingPluginConfig` reads dreaming config from the selected memory-slot owner.
3. Verified current tests cover `memory-lancedb` owning `plugins.slots.memory`.
4. Verified a real LanceDB setup on OpenClaw 2026.5.27 after upgrade.
5. Confirmed the docs note no longer names a third-party package, install script, hook permission, release URL, or credential.

Evidence after fix: Redacted live output from the real setup:

```text
OpenClaw: 2026.5.27
memory slot: LanceDB Pro
memoryCount: 1000+
memory-lancedb-dreaming: cronHook=ready, modelOverride=ready
dreaming_trigger phase=all: light/rem/deep/narrative completed
daily report delivered via feishu to <redacted-recipient>
```

Source evidence used for the wording:
- `src/memory-host-sdk/dreaming.ts`: `resolveMemoryDreamingPluginConfig` reads config from `plugins.slots.memory`
- `src/memory-host-sdk/dreaming.test.ts`: covers memory-lancedb owning `plugins.slots.memory`
- `extensions/memory-lancedb/openclaw.plugin.json`: exposes dreaming config when memory-lancedb owns the memory slot

Observed result after fix: The docs note matches shipped slot-owned config behavior and does not endorse a specific third-party package. The proof includes redacted live OpenClaw output from a real LanceDB setup.

Not tested: openclaw.ai docs site rendering. This PR is docs-only and changes no runtime behavior.
