### PR TITLE
Fix browser device tokens after shared auth rotation

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -53,6 +53,7 @@ import {
 } from "./http-utils.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { resolveRequestClientIp } from "./net.js";
+import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
 
 const ROOT_PREFIX = "/";
 const CONTROL_UI_ASSISTANT_MEDIA_PREFIX = "/__openclaw__/assistant-media";
@@ -323,7 +324,13 @@ async function authorizeControlUiReadRequest(
         retryAfterMs: deviceRateCheck.retryAfterMs,
       };
     } else {
-      const deviceTokenOk = await authorizeControlUiDeviceReadToken(token);
+      const deviceTokenOk = await authorizeControlUiDeviceReadToken({
+        token,
+        sharedGatewayAuthGeneration: resolveSharedGatewaySessionGeneration(
+          opts.auth,
+          opts.trustedProxies,
+        ),
+      });
       if (deviceTokenOk) {
         opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
         opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
@@ -358,21 +365,25 @@ async function authorizeControlUiReadRequest(
   return true;
 }
 
-async function authorizeControlUiDeviceReadToken(token: string): Promise<boolean> {
+async function authorizeControlUiDeviceReadToken(params: {
+  token: string;
+  sharedGatewayAuthGeneration?: string;
+}): Promise<boolean> {
   const pairing = await listDevicePairing();
   for (const device of pairing.paired) {
     const operatorToken = device.tokens?.[CONTROL_UI_OPERATOR_ROLE];
     if (!operatorToken || operatorToken.revokedAtMs) {
       continue;
     }
-    if (!verifyPairingToken(token, operatorToken.token)) {
+    if (!verifyPairingToken(params.token, operatorToken.token)) {
       continue;
     }
     const verified = await verifyDeviceToken({
       deviceId: device.deviceId,
-      token,
+      token: params.token,
       role: CONTROL_UI_OPERATOR_ROLE,
       scopes: [CONTROL_UI_OPERATOR_READ_SCOPE],
+      sharedGatewayAuthGeneration: params.sharedGatewayAuthGeneration,
     });
     if (verified.ok) {
       return true;

--- a/src/gateway/server.shared-auth-rotation.test.ts
+++ b/src/gateway/server.shared-auth-rotation.test.ts
@@ -26,6 +26,16 @@ const OLD_TOKEN = "shared-token-old";
 const NEW_TOKEN = "shared-token-new";
 const DEFERRED_RESTART_DELAY_MS = 1_000;
 const SECRET_REF_TOKEN_ID = "OPENCLAW_SHARED_AUTH_ROTATION_SECRET_REF";
+const CONTROL_UI_CLIENT = {
+  id: "openclaw-control-ui",
+  version: "1.0.0",
+  platform: "browser",
+  mode: "webchat",
+} as const;
+
+function browserOrigin() {
+  return `http://127.0.0.1:${port}`;
+}
 
 let port = 0;
 
@@ -74,6 +84,36 @@ async function openDeviceTokenWs(): Promise<WebSocket> {
     scopes: ["operator.admin"],
   });
   return ws;
+}
+
+async function openBrowserDeviceTokenWs(): Promise<{
+  ws: WebSocket;
+  deviceToken: string;
+  identityPath: string;
+}> {
+  const identityPath = path.join(
+    os.tmpdir(),
+    `openclaw-shared-auth-browser-${process.pid}-${port}.json`,
+  );
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+    headers: { origin: browserOrigin() },
+  });
+  trackConnectChallengeNonce(ws);
+  await new Promise<void>((resolve) => ws.once("open", resolve));
+  const payload = await connectOk(ws, {
+    token: OLD_TOKEN,
+    client: CONTROL_UI_CLIENT,
+    deviceIdentityPath: identityPath,
+    scopes: ["operator.admin"],
+  });
+  const deviceToken = (payload as { auth?: { deviceToken?: unknown } }).auth?.deviceToken;
+  expect(typeof deviceToken).toBe("string");
+  const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
+  const { getPairedDevice } = await import("../infra/device-pairing.js");
+  const identity = loadOrCreateDeviceIdentity(identityPath);
+  const paired = await getPairedDevice(identity.deviceId);
+  expect(paired?.tokens?.operator?.issuer?.kind).toBe("shared-gateway-auth");
+  return { ws, deviceToken: String(deviceToken), identityPath };
 }
 
 async function closeWsAndWait(ws: WebSocket, timeoutMs = 2_000): Promise<void> {
@@ -164,6 +204,11 @@ describe("gateway shared auth rotation", () => {
     } finally {
       await closeWsAndWait(ws);
     }
+  });
+
+  it("tags browser device tokens minted from shared token auth", async () => {
+    const { ws } = await openBrowserDeviceTokenWs();
+    await closeWsAndWait(ws);
   });
 });
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -911,7 +911,13 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               role,
               scopes,
             }),
