### PR TITLE
fix(agents): honor OpenAI-compatible cache retention

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -104,8 +104,8 @@ Per-agent heartbeat is supported at `agents.list[].heartbeat`.
 ### OpenAI (direct API)
 
 - Prompt caching is automatic on supported recent models. OpenClaw does not need to inject block-level cache markers.
-- OpenClaw uses `prompt_cache_key` to keep cache routing stable across turns and uses `prompt_cache_retention: "24h"` only when `cacheRetention: "long"` is selected on direct OpenAI hosts.
-- OpenAI-compatible Completions providers receive `prompt_cache_key` only when their model config explicitly sets `compat.supportsPromptCacheKey: true`; `cacheRetention: "none"` still suppresses it.
+- OpenClaw uses `prompt_cache_key` to keep cache routing stable across turns. Direct OpenAI hosts use `prompt_cache_retention: "24h"` when `cacheRetention: "long"` is selected.
+- OpenAI-compatible Completions providers receive `prompt_cache_key` only when their model config explicitly sets `compat.supportsPromptCacheKey: true`; with that same opt-in, explicit `cacheRetention: "long"` also forwards `prompt_cache_retention: "24h"`, and `cacheRetention: "none"` suppresses both fields.
 - OpenAI responses expose cached prompt tokens via `usage.prompt_tokens_details.cached_tokens` (or `input_tokens_details.cached_tokens` on Responses API events). OpenClaw maps that to `cacheRead`.
 - OpenAI does not expose a separate cache-write token counter, so `cacheWrite` stays `0` on OpenAI paths even when the provider is warming a cache.
 - OpenAI returns useful tracing and rate-limit headers such as `x-request-id`, `openai-processing-ms`, and `x-ratelimit-*`, but cache-hit accounting should come from the usage payload, not from headers.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4637,6 +4637,67 @@ describe("openai transport stream", () => {
     expect(notOptedIn.prompt_cache_key).toBeUndefined();
   });
 
+  it("emits prompt_cache_retention=24h for completions when cacheRetention is long", () => {
+    const model = {
+      id: "custom-model",
+      name: "Custom Model",
+      api: "openai-completions",
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsPromptCacheKey: true },
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32768,
+      maxTokens: 8192,
+    } as unknown as Model<"openai-completions">;
+    const context = {
+      systemPrompt: "system",
+      messages: [],
+      tools: [],
+    } as never;
+
+    const longRetention = buildOpenAICompletionsParams(model, context, {
+      sessionId: "session-123",
+      cacheRetention: "long",
+    }) as { prompt_cache_key?: string; prompt_cache_retention?: string };
+
+    expect(longRetention.prompt_cache_key).toBe("session-123");
+    expect(longRetention.prompt_cache_retention).toBe("24h");
+  });
+
+  it("omits prompt_cache_retention for completions when cacheRetention is short or unset", () => {
+    const model = {
+      id: "custom-model",
+      name: "Custom Model",
+      api: "openai-completions",
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsPromptCacheKey: true },
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32768,
+      maxTokens: 8192,
+    } as unknown as Model<"openai-completions">;
+    const context = {
+      systemPrompt: "system",
+      messages: [],
+      tools: [],
+    } as never;
+
+    const shortRetention = buildOpenAICompletionsParams(model, context, {
+      sessionId: "session-123",
+      cacheRetention: "short",
+    }) as Record<string, unknown>;
+    const defaultRetention = buildOpenAICompletionsParams(model, context, {
+      sessionId: "session-123",
+    }) as Record<string, unknown>;
+
+    expect(shortRetention).not.toHaveProperty("prompt_cache_retention");
+    expect(defaultRetention).not.toHaveProperty("prompt_cache_retention");
+  });
+
   it("sorts Chat Completions tools by function name for stable prompt-cache payloads", () => {
     const model = {
       id: "custom-model",

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4689,10 +4689,10 @@ describe("openai transport stream", () => {
     const shortRetention = buildOpenAICompletionsParams(model, context, {
       sessionId: "session-123",
       cacheRetention: "short",
-    }) as Record<string, unknown>;
+    });
     const defaultRetention = buildOpenAICompletionsParams(model, context, {
       sessionId: "session-123",
-    }) as Record<string, unknown>;
+    });
 
     expect(shortRetention).not.toHaveProperty("prompt_cache_retention");
     expect(defaultRetention).not.toHaveProperty("prompt_cache_retention");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3499,6 +3499,15 @@ export function buildOpenAICompletionsParams(
   }
   if (compat.supportsPromptCacheKey && cacheRetention !== "none" && options?.sessionId) {
     params.prompt_cache_key = options.sessionId;
+    // When the caller explicitly opted into long retention, forward the
+    // canonical prompt_cache_retention value alongside the cache key so
+    // OpenAI-compatible completions backends (oMLX, llama.cpp, official
+    // OpenAI, etc.) can honor the 24h prefix-cache lifetime. Without this
+    // the key reaches the wire but the retention preference is silently
+    // dropped (issue #81281).
+    if (cacheRetention === "long") {
+      params.prompt_cache_retention = "24h";
+    }
   }
   if (options?.temperature !== undefined) {
     params.temperature = options.temperature;

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2647,6 +2647,55 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.cacheRetention).toBe("long");
   });
 
