### PR TITLE
Fix MiniMax usage count parsing

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -55,7 +55,7 @@ describe("fetchMinimaxUsage", () => {
     });
 
     const result = await fetchMinimaxUsage("key", 5000, mockFetch, { baseUrl });
-    expect(result.windows).toEqual([{ label: "5h", usedPercent: 2, resetAt: undefined }]);
+    expect(result.windows).toEqual([{ label: "5h", usedPercent: 98, resetAt: undefined }]);
   });
 
   it.each([
@@ -153,7 +153,7 @@ describe("fetchMinimaxUsage", () => {
       },
     },
     {
-      name: "treats MiniMax current_interval_usage_count as remaining quota (not consumed)",
+      name: "treats MiniMax current_interval_usage_count as consumed usage",
       payload: {
         data: {
           current_interval_total_count: 100,
@@ -163,7 +163,7 @@ describe("fetchMinimaxUsage", () => {
       },
       expected: {
         plan: "Coding Plan",
-        windows: [{ label: "5h", usedPercent: 2, resetAt: undefined }],
+        windows: [{ label: "5h", usedPercent: 98, resetAt: undefined }],
       },
     },
     {
@@ -224,7 +224,7 @@ describe("fetchMinimaxUsage", () => {
       },
       expected: {
         plan: "Coding Plan · MiniMax-M*",
-        windows: [{ label: "4h", usedPercent: 0.8333333333333334, resetAt: 1_774_195_200_000 }],
+        windows: [{ label: "4h", usedPercent: 99.16666666666667, resetAt: 1_774_195_200_000 }],
       },
     },
     {
@@ -249,7 +249,7 @@ describe("fetchMinimaxUsage", () => {
       },
       expected: {
         plan: "Coding Plan · video-01",
-        windows: [{ label: "4h", usedPercent: 25, resetAt: 1_774_195_200_000 }],
+        windows: [{ label: "4h", usedPercent: 75, resetAt: 1_774_195_200_000 }],
       },
     },
   ])("$name", async ({ payload, expected }) => {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -79,6 +79,10 @@ const USED_KEYS = [
   "prompts_used",
   "promptsUsed",
   "consumed",
+  "current_interval_usage_count",
+  "currentIntervalUsageCount",
+  "current_weekly_usage_count",
+  "currentWeeklyUsageCount",
 ] as const;
 
 const TOTAL_KEYS = [
@@ -144,12 +148,6 @@ const REMAINING_KEYS = [
   "prompts_left",
   "promptsLeft",
   "left",
-  // MiniMax usage endpoints misname these: values are remaining quota, not consumed.
-  // See https://github.com/MiniMax-AI/MiniMax-M2/issues/99
-  "current_interval_usage_count",
-  "currentIntervalUsageCount",
-  "current_weekly_usage_count",
-  "currentWeeklyUsageCount",
 ] as const;
 
 const PLAN_KEYS = ["plan", "plan_name", "planName", "product", "tier"] as const;


### PR DESCRIPTION
## Summary\n- Treat MiniMax current_interval_usage_count/current_weekly_usage_count as consumed usage, not remaining quota\n- Correct stale tests that inverted MiniMax usage math\n- Prevent false low-remaining reports when the web portal still shows available usage\n\n## Testing\n- node scripts/test-projects.mjs src/infra/provider-usage.fetch.minimax.test.ts