### PR TITLE
fix(plugins) expand default diffs language bucket

### DIFF
--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -206,9 +206,9 @@ All fields are optional unless noted.
 
 OpenClaw includes syntax highlighting for common source, config, and documentation languages:
 
-`javascript`, `typescript`, `tsx`, `jsx`, `json`, `markdown`, `yaml`, `css`, `html`, `sh`, `python`, `go`, `rust`, `java`, `c`, `cpp`, `csharp`, `php`, `sql`, and `docker`.
+`javascript`, `typescript`, `tsx`, `jsx`, `json`, `markdown`, `yaml`, `css`, `html`, `sh`, `python`, `go`, `rust`, `java`, `c`, `cpp`, `csharp`, `php`, `sql`, `docker`, `ruby`, `swift`, `kotlin`, `r`, `dart`, `lua`, `powershell`, `xml`, and `toml`.
 
-Common aliases such as `js`, `ts`, `bash`, `md`, `yml`, `c++`, and `dockerfile` are normalized to those default languages.
+Common aliases such as `js`, `ts`, `bash`, `md`, `yml`, `c++`, `dockerfile`, `rb`, `kt`, and `ps1` are normalized to those default languages.
 
 Install the Diff Viewer Language Pack plugin to highlight other languages:
 

--- a/extensions/diffs/README.md
+++ b/extensions/diffs/README.md
@@ -61,7 +61,7 @@ Useful options:
 - `expandUnchanged`: expand unchanged sections (per-call option only, not a plugin default key)
 - `path`: display name for before and after input
 - `lang`: language hint for before/after input; unknown values fall back to plain text
-- Default syntax highlighting covers common languages. Install `diffs-language-pack` for the extended language catalog.
+- Default syntax highlighting covers common source, config, and documentation languages. Install `diffs-language-pack` for the extended language catalog.
 - `title`: explicit viewer title
 - `ttlSeconds`: artifact lifetime for viewer and standalone file outputs
 - `baseUrl`: override the gateway base URL used in the returned viewer link (origin or origin+base path only; no query/hash)

