### PR TITLE
Fix Codex native hook relay after restart

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -84,8 +84,9 @@ export async function startCodexAttemptThread(params: {
   effectiveWorkspace: string;
   dynamicTools: CodexDynamicToolSpec[];
   developerInstructions: string | undefined;
-  finalConfigPatch: Parameters<typeof startOrResumeThread>[0]["finalConfigPatch"];
-  nativeHookRelayGeneration: string | undefined;
+  finalConfigPatch?: Parameters<typeof startOrResumeThread>[0]["finalConfigPatch"];
+  buildFinalConfigPatch?: Parameters<typeof startOrResumeThread>[0]["buildFinalConfigPatch"];
+  nativeHookRelayGeneration?: string;
   bundleMcpThreadConfig: CodexBundleMcpThreadConfig;
   nativeToolSurfaceEnabled: boolean;
   sandboxExecServerEnabled: boolean;
@@ -254,6 +255,7 @@ export async function startCodexAttemptThread(params: {
                 developerInstructions: params.developerInstructions,
                 config: threadConfig,
                 finalConfigPatch: params.finalConfigPatch,
+                buildFinalConfigPatch: params.buildFinalConfigPatch,
                 nativeHookRelayGeneration: params.nativeHookRelayGeneration,
                 nativeCodeModeEnabled: params.nativeToolSurfaceEnabled,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -85,6 +85,7 @@ export async function startCodexAttemptThread(params: {
   dynamicTools: CodexDynamicToolSpec[];
   developerInstructions: string | undefined;
   finalConfigPatch: Parameters<typeof startOrResumeThread>[0]["finalConfigPatch"];
+  nativeHookRelayGeneration: string | undefined;
   bundleMcpThreadConfig: CodexBundleMcpThreadConfig;
   nativeToolSurfaceEnabled: boolean;
   sandboxExecServerEnabled: boolean;
@@ -253,6 +254,7 @@ export async function startCodexAttemptThread(params: {
                 developerInstructions: params.developerInstructions,
                 config: threadConfig,
                 finalConfigPatch: params.finalConfigPatch,
+                nativeHookRelayGeneration: params.nativeHookRelayGeneration,
                 nativeCodeModeEnabled: params.nativeToolSurfaceEnabled,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,
                 userMcpServersEnabled: params.nativeToolSurfaceEnabled,

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -95,6 +95,8 @@ export function createCodexNativeHookRelay(params: {
         gatewayTimeoutMs?: number;
       }
     | undefined;
+  generation?: string;
+  generationMismatchGraceMs?: number;
   events: readonly NativeHookRelayEvent[];
   agentId: string | undefined;
   sessionId: string;
@@ -117,6 +119,10 @@ export function createCodexNativeHookRelay(params: {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
     }),
+    ...(params.generation ? { generation: params.generation } : {}),
+    ...(params.generationMismatchGraceMs
+      ? { generationMismatchGraceMs: params.generationMismatchGraceMs }
+      : {}),
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionId: params.sessionId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -394,6 +394,24 @@ export function createResumeHarness() {
 }
 
 export function extractRelayIdFromThreadRequest(params: unknown): string {
+  const command = extractNativeHookRelayCommandFromThreadRequest(params);
+  const match = command.match(/--relay-id ([^ ]+)/);
+  if (!match?.[1]) {
+    throw new Error(`relay id missing from command: ${command}`);
+  }
+  return match[1];
+}
+
+export function extractGenerationFromThreadRequest(params: unknown): string {
+  const command = extractNativeHookRelayCommandFromThreadRequest(params);
+  const match = command.match(/--generation ([^ ]+)/);
+  if (!match?.[1]) {
+    throw new Error(`relay generation missing from command: ${command}`);
+  }
+  return match[1];
+}
+
+function extractNativeHookRelayCommandFromThreadRequest(params: unknown): string {
   const config = (params as { config?: Record<string, unknown> }).config;
   let command: string | undefined;
   for (const key of [
@@ -416,11 +434,10 @@ export function extractRelayIdFromThreadRequest(params: unknown): string {
       break;
     }
   }
-  const match = command?.match(/--relay-id ([^ ]+)/);
-  if (!match?.[1]) {
-    throw new Error(`relay id missing from command: ${command}`);
+  if (!command) {
+    throw new Error("native hook relay command missing from thread request");
   }
-  return match[1];
+  return command;
 }
 
 type RuntimeDynamicToolForTest = Parameters<

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -10,12 +10,14 @@ import {
   createParams,
   createResumeHarness,
   createStartedThreadHarness,
+  extractGenerationFromThreadRequest,
   extractRelayIdFromThreadRequest,
   runCodexAppServerAttempt,
   setupRunAttemptTestHooks,
   tempDir,
 } from "./run-attempt-test-harness.js";
 import { testing } from "./run-attempt.js";
+import { readCodexAppServerBinding, writeCodexAppServerBinding } from "./session-binding.js";
 
 setupRunAttemptTestHooks();
 
@@ -438,6 +440,100 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect(
       nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId),
     ).toBeUndefined();
+  });
+
+  it("persists and reuses Codex native hook relay generations for resumed threads", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const firstHarness = createStartedThreadHarness();
+
+    const firstRun = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+      },
+    });
+    await firstHarness.waitForMethod("turn/start");
+    const firstStartRequest = firstHarness.requests.find(
+      (request) => request.method === "thread/start",
+    );
+    const firstRelayId = extractRelayIdFromThreadRequest(firstStartRequest?.params);
+    const firstGeneration = extractGenerationFromThreadRequest(firstStartRequest?.params);
+
+    await firstHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await firstRun;
+    expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
+      firstGeneration,
+    );
+
+    const secondHarness = createResumeHarness();
+    const secondParams = createParams(sessionFile, workspaceDir);
+    secondParams.runId = "run-2";
+    const secondRun = runCodexAppServerAttempt(secondParams, {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+      },
+    });
+    await secondHarness.waitForMethod("turn/start");
+
+    const resumeRequest = secondHarness.requests.find(
+      (request) => request.method === "thread/resume",
+    );
+    expect(extractRelayIdFromThreadRequest(resumeRequest?.params)).toBe(firstRelayId);
+    expect(extractGenerationFromThreadRequest(resumeRequest?.params)).toBe(firstGeneration);
+
+    await secondHarness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await secondRun;
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+  });
+
+  it("accepts a stale first hook generation when resuming a pre-generation binding", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      dynamicToolsFingerprint: "[]",
+    });
+    const harness = createResumeHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+      },
+    });
+    await harness.waitForMethod("turn/start");
+
+    const resumeRequest = harness.requests.find((request) => request.method === "thread/resume");
+    const relayId = extractRelayIdFromThreadRequest(resumeRequest?.params);
+    const currentGeneration = extractGenerationFromThreadRequest(resumeRequest?.params);
+    expect(currentGeneration).not.toBe("legacy-generation-from-running-thread");
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        generation: "legacy-generation-from-running-thread",
+        event: "pre_tool_use",
+        requireGeneration: true,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "first-tool-after-restart",
+          tool_input: { command: "pwd" },
+        },
+      }),
+    ).resolves.toMatchObject({ exitCode: 0 });
+
+    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await run;
+    expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
+      currentGeneration,
+    );
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
   it("builds deterministic opaque Codex native hook relay ids", () => {

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -585,6 +585,59 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
+  it("rotates native hook relay generations when resume fails over to a fresh thread", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      nativeHookRelayGeneration: "generation-from-failed-resume",
+    });
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        throw new Error("resume failed");
+      }
+      return undefined;
+    });
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+      },
+    });
+    await harness.waitForMethod("turn/start");
+
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    const currentGeneration = extractGenerationFromThreadRequest(startRequest?.params);
+    expect(currentGeneration).not.toBe("generation-from-failed-resume");
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        generation: "generation-from-failed-resume",
+        event: "pre_tool_use",
+        requireGeneration: true,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "failed-resume-stale-tool",
+          tool_input: { command: "pwd" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
+      currentGeneration,
+    );
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+  });
+
   it("builds deterministic opaque Codex native hook relay ids", () => {
     const relayId = testing.buildCodexNativeHookRelayId({
       agentId: "dev-codex",

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -536,6 +536,55 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
+  it("rotates native hook relay generations when an existing binding starts a fresh thread", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      userMcpServersFingerprint: "stale-user-mcp-fingerprint",
+      nativeHookRelayGeneration: "generation-from-stale-thread",
+    });
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+      },
+    });
+    await harness.waitForMethod("turn/start");
+
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    const currentGeneration = extractGenerationFromThreadRequest(startRequest?.params);
+    expect(currentGeneration).not.toBe("generation-from-stale-thread");
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        generation: "generation-from-stale-thread",
+        event: "pre_tool_use",
+        requireGeneration: true,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "stale-thread-tool",
+          tool_input: { command: "pwd" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
+      currentGeneration,
+    );
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+  });
+
   it("builds deterministic opaque Codex native hook relay ids", () => {
     const relayId = testing.buildCodexNativeHookRelayId({
       agentId: "dev-codex",

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -113,7 +113,6 @@ import {
   isCodexAppServerApprovalPolicyAllowedByRequirements,
   isCodexSandboxExecServerEnabled,
   readCodexPluginConfig,
-  resolveCodexPluginsPolicy,
   resolveCodexComputerUseConfig,
   resolveCodexAppServerRuntimeOptions,
   shouldAutoApproveCodexAppServerApprovals,
@@ -127,7 +126,6 @@ import {
 import {
   buildDynamicTools,
   createCodexDynamicToolBuildStageTracker,
-  disableCodexPluginThreadConfig,
   filterCodexDynamicToolsForAllowlist,
   formatCodexDynamicToolBuildStageSummary,
   includeForcedCodexDynamicToolAllow,
@@ -181,11 +179,6 @@ import {
 } from "./native-hook-relay.js";
 import { registerCodexNativeSubagentMonitor } from "./native-subagent-monitor.js";
 import { describeCodexNotificationCorrelation } from "./notification-correlation.js";
-import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
-import {
-  buildCodexPluginThreadConfigInputFingerprint,
-  shouldBuildCodexPluginThreadConfig,
-} from "./plugin-thread-config.js";
 import { isCodexAppServerProfilerEnabled } from "./profiler-flag.js";
 import {
   assertCodexTurnStartResponse,
@@ -214,7 +207,6 @@ import {
   buildTurnCollaborationMode,
   buildTurnStartParams,
   codexDynamicToolsFingerprint,
-  resolveCodexNativeHookRelayBindingReuse,
   type CodexAppServerThreadLifecycleBinding,
   type CodexContextEngineThreadBootstrapProjection,
 } from "./thread-lifecycle.js";
@@ -802,58 +794,16 @@ export async function runCodexAppServerAttempt(
     timeoutMs: params.timeoutMs,
     timeoutFloorMs: options.startupTimeoutFloorMs,
   });
-  const nativeHookRelayPluginThreadConfigRequired =
-    !nativeToolSurfaceEnabled || shouldBuildCodexPluginThreadConfig(pluginConfig);
-  const nativeHookRelayPluginThreadConfigPluginConfig = nativeToolSurfaceEnabled
-    ? pluginConfig
-    : disableCodexPluginThreadConfig(pluginConfig);
-  const nativeHookRelayPluginAppCacheKey = nativeHookRelayPluginThreadConfigRequired
-    ? buildCodexPluginAppCacheKey({
-        appServer,
-        agentDir,
-        authProfileId: startupAuthProfileId,
-        accountId: startupAuthAccountCacheKey,
-        envApiKeyFingerprint: startupEnvApiKeyCacheKey,
-      })
-    : undefined;
-  const nativeHookRelayResolvedPluginPolicy = nativeHookRelayPluginThreadConfigRequired
-    ? resolveCodexPluginsPolicy(nativeHookRelayPluginThreadConfigPluginConfig)
-    : undefined;
-  const nativeHookRelayBindingReuse = resolveCodexNativeHookRelayBindingReuse({
-    binding: startupBinding,
-    attemptParams: buildActiveRunAttemptParams(),
-    agentId: sessionAgentId,
-    dynamicTools: toolBridge.specs,
-    nativeCodeModeEnabled: nativeToolSurfaceEnabled,
-    userMcpServersEnabled: nativeToolSurfaceEnabled,
-    mcpServersFingerprint: bundleMcpThreadConfig.fingerprint,
-    mcpServersFingerprintEvaluated: bundleMcpThreadConfig.evaluated,
-    environmentSelection: undefined,
-    contextEngineProjection,
-    pluginThreadConfig: nativeHookRelayPluginThreadConfigRequired
-      ? {
-          enabled: true,
-          inputFingerprint: buildCodexPluginThreadConfigInputFingerprint({
-            pluginConfig: nativeHookRelayPluginThreadConfigPluginConfig,
-            appCacheKey: nativeHookRelayPluginAppCacheKey!,
-          }),
-          enabledPluginConfigKeys: nativeHookRelayResolvedPluginPolicy?.pluginPolicies
-            .filter((plugin) => plugin.enabled)
-            .map((plugin) => plugin.configKey)
-            .toSorted(),
-        }
-      : undefined,
-  });
-  try {
-    emitCodexAppServerEvent(params, {
-      stream: "codex_app_server.lifecycle",
-      data: { phase: "startup" },
-    });
+  const buildNativeHookRelayFinalConfigPatch = (
+    decision: { action: "resume"; binding: CodexAppServerThreadBinding } | { action: "start" },
+  ) => {
+    nativeHookRelay?.unregister();
     nativeHookRelay = createCodexNativeHookRelay({
       options: options.nativeHookRelay,
-      generation: nativeHookRelayBindingReuse.generation,
+      generation:
+        decision.action === "resume" ? decision.binding.nativeHookRelayGeneration : undefined,
       generationMismatchGraceMs:
-        nativeHookRelayBindingReuse.canReuseBinding && !nativeHookRelayBindingReuse.generation
+        decision.action === "resume" && !decision.binding.nativeHookRelayGeneration
           ? CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS
           : undefined,
       events: nativeHookRelayEvents,
@@ -868,15 +818,24 @@ export async function runCodexAppServerAttempt(
       turnStartTimeoutMs: params.timeoutMs,
       signal: runAbortController.signal,
     });
-    const nativeHookRelayConfig = nativeHookRelay
-      ? buildCodexNativeHookRelayConfig({
-          relay: nativeHookRelay,
-          events: nativeHookRelayEvents,
-          hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
-        })
-      : options.nativeHookRelay?.enabled === false
-        ? buildCodexNativeHookRelayDisabledConfig()
-        : undefined;
+    return {
+      configPatch: nativeHookRelay
+        ? buildCodexNativeHookRelayConfig({
+            relay: nativeHookRelay,
+            events: nativeHookRelayEvents,
+            hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
+          })
+        : options.nativeHookRelay?.enabled === false
+          ? buildCodexNativeHookRelayDisabledConfig()
+          : undefined,
+      nativeHookRelayGeneration: nativeHookRelay?.generation,
+    };
+  };
+  try {
+    emitCodexAppServerEvent(params, {
+      stream: "codex_app_server.lifecycle",
+      data: { phase: "startup" },
+    });
     const startupResult = await startCodexAttemptThread({
       attemptClientFactory,
       appServer,
@@ -892,8 +851,7 @@ export async function runCodexAppServerAttempt(
       effectiveWorkspace,
       dynamicTools: toolBridge.specs,
       developerInstructions: promptBuild.developerInstructions,
-      finalConfigPatch: nativeHookRelayConfig,
-      nativeHookRelayGeneration: nativeHookRelay?.generation,
+      buildFinalConfigPatch: buildNativeHookRelayFinalConfigPatch,
       bundleMcpThreadConfig,
       nativeToolSurfaceEnabled,
       sandboxExecServerEnabled,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -113,6 +113,7 @@ import {
   isCodexAppServerApprovalPolicyAllowedByRequirements,
   isCodexSandboxExecServerEnabled,
   readCodexPluginConfig,
+  resolveCodexPluginsPolicy,
   resolveCodexComputerUseConfig,
   resolveCodexAppServerRuntimeOptions,
   shouldAutoApproveCodexAppServerApprovals,
@@ -126,6 +127,7 @@ import {
 import {
   buildDynamicTools,
   createCodexDynamicToolBuildStageTracker,
+  disableCodexPluginThreadConfig,
   filterCodexDynamicToolsForAllowlist,
   formatCodexDynamicToolBuildStageSummary,
   includeForcedCodexDynamicToolAllow,
@@ -179,6 +181,11 @@ import {
 } from "./native-hook-relay.js";
 import { registerCodexNativeSubagentMonitor } from "./native-subagent-monitor.js";
 import { describeCodexNotificationCorrelation } from "./notification-correlation.js";
+import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
+import {
+  buildCodexPluginThreadConfigInputFingerprint,
+  shouldBuildCodexPluginThreadConfig,
+} from "./plugin-thread-config.js";
 import { isCodexAppServerProfilerEnabled } from "./profiler-flag.js";
 import {
   assertCodexTurnStartResponse,
@@ -207,6 +214,7 @@ import {
   buildTurnCollaborationMode,
   buildTurnStartParams,
   codexDynamicToolsFingerprint,
+  resolveCodexNativeHookRelayBindingReuse,
   type CodexAppServerThreadLifecycleBinding,
   type CodexContextEngineThreadBootstrapProjection,
 } from "./thread-lifecycle.js";
@@ -794,6 +802,48 @@ export async function runCodexAppServerAttempt(
     timeoutMs: params.timeoutMs,
     timeoutFloorMs: options.startupTimeoutFloorMs,
   });
+  const nativeHookRelayPluginThreadConfigRequired =
+    !nativeToolSurfaceEnabled || shouldBuildCodexPluginThreadConfig(pluginConfig);
+  const nativeHookRelayPluginThreadConfigPluginConfig = nativeToolSurfaceEnabled
+    ? pluginConfig
+    : disableCodexPluginThreadConfig(pluginConfig);
+  const nativeHookRelayPluginAppCacheKey = nativeHookRelayPluginThreadConfigRequired
+    ? buildCodexPluginAppCacheKey({
+        appServer,
+        agentDir,
+        authProfileId: startupAuthProfileId,
+        accountId: startupAuthAccountCacheKey,
+        envApiKeyFingerprint: startupEnvApiKeyCacheKey,
+      })
+    : undefined;
+  const nativeHookRelayResolvedPluginPolicy = nativeHookRelayPluginThreadConfigRequired
+    ? resolveCodexPluginsPolicy(nativeHookRelayPluginThreadConfigPluginConfig)
+    : undefined;
+  const nativeHookRelayBindingReuse = resolveCodexNativeHookRelayBindingReuse({
+    binding: startupBinding,
+    attemptParams: buildActiveRunAttemptParams(),
+    agentId: sessionAgentId,
+    dynamicTools: toolBridge.specs,
+    nativeCodeModeEnabled: nativeToolSurfaceEnabled,
+    userMcpServersEnabled: nativeToolSurfaceEnabled,
+    mcpServersFingerprint: bundleMcpThreadConfig.fingerprint,
+    mcpServersFingerprintEvaluated: bundleMcpThreadConfig.evaluated,
+    environmentSelection: undefined,
+    contextEngineProjection,
+    pluginThreadConfig: nativeHookRelayPluginThreadConfigRequired
+      ? {
+          enabled: true,
+          inputFingerprint: buildCodexPluginThreadConfigInputFingerprint({
+            pluginConfig: nativeHookRelayPluginThreadConfigPluginConfig,
+            appCacheKey: nativeHookRelayPluginAppCacheKey!,
+          }),
+          enabledPluginConfigKeys: nativeHookRelayResolvedPluginPolicy?.pluginPolicies
+            .filter((plugin) => plugin.enabled)
+            .map((plugin) => plugin.configKey)
+            .toSorted(),
+        }
+      : undefined,
+  });
   try {
     emitCodexAppServerEvent(params, {
       stream: "codex_app_server.lifecycle",
@@ -801,9 +851,9 @@ export async function runCodexAppServerAttempt(
     });
     nativeHookRelay = createCodexNativeHookRelay({
       options: options.nativeHookRelay,
-      generation: startupBinding?.nativeHookRelayGeneration,
+      generation: nativeHookRelayBindingReuse.generation,
       generationMismatchGraceMs:
-        startupBinding && !startupBinding.nativeHookRelayGeneration
+        nativeHookRelayBindingReuse.canReuseBinding && !nativeHookRelayBindingReuse.generation
           ? CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS
           : undefined,
       events: nativeHookRelayEvents,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -801,6 +801,11 @@ export async function runCodexAppServerAttempt(
     });
     nativeHookRelay = createCodexNativeHookRelay({
       options: options.nativeHookRelay,
+      generation: startupBinding?.nativeHookRelayGeneration,
+      generationMismatchGraceMs:
+        startupBinding && !startupBinding.nativeHookRelayGeneration
+          ? CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS
+          : undefined,
       events: nativeHookRelayEvents,
       agentId: sessionAgentId,
       sessionId: params.sessionId,
@@ -838,6 +843,7 @@ export async function runCodexAppServerAttempt(
       dynamicTools: toolBridge.specs,
       developerInstructions: promptBuild.developerInstructions,
       finalConfigPatch: nativeHookRelayConfig,
+      nativeHookRelayGeneration: nativeHookRelay?.generation,
       bundleMcpThreadConfig,
       nativeToolSurfaceEnabled,
       sandboxExecServerEnabled,

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -60,6 +60,7 @@ describe("codex app-server session binding", () => {
       modelProvider: "openai",
       dynamicToolsFingerprint: "tools-v1",
       userMcpServersFingerprint: "user-mcp-v1",
+      nativeHookRelayGeneration: "generation-v1",
     });
 
     const binding = await readCodexAppServerBinding(sessionFile);
@@ -72,6 +73,7 @@ describe("codex app-server session binding", () => {
     expect(binding?.modelProvider).toBe("openai");
     expect(binding?.dynamicToolsFingerprint).toBe("tools-v1");
     expect(binding?.userMcpServersFingerprint).toBe("user-mcp-v1");
+    expect(binding?.nativeHookRelayGeneration).toBe("generation-v1");
     const bindingStat = await fs.stat(resolveCodexAppServerBindingPath(sessionFile));
     expect(bindingStat.isFile()).toBe(true);
   });

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -42,6 +42,7 @@ export type CodexAppServerThreadBinding = {
   dynamicToolsFingerprint?: string;
   userMcpServersFingerprint?: string;
   mcpServersFingerprint?: string;
+  nativeHookRelayGeneration?: string;
   pluginAppsFingerprint?: string;
   pluginAppsInputFingerprint?: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
@@ -116,6 +117,11 @@ export async function readCodexAppServerBinding(
           : undefined,
       mcpServersFingerprint:
         typeof parsed.mcpServersFingerprint === "string" ? parsed.mcpServersFingerprint : undefined,
+      nativeHookRelayGeneration:
+        typeof parsed.nativeHookRelayGeneration === "string" &&
+        parsed.nativeHookRelayGeneration.trim()
+          ? parsed.nativeHookRelayGeneration
+          : undefined,
       pluginAppsFingerprint:
         typeof parsed.pluginAppsFingerprint === "string" ? parsed.pluginAppsFingerprint : undefined,
       pluginAppsInputFingerprint:
@@ -166,6 +172,7 @@ export async function writeCodexAppServerBinding(
     dynamicToolsFingerprint: binding.dynamicToolsFingerprint,
     userMcpServersFingerprint: binding.userMcpServersFingerprint,
     mcpServersFingerprint: binding.mcpServersFingerprint,
+    nativeHookRelayGeneration: binding.nativeHookRelayGeneration,
     pluginAppsFingerprint: binding.pluginAppsFingerprint,
     pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
     pluginAppPolicyContext: binding.pluginAppPolicyContext,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -202,6 +202,7 @@ export async function startOrResumeThread(params: {
   developerInstructions?: string;
   config?: JsonObject;
   finalConfigPatch?: JsonObject;
+  nativeHookRelayGeneration?: string;
   nativeCodeModeEnabled?: boolean;
   nativeCodeModeOnlyEnabled?: boolean;
   userMcpServersEnabled?: boolean;
@@ -433,6 +434,8 @@ export async function startOrResumeThread(params: {
               dynamicToolsFingerprint,
               userMcpServersFingerprint,
               mcpServersFingerprint: nextMcpServersFingerprint,
+              nativeHookRelayGeneration:
+                params.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
               pluginAppsFingerprint: binding.pluginAppsFingerprint,
               pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
               pluginAppPolicyContext: binding.pluginAppPolicyContext,
@@ -475,6 +478,8 @@ export async function startOrResumeThread(params: {
           dynamicToolsFingerprint,
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
+          nativeHookRelayGeneration:
+            params.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
           pluginAppsFingerprint: binding.pluginAppsFingerprint,
           pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
           pluginAppPolicyContext: binding.pluginAppPolicyContext,
@@ -548,6 +553,7 @@ export async function startOrResumeThread(params: {
           dynamicToolsFingerprint,
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
+          nativeHookRelayGeneration: params.nativeHookRelayGeneration,
           pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
           pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
           pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -592,6 +598,7 @@ export async function startOrResumeThread(params: {
     dynamicToolsFingerprint,
     userMcpServersFingerprint,
     mcpServersFingerprint: nextMcpServersFingerprint,
+    nativeHookRelayGeneration: params.nativeHookRelayGeneration,
     pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
     pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
     pluginAppPolicyContext: pluginThreadConfig?.policyContext,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -69,6 +69,11 @@ export type CodexPluginThreadConfigProvider = {
   build: () => Promise<CodexPluginThreadConfig>;
 };
 
+export type CodexNativeHookRelayBindingReuseDecision = {
+  canReuseBinding: boolean;
+  generation?: string;
+};
+
 export const CODEX_NATIVE_PERSONALITY_NONE = "none";
 
 export const CODEX_CODE_MODE_THREAD_CONFIG: JsonObject = {
@@ -611,6 +616,94 @@ export async function startOrResumeThread(params: {
       ...(rotatedContextEngineBinding ? { rotatedContextEngineBinding } : {}),
     },
   };
+}
+
+export function resolveCodexNativeHookRelayBindingReuse(params: {
+  binding: CodexAppServerThreadBinding | undefined;
+  attemptParams: EmbeddedRunAttemptParams;
+  agentId?: string;
+  dynamicTools: CodexDynamicToolSpec[];
+  nativeCodeModeEnabled?: boolean;
+  userMcpServersEnabled?: boolean;
+  mcpServersFingerprint?: string;
+  mcpServersFingerprintEvaluated?: boolean;
+  environmentSelection?: CodexTurnEnvironmentParams[];
+  pluginThreadConfig?: Pick<
+    CodexPluginThreadConfigProvider,
+    "enabled" | "inputFingerprint" | "enabledPluginConfigKeys"
+  >;
+  contextEngineProjection?: CodexContextEngineThreadBootstrapProjection;
+}): CodexNativeHookRelayBindingReuseDecision {
+  const binding = params.binding;
+  if (!binding?.threadId || params.nativeCodeModeEnabled === false) {
+    return { canReuseBinding: false };
+  }
+
+  const contextEngineBinding = buildContextEngineBinding(
+    params.attemptParams,
+    params.contextEngineProjection,
+  );
+  if (binding.contextEngine || contextEngineBinding) {
+    if (
+      !contextEngineBinding ||
+      !isContextEngineBindingCompatible(binding.contextEngine, contextEngineBinding)
+    ) {
+      return { canReuseBinding: false };
+    }
+  }
+
+  const userMcpServersConfigPatch =
+    params.userMcpServersEnabled === false
+      ? undefined
+      : buildCodexUserMcpServersThreadConfigPatch(params.attemptParams.config, {
+          agentId: params.agentId ?? params.attemptParams.agentId,
+        });
+  if (
+    binding.userMcpServersFingerprint !==
+    fingerprintUserMcpServersConfigPatch(userMcpServersConfigPatch)
+  ) {
+    return { canReuseBinding: false };
+  }
+
+  if (
+    binding.environmentSelectionFingerprint !==
+    fingerprintEnvironmentSelection(params.environmentSelection)
+  ) {
+    return { canReuseBinding: false };
+  }
+
+  if (
+    params.mcpServersFingerprintEvaluated === true &&
+    binding.mcpServersFingerprint !== params.mcpServersFingerprint
+  ) {
+    return { canReuseBinding: false };
+  }
+
+  if (
+    isCodexPluginThreadBindingStale({
+      codexPluginsEnabled: params.pluginThreadConfig?.enabled ?? false,
+      bindingFingerprint: binding.pluginAppsFingerprint,
+      bindingInputFingerprint: binding.pluginAppsInputFingerprint,
+      currentInputFingerprint: params.pluginThreadConfig?.inputFingerprint,
+      hasBindingPolicyContext: Boolean(binding.pluginAppPolicyContext),
+    }) ||
+    shouldRecheckRecoverablePluginBinding({
+      binding,
+      pluginThreadConfig: params.pluginThreadConfig as CodexPluginThreadConfigProvider | undefined,
+    })
+  ) {
+    return { canReuseBinding: false };
+  }
+
+  const dynamicToolsFingerprint = fingerprintDynamicTools(params.dynamicTools);
+  if (
+    binding.dynamicToolsFingerprint &&
+    !areDynamicToolFingerprintsCompatible(binding.dynamicToolsFingerprint, dynamicToolsFingerprint)
+  ) {
+    return { canReuseBinding: false };
+  }
+
+  return { canReuseBinding: true, generation: binding.nativeHookRelayGeneration };
 }
 
 export function buildContextEngineBinding(

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -56,6 +56,15 @@ export type CodexAppServerThreadLifecycleBinding = CodexAppServerThreadBinding &
   lifecycle: CodexAppServerThreadLifecycle;
 };
 
+export type CodexThreadFinalConfigPatchDecision =
+  | { action: "resume"; binding: CodexAppServerThreadBinding }
+  | { action: "start" };
+
+export type CodexThreadFinalConfigPatchResult = {
+  configPatch?: JsonObject;
+  nativeHookRelayGeneration?: string;
+};
+
 export type CodexContextEngineThreadBootstrapProjection = {
   mode: "thread_bootstrap";
   epoch: string;
@@ -67,11 +76,6 @@ export type CodexPluginThreadConfigProvider = {
   inputFingerprint?: string;
   enabledPluginConfigKeys?: readonly string[];
   build: () => Promise<CodexPluginThreadConfig>;
-};
-
-export type CodexNativeHookRelayBindingReuseDecision = {
-  canReuseBinding: boolean;
-  generation?: string;
 };
 
 export const CODEX_NATIVE_PERSONALITY_NONE = "none";
@@ -207,6 +211,9 @@ export async function startOrResumeThread(params: {
   developerInstructions?: string;
   config?: JsonObject;
   finalConfigPatch?: JsonObject;
+  buildFinalConfigPatch?: (
+    decision: CodexThreadFinalConfigPatchDecision,
+  ) => CodexThreadFinalConfigPatchResult;
   nativeHookRelayGeneration?: string;
   nativeCodeModeEnabled?: boolean;
   nativeCodeModeOnlyEnabled?: boolean;
@@ -393,10 +400,17 @@ export async function startOrResumeThread(params: {
     } else {
       try {
         const authProfileId = params.params.authProfileId ?? binding.authProfileId;
+        const finalConfigPatch = params.buildFinalConfigPatch?.({
+          action: "resume",
+          binding,
+        }) ?? {
+          configPatch: params.finalConfigPatch,
+          nativeHookRelayGeneration: params.nativeHookRelayGeneration,
+        };
         const resumeConfig = mergeCodexThreadConfigs(
           params.config,
           userMcpServersConfigPatch,
-          params.finalConfigPatch,
+          finalConfigPatch.configPatch,
         );
         const resumeParams = lifecycleTiming.measureSync("thread_resume_params", () =>
           buildThreadResumeParams(params.params, {
@@ -440,7 +454,7 @@ export async function startOrResumeThread(params: {
               userMcpServersFingerprint,
               mcpServersFingerprint: nextMcpServersFingerprint,
               nativeHookRelayGeneration:
-                params.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
+                finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
               pluginAppsFingerprint: binding.pluginAppsFingerprint,
               pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
               pluginAppPolicyContext: binding.pluginAppPolicyContext,
@@ -484,7 +498,7 @@ export async function startOrResumeThread(params: {
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
           nativeHookRelayGeneration:
-            params.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
+            finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
           pluginAppsFingerprint: binding.pluginAppsFingerprint,
           pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
           pluginAppPolicyContext: binding.pluginAppPolicyContext,
@@ -510,12 +524,16 @@ export async function startOrResumeThread(params: {
         params.pluginThreadConfig?.build(),
       )))
     : undefined;
+  const finalConfigPatch = params.buildFinalConfigPatch?.({ action: "start" }) ?? {
+    configPatch: params.finalConfigPatch,
+    nativeHookRelayGeneration: params.nativeHookRelayGeneration,
+  };
   const config = lifecycleTiming.measureSync("merge_thread_config", () =>
     mergeCodexThreadConfigs(
       params.config,
       userMcpServersConfigPatch,
       pluginThreadConfig?.configPatch,
-      params.finalConfigPatch,
+      finalConfigPatch.configPatch,
     ),
   );
   const startParams = lifecycleTiming.measureSync("thread_start_params", () =>
@@ -558,7 +576,7 @@ export async function startOrResumeThread(params: {
           dynamicToolsFingerprint,
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
-          nativeHookRelayGeneration: params.nativeHookRelayGeneration,
+          nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
           pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
           pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
           pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -603,7 +621,7 @@ export async function startOrResumeThread(params: {
     dynamicToolsFingerprint,
     userMcpServersFingerprint,
     mcpServersFingerprint: nextMcpServersFingerprint,
-    nativeHookRelayGeneration: params.nativeHookRelayGeneration,
+    nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
     pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
     pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
     pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -616,94 +634,6 @@ export async function startOrResumeThread(params: {
       ...(rotatedContextEngineBinding ? { rotatedContextEngineBinding } : {}),
     },
   };
-}
-
-export function resolveCodexNativeHookRelayBindingReuse(params: {
-  binding: CodexAppServerThreadBinding | undefined;
-  attemptParams: EmbeddedRunAttemptParams;
-  agentId?: string;
-  dynamicTools: CodexDynamicToolSpec[];
-  nativeCodeModeEnabled?: boolean;
-  userMcpServersEnabled?: boolean;
-  mcpServersFingerprint?: string;
-  mcpServersFingerprintEvaluated?: boolean;
-  environmentSelection?: CodexTurnEnvironmentParams[];
-  pluginThreadConfig?: Pick<
-    CodexPluginThreadConfigProvider,
-    "enabled" | "inputFingerprint" | "enabledPluginConfigKeys"
-  >;
-  contextEngineProjection?: CodexContextEngineThreadBootstrapProjection;
-}): CodexNativeHookRelayBindingReuseDecision {
-  const binding = params.binding;
-  if (!binding?.threadId || params.nativeCodeModeEnabled === false) {
-    return { canReuseBinding: false };
-  }
-
-  const contextEngineBinding = buildContextEngineBinding(
-    params.attemptParams,
-    params.contextEngineProjection,
-  );
-  if (binding.contextEngine || contextEngineBinding) {
-    if (
-      !contextEngineBinding ||
-      !isContextEngineBindingCompatible(binding.contextEngine, contextEngineBinding)
-    ) {
-      return { canReuseBinding: false };
-    }
-  }
-
-  const userMcpServersConfigPatch =
-    params.userMcpServersEnabled === false
-      ? undefined
-      : buildCodexUserMcpServersThreadConfigPatch(params.attemptParams.config, {
-          agentId: params.agentId ?? params.attemptParams.agentId,
-        });
-  if (
-    binding.userMcpServersFingerprint !==
-    fingerprintUserMcpServersConfigPatch(userMcpServersConfigPatch)
-  ) {
-    return { canReuseBinding: false };
-  }
-
-  if (
-    binding.environmentSelectionFingerprint !==
-    fingerprintEnvironmentSelection(params.environmentSelection)
-  ) {
-    return { canReuseBinding: false };
-  }
-
-  if (
-    params.mcpServersFingerprintEvaluated === true &&
-    binding.mcpServersFingerprint !== params.mcpServersFingerprint
-  ) {
-    return { canReuseBinding: false };
-  }
-
-  if (
-    isCodexPluginThreadBindingStale({
-      codexPluginsEnabled: params.pluginThreadConfig?.enabled ?? false,
-      bindingFingerprint: binding.pluginAppsFingerprint,
-      bindingInputFingerprint: binding.pluginAppsInputFingerprint,
-      currentInputFingerprint: params.pluginThreadConfig?.inputFingerprint,
-      hasBindingPolicyContext: Boolean(binding.pluginAppPolicyContext),
-    }) ||
-    shouldRecheckRecoverablePluginBinding({
-      binding,
-      pluginThreadConfig: params.pluginThreadConfig as CodexPluginThreadConfigProvider | undefined,
-    })
-  ) {
-    return { canReuseBinding: false };
-  }
-
-  const dynamicToolsFingerprint = fingerprintDynamicTools(params.dynamicTools);
-  if (
-    binding.dynamicToolsFingerprint &&
-    !areDynamicToolFingerprintsCompatible(binding.dynamicToolsFingerprint, dynamicToolsFingerprint)
-  ) {
-    return { canReuseBinding: false };
-  }
-
-  return { canReuseBinding: true, generation: binding.nativeHookRelayGeneration };
 }
 
 export function buildContextEngineBinding(

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -743,6 +743,65 @@ describe("native hook relay registry", () => {
     });
   });
 
+  it("accepts bootstrap generation mismatches during a bounded grace window", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-bootstrap-stale-generation",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+      generationMismatchGraceMs: 60_000,
+    });
+
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: "stale-generation-from-resumed-thread",
+        event: "pre_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    expect(getOnlyNativeHookRelayInvocation()).toMatchObject({
+      relayId: relay.relayId,
+      runId: "run-1",
+      event: "pre_tool_use",
+    });
+  });
+
+  it("rejects bootstrap generation mismatches after the grace window", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-expired-bootstrap-stale-generation",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+      generationMismatchGraceMs: 1,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: "stale-generation-from-resumed-thread",
+        event: "pre_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+  });
+
   it("renews relay ttl without rotating the direct hook bridge", async () => {
     const relay = registerNativeHookRelay({
       provider: "codex",

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -76,6 +76,7 @@ export type NativeHookRelayProcessResponse = {
 export type NativeHookRelayRegistration = {
   relayId: string;
   provider: NativeHookRelayProvider;
+  generationMismatchGraceExpiresAtMs?: number;
   agentId?: string;
   sessionId: string;
   sessionKey?: string;
@@ -98,6 +99,8 @@ export type NativeHookRelayRegistrationHandle = NativeHookRelayRegistration & {
 export type RegisterNativeHookRelayParams = {
   provider: NativeHookRelayProvider;
   relayId?: string;
+  generation?: string;
+  generationMismatchGraceMs?: number;
   agentId?: string;
   sessionId: string;
   sessionKey?: string;
@@ -353,12 +356,18 @@ export function registerNativeHookRelay(
   pruneExpiredNativeHookRelays();
   pruneNativeHookRelayPermissionAllowAlways();
   const relayId = normalizeRelayId(params.relayId) ?? randomUUID();
+  const generation = normalizeRelayGeneration(params.generation) ?? randomUUID();
+  const generationMismatchGraceMs = normalizePositiveInteger(params.generationMismatchGraceMs, 0);
+  const now = Date.now();
   const allowedEvents = normalizeAllowedEvents(params.allowedEvents);
   unregisterNativeHookRelay(relayId);
   const registration: ActiveNativeHookRelayRegistration = {
     relayId,
     provider: params.provider,
-    generation: randomUUID(),
+    generation,
+    ...(generationMismatchGraceMs > 0
+      ? { generationMismatchGraceExpiresAtMs: now + generationMismatchGraceMs }
+      : {}),
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionId: params.sessionId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
@@ -366,7 +375,7 @@ export function registerNativeHookRelay(
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
     allowedEvents,
-    expiresAtMs: Date.now() + normalizePositiveInteger(params.ttlMs, DEFAULT_RELAY_TTL_MS),
+    expiresAtMs: now + normalizePositiveInteger(params.ttlMs, DEFAULT_RELAY_TTL_MS),
     ...(params.signal ? { signal: params.signal } : {}),
   };
   relays.set(relayId, registration);
@@ -423,6 +432,17 @@ function normalizeRelayId(value: string | undefined): string | undefined {
   }
   if (trimmed.length > 160 || !/^[A-Za-z0-9._:-]+$/u.test(trimmed)) {
     throw new Error("native hook relay id must be non-empty, compact, and URL-safe");
+  }
+  return trimmed;
+}
+
+function normalizeRelayGeneration(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.length > 160 || !/^[A-Za-z0-9._:-]+$/u.test(trimmed)) {
+    throw new Error("native hook relay generation must be non-empty, compact, and URL-safe");
   }
   return trimmed;
 }
@@ -522,7 +542,14 @@ export async function invokeNativeHookRelay(
   if (params.requireGeneration) {
     const generation = readNonEmptyString(params.generation, "generation");
     if (generation !== registration.generation) {
-      throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
+      if (!canAcceptNativeHookRelayGenerationMismatch(registration)) {
+        throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
+      }
+      log.debug("native hook relay accepted bootstrap generation mismatch", {
+        relayId,
+        event,
+        runId: registration.runId,
+      });
     }
   }
   if (!registration.allowedEvents.includes(event)) {
@@ -649,6 +676,13 @@ function removeNativeHookRelayInvocations(relayId: string): void {
       invocations.splice(index, 1);
     }
   }
+}
+
+function canAcceptNativeHookRelayGenerationMismatch(
+  registration: NativeHookRelayRegistration,
+): boolean {
+  const expiresAtMs = registration.generationMismatchGraceExpiresAtMs;
+  return typeof expiresAtMs === "number" && Date.now() <= expiresAtMs;
 }
 
 function pruneExpiredNativeHookRelays(now = Date.now()): void {


### PR DESCRIPTION
## Summary

Fixes #87331.

Fixes the Codex native hook relay generation mismatch that can make the first native tool call after a Gateway restart fail with `Native hook relay unavailable`.

The root cause is that OpenClaw rotated the relay generation on every registration while resumed Codex app-server threads can briefly keep using the previous hook command. After a Gateway restart, the old generation was not available in process memory, so the resumed thread's first hook invocation was rejected as stale even though it targeted the same stable relay id.

## Changes

- Persist the active Codex native hook relay generation in the Codex app-server thread binding.
- Reuse that persisted generation when resuming an existing Codex thread after restart.
- Add a bounded compatibility grace window for older bindings that do not yet have a persisted generation, so upgraded installs recover immediately.
- Keep normal stale-generation rejection behavior outside that explicit grace window.
- Add regression coverage for the direct relay bridge, resumed-thread generation reuse, and old binding compatibility.

## Validation

- `node scripts/run-vitest.mjs src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts extensions/codex/src/app-server/session-binding.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts --run`
- `./node_modules/.bin/oxfmt --check extensions/codex/src/app-server/attempt-startup.ts extensions/codex/src/app-server/native-hook-relay.ts extensions/codex/src/app-server/run-attempt-test-harness.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/session-binding.test.ts extensions/codex/src/app-server/session-binding.ts extensions/codex/src/app-server/thread-lifecycle.ts src/agents/harness/native-hook-relay.test.ts src/agents/harness/native-hook-relay.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
