### PR TITLE
fix(agents): bound plugin system context

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -72,6 +72,19 @@ function flushDiagnosticEvents() {
   return waitForDiagnosticEventsDrained();
 }
 
+function expectedPluginSystemContext(text: string): string {
+  return [
+    "---",
+    "# OpenClaw Plugin System Context",
+    "",
+    "The following instructions were supplied by OpenClaw plugins. They are not part of any workspace file or project document.",
+    "",
+    text,
+    "",
+    "---",
+  ].join("\n");
+}
+
 function openSocket(url: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const socket = new WebSocket(url);
@@ -1566,7 +1579,13 @@ describe("runCodexAppServerAttempt", () => {
     expect(hookContext.sessionId).toBe("session-1");
     const threadStart = harness.requests.find((request) => request.method === "thread/start");
     const threadStartParams = threadStart?.params as { developerInstructions?: string } | undefined;
-    expect(threadStartParams?.developerInstructions).toContain("pre system\n\ncustom codex system");
+    expect(threadStartParams?.developerInstructions).toContain(
+      [
+        expectedPluginSystemContext("pre system"),
+        "custom codex system",
+        expectedPluginSystemContext("post system"),
+      ].join("\n\n"),
+    );
     const turnStart = harness.requests.find((request) => request.method === "turn/start");
     const turnStartParams = turnStart?.params as
       | { input?: Array<{ text?: string; text_elements?: unknown[]; type?: string }> }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -17,6 +17,7 @@ import { hashCliSessionText } from "../cli-session.js";
 import { resetContextWindowCacheForTest } from "../context.js";
 import { buildActiveImageGenerationTaskPromptContextForSession } from "../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../music-generation-task-status.js";
+import { wrapPluginSystemContextSection } from "../system-prompt-hook-context.js";
 import { buildActiveVideoGenerationTaskPromptContextForSession } from "../video-generation-task-status.js";
 import {
   prepareCliRunContext,
@@ -81,6 +82,10 @@ const mockBuildActiveImageGenerationTaskPromptContextForSession = vi.mocked(
 const mockBuildActiveMusicGenerationTaskPromptContextForSession = vi.mocked(
   buildActiveMusicGenerationTaskPromptContextForSession,
 );
+
+function wrappedPluginSystemContext(text: string): string {
+  return wrapPluginSystemContextSection(text) ?? "";
+}
 
 function createTestMcpLoopbackServerConfig(port: number) {
   return {
@@ -326,7 +331,12 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.params.prompt).toBe("history:2\n\nlatest ask");
       expect(context.contextEngineTurnPrompt).toBe("latest ask");
       expect(context.systemPrompt).toBe(
-        "prepend system\n\nhook system\n\nappend system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        [
+          wrappedPluginSystemContext("prepend system"),
+          "hook system",
+          wrappedPluginSystemContext("append system"),
+          "Current model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        ].join("\n\n"),
       );
       expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledTimes(1);
       const beforePromptBuildCalls = hookRunner.runBeforePromptBuild.mock.calls as unknown as Array<
@@ -561,7 +571,14 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(context.params.prompt).toBe("prompt prepend\n\nlegacy prepend\n\nlatest ask");
       expect(context.systemPrompt).toBe(
-        "prompt prepend system\n\nlegacy prepend system\n\nprompt system\n\nprompt append system\n\nlegacy append system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        [
+          wrappedPluginSystemContext("prompt prepend system"),
+          wrappedPluginSystemContext("legacy prepend system"),
+          "prompt system",
+          wrappedPluginSystemContext("prompt append system"),
+          wrappedPluginSystemContext("legacy append system"),
+          "Current model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        ].join("\n\n"),
       );
       expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledOnce();
       expect(hookRunner.runBeforeAgentStart).toHaveBeenCalledOnce();
@@ -992,7 +1009,13 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.systemPrompt).toBe(
-        "active image task\n\nactive video task\n\nhook prepend system\n\nhook system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        [
+          "active image task",
+          "active video task",
+          wrappedPluginSystemContext("hook prepend system"),
+          "hook system",
+          "Current model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        ].join("\n\n"),
       );
       expect(mockBuildActiveImageGenerationTaskPromptContextForSession).toHaveBeenCalledWith(
         "agent:main:test",

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -20,6 +20,7 @@ import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-pr
 import { buildActiveImageGenerationTaskPromptContextForSession } from "../../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
+import { wrapPluginSystemContextSection } from "../../system-prompt-hook-context.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { derivePromptTokens, type NormalizedUsage } from "../../usage.js";
 import { buildActiveVideoGenerationTaskPromptContextForSession } from "../../video-generation-task-status.js";
@@ -197,12 +198,12 @@ export async function resolvePromptBuildHookResult(params: {
       beforeAgentStartResult?.appendContext,
     ]),
     prependSystemContext: joinPresentTextSegments([
-      promptBuildResult?.prependSystemContext,
-      beforeAgentStartResult?.prependSystemContext,
+      wrapPluginSystemContextSection(promptBuildResult?.prependSystemContext),
+      wrapPluginSystemContextSection(beforeAgentStartResult?.prependSystemContext),
     ]),
     appendSystemContext: joinPresentTextSegments([
-      promptBuildResult?.appendSystemContext,
-      beforeAgentStartResult?.appendSystemContext,
+      wrapPluginSystemContextSection(promptBuildResult?.appendSystemContext),
+      wrapPluginSystemContextSection(beforeAgentStartResult?.appendSystemContext),
     ]),
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import { addSession, resetProcessRegistryForTests } from "../../bash-process-registry.js";
 import { createProcessSessionFixture } from "../../bash-process-registry.test-helpers.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../system-prompt-cache-boundary.js";
+import { wrapPluginSystemContextSection } from "../../system-prompt-hook-context.js";
 import { buildAgentSystemPrompt } from "../../system-prompt.js";
 import { resolveBootstrapContextTargets } from "./attempt-bootstrap-routing.js";
 import {
@@ -62,6 +63,10 @@ function createFakeStream(params: {
       })();
     },
   };
+}
+
+function wrappedPluginSystemContext(text: string): string {
+  return wrapPluginSystemContextSection(text) ?? "";
 }
 
 async function invokeWrappedTestStream(
@@ -715,8 +720,16 @@ describe("resolvePromptBuildHookResult", () => {
 
     expect(result.prependContext).toBe("prompt context\n\nagent start context");
     expect(result.appendContext).toBe("prompt append context\n\nagent start append context");
-    expect(result.prependSystemContext).toBe("prompt prepend\n\nagent start prepend");
-    expect(result.appendSystemContext).toBe("prompt append\n\nagent start append");
+    expect(result.prependSystemContext).toBe(
+      `${wrappedPluginSystemContext("prompt prepend")}\n\n${wrappedPluginSystemContext(
+        "agent start prepend",
+      )}`,
+    );
+    expect(result.appendSystemContext).toBe(
+      `${wrappedPluginSystemContext("prompt append")}\n\n${wrappedPluginSystemContext(
+        "agent start append",
+      )}`,
+    );
   });
 
   it("applies heartbeat prompt contributions only during heartbeat turns", async () => {
@@ -758,6 +771,10 @@ describe("resolvePromptBuildHookResult", () => {
 });
 
 describe("composeSystemPromptWithHookContext", () => {
+  const pluginContextHeading = "# OpenClaw Plugin System Context";
+  const pluginContextNote =
+    "The following instructions were supplied by OpenClaw plugins. They are not part of any workspace file or project document.";
+
   it("returns undefined when no hook system context is provided", () => {
     expect(composeSystemPromptWithHookContext({ baseSystemPrompt: "base" })).toBeUndefined();
   });
@@ -782,13 +799,35 @@ describe("composeSystemPromptWithHookContext", () => {
     ).toBe("prepend line\nsecond line\n\nbase system\n\nappend");
   });
 
+  it("preserves wrapped plugin system context as separate from workspace files", () => {
+    const composed = composeSystemPromptWithHookContext({
+      baseSystemPrompt: "## TOOLS.md\n\n## Workspace Heading\n\nWorkspace guidance.",
+      appendSystemContext: wrappedPluginSystemContext("## My Custom Rules\n\nFoo bar baz."),
+    });
+
+    expect(composed).toContain(pluginContextHeading);
+    expect(composed).toContain(pluginContextNote);
+    expect(composed?.startsWith("## TOOLS.md")).toBe(true);
+    expect(composed).toContain("Workspace guidance.\n\n---\n# OpenClaw Plugin System Context");
+    expect(composed).toContain("## My Custom Rules\n\nFoo bar baz.");
+  });
+
   it("avoids blank separators when base system prompt is empty", () => {
+    const composed = composeSystemPromptWithHookContext({
+      baseSystemPrompt: "   ",
+      appendSystemContext: "  append only  ",
+    });
+
+    expect(composed).toBe("append only");
+  });
+
+  it("ignores blank hook system context", () => {
     expect(
       composeSystemPromptWithHookContext({
-        baseSystemPrompt: "   ",
-        appendSystemContext: "  append only  ",
+        baseSystemPrompt: "  base system  ",
+        appendSystemContext: " \t\r\n",
       }),
-    ).toBe("append only");
+    ).toBeUndefined();
   });
 
   it("keeps bootstrap truncation notices in the system prompt instead of the user prompt", () => {

--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { resolveAgentHarnessBeforePromptBuildResult } from "./prompt-compaction-hook-helpers.js";
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+function mockHookRunner(result: { prependSystemContext?: string; appendSystemContext?: string }) {
+  const runner = {
+    hasHooks: vi.fn((name: string) => name === "before_prompt_build"),
+    runBeforePromptBuild: vi.fn(async () => result),
+    runBeforeAgentStart: vi.fn(),
+  } as unknown as NonNullable<ReturnType<typeof getGlobalHookRunner>>;
+  mockGetGlobalHookRunner.mockReturnValue(runner);
+  return runner;
+}
+
+describe("resolveAgentHarnessBeforePromptBuildResult", () => {
+  beforeEach(() => {
+    mockGetGlobalHookRunner.mockReset();
+    mockGetGlobalHookRunner.mockReturnValue(null);
+  });
+
+  it("frames plugin system context separately from base developer instructions", async () => {
+    mockHookRunner({
+      appendSystemContext: "## My Custom Rules\n\nFoo bar baz.",
+    });
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "hello",
+      developerInstructions: "## TOOLS.md\n\n## Workspace Heading\n\nWorkspace guidance.",
+      messages: [],
+      ctx: { runId: "run-1" },
+    });
+
+    expect(result.prompt).toBe("hello");
+    expect(result.developerInstructions).toContain("## TOOLS.md");
+    expect(result.developerInstructions).toContain("# OpenClaw Plugin System Context");
+    expect(result.developerInstructions).toContain(
+      "They are not part of any workspace file or project document.",
+    );
+    expect(result.developerInstructions).toContain(
+      "Workspace guidance.\n\n---\n# OpenClaw Plugin System Context",
+    );
+    expect(result.developerInstructions).toContain("## My Custom Rules\n\nFoo bar baz.");
+  });
+});

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../plugins/types.js";
 import { joinPresentTextSegments } from "../../shared/text/join-segments.js";
 import type { AgentMessage } from "../runtime/index.js";
+import { wrapPluginSystemContextSection } from "../system-prompt-hook-context.js";
 import { buildAgentHookContext, type AgentHarnessHookContext } from "./hook-context.js";
 
 const log = createSubsystemLogger("agents/harness");
@@ -61,11 +62,11 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
       ]) ?? params.prompt,
     developerInstructions:
       joinPresentTextSegments([
-        promptBuildResult?.prependSystemContext,
-        beforeAgentStartResult?.prependSystemContext,
+        wrapPluginSystemContextSection(promptBuildResult?.prependSystemContext),
+        wrapPluginSystemContextSection(beforeAgentStartResult?.prependSystemContext),
         systemPrompt,
-        promptBuildResult?.appendSystemContext,
-        beforeAgentStartResult?.appendSystemContext,
+        wrapPluginSystemContextSection(promptBuildResult?.appendSystemContext),
+        wrapPluginSystemContextSection(beforeAgentStartResult?.appendSystemContext),
       ]) ?? systemPrompt,
   };
 }

--- a/src/agents/system-prompt-hook-context.ts
+++ b/src/agents/system-prompt-hook-context.ts
@@ -1,0 +1,29 @@
+import { normalizeStructuredPromptSection } from "./prompt-cache-stability.js";
+
+const PLUGIN_SYSTEM_CONTEXT_HEADING = "# OpenClaw Plugin System Context";
+const PLUGIN_SYSTEM_CONTEXT_NOTE =
+  "The following instructions were supplied by OpenClaw plugins. They are not part of any workspace file or project document.";
+
+function normalizeSystemContext(text: string | undefined): string {
+  if (typeof text !== "string") {
+    return "";
+  }
+  return normalizeStructuredPromptSection(text);
+}
+
+export function wrapPluginSystemContextSection(text: string | undefined): string | undefined {
+  const normalized = normalizeSystemContext(text);
+  if (!normalized) {
+    return undefined;
+  }
+  return [
+    "---",
+    PLUGIN_SYSTEM_CONTEXT_HEADING,
+    "",
+    PLUGIN_SYSTEM_CONTEXT_NOTE,
+    "",
+    normalized,
+    "",
+    "---",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary

Fixes #87045 by wrapping plugin-emitted system context with a stable boundary and attribution note before it is joined into model-visible system/developer instructions.

The wrapper is applied only at plugin hook merge points for `before_prompt_build` / legacy `before_agent_start` system context. The lower-level system prompt composer remains unchanged, so non-plugin runtime context is not mislabeled as plugin content.

## Root Cause

Plugin hook fields such as `appendSystemContext` were joined next to the base system prompt with only blank-line separation. When the base prompt ended with Codex workspace-file Markdown and the plugin emitted another `##` heading, the model could treat the plugin block as another section of the preceding workspace file.

## Behavior Change

Plugin-provided `prependSystemContext` and `appendSystemContext` now render as a separate `# OpenClaw Plugin System Context` block bounded by `---`, with a note that the content came from OpenClaw plugins and is not part of a workspace file or project document.

## Real behavior proof

Behavior addressed: Plugin hook system context no longer appears as an unbounded continuation of workspace-file Markdown across harness, embedded runner, CLI prompt preparation, and Codex app-server prompt preparation paths.

Real environment tested: Local OpenClaw checkout on macOS, branch `codex/87045-plugin-context-boundary`, current head `0b42c568795839cb13f8494e6ca356f635161028`, rebased onto `origin/main` before rerunning verification on May 27, 2026.

Exact steps or command run after this patch:

```sh
git rev-parse HEAD

node --import tsx --input-type=module <<'EOF'
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
import {
  getGlobalHookRunner,
  initializeGlobalHookRunner,
  resetGlobalHookRunner,
} from "./src/plugins/hook-runner-global.ts";
import { prepareCliRunContext } from "./src/agents/cli-runner/prepare.ts";

const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-context-proof-"));
process.env.OPENCLAW_STATE_DIR = workspaceDir;
const sessionFile = path.join(workspaceDir, "agents", "main", "sessions", "proof-session.jsonl");
fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
fs.writeFileSync(
  sessionFile,
  `${JSON.stringify({
    type: "session",
    version: CURRENT_SESSION_VERSION,
    id: "proof-session",
    timestamp: new Date(0).toISOString(),
    cwd: workspaceDir,
  })}\n`,
  "utf8",
);

initializeGlobalHookRunner({
  plugins: [{ id: "proof-plugin", status: "loaded" }],
  hooks: [],
  typedHooks: [
    {
      pluginId: "proof-plugin",
      hookName: "before_prompt_build",
      source: "local-proof-plugin",
      priority: 0,
      handler: async () => ({ appendSystemContext: "## My Custom Rules\n\nFoo bar baz." }),
    },
  ],
});

const context = await prepareCliRunContext({
  sessionId: "proof-session",
  sessionKey: "agent:main:proof",
  agentId: "main",
  trigger: "user",
  sessionFile,
  workspaceDir,
  prompt: "where is Foo bar baz documented?",
  provider: "proof-cli",
  model: "proof-model",
  timeoutMs: 1000,
  runId: "proof-run",
  config: {
    agents: {
      defaults: {
        systemPromptOverride: "## TOOLS.md\n\n## Workspace Heading\n\nWorkspace guidance.",
        cliBackends: {
          "proof-cli": {
            command: "proof-cli",
            args: ["--print"],
            systemPromptArg: "--system-prompt",
            systemPromptWhen: "first",
            sessionMode: "existing",
            output: "text",
            input: "arg",
          },
        },
      },
    },
  },
});

console.log(`global hook runner has before_prompt_build: ${getGlobalHookRunner()?.hasHooks("before_prompt_build") === true}`);
console.log("compiled system prompt:");
console.log(context.systemPrompt.replaceAll(workspaceDir, "$WORKSPACE"));
resetGlobalHookRunner();
fs.rmSync(workspaceDir, { recursive: true, force: true });
EOF

node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts src/agents/harness/prompt-compaction-hook-helpers.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/cli-runner/prepare.test.ts
git diff --check origin/main...HEAD
```

Evidence after fix: Terminal output from the real local plugin smoke on current head showed the compiled system prompt with a plugin boundary and attribution note before the plugin-supplied rules. Current head was verified as `0b42c568795839cb13f8494e6ca356f635161028`; focused regression proof passed 7 test files / 439 tests, including the Codex app-server sibling coverage requested by review, and `git diff --check origin/main...HEAD` completed cleanly. The copied terminal output is included below.

Observed result after fix: The real local plugin hook returned `appendSystemContext: "## My Custom Rules\n\nFoo bar baz."`; the compiled system prompt places the workspace-style `## TOOLS.md` content first, then inserts `---`, `# OpenClaw Plugin System Context`, the plugin attribution note, the plugin rules, and a closing `---` before the model identity text. The Codex app-server sibling test now also asserts wrapped pre- and post-system plugin context around the custom Codex system prompt.

What was not tested: Live model attribution smoke. Focused oxlint was attempted, but the wrapper is currently blocked before linting by unrelated plugin-sdk boundary DTS errors in current main under `src/media/*` and `src/gateway/managed-image-attachments.ts`.

Before evidence (optional but encouraged): Not captured; the proof here is after-fix terminal output plus focused regression coverage.

Current head verified:

```text
0b42c568795839cb13f8494e6ca356f635161028
```

Terminal output copied from the smoke:

```text
global hook runner has before_prompt_build: true
compiled system prompt:
## TOOLS.md

## Workspace Heading

Workspace guidance.

---
# OpenClaw Plugin System Context

The following instructions were supplied by OpenClaw plugins. They are not part of any workspace file or project document.

## My Custom Rules

Foo bar baz.

---

Current model identity: proof-cli/proof-model. If asked what model you are, answer with this value for the current run.
```

Focused regression proof also passed:

```text
Test Files  7 passed (7)
Tests       439 passed (439)
```

`git diff --check origin/main...HEAD` completed cleanly.

## Verification

- Current head verified: `0b42c568795839cb13f8494e6ca356f635161028`
- Local plugin smoke through `initializeGlobalHookRunner` + `prepareCliRunContext`, with redacted compiled `context.systemPrompt` shown above
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts src/agents/harness/prompt-compaction-hook-helpers.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/cli-runner/prepare.test.ts`
- `git diff --check origin/main...HEAD`

Fixes #87045