### PR TITLE
fix(agents): retry stale session lock reports

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -1157,6 +1157,28 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("retries stale lock reports that become recoverable before surfacing raw lock errors", async () => {
+    if (process.platform !== "linux") {
+      return;
+    }
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      await writeCurrentProcessLock(lockPath, { starttime: 999_999_999 });
+      let resolverCalls = 0;
+      testing.setProcessStartTimeResolverForTest((pid) => {
+        if (pid !== process.pid) {
+          return null;
+        }
+        resolverCalls += 1;
+        return resolverCalls === 1 ? FAKE_STARTTIME : 999_999_999;
+      });
+
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+      await lock.release();
+      expect(resolverCalls).toBeGreaterThan(1);
+      await expectPathMissing(lockPath);
+    });
+  });
+
   it("reclaims orphan lock files without starttime when PID matches current process", async () => {
     await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
       // Simulate an old-format lock file left behind by a previous process

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -1179,6 +1179,52 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("preserves one acquire timeout budget after stale lock retries", async () => {
+    if (process.platform !== "linux") {
+      return;
+    }
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      let nowMs = 1_000;
+      const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+      const acquireTimeouts: number[] = [];
+      testing.setSessionLockAcquireForTest(async (_targetPath, options) => {
+        acquireTimeouts.push(options.timeoutMs ?? -1);
+        if (acquireTimeouts.length % 2 === 1) {
+          nowMs += 89;
+          throw Object.assign(new Error("stale"), {
+            code: "file_lock_stale",
+            lockPath,
+          });
+        }
+        throw Object.assign(new Error("timeout"), {
+          code: "file_lock_timeout",
+          lockPath,
+        });
+      });
+      try {
+        await expect(
+          acquireSessionWriteLock({
+            sessionFile,
+            timeoutMs: 90,
+            allowReentrant: false,
+          }),
+        ).rejects.toThrow(/session file locked/);
+
+        expect(acquireTimeouts).toEqual([90, 1]);
+        await expect(
+          acquireSessionWriteLock({
+            sessionFile,
+            timeoutMs: 90,
+            allowReentrant: false,
+          }),
+        ).rejects.toThrow(/session file locked/);
+        expect(acquireTimeouts).toEqual([90, 1, 90, 1]);
+      } finally {
+        dateNowSpy.mockRestore();
+      }
+    });
+  });
+
   it("reclaims orphan lock files without starttime when PID matches current process", async () => {
     await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
       // Simulate an old-format lock file left behind by a previous process

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -3,7 +3,7 @@ import type fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { createFileLockManager } from "../infra/file-lock-manager.js";
+import { createFileLockManager, type FileLockManager } from "../infra/file-lock-manager.js";
 import { readGatewayProcessArgsSync as readProcessArgsSync } from "../infra/gateway-processes.js";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
@@ -77,8 +77,10 @@ type LockInspectionDetails = Pick<
   "pid" | "pidAlive" | "createdAt" | "ageMs" | "stale" | "staleReasons"
 >;
 
+type SessionLockAcquire = FileLockManager["acquire"];
 const SESSION_LOCKS = createFileLockManager("openclaw.session-write-lock");
 let resolveProcessStartTimeForLock = getProcessStartTime;
+let acquireSessionLockForTest: SessionLockAcquire | null = null;
 
 function isFileLockError(error: unknown, code: string): boolean {
   return (error as { code?: unknown } | null)?.code === code;
@@ -818,10 +820,24 @@ export async function acquireSessionWriteLock(params: {
   await fs.mkdir(sessionDir, { recursive: true });
 
   while (true) {
-    try {
-      const lock = await SESSION_LOCKS.acquire(sessionFile, {
-        staleMs,
+    const elapsedBeforeAcquireMs = Date.now() - startedAt;
+    const acquireTimeoutMs =
+      timeoutMs === Number.POSITIVE_INFINITY
+        ? timeoutMs
+        : Math.max(0, timeoutMs - elapsedBeforeAcquireMs);
+    if (acquireTimeoutMs <= 0) {
+      await throwSessionWriteLockTimeout({
         timeoutMs,
+        lockPath,
+      });
+    }
+
+    try {
+      const acquireSessionLock =
+        acquireSessionLockForTest ?? SESSION_LOCKS.acquire.bind(SESSION_LOCKS);
+      const lock = await acquireSessionLock(sessionFile, {
+        staleMs,
+        timeoutMs: acquireTimeoutMs,
         retry: { minTimeout: 50, maxTimeout: 1000, factor: 1 },
         staleRecovery: "remove-if-unchanged",
         allowReentrant,
@@ -915,6 +931,9 @@ export const testing = {
   setProcessStartTimeResolverForTest(resolver: ((pid: number) => number | null) | null): void {
     resolveProcessStartTimeForLock = resolver ?? getProcessStartTime;
   },
+  setSessionLockAcquireForTest(acquire: SessionLockAcquire | null): void {
+    acquireSessionLockForTest = acquire;
+  },
 };
 
 export async function drainSessionWriteLockStateForTest(): Promise<void> {
@@ -928,5 +947,6 @@ export function resetSessionWriteLockStateForTest(): void {
   stopWatchdogTimer();
   unregisterCleanupHandlers();
   resolveProcessStartTimeForLock = getProcessStartTime;
+  acquireSessionLockForTest = null;
 }
 export { testing as __testing };

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -44,6 +44,7 @@ export const DEFAULT_SESSION_WRITE_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
 const DEFAULT_WATCHDOG_INTERVAL_MS = 60_000;
 const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
 const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old", "hold-exceeded"]);
+const STALE_LOCK_RETRY_DELAY_MS = 50;
 
 /**
  * Yield control to the event loop so other sessions can make progress
@@ -81,6 +82,11 @@ let resolveProcessStartTimeForLock = getProcessStartTime;
 
 function isFileLockError(error: unknown, code: string): boolean {
   return (error as { code?: unknown } | null)?.code === code;
+}
+
+function resolveFileLockErrorPath(error: unknown, fallback: string): string {
+  const lockPath = (error as { lockPath?: unknown } | null)?.lockPath;
+  return typeof lockPath === "string" && lockPath ? lockPath : fallback;
 }
 
 export type SessionWriteLockAcquireTimeoutConfig = {
@@ -407,6 +413,19 @@ async function readLockPayload(lockPath: string): Promise<LockFilePayload | null
   } catch {
     return null;
   }
+}
+
+async function throwSessionWriteLockTimeout(params: {
+  timeoutMs: number;
+  lockPath: string;
+}): Promise<never> {
+  const payload = await readLockPayload(params.lockPath);
+  const owner = typeof payload?.pid === "number" ? `pid=${payload.pid}` : "unknown";
+  throw new SessionWriteLockTimeoutError({
+    timeoutMs: params.timeoutMs,
+    owner,
+    lockPath: params.lockPath,
+  });
 }
 
 async function resolveNormalizedSessionFile(sessionFile: string): Promise<string> {
@@ -795,6 +814,7 @@ export async function acquireSessionWriteLock(params: {
   const sessionDir = path.dirname(sessionFile);
   const normalizedSessionFile = await resolveNormalizedSessionFile(sessionFile);
   const lockPath = `${normalizedSessionFile}.lock`;
+  const startedAt = Date.now();
   await fs.mkdir(sessionDir, { recursive: true });
 
   while (true) {
@@ -860,13 +880,28 @@ export async function acquireSessionWriteLock(params: {
       });
       return { release: lock.release };
     } catch (err) {
+      if (isFileLockError(err, "file_lock_stale")) {
+        const elapsedMs = Date.now() - startedAt;
+        const staleLockPath = resolveFileLockErrorPath(err, lockPath);
+        if (timeoutMs !== Number.POSITIVE_INFINITY && elapsedMs >= timeoutMs) {
+          await throwSessionWriteLockTimeout({ timeoutMs, lockPath: staleLockPath });
+        }
+        const remainingMs =
+          timeoutMs === Number.POSITIVE_INFINITY
+            ? STALE_LOCK_RETRY_DELAY_MS
+            : Math.max(0, timeoutMs - elapsedMs);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, Math.min(STALE_LOCK_RETRY_DELAY_MS, remainingMs));
+        });
+        continue;
+      }
       if (!isFileLockError(err, "file_lock_timeout")) {
         throw err;
       }
-      const timeoutLockPath = (err as { lockPath?: string }).lockPath ?? lockPath;
-      const payload = await readLockPayload(timeoutLockPath);
-      const owner = typeof payload?.pid === "number" ? `pid=${payload.pid}` : "unknown";
-      throw new SessionWriteLockTimeoutError({ timeoutMs, owner, lockPath: timeoutLockPath });
+      await throwSessionWriteLockTimeout({
+        timeoutMs,
+        lockPath: resolveFileLockErrorPath(err, lockPath),
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #87340.

`acquireSessionWriteLock()` could surface the raw `file_lock_stale` error from the sidecar lock manager when a stale-lock observation raced with recovery. In agent/tool execution that raw lock-manager message can look like actionable tool stderr even though the correct session-write behavior is to keep treating it as contention until the configured acquire timeout expires.

This change keeps stale lock reports inside the session write-lock policy: retry briefly within the existing acquire timeout, and if the lock remains unavailable, raise the existing `SessionWriteLockTimeoutError` shape instead of leaking `file lock stale for ...`. The latest refresh preserves current-main lock cleanup behavior and the PR's stale-lock retry/timeout-budget behavior.

No config surface or plugin surface changes.

## Real behavior proof

Behavior addressed: recovered or racey stale session write-lock reports no longer surface as raw `file_lock_stale` / `file lock stale for ...` errors during session journal acquisition.

Real environment tested: local OpenClaw Linux/WSL source worktree rebased onto current `main` (`4dad7bd93b6caae036342fd4efbdb47c217b459f`).

Exact steps or command run after this patch:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts --reporter=dot
./node_modules/.bin/oxfmt --check src/agents/session-write-lock.ts src/agents/session-write-lock.test.ts
./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/session-write-lock.ts src/agents/session-write-lock.test.ts
git diff --check origin/main...HEAD
git diff --check
/home/giodl/.local/toolchains/node-v22.22.3-linux-x64/bin/codex review --base origin/main
```

Evidence after fix:

```text
Test Files 1 passed (1)
Tests 49 passed (49)
All matched files use the correct format.
Found 0 warnings and 0 errors.
git diff --check origin/main...HEAD: passed
git diff --check: passed
Codex review: no actionable correctness issues found.
```

Observed result after fix: the stale-lock retry path keeps one acquire timeout budget, retries stale reports through session write-lock policy, and converts exhausted stale/timeout paths to the existing session lock timeout error shape.

Rebased signed head: `2696c8b89f94fa132a00fad3562b130db27473c8`.