### PR TITLE
feat(cron): surface fallback progress

### DIFF
--- a/docs/architecture/production-ai-governance.md
+++ b/docs/architecture/production-ai-governance.md
@@ -1,0 +1,141 @@
+---
+summary: "Lightweight production AI governance checklist for OpenClaw architecture changes"
+read_when:
+  - Adopting external AI architecture advice for OpenClaw
+  - Adding evaluation, replay, tracing, cost, or agent context governance
+  - Reviewing whether an AI system change needs a larger architecture project
+title: "Production AI governance"
+---
+
+OpenClaw already has several production AI building blocks: scoped
+`AGENTS.md` files, workspace skills, memory search, provider replay policies,
+diagnostic traces, session usage accounting, plugin lifecycle traces, channel
+routing, and QA lanes. Use this page when an external production AI checklist
+or architecture diagram looks useful, but the right answer is governance and
+verification rather than a repo-wide rewrite.
+
+The default stance is lightweight adoption:
+
+- Strengthen existing OpenClaw contracts before adding new layers.
+- Prefer evidence, replay, and targeted docs over broad directory reshuffles.
+- Keep core extension-agnostic; owner-specific behavior stays in the owning
+  plugin, channel, or provider.
+- Do not change live config, credentials, provider defaults, channel defaults,
+  or runtime services as part of this pass.
+
+## Adoption matrix
+
+| External layer                                  | OpenClaw mapping                                                                                           | Decision                                                                         |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| App entry and config                            | Gateway, CLI, Control UI, typed config docs                                                                | Adapt through existing docs and config contracts                                 |
+| Retrieval and memory                            | [Memory search](/concepts/memory-search), memory backends, QMD/session search                              | Adopt source and scope requirements; do not add a new retrieval stack by default |
+| Services and routing                            | [Agent loop](/concepts/agent-loop), [Channel routing](/channels/channel-routing), provider/runtime helpers | Adapt through existing owner boundaries                                          |
+| Prompt and agent context                        | [System prompt](/concepts/system-prompt), scoped `AGENTS.md`, [Skills](/tools/skills), workspace files     | Adopt as task contracts and scoped context, not hardcoded prompts                |
+| Agents and tools                                | Agent runtime hooks, plugin hooks, tools, subagents                                                        | Adapt with documented hook points; avoid hidden contract bypasses                |
+| Security guards                                 | Gateway security, tool policy, exec approvals, sandboxing, hooks                                           | Adapt; fix the core path first unless the surface is high risk                   |
+| Evaluation                                      | Unit tests, replay tests, QA lanes, live tests                                                             | Adopt a minimum golden and replay contract for high-risk paths                   |
+| Observability and cost                          | Diagnostics, stability events, traces, session usage, `/usage`, `/status`                                  | Adopt a stage-level checklist before adding new telemetry backends               |
+| Data boundaries                                 | Memory roots, session stores, external artifacts such as cron task ledgers and command lane snapshots      | Adapt via explicit snapshot or artifact boundaries                               |
+| Docs and coding agent context                   | Docs read hints, scoped `AGENTS.md`, skills, repo rules                                                    | Adopt; keep guidance discoverable and scoped                                     |
+| Semantic cache, query rewriter, adaptive router | No default adoption                                                                                        | Defer until cost or quality evidence proves the need                             |
+| Repo-wide folder structure                      | Existing OpenClaw layout and owner boundaries                                                              | Reject as-is                                                                     |
+
+## Minimum evaluation contract
+
+Any high-risk AI pipeline should have at least one executable or documented
+golden case for each relevant behavior below. Link to existing tests when they
+already cover the behavior; do not invent a parallel test harness only to match
+an external checklist.
+
+- **Memory retrieval:** results preserve source, scope, and degraded-mode
+  behavior. A memory failure should not silently become unscoped context.
+- **Provider and tool replay:** replay preserves transcript bytes and tool
+  results unless a documented repair path intentionally rewrites them.
+- **Channel routing:** every configured inbound surface is named separately.
+  DMs, groups, channels, threads, mentions, slash commands, webhooks, and
+  native command delivery are distinct surfaces when the config exposes them.
+- **Agent context:** scoped `AGENTS.md`, workspace files, skills, and memory
+  rules are loaded through the documented prompt/context path.
+- **Cost and context growth:** unusually large token, context, or cache-read
+  changes can be traced back to a session, model, provider, or stage.
+
+Use [Testing](/help/testing) for regular suite selection and QA commands.
+
+## Observability checklist
+
+Before a high-risk pipeline change is considered production-ready, an operator
+should be able to answer these questions from existing logs, diagnostics,
+session metadata, or test artifacts:
+
+- Which stage failed or produced the surprising output?
+- Which session, agent, model, provider, channel, and inbound surface were
+  involved?
+- What input and output summaries are safe to inspect without exposing raw
+  payloads or credentials?
+- Are token, cache, and cost changes attributable to a stage or provider?
+- Can user feedback, a support report, or a diagnostics bundle be linked back
+  to the relevant run?
+- Is the failure mode covered by a targeted test, replay, QA scenario, or live
+  smoke?
+
+Start with existing surfaces such as diagnostics export, stability events,
+session usage, cache traces, plugin lifecycle traces, and provider replay tests.
+Add a new telemetry backend only after this checklist shows an actual gap.
+
+## Agent context boundaries
+
+The coding-agent context layer maps to OpenClaw's existing scoped context
+system:
+
+- Repo rules live in `AGENTS.md` and scoped `AGENTS.md` files.
+- Agent persona and workspace memory live in the agent workspace, not in repo
+  docs.
+- Skills provide reusable operating procedures and should stay scoped to the
+  agent or plugin that needs them.
+- System prompt changes must go through the documented prompt assembly path.
+- Multi-agent or multi-persona setups need separate workspaces and agent state;
+  do not rely on `agentId` alone to isolate persona, memory, or auth behavior.
+
+When a new channel, plugin, agent, or automation surface is added, document the
+inbound surfaces it exposes and the context sources it is allowed to load.
+
+## Stop rules
+
+Stop this lightweight adoption path and open a separate architecture project if
+the change requires any of the following:
+
+- Public SDK or Gateway protocol changes.
+- Provider defaults, channel defaults, credential handling, or live config
+  mutation.
+- A new telemetry backend, database, queue, or external service.
+- Moving owner-specific extension behavior into core without evidence that
+  multiple owners need a generic seam.
+- Semantic cache, query rewriting, or adaptive routing without concrete cost,
+  quality, or reliability evidence.
+- Repo-wide folder or package restructuring.
+
+## Verification entry points
+
+For docs-only governance changes, use:
+
+```bash
+pnpm docs:list
+git diff --check
+```
+
+If trace, cost, replay, routing, or runtime code changes are made, run the
+smallest targeted test that covers the touched surface first. Escalate to
+`pnpm check:changed` when shared runtime, config, protocol, or public contract
+behavior changes.
+
+## Related
+
+- [Gateway architecture](/concepts/architecture)
+- [Agent loop](/concepts/agent-loop)
+- [System prompt](/concepts/system-prompt)
+- [Agent workspace](/concepts/agent-workspace)
+- [Memory search](/concepts/memory-search)
+- [Channel routing](/channels/channel-routing)
+- [Usage tracking](/concepts/usage-tracking)
+- [Diagnostics export](/gateway/diagnostics)
+- [Testing](/help/testing)

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -148,6 +148,7 @@ Details: [Gateway protocol](/gateway/protocol), [Pairing](/channels/pairing),
 
 ## Related
 
+- [Production AI governance](/architecture/production-ai-governance) — lightweight adoption checklist for evaluation, replay, tracing, cost, and agent context governance
 - [Agent Loop](/concepts/agent-loop) — detailed agent execution cycle
 - [Gateway Protocol](/gateway/protocol) — WebSocket protocol contract
 - [Queue](/concepts/queue) — command queue and concurrency

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -381,7 +381,9 @@ The persisted fallback override closes that window, and the narrow rollback keep
 - optional status/code
 - human-readable error summary
 
