### PR TITLE
fix(talk): diagnose invalid OpenAI realtime auth

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -113,6 +113,7 @@ Defaults:
 - `consultFastMode`: optional fast-mode override for realtime `openclaw_agent_consult` calls.
 - `realtime.provider`: selects the active browser/server realtime voice provider. Use `openai` for WebRTC, `google` for provider WebSocket, or a bridge-only provider through Gateway relay.
 - `realtime.providers.<provider>` stores provider-owned realtime config. The browser receives only ephemeral or constrained session credentials, never a standard API key.
+- `realtime.providers.openai.apiKey`: must be a direct OpenAI Platform key for OpenAI Realtime, not an Azure AI Foundry / Azure OpenAI model key or OpenAI-compatible proxy key. Use `openai-codex` OAuth where supported, or `gateway-relay` with `azureEndpoint` + `azureDeployment` for Azure Realtime.
 - `realtime.providers.openai.voice`: built-in OpenAI Realtime voice id. Current `gpt-realtime-2` voices are `alloy`, `ash`, `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`, `marin`, and `cedar`; `marin` and `cedar` are recommended for best quality.
 - `realtime.transport`: `webrtc` and `provider-websocket` are browser realtime transports. Android uses realtime relay only when this is `gateway-relay`; otherwise Android Talk uses its native STT/TTS loop.
 - `realtime.brain`: `agent-consult` routes realtime tool calls through Gateway policy; `direct-tools` is legacy direct-tool compatibility behavior; `none` is for transcription or external orchestration.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -719,6 +719,15 @@ Legacy `plugins.entries.openai.config.personality` is still read as a compatibil
     | Reasoning effort | `...openai.reasoningEffort` | (unset) |
     | Auth | `...openai.apiKey`, `OPENAI_API_KEY`, or `openai-codex` OAuth | Browser Talk and non-Azure backend bridges can use Codex OAuth |
 
+    <Note>
+    OpenAI Realtime Talk auth is not shared with Azure AI Foundry or Azure
+    OpenAI model providers. Browser WebRTC sessions and native OpenAI backend
+    bridges need a direct OpenAI Platform API key or supported `openai-codex`
+    OAuth; OpenAI-compatible proxy keys are not valid for the
+    `api.openai.com` Realtime client-secret flow. Azure Realtime voice uses the
+    backend `gateway-relay` path with `azureEndpoint` and `azureDeployment`.
+    </Note>
+
     Available built-in Realtime voices for `gpt-realtime-2`: `alloy`, `ash`,
     `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`, `marin`, `cedar`.
     OpenAI recommends `marin` and `cedar` for the best Realtime quality. This

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -201,6 +201,29 @@ function requireFetchJsonBody(callIndex = 0): Record<string, unknown> {
   return requireRecord(JSON.parse(body as string), "fetch JSON body");
 }
 
+function expectDirectOpenAIRealtimeAuthMessage(error: unknown, unexpectedSecret?: string): void {
+  const message = error instanceof Error ? error.message : String(error);
+  expect(message).toContain("Talk Realtime provider 'openai' requires a direct OpenAI API key");
+  expect(message).toContain("Azure AI Foundry / Azure OpenAI model credentials");
+  expect(message).toContain("OpenAI-compatible proxy keys");
+  if (unexpectedSecret) {
+    expect(message).not.toContain(unexpectedSecret);
+  }
+}
+
+async function expectRejectsDirectOpenAIRealtimeAuth(
+  promise: Promise<unknown>,
+  unexpectedSecret?: string,
+): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expectDirectOpenAIRealtimeAuthMessage(error, unexpectedSecret);
+    return;
+  }
+  throw new Error("Expected OpenAI Realtime direct auth diagnostic");
+}
+
 function requireSession(socket: FakeWebSocketInstance, index = 0): Record<string, unknown> {
   return requireRecord(parseSent(socket)[index]?.session, "session");
 }
@@ -673,6 +696,150 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     });
   });
 
