### PR TITLE
fix: prevent sessions_yield completion wake freeze

### DIFF
--- a/src/agents/pi-embedded-runner/run-state.ts
+++ b/src/agents/pi-embedded-runner/run-state.ts
@@ -11,6 +11,7 @@ export type EmbeddedPiQueueHandle = {
   queueMessage: (text: string, options?: EmbeddedPiQueueMessageOptions) => Promise<void>;
   isStreaming: () => boolean;
   isCompacting: () => boolean;
+  isAcceptingMessages?: () => boolean;
   supportsTranscriptCommitWait?: boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
   abort: () => void;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1792,6 +1792,7 @@ export async function runEmbeddedAttempt(
             onYield: (message) => {
               yieldDetected = true;
               yieldMessage = message;
+              yieldAbortInProgress = true;
               queueYieldInterruptForSession?.();
               runAbortController.abort("sessions_yield");
               abortSessionForYield?.();
@@ -1945,6 +1946,7 @@ export async function runEmbeddedAttempt(
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
     let yieldMessage: string | null = null;
+    let yieldAbortInProgress = false;
     // Late-binding reference so onYield can abort the session (declared after tool creation)
     let abortSessionForYield: (() => void) | null = null;
     let queueYieldInterruptForSession: (() => void) | null = null;
@@ -3746,6 +3748,7 @@ export async function runEmbeddedAttempt(
         },
         isStreaming: () => activeSession.isStreaming,
         isCompacting: () => subscription.isCompacting(),
+        isAcceptingMessages: () => !yieldAbortInProgress,
         supportsTranscriptCommitWait: true,
         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
         cancel: () => {

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -41,6 +41,7 @@ function createRunHandle(
     isCompacting?: boolean;
     isStreaming?: boolean;
     supportsTranscriptCommitWait?: boolean;
+    isAcceptingMessages?: boolean;
   } = {},
 ): RunHandle {
   const abort = overrides.abort ?? (() => {});
@@ -48,6 +49,9 @@ function createRunHandle(
     queueMessage: async () => {},
     isStreaming: () => overrides.isStreaming ?? true,
     isCompacting: () => overrides.isCompacting ?? false,
+    ...(overrides.isAcceptingMessages !== undefined
+      ? { isAcceptingMessages: () => overrides.isAcceptingMessages ?? true }
+      : {}),
     supportsTranscriptCommitWait: overrides.supportsTranscriptCommitWait,
     abort,
   };
@@ -226,6 +230,31 @@ describe("pi-embedded runner run registry", () => {
       reason: "compacting",
       gatewayHealth: "live",
     });
+  });
+
+  it("rejects queueing into a sessions_yield-aborting run before the stream fully clears", () => {
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "session-yield-aborting",
+      {
+        ...createRunHandle({ isStreaming: true, isAcceptingMessages: false }),
+        queueMessage,
+      },
+      "agent:main:yield-parent",
+    );
+
+    const outcome = queueEmbeddedPiMessageWithOutcome(
+      "session-yield-aborting",
+      "subagent completion",
+    );
+
+    expect(outcome).toEqual({
+      queued: false,
+      sessionId: "session-yield-aborting",
+      reason: "not_streaming",
+      gatewayHealth: "live",
+    });
+    expect(queueMessage).not.toHaveBeenCalled();
   });
 
   it("returns runtime rejection details when async queue delivery fails", async () => {

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -261,7 +261,7 @@ function prepareEmbeddedPiQueueMessage(
     diag.debug(`queue message failed: sessionId=${sessionId} reason=no_active_run`);
     return { kind: "complete", outcome: createQueueFailureOutcome(sessionId, "no_active_run") };
   }
-  if (!handle.isStreaming()) {
+  if (handle.isAcceptingMessages?.() === false || !handle.isStreaming()) {
     diag.debug(`queue message failed: sessionId=${sessionId} reason=not_streaming`);
     return { kind: "complete", outcome: createQueueFailureOutcome(sessionId, "not_streaming") };
   }

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -884,7 +884,7 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
 });
 
 describe("deliverSubagentAnnouncement completion delivery", () => {
-  it("uses an active requester queue as the completion handoff when message-tool delivery is not required", async () => {
+  it("uses direct requester-agent handoff before steering active completion requesters", async () => {
     const callGateway = createGatewayMock();
     const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(true);
     const result = await deliverSlackThreadAnnouncement({
@@ -898,24 +898,21 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expectRecordFields(result, {
       delivered: true,
-      path: "steered",
-      enqueuedAt: 4_100,
-      deliveredAt: 4_200,
+      path: "direct",
+      phases: [{ phase: "direct-primary", delivered: true, path: "direct", error: undefined }],
     });
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledWith(
-      "requester-session-1",
-      "child done",
-      {
-        steeringMode: "all",
-        debounceMs: 500,
-        waitForTranscriptCommit: true,
-        deliveryTimeoutMs: 120_000,
-      },
-    );
-    expect(callGateway).not.toHaveBeenCalled();
+    expectGatewayAgentParams(callGateway, {
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: "171.222",
+      bestEffortDeliver: true,
+    });
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
   });
 
-  it("does not also direct-run a queued active completion", async () => {
+  it("falls back to queued steering only after direct active completion handoff fails", async () => {
     const callGateway = createGatewayMock();
     const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(true);
     const result = await deliverSlackThreadAnnouncement({
@@ -931,11 +928,27 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: true,
       path: "steered",
-      enqueuedAt: 4_100,
-      deliveredAt: 4_200,
+      phases: [
+        {
+          phase: "direct-primary",
+          delivered: false,
+          path: "direct",
+          deliveredAt: undefined,
+          enqueuedAt: undefined,
+          error: "completion agent did not produce a visible reply",
+        },
+        {
+          phase: "steer-fallback",
+          delivered: true,
+          path: "steered",
+          deliveredAt: 4_200,
+          enqueuedAt: 4_100,
+          error: undefined,
+        },
+      ],
     });
+    expect(callGateway).toHaveBeenCalledTimes(1);
     expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(1);
-    expect(callGateway).not.toHaveBeenCalled();
   });
 
   it("keeps direct external delivery for dormant completion requesters", async () => {
@@ -1525,28 +1538,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       to: "channel:C123",
       threadId: "171.222",
     });
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(2);
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
-      1,
-      "requester-session-4",
-      "child done",
-      {
-        debounceMs: 500,
-        deliveryTimeoutMs: 120_000,
-        steeringMode: "all",
-        waitForTranscriptCommit: true,
-      },
-    );
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
-      2,
-      "requester-session-4",
-      "child done",
-      {
-        debounceMs: 500,
-        deliveryTimeoutMs: 120_000,
-        steeringMode: "all",
-      },
-    );
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
@@ -1765,17 +1757,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         },
       ],
     });
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(1);
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledWith(
-      "requester-session-telegram",
-      "child done",
-      {
-        steeringMode: "all",
-        debounceMs: 500,
-        waitForTranscriptCommit: true,
-        deliveryTimeoutMs: 10,
-      },
-    );
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
   });
@@ -1835,7 +1817,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         },
       ],
     });
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(1);
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
     expect(callGateway).toHaveBeenCalledTimes(1);
   });
 
