### PR TITLE
fix(codex): exclude tool_search for nano models that reject it [AI-assisted]

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -629,6 +629,45 @@ describe("runCodexAppServerAttempt", () => {
     ).toEqual(["message"]);
   });
 
+  it("excludes the tool_search family for OpenAI nano models that reject it (#85806)", () => {
+    const tools = [
+      "message",
+      "tool_search",
+      "tool_search_code",
+      "tool_describe",
+      "tool_call",
+      "web_search",
+    ].map((name) => ({ name }));
+
+    expect(
+      __testing
+        .filterToolsForToolSearchSupport(tools, { modelId: "gpt-5.4-nano" })
+        .map((tool) => tool.name),
+    ).toEqual(["message", "web_search"]);
+  });
+
+  it("keeps the tool_search family for non-nano models", () => {
+    const tools = ["message", "tool_search", "tool_search_code", "tool_describe", "tool_call"].map(
+      (name) => ({ name }),
+    );
+
+    expect(
+      __testing
+        .filterToolsForToolSearchSupport(tools, { modelId: "gpt-5.5" })
+        .map((tool) => tool.name),
+    ).toEqual(["message", "tool_search", "tool_search_code", "tool_describe", "tool_call"]);
+  });
+
+  it("treats an undefined modelId as supporting tool_search (preserves prior behavior)", () => {
+    const tools = ["message", "tool_search"].map((name) => ({ name }));
+
+    expect(
+      __testing
+        .filterToolsForToolSearchSupport(tools, { modelId: undefined })
+        .map((tool) => tool.name),
+    ).toEqual(["message", "tool_search"]);
+  });
+
   it("starts Codex threads without duplicate OpenClaw workspace tools by default", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -134,6 +134,7 @@ import {
   sanitizeCodexToolArguments,
   sanitizeCodexToolResponse,
 } from "./tool-progress-normalization.js";
+import { filterToolsForToolSearchSupport } from "./tool-search-support.js";
 import {
   createCodexTrajectoryRecorder,
   normalizeCodexTrajectoryError,
@@ -2343,8 +2344,11 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
+  const toolSearchFilteredTools = filterToolsForToolSearchSupport(visionFilteredTools, {
+    modelId: params.modelId,
+  });
   const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
-  const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
+  const filteredTools = filterCodexDynamicToolsForAllowlist(toolSearchFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
     runtimePlan: params.runtimePlan,
     tools: filteredTools,
@@ -3284,6 +3288,7 @@ export const __testing = {
   filterCodexDynamicTools,
   buildDynamicTools,
   filterCodexDynamicToolsForAllowlist,
+  filterToolsForToolSearchSupport,
   filterToolsForVisionInputs,
   handleDynamicToolCallWithTimeout,
   remapCodexContextFilePath,

--- a/extensions/codex/src/app-server/tool-search-support.ts
+++ b/extensions/codex/src/app-server/tool-search-support.ts
@@ -1,0 +1,33 @@
+// Codex tool_search capability gate.
+//
+// OpenAI's nano-tier models (e.g. `gpt-5.4-nano`, `gpt-5.5-nano`) reject the
+// `tool_search` tool family with a 400 `invalid_request_error`. The codex
+// harness must omit these tools from the dynamic tool list when the active
+// model does not support them. Mirrors the `supportsModelTools` capability-
+// gate pattern in src/agents/model-tool-support.ts.
+
+const NANO_MODEL_ID_PATTERN = /^gpt-.*-nano(?:[-:.@].*)?$/i;
+
+const TOOL_SEARCH_FAMILY_NAMES = new Set([
+  "tool_search",
+  "tool_search_code",
+  "tool_describe",
+  "tool_call",
+]);
+
+export function isToolSearchSupported(modelId: string | undefined): boolean {
+  if (typeof modelId !== "string" || modelId.trim() === "") {
+    return true;
+  }
+  return !NANO_MODEL_ID_PATTERN.test(modelId.trim());
+}
+
+export function filterToolsForToolSearchSupport<T extends { name?: string }>(
+  tools: T[],
+  params: { modelId: string | undefined },
+): T[] {
+  if (isToolSearchSupported(params.modelId)) {
+    return tools;
+  }
+  return tools.filter((tool) => !TOOL_SEARCH_FAMILY_NAMES.has(tool.name ?? ""));
+}


### PR DESCRIPTION
Closes #85806.

## Summary
OpenAI's nano-tier models (`gpt-*-nano`) reject the `tool_search` tool with `400 invalid_request_error: Tool 'tool_search' is not supported with gpt-*-nano`. The codex harness unconditionally includes `tool_search` in the tool list, so every turn fails for users configured on nano (per the issue logs) and falls back to `gpt-*-mini`.

## Fix
Adds `isToolSearchSupported(modelId)` mirroring the existing capability-gate pattern in the codex extension (see `src/agents/model-tool-support.ts` and `extensions/codex/src/app-server/vision-tools.ts`). Skips injecting `tool_search` (plus the related `tool_search_code`, `tool_describe`, `tool_call` family) into the dynamic tool list when the gate returns false. Non-nano models unchanged.

## Files
- `extensions/codex/src/app-server/tool-search-support.ts` *(new)* — `isToolSearchSupported(modelId)` + `filterToolsForToolSearchSupport(tools, { modelId })`. Regex `/^gpt-.*-nano(?:[-:.@].*)?$/i` matches `gpt-5.4-nano`, `gpt-5.5-nano`, dated/aliased variants.
- `extensions/codex/src/app-server/run-attempt.ts` — wires the new filter into `buildDynamicTools` immediately after `filterToolsForVisionInputs` (same composition pattern); exposes via `__testing` for unit tests.
- `extensions/codex/src/app-server/run-attempt.test.ts` — three unit tests (nano strips the family, non-nano keeps it, undefined modelId preserves prior behavior).

## Real behavior proof (required for external PRs)
- **Behavior or issue addressed:** `Tool 'tool_search' is not supported with gpt-*-nano` 400 from OpenAI Codex transport.
- **Real environment tested (synthetic):** Linux + extension test suite — `pnpm test:extension codex` → **53 files / 764 tests passed**; new tests verify `tool_search` correctly absent for nano model id and present for non-nano. **⚠ Live OpenAI nano account run REQUESTED from @eldar702 before marking ready-for-review.** Exact command:
  ```
  # With models.default = openai/gpt-5.4-nano and fallback openai/gpt-5.4-mini, real OPENAI_API_KEY
  openclaw chat --agent main --message "hi"
  tail -n 50 ~/.openclaw/logs/gateway.log
  ```
  Expect: gateway log shows nano turn succeeds (no 400, no fallback to mini); before fix on `main` shows the 400.
- **Evidence after fix (linux extension test):** `Test Files  53 passed (53)  /  Tests  764 passed (764)`.
- **What was not tested:** Non-OpenAI providers (out of scope); reasoning-mode interaction (kept off — existing `unsupported thinking level` retry path remains untouched).

## AI disclosure
Drafted with assistance from Claude (Opus 4.7). All real-environment OpenAI-account validation will be done by the human contributor (@eldar702).