### PR TITLE
fix: add ClawHub plugin display metadata

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -5,7 +5,7 @@
   },
   "enabledByDefault": true,
   "name": "ACPX Runtime",
-  "description": "Embedded ACP runtime backend with plugin-owned session and transport management.",
+  "description": "OpenClaw ACP runtime backend with plugin-owned session and transport management.",
   "skills": ["./skills"],
   "configSchema": {
     "type": "object",

--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/acpx",
   "version": "2026.5.27",
-  "description": "OpenClaw ACP runtime backend",
+  "description": "OpenClaw ACP runtime backend with plugin-owned session and transport management.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/amazon-bedrock-mantle/openclaw.plugin.json
+++ b/extensions/amazon-bedrock-mantle/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "amazon-bedrock-mantle",
+  "name": "Amazon Bedrock Mantle",
+  "description": "OpenClaw Amazon Bedrock Mantle provider plugin for OpenAI-compatible model routing.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/amazon-bedrock-mantle/package.json
+++ b/extensions/amazon-bedrock-mantle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/amazon-bedrock-mantle-provider",
   "version": "2026.5.27",
-  "description": "OpenClaw Amazon Bedrock Mantle (OpenAI-compatible) provider plugin",
+  "description": "OpenClaw Amazon Bedrock Mantle provider plugin for OpenAI-compatible model routing.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/amazon-bedrock/openclaw.plugin.json
+++ b/extensions/amazon-bedrock/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "amazon-bedrock",
+  "name": "Amazon Bedrock",
+  "description": "OpenClaw Amazon Bedrock provider plugin with model discovery, embeddings, and guardrail support.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/amazon-bedrock/package.json
+++ b/extensions/amazon-bedrock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
   "version": "2026.5.27",
-  "description": "OpenClaw Amazon Bedrock provider plugin",
+  "description": "OpenClaw Amazon Bedrock provider plugin with model discovery, embeddings, and guardrail support.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/anthropic-vertex/openclaw.plugin.json
+++ b/extensions/anthropic-vertex/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "anthropic-vertex",
+  "name": "Anthropic Vertex",
+  "description": "OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
   "version": "2026.5.27",
-  "description": "OpenClaw Anthropic Vertex provider plugin",
+  "description": "OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/brave/openclaw.plugin.json
+++ b/extensions/brave/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "brave",
+  "name": "Brave",
+  "description": "OpenClaw Brave Search provider plugin for web search.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/brave-plugin",
   "version": "2026.5.27",
-  "description": "OpenClaw Brave plugin",
+  "description": "OpenClaw Brave Search provider plugin for web search.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "codex",
   "name": "Codex",
-  "description": "Codex app-server harness and Codex-managed GPT model catalog.",
+  "description": "OpenClaw Codex app-server harness and model provider plugin with a Codex-managed GPT catalog.",
   "providers": ["codex"],
   "contracts": {
     "mediaUnderstandingProviders": ["codex"],

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/codex",
   "version": "2026.5.27",
-  "description": "OpenClaw Codex harness and model provider plugin",
+  "description": "OpenClaw Codex app-server harness and model provider plugin with a Codex-managed GPT catalog.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/diagnostics-otel/openclaw.plugin.json
+++ b/extensions/diagnostics-otel/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "diagnostics-otel",
+  "name": "Diagnostics OpenTelemetry",
+  "description": "OpenClaw diagnostics OpenTelemetry exporter for metrics and traces.",
   "activation": {
     "onStartup": true
   },

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/diagnostics-otel",
   "version": "2026.5.27",
-  "description": "OpenClaw diagnostics OpenTelemetry exporter",
+  "description": "OpenClaw diagnostics OpenTelemetry exporter for metrics and traces.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/diagnostics-prometheus/openclaw.plugin.json
+++ b/extensions/diagnostics-prometheus/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "diagnostics-prometheus",
+  "name": "Diagnostics Prometheus",
+  "description": "OpenClaw diagnostics Prometheus exporter for runtime metrics.",
   "activation": {
     "onStartup": true
   },

--- a/extensions/diagnostics-prometheus/package.json
+++ b/extensions/diagnostics-prometheus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/diagnostics-prometheus",
   "version": "2026.5.27",
-  "description": "OpenClaw diagnostics Prometheus exporter",
+  "description": "OpenClaw diagnostics Prometheus exporter for runtime metrics.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -4,7 +4,7 @@
     "onStartup": true
   },
   "name": "Diffs",
-  "description": "Read-only diff viewer and file renderer for agents.",
+  "description": "OpenClaw read-only diff viewer plugin and file renderer for agents.",
   "contracts": {
     "tools": ["diffs"]
   },

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/diffs",
   "version": "2026.5.27",
-  "description": "OpenClaw diff viewer plugin",
+  "description": "OpenClaw read-only diff viewer plugin and file renderer for agents.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/discord/openclaw.plugin.json
+++ b/extensions/discord/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "discord",
+  "name": "Discord",
+  "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/discord",
   "version": "2026.5.27",
-  "description": "OpenClaw Discord channel plugin",
+  "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/feishu/openclaw.plugin.json
+++ b/extensions/feishu/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "feishu",
+  "name": "Feishu/Lark",
+  "description": "OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).",
   "activation": {
     "onStartup": false
   },

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/feishu",
   "version": "2026.5.27",
-  "description": "OpenClaw Feishu/Lark channel plugin (community maintained by @m1heng)",
+  "description": "OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/google-meet/openclaw.plugin.json
+++ b/extensions/google-meet/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "google-meet",
   "name": "Google Meet",
-  "description": "Join Google Meet calls through Chrome or Twilio transports.",
+  "description": "OpenClaw Google Meet participant plugin for joining calls through Chrome or Twilio transports.",
   "enabledByDefault": false,
   "commandAliases": [{ "name": "googlemeet" }],
   "activation": {

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/google-meet",
   "version": "2026.5.27",
-  "description": "OpenClaw Google Meet participant plugin",
+  "description": "OpenClaw Google Meet participant plugin for joining calls through Chrome or Twilio transports.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/googlechat/openclaw.plugin.json
+++ b/extensions/googlechat/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "googlechat",
+  "name": "Google Chat",
+  "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/googlechat",
   "version": "2026.5.27",
-  "description": "OpenClaw Google Chat channel plugin",
+  "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/line/openclaw.plugin.json
+++ b/extensions/line/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "line",
+  "name": "LINE",
+  "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/line",
   "version": "2026.5.27",
-  "description": "OpenClaw LINE channel plugin",
+  "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/lobster/openclaw.plugin.json
+++ b/extensions/lobster/openclaw.plugin.json
@@ -4,7 +4,7 @@
     "onStartup": true
   },
   "name": "Lobster",
-  "description": "Typed workflow tool with resumable approvals.",
+  "description": "Lobster workflow tool plugin for typed pipelines and resumable approvals.",
   "contracts": {
     "tools": ["lobster"]
   },

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/lobster",
   "version": "2026.5.27",
-  "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
+  "description": "Lobster workflow tool plugin for typed pipelines and resumable approvals.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/matrix/openclaw.plugin.json
+++ b/extensions/matrix/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "matrix",
+  "name": "Matrix",
+  "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
   "commandAliases": [{ "name": "matrix" }],
   "activation": {
     "onStartup": false,

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/matrix",
   "version": "2026.5.27",
-  "description": "OpenClaw Matrix channel plugin",
+  "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "memory-lancedb",
+  "name": "Memory LanceDB",
+  "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.",
   "commandAliases": [{ "name": "ltm" }],
   "activation": {
     "onStartup": false,

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/memory-lancedb",
   "version": "2026.5.27",
-  "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall/capture",
+  "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/msteams/openclaw.plugin.json
+++ b/extensions/msteams/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "msteams",
+  "name": "Microsoft Teams",
+  "description": "OpenClaw Microsoft Teams channel plugin for bot conversations.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/msteams",
   "version": "2026.5.27",
-  "description": "OpenClaw Microsoft Teams channel plugin",
+  "description": "OpenClaw Microsoft Teams channel plugin for bot conversations.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/nextcloud-talk/openclaw.plugin.json
+++ b/extensions/nextcloud-talk/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "nextcloud-talk",
+  "name": "Nextcloud Talk",
+  "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/nextcloud-talk",
   "version": "2026.5.27",
-  "description": "OpenClaw Nextcloud Talk channel plugin",
+  "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/nostr/openclaw.plugin.json
+++ b/extensions/nostr/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "nostr",
+  "name": "Nostr",
+  "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/nostr",
   "version": "2026.5.27",
-  "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted DMs",
+  "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/openshell/openclaw.plugin.json
+++ b/extensions/openshell/openclaw.plugin.json
@@ -4,7 +4,7 @@
     "onStartup": true
   },
   "name": "OpenShell Sandbox",
-  "description": "Sandbox backend powered by the NVIDIA OpenShell CLI with mirrored local workspaces and SSH-based command execution.",
+  "description": "OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/openshell-sandbox",
   "version": "2026.5.27",
-  "description": "OpenClaw sandbox backend for the NVIDIA OpenShell CLI",
+  "description": "OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/pixverse/openclaw.plugin.json
+++ b/extensions/pixverse/openclaw.plugin.json
@@ -1,6 +1,7 @@
 {
   "id": "pixverse",
-  "description": "Adds PixVerse video generation provider support to OpenClaw.",
+  "name": "PixVerse",
+  "description": "OpenClaw PixVerse video generation provider plugin.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/pixverse/package.json
+++ b/extensions/pixverse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/pixverse-provider",
   "version": "2026.5.27",
-  "description": "OpenClaw PixVerse video provider plugin",
+  "description": "OpenClaw PixVerse video generation provider plugin.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/qqbot/openclaw.plugin.json
+++ b/extensions/qqbot/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "qqbot",
+  "name": "QQ Bot",
+  "description": "OpenClaw QQ Bot channel plugin for group and direct-message workflows.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/qqbot/package.json
+++ b/extensions/qqbot/package.json
@@ -2,7 +2,7 @@
   "name": "@openclaw/qqbot",
   "version": "2026.5.27",
   "private": false,
-  "description": "OpenClaw QQ Bot channel plugin",
+  "description": "OpenClaw QQ Bot channel plugin for group and direct-message workflows.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/slack/openclaw.plugin.json
+++ b/extensions/slack/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "slack",
+  "name": "Slack",
+  "description": "OpenClaw Slack channel plugin for channels, DMs, commands, and app events.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/slack",
   "version": "2026.5.27",
-  "description": "OpenClaw Slack channel plugin",
+  "description": "OpenClaw Slack channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/synology-chat/openclaw.plugin.json
+++ b/extensions/synology-chat/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "synology-chat",
+  "name": "Synology Chat",
+  "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/synology-chat",
   "version": "2026.5.27",
-  "description": "Synology Chat channel plugin for OpenClaw",
+  "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/tlon/openclaw.plugin.json
+++ b/extensions/tlon/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "tlon",
+  "name": "Tlon/Urbit",
+  "description": "OpenClaw Tlon/Urbit channel plugin for chat workflows.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/tlon",
   "version": "2026.5.27",
-  "description": "OpenClaw Tlon/Urbit channel plugin",
+  "description": "OpenClaw Tlon/Urbit channel plugin for chat workflows.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/twitch/openclaw.plugin.json
+++ b/extensions/twitch/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "twitch",
+  "name": "Twitch",
+  "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/twitch",
   "version": "2026.5.27",
-  "description": "OpenClaw Twitch channel plugin",
+  "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "voice-call",
+  "name": "Voice Call",
+  "description": "OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.",
   "commandAliases": [{ "name": "voicecall" }],
   "activation": {
     "onStartup": true,

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/voice-call",
   "version": "2026.5.27",
-  "description": "OpenClaw voice-call plugin",
+  "description": "OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/whatsapp/openclaw.plugin.json
+++ b/extensions/whatsapp/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "whatsapp",
+  "name": "WhatsApp",
+  "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/whatsapp",
   "version": "2026.5.27",
-  "description": "OpenClaw WhatsApp channel plugin",
+  "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/zalo/openclaw.plugin.json
+++ b/extensions/zalo/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "zalo",
+  "name": "Zalo",
+  "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/zalo",
   "version": "2026.5.27",
-  "description": "OpenClaw Zalo channel plugin",
+  "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/zalouser/openclaw.plugin.json
+++ b/extensions/zalouser/openclaw.plugin.json
@@ -1,5 +1,7 @@
 {
   "id": "zalouser",
+  "name": "Zalo Personal",
+  "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
   "activation": {
     "onStartup": false
   },

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/zalouser",
   "version": "2026.5.27",
-  "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration",
+  "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"


### PR DESCRIPTION
## Summary
- Add `openclaw.plugin.json` `name` metadata for ClawHub-published plugins that were missing it.
- Improve package and manifest descriptions while preserving existing facts/credits, including Feishu/Lark's `@m1heng` maintainer note, NIP-04, zca-js, Codex app-server/catalog, LanceDB auto-recall/capture, OpenShell CLI details, and similar context.
- Include the current `pixverse` publishable plugin added on `main`.

## Diagnosis
ClawHub package publishing resolves the card display name from `openclaw.plugin.json.name` before falling back to README/folder naming. The screenshot items with broken names (WhatsApp, Matrix, Discord, Feishu/Lark, Memory LanceDB, Brave) were missing manifest names, so publishing a `.tgz` made ClawHub title-case the tarball filename (`openclaw-whatsapp-2026.5.26.tgz`). Codex already had `openclaw.plugin.json.name`, which is why it rendered correctly.

## Verification
- `python3` JSON/metadata check for all publishable ClawHub plugin manifests and package descriptions
- targeted preservation check for existing description facts/credits (`@m1heng`, `NIP-04`, `native zca-js`, Codex app-server/catalog, LanceDB auto-recall/capture, OpenShell CLI details, etc.)
- `git diff --check -- extensions`
- `pnpm release:plugins:clawhub:check`

## Real behavior proof
Behavior addressed: ClawHub-published plugin cards can use explicit manifest display names instead of title-casing uploaded tarball filenames, and summaries are clearer without dropping existing attribution/details.
Real environment tested: Local OpenClaw checkout metadata and release-check scripts.
Exact steps or command run after this patch: `pnpm release:plugins:clawhub:check`; `git diff --check -- extensions`; JSON parse/metadata assertion over ClawHub-published plugin manifests/package metadata; targeted description fact-preservation check.
Evidence after fix: All `publishToClawHub` plugins report non-empty manifest `name` and `description`; package descriptions are non-empty; `plugin-clawhub-release-check` reports publishable plugin metadata OK.
Observed result after fix: Release metadata validates for all ClawHub-published plugins.
What was not tested: Live ClawHub publish/render path.