--- a/extensions/diffs/src/language-hints.test.ts
+++ b/extensions/diffs/src/language-hints.test.ts
@@ -16,8 +16,43 @@ describe("filterSupportedLanguageHints", () => {
 
   it("normalizes common aliases to base viewer languages", async () => {
     await expect(
-      filterSupportedLanguageHints(["ts", "c++", "c#", "bash", "dockerfile"]),
-    ).resolves.toEqual(["typescript", "cpp", "csharp", "sh", "docker"]);
+      filterSupportedLanguageHints(["ts", "c++", "c#", "bash", "dockerfile", "rb", "kt", "ps1"]),
+    ).resolves.toEqual([
+      "typescript",
+      "cpp",
+      "csharp",
+      "sh",
+      "docker",
+      "ruby",
+      "kotlin",
+      "powershell",
+    ]);
+  });
+
+  it("keeps mainstream languages in the base viewer without the language pack", async () => {
+    await expect(
+      filterSupportedLanguageHints([
+        "ruby",
+        "swift",
+        "kotlin",
+        "r",
+        "dart",
+        "lua",
+        "powershell",
+        "xml",
+        "toml",
+      ]),
+    ).resolves.toEqual([
+      "ruby",
+      "swift",
+      "kotlin",
+      "r",
+      "dart",
+      "lua",
+      "powershell",
+      "xml",
+      "toml",
+    ]);
   });
 
   it("drops uncommon languages without the language pack", async () => {

--- a/extensions/diffs/src/shiki-curated-languages.ts
+++ b/extensions/diffs/src/shiki-curated-languages.ts
@@ -18,6 +18,15 @@ const csharp = () => import("@shikijs/langs/csharp");
 const php = () => import("@shikijs/langs/php");
 const sql = () => import("@shikijs/langs/sql");
 const docker = () => import("@shikijs/langs/docker");
+const ruby = () => import("@shikijs/langs/ruby");
+const swift = () => import("@shikijs/langs/swift");
+const kotlin = () => import("@shikijs/langs/kotlin");
+const r = () => import("@shikijs/langs/r");
+const dart = () => import("@shikijs/langs/dart");
+const lua = () => import("@shikijs/langs/lua");
+const powershell = () => import("@shikijs/langs/powershell");
+const xml = () => import("@shikijs/langs/xml");
+const toml = () => import("@shikijs/langs/toml");
 
 type CuratedLanguageInfo = {
   readonly id: string;
@@ -47,6 +56,15 @@ export const bundledLanguagesInfo = [
   { id: "php", name: "PHP", import: php },
   { id: "sql", name: "SQL", import: sql },
   { id: "docker", name: "Docker", aliases: ["dockerfile"], import: docker },
+  { id: "ruby", name: "Ruby", aliases: ["rb"], import: ruby },
+  { id: "swift", name: "Swift", import: swift },
+  { id: "kotlin", name: "Kotlin", aliases: ["kt", "kts"], import: kotlin },
+  { id: "r", name: "R", import: r },
+  { id: "dart", name: "Dart", import: dart },
+  { id: "lua", name: "Lua", import: lua },
+  { id: "powershell", name: "PowerShell", aliases: ["ps", "ps1"], import: powershell },
+  { id: "xml", name: "XML", import: xml },
+  { id: "toml", name: "TOML", import: toml },
 ] as const satisfies readonly CuratedLanguageInfo[];
 
 export const bundledLanguagesBase = Object.fromEntries(


### PR DESCRIPTION
## Summary

Follow-up to #87162 after reviewing the default syntax-highlighting split.

- Expands the diffs viewer default highlighted language bucket from 20 to 29 languages by adding Ruby, Swift, Kotlin, R, Dart, Lua, PowerShell, XML, and TOML.
- Keeps less common grammars behind the optional `diffs-language-pack`; when the pack is missing, those languages continue to fall back to plain text instead of failing.
- Rebuilds the committed default viewer runtime and updates the docs/tests for the new default bucket.

## Default languages

The default diffs viewer now ships syntax highlighting for: `javascript`, `typescript`, `tsx`, `jsx`, `json`, `markdown`, `yaml`, `css`, `html`, `sh`, `python`, `go`, `rust`, `java`, `c`, `cpp`, `csharp`, `php`, `sql`, `docker`, `ruby`, `swift`, `kotlin`, `r`, `dart`, `lua`, `powershell`, `xml`, `toml`.

## Bundle size metrics

Measured with Node raw bytes, `zlib.gzipSync` level 9, and Brotli quality 11 after rebuilding the curated runtime.

### Overall default viewer runtime

| Runtime | Raw bytes | gzip bytes | brotli bytes |
| --- | ---: | ---: | ---: |
| Original full default runtime | 9,899,054 | 1,726,255 | 1,131,149 |
| Current default runtime | 4,705,105 | 769,055 | 492,831 |
| Reduction | 5,193,949 | 957,200 | 638,318 |
| Reduction percent | 52.47% | 55.45% | 56.43% |

### Shiki-only comparison

| Runtime | Raw bytes | gzip bytes | brotli bytes |
| --- | ---: | ---: | ---: |
| Full generated Shiki runtime | 9,958,851 | 1,728,053 | 1,135,069 |
| Current curated runtime | 4,705,105 | 769,055 | 492,831 |
| Reduction | 5,253,746 | 958,998 | 642,238 |
| Reduction percent | 52.75% | 55.50% | 56.58% |

### Cost of expanding the default bucket from 20 to 29 languages

| Change | Raw bytes | gzip bytes | brotli bytes |
| --- | ---: | ---: | ---: |
| Added by moving 9 languages into default | 225,956 | 34,402 | 26,908 |

## Verification

- `node scripts/build-diffs-viewer-runtime.mjs curated`
- `node scripts/run-vitest.mjs run extensions/diffs/src/language-hints.test.ts extensions/diffs/src/render.test.ts extensions/diffs/src/config.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false`
- `pnpm format:docs:check docs/tools/diffs.md docs/plugins/manifest.md`
- `git diff --check`

## Real behavior proof

Behavior addressed: The diffs viewer now highlights a larger mainstream language bucket by default without requiring the optional language pack.

Real environment tested: Local Codex worktree on macOS using the repo Node wrappers.

Exact steps or command run after this patch: The verification commands listed above.

Evidence after fix: The targeted language-hint, render, and config tests passed; extension typechecking passed; docs formatting and whitespace checks passed; the default viewer runtime was rebuilt from source.

Observed result after fix: Ruby, Swift, Kotlin, R, Dart, Lua, PowerShell, XML, and TOML are treated as default viewer languages. Less common languages still require `diffs-language-pack` and fall back gracefully when it is not installed.

What was not tested: Full release/package publishing was not run locally.
