### PR TITLE
Align diffs language pack host floor

### DIFF
--- a/extensions/diffs-language-pack/npm-shrinkwrap.json
+++ b/extensions/diffs-language-pack/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diffs-language-pack",
-  "version": "2026.5.26",
+  "version": "2026.5.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diffs-language-pack",
-      "version": "2026.5.26"
+      "version": "2026.5.27"
     }
   }
 }

--- a/extensions/diffs-language-pack/package.json
+++ b/extensions/diffs-language-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs-language-pack",
-  "version": "2026.5.26",
+  "version": "2026.5.27",
   "description": "OpenClaw diffs viewer syntax highlighting language pack",
   "repository": {
     "type": "git",
@@ -22,16 +22,16 @@
       "clawhubSpec": "clawhub:@openclaw/diffs-language-pack",
       "localPath": "extensions/diffs-language-pack",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.30"
+      "minHostVersion": ">=2026.5.27"
     },
     "compat": {
-      "pluginApi": ">=2026.5.26"
+      "pluginApi": ">=2026.5.27"
     },
     "assetScripts": {
       "build": "pnpm build:viewer"
     },
     "build": {
-      "openclawVersion": "2026.5.26",
+      "openclawVersion": "2026.5.27",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -117,7 +117,7 @@
           "npmSpec": "@openclaw/diffs-language-pack",
           "clawhubSpec": "clawhub:@openclaw/diffs-language-pack",
           "defaultChoice": "npm",
-          "minHostVersion": ">=2026.4.30"
+          "minHostVersion": ">=2026.5.27"
         }
       }
     },

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -47,7 +47,7 @@ describe("official external plugin catalog", () => {
         npmSpec: "@openclaw/diffs-language-pack",
         clawhubSpec: "clawhub:@openclaw/diffs-language-pack",
         defaultChoice: "npm",
-        minHostVersion: ">=2026.4.30",
+        minHostVersion: ">=2026.5.27",
       },
     );
   });


### PR DESCRIPTION
## Summary

- Align `@openclaw/diffs-language-pack` package, compat, and build metadata with the `2026.5.27` host release that introduced the required manifest/runtime support.
- Raise the official external plugin catalog floor for `diffs-language-pack` to the same host line and update the catalog contract test.

Refs #87162.

## Verification

Behavior addressed: `diffs-language-pack` no longer advertises install/API/build compatibility with host releases older than the release containing the required diffs runtime and manifest support.
Real environment tested: local macOS worktree on `origin/main` (`085228c961`) with dependencies installed via `pnpm install --frozen-lockfile`.
Exact steps or command run after this patch:
- `node scripts/generate-npm-shrinkwrap.mjs --package-dir extensions/diffs-language-pack --check`
- `node scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog.test.ts test/plugin-clawhub-release.test.ts test/plugin-npm-release.test.ts test/plugin-npm-package-manifest.test.ts`
- `git diff --check`
Evidence after fix: shrinkwrap check passed; 4 Vitest files passed, 53 tests passed; whitespace check passed.
Observed result after fix: package metadata, shrinkwrap, official catalog, and test expectation all agree on `2026.5.27` for the new language-pack release floor.
What was not tested: `node scripts/generate-plugin-inventory-doc.mjs --check` still reports pre-existing generated docs drift on current `main` (`docs/plugins/plugin-inventory.md is stale`); I did not include the broad unrelated generated doc rewrite in this PR.