+  it("rejects obvious proxy API keys before minting browser realtime client secrets", async () => {
+    const proxyKey = "sk-litellm-realtime-proxy-key"; // pragma: allowlist secret
+    vi.stubEnv("OPENAI_API_KEY", proxyKey);
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    if (!provider.createBrowserSession) {
+      throw new Error("expected OpenAI realtime provider to support browser sessions");
+    }
+
+    await expectRejectsDirectOpenAIRealtimeAuth(
+      provider.createBrowserSession({
+        cfg: {
+          models: {
+            providers: {
+              "azure-openai-responses": {
+                baseUrl: "https://example.services.ai.azure.com/models",
+                models: [],
+              },
+            },
+          },
+        } as never,
+        providerConfig: {},
+        instructions: "Be concise.",
+      }),
+      proxyKey,
+    );
+
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects Azure-looking API keys before browser realtime client secret requests", async () => {
+    const azureKey = "0123456789abcdef0123456789abcdef"; // pragma: allowlist secret
+    vi.stubEnv("OPENAI_API_KEY", azureKey);
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    if (!provider.createBrowserSession) {
+      throw new Error("expected OpenAI realtime provider to support browser sessions");
+    }
+
+    await expectRejectsDirectOpenAIRealtimeAuth(
+      provider.createBrowserSession({
+        providerConfig: {},
+        instructions: "Be concise.",
+      }),
+      azureKey,
+    );
+
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Codex OAuth when an obvious proxy API key is present", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-or-openrouter-proxy-key"); // pragma: allowlist secret
+    resolveProviderAuthProfileApiKeyMock.mockResolvedValueOnce("oauth-realtime-token");
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: createJsonResponse({
+        client_secret: { value: "client-secret-123" },
+      }),
+      release: vi.fn(async () => undefined),
+    });
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    if (!provider.createBrowserSession) {
+      throw new Error("expected OpenAI realtime provider to support browser sessions");
+    }
+
+    await provider.createBrowserSession({
+      cfg: { agents: { defaults: {} } } as never,
+      providerConfig: {},
+      instructions: "Be concise.",
+    });
+
+    expect(resolveProviderAuthProfileApiKeyMock).toHaveBeenCalledWith({
+      provider: "openai-codex",
+      cfg: { agents: { defaults: {} } },
+      includeExternalCliAuth: true,
+    });
+    expectRecordFields(requireFetchHeaders(), "fetch headers", {
+      Authorization: "Bearer oauth-realtime-token", // pragma: allowlist secret
+    });
+  });
+
+  it("rejects configured proxy API keys before browser realtime client secret requests", async () => {
+    const configuredProxyKey = "sk-litel-configured-proxy-key"; // pragma: allowlist secret
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    if (!provider.createBrowserSession) {
+      throw new Error("expected OpenAI realtime provider to support browser sessions");
+    }
+
+    await expectRejectsDirectOpenAIRealtimeAuth(
+      provider.createBrowserSession({
+        providerConfig: { apiKey: configuredProxyKey },
+        instructions: "Be concise.",
+      }),
+      configuredProxyKey,
+    );
+
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects keychain-resolved proxy API keys before browser realtime client secret requests", async () => {
+    const resolvedProxyKey = "sk-litellm-keychain-proxy-key"; // pragma: allowlist secret
+    vi.stubEnv("OPENAI_API_KEY", "keychain:openclaw:OPENAI_REALTIME_PROXY_TEST");
+    execFileSyncMock.mockReturnValueOnce(`${resolvedProxyKey}\n`);
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    if (!provider.createBrowserSession) {
+      throw new Error("expected OpenAI realtime provider to support browser sessions");
+    }
+
+    await expectRejectsDirectOpenAIRealtimeAuth(
+      provider.createBrowserSession({
+        providerConfig: {},
+        instructions: "Be concise.",
+      }),
+      resolvedProxyKey,
+    );
+
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("wraps OpenAI invalid-key responses from realtime client secret requests", async () => {
+    const directLookingKey = "sk-test-direct-looking-invalid-key"; // pragma: allowlist secret
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: createJsonResponse(
+        {
+          error: {
+            code: "invalid_api_key",
+            message: `Incorrect API key provided: ${directLookingKey}`,
+          },
+        },
+        { status: 401 },
+      ),
+      release: vi.fn(async () => undefined),
+    });
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    if (!provider.createBrowserSession) {
+      throw new Error("expected OpenAI realtime provider to support browser sessions");
+    }
+
+    await expectRejectsDirectOpenAIRealtimeAuth(
+      provider.createBrowserSession({
+        providerConfig: { apiKey: directLookingKey },
+        instructions: "Be concise.",
+      }),
+      directLookingKey,
+    );
+  });
+
   it("fails closed when keychain refs cannot be resolved", async () => {
     vi.stubEnv("OPENAI_API_KEY", "keychain:openclaw:OPENAI_REALTIME_MISSING_TEST");
     execFileSyncMock.mockImplementationOnce(() => {
@@ -686,7 +853,9 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       onClearAudio: vi.fn(),
     });
 
-    await expect(bridge.connect()).rejects.toThrow("OpenAI API key or Codex OAuth missing");
+    await expect(bridge.connect()).rejects.toThrow(
+      "Talk Realtime provider 'openai' requires a direct OpenAI API key",
+    );
   });
 
   it("normalizes provider-owned voice settings from raw provider config", () => {
@@ -971,7 +1140,9 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       ),
     );
 
