### PR TITLE
fix(imessage): suppress duplicate native exec approvals

### DIFF
--- a/extensions/imessage/src/approval-handler.runtime.test.ts
+++ b/extensions/imessage/src/approval-handler.runtime.test.ts
@@ -10,7 +10,7 @@ vi.mock("./send.js", () => ({
 }));
 
 describe("imessageApprovalNativeRuntime", () => {
-  it("renders allowed thumbs-only reactions in pending exec approvals", async () => {
+  it("renders shared reactions in pending exec approvals", async () => {
     const payload = await imessageApprovalNativeRuntime.presentation.buildPendingPayload({
       cfg: {} as never,
       accountId: "default",
@@ -54,7 +54,7 @@ describe("imessageApprovalNativeRuntime", () => {
     expect(payload.allowedDecisions).toEqual(["allow-once", "deny"]);
   });
 
-  it("renders allowed thumbs-only reactions in pending plugin approvals", async () => {
+  it("renders shared reactions in pending plugin approvals", async () => {
     const payload = await imessageApprovalNativeRuntime.presentation.buildPendingPayload({
       cfg: {} as never,
       accountId: "default",
@@ -105,6 +105,7 @@ describe("imessageApprovalNativeRuntime", () => {
     expect(payload.text).toContain("Plugin approval required");
     expect(payload.text).toContain("Reply with: /approve plugin:abc allow-once|allow-always|deny");
     expect(payload.text).toContain("👍 Allow Once");
+    expect(payload.text).toContain("♾️ Allow Always");
     expect(payload.text).toContain("👎 Deny");
     expect(payload.text).not.toContain("/approve <id>");
     expect(payload.allowedDecisions).toEqual(["allow-once", "allow-always", "deny"]);

--- a/extensions/imessage/src/approval-handler.runtime.ts
+++ b/extensions/imessage/src/approval-handler.runtime.ts
@@ -5,15 +5,11 @@ import {
   type ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
-import {
-  buildExecApprovalPendingReplyPayload,
-  type ExecApprovalReplyDecision,
-  type ExecApprovalPendingReplyParams,
-} from "openclaw/plugin-sdk/approval-reply-runtime";
+import { buildApprovalReactionPendingContent } from "openclaw/plugin-sdk/approval-reaction-runtime";
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import {
   buildApprovalResolvedReplyPayload,
   buildPluginApprovalExpiredMessage,
-  buildPluginApprovalPendingReplyPayload,
   buildPluginApprovalResolvedMessage,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -23,12 +19,10 @@ import {
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
-  addIMessageApprovalReactionHintToText,
   registerIMessageApprovalReactionTarget,
   unregisterIMessageApprovalReactionTarget,
   type IMessageApprovalConversationKey,
 } from "./approval-reactions.js";
-import { replaceApprovalIdPlaceholder } from "./approval-text.js";
 import { normalizeIMessageMessagingTarget } from "./normalize.js";
 import { sendMessageIMessage } from "./send.js";
 import { normalizeIMessageHandle, parseIMessageTarget } from "./targets.js";
@@ -61,44 +55,14 @@ function buildPendingPayload(params: {
   nowMs: number;
   view: PendingApprovalView;
 }): IMessagePendingDelivery {
-  const allowedDecisions = params.view.actions.map((action) => action.decision);
-  const payload =
-    params.approvalKind === "plugin"
-      ? buildPluginApprovalPendingReplyPayload({
-          request: params.request as PluginApprovalRequest,
-          nowMs: params.nowMs,
-          allowedDecisions,
-        })
-      : buildExecApprovalPendingReplyPayload({
-          approvalId: params.request.id,
-          approvalSlug: params.request.id.slice(0, 8),
-          approvalCommandId: params.request.id,
-          warningText:
-            params.view.approvalKind === "exec"
-              ? (params.view.warningText ?? undefined)
-              : undefined,
-          ask: params.view.approvalKind === "exec" ? (params.view.ask ?? null) : null,
-          agentId: params.view.approvalKind === "exec" ? (params.view.agentId ?? null) : null,
-          sessionKey: params.view.approvalKind === "exec" ? (params.view.sessionKey ?? null) : null,
-          command: params.view.approvalKind === "exec" ? params.view.commandText : "",
-          cwd: params.view.approvalKind === "exec" ? (params.view.cwd ?? undefined) : undefined,
-          host:
-            params.view.approvalKind === "exec" && params.view.host === "node" ? "node" : "gateway",
-          nodeId:
-            params.view.approvalKind === "exec" ? (params.view.nodeId ?? undefined) : undefined,
-          allowedDecisions,
-          expiresAtMs: params.request.expiresAtMs,
-          nowMs: params.nowMs,
-        } satisfies ExecApprovalPendingReplyParams);
+  const pendingContent = buildApprovalReactionPendingContent({
+    request: params.request,
+    view: params.view as never,
+    nowMs: params.nowMs,
+  });
   return {
-    // Use the same hint-insertion helper as the render path so the two routes
-    // produce identical prompt text and the helper's idempotency guard
-    // prevents a double-hint when the upstream payload already includes one.
-    text: addIMessageApprovalReactionHintToText({
-      text: replaceApprovalIdPlaceholder(payload.text, params.request.id),
-      allowedDecisions,
-    }),
-    allowedDecisions,
+    text: pendingContent.reactionPayload.text ?? "",
+    allowedDecisions: pendingContent.reactionPayload.allowedDecisions,
   };
 }
 

--- a/extensions/imessage/src/approval-native.test.ts
+++ b/extensions/imessage/src/approval-native.test.ts
@@ -4,7 +4,11 @@ import type {
 } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
-import { imessageApprovalCapability, imessageNativeApprovalAdapter } from "./approval-native.js";
+import {
+  imessageApprovalCapability,
+  imessageNativeApprovalAdapter,
+  shouldSuppressLocalIMessageExecApprovalPrompt,
+} from "./approval-native.js";
 
 type IMessageConfig = NonNullable<NonNullable<OpenClawConfig["channels"]>["imessage"]>;
 
@@ -77,6 +81,27 @@ function nativeShouldHandle(params: {
     context: {},
     request: params.request,
   });
+}
+
+function buildLocalApprovalPayload(
+  params: {
+    approvalKind?: "exec" | "plugin";
+    agentId?: string | null;
+    sessionKey?: string | null;
+  } = {},
+) {
+  return {
+    text: "Approval required.",
+    channelData: {
+      execApproval: {
+        approvalId: params.approvalKind === "plugin" ? "plugin:approval-1" : "exec-1",
+        approvalSlug: params.approvalKind === "plugin" ? "plugin:approval-1" : "exec-1",
+        approvalKind: params.approvalKind ?? "exec",
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      },
+    },
+  };
 }
 
 describe("imessage approval capability", () => {
@@ -568,5 +593,234 @@ describe("imessage approval capability", () => {
       to: "chat_guid:iMessage;+;chat42",
       accountId: "default",
     });
+  });
+});
+
+describe("shouldSuppressLocalIMessageExecApprovalPrompt", () => {
+  const activeExecHint = {
+    kind: "approval-pending",
+    approvalKind: "exec",
+    nativeRouteActive: true,
+  } as const;
+
+  it("suppresses eligible session-mode exec approval prompts", () => {
+    const cfg = buildConfig({
+      imessage: { allowFrom: ["+15551230000"] },
+      approvals: {
+        exec: {
+          enabled: true,
+          agentFilter: ["main"],
+        },
+      },
+    });
+
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        accountId: "default",
+        payload: buildLocalApprovalPayload({
+          agentId: null,
+          sessionKey: "agent:main:imessage:+15551230000",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps local prompts for disabled, target-only, inactive, or non-exec cases", () => {
+    const enabledConfig = buildConfig({
+      imessage: { allowFrom: ["+15551230000"] },
+      approvals: { exec: { enabled: true } },
+    });
+    const payload = buildLocalApprovalPayload({
+      agentId: "main",
+      sessionKey: "agent:main:imessage:+15551230000",
+    });
+
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg: buildConfig(),
+        payload,
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg: buildConfig({
+          imessage: { allowFrom: ["+15551230000"] },
+          approvals: { exec: { enabled: false } },
+        }),
+        payload,
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg: buildConfig({
+          imessage: { allowFrom: ["+15551230000"] },
+          approvals: {
+            exec: {
+              enabled: true,
+              mode: "targets",
+              targets: [{ channel: "imessage", to: "+15551230000" }],
+            },
+          },
+        }),
+        payload,
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg: enabledConfig,
+        payload,
+        hint: { ...activeExecHint, nativeRouteActive: false },
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg: enabledConfig,
+        payload: buildLocalApprovalPayload({ approvalKind: "plugin" }),
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg: enabledConfig,
+        payload: { text: "Approval required." },
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses direct same-chat iMessage prompts without explicit approvers", () => {
+    const cfg = buildConfig({
+      approvals: { exec: { enabled: true } },
+    });
+
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        payload: buildLocalApprovalPayload({
+          agentId: "main",
+          sessionKey: "agent:main:imessage:+15551230000",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        accountId: "default",
+        payload: buildLocalApprovalPayload({
+          agentId: "main",
+          sessionKey: "agent:main:imessage:direct:+15551230000",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        accountId: "default",
+        payload: buildLocalApprovalPayload({
+          agentId: "main",
+          sessionKey: "agent:main:imessage:default:direct:+15551230000",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps no-approver local prompts for ambiguous or group iMessage sessions", () => {
+    const cfg = buildConfig({
+      approvals: { exec: { enabled: true } },
+    });
+
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        payload: buildLocalApprovalPayload({
+          agentId: "main",
+          sessionKey: "agent:main:imessage:group:test-group",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        payload: buildLocalApprovalPayload({
+          agentId: "main",
+          sessionKey: "agent:main:imessage:chat_guid:iMessage;+;chat42",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        payload: buildLocalApprovalPayload({
+          agentId: "main",
+          sessionKey: "agent:main:slack:C123",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        accountId: "work",
+        payload: buildLocalApprovalPayload({
+          agentId: "main",
+          sessionKey: "agent:main:imessage:default:direct:+15551230000",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+  });
+
+  it("applies top-level approval filters with agent fallback from session key", () => {
+    const cfg = buildConfig({
+      imessage: { allowFrom: ["+15551230000"] },
+      approvals: {
+        exec: {
+          enabled: true,
+          agentFilter: ["ops"],
+          sessionFilter: ["imessage"],
+        },
+      },
+    });
+
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        payload: buildLocalApprovalPayload({
+          agentId: null,
+          sessionKey: "agent:ops:imessage:+15551230000",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        payload: buildLocalApprovalPayload({
+          agentId: null,
+          sessionKey: "agent:main:imessage:+15551230000",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalIMessageExecApprovalPrompt({
+        cfg,
+        payload: buildLocalApprovalPayload({
+          agentId: null,
+          sessionKey: "agent:ops:slack:C123",
+        }),
+        hint: activeExecHint,
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/imessage/src/approval-native.ts
+++ b/extensions/imessage/src/approval-native.ts
@@ -15,6 +15,7 @@ import {
 import {
   buildExecApprovalPendingReplyPayload,
   buildPluginApprovalPendingReplyPayload,
+  getExecApprovalReplyMetadata,
   resolveExecApprovalCommandDisplay,
   resolveExecApprovalRequestAllowedDecisions,
 } from "openclaw/plugin-sdk/approval-runtime";
@@ -416,24 +417,55 @@ export function shouldSuppressLocalIMessageExecApprovalPrompt(params: {
   payload: ReplyPayload;
   hint?: ChannelOutboundPayloadHint;
 }): boolean {
-  return shouldSuppressLocalNativeExecApprovalPrompt({
+  if (
+    shouldSuppressLocalNativeExecApprovalPrompt({
+      ...params,
+      isTransportEnabled: isIMessageApprovalTransportEnabled,
+      isSessionRouteEligible: ({ cfg, accountId, metadata }) => {
+        if (getIMessageApprovalApprovers({ cfg, accountId }).length > 0) {
+          return true;
+        }
+        const sessionTarget = resolveIMessageSessionTargetFromSessionKey(metadata.sessionKey);
+        if (!sessionTarget || inferIMessageTargetChatType(sessionTarget.to) !== "direct") {
+          return false;
+        }
+        const targetAccountId = normalizeOptionalString(sessionTarget.accountId);
+        return (
+          !targetAccountId ||
+          !accountId ||
+          normalizeAccountId(targetAccountId) === normalizeAccountId(accountId)
+        );
+      },
+    })
+  ) {
+    return true;
+  }
+
+  const metadata = getExecApprovalReplyMetadata(params.payload);
+  if (
+    params.hint?.kind !== "approval-pending" ||
+    params.hint.approvalKind !== "exec" ||
+    params.hint.nativeRouteActive !== true ||
+    metadata?.approvalKind !== "exec"
+  ) {
+    return false;
+  }
+
+  // The Pi tool-result path currently rebuilds the local approval prompt from
+  // exec result details that omit agentId/sessionKey. The native iMessage
+  // approval runtime has already received the full request and will deliver the
+  // reaction prompt. When explicit iMessage approvers exist, keep the local
+  // fallback from sending a second manual prompt for the same approval.
+  if (metadata.agentId || metadata.sessionKey) {
+    return false;
+  }
+  if (getIMessageApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }).length === 0) {
+    return false;
+  }
+  return canApprovalPotentiallyRouteToIMessage({
     ...params,
-    isTransportEnabled: isIMessageApprovalTransportEnabled,
-    isSessionRouteEligible: ({ cfg, accountId, metadata }) => {
-      if (getIMessageApprovalApprovers({ cfg, accountId }).length > 0) {
-        return true;
-      }
-      const sessionTarget = resolveIMessageSessionTargetFromSessionKey(metadata.sessionKey);
-      if (!sessionTarget || inferIMessageTargetChatType(sessionTarget.to) !== "direct") {
-        return false;
-      }
-      const targetAccountId = normalizeOptionalString(sessionTarget.accountId);
-      return (
-        !targetAccountId ||
-        !accountId ||
-        normalizeAccountId(targetAccountId) === normalizeAccountId(accountId)
-      );
-    },
+    approvalKind: "exec",
+    nativeSessionOnly: true,
   });
 }
 

--- a/extensions/imessage/src/approval-native.ts
+++ b/extensions/imessage/src/approval-native.ts
@@ -10,6 +10,7 @@ import {
   createChannelNativeOriginTargetResolver,
   doesApprovalRequestMatchChannelAccount,
   resolveApprovalRequestSessionTarget,
+  shouldSuppressLocalNativeExecApprovalPrompt,
 } from "openclaw/plugin-sdk/approval-native-runtime";
 import {
   buildExecApprovalPendingReplyPayload,
@@ -22,10 +23,14 @@ import type {
   ExecApprovalReplyDecision,
   PluginApprovalRequest,
 } from "openclaw/plugin-sdk/approval-runtime";
-import type { ChannelApprovalCapability } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  ChannelApprovalCapability,
+  ChannelOutboundPayloadHint,
+} from "openclaw/plugin-sdk/channel-contract";
 import { channelRouteTargetsMatchExact } from "openclaw/plugin-sdk/channel-route";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { normalizeAccountId, parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -365,6 +370,71 @@ function resolveSessionIMessageOriginTarget(sessionTarget: {
 }): IMessageApprovalTarget | null {
   const to = normalizeIMessageMessagingTarget(sessionTarget.to);
   return to ? { to, accountId: normalizeOptionalString(sessionTarget.accountId) } : null;
+}
+
+function resolveIMessageSessionTargetFromSessionKey(
+  sessionKey?: string | null,
+): IMessageApprovalTarget | null {
+  const parsed = parseAgentSessionKey(sessionKey);
+  const rest = parsed?.rest ?? normalizeOptionalString(sessionKey);
+  if (!rest || !normalizeLowercaseStringOrEmpty(rest).startsWith("imessage:")) {
+    return null;
+  }
+  const route = rest.slice("imessage:".length).trim();
+  const routeLower = normalizeLowercaseStringOrEmpty(route);
+  if (
+    !route ||
+    routeLower.startsWith("group:") ||
+    routeLower.startsWith("channel:") ||
+    routeLower.startsWith("chat:")
+  ) {
+    return null;
+  }
+
+  const directPrefix = "direct:";
+  if (routeLower.startsWith(directPrefix)) {
+    const to = normalizeIMessageMessagingTarget(route.slice(directPrefix.length));
+    return to ? { to } : null;
+  }
+
+  const accountScopedDirect = /^([^:]+):direct:(.+)$/i.exec(route);
+  if (accountScopedDirect) {
+    const to = normalizeIMessageMessagingTarget(accountScopedDirect[2] ?? "");
+    return to ? { to, accountId: normalizeAccountId(accountScopedDirect[1] ?? "") } : null;
+  }
+
+  const to = normalizeIMessageMessagingTarget(route);
+  if (!to || inferIMessageTargetChatType(to) !== "direct") {
+    return null;
+  }
+  return { to };
+}
+
+export function shouldSuppressLocalIMessageExecApprovalPrompt(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  payload: ReplyPayload;
+  hint?: ChannelOutboundPayloadHint;
+}): boolean {
+  return shouldSuppressLocalNativeExecApprovalPrompt({
+    ...params,
+    isTransportEnabled: isIMessageApprovalTransportEnabled,
+    isSessionRouteEligible: ({ cfg, accountId, metadata }) => {
+      if (getIMessageApprovalApprovers({ cfg, accountId }).length > 0) {
+        return true;
+      }
+      const sessionTarget = resolveIMessageSessionTargetFromSessionKey(metadata.sessionKey);
+      if (!sessionTarget || inferIMessageTargetChatType(sessionTarget.to) !== "direct") {
+        return false;
+      }
+      const targetAccountId = normalizeOptionalString(sessionTarget.accountId);
+      return (
+        !targetAccountId ||
+        !accountId ||
+        normalizeAccountId(targetAccountId) === normalizeAccountId(accountId)
+      );
+    },
+  });
 }
 
 function shouldHandleIMessageApprovalRequest(params: {

--- a/extensions/imessage/src/approval-reaction-poller.test.ts
+++ b/extensions/imessage/src/approval-reaction-poller.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { pollPendingIMessageApprovalReactions } from "./approval-reaction-poller.js";
+import {
+  clearIMessageApprovalReactionTargetsForTest,
+  registerIMessageApprovalReactionTarget,
+} from "./approval-reactions.js";
+import type { IMessageRpcClient } from "./client.js";
+
+const resolverMocks = vi.hoisted(() => ({
+  resolveIMessageApproval: vi.fn(),
+  isApprovalNotFoundError: vi.fn(() => false),
+}));
+
+vi.mock("./approval-resolver.js", () => ({
+  resolveIMessageApproval: resolverMocks.resolveIMessageApproval,
+  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+}));
+
+function createClient(request: ReturnType<typeof vi.fn>): IMessageRpcClient {
+  return { request } as unknown as IMessageRpcClient;
+}
+
+describe("iMessage approval reaction poller", () => {
+  beforeEach(() => {
+    clearIMessageApprovalReactionTargetsForTest();
+    resolverMocks.resolveIMessageApproval.mockReset();
+    resolverMocks.resolveIMessageApproval.mockResolvedValue(undefined);
+    resolverMocks.isApprovalNotFoundError.mockReset();
+    resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
+  });
+
+  it("does not scan recent chats during fast polling with no pending targets", async () => {
+    const request = vi.fn();
+
+    await pollPendingIMessageApprovalReactions({
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("does not scan recent chats during fast polling for handle-only targets", async () => {
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { handle: "+15551230000" },
+      messageId: "msg-1",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    const request = vi.fn();
+
+    await pollPendingIMessageApprovalReactions({
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("discovers observed approval prompts on the bounded recent-chat path", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 42 }] };
+      }
+      if (method === "messages.history") {
+        return {
+          messages: [
+            {
+              guid: "msg-1",
+              chat_id: 42,
+              chat_guid: "SMS;-;+15551230000",
+              chat_identifier: "+15551230000",
+              is_from_me: true,
+              sender: "+15551230000",
+              text: [
+                "Exec approval required",
+                "ID: exec-1",
+                "",
+                "Reply with: /approve exec-1 allow-once|deny",
+              ].join("\n"),
+              reactions: [
+                {
+                  id: 7,
+                  sender: "+15551230000",
+                  is_from_me: true,
+                  type: "like",
+                  emoji: "👍",
+                  created_at: "2026-05-27T21:00:00.000Z",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    await pollPendingIMessageApprovalReactions({
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+      allowRecentChatDiscovery: true,
+    });
+
+    expect(request).toHaveBeenCalledWith("chats.list", { limit: 50 }, { timeoutMs: 10_000 });
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      approvalId: "exec-1",
+      decision: "allow-once",
+      senderId: "+15551230000",
+      gatewayUrl: undefined,
+    });
+  });
+
+  it("uses learned chat ids for fast scoped polling after discovery", async () => {
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { handle: "+15551230000" },
+      messageId: "msg-1",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { chatId: 42, chatGuid: "SMS;-;+15551230000" },
+      messageId: "msg-1",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "messages.history") {
+        return { messages: [] };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    await pollPendingIMessageApprovalReactions({
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "messages.history",
+      { chat_id: 42, limit: 30 },
+      { timeoutMs: 10_000 },
+    );
+  });
+
+  it("includes recent chats during discovery when scoped and unscoped targets are pending", async () => {
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { chatId: 42, chatGuid: "SMS;-;+15551230000" },
+      messageId: "msg-scoped",
+      approvalId: "exec-scoped",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { handle: "+15551239999" },
+      messageId: "msg-handle",
+      approvalId: "exec-handle",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    const request = vi.fn(async (method: string, payload?: { chat_id?: number }) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 42 }, { id: 99 }] };
+      }
+      if (method === "messages.history" && payload?.chat_id === 42) {
+        return { messages: [] };
+      }
+      if (method === "messages.history" && payload?.chat_id === 99) {
+        return {
+          messages: [
+            {
+              guid: "msg-handle",
+              chat_id: 99,
+              chat_guid: "SMS;-;+15551239999",
+              chat_identifier: "+15551239999",
+              is_from_me: true,
+              sender: "+15551239999",
+              text: "Exec approval required\nID: exec-handle",
+              reactions: [
+                {
+                  id: 8,
+                  sender: "+15551239999",
+                  is_from_me: true,
+                  type: "like",
+                  emoji: "👍",
+                  created_at: "2026-05-27T21:01:00.000Z",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected request ${method} ${JSON.stringify(payload)}`);
+    });
+
+    await pollPendingIMessageApprovalReactions({
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551239999"] } } },
+      accountId: "default",
+      allowRecentChatDiscovery: true,
+    });
+
+    expect(request).toHaveBeenCalledWith("chats.list", { limit: 50 }, { timeoutMs: 10_000 });
+    expect(request).toHaveBeenCalledWith(
+      "messages.history",
+      { chat_id: 42, limit: 30 },
+      { timeoutMs: 10_000 },
+    );
+    expect(request).toHaveBeenCalledWith(
+      "messages.history",
+      { chat_id: 99, limit: 30 },
+      { timeoutMs: 10_000 },
+    );
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+      cfg: { channels: { imessage: { allowFrom: ["+15551239999"] } } },
+      approvalId: "exec-handle",
+      decision: "allow-once",
+      senderId: "+15551239999",
+      gatewayUrl: undefined,
+    });
+  });
+});

--- a/extensions/imessage/src/approval-reaction-poller.ts
+++ b/extensions/imessage/src/approval-reaction-poller.ts
@@ -1,0 +1,260 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  extractIMessageApprovalPromptBinding,
+  listPendingIMessageApprovalReactionPollTargets,
+  maybeResolveIMessageApprovalReaction,
+  registerIMessageApprovalReactionTarget,
+  type PendingIMessageApprovalReactionPollTarget,
+  type IMessageApprovalConversationKey,
+} from "./approval-reactions.js";
+import type { IMessageRpcClient } from "./client.js";
+import type { IMessagePayload } from "./monitor/types.js";
+
+const RECENT_CHAT_LIMIT = 50;
+const PER_CHAT_HISTORY_LIMIT = 30;
+const OBSERVED_APPROVAL_PROMPT_TARGET_TTL_MS = 5 * 60 * 1000;
+
+type ChatListEntry = {
+  id?: number | null;
+};
+
+type HistoryMessage = IMessagePayload & {
+  reactions?: Array<{
+    id?: number | string | null;
+    sender?: string | null;
+    is_from_me?: boolean | null;
+    type?: string | null;
+    emoji?: string | null;
+    created_at?: string | null;
+  }> | null;
+};
+
+function normalizeChatId(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function listTargetChatIds(
+  targets: readonly PendingIMessageApprovalReactionPollTarget[],
+): number[] {
+  const chatIds = new Set<number>();
+  for (const target of targets) {
+    const chatId = normalizeChatId(target.conversation.chatId);
+    if (chatId !== null) {
+      chatIds.add(chatId);
+    }
+  }
+  return [...chatIds];
+}
+
+function normalizeMessageGuid(value: string): string {
+  return value.trim().replace(/^p:\d+\//iu, "");
+}
+
+function enumerateMessageGuidCandidates(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const normalized = normalizeMessageGuid(trimmed);
+  return [trimmed, normalized].filter(
+    (candidate, index, candidates) =>
+      candidate.length > 0 && candidates.indexOf(candidate) === index,
+  );
+}
+
+function buildPendingTargetsByMessageId(
+  targets: readonly PendingIMessageApprovalReactionPollTarget[],
+): Map<string, PendingIMessageApprovalReactionPollTarget> {
+  const pendingByMessageId = new Map<string, PendingIMessageApprovalReactionPollTarget>();
+  for (const target of targets) {
+    for (const candidate of enumerateMessageGuidCandidates(target.messageId)) {
+      pendingByMessageId.set(candidate, target);
+    }
+  }
+  return pendingByMessageId;
+}
+
+async function listRecentChatIds(client: IMessageRpcClient): Promise<number[]> {
+  const result = await client.request<{ chats?: ChatListEntry[] }>(
+    "chats.list",
+    { limit: RECENT_CHAT_LIMIT },
+    { timeoutMs: 10_000 },
+  );
+  return (result.chats ?? [])
+    .map((chat) => normalizeChatId(chat.id))
+    .filter((chatId): chatId is number => chatId !== null);
+}
+
+async function fetchRecentHistory(params: {
+  client: IMessageRpcClient;
+  chatId: number;
+}): Promise<HistoryMessage[]> {
+  const result = await params.client.request<{ messages?: unknown[] }>(
+    "messages.history",
+    {
+      chat_id: params.chatId,
+      limit: PER_CHAT_HISTORY_LIMIT,
+    },
+    { timeoutMs: 10_000 },
+  );
+  return (result.messages ?? []).filter((message): message is HistoryMessage =>
+    Boolean(message && typeof message === "object"),
+  );
+}
+
+function buildReactionPayload(params: {
+  targetMessage: HistoryMessage;
+  reaction: NonNullable<HistoryMessage["reactions"]>[number];
+}): IMessagePayload | null {
+  const emoji = params.reaction.emoji?.trim();
+  const sender = params.reaction.sender?.trim();
+  const targetGuid = params.targetMessage.guid?.trim();
+  if (!emoji || !sender || !targetGuid) {
+    return null;
+  }
+  const reactionId = normalizeChatId(params.reaction.id);
+  return {
+    ...(reactionId !== null ? { id: reactionId } : {}),
+    guid: `reaction:${targetGuid}:${sender}:${emoji}:${params.reaction.created_at ?? ""}`,
+    chat_id: params.targetMessage.chat_id,
+    chat_guid: params.targetMessage.chat_guid,
+    chat_identifier: params.targetMessage.chat_identifier,
+    chat_name: params.targetMessage.chat_name,
+    participants: params.targetMessage.participants,
+    is_group: params.targetMessage.is_group,
+    sender,
+    destination_caller_id: params.targetMessage.destination_caller_id,
+    is_from_me: params.reaction.is_from_me,
+    text: `${params.reaction.type ?? "reaction"} "${params.targetMessage.text ?? ""}"`,
+    created_at: params.reaction.created_at,
+    is_reaction: true,
+    is_tapback: true,
+    associated_message_guid: targetGuid,
+    associated_message_type: 2000,
+    reaction_type: params.reaction.type ?? undefined,
+    reaction_emoji: emoji,
+    is_reaction_add: true,
+    reacted_to_guid: targetGuid,
+  };
+}
+
+function buildConversationKeyFromMessage(message: HistoryMessage): IMessageApprovalConversationKey {
+  return {
+    ...(message.chat_guid?.trim() ? { chatGuid: message.chat_guid.trim() } : {}),
+    ...(message.chat_identifier?.trim() ? { chatIdentifier: message.chat_identifier.trim() } : {}),
+    ...(normalizeChatId(message.chat_id) !== null ? { chatId: message.chat_id as number } : {}),
+  };
+}
+
+function bindObservedConversation(params: {
+  target: PendingIMessageApprovalReactionPollTarget;
+  message: HistoryMessage;
+}): void {
+  const ttlMs = params.target.expiresAtMs - Date.now();
+  if (ttlMs <= 0) {
+    return;
+  }
+  const conversation = buildConversationKeyFromMessage(params.message);
+  const messageIds = new Set([
+    ...enumerateMessageGuidCandidates(params.target.messageId),
+    ...enumerateMessageGuidCandidates(params.message.guid ?? ""),
+  ]);
+  for (const messageId of messageIds) {
+    registerIMessageApprovalReactionTarget({
+      accountId: params.target.accountId,
+      conversation,
+      messageId,
+      approvalId: params.target.approvalId,
+      allowedDecisions: params.target.allowedDecisions,
+      ttlMs,
+    });
+  }
+}
+
+function bindObservedApprovalPrompt(params: {
+  accountId: string;
+  message: HistoryMessage;
+}): PendingIMessageApprovalReactionPollTarget | null {
+  if (params.message.is_from_me !== true) {
+    return null;
+  }
+  const messageId = params.message.guid?.trim();
+  if (!messageId) {
+    return null;
+  }
+  const binding = extractIMessageApprovalPromptBinding(params.message.text ?? "");
+  if (!binding) {
+    return null;
+  }
+  const conversation = buildConversationKeyFromMessage(params.message);
+  const target: PendingIMessageApprovalReactionPollTarget = {
+    accountId: params.accountId,
+    conversation,
+    messageId,
+    approvalId: binding.approvalId,
+    allowedDecisions: binding.allowedDecisions,
+    expiresAtMs: Date.now() + OBSERVED_APPROVAL_PROMPT_TARGET_TTL_MS,
+  };
+  bindObservedConversation({ target, message: params.message });
+  return target;
+}
+
+export async function pollPendingIMessageApprovalReactions(params: {
+  client: IMessageRpcClient;
+  cfg: OpenClawConfig;
+  accountId: string;
+  logVerboseMessage?: (message: string) => void;
+}): Promise<void> {
+  const targets = listPendingIMessageApprovalReactionPollTargets({
+    accountId: params.accountId,
+  });
+
+  const pendingByMessageId = buildPendingTargetsByMessageId(targets);
+  const explicitChatIds = listTargetChatIds(targets);
+  const chatIds =
+    explicitChatIds.length > 0 ? explicitChatIds : await listRecentChatIds(params.client);
+  for (const chatId of chatIds) {
+    let messages: HistoryMessage[];
+    try {
+      messages = await fetchRecentHistory({ client: params.client, chatId });
+    } catch (err) {
+      params.logVerboseMessage?.(
+        `imessage: approval reaction poll skipped chat_id=${chatId}: ${String(err)}`,
+      );
+      continue;
+    }
+    for (const message of messages) {
+      const targetGuid = message.guid?.trim();
+      if (!targetGuid) {
+        continue;
+      }
+      const target =
+        pendingByMessageId.get(targetGuid) ??
+        pendingByMessageId.get(normalizeMessageGuid(targetGuid)) ??
+        bindObservedApprovalPrompt({
+          accountId: params.accountId,
+          message,
+        });
+      if (!target) {
+        continue;
+      }
+      bindObservedConversation({ target, message });
+      for (const reaction of message.reactions ?? []) {
+        const reactionPayload = buildReactionPayload({ targetMessage: message, reaction });
+        if (!reactionPayload) {
+          continue;
+        }
+        const handled = await maybeResolveIMessageApprovalReaction({
+          cfg: params.cfg,
+          accountId: params.accountId,
+          message: reactionPayload,
+          bodyText: reactionPayload.text ?? "",
+          logVerboseMessage: params.logVerboseMessage,
+        });
+        if (handled) {
+          return;
+        }
+      }
+    }
+  }
+}

--- a/extensions/imessage/src/approval-reaction-poller.ts
+++ b/extensions/imessage/src/approval-reaction-poller.ts
@@ -46,6 +46,14 @@ function listTargetChatIds(
   return [...chatIds];
 }
 
+function hasUnscopedTarget(targets: readonly PendingIMessageApprovalReactionPollTarget[]): boolean {
+  return targets.some((target) => normalizeChatId(target.conversation.chatId) === null);
+}
+
+function uniqueChatIds(chatIds: readonly number[]): number[] {
+  return [...new Set(chatIds)];
+}
+
 function normalizeMessageGuid(value: string): string {
   return value.trim().replace(/^p:\d+\//iu, "");
 }
@@ -203,16 +211,27 @@ export async function pollPendingIMessageApprovalReactions(params: {
   client: IMessageRpcClient;
   cfg: OpenClawConfig;
   accountId: string;
+  allowRecentChatDiscovery?: boolean;
   logVerboseMessage?: (message: string) => void;
 }): Promise<void> {
   const targets = listPendingIMessageApprovalReactionPollTargets({
     accountId: params.accountId,
   });
+  if (targets.length === 0 && params.allowRecentChatDiscovery !== true) {
+    return;
+  }
 
   const pendingByMessageId = buildPendingTargetsByMessageId(targets);
   const explicitChatIds = listTargetChatIds(targets);
-  const chatIds =
-    explicitChatIds.length > 0 ? explicitChatIds : await listRecentChatIds(params.client);
+  const shouldDiscoverRecentChats =
+    params.allowRecentChatDiscovery === true &&
+    (targets.length === 0 || hasUnscopedTarget(targets));
+  const chatIds = shouldDiscoverRecentChats
+    ? uniqueChatIds([...explicitChatIds, ...(await listRecentChatIds(params.client))])
+    : explicitChatIds;
+  if (chatIds.length === 0) {
+    return;
+  }
   for (const chatId of chatIds) {
     let messages: HistoryMessage[];
     try {

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -4,6 +4,7 @@ import {
   buildIMessageApprovalReactionHint,
   clearIMessageApprovalReactionTargetsForTest,
   extractIMessageApprovalPromptBinding,
+  listPendingIMessageApprovalReactionPollTargets,
   maybeResolveIMessageApprovalReaction,
   registerIMessageApprovalReactionTargetForOutboundMessage,
   registerIMessageApprovalReactionTarget,
@@ -123,6 +124,40 @@ describe("iMessage approval reactions", () => {
       approvalId: "exec-1",
       decision: "deny",
     });
+  });
+
+  it("merges learned chat ids into pending poll targets", () => {
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { handle: "+15551230000" },
+      messageId: "p:0/msg-1",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: {
+        chatGuid: "SMS;-;+15551230000",
+        chatIdentifier: "+15551230000",
+        chatId: 42,
+      },
+      messageId: "msg-1",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    expect(listPendingIMessageApprovalReactionPollTargets({ accountId: "default" })).toEqual([
+      expect.objectContaining({
+        approvalId: "exec-1",
+        conversation: {
+          chatGuid: "SMS;-;+15551230000",
+          chatIdentifier: "+15551230000",
+          chatId: 42,
+          handle: "+15551230000",
+        },
+        messageId: "p:0/msg-1",
+      }),
+    ]);
   });
 
   it("resolves a registered group reaction target keyed by chat_guid", async () => {

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -40,9 +40,9 @@ describe("iMessage approval reactions", () => {
     resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
   });
 
-  it("renders thumbs-only reaction choices for allowed decisions", () => {
-    expect(buildIMessageApprovalReactionHint(["allow-once", "deny"])).toBe(
-      "React with:\n\n👍 Allow Once\n👎 Deny",
+  it("renders shared reaction choices for allowed decisions", () => {
+    expect(buildIMessageApprovalReactionHint(["allow-once", "allow-always", "deny"])).toBe(
+      "React with:\n\n👍 Allow Once\n♾️ Allow Always\n👎 Deny",
     );
   });
 
@@ -70,13 +70,13 @@ describe("iMessage approval reactions", () => {
     expect(appendIMessageApprovalReactionHintForOutboundMessage(prompt)).toBe(prompt);
   });
 
-  it("does not expose allow-always as a reaction choice", () => {
+  it("exposes allow-always as the shared infinity reaction choice", () => {
     expect(buildIMessageApprovalReactionHint(["allow-once", "allow-always", "deny"])).toBe(
-      "React with:\n\n👍 Allow Once\n👎 Deny",
+      "React with:\n\n👍 Allow Once\n♾️ Allow Always\n👎 Deny",
     );
   });
 
-  it("does not register reaction state when only allow-always is available", () => {
+  it("registers and resolves allow-always through the shared infinity reaction", async () => {
     expect(
       registerIMessageApprovalReactionTarget({
         accountId: "default",
@@ -85,7 +85,22 @@ describe("iMessage approval reactions", () => {
         approvalId: "exec-allow-always",
         allowedDecisions: ["allow-always"],
       }),
-    ).toBeNull();
+    ).toEqual({
+      approvalId: "exec-allow-always",
+      allowedDecisions: ["allow-always"],
+    });
+
+    await expect(
+      resolveIMessageApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        conversation: { handle: "+15551230000" },
+        messageId: "msg-allow-always",
+        reactionKey: "♾",
+      }),
+    ).resolves.toEqual({
+      approvalId: "exec-allow-always",
+      decision: "allow-always",
+    });
   });
 
   it("resolves a registered reaction target keyed by handle", async () => {
@@ -172,7 +187,7 @@ describe("iMessage approval reactions", () => {
       decision: "deny",
     });
 
-    for (const reactionKey of ["1️⃣", "2️⃣", "3️⃣", "1", "2", "3", "❤️"]) {
+    for (const reactionKey of ["1️⃣", "2️⃣", "3️⃣", "1", "2", "3", "❤️", "♾️"]) {
       await expect(
         resolveIMessageApprovalReactionTargetWithPersistence({
           accountId: "default",
@@ -217,7 +232,7 @@ describe("iMessage approval reactions", () => {
     });
   });
 
-  it("ignores cross-device is_from_me tapbacks even when the actor is an approver", async () => {
+  it("resolves is_from_me tapbacks when the actor is an explicit approver", async () => {
     registerIMessageApprovalReactionTarget({
       accountId: "default",
       conversation: { handle: "+15551230000" },
@@ -238,8 +253,14 @@ describe("iMessage approval reactions", () => {
       bodyText: "",
     });
 
-    expect(handled).toBe(false);
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(handled).toBe(true);
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalId: "exec-self",
+        decision: "allow-once",
+        senderId: "+15551230000",
+      }),
+    );
   });
 
   it("clears the in-memory binding on successful approval resolve so toggle 👍→👎 does not refire", async () => {

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -35,7 +35,17 @@ export type IMessageApprovalConversationKey = {
   handle?: string;
 };
 
+export type PendingIMessageApprovalReactionPollTarget = {
+  accountId: string;
+  conversation: IMessageApprovalConversationKey;
+  messageId: string;
+  approvalId: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+  expiresAtMs: number;
+};
+
 let resolverRuntimePromise: Promise<typeof import("./approval-resolver.js")> | undefined;
+const pendingReactionPollTargets = new Map<string, PendingIMessageApprovalReactionPollTarget>();
 
 function loadApprovalResolver(): Promise<typeof import("./approval-resolver.js")> {
   resolverRuntimePromise ??= import("./approval-resolver.js");
@@ -94,6 +104,38 @@ function enumerateReactionTargetKeys(params: {
   return enumerateConversationKeyForms(params.conversation).map(
     (form) => `${accountId}:${form}:${messageId}`,
   );
+}
+
+function prunePendingReactionPollTargets(nowMs = Date.now()): void {
+  for (const [key, target] of pendingReactionPollTargets.entries()) {
+    if (target.expiresAtMs <= nowMs) {
+      pendingReactionPollTargets.delete(key);
+    }
+  }
+}
+
+export function listPendingIMessageApprovalReactionPollTargets(params: {
+  accountId: string;
+}): PendingIMessageApprovalReactionPollTarget[] {
+  const accountId = params.accountId.trim();
+  if (!accountId) {
+    return [];
+  }
+  prunePendingReactionPollTargets();
+  const seen = new Set<string>();
+  const targets: PendingIMessageApprovalReactionPollTarget[] = [];
+  for (const target of pendingReactionPollTargets.values()) {
+    if (target.accountId !== accountId) {
+      continue;
+    }
+    const key = `${target.approvalId}:${target.messageId}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    targets.push(target);
+  }
+  return targets;
 }
 
 function reportPersistentApprovalReactionError(error: unknown): void {
@@ -272,7 +314,16 @@ export function registerIMessageApprovalReactionTarget(params: {
   }
   for (const key of keys) {
     imessageApprovalReactionTargets.register(key, target, { ttlMs });
+    pendingReactionPollTargets.set(key, {
+      accountId: params.accountId,
+      conversation: params.conversation,
+      messageId: params.messageId,
+      approvalId,
+      allowedDecisions,
+      expiresAtMs: Date.now() + ttlMs,
+    });
   }
+  prunePendingReactionPollTargets();
   return target;
 }
 
@@ -307,6 +358,7 @@ export function unregisterIMessageApprovalReactionTarget(params: {
   const keys = enumerateReactionTargetKeys(params);
   for (const key of keys) {
     imessageApprovalReactionTargets.delete(key);
+    pendingReactionPollTargets.delete(key);
   }
 }
 

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -114,6 +114,22 @@ function prunePendingReactionPollTargets(nowMs = Date.now()): void {
   }
 }
 
+function normalizePollTargetMessageId(messageId: string): string {
+  return messageId.trim().replace(/^p:\d+\//iu, "");
+}
+
+function mergePollTargetConversation(
+  left: IMessageApprovalConversationKey,
+  right: IMessageApprovalConversationKey,
+): IMessageApprovalConversationKey {
+  return {
+    chatGuid: left.chatGuid ?? right.chatGuid,
+    chatIdentifier: left.chatIdentifier ?? right.chatIdentifier,
+    chatId: left.chatId ?? right.chatId,
+    handle: left.handle ?? right.handle,
+  };
+}
+
 export function listPendingIMessageApprovalReactionPollTargets(params: {
   accountId: string;
 }): PendingIMessageApprovalReactionPollTarget[] {
@@ -122,20 +138,24 @@ export function listPendingIMessageApprovalReactionPollTargets(params: {
     return [];
   }
   prunePendingReactionPollTargets();
-  const seen = new Set<string>();
-  const targets: PendingIMessageApprovalReactionPollTarget[] = [];
+  const targetByApprovalAndMessage = new Map<string, PendingIMessageApprovalReactionPollTarget>();
   for (const target of pendingReactionPollTargets.values()) {
     if (target.accountId !== accountId) {
       continue;
     }
-    const key = `${target.approvalId}:${target.messageId}`;
-    if (seen.has(key)) {
+    const key = `${target.approvalId}:${normalizePollTargetMessageId(target.messageId)}`;
+    const existing = targetByApprovalAndMessage.get(key);
+    if (!existing) {
+      targetByApprovalAndMessage.set(key, target);
       continue;
     }
-    seen.add(key);
-    targets.push(target);
+    targetByApprovalAndMessage.set(key, {
+      ...existing,
+      conversation: mergePollTargetConversation(existing.conversation, target.conversation),
+      expiresAtMs: Math.max(existing.expiresAtMs, target.expiresAtMs),
+    });
   }
-  return targets;
+  return [...targetByApprovalAndMessage.values()];
 }
 
 function reportPersistentApprovalReactionError(error: unknown): void {
@@ -569,5 +589,6 @@ export async function maybeResolveIMessageApprovalReaction(params: {
 
 export function clearIMessageApprovalReactionTargetsForTest(): void {
   imessageApprovalReactionTargets.clearForTest();
+  pendingReactionPollTargets.clear();
   resolverRuntimePromise = undefined;
 }

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -1,3 +1,11 @@
+import {
+  buildApprovalReactionHint,
+  createApprovalReactionTargetStore,
+  listApprovalReactionBindings,
+  resolveApprovalReactionTarget,
+  type ApprovalReactionDecisionBinding,
+  type ApprovalReactionTargetRecord,
+} from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { getIMessageApprovalApprovers, imessageApprovalAuth } from "./approval-auth.js";
@@ -6,56 +14,18 @@ import type { IMessagePayload } from "./monitor/types.js";
 import { getOptionalIMessageRuntime } from "./runtime.js";
 import { normalizeIMessageHandle } from "./targets.js";
 
-const IMESSAGE_APPROVAL_REACTION_META = {
-  "allow-once": {
-    emoji: "👍",
-    label: "Allow Once",
-  },
-  deny: {
-    emoji: "👎",
-    label: "Deny",
-  },
-} satisfies Partial<Record<ExecApprovalReplyDecision, { emoji: string; label: string }>>;
-
-const IMESSAGE_APPROVAL_REACTION_ORDER = [
-  "allow-once",
-  "deny",
-] as const satisfies readonly ExecApprovalReplyDecision[];
-
 const PERSISTENT_NAMESPACE = "imessage.approval-reactions";
 const PERSISTENT_MAX_ENTRIES = 1000;
 const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 
-export type IMessageApprovalReactionBinding = {
-  decision: ExecApprovalReplyDecision;
-  emoji: string;
-  label: string;
-};
+export type IMessageApprovalReactionBinding = ApprovalReactionDecisionBinding;
 
 type IMessageApprovalReactionResolution = {
   approvalId: string;
   decision: ExecApprovalReplyDecision;
 };
 
-type IMessageApprovalReactionTarget = {
-  approvalId: string;
-  allowedDecisions: readonly ExecApprovalReplyDecision[];
-};
-
-type PersistedIMessageApprovalReactionTarget = {
-  version: 1;
-  target: IMessageApprovalReactionTarget;
-};
-
-type IMessageApprovalReactionStore = {
-  register(
-    key: string,
-    value: PersistedIMessageApprovalReactionTarget,
-    opts?: { ttlMs?: number },
-  ): Promise<void>;
-  lookup(key: string): Promise<PersistedIMessageApprovalReactionTarget | undefined>;
-  delete(key: string): Promise<boolean>;
-};
+type IMessageApprovalReactionTarget = ApprovalReactionTargetRecord;
 
 export type IMessageApprovalConversationKey = {
   chatGuid?: string;
@@ -65,14 +35,6 @@ export type IMessageApprovalConversationKey = {
   handle?: string;
 };
 
-type InMemoryReactionEntry = {
-  target: IMessageApprovalReactionTarget;
-  expiresAtMs: number;
-};
-
-const imessageApprovalReactionTargets = new Map<string, InMemoryReactionEntry>();
-let persistentStore: IMessageApprovalReactionStore | undefined;
-let persistentStoreDisabled = false;
 let resolverRuntimePromise: Promise<typeof import("./approval-resolver.js")> | undefined;
 
 function loadApprovalResolver(): Promise<typeof import("./approval-resolver.js")> {
@@ -144,108 +106,46 @@ function reportPersistentApprovalReactionError(error: unknown): void {
   }
 }
 
-function disablePersistentApprovalReactionStore(error: unknown): void {
-  persistentStoreDisabled = true;
-  persistentStore = undefined;
-  reportPersistentApprovalReactionError(error);
-}
-
-function getPersistentApprovalReactionStore(): IMessageApprovalReactionStore | undefined {
-  if (persistentStoreDisabled) {
-    return undefined;
-  }
-  if (persistentStore) {
-    return persistentStore;
-  }
-  const runtime = getOptionalIMessageRuntime();
-  if (!runtime) {
-    return undefined;
-  }
-  try {
-    persistentStore = runtime.state.openKeyedStore<PersistedIMessageApprovalReactionTarget>({
-      namespace: PERSISTENT_NAMESPACE,
-      maxEntries: PERSISTENT_MAX_ENTRIES,
-      defaultTtlMs: DEFAULT_REACTION_TARGET_TTL_MS,
-    });
-    return persistentStore;
-  } catch (error) {
-    disablePersistentApprovalReactionStore(error);
-    return undefined;
-  }
-}
-
 function readPersistedTarget(value: unknown): IMessageApprovalReactionTarget | null {
-  const persisted = value as PersistedIMessageApprovalReactionTarget | undefined;
-  if (
-    persisted?.version !== 1 ||
-    !persisted.target ||
-    typeof persisted.target.approvalId !== "string" ||
-    !Array.isArray(persisted.target.allowedDecisions)
-  ) {
+  const target = value as Partial<IMessageApprovalReactionTarget> | undefined;
+  if (!target || typeof target.approvalId !== "string" || !Array.isArray(target.allowedDecisions)) {
     return null;
   }
-  return persisted.target;
-}
-
-function rememberPersistentApprovalReactionTarget(params: {
-  key: string;
-  target: IMessageApprovalReactionTarget;
-  ttlMs?: number;
-}): void {
-  const ttlMs = params.ttlMs == null ? DEFAULT_REACTION_TARGET_TTL_MS : Math.max(1, params.ttlMs);
-  const store = getPersistentApprovalReactionStore();
-  if (!store) {
-    return;
-  }
-  void store
-    .register(params.key, { version: 1, target: params.target }, { ttlMs })
-    .catch(disablePersistentApprovalReactionStore);
-}
-
-function forgetPersistentApprovalReactionTarget(key: string): void {
-  const store = getPersistentApprovalReactionStore();
-  if (!store) {
-    return;
-  }
-  void store.delete(key).catch(disablePersistentApprovalReactionStore);
-}
-
-async function lookupPersistentApprovalReactionTarget(
-  key: string,
-): Promise<IMessageApprovalReactionTarget | null> {
-  const store = getPersistentApprovalReactionStore();
-  if (!store) {
+  const allowedDecisions = target.allowedDecisions
+    .map((value) => (typeof value === "string" ? normalizeApprovalDecision(value) : null))
+    .filter((value): value is ExecApprovalReplyDecision => Boolean(value));
+  if (allowedDecisions.length === 0) {
     return null;
   }
-  try {
-    return readPersistedTarget(await store.lookup(key));
-  } catch (error) {
-    disablePersistentApprovalReactionStore(error);
-    return null;
-  }
+  return {
+    approvalId: target.approvalId,
+    allowedDecisions,
+    ...(target.approvalKind === "exec" || target.approvalKind === "plugin"
+      ? { approvalKind: target.approvalKind }
+      : {}),
+  };
 }
+
+const imessageApprovalReactionTargets =
+  createApprovalReactionTargetStore<IMessageApprovalReactionTarget>({
+    namespace: PERSISTENT_NAMESPACE,
+    maxEntries: PERSISTENT_MAX_ENTRIES,
+    defaultTtlMs: DEFAULT_REACTION_TARGET_TTL_MS,
+    openStore: (params) => getOptionalIMessageRuntime()?.state.openKeyedStore(params),
+    logPersistentError: reportPersistentApprovalReactionError,
+    readPersistedTarget,
+  });
 
 export function listIMessageApprovalReactionBindings(
   allowedDecisions: readonly ExecApprovalReplyDecision[],
 ): IMessageApprovalReactionBinding[] {
-  const allowed = new Set(allowedDecisions);
-  return IMESSAGE_APPROVAL_REACTION_ORDER.filter((decision) => allowed.has(decision)).map(
-    (decision) => ({
-      decision,
-      emoji: IMESSAGE_APPROVAL_REACTION_META[decision].emoji,
-      label: IMESSAGE_APPROVAL_REACTION_META[decision].label,
-    }),
-  );
+  return listApprovalReactionBindings({ allowedDecisions });
 }
 
 export function buildIMessageApprovalReactionHint(
   allowedDecisions: readonly ExecApprovalReplyDecision[],
 ): string | null {
-  const bindings = listIMessageApprovalReactionBindings(allowedDecisions);
-  if (bindings.length === 0) {
-    return null;
-  }
-  return `React with:\n\n${bindings.map((binding) => `${binding.emoji} ${binding.label}`).join("\n")}`;
+  return buildApprovalReactionHint({ allowedDecisions });
 }
 
 function insertIMessageApprovalReactionHintNearHeader(params: {
@@ -290,26 +190,6 @@ export function appendIMessageApprovalReactionHintForOutboundMessage(text: strin
     text,
     allowedDecisions: binding.allowedDecisions,
   });
-}
-
-function resolveIMessageApprovalReactionDecision(
-  reactionKey: string,
-  allowedDecisions: readonly ExecApprovalReplyDecision[],
-): ExecApprovalReplyDecision | null {
-  const normalizedReaction = reactionKey.trim();
-  if (!normalizedReaction) {
-    return null;
-  }
-  const allowed = new Set(allowedDecisions);
-  for (const decision of IMESSAGE_APPROVAL_REACTION_ORDER) {
-    if (!allowed.has(decision)) {
-      continue;
-    }
-    if (IMESSAGE_APPROVAL_REACTION_META[decision].emoji === normalizedReaction) {
-      return decision;
-    }
-  }
-  return null;
 }
 
 function normalizeApprovalDecision(value: string): ExecApprovalReplyDecision | null {
@@ -376,7 +256,6 @@ export function registerIMessageApprovalReactionTarget(params: {
   }
   const target = { approvalId, allowedDecisions };
   const ttlMs = params.ttlMs == null ? DEFAULT_REACTION_TARGET_TTL_MS : Math.max(1, params.ttlMs);
-  const expiresAtMs = Date.now() + ttlMs;
   // Register the binding under every key we can derive from the conversation
   // (chat_guid / chat_identifier / chat_id / handle). Inbound lookup precedence
   // can differ from outbound — e.g. send only sees `{handle: "+1..."}` for a
@@ -392,10 +271,8 @@ export function registerIMessageApprovalReactionTarget(params: {
     return null;
   }
   for (const key of keys) {
-    imessageApprovalReactionTargets.set(key, { target, expiresAtMs });
-    rememberPersistentApprovalReactionTarget({ key, target, ttlMs });
+    imessageApprovalReactionTargets.register(key, target, { ttlMs });
   }
-  pruneExpiredInMemoryReactionTargets();
   return target;
 }
 
@@ -430,7 +307,6 @@ export function unregisterIMessageApprovalReactionTarget(params: {
   const keys = enumerateReactionTargetKeys(params);
   for (const key of keys) {
     imessageApprovalReactionTargets.delete(key);
-    forgetPersistentApprovalReactionTarget(key);
   }
 }
 
@@ -438,36 +314,8 @@ function resolveTarget(params: {
   target: IMessageApprovalReactionTarget | null | undefined;
   reactionKey: string;
 }): IMessageApprovalReactionResolution | null {
-  const target = params.target;
-  if (!target) {
-    return null;
-  }
-  const decision = resolveIMessageApprovalReactionDecision(
-    params.reactionKey,
-    target.allowedDecisions,
-  );
-  return decision ? { approvalId: target.approvalId, decision } : null;
-}
-
-function lookupInMemoryReactionTarget(key: string): IMessageApprovalReactionTarget | null {
-  const entry = imessageApprovalReactionTargets.get(key);
-  if (!entry) {
-    return null;
-  }
-  if (entry.expiresAtMs <= Date.now()) {
-    imessageApprovalReactionTargets.delete(key);
-    return null;
-  }
-  return entry.target;
-}
-
-function pruneExpiredInMemoryReactionTargets(): void {
-  const now = Date.now();
-  for (const [key, entry] of imessageApprovalReactionTargets) {
-    if (entry.expiresAtMs <= now) {
-      imessageApprovalReactionTargets.delete(key);
-    }
-  }
+  const target = resolveApprovalReactionTarget(params);
+  return target ? { approvalId: target.approvalId, decision: target.decision } : null;
 }
 
 export async function resolveIMessageApprovalReactionTargetWithPersistence(params: {
@@ -482,21 +330,12 @@ export async function resolveIMessageApprovalReactionTargetWithPersistence(param
   // (chat_guid → chat_identifier → chat_id → handle) and accept the first hit.
   const keys = enumerateReactionTargetKeys(params);
   for (const key of keys) {
-    const inMemory = resolveTarget({
-      target: lookupInMemoryReactionTarget(key),
+    const target = resolveTarget({
+      target: await imessageApprovalReactionTargets.lookup(key),
       reactionKey: params.reactionKey,
     });
-    if (inMemory) {
-      return inMemory;
-    }
-  }
-  for (const key of keys) {
-    const persisted = resolveTarget({
-      target: await lookupPersistentApprovalReactionTarget(key),
-      reactionKey: params.reactionKey,
-    });
-    if (persisted) {
-      return persisted;
+    if (target) {
+      return target;
     }
   }
   return null;
@@ -523,13 +362,6 @@ function readApprovalReactionEvent(
   message: IMessagePayload,
   bodyText: string,
 ): IMessageApprovalReactionEvent | null {
-  // Cross-device echo: Apple delivers is_from_me=true rows for the operator's
-  // own tapbacks across paired devices. Ignoring them prevents a bot whose
-  // own handle is in `allowFrom` (a common dogfooding setup) from
-  // self-approving via the operator's reaction on a different Apple device.
-  if (message.is_from_me === true) {
-    return null;
-  }
   const reaction = resolveIMessageReactionContext(message, bodyText);
   if (!reaction) {
     return null;
@@ -684,8 +516,6 @@ export async function maybeResolveIMessageApprovalReaction(params: {
 }
 
 export function clearIMessageApprovalReactionTargetsForTest(): void {
-  imessageApprovalReactionTargets.clear();
-  persistentStore = undefined;
-  persistentStoreDisabled = false;
+  imessageApprovalReactionTargets.clearForTest();
   resolverRuntimePromise = undefined;
 }

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -16,7 +16,10 @@ import {
 } from "openclaw/plugin-sdk/status-helpers";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import { imessageMessageActions } from "./actions.js";
-import { imessageApprovalCapability } from "./approval-native.js";
+import {
+  imessageApprovalCapability,
+  shouldSuppressLocalIMessageExecApprovalPrompt,
+} from "./approval-native.js";
 import {
   chunkTextForOutbound,
   collectStatusIssuesFromLastError,
@@ -320,6 +323,8 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
         chunkerMode: "text",
         textChunkLimit: 4000,
         sanitizeText: ({ text }) => sanitizeForPlainText(sanitizeOutboundText(text)),
+        shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload, hint }) =>
+          shouldSuppressLocalIMessageExecApprovalPrompt({ cfg, accountId, payload, hint }),
         deliveryCapabilities: {
           durableFinal: {
             text: true,

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -88,7 +88,7 @@ export class IMessageRpcClient {
     if (isTestEnv()) {
       throw new Error("Refusing to start imsg rpc in test environment; mock iMessage RPC client");
     }
-    const args = ["rpc"];
+    const args = ["rpc", "--json"];
     if (this.dbPath) {
       args.push("--db", this.dbPath);
     }

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -39,6 +39,7 @@ import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/sess
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import { resolveIMessageAccount } from "../accounts.js";
+import { pollPendingIMessageApprovalReactions } from "../approval-reaction-poller.js";
 import { maybeResolveIMessageApprovalReaction } from "../approval-reactions.js";
 import { markIMessageChatRead, sendIMessageTyping } from "../chat.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "../client.js";
@@ -82,6 +83,7 @@ import { sanitizeIMessageWatchErrorPayload } from "./watch-error-log.js";
 
 const WATCH_SUBSCRIBE_MAX_ATTEMPTS = 3;
 const WATCH_SUBSCRIBE_RETRY_DELAY_MS = 1_000;
+const APPROVAL_REACTION_POLL_INTERVAL_MS = 2_000;
 
 function isIMessagePluginPayloadAttachment(attachment: {
   original_path?: string | null;
@@ -1052,6 +1054,29 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         abortSignal: abort,
       })
     : undefined;
+  let approvalReactionPollInFlight = false;
+  const pollApprovalReactions = async () => {
+    if (approvalReactionPollInFlight) {
+      return;
+    }
+    approvalReactionPollInFlight = true;
+    try {
+      await pollPendingIMessageApprovalReactions({
+        client: activeClient,
+        cfg,
+        accountId: accountInfo.accountId,
+        logVerboseMessage: logVerbose,
+      });
+    } catch (err) {
+      logVerbose(`imessage: approval reaction poll failed: ${String(err)}`);
+    } finally {
+      approvalReactionPollInFlight = false;
+    }
+  };
+  const approvalReactionPollTimer = setInterval(() => {
+    void pollApprovalReactions();
+  }, APPROVAL_REACTION_POLL_INTERVAL_MS);
+  void pollApprovalReactions();
 
   // Catchup runs once between watch.subscribe and the live dispatch loop.
   // Anything that arrives during the catchup pass itself flows through
@@ -1100,6 +1125,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     runtime.error?.(danger(`imessage: monitor failed: ${String(err)}`));
     throw err;
   } finally {
+    clearInterval(approvalReactionPollTimer);
     approvalContextLease?.dispose();
     detachAbortHandler();
     await activeClient.stop();

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -84,6 +84,7 @@ import { sanitizeIMessageWatchErrorPayload } from "./watch-error-log.js";
 const WATCH_SUBSCRIBE_MAX_ATTEMPTS = 3;
 const WATCH_SUBSCRIBE_RETRY_DELAY_MS = 1_000;
 const APPROVAL_REACTION_POLL_INTERVAL_MS = 2_000;
+const APPROVAL_REACTION_DISCOVERY_INTERVAL_MS = 60_000;
 
 function isIMessagePluginPayloadAttachment(attachment: {
   original_path?: string | null;
@@ -1055,7 +1056,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       })
     : undefined;
   let approvalReactionPollInFlight = false;
-  const pollApprovalReactions = async () => {
+  const pollApprovalReactions = async (allowRecentChatDiscovery = false) => {
     if (approvalReactionPollInFlight) {
       return;
     }
@@ -1065,6 +1066,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         client: activeClient,
         cfg,
         accountId: accountInfo.accountId,
+        allowRecentChatDiscovery,
         logVerboseMessage: logVerbose,
       });
     } catch (err) {
@@ -1076,7 +1078,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const approvalReactionPollTimer = setInterval(() => {
     void pollApprovalReactions();
   }, APPROVAL_REACTION_POLL_INTERVAL_MS);
-  void pollApprovalReactions();
+  const approvalReactionDiscoveryTimer = setInterval(() => {
+    void pollApprovalReactions(true);
+  }, APPROVAL_REACTION_DISCOVERY_INTERVAL_MS);
+  void pollApprovalReactions(true);
 
   // Catchup runs once between watch.subscribe and the live dispatch loop.
   // Anything that arrives during the catchup pass itself flows through
@@ -1126,6 +1131,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     throw err;
   } finally {
     clearInterval(approvalReactionPollTimer);
+    clearInterval(approvalReactionDiscoveryTimer);
     approvalContextLease?.dispose();
     detachAbortHandler();
     await activeClient.stop();

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -32,9 +32,19 @@ function createRejectingClient(error: Error): IMessageRpcClient {
   } as unknown as IMessageRpcClient;
 }
 
+function createApprovalText(id = "approval-123"): string {
+  return [
+    "Exec approval required",
+    `ID: ${id}`,
+    "",
+    `Reply with: /approve ${id} allow-once|deny`,
+  ].join("\n");
+}
+
 describe("sendMessageIMessage receipts", () => {
   afterEach(() => {
     clearIMessageApprovalReactionTargetsForTest();
+    vi.unstubAllEnvs();
   });
 
   it("attaches a text receipt for native send ids", async () => {
@@ -333,13 +343,14 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.guid).toBeUndefined();
   });
 
-  it("falls back to one-shot imsg send when rpc text send times out", async () => {
+  it("recovers approval prompt GUID without resending when rpc send times out", async () => {
     const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
     const createClient = vi.fn(async () => client);
-    const runCliJson = vi.fn(async () => ({ status: "sent" }));
+    const runCliJson = vi.fn();
     const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/fallback-guid");
+    const approvalText = createApprovalText();
 
-    const result = await sendMessageIMessage("chat_id:42", "hello", {
+    const result = await sendMessageIMessage("chat_id:42", approvalText, {
       config: IMESSAGE_TEST_CFG,
       createClient,
       runCliJson,
@@ -348,29 +359,111 @@ describe("sendMessageIMessage receipts", () => {
       resolveSentMessageGuidImpl,
     });
 
-    expect(result.messageId).toBe("ok");
+    expect(result.messageId).toBe("p:0/fallback-guid");
     expect(result.guid).toBe("p:0/fallback-guid");
     expect(client.stop).toHaveBeenCalledOnce();
-    expect(runCliJson.mock.calls).toEqual([
-      [["send", "--text", "hello", "--service", "sms", "--region", "US", "--chat-id", "42"]],
-    ]);
+    expect(runCliJson).not.toHaveBeenCalled();
     expect(resolveSentMessageGuidImpl).toHaveBeenCalledWith({
       dbPath: "/Users/me/Library/Messages/chat.db",
       target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
-      text: "hello",
+      text: expect.stringContaining("ID: approval-123"),
       sentAfterMs: expect.any(Number),
     });
+  });
+
+  it("uses the default local chat.db path for timeout GUID recovery", async () => {
+    vi.stubEnv("HOME", "/Users/me");
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn();
+    const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/default-db-guid");
+    const approvalText = createApprovalText("approval-default");
+
+    const result = await sendMessageIMessage("chat_id:42", approvalText, {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      runCliJson,
+      resolveSentMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("p:0/default-db-guid");
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(resolveSentMessageGuidImpl).toHaveBeenCalledWith({
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
+      text: expect.stringContaining("ID: approval-default"),
+      sentAfterMs: expect.any(Number),
+    });
+  });
+
+  it("does not use the local default chat.db path for custom cliPath wrappers", async () => {
+    vi.stubEnv("HOME", "/Users/me");
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn();
+    const resolveSentMessageGuidImpl = vi.fn(async () => null);
+    const approvalText = createApprovalText("approval-remote");
+
+    await expect(
+      sendMessageIMessage("chat_id:42", approvalText, {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        cliPath: "/usr/local/bin/imsg-remote",
+        runCliJson,
+        resolveSentMessageGuidImpl,
+      }),
+    ).rejects.toThrow("imsg rpc timeout (send)");
+
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(resolveSentMessageGuidImpl).toHaveBeenCalledWith({
+      dbPath: undefined,
+      target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
+      text: expect.stringContaining("ID: approval-remote"),
+      sentAfterMs: expect.any(Number),
+    });
+  });
+
+  it("throws the rpc timeout without resending for generic text", async () => {
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn();
+    const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/stale-guid");
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        runCliJson,
+        dbPath: "/Users/me/Library/Messages/chat.db",
+        resolveSentMessageGuidImpl,
+      }),
+    ).rejects.toThrow("imsg rpc timeout (send)");
+
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(resolveSentMessageGuidImpl).not.toHaveBeenCalled();
+  });
+
+  it("throws the rpc timeout without resending when approval GUID recovery misses", async () => {
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn();
+    const resolveSentMessageGuidImpl = vi.fn(async () => null);
+    const approvalText = createApprovalText();
+
+    await expect(
+      sendMessageIMessage("chat_id:42", approvalText, {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        runCliJson,
+        dbPath: "/Users/me/Library/Messages/chat.db",
+        resolveSentMessageGuidImpl,
+      }),
+    ).rejects.toThrow("imsg rpc timeout (send)");
+
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(resolveSentMessageGuidImpl).toHaveBeenCalled();
   });
 
   it("recovers a GUID for approval prompts when rpc send returns only sent status", async () => {
     const client = createClient({ status: "sent" });
     const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/recovered-guid");
-    const approvalText = [
-      "Exec approval required",
-      "ID: approval-123",
-      "",
-      "Reply with: /approve approval-123 allow-once|deny",
-    ].join("\n");
+    const approvalText = createApprovalText();
 
     const result = await sendMessageIMessage("chat_id:42", approvalText, {
       config: IMESSAGE_TEST_CFG,
@@ -402,12 +495,7 @@ describe("sendMessageIMessage receipts", () => {
 
   it("does not poll for approval prompt GUIDs when chat.db is unavailable", async () => {
     const client = createClient({ status: "sent" });
-    const approvalText = [
-      "Exec approval required",
-      "ID: approval-123",
-      "",
-      "Reply with: /approve approval-123 allow-once|deny",
-    ].join("\n");
+    const approvalText = createApprovalText();
     const startedAt = performance.now();
 
     const result = await sendMessageIMessage("chat_id:42", approvalText, {

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearIMessageApprovalReactionTargetsForTest,
@@ -395,6 +398,31 @@ describe("sendMessageIMessage receipts", () => {
     });
   });
 
+  it("uses the default local chat.db path for Homebrew imsg paths", async () => {
+    vi.stubEnv("HOME", "/Users/me");
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn();
+    const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/homebrew-guid");
+    const approvalText = createApprovalText("approval-homebrew");
+
+    const result = await sendMessageIMessage("chat_id:42", approvalText, {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      cliPath: "/opt/homebrew/bin/imsg",
+      runCliJson,
+      resolveSentMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("p:0/homebrew-guid");
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(resolveSentMessageGuidImpl).toHaveBeenCalledWith({
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
+      text: expect.stringContaining("ID: approval-homebrew"),
+      sentAfterMs: expect.any(Number),
+    });
+  });
+
   it("does not use the local default chat.db path for custom cliPath wrappers", async () => {
     vi.stubEnv("HOME", "/Users/me");
     const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
@@ -404,9 +432,19 @@ describe("sendMessageIMessage receipts", () => {
 
     await expect(
       sendMessageIMessage("chat_id:42", approvalText, {
-        config: IMESSAGE_TEST_CFG,
+        config: {
+          channels: {
+            imessage: {
+              accounts: {
+                default: {
+                  remoteHost: "bot@gateway-host",
+                },
+              },
+            },
+          },
+        },
         client,
-        cliPath: "/usr/local/bin/imsg-remote",
+        cliPath: "/Users/me/.openclaw/scripts/imsg",
         runCliJson,
         resolveSentMessageGuidImpl,
       }),
@@ -417,6 +455,39 @@ describe("sendMessageIMessage receipts", () => {
       dbPath: undefined,
       target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
       text: expect.stringContaining("ID: approval-remote"),
+      sentAfterMs: expect.any(Number),
+    });
+  });
+
+  it("does not use the local default chat.db path for auto-detected ssh wrappers", async () => {
+    vi.stubEnv("HOME", "/Users/me");
+    const wrapperDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-wrapper-"));
+    const wrapperPath = path.join(wrapperDir, "imsg");
+    fs.writeFileSync(wrapperPath, '#!/bin/sh\nexec ssh -T gateway-host imsg "$@"\n');
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn();
+    const resolveSentMessageGuidImpl = vi.fn(async () => null);
+    const approvalText = createApprovalText("approval-ssh-wrapper");
+
+    try {
+      await expect(
+        sendMessageIMessage("chat_id:42", approvalText, {
+          config: IMESSAGE_TEST_CFG,
+          client,
+          cliPath: wrapperPath,
+          runCliJson,
+          resolveSentMessageGuidImpl,
+        }),
+      ).rejects.toThrow("imsg rpc timeout (send)");
+    } finally {
+      fs.rmSync(wrapperDir, { recursive: true, force: true });
+    }
+
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(resolveSentMessageGuidImpl).toHaveBeenCalledWith({
+      dbPath: undefined,
+      target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
+      text: expect.stringContaining("ID: approval-ssh-wrapper"),
       sentAfterMs: expect.any(Number),
     });
   });

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearIMessageApprovalReactionTargetsForTest,
+  resolveIMessageApprovalReactionTargetWithPersistence,
+} from "./approval-reactions.js";
 import type { IMessageRpcClient } from "./client.js";
 import { sendMessageIMessage } from "./send.js";
 
@@ -19,7 +23,20 @@ function createClient(result: Record<string, unknown>): IMessageRpcClient {
   } as unknown as IMessageRpcClient;
 }
 
+function createRejectingClient(error: Error): IMessageRpcClient {
+  return {
+    request: vi.fn(async () => {
+      throw error;
+    }),
+    stop: vi.fn(async () => {}),
+  } as unknown as IMessageRpcClient;
+}
+
 describe("sendMessageIMessage receipts", () => {
+  afterEach(() => {
+    clearIMessageApprovalReactionTargetsForTest();
+  });
+
   it("attaches a text receipt for native send ids", async () => {
     const client = createClient({ guid: "p:0/imsg-1" });
 
@@ -264,5 +281,158 @@ describe("sendMessageIMessage receipts", () => {
 
     expect(result.messageId).toBe("ok");
     expect(result.receipt.platformMessageIds).toStrictEqual([]);
+  });
+
+  it("resolves numeric chat.db ROWIDs to GUIDs for approval reaction binding", async () => {
+    const client = createClient({ message_id: 12345 });
+    const resolveMessageGuidImpl = vi.fn(async () => "p:0/resolved-guid");
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      resolveMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("12345");
+    expect(result.guid).toBe("p:0/resolved-guid");
+    expect(resolveMessageGuidImpl).toHaveBeenCalledWith({
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      messageId: "12345",
+    });
+  });
+
+  it("does not resolve chat.db GUIDs when the bridge already returned a GUID", async () => {
+    const client = createClient({ guid: "p:0/native-guid" });
+    const resolveMessageGuidImpl = vi.fn(async () => "p:0/resolved-guid");
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      resolveMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("p:0/native-guid");
+    expect(result.guid).toBe("p:0/native-guid");
+    expect(resolveMessageGuidImpl).not.toHaveBeenCalled();
+  });
+
+  it("leaves reaction binding unset when numeric ROWID cannot be resolved", async () => {
+    const client = createClient({ message_id: 12345 });
+    const resolveMessageGuidImpl = vi.fn(async () => null);
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      resolveMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("12345");
+    expect(result.guid).toBeUndefined();
+  });
+
+  it("falls back to one-shot imsg send when rpc text send times out", async () => {
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const createClient = vi.fn(async () => client);
+    const runCliJson = vi.fn(async () => ({ status: "sent" }));
+    const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/fallback-guid");
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      createClient,
+      runCliJson,
+      service: "sms",
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      resolveSentMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("ok");
+    expect(result.guid).toBe("p:0/fallback-guid");
+    expect(client.stop).toHaveBeenCalledOnce();
+    expect(runCliJson.mock.calls).toEqual([
+      [["send", "--text", "hello", "--service", "sms", "--region", "US", "--chat-id", "42"]],
+    ]);
+    expect(resolveSentMessageGuidImpl).toHaveBeenCalledWith({
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
+      text: "hello",
+      sentAfterMs: expect.any(Number),
+    });
+  });
+
+  it("recovers a GUID for approval prompts when rpc send returns only sent status", async () => {
+    const client = createClient({ status: "sent" });
+    const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/recovered-guid");
+    const approvalText = [
+      "Exec approval required",
+      "ID: approval-123",
+      "",
+      "Reply with: /approve approval-123 allow-once|deny",
+    ].join("\n");
+
+    const result = await sendMessageIMessage("chat_id:42", approvalText, {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      resolveSentMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("ok");
+    expect(result.guid).toBe("p:0/recovered-guid");
+    await expect(
+      resolveIMessageApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        conversation: { chatId: 42 },
+        messageId: "p:0/recovered-guid",
+        reactionKey: "👍",
+      }),
+    ).resolves.toEqual({
+      approvalId: "approval-123",
+      decision: "allow-once",
+    });
+    expect(resolveSentMessageGuidImpl).toHaveBeenCalledWith({
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
+      text: expect.stringContaining("ID: approval-123"),
+      sentAfterMs: expect.any(Number),
+    });
+  });
+
+  it("does not poll for approval prompt GUIDs when chat.db is unavailable", async () => {
+    const client = createClient({ status: "sent" });
+    const approvalText = [
+      "Exec approval required",
+      "ID: approval-123",
+      "",
+      "Reply with: /approve approval-123 allow-once|deny",
+    ].join("\n");
+    const startedAt = performance.now();
+
+    const result = await sendMessageIMessage("chat_id:42", approvalText, {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      dbPath: "/path/to/missing/chat.db",
+    });
+
+    expect(performance.now() - startedAt).toBeLessThan(250);
+    expect(result.messageId).toBe("ok");
+    expect(result.guid).toBeUndefined();
+  });
+
+  it("does not use one-shot imsg fallback for non-timeout rpc send errors", async () => {
+    const client = createRejectingClient(new Error("imsg rpc error (send)"));
+    const runCliJson = vi.fn();
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        runCliJson,
+      }),
+    ).rejects.toThrow("imsg rpc error (send)");
+
+    expect(runCliJson).not.toHaveBeenCalled();
   });
 });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { constants, accessSync } from "node:fs";
+import { constants, accessSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
@@ -96,6 +96,7 @@ export type IMessageSendResult = {
 };
 
 const MAX_REPLY_TO_ID_LENGTH = 256;
+const sshWrapperCliPathCache = new Map<string, boolean>();
 
 function safeHomeDir(): string | undefined {
   const home = process.env.HOME?.trim();
@@ -109,17 +110,53 @@ function safeHomeDir(): string | undefined {
   }
 }
 
-function isLocalIMessageCliPath(cliPath: string): boolean {
-  const trimmed = cliPath.trim();
-  return trimmed === "imsg" || path.basename(trimmed) === "imsg";
+function expandCliPathForInspection(cliPath: string): string {
+  if (!cliPath.startsWith("~")) {
+    return cliPath;
+  }
+  const home = safeHomeDir();
+  return home ? cliPath.replace(/^~(?=$|[\\/])/, home) : cliPath;
 }
 
-function resolveChatDbLookupPath(params: { cliPath: string; dbPath?: string }): string | undefined {
+function isSshIMessageCliWrapper(cliPath: string): boolean {
+  if (cliPath === "imsg") {
+    return false;
+  }
+  const cached = sshWrapperCliPathCache.get(cliPath);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let detected = false;
+  try {
+    const content = readFileSync(expandCliPathForInspection(cliPath), "utf8");
+    detected = /\bssh\b[\s\S]*\bimsg\b/u.test(content);
+  } catch {
+    detected = false;
+  }
+  // cliPath scripts are process-stable channel metadata; cache inspection so
+  // repeated sends do not poll wrapper files on the hot path.
+  sshWrapperCliPathCache.set(cliPath, detected);
+  return detected;
+}
+
+function isLocalIMessageCliPath(params: { cliPath: string; remoteHost?: string }): boolean {
+  const cliPath = params.cliPath.trim();
+  if (params.remoteHost?.trim() || isSshIMessageCliWrapper(cliPath)) {
+    return false;
+  }
+  return cliPath === "imsg" || path.basename(cliPath) === "imsg";
+}
+
+function resolveChatDbLookupPath(params: {
+  cliPath: string;
+  dbPath?: string;
+  remoteHost?: string;
+}): string | undefined {
   const configured = params.dbPath?.trim();
   if (configured) {
     return configured;
   }
-  if (!isLocalIMessageCliPath(params.cliPath)) {
+  if (!isLocalIMessageCliPath({ cliPath: params.cliPath, remoteHost: params.remoteHost })) {
     return undefined;
   }
   const home = safeHomeDir();
@@ -717,7 +754,11 @@ export async function sendMessageIMessage(
     });
   const cliPath = opts.cliPath?.trim() || account.config.cliPath?.trim() || "imsg";
   const dbPath = opts.dbPath?.trim() || account.config.dbPath?.trim();
-  const chatDbLookupPath = resolveChatDbLookupPath({ cliPath, dbPath });
+  const chatDbLookupPath = resolveChatDbLookupPath({
+    cliPath,
+    dbPath,
+    remoteHost: account.config.remoteHost,
+  });
   const target = parseIMessageTarget(opts.chatId ? formatIMessageChatTarget(opts.chatId) : to);
   const service =
     opts.service ??

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -1,6 +1,8 @@
 import { spawn } from "node:child_process";
 import { constants, accessSync } from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -94,6 +96,35 @@ export type IMessageSendResult = {
 };
 
 const MAX_REPLY_TO_ID_LENGTH = 256;
+
+function safeHomeDir(): string | undefined {
+  const home = process.env.HOME?.trim();
+  if (home) {
+    return home;
+  }
+  try {
+    return os.homedir().trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isLocalIMessageCliPath(cliPath: string): boolean {
+  const trimmed = cliPath.trim();
+  return trimmed === "imsg" || path.basename(trimmed) === "imsg";
+}
+
+function resolveChatDbLookupPath(params: { cliPath: string; dbPath?: string }): string | undefined {
+  const configured = params.dbPath?.trim();
+  if (configured) {
+    return configured;
+  }
+  if (!isLocalIMessageCliPath(params.cliPath)) {
+    return undefined;
+  }
+  const home = safeHomeDir();
+  return home ? path.join(home, "Library", "Messages", "chat.db") : undefined;
+}
 
 function stripUnsafeReplyTagChars(value: string): string {
   let next = "";
@@ -468,33 +499,6 @@ function isIMessageRpcSendTimeout(error: unknown): boolean {
   return /imsg rpc timeout \(send\)/i.test(message);
 }
 
-function buildTextSendCliArgs(params: {
-  target: ParsedIMessageTarget;
-  message: string;
-  service: IMessageService | undefined;
-  region: string;
-}): string[] {
-  const args = [
-    "send",
-    "--text",
-    params.message,
-    "--service",
-    params.service || "auto",
-    "--region",
-    params.region,
-  ];
-  if (params.target.kind === "chat_id") {
-    args.push("--chat-id", String(params.target.chatId));
-  } else if (params.target.kind === "chat_guid") {
-    args.push("--chat-guid", params.target.chatGuid);
-  } else if (params.target.kind === "chat_identifier") {
-    args.push("--chat-identifier", params.target.chatIdentifier);
-  } else {
-    args.push("--to", params.target.to);
-  }
-  return args;
-}
-
 async function runIMessageCliJson(
   cliPath: string,
   dbPath: string | undefined,
@@ -713,6 +717,7 @@ export async function sendMessageIMessage(
     });
   const cliPath = opts.cliPath?.trim() || account.config.cliPath?.trim() || "imsg";
   const dbPath = opts.dbPath?.trim() || account.config.dbPath?.trim();
+  const chatDbLookupPath = resolveChatDbLookupPath({ cliPath, dbPath });
   const target = parseIMessageTarget(opts.chatId ? formatIMessageChatTarget(opts.chatId) : to);
   const service =
     opts.service ??
@@ -774,7 +779,7 @@ export async function sendMessageIMessage(
   if (filePath && !message.trim() && !resolvedReplyToId) {
     const attachmentResult = await trySendAttachmentForExplicitChat({
       accountId: account.accountId,
-      dbPath,
+      dbPath: chatDbLookupPath,
       target,
       filePath,
       echoText,
@@ -817,7 +822,6 @@ export async function sendMessageIMessage(
       : await createIMessageRpcClient({ cliPath, dbPath }));
   let shouldClose = !opts.client;
   let result: Record<string, unknown>;
-  let usedCliFallback = false;
   let sendStartedAtMs = Date.now();
   try {
     try {
@@ -828,20 +832,26 @@ export async function sendMessageIMessage(
       if (filePath || resolvedReplyToId || !isIMessageRpcSendTimeout(error)) {
         throw error;
       }
-      if (shouldClose) {
-        await client.stop();
-        shouldClose = false;
-      }
-      sendStartedAtMs = Date.now();
-      result = await runCliJson(
-        buildTextSendCliArgs({
-          target,
+      if (
+        !shouldRecoverApprovalPromptGuid({
           message,
-          service,
-          region,
-        }),
-      );
-      usedCliFallback = true;
+          filePath,
+          replyToId: resolvedReplyToId,
+        })
+      ) {
+        throw error;
+      }
+      const recoveredGuid = await resolveFallbackSentMessageGuid({
+        dbPath: chatDbLookupPath,
+        target,
+        text: message,
+        sentAfterMs: sendStartedAtMs,
+        resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
+      });
+      if (!recoveredGuid) {
+        throw error;
+      }
+      result = { guid: recoveredGuid, status: "sent" };
     }
     const resolvedId = resolveMessageId(result);
     const messageId =
@@ -852,22 +862,21 @@ export async function sendMessageIMessage(
     // resolved through chat.db when available so chat_id sends can still bind
     // to the stable GUID surfaced by inbound tapbacks.
     let approvalBindingMessageId = await resolveApprovalBindingMessageGuid({
-      dbPath,
+      dbPath: chatDbLookupPath,
       messageId: resolvedId,
       result,
       resolveMessageGuidImpl: opts.resolveMessageGuidImpl,
     });
     if (
       !approvalBindingMessageId &&
-      (usedCliFallback ||
-        shouldRecoverApprovalPromptGuid({
-          message,
-          filePath,
-          replyToId: resolvedReplyToId,
-        }))
+      shouldRecoverApprovalPromptGuid({
+        message,
+        filePath,
+        replyToId: resolvedReplyToId,
+      })
     ) {
       approvalBindingMessageId = await resolveFallbackSentMessageGuid({
-        dbPath,
+        dbPath: chatDbLookupPath,
         target,
         text: message,
         sentAfterMs: sendStartedAtMs,

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { constants, accessSync } from "node:fs";
+import { createRequire } from "node:module";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -14,6 +16,7 @@ import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-ch
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import {
   appendIMessageApprovalReactionHintForOutboundMessage,
+  extractIMessageApprovalPromptBinding,
   type IMessageApprovalConversationKey,
   registerIMessageApprovalReactionTargetForOutboundMessage,
 } from "./approval-reactions.js";
@@ -27,6 +30,9 @@ import {
   normalizeIMessageHandle,
   parseIMessageTarget,
 } from "./targets.js";
+
+const require = createRequire(import.meta.url);
+type ParsedIMessageTarget = ReturnType<typeof parseIMessageTarget>;
 
 type IMessageSendOpts = {
   cliPath?: string;
@@ -54,6 +60,16 @@ type IMessageSendOpts = {
   ) => Promise<{ path: string; contentType?: string }>;
   createClient?: (params: { cliPath: string; dbPath?: string }) => Promise<IMessageRpcClient>;
   runCliJson?: (args: readonly string[]) => Promise<Record<string, unknown>>;
+  resolveMessageGuidImpl?: (params: {
+    dbPath?: string;
+    messageId: string;
+  }) => Promise<string | null> | string | null;
+  resolveSentMessageGuidImpl?: (params: {
+    dbPath?: string;
+    target: ParsedIMessageTarget;
+    text: string;
+    sentAfterMs?: number;
+  }) => Promise<string | null> | string | null;
 };
 
 export type IMessageSendResult = {
@@ -147,6 +163,227 @@ function resolveOutboundMessageGuid(
   return null;
 }
 
+function isNumericMessageRowId(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^\d+$/.test(value.trim());
+}
+
+function normalizeResolvedMessageGuid(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed && !isNumericMessageRowId(trimmed) ? trimmed : null;
+}
+
+function loadNodeSqlite(): typeof import("node:sqlite") | null {
+  try {
+    return require("node:sqlite") as typeof import("node:sqlite");
+  } catch {
+    return null;
+  }
+}
+
+function resolveMessageGuidFromChatDb(params: {
+  dbPath?: string;
+  messageId: string;
+}): string | null {
+  const dbPath = params.dbPath?.trim();
+  const messageId = params.messageId.trim();
+  if (!dbPath || !isNumericMessageRowId(messageId)) {
+    return null;
+  }
+  const sqlite = loadNodeSqlite();
+  if (!sqlite) {
+    return null;
+  }
+  let db: import("node:sqlite").DatabaseSync | null = null;
+  try {
+    db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
+    const row = db.prepare("SELECT guid FROM message WHERE ROWID = ?").get(messageId) as
+      | { guid?: unknown }
+      | undefined;
+    return normalizeResolvedMessageGuid(row?.guid);
+  } catch {
+    return null;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+function getStringRowValue(row: Record<string, unknown> | undefined, key: string): string | null {
+  return normalizeResolvedMessageGuid(row?.[key]);
+}
+
+function appleMessageDateLowerBoundMs(sentAfterMs: number | undefined): number | null {
+  if (!Number.isFinite(sentAfterMs)) {
+    return null;
+  }
+  // chat.db stores message.date as nanoseconds since 2001-01-01. Give the
+  // bridge a small amount of clock/write skew so a just-sent row is included.
+  return Math.max(0, Math.floor(((sentAfterMs as number) - 978_307_200_000 - 5_000) * 1_000_000));
+}
+
+function resolveLatestSentMessageGuidFromChatDb(params: {
+  dbPath?: string;
+  target: ParsedIMessageTarget;
+  text: string;
+  sentAfterMs?: number;
+}): string | null {
+  const dbPath = params.dbPath?.trim();
+  if (!dbPath) {
+    return null;
+  }
+  const sqlite = loadNodeSqlite();
+  if (!sqlite) {
+    return null;
+  }
+  let db: import("node:sqlite").DatabaseSync | null = null;
+  try {
+    db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
+    const targetClauses: string[] = [];
+    const targetParams: Array<string | number> = [];
+    const lowerBound = appleMessageDateLowerBoundMs(params.sentAfterMs);
+    if (params.text) {
+      targetClauses.push("m.text = ?");
+      targetParams.push(params.text);
+    }
+    if (lowerBound !== null) {
+      targetClauses.push("m.date >= ?");
+      targetParams.push(lowerBound);
+    }
+    if (params.target.kind === "chat_id") {
+      targetClauses.push("cmj.chat_id = ?");
+      targetParams.push(params.target.chatId);
+    } else if (params.target.kind === "chat_guid") {
+      targetClauses.push("c.guid = ?");
+      targetParams.push(params.target.chatGuid);
+    } else if (params.target.kind === "chat_identifier") {
+      targetClauses.push("c.chat_identifier = ?");
+      targetParams.push(params.target.chatIdentifier);
+    } else {
+      const normalizedHandle = normalizeIMessageHandle(params.target.to);
+      targetClauses.push("(h.id = ? OR h.uncanonicalized_id = ?)");
+      targetParams.push(normalizedHandle, params.target.to);
+    }
+    const targetWhere = targetClauses.length ? `AND ${targetClauses.join(" AND ")}` : "";
+    const selectSql = `
+      SELECT m.guid
+      FROM message m
+      LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+      LEFT JOIN chat c ON c.ROWID = cmj.chat_id
+      LEFT JOIN handle h ON h.ROWID = m.handle_id
+      WHERE m.is_from_me = 1
+      ${targetWhere}
+      ORDER BY m.date DESC, m.ROWID DESC
+      LIMIT 10
+    `;
+    const rows = db.prepare(selectSql).all(...targetParams) as Array<Record<string, unknown>>;
+    return getStringRowValue(rows[0], "guid");
+  } catch {
+    return null;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+function canResolveLatestSentMessageGuidFromChatDb(dbPath?: string): boolean {
+  const normalizedDbPath = dbPath?.trim();
+  if (!normalizedDbPath || !loadNodeSqlite()) {
+    return false;
+  }
+  try {
+    accessSync(normalizedDbPath, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveApprovalBindingMessageGuid(params: {
+  dbPath?: string;
+  messageId: string | null;
+  result: Record<string, unknown> | null | undefined;
+  resolveMessageGuidImpl?: IMessageSendOpts["resolveMessageGuidImpl"];
+}): Promise<string | null> {
+  const immediateGuid = resolveOutboundMessageGuid(params.result);
+  if (immediateGuid) {
+    return immediateGuid;
+  }
+  const messageId = params.messageId?.trim();
+  if (!messageId || !isNumericMessageRowId(messageId)) {
+    return null;
+  }
+  const resolver = params.resolveMessageGuidImpl ?? resolveMessageGuidFromChatDb;
+  return normalizeResolvedMessageGuid(
+    await resolver({
+      dbPath: params.dbPath,
+      messageId,
+    }),
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function resolveFallbackSentMessageGuid(params: {
+  dbPath?: string;
+  target: ParsedIMessageTarget;
+  text: string;
+  sentAfterMs?: number;
+  resolveSentMessageGuidImpl?: IMessageSendOpts["resolveSentMessageGuidImpl"];
+}): Promise<string | null> {
+  const resolver = params.resolveSentMessageGuidImpl ?? resolveLatestSentMessageGuidFromChatDb;
+  if (
+    !params.resolveSentMessageGuidImpl &&
+    !canResolveLatestSentMessageGuidFromChatDb(params.dbPath)
+  ) {
+    return null;
+  }
+  const deadlineMs = Date.now() + 5_000;
+  while (Date.now() <= deadlineMs) {
+    const resolved = normalizeResolvedMessageGuid(
+      await resolver({
+        dbPath: params.dbPath,
+        target: params.target,
+        text: params.text,
+        sentAfterMs: params.sentAfterMs,
+      }),
+    );
+    if (resolved) {
+      return resolved;
+    }
+    if (Date.now() >= deadlineMs) {
+      return null;
+    }
+    await delay(250);
+  }
+  return null;
+}
+
+function shouldRecoverApprovalPromptGuid(params: {
+  message: string;
+  filePath?: string;
+  replyToId?: string | null;
+}): boolean {
+  return (
+    !params.filePath &&
+    !params.replyToId &&
+    Boolean(params.message.trim()) &&
+    Boolean(extractIMessageApprovalPromptBinding(params.message))
+  );
+}
+
 function resolveOutboundEchoText(text: string, mediaContentType?: string): string | undefined {
   if (text.trim()) {
     return text;
@@ -224,6 +461,38 @@ function resolveIMessageCliFailure(result: Record<string, unknown>): string | nu
   return typeof result.error === "string" && result.error.trim()
     ? result.error.trim()
     : "iMessage action failed";
+}
+
+function isIMessageRpcSendTimeout(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /imsg rpc timeout \(send\)/i.test(message);
+}
+
+function buildTextSendCliArgs(params: {
+  target: ParsedIMessageTarget;
+  message: string;
+  service: IMessageService | undefined;
+  region: string;
+}): string[] {
+  const args = [
+    "send",
+    "--text",
+    params.message,
+    "--service",
+    params.service || "auto",
+    "--region",
+    params.region,
+  ];
+  if (params.target.kind === "chat_id") {
+    args.push("--chat-id", String(params.target.chatId));
+  } else if (params.target.kind === "chat_guid") {
+    args.push("--chat-guid", params.target.chatGuid);
+  } else if (params.target.kind === "chat_identifier") {
+    args.push("--chat-identifier", params.target.chatIdentifier);
+  } else {
+    args.push("--to", params.target.to);
+  }
+  return args;
 }
 
 async function runIMessageCliJson(
@@ -339,10 +608,12 @@ async function resolveAttachmentChatGuid(params: {
 
 async function trySendAttachmentForExplicitChat(params: {
   accountId: string;
+  dbPath?: string;
   target: ReturnType<typeof parseIMessageTarget>;
   filePath: string;
   echoText?: string;
   runCliJson: (args: readonly string[]) => Promise<Record<string, unknown>>;
+  resolveMessageGuidImpl?: IMessageSendOpts["resolveMessageGuidImpl"];
 }): Promise<IMessageSendResult | null> {
   let attachmentChatGuid: string | null = null;
   try {
@@ -387,7 +658,12 @@ async function trySendAttachmentForExplicitChat(params: {
   }
 
   const resolvedId = resolveMessageId(result);
-  const approvalBindingMessageId = resolveOutboundMessageGuid(result);
+  const approvalBindingMessageId = await resolveApprovalBindingMessageGuid({
+    dbPath: params.dbPath,
+    messageId: resolvedId,
+    result,
+    resolveMessageGuidImpl: params.resolveMessageGuidImpl,
+  });
   const messageId = resolvedId ?? (result.ok || result.success ? "ok" : "unknown");
   const echoScope = resolveOutboundEchoScope({
     accountId: params.accountId,
@@ -498,10 +774,12 @@ export async function sendMessageIMessage(
   if (filePath && !message.trim() && !resolvedReplyToId) {
     const attachmentResult = await trySendAttachmentForExplicitChat({
       accountId: account.accountId,
+      dbPath,
       target,
       filePath,
       echoText,
       runCliJson,
+      resolveMessageGuidImpl: opts.resolveMessageGuidImpl,
     });
     if (attachmentResult) {
       return attachmentResult;
@@ -537,17 +815,65 @@ export async function sendMessageIMessage(
     (opts.createClient
       ? await opts.createClient({ cliPath, dbPath })
       : await createIMessageRpcClient({ cliPath, dbPath }));
-  const shouldClose = !opts.client;
+  let shouldClose = !opts.client;
+  let result: Record<string, unknown>;
+  let usedCliFallback = false;
+  let sendStartedAtMs = Date.now();
   try {
-    const result = await client.request<{ ok?: string }>("send", params, {
-      timeoutMs: opts.timeoutMs,
-    });
+    try {
+      result = await client.request<Record<string, unknown>>("send", params, {
+        timeoutMs: opts.timeoutMs,
+      });
+    } catch (error) {
+      if (filePath || resolvedReplyToId || !isIMessageRpcSendTimeout(error)) {
+        throw error;
+      }
+      if (shouldClose) {
+        await client.stop();
+        shouldClose = false;
+      }
+      sendStartedAtMs = Date.now();
+      result = await runCliJson(
+        buildTextSendCliArgs({
+          target,
+          message,
+          service,
+          region,
+        }),
+      );
+      usedCliFallback = true;
+    }
     const resolvedId = resolveMessageId(result);
-    const messageId = resolvedId ?? (result?.ok ? "ok" : "unknown");
+    const messageId =
+      resolvedId ?? (result?.ok || result?.success || result?.status === "sent" ? "ok" : "unknown");
     // GUID-only id for approval-reaction binding (inbound `reacted_to_guid`
     // never carries a numeric ROWID, so the bind key must match). Undefined
-    // when the bridge only returned a numeric or placeholder id.
-    const approvalBindingMessageId = resolveOutboundMessageGuid(result);
+    // when the bridge only returned a placeholder id. Numeric ROWIDs are
+    // resolved through chat.db when available so chat_id sends can still bind
+    // to the stable GUID surfaced by inbound tapbacks.
+    let approvalBindingMessageId = await resolveApprovalBindingMessageGuid({
+      dbPath,
+      messageId: resolvedId,
+      result,
+      resolveMessageGuidImpl: opts.resolveMessageGuidImpl,
+    });
+    if (
+      !approvalBindingMessageId &&
+      (usedCliFallback ||
+        shouldRecoverApprovalPromptGuid({
+          message,
+          filePath,
+          replyToId: resolvedReplyToId,
+        }))
+    ) {
+      approvalBindingMessageId = await resolveFallbackSentMessageGuid({
+        dbPath,
+        target,
+        text: message,
+        sentAfterMs: sendStartedAtMs,
+        resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
+      });
+    }
     const echoScope = resolveOutboundEchoScope({ accountId: account.accountId, target });
     if (echoScope) {
       rememberPersistedIMessageEcho({
@@ -575,24 +901,22 @@ export async function sendMessageIMessage(
         timestamp: Date.now(),
         isFromMe: true,
       });
-      if (message) {
-        if (approvalBindingMessageId) {
-          const handleForKey =
-            target.kind === "handle" ? normalizeIMessageHandle(target.to) : undefined;
-          const conversation: IMessageApprovalConversationKey = {
-            ...(target.kind === "chat_guid" ? { chatGuid: target.chatGuid } : {}),
-            ...(target.kind === "chat_identifier" ? { chatIdentifier: target.chatIdentifier } : {}),
-            ...(target.kind === "chat_id" ? { chatId: target.chatId } : {}),
-            ...(handleForKey ? { handle: handleForKey } : {}),
-          };
-          registerIMessageApprovalReactionTargetForOutboundMessage({
-            accountId: account.accountId,
-            conversation,
-            messageId: approvalBindingMessageId,
-            text: message,
-          });
-        }
-      }
+    }
+    if (message && approvalBindingMessageId) {
+      const handleForKey =
+        target.kind === "handle" ? normalizeIMessageHandle(target.to) : undefined;
+      const conversation: IMessageApprovalConversationKey = {
+        ...(target.kind === "chat_guid" ? { chatGuid: target.chatGuid } : {}),
+        ...(target.kind === "chat_identifier" ? { chatIdentifier: target.chatIdentifier } : {}),
+        ...(target.kind === "chat_id" ? { chatId: target.chatId } : {}),
+        ...(handleForKey ? { handle: handleForKey } : {}),
+      };
+      registerIMessageApprovalReactionTargetForOutboundMessage({
+        accountId: account.accountId,
+        conversation,
+        messageId: approvalBindingMessageId,
+        text: message,
+      });
     }
     return {
       messageId,

--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -3,6 +3,7 @@ import {
   verifyChannelMessageAdapterCapabilityProofs,
   verifyDurableFinalCapabilityProofs,
 } from "openclaw/plugin-sdk/channel-outbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   listImportedBundledPluginFacadeIds,
   resetFacadeRuntimeStateForTest,
@@ -108,6 +109,48 @@ describe("createIMessageTestPlugin", () => {
       replyTo: true,
       messageSendingHooks: true,
     });
+  });
+
+  it("preserves the local approval prompt suppressor through attached-result composition", () => {
+    const suppressor = imessagePlugin.outbound?.shouldSuppressLocalPayloadPrompt;
+    if (!suppressor) {
+      throw new Error("iMessage outbound approval suppressor unavailable");
+    }
+
+    expect(
+      suppressor({
+        cfg: {
+          channels: {
+            imessage: {
+              enabled: true,
+              allowFrom: ["+15551230000"],
+            },
+          },
+          approvals: {
+            exec: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        accountId: "default",
+        payload: {
+          text: "Approval required.",
+          channelData: {
+            execApproval: {
+              approvalId: "exec-1",
+              approvalSlug: "exec-1",
+              approvalKind: "exec",
+              sessionKey: "agent:main:imessage:+15551230000",
+            },
+          },
+        },
+        hint: {
+          kind: "approval-pending",
+          approvalKind: "exec",
+          nativeRouteActive: true,
+        },
+      }),
+    ).toBe(true);
   });
 
   it("backs declared durable final capabilities with delivery proofs", async () => {


### PR DESCRIPTION
## Summary

- Suppresses the local bash-tool `approval-pending` reply for eligible iMessage native exec approvals, so the iMessage route shows one native approval prompt instead of a native prompt plus a fallback `/approve` prompt.
- Adds an iMessage approval-reaction history poller for tapbacks that land as nested `reactions[]` on the outbound Messages row and are not emitted by `watch.subscribe`.
- Recovers approval-reaction bindings from observed outbound approval prompt text and normalizes Messages GUID candidates so 👍 tapbacks resolve against the actual approval prompt.
- Starts `imsg rpc` in JSON mode so the extension can parse RPC responses consistently.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related milestone: `.mem/main/specs/24-mainstream-channel-exec-plugin-approvals/milestones/24.7-imessage-local-exec-approval-suppression.md`

Was this requested by a maintainer or owner?

Yes, requested by Kevin in Codex while testing iMessage reaction approvals.

## Real behavior proof (required for external PRs)

- Behavior addressed: iMessage exec approvals could double-send one native reaction approval prompt plus the local bash-tool `approval-pending` fallback prompt.
- Real environment tested: local dev OpenClaw profile, iMessage/SMS route through Google Voice to the configured OpenClaw iMessage chat, approval-required shell exec harness.
- Exact step after this patch: sent `touch /tmp/openclaw-imsg-allow-20260527-133544` through the verified Google Voice thread, then reacted 👍 to the iMessage approval prompt with id `dfb59e2f-ab2a-493c-bac1-df3e38897cb8`.
- Evidence after fix: Messages history showed `promptCount=1`, `localFallbackCount=0`, `backgroundCount=1`, and `fileExists=true` for `/tmp/openclaw-imsg-allow-20260527-133544`.
- Observed result after fix: exactly one visible iMessage approval prompt was delivered, the 👍 tapback resolved allow-once, and the command completed.
- Proof artifact captured locally: `/tmp/imessage-native-approval-proof-final2.png`.
- What was not tested in this final push: a live 👎 denial pass on this exact final commit.
- Proof limitations or environment constraints: proof uses Kevin's local Messages/Google Voice setup; phone numbers and route details are redacted from this PR body.

## Tests and validation

Which commands did you run?

- `pnpm format:check extensions/imessage/src/approval-native.ts extensions/imessage/src/approval-reactions.ts extensions/imessage/src/client.ts extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/approval-reaction-poller.ts`
- `pnpm tsgo:extensions`
- `pnpm lint:extensions`
- `pnpm build`
- `git diff --check`

What regression coverage was added or updated?

- iMessage native exec fallback suppression for approval-pending tool-result replies.
- iMessage reaction target polling for nested Messages tapbacks.
- Observed approval-prompt binding recovery when the in-memory send target is unavailable.

What failed before this fix, if known?

Real iMessage exec approval requests could show duplicate approval replies, and Messages tapbacks could be missed because the reaction was stored on the outbound message history row rather than emitted through the live watch stream.

If no test was added, why not?

This final push was verified with the live Google Voice -> iMessage route as requested.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, iMessage 👍 tapbacks can now resolve eligible pending exec approvals when the sender is authorized.

What is the highest-risk area?

Suppressing the local exec fallback when native iMessage delivery is not actually eligible.

How is that risk mitigated?

The suppressor still fails open unless the approval-pending hint is active, the payload is exec approval metadata, the native route is active, and iMessage approval routing is eligible. The live proof confirmed the intended native route delivered one prompt and resolved the approval.

## Current review state

What is the next action?

Review and wait for CI.

What is still waiting on author, maintainer, CI, or external proof?

CI is pending for the latest head.

Which bot or reviewer comments were addressed?

N/A.
