### PR TITLE
fix(gateway): reject no-auth tailscale exposure

### DIFF
--- a/src/commands/doctor-gateway-auth-token.test.ts
+++ b/src/commands/doctor-gateway-auth-token.test.ts
@@ -6,6 +6,7 @@ import {
   resolveGatewayAuthTokenForService,
   shouldRequireGatewayTokenForInstall,
 } from "./doctor-gateway-auth-token.js";
+import { resolveGatewayInstallToken } from "./gateway-install-token.js";
 
 const envVar = (...parts: string[]) => parts.join("_");
 
@@ -269,5 +270,22 @@ describe("shouldRequireGatewayTokenForInstall", () => {
       {} as NodeJS.ProcessEnv,
     );
     expect(required).toBe(true);
+  });
+
+  it("blocks install token resolution for tailscale serve with explicit no-auth", async () => {
+    const resolved = await resolveGatewayInstallToken({
+      config: {
+        gateway: {
+          auth: { mode: "none" },
+          tailscale: { mode: "serve" },
+        },
+      } as OpenClawConfig,
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(resolved.token).toBeUndefined();
+    expect(resolved.unavailableReason).toBe(
+      "gateway.auth.mode=none cannot be used with gateway.tailscale.mode=serve; configure token, password, or trusted-proxy auth before exposing the gateway through Tailscale",
+    );
   });
 });

--- a/src/commands/gateway-install-token.ts
+++ b/src/commands/gateway-install-token.ts
@@ -7,6 +7,10 @@ import { shouldRequireGatewayTokenForInstall } from "../gateway/auth-install-pol
 import { hasAmbiguousGatewayAuthModeConfig } from "../gateway/auth-mode-policy.js";
 import { resolveGatewayAuthToken } from "../gateway/auth-token-resolution.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
+import {
+  formatUnsafeGatewayTailscaleNoAuthMessage,
+  isUnsafeGatewayTailscaleNoAuth,
+} from "../shared/gateway-tailscale-auth-policy.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
   readConfigFileSnapshotForWrite,
@@ -133,6 +137,15 @@ export async function resolveGatewayInstallToken(
     env: options.env,
     tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
   });