@@ -2507,7 +2489,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("keeps generated media completions on the active requester session path", async () => {
+  it("keeps generated media completions on the direct requester handoff path", async () => {
     const callGateway = createGatewayMock();
     const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(true);
     const sendMessage = createSendMessageMock();
@@ -2540,23 +2522,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expectRecordFields(result, {
       delivered: true,
-      path: "steered",
-      enqueuedAt: 4_100,
-      deliveredAt: 4_200,
+      path: "direct",
     });
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledWith(
-      "requester-session-channel",
-      "child done",
-      {
-        steeringMode: "all",
-        sourceReplyDeliveryMode: "message_tool_only",
-        debounceMs: 500,
-        waitForTranscriptCommit: true,
-        deliveryTimeoutMs: 120_000,
-      },
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        accountId: "acct-1",
+        to: "channel:C123",
+        content: "The generated video is ready.",
+        mediaUrls: ["/tmp/generated-corgi.mp4"],
+        idempotencyKey: "announce-channel-media-active-direct:generated-media-direct",
+      }),
     );
-    expect(callGateway).not.toHaveBeenCalled();
-    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("directly delivers missing generated media after active requester wake failure", async () => {
@@ -2612,7 +2591,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(2);
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -459,6 +459,7 @@ async function maybeSteerSubagentAnnounce(params: {
   deliveryTimeoutMs?: number;
   requesterSessionKey: string;
   steerMessage: string;
+  sourceReplyDeliveryMode?: "message_tool_only";
   signal?: AbortSignal;
 }): Promise<
   { status: "steered"; deliveredAt?: number; enqueuedAt?: number } | { status: "none" | "dropped" }
@@ -484,6 +485,9 @@ async function maybeSteerSubagentAnnounce(params: {
   const queueOptions: EmbeddedPiQueueMessageOptions = {
     deliveryTimeoutMs: params.deliveryTimeoutMs,
     steeringMode: "all",
+    ...(params.sourceReplyDeliveryMode
+      ? { sourceReplyDeliveryMode: params.sourceReplyDeliveryMode }
+      : {}),
     ...(queueSettings.debounceMs !== undefined ? { debounceMs: queueSettings.debounceMs } : {}),
     waitForTranscriptCommit: true,
   };
@@ -566,7 +570,7 @@ function requiresAgentMediatedCompletionDelivery(params: {
 }
 
 function collectExpectedMediaFromInternalEvents(
-  events: AgentInternalEvent[] | undefined,
+  events: readonly AgentInternalEvent[] | undefined,
 ): string[] {
   if (!events?.length) {
     return [];
@@ -880,6 +884,7 @@ async function sendSubagentAnnounceDirectly(params: {
   triggerMessage: string;
   internalEvents?: AgentInternalEvent[];
   expectsCompletionMessage: boolean;
+  allowActiveRequesterWake?: boolean;
   bestEffortDeliver?: boolean;
   directIdempotencyKey: string;
   completionDirectOrigin?: DeliveryContext;
@@ -965,7 +970,11 @@ async function sendSubagentAnnounceDirectly(params: {
     const requesterActivity = resolveRequesterSessionActivity(canonicalRequesterSessionKey);
     let activeRequesterWakeFailed = false;
     const tryGeneratedMediaDirectDelivery = async (announceResponse?: unknown) => {
-      if (requesterActivity.isActive && !activeRequesterWakeFailed) {
+      if (
+        params.allowActiveRequesterWake === true &&
+        requesterActivity.isActive &&
+        !activeRequesterWakeFailed
+      ) {
         return undefined;
       }
       const missingMediaUrls = resolveGeneratedMediaDirectFallbackUrls({
@@ -998,6 +1007,7 @@ async function sendSubagentAnnounceDirectly(params: {
     });
     if (
       params.expectsCompletionMessage &&
+      params.allowActiveRequesterWake === true &&
       requesterActivity.sessionId &&
       requesterActivity.isActive
     ) {
@@ -1252,6 +1262,23 @@ async function sendSubagentAnnounceDirectly(params: {
   }
 }
 
+function resolveFallbackSteerSourceReplyDeliveryMode(params: {
+  expectsCompletionMessage: boolean;
+  sourceTool?: string;
+  internalEvents?: readonly AgentInternalEvent[];
+}): "message_tool_only" | undefined {
+  if (
+    requiresAgentMediatedCompletionDelivery({
+      expectsCompletionMessage: params.expectsCompletionMessage,
+      sourceTool: params.sourceTool,
+    }) &&
+    collectExpectedMediaFromInternalEvents(params.internalEvents).length > 0
+  ) {
+    return "message_tool_only";
+  }
+  return undefined;
+}
+
 export async function deliverSubagentAnnouncement(params: {
   requesterSessionKey: string;
   announceId?: string;
@@ -1283,6 +1310,11 @@ export async function deliverSubagentAnnouncement(params: {
         ),
         requesterSessionKey: params.requesterSessionKey,
         steerMessage: params.steerMessage,
+        sourceReplyDeliveryMode: resolveFallbackSteerSourceReplyDeliveryMode({
+          expectsCompletionMessage: params.expectsCompletionMessage,
+          sourceTool: params.sourceTool,
+          internalEvents: params.internalEvents,
+        }),
         signal: params.signal,
       }),
     direct: async () =>
@@ -1300,6 +1332,7 @@ export async function deliverSubagentAnnouncement(params: {
         sourceTool: params.sourceTool,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        allowActiveRequesterWake: !params.expectsCompletionMessage,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
       }),


### PR DESCRIPTION
## Summary
- Prefer direct requester-agent handoff for expected subagent completion messages so yielded parent sessions resume instead of being steered into an aborting active run.
- Mark sessions_yield abort transitions as temporarily not accepting embedded messages, forcing completion delivery fallback instead of queueing into a stale active context.
- Add focused regression coverage for completion handoff and yield-aborting run queue rejection.

## Tests
- pnpm exec vitest run src/agents/pi-embedded-runner/runs.test.ts src/agents/subagent-announce-delivery.test.ts
- npx -y pnpm@11.2.2 format:check src/agents/pi-embedded-runner/run-state.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/runs.test.ts src/agents/pi-embedded-runner/runs.ts src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce-delivery.ts
- npx -y pnpm@11.2.2 tsgo:core

BR-0593