### PR TITLE
fix(deps): stabilize npm shrinkwrap drift [AI]

### DIFF
--- a/scripts/generate-npm-shrinkwrap.mjs
+++ b/scripts/generate-npm-shrinkwrap.mjs
@@ -109,6 +109,136 @@ function collectPnpmLockPackageVersions(lockfile) {
   return versionsByName;
 }
 
+function exactVersionFromPnpmDependencyResolution(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const version = value.replace(/\(.*/u, "");
+  if (EXACT_VERSION_PATTERN.test(version)) {
+    return version;
+  }
+  return exactVersionFromOverrideSpec(value);
+}
+
+function sameStableVersionLine(left, right) {
+  const leftParts = stableVersionParts(left);
+  const rightParts = stableVersionParts(right);
+  return (
+    leftParts !== null &&
+    rightParts !== null &&
+    leftParts.major === rightParts.major &&
+    leftParts.minor === rightParts.minor
+  );
+}
+
+function collectPnpmLockParentDependencyOverrides(
+  lockfile,
+  versionsByName,
+  dependencyVersionsByName,
+) {
+  const snapshots = lockfile?.snapshots;
+  if (!snapshots || typeof snapshots !== "object" || Array.isArray(snapshots)) {
+    return {};
+  }
+  const overrides = new Map();
+  for (const [packageKey, snapshot] of Object.entries(snapshots)) {
+    if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+      continue;
+    }
+    const parent = parsePnpmPackageKey(packageKey);
+    if (!parent) {
+      continue;
+    }
+    const dependencies = {
+      ...snapshot.dependencies,
+      ...snapshot.optionalDependencies,
+    };
+    for (const [dependencyName, resolution] of Object.entries(dependencies)) {
+      const dependencyVersions = dependencyVersionsByName?.get(dependencyName);
+      if (dependencyVersionsByName && !dependencyVersions) {
+        continue;
+      }
+      const lockedVersions = versionsByName.get(dependencyName);
+      if (!lockedVersions || lockedVersions.size < 2) {
+        continue;
+      }
+      const dependencyVersion = exactVersionFromPnpmDependencyResolution(resolution);
+      if (!dependencyVersion || !lockedVersions.has(dependencyVersion)) {
+        continue;
+      }
+      if (dependencyVersions && !dependencyVersions.has(dependencyVersion)) {
+        continue;
+      }
+      const parentKey = `${parent.name}@${parent.version}`;
+      const parentOverrides = overrides.get(parentKey) ?? {};
+      parentOverrides[dependencyName] = dependencyVersion;
+      overrides.set(parentKey, parentOverrides);
+    }
+  }
+  return Object.fromEntries(
+    [...overrides.entries()]
+      .map(([parentKey, parentOverrides]) => [
+        parentKey,
+        Object.fromEntries(
+          Object.entries(parentOverrides).toSorted(([left], [right]) => left.localeCompare(right)),
+        ),
+      ])
+      .toSorted(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function addVersion(versionMap, packageName, version) {
+  const versions = versionMap.get(packageName) ?? new Set();
+  versions.add(version);
+  versionMap.set(packageName, versions);
+}
+
+function collectPnpmLockDriftOverrides(
+  lockfile,
+  versionsByName,
+  violations,
+  directDependencyNames = new Set(),
+) {
+  const flatOverrides = {};
+  const parentOverrideVersionsByName = new Map();
+  for (const violation of violations) {
+    const parsed = parsePnpmPackageKey(violation.packageKey);
+    const lockedVersions = parsed ? versionsByName.get(parsed.name) : undefined;
+    const lockVersion = lockedVersions
+      ? [...lockedVersions].find((version) => sameStableVersionLine(version, parsed.version))
+      : undefined;
+    if (!parsed || !lockVersion || flatOverrides[parsed.name] !== undefined) {
+      continue;
+    }
+    if (directDependencyNames.has(parsed.name)) {
+      addVersion(parentOverrideVersionsByName, parsed.name, lockVersion);
+      continue;
+    }
+    flatOverrides[parsed.name] = lockVersion;
+    const exceptionVersions = new Set(
+      [...lockedVersions].filter((version) => version !== lockVersion),
+    );
+    for (const version of exceptionVersions) {
+      addVersion(parentOverrideVersionsByName, parsed.name, version);
+    }
+  }
+  if (Object.keys(flatOverrides).length === 0 && parentOverrideVersionsByName.size === 0) {
+    return {};
+  }
+  return Object.fromEntries(
+    [
+      ...Object.entries(flatOverrides),
+      ...Object.entries(
+        collectPnpmLockParentDependencyOverrides(
+          lockfile,
+          versionsByName,
+          parentOverrideVersionsByName,
+        ),
+      ),
+    ].toSorted(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
 function stableVersionParts(version) {
   const match = version.match(STABLE_VERSION_PATTERN);
   return match
@@ -154,12 +284,13 @@ function readPnpmLockVersionOverrides() {
   if (versionsByName.size === 0) {
     throw new Error("pnpm-lock.yaml is missing package resolution data.");
   }
-  return Object.fromEntries(
+  const flatOverrides = Object.fromEntries(
     [...versionsByName.entries()]
       .map(([name, versions]) => [name, pnpmLockOverrideVersionForVersions(versions)])
       .filter(([, version]) => version !== null)
       .toSorted(([left], [right]) => left.localeCompare(right)),
   );
+  return flatOverrides;
 }
 
 function setKey(values) {
@@ -462,6 +593,45 @@ function normalizeNpmVersionDrift(lockfile) {
   return lockfile;
 }
 
+function readGeneratedShrinkwrap(tempDir) {
+  return normalizeNpmVersionDrift(
+    applyPackageExtensionPeerMetadata(
+      JSON.parse(readFileSync(path.join(tempDir, "npm-shrinkwrap.json"), "utf8")),
+    ),
+  );
+}
+
+function regenerateShrinkwrapWithPnpmLockDriftOverrides(
+  tempDir,
+  packageJson,
+  shrinkwrapOverrides,
+  violations,
+  npmInstallArgs,
+) {
+  const pnpmLock = parseYaml(readFileSync(path.join(ROOT_DIR, "pnpm-lock.yaml"), "utf8"));
+  const versionsByName = collectPnpmLockPackageVersions(pnpmLock);
+  const driftOverrides = collectPnpmLockDriftOverrides(
+    pnpmLock,
+    versionsByName,
+    violations,
+    declaredPackageDependencies(packageJson),
+  );
+  if (Object.keys(driftOverrides).length === 0) {
+    return null;
+  }
+  const retryOverrides = mergeOverrides(driftOverrides, shrinkwrapOverrides, {});
+  rmSync(path.join(tempDir, "npm-shrinkwrap.json"), { force: true });
+  rmSync(path.join(tempDir, "package-lock.json"), { force: true });
+  writeFileSync(
+    path.join(tempDir, "package.json"),
+    `${JSON.stringify(packageJsonForShrinkwrap(packageJson, retryOverrides), null, 2)}\n`,
+  );
+  runNpm(npmInstallArgs, tempDir);
+  runNpm(["shrinkwrap", "--ignore-scripts", "--no-audit", "--no-fund"], tempDir);
+  normalizeShrinkwrapOverrides(tempDir, shrinkwrapOverrides, npmInstallArgs);
+  return readGeneratedShrinkwrap(tempDir);
+}
+
 function generateShrinkwrap(packageDir, options = {}) {
   const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-shrinkwrap-"));
   try {
@@ -488,12 +658,20 @@ function generateShrinkwrap(packageDir, options = {}) {
     runNpm(npmInstallArgs, tempDir);
     runNpm(["shrinkwrap", "--ignore-scripts", "--no-audit", "--no-fund"], tempDir);
     normalizeShrinkwrapOverrides(tempDir, shrinkwrapOverrides, npmInstallArgs);
-    const generated = normalizeNpmVersionDrift(
-      applyPackageExtensionPeerMetadata(
-        JSON.parse(readFileSync(path.join(tempDir, "npm-shrinkwrap.json"), "utf8")),
-      ),
-    );
-    assertShrinkwrapMatchesPnpmLock(generated);
+    let generated = readGeneratedShrinkwrap(tempDir);
+    let violations = collectPnpmLockViolations(generated);
+    if (violations.length > 0) {
+      generated =
+        regenerateShrinkwrapWithPnpmLockDriftOverrides(
+          tempDir,
+          packageJson,
+          shrinkwrapOverrides,
+          violations,
+          npmInstallArgs,
+        ) ?? generated;
+      violations = collectPnpmLockViolations(generated);
+    }
+    assertShrinkwrapMatchesPnpmLock(generated, violations);
     return `${JSON.stringify(generated, null, 2)}\n`;
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
@@ -589,8 +767,10 @@ function readCurrentShrinkwrapOverrides(
   }
 }
 
-function assertShrinkwrapMatchesPnpmLock(shrinkwrap) {
-  const violations = collectPnpmLockViolations(shrinkwrap);
+function assertShrinkwrapMatchesPnpmLock(
+  shrinkwrap,
+  violations = collectPnpmLockViolations(shrinkwrap),
+) {
   if (violations.length === 0) {
     return;
   }
@@ -860,8 +1040,11 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
 export {
   collectCurrentShrinkwrapOverrides,
   collectOverrideViolations,
+  collectPnpmLockDriftOverrides,
+  collectPnpmLockParentDependencyOverrides,
   collectPnpmLockViolations,
   disableShrinkwrappedOverrideConflictSources,
+  exactVersionFromPnpmDependencyResolution,
   exactOverrideRulesFromOverrides,
   exactVersionFromOverrideSpec,
   applyPackageExtensionPeerMetadata,

--- a/test/scripts/generate-npm-shrinkwrap.test.ts
+++ b/test/scripts/generate-npm-shrinkwrap.test.ts
@@ -4,9 +4,12 @@ import {
   applyPackageExtensionPeerMetadata,
   collectCurrentShrinkwrapOverrides,
   collectOverrideViolations,
+  collectPnpmLockDriftOverrides,
+  collectPnpmLockParentDependencyOverrides,
   collectPnpmLockViolations,
   createNpmShrinkwrapCommand,
   disableShrinkwrappedOverrideConflictSources,
+  exactVersionFromPnpmDependencyResolution,
   exactOverrideRulesFromOverrides,
   exactVersionFromOverrideSpec,
   normalizeNpmVersionDrift,
@@ -53,6 +56,110 @@ describe("generate-npm-shrinkwrap", () => {
     expect(pnpmLockOverrideVersionForVersions(new Set(["3.972.38", "3.972.39"]))).toBe("3.972.39");
     expect(pnpmLockOverrideVersionForVersions(new Set(["3.972.39", "3.973.0"]))).toBeNull();
     expect(pnpmLockOverrideVersionForVersions(new Set(["3.972.39", "4.0.0"]))).toBeNull();
+  });
+
+  it("parses exact pnpm dependency resolution versions", () => {
+    expect(exactVersionFromPnpmDependencyResolution("11.5.0")).toBe("11.5.0");
+    expect(exactVersionFromPnpmDependencyResolution("19.2.4(react@19.2.4)")).toBe("19.2.4");
+    expect(exactVersionFromPnpmDependencyResolution("npm:@nolyfill/domexception@1.0.28")).toBe(
+      "1.0.28",
+    );
+    expect(exactVersionFromPnpmDependencyResolution("workspace:*")).toBeNull();
+  });
+
+  it("pins mixed-version transitive dependency edges by parent package version", () => {
+    const versionsByName = new Map([
+      ["lru-cache", new Set(["6.0.0", "11.5.0"])],
+      ["lodash.clonedeep", new Set(["4.5.0"])],
+    ]);
+    const lockfile = {
+      snapshots: {
+        "lru-memoizer@2.3.0": {
+          dependencies: {
+            "lodash.clonedeep": "4.5.0",
+            "lru-cache": "6.0.0",
+          },
+        },
+        "lru-memoizer@3.0.0": {
+          dependencies: {
+            "lodash.clonedeep": "4.5.0",
+            "lru-cache": "11.5.0",
+          },
+        },
+      },
+    };
+
+    expect(collectPnpmLockParentDependencyOverrides(lockfile, versionsByName)).toEqual({
+      "lru-memoizer@2.3.0": {
+        "lru-cache": "6.0.0",
+      },
+      "lru-memoizer@3.0.0": {
+        "lru-cache": "11.5.0",
+      },
+    });
+  });
+
+  it("builds focused npm overrides for same-line registry drift", () => {
+    const versionsByName = new Map([["lru-cache", new Set(["6.0.0", "11.5.0"])]]);
+    const lockfile = {
+      snapshots: {
+        "lru-memoizer@2.3.0": {
+          dependencies: {
+            "lru-cache": "6.0.0",
+          },
+        },
+        "lru-memoizer@3.0.0": {
+          dependencies: {
+            "lru-cache": "11.5.0",
+          },
+        },
+      },
+    };
+
+    expect(
+      collectPnpmLockDriftOverrides(lockfile, versionsByName, [
+        {
+          packageKey: "lru-cache@11.5.1",
+          path: "node_modules/lru-cache",
+        },
+      ]),
+    ).toEqual({
+      "lru-cache": "11.5.0",
+      "lru-memoizer@2.3.0": {
+        "lru-cache": "6.0.0",
+      },
+    });
+  });
+
+  it("uses parent-specific drift overrides when a package is a direct dependency", () => {
+    const versionsByName = new Map([["jwks-rsa", new Set(["3.2.2", "4.0.1"])]]);
+    const lockfile = {
+      snapshots: {
+        "@microsoft/teams.apps@2.0.11": {
+          dependencies: {
+            "jwks-rsa": "3.2.2",
+          },
+        },
+      },
+    };
+
+    expect(
+      collectPnpmLockDriftOverrides(
+        lockfile,
+        versionsByName,
+        [
+          {
+            packageKey: "jwks-rsa@3.2.3",
+            path: "node_modules/@microsoft/teams.apps/node_modules/jwks-rsa",
+          },
+        ],
+        new Set(["jwks-rsa"]),
+      ),
+    ).toEqual({
+      "@microsoft/teams.apps@2.0.11": {
+        "jwks-rsa": "3.2.2",
+      },
+    });
   });
 
   it("parses nested scoped package paths", () => {


### PR DESCRIPTION
## Summary

- Stabilizes `scripts/generate-npm-shrinkwrap.mjs` when npm publishes a newer patch on a transitive range that is intentionally still pinned to the current `pnpm-lock.yaml` version.
- Keeps the guard strict: generated shrinkwraps still must contain only package versions present in `pnpm-lock.yaml`; the retry only supplies temporary npm overrides so npm can reproduce the pnpm-locked version graph.
- Adds focused regression coverage for the mixed-version `lru-cache` shape that broke `extensions/msteams`, plus a direct-dependency safety case from local autoreview.
- Intentionally does not refresh package versions, edit generated shrinkwrap baselines, or weaken `deps:shrinkwrap:check`.

## AI assistance disclosure

This draft was implemented with Codex assistance in Fermin Quant's workspace. It is intentionally opened as a draft so Fermin can review and confirm understanding of the affected shrinkwrap generator path before it is marked ready.

## Linked context

Related #87309: that PR's `check-guards` failure showed this mainline shrinkwrap drift, but its diff does not touch package-manager files.

Related #87304: also affected by the same upstream baseline failure; it is not the fix for this drift.

## Real behavior proof (required for external PRs)

Behavior addressed: `pnpm deps:shrinkwrap:check` no longer fails when npm resolves `lru-cache@11.5.1` for `lru-memoizer@3.0.0` while the repo pnpm lock intentionally contains `lru-cache@11.5.0` and `lru-cache@6.0.0`.

Real environment tested: local Linux source checkout at `e31954c714d4ff0226c84177cd3d8e44b5ba5a30`, Node `v22.22.0`, npm `10.9.4`, pnpm `11.2.2`, clean worktree after `pnpm install`.

Exact steps or command run after this patch:

```bash
node scripts/generate-npm-shrinkwrap.mjs --all --check
pnpm deps:shrinkwrap:check
node scripts/check-changed.mjs --base origin/main
node scripts/run-vitest.mjs test/scripts/generate-npm-shrinkwrap.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Evidence after fix:

```text
$ pnpm deps:shrinkwrap:check
$ node scripts/generate-npm-shrinkwrap.mjs --all --check
.: npm-shrinkwrap.json is current.
extensions/acpx: npm-shrinkwrap.json is current.
...
extensions/msteams: npm-shrinkwrap.json is current.
...
extensions/zalouser: npm-shrinkwrap.json is current.
```

Observed result after fix: the exact guard command exits 0 and all 32 shrinkwrap-managed packages report `npm-shrinkwrap.json is current`; no `npm-shrinkwrap.json` or `pnpm-lock.yaml` baseline changed.

What was not tested: GitHub-hosted CI for this draft PR has not completed yet, and I did not run a remote Testbox/Crabbox broad lane. Local proof used Node 22.22.0; CI will also exercise the workflow's Node 24 setup.

Proof limitations or environment constraints: this is a tooling/generator fix, so the real behavior proof is the same generator command that failed in CI, not an end-user app flow.

Before evidence:

```text
$ node scripts/generate-npm-shrinkwrap.mjs --all --check
...
extensions/memory-lancedb: npm-shrinkwrap.json is current.
generated npm-shrinkwrap.json contains package versions absent from pnpm-lock.yaml: node_modules/lru-cache locked lru-cache@11.5.1
```

## Root Cause

`extensions/msteams` has two legitimate `lru-cache` lines: `lru-cache@6.0.0` through `lru-memoizer@2.3.0` and `lru-cache@11.5.0` through `lru-memoizer@3.0.0`. The generator already creates flat npm overrides from `pnpm-lock.yaml` when a package has one locked line, but it intentionally avoids a flat override when one package name has multiple real version lines.

When `lru-cache@11.5.1` was published on May 27, 2026 at 15:04 UTC, npm floated the `^11.0.1` range to `11.5.1` while `pnpm-lock.yaml` still contained `11.5.0`. The final guard assertion correctly rejected that generated shrinkwrap because `11.5.1` was absent from the pnpm lock.

## Dependency / Package-Manager Contract

- `npm view lru-memoizer@3.0.0 dependencies --json` shows `lru-cache: ^11.0.1`, so npm can resolve newer 11.x patches when no lock pins the generated package.
- `npm view lru-cache version time --json` showed `11.5.1` as the current version, published on `2026-05-27T15:04:12.732Z`.
- npm package `overrides` support nested and version-qualified override keys; this patch uses those only inside the temporary generation package and still asserts the final shrinkwrap against `pnpm-lock.yaml`.

## Regression Test Plan

- Added tests for parsing exact pnpm dependency resolutions, building focused drift overrides for the `lru-cache@11.5.1` case, and avoiding flat overrides when the package name is also a direct dependency on another locked line.
- Existing tests continue covering pnpm lock package parsing, current shrinkwrap override extraction, pnpm lock violation detection, and package-dir selection.

## Security Impact

No runtime code, auth, secrets, network calls, or package baselines changed. This is still security-sensitive because it touches the shrinkwrap generator, but the final assertion remains fail-closed against `pnpm-lock.yaml` and no new package version is admitted unless the pnpm lock already contains it.

## Human Verification

Local verification was run from Fermin's checkout by Codex. Before marking ready, Fermin should review the generator change and confirm ownership of the dependency/tooling behavior.

## CODEOWNERS / owner review

`.github/CODEOWNERS` maps `/scripts/generate-npm-shrinkwrap.mjs` to `@openclaw/openclaw-secops`. Expected owner review: `@openclaw/openclaw-secops`.

## Changelog

No `CHANGELOG.md` edit. This is a normal tooling fix, not release changelog generation.

## Review conversations

No GitHub review conversations exist yet on this draft. Local autoreview final pass:

```text
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.78)
```

## Risks

The main risk is that temporary npm overrides could alter generated shrinkwrap placement. Mitigation: the retry is only entered after the strict pnpm-lock assertion finds absent versions, it scopes overrides to the violated package/version line, it keeps direct-dependency drift on parent-specific overrides, and it re-runs the final pnpm-lock membership assertion.

## Behavior tradeoffs

The generator now prefers reproducing the existing pnpm-locked dependency graph over refreshing a package baseline just because the registry moved. That preserves the guard's lockfile authority, at the cost of a slightly more complex retry path for mixed-version package names.

## Scope boundaries

No `pnpm-lock.yaml`, `npm-shrinkwrap.json`, package manifest, runtime, plugin, or docs baseline is changed. This PR only changes the generator and its script-level regression tests.

## Validation

```text
pnpm install
node scripts/generate-npm-shrinkwrap.mjs --package-dir extensions/msteams --check
node scripts/generate-npm-shrinkwrap.mjs --all --check
pnpm deps:shrinkwrap:check
pnpm exec oxfmt --check --threads=1 scripts/generate-npm-shrinkwrap.mjs test/scripts/generate-npm-shrinkwrap.test.ts
node scripts/run-vitest.mjs test/scripts/generate-npm-shrinkwrap.test.ts
node scripts/check-changed.mjs --base origin/main
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

All listed commands passed after the final patch.
