### PR TITLE
fix(tui): force repaint final chat events

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -469,7 +469,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("keeps a local BTW result visible when its empty final chat event arrives", () => {
-    const { state, btw, loadHistory, noteLocalBtwRunId, handleBtwEvent, handleChatEvent } =
+    const { state, btw, loadHistory, noteLocalBtwRunId, tui, handleBtwEvent, handleChatEvent } =
       createHandlersHarness({
         state: { activeChatRunId: null },
       });
@@ -482,6 +482,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       question: "what changed?",
       text: "nothing important",
     } satisfies BtwEvent);
+    tui.requestRender.mockClear();
 
     handleChatEvent({
       runId: "run-btw",
@@ -495,6 +496,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       text: "nothing important",
       isError: undefined,
     });
+    expect(tui.requestRender).toHaveBeenCalledWith(true);
   });
 
   it("clears stale streaming for a local BTW empty final without hiding the result", () => {
@@ -699,6 +701,25 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("forces render when a command final only adds system text", () => {
+    const { state, chatLog, tui, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-command" },
+    });
+
+    handleChatEvent({
+      runId: "run-command",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: {
+        command: true,
+        content: [{ type: "text", text: "/status done" }],
+      },
+    });
+
+    expect(chatLog.addSystem).toHaveBeenCalledWith("/status done");
+    expect(tui.requestRender).toHaveBeenCalledWith(true);
   });
 
   it("binds optimistic pending messages to the first gateway run id and skips history reload", () => {
@@ -1127,7 +1148,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("reloads history when a local run ends without a displayable final message", () => {
-    const { state, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+    const { state, loadHistory, noteLocalRunId, tui, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-local-silent" },
     });
 
@@ -1140,6 +1161,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
+    expect(tui.requestRender).toHaveBeenCalledWith(true);
   });
 
   it("does not reload history for local run with empty final when another run is active (#53115)", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -22,7 +22,7 @@ type EventHandlerChatLog = {
 };
 
 type EventHandlerTui = {
-  requestRender: () => void;
+  requestRender: (force?: boolean) => void;
 };
 
 type EventHandlerBtwPresenter = {
@@ -489,7 +489,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         forgetLocalBtwRunId?.(evt.runId);
         noteFinalizedRun(evt.runId);
         clearStaleStreamingIfNoTrackedRunRemains();
-        tui.requestRender();
+        tui.requestRender(true);
         return;
       }
       if (!evt.message) {
@@ -498,7 +498,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         });
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
-        tui.requestRender();
+        tui.requestRender(true);
         return;
       }
       if (isCommandMessage(evt.message)) {
@@ -508,7 +508,7 @@ export function createEventHandlers(context: EventHandlerContext) {
           chatLog.addSystem(text);
         }
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle", displayedFinal: true });
-        tui.requestRender();
+        tui.requestRender(true);
         return;
       }
       maybeRefreshHistoryForRun(evt.runId);


### PR DESCRIPTION
## Summary

- Force a full TUI repaint for `handleChatEvent` final-event early returns that otherwise only mutate state, drop assistant output, or add command/system text.
- Cover the three reported branches with focused `tui-event-handlers` regression assertions.

Fixes #86871.

## Root Cause

`@earendil-works/pi-tui` exposes `requestRender(force?: boolean)`, and passing `true` resets the previous-line diff state before scheduling a repaint. The TUI already uses that forced path in other full-refresh cases, but the three final-event early returns in `src/tui/tui-event-handlers.ts` only called `requestRender()` and could leave the terminal unchanged until another action forced a repaint.

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`
- `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`
- `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 OPENCLAW_TUI_PTY_MIRROR_PATH=<tmpfile> node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts`
- Temporary command-final PTY proof script using the real `runTui()` loop and a PTY-backed fixture backend
- `git diff --check`

## Real behavior proof

Behavior addressed: TUI final chat events that finish through the local BTW empty-final path, the no-message final path, or the command-message final path now request a forced repaint with `tui.requestRender(true)`. This directly addresses the reported symptom where final assistant/system output could remain off-screen until another action, such as toggling `/verbose`, forced a full redraw.

Real environment tested: local macOS source worktree with repo dependencies installed from the lockfile. I exercised the changed code in three layers: focused handler regression coverage, the scoped fake-backend PTY harness, and a real `tui --local` process under a pseudo-terminal with only the model HTTP endpoint mocked. I also ran a temporary PTY proof that starts the real `runTui()` loop and emits a `command: true` final chat event, which is one of the patched early-return branches.

Exact steps or command run after this patch: `pnpm install --frozen-lockfile`; `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts`; `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`; `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`; `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 OPENCLAW_TUI_PTY_MIRROR_PATH=<tmpfile> node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts`; temporary command-final PTY proof script; `git diff --check`.

Evidence after fix: the focused handler suite passed with 57 tests, including assertions that all three #86871 early-return branches call `requestRender(true)`. The fake-backend TUI PTY harness passed with 13 tests. The local-backend TUI PTY lane passed with 14 tests, and the mirrored `tui --local` terminal output showed the final model response visible in the terminal after submitting one prompt, with no `/verbose` command sent. The temporary command-final PTY proof showed `VISIBLE_COMMAND_FINAL_PROOF` rendered on the terminal after a `command: true` final chat event, also with no `/verbose` command sent. The installed `@earendil-works/pi-tui` contract was checked: `dist/tui.d.ts` declares `requestRender(force?: boolean)`, and `dist/tui.js` resets `previousLines`, previous dimensions, cursor rows, and viewport state when `force` is true.

Copied redacted terminal proof from the real `tui --local` PTY run, ANSI stripped:

```text
local ready | idle
agent main | session main | tui-pty-mock/gpt-5.5 | tokens ?/128k
send the local PTY smoke response
running - 0s | local ready
LOCAL_PTY_RESPONSE
local ready | idle
agent main | session main | tui-pty-mock/gpt-5.5 | tokens ?/128k
```

Copied redacted terminal proof from the command-final PTY run, ANSI stripped. This proof hits the patched `isCommandMessage(evt.message)` early-return branch:

```text
openclaw tui command final proof - pty-proof://command-final - agent main (Main) - session main
local ready | idle
agent main (Main) | session main | proof-provider/proof-provider/proof-model | tokens ?/128
trigger command final proof
running - 0s | local ready
trigger command final proof
VISIBLE_COMMAND_FINAL_PROOF
local ready | idle
agent main (Main) | session main | proof-provider/proof-provider/proof-model | tokens ?/128
```

Observed result after fix: the final output was visible in the terminal immediately after the final event in both PTY captures, and the command-final proof confirmed no `/verbose` command appeared in the transcript.

What was not tested: a real external model provider was not used. The local PTY smoke mocks only the model HTTP endpoint, and the command-final proof uses a fixture backend to emit the specific patched final-event shape. Gateway network transport, real provider behavior, session persistence, and live streaming were not exercised by this proof.
