### PR TITLE
fix(msteams): block untrusted Teams service URLs

### DIFF
--- a/extensions/msteams/src/bot-framework-service-url.ts
+++ b/extensions/msteams/src/bot-framework-service-url.ts
@@ -1,0 +1,67 @@
+import {
+  buildHostnameAllowlistPolicyFromSuffixAllowlist,
+  isHttpsUrlAllowedByHostnameSuffixAllowlist,
+  normalizeHostnameSuffixAllowlist,
+  type SsrFPolicy,
+} from "openclaw/plugin-sdk/ssrf-policy";
+
+const DEFAULT_BOT_FRAMEWORK_SERVICE_URL_HOST_ALLOWLIST = [
+  // Microsoft Teams Bot Framework serviceUrl endpoints documented for
+  // commercial, GCC, GCC High, and DOD clouds. These are the only hosts that may
+  // receive Bot Framework service tokens from this plugin.
+  "smba.trafficmanager.net",
+  "smba.infra.gcc.teams.microsoft.com",
+  "smba.infra.gov.teams.microsoft.us",
+  "smba.infra.dod.teams.microsoft.us",
+] as const;
+
+export const BOT_FRAMEWORK_SERVICE_URL_HOST_ALLOWLIST = normalizeHostnameSuffixAllowlist(
+  DEFAULT_BOT_FRAMEWORK_SERVICE_URL_HOST_ALLOWLIST,
+);
+
+const serviceUrlSsrfPolicy = buildHostnameAllowlistPolicyFromSuffixAllowlist(
+  BOT_FRAMEWORK_SERVICE_URL_HOST_ALLOWLIST,
+);
+
+if (!serviceUrlSsrfPolicy) {
+  throw new Error("Microsoft Teams Bot Framework serviceUrl allowlist is empty");
+}
+
+export const BOT_FRAMEWORK_SERVICE_URL_SSRF_POLICY: SsrFPolicy = serviceUrlSsrfPolicy;
+
+export function describeBotFrameworkServiceUrlHost(serviceUrl: string): string {
+  try {
+    const parsed = new URL(serviceUrl.trim());
+    return parsed.hostname || "invalid-url";
+  } catch {
+    return "invalid-url";
+  }
+}
+
+export function isAllowedBotFrameworkServiceUrl(serviceUrl: unknown): serviceUrl is string {
+  if (typeof serviceUrl !== "string") {
+    return false;
+  }
+  const trimmed = serviceUrl.trim();
+  return Boolean(
+    trimmed &&
+    isHttpsUrlAllowedByHostnameSuffixAllowlist(trimmed, BOT_FRAMEWORK_SERVICE_URL_HOST_ALLOWLIST),
+  );
+}
+
+export function tryNormalizeBotFrameworkServiceUrl(serviceUrl: unknown): string | undefined {
+  if (!isAllowedBotFrameworkServiceUrl(serviceUrl)) {
+    return undefined;
+  }
+  return serviceUrl.trim().replace(/\/+$/, "");
+}
+
+export function normalizeBotFrameworkServiceUrl(serviceUrl: string): string {
+  const normalized = tryNormalizeBotFrameworkServiceUrl(serviceUrl);
+  if (normalized) {
+    return normalized;
+  }
+  throw new Error(
+    `Blocked Microsoft Teams serviceUrl host: ${describeBotFrameworkServiceUrlHost(serviceUrl)}`,
+  );
+}

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { appendRegularFile } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { tryNormalizeBotFrameworkServiceUrl } from "./bot-framework-service-url.js";
 import { formatUnknownError } from "./errors.js";
 import { buildFeedbackEvent, runFeedbackReflection } from "./feedback-reflection.js";
 import { respondToMSTeamsFileConsentInvoke } from "./file-consent-invoke.js";
@@ -268,6 +269,7 @@ async function handleFeedbackInvoke(
   }
 
   // Build conversation reference for proactive messages (ack + reflection follow-up)