-Structured `model_fallback_decision` logs also include flat `fallbackStep*` fields when a candidate fails, is skipped, or a later fallback succeeds. These fields make the attempted transition explicit (`fallbackStepFromModel`, `fallbackStepToModel`, `fallbackStepFromFailureReason`, `fallbackStepFromFailureDetail`, `fallbackStepFinalOutcome`) so log and diagnostic exporters can reconstruct the primary failure even when the terminal fallback also fails.
+Structured `model_fallback_decision` logs also include flat `fallbackStep*` fields when a candidate fails, is skipped, or a later fallback succeeds. These fields make the attempted transition explicit (`fallbackStepFromModel`, `fallbackStepToModel`, `fallbackStepFromFailureReason`, `fallbackStepFromFailureDetail`, `fallbackStepFinalOutcome`) and include aggregate queue pressure (`fallbackStepQueueActive`, `fallbackStepQueueQueued`, `fallbackStepQueueDraining`) so log and diagnostic exporters can reconstruct the primary failure even when the terminal fallback also fails.
+
+Isolated cron agent runs mirror the same primary/fallback/queue chain into the cron task `progressSummary`, so `openclaw tasks show <task>` can identify the primary model, fallback target, failure reason, and queue/drain state without replaying gateway logs.
 
 When every candidate fails, OpenClaw throws `FallbackSummaryError`. The outer reply runner can use that to build a more specific message such as "all models are temporarily rate-limited" and include the soonest cooldown expiry when one is known.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1151,6 +1151,7 @@
                 "group": "Fundamentals",
                 "pages": [
                   "concepts/architecture",
+                  "architecture/production-ai-governance",
                   "concepts/agent",
                   "concepts/agent-loop",
                   "concepts/agent-runtimes",

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -25,6 +25,26 @@ of Docker runners. This doc is a "how we test" guide:
 This page covers running the regular test suites and Docker/Parallels runners. The QA-specific runners section below ([QA-specific runners](#qa-specific-runners)) lists the concrete `qa` invocations and points back at the references above.
 </Note>
 
+## Production AI regression contract
+
+For high-risk AI pipeline changes, pair the regular test selection below with
+the lightweight [Production AI governance](/architecture/production-ai-governance)
+contract. The minimum golden coverage is:
+
+- memory retrieval preserves source, scope, and degraded-mode behavior
+- provider and tool replay preserves transcript bytes unless a documented
+  repair path intentionally rewrites them
+- channel routing names every configured inbound surface separately, including
+  DMs, groups, channels, threads, mentions, slash commands, webhooks, and native
+  command delivery when they exist
+- agent context enters through scoped `AGENTS.md`, workspace files, skills, and
+  the documented system prompt path
+- token, cache, and cost changes can be attributed to a session, provider, model,
+  or pipeline stage
+
+When existing tests already cover a behavior, link to or run those tests instead
+of adding a parallel harness only to satisfy a checklist.
+
 ## Quick start
 
 Most days:

--- a/scripts/repro/cron-fallback-progress-proof.ts
+++ b/scripts/repro/cron-fallback-progress-proof.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env tsx
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const stateDir = mkdtempSync(path.join(tmpdir(), "openclaw-pr-87343-proof-"));
+process.env.OPENCLAW_STATE_DIR = stateDir;
+
+const {
+  GatewayDrainingError,
+  enqueueCommand,
+  enqueueCommandInLane,
+  getCommandLaneSnapshot,
+  markGatewayDraining,
+  resetCommandQueueStateForTest,
+} = await import("../../src/process/command-queue.js");
+const {
+  createRunningTaskRun,
+  recordTaskRunProgressByRunId,
+  resetDetachedTaskLifecycleRuntimeForTests,
+} = await import("../../src/tasks/detached-task-runtime.js");
+const { findTaskByRunId, resetTaskRegistryForTests } =
+  await import("../../src/tasks/task-registry.js");
+const { resetTaskFlowRegistryForTests } = await import("../../src/tasks/task-flow-registry.js");
+const { FailoverError } = await import("../../src/agents/failover-error.js");
+const { runWithModelFallback } = await import("../../src/agents/model-fallback.js");
+
+const runId = "pr-87343-cron-proof";
+const sessionLane = "session:pr-87343-cron-proof";
+const globalLane = "agent:cron:pr-87343-cron-proof";
+const primary = "openai/gpt-4.1-mini";
+const fallback = "anthropic/claude-haiku-3-5";
+const cfg = {
+  agents: {
+    defaults: {
+      model: {
+        primary,
+        fallbacks: [fallback],
+      },
+    },
+  },
+};
+
+function formatProgressSummary(step?: {
+  fallbackStepFromModel: string;
+  fallbackStepToModel?: string;
+  fallbackStepFromFailureReason?: string;
+  fallbackStepFinalOutcome: string;
+  fallbackStepFromFailureDetail?: string;
+  fallbackStepQueueActive?: number;
+  fallbackStepQueueQueued?: number;
+  fallbackStepQueueDraining?: boolean;
+}): string {
+  if (!step) {
+    return `model primary=${primary}; queue active=0 queued=0 draining=no`;
+  }
+  const target = step.fallbackStepToModel ? ` -> ${step.fallbackStepToModel}` : "";
+  const reason = step.fallbackStepFromFailureReason
+    ? ` reason=${step.fallbackStepFromFailureReason}`
+    : "";
+  const detail = step.fallbackStepFromFailureDetail
+    ? ` detail=${step.fallbackStepFromFailureDetail}`
+    : "";
+  const active = step.fallbackStepQueueActive ?? 0;
+  const queued = step.fallbackStepQueueQueued ?? 0;
+  const draining = step.fallbackStepQueueDraining === true ? "yes" : "no";
+  return `model fallback: ${step.fallbackStepFromModel}${target}${reason} outcome=${step.fallbackStepFinalOutcome}${detail}; queue active=${active} queued=${queued} draining=${draining}`;
+}
+
+resetDetachedTaskLifecycleRuntimeForTests();
+resetTaskRegistryForTests({ persist: false });
+resetTaskFlowRegistryForTests({ persist: false });
+resetCommandQueueStateForTest();
+
+const task = createRunningTaskRun({
+  runtime: "cron",
+  ownerKey: "agent:main:main",
+  scopeKind: "session",
+  runId,
+  task: "PR #87343 cron fallback progress proof",
+  startedAt: Date.now(),
+  progressSummary: formatProgressSummary(),
+});
+
+if (!task) {
+  throw new Error("failed to create cron proof task run");
+}
+
+console.log(`[proof] stateDir=${stateDir}`);
+console.log(`[proof] task created runtime=${task.runtime} runId=${task.runId}`);
+console.log(`[proof] initial progressSummary=${task.progressSummary}`);
+
+const activeTask = enqueueCommand(async () => {
+  console.log(`[proof] active queue before fallback=${JSON.stringify(getCommandLaneSnapshot())}`);
+  let embeddedFallbackContinuationObserved = false;
+  const result = await runWithModelFallback({
+    cfg,
+    provider: "openai",
+    model: "gpt-4.1-mini",
+    manifestPlugins: [],
+    skipAuthProfileRuntime: true,
+    allowGatewayDrainingContinuation: true,
+    onFallbackStep: (step) => {
+      const progressSummary = formatProgressSummary(step);
+      const updated = recordTaskRunProgressByRunId({
+        runId,
+        runtime: "cron",
+        lastEventAt: Date.now(),
+        progressSummary,
+      });
+      console.log(`[proof] fallback step=${JSON.stringify(step)}`);
+      console.log(`[proof] recorded progressSummary=${updated.at(-1)?.progressSummary}`);
+    },
+    run: async (provider, model, options) => {
+      console.log(
+        `[proof] attempt provider=${provider} model=${model} allowGatewayDrainingContinuation=${options?.allowGatewayDrainingContinuation === true}`,
+      );
+      return enqueueCommandInLane(
+        sessionLane,
+        () =>
+          enqueueCommandInLane(
+            globalLane,
+            async () => {
+              if (provider === "openai") {
+                markGatewayDraining();
+                console.log("[proof] gateway drain marked while embedded queue work is active");
+                throw new FailoverError("primary rate limited", {
+                  reason: "rate_limit",
+                  provider,
+                  model,
+                  status: 429,
+                  code: "RESOURCE_EXHAUSTED",
+                });
+              }
+              embeddedFallbackContinuationObserved =
+                options?.allowGatewayDrainingContinuation === true;
+              return "fallback ok";
+            },
+            {
+              allowGatewayDrainingContinuation: options?.allowGatewayDrainingContinuation === true,
+            },
+          ),
+        {
+          allowGatewayDrainingContinuation: options?.allowGatewayDrainingContinuation === true,
+        },
+      );
+    },
+  });
+  if (!embeddedFallbackContinuationObserved) {
+    throw new Error("fallback attempt did not run as an embedded queue continuation");
+  }
+  console.log(`[proof] active task result=${result.provider}/${result.model}:${result.result}`);
+  return result;
+});
+
+await activeTask;
+
+try {
+  await enqueueCommand(async () => "should not enqueue during drain");
+  throw new Error("enqueue unexpectedly succeeded during gateway drain");
+} catch (error) {
+  if (!(error instanceof GatewayDrainingError)) {
+    throw error;
+  }
+  console.log("[proof] new enqueue rejected with GatewayDrainingError");
+}
+
+const finalTask = findTaskByRunId(runId);
+console.log(`[proof] final task progressSummary=${finalTask?.progressSummary}`);
+console.log(
+  "[proof] PASS embedded queue-shaped fallback continued during drain; new enqueue still rejected",
+);

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1728,6 +1728,7 @@ async function agentCommandInternal(
               model: modelLocal,
               result: resultLocal,
             }),
+          allowGatewayDrainingContinuation: true,
           abortSignal: opts.abortSignal,
           run: async (providerOverride, modelOverride, runOptions) => {
             const isAutoFallbackPrimaryProbeCandidate =
@@ -1790,6 +1791,8 @@ async function agentCommandInternal(
               pluginsEnabled,
               ...(manifestMetadataSnapshot ? { metadataSnapshot: manifestMetadataSnapshot } : {}),
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+              allowGatewayDrainingContinuation:
+                runOptions?.allowGatewayDrainingContinuation === true,
               sessionHasHistory:
                 !isNewSession ||
                 (await attemptExecutionRuntime.sessionFileHasContent(attemptSessionFile)),

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -430,6 +430,7 @@ export function runAgentAttempt(params: {
   pluginsEnabled?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
   allowTransientCooldownProbe?: boolean;
+  allowGatewayDrainingContinuation?: boolean;
   modelFallbacksOverride?: string[];
   sessionHasHistory?: boolean;
   suppressPromptPersistenceOnRetry?: boolean;
@@ -702,6 +703,7 @@ export function runAgentAttempt(params: {
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    allowGatewayDrainingContinuation: params.allowGatewayDrainingContinuation,
     cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
     modelRun: params.opts.modelRun,
     promptMode: params.opts.promptMode,

--- a/src/agents/console-sanitize.ts
+++ b/src/agents/console-sanitize.ts
@@ -14,6 +14,7 @@ export function sanitizeForConsole(text: string | undefined, maxChars = 200): st
         code === 0x0b ||
         code === 0x0c ||
         (code >= 0x0e && code <= 0x1f) ||
+        (code >= 0x80 && code <= 0x9f) ||
         code === 0x7f
       );
     })

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -486,6 +486,7 @@ export async function runEmbeddedAgent(
   const globalLane = resolveGlobalLane(params.lane);
   const sessionQueuePriority = resolveEmbeddedRunSessionQueuePriority(params.trigger);
   const laneTaskTimeoutMs = resolveEmbeddedRunLaneTimeoutMs(params.timeoutMs);
+  const allowGatewayDrainingContinuation = params.allowGatewayDrainingContinuation === true;
   let laneTaskProgressAtMs = Date.now();
   const noteLaneTaskProgress = () => {
     laneTaskProgressAtMs = Date.now();
@@ -502,13 +503,18 @@ export async function runEmbeddedAgent(
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
+      allowGatewayDrainingContinuation,
     };
     return params.enqueue
       ? params.enqueue(task, withLaneTimeout(globalOpts))
       : enqueueCommandInLane(globalLane, task, withLaneTimeout(globalOpts));
   };
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
-    const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
+    const sessionOpts: CommandQueueEnqueueOptions = {
+      ...opts,
+      priority: sessionQueuePriority,
+      allowGatewayDrainingContinuation,
+    };
     return params.enqueue
       ? params.enqueue(task, sessionOpts)
       : enqueueCommandInLane(sessionLane, task, sessionOpts);

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -129,6 +129,8 @@ export type RunEmbeddedAgentParams = {
   model?: string;
   /** Effective model fallback chain for this session attempt. Undefined uses config defaults. */
   modelFallbacksOverride?: string[];
+  /** Continue an already-admitted fallback chain while the gateway is draining. */
+  allowGatewayDrainingContinuation?: boolean;
   /** Session-pinned embedded harness id. Prevents runtime hot-switching. */
   agentHarnessId?: string;
   /** Explicit runtime override selected for this turn. Unlike agentHarnessId, this may force OpenClaw. */

--- a/src/agents/model-fallback-observation.ts
+++ b/src/agents/model-fallback-observation.ts
@@ -5,6 +5,7 @@
  */
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getCommandLaneSnapshots, isGatewayDraining } from "../process/command-queue.js";
 import { buildTextObservationFields } from "./embedded-agent-error-observation.js";
 import type { FailoverReason } from "./embedded-agent-helpers.js";
 import type { FallbackAttempt, ModelCandidate } from "./model-fallback.types.js";
@@ -48,6 +49,9 @@ export type ModelFallbackStepFields = {
   fallbackStepFromFailureDetail?: string;
   fallbackStepChainPosition?: number;
   fallbackStepFinalOutcome: FallbackStepOutcome;
+  fallbackStepQueueActive?: number;
+  fallbackStepQueueQueued?: number;
+  fallbackStepQueueDraining?: boolean;
 };
 
 /** Input payload for logging one model fallback decision. */
@@ -82,6 +86,18 @@ function formatModelRef(candidate: ModelCandidate): string {
   return `${candidate.provider}/${candidate.model}`;
 }
 
+function buildQueueObservationFields(): Pick<
+  ModelFallbackStepFields,
+  "fallbackStepQueueActive" | "fallbackStepQueueQueued" | "fallbackStepQueueDraining"
+> {
+  const snapshots = getCommandLaneSnapshots();
+  return {
+    fallbackStepQueueActive: snapshots.reduce((total, lane) => total + lane.activeCount, 0),
+    fallbackStepQueueQueued: snapshots.reduce((total, lane) => total + lane.queuedCount, 0),
+    fallbackStepQueueDraining: isGatewayDraining(),
+  };
+}
+
 function buildFallbackStepFields(params: {
   decision: "skip_candidate" | "candidate_failed" | "candidate_succeeded";
   candidate: ModelCandidate;
@@ -98,6 +114,9 @@ function buildFallbackStepFields(params: {
     if (!lastPreviousAttempt) {
       return undefined;
     }
+    const observedPrevious = buildErrorObservationFields(lastPreviousAttempt.error);
+    const previousFailureDetail =
+      observedPrevious.providerErrorMessagePreview ?? observedPrevious.errorPreview;
     return {
       fallbackStepType: "fallback_step",
       fallbackStepFromModel: `${lastPreviousAttempt.provider}/${lastPreviousAttempt.model}`,
@@ -105,11 +124,10 @@ function buildFallbackStepFields(params: {
       ...(lastPreviousAttempt.reason
         ? { fallbackStepFromFailureReason: lastPreviousAttempt.reason }
         : {}),
-      ...(lastPreviousAttempt.error
-        ? { fallbackStepFromFailureDetail: lastPreviousAttempt.error }
-        : {}),
+      ...(previousFailureDetail ? { fallbackStepFromFailureDetail: previousFailureDetail } : {}),
       ...(typeof params.attempt === "number" ? { fallbackStepChainPosition: params.attempt } : {}),
       fallbackStepFinalOutcome: "succeeded",
+      ...buildQueueObservationFields(),
     };
   }
 
@@ -127,6 +145,7 @@ function buildFallbackStepFields(params: {
       : {}),
     ...(typeof params.attempt === "number" ? { fallbackStepChainPosition: params.attempt } : {}),
     fallbackStepFinalOutcome: params.nextCandidate ? "next_fallback" : "chain_exhausted",
+    ...buildQueueObservationFields(),
   };
 }
 

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -4,10 +4,17 @@ import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  GatewayDrainingError,
+  enqueueCommandInLane,
+  markGatewayDraining,
+  resetCommandQueueStateForTest,
+} from "../process/command-queue.js";
 import type { AuthProfileFailureReason } from "./auth-profiles.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./auth-profiles/store.js";
 import { classifyEmbeddedAgentRunResultForModelFallback } from "./embedded-agent-runner/result-fallback-classifier.js";
 import type { EmbeddedRunAttemptResult } from "./embedded-agent-runner/run/types.js";
+import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import { runWithModelFallback } from "./model-fallback.js";
 import {
   buildEmbeddedRunnerAssistant,
@@ -68,6 +75,7 @@ beforeEach(() => {
   runEmbeddedAttemptMock.mockReset();
   computeBackoffMock.mockClear();
   sleepWithAbortMock.mockClear();
+  resetCommandQueueStateForTest();
 });
 
 const OVERLOADED_ERROR_PAYLOAD =
@@ -221,6 +229,7 @@ async function runEmbeddedFallback(params: {
   runId: string;
   abortSignal?: AbortSignal;
   config?: OpenClawConfig;
+  queueMode?: "default" | "immediate";
 }) {
   // Runs the same embedded-agent entrypoint that production fallback uses while
   // keeping provider/model attempts deterministic through mocks.
@@ -231,8 +240,9 @@ async function runEmbeddedFallback(params: {
     model: "mock-1",
     runId: params.runId,
     agentDir: params.agentDir,
-    run: (provider, model, options) =>
-      runEmbeddedAgent({
+    allowGatewayDrainingContinuation: params.queueMode === "default",
+    run: (provider, model, options) => {
+      const embeddedParams: Parameters<typeof runEmbeddedAgent>[0] = {
         sessionId: `session:${params.runId}`,
         sessionKey: params.sessionKey,
         sessionFile: path.join(params.workspaceDir, `${params.runId}.jsonl`),
@@ -244,11 +254,16 @@ async function runEmbeddedFallback(params: {
         model,
         authProfileIdSource: "auto",
         allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
+        allowGatewayDrainingContinuation: options?.allowGatewayDrainingContinuation === true,
         timeoutMs: 5_000,
         runId: params.runId,
         abortSignal: params.abortSignal,
-        enqueue: async (task) => await task(),
-      }),
+      };
+      if (params.queueMode !== "default") {
+        embeddedParams.enqueue = async (task) => await task();
+      }
+      return runEmbeddedAgent(embeddedParams);
+    },
   });
 }
 
@@ -478,6 +493,84 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       expectOpenAiThenGroqAttemptOrder();
       expect(computeBackoffMock).not.toHaveBeenCalled();
       expect(sleepWithAbortMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keeps embedded fallback candidates admitted during gateway drain", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir);
+      runEmbeddedAttemptMock.mockImplementation(async (params: unknown) => {
+        const attemptParams = params as EmbeddedAttemptParams;
+        if (attemptParams.provider === "openai") {
+          markGatewayDraining();
+          return makeEmbeddedRunnerAttempt({
+            assistantTexts: [],
+            lastAssistant: buildEmbeddedRunnerAssistant({
+              provider: "openai",
+              model: "mock-1",
+              stopReason: "error",
+              errorMessage: OVERLOADED_ERROR_PAYLOAD,
+            }),
+          });
+        }
+        if (attemptParams.provider === "groq") {
+          return makeFallbackSuccessAttempt();
+        }
+        throw new Error(`Unexpected provider ${attemptParams.provider}`);
+      });
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        sessionKey: "agent:test:embedded-drain-fallback",
+        runId: "run:embedded-drain-fallback",
+        queueMode: "default",
+      });
+
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+      expectOpenAiThenGroqAttemptOrder();
+      await expect(
+        enqueueCommandInLane("new-task-after-drain", async () => "blocked"),
+      ).rejects.toBeInstanceOf(GatewayDrainingError);
+    });
+  });
+
+  it("keeps live-switch redirected embedded fallback candidates admitted during gateway drain", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir);
+      runEmbeddedAttemptMock.mockImplementation(async (params: unknown) => {
+        const attemptParams = params as EmbeddedAttemptParams;
+        if (attemptParams.provider === "openai") {
+          markGatewayDraining();
+          throw new LiveSessionModelSwitchError({
+            provider: "groq",
+            model: "mock-2",
+          });
+        }
+        if (attemptParams.provider === "groq") {
+          return makeFallbackSuccessAttempt();
+        }
+        throw new Error(`Unexpected provider ${attemptParams.provider}`);
+      });
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        sessionKey: "agent:test:embedded-drain-live-switch-redirect",
+        runId: "run:embedded-drain-live-switch-redirect",
+        queueMode: "default",
+      });
+
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.attempts).toStrictEqual([]);
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+      expectOpenAiThenGroqAttemptOrder();
+      await expect(
+        enqueueCommandInLane("new-task-after-live-switch-drain", async () => "blocked"),
+      ).rejects.toBeInstanceOf(GatewayDrainingError);
     });
   });
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -14,7 +14,13 @@ import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plug
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
-import { CommandLaneTaskTimeoutError } from "../process/command-queue.js";
+import {
+  CommandLaneTaskTimeoutError,
+  enqueueCommand,
+  getCommandLaneSnapshot,
+  markGatewayDraining,
+  resetCommandQueueStateForTest,
+} from "../process/command-queue.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { classifyEmbeddedAgentRunResultForModelFallback } from "./embedded-agent-runner/result-fallback-classifier.js";
@@ -206,6 +212,7 @@ function resetModelFallbackTestState(): void {
   providerModelNormalizationMock.normalizeProviderModelIdWithRuntime
     .mockReset()
     .mockReturnValue(undefined);
+  resetCommandQueueStateForTest();
 }
 
 function setDefaultPluginMetadataSnapshot(): void {
@@ -281,6 +288,7 @@ afterEach(resetModelFallbackTestState);
 
 beforeEach(() => {
   setLoggerOverride({ level: "silent", consoleLevel: "silent" });
+  resetCommandQueueStateForTest();
 });
 
 afterEach(() => {
@@ -1216,6 +1224,123 @@ describe("runWithModelFallback", () => {
       status: 429,
       code: "RESOURCE_EXHAUSTED",
     });
+  });
+
+  it("continues fallback candidates when restart drain begins after an active failed attempt", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        markGatewayDraining();
+        throw new FailoverError("primary timed out", {
+          reason: "rate_limit",
+          provider: "openai",
+          model: "gpt-4.1-mini",
+        });
+      })
+      .mockResolvedValueOnce("fallback ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result).toMatchObject({
+      result: "fallback ok",
+      provider: "anthropic",
+      model: "claude-haiku-3-5",
+    });
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5");
+  });
+
+  it("includes queue pressure on fallback step observations", async () => {
+    const cfg = makeCfg();
+    let releaseActive!: () => void;
+    const activeTask = enqueueCommand(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releaseActive = resolve;
+        }),
+    );
+    await vi.waitFor(() =>
+      expect(getCommandLaneSnapshot()).toMatchObject({ activeCount: 1, queuedCount: 0 }),
+    );
+    const queuedTask = enqueueCommand(async () => undefined);
+    await vi.waitFor(() =>
+      expect(getCommandLaneSnapshot()).toMatchObject({ activeCount: 1, queuedCount: 1 }),
+    );
+
+    const onFallbackStep = vi.fn();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("unsupported primary", {
+          reason: "model_not_found",
+          provider: "openai",
+          model: "gpt-4.1-mini",
+        }),
+      )
+      .mockResolvedValueOnce("ok");
+
+    try {
+      await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+        onFallbackStep,
+      });
+    } finally {
+      releaseActive();
+      await Promise.all([activeTask, queuedTask]);
+    }
+
+    expect(onFallbackStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fallbackStepFromModel: "openai/gpt-4.1-mini",
+        fallbackStepToModel: "anthropic/claude-haiku-3-5",
+        fallbackStepFromFailureReason: "model_not_found",
+        fallbackStepQueueActive: 1,
+        fallbackStepQueueQueued: 1,
+        fallbackStepQueueDraining: false,
+      }),
+    );
+  });
+
+  it("redacts reused fallback failure detail before success step observations", async () => {
+    const cfg = makeCfg();
+    const onFallbackStep = vi.fn();
+    const rawProviderError =
+      '{"type":"error","error":{"type":"rate_limit_error","message":"Quota exceeded for api_key=sk-secret1234567890abcd"},"request_id":"req_plaintext_123"}';
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error(rawProviderError))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+      onFallbackStep,
+    });
+
+    expect(result.result).toBe("ok");
+    const successStep = onFallbackStep.mock.calls
+      .map(
+        ([step]) =>
+          step as {
+            fallbackStepFinalOutcome?: string;
+            fallbackStepFromFailureDetail?: string;
+          },
+      )
+      .find((step) => step.fallbackStepFinalOutcome === "succeeded");
+    expect(successStep?.fallbackStepFromFailureDetail).toContain("Quota exceeded");
+    expect(successStep?.fallbackStepFromFailureDetail).not.toContain("sk-secret1234567890abcd");
+    expect(successStep?.fallbackStepFromFailureDetail).not.toContain("req_plaintext_123");
   });
 
   it("keeps raw provider schema errors in fallback summaries", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -161,6 +161,7 @@ export function isFallbackSummaryError(err: unknown): err is FallbackSummaryErro
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
+  allowGatewayDrainingContinuation?: boolean;
 };
 
 type ModelFallbackRuntimeContext = {
@@ -1222,6 +1223,7 @@ export async function runWithModelFallback<T>(
     onError?: ModelFallbackErrorHandler;
     onFallbackStep?: ModelFallbackStepHandler;
     classifyResult?: ModelFallbackResultClassifier<T>;
+    allowGatewayDrainingContinuation?: boolean;
     skipAuthProfileRuntime?: boolean;
     abortSignal?: AbortSignal;
   } & ModelManifestNormalizationContext,
@@ -1272,6 +1274,7 @@ export async function runWithModelFallback<T>(
 
   const hasFallbackCandidates = candidates.length > 1;
   const requestedCandidate = candidates[0];
+  let liveSwitchRedirectContinuationPending = false;
 
   for (let i = 0; i < candidates.length; i += 1) {
     const candidate = candidates[i];
@@ -1509,11 +1512,20 @@ export async function runWithModelFallback<T>(
       }
     }
 
+    const shouldAllowGatewayDrainingContinuation =
+      params.allowGatewayDrainingContinuation === true &&
+      i > 0 &&
+      (attempts.length > 0 || liveSwitchRedirectContinuationPending);
+    const attemptRunOptions: ModelFallbackRunOptions | undefined =
+      shouldAllowGatewayDrainingContinuation
+        ? { ...runOptions, allowGatewayDrainingContinuation: true }
+        : runOptions;
+    liveSwitchRedirectContinuationPending = false;
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,
       attempts,
-      options: runOptions,
+      options: attemptRunOptions,
       classifyResult: params.classifyResult,
       attempt: i + 1,
       total: candidates.length,
@@ -1594,6 +1606,7 @@ export async function runWithModelFallback<T>(
           currentIndex: i,
         });
         if (liveSwitchTargetIndex !== null) {
+          liveSwitchRedirectContinuationPending = true;
           i = liveSwitchTargetIndex - 1;
           continue;
         }

--- a/src/agents/utils/ansi.ts
+++ b/src/agents/utils/ansi.ts
@@ -30,8 +30,8 @@ function ansiRegex({ onlyFirst = false }: { onlyFirst?: boolean } = {}): RegExp 
   // Valid string terminator sequences are BEL, ESC\, and 0x9c
   const ST = "(?:\\u0007|\\u001B\\u005C|\\u009C)";
 
-  // OSC sequences only: ESC ] ... ST (non-greedy until the first ST)
-  const osc = `(?:\\u001B\\][\\s\\S]*?${ST})`;
+  // OSC sequences only: ESC ] / C1 OSC ... ST (non-greedy until the first ST)
+  const osc = `(?:(?:\\u001B\\]|\\u009D)[\\s\\S]*?${ST})`;
 
   // CSI and related: ESC/C1, optional intermediates, optional params (supports ; and :) then final byte
   const csi = "[\\u001B\\u009B][[\\]()#;?]*(?:\\d{1,4}(?:[;:]\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]";
@@ -48,8 +48,8 @@ export function stripAnsi(value: string): string {
     throw new TypeError(`Expected a \`string\`, got \`${typeof value}\``);
   }
 
-  // Fast path: ANSI codes require ESC (7-bit) or CSI (8-bit) introducer
-  if (!value.includes("\u001B") && !value.includes("\u009B")) {
+  // Fast path: ANSI codes require ESC (7-bit), CSI (8-bit), or OSC (8-bit) introducer
+  if (!value.includes("\u001B") && !value.includes("\u009B") && !value.includes("\u009D")) {
     return value;
   }
 

--- a/src/commands/migrate/skill-selection-prompt.ts
+++ b/src/commands/migrate/skill-selection-prompt.ts
@@ -256,5 +256,9 @@ export function promptMigrationSkillSelectionValues(
   return prompt.prompt();
 }
 
-/** Compatibility alias for plugin selection prompts that share the same picker. */
+/**
+ * Back-compat alias for plugin selection prompts that share the same picker.
+ *
+ * @deprecated Use `promptMigrationSkillSelectionValues` instead.
+ */
 export const promptMigrationSelectionValues = promptMigrationSkillSelectionValues;

--- a/src/cron/isolated-agent/run-executor.task-progress.test.ts
+++ b/src/cron/isolated-agent/run-executor.task-progress.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import type { CronJob } from "../types.js";
+
+const runtimeMocks = vi.hoisted(() => ({
+  runWithModelFallback: vi.fn(),
+  resolveEffectiveModelFallbacks: vi.fn(() => undefined),
+  logWarn: vi.fn(),
+}));
+
+const taskRuntimeMocks = vi.hoisted(() => ({
+  recordTaskRunProgressByRunId: vi.fn(),
+}));
+
+vi.mock("./run-execution.runtime.js", () => ({
+  getCliSessionId: vi.fn(),
+  ensureSelectedAgentHarnessPlugin: vi.fn(),
+  isCliProvider: vi.fn(() => false),
+  LiveSessionModelSwitchError: class LiveSessionModelSwitchError extends Error {},
+  logWarn: runtimeMocks.logWarn,
+  normalizeVerboseLevel: vi.fn((value) => value),
+  registerAgentRunContext: vi.fn(),
+  resolveBootstrapWarningSignaturesSeen: vi.fn(() => []),
+  resolveCronAgentLane: vi.fn((lane?: string) => lane ?? "cron"),
+  resolveEffectiveModelFallbacks: runtimeMocks.resolveEffectiveModelFallbacks,
+  resolveSessionTranscriptPath: vi.fn(() => "/tmp/openclaw-cron-test-session.jsonl"),
+  runCliAgent: vi.fn(),
+  runWithModelFallback: runtimeMocks.runWithModelFallback,
+}));
+
+vi.mock("../../tasks/detached-task-runtime.js", () => ({
+  recordTaskRunProgressByRunId: taskRuntimeMocks.recordTaskRunProgressByRunId,
+}));
+
+const { createCronPromptExecutor } = await import("./run-executor.js");
+
+function makeJob(): CronJob {
+  return {
+    id: "weekly-task-review",
+    name: "weekly-task-review",
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "review tasks" },
+    state: {},
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  } as CronJob;
+}
+
+function hasTerminalControlCharacter(value: string): boolean {
+  return Array.from(value).some((char) => {
+    const code = char.charCodeAt(0);
+    return (
+      code <= 0x08 ||
+      code === 0x0b ||
+      code === 0x0c ||
+      (code >= 0x0e && code <= 0x1f) ||
+      (code >= 0x80 && code <= 0x9f) ||
+      code === 0x7f
+    );
+  });
+}
+
+describe("cron isolated run model progress", () => {
+  beforeEach(() => {
+    runtimeMocks.runWithModelFallback.mockReset();
+    runtimeMocks.resolveEffectiveModelFallbacks.mockClear();
+    runtimeMocks.logWarn.mockClear();
+    taskRuntimeMocks.recordTaskRunProgressByRunId.mockClear();
+  });
+
+  it("records primary, fallback, and queue causality to the cron task ledger", async () => {
+    runtimeMocks.runWithModelFallback.mockImplementation(
+      async (params: {
+        onFallbackStep?: (step: Record<string, unknown>) => void | Promise<void>;
+      }) => {
+        await params.onFallbackStep?.({
+          fallbackStepType: "fallback_step",
+          fallbackStepFromModel: "openai/gpt-5.5-preview",
+          fallbackStepToModel: "github-copilot/gpt-5-mini",
+          fallbackStepFromFailureReason: "model_not_found",
+          fallbackStepFromFailureDetail: "unsupported model",
+          fallbackStepChainPosition: 1,
+          fallbackStepFinalOutcome: "next_fallback",
+          fallbackStepQueueActive: 1,
+          fallbackStepQueueQueued: 2,
+          fallbackStepQueueDraining: false,
+        });
+        return {
+          result: { payloads: [{ text: "done" }], meta: {} },
+          provider: "github-copilot",
+          model: "gpt-5-mini",
+        };
+      },
+    );
+
+    const executor = createCronPromptExecutor({
+      cfg: {},
+      cfgWithAgentDefaults: {},
+      job: makeJob(),
+      agentId: "main",
+      agentDir: "/tmp/openclaw-agent",
+      agentSessionKey: "agent:main",
+      runSessionKey: "cron:weekly-task-review",
+      workspaceDir: "/tmp/openclaw-workspace",
+      resolvedVerboseLevel: "off",
+      thinkLevel: undefined,
+      timeoutMs: 60_000,
+      suppressExecNotifyOnExit: false,
+      resolvedDelivery: { channel: "discord" },
+      sourceDelivery: createSourceDeliveryPlan({
+        owner: "direct_fallback",
+        reason: "cron_announce",
+        target: { channel: "discord" },
+        messageToolEnabled: true,
+        messageToolForced: false,
+        directFallback: true,
+      }),
+      skillsSnapshot: { prompt: "", skills: [], resolvedSkills: [], version: 1 },
+      agentPayload: { kind: "agentTurn", message: "review tasks" },
+      useSubagentFallbacks: false,
+      liveSelection: {
+        provider: "openai",
+        model: "gpt-5.5-preview",
+      },
+      cronSession: {
+        storePath: "/tmp/openclaw-cron-sessions.json",
+        store: {},
+        systemSent: false,
+        isNewSession: true,
+        previousSessionId: undefined,
+        sessionEntry: {
+          sessionId: "cron-session",
+          sessionFile: "/tmp/openclaw-cron-test-session.jsonl",
+          updatedAt: 1,
+        },
+      },
+      abortReason: () => "aborted",
+      taskRunId: "cron-run-1",
+    });
+
+    await executor.runPrompt("review tasks");
+
+    expect(taskRuntimeMocks.recordTaskRunProgressByRunId).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        runId: "cron-run-1",
+        runtime: "cron",
+        progressSummary:
+          "model primary=openai/gpt-5.5-preview; queue active=0 queued=0 draining=no",
+      }),
+    );
+    expect(taskRuntimeMocks.recordTaskRunProgressByRunId).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        runId: "cron-run-1",
+        runtime: "cron",
+        progressSummary:
+          "model fallback: openai/gpt-5.5-preview -> github-copilot/gpt-5-mini reason=model_not_found outcome=next_fallback detail=unsupported model; queue active=1 queued=2 draining=no",
+      }),
+    );
+  });
+
+  it("sanitizes terminal control sequences before persisting cron progress", async () => {
+    runtimeMocks.runWithModelFallback.mockImplementation(
+      async (params: {
+        onFallbackStep?: (step: Record<string, unknown>) => void | Promise<void>;
+      }) => {
+        await params.onFallbackStep?.({
+          fallbackStepType: "fallback_step",
+          fallbackStepFromModel: "openai/\u001b[31mgpt\u001b[0m",
+          fallbackStepToModel: "anthropic/\u009d0;owned-c1-title\u009cclaude",
+          fallbackStepFromFailureReason: "rate\nlimit",
+          fallbackStepFromFailureDetail:
+            "quota \u009d8;;https://example.invalid\u009chidden\u009c request",
+          fallbackStepChainPosition: 1,
+          fallbackStepFinalOutcome: "succeeded",
+          fallbackStepQueueActive: 1,
+          fallbackStepQueueQueued: 0,
+          fallbackStepQueueDraining: false,
+        });
+        return {
+          result: { payloads: [{ text: "done" }], meta: {} },
+          provider: "anthropic",
+          model: "claude",
+        };
+      },
+    );
+
+    const executor = createCronPromptExecutor({
+      cfg: {},
+      cfgWithAgentDefaults: {},
+      job: makeJob(),
+      agentId: "main",
+      agentDir: "/tmp/openclaw-agent",
+      agentSessionKey: "agent:main",
+      runSessionKey: "cron:weekly-task-review",
+      workspaceDir: "/tmp/openclaw-workspace",
+      resolvedVerboseLevel: "off",
+      thinkLevel: undefined,
+      timeoutMs: 60_000,
+      suppressExecNotifyOnExit: false,
+      resolvedDelivery: { channel: "discord" },
+      sourceDelivery: createSourceDeliveryPlan({
+        owner: "direct_fallback",
+        reason: "cron_announce",
+        target: { channel: "discord" },
+        messageToolEnabled: true,
+        messageToolForced: false,
+        directFallback: true,
+      }),
+      skillsSnapshot: { prompt: "", skills: [], resolvedSkills: [], version: 1 },
+      agentPayload: { kind: "agentTurn", message: "review tasks" },
+      useSubagentFallbacks: false,
+      liveSelection: {
+        provider: "openai\u001b]8;;https://example.invalid\u0007\u009d0;owned-primary\u009c",
+        model: "gpt\nmodel\tname",
+      },
+      cronSession: {
+        storePath: "/tmp/openclaw-cron-sessions.json",
+        store: {},
+        systemSent: false,
+        isNewSession: true,
+        previousSessionId: undefined,
+        sessionEntry: {
+          sessionId: "cron-session",
+          sessionFile: "/tmp/openclaw-cron-test-session.jsonl",
+          updatedAt: 1,
+        },
+      },
+      abortReason: () => "aborted",
+      taskRunId: "cron-run-1",
+    });
+
+    await executor.runPrompt("review tasks");
+
+    const progressSummaries = taskRuntimeMocks.recordTaskRunProgressByRunId.mock.calls.map(
+      ([call]) => call.progressSummary,
+    );
+    const joinedProgress = progressSummaries.join("\n");
+    expect(hasTerminalControlCharacter(joinedProgress)).toBe(false);
+    expect(joinedProgress).not.toContain("[31m");
+    expect(joinedProgress).not.toContain("[0m");
+    expect(joinedProgress).not.toContain("]0;");
+    expect(joinedProgress).not.toContain("]8;;");
+    expect(joinedProgress).not.toContain("owned-c1-title");
+    expect(joinedProgress).not.toContain("owned-primary");
+    expect(progressSummaries[0]).toBe(
+      "model primary=openai/gpt model name; queue active=0 queued=0 draining=no",
+    );
+    expect(progressSummaries[1]).toBe(
+      "model fallback: openai/gpt -> anthropic/claude reason=rate limit outcome=succeeded detail=quota hidden request; queue active=1 queued=0 draining=no",
+    );
+  });
+});

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,13 +1,18 @@
 /** Executes isolated cron prompts with model fallbacks and interim-ack retries. */
 import { createHash } from "node:crypto";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import { sanitizeForConsole } from "../../agents/console-sanitize.js";
