### PR TITLE
docs: add secure multi-agent routing pattern for research workflows

### DIFF
--- a/docs/concepts/secure-multi-agent-routing.md
+++ b/docs/concepts/secure-multi-agent-routing.md
@@ -1,0 +1,100 @@
+---
+title: "Secure Multi-Agent Routing with DuckDuckGo and Perplexity MCP"
+summary: "A documentation pattern for separating lightweight execution from research-heavy workflows using agent boundaries."
+read_when:
+  - You want to keep the default agent lightweight while reserving deep web research for a dedicated specialist agent.
+---
+
+This guide describes a community routing pattern for OpenClaw that separates routine execution from research-heavy workflows.
+
+## Background
+
+As users connect more tools and MCP servers, one default agent can become overloaded:
+
+- expensive research APIs may be called too often;
+- lightweight requests and deep research can mix in one execution context;
+- tool boundaries become harder to reason about and audit.
+
+The goal of this pattern is to keep everyday execution simple and predictable, while making deep research explicit and constrained.
+
+## Pattern Overview
+
+Use two agents with distinct responsibilities:
+
+- `main` (default interaction and execution entrypoint)
+- `web-researcher` (research-only specialist)
+
+High-level flow:
+
+1. `main` handles normal chat and execution.
+2. `main` uses DuckDuckGo for lightweight search by default.
+3. `main` delegates to `web-researcher` only when deep research is required.
+4. `web-researcher` uses Perplexity MCP for multi-source research and synthesis.
+5. `web-researcher` returns findings to `main`, and `main` remains the final execution surface.
+
+## Responsibility Boundaries
+
+### `main` agent
+
+`main` should own routine work:
+
+- normal Q&A;
+- code edits;
+- file operations;
+- task planning;
+- lightweight search (DuckDuckGo by default).
+
+`main` should not call Perplexity MCP by default.
+
+### `web-researcher` agent
+
+`web-researcher` is a bounded specialist for complex web research:
+
+- deep research;
+- multi-source verification;
+- architecture tradeoff analysis;
+- model/API comparison;
+- reasoning and summarization.
+
+`web-researcher` should be restricted from execution-side actions:
+
+- no file modification;
+- no deployment;
+- no deletion;
+- no `git push`;
+- no secret access or exposure.
+
+## Layered Search Strategy
+
+A practical decision policy:
+
+- Use DuckDuckGo via `main` for quick fact checks, lightweight lookups, and low-cost retrieval.
+- Escalate to `web-researcher` + Perplexity MCP only when tasks need:
+  - deep synthesis across multiple sources;
+  - stronger verification confidence;
+  - architecture or vendor tradeoff judgment;
+  - explicit user request for research-specialist handling.
+
+This layered strategy keeps baseline cost and latency low while preserving a path for higher-confidence research.
+
+## Security Boundaries
+
+This pattern depends on strict hygiene:
+
+- never commit real `.env` files;
+- never commit API keys, tokens, or private keys;
+- never upload user-specific runtime secrets;
+- keep research agent permissions narrower than execution agents;
+- enforce review/validation scripts before commits.
+
+## Community Preset
+
+A standalone community preset that demonstrates this pattern is available at:
+
+- https://github.com/SeverinQuan/openclaw-sentinel
+
+The preset includes example agent policies, routing rules, validation scripts, and security notes.
+
+## Scope Note
+
+This document describes an operational pattern and does **not** change OpenClaw core behavior.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1170,6 +1170,7 @@
                 "group": "Multi-agent",
                 "pages": [
                   "concepts/multi-agent",
+                  "concepts/secure-multi-agent-routing",
                   "concepts/parallel-specialist-lanes",
                   "concepts/presence",
                   "concepts/delegate-architecture"


### PR DESCRIPTION
## Summary

This PR adds a documentation example for a secure Multi-Agent routing pattern in OpenClaw.

The pattern separates routine execution from research-heavy workflows:

- `main Agent` remains the default interaction and execution entrypoint.
- `main Agent` uses DuckDuckGo for lightweight search by default.
- Perplexity MCP is reserved for a dedicated `web-researcher` agent.
- `web-researcher` is only invoked for deep research, multi-source verification, architecture decisions, model/API comparisons, or explicit user requests.
- `web-researcher` is restricted to search, research, verification, reasoning, and summarization.
- It should not modify files, deploy, delete data, push commits, or access secrets.

## Motivation

As OpenClaw users connect more tools and MCP servers, tool boundaries become increasingly important.

This routing pattern helps users:

- reduce unnecessary calls to expensive research APIs;
- keep the main Agent lightweight and predictable;
- separate execution tasks from research tasks;
- reduce the risk of accidental secret exposure;
- make Multi-Agent delegation more explicit and auditable.

## Community Preset

A standalone community preset is available here:

https://github.com/SeverinQuan/openclaw-sentinel

The preset includes example agent policies, routing rules, validation scripts, and security notes.

## Safety

This PR only adds documentation / example guidance.

It does not include:

- real `.env` files;
- API keys;
- tokens;
- secrets;
- SSH keys;
- user-specific OpenClaw runtime configuration.