+  const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+  if (isUnsafeGatewayTailscaleNoAuth({ authMode: resolvedAuth.mode, tailscaleMode })) {
+    return {
+      token: undefined,
+      tokenRefConfigured: false,
+      unavailableReason: formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode),
+      warnings,
+    };
+  }
   const needsToken =
     shouldRequireGatewayTokenForInstall(cfg, options.env) && !resolvedAuth.allowTailscale;
   if (!needsToken) {

--- a/src/config/config.gateway-tailscale-bind.test.ts
+++ b/src/config/config.gateway-tailscale-bind.test.ts
@@ -20,6 +20,55 @@ describe("gateway tailscale bind validation", () => {
     expect(funnelRes.ok).toBe(true);
   });
 
+  it("rejects explicit no-auth when tailscale serve or funnel exposes the gateway", () => {
+    const serveRes = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        auth: { mode: "none" },
+        tailscale: { mode: "serve" },
+      },
+    });
+    expect(serveRes.ok).toBe(false);
+    if (!serveRes.ok) {
+      expect(serveRes.issues).toEqual([
+        {
+          path: "gateway.auth.mode",
+          message:
+            "gateway.auth.mode=none cannot be used with gateway.tailscale.mode=serve; configure token, password, or trusted-proxy auth before exposing the gateway through Tailscale",
+        },
+      ]);
+    }
+
+    const funnelRes = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        auth: { mode: "none" },
+        tailscale: { mode: "funnel" },
+      },
+    });
+    expect(funnelRes.ok).toBe(false);
+    if (!funnelRes.ok) {
+      expect(funnelRes.issues).toEqual([
+        {
+          path: "gateway.auth.mode",
+          message:
+            "gateway.tailscale.mode=funnel requires gateway.auth.mode=password; auth.mode=none cannot be used when exposing the gateway through Tailscale Funnel",
+        },
+      ]);
+    }
+  });
+
+  it("allows explicit no-auth for loopback-only gateway config", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        auth: { mode: "none" },
+        tailscale: { mode: "off" },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts custom loopback bind host with tailscale serve/funnel", () => {
     const res = validateConfigObject({
       gateway: {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -31,6 +31,10 @@ import {
   isPathWithinRoot,
   isWindowsAbsolutePath,
 } from "../shared/avatar-policy.js";
+import {
+  formatUnsafeGatewayTailscaleNoAuthMessage,
+  isUnsafeGatewayTailscaleNoAuth,
+} from "../shared/gateway-tailscale-auth-policy.js";
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "../shared/net/ip.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { isRecord, resolveUserPath } from "../utils.js";
@@ -854,6 +858,19 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
   ];
 }
 
+function validateGatewayTailscaleAuth(config: OpenClawConfig): ConfigValidationIssue[] {
+  const tailscaleMode = config.gateway?.tailscale?.mode ?? "off";
+  if (!isUnsafeGatewayTailscaleNoAuth({ authMode: config.gateway?.auth?.mode, tailscaleMode })) {
+    return [];
+  }
+  return [
+    {
+      path: "gateway.auth.mode",
+      message: formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode),
+    },
+  ];
+}
+
 /**
  * Validates config without applying runtime defaults.
  * Use this when you need the raw validated config (e.g., for writing back to file).
@@ -913,6 +930,10 @@ export function validateConfigObjectRaw(
   const gatewayTailscaleBindIssues = validateGatewayTailscaleBind(validatedConfig);
   if (gatewayTailscaleBindIssues.length > 0) {
     return { ok: false, issues: gatewayTailscaleBindIssues };
+  }
+  const gatewayTailscaleAuthIssues = validateGatewayTailscaleAuth(validatedConfig);
+  if (gatewayTailscaleAuthIssues.length > 0) {
+    return { ok: false, issues: gatewayTailscaleAuthIssues };
   }
   return {
     ok: true,

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -298,6 +298,20 @@ describe("resolveGatewayRuntimeConfig", () => {
       ).rejects.toThrow(/refusing to bind gateway/);
     });
 
+    it("rejects tailscale serve with explicit no-auth", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              auth: { mode: "none" },
+              tailscale: { mode: "serve" },
+            },
+          },
+          port: 18789,
+        }),
+      ).rejects.toThrow("gateway.auth.mode=none cannot be used with gateway.tailscale.mode=serve");
+    });
+
     it("respects explicit loopback config even inside a container", async () => {
       const fs = require("node:fs");
       vi.spyOn(fs, "accessSync").mockImplementation(() => undefined); // /.dockerenv exists
@@ -314,7 +328,7 @@ describe("resolveGatewayRuntimeConfig", () => {
       const result = await resolveGatewayRuntimeConfig({
         cfg: {
           gateway: {
-            auth: { mode: "none" },
+            auth: TOKEN_AUTH,
             tailscale: { mode: "serve" },
           },
         },

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -5,6 +5,10 @@ import type {
 } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  formatUnsafeGatewayTailscaleNoAuthMessage,
+  isUnsafeGatewayTailscaleNoAuth,
+} from "../shared/gateway-tailscale-auth-policy.js";
+import {
   assertGatewayAuthConfigured,
   type ResolvedGatewayAuth,
   resolveGatewayAuth,
@@ -133,6 +137,9 @@ export async function resolveGatewayRuntimeConfig(params: {
     throw new Error(
       "tailscale funnel requires gateway auth mode=password (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",
     );
+  }
+  if (isUnsafeGatewayTailscaleNoAuth({ authMode, tailscaleMode })) {
+    throw new Error(formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode));
   }
   if (tailscaleMode !== "off" && !isLoopbackHost(bindHost)) {
     throw new Error("tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)");

--- a/src/shared/gateway-tailscale-auth-policy.ts
+++ b/src/shared/gateway-tailscale-auth-policy.ts
@@ -1,0 +1,20 @@
+import type { GatewayAuthMode, GatewayTailscaleMode } from "../config/types.gateway.js";
+
+export function isUnsafeGatewayTailscaleNoAuth(params: {
+  authMode?: GatewayAuthMode;
+  tailscaleMode?: GatewayTailscaleMode;
+}): boolean {
+  return (
+    params.authMode === "none" &&
+    (params.tailscaleMode === "serve" || params.tailscaleMode === "funnel")
+  );
+}
+
+export function formatUnsafeGatewayTailscaleNoAuthMessage(
+  tailscaleMode: GatewayTailscaleMode,
+): string {
+  if (tailscaleMode === "funnel") {
+    return "gateway.tailscale.mode=funnel requires gateway.auth.mode=password; auth.mode=none cannot be used when exposing the gateway through Tailscale Funnel";
+  }
+  return `gateway.auth.mode=none cannot be used with gateway.tailscale.mode=${tailscaleMode}; configure token, password, or trusted-proxy auth before exposing the gateway through Tailscale`;
+}


### PR DESCRIPTION
## Summary

Fixes #50630.
Replaces the stale/conflicting runtime-only fix in #50631.

This rejects explicit `gateway.auth.mode=none` whenever the gateway is exposed through Tailscale Serve or Funnel. The policy is shared across config validation, install-token preflight, and runtime startup so setup paths fail before writing/accepting a service plan, while loopback-only no-auth remains valid.

## Verification

Behavior addressed: `gateway.auth.mode=none` plus `gateway.tailscale.mode=serve` no longer reaches a running gateway exposed to the Tailnet; config and install preflight reject it before daemon startup, and runtime startup also fails closed.

Real environment tested: No live Tailnet device run. This patch is preflight/runtime validation; the verified behavior is config rejection and startup/install blocking.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs src/config/config.gateway-tailscale-bind.test.ts src/gateway/server-runtime-config.test.ts src/commands/doctor-gateway-auth-token.test.ts`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01ksmpwc2fqfv5s9zpw3syvzzd`, GitHub Actions run `26511438060`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Evidence after fix:
- Config validation rejects Serve/Funnel plus explicit no-auth at `gateway.auth.mode`.
- Gateway install token resolution returns an unavailable reason for Serve plus explicit no-auth before token generation/service planning.
- Runtime config rejects Serve plus explicit no-auth even when invoked through overrides.

Observed result after fix: focused Vitest passed, Testbox `check:changed` exited 0, autoreview returned clean with no accepted/actionable findings.

What was not tested: real Tailscale Serve/Funnel network access from another Tailnet device.

## Risk

Did user-visible behavior change? Yes.
Did config, environment, or migration behavior change? Yes.
Did security, auth, secrets, network, or tool execution behavior change? Yes.

Existing explicit no-auth Tailscale exposure now fails closed. Loopback-only `gateway.auth.mode=none` remains accepted.
