### PR TITLE
fix(plugin-state): evict current namespace on plugin row cap

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -240,6 +240,16 @@ jobs:
           fetch-depth: 1
           persist-credentials: true
 
+      - name: Verify Docker runtime-assets prune path
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: |
+          set -euo pipefail
+          timeout --kill-after=30s 35m docker build \
+            --target runtime-assets \
+            --build-arg OPENCLAW_EXTENSIONS="diagnostics-otel,codex" \
+            .
+
       - name: Build and smoke test final Docker runtime image
         env:
           DOCKER_BUILDKIT: "1"

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -524,7 +524,7 @@ two-party event loops that do not go through the shared inbound reply runner.
     await store.clear();
     ```
 
-    Keyed stores survive restarts and are isolated by the runtime-bound plugin id. Use `registerIfAbsent(...)` for atomic dedupe claims: it returns `true` when the key was missing or expired and registered, or `false` when a live value already exists without overwriting its value, creation time, or TTL. Limits: `maxEntries` per namespace, 3,000 live rows per plugin, JSON values under 64KB, and optional TTL expiry. When a write would exceed the plugin row cap, the runtime may evict the oldest live rows from the namespace being written; sibling namespaces are not evicted for that write, and the write still fails if the namespace cannot free enough rows.
+    Keyed stores survive restarts and are isolated by the runtime-bound plugin id. Use `registerIfAbsent(...)` for atomic dedupe claims: it returns `true` when the key was missing or expired and registered, or `false` when a live value already exists without overwriting its value, creation time, or TTL. Limits: `maxEntries` per namespace, 6,000 live rows per plugin, JSON values under 64KB, and optional TTL expiry. When a write would exceed the plugin row cap, the runtime may evict the oldest live rows from the namespace being written; sibling namespaces are not evicted for that write, and the write still fails if the namespace cannot free enough rows.
 
     <Warning>
     Bundled plugins only in this release.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -524,7 +524,7 @@ two-party event loops that do not go through the shared inbound reply runner.
     await store.clear();
     ```
 
-    Keyed stores survive restarts and are isolated by the runtime-bound plugin id. Use `registerIfAbsent(...)` for atomic dedupe claims: it returns `true` when the key was missing or expired and registered, or `false` when a live value already exists without overwriting its value, creation time, or TTL. Limits: `maxEntries` per namespace, 1,000 live rows per plugin, JSON values under 64KB, and optional TTL expiry.
+    Keyed stores survive restarts and are isolated by the runtime-bound plugin id. Use `registerIfAbsent(...)` for atomic dedupe claims: it returns `true` when the key was missing or expired and registered, or `false` when a live value already exists without overwriting its value, creation time, or TTL. Limits: `maxEntries` per namespace, 3,000 live rows per plugin, JSON values under 64KB, and optional TTL expiry. When a write would exceed the plugin row cap, the runtime may evict the oldest live rows from the namespace being written; sibling namespaces are not evicted for that write, and the write still fails if the namespace cannot free enough rows.
 
     <Warning>
     Bundled plugins only in this release.

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -7,6 +7,7 @@ import {
   createTelegramMessageCache,
   resetTelegramMessageCacheBucketsForTest,
   resolveTelegramMessageCachePath,
+  TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
   type TelegramMessageCachePersistentStore,
 } from "./message-cache.js";
 