-    await expect(connecting).rejects.toThrow("Incorrect API key provided");
+    await expect(connecting).rejects.toThrow(
+      "Talk Realtime provider 'openai' requires a direct OpenAI API key",
+    );
     expect(onError).not.toHaveBeenCalled();
     expect(socket.closed).toBe(true);
     expect(bridge.isConnected()).toBe(false);

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -92,6 +92,9 @@ const OPENAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR =
   "Cancellation failed: no active response found";
 const OPENAI_REALTIME_MAX_SESSION_DURATION_FRAGMENT = "maximum duration";
 const OPENAI_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS = 250;
+const OPENAI_REALTIME_ALLOW_UNVALIDATED_KEY_ENV = "OPENCLAW_OPENAI_REALTIME_ALLOW_UNVALIDATED_KEY";
+const OPENAI_REALTIME_DIRECT_AUTH_MESSAGE =
+  "Talk Realtime provider 'openai' requires a direct OpenAI API key (or supported OpenAI Realtime auth such as openai-codex OAuth). Azure AI Foundry / Azure OpenAI model credentials and OpenAI-compatible proxy keys are not valid for OpenAI Realtime sessions against api.openai.com. Configure talk.realtime.providers.openai.apiKey or OPENAI_API_KEY with a direct OpenAI Platform key, configure openai-codex OAuth, or use Talk gateway relay with an Azure Realtime deployment (azureEndpoint + azureDeployment).";
 const OPENAI_REALTIME_VOICES = [
   "alloy",
   "ash",
@@ -237,6 +240,7 @@ type OpenAIRealtimeApiKeyResolution =
 
 type OpenAIRealtimeAuthResolution =
   | { status: "available"; kind: "api-key" | "codex-oauth"; value: string }
+  | { status: "invalid-api-key" }
   | { status: "missing" };
 
 const KEYCHAIN_SECRET_REF_RE = /^keychain:([^:]+):([^:]+)$/;
@@ -339,6 +343,72 @@ function isOpenAIRealtimeMaxSessionDurationError(detail: string): boolean {
   );
 }
 
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test(value?.trim() ?? "");
+}
+
+function isObviouslyNotDirectOpenAIRealtimeApiKey(value: string): boolean {
+  if (isTruthyEnvFlag(process.env[OPENAI_REALTIME_ALLOW_UNVALIDATED_KEY_ENV])) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (/^[a-f0-9]{32}$/i.test(normalized)) {
+    return true;
+  }
+  if (!normalized.startsWith("sk-")) {
+    return true;
+  }
+  return (
+    normalized.startsWith("sk-or-") ||
+    normalized.startsWith("sk-openrouter-") ||
+    normalized.startsWith("sk-litellm") ||
+    normalized.startsWith("sk-litel") ||
+    normalized.includes("litellm")
+  );
+}
+
+function openAIRealtimeDirectAuthError(cause?: unknown): Error {
+  return cause instanceof Error
+    ? new Error(OPENAI_REALTIME_DIRECT_AUTH_MESSAGE, { cause })
+    : new Error(OPENAI_REALTIME_DIRECT_AUTH_MESSAGE);
+}
+
+function isOpenAIRealtimeAuthFailure(error: unknown): boolean {
+  const record =
+    typeof error === "object" && error !== null ? (error as Record<string, unknown>) : undefined;
+  const status = record?.status ?? record?.statusCode;
+  const rawCode = record?.code ?? record?.errorCode;
+  const code = typeof rawCode === "string" ? rawCode.toLowerCase() : "";
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return (
+    status === 401 ||
+    status === 403 ||
+    code === "invalid_api_key" ||
+    message.includes("invalid_api_key") ||
+    message.includes("incorrect api key provided") ||
+    message.includes("unexpected server response: 401")
+  );
+}
+
+async function createOpenAIRealtimeClientSecretWithAuthHint(params: {
+  authToken: string;
+  auditContext: string;
+  session: Record<string, unknown>;
+}) {
+  try {
+    return await createOpenAIRealtimeClientSecret(params);
+  } catch (error) {
+    if (isOpenAIRealtimeAuthFailure(error)) {
+      throw openAIRealtimeDirectAuthError(error);
+    }
+    throw error;
+  }
+}
+
 async function resolveOpenAIRealtimeDefaultAuth(params: {
   configuredApiKey: string | undefined;
   cfg: RealtimeVoiceBrowserSessionCreateRequest["cfg"] | undefined;
@@ -349,8 +419,24 @@ async function resolveOpenAIRealtimeDefaultAuth(params: {
     configured.status === "available" ||
     hasOpenAIRealtimeConfiguredApiKeyInput(params.configuredApiKey)
   ) {
+    if (
+      configured.status === "available" &&
+      !isObviouslyNotDirectOpenAIRealtimeApiKey(configured.value)
+    ) {
+      return { status: "available", kind: "api-key", value: configured.value };
+    }
+    if (prefersCodexOAuthForRealtimeModel(params.model)) {
+      const codexToken = await resolveProviderAuthProfileApiKey({
+        provider: "openai-codex",
+        cfg: params.cfg,
+        includeExternalCliAuth: true,
+      });
+      if (codexToken) {
+        return { status: "available", kind: "codex-oauth", value: codexToken };
+      }
+    }
     return configured.status === "available"
-      ? { status: "available", kind: "api-key", value: configured.value }
+      ? { status: "invalid-api-key" }
       : { status: "missing" };
   }
 
@@ -366,10 +452,10 @@ async function resolveOpenAIRealtimeDefaultAuth(params: {
   }
 
   const env = resolveOpenAIRealtimeEnvApiKey();
-  if (env.status === "available") {
+  if (env.status === "available" && !isObviouslyNotDirectOpenAIRealtimeApiKey(env.value)) {
     return { status: "available", kind: "api-key", value: env.value };
   }
-  return { status: "missing" };
+  return env.status === "available" ? { status: "invalid-api-key" } : { status: "missing" };
 }
 
 async function requireOpenAIRealtimeDefaultAuth(params: {
@@ -381,7 +467,10 @@ async function requireOpenAIRealtimeDefaultAuth(params: {
   if (auth.status === "available") {
     return auth;
   }
-  throw new Error("OpenAI API key or Codex OAuth missing");
+  if (auth.status === "invalid-api-key") {
+    throw openAIRealtimeDirectAuthError();
+  }
+  throw openAIRealtimeDirectAuthError();
 }
 
 function hasOpenAIRealtimeBrowserAuthInput(params: {
@@ -619,7 +708,12 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           try {
             const event = JSON.parse(data.toString()) as RealtimeEvent;
             if (event.type === "error" && !this.sessionConfigured) {
-              rejectStartup(new Error(readRealtimeErrorDetail(event.error)));
+              const startupError = new Error(readRealtimeErrorDetail(event.error));
+              rejectStartup(
+                isOpenAIRealtimeAuthFailure(startupError)
+                  ? openAIRealtimeDirectAuthError(startupError)
+                  : startupError,
+              );
               return;
             }
             this.handleEvent(event);
@@ -644,7 +738,12 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
             },
           });
           if (!this.sessionConfigured) {
-            rejectStartup(error instanceof Error ? error : new Error(String(error)));
+            const startupError = error instanceof Error ? error : new Error(String(error));
+            rejectStartup(
+              isOpenAIRealtimeAuthFailure(startupError)
+                ? openAIRealtimeDirectAuthError(startupError)
+                : startupError,
+            );
             return;
           }
           this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
@@ -717,6 +816,12 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       if (directApiKey.status === "missing") {
         throw new Error("OpenAI API key missing");
       }
+      if (isObviouslyNotDirectOpenAIRealtimeApiKey(directApiKey.value)) {
+        if (cfg.azureEndpoint) {
+          throw openAIRealtimeDirectAuthError();
+        }
+        return this.resolveDefaultConnectionParams(model);
+      }
       return this.resolveApiKeyConnectionParams(directApiKey.value, model);
     }
 
@@ -725,6 +830,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       if (directApiKey.status === "missing") {
         throw new Error("OpenAI API key missing");
       }
+      if (isObviouslyNotDirectOpenAIRealtimeApiKey(directApiKey.value)) {
+        throw openAIRealtimeDirectAuthError();
+      }
       return this.resolveApiKeyConnectionParams(directApiKey.value, model);
     }
 
@@ -732,6 +840,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       const directApiKey = resolveOpenAIRealtimeEnvApiKey();
       if (directApiKey.status === "missing") {
         throw new Error("OpenAI API key missing");
+      }
+      if (isObviouslyNotDirectOpenAIRealtimeApiKey(directApiKey.value)) {
+        throw openAIRealtimeDirectAuthError();
       }
       return this.resolveApiKeyConnectionParams(directApiKey.value, model);
     }
@@ -744,7 +855,10 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       })
     ) {
       const directApiKey = resolveOpenAIRealtimeEnvApiKey();
-      if (directApiKey.status === "available") {
+      if (
+        directApiKey.status === "available" &&
+        !isObviouslyNotDirectOpenAIRealtimeApiKey(directApiKey.value)
+      ) {
         return this.resolveApiKeyConnectionParams(directApiKey.value, model);
       }
     }
@@ -818,7 +932,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     headers: Record<string, string>;
   }> {
     const cfg = this.config;
-    const clientSecret = await createOpenAIRealtimeClientSecret({
+    const clientSecret = await createOpenAIRealtimeClientSecretWithAuthHint({
       authToken,
       auditContext: "openai-realtime-bridge-session",
       session: {
@@ -1401,7 +1515,7 @@ async function createOpenAIRealtimeBrowserSession(
     session.reasoning = { effort: reasoningEffort };
   }
 
-  const clientSecret = await createOpenAIRealtimeClientSecret({
+  const clientSecret = await createOpenAIRealtimeClientSecretWithAuthHint({
     authToken: auth.value,
     auditContext: "openai-realtime-browser-session",
     session,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Talk configured for OpenAI Realtime could surface a raw provider error such as `Incorrect API key provided` when the available credential was an Azure AI Foundry / Azure OpenAI model key or OpenAI-compatible proxy key rather than a direct OpenAI Platform credential.

Why does this matter now?

- OpenAI Realtime Talk auth is separate from the regular model-provider stack. Users with Azure-backed model configs need a clear diagnostic instead of a misleading low-level OpenAI API-key failure.

What is the intended outcome?

- OpenAI Realtime Talk fails early with an actionable message that explains direct OpenAI Realtime auth, `openai-codex` OAuth, or Azure gateway relay configuration.
- Obvious Azure/proxy-style keys are not sent to the OpenAI Realtime client-secret endpoint.
- Upstream invalid-key responses and pre-ready WebSocket auth failures are translated into the same safe diagnostic without leaking the configured secret.

What is intentionally out of scope?

- This does not add a new Azure Foundry browser WebRTC flow.
- This does not change Google Gemini Live or other Talk providers.
- This does not edit `CHANGELOG.md`.

What does success look like?

- A user with only Azure AI Foundry / Azure OpenAI model credentials no longer sees only a raw `Incorrect API key provided` error when enabling OpenAI Realtime Talk.

What should reviewers focus on?

- The auth-resolution behavior in `extensions/openai/realtime-voice-provider.ts`, especially preserving valid direct OpenAI Realtime setups and `openai-codex` OAuth fallback.
- The diagnostics avoid leaking key material.

AI-assisted: yes. I used GitHub Copilot CLI to implement and validate this fix, and I understand the resulting code changes.

## Linked context

Which issue does this close?

- N/A; no public issue exists for this local reproduction.

Which issues, PRs, or discussions are related?

- N/A.

Was this requested by a maintainer or owner?

- No maintainer request; this is a focused bug fix from a real local Talk/OpenAI Realtime configuration issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenAI Realtime Talk with Azure AI Foundry / Azure OpenAI or OpenAI-compatible proxy credentials could expose a raw provider invalid-key error instead of explaining that direct OpenAI Realtime auth is required.
- Real environment tested: Local OpenClaw checkout on Ubuntu 24.04 under WSL, using the same local OpenClaw config directory as my running setup. The setup is Azure-backed for regular model providers and has no valid direct OpenAI Platform Realtime key.
- Exact steps or command run after this patch:
  - `OPENAI_API_KEY=<redacted proxy key> node --import tsx -e "import { buildOpenAIRealtimeVoiceProvider } from './extensions/openai/realtime-voice-provider.ts'; const provider = buildOpenAIRealtimeVoiceProvider(); try { await provider.createBrowserSession?.({ providerConfig: {}, instructions: 'diagnostic smoke test' }); console.log('unexpected success'); process.exitCode = 1; } catch (error) { const message = error instanceof Error ? error.message : String(error); console.log(message.replace(/REDACTED_KEY_PATTERN/g, '<redacted key>')); console.log('secret leaked:', message.includes(process.env.OPENAI_API_KEY ?? '')); }"`
  - `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts src/gateway/server-methods/talk.test.ts --run`
  - `corepack pnpm check:changed`
  - `git diff --check`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Config (/home/<user>/.openclaw/openclaw.json): missing env var "GEMINI_API_KEY" at talk.realtime.providers.google.apiKey - feature using this value will be unavailable
Talk Realtime provider 'openai' requires a direct OpenAI API key (or supported OpenAI Realtime auth such as openai-codex OAuth). Azure AI Foundry / Azure OpenAI model credentials and OpenAI-compatible proxy keys are not valid for OpenAI Realtime sessions against api.openai.com. Configure talk.realtime.providers.openai.apiKey or OPENAI_API_KEY with a direct OpenAI Platform key, configure openai-codex OAuth, or use Talk gateway relay with an Azure Realtime deployment (azureEndpoint + azureDeployment).
secret leaked: false
```

Additional local validation output:

```text
Test Files  3 passed (3)
Tests  96 passed (96)
```

`check:changed` completed with typecheck extensions, typecheck extension tests, lint extensions, media download helper guard, runtime sidecar loader guard, and runtime import cycles all passing. Re-run after the Codex follow-up fix. Re-run after the Codex follow-up fix.

- Observed result after fix: The OpenAI Realtime browser-session path rejects obvious non-direct keys before minting client secrets, preserves OAuth fallback when available, and wraps upstream invalid-key failures into the actionable diagnostic.
- What was not tested: A live OpenAI Realtime WebRTC session with a real OpenAI Platform key, and a live Azure Realtime deployment through gateway relay.
- Proof limitations or environment constraints: I do not have a valid direct OpenAI Platform Realtime key or Azure Realtime deployment available in this environment, so live provider calls were not performed. The proof includes a real local OpenClaw source execution of the failing credential class plus targeted regression coverage and repository checks.
- Before evidence (optional but encouraged): The previous behavior was represented by existing tests expecting the raw `Incorrect API key provided` startup failure; this PR updates that behavior to the clearer Talk Realtime auth diagnostic.

## Tests and validation

Which commands did you run?

- `OPENAI_API_KEY=<redacted proxy key> node --import tsx -e "..."`
- `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts src/gateway/server-methods/talk.test.ts --run`
- `corepack pnpm check:changed`
- `git diff --check`

What regression coverage was added or updated?

- Added OpenAI Realtime provider tests for obvious proxy keys, Azure-looking keys, configured proxy keys, keychain-resolved proxy keys, OAuth fallback, and upstream invalid-key wrapping.
- Updated the pre-ready WebSocket auth-failure expectation to the new diagnostic.

What failed before this fix, if known?

- Users could receive a raw OpenAI provider error such as `Incorrect API key provided: <redacted OpenAI-like key>` when Talk used OpenAI Realtime with a non-direct OpenAI credential.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No migration. There is a diagnostic-only auth behavior change for clearly invalid OpenAI Realtime credentials, plus an escape hatch `OPENCLAW_OPENAI_REALTIME_ALLOW_UNVALIDATED_KEY` for unusual direct-key formats.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes.

What is the highest-risk area?

- Misclassifying an unusual but valid OpenAI Realtime credential as non-direct.

How is that risk mitigated?

- The early rejection is limited to high-confidence proxy/Azure-looking formats and invalid prefixes, valid-looking direct OpenAI keys still reach the existing OpenAI flow, `openai-codex` OAuth is preferred/fallback capable for GPT Realtime models, and an environment escape hatch allows unvalidated keys.

## Current review state

What is the next action?

- Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- CI and maintainer review.
- Maintainers can decide whether the provided local proof is sufficient or if they want live Azure/OpenAI Realtime proof.
- `codex review --base origin/main` was not run because the `codex` CLI is not available in this environment.
- Maintainer edits are enabled on the fork PR.

Which bot or reviewer comments were addressed?

- Addressed Codex feedback about overly broad 403 mapping: non-auth 403 responses from the Realtime client-secret endpoint are now preserved as provider permission errors, and a regression test covers this behavior.





