### PR TITLE
docs(gateway): troubleshoot macOS Maintenance Sleep / ENETDOWN / launchd silent-park

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -454,6 +454,53 @@ Related:
 - [Configuration](/gateway/configuration)
 - [Doctor](/gateway/doctor)
 
+## macOS: gateway silently stops responding, then resumes when you touch the dashboard
+
+Use this when channels (Telegram, WhatsApp, etc.) on a macOS host go quiet for minutes to hours at a time, and the gateway appears to "come back" the moment you open the Control UI, SSH in, or otherwise interact with the host. There is usually no obvious symptom in `openclaw status` because by the time you look the gateway is alive again.
+
+```bash
+ls ~/.openclaw/logs/stability/ | tail -5
+openclaw gateway stability --bundle latest
+pmset -g log | grep -iE "sleep|wake|maintenance" | tail -50
+launchctl print gui/$UID/ai.openclaw.gateway | grep -E "state|last exit|runs"
+```
+
+Look for:
+
+- One or more `*-uncaught_exception.json` bundles in `~/.openclaw/logs/stability/` with `error.code` set to a transient network code such as `ENETDOWN`, `ENETUNREACH`, `EHOSTUNREACH`, or `ECONNREFUSED`.
+- `pmset -g log` lines like `Entering Sleep state due to 'Maintenance Sleep'` or `en0 driver is slow (msg: WillChangeState to 0)` aligned with the crash timestamps. Power Nap / Maintenance Sleep briefly puts the Wi-Fi driver into state 0; any outbound `connect()` that lands in that window can fail with `ENETDOWN` even on a host that otherwise has full network connectivity.
+- `launchctl print` output showing `state = not running` with multiple recent `runs` and an exit code, especially when the gap between crash and the next launch is on the order of an hour rather than seconds. macOS launchd applies an undocumented respawn-protection gate after a crash burst that can stop honoring `KeepAlive=true` until an external trigger (interactive login, dashboard connection, `launchctl kickstart`) re-arms it.
+
+Common signatures:
+
+- A stability bundle whose `error.code` is `ENETDOWN` (or sibling code) with the call stack pointing into Node's `net` `lookupAndConnect` / `Socket.connect` path. Recent OpenClaw releases classify these as benign transient network errors so they no longer propagate to the top-level uncaught handler; if you are on an older release, upgrade first.
+- Long quiet periods that end the instant you connect to the Control UI or SSH into the host: the user-visible activity is what re-arms launchd's respawn gate, not anything the dashboard does to the gateway.
+- `runs` count incrementing across the day with no corresponding `received SIG*; shutting down` line in `~/Library/Logs/openclaw/gateway.log`: clean shutdowns log a signal; transient crashes do not.
+
+What to do:
+
+1. **Upgrade the gateway** if you are running a release before the transient network code classification landed for `ENETDOWN`. After upgrading, future `ENETDOWN` errors are logged as warnings instead of terminating the process.
+2. **Reduce maintenance sleep activity** on Mac mini / desktop hosts that are meant to run as always-on servers:
+   ```bash
+   sudo pmset -a sleep 0 disksleep 0 standby 0 powernap 0
+   ```
+   This significantly reduces (but does not entirely eliminate) the underlying driver flap. The system can still perform some maintenance sleeps for TCP keepalive and mDNS upkeep regardless of these flags.
+3. **Add a liveness watchdog** so a future crash burst that gets parked by launchd is caught quickly:
+   ```bash
+   # Example launchd-aware liveness check, suitable for a 5-minute cron or LaunchAgent
+   state=$(launchctl print gui/$UID/ai.openclaw.gateway 2>/dev/null | awk -F'= ' '/state =/ {print $2; exit}')
+   if [ "$state" != "running" ]; then
+     launchctl kickstart -k gui/$UID/ai.openclaw.gateway
+   fi
+   ```
+   The point is to externally re-arm the respawn gate; `KeepAlive=true` alone is not sufficient on macOS after a crash burst.
+
+Related:
+
+- [macOS platform notes](/platforms/macos)
+- [Logging](/logging)
+- [Doctor](/gateway/doctor)
+
 ## Gateway exits during high memory use
 
 Use this when the Gateway disappears under load, the supervisor reports an OOM-style restart, or logs mention `critical memory pressure bundle written`.

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -47,6 +47,8 @@ Replace the label with `ai.openclaw.<profile>` when running a named profile.
 If the LaunchAgent isn't installed, enable it from the app or run
 `openclaw gateway install`.
 
