### PR TITLE
fix(docs): document Codex Computer Use enabled setting

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -76,8 +76,10 @@ driver's safety model.
 
 ## Quick setup
 
-Set `plugins.entries.codex.config.computerUse` when Codex-mode turns must have
-Computer Use available before a thread starts:
+Set `plugins.entries.codex.config.computerUse.enabled` to `true` when
+Codex-mode turns must have Computer Use available before a thread starts. Pair
+it with `autoInstall` when OpenClaw should install or re-enable the Codex
+Computer Use plugin from discovered local marketplaces:
 
 ```json5
 {
@@ -87,6 +89,7 @@ Computer Use available before a thread starts:
         enabled: true,
         config: {
           computerUse: {
+            enabled: true,
             autoInstall: true,
           },
         },

--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -76,10 +76,9 @@ driver's safety model.
 
 ## Quick setup
 
-Set `plugins.entries.codex.config.computerUse.enabled` to `true` when
-Codex-mode turns must have Computer Use available before a thread starts. Pair
-it with `autoInstall` when OpenClaw should install or re-enable the Codex
-Computer Use plugin from discovered local marketplaces:
+Set `plugins.entries.codex.config.computerUse` when Codex-mode turns must have
+Computer Use available before a thread starts. `autoInstall: true` opts
+Computer Use in and lets OpenClaw install or re-enable it before the turn:
 
 ```json5
 {
@@ -89,7 +88,6 @@ Computer Use plugin from discovered local marketplaces:
         enabled: true,
         config: {
           computerUse: {
-            enabled: true,
             autoInstall: true,
           },
         },
@@ -132,7 +130,8 @@ not `openclaw codex ...` CLI subcommands:
 ```
 
 `status` is read-only. It does not add marketplace sources, install plugins, or
-enable Codex plugin support.
+enable Codex plugin support. If no config opts Computer Use in, `status` can
+report disabled even after a one-off install command.
 
 `install` enables Codex app-server plugin support, optionally adds a configured
 marketplace source, installs or re-enables the configured plugin through Codex
@@ -180,9 +179,10 @@ You can also register it explicitly from a shell with Codex:
 codex plugin marketplace add /Applications/Codex.app/Contents/Resources/plugins/openai-bundled
 ```
 
-If you use a nonstandard Codex app path, set `computerUse.marketplacePath` to a
-local marketplace file path or run `/codex computer-use install --source
-<marketplace-source>` once.
+If you use a nonstandard Codex app path, run `/codex computer-use install
+--source <marketplace-root>` once or set `computerUse.marketplacePath` to a
+local marketplace file path. Use `--marketplace-path` only when you have the
+marketplace JSON file path, not the bundled marketplace root.
 
 ## Remote catalog limit
 


### PR DESCRIPTION
## Summary
- Clarify that `computerUse.autoInstall` opts Codex Computer Use in for turn-start setup.
- Document that `/codex computer-use status` is read-only and can still report disabled when no config opts Computer Use in.
- Clarify `--source <marketplace-root>` versus `--marketplace-path <marketplace.json>` for nonstandard Codex app paths.

## Why
The current docs did not make the inferred opt-in and marketplace path/source split obvious. Users can confuse the bundled marketplace root with the local marketplace JSON path when running `/codex computer-use install`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex Computer Use setup docs now match the existing inferred opt-in and marketplace source/path behavior.
- Real environment tested: Maintainer source-backed docs review; docs-only change.
- Exact steps or command run after this patch: `pnpm docs:list`; CI `check-docs` on PR head `4bcc150a719c517a34b74a8a41ef781113809c6b`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): CI `check-docs` passed; source review verified `resolveCodexComputerUseConfig` infers `enabled` from `autoInstall`, `marketplaceSource`, `marketplacePath`, or `marketplaceName`, and `install` passes configured `marketplacePath` directly while `marketplaceSource` goes through `marketplace/add`.
- Observed result after fix: The docs wording matches current source and tests for inferred opt-in and marketplace JSON path usage.
- What was not tested: No live Codex desktop install was run for this docs-only PR.
- Proof limitations or environment constraints: Maintainer applied `proof: override` because the external real-behavior gate should not block this docs-only clarification.

## Verification
- `pnpm docs:list`
- CI: `check-docs` passed
- Source review: `extensions/codex/src/app-server/config.ts`, `extensions/codex/src/app-server/computer-use.ts`, and adjacent tests
