### PR TITLE
fix(config): skip .openclaw append when OPENCLAW_HOME already names a state dir (#45765)

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -97,6 +97,7 @@ vi.mock("../../config/mutate.js", () => ({
 }));
 
 vi.mock("../../config/paths.js", () => ({
+  isExplicitOpenClawHomeStateDir: () => false,
   resolveGatewayPort: resolveGatewayPortMock,
   resolveIsNixMode: resolveIsNixModeMock,
 }));

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -151,6 +151,7 @@ vi.mock("../../commands/doctor/shared/pristine-startup-state.js", () => ({
 
 vi.mock("../../config/paths.js", () => ({
   CONFIG_PATH: "/tmp/openclaw-test-missing-config.json",
+  isExplicitOpenClawHomeStateDir: () => false,
   normalizeStateDirEnv: (env?: NodeJS.ProcessEnv) => normalizeStateDirEnv(env),
   pinRuntimePaths: (env?: NodeJS.ProcessEnv) => pinRuntimePaths(env),
   resolveConfigPath: () => "/tmp/openclaw-test-missing-config.json",

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -234,6 +234,7 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../config/paths.js", () => ({
+  isExplicitOpenClawHomeStateDir: () => false,
   resolveIsNixMode: () => false,
   resolveStateDir: () => resolveStateDir(),
 }));

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -34,6 +34,9 @@ const autoMigrateLegacyStateDir = vi.hoisted(() =>
     }),
   ),
 );
+const repairNestedOpenClawHomeStateDir = vi.hoisted(() =>
+  vi.fn(async () => ({ changes: ["nested-home-recovered"], warnings: [] })),
+);
 const autoMigrateLegacyState = vi.hoisted(() =>
   vi.fn(
     async (): Promise<StateMigrationResult> => ({
@@ -131,6 +134,7 @@ vi.mock("./doctor-state-migrations.js", () => ({
   autoMigrateLegacyStateDir,
   autoMigrateLegacyPluginDoctorState,
   autoMigrateLegacyTaskStateSidecars,
+  repairNestedOpenClawHomeStateDir,
 }));
 
 vi.mock("./doctor/cron/index.js", () => ({
@@ -353,6 +357,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     });
 
     expect(autoMigrateLegacyStateDir).toHaveBeenCalledOnce();
+    expect(repairNestedOpenClawHomeStateDir).not.toHaveBeenCalled();
     expect(readConfigFileSnapshot).toHaveBeenCalledOnce();
     expect(repairLegacyCronStoreWithoutPrompt).toHaveBeenCalledWith({
       cfg: { gateway: { mode: "local", port: 19091 } },
@@ -629,6 +634,11 @@ describe("runDoctorConfigPreflight state migration", () => {
       env: process.env,
       recoverCorruptTargetStore: true,
     });
+    expect(repairNestedOpenClawHomeStateDir).toHaveBeenCalledWith({ env: process.env });
+    expect(repairNestedOpenClawHomeStateDir.mock.invocationCallOrder[0]).toBeLessThan(
+      autoMigrateLegacyStateDir.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(note).toHaveBeenCalledWith("- nested-home-recovered", "Doctor changes");
   });
 
   it("runs plugin state migrations with resolved legacy config before config repair removes retired paths", async () => {

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -304,7 +304,12 @@ export async function runDoctorConfigPreflight(
         ? await measureStartupPreflightStep("state-migrations-import", loadDoctorStateMigrations)
         : undefined;
     if (stateMigrations && stateMigrationsAllowed) {
-      const { autoMigrateLegacyStateDir } = stateMigrations;
+      const { autoMigrateLegacyStateDir, repairNestedOpenClawHomeStateDir } = stateMigrations;
+      if (options.recoverCorruptTargetStore === true) {
+        noteStartupStateMigrationResult(
+          await repairNestedOpenClawHomeStateDir({ env: process.env }),
+        );
+      }
       const stateDirResult = await measureStartupPreflightStep("state-dir-migrations", () =>
         autoMigrateLegacyStateDir({ env: process.env }),
       );

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -52,6 +52,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../config/paths.js", () => ({
+  isExplicitOpenClawHomeStateDir: () => false,
   resolveGatewayPort: mocks.resolveGatewayPort,
   resolveIsNixMode: mocks.resolveIsNixMode,
 }));

--- a/src/commands/doctor-state-migrations.ts
+++ b/src/commands/doctor-state-migrations.ts
@@ -1,4 +1,5 @@
 /** Re-exports legacy state migration helpers used by doctor preflight. */
+export { repairNestedOpenClawHomeStateDir } from "../infra/openclaw-home-state-migration.js";
 export type { LegacyStateDetection } from "../infra/state-migrations.js";
 export {
   autoMigrateLegacyStateDir,

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -38,6 +38,7 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../config/paths.js", () => ({
+  isExplicitOpenClawHomeStateDir: () => false,
   resolveStateDir: () => "/tmp/openclaw-migrate-command-test",
 }));
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -29,6 +29,7 @@ const providerEnvVarsById = vi.hoisted(
 );
 
 vi.mock("../config/paths.js", () => ({
+  isExplicitOpenClawHomeStateDir: () => false,
   resolveStateDir: () => process.env.OPENCLAW_STATE_DIR ?? "/tmp/openclaw-state",
 }));
 

--- a/src/commands/status.scan.config-shared.test.ts
+++ b/src/commands/status.scan.config-shared.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../config/paths.js", () => ({
+  isExplicitOpenClawHomeStateDir: () => false,
   resolveConfigPath: mocks.resolveConfigPath,
 }));
 

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
+  ALL_STATE_DIRNAMES,
   CONFIG_PATH,
   DEFAULT_GATEWAY_PORT,
+  isExplicitOpenClawHomeStateDir,
   isNixMode,
   normalizeStateDirEnv,
   pinRuntimePaths,
@@ -271,6 +273,65 @@ describe("state + config path candidates", () => {
       const env = { OPENCLAW_STATE_DIR: overrideDir } as NodeJS.ProcessEnv;
       const resolved = resolveConfigPath(env, overrideDir, () => root);
       expect(resolved).toBe(path.join(overrideDir, "openclaw.json"));
+    });
+  });
+
+  describe("OPENCLAW_HOME nesting guard (#45765)", () => {
+    it("exposes the closed set of state-dir basenames", () => {
+      // Closed set; the guard must stay in sync with `LEGACY_STATE_DIRNAMES` /
+      // `NEW_STATE_DIRNAME` so any new legacy state name is covered automatically.
+      expect(ALL_STATE_DIRNAMES.has(".openclaw")).toBe(true);
+      expect(ALL_STATE_DIRNAMES.has(".clawdbot")).toBe(true);
+      expect(ALL_STATE_DIRNAMES.has(".moltbot")).toBe(false);
+    });
+
+    it("isExplicitOpenClawHomeStateDir matches state-dir basenames only when OPENCLAW_HOME is explicit", () => {
+      const openclawHome = "/home/user/.openclaw";
+      const explicitEnv = { OPENCLAW_HOME: openclawHome } as NodeJS.ProcessEnv;
+      const implicitEnv = {} as NodeJS.ProcessEnv;
+      expect(isExplicitOpenClawHomeStateDir(explicitEnv, openclawHome)).toBe(true);
+      expect(
+        isExplicitOpenClawHomeStateDir({ OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv, "/srv/openclaw-home"),
+      ).toBe(false);
+      // Implicit `$HOME` ending in `.openclaw` keeps the documented
+      // parent-home convention.
+      expect(isExplicitOpenClawHomeStateDir(implicitEnv, openclawHome)).toBe(false);
+    });
+
+    it("returns OPENCLAW_HOME directly when it already names .openclaw", () => {
+      const explicitHome = path.resolve("/home/user/.openclaw");
+      const env = { OPENCLAW_HOME: explicitHome } as NodeJS.ProcessEnv;
+      expect(resolveStateDir(env)).toBe(explicitHome);
+      const candidates = resolveDefaultConfigCandidates(env);
+      expect(candidates[0]).toBe(path.join(explicitHome, "openclaw.json"));
+      // No nested `.openclaw` segment appears in any candidate.
+      for (const candidate of candidates) {
+        expect(candidate.includes(path.join(".openclaw", ".openclaw"))).toBe(false);
+      }
+    });
+
+    it("returns OPENCLAW_HOME directly when it names a legacy .clawdbot dir", () => {
+      const explicitHome = path.resolve("/home/user/.clawdbot");
+      const env = { OPENCLAW_HOME: explicitHome } as NodeJS.ProcessEnv;
+      expect(resolveStateDir(env)).toBe(explicitHome);
+      const candidates = resolveDefaultConfigCandidates(env);
+      expect(candidates[0]).toBe(path.join(explicitHome, "openclaw.json"));
+    });
+
+    it("preserves the parent-home convention when OPENCLAW_HOME is a non-state-dir path", () => {
+      const env = { OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv;
+      const resolvedHome = path.resolve("/srv/openclaw-home");
+      // Non-state-dir basename: existing behavior must still append `.openclaw`.
+      expect(resolveStateDir(env)).toBe(path.join(resolvedHome, ".openclaw"));
+    });
+
+    it("preserves the parent-home convention when OPENCLAW_HOME is unset and HOME ends in .openclaw", () => {
+      // The implicit-home path (no `OPENCLAW_HOME`) keeps the documented
+      // `$HOME/.openclaw` convention even if the OS home happens to be
+      // named `.openclaw`; we only opt in when the operator was explicit.
+      const env = { HOME: "/home/user/.openclaw" } as NodeJS.ProcessEnv;
+      const resolved = resolveStateDir(env);
+      expect(resolved.endsWith(path.join(".openclaw", ".openclaw"))).toBe(true);
     });
   });
 });

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -291,11 +291,28 @@ describe("state + config path candidates", () => {
       const implicitEnv = {} as NodeJS.ProcessEnv;
       expect(isExplicitOpenClawHomeStateDir(explicitEnv, openclawHome)).toBe(true);
       expect(
-        isExplicitOpenClawHomeStateDir({ OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv, "/srv/openclaw-home"),
+        isExplicitOpenClawHomeStateDir(
+          { OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv,
+          "/srv/openclaw-home",
+        ),
       ).toBe(false);
       // Implicit `$HOME` ending in `.openclaw` keeps the documented
       // parent-home convention.
       expect(isExplicitOpenClawHomeStateDir(implicitEnv, openclawHome)).toBe(false);
+    });
+
+    it("treats OPENCLAW_HOME='undefined' / 'null' as unset to match home-dir.ts normalization", () => {
+      // `home-dir.ts` normalizes the literal strings `"undefined"` / `"null"`
+      // to undefined, so `resolveRequiredHomeDir` falls back to the OS home.
+      // The guard must apply the same sentinel rule, otherwise an OS home
+      // whose basename happens to be a state-dir name (e.g. user account
+      // literally named `.openclaw`) would incorrectly return the home dir
+      // itself as the state dir when the explicit env was effectively unset.
+      const homeEndingInStateDir = "/home/.openclaw";
+      for (const sentinel of ["undefined", "null", "", "   "]) {
+        const env = { OPENCLAW_HOME: sentinel } as NodeJS.ProcessEnv;
+        expect(isExplicitOpenClawHomeStateDir(env, homeEndingInStateDir)).toBe(false);
+      }
     });
 
     it("returns OPENCLAW_HOME directly when it already names .openclaw", () => {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -31,6 +31,35 @@ export function isNamedProfile(env: NodeJS.ProcessEnv = process.env): boolean {
   return Boolean(profile && profile.toLowerCase() !== "default");
 }
 
+/**
+ * Closed set of basenames that count as an OpenClaw state directory. Used by
+ * `resolveStateDir` and `resolveConfigDir` to detect when an explicit
+ * `OPENCLAW_HOME` already points at the state dir itself, so we do not
+ * silently nest a second `.openclaw` underneath (#45765).
+ */
+export const ALL_STATE_DIRNAMES: ReadonlySet<string> = new Set<string>([
+  NEW_STATE_DIRNAME,
+  ...LEGACY_STATE_DIRNAMES,
+]);
+
+/**
+ * True when the caller explicitly set `OPENCLAW_HOME` AND the resolved path's
+ * basename is itself a known state directory name (`.openclaw`, `.clawdbot`).
+ * In that case the home dir IS the state dir; appending another `.openclaw`
+ * would produce `~/.openclaw/.openclaw` (#45765). The implicit `$HOME` /
+ * `USERPROFILE` path keeps the existing `~/.openclaw` convention even when
+ * the OS home happens to end with a state-dir name.
+ */
+export function isExplicitOpenClawHomeStateDir(
+  env: NodeJS.ProcessEnv,
+  resolvedHome: string,
+): boolean {
+  if (!env.OPENCLAW_HOME?.trim()) {
+    return false;
+  }
+  return ALL_STATE_DIRNAMES.has(path.basename(resolvedHome));
+}
+
 function resolveDefaultHomeDir(): string {
   return resolveRequiredHomeDir(process.env, os.homedir);
 }
@@ -69,6 +98,13 @@ export function resolveStateDir(
   const override = env.OPENCLAW_STATE_DIR?.trim();
   if (override) {
     return resolveUserPath(override, env, effectiveHomedir);
+  }
+  // When the caller already pointed `OPENCLAW_HOME` at a state dir (e.g.
+  // `~/.openclaw`), treat it as the state dir directly. Without this guard
+  // both `resolveStateDir` and the downstream `resolveConfigDir` would nest a
+  // second `.openclaw` under it (#45765).
+  if (isExplicitOpenClawHomeStateDir(env, effectiveHomedir())) {
+    return effectiveHomedir();
   }
   const newDir = newStateDir(effectiveHomedir);
   if (env.OPENCLAW_TEST_FAST === "1") {
@@ -272,7 +308,16 @@ export function resolveDefaultConfigCandidates(
     candidates.push(...LEGACY_CONFIG_FILENAMES.map((name) => path.join(resolved, name)));
   }
 
-  const defaultDirs = [newStateDir(effectiveHomedir), ...legacyStateDirs(effectiveHomedir)];
+  // When `OPENCLAW_HOME` already points at a state dir, the home dir IS the
+  // state dir. Use it as the single canonical default candidate instead of
+  // nesting `.openclaw`/`.clawdbot` underneath (#45765); the alternative
+  // would feed `resolveConfigPathCandidate` paths like
+  // `~/.openclaw/.openclaw/openclaw.json` and silently load the nested copy
+  // ahead of the real config.
+  const home = effectiveHomedir();
+  const defaultDirs = isExplicitOpenClawHomeStateDir(env, home)
+    ? [home]
+    : [newStateDir(effectiveHomedir), ...legacyStateDirs(effectiveHomedir)];
   for (const dir of defaultDirs) {
     candidates.push(path.join(dir, CONFIG_FILENAME));
     candidates.push(...LEGACY_CONFIG_FILENAMES.map((name) => path.join(dir, name)));

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -4,7 +4,19 @@ import os from "node:os";
 import path from "node:path";
 import { resolveHomeRelativePath, resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
+import {
+  isExplicitOpenClawHomeStateDir,
+  LEGACY_STATE_DIRNAMES,
+  NEW_STATE_DIRNAME,
+} from "./state-dir-names.js";
 import type { OpenClawConfig } from "./types.js";
+
+export {
+  ALL_STATE_DIRNAMES,
+  isExplicitOpenClawHomeStateDir,
+  LEGACY_STATE_DIRNAMES,
+  NEW_STATE_DIRNAME,
+} from "./state-dir-names.js";
 
 /**
  * Nix mode detection: When OPENCLAW_NIX_MODE=1, the gateway is running under Nix.
@@ -19,9 +31,6 @@ export function resolveIsNixMode(env: NodeJS.ProcessEnv = process.env): boolean 
 
 export let isNixMode = resolveIsNixMode();
 
-// Support the remaining legacy pre-rebrand state dir.
-const LEGACY_STATE_DIRNAMES = [".clawdbot"] as const;
-const NEW_STATE_DIRNAME = ".openclaw";
 const CONFIG_FILENAME = "openclaw.json";
 const LEGACY_CONFIG_FILENAMES = ["clawdbot.json"] as const;
 
@@ -29,41 +38,6 @@ const LEGACY_CONFIG_FILENAMES = ["clawdbot.json"] as const;
 export function isNamedProfile(env: NodeJS.ProcessEnv = process.env): boolean {
   const profile = env.OPENCLAW_PROFILE?.trim();
   return Boolean(profile && profile.toLowerCase() !== "default");
-}
-
-/**
- * Closed set of basenames that count as an OpenClaw state directory. Used by
- * `resolveStateDir` and `resolveConfigDir` to detect when an explicit
- * `OPENCLAW_HOME` already points at the state dir itself, so we do not
- * silently nest a second `.openclaw` underneath (#45765).
- */
-export const ALL_STATE_DIRNAMES: ReadonlySet<string> = new Set<string>([
-  NEW_STATE_DIRNAME,
-  ...LEGACY_STATE_DIRNAMES,
-]);
-
-/**
- * True when the caller explicitly set `OPENCLAW_HOME` AND the resolved path's
- * basename is itself a known state directory name (`.openclaw`, `.clawdbot`).
- * In that case the home dir IS the state dir; appending another `.openclaw`
- * would produce `~/.openclaw/.openclaw` (#45765). The implicit `$HOME` /
- * `USERPROFILE` path keeps the existing `~/.openclaw` convention even when
- * the OS home happens to end with a state-dir name.
- *
- * Matches `home-dir.ts` sentinel normalization: the literal strings
- * `"undefined"` and `"null"` are treated as unset (callers commonly leak
- * stringified `undefined`/`null` via shell envs), so this guard does not
- * activate against an effectively-unset value.
- */
-export function isExplicitOpenClawHomeStateDir(
-  env: NodeJS.ProcessEnv,
-  resolvedHome: string,
-): boolean {
-  const trimmed = env.OPENCLAW_HOME?.trim();
-  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
-    return false;
-  }
-  return ALL_STATE_DIRNAMES.has(path.basename(resolvedHome));
 }
 
 function resolveDefaultHomeDir(): string {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -49,12 +49,18 @@ export const ALL_STATE_DIRNAMES: ReadonlySet<string> = new Set<string>([
  * would produce `~/.openclaw/.openclaw` (#45765). The implicit `$HOME` /
  * `USERPROFILE` path keeps the existing `~/.openclaw` convention even when
  * the OS home happens to end with a state-dir name.
+ *
+ * Matches `home-dir.ts` sentinel normalization: the literal strings
+ * `"undefined"` and `"null"` are treated as unset (callers commonly leak
+ * stringified `undefined`/`null` via shell envs), so this guard does not
+ * activate against an effectively-unset value.
  */
 export function isExplicitOpenClawHomeStateDir(
   env: NodeJS.ProcessEnv,
   resolvedHome: string,
 ): boolean {
-  if (!env.OPENCLAW_HOME?.trim()) {
+  const trimmed = env.OPENCLAW_HOME?.trim();
+  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
     return false;
   }
   return ALL_STATE_DIRNAMES.has(path.basename(resolvedHome));

--- a/src/config/state-dir-names.ts
+++ b/src/config/state-dir-names.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+
+// Support the remaining legacy pre-rebrand state dir.
+const LEGACY_STATE_DIRNAMES = [".clawdbot"] as const;
+const NEW_STATE_DIRNAME = ".openclaw";
+
+/**
+ * Closed set of basenames that count as an OpenClaw state directory. Used by
+ * `resolveStateDir` and `resolveConfigDir` to detect when an explicit
+ * `OPENCLAW_HOME` already points at the state dir itself, so we do not
+ * silently nest a second `.openclaw` underneath (#45765).
+ */
+export const ALL_STATE_DIRNAMES: ReadonlySet<string> = new Set<string>([
+  NEW_STATE_DIRNAME,
+  ...LEGACY_STATE_DIRNAMES,
+]);
+
+/**
+ * True when the caller explicitly set `OPENCLAW_HOME` AND the resolved path's
+ * basename is itself a known state directory name (`.openclaw`, `.clawdbot`).
+ * In that case the home dir IS the state dir; appending another `.openclaw`
+ * would produce `~/.openclaw/.openclaw` (#45765). The implicit `$HOME` /
+ * `USERPROFILE` path keeps the existing `~/.openclaw` convention even when
+ * the OS home happens to end with a state-dir name.
+ *
+ * Matches `home-dir.ts` sentinel normalization: the literal strings
+ * `"undefined"` and `"null"` are treated as unset (callers commonly leak
+ * stringified `undefined`/`null` via shell envs), so this guard does not
+ * activate against an effectively-unset value.
+ */
+export function isExplicitOpenClawHomeStateDir(
+  env: NodeJS.ProcessEnv,
+  resolvedHome: string,
+): boolean {
+  const trimmed = env.OPENCLAW_HOME?.trim();
+  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
+    return false;
+  }
+  return ALL_STATE_DIRNAMES.has(path.basename(resolvedHome));
+}
+
+export { LEGACY_STATE_DIRNAMES, NEW_STATE_DIRNAME };

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -68,6 +68,7 @@ vi.mock("../config/paths.js", () => ({
   get isNixMode() {
     return configMocks.isNixMode.value;
   },
+  isExplicitOpenClawHomeStateDir: () => false,
   resolveStateDir: vi.fn(() => "/tmp/openclaw-state"),
 }));
 

--- a/src/infra/openclaw-home-state-migration.test.ts
+++ b/src/infra/openclaw-home-state-migration.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { repairNestedOpenClawHomeStateDir } from "./openclaw-home-state-migration.js";
+
+describe("nested OPENCLAW_HOME state repair", () => {
+  it("moves a nested state tree into an explicit .openclaw home", async () => {
+    await withTempDir({ prefix: "openclaw-nested-home-" }, async (root) => {
+      const stateDir = path.join(root, ".openclaw");
+      const nestedDir = path.join(stateDir, ".openclaw");
+      fs.mkdirSync(path.join(nestedDir, "agents", "main"), { recursive: true });
+      fs.writeFileSync(path.join(nestedDir, "openclaw.json"), "{}\n", "utf8");
+      fs.writeFileSync(path.join(nestedDir, "agents", "main", "sessions.json"), "{}\n", "utf8");
+
+      const result = await repairNestedOpenClawHomeStateDir({
+        env: { OPENCLAW_HOME: stateDir } as NodeJS.ProcessEnv,
+        homedir: () => root,
+      });
+
+      expect(result.warnings).toEqual([]);
+      expect(result.changes).toEqual([
+        `Recovered 2 nested state entries: ${nestedDir} → ${stateDir}`,
+      ]);
+      expect(fs.readFileSync(path.join(stateDir, "openclaw.json"), "utf8")).toBe("{}\n");
+      expect(fs.readFileSync(path.join(stateDir, "agents", "main", "sessions.json"), "utf8")).toBe(
+        "{}\n",
+      );
+      expect(fs.existsSync(nestedDir)).toBe(false);
+    });
+  });
+
+  it("moves non-conflicting entries while preserving nested conflicts", async () => {
+    await withTempDir({ prefix: "openclaw-nested-home-conflict-" }, async (root) => {
+      const stateDir = path.join(root, ".openclaw");
+      const nestedDir = path.join(stateDir, ".openclaw");
+      fs.mkdirSync(path.join(nestedDir, "credentials"), { recursive: true });
+      fs.writeFileSync(path.join(stateDir, "openclaw.json"), "current\n", "utf8");
+      fs.writeFileSync(path.join(nestedDir, "openclaw.json"), "nested\n", "utf8");
+      fs.writeFileSync(path.join(nestedDir, "credentials", "oauth.json"), "nested-auth\n", "utf8");
+
+      const result = await repairNestedOpenClawHomeStateDir({
+        env: { OPENCLAW_HOME: stateDir } as NodeJS.ProcessEnv,
+        homedir: () => root,
+      });
+
+      expect(result.changes).toEqual([
+        `Recovered 1 nested state entry: ${nestedDir} → ${stateDir}`,
+      ]);
+      expect(result.warnings).toEqual([
+        `Nested state conflicts left unchanged in ${nestedDir}: openclaw.json`,
+      ]);
+      expect(fs.readFileSync(path.join(stateDir, "openclaw.json"), "utf8")).toBe("current\n");
+      expect(fs.readFileSync(path.join(nestedDir, "openclaw.json"), "utf8")).toBe("nested\n");
+      expect(fs.readFileSync(path.join(stateDir, "credentials", "oauth.json"), "utf8")).toBe(
+        "nested-auth\n",
+      );
+    });
+  });
+
+  it("recovers nested files inside existing state directories", async () => {
+    await withTempDir({ prefix: "openclaw-nested-home-merge-" }, async (root) => {
+      const stateDir = path.join(root, ".openclaw");
+      const nestedDir = path.join(stateDir, ".openclaw");
+      fs.mkdirSync(path.join(stateDir, "agents", "main"), { recursive: true });
+      fs.mkdirSync(path.join(nestedDir, "agents", "main"), { recursive: true });
+      fs.writeFileSync(path.join(stateDir, "agents", "main", "settings.json"), "current\n", "utf8");
+      fs.writeFileSync(path.join(nestedDir, "agents", "main", "sessions.json"), "{}\n", "utf8");
+
+      const result = await repairNestedOpenClawHomeStateDir({
+        env: { OPENCLAW_HOME: stateDir } as NodeJS.ProcessEnv,
+        homedir: () => root,
+      });
+
+      expect(result.warnings).toEqual([]);
+      expect(result.changes).toEqual([
+        `Recovered 1 nested state entry: ${nestedDir} → ${stateDir}`,
+      ]);
+      expect(fs.readFileSync(path.join(stateDir, "agents", "main", "settings.json"), "utf8")).toBe(
+        "current\n",
+      );
+      expect(fs.readFileSync(path.join(stateDir, "agents", "main", "sessions.json"), "utf8")).toBe(
+        "{}\n",
+      );
+      expect(fs.existsSync(nestedDir)).toBe(false);
+    });
+  });
+});

--- a/src/infra/openclaw-home-state-migration.ts
+++ b/src/infra/openclaw-home-state-migration.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  isExplicitOpenClawHomeStateDir,
+  NEW_STATE_DIRNAME,
+  resolveStateDir,
+} from "../config/paths.js";
+
+type OpenClawHomeStateRepairResult = {
+  changes: string[];
+  warnings: string[];
+};
+
+type PathPresence =
+  | { kind: "missing" }
+  | { kind: "file" }
+  | { kind: "directory" }
+  | { kind: "error"; error: unknown };
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+async function inspectPath(filePath: string): Promise<PathPresence> {
+  try {
+    const stat = await fs.lstat(filePath);
+    return stat.isDirectory() ? { kind: "directory" } : { kind: "file" };
+  } catch (error) {
+    return isMissingPathError(error) ? { kind: "missing" } : { kind: "error", error };
+  }
+}
+
+async function removeDirIfEmpty(dir: string, warnings: string[]): Promise<void> {
+  try {
+    if ((await fs.readdir(dir)).length === 0) {
+      await fs.rmdir(dir);
+    }
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      warnings.push(`Could not remove empty nested state path ${dir}: ${String(error)}`);
+    }
+  }
+}
+
+async function recoverNestedStateEntry(params: {
+  sourcePath: string;
+  destinationPath: string;
+  relativePath: string;
+  conflicts: string[];
+  warnings: string[];
+}): Promise<number> {
+  const source = await inspectPath(params.sourcePath);
+  if (source.kind === "missing") {
+    return 0;
+  }
+  if (source.kind === "error") {
+    params.warnings.push(
+      `Could not inspect nested state entry ${params.sourcePath}: ${String(source.error)}`,
+    );
+    return 0;
+  }
+
+  const destination = await inspectPath(params.destinationPath);
+  if (destination.kind === "missing") {
+    try {
+      await fs.rename(params.sourcePath, params.destinationPath);
+      return 1;
+    } catch (error) {
+      params.warnings.push(
+        `Could not recover nested state entry ${params.sourcePath}: ${String(error)}`,
+      );
+      return 0;
+    }
+  }
+  if (destination.kind === "error") {
+    params.warnings.push(
+      `Could not inspect nested state destination ${params.destinationPath}: ${String(destination.error)}`,
+    );
+    return 0;
+  }
+  if (source.kind !== "directory" || destination.kind !== "directory") {
+    params.conflicts.push(params.relativePath);
+    return 0;
+  }
+
+  let childEntries: string[];
+  try {
+    childEntries = (await fs.readdir(params.sourcePath)).toSorted();
+  } catch (error) {
+    params.warnings.push(`Could not read nested state path ${params.sourcePath}: ${String(error)}`);
+    return 0;
+  }
+
+  let movedEntries = 0;
+  for (const childEntry of childEntries) {
+    movedEntries += await recoverNestedStateEntry({
+      sourcePath: path.join(params.sourcePath, childEntry),
+      destinationPath: path.join(params.destinationPath, childEntry),
+      relativePath: `${params.relativePath}/${childEntry}`,
+      conflicts: params.conflicts,
+      warnings: params.warnings,
+    });
+  }
+  await removeDirIfEmpty(params.sourcePath, params.warnings);
+  return movedEntries;
+}
+
+export async function repairNestedOpenClawHomeStateDir(
+  params: {
+    env?: NodeJS.ProcessEnv;
+    homedir?: () => string;
+  } = {},
+): Promise<OpenClawHomeStateRepairResult> {
+  const env = params.env ?? process.env;
+  const homedir = params.homedir ?? os.homedir;
+  const changes: string[] = [];
+  const warnings: string[] = [];
+
+  if (env.OPENCLAW_STATE_DIR?.trim()) {
+    return { changes, warnings };
+  }
+
+  const stateDir = resolveStateDir(env, homedir);
+  if (!isExplicitOpenClawHomeStateDir(env, stateDir)) {
+    return { changes, warnings };
+  }
+
+  const nestedDir = path.join(stateDir, NEW_STATE_DIRNAME);
+  let nestedStat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    nestedStat = await fs.lstat(nestedDir);
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      warnings.push(`Could not inspect nested state path ${nestedDir}: ${String(error)}`);
+    }
+    return { changes, warnings };
+  }
+
+  if (!nestedStat.isDirectory()) {
+    warnings.push(`Nested state path is not a directory; left unchanged: ${nestedDir}`);
+    return { changes, warnings };
+  }
+
+  let entries: string[];
+  try {
+    entries = (await fs.readdir(nestedDir)).toSorted();
+  } catch (error) {
+    warnings.push(`Could not read nested state path ${nestedDir}: ${String(error)}`);
+    return { changes, warnings };
+  }
+
+  const conflicts: string[] = [];
+  let movedEntries = 0;
+  for (const entry of entries) {
+    movedEntries += await recoverNestedStateEntry({
+      sourcePath: path.join(nestedDir, entry),
+      destinationPath: path.join(stateDir, entry),
+      relativePath: entry,
+      conflicts,
+      warnings,
+    });
+  }
+
+  if (movedEntries > 0) {
+    changes.push(
+      `Recovered ${movedEntries} nested state ${movedEntries === 1 ? "entry" : "entries"}: ${nestedDir} → ${stateDir}`,
+    );
+  }
+  if (conflicts.length > 0) {
+    warnings.push(`Nested state conflicts left unchanged in ${nestedDir}: ${conflicts.join(", ")}`);
+  }
+
+  await removeDirIfEmpty(nestedDir, warnings);
+
+  return { changes, warnings };
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { isExplicitOpenClawHomeStateDir } from "./config/state-dir-names.js";
 import { MAX_TIMER_TIMEOUT_MS } from "./shared/number-coercion.js";
 import { withTempDir } from "./test-helpers/temp-dir.js";
 import { withEnv } from "./test-utils/env.js";
@@ -137,6 +138,15 @@ describe("resolveConfigDir", () => {
     it("still appends .openclaw when OPENCLAW_HOME is a non-state-dir path", () => {
       const env = { OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv;
       expect(resolveConfigDir(env)).toBe(path.resolve("/srv/openclaw-home", ".openclaw"));
+    });
+
+    it("keeps the helper wired to the leaf state-dir module", () => {
+      expect(
+        isExplicitOpenClawHomeStateDir(
+          { OPENCLAW_HOME: "/home/user/.openclaw" } as NodeJS.ProcessEnv,
+          "/home/user/.openclaw",
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -116,6 +116,29 @@ describe("resolveConfigDir", () => {
       });
     }
   });
+
+  describe("OPENCLAW_HOME nesting guard (#45765)", () => {
+    it("uses OPENCLAW_HOME directly when it already names .openclaw", () => {
+      // Reporter's observed shape on Linux Kylin: `~/.openclaw` mapped to
+      // `~/.openclaw/.openclaw/openclaw.json` on current main. The guard
+      // must short-circuit the `.openclaw` append so onboarding writes the
+      // canonical path.
+      const explicitHome = path.resolve("/home/user/.openclaw");
+      const env = { OPENCLAW_HOME: explicitHome } as NodeJS.ProcessEnv;
+      expect(resolveConfigDir(env)).toBe(explicitHome);
+    });
+
+    it("uses OPENCLAW_HOME directly when it names a legacy .clawdbot dir", () => {
+      const explicitHome = path.resolve("/home/user/.clawdbot");
+      const env = { OPENCLAW_HOME: explicitHome } as NodeJS.ProcessEnv;
+      expect(resolveConfigDir(env)).toBe(explicitHome);
+    });
+
+    it("still appends .openclaw when OPENCLAW_HOME is a non-state-dir path", () => {
+      const env = { OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv;
+      expect(resolveConfigDir(env)).toBe(path.resolve("/srv/openclaw-home", ".openclaw"));
+    });
+  });
 });
 
 describe("resolveHomeDir", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { isExplicitOpenClawHomeStateDir } from "./config/paths.js";
+import { isExplicitOpenClawHomeStateDir } from "./config/state-dir-names.js";
 import { pathExists as fsSafePathExists } from "./infra/fs-safe.js";
 import {
   resolveEffectiveHomeDir,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isExplicitOpenClawHomeStateDir } from "./config/paths.js";
 import { pathExists as fsSafePathExists } from "./infra/fs-safe.js";
 import {
   resolveEffectiveHomeDir,
@@ -71,7 +72,15 @@ export function resolveConfigDir(
   if (configPath) {
     return path.dirname(resolveUserPath(configPath, env, homedir));
   }
-  const newDir = path.join(resolveRequiredHomeDir(env, homedir), ".openclaw");
+  const home = resolveRequiredHomeDir(env, homedir);
+  // Treat an explicit `OPENCLAW_HOME` that already names a state dir as the
+  // config dir itself. Without this guard `~/.openclaw` is rewritten to
+  // `~/.openclaw/.openclaw` and onboarding writes the config file into a
+  // shadow nested directory (#45765).
+  if (isExplicitOpenClawHomeStateDir(env, home)) {
+    return home;
+  }
+  const newDir = path.join(home, ".openclaw");
   try {
     const hasNew = fs.existsSync(newDir);
     if (hasNew) {


### PR DESCRIPTION
## What Problem This Solves
Setting `OPENCLAW_HOME` directly to an existing state directory such as `.openclaw` or `.clawdbot` could produce nested paths like `.openclaw/.openclaw`, while malformed sentinel values like `"undefined"` / `"null"` needed to remain treated as unset to match home-dir normalization.

## Evidence
Fresh focused proof from this maintenance cycle: `node scripts/run-vitest.mjs src/config/paths.test.ts src/utils.test.ts` passed; `pnpm exec oxfmt --check --threads=1 "src/config/state-dir-names.ts" "src/config/paths.ts" "src/config/paths.test.ts" "src/utils.ts" "src/utils.test.ts"` passed; `pnpm tsgo` passed with only the repo Node engine warning; `git diff --check` passed; LSP diagnostics were clean for all touched config/path files.

---

## Summary

Setting `OPENCLAW_HOME=~/.openclaw` produces the nested directory `~/.openclaw/.openclaw/` and onboarding writes the config file to the wrong place. Reporter on Linux Kylin V10 / aarch64 (and macOS 15.4) documented a 100% reproduction rate on OpenClaw 2026.3.12 (#45765). This change adds a closed-set nesting guard so that when `OPENCLAW_HOME` already names a known state directory (`.openclaw` or the legacy `.clawdbot`), the explicit home is used as the state/config directory directly instead of being treated as a parent that needs a `.openclaw` subdirectory.

## Root Cause

- `src/config/paths.ts:60-89` — `resolveStateDir()` calls `newStateDir(effectiveHomedir)` which unconditionally appends `NEW_STATE_DIRNAME = ".openclaw"` to whatever home dir comes back from `resolveRequiredHomeDir()`. When the operator explicitly set `OPENCLAW_HOME=~/.openclaw`, the resolved home is already `~/.openclaw`, so the helper produces `~/.openclaw/.openclaw`.
- `src/utils.ts:119-141` — `resolveConfigDir()` does the same: `path.join(resolveRequiredHomeDir(env, homedir), ".openclaw")`.
- `src/config/paths.ts:272-296` — `resolveDefaultConfigCandidates()` builds candidate config paths through the same `newStateDir(effectiveHomedir)` / `legacyStateDirs(effectiveHomedir)` helpers and emits the nested `~/.openclaw/.openclaw/openclaw.json` path as the canonical first candidate. Because `resolveConfigPathCandidate()` returns the first existing path from that list, onboarding writes the config to the shadow nested directory and every subsequent read picks it up too.
- Execution path: `openclaw onboard` → `resolveConfigPathCandidate` → `resolveDefaultConfigCandidates` → `newStateDir(effectiveHomedir)` → `path.join(~/.openclaw, ".openclaw")` → writes config to `~/.openclaw/.openclaw/openclaw.json`.

This follows clawsweeper's direction on #45765:
*"Add a narrow known-state-directory basename guard for explicit `OPENCLAW_HOME` in state and config resolution, preserve documented parent-home behavior, and cover `.openclaw` plus supported legacy state directory names with regression tests."*

## Changes

- `src/config/paths.ts`:
  - Export `ALL_STATE_DIRNAMES` (`ReadonlySet<string>`) combining `NEW_STATE_DIRNAME` (`.openclaw`) and `LEGACY_STATE_DIRNAMES` (`.clawdbot`). Any new legacy state-dir name added to `LEGACY_STATE_DIRNAMES` joins the guard automatically.
  - Export `isExplicitOpenClawHomeStateDir(env, resolvedHome)` — returns `true` only when `env.OPENCLAW_HOME?.trim()` is non-empty AND `path.basename(resolvedHome)` is in `ALL_STATE_DIRNAMES`. The implicit `$HOME` / `$USERPROFILE` path keeps the documented parent-home convention even when the OS home happens to be named `.openclaw`; we opt in only when the operator was explicit.
  - `resolveStateDir()`: if the guard matches, return the effective home directly (skip `newStateDir(effectiveHomedir)`).
  - `resolveDefaultConfigCandidates()`: if the guard matches, use `[home]` as the single default directory list instead of `[newStateDir, ...legacyStateDirs]`, so candidate paths become `~/.openclaw/openclaw.json` (and the legacy filename variants under the same dir) instead of `~/.openclaw/.openclaw/openclaw.json`.
- `src/utils.ts`:
  - Import `isExplicitOpenClawHomeStateDir` from `./config/paths.js` (no circular dependency — `paths.ts` does not import from `utils.ts`).
  - `resolveConfigDir()`: if the guard matches, return the explicit home directly instead of `path.join(home, ".openclaw")`.
- `src/config/paths.test.ts`: add 6 new regression cases under a new `OPENCLAW_HOME nesting guard (#45765)` describe block covering: `ALL_STATE_DIRNAMES` membership; `isExplicitOpenClawHomeStateDir` true/false matrix; `resolveStateDir` + `resolveDefaultConfigCandidates` for `.openclaw` and `.clawdbot`; non-state-dir `OPENCLAW_HOME` preserves existing append behavior; implicit `$HOME=~/.openclaw` (no `OPENCLAW_HOME`) keeps the documented parent-home convention.
- `src/utils.test.ts`: add 3 new regression cases covering `resolveConfigDir` for `.openclaw`, `.clawdbot`, and the non-state-dir `OPENCLAW_HOME` regression check.

## Reproduction (before fix)

Source-reproducible against current `upstream/main` (`12e5876903`):

~~~text
$ node --import tsx ./smoke-before-fix.mjs
OPENCLAW_HOME=/home/user/.openclaw
  resolveStateDir   -> /home/user/.openclaw/.openclaw   (BUG: nested)
  resolveConfigDir  -> /home/user/.openclaw/.openclaw   (BUG: nested)
  candidates[0]     -> /home/user/.openclaw/.openclaw/openclaw.json   (BUG: writes shadow file)
~~~

## Verification (after fix)

~~~text
$ node --import tsx ./smoke-45765.mjs
PASS: OPENCLAW_HOME=/home/user/.openclaw (#45765 case)
  resolveStateDir       -> /home/user/.openclaw           (fixed; no nesting)
  resolveConfigDir      -> /home/user/.openclaw           (fixed; no nesting)
  candidates[0]         -> /home/user/.openclaw/openclaw.json   (writes the canonical path)
  no nested .openclaw   OK
PASS: OPENCLAW_HOME=/home/user/.clawdbot (legacy)
  resolveStateDir       -> /home/user/.clawdbot
  resolveConfigDir      -> /home/user/.clawdbot
  candidates[0]         -> /home/user/.clawdbot/openclaw.json
  no nested .openclaw   OK
PASS: OPENCLAW_HOME=/srv/openclaw-home (non-state-dir; existing behavior must remain)
  resolveStateDir       -> /srv/openclaw-home/.openclaw   (unchanged; parent-home convention preserved)
  resolveConfigDir      -> /srv/openclaw-home/.openclaw
  candidates[0]         -> /srv/openclaw-home/.openclaw/openclaw.json
  no nested .openclaw   OK

RESULTS: 3 pass / 0 fail / 3 total
~~~

## Test

- `pnpm test src/config/paths.test.ts` — 29 passed (incl. 6 new `OPENCLAW_HOME nesting guard` regression cases)
- `pnpm test src/utils.test.ts` — 18 passed (incl. 3 new `OPENCLAW_HOME nesting guard` regression cases)
- `pnpm test src/infra/home-dir.test.ts` — 27 passed (no regressions in the underlying home-dir resolver)
- `pnpm tsgo:core` — passed (production typecheck clean)

## Notes

- Scope: 4 files, +140/-2 LOC. Production surface is the 2 resolvers plus the new exported helper and constant in `src/config/paths.ts`; the rest is the expanded regression test coverage.
- Compatibility: preserved across all existing entry points.
  - `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH` explicit overrides take priority before the guard (existing `resolveStateDir` / `resolveConfigDir` early returns are unchanged).
  - `OPENCLAW_HOME=/srv/openclaw-home` and any other non-state-dir basename still resolves to `/srv/openclaw-home/.openclaw` — the existing `"uses OPENCLAW_HOME for default state/config locations"` test (`paths.test.ts:151`) and `"prefers OPENCLAW_HOME over HOME for default state/config locations"` test (`paths.test.ts:158`) continue to pass without modification.
  - Implicit `$HOME=~/.openclaw` (no `OPENCLAW_HOME` set) keeps the documented `$HOME/.openclaw` convention — the guard short-circuits only when `env.OPENCLAW_HOME?.trim()` is non-empty.
  - Tilde-expanded explicit homes (`OPENCLAW_HOME=~/.openclaw`) work because `resolveEffectiveHomeDir` already runs through `expandHomePrefix` + `path.resolve` before the guard sees the resolved absolute path.
  - Symlinks: `path.basename(resolvedHome)` operates on the symlink name, not its target, so the guard matches the operator's chosen path name. This is the right semantic ("what did the user ask for?") and matches the analysis already in the prior closed attempt #45793.
- This is a narrower replacement for the closed-stale #45793 (also from a separate contributor, technically correct, lost to no maintainer engagement). The shape is the same; the new test coverage explicitly pins the implicit-`HOME` case so the guard cannot accidentally widen.
- Out-of-scope: `OPENCLAW_HOME` poisoning (already handled by `normalize()` in `src/infra/home-dir.ts:4`) and `OPENCLAW_STATE_DIR=/path/.openclaw` style explicit-state-dir overrides (those already short-circuit before the guard at line 65).

## Real behavior proof

- Behavior addressed: Onboarding with `OPENCLAW_HOME=~/.openclaw` writes the config file to the wrong place (`~/.openclaw/.openclaw/openclaw.json`) and produces a nested directory. After the fix, the config is written to the canonical `~/.openclaw/openclaw.json` location.
- Real environment tested: Local checkout at `../openclaw-45765` on Windows 11 + Node 22.14 with the patched `src/config/paths.ts` and `src/utils.ts`. Smoke run exercises the actual production `resolveStateDir`, `resolveConfigDir`, and `resolveDefaultConfigCandidates` exports through `node --import tsx`, no test runner, no mocks. PR head: `44b9b82478`.
- Exact steps or command run after this patch:
  - `git checkout fix/openclaw-home-state-dir-nesting && pnpm install`
  - `pnpm test src/config/paths.test.ts` (29 passed)
  - `pnpm test src/utils.test.ts` (18 passed)
  - `pnpm test src/infra/home-dir.test.ts` (27 passed)
  - `pnpm tsgo:core` (EXIT=0)
  - `node --import tsx ./smoke-45765.mjs` against the three observed shapes
- Evidence after fix:
~~~text
PR head 44b9b82478
$ pnpm test src/config/paths.test.ts
 Test Files  1 passed (1)
      Tests  29 passed (29)
   Duration  1.96s

$ pnpm test src/utils.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)
   Duration  1.97s

$ pnpm test src/infra/home-dir.test.ts
 Test Files  1 passed (1)
      Tests  27 passed (27)
   Duration  331ms

$ pnpm tsgo:core
EXIT=0
~~~
- Observed result after fix: with `OPENCLAW_HOME=~/.openclaw` set, `resolveStateDir` / `resolveConfigDir` both return the explicit home directly and `resolveDefaultConfigCandidates` lists `~/.openclaw/openclaw.json` as the canonical first candidate — no `~/.openclaw/.openclaw/...` candidate is produced anywhere in the list. With `OPENCLAW_HOME=/srv/openclaw-home` (non-state-dir basename), behavior is unchanged: `~/.openclaw` is still appended.
- What was not tested: a live `openclaw onboard` wizard run on Linux Kylin V10 / aarch64 (the reporter's environment). The behavior is source-reproducible from the patched production code through `node --import tsx` and is unit-covered by the new regression tests; a live onboarding run would only exercise the same call chain.

Closes #45765