+  const serviceUrl = tryNormalizeBotFrameworkServiceUrl(activity.serviceUrl);
   const conversationRef = {
     activityId: activity.id,
     user: {
@@ -287,7 +289,7 @@ async function handleFeedbackInvoke(
       tenantId: activity.conversation?.tenantId,
     },
     channelId: activity.channelId ?? "msteams",
-    serviceUrl: activity.serviceUrl,
+    ...(serviceUrl ? { serviceUrl } : {}),
     locale: activity.locale,
   };
 

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -441,7 +441,7 @@ describe("msteams monitor handler authz", () => {
       tenantId: "tenant-1",
       aadObjectId: "new-user-aad",
       channelId: "msteams",
-      serviceUrl: "https://smba.trafficmanager.net/amer/",
+      serviceUrl: "https://smba.trafficmanager.net/amer",
       locale: "en-US",
       timezone: "America/New_York",
     });
@@ -505,6 +505,48 @@ describe("msteams monitor handler authz", () => {
     const storedConversation = recordFromMockCall(storedRef.conversation);
     expect(storedConversation.id).toBe("19:team-channel@thread.tacv2");
     expect(storedConversation.tenantId).toBe("tenant-from-channel-data");
+  });
+
+  it("does not persist blocked serviceUrl hosts in conversation references", async () => {
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "allowlist",
+          allowFrom: ["sender-aad"],
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-blocked-service-url",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "sender-id",
+          aadObjectId: "sender-aad",
+          name: "Sender",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "a:personal-chat",
+          conversationType: "personal",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://attacker.example.com/teams/",
+        channelData: {},
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(conversationStore.upsert).toHaveBeenCalledTimes(1);
+    const storedRef = recordFromMockCall(mockCallArg(conversationStore.upsert, 0, 1));
+    expect("serviceUrl" in storedRef).toBe(false);
   });
 
   it("stores no tenantId when channelData.tenant is missing", async () => {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -26,6 +26,7 @@ import {
   summarizeMSTeamsHtmlAttachments,
 } from "../attachments.js";
 import { isRecord } from "../attachments/shared.js";
+import { tryNormalizeBotFrameworkServiceUrl } from "../bot-framework-service-url.js";
 import type { StoredConversationReference } from "../conversation-store.js";
 import { formatUnknownError } from "../errors.js";
 import {
@@ -154,6 +155,7 @@ function buildStoredConversationReference(params: {
   const channelDataTenantId = activity.channelData?.tenant?.id;
   const tenantId = channelDataTenantId ?? conversation?.tenantId;
   const aadObjectId = from?.aadObjectId;
+  const serviceUrl = tryNormalizeBotFrameworkServiceUrl(activity.serviceUrl);
   return {
     activityId: activity.id,
     user: from ? { id: from.id, name: from.name, aadObjectId: from.aadObjectId } : undefined,
@@ -168,7 +170,7 @@ function buildStoredConversationReference(params: {
     ...(aadObjectId ? { aadObjectId } : {}),
     teamId,
     channelId: activity.channelId,
-    serviceUrl: activity.serviceUrl,
+    ...(serviceUrl ? { serviceUrl } : {}),
     locale: activity.locale,
     ...(clientInfo?.timezone ? { timezone: clientInfo.timezone } : {}),
     ...(threadId ? { threadId } : {}),

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -1,6 +1,11 @@
 import * as fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BOT_FRAMEWORK_SERVICE_URL_SSRF_POLICY,
+  isAllowedBotFrameworkServiceUrl,
+  normalizeBotFrameworkServiceUrl,
+} from "./bot-framework-service-url.js";
+import {
   createBotFrameworkJwtValidator,
   createMSTeamsAdapter,
   createMSTeamsApp,
@@ -12,6 +17,15 @@ import type {
   MSTeamsFederatedCredentials,
 } from "./token.js";
 
+const fetchGuardState = vi.hoisted(() => ({
+  calls: [] as Array<{
+    url: string;
+    init?: RequestInit;
+    auditContext?: string;
+    policy?: unknown;
+  }>,
+}));
+
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
     "openclaw/plugin-sdk/ssrf-runtime",
@@ -22,11 +36,16 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
       url: string;
       init?: RequestInit;
       fetchImpl?: typeof fetch;
-    }) => ({
-      response: await (params.fetchImpl ?? fetch)(params.url, params.init),
-      finalUrl: params.url,
-      release: async () => {},
-    }),
+      auditContext?: string;
+      policy?: unknown;
+    }) => {
+      fetchGuardState.calls.push(params);
+      return {
+        response: await (params.fetchImpl ?? fetch)(params.url, params.init),
+        finalUrl: params.url,
+        release: async () => {},
+      };
+    },
   };
 });
 
@@ -108,6 +127,7 @@ const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  fetchGuardState.calls.length = 0;
   clientConstructorState.calls.length = 0;
   jwtState.verifyCalls.length = 0;
   jwtState.verifyBehavior = "success";
@@ -186,6 +206,29 @@ function readFirstCreatedActivity(createFn: ReturnType<typeof vi.fn>): {
   return activity as { type?: string; text?: string };
 }
 
+describe("Bot Framework serviceUrl allowlist", () => {
+  it("allows documented Teams service hosts and normalizes trailing slashes", () => {
+    expect(isAllowedBotFrameworkServiceUrl("https://smba.trafficmanager.net/amer/")).toBe(true);
+    expect(
+      isAllowedBotFrameworkServiceUrl("https://smba.infra.gcc.teams.microsoft.com/teams/"),
+    ).toBe(true);
+    expect(
+      isAllowedBotFrameworkServiceUrl("https://smba.infra.gov.teams.microsoft.us/teams/"),
+    ).toBe(true);
+    expect(normalizeBotFrameworkServiceUrl("https://smba.trafficmanager.net/amer/")).toBe(
+      "https://smba.trafficmanager.net/amer",
+    );
+  });
+
+  it("rejects non-HTTPS and non-Microsoft service hosts", () => {
+    expect(isAllowedBotFrameworkServiceUrl("http://smba.trafficmanager.net/amer/")).toBe(false);
+    expect(isAllowedBotFrameworkServiceUrl("https://attacker.example.com/teams/")).toBe(false);
+    expect(() => normalizeBotFrameworkServiceUrl("https://attacker.example.com/teams/")).toThrow(
+      /Blocked Microsoft Teams serviceUrl host: attacker\.example\.com/,
+    );
+  });
+});
+
 describe("createMSTeamsApp", () => {
   it("creates app without the Express 5 wildcard route regression (#55161)", async () => {
     // Regression test for: https://github.com/openclaw/openclaw/issues/55161
@@ -230,7 +273,7 @@ describe("createMSTeamsAdapter", () => {
     await adapter.continueConversation(
       creds.appId,
       {
-        serviceUrl: "https://example.com/",
+        serviceUrl: "https://smba.trafficmanager.net/amer/",
         conversation: { id: "19:conversation@thread.tacv2" },
         channelId: "msteams",
       },
@@ -242,10 +285,11 @@ describe("createMSTeamsAdapter", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, options] = readFirstFetchCall(fetchMock);
     expect(url).toBe(
-      "https://example.com/v3/conversations/19%3Aconversation%40thread.tacv2/activities/activity-123",
+      "https://smba.trafficmanager.net/amer/v3/conversations/19%3Aconversation%40thread.tacv2/activities/activity-123",
     );
     expect(options.method).toBe("DELETE");
     expect(options.headers?.Authorization).toBe("Bearer bot-token");
+    expect(fetchGuardState.calls[0]?.policy).toEqual(BOT_FRAMEWORK_SERVICE_URL_SSRF_POLICY);
   });
 
   it("passes the OpenClaw User-Agent to the Bot Framework connector client", async () => {
@@ -266,7 +310,7 @@ describe("createMSTeamsAdapter", () => {
     await adapter.continueConversation(
       creds.appId,
       {
-        serviceUrl: "https://service.example.com/",
+        serviceUrl: "https://smba.trafficmanager.net/amer/",
         conversation: { id: "19:conversation@thread.tacv2" },
         channelId: "msteams",
       },
@@ -277,7 +321,7 @@ describe("createMSTeamsAdapter", () => {
 
     expect(clientConstructorState.calls).toHaveLength(1);
     const clientCall = clientConstructorState.calls[0];
-    expect(clientCall?.serviceUrl).toBe("https://service.example.com/");
+    expect(clientCall?.serviceUrl).toBe("https://smba.trafficmanager.net/amer");
     const options = clientCall?.options as { headers?: { "User-Agent"?: string } } | undefined;
     expect(options?.headers?.["User-Agent"]).toMatch(/^teams\.ts\[apps\]\/.+ OpenClaw\/.+$/);
   });
@@ -619,6 +663,12 @@ function makeFakeApiSdk() {
   };
 }
 
+type TestSendContext = {
+  sendActivity: (textOrActivity: string | object) => Promise<unknown>;
+  updateActivity: (activityUpdate: object) => Promise<{ id?: string } | void>;
+  deleteActivity: (activityId: string) => Promise<void>;
+};
+
 describe("createMSTeamsAdapter – continueConversation", () => {
   const originalFetch = globalThis.fetch;
 
@@ -647,6 +697,30 @@ describe("createMSTeamsAdapter – continueConversation", () => {
     expect(activity.text).toBe("hello from proactive send");
   });
 
+  it("rejects blocked proactive serviceUrl before token lookup or send", async () => {
+    const { sdk, createFn } = makeFakeApiSdk();
+    const app = makeFakeApp();
+    const adapter = createMSTeamsAdapter(app, sdk);
+
+    await expect(
+      adapter.continueConversation(
+        "app-id",
+        {
+          serviceUrl: "https://attacker.example.com/teams/",
+          conversation: { id: "conv-123", conversationType: "personal" },
+          channelId: "msteams",
+        },
+        async (ctx) => {
+          await ctx.sendActivity("should not send");
+        },
+      ),
+    ).rejects.toThrow(/Blocked Microsoft Teams serviceUrl host: attacker\.example\.com/);
+
+    expect(app.getBotToken).not.toHaveBeenCalled();
+    expect(createFn).not.toHaveBeenCalled();
+    expect(fetchGuardState.calls).toHaveLength(0);
+  });
+
   it("provides deleteActivity via REST DELETE in logic callback", async () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     globalThis.fetch = mockFetch;
@@ -668,6 +742,38 @@ describe("createMSTeamsAdapter – continueConversation", () => {
     expect(url).toContain("/v3/conversations/conv-456/activities/activity-789");
     expect(opts.method).toBe("DELETE");
     expect(opts.headers.Authorization).toBe("Bearer fake-bot-token");
+    expect(fetchGuardState.calls[0]?.policy).toEqual(BOT_FRAMEWORK_SERVICE_URL_SSRF_POLICY);
+  });
+
+  it("passes the serviceUrl allowlist to updateActivity REST calls", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "activity-789" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = mockFetch;
+    const { sdk } = makeFakeApiSdk();
+    const adapter = createMSTeamsAdapter(makeFakeApp(), sdk);
+
+    await adapter.continueConversation(
+      "app-id",
+      {
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+        conversation: { id: "conv-456", conversationType: "personal" },
+        channelId: "msteams",
+      },
+      async (ctx) => {
+        await ctx.updateActivity({ id: "activity-789", text: "edited" });
+      },
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = readFirstFetchCall(mockFetch);
+    expect(url).toContain("/v3/conversations/conv-456/activities/activity-789");
+    expect(opts.method).toBe("PUT");
+    expect(opts.headers.Authorization).toBe("Bearer fake-bot-token");
+    expect(fetchGuardState.calls[0]?.policy).toEqual(BOT_FRAMEWORK_SERVICE_URL_SSRF_POLICY);
   });
 
   it("throws when serviceUrl is missing", async () => {
@@ -686,7 +792,7 @@ describe("createMSTeamsAdapter – continueConversation", () => {
     await expect(
       adapter.continueConversation(
         "app-id",
-        { serviceUrl: "https://example.com" } as any,
+        { serviceUrl: "https://smba.trafficmanager.net/teams" } as any,
         async () => {},
       ),
     ).rejects.toThrow(/Missing conversation\.id/);
@@ -694,6 +800,47 @@ describe("createMSTeamsAdapter – continueConversation", () => {
 });
 
 describe("createMSTeamsAdapter – process", () => {
+  it.each([
+    ["sendActivity", async (ctx: TestSendContext) => await ctx.sendActivity("blocked")],
+    [
+      "updateActivity",
+      async (ctx: TestSendContext) => await ctx.updateActivity({ id: "activity-1" }),
+    ],
+    ["deleteActivity", async (ctx: TestSendContext) => await ctx.deleteActivity("activity-1")],
+  ])("blocks inbound %s serviceUrls before token lookup or fetch", async (_name, run) => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = mockFetch;
+    const { sdk, createFn } = makeFakeApiSdk();
+    const app = makeFakeApp();
+    const adapter = createMSTeamsAdapter(app, sdk);
+
+    const sendFn = vi.fn();
+    const res = { status: vi.fn(() => ({ send: sendFn })) };
+
+    await adapter.process(
+      {
+        body: {
+          id: "activity-1",
+          type: "message",
+          text: "hi",
+          serviceUrl: "https://attacker.example.com/teams/",
+          conversation: { id: "conv-123", conversationType: "personal" },
+          recipient: { id: "bot-id", name: "Bot" },
+        },
+      },
+      res,
+      async (ctx) => {
+        await run(ctx as TestSendContext);
+      },
+    );
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(app.getBotToken).not.toHaveBeenCalled();
+    expect(createFn).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(fetchGuardState.calls).toHaveLength(0);
+  });
+
   it("sends 200 for normal message activities", async () => {
     const { sdk } = makeFakeApiSdk();
     const adapter = createMSTeamsAdapter(makeFakeApp(), sdk);

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -4,6 +4,11 @@ import * as fs from "node:fs";
 import type { IHttpServerAdapter } from "@microsoft/teams.apps/dist/http/index.js";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  BOT_FRAMEWORK_SERVICE_URL_SSRF_POLICY,
+  normalizeBotFrameworkServiceUrl,
+  tryNormalizeBotFrameworkServiceUrl,
+} from "./bot-framework-service-url.js";
 import { formatUnknownError } from "./errors.js";
 import type { MSTeamsAdapter } from "./messenger.js";
 import type { MSTeamsCredentials, MSTeamsFederatedCredentials } from "./token.js";
@@ -263,7 +268,8 @@ function createApiClient(
   serviceUrl: string,
   getToken: () => Promise<string | undefined>,
 ) {
-  return new sdk.Client(serviceUrl, {
+  const normalizedServiceUrl = normalizeBotFrameworkServiceUrl(serviceUrl);
+  return new sdk.Client(normalizedServiceUrl, {
     token: async () => (await getToken()) || undefined,
     headers: { "User-Agent": buildUserAgent() },
   } as Record<string, unknown>);
@@ -295,9 +301,10 @@ function createSendContext(params: {
   /** Target user's Azure AD object ID; included as the recipient on personal DMs. */
   recipientAadObjectId?: string;
 }): MSTeamsSendContext {
+  const normalizedServiceUrl = tryNormalizeBotFrameworkServiceUrl(params.serviceUrl);
   const apiClient =
-    params.serviceUrl && params.conversationId
-      ? createApiClient(params.sdk, params.serviceUrl, params.getToken)
+    normalizedServiceUrl && params.conversationId
+      ? createApiClient(params.sdk, normalizedServiceUrl, params.getToken)
       : undefined;
 
   return {
@@ -305,6 +312,9 @@ function createSendContext(params: {
       const msg = normalizeOutboundActivity(textOrActivity);
       if (params.treatInvokeResponseAsNoop && msg.type === "invokeResponse") {
         return { id: "invokeResponse" };
+      }
+      if (params.serviceUrl && !normalizedServiceUrl) {
+        normalizeBotFrameworkServiceUrl(params.serviceUrl);
       }
       if (!apiClient || !params.conversationId) {
         return { id: "unknown" };
@@ -368,8 +378,9 @@ function createSendContext(params: {
       if (!params.serviceUrl || !params.conversationId) {
         return { id: "unknown" };
       }
+      const serviceUrl = normalizeBotFrameworkServiceUrl(params.serviceUrl);
       return await updateActivityViaRest({
-        serviceUrl: params.serviceUrl,
+        serviceUrl,
         conversationId: params.conversationId,
         activityId,
         activity: nextActivity,
@@ -384,8 +395,9 @@ function createSendContext(params: {
       if (!params.serviceUrl || !params.conversationId) {
         return;
       }
+      const serviceUrl = normalizeBotFrameworkServiceUrl(params.serviceUrl);
       await deleteActivityViaRest({
-        serviceUrl: params.serviceUrl,
+        serviceUrl,
         conversationId: params.conversationId,
         activityId,
         token: await params.getToken(),
@@ -449,7 +461,7 @@ async function updateActivityViaRest(params: {
   token?: string;
 }): Promise<{ id?: string }> {
   const { serviceUrl, conversationId, activityId, activity, token } = params;
-  const baseUrl = serviceUrl.replace(/\/+$/, "");
+  const baseUrl = normalizeBotFrameworkServiceUrl(serviceUrl);
   const url = `${baseUrl}/v3/conversations/${encodeURIComponent(conversationId)}/activities/${encodeURIComponent(activityId)}`;
 
   const headers: Record<string, string> = {
@@ -474,6 +486,7 @@ async function updateActivityViaRest(params: {
       }),
     },
     auditContext: "msteams-update-activity",
+    policy: BOT_FRAMEWORK_SERVICE_URL_SSRF_POLICY,
   });
 
   try {
@@ -501,7 +514,7 @@ async function deleteActivityViaRest(params: {
   token?: string;
 }): Promise<void> {
   const { serviceUrl, conversationId, activityId, token } = params;
-  const baseUrl = serviceUrl.replace(/\/+$/, "");
+  const baseUrl = normalizeBotFrameworkServiceUrl(serviceUrl);
   const url = `${baseUrl}/v3/conversations/${encodeURIComponent(conversationId)}/activities/${encodeURIComponent(activityId)}`;
 
   const headers: Record<string, string> = {
@@ -520,6 +533,7 @@ async function deleteActivityViaRest(params: {
       headers,
     },
     auditContext: "msteams-delete-activity",
+    policy: BOT_FRAMEWORK_SERVICE_URL_SSRF_POLICY,
   });
 
   try {
@@ -545,10 +559,11 @@ async function deleteActivityViaRest(params: {
 export function createMSTeamsAdapter(app: MSTeamsApp, sdk: MSTeamsTeamsSdk): MSTeamsAdapter {
   return {
     async continueConversation(_appId, reference, logic) {
-      const serviceUrl = reference.serviceUrl;
-      if (!serviceUrl) {
+      const rawServiceUrl = reference.serviceUrl;
+      if (!rawServiceUrl) {
         throw new Error("Missing serviceUrl in conversation reference");
       }
+      const serviceUrl = normalizeBotFrameworkServiceUrl(rawServiceUrl);
 
       const conversationId = reference.conversation?.id;
       if (!conversationId) {

--- a/extensions/msteams/src/send-context.test.ts
+++ b/extensions/msteams/src/send-context.test.ts
@@ -1,7 +1,34 @@
-import { describe, expect, it } from "vitest";
-import type { MSTeamsConfig } from "../runtime-api.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MSTeamsConfig, OpenClawConfig } from "../runtime-api.js";
 import type { StoredConversationReference } from "./conversation-store.js";
-import { resolveMSTeamsProactiveReplyStyle } from "./send-context.js";
+import { resolveMSTeamsProactiveReplyStyle, resolveMSTeamsSendContext } from "./send-context.js";
+
+const sendContextMockState = vi.hoisted(() => {
+  const store = {
+    upsert: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    remove: vi.fn(),
+    findPreferredDmByUserId: vi.fn(),
+    findByUserId: vi.fn(),
+  };
+  return {
+    store,
+    logWarn: vi.fn(),
+  };
+});
+
+vi.mock("./conversation-store-fs.js", () => ({
+  createMSTeamsConversationStoreFs: () => sendContextMockState.store,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getMSTeamsRuntime: () => ({
+    logging: {
+      getChildLogger: () => ({ warn: sendContextMockState.logWarn }),
+    },
+  }),
+}));
 
 function channelRef(params?: Partial<StoredConversationReference>): StoredConversationReference {
   return {
@@ -13,6 +40,49 @@ function channelRef(params?: Partial<StoredConversationReference>): StoredConver
     ...params,
   };
 }
+
+beforeEach(() => {
+  sendContextMockState.store.upsert.mockReset();
+  sendContextMockState.store.get.mockReset();
+  sendContextMockState.store.list.mockReset();
+  sendContextMockState.store.remove.mockReset();
+  sendContextMockState.store.findPreferredDmByUserId.mockReset();
+  sendContextMockState.store.findByUserId.mockReset();
+  sendContextMockState.logWarn.mockReset();
+});
+
+describe("resolveMSTeamsSendContext", () => {
+  it("removes stored conversation references with blocked serviceUrl hosts", async () => {
+    sendContextMockState.store.get.mockResolvedValue(
+      channelRef({
+        serviceUrl: "https://attacker.example.com/teams/",
+      }),
+    );
+    sendContextMockState.store.remove.mockResolvedValue(true);
+
+    const cfg = {
+      channels: {
+        msteams: {
+          enabled: true,
+          appId: "app-id",
+          appPassword: "app-password",
+          tenantId: "tenant-id",
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      resolveMSTeamsSendContext({
+        cfg,
+        to: "conversation:19:channel@thread.tacv2",
+      }),
+    ).rejects.toThrow(
+      /Stored Microsoft Teams conversation reference has blocked serviceUrl host: attacker\.example\.com/,
+    );
+
+    expect(sendContextMockState.store.remove).toHaveBeenCalledWith("19:channel@thread.tacv2");
+  });
+});
 
 describe("resolveMSTeamsProactiveReplyStyle", () => {
   it("uses thread for channel conversations with a stored thread root", () => {

--- a/extensions/msteams/src/send-context.ts
+++ b/extensions/msteams/src/send-context.ts
@@ -7,6 +7,11 @@ import {
   type PluginRuntime,
 } from "../runtime-api.js";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
+import {
+  describeBotFrameworkServiceUrlHost,
+  isAllowedBotFrameworkServiceUrl,
+  normalizeBotFrameworkServiceUrl,
+} from "./bot-framework-service-url.js";
 import { createMSTeamsConversationStoreFs } from "./conversation-store-fs.js";
 import type {
   MSTeamsConversationStore,
@@ -161,13 +166,35 @@ export async function resolveMSTeamsSendContext(params: {
   }
 
   const { conversationId, ref } = found;
+  const core = getMSTeamsRuntime();
+  const log = core.logging.getChildLogger({ name: "msteams:send" });
+
+  if (ref.serviceUrl && !isAllowedBotFrameworkServiceUrl(ref.serviceUrl)) {
+    try {
+      await store.remove(conversationId);
+    } catch (err) {
+      log.warn?.("failed to remove blocked msteams conversation reference", {
+        conversationId,
+        error: formatUnknownError(err),
+      });
+    }
+    throw new Error(
+      `Stored Microsoft Teams conversation reference has blocked serviceUrl host: ${describeBotFrameworkServiceUrlHost(ref.serviceUrl)}. ` +
+        `The bot must receive a new message from this conversation before it can send proactively.`,
+    );
+  }
+  const safeRef = ref.serviceUrl
+    ? { ...ref, serviceUrl: normalizeBotFrameworkServiceUrl(ref.serviceUrl) }
+    : ref;
 
   // Safety check: when the caller targeted a specific user (DM), verify the
   // resolved conversation is actually a personal DM.  Without this guard a
   // stale or mismatched conversation store could route a private DM reply
   // into a shared channel or group chat -- see #54520.
   if (recipient.type === "user") {
-    const resolvedType = normalizeLowercaseStringOrEmpty(ref.conversation?.conversationType ?? "");
+    const resolvedType = normalizeLowercaseStringOrEmpty(
+      safeRef.conversation?.conversationType ?? "",
+    );
     if (resolvedType && resolvedType !== "personal") {
       throw new Error(
         `Conversation reference for user:${recipient.id} resolved to a ${resolvedType} ` +
@@ -176,8 +203,6 @@ export async function resolveMSTeamsSendContext(params: {
       );
     }
   }
-  const core = getMSTeamsRuntime();
-  const log = core.logging.getChildLogger({ name: "msteams:send" });
 
   const { sdk, app } = await loadMSTeamsSdkWithAuth(creds);
   const adapter = createMSTeamsAdapter(app, sdk);
@@ -187,7 +212,7 @@ export async function resolveMSTeamsSendContext(params: {
 
   // Determine conversation type from stored reference
   const storedConversationType = normalizeLowercaseStringOrEmpty(
-    ref.conversation?.conversationType ?? "",
+    safeRef.conversation?.conversationType ?? "",
   );
   let conversationType: MSTeamsConversationType;
   if (storedConversationType === "personal") {
@@ -201,7 +226,7 @@ export async function resolveMSTeamsSendContext(params: {
   const replyStyle = resolveMSTeamsProactiveReplyStyle({
     cfg: msteamsCfg,
     conversationId,
-    ref,
+    ref: safeRef,
     conversationType,
   });
 
@@ -219,13 +244,13 @@ export async function resolveMSTeamsSendContext(params: {
   // be used directly with Graph /chats/{chatId} endpoints — the Graph API requires the
   // `19:xxx@thread.tacv2` or `19:xxx@unq.gbl.spaces` format.
   // We check the cached value first, then resolve via Graph API and cache for future sends.
-  let graphChatId: string | null | undefined = ref.graphChatId ?? undefined;
+  let graphChatId: string | null | undefined = safeRef.graphChatId ?? undefined;
   if (graphChatId === undefined && sharePointSiteId) {
     // Only resolve when SharePoint is configured (the only place chatId matters currently)
     try {
       const resolved = await resolveGraphChatId({
         botFrameworkConversationId: conversationId,
-        userAadObjectId: ref.user?.aadObjectId,
+        userAadObjectId: safeRef.user?.aadObjectId,
         tokenProvider,
       });
       graphChatId = resolved;
@@ -235,7 +260,7 @@ export async function resolveMSTeamsSendContext(params: {
       // (network, 401, rate limit) should be retried on subsequent sends rather than
       // permanently blocking file uploads for this conversation.
       if (resolved) {
-        await store.upsert(conversationId, { ...ref, graphChatId: resolved });
+        await store.upsert(conversationId, { ...safeRef, graphChatId: resolved });
       } else {
         log.warn?.("could not resolve Graph chat ID; file uploads may fail for this conversation", {
           conversationId,
@@ -256,7 +281,7 @@ export async function resolveMSTeamsSendContext(params: {
   return {
     appId: creds.appId,
     conversationId,
-    ref,
+    ref: safeRef,
     adapter: adapter as unknown as MSTeamsAdapter,
     log,
     conversationType,


### PR DESCRIPTION
## Summary

Block Microsoft Teams Bot Framework outbound activity requests from using connector credentials with untrusted `serviceUrl` hosts.

## Changes

- Add a Teams Bot Framework `serviceUrl` allowlist and matching SSRF policy for documented Microsoft Teams connector hosts.
- Validate `serviceUrl` before constructing the Teams API client or sending update/delete REST calls with Bot Framework tokens.
- Stop persisting blocked inbound `serviceUrl` values and remove blocked stored proactive references before reuse.
- Add regression coverage for send, update, delete, stored-reference cleanup, and valid-host guard policy behavior.

## Validation

Behavior addressed: Teams outbound send/update/delete paths no longer attach Bot Framework credentials to non-allowlisted `serviceUrl` hosts.

Real environment tested: Local Linux source checkout; Crabbox/Testbox remote proof was unavailable because no working `crabbox` binary is installed in this container.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs extensions/msteams/src/sdk.test.ts extensions/msteams/src/send-context.test.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`
- `corepack pnpm check:changed`
- `node scripts/run-vitest.mjs extensions/msteams`

Evidence after fix: Targeted Teams tests passed with 3 files / 62 tests; local changed check passed; full `extensions/msteams` Vitest lane passed with 66 files / 924 tests.

Observed result after fix: Blocked `serviceUrl` hosts reject before token lookup or fetch; valid Microsoft Teams service URLs still send through the guarded connector path.

What was not tested: Live Microsoft Teams tenant traffic and remote Crabbox/Testbox proof.

## Notes

- AI-assisted with Codex.
- No `CHANGELOG.md` update.
- No exploit walkthrough or advisory details are included in this public PR body.
