### PR TITLE
fix(doctor): make restart follow-up actionable

### DIFF
--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -219,7 +219,7 @@ describe("gateway tool", () => {
           };
           expect(parsed.payload?.kind).toBe("restart");
           expect(parsed.payload?.doctorHint).toBe(
-            "Run: openclaw --profile isolated doctor --non-interactive",
+            "Recommended follow-up: run openclaw --profile isolated doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.",
           );
         },
       );

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -22,7 +22,10 @@ const {
     },
     threadId: "thread-42",
   })),
-  formatDoctorNonInteractiveHintMock: vi.fn(() => "Run: openclaw doctor --non-interactive"),
+  formatDoctorNonInteractiveHintMock: vi.fn(
+    () =>
+      "Recommended follow-up: run openclaw doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.",
+  ),
   writeRestartSentinelMock: vi.fn(async (_payload: RestartSentinelPayload) => "/tmp/restart"),
   removeRestartSentinelFileMock: vi.fn(async (_path: string | null | undefined) => undefined),
   scheduleGatewaySigusr1RestartMock: vi.fn((_opts?: ScheduleGatewayRestartArgs) => ({
@@ -98,7 +101,9 @@ describe("gateway tool restart continuation", () => {
       threadId: "thread-42",
     });
     formatDoctorNonInteractiveHintMock.mockReset();
-    formatDoctorNonInteractiveHintMock.mockReturnValue("Run: openclaw doctor --non-interactive");
+    formatDoctorNonInteractiveHintMock.mockReturnValue(
+      "Recommended follow-up: run openclaw doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.",
+    );
     writeRestartSentinelMock.mockReset();
     writeRestartSentinelMock.mockResolvedValue("/tmp/restart");
     removeRestartSentinelFileMock.mockClear();

--- a/src/auto-reply/reply/commands-session-restart.test.ts
+++ b/src/auto-reply/reply/commands-session-restart.test.ts
@@ -16,7 +16,10 @@ const mocks = vi.hoisted(() => ({
     },
     threadId: "thread-1",
   })),
-  formatDoctorNonInteractiveHint: vi.fn(() => "Run: openclaw doctor --non-interactive"),
+  formatDoctorNonInteractiveHint: vi.fn(
+    () =>
+      "Recommended follow-up: run openclaw doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.",
+  ),
   writeRestartSentinel: vi.fn(async (_payload: RestartSentinelPayload) => "/tmp/sentinel.json"),
   scheduleGatewaySigusr1Restart: vi.fn((_opts?: ScheduleGatewayRestartArgs) => ({
     scheduled: true,
@@ -148,7 +151,9 @@ describe("handleRestartCommand", () => {
       kind: "agentTurn",
       message: DEFAULT_RESTART_SUCCESS_CONTINUATION_MESSAGE,
     });
-    expect(sentinelPayload?.doctorHint).toBe("Run: openclaw doctor --non-interactive");
+    expect(sentinelPayload?.doctorHint).toBe(
+      "Recommended follow-up: run openclaw doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.",
+    );
     expect(sentinelPayload?.stats).toEqual({
       mode: "gateway.restart",
       reason: "/restart",

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -367,9 +367,20 @@ describe("restart sentinel message dedup", () => {
     expect(result).toContain("Reason: /restart");
   });
 
-  it("formats the non-interactive doctor command", () => {
-    expect(formatDoctorNonInteractiveHint({ PATH: "/usr/bin:/bin" })).toContain(
-      "openclaw doctor --non-interactive",
+  it("formats the non-interactive doctor command as actionability guidance", () => {
+    expect(formatDoctorNonInteractiveHint({ PATH: "/usr/bin:/bin" })).toBe(
+      "Recommended follow-up: run openclaw doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.",
+    );
+  });
+
+  it("keeps profile-aware doctor guidance actionable outside constrained delivery surfaces", () => {
+    expect(
+      formatDoctorNonInteractiveHint({
+        OPENCLAW_PROFILE: "isolated",
+        PATH: "/usr/bin:/bin",
+      }),
+    ).toBe(
+      "Recommended follow-up: run openclaw --profile isolated doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.",
     );
   });
 });

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -73,7 +73,10 @@ const SENTINEL_FILENAME = "restart-sentinel.json";
 export function formatDoctorNonInteractiveHint(
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
 ): string {
-  return `Run: ${formatCliCommand("openclaw doctor --non-interactive", env)}`;
+  return `Recommended follow-up: run ${formatCliCommand(
+    "openclaw doctor --non-interactive",
+    env,
+  )} in a terminal or approvals-capable OpenClaw surface.`;
 }
 
 export function resolveRestartSentinelPath(env: NodeJS.ProcessEnv = process.env): string {


### PR DESCRIPTION
Closes #69755.

## Behavior addressed

Post-restart doctor guidance no longer presents `openclaw doctor --non-interactive` as an immediate command that can be run from every delivery surface. The generated restart sentinel hint now tells users to run the profile-aware command from a terminal or approvals-capable OpenClaw surface.

## Real environment tested

WSL Ubuntu local checkout on branch `fix-69755-doctor-hint-actionable`, based on `origin/main` at `11dfef201f`.

## Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/infra/restart-sentinel.test.ts src/gateway/server-methods/update.test.ts src/gateway/server-restart-sentinel.test.ts src/agents/tools/gateway-tool.test.ts src/auto-reply/reply/commands-session-restart.test.ts src/agents/openclaw-gateway-tool.test.ts --reporter=dot
./node_modules/.bin/oxfmt --check src/infra/restart-sentinel.ts src/gateway/server-methods/config-write-flow.ts src/infra/update-restart-sentinel-payload.ts src/gateway/server-restart-sentinel.ts src/agents/tools/gateway-tool.ts src/auto-reply/reply/commands-session.ts src/infra/restart-sentinel.test.ts src/gateway/server-methods/update.test.ts src/gateway/server-restart-sentinel.test.ts src/agents/tools/gateway-tool.test.ts src/auto-reply/reply/commands-session-restart.test.ts src/agents/openclaw-gateway-tool.test.ts
./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/infra/restart-sentinel.ts src/infra/restart-sentinel.test.ts src/agents/openclaw-gateway-tool.test.ts src/agents/tools/gateway-tool.test.ts src/auto-reply/reply/commands-session-restart.test.ts
git diff --check
```

Real restart-sentinel round trip using the patched source module:

```bash
export OPENCLAW_STATE_DIR=$(mktemp -d)
export OPENCLAW_PROFILE=isolated
./node_modules/.bin/tsx --eval 'import { consumeRestartSentinel, formatDoctorNonInteractiveHint, formatRestartSentinelMessage, writeRestartSentinel } from "./src/infra/restart-sentinel.ts"; void (async () => { const payload = { kind: "restart", status: "ok", ts: Date.now(), sessionKey: "agent:main:redacted:dm:redacted", message: "/restart", doctorHint: formatDoctorNonInteractiveHint(), stats: { mode: "gateway.restart", reason: "/restart" } }; const sentinelPath = await writeRestartSentinel(payload); const sentinel = await consumeRestartSentinel(); console.log("sentinelPath=" + sentinelPath.replace(process.env.OPENCLAW_STATE_DIR, "$OPENCLAW_STATE_DIR")); console.log("--- delivered restart notice ---"); console.log(formatRestartSentinelMessage(sentinel.payload)); })();'
```

## Evidence after fix

`formatDoctorNonInteractiveHint()` now returns:

```text
Recommended follow-up: run openclaw doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.
```

With `OPENCLAW_PROFILE=isolated`, it preserves profile-aware command formatting:

```text
Recommended follow-up: run openclaw --profile isolated doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.
```

Redacted real restart-sentinel output from the command above:

```text
sentinelPath=$OPENCLAW_STATE_DIR/restart-sentinel.json
--- delivered restart notice ---
Gateway restart restart ok (gateway.restart)
/restart
Recommended follow-up: run openclaw --profile isolated doctor --non-interactive in a terminal or approvals-capable OpenClaw surface.
```

Focused restart/update delivery tests passed: 9 files, 153 tests.

GitHub CI for this PR is green, including `check-guards`, `check-lint`, `check-prod-types`, `check-test-types`, `checks-node-agentic-commands-doctor`, `checks-node-agentic-commands-doctor-shared`, `checks-node-agentic-gateway-core`, `checks-node-auto-reply-reply-commands`, and the changed-path node shards.

## Observed result after fix

The restart sentinel still carries a single `doctorHint` string, so no public config, plugin, or payload-shape surface changed. The hint text now distinguishes recommended follow-up from actionability in constrained heartbeat/outbound contexts.

## What was not tested

I did not exercise a live macOS heartbeat session or live approval-timeout flow.

`node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` could not run because the local crabbox binary failed its own `--version/--help` sanity check before invoking the command. Running `pnpm check:changed` directly also stopped before checks due this WSL worktree using a symlinked `node_modules` and pnpm requiring an interactive purge confirmation.