+If the gateway is repeatedly disappearing for minutes to hours at a time and only resumes when you touch the Control UI or SSH into the host, see the troubleshooting note for macOS Maintenance Sleep / `ENETDOWN` crashes and launchd's respawn-protection gate in [Gateway troubleshooting](/gateway/troubleshooting#macos-gateway-silently-stops-responding-then-resumes-when-you-touch-the-dashboard).
+
 ## Node capabilities (mac)
 
 The macOS app presents itself as a node. Common commands:


### PR DESCRIPTION
## Summary

Adds a troubleshooting section to `docs/gateway/troubleshooting.md` for the symptom pattern that prompted #86688: on a macOS host, the gateway goes silent on all channels (Telegram, WhatsApp, etc.) for minutes to hours at a time, and only resumes when the operator opens the Control UI, SSHs in, or otherwise interacts with the host. There is usually no obvious symptom in `openclaw status` because by the time the operator looks, the gateway is alive again.

The code-level fix for the actual exception (`ENETDOWN` propagating as an uncaught exception out of the SSRF guard's outbound `connect`) has already landed via #86762, which classifies `ENETDOWN` as a benign transient network error so it no longer terminates the gateway process. This PR is the operational/docs companion to that fix and covers the two other layers of the same outage:

1. The macOS-specific power-management layer (`pmset` Maintenance Sleep / Power Nap) that drove the `ENETDOWN`s in the first place, and which still produces some sleep activity even with all the user-facing flags off.
2. The macOS launchd respawn-protection gate that turned what should have been a 2-second blip into multi-hour silent outages, by silently parking the LaunchAgent after a crash burst even with `KeepAlive=true`. This was the operator-visible half of #86688 and is not addressed by the `ENETDOWN` classification change alone — any future crash burst (from a different root cause) can still trigger the same parking behavior.

Also adds a one-line breadcrumb from `docs/platforms/macos.md` (Launchd control section) pointing at the new troubleshooting entry.

No code changes, no test changes, no UI changes. Docs-only.

## Why operational docs rather than another code patch

The shipped fix in #86762 correctly handles the `ENETDOWN` family at the `isBenignUncaughtExceptionError` layer. The remaining gap from the original issue (#86688) is twofold:

- Operators hitting this for the first time will not have the vocabulary to recognize the pattern. The symptom presents as "channels stop responding," not as "transient network errors," and the actual evidence is in `~/.openclaw/logs/stability/`, `pmset -g log`, and `launchctl print` — all places an operator is unlikely to look on their own.
- The launchd silent-park-after-crash-burst behavior is independent of any particular error code. Even now that `ENETDOWN` is classified as benign, the same launchd behavior will park the agent on the next unrelated crash burst. The doc captures the diagnostic workflow and an external watchdog snippet so operators are not relying on `KeepAlive=true` alone.

I considered adding an internal launchctl-aware watchdog, but the project has previously closed two attempts at supervisor-side caffeinate/keep-awake helpers (#15444 stale, #40846 closed), so operator-side documentation is the lower-risk contribution.

## Changes

- **`docs/gateway/troubleshooting.md`**: New section "macOS: gateway silently stops responding, then resumes when you touch the dashboard." Lists the diagnostic commands (`ls ~/.openclaw/logs/stability/`, `pmset -g log`, `launchctl print`), the `pmset -g log` evidence pattern that correlates with `ENETDOWN` crashes, the launchd `state = not running` / multi-run signature, and a three-step recovery sequence (upgrade, `pmset` flags, optional liveness watchdog snippet).
- **`docs/platforms/macos.md`**: Single sentence added under "Launchd control" linking to the new troubleshooting section.

## Real behavior proof

This is the same host that originally surfaced #86688's symptom pattern. Three stability bundles in the operator's `~/.openclaw/logs/stability/` directory all with `error.code: ENETDOWN`, against the SSRF guard's outbound connect path, on Apple Silicon Mac mini, OpenClaw `2026.5.22`:

```
openclaw-stability-2026-05-26T00-39-54-975Z-56031-uncaught_exception.json
  reason: uncaught_exception
  error.code: ENETDOWN
  error.message: connect ENETDOWN 160.79.104.10:443 - Local (192.168.1.161:62056)
  process.uptimeMs: 7586482

openclaw-stability-2026-05-26T13-01-00-188Z-58232-uncaught_exception.json
  reason: uncaught_exception
  error.code: ENETDOWN
  error.message: connect ENETDOWN 149.154.167.220:443 - Local (192.168.1.161:63404)
  process.uptimeMs: 29705727
```

`160.79.104.10` is Anthropic's API; `149.154.167.220` is a Telegram CDN edge. Both align with `pmset -g log` Maintenance Sleep entries inside the same second on this host. The matching launchd behavior was observed too: `runs` count incrementing across the day with no `received SIG*; shutting down` line in `~/Library/Logs/openclaw/gateway.log`, and gaps between crash time and next visible startup well in excess of the normal launchd `ThrottleInterval`.

Steps run after writing the docs:

```bash
# Rendered the new section in a local Mintlify-equivalent markdown preview to confirm
# the code blocks, headings, and anchor render correctly.
# Anchor verified: /gateway/troubleshooting#macos-gateway-silently-stops-responding-then-resumes-when-you-touch-the-dashboard
# (slug matches the Mintlify heading-to-anchor convention used elsewhere in this file).

# Confirmed the diagnostic commands in the doc all return expected output on the affected
# host (or expected empty output now that the ENETDOWN classification has shipped):
ls ~/.openclaw/logs/stability/
pmset -g log | grep -iE "sleep|wake|maintenance" | tail -50
launchctl print gui/$UID/ai.openclaw.gateway | grep -E "state|last exit|runs"
```

Result after the operator workarounds described in the doc were applied to this host on 2026-05-26:

- Maintenance Sleep events (`pmset -g log | grep 'Entering Sleep state'`): zero across the next ~20 hours.
- New `*-uncaught_exception.json` bundles: zero across the next ~20 hours.
- Gateway uptime continuous across the overnight window with no respawns.

What I did not test:

- I did not exercise the new troubleshooting section against a Mintlify production build of the docs site; only verified locally that the heading slug, internal links, and code-block syntax are consistent with the surrounding sections of `docs/gateway/troubleshooting.md`.
- The `launchctl print | awk` snippet was sanity-checked against the running LaunchAgent on this host; I did not test it against every supported macOS release.

## Related

- Original issue: #86688
- Code-level fix (already merged): #86762
- Earlier supervisor-side approaches that did not land, for context on why this PR is docs-only: #15444 (stale), #40846 (closed)

## AI-assisted disclosure

This PR was drafted with AI assistance. The diagnostic narrative, the `pmset` / `launchctl` recovery snippets, and the wording were drafted by an assistant working from the operator's own stability bundles, `pmset -g log` output, and the existing language in `docs/gateway/troubleshooting.md`. The operator (me) reviewed the diff in full, confirmed the diagnostic commands match what is actually on this host, and confirmed the symptom-pattern description matches their real-world experience. I understand exactly what each line of the new section says and can defend it on review.
