### PR TITLE
fix: stabilize isolated cron prompt cache affinity

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -18,6 +18,7 @@ function createAttemptParams(): EmbeddedRunAttemptParams {
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
     sessionFile: "/tmp/session.jsonl",
+    effectiveCwd: "/tmp",
     workspaceDir: "/tmp",
     runId: "run-1",
     provider: "codex",

--- a/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
@@ -409,8 +409,8 @@ function buildDynamicModel(
               : lower === "gpt-5.4-mini"
                 ? ["gpt-5.4-mini"]
                 : lower === "gpt-5.4-nano"
-                  ? ["gpt-5.4-nano", "gpt-5.4-mini"]
-                  : undefined;
+              ? ["gpt-5.4-nano", "gpt-5.4-mini"]
+              : undefined;
       if (!templateIds) {
         return undefined;
       }
@@ -423,7 +423,7 @@ function buildDynamicModel(
               baseUrl: OPENAI_BASE_URL,
               reasoning: true,
               input: ["text", "image"],
-              cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+              cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
               contextWindow: 1_000_000,
               contextTokens: 272_000,
               maxTokens: 128_000,

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
@@ -140,7 +140,7 @@ describe("prompt cache observability", () => {
   it("tracks recurring prompt-cache affinity across rotating session ids", () => {
     beginPromptCacheObservation({
       sessionId: "isolated-run-1",
-      promptCacheKey: "openclaw:cron:stable-cache-key",
+      promptCacheKey: "openclaw-cron-stable-cache-key",
       sessionKey: "agent:cron:run:isolated-run-1",
       provider: "openai",
       modelId: "gpt-5.4",
@@ -151,14 +151,14 @@ describe("prompt cache observability", () => {
     });
     completePromptCacheObservation({
       sessionId: "isolated-run-1",
-      promptCacheKey: "openclaw:cron:stable-cache-key",
+      promptCacheKey: "openclaw-cron-stable-cache-key",
       sessionKey: "agent:cron:run:isolated-run-1",
       usage: { cacheRead: 8_000 },
     });
 
     const nextRun = beginPromptCacheObservation({
       sessionId: "isolated-run-2",
-      promptCacheKey: "openclaw:cron:stable-cache-key",
+      promptCacheKey: "openclaw-cron-stable-cache-key",
       sessionKey: "agent:cron:run:isolated-run-2",
       provider: "openai",
       modelId: "gpt-5.4",

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
@@ -137,6 +137,41 @@ describe("prompt cache observability", () => {
     expect(second.changes).toBeNull();
   });
 
+  it("tracks recurring prompt-cache affinity across rotating session ids", () => {
+    beginPromptCacheObservation({
+      sessionId: "isolated-run-1",
+      promptCacheKey: "openclaw:cron:stable-cache-key",
+      sessionKey: "agent:cron:run:isolated-run-1",
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      streamStrategy: "boundary-aware:openai-responses",
+      systemPrompt: "stable system",
+      toolNames: ["read"],
+    });
+    completePromptCacheObservation({
+      sessionId: "isolated-run-1",
+      promptCacheKey: "openclaw:cron:stable-cache-key",
+      sessionKey: "agent:cron:run:isolated-run-1",
+      usage: { cacheRead: 8_000 },
+    });
+
+    const nextRun = beginPromptCacheObservation({
+      sessionId: "isolated-run-2",
+      promptCacheKey: "openclaw:cron:stable-cache-key",
+      sessionKey: "agent:cron:run:isolated-run-2",
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      streamStrategy: "boundary-aware:openai-responses",
+      systemPrompt: "stable system",
+      toolNames: ["read"],
+    });
+
+    expect(nextRun.previousCacheRead).toBe(8_000);
+    expect(nextRun.changes).toBeNull();
+  });
+
   it("evicts old tracker entries when the tracker map grows past the soft cap", () => {
     beginPromptCacheObservation({
       sessionId: "session-0",

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.ts
@@ -55,7 +55,15 @@ function digestText(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
-function buildTrackerKey(params: { sessionKey?: string; sessionId: string }): string {
+function buildTrackerKey(params: {
+  promptCacheKey?: string;
+  sessionKey?: string;
+  sessionId: string;
+}): string {
+  const promptCacheKey = params.promptCacheKey?.trim();
+  if (promptCacheKey) {
+    return promptCacheKey;
+  }
   return params.sessionKey?.trim() || params.sessionId;
 }
 
@@ -135,6 +143,7 @@ export function collectPromptCacheToolNames(tools: Array<{ name?: string }>): st
 
 export function beginPromptCacheObservation(params: {
   sessionId: string;
+  promptCacheKey?: string;
   sessionKey?: string;
   provider: string;
   modelId: string;
@@ -174,6 +183,7 @@ export function beginPromptCacheObservation(params: {
 
 export function completePromptCacheObservation(params: {
   sessionId: string;
+  promptCacheKey?: string;
   sessionKey?: string;
   usage?: NormalizedUsage;
 }): PromptCacheBreak | null {

--- a/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
@@ -19,9 +19,13 @@ function firstBeforeAgentReplyCall() {
   return call;
 }
 
-function firstAttemptParams(): { modelRun?: boolean; promptMode?: string } {
+function firstAttemptParams(): {
+  modelRun?: boolean;
+  promptMode?: string;
+  promptCacheKey?: string;
+} {
   const call = mockedRunEmbeddedAttempt.mock.calls[0] as
-    | [{ modelRun?: boolean; promptMode?: string }]
+    | [{ modelRun?: boolean; promptMode?: string; promptCacheKey?: string }]
     | undefined;
   if (!call) {
     throw new Error("expected embedded attempt call");
@@ -142,5 +146,16 @@ describe("runEmbeddedAgent cron before_agent_reply seam", () => {
     const attemptParams = firstAttemptParams();
     expect(attemptParams.modelRun).toBe(true);
     expect(attemptParams.promptMode).toBe("none");
+  });
+
+  it("forwards prompt cache identity into the embedded attempt", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      promptCacheKey: "cron-cache-key",
+    });
+
+    expect(firstAttemptParams().promptCacheKey).toBe("cron-cache-key");
   });
 });

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1473,6 +1473,7 @@ export async function runEmbeddedAgent(
           const rawAttempt = await runEmbeddedAttemptWithBackend({
             sessionId: activeSessionId,
             sessionKey: resolvedSessionKey,
+            promptCacheKey: params.promptCacheKey,
             sandboxSessionKey: params.sandboxSessionKey,
             trigger: params.trigger,
             memoryFlushWritePath: params.memoryFlushWritePath,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3007,6 +3007,7 @@ export async function runEmbeddedAttempt(
         currentStreamFn: defaultSessionStreamFn,
         providerStreamFn,
         sessionId: params.sessionId,
+        promptCacheKey: params.promptCacheKey,
         signal: runAbortController.signal,
         model: params.model,
         resolvedApiKey: params.resolvedApiKey,
@@ -3918,6 +3919,7 @@ export async function runEmbeddedAttempt(
         if (cacheObservabilityEnabled) {
           const cacheObservation = beginPromptCacheObservation({
             sessionId: params.sessionId,
+            promptCacheKey: params.promptCacheKey,
             sessionKey: params.sessionKey,
             provider: params.provider,
             modelId: params.modelId,
@@ -4675,6 +4677,7 @@ export async function runEmbeddedAttempt(
           cacheBreak = cacheObservabilityEnabled
             ? completePromptCacheObservation({
                 sessionId: params.sessionId,
+                promptCacheKey: params.promptCacheKey,
                 sessionKey: params.sessionKey,
                 usage: attemptUsage,
               })

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -39,6 +39,8 @@ export type CurrentInboundPromptContext = {
 export type RunEmbeddedAgentParams = {
   sessionId: string;
   sessionKey?: string;
+  /** Provider prompt-cache affinity key; distinct from transcript/session identity. */
+  promptCacheKey?: string;
   /** Session-like key for sandbox and tool-policy resolution. Defaults to sessionKey. */
   sandboxSessionKey?: string;
   agentId?: string;

--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -325,6 +325,32 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     expect(result.promptCacheKey).toBe("caller-cache-key");
   });
 
+  it("propagates prompt cache identity into custom session streams", async () => {
+    const currentStreamFn = vi.fn(async (_model, _context, options) => options);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: currentStreamFn as never,
+      sessionId: "run-session",
+      promptCacheKey: "cron-cache-key",
+      model: {
+        api: "custom-api",
+        provider: "custom-provider",
+        id: "custom-model",
+      } as never,
+    });
+
+    expect(streamFn).not.toBe(currentStreamFn);
+    const result = await expectStreamResultRecord(
+      streamFn(
+        { provider: "custom-provider", id: "custom-model" } as never,
+        {} as never,
+        { sessionId: "run-session" } as never,
+      ),
+      "custom prompt cache result",
+    );
+    expect(result.sessionId).toBe("run-session");
+    expect(result.promptCacheKey).toBe("cron-cache-key");
+  });
+
   it("forwards the run abort signal into provider-owned stream functions", async () => {
     const providerStreamFn = vi.fn(async (_model, _context, options) => options);
     const signal = new AbortController().signal;

--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -274,6 +274,57 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     expect(providerStreamFn).toHaveBeenCalledTimes(1);
   });
 
+  it("propagates prompt cache identity separately from the session id", async () => {
+    const providerStreamFn = vi.fn(async (_model, _context, options) => options);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      providerStreamFn,
+      sessionId: "run-session",
+      promptCacheKey: "cron-cache-key",
+      model: {
+        api: "openai-completions",
+        provider: "demo-provider",
+        id: "demo-model",
+      } as never,
+    });
+
+    const result = await expectStreamResultRecord(
+      streamFn(
+        { provider: "demo-provider", id: "demo-model" } as never,
+        {} as never,
+        { sessionId: "run-session" } as never,
+      ),
+      "provider-owned prompt cache result",
+    );
+    expect(result.sessionId).toBe("run-session");
+    expect(result.promptCacheKey).toBe("cron-cache-key");
+  });
+
+  it("does not overwrite caller-supplied prompt cache identity", async () => {
+    const providerStreamFn = vi.fn(async (_model, _context, options) => options);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      providerStreamFn,
+      sessionId: "run-session",
+      promptCacheKey: "cron-cache-key",
+      model: {
+        api: "openai-completions",
+        provider: "demo-provider",
+        id: "demo-model",
+      } as never,
+    });
+
+    const result = await expectStreamResultRecord(
+      streamFn(
+        { provider: "demo-provider", id: "demo-model" } as never,
+        {} as never,
+        { promptCacheKey: "caller-cache-key" } as never,
+      ),
+      "provider-owned caller prompt cache result",
+    );
+    expect(result.promptCacheKey).toBe("caller-cache-key");
+  });
+
   it("forwards the run abort signal into provider-owned stream functions", async () => {
     const providerStreamFn = vi.fn(async (_model, _context, options) => options);
     const signal = new AbortController().signal;

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -11,6 +11,7 @@ let openClawNativeCodexResponsesStreamFnForTest: StreamFn | undefined;
 
 type EmbeddedStreamOptions = Parameters<StreamFn>[2] & {
   authProfileId?: string;
+  promptCacheKey?: string;
 };
 
 export function resolveEmbeddedAgentBaseStreamFn(params: {
@@ -115,6 +116,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
   currentStreamFn: StreamFn | undefined;
   providerStreamFn?: StreamFn;
   sessionId: string;
+  promptCacheKey?: string;
   signal?: AbortSignal;
   model: EmbeddedRunAttemptParams["model"];
   resolvedApiKey?: string;
@@ -128,6 +130,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
       authProfileId: params.authProfileId,
       authStorage: params.authStorage,
       providerId: params.model.provider,
+      promptCacheKey: params.promptCacheKey,
       transformContext: (context) =>
         context.systemPrompt
           ? {
@@ -155,6 +158,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
       authStorage: params.authStorage,
       providerId: params.model.provider,
       sessionId: params.sessionId,
+      promptCacheKey: params.promptCacheKey,
       transformContext: (context) =>
         context.systemPrompt
           ? {
@@ -186,6 +190,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
         authProfileId: params.authProfileId,
         authStorage: params.authStorage,
         providerId: params.model.provider,
+        promptCacheKey: params.promptCacheKey,
       });
     }
   }
@@ -211,6 +216,7 @@ function wrapEmbeddedAgentStreamFn(
     authStorage: { getApiKey(provider: string): Promise<string | undefined> } | undefined;
     providerId: string;
     sessionId?: string;
+    promptCacheKey?: string;
     transformContext?: (context: Parameters<StreamFn>[1]) => Parameters<StreamFn>[1];
   },
 ): StreamFn {
@@ -223,6 +229,10 @@ function wrapEmbeddedAgentStreamFn(
       params.sessionId && !embeddedOptions?.sessionId
         ? { ...embeddedOptions, sessionId: params.sessionId }
         : embeddedOptions;
+    const promptCacheKey = params.promptCacheKey?.trim();
+    if (promptCacheKey && !merged?.promptCacheKey) {
+      merged = { ...merged, promptCacheKey };
+    }
     if (params.authProfileId && !merged?.authProfileId) {
       merged = { ...merged, authProfileId: params.authProfileId };
     }

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -195,7 +195,18 @@ export function resolveEmbeddedAgentStreamFn(params: {
     }
   }
 
-  return currentStreamFn;
+  const promptCacheKey = params.promptCacheKey?.trim();
+  if (!promptCacheKey) {
+    return currentStreamFn;
+  }
+  return wrapEmbeddedAgentStreamFn(currentStreamFn, {
+    runSignal: params.signal,
+    resolvedApiKey: undefined,
+    authProfileId: undefined,
+    authStorage: undefined,
+    providerId: params.model.provider,
+    promptCacheKey,
+  });
 }
 
 export const testing = {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2236,6 +2236,34 @@ describe("openai transport stream", () => {
     expect(params.prompt_cache_key).toBe("cron-cache-key");
   });
 
+  it("clamps Responses promptCacheKey before sending it upstream", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        promptCacheKey: "x".repeat(80),
+        sessionId: "session-123",
+      },
+    ) as { prompt_cache_key?: string };
+
+    expect(params.prompt_cache_key).toBe("x".repeat(64));
+  });
+
   it("omits Responses prompt_cache_key when caching is disabled", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2208,6 +2208,63 @@ describe("openai transport stream", () => {
     expect(params.max_output_tokens).toBe(65_536);
   });
 
+  it("prefers promptCacheKey over sessionId for Responses prompt-cache affinity", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        sessionId: "run-session",
+        promptCacheKey: "cron-cache-key",
+      },
+    ) as { prompt_cache_key?: string };
+
+    expect(params.prompt_cache_key).toBe("cron-cache-key");
+  });
+
+  it("omits Responses prompt_cache_key when caching is disabled", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        sessionId: "run-session",
+        promptCacheKey: "cron-cache-key",
+        cacheRetention: "none",
+      },
+    ) as { prompt_cache_key?: string };
+
+    expect(params.prompt_cache_key).toBeUndefined();
+  });
+
   it("uses top-level instructions for Codex responses and preserves prompt cache identity", () => {
     const params = buildOpenAIResponsesParams(
       {
@@ -4596,10 +4653,10 @@ describe("openai transport stream", () => {
         messages: [],
         tools: [],
       } as never,
-      { sessionId: "session-123" },
+      { sessionId: "session-123", promptCacheKey: "cron-cache-key" },
     ) as { prompt_cache_key?: string };
 
-    expect(params.prompt_cache_key).toBe("session-123");
+    expect(params.prompt_cache_key).toBe("cron-cache-key");
   });
 
   it("omits prompt_cache_key for completions when caching is disabled or not opted in", () => {
@@ -4627,7 +4684,7 @@ describe("openai transport stream", () => {
         compat: { supportsPromptCacheKey: true },
       } as unknown as Model<"openai-completions">,
       context,
-      { sessionId: "session-123", cacheRetention: "none" },
+      { sessionId: "session-123", promptCacheKey: "cron-cache-key", cacheRetention: "none" },
     ) as { prompt_cache_key?: string };
     const notOptedIn = buildOpenAICompletionsParams(baseModel, context, {
       sessionId: "session-123",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -16,6 +16,7 @@ import type { ModelCompatConfig } from "../config/types.models.js";
 import { getEnvApiKey } from "../llm/env-api-keys.js";
 import { calculateCost } from "../llm/model-utils.js";
 import { convertMessages } from "../llm/providers/openai-completions.js";
+import { clampOpenAIPromptCacheKey } from "../llm/providers/openai-prompt-cache.js";
 import type { Api, Context, Model } from "../llm/types.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { parseStreamingJson } from "../llm/utils/json-parse.js";
@@ -1851,7 +1852,7 @@ function resolvePromptCacheKey(
   if (cacheRetention === "none") {
     return undefined;
   }
-  return options?.promptCacheKey ?? options?.sessionId;
+  return clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId);
 }
 
 function getPromptCacheRetention(

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -115,6 +115,7 @@ type BaseStreamOptions = {
   apiKey?: string;
   cacheRetention?: "none" | "short" | "long";
   sessionId?: string;
+  promptCacheKey?: string;
   authProfileId?: string;
   onPayload?: (payload: unknown, model: Model) => unknown;
   headers?: Record<string, string>;
@@ -1843,6 +1844,16 @@ function resolveCacheRetention(cacheRetention: string | undefined): "short" | "l
   return "short";
 }
 
+function resolvePromptCacheKey(
+  options: Pick<BaseStreamOptions, "promptCacheKey" | "sessionId"> | undefined,
+  cacheRetention: "short" | "long" | "none",
+): string | undefined {
+  if (cacheRetention === "none") {
+    return undefined;
+  }
+  return options?.promptCacheKey ?? options?.sessionId;
+}
+
 function getPromptCacheRetention(
   baseUrl: string | undefined,
   cacheRetention: "short" | "long" | "none",
@@ -2041,6 +2052,7 @@ export function buildOpenAIResponsesParams(
     ensureOpenAICodexResponsesInput(messages, context);
   }
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
+  const promptCacheKey = resolvePromptCacheKey(options, cacheRetention);
   const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(model, {
     storeMode: "disable",
   });
@@ -2048,7 +2060,7 @@ export function buildOpenAIResponsesParams(
     model: model.id,
     input: messages,
     stream: true,
-    prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
+    prompt_cache_key: promptCacheKey,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
     ...(isCodexResponses ? { instructions: buildOpenAICodexResponsesInstructions(context) } : {}),
     ...(metadata ? { metadata } : {}),
@@ -3480,6 +3492,7 @@ export function buildOpenAICompletionsParams(
     messages = stripCompletionMessagesToRoleContent(messages) as typeof messages;
   }
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
+  const promptCacheKey = resolvePromptCacheKey(options, cacheRetention);
   const params: Record<string, unknown> = {
     model: model.id,
     messages: compat.requiresStringContent
@@ -3493,8 +3506,8 @@ export function buildOpenAICompletionsParams(
   if (compat.supportsStore) {
     params.store = false;
   }
-  if (compat.supportsPromptCacheKey && cacheRetention !== "none" && options?.sessionId) {
-    params.prompt_cache_key = options.sessionId;
+  if (compat.supportsPromptCacheKey && promptCacheKey) {
+    params.prompt_cache_key = promptCacheKey;
     // When the caller explicitly opted into long retention, forward the
     // canonical prompt_cache_retention value alongside the cache key so
     // OpenAI-compatible completions backends (oMLX, llama.cpp, official

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -78,10 +78,41 @@ describe("streamProxy", () => {
     expect(typeof rawBody).toBe("string");
     const body = JSON.parse(rawBody as string) as {
       model?: { headers?: unknown };
-      options?: { headers?: unknown };
+      options?: { headers?: unknown; promptCacheKey?: string };
     };
     expect(body.options).not.toHaveProperty("headers");
+    expect(body.options?.promptCacheKey).toBeUndefined();
     expect(body.model).not.toHaveProperty("headers");
+  });
+
+  it("forwards prompt cache affinity separately from session identity", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      responseFromText(
+        `data: ${JSON.stringify({
+          type: "done",
+          reason: "stop",
+          usage,
+        })}`,
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+      sessionId: "run-session",
+      promptCacheKey: "stable-cache-key",
+    }).result();
+
+    const rawBody = fetchMock.mock.calls[0]?.[1]?.body;
+    expect(typeof rawBody).toBe("string");
+    const body = JSON.parse(rawBody as string) as {
+      options?: { promptCacheKey?: string; sessionId?: string };
+    };
+    expect(body.options).toMatchObject({
+      sessionId: "run-session",
+      promptCacheKey: "stable-cache-key",
+    });
   });
 
   it("returns an error result when EOF arrives without a terminal event", async () => {

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -69,6 +69,7 @@ type ProxySerializableStreamOptions = Pick<
   | "reasoning"
   | "cacheRetention"
   | "sessionId"
+  | "promptCacheKey"
   | "metadata"
   | "transport"
   | "thinkingBudgets"
@@ -110,6 +111,7 @@ function buildProxyRequestOptions(options: ProxyStreamOptions): ProxySerializabl
     reasoning: options.reasoning,
     cacheRetention: options.cacheRetention,
     sessionId: options.sessionId,
+    promptCacheKey: options.promptCacheKey,
     metadata: options.metadata,
     transport: options.transport,
     thinkingBudgets: options.thinkingBudgets,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -81,7 +81,7 @@ function resolveIsolatedCronPromptCacheKey(params: {
   const digest = createHash("sha256").update(material).digest("hex").slice(0, 32);
   // Isolated cron rotates transcript/session ids per run; keep cache affinity
   // on stable job identity without sending raw local session labels upstream.
-  return `openclaw:cron:${digest}`;
+  return `openclaw-cron-${digest}`;
 }
 
 export function isCommandStyleCronMessage(message: string): boolean {

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
@@ -57,6 +58,31 @@ async function loadCronSubagentRegistryRuntime() {
 
 const COMMAND_STYLE_CRON_PREFIX =
   /^(?:(?:[A-Z_][A-Z0-9_]*=\S+\s+)+)?(?:cd\s+\S+|(?:\.{1,2}|~)?\/\S+|[A-Za-z]:[\\/]\S+|(?:bash|bun|cargo|deno|docker|gh|git|go|make|node|npm|npx|pnpm|python|python3|ruby|sh|tsx|uv|zsh)\b)/u;
+
+function resolveIsolatedCronPromptCacheKey(params: {
+  job: CronJob;
+  agentId: string;
+  agentSessionKey: string;
+  provider: string;
+  model: string;
+}): string | undefined {
+  if (params.job.sessionTarget !== "isolated") {
+    return undefined;
+  }
+  const material = JSON.stringify({
+    version: 1,
+    kind: "isolated-cron",
+    jobId: params.job.id,
+    agentId: params.agentId,
+    agentSessionKey: params.agentSessionKey,
+    provider: params.provider,
+    model: params.model,
+  });
+  const digest = createHash("sha256").update(material).digest("hex").slice(0, 32);
+  // Isolated cron rotates transcript/session ids per run; keep cache affinity
+  // on stable job identity without sending raw local session labels upstream.
+  return `openclaw:cron:${digest}`;
+}
 
 export function isCommandStyleCronMessage(message: string): boolean {
   const trimmed = message.trim();
@@ -222,6 +248,13 @@ export function createCronPromptExecutor(params: {
           return result;
         }
         const { resolveFastModeState, runEmbeddedAgent } = await loadCronEmbeddedRuntime();
+        const promptCacheKey = resolveIsolatedCronPromptCacheKey({
+          job: params.job,
+          agentId: params.agentId,
+          agentSessionKey: params.agentSessionKey,
+          provider: providerOverride,
+          model: modelOverride,
+        });
         const currentChannelId = await resolveCurrentChannelTarget({
           channel: messageChannel,
           to: params.resolvedDelivery.to,
@@ -230,6 +263,7 @@ export function createCronPromptExecutor(params: {
         const result = await runEmbeddedAgent({
           sessionId: params.cronSession.sessionEntry.sessionId,
           sessionKey: params.runSessionKey,
+          promptCacheKey,
           agentId: params.agentId,
           trigger: "cron",
           jobId: params.job.id,

--- a/src/cron/isolated-agent/run.session-key-isolation.test.ts
+++ b/src/cron/isolated-agent/run.session-key-isolation.test.ts
@@ -63,14 +63,66 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
     const runRequest = requireFirstMockArg(runEmbeddedAgentMock, "runEmbeddedAgentMock") as {
       sessionId?: string;
       sessionKey?: string;
+      promptCacheKey?: string;
       bootstrapContextMode?: string;
       bootstrapContextRunKind?: string;
     };
     expect(runRequest.sessionId).toBe("isolated-run-1");
     expect(runRequest.sessionKey).toBe("agent:default:cron:daily-monitor:run:isolated-run-1");
     expect(runRequest.sessionKey).not.toBe("agent:default:cron:daily-monitor");
+    expect(runRequest.promptCacheKey).toMatch(/^openclaw:cron:[a-f0-9]{32}$/u);
+    expect(runRequest.promptCacheKey).not.toContain("isolated-run-1");
+    expect(runRequest.promptCacheKey).not.toContain("daily-monitor");
     expect(runRequest.bootstrapContextMode).toBe("lightweight");
     expect(runRequest.bootstrapContextRunKind).toBe("cron");
+  });
+
+  it("keeps embedded isolated cron prompt-cache affinity stable across run sessions", async () => {
+    resolveCronSessionMock
+      .mockReturnValueOnce(
+        makeCronSession({
+          sessionEntry: {
+            ...makeCronSession().sessionEntry,
+            sessionId: "isolated-run-a",
+          },
+        }),
+      )
+      .mockReturnValueOnce(
+        makeCronSession({
+          sessionEntry: {
+            ...makeCronSession().sessionEntry,
+            sessionId: "isolated-run-b",
+          },
+        }),
+      );
+    mockRunCronFallbackPassthrough();
+
+    const params = makeIsolatedAgentTurnParams({
+      sessionKey: "cron:daily-monitor",
+      job: makeIsolatedAgentTurnJob({
+        payload: {
+          kind: "agentTurn",
+          message: "test",
+          lightContext: true,
+        },
+      }),
+    });
+    await runCronIsolatedAgentTurn(params);
+    await runCronIsolatedAgentTurn(params);
+
+    const requests = runEmbeddedAgentMock.mock.calls.map(
+      ([arg]) =>
+        arg as {
+          sessionId?: string;
+          sessionKey?: string;
+          promptCacheKey?: string;
+        },
+    );
+    expect(requests[0]?.sessionId).toBe("isolated-run-a");
+    expect(requests[1]?.sessionId).toBe("isolated-run-b");
+    expect(requests[0]?.sessionKey).not.toBe(requests[1]?.sessionKey);
+    expect(requests[0]?.promptCacheKey).toBe(requests[1]?.promptCacheKey);
+    expect(requests[0]?.promptCacheKey).toMatch(/^openclaw:cron:[a-f0-9]{32}$/u);
   });
 
   it("keeps explicit session-bound cron execution on the requested session key", async () => {
@@ -99,11 +151,13 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
     const runRequest = requireFirstMockArg(runEmbeddedAgentMock, "runEmbeddedAgentMock") as {
       sessionId?: string;
       sessionKey?: string;
+      promptCacheKey?: string;
       bootstrapContextMode?: string;
       bootstrapContextRunKind?: string;
     };
     expect(runRequest.sessionId).toBe("bound-run-1");
     expect(runRequest.sessionKey).toBe("agent:default:project-alpha-monitor");
+    expect(runRequest.promptCacheKey).toBeUndefined();
     expect(runRequest.bootstrapContextMode).toBeUndefined();
     expect(runRequest.bootstrapContextRunKind).toBe("cron");
   });
@@ -143,12 +197,14 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
     const runRequest = requireFirstMockArg(runCliAgentMock, "runCliAgentMock") as {
       sessionId?: string;
       sessionKey?: string;
+      promptCacheKey?: string;
       bootstrapContextMode?: string;
       bootstrapContextRunKind?: string;
     };
     expect(runRequest.sessionId).toBe("isolated-cli-run-1");
     expect(runRequest.sessionKey).toBe("agent:default:cron:cli-monitor:run:isolated-cli-run-1");
     expect(runRequest.sessionKey).not.toBe("agent:default:cron:cli-monitor");
+    expect(runRequest.promptCacheKey).toBeUndefined();
     expect(runRequest.bootstrapContextMode).toBe("lightweight");
     expect(runRequest.bootstrapContextRunKind).toBe("cron");
   });

--- a/src/cron/isolated-agent/run.session-key-isolation.test.ts
+++ b/src/cron/isolated-agent/run.session-key-isolation.test.ts
@@ -70,7 +70,7 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
     expect(runRequest.sessionId).toBe("isolated-run-1");
     expect(runRequest.sessionKey).toBe("agent:default:cron:daily-monitor:run:isolated-run-1");
     expect(runRequest.sessionKey).not.toBe("agent:default:cron:daily-monitor");
-    expect(runRequest.promptCacheKey).toMatch(/^openclaw:cron:[a-f0-9]{32}$/u);
+    expect(runRequest.promptCacheKey).toMatch(/^openclaw-cron-[a-f0-9]{32}$/u);
     expect(runRequest.promptCacheKey).not.toContain("isolated-run-1");
     expect(runRequest.promptCacheKey).not.toContain("daily-monitor");
     expect(runRequest.bootstrapContextMode).toBe("lightweight");
@@ -122,7 +122,7 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
     expect(requests[1]?.sessionId).toBe("isolated-run-b");
     expect(requests[0]?.sessionKey).not.toBe(requests[1]?.sessionKey);
     expect(requests[0]?.promptCacheKey).toBe(requests[1]?.promptCacheKey);
-    expect(requests[0]?.promptCacheKey).toMatch(/^openclaw:cron:[a-f0-9]{32}$/u);
+    expect(requests[0]?.promptCacheKey).toMatch(/^openclaw-cron-[a-f0-9]{32}$/u);
   });
 
   it("keeps explicit session-bound cron execution on the requested session key", async () => {

--- a/src/llm/providers/azure-openai-responses.ts
+++ b/src/llm/providers/azure-openai-responses.ts
@@ -301,7 +301,7 @@ function buildParams(
     model: deploymentName,
     input: messages,
     stream: true,
-    prompt_cache_key: clampOpenAIPromptCacheKey(options?.sessionId),
+    prompt_cache_key: clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
   };
 
   if (options?.maxTokens) {

--- a/src/llm/providers/azure-openai-responses.ts
+++ b/src/llm/providers/azure-openai-responses.ts
@@ -301,7 +301,10 @@ function buildParams(
     model: deploymentName,
     input: messages,
     stream: true,
-    prompt_cache_key: clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
+    prompt_cache_key:
+      options?.cacheRetention === "none"
+        ? undefined
+        : clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
   };
 
   if (options?.maxTokens) {

--- a/src/llm/providers/openai-codex-responses.test.ts
+++ b/src/llm/providers/openai-codex-responses.test.ts
@@ -217,4 +217,32 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("Request timed out after 5ms");
   });
+
+  it("prefers promptCacheKey over sessionId for request cache affinity", async () => {
+    let payload: unknown;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("stop after payload");
+      }),
+    );
+
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      sessionId: "run-session",
+      promptCacheKey: "stable-cache-key",
+      transport: "sse",
+      onPayload: (nextPayload) => {
+        payload = nextPayload;
+      },
+    });
+
+    await stream.result();
+
+    expect(payload).toMatchObject({ prompt_cache_key: "stable-cache-key" });
+  });
 });

--- a/src/llm/providers/openai-codex-responses.ts
+++ b/src/llm/providers/openai-codex-responses.ts
@@ -477,7 +477,10 @@ function buildRequestBody(
     input: messages,
     text: { verbosity: options?.textVerbosity || "low" },
     include: ["reasoning.encrypted_content"],
-    prompt_cache_key: clampOpenAIPromptCacheKey(options?.sessionId),
+    prompt_cache_key:
+      options?.cacheRetention === "none"
+        ? undefined
+        : clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
     tool_choice: "auto",
     parallel_tool_calls: true,
   };

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -559,7 +559,7 @@ function buildParams(
     prompt_cache_key:
       (model.baseUrl.includes("api.openai.com") && cacheRetention !== "none") ||
       (cacheRetention === "long" && compat.supportsLongCacheRetention)
-        ? clampOpenAIPromptCacheKey(options?.sessionId)
+        ? clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId)
         : undefined,
     prompt_cache_retention:
       cacheRetention === "long" && compat.supportsLongCacheRetention ? "24h" : undefined,

--- a/src/llm/providers/openai-responses.ts
+++ b/src/llm/providers/openai-responses.ts
@@ -252,7 +252,9 @@ function buildParams(
     input: messages,
     stream: true,
     prompt_cache_key:
-      cacheRetention === "none" ? undefined : clampOpenAIPromptCacheKey(options?.sessionId),
+      cacheRetention === "none"
+        ? undefined
+        : clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
     prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
     store: false,
   };

--- a/src/llm/providers/simple-options.ts
+++ b/src/llm/providers/simple-options.ts
@@ -20,6 +20,7 @@ export function buildBaseOptions(
     transport: options?.transport,
     cacheRetention: options?.cacheRetention,
     sessionId: options?.sessionId,
+    promptCacheKey: options?.promptCacheKey,
     headers: options?.headers,
     onPayload: options?.onPayload,
     onResponse: options?.onResponse,

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -69,6 +69,11 @@ export interface StreamOptions {
    */
   sessionId?: string;
   /**
+   * Optional provider prompt-cache affinity key, distinct from transcript/session identity.
+   * Providers that do not support separate cache affinity ignore it.
+   */
+  promptCacheKey?: string;
+  /**
    * Optional callback for inspecting or replacing provider payloads before sending.
    * Return undefined to keep the payload unchanged.
    */


### PR DESCRIPTION
Fixes #62809

## Summary
- Add a stable hashed prompt-cache affinity key for embedded isolated cron runs.
- Thread that key through the embedded runner into OpenClaw-managed OpenAI transports.
- Preserve fresh isolated run session ids and existing session-bound and CLI cron behavior.

## AI assistance disclosure
AI assistance was used. I reviewed and understand the affected cron executor, embedded runner, stream-resolution, and OpenAI transport paths.

## Real behavior proof
Behavior addressed: recurring isolated cron runs now keep stable OpenAI prompt-cache affinity while preserving fresh run sessions.

Real environment tested: local source checkout, actual OpenAI transport parameter builders, no live credentials.

Exact steps or command run after this patch:

```sh
node --import tsx --input-type=module
```

with a small script invoking `buildOpenAIResponsesParams` and `buildOpenAICompletionsParams` using a sanitized cron-style `promptCacheKey` plus a distinct run `sessionId`.

Evidence after fix:

```text
responses.prompt_cache_key=openclaw:cron:0123456789abcdef0123456789abcdef
responses.cache_disabled.prompt_cache_key=absent
completions.prompt_cache_key=openclaw:cron:0123456789abcdef0123456789abcdef
session_identity_still_separate=true
```

Observed result after fix: OpenAI Responses and opted-in OpenAI-compatible Completions payloads use the stable cron prompt-cache key, while `cacheRetention: "none"` omits `prompt_cache_key` and the run session identity remains separate.

What was not tested: live OpenAI cache-hit telemetry was not exercised because it would require real provider credentials and billing-side cache observations. Testbox `pnpm check:changed` was also blocked because the local Crabbox wrapper could not find a usable `crabbox` binary.

## Root Cause
Isolated cron deliberately rotates the transcript/session identity for each run so recurring jobs do not accumulate an ever-growing transcript. The OpenAI payload builders used `sessionId` as the `prompt_cache_key` fallback, so the same recurring isolated cron job also rotated its prompt-cache affinity across runs.

## Dependency contract
OpenAI's SDK exposes `prompt_cache_key` on Responses and Chat Completions request params as the cache-affinity field for similar requests. The local `@earendil-works/pi-ai@0.75.5` stream options expose `sessionId` and `cacheRetention`, but no first-class `promptCacheKey`; its OpenAI providers use `sessionId` for `prompt_cache_key` when prompt caching is enabled. OpenClaw therefore needs a separate internal option so cache affinity can be stable without changing session semantics.

## Regression Test Plan
Focused tests cover:

- isolated cron embedded runs get a stable hashed prompt-cache key across fresh run sessions
- session-bound cron and CLI cron do not receive the embedded prompt-cache key
- `runEmbeddedPiAgent` forwards the key into the embedded attempt
- stream resolution propagates the key without overwriting caller-supplied values
- OpenAI Responses and opted-in Completions prefer `promptCacheKey` over `sessionId`, and omit it when caching is disabled

## Security Impact
No credentials, lockfiles, config files, or secret-handling paths changed. The upstream cache key is derived from stable cron/provider/model identity but sent as a truncated SHA-256 digest, so raw cron names, local session labels, and per-run session ids are not exposed in `prompt_cache_key`.

## Human Verification
I reviewed the affected runtime path from cron execution through embedded runner stream resolution and the OpenAI transport builders, then rechecked the diff against issue #62809 after focused validation.

## CODEOWNERS / owner review
`.github/CODEOWNERS` only names `src/cron/stagger.ts` and `src/cron/service/jobs.ts` under cron. Neither file is touched, so no direct CODEOWNERS owner gate was found for this diff.

## Changelog
No `CHANGELOG.md` edit. This is a normal contributor bugfix PR.

## Review conversations
`codex review --base origin/main` reported no actionable correctness issues after the final patch.

## Risks
Live OpenAI cache-hit telemetry was not tested. The local proof validates the outgoing request payload contract, not OpenAI's server-side cache accounting.

## Behavior tradeoffs
The patch keeps transcript/session isolation and transport session identity separate from prompt-cache affinity. That means recurring isolated cron jobs can share cache buckets across runs without sharing a transcript.

## Scope boundaries
This targets OpenClaw-managed embedded isolated cron OpenAI transport paths. It does not change session-bound cron jobs, CLI cron execution, prompt-prefix construction, source-dependent tool ordering, or arbitrary custom stream implementations that do not use OpenClaw's managed OpenAI transports.

## Validation
```text
node scripts/run-vitest.mjs src/cron/isolated-agent/run.session-key-isolation.test.ts src/agents/pi-embedded-runner/stream-resolution.test.ts src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
Test Files  8 passed (8)
Tests       469 passed (469)

pnpm exec oxfmt --check --threads=1 src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner/prompt-cache-retention.test.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.session-key-isolation.test.ts src/agents/pi-embedded-runner/run/params.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/stream-resolution.ts src/agents/pi-embedded-runner/stream-resolution.test.ts src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts
All matched files use the correct format.

git diff --check
passed

codex review --base origin/main
No actionable correctness issues found
```

Blocked broad validation:

```text
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- corepack pnpm check:changed
[crabbox] selected binary failed basic --version/--help sanity checks
```
