### PR TITLE
fix(slack): retain delivered final replies during late cleanup

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1238,6 +1238,42 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(draftStream.clear).not.toHaveBeenCalled();
   });
 
+  it("does not reuse draft cleanup after a normally delivered final reply", async () => {
+    const draftStream = {
+      ...createDraftStreamStub(),
+      flush: vi.fn(noopAsync),
+      clear: vi.fn(noopAsync),
+      discardPending: vi.fn(noopAsync),
+      seal: vi.fn(noopAsync),
+    };
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: { text: "answer", mediaUrl: "https://example.com/final.png" },
+      },
+      { kind: "final", payload: { text: "late cleanup failed", isError: true } },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(2);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    const firstDelivered = requireRecord(
+      requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],
+      "deliver replies params",
+    );
+    expect(firstDelivered.replies).toEqual([
+      { text: "answer", mediaUrl: "https://example.com/final.png" },
+    ]);
+    const lateDelivered = requireRecord(
+      requireMockCall(deliverRepliesMock, 1, "deliver replies")[0],
+      "deliver replies params",
+    );
+    expect(lateDelivered.replies).toEqual([{ text: "late cleanup failed", isError: true }]);
+  });
+
   it("suppresses block streaming when Slack draft preview streaming is active", async () => {
     mockedBlockStreamingEnabled = true;
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -591,6 +591,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let usedReplyThreadTs: string | undefined;
   let usedBlockReplyThreadTs: string | undefined;
   let observedReplyDelivery = false;
+  let observedFinalReplyDelivery = false;
   const deliveryTracker = createSlackEventDeliveryTracker();
   const resolveDeliveryThreadTs = (params: {
     kind: ReplyDispatchKind;
@@ -693,6 +694,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
     });
     observedReplyDelivery = true;
+    if (params.kind === "final") {
+      observedFinalReplyDelivery = true;
+    }
     const deliveredThreadTs = resolveDeliveredSlackReplyThreadTs({
       replyToMode: replyDeliveryMode,
       payloadReplyToId: params.payload.replyToId,
@@ -720,6 +724,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       return false;
     }
     replyPlan.markSent();
+    if (params.kind === "final") {
+      observedFinalReplyDelivery = true;
+    }
     deliveryTracker.markDelivered({
       kind: params.kind,
       payload: params.payload,
@@ -798,6 +805,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         // the SDK reports a real Slack response.
         if (streamSession.delivered) {
           observedReplyDelivery = true;
+          if (params.kind === "final") {
+            observedFinalReplyDelivery = true;
+          }
         }
         rememberDeliveredThreadTs(params.kind, streamThreadTs);
         replyPlan.markSent();
@@ -829,6 +839,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       // optimistic "done" status until Slack acknowledges a flush.
       if (streamSession.delivered) {
         observedReplyDelivery = true;
+        if (params.kind === "final") {
+          observedFinalReplyDelivery = true;
+        }
       }
       deliveryTracker.markDelivered({
         kind: params.kind,
@@ -915,6 +928,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       ttsSupplement?.visibleTextAlreadyDelivered !== true &&
       Boolean(draftStream) &&
       !draftPreviewCommitted &&
+      !observedFinalReplyDelivery &&
       previewStreamingEnabled &&
       !payload.text?.trim();
 
@@ -923,6 +937,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       ttsSupplement &&
       draftStream &&
       !draftPreviewCommitted &&
+      !observedFinalReplyDelivery &&
       previewStreamingEnabled &&
       !payload.isError &&
       trimmedFinalText.length > 0
@@ -970,6 +985,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           return;
         }
         draftPreviewCommitted = true;
+        observedFinalReplyDelivery = true;
         observedReplyDelivery = true;
         replyPlan.markSent();
         await deliverNormally({
@@ -987,7 +1003,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       payload,
       adapter: defineFinalizableLivePreviewAdapter({
         draft:
-          draftStream && !draftPreviewCommitted
+          draftStream && !draftPreviewCommitted && !observedFinalReplyDelivery
             ? {
                 flush: draftStream.flush,
                 clear: draftStream.clear,
@@ -1030,11 +1046,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             threadTs: edit.threadTs,
           });
           draftPreviewCommitted = true;
+          observedFinalReplyDelivery = true;
         },
         onPreviewFinalized: (_preview) => {
           // The preview edit promotes the draft message into the final answer.
           // Later same-turn payloads must not let fallback cleanup clear it.
           draftPreviewCommitted = true;
+          observedFinalReplyDelivery = true;
           const finalThreadTs = usedReplyThreadTs ?? statusThreadTs;
           observedReplyDelivery = true;
           replyPlan.markSent();


### PR DESCRIPTION
## Summary

- Track when a Slack turn has already produced a visible final reply, including normal delivery, native stream delivery, and preview finalization.
- Stop passing the draft stream into later finalizable-preview handling after that point, so late same-turn error/recovery payloads cannot call `draftStream.clear()` and delete a visible answer.
- Keep the existing first-fallback behavior unchanged for non-finalized previews, so transient previews are still cleaned up when initially replaced by normal delivery.

Fixes #87363.

## Root cause

Slack's `draftStream.clear()` deletes the draft message. The dispatch path already protected in-place finalized previews with `draftPreviewCommitted`, but a final reply can also become visible through normal or streaming delivery. A later same-turn payload could still reuse the draft finalizer when `draftPreviewCommitted` was false, reaching fallback cleanup and deleting the message.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Slack draft cleanup can delete or replace a user-visible final reply when a late same-turn error/recovery payload reuses the draft finalizer after final delivery.
- Real environment tested: local macOS OpenClaw source checkout on this PR branch, running the real OpenClaw Vitest project runner against the Slack extension dispatch shard and the shared channel lifecycle shard.
- Exact steps or command run after this patch: `node scripts/test-projects.mjs extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts src/channels/message/lifecycle.test.ts -- --reporter=verbose`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output from the local run:

```text
[test] starting test/vitest/vitest.extension-slack.config.ts
✓ |extension-slack| extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts > dispatchPreparedSlackMessage preview fallback > does not reuse draft cleanup after a normally delivered final reply
Test Files  1 passed (1)
Tests  40 passed (40)

[test] starting test/vitest/vitest.channels.config.ts
✓ |channels| src/channels/message/lifecycle.test.ts > message lifecycle primitives > treats live preview fallback delivery as terminal state
Test Files  1 passed (1)
Tests  16 passed (16)

[test] passed 2 Vitest shards in 8.75s
```

- Observed result after fix: the new Slack regression delivers the original final payload and the later error payload, but `draftStream.clear()` is called only for the initial normal-delivery fallback and is not reused for the late same-turn cleanup payload. The shared lifecycle tests still pass, confirming the generic first-fallback cleanup behavior remains intact.
- What was not tested: I did not send a new live message to a private Slack workspace from this PR branch.
- Proof limitations or environment constraints: the original reproduction involved a private Slack channel and private runtime logs, so public proof is limited to redacted log timing plus the local OpenClaw Slack dispatch shard. The patch is intentionally Slack dispatch-scoped and does not change the generic live-preview lifecycle.
- Before evidence (optional but encouraged): redacted local runtime/session evidence showed `delivered reply to channel:[redacted]` around `2026-05-28 00:45:22 +08:00`, followed by a Slack `message_deleted` session event roughly 15 seconds later during the same broader recovery/error sequence. No token, account, full channel id, user id, session id, or full Responses item id is included.

## Tests and validation

- `node scripts/test-projects.mjs extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts src/channels/message/lifecycle.test.ts -- --reporter=verbose`

Regression coverage added:

- A Slack dispatch regression where a normally delivered final reply is followed by a late same-turn error final; the late payload is delivered without reusing draft cleanup.

What failed before this fix:

- The late same-turn payload could still receive the draft stream and reach `draftStream.clear()` because only in-place preview finalization set `draftPreviewCommitted`.
