### PR TITLE
fix(logging): resolve hostname lazily to avoid caching empty string on macOS

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1,3 +1,7 @@
+// Initialize hostname env before any module that might import tslog.
+// tslog captures hostname at module load via os.hostname(), which returns
+// empty string intermittently on macOS during ESM resolution.
+import "../logging/logger-hostname-init.js";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";

--- a/src/logging/logger-hostname-init.ts
+++ b/src/logging/logger-hostname-init.ts
@@ -1,0 +1,12 @@
+import os from "node:os";
+
+// Set HOSTNAME env var before any tslog imports.
+// tslog reads hostname at module load time via os.hostname() or env vars,
+// and macOS intermittently returns empty string during ESM module resolution.
+// Setting env ensures tslog's _meta.hostname is correct.
+if (!process.env.HOSTNAME && !process.env.HOST && !process.env.COMPUTERNAME) {
+  const hostname = os.hostname();
+  if (hostname) {
+    process.env.HOSTNAME = hostname;
+  }
+}

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+// Initialize hostname env before tslog import; must be first import.
+import "./logger-hostname-init.js";
+
 import { Logger as TsLogger } from "tslog";
 import type { OpenClawConfig } from "../config/types.js";
 import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -95,7 +95,17 @@ const MAX_DIAGNOSTIC_LOG_NAME_CHARS = 120;
 const MAX_FILE_LOG_MESSAGE_CHARS = 4 * 1024;
 const MAX_FILE_LOG_CONTEXT_VALUE_CHARS = 512;
 const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
-const HOSTNAME = os.hostname() || "unknown";
+
+// macOS intermittently returns empty hostname during module load.
+// Resolve lazily to avoid caching "unknown" for the entire gateway lifetime.
+let cachedHostname: string | null = null;
+function getHostname(): string {
+  if (cachedHostname === null) {
+    const h = os.hostname();
+    cachedHostname = h || "unknown";
+  }
+  return cachedHostname;
+}
 
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
 
@@ -361,7 +371,7 @@ function buildStructuredFileLogFields(logObj: TsLogRecord): Record<string, strin
   const sessionId = readFirstContextString(sources, ["session_id", "sessionId", "sessionKey"]);
   const channel = readFirstContextString(sources, ["channel", "messageProvider"]);
   return {
-    hostname: HOSTNAME,
+    hostname: getHostname(),
     ...(message ? { message } : {}),
     ...(agentId ? { agent_id: agentId } : {}),
     ...(sessionId ? { session_id: sessionId } : {}),

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -1,4 +1,7 @@
 import { Chalk } from "chalk";
+// Initialize hostname env before tslog import; must be first import.
+import "./logger-hostname-init.js";
+
 import type { Logger as TsLogger } from "tslog";
 import { isVerbose } from "../global-state.js";
 import { defaultRuntime, type OutputRuntimeEnv, type RuntimeEnv } from "../runtime.js";


### PR DESCRIPTION
## Summary
- Replace module-level `HOSTNAME` constant with lazy `getHostname()` function
- macOS intermittently returns empty hostname during ESM module load phase
- Lazy resolution ensures hostname is captured correctly after gateway startup

## Reproduction
```bash
grep '"hostname"' /tmp/openclaw/openclaw-*.log | head -5
```
Before fix:
```
_meta.hostname: "unknown"   ← wrong
hostname: "hopembpm5deMBP"  ← correct (from different source)
```

## Root Cause
`os.hostname()` returns empty string on macOS during module load, cached as "unknown" for entire gateway lifetime.

Fixes #87258