### PR TITLE
fix(usage): return all agent sessions when no agentId specified

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -213,28 +213,36 @@ describe("sessions.usage", () => {
   });
 
   it("loads selected session summaries concurrently and reports cache refresh status", async () => {
-    vi.mocked(discoverAllSessions).mockResolvedValueOnce([
-      {
-        sessionId: "s-a",
-        sessionFile: "/tmp/agents/main/sessions/s-a.jsonl",
-        mtime: 300,
-      },
-      {
-        sessionId: "s-b",
-        sessionFile: "/tmp/agents/main/sessions/s-b.jsonl",
-        mtime: 200,
-      },
-      {
-        sessionId: "s-c",
-        sessionFile: "/tmp/agents/main/sessions/s-c.jsonl",
-        mtime: 100,
-      },
-    ]);
+    vi.mocked(discoverAllSessions)
+      .mockResolvedValueOnce([
+        {
+          sessionId: "s-a",
+          sessionFile: "/tmp/agents/main/sessions/s-a.jsonl",
+          mtime: 300,
+        },
+        {
+          sessionId: "s-b",
+          sessionFile: "/tmp/agents/main/sessions/s-b.jsonl",
+          mtime: 200,
+        },
+        {
+          sessionId: "s-c",
+          sessionFile: "/tmp/agents/main/sessions/s-c.jsonl",
+          mtime: 100,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          sessionId: "s-opus",
+          sessionFile: "/tmp/agents/opus/sessions/s-opus.jsonl",
+          mtime: 50,
+        },
+      ]);
     const pending: Array<{
       sessionId?: string;
       resolve: (value: Awaited<ReturnType<typeof loadSessionCostSummaryFromCache>>) => void;
     }> = [];
-    for (let i = 0; i < 3; i += 1) {
+    for (let i = 0; i < 4; i += 1) {
       vi.mocked(loadSessionCostSummaryFromCache).mockImplementationOnce(
         async ({ sessionId }) =>
           await new Promise<Awaited<ReturnType<typeof loadSessionCostSummaryFromCache>>>(
@@ -247,10 +255,10 @@ describe("sessions.usage", () => {
 
     const respondPromise = runSessionsUsage({ ...BASE_USAGE_RANGE, limit: 3 });
     await vi.waitFor(() =>
-      expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledTimes(3),
+      expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledTimes(4),
     );
     for (const item of pending) {
-      const tokens = item.sessionId === "s-a" ? 10 : item.sessionId === "s-b" ? 20 : 30;
+      const tokens = item.sessionId === "s-a" ? 10 : item.sessionId === "s-b" ? 20 : item.sessionId === "s-c" ? 30 : 40;
       item.resolve({
         summary: {
           input: tokens,
@@ -282,8 +290,8 @@ describe("sessions.usage", () => {
       totals: { totalTokens: number };
     };
     expect(result.cacheStatus?.status).toBe("refreshing");
-    expect(result.sessions.map((session) => session.sessionId)).toEqual(["s-a", "s-b", "s-c"]);
-    expect(result.totals.totalTokens).toBe(60);
+    expect(result.sessions.map((session) => session.sessionId)).toEqual(["s-a", "s-b", "s-c", "s-opus"]);
+    expect(result.totals.totalTokens).toBe(100);
   });
 
   it("discovers usage for requested disk-only agents not listed in config", async () => {

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -176,22 +176,22 @@ describe("sessions.usage", () => {
     vi.clearAllMocks();
   });
 
-  it("defaults list-style usage queries without agentId to the default agent", async () => {
+  it("returns all agent sessions when no agentId specified", async () => {
     const respond = await runSessionsUsage(BASE_USAGE_RANGE);
 
     expect(vi.mocked(loadCombinedSessionStoreForGateway)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      { agentId: "main" },
+      {},
     );
-    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(1);
-    expect((mockArg(vi.mocked(discoverAllSessions), 0, 0) as { agentId?: string }).agentId).toBe(
-      "main",
-    );
+    // Should discover sessions for all configured agents (main, opus)
+    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
 
     const sessions = expectSuccessfulSessionsUsage(respond);
-    expect(sessions).toHaveLength(1);
-    expect(sessions[0].key).toBe("agent:main:s-main");
-    expect(sessions[0].agentId).toBe("main");
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].key).toBe("agent:opus:s-opus");
+    expect(sessions[0].agentId).toBe("opus");
+    expect(sessions[1].key).toBe("agent:main:s-main");
+    expect(sessions[1].agentId).toBe("main");
   });
 
   it("uses the requested agent for list-style usage queries", async () => {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -897,13 +897,16 @@ export const usageHandlers: GatewayRequestHandlers = {
 
     // Optimization: If a specific key is requested, skip full directory scan
     if (specificKey) {
+      // When specificKey is provided, effectiveAgentId is guaranteed to be a string
+      // (either from requestedAgentId, specificKeyAgentId, or resolveDefaultAgentId)
+      const effectiveAgentIdForKey = effectiveAgentId as string;
       const scopedSpecificKey = resolveStoredSessionKeyForAgentStore({
         cfg: config,
-        agentId: effectiveAgentId,
+        agentId: effectiveAgentIdForKey,
         sessionKey: specificKey,
       });
       const scopedParsed = parseAgentSessionKey(scopedSpecificKey);
-      const agentIdFromKey = scopedParsed?.agentId ?? effectiveAgentId;
+      const agentIdFromKey: string = scopedParsed?.agentId ?? effectiveAgentIdForKey;
       const keyRest = scopedParsed?.rest ?? specificKey;
 
       // Prefer the store entry when available, even if the caller provides a discovered key

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -874,9 +874,13 @@ export const usageHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const effectiveAgentId = normalizeAgentId(
-      requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config),
-    );
+    const effectiveAgentId: string | undefined = requestedAgentId
+      ? normalizeAgentId(requestedAgentId)
+      : specificKeyAgentId
+        ? normalizeAgentId(specificKeyAgentId)
+        : specificKey
+          ? normalizeAgentId(resolveDefaultAgentId(config))
+          : undefined;
     const groupingMode: UsageGroupingMode =
       p.groupBy === "family" || p.includeHistorical === true ? "family" : "instance";
 
@@ -884,11 +888,9 @@ export const usageHandlers: GatewayRequestHandlers = {
     const { storePath, store } = loadCombinedSessionStoreForGateway(config, {
       agentId: effectiveAgentId,
     });
-    const scopedStore = filterSessionStoreByAgent({
-      config,
-      store,
-      agentId: effectiveAgentId,
-    });
+    const scopedStore = effectiveAgentId
+      ? filterSessionStoreByAgent({ config, store, agentId: effectiveAgentId })
+      : store;
     const now = Date.now();
 
     const mergedEntries: MergedEntry[] = [];


### PR DESCRIPTION
## Summary

Fixes #87132.

When no  is specified in the  request, the backend previously defaulted to returning only the default agent's sessions (usually "main"). This caused the Web UI's agent filter to only show main agent sessions, making it impossible to filter by other agents.

## Changes

- When  is omitted and no specific session key is provided,  is now  instead of defaulting to the configured default agent
- When  is undefined, skip the  step so all agents' sessions are returned
- Updated test to verify that sessions from all configured agents are returned when no agentId is specified

## Test Plan

- Updated existing test to expect all agent sessions returned when no agentId is specified
- Verified existing tests for specific agentId filtering still pass

Issue: https://github.com/openclaw/openclaw/issues/87132