### PR TITLE
fix(agents): use runtime alias equivalence in live model switch comparison

### DIFF
--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -361,6 +361,53 @@ describe("live model switch", () => {
     expect(state.piEmbeddedModuleImported).toBe(false);
   });
 
+  it("treats openai-codex and openai as equivalent runtime providers", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.5",
+        },
+      ),
+    ).toBe(false);
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai",
+          model: "gpt-5.5",
+        },
+        {
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not suppress switch when model actually differs across runtime alias", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+        },
+      ),
+    ).toBe(true);
+  });
+
   it("treats auth-profile-source changes as no-op when no auth profile is selected", async () => {
     const { hasDifferentLiveSessionModelSelection } = await loadModule();
 
@@ -482,6 +529,28 @@ describe("live model switch", () => {
       const { shouldSwitchToLiveModel } = await loadModule();
 
       const result = shouldSwitchToLiveModel(makeShouldSwitchParams({ sessionKey: undefined }));
+
+      expect(result).toBeUndefined();
+    });
+
+    it("does not trigger switch when runtime promotes openai to openai-codex", async () => {
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+      };
+      state.loadSessionStoreMock.mockReturnValue({ main: sessionEntry });
+
+      const { shouldSwitchToLiveModel } = await loadModule();
+
+      const result = shouldSwitchToLiveModel(
+        makeShouldSwitchParams({
+          currentProvider: "openai-codex",
+          currentModel: "gpt-5.5",
+          defaultProvider: "openai",
+          defaultModel: "gpt-5.5",
+        }),
+      );
 
       expect(result).toBeUndefined();
     });

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -361,7 +361,7 @@ describe("live model switch", () => {
     expect(state.piEmbeddedModuleImported).toBe(false);
   });
 
-  it("treats openai-codex and openai as equivalent runtime providers", async () => {
+  it("treats active openai-codex as an already-applied openai runtime promotion", async () => {
     const { hasDifferentLiveSessionModelSelection } = await loadModule();
 
     expect(
@@ -376,6 +376,10 @@ describe("live model switch", () => {
         },
       ),
     ).toBe(false);
+  });
+
+  it("does not suppress explicit runtime provider switches with the same model", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
 
     expect(
       hasDifferentLiveSessionModelSelection(
@@ -388,7 +392,20 @@ describe("live model switch", () => {
           model: "gpt-5.5",
         },
       ),
-    ).toBe(false);
+    ).toBe(true);
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+        {
+          provider: "claude-cli",
+          model: "claude-sonnet-4-6",
+        },
+      ),
+    ).toBe(true);
   });
 
   it("does not suppress switch when model actually differs across runtime alias", async () => {

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -15,6 +15,7 @@ import {
 export { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 export type LiveSessionModelSelection = EmbeddedRunModelSwitchRequest;
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { areRuntimeModelRefsEquivalent } from "./model-runtime-aliases.js";
 export function resolveLiveSessionModelSelection(params: {
   cfg?: { session?: { store?: string } } | undefined;
   sessionKey?: string;
@@ -98,9 +99,10 @@ export function hasDifferentLiveSessionModelSelection(
   if (!next) {
     return false;
   }
+  const currentRef = `${current.provider}/${current.model}`;
+  const nextRef = `${next.provider}/${next.model}`;
   return (
-    current.provider !== next.provider ||
-    current.model !== next.model ||
+    !areRuntimeModelRefsEquivalent(currentRef, nextRef) ||
     normalizeOptionalString(current.authProfileId) !== next.authProfileId ||
     (normalizeOptionalString(current.authProfileId) ? current.authProfileIdSource : undefined) !==
       next.authProfileIdSource

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -15,7 +15,11 @@ import {
 export { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 export type LiveSessionModelSelection = EmbeddedRunModelSwitchRequest;
 import { normalizeOptionalString } from "../shared/string-coerce.js";
-import { areRuntimeModelRefsEquivalent } from "./model-runtime-aliases.js";
+import { normalizeProviderId } from "./provider-id.js";
+
+const OPENAI_PROVIDER_ID = "openai";
+const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+
 export function resolveLiveSessionModelSelection(params: {
   cfg?: { session?: { store?: string } } | undefined;
   sessionKey?: string;
@@ -87,6 +91,19 @@ export function consumeLiveSessionModelSwitch(
   return consumeEmbeddedRunModelSwitch(sessionId);
 }
 
+function isAlreadyAppliedOpenAICodexRuntimePromotion(
+  current: { provider: string; model: string },
+  next: LiveSessionModelSelection,
+): boolean {
+  // The embedded Codex runtime reports openai-codex after applying a canonical
+  // openai selection. Other runtime aliases remain real live-switch targets.
+  return (
+    normalizeProviderId(current.provider) === OPENAI_CODEX_PROVIDER_ID &&
+    normalizeProviderId(next.provider) === OPENAI_PROVIDER_ID &&
+    current.model === next.model
+  );
+}
+
 export function hasDifferentLiveSessionModelSelection(
   current: {
     provider: string;
@@ -99,10 +116,11 @@ export function hasDifferentLiveSessionModelSelection(
   if (!next) {
     return false;
   }
-  const currentRef = `${current.provider}/${current.model}`;
-  const nextRef = `${next.provider}/${next.model}`;
+  const modelSelectionDiffers =
+    (current.provider !== next.provider || current.model !== next.model) &&
+    !isAlreadyAppliedOpenAICodexRuntimePromotion(current, next);
   return (
-    !areRuntimeModelRefsEquivalent(currentRef, nextRef) ||
+    modelSelectionDiffers ||
     normalizeOptionalString(current.authProfileId) !== next.authProfileId ||
     (normalizeOptionalString(current.authProfileId) ? current.authProfileIdSource : undefined) !==
       next.authProfileIdSource


### PR DESCRIPTION
## Summary

- Fix the false live-session model switch when a running Codex app-server attempt reports `openai-codex/gpt-5.5` after applying a persisted canonical `openai/gpt-5.5` selection.
- Keep the comparison narrow and asymmetric: only the already-applied `openai` to `openai-codex` runtime promotion is suppressed.
- Preserve real live-switch behavior for explicit runtime provider changes with the same model, including `openai -> openai-codex` and `anthropic -> claude-cli`.

## Context

This targets the active-turn crash from #87226 without folding all runtime provider aliases into the live-switch comparator. The running embedded Codex runtime can legitimately report `openai-codex` after startup, while the resolved persisted selection remains `openai`; that state should not kill the turn as a user-requested switch.

Fixes #87226.

## Test plan

- [x] Active `openai-codex` with persisted `openai` and the same model is treated as already applied.
- [x] Reverse `openai -> openai-codex` still switches.
- [x] `anthropic -> claude-cli` with the same model still switches.
- [x] Model differences still trigger switch across the Codex runtime promotion.

## Real behavior proof

Behavior addressed: active Codex app-server attempts no longer treat the already-applied `openai` to `openai-codex` runtime promotion as a user-requested live model switch, while explicit runtime provider switches with the same model still differ.

Real environment tested: local OpenClaw source checkout on the rebased PR branch plus Blacksmith Testbox delegated runner for changed core lanes.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/live-model-switch.test.ts`; `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `pnpm check:changed` via Testbox `tbx_01ksmr59zdaqj3617w8w53xv4t` / Actions run `26512418770`.

Evidence after fix: focused Vitest reported `Test Files 2 passed (2)` and `Tests 46 passed (46)`; autoreview reported `autoreview clean: no accepted/actionable findings reported`; Testbox reported `exitCode: 0` for `pnpm check:changed`.

Observed result after fix: `current=openai-codex/gpt-5.5` with persisted `openai/gpt-5.5` returns no pending switch; reverse `openai -> openai-codex` and `anthropic -> claude-cli` same-model provider changes still return a switch.

What was not tested: no live gateway turn with real Codex credentials was run; this was verified through the exact live-switch decision path and remote changed gate.

Maintainer proof override: applied because the affected behavior is the deterministic live-switch decision path and the real-credential gateway turn was not run.