@@ -24,7 +25,7 @@ type PersistedCacheValue = {
 
 let persistentStoreId = 0;
 
-function createMemoryPersistentStore(maxEntries = 1000): {
+function createMemoryPersistentStore(maxEntries = TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES): {
   bucketKey: string;
   entries: Map<string, PersistedCacheValue>;
   store: TelegramMessageCachePersistentStore;

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -82,7 +82,7 @@ type TelegramCachedMessageObservation = {
 type TelegramEmbeddedReplyMessage = NonNullable<Message["reply_to_message"]>;
 
 const DEFAULT_MAX_MESSAGES = 5000;
-export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES = 1000;
+export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES = 3000;
 export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE = "telegram.message-cache";
 const PERSISTENT_BUCKET_KEY = `plugin-state:${TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE}`;
 const COMPACT_THRESHOLD_RATIO = 2;

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -711,6 +711,66 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("keeps plugin-state import source when plugin cap eviction drops an imported row", async () => {
+    const root = await makeTempRoot();
+    const sourcePath = path.join(root, "legacy-cache.json");
+    fs.writeFileSync(sourcePath, "legacy", "utf-8");
+    mockedChannelMigrationPlans.plans = [
+      {
+        kind: "plugin-state-import",
+        label: "Test capped cache",
+        sourcePath,
+        targetPath: "plugin state:test.capped-cache",
+        pluginId: "telegram",
+        namespace: "test.capped-cache",
+        maxEntries: 3000,
+        scopeKey: "scope",
+        cleanupSource: "rename",
+        readEntries: () => [
+          { key: "first", value: { body: "first" } },
+          { key: "second", value: { body: "second" } },
+        ],
+      },
+    ];
+
+    await withStateDir(root, async () => {
+      const siblingStore = createPluginStateKeyedStore<{ body: string }>("telegram", {
+        namespace: "test.sibling-cache",
+        maxEntries: 3000,
+      });
+      for (let index = 0; index < 2999; index++) {
+        await siblingStore.register(`sibling-${index}`, { body: "sibling" });
+      }
+    });
+    resetPluginStateStoreForTests();
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain("Migrated 2 Test capped cache entries → plugin state");
+    expect(result.changes).not.toContain(
+      `Archived Test capped cache legacy source → ${sourcePath}.migrated`,
+    );
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
+
+    await withStateDir(root, async () => {
+      const store = createPluginStateKeyedStore<{ body: string }>("telegram", {
+        namespace: "test.capped-cache",
+        maxEntries: 3000,
+      });
+      const valuesByKey = new Map(
+        (await store.entries()).map(({ key, value }) => [key, value.body]),
+      );
+      expect(valuesByKey.has("scope:first")).toBe(false);
+      expect(valuesByKey.get("scope:second")).toBe("second");
+    });
+  });
+
   it("routes legacy state to the default agent entry", async () => {
     const root = await makeTempRoot();
     const cfg: OpenClawConfig = {

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -753,7 +753,7 @@ describe("doctor legacy state migrations", () => {
     const result = await runLegacyStateMigrations({ detected });
 
     expect(result.warnings).toStrictEqual([
-      "Stopped migrating Test capped cache because plugin state cap evicted scope:first; left legacy source in place",
+      "Skipped migrating Test capped cache because plugin state has room for 1 of 2 missing entries; left legacy source in place",
     ]);
     expect(result.changes).not.toContain("Migrated 2 Test capped cache entries → plugin state");
     expect(result.changes).not.toContain(

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -7,6 +7,7 @@ import {
   createPluginStateKeyedStore,
   resetPluginStateStoreForTests,
 } from "../plugin-state/plugin-state-store.js";
+import { seedPluginStateEntriesForTests } from "../plugin-state/plugin-state-store.test-helpers.js";
 import {
   autoMigrateLegacyStateDir,
   autoMigrateLegacyState,
@@ -723,7 +724,7 @@ describe("doctor legacy state migrations", () => {
         targetPath: "plugin state:test.capped-cache",
         pluginId: "telegram",
         namespace: "test.capped-cache",
-        maxEntries: 3000,
+        maxEntries: 6_000,
         scopeKey: "scope",
         cleanupSource: "rename",
         readEntries: () => [
@@ -734,13 +735,14 @@ describe("doctor legacy state migrations", () => {
     ];
 
     await withStateDir(root, async () => {
-      const siblingStore = createPluginStateKeyedStore<{ body: string }>("telegram", {
-        namespace: "test.sibling-cache",
-        maxEntries: 3000,
-      });
-      for (let index = 0; index < 2999; index++) {
-        await siblingStore.register(`sibling-${index}`, { body: "sibling" });
-      }
+      seedPluginStateEntriesForTests(
+        Array.from({ length: 5_999 }, (_, index) => ({
+          pluginId: "telegram",
+          namespace: "test.sibling-cache",
+          key: `sibling-${index}`,
+          value: { body: "sibling" },
+        })),
+      );
     });
     resetPluginStateStoreForTests();
 
@@ -761,7 +763,7 @@ describe("doctor legacy state migrations", () => {
     await withStateDir(root, async () => {
       const store = createPluginStateKeyedStore<{ body: string }>("telegram", {
         namespace: "test.capped-cache",
-        maxEntries: 3000,
+        maxEntries: 6_000,
       });
       const valuesByKey = new Map(
         (await store.entries()).map(({ key, value }) => [key, value.body]),

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -752,8 +752,10 @@ describe("doctor legacy state migrations", () => {
     });
     const result = await runLegacyStateMigrations({ detected });
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toContain("Migrated 2 Test capped cache entries → plugin state");
+    expect(result.warnings).toStrictEqual([
+      "Stopped migrating Test capped cache because plugin state cap evicted scope:first; left legacy source in place",
+    ]);
+    expect(result.changes).not.toContain("Migrated 2 Test capped cache entries → plugin state");
     expect(result.changes).not.toContain(
       `Archived Test capped cache legacy source → ${sourcePath}.migrated`,
     );
@@ -769,7 +771,7 @@ describe("doctor legacy state migrations", () => {
         (await store.entries()).map(({ key, value }) => [key, value.body]),
       );
       expect(valuesByKey.has("scope:first")).toBe(false);
-      expect(valuesByKey.get("scope:second")).toBe("second");
+      expect(valuesByKey.has("scope:second")).toBe(false);
     });
   });
 

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -127,6 +127,15 @@ function resolvePluginStateImportTargetKey(scopeKey: string, key: string): strin
   return scopeKey ? `${scopeKey}:${key}` : key;
 }
 
+function findMissingKey(expected: Set<string>, actual: Set<string>): string | undefined {
+  for (const key of expected) {
+    if (!actual.has(key)) {
+      return key;
+    }
+  }
+  return undefined;
+}
+
 async function withPluginStateImportEnv<T>(
   plan: Extract<ChannelLegacyStateMigrationPlan, { kind: "plugin-state-import" }>,
   run: () => Promise<T>,
@@ -169,9 +178,11 @@ async function runLegacyMigrationPlans(
           return;
         }
         const existingKeys = new Set(storeEntries.map(({ key }) => key));
+        const expectedKeys = new Set(existingKeys);
         let remainingCapacity = Math.max(0, plan.maxEntries - storeEntries.length);
         const entries = await plan.readEntries();
         let imported = 0;
+        const importedKeys: string[] = [];
         for (const entry of entries) {
           const targetKey = resolvePluginStateImportTargetKey(plan.scopeKey, entry.key);
           if (existingKeys.has(targetKey)) {
@@ -182,7 +193,23 @@ async function runLegacyMigrationPlans(
           }
           try {
             await store.register(targetKey, entry.value);
+            const nextExpectedKeys = new Set(expectedKeys);
+            nextExpectedKeys.add(targetKey);
+            const liveKeys = new Set((await store.entries()).map(({ key }) => key));
+            const missingKey = findMissingKey(nextExpectedKeys, liveKeys);
+            if (missingKey) {
+              for (const importedKey of importedKeys.toReversed()) {
+                await store.delete(importedKey);
+              }
+              await store.delete(targetKey);
+              warnings.push(
+                `Stopped migrating ${plan.label} because plugin state cap evicted ${missingKey}; left legacy source in place`,
+              );
+              return;
+            }
+            expectedKeys.add(targetKey);
             existingKeys.add(targetKey);
+            importedKeys.push(targetKey);
             remainingCapacity--;
             imported++;
           } catch (err) {
@@ -196,14 +223,7 @@ async function runLegacyMigrationPlans(
         }
         let cleanupKeys = existingKeys;
         if (plan.cleanupSource === "rename") {
-          try {
-            cleanupKeys = new Set((await store.entries()).map(({ key }) => key));
-          } catch (err) {
-            warnings.push(
-              `Left migrated ${plan.label} source in place because plugin state could not be verified: ${String(err)}`,
-            );
-            return;
-          }
+          cleanupKeys = expectedKeys;
         }
         const allEntriesCovered =
           entries.length > 0 &&

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -19,7 +19,11 @@ import { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js
 import type { SessionScope } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { createPluginStateKeyedStore } from "../plugin-state/plugin-state-store.js";
+import {
+  countPluginStateLiveEntries,
+  createPluginStateKeyedStore,
+  MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN,
+} from "../plugin-state/plugin-state-store.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
@@ -164,13 +168,15 @@ async function runLegacyMigrationPlans(
   for (const plan of plans) {
     if (plan.kind === "plugin-state-import") {
       await withPluginStateImportEnv(plan, async () => {
-        let storeEntries: Array<{ key: string }> = [];
+        let storeEntries: Array<{ key: string; value: unknown }> = [];
+        let pluginEntryCount = 0;
         const store = createPluginStateKeyedStore<unknown>(plan.pluginId, {
           namespace: plan.namespace,
           maxEntries: plan.maxEntries,
         });
         try {
           storeEntries = await store.entries();
+          pluginEntryCount = countPluginStateLiveEntries(plan.pluginId);
         } catch (err) {
           warnings.push(
             `Failed reading ${plan.label} plugin state before migration: ${String(err)}`,
@@ -178,9 +184,23 @@ async function runLegacyMigrationPlans(
           return;
         }
         const existingKeys = new Set(storeEntries.map(({ key }) => key));
+        const existingValuesByKey = new Map(storeEntries.map(({ key, value }) => [key, value]));
         const expectedKeys = new Set(existingKeys);
         let remainingCapacity = Math.max(0, plan.maxEntries - storeEntries.length);
         const entries = await plan.readEntries();
+        const missingEntries = entries.filter(
+          ({ key }) => !existingKeys.has(resolvePluginStateImportTargetKey(plan.scopeKey, key)),
+        );
+        const pluginRemainingCapacity = Math.max(
+          0,
+          MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN - pluginEntryCount,
+        );
+        if (missingEntries.length > pluginRemainingCapacity) {
+          warnings.push(
+            `Skipped migrating ${plan.label} because plugin state has room for ${pluginRemainingCapacity} of ${missingEntries.length} missing entries; left legacy source in place`,
+          );
+          return;
+        }
         let imported = 0;
         const importedKeys: string[] = [];
         for (const entry of entries) {
@@ -202,6 +222,9 @@ async function runLegacyMigrationPlans(
                 await store.delete(importedKey);
               }
               await store.delete(targetKey);
+              if (existingValuesByKey.has(missingKey)) {
+                await store.register(missingKey, existingValuesByKey.get(missingKey));
+              }
               warnings.push(
                 `Stopped migrating ${plan.label} because plugin state cap evicted ${missingKey}; left legacy source in place`,
               );

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -194,10 +194,21 @@ async function runLegacyMigrationPlans(
             `Migrated ${imported} ${plan.label} ${imported === 1 ? "entry" : "entries"} → plugin state`,
           );
         }
+        let cleanupKeys = existingKeys;
+        if (plan.cleanupSource === "rename") {
+          try {
+            cleanupKeys = new Set((await store.entries()).map(({ key }) => key));
+          } catch (err) {
+            warnings.push(
+              `Left migrated ${plan.label} source in place because plugin state could not be verified: ${String(err)}`,
+            );
+            return;
+          }
+        }
         const allEntriesCovered =
           entries.length > 0 &&
           entries.every(({ key }) =>
-            existingKeys.has(resolvePluginStateImportTargetKey(plan.scopeKey, key)),
+            cleanupKeys.has(resolvePluginStateImportTargetKey(plan.scopeKey, key)),
           );
         if (allEntriesCovered && plan.cleanupSource === "rename" && fileExists(plan.sourcePath)) {
           const archivedPath = `${plan.sourcePath}.migrated`;

--- a/src/plugin-state/plugin-state-store.e2e.test.ts
+++ b/src/plugin-state/plugin-state-store.e2e.test.ts
@@ -196,10 +196,9 @@ describe("limits", () => {
 
   it("enforces the per-plugin live-row cap", async () => {
     await withOpenClawTestState({ label: "e2e-limit-plugin" }, async () => {
-      // Spread MAX_ENTRIES_PER_PLUGIN rows across several namespaces so
-      // namespace eviction never fires (each namespace has generous room).
+      // Fill the plugin budget outside the namespace that attempts the write.
       const nsCount = 10;
-      const perNs = MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN / nsCount; // 100
+      const perNs = MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN / nsCount;
       seedPluginStateEntriesForTests(
         Array.from({ length: MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN }, (_, index) => {
           const ns = Math.floor(index / perNs);
@@ -213,8 +212,8 @@ describe("limits", () => {
         }),
       );
       const store = createPluginStateKeyedStore("fixture-plugin", {
-        namespace: "ns-0",
-        maxEntries: perNs + 1,
+        namespace: "overflow-ns",
+        maxEntries: 10,
       });
 
       // One more row tips over the plugin-wide limit.

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -16,7 +16,8 @@ const PLUGIN_STATE_SCHEMA_VERSION = 1;
 const PLUGIN_STATE_DIR_MODE = 0o700;
 const PLUGIN_STATE_FILE_MODE = 0o600;
 const PLUGIN_STATE_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
-const MAX_ENTRIES_PER_PLUGIN = 3_000;
+// Plugin-wide fuse only; namespace maxEntries still owns normal cache eviction.
+const MAX_ENTRIES_PER_PLUGIN = 6_000;
 
 export const MAX_PLUGIN_STATE_VALUE_BYTES = 65_536;
 export const MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN = MAX_ENTRIES_PER_PLUGIN;

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -627,6 +627,20 @@ export function pluginStateEntries(params: {
   }
 }
 
+export function countPluginStateLiveEntries(pluginId: string): number {
+  try {
+    const { statements } = openPluginStateDatabase("entries");
+    return countRow(statements.countLivePlugin.get(pluginId, Date.now()) as CountRow | undefined);
+  } catch (error) {
+    throw wrapPluginStateError(
+      error,
+      "entries",
+      "PLUGIN_STATE_READ_FAILED",
+      "Failed to count plugin state entries.",
+    );
+  }
+}
+
 export function pluginStateClear(params: { pluginId: string; namespace: string }): void {
   try {
     const { statements } = openPluginStateDatabase("clear");

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -16,7 +16,7 @@ const PLUGIN_STATE_SCHEMA_VERSION = 1;
 const PLUGIN_STATE_DIR_MODE = 0o700;
 const PLUGIN_STATE_FILE_MODE = 0o600;
 const PLUGIN_STATE_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
-const MAX_ENTRIES_PER_PLUGIN = 1_000;
+const MAX_ENTRIES_PER_PLUGIN = 3_000;
 
 export const MAX_PLUGIN_STATE_VALUE_BYTES = 65_536;
 export const MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN = MAX_ENTRIES_PER_PLUGIN;
@@ -421,7 +421,24 @@ function enforcePostRegisterLimits(params: {
       | CountRow
       | undefined,
   );
-  if (pluginCount > MAX_ENTRIES_PER_PLUGIN) {
+  if (pluginCount <= MAX_ENTRIES_PER_PLUGIN) {
+    return;
+  }
+
+  // Shed rows from the namespace that grew before failing the plugin write.
+  params.store.statements.deleteOldestNamespace.run(
+    params.pluginId,
+    params.namespace,
+    params.protectedKey,
+    params.now,
+    pluginCount - MAX_ENTRIES_PER_PLUGIN,
+  );
+  const remainingPluginCount = countRow(
+    params.store.statements.countLivePlugin.get(params.pluginId, params.now) as
+      | CountRow
+      | undefined,
+  );
+  if (remainingPluginCount > MAX_ENTRIES_PER_PLUGIN) {
     throw createPluginStateError({
       code: "PLUGIN_STATE_LIMIT_EXCEEDED",
       operation: "register",

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -210,7 +210,7 @@ describe("plugin state keyed store", () => {
       expect((await evicting.entries()).map((entry) => entry.key)).toEqual(["b", "c"]);
 
       seedPluginStateEntriesForTests([
-        ...Array.from({ length: 2_999 }, (_, entryIndex) => ({
+        ...Array.from({ length: 5_999 }, (_, entryIndex) => ({
           pluginId: "limited-plugin",
           namespace: "limit",
           key: `k-${entryIndex}`,
@@ -225,7 +225,7 @@ describe("plugin state keyed store", () => {
       ]);
       const limited = createPluginStateKeyedStore("limited-plugin", {
         namespace: "limit",
-        maxEntries: 3_001,
+        maxEntries: 6_001,
       });
       const sibling = createPluginStateKeyedStore("limited-plugin", {
         namespace: "sibling",
@@ -342,7 +342,7 @@ describe("plugin state keyed store", () => {
   it("evicts current namespace rows when sibling namespaces consume plugin row budget", async () => {
     await withPluginStateTestState(async () => {
       seedPluginStateEntriesForTests([
-        ...Array.from({ length: 2_989 }, (_, entryIndex) => ({
+        ...Array.from({ length: 5_989 }, (_, entryIndex) => ({
           pluginId: "telegram",
           namespace: "telegram.message-cache",
           key: `k-${entryIndex}`,
@@ -358,7 +358,7 @@ describe("plugin state keyed store", () => {
 
       const messageStore = createPluginStateKeyedStore("telegram", {
         namespace: "telegram.message-cache",
-        maxEntries: 3_000,
+        maxEntries: 6_000,
       });
       const topicStore = createPluginStateKeyedStore("telegram", {
         namespace: "telegram.topic-name-cache",
@@ -378,15 +378,65 @@ describe("plugin state keyed store", () => {
         kind: "topic",
         entryIndex: 0,
       });
-      await expect(messageStore.entries()).resolves.toHaveLength(2_989);
+      await expect(messageStore.entries()).resolves.toHaveLength(5_989);
       await expect(topicStore.entries()).resolves.toHaveLength(11);
+    });
+  });
+
+  it("leaves room for Telegram sibling namespaces at their persistent budgets", async () => {
+    await withPluginStateTestState(async () => {
+      seedPluginStateEntriesForTests([
+        ...Array.from({ length: 3_000 }, (_, entryIndex) => ({
+          pluginId: "telegram",
+          namespace: "telegram.message-cache",
+          key: `message-${entryIndex}`,
+          value: { kind: "message", entryIndex },
+        })),
+        ...Array.from({ length: 2_047 }, (_, entryIndex) => ({
+          pluginId: "telegram",
+          namespace: "telegram.topic-name-cache",
+          key: `topic-${entryIndex}`,
+          value: { kind: "topic", updatedAt: entryIndex },
+        })),
+        ...Array.from({ length: 127 }, (_, entryIndex) => ({
+          pluginId: "telegram",
+          namespace: "telegram.bot-info-cache",
+          key: `bot-${entryIndex}`,
+          value: { kind: "bot-info", fetchedAt: String(entryIndex) },
+        })),
+      ]);
+
+      const topicStore = createPluginStateKeyedStore("telegram", {
+        namespace: "telegram.topic-name-cache",
+        maxEntries: 2_048,
+      });
+      const botInfoStore = createPluginStateKeyedStore("telegram", {
+        namespace: "telegram.bot-info-cache",
+        maxEntries: 128,
+      });
+
+      await expect(
+        topicStore.register("topic-final", { kind: "topic", updatedAt: 2_048 }),
+      ).resolves.toBeUndefined();
+      await expect(
+        botInfoStore.register("default", { kind: "bot-info", fetchedAt: "now" }),
+      ).resolves.toBeUndefined();
+
+      await expect(topicStore.lookup("topic-final")).resolves.toEqual({
+        kind: "topic",
+        updatedAt: 2_048,
+      });
+      await expect(botInfoStore.lookup("default")).resolves.toEqual({
+        kind: "bot-info",
+        fetchedAt: "now",
+      });
     });
   });
 
   it("rejects plugin overflow when the current namespace cannot shed old rows", async () => {
     await withPluginStateTestState(async () => {
       seedPluginStateEntriesForTests(
-        Array.from({ length: 3_000 }, (_, entryIndex) => ({
+        Array.from({ length: 6_000 }, (_, entryIndex) => ({
           pluginId: "telegram",
           namespace: "telegram.topic-name-cache",
           key: `topic-${entryIndex}`,
@@ -396,11 +446,11 @@ describe("plugin state keyed store", () => {
 
       const messageStore = createPluginStateKeyedStore("telegram", {
         namespace: "telegram.message-cache",
-        maxEntries: 3_000,
+        maxEntries: 6_000,
       });
       const topicStore = createPluginStateKeyedStore("telegram", {
         namespace: "telegram.topic-name-cache",
-        maxEntries: 3_000,
+        maxEntries: 6_000,
       });
 
       await expectPluginStateStoreError(messageStore.register("new-message", { fresh: true }), {

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -210,7 +210,7 @@ describe("plugin state keyed store", () => {
       expect((await evicting.entries()).map((entry) => entry.key)).toEqual(["b", "c"]);
 
       seedPluginStateEntriesForTests([
-        ...Array.from({ length: 999 }, (_, entryIndex) => ({
+        ...Array.from({ length: 2_999 }, (_, entryIndex) => ({
           pluginId: "limited-plugin",
           namespace: "limit",
           key: `k-${entryIndex}`,
@@ -225,12 +225,16 @@ describe("plugin state keyed store", () => {
       ]);
       const limited = createPluginStateKeyedStore("limited-plugin", {
         namespace: "limit",
-        maxEntries: 1_001,
+        maxEntries: 3_001,
       });
-      await expectPluginStateStoreError(limited.registerIfAbsent("overflow", { overflow: true }), {
-        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+      const sibling = createPluginStateKeyedStore("limited-plugin", {
+        namespace: "sibling",
+        maxEntries: 10,
       });
-      await expect(limited.lookup("overflow")).resolves.toBeUndefined();
+      await expect(limited.registerIfAbsent("overflow", { overflow: true })).resolves.toBe(true);
+      await expect(limited.lookup("k-0")).resolves.toBeUndefined();
+      await expect(limited.lookup("overflow")).resolves.toEqual({ overflow: true });
+      await expect(sibling.lookup("k-0")).resolves.toEqual({ sibling: true });
     });
   });
 
@@ -335,40 +339,75 @@ describe("plugin state keyed store", () => {
     });
   });
 
-  it("rejects when the per-plugin live row ceiling would be exceeded without evicting siblings", async () => {
+  it("evicts current namespace rows when sibling namespaces consume plugin row budget", async () => {
     await withPluginStateTestState(async () => {
       seedPluginStateEntriesForTests([
-        ...Array.from({ length: 999 }, (_, entryIndex) => ({
-          pluginId: "discord",
-          namespace: "limit",
+        ...Array.from({ length: 2_989 }, (_, entryIndex) => ({
+          pluginId: "telegram",
+          namespace: "telegram.message-cache",
           key: `k-${entryIndex}`,
-          value: { namespaceIndex: 0, entryIndex },
+          value: { kind: "message", entryIndex },
         })),
-        {
-          pluginId: "discord",
-          namespace: "sibling",
-          key: "k-0",
-          value: { namespaceIndex: 1, entryIndex: 0 },
-        },
+        ...Array.from({ length: 11 }, (_, entryIndex) => ({
+          pluginId: "telegram",
+          namespace: "telegram.topic-name-cache",
+          key: `topic-${entryIndex}`,
+          value: { kind: "topic", entryIndex },
+        })),
       ]);
 
-      const limitStore = createPluginStateKeyedStore("discord", {
-        namespace: "limit",
-        maxEntries: 1_001,
+      const messageStore = createPluginStateKeyedStore("telegram", {
+        namespace: "telegram.message-cache",
+        maxEntries: 3_000,
       });
-      const siblingStore = createPluginStateKeyedStore("discord", {
-        namespace: "sibling",
-        maxEntries: 10,
+      const topicStore = createPluginStateKeyedStore("telegram", {
+        namespace: "telegram.topic-name-cache",
+        maxEntries: 100,
       });
 
-      await expectPluginStateStoreError(limitStore.register("overflow", { overflow: true }), {
-        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+      await expect(
+        messageStore.register("new-message", { kind: "message", fresh: true }),
+      ).resolves.toBeUndefined();
+
+      await expect(messageStore.lookup("k-0")).resolves.toBeUndefined();
+      await expect(messageStore.lookup("new-message")).resolves.toEqual({
+        kind: "message",
+        fresh: true,
       });
-      await expect(siblingStore.lookup("k-0")).resolves.toEqual({
-        namespaceIndex: 1,
+      await expect(topicStore.lookup("topic-0")).resolves.toEqual({
+        kind: "topic",
         entryIndex: 0,
       });
-      await expect(limitStore.lookup("overflow")).resolves.toBeUndefined();
+      await expect(messageStore.entries()).resolves.toHaveLength(2_989);
+      await expect(topicStore.entries()).resolves.toHaveLength(11);
+    });
+  });
+
+  it("rejects plugin overflow when the current namespace cannot shed old rows", async () => {
+    await withPluginStateTestState(async () => {
+      seedPluginStateEntriesForTests(
+        Array.from({ length: 3_000 }, (_, entryIndex) => ({
+          pluginId: "telegram",
+          namespace: "telegram.topic-name-cache",
+          key: `topic-${entryIndex}`,
+          value: { entryIndex },
+        })),
+      );
+
+      const messageStore = createPluginStateKeyedStore("telegram", {
+        namespace: "telegram.message-cache",
+        maxEntries: 3_000,
+      });
+      const topicStore = createPluginStateKeyedStore("telegram", {
+        namespace: "telegram.topic-name-cache",
+        maxEntries: 3_000,
+      });
+
+      await expectPluginStateStoreError(messageStore.register("new-message", { fresh: true }), {
+        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+      });
+      await expect(messageStore.lookup("new-message")).resolves.toBeUndefined();
+      await expect(topicStore.lookup("topic-0")).resolves.toEqual({ entryIndex: 0 });
     });
   });
 

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -30,6 +30,8 @@ export type {
 export { PluginStateStoreError } from "./plugin-state-store.types.js";
 export {
   closePluginStateSqliteStore,
+  countPluginStateLiveEntries,
+  MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN,
   isPluginStateDatabaseOpen,
   probePluginStateStore,
   sweepExpiredPluginStateEntries,


### PR DESCRIPTION
## Summary

- Make plugin-state shed old rows only from the namespace that just grew before failing a plugin-wide row-limit write.
- Raise the plugin-wide live-row fuse to 6,000 and keep Telegram's persistent message-cache namespace at 3,000 entries so sibling namespaces have room.
- Keep sibling namespaces protected; if the current namespace cannot free enough old rows, the write still fails atomically.
- Preflight and verify legacy plugin-state imports so cap pressure cannot archive a recoverable source after dropping imported keys.
- Update SDK runtime docs and regression tests for the new cap, Telegram production shape, and import cleanup edge case.
- Restore the full release validation Docker runtime-assets preflight step expected by release workflow tests.

## Verification

- `node scripts/run-vitest.mjs src/commands/doctor-state-migrations.test.ts src/plugin-state/plugin-state-store.test.ts src/plugins/contracts/extension-runtime-dependencies.contract.test.ts --reporter=dot` -> 3 files passed, 423 tests.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts test/scripts/plugin-prerelease-test-plan.test.ts --reporter=dot` -> 2 files passed, 40 tests.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/plugin-state/plugin-state-store.e2e.test.ts -t "enforces the per-plugin live-row cap" --reporter=dot` -> 1 passed, 11 skipped.
- `pnpm run lint:plugins:no-monolithic-plugin-sdk-entry-imports` -> passed.
- `pnpm check:deprecated-api-usage` -> passed.
- `git diff --check` -> passed.
- `pnpm check:changed` -> Blacksmith Testbox `tbx_01ksn9rwqjbxv3z044eayw769v`, passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings.
- PR head `fee021cfa6626a0519c9d37ad5e1ec5e702c0333`: CI `26533459654`, build-artifacts `26533459423`, CodeQL `26533459425`, Workflow Sanity `26533459428`, OpenGrep `26533459424`, Blacksmith Testbox `26533459462` all passed.

## Real behavior proof

Behavior addressed: Telegram plugin state reached the old shared plugin budget with message-cache plus sibling namespaces, so a new Telegram cache write could throw `PluginStateStoreError` instead of evicting an old message-cache row.

Real environment tested: Local source checkout on PR head `fee021cfa6626a0519c9d37ad5e1ec5e702c0333`, actual plugin-state SQLite store paths exercised by the focused unit and e2e tests, plus GitHub Actions CI and Blacksmith Testbox on the pushed PR head.

Exact steps or command run after this patch: Filled plugin-state namespaces to cap boundaries in `src/plugin-state/plugin-state-store.test.ts` and `src/plugin-state/plugin-state-store.e2e.test.ts`, then registered new keys through the real keyed-store API; also ran the Telegram message-cache regression test with `TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES` at 3,000.

Evidence after fix: After-fix terminal output from a real plugin-state runtime probe on final head `fee021cfa6626a0519c9d37ad5e1ec5e702c0333`:

```text
NODE_VERSION=v26.0.0
PR_HEAD=fee021cfa6626a0519c9d37ad5e1ec5e702c0333
STATE_DIR=/var/folders/m_/4htdcqkn5cjdh0cs4psnxs5w0000gn/T/openclaw-pr87254-proof-2K74Pu/state
DB_PATH=/var/folders/m_/4htdcqkn5cjdh0cs4psnxs5w0000gn/T/openclaw-pr87254-proof-2K74Pu/state/plugin-state/state.sqlite
PLUGIN_CAP=6000
SEEDED_BEFORE message_cache=5989 topic_cache=11 total=6000
REGISTER_NEW result=success key=msg-new
AFTER message_cache=5989 topic_cache=11 total=6000
ASSERT oldest_message_evicted=true
ASSERT new_message_present=true
ASSERT topic_cache_preserved=true
ASSERT plugin_total_within_cap=true
```

Focused tests also prove the same eviction behavior plus the atomic failure path when the current namespace cannot free enough rows. CI run `26533459654` and Blacksmith build-artifacts run `26533459423` passed on the final PR head.

Observed result after fix: Current-namespace cache growth no longer fails merely because sibling plugin-state namespaces also use rows. Telegram can keep its 3,000-row message cache while sibling namespaces keep their rows under the 6,000-row plugin fuse.

What was not tested: A live Telegram gateway session on this final head; the after-fix behavior was verified with the runtime plugin-state API, SQLite store tests, focused Telegram message-cache tests, and CI/Testbox proof.
