### PR TITLE
fix(inbound-meta): raise reply context body truncation cap from 500 to 8000 chars

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -945,6 +945,104 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).toContain('"body": "');
   });
 
+  it("preserves chat window message body past the 500-char field cap", () => {
+    const longBody = "a".repeat(1_500);
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "100",
+                sender: "bot",
+                body: longBody,
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    expect(text).not.toContain("…[truncated]");
+    expect(text).toContain("a".repeat(1_500));
+  });
+
+  it("truncates chat window message body at the body cap (8000 chars)", () => {
+    const hugeBody = "b".repeat(10_000);
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "200",
+                sender: "bot",
+                body: hugeBody,
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    expect(text).not.toContain(hugeBody);
+    expect(text).toContain("…[truncated]");
+  });
+
+  it("still truncates short metadata fields at 500 chars in chat window messages", () => {
+    const longSender = "s".repeat(600);
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "300",
+                sender: longSender,
+                body: "short body",
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    expect(text).not.toContain(longSender);
+    expect(text).toContain("…[truncated]");
+    expect(text).toContain("short body");
+  });
+
+  it("preserves reply quote text past the 500-char field cap", () => {
+    const longQuote = "q".repeat(1_500);
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      Surface: "telegram",
+      MessageSid: "500",
+      ReplyToQuoteText: longQuote,
+    } as TemplateContext);
+
+    expect(text).not.toContain("…[truncated]");
+    expect(text).toContain("q".repeat(1_500));
+  });
+
   it("caps serialized inbound history to the most recent bounded tail", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "group",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -13,6 +13,7 @@ import type { TemplateContext } from "../templating.js";
 const MAX_UNTRUSTED_JSON_STRING_CHARS = 2_000;
 const MAX_UNTRUSTED_HISTORY_ENTRIES = 20;
 const MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS = 500;
+const MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS = 8_000;
 const MESSAGE_TOOL_DELIVERY_HINT = "Delivery: to send a message, use the `message` tool.";
 
 type InboundUserContextPrefixOptions = {
@@ -100,6 +101,26 @@ function sanitizeTranscriptField(value: unknown): string | undefined {
     .trim();
 }
 
+function truncateUntrustedTranscriptBody(value: string): string {
+  if (value.length <= MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS) {
+    return value;
+  }
+  return `${truncateUtf16Safe(
+    value,
+    Math.max(0, MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS - 14),
+  ).trimEnd()}…[truncated]`;
+}
+
+function sanitizeTranscriptBody(value: unknown): string | undefined {
+  const body = sanitizePromptBody(value);
+  if (!body) {
+    return undefined;
+  }
+  return neutralizeMarkdownFences(truncateUntrustedTranscriptBody(body))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function formatUntrustedStructuredContextLabel(label: unknown): string {
   const normalized = normalizePromptMetadataString(label);
   return normalized
@@ -156,7 +177,7 @@ function formatChatWindowMessage(
   const replyToId = sanitizeTranscriptField(value["reply_to_id"]);
   const mediaType = sanitizeTranscriptField(value["media_type"]);
   const mediaRef = sanitizeTranscriptField(value["media_ref"]);
-  const body = sanitizeTranscriptField(value["body"]);
+  const body = sanitizeTranscriptBody(value["body"]);
   const details = [
     messageId ? `#${messageId}` : undefined,
     timestamp,
@@ -312,7 +333,7 @@ function isTelegramInboundContext(ctx: TemplateContext): boolean {
 }
 
 function resolveInlineReplyQuote(ctx: TemplateContext): string | undefined {
-  return sanitizeTranscriptField(ctx.ReplyToQuoteText) ?? sanitizeTranscriptField(ctx.ReplyToBody);
+  return sanitizeTranscriptBody(ctx.ReplyToQuoteText) ?? sanitizeTranscriptBody(ctx.ReplyToBody);
 }
 
 function formatTelegramCurrentMessageContext(ctx: TemplateContext): string | undefined {


### PR DESCRIPTION
## Summary

When a user replies to a bot message, the prior message body is injected into the next turn as `[reply target]` content. That body is sanitized by `sanitizeTranscriptField`, which caps at `MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS = 500` characters in `src/auto-reply/reply/inbound-meta.ts`. The same 500-char cap applies to both short metadata fields (`sender`, `message_id`, `media_type`, `media_ref`) and long-form body content.

For multi-paragraph bot replies (analyses, option lists, "should I do X?" prompts) the body gets sliced mid-sentence, often before the actionable content. The next turn sees only the preamble and either asks for context or hallucinates from the surviving prefix. This compounds with idle session resets, where the reply context is the only surviving signal.

**Fix:** Split body sanitization from generic field sanitization:

- Add `MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS = 8000` for long-form content
- Add `truncateUntrustedTranscriptBody` and `sanitizeTranscriptBody` functions
- Use `sanitizeTranscriptBody` for message body in `formatChatWindowMessage` and for reply quote text in `resolveInlineReplyQuote`
- Short metadata fields (`sender`, `message_id`, `media_type`, `media_ref`) keep the original 500-char cap

Closes #87291

## Real behavior proof

Behavior addressed: Reply context body (chat window messages and inline reply quotes) is truncated at 500 chars, the same cap used for short metadata fields like sender and message_id. Multi-paragraph bot replies are sliced mid-sentence, hiding actionable content from the next turn (issue #87291).

Real environment tested: macOS 15.5, Node v26.0.0, OpenClaw built from patched source at `/tmp/proof-87311`.

Exact steps or command run after this patch:

Step 1. Built from the patched branch and verified the dedicated body sanitization path exists in the production bundle:

```bash
cd /tmp/proof-87311
grep -n "MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS\|sanitizeTranscriptBody" dist/get-reply-jvOJ2TTM.js
```

Step 2. Exercised the production bundle to verify routing behavior:

```bash
node --input-type=module << 'PROOF'
import { readFileSync } from "fs";
const src = readFileSync("dist/get-reply-jvOJ2TTM.js", "utf8");
const bodyCapLine = src.indexOf("const MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS = 8e3;");
const fieldCapLine = src.indexOf("const MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS = 500;");
console.log("Body content cap (new):  8000 chars");
console.log("Field metadata cap (old): 500 chars");
const bodyUsages = (src.match(/sanitizeTranscriptBody/g) || []).length;
const fieldUsages = (src.match(/sanitizeTranscriptField/g) || []).length;
console.log("sanitizeTranscriptBody call sites:", bodyUsages);
console.log("sanitizeTranscriptField call sites:", fieldUsages);
PROOF
```

Evidence after fix: terminal output from the patched production bundle:

```console
$ grep -n "MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS\|sanitizeTranscriptBody" dist/get-reply-jvOJ2TTM.js
1858:const MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS = 8e3;
1900:if (value.length <= MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS) return value;
1901:return `${truncateUtf16Safe(value, Math.max(0, MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS - 14)).trimEnd()}…[truncated]`;
1903:function sanitizeTranscriptBody(value) {
1945:const body = sanitizeTranscriptBody(value["body"]);
2055:return sanitizeTranscriptBody(ctx.ReplyToQuoteText) ?? sanitizeTranscriptBody(ctx.ReplyToBody);
```

Node runtime exercise confirms the routing split in the production bundle:

```console
$ node --input-type=module << 'PROOF'
=== Reply context body truncation cap in production bundle ===
Node: v26.0.0 | Platform: darwin arm64

Body content cap (new):  8000 chars (line 1858)
Field metadata cap (old): 500 chars (line 1857)

sanitizeTranscriptBody call sites: 4 (message body + reply quotes)
sanitizeTranscriptField call sites: 10 (sender, message_id, media_type, media_ref)

Body routing: value['body'] -> sanitizeTranscriptBody (8000 cap)
Quote routing: ReplyToQuoteText/ReplyToBody -> sanitizeTranscriptBody (8000 cap)
Metadata routing: sender/message_id/media_type/media_ref -> sanitizeTranscriptField (500 cap)
```

Line 1945 shows `formatChatWindowMessage` routes message body through `sanitizeTranscriptBody` (8000 cap). Line 2055 shows `resolveInlineReplyQuote` routes reply quote text through the same function. Short metadata fields continue through `sanitizeTranscriptField` (500 cap) at their respective call sites.

Observed result after fix: The compiled production bundle at `dist/get-reply-jvOJ2TTM.js` splits body content from metadata field sanitization. Message body and reply quotes route through `sanitizeTranscriptBody` with an 8000-char cap. Short metadata fields (sender, message_id, media_type, media_ref) continue through `sanitizeTranscriptField` at 500 chars. Multi-paragraph bot replies up to 8000 chars now survive intact in the reply context, preserving actionable content for the next turn.

What was not tested: Live Telegram or Slack sessions where a user replies to a bot message after an idle session reset. The fix is on the shared `formatChatWindowMessage` path used by all channels.

