### PR TITLE
fix(docker): copy workspace templates to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,6 +182,7 @@ COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 COPY --from=runtime-assets --chown=node:node /app/qa ./qa
+COPY --from=runtime-assets --chown=node:node /app/src/agents/templates ./src/agents/templates
 
 # Keep pnpm available in the runtime image for container-local workflows.
 # Use a shared Corepack home so the non-root `node` user does not need a


### PR DESCRIPTION
## Summary

The heartbeat workspace template was moved from `docs/reference/templates/HEARTBEAT.md` to `src/agents/templates/HEARTBEAT.md` in #85416. That PR updated the npm `files` field to ship the new path, but the Dockerfile's runtime-image `COPY` list was not updated. The runtime stage copies `dist`, `node_modules`, `extensions`, `skills`, `docs`, and `qa`, but never `src/agents/templates`. The template's old home lived under `docs/`, which the runtime image *does* copy, so the move regressed only the Docker distribution channel.

As a result, Docker deployments on 2026.5.26 fail on every message dispatch with `Missing workspace template: HEARTBEAT.md (/app/src/agents/templates/HEARTBEAT.md)`, leaving the agent completely unresponsive (#87302).

This adds the single missing `COPY` so the runtime image ships the template at exactly the path the resolver looks for (`Dockerfile:185`).

- **Behavior:** Docker containers can again bootstrap the agent workspace and respond to messages.
- **Surface:** `Dockerfile` runtime stage, one `COPY` line.
- **Fixes** #87302. **Regression from** #85416.

## Verification

Built the full runtime image from this branch (native arm64 / colima) and exercised the exact failing code path — `agent` workspace bootstrap — inside the running container. Commands and evidence below.

## Real behavior proof

**Behavior addressed:** Runtime image was missing `src/agents/templates/HEARTBEAT.md`, causing `Missing workspace template: HEARTBEAT.md` on every message dispatch in Docker.

**Real environment tested:** Local full `docker build` of this branch's Dockerfile on colima (aarch64, native), producing image `openclaw-87302-e2e` (1.33GB), then `docker run` against the built image.

**Exact steps or command run after this patch:**

```
docker build -t openclaw-87302-e2e .
docker run --rm openclaw-87302-e2e ls -la /app/src/agents/templates/
docker run --rm openclaw-87302-e2e cat /app/src/agents/templates/HEARTBEAT.md
docker run --rm -e OPENCLAW_NO_ONBOARD=1 -e OPENCLAW_SUPPRESS_NOTES=1 openclaw-87302-e2e \
  sh -c 'node openclaw.mjs agent --message "workspace bootstrap smoke" --session-id smoke --local --timeout 1 --json > /tmp/out.log 2>&1; \
         grep -c "Missing workspace template" /tmp/out.log; \
         ls -1 /home/node/.openclaw/workspace/'
```

**Evidence after fix:**

- `/app/src/agents/templates/HEARTBEAT.md` is present in the runtime image (152 bytes, owned `node:node`); content matches the source template.
- `grep -c "Missing workspace template"` over the agent output returns `0`.
- Workspace bootstrap created all seven files: `AGENTS.md`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `IDENTITY.md`, `SOUL.md`, `TOOLS.md`, `USER.md`.

**Observed result after fix:** No `Missing workspace template` error. Workspace bootstrap succeeds and reads `HEARTBEAT.md` correctly. The agent process exits non-zero only because the test container has no model API key (`No API key found for provider "openai"`), which happens *after* bootstrap and is unrelated to this fix.

**What was not tested:** A live channel round-trip (e.g. Discord) with a configured model. The regressed path is workspace bootstrap, which is fully covered here; channel delivery is untouched by this change.

## Note for reviewers

The regression slipped through because packaging is tracked in two places — the npm `files` field (updated in #85416) and the Dockerfile `COPY` list (not updated). A follow-up could add a Docker packaging guard (e.g. asserting `WORKSPACE_TEMPLATE_PACK_PATHS` from `scripts/lib/workspace-bootstrap-smoke.mjs` are present in the built image) so this class of regression fails CI rather than reaching users. Out of scope for this hotfix.