-          verifyDeviceToken,
+          verifyDeviceToken: async (params) =>
+            await verifyDeviceToken({
+              ...params,
+              sharedGatewayAuthGeneration:
+                getRequiredSharedGatewaySessionGeneration?.() ??
+                resolveSharedGatewaySessionGeneration(resolvedAuth, trustedProxies),
+            }),
         }));
         pairingLocality = resolvePairingLocality({
           connectParams,
@@ -935,11 +941,12 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           rejectUnauthorized(authResult);
           return;
         }
-        if (authMethod === "token" || authMethod === "password" || authMethod === "trusted-proxy") {
-          const sharedGatewaySessionGeneration = resolveSharedGatewaySessionGeneration(
-            resolvedAuth,
-            trustedProxies,
-          );
+        const usesSharedGatewayAuth =
+          authMethod === "token" || authMethod === "password" || authMethod === "trusted-proxy";
+        const sharedGatewaySessionGeneration = usesSharedGatewayAuth
+          ? resolveSharedGatewaySessionGeneration(resolvedAuth, trustedProxies)
+          : undefined;
+        if (usesSharedGatewayAuth) {
           const requiredSharedGatewaySessionGeneration =
             getRequiredSharedGatewaySessionGeneration?.();
           if (
@@ -1320,9 +1327,17 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         }
 
         const shouldIssueDeviceToken = !trustedProxyAuthOk;
+        const issuer =
+          sharedGatewaySessionGeneration &&
+          (isBrowserOperatorUiClient(connectParams.client) || isWebchat)
+            ? {
+                kind: "shared-gateway-auth" as const,
+                generation: sharedGatewaySessionGeneration,
+              }
+            : undefined;
         const deviceToken =
           shouldIssueDeviceToken && device && hasServerApprovedDeviceTokenBaseline
-            ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
+            ? await ensureDeviceToken({ deviceId: device.id, role, scopes, issuer })
             : null;
         if (role === "node") {
           const reconciliation = await reconcileNodePairingOnConnect({
@@ -1401,11 +1416,6 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             });
           }
         }
-        const usesSharedGatewayAuth =
-          authMethod === "token" || authMethod === "password" || authMethod === "trusted-proxy";
-        const sharedGatewaySessionGeneration = usesSharedGatewayAuth
-          ? resolveSharedGatewaySessionGeneration(resolvedAuth, trustedProxies)
-          : undefined;
         const isTrustedApprovalRuntime =
           scopes.includes(APPROVALS_SCOPE) &&
           connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1009,6 +1009,90 @@ describe("device pairing tokens", () => {
     ).resolves.toEqual({ ok: true });
   });
 
+  test("ties browser operator tokens to the shared gateway auth generation", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const request = await requestDevicePairing(
+      {
+        deviceId: "browser-1",
+        publicKey: "public-key-browser-1",
+        role: "operator",
+        scopes: ["operator.read"],
+        clientId: "openclaw-control-ui",
+        clientMode: "webchat",
+      },
+      baseDir,
+    );
+    await approveDevicePairing(
+      request.request.requestId,
+      {
+        callerScopes: ["operator.read"],
+      },
+      baseDir,
+    );
+
+    const legacy = await getPairedDevice("browser-1", baseDir);
+    const legacyToken = requireToken(legacy?.tokens?.operator?.token);
+    await expect(
+      verifyDeviceToken({
+        deviceId: "browser-1",
+        token: legacyToken,
+        role: "operator",
+        scopes: ["operator.read"],
+        sharedGatewayAuthGeneration: "generation-a",
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "issuer-missing" });
+
+    const tagged = await ensureDeviceToken({
+      deviceId: "browser-1",
+      role: "operator",
+      scopes: ["operator.read"],
+      issuer: { kind: "shared-gateway-auth", generation: "generation-a" },
+      baseDir,
+    });
+    expect(tagged?.token).not.toBe(legacyToken);
+    expect(tagged?.issuer).toEqual({
+      kind: "shared-gateway-auth",
+      generation: "generation-a",
+    });
+
+    await expect(
+      verifyDeviceToken({
+        deviceId: "browser-1",
+        token: tagged?.token ?? "",
+        role: "operator",
+        scopes: ["operator.read"],
+        sharedGatewayAuthGeneration: "generation-a",
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      verifyDeviceToken({
+        deviceId: "browser-1",
+        token: tagged?.token ?? "",
+        role: "operator",
+        scopes: ["operator.read"],
+        sharedGatewayAuthGeneration: "generation-b",
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "issuer-mismatch" });
+  });
+
+  test("keeps legacy non-browser operator tokens usable across generation checks", async () => {
+    const { baseDir, token } = await setupOperatorToken(["operator.read"]);
+
+    await expect(
+      verifyDeviceToken({
+        deviceId: "device-1",
+        token,
+        role: "operator",
+        scopes: ["operator.read"],
+        sharedGatewayAuthGeneration: "generation-a",
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
   test("normalizes legacy node token scopes back to [] on re-approval", async () => {
     const baseDir = await makeDevicePairingDir();
     await setupPairedNodeDevice(baseDir);

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -44,10 +44,16 @@ export type DeviceAuthToken = {
   token: string;
   role: string;
   scopes: string[];
+  issuer?: DeviceAuthTokenIssuer;
   createdAtMs: number;
   rotatedAtMs?: number;
   revokedAtMs?: number;
   lastUsedAtMs?: number;
+};
+
+export type DeviceAuthTokenIssuer = {
+  kind: "shared-gateway-auth";
+  generation: string;
 };
 
 export type DeviceAuthTokenSummary = {
@@ -138,6 +144,8 @@ type DevicePairingStateFile = {
 const PENDING_TTL_MS = 5 * 60 * 1000;
 const OPERATOR_ROLE = "operator";
 const OPERATOR_SCOPE_PREFIX = "operator.";
+const BROWSER_CLIENT_MODE = "webchat";
+const BROWSER_CLIENT_IDS = new Set(["openclaw-control-ui", "webchat-ui"]);
 
 const withLock = createAsyncLock();
 
@@ -414,6 +422,7 @@ function buildDeviceAuthToken(params: {
   role: string;
   scopes: string[];
   existing?: DeviceAuthToken;
+  issuer?: DeviceAuthTokenIssuer;
   now: number;
   rotatedAtMs?: number;
 }): DeviceAuthToken {
@@ -421,11 +430,60 @@ function buildDeviceAuthToken(params: {
     token: newToken(),
     role: params.role,
     scopes: params.scopes,
+    issuer: params.issuer ?? params.existing?.issuer,
     createdAtMs: params.existing?.createdAtMs ?? params.now,
     rotatedAtMs: params.rotatedAtMs,
     revokedAtMs: undefined,
     lastUsedAtMs: params.existing?.lastUsedAtMs,
   };
+}
+
+function isBrowserPairedDevice(device: PairedDevice): boolean {
+  return device.clientMode === BROWSER_CLIENT_MODE || BROWSER_CLIENT_IDS.has(device.clientId ?? "");
+}
+
+function sharedGatewayIssuerMatches(
+  issuer: DeviceAuthTokenIssuer | undefined,
+  sharedGatewayAuthGeneration: string | undefined,
+): boolean {
+  return (
+    issuer?.kind === "shared-gateway-auth" &&
+    sharedGatewayAuthGeneration !== undefined &&
+    issuer.generation === sharedGatewayAuthGeneration
+  );
+}
+
+function deviceTokenIssuerAllowsUse(params: {
+  device: PairedDevice;
+  token: DeviceAuthToken;
+  sharedGatewayAuthGeneration?: string;
+}): { ok: true } | { ok: false; reason: string } {
+  if (params.sharedGatewayAuthGeneration === undefined) {
+    return { ok: true };
+  }
+  if (params.token.issuer?.kind === "shared-gateway-auth") {
+    return sharedGatewayIssuerMatches(params.token.issuer, params.sharedGatewayAuthGeneration)
+      ? { ok: true }
+      : { ok: false, reason: "issuer-mismatch" };
+  }
+  if (isBrowserPairedDevice(params.device)) {
+    return { ok: false, reason: "issuer-missing" };
+  }
+  return { ok: true };
+}
+
+function shouldReuseExistingDeviceToken(params: {
+  device: PairedDevice;
+  token: DeviceAuthToken;
+  issuer?: DeviceAuthTokenIssuer;
+}): boolean {
+  if (!params.issuer) {
+    return true;
+  }
+  if (sharedGatewayIssuerMatches(params.token.issuer, params.issuer.generation)) {
+    return true;
+  }
+  return !isBrowserPairedDevice(params.device) && !params.token.issuer;
 }
 
 function resolveRoleScopedDeviceTokenScopes(role: string, scopes: string[] | undefined): string[] {
@@ -909,6 +967,7 @@ export async function verifyDeviceToken(params: {
   token: string;
   role: string;
   scopes: string[];
+  sharedGatewayAuthGeneration?: string;
   baseDir?: string;
 }): Promise<{ ok: boolean; reason?: string }> {
   return await withLock(async () => {
@@ -930,6 +989,14 @@ export async function verifyDeviceToken(params: {
     }
     if (!verifyPairingToken(params.token, entry.token)) {
       return { ok: false, reason: "token-mismatch" };
+    }
+    const issuerCheck = deviceTokenIssuerAllowsUse({
+      device,
+      token: entry,
+      sharedGatewayAuthGeneration: params.sharedGatewayAuthGeneration,
+    });
+    if (!issuerCheck.ok) {
+      return issuerCheck;
     }
     const approvedScopes = resolveApprovedDeviceScopeBaseline(device);
     if (
@@ -958,6 +1025,7 @@ export async function ensureDeviceToken(params: {
   deviceId: string;
   role: string;
   scopes: string[];
+  issuer?: DeviceAuthTokenIssuer;
   baseDir?: string;
 }): Promise<DeviceAuthToken | null> {
   return await withLock(async () => {
@@ -990,7 +1058,8 @@ export async function ensureDeviceToken(params: {
       });
       if (
         existingWithinApproved &&
-        roleScopesAllow({ role, requestedScopes, allowedScopes: existing.scopes })
+        roleScopesAllow({ role, requestedScopes, allowedScopes: existing.scopes }) &&
+        shouldReuseExistingDeviceToken({ device, token: existing, issuer: params.issuer })
       ) {
         return existing;
       }
@@ -1000,6 +1069,7 @@ export async function ensureDeviceToken(params: {
       role,
       scopes: requestedScopes,
       existing,
+      issuer: params.issuer,
       now,
       rotatedAtMs: existing ? now : undefined,
     });


### PR DESCRIPTION
Summary:
- Tag browser Control UI device tokens minted from shared gateway auth with the current shared-auth generation.
- Reject stale or legacy untagged browser device tokens when a shared-auth generation is required, while leaving non-browser legacy tokens usable.
- Pass the shared-auth generation through Control UI HTTP reads and websocket device-token verification/reminting.

Verification:
- `pnpm exec oxfmt --write --threads=1 src/infra/device-pairing.ts src/infra/device-pairing.test.ts src/gateway/control-ui.ts src/gateway/server/ws-connection/message-handler.ts src/gateway/server.shared-auth-rotation.test.ts`
- `node scripts/run-vitest.mjs src/infra/device-pairing.test.ts src/gateway/server.shared-auth-rotation.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Real behavior proof:
Behavior addressed: Browser Control UI device tokens minted through shared gateway auth are tied to the current auth generation, stale browser tokens are rejected/reminted after rotation, and unrelated non-browser legacy tokens are not invalidated.
Real environment tested: Local Codex worktree on Linux with Node 24 and the repository Vitest wrapper.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/device-pairing.test.ts src/gateway/server.shared-auth-rotation.test.ts`
Evidence after fix: Device-pairing tests cover browser issuer-missing and issuer-mismatch rejection plus non-browser legacy allowance; gateway rotation coverage verifies Control UI browser token issuer tagging.
Observed result after fix: 2 test files passed; 57 tests passed. Local autoreview exited 0 with no accepted/actionable findings.
What was not tested: Full GitHub CI is pending on this draft PR.

This PR was AI-assisted.
