### PR TITLE
fix(anthropic): merge consecutive assistant turns in turn validation

### DIFF
--- a/src/agents/embedded-agent-helpers.validate-turns.test.ts
+++ b/src/agents/embedded-agent-helpers.validate-turns.test.ts
@@ -323,7 +323,7 @@ describe("validateAnthropicTurns", () => {
     ]);
   });
 
-  it("should not merge consecutive assistant messages", () => {
+  it("merges consecutive assistant messages", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Question" }] },
       {
@@ -338,7 +338,60 @@ describe("validateAnthropicTurns", () => {
 
     const result = validateAnthropicTurns(msgs);
 
-    expect(result).toEqual(msgs);
+    expect(result).toEqual([
+      { role: "user", content: [{ type: "text", text: "Question" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Answer 1" },
+          { type: "text", text: "Answer 2" },
+        ],
+      },
+    ]);
+  });
+
+  it("merges an injected assistant turn before validating signed tool-result pairing", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use the gateway" }] },
+      {
+        role: "assistant",
+        content: makeSignedThinkingGatewayToolCall("tool-1"),
+        stopReason: "toolUse",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Subagent completion delivered." }],
+        stopReason: "stop",
+      },
+      {
+        role: "toolResult",
+        toolUseId: "tool-1",
+        toolName: "gateway",
+        content: [{ type: "text", text: "done" }],
+        isError: false,
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toEqual([
+      { role: "user", content: [{ type: "text", text: "Use the gateway" }] },
+      {
+        role: "assistant",
+        content: [
+          ...makeSignedThinkingGatewayToolCall("tool-1"),
+          { type: "text", text: "Subagent completion delivered." },
+        ],
+        stopReason: "stop",
+      },
+      {
+        role: "toolResult",
+        toolUseId: "tool-1",
+        toolName: "gateway",
+        content: [{ type: "text", text: "done" }],
+        isError: false,
+      },
+    ]);
   });
 
   it("should handle mixed scenario with steering messages", () => {

--- a/src/agents/embedded-agent-helpers/turns.ts
+++ b/src/agents/embedded-agent-helpers/turns.ts
@@ -389,8 +389,16 @@ export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[]
   // First, strip dangling tool-call blocks from assistant messages.
   const stripped = stripDanglingAnthropicToolUses(messages);
 
-  return validateTurnsWithConsecutiveMerge({
+  // Merge consecutive assistant turns (e.g. subagent announce-delivery echo
+  // messages that leak into the transcript with real assistant responses).
+  const mergedAssistant = validateTurnsWithConsecutiveMerge({
     messages: stripped,
+    role: "assistant",
+    merge: mergeConsecutiveAssistantTurns,
+  });
+
+  return validateTurnsWithConsecutiveMerge({
+    messages: mergedAssistant,
     role: "user",
     merge: mergeConsecutiveUserTurns,
   });

--- a/src/agents/embedded-agent-helpers/turns.ts
+++ b/src/agents/embedded-agent-helpers/turns.ts
@@ -386,19 +386,18 @@ function normalizeUserContentForMerge(content: unknown): UserContentBlock[] {
  * Also strips dangling tool_use blocks that lack corresponding tool_result blocks.
  */
 export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[] {
-  // First, strip dangling tool-call blocks from assistant messages.
-  const stripped = stripDanglingAnthropicToolUses(messages);
-
-  // Merge consecutive assistant turns (e.g. subagent announce-delivery echo
-  // messages that leak into the transcript with real assistant responses).
+  // Merge first so an injected assistant turn cannot hide the tool result that
+  // resolves the preceding signed tool call. Stripping first would destroy the
+  // active Anthropic tool-use turn before the adjacent turns can be repaired.
   const mergedAssistant = validateTurnsWithConsecutiveMerge({
-    messages: stripped,
+    messages,
     role: "assistant",
     merge: mergeConsecutiveAssistantTurns,
   });
+  const stripped = stripDanglingAnthropicToolUses(mergedAssistant);
 
   return validateTurnsWithConsecutiveMerge({
-    messages: mergedAssistant,
+    messages: stripped,
     role: "user",
     merge: mergeConsecutiveUserTurns,
   });


### PR DESCRIPTION
## Summary

Fixes #87329.

Anthropic replay now merges consecutive assistant turns before validating tool-use/result pairing. This repairs dormant/restarted subagent delivery sequences without weakening official Anthropic tool calling:

- signed `thinking` and `tool_use` blocks stay unchanged
- an injected or genuine adjacent assistant turn is appended to the same replay turn
- the following `tool_result` remains immediately paired with its `tool_use`
- genuinely dangling tool calls are still stripped after the merge
- consecutive user turns keep their existing merge behavior
- OpenAI replay policy remains unchanged and does not call this validator

The merge must happen before dangling-tool stripping. Stripping first treats the intervening assistant as the end of the tool-use span and deletes the valid signed tool call before repair.

## Verification

- Anthropic turn/replay tests: 129 passed
- OpenAI isolation and thinking-policy tests: 95 passed
- Targeted oxlint: passed
- Testbox changed gate: passed
  - Testbox: `tbx_01kv29c0ttq9sd4x0adpvkzygk`
  - Actions: https://github.com/openclaw/openclaw/actions/runs/27489370973
- Fresh Codex autoreview: no actionable findings, confidence 0.93

## Real behavior proof

Behavior addressed: a signed Anthropic tool-use turn followed by another assistant transcript entry no longer loses adjacency with its required tool result.

Real environment tested: macOS, Node.js, OpenClaw working tree, live `anthropic/claude-sonnet-4-6` API.

Exact steps or command run after this patch:

```bash
env -u ANTHROPIC_API_KEY pnpm exec tsx /tmp/anthropic-consecutive-assistant-live.ts

node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.validate-turns.test.ts src/agents/embedded-agent-runner/replay-history.test.ts src/agents/embedded-agent-runner.sanitize-session-history.test.ts

node scripts/run-vitest.mjs src/agents/transcript-policy.test.ts src/agents/embedded-agent-runner.openai-tool-id-preservation.test.ts src/agents/embedded-agent-runner/thinking.test.ts

node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed
```

Evidence after fix: copied live terminal output from the real Claude request:

```text
consecutive_result=error thinking_blocks=1
consecutive_error=400 ... unexpected `tool_use_id` found in `tool_result` blocks ... Each `tool_result` block must have a corresponding `tool_use` block in the previous message.
validated_result=ok messages=3 thinking_blocks=1
credential_attempt=2 credential_count=8
```

Observed result after fix: the raw four-message sequence failed exactly at Anthropic's tool-result adjacency check. Passing the same sequence through the patched production `validateAnthropicTurns` helper produced three messages, preserved one signed thinking block, and completed successfully.

What was not tested: no gateway-restart UI flow or cross-OS live Anthropic call; the Linux Testbox changed gate passed.