+  it("passes through explicit cacheRetention for prompt-cache-key openai-completions providers", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = buildModelConfig("omlx-local/local_model", {
+      cacheRetention: "long",
+    });
+
+    applyExtraParamsToAgent(agent, cfg, "omlx-local", "local_model");
+
+    const model = {
+      api: "openai-completions",
+      provider: "omlx-local",
+      id: "local_model",
+      compat: { supportsPromptCacheKey: true },
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      sessionId: "session-81281",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBe("long");
+    expect(calls[0]?.sessionId).toBe("session-81281");
+  });
+
+  it("keeps explicit cacheRetention off openai-completions providers without prompt-cache-key support", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = buildModelConfig("omlx-local/local_model", {
+      cacheRetention: "long",
+    });
+
+    applyExtraParamsToAgent(agent, cfg, "omlx-local", "local_model");
+
+    const model = {
+      api: "openai-completions",
+      provider: "omlx-local",
+      id: "local_model",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      sessionId: "session-81281",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBeUndefined();
+    expect(calls[0]?.sessionId).toBe("session-81281");
+  });
+
   it("passes through explicit cacheRetention for custom anthropic-messages providers", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2660,7 +2660,7 @@ describe("applyExtraParamsToAgent", () => {
       provider: "omlx-local",
       id: "local_model",
       compat: { supportsPromptCacheKey: true },
-    } as Model<"openai-completions">;
+    } as unknown as Model<"openai-completions">;
     const context: Context = { messages: [] };
 
     void agent.streamFn?.(model, context, {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -494,11 +494,20 @@ function createStreamFnWithExtraParams(
     streamParams.seed = resolvedSeed;
   }
 
+  const readSupportsPromptCacheKey = (m: unknown): boolean => {
+    const compat = (m as { compat?: unknown })?.compat;
+    if (!compat || typeof compat !== "object") {
+      return false;
+    }
+    return (compat as Record<string, unknown>).supportsPromptCacheKey === true;
+  };
+
   const initialCacheRetention = resolveCacheRetention(
     extraParams,
     provider,
     typeof model?.api === "string" ? model.api : undefined,
     typeof model?.id === "string" ? model.id : undefined,
+    readSupportsPromptCacheKey(model),
   );
   if (Object.keys(streamParams).length > 0 || initialCacheRetention) {
     const debugParams = initialCacheRetention
@@ -514,6 +523,7 @@ function createStreamFnWithExtraParams(
       provider,
       typeof callModel.api === "string" ? callModel.api : undefined,
       typeof callModel.id === "string" ? callModel.id : undefined,
+      readSupportsPromptCacheKey(callModel),
     );
     const hasStreamParams = Object.keys(streamParams).length > 0 || cacheRetention;
     if (!hasStreamParams) {

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
@@ -30,6 +30,50 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
+  it("passes explicit cacheRetention through for openai-completions providers (issue #81281)", () => {
+    // Regression: openai-completions providers with prefix-caching backends
+    // (oMLX, llama.cpp, etc.) configure compat.supportsPromptCacheKey: true
+    // and cacheRetention: "long" but the wrapper was silently dropping the
+    // user's explicit cacheRetention because the provider is neither in the
+    // anthropic family nor google-eligible.
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+      ),
+    ).toBe("long");
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "short" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+      ),
+    ).toBe("short");
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "none" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+      ),
+    ).toBe("none");
+  });
+
+  it("returns undefined for openai-completions without explicit cacheRetention", () => {
+    // Without an explicit user choice, openai-completions providers fall back
+    // to the transport-level default ("short") rather than receiving a
+    // wrapper-injected value.
+    expect(
+      resolveCacheRetention(undefined, "omlx-local", "openai-completions", "local_model"),
+    ).toBeUndefined();
+    expect(
+      resolveCacheRetention({}, "omlx-local", "openai-completions", "local_model"),
+    ).toBeUndefined();
+  });
+
   it("identifies supported direct Google cache families", () => {
     expect(
       isGooglePromptCacheEligible({

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
@@ -100,6 +100,30 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
+  it("does not map legacy cacheControlTtl for openai-completions prompt-cache-key providers", () => {
+    // Legacy TTL aliases were Anthropic/Google semantics; OpenAI-compatible
+    // completions providers need an explicit cacheRetention value before the
+    // wrapper forwards retention to the transport.
+    expect(
+      resolveCacheRetention(
+        { cacheControlTtl: "1h" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+        true,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveCacheRetention(
+        { cacheControlTtl: "5m" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+        true,
+      ),
+    ).toBeUndefined();
+  });
+
   it("identifies supported direct Google cache families", () => {
     expect(
       isGooglePromptCacheEligible({

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
@@ -30,10 +30,10 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
-  it("passes explicit cacheRetention through for openai-completions providers (issue #81281)", () => {
+  it("passes explicit cacheRetention through for openai-completions providers when supportsPromptCacheKey (issue #81281)", () => {
     // Regression: openai-completions providers with prefix-caching backends
-    // (oMLX, llama.cpp, etc.) configure compat.supportsPromptCacheKey: true
-    // and cacheRetention: "long" but the wrapper was silently dropping the
+    // (oMLX, llama.cpp, etc.) set compat.supportsPromptCacheKey: true and
+    // cacheRetention: "long" but the wrapper was silently dropping the
     // user's explicit cacheRetention because the provider is neither in the
     // anthropic family nor google-eligible.
     expect(
@@ -42,6 +42,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
+        true,
       ),
     ).toBe("long");
     expect(
@@ -50,6 +51,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
+        true,
       ),
     ).toBe("short");
     expect(
@@ -58,8 +60,32 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
+        true,
       ),
     ).toBe("none");
+  });
+
+  it("does not honor explicit cacheRetention for openai-completions without supportsPromptCacheKey", () => {
+    // Providers that route via openai-completions but do not advertise prompt
+    // caching (e.g. amazon-bedrock proxying amazon.* nova models) must keep
+    // the explicit cacheRetention from leaking into the outgoing payload.
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "amazon-bedrock",
+        "openai-completions",
+        "amazon.nova-micro-v1:0",
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+        false,
+      ),
+    ).toBeUndefined();
   });
 
   it("returns undefined for openai-completions without explicit cacheRetention", () => {
@@ -67,10 +93,10 @@ describe("prompt cache retention", () => {
     // to the transport-level default ("short") rather than receiving a
     // wrapper-injected value.
     expect(
-      resolveCacheRetention(undefined, "omlx-local", "openai-completions", "local_model"),
+      resolveCacheRetention(undefined, "omlx-local", "openai-completions", "local_model", true),
     ).toBeUndefined();
     expect(
-      resolveCacheRetention({}, "omlx-local", "openai-completions", "local_model"),
+      resolveCacheRetention({}, "omlx-local", "openai-completions", "local_model", true),
     ).toBeUndefined();
   });
 

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.ts
@@ -19,6 +19,7 @@ export function resolveCacheRetention(
   provider: string,
   modelApi?: string,
   modelId?: string,
+  supportsPromptCacheKey?: boolean,
 ): CacheRetention | undefined {
   const hasExplicitCacheConfig =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
@@ -29,13 +30,19 @@ export function resolveCacheRetention(
     hasExplicitCacheConfig,
   });
   const googleEligible = isGooglePromptCacheEligible({ modelApi, modelId });
+  // OpenAI-compatible completions backends (oMLX, llama.cpp, etc.) opt into
+  // prompt caching via `compat.supportsPromptCacheKey: true`. Without that
+  // flag they sit outside the anthropic/google family gates, so issue #81281
+  // dropped the user's explicit `cacheRetention` before the transport layer
+  // could emit it. Proxies that route non-cacheable models via the same
+  // openai-completions wire (amazon-bedrock + amazon.* nova models) leave
+  // the flag unset, so the existing family gate still applies to them.
+  const cacheKeyEligible = supportsPromptCacheKey === true;
 
-  // Honor an explicit user-provided cacheRetention regardless of provider
-  // family. OpenAI-compatible completions backends (oMLX, llama.cpp, etc.)
-  // opt in to prompt caching via compat.supportsPromptCacheKey: true, and
-  // their users set cacheRetention to control prefix caching. Dropping the
-  // explicit value silently here meant the transport layer never received
-  // the user's choice (issue #81281).
+  if (!family && !googleEligible && !cacheKeyEligible) {
+    return undefined;
+  }
+
   const newVal = extraParams?.cacheRetention;
   if (newVal === "none" || newVal === "short" || newVal === "long") {
     return newVal;
@@ -47,10 +54,6 @@ export function resolveCacheRetention(
   }
   if (legacy === "1h" && (family || googleEligible)) {
     return "long";
-  }
-
-  if (!family && !googleEligible) {
-    return undefined;
   }
 
   return family === "anthropic-direct" ? "short" : undefined;

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.ts
@@ -30,21 +30,27 @@ export function resolveCacheRetention(
   });
   const googleEligible = isGooglePromptCacheEligible({ modelApi, modelId });
 
-  if (!family && !googleEligible) {
-    return undefined;
-  }
-
+  // Honor an explicit user-provided cacheRetention regardless of provider
+  // family. OpenAI-compatible completions backends (oMLX, llama.cpp, etc.)
+  // opt in to prompt caching via compat.supportsPromptCacheKey: true, and
+  // their users set cacheRetention to control prefix caching. Dropping the
+  // explicit value silently here meant the transport layer never received
+  // the user's choice (issue #81281).
   const newVal = extraParams?.cacheRetention;
   if (newVal === "none" || newVal === "short" || newVal === "long") {
     return newVal;
   }
 
   const legacy = extraParams?.cacheControlTtl;
-  if (legacy === "5m") {
+  if (legacy === "5m" && (family || googleEligible)) {
     return "short";
   }
-  if (legacy === "1h") {
+  if (legacy === "1h" && (family || googleEligible)) {
     return "long";
+  }
+
+  if (!family && !googleEligible) {
+    return undefined;
   }
 
   return family === "anthropic-direct" ? "short" : undefined;


### PR DESCRIPTION
## Summary

- Carries over #82973 with the cache-retention fix for OpenAI-compatible completions providers.
- Adds regression coverage for explicit `cacheRetention` passthrough only when `compat.supportsPromptCacheKey` is set, plus the negative path when it is not.
- Updates prompt-caching docs for OpenAI-compatible completions providers that opt into `prompt_cache_key` / `prompt_cache_retention`.

Fixes #81281.
Supersedes #82973 because GitHub stopped syncing the updated fork branch after maintainer fixups; the fork ref is at the fixed SHA, but the PR ref stayed pinned to the prior red SHA.

## Verification

- `pnpm test src/agents/pi-embedded-runner/prompt-cache-retention.test.ts src/agents/pi-embedded-runner-extraparams.test.ts src/agents/openai-transport-stream.test.ts -- --reporter=verbose`
- `pnpm check:test-types`
- `pnpm check:docs`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: OpenAI-compatible completions providers with `compat.supportsPromptCacheKey: true` now keep explicit `cacheRetention: "long"` through extra params and emit `prompt_cache_retention: "24h"` with `prompt_cache_key`.
Real environment tested: local OpenClaw source checkout on Node/pnpm plus GitHub CI on the original PR SHA before the fork PR ref stopped syncing.
Exact steps or command run after this patch: focused Vitest command above, `pnpm check:test-types`, `pnpm check:docs`, `git diff --check`, and local autoreview.
Evidence after fix: focused Vitest passed 327 tests; `check:test-types` passed; docs formatting, markdownlint, MDX, i18n glossary, and link audit passed with `broken_links=0`; autoreview reported no actionable findings.
Observed result after fix: regression tests prove explicit cache retention reaches prompt-cache-key OpenAI-compatible completions providers and stays suppressed for providers without that compat flag.
What was not tested: live oMLX/llama.cpp backend payload trace.

Co-authored-by: lonexreb <reach2shubhankar@gmail.com>
