### PR TITLE
fix(tools): treat non-positive gateway timeoutMs as absent

### DIFF
--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -75,6 +75,11 @@ describe("gateway tool defaults", () => {
     expect(opts.token).toBe("env-token");
   });
 
+  it("treats non-positive timeout overrides as absent", () => {
+    expect(resolveGatewayOptions({ timeoutMs: 0 }).timeoutMs).toBe(30_000);
+    expect(resolveGatewayOptions({ timeoutMs: -1 }).timeoutMs).toBe(30_000);
+  });
+
   it("falls back to config gateway.auth.token when env is unset for local overrides", () => {
     mocks.configState.value = {
       gateway: {

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -139,9 +139,14 @@ export function resolveGatewayOptions(opts?: GatewayCallOptions) {
         explicitToken,
       })
     : explicitToken;
+  // Ignore non-positive timeoutMs overrides. The previous clamp
+  // (Math.max(1, Math.floor(opts.timeoutMs))) turned a caller-supplied 0 into
+  // 1ms, which fails the very next request. GPT-5.5 / Codex routinely fill
+  // optional `timeoutMs` with 0; the intent is "use the default", not
+  // "time out immediately".
   const timeoutMs =
-    typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
-      ? Math.max(1, Math.floor(opts.timeoutMs))
+    typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
+      ? Math.floor(opts.timeoutMs)
       : 30_000;
   return { url: validatedOverride?.url, token, timeoutMs };
 }


### PR DESCRIPTION
## Summary

`resolveGatewayOptions` in `src/agents/tools/gateway.ts` clamps an optional `opts.timeoutMs` via `Math.max(1, Math.floor(opts.timeoutMs))` before falling back to the 30s default. A caller-supplied `0` was rewritten to `1ms` instead of falling back to the default, so the very next gateway call timed out instantly.

This matters in practice because **GPT-5.5 and Codex both fill optional integer fields with `0`** when they have no opinion. Any tool wrapping a gateway call with an optional `timeoutMs` (the WhatsApp `message` / `reaction` tools were the first I hit, but the same shape exists in other channel tools) silently turns real user requests into 1ms timeouts on dispatch.

## Fix

Only honour `timeoutMs` when it is a finite, **strictly positive** number. Non-positive or non-finite values fall through to the 30s default — i.e. treated the same as the field being absent.

```ts
const timeoutMs =
  typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
    ? Math.floor(opts.timeoutMs)
    : 30_000;
```

## Tests

Added a regression case in `src/agents/tools/gateway.test.ts`. All 38 cases in the two gateway test files pass locally.

## Production evidence

Carried as a local patch on cluster image `2026.5.19-beta.1-lue.2-timeout-zero` (2026-05-20). After the fix, a real WhatsApp reaction smoke test logged `message.action 1021ms` and returned `ok: true`; before, the same call timed out instantly. Bookkeeping in [`valkyriweb/openclaw-claude` ISSUE-104](https://github.com/valkyriweb/openclaw-claude/blob/main/docs/issues/issue-104.md).

## Tradeoff

None I can see. A `timeoutMs: 0` override is never useful — it cannot succeed. Treating it as absent is the only sensible behaviour. Negative values (currently also clamped to 1ms) get the same fix as a side effect; same argument.