+import type { ModelFallbackStepFields } from "../../agents/model-fallback-observation.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
+import { stripAnsi } from "../../agents/utils/ansi.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import { getCommandLaneSnapshots, isGatewayDraining } from "../../process/command-queue.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../../skills/types.js";
+import { recordTaskRunProgressByRunId } from "../../tasks/detached-task-runtime.js";
 import type { CronAgentExecutionPhaseUpdate, CronJob } from "../types.js";
 import {
   resolveCronChannelOutputPolicy,
@@ -59,6 +64,7 @@ async function loadCronSubagentRegistryRuntime() {
 
 const COMMAND_STYLE_CRON_PREFIX =
   /^(?:(?:[A-Z_][A-Z0-9_]*=\S+\s+)+)?(?:cd\s+\S+|(?:\.{1,2}|~)?\/\S+|[A-Za-z]:[\\/]\S+|(?:bash|bun|cargo|deno|docker|gh|git|go|make|node|npm|npx|pnpm|python|python3|ruby|sh|tsx|uv|zsh)\b)/u;
+const CRON_PROGRESS_FIELD_MAX_CHARS = 200;
 
 function resolveIsolatedCronPromptCacheKey(params: {
   job: CronJob;
@@ -108,6 +114,77 @@ function resolveCronBootstrapContextMode(
   return isCommandStyleCronMessage(payload?.message ?? "") ? "lightweight" : undefined;
 }
 
+function formatQueueStateForTaskStatus(params: {
+  active?: number;
+  queued?: number;
+  draining?: boolean;
+}): string {
+  const currentSnapshots = getCommandLaneSnapshots();
+  const active =
+    params.active ?? currentSnapshots.reduce((total, lane) => total + lane.activeCount, 0);
+  const queued =
+    params.queued ?? currentSnapshots.reduce((total, lane) => total + lane.queuedCount, 0);
+  const isDraining = params.draining ?? isGatewayDraining();
+  const draining = isDraining ? "yes" : "no";
+  return `queue active=${active} queued=${queued} draining=${draining}`;
+}
+
+function sanitizeCronProgressField(value: string | undefined): string | undefined {
+  return sanitizeForConsole(
+    value !== undefined ? stripAnsi(value) : undefined,
+    CRON_PROGRESS_FIELD_MAX_CHARS,
+  );
+}
+
+function formatCronModelProgress(params: {
+  provider: string;
+  model: string;
+  step?: ModelFallbackStepFields;
+}): string {
+  if (!params.step) {
+    const provider = sanitizeCronProgressField(params.provider) ?? "unknown";
+    const model = sanitizeCronProgressField(params.model) ?? "unknown";
+    return `model primary=${provider}/${model}`;
+  }
+  const fromModel = sanitizeCronProgressField(params.step.fallbackStepFromModel) ?? "unknown";
+  const toModel = sanitizeCronProgressField(params.step.fallbackStepToModel);
+  const reason = sanitizeCronProgressField(params.step.fallbackStepFromFailureReason);
+  const outcome = sanitizeCronProgressField(params.step.fallbackStepFinalOutcome) ?? "unknown";
+  const detail = sanitizeCronProgressField(params.step.fallbackStepFromFailureDetail);
+  const target = toModel ? ` -> ${toModel}` : "";
+  const reasonSummary = reason ? ` reason=${reason}` : "";
+  const detailSummary = detail ? ` detail=${detail}` : "";
+  return `model fallback: ${fromModel}${target}${reasonSummary} outcome=${outcome}${detailSummary}`;
+}
+
+function recordCronModelProgress(params: {
+  taskRunId?: string;
+  provider: string;
+  model: string;
+  step?: ModelFallbackStepFields;
+}): void {
+  const taskRunId = params.taskRunId?.trim();
+  if (!taskRunId) {
+    return;
+  }
+  const progress = formatCronModelProgress(params);
+  const queue = formatQueueStateForTaskStatus({
+    active: params.step?.fallbackStepQueueActive,
+    queued: params.step?.fallbackStepQueueQueued,
+    draining: params.step?.fallbackStepQueueDraining,
+  });
+  try {
+    recordTaskRunProgressByRunId({
+      runId: taskRunId,
+      runtime: "cron",
+      lastEventAt: Date.now(),
+      progressSummary: `${progress}; ${queue}`,
+    });
+  } catch (err) {
+    logWarn(`[cron] failed to record model fallback task progress: ${String(err)}`);
+  }
+}
+
 /** Result envelope returned after an isolated cron prompt completes. */
 export type CronExecutionResult = {
   runResult: CronPromptRunResult;
@@ -155,6 +232,7 @@ export function createCronPromptExecutor(params: {
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
       Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
   ) => void;
+  taskRunId?: string;
 }) {
   const sessionFile =
     params.cronSession.sessionEntry.sessionFile?.trim() ||
@@ -183,6 +261,11 @@ export function createCronPromptExecutor(params: {
   const messageChannel = params.sourceDelivery.target.channel ?? params.resolvedDelivery.channel;
 
   const runPrompt = async (promptText: string) => {
+    recordCronModelProgress({
+      taskRunId: params.taskRunId,
+      provider: params.liveSelection.provider,
+      model: params.liveSelection.model,
+    });
     const fallbackResult = await runWithModelFallback({
       cfg: params.cfgWithAgentDefaults,
       provider: params.liveSelection.provider,
@@ -205,6 +288,15 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      onFallbackStep: (step) => {
+        recordCronModelProgress({
+          taskRunId: params.taskRunId,
+          provider: params.liveSelection.provider,
+          model: params.liveSelection.model,
+          step,
+        });
+      },
+      allowGatewayDrainingContinuation: true,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());
@@ -301,6 +393,7 @@ export function createCronPromptExecutor(params: {
           authProfileIdSource: params.liveSelection.authProfileId
             ? params.liveSelection.authProfileIdSource
             : undefined,
+          allowGatewayDrainingContinuation: runOptions?.allowGatewayDrainingContinuation === true,
           thinkLevel: params.thinkLevel,
           fastMode: resolveFastModeState({
             cfg: params.cfgWithAgentDefaults,
@@ -386,6 +479,7 @@ export async function executeCronRun(params: {
   cronSession: MutableCronSession;
   commandBody: string;
   persistSessionEntry: PersistCronSessionEntry;
+  taskRunId?: string;
   abortSignal?: AbortSignal;
   abortReason: () => string;
   isAborted: () => boolean;
@@ -437,6 +531,7 @@ export async function executeCronRun(params: {
     abortReason: params.abortReason,
     onExecutionStarted: params.onExecutionStarted,
     onExecutionPhase: params.onExecutionPhase,
+    taskRunId: params.taskRunId,
   });
 
   const runStartedAt = params.runStartedAt ?? Date.now();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -447,6 +447,7 @@ type RunCronAgentTurnParams = {
   deps: CliDeps;
   job: CronJob;
   message: string;
+  taskRunId?: string;
   abortSignal?: AbortSignal;
   signal?: AbortSignal;
   onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
@@ -1221,6 +1222,7 @@ export async function runCronIsolatedAgentTurn(params: {
   deps: CliDeps;
   job: CronJob;
   message: string;
+  taskRunId?: string;
   abortSignal?: AbortSignal;
   signal?: AbortSignal;
   onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
@@ -1314,6 +1316,7 @@ export async function runCronIsolatedAgentTurn(params: {
       cronSession: prepared.context.cronSession,
       commandBody: prepared.context.commandBody,
       persistSessionEntry: prepared.context.persistSessionEntry,
+      taskRunId: params.taskRunId,
       abortSignal,
       onExecutionStarted: notifyExecutionStarted,
       onExecutionPhase: notifyExecutionPhase,

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -809,10 +809,10 @@ async function finishPreparedManualRun(
   const taskRunId = prepared.taskRunId;
   const runId = prepared.runId;
 
+  let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
   try {
-    let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
     try {
-      coreResult = await executeJobCoreWithTimeout(state, executionJob);
+      coreResult = await executeJobCoreWithTimeout(state, executionJob, { taskRunId });
     } catch (err) {
       coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
     }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -112,6 +112,7 @@ export type CronServiceDeps = {
   runIsolatedAgentJob: (params: {
     job: CronJob;
     message: string;
+    taskRunId?: string;
     abortSignal?: AbortSignal;
     onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
     onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -121,10 +121,11 @@ type StartupCatchupPlan = {
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
+  options?: { taskRunId?: string },
 ): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
   const jobTimeoutMs = resolveCronJobTimeoutMs(job);
   if (typeof jobTimeoutMs !== "number") {
-    return await executeJobCore(state, job);
+    return await executeJobCore(state, job, undefined, { taskRunId: options?.taskRunId });
   }
 
   const runAbortController = new AbortController();
@@ -155,6 +156,7 @@ export async function executeJobCoreWithTimeout(
   const corePromise = executeJobCore(state, job, runAbortController.signal, {
     onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog.noteRunnerStarted : undefined,
     onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog.notePhase : undefined,
+    taskRunId: options?.taskRunId,
   });
   watchdog.start();
   void corePromise.catch((err: unknown) => {
@@ -844,7 +846,7 @@ export async function onTimer(state: CronServiceState) {
       const taskRunId = tryCreateCronTaskRun({ state, job, startedAt });
 
       try {
-        const result = await executeJobCoreWithTimeout(state, job);
+        const result = await executeJobCoreWithTimeout(state, job, { taskRunId });
         return {
           jobId: id,
           job,
@@ -1238,7 +1240,7 @@ async function runStartupCatchupCandidate(
     runAtMs: startedAt,
   });
   try {
-    const result = await executeJobCoreWithTimeout(state, candidate.job);
+    const result = await executeJobCoreWithTimeout(state, candidate.job, { taskRunId });
     return {
       jobId: candidate.jobId,
       job: candidate.job,
@@ -1326,6 +1328,7 @@ export async function executeJobCore(
   options?: {
     onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
     onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+    taskRunId?: string;
   },
 ): Promise<
   CronRunOutcome &
@@ -1507,6 +1510,7 @@ async function executeDetachedCronJob(
   options?: {
     onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
     onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+    taskRunId?: string;
   },
 ): Promise<
   CronRunOutcome &
@@ -1540,6 +1544,7 @@ async function executeDetachedCronJob(
   const res = await state.deps.runIsolatedAgentJob({
     job,
     message: job.payload.message,
+    taskRunId: options?.taskRunId,
     abortSignal,
     onExecutionStarted: options?.onExecutionStarted,
     onExecutionPhase: options?.onExecutionPhase,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -356,6 +356,7 @@ export function buildGatewayCronService(params: {
     runIsolatedAgentJob: async ({
       job,
       message,
+      taskRunId,
       abortSignal,
       onExecutionStarted,
       onExecutionPhase,
@@ -368,6 +369,7 @@ export function buildGatewayCronService(params: {
           deps: params.deps,
           job,
           message,
+          taskRunId,
           abortSignal,
           onExecutionStarted,
           onExecutionPhase,

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -31,6 +31,7 @@ let getActiveTaskCount: CommandQueueModule["getActiveTaskCount"];
 let getCommandLaneSnapshot: CommandQueueModule["getCommandLaneSnapshot"];
 let getCommandLaneSnapshots: CommandQueueModule["getCommandLaneSnapshots"];
 let getQueueSize: CommandQueueModule["getQueueSize"];
+let isGatewayDraining: CommandQueueModule["isGatewayDraining"];
 let markGatewayDraining: CommandQueueModule["markGatewayDraining"];
 let resetAllLanes: CommandQueueModule["resetAllLanes"];
 let resetCommandLane: CommandQueueModule["resetCommandLane"];
@@ -104,6 +105,7 @@ describe("command queue", () => {
       getCommandLaneSnapshot,
       getCommandLaneSnapshots,
       getQueueSize,
+      isGatewayDraining,
       markGatewayDraining,
       resetAllLanes,
       resetCommandLane,
@@ -730,7 +732,20 @@ describe("command queue", () => {
 
   it("rejects new enqueues with GatewayDrainingError after markGatewayDraining", async () => {
     markGatewayDraining();
+    expect(isGatewayDraining()).toBe(true);
     await expect(enqueueCommand(async () => "blocked")).rejects.toBeInstanceOf(
+      GatewayDrainingError,
+    );
+  });
+
+  it("admits explicit continuation work while gateway is draining", async () => {
+    markGatewayDraining();
+    await expect(
+      enqueueCommandInLane("continuation", async () => "continued", {
+        allowGatewayDrainingContinuation: true,
+      }),
+    ).resolves.toBe("continued");
+    await expect(enqueueCommandInLane("new-task", async () => "blocked")).rejects.toBeInstanceOf(
       GatewayDrainingError,
     );
   });
@@ -745,6 +760,7 @@ describe("command queue", () => {
   it("resetAllLanes clears gateway draining flag and re-allows enqueue", async () => {
     markGatewayDraining();
     resetAllLanes();
+    expect(isGatewayDraining()).toBe(false);
     await expect(enqueueCommand(async () => "ok")).resolves.toBe("ok");
   });
 

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -426,7 +426,7 @@ export function enqueueCommandInLane<T>(
   opts?: CommandQueueEnqueueOptions,
 ): Promise<T> {
   const queueState = getQueueState();
-  if (queueState.gatewayDraining) {
+  if (queueState.gatewayDraining && opts?.allowGatewayDrainingContinuation !== true) {
     return Promise.reject(new GatewayDrainingError());
   }
   const cleaned = normalizeLane(lane);

--- a/src/process/command-queue.types.ts
+++ b/src/process/command-queue.types.ts
@@ -8,6 +8,11 @@ export type CommandQueueEnqueueOptions = {
   taskTimeoutMs?: number;
   taskTimeoutProgressAtMs?: () => number | undefined;
   priority?: "foreground" | "normal" | "background";
+  /**
+   * Internal continuation escape hatch for work that already owns a logical
+   * active turn before gateway drain begins. Do not set for new user work.
+   */
+  allowGatewayDrainingContinuation?: boolean;
 };
 
 /** Minimal queue function contract used by code that only needs to schedule work. */


### PR DESCRIPTION
## Summary

- Stop already-admitted model fallback chains from losing their embedded cron fallback candidate when Gateway drain begins; new queue enqueues still reject during drain.
- Carry the drain-continuation state through `LiveSessionModelSwitchError` redirects so later embedded fallback candidates stay admitted after Gateway drain starts.
- Add queue pressure fields to model fallback observations and surface cron primary/fallback progress into detached task run status.
- Sanitize fallback failure detail and persisted cron progress fields before task status/CLI surfaces can read them, including ANSI, OSC, C0, C1, and DEL control-character coverage.
- Strip 8-bit C1 OSC sequences in the shared ANSI helper and remove the full C1 control range in compact console sanitization.
- Replace the undefined docs example with source-backed OpenClaw artifacts (`cron task ledgers` and `command lane snapshots`).
- Rebase onto latest `upstream/main` and keep the inherited migration selection compatibility alias explicitly deprecated so architecture/deprecated-JSDoc passes.
- Thread cron task run ids through manual/isolated execution, add a reproducible runtime proof script, and document the production AI governance checklist.

## Verification

- PASS: `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts src/process/command-queue.test.ts src/cron/isolated-agent/run-executor.task-progress.test.ts src/agents/model-fallback.run-embedded.e2e.test.ts` (4 shards, 133 tests)
- PASS: `pnpm exec tsx scripts/repro/cron-fallback-progress-proof.ts`
- PASS: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- PASS: `pnpm lint --threads=8`
- PASS: `pnpm check:architecture`
- PASS: `node scripts/docs-list.js`
- PASS: `./node_modules/.bin/oxfmt --check --threads=1 src/agents/model-fallback.ts src/agents/model-fallback.run-embedded.e2e.test.ts`
- PASS: `git diff --check`
- PASS: `git diff --check HEAD~1..HEAD`

## Real behavior proof

- Behavior addressed: Already-active cron/background work can continue its configured model fallback chain after Gateway drain begins, including the embedded runner's session/global queue shape. New command enqueues still reject during drain. Cron-style task progress records primary/fallback model status plus queue active/queued/draining state, with fallback failure detail and terminal-control-bearing progress fields sanitized before persistence.
- Redirect repair after review: if a `LiveSessionModelSwitchError` redirects an already-started fallback chain to a later candidate after Gateway drain starts, the redirected embedded candidate now receives `allowGatewayDrainingContinuation=true`. The focused embedded e2e covers this by marking drain in the primary attempt, throwing a live-switch redirect to groq, verifying groq succeeds, and verifying new work is still rejected during drain.
- Sanitizer repair after review: C1 OSC (`0x9d ... 0x9c`) is stripped by `stripAnsi`, and compact console sanitization removes the full C1 control range (`0x80`-`0x9f`) before cron progress is persisted. The cron progress regression injects C1 OSC in provider/model/fallback detail and asserts no C1/control bytes or C1 OSC payload remain.
- Real environment tested: Local macOS source checkout at `/private/tmp/openclaw-pr-87343-rebase`; PR head `a894a559da2d5549282e28a08cf05fe7656d1a92`; rebased onto `upstream/main@1a3ce7c2a8da266cd0bb2844d44ba5af3942908b`; proof used isolated temp `OPENCLAW_STATE_DIR=/var/folders/_x/34p90_ts62zcl8g4bvfkyjsw0000gn/T/openclaw-pr-87343-proof-6OmK7F`.
- Exact steps or command run after this patch: `pnpm exec tsx scripts/repro/cron-fallback-progress-proof.ts`.
- Evidence after fix:

```text
[proof] stateDir=/var/folders/_x/34p90_ts62zcl8g4bvfkyjsw0000gn/T/openclaw-pr-87343-proof-6OmK7F
[proof] task created runtime=cron runId=pr-87343-cron-proof
[proof] initial progressSummary=model primary=openai/gpt-4.1-mini; queue active=0 queued=0 draining=no
[proof] active queue before fallback={"lane":"main","queuedCount":0,"activeCount":1,"maxConcurrent":1,"draining":false,"generation":0}
[proof] attempt provider=openai model=gpt-4.1-mini allowGatewayDrainingContinuation=false
[proof] gateway drain marked while embedded queue work is active
[proof] fallback step={"fallbackStepType":"fallback_step","fallbackStepFromModel":"openai/gpt-4.1-mini","fallbackStepToModel":"anthropic/claude-haiku-3-5","fallbackStepFromFailureReason":"rate_limit","fallbackStepFromFailureDetail":"primary rate limited","fallbackStepChainPosition":1,"fallbackStepFinalOutcome":"next_fallback","fallbackStepQueueActive":1,"fallbackStepQueueQueued":0,"fallbackStepQueueDraining":true}
[proof] recorded progressSummary=model fallback: openai/gpt-4.1-mini -> anthropic/claude-haiku-3-5 reason=rate_limit outcome=next_fallback detail=primary rate limited; queue active=1 queued=0 draining=yes
[proof] attempt provider=anthropic model=claude-haiku-3-5 allowGatewayDrainingContinuation=true
[proof] fallback step={"fallbackStepType":"fallback_step","fallbackStepFromModel":"openai/gpt-4.1-mini","fallbackStepToModel":"anthropic/claude-haiku-3-5","fallbackStepFromFailureReason":"rate_limit","fallbackStepFromFailureDetail":"primary rate limited","fallbackStepChainPosition":2,"fallbackStepFinalOutcome":"succeeded","fallbackStepQueueActive":1,"fallbackStepQueueQueued":0,"fallbackStepQueueDraining":true}
[proof] recorded progressSummary=model fallback: openai/gpt-4.1-mini -> anthropic/claude-haiku-3-5 reason=rate_limit outcome=succeeded detail=primary rate limited; queue active=1 queued=0 draining=yes
[proof] active task result=anthropic/claude-haiku-3-5:fallback ok
[proof] new enqueue rejected with GatewayDrainingError
[proof] final task progressSummary=model fallback: openai/gpt-4.1-mini -> anthropic/claude-haiku-3-5 reason=rate_limit outcome=succeeded detail=primary rate limited; queue active=1 queued=0 draining=yes
[proof] PASS embedded queue-shaped fallback continued during drain; new enqueue still rejected
```

- Observed result after fix: The primary embedded queue-shaped attempt marked Gateway drain while active; the fallback attempt then ran with `allowGatewayDrainingContinuation=true`, reached `anthropic/claude-haiku-3-5`, and returned `fallback ok`. A new enqueue during drain was still rejected with `GatewayDrainingError`.
- What was not tested: A live external-provider cron run was not executed; the proof script uses production model fallback, command queue, and detached task runtime APIs with a deterministic local provider callback. GitHub CI and ClawSweeper re-review are pending on the pushed head.
