### PR TITLE
fix(codex): preserve shared app-server when spawned helper run fails logically (#72574)

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -95,6 +95,7 @@ export async function startCodexAttemptThread(params: {
   startupTimeoutMs: number;
   signal: AbortSignal;
   onStartupTimeout: () => void | Promise<void>;
+  spawnedBy: string | undefined;
 }): Promise<StartCodexAttemptThreadResult> {
   let pluginAppServer = params.appServer;
   let releaseSharedClientLease: (() => void) | undefined;
@@ -373,7 +374,11 @@ export async function startCodexAttemptThread(params: {
       releaseSharedClientLease,
     };
   } catch (error) {
-    clearSharedCodexAppServerClientIfCurrent(startupClientForCleanup);
+    const transportPoisoned = isCodexAppServerConnectionClosedError(error);
+    const isSpawnedHelperRun = Boolean(params.spawnedBy?.trim());
+    if (transportPoisoned || !isSpawnedHelperRun) {
+      clearSharedCodexAppServerClientIfCurrent(startupClientForCleanup);
+    }
     throw error;
   }
 }

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -49,6 +49,7 @@ import {
 } from "./shared-client.js";
 import {
   startOrResumeThread,
+  isCodexThreadStartRequestError,
   type CodexAppServerThreadLifecycleBinding,
   type CodexContextEngineThreadBootstrapProjection,
 } from "./thread-lifecycle.js";
@@ -375,8 +376,9 @@ export async function startCodexAttemptThread(params: {
     };
   } catch (error) {
     const transportPoisoned = isCodexAppServerConnectionClosedError(error);
-    const isSpawnedHelperRun = Boolean(params.spawnedBy?.trim());
-    if (transportPoisoned || !isSpawnedHelperRun) {
+    const preserveSharedClientForSpawnedThreadStartError =
+      Boolean(params.spawnedBy?.trim()) && isCodexThreadStartRequestError(error);
+    if (transportPoisoned || !preserveSharedClientForSpawnedThreadStartError) {
       clearSharedCodexAppServerClientIfCurrent(startupClientForCleanup);
     }
     throw error;

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -95,7 +95,7 @@ export async function startCodexAttemptThread(params: {
   startupTimeoutMs: number;
   signal: AbortSignal;
   onStartupTimeout: () => void | Promise<void>;
-  spawnedBy: string | null | undefined;
+  spawnedBy: EmbeddedRunAttemptParams["spawnedBy"];
 }): Promise<StartCodexAttemptThreadResult> {
   let pluginAppServer = params.appServer;
   let releaseSharedClientLease: (() => void) | undefined;

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -95,7 +95,7 @@ export async function startCodexAttemptThread(params: {
   startupTimeoutMs: number;
   signal: AbortSignal;
   onStartupTimeout: () => void | Promise<void>;
-  spawnedBy: string | undefined;
+  spawnedBy: string | null | undefined;
 }): Promise<StartCodexAttemptThreadResult> {
   let pluginAppServer = params.appServer;
   let releaseSharedClientLease: (() => void) | undefined;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -65,6 +65,7 @@ import {
 } from "./sandbox-exec-server.js";
 import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
 import { readCodexAppServerBinding, writeCodexAppServerBinding } from "./session-binding.js";
+import * as sharedClientModule from "./shared-client.js";
 import { createCodexTestModel } from "./test-support.js";
 import { buildTurnStartParams, startOrResumeThread } from "./thread-lifecycle.js";
 
@@ -3487,6 +3488,65 @@ describe("runCodexAppServerAttempt", () => {
       ["thread/resume"],
       ["thread/resume", "turn/start", "thread/unsubscribe"],
     ]);
+  });
+
+  it("does not retire the shared Codex client when a spawned helper run fails with a logical thread/start error", async () => {
+    const clearSpy = vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent");
+    clearSpy.mockClear();
+    let failedClient: unknown;
+    setCodexAppServerClientFactoryForTest(async () => {
+      const c = {
+        request: vi.fn(async (method: string) => {
+          if (method === "thread/start") {
+            throw new Error("401 authentication_error: Invalid bearer token");
+          }
+          return {};
+        }),
+        addNotificationHandler: vi.fn(() => () => undefined),
+        addRequestHandler: vi.fn(() => () => undefined),
+      };
+      failedClient = c;
+      return c as never;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.spawnedBy = "agent:main:session-parent";
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow("Invalid bearer token");
+    const calledWithFailedClient = clearSpy.mock.calls.some(([arg]) => arg === failedClient);
+    expect(calledWithFailedClient).toBe(false);
+    clearSpy.mockRestore();
+  });
+
+  it("retires the shared Codex client when a top-level run fails with a logical thread/start error", async () => {
+    const clearSpy = vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent");
+    clearSpy.mockClear();
+    let failedClient: unknown;
+    setCodexAppServerClientFactoryForTest(async () => {
+      const c = {
+        request: vi.fn(async (method: string) => {
+          if (method === "thread/start") {
+            throw new Error("401 authentication_error: Invalid bearer token");
+          }
+          return {};
+        }),
+        addNotificationHandler: vi.fn(() => () => undefined),
+        addRequestHandler: vi.fn(() => () => undefined),
+      };
+      failedClient = c;
+      return c as never;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow("Invalid bearer token");
+    const calledWithFailedClient = clearSpy.mock.calls.some(([arg]) => arg === failedClient);
+    expect(calledWithFailedClient).toBe(true);
+    clearSpy.mockRestore();
   });
 
   it("passes configured app-server policy, sandbox, service tier, and model on resume", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -27,6 +27,7 @@ import { CODEX_GPT5_BEHAVIOR_CONTRACT } from "../../prompt-overlay.js";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import * as authBridge from "./auth-bridge.js";
 import { resolveCodexAppServerEnvApiKeyCacheKey } from "./auth-bridge.js";
+import { CodexAppServerRpcError } from "./client.js";
 import { readCodexPluginConfig, resolveCodexAppServerRuntimeOptions } from "./config.js";
 import {
   CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
@@ -3498,7 +3499,10 @@ describe("runCodexAppServerAttempt", () => {
       const c = {
         request: vi.fn(async (method: string) => {
           if (method === "thread/start") {
-            throw new Error("401 authentication_error: Invalid bearer token");
+            throw new CodexAppServerRpcError(
+              { message: "401 authentication_error: Invalid bearer token" },
+              "thread/start",
+            );
           }
           return {};
         }),
@@ -3553,6 +3557,36 @@ describe("runCodexAppServerAttempt", () => {
     clearSpy.mockRestore();
   });
 
+  it("retires the shared Codex client when a spawned helper hits a thread/start write failure", async () => {
+    const clearSpy = vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent");
+    clearSpy.mockClear();
+    let failedClient: unknown;
+    setCodexAppServerClientFactoryForTest(async () => {
+      const c = {
+        request: vi.fn(async (method: string) => {
+          if (method === "thread/start") {
+            throw new Error("write EPIPE");
+          }
+          return {};
+        }),
+        addNotificationHandler: vi.fn(() => () => undefined),
+        addRequestHandler: vi.fn(() => () => undefined),
+      };
+      failedClient = c;
+      return c as never;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.spawnedBy = "agent:main:session-parent";
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow("write EPIPE");
+    const calledWithFailedClient = clearSpy.mock.calls.some(([arg]) => arg === failedClient);
+    expect(calledWithFailedClient).toBe(true);
+    clearSpy.mockRestore();
+  });
+
   it("retires the shared Codex client when a top-level run fails with a logical thread/start error", async () => {
     const clearSpy = vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent");
     clearSpy.mockClear();
@@ -3561,7 +3595,10 @@ describe("runCodexAppServerAttempt", () => {
       const c = {
         request: vi.fn(async (method: string) => {
           if (method === "thread/start") {
-            throw new Error("401 authentication_error: Invalid bearer token");
+            throw new CodexAppServerRpcError(
+              { message: "401 authentication_error: Invalid bearer token" },
+              "thread/start",
+            );
           }
           return {};
         }),

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3520,6 +3520,39 @@ describe("runCodexAppServerAttempt", () => {
     clearSpy.mockRestore();
   });
 
+  it("retires the shared Codex client when a spawned helper run times out during thread/start", async () => {
+    const clearSpy = vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent");
+    clearSpy.mockClear();
+    let failedClient: unknown;
+    setCodexAppServerClientFactoryForTest(async () => {
+      const c = {
+        request: vi.fn(async (method: string) => {
+          if (method === "thread/start") {
+            return await new Promise<never>(() => undefined);
+          }
+          return {};
+        }),
+        addNotificationHandler: vi.fn(() => () => undefined),
+        addRequestHandler: vi.fn(() => () => undefined),
+      };
+      failedClient = c;
+      return c as never;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.spawnedBy = "agent:main:session-parent";
+    params.timeoutMs = 1;
+
+    await expect(runCodexAppServerAttempt(params, { startupTimeoutFloorMs: 1 })).rejects.toThrow(
+      "codex app-server startup timed out",
+    );
+    const calledWithFailedClient = clearSpy.mock.calls.some(([arg]) => arg === failedClient);
+    expect(calledWithFailedClient).toBe(true);
+    clearSpy.mockRestore();
+  });
+
   it("retires the shared Codex client when a top-level run fails with a logical thread/start error", async () => {
     const clearSpy = vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent");
     clearSpy.mockClear();

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -864,6 +864,7 @@ export async function runCodexAppServerAttempt(
       onStartupTimeout: () => {
         runAbortController.abort("codex_startup_timeout");
       },
+      spawnedBy: params.spawnedBy,
     });
     client = startupResult.client;
     thread = startupResult.thread;

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -1,5 +1,6 @@
 import {
   embeddedAgentLog,
+  formatErrorMessage,
   isActiveHarnessContextEngine,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -55,6 +56,17 @@ export type CodexAppServerThreadLifecycle = {
 export type CodexAppServerThreadLifecycleBinding = CodexAppServerThreadBinding & {
   lifecycle: CodexAppServerThreadLifecycle;
 };
+
+class CodexThreadStartRequestError extends Error {
+  constructor(cause: unknown) {
+    super(formatErrorMessage(cause), { cause });
+    this.name = "CodexThreadStartRequestError";
+  }
+}
+
+export function isCodexThreadStartRequestError(error: unknown): boolean {
+  return error instanceof CodexThreadStartRequestError;
+}
 
 export type CodexThreadFinalConfigPatchDecision =
   | { action: "resume"; binding: CodexAppServerThreadBinding }
@@ -548,11 +560,17 @@ export async function startOrResumeThread(params: {
       environmentSelection: params.environmentSelection,
     }),
   );
-  const response = assertCodexThreadStartResponse(
-    await lifecycleTiming.measure("thread_start_request", () =>
-      params.client.request("thread/start", startParams),
-    ),
-  );
+  const threadStartResponse = await lifecycleTiming.measure("thread_start_request", async () => {
+    try {
+      return await params.client.request("thread/start", startParams);
+    } catch (error) {
+      if (isCodexAppServerConnectionClosedError(error)) {
+        throw error;
+      }
+      throw new CodexThreadStartRequestError(error);
+    }
+  });
+  const response = assertCodexThreadStartResponse(threadStartResponse);
   const modelProvider = resolveCodexAppServerModelProvider({
     provider: params.params.provider,
     authProfileId: params.params.authProfileId,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -8,7 +8,11 @@ import { buildCodexUserMcpServersThreadConfigPatch } from "openclaw/plugin-sdk/c
 import { listRegisteredPluginAgentPromptGuidance } from "openclaw/plugin-sdk/plugin-runtime";
 import { CODEX_GPT5_HEARTBEAT_PROMPT_OVERLAY } from "../../prompt-overlay.js";
 import { isModernCodexModel } from "../../provider.js";
-import { isCodexAppServerConnectionClosedError, type CodexAppServerClient } from "./client.js";
+import {
+  CodexAppServerRpcError,
+  isCodexAppServerConnectionClosedError,
+  type CodexAppServerClient,
+} from "./client.js";
 import { codexSandboxPolicyForTurn, type CodexAppServerRuntimeOptions } from "./config.js";
 import {
   resolveCodexContextEngineProjectionMaxChars,
@@ -564,10 +568,10 @@ export async function startOrResumeThread(params: {
     try {
       return await params.client.request("thread/start", startParams);
     } catch (error) {
-      if (isCodexAppServerConnectionClosedError(error)) {
-        throw error;
+      if (error instanceof CodexAppServerRpcError) {
+        throw new CodexThreadStartRequestError(error);
       }
-      throw new CodexThreadStartRequestError(error);
+      throw error;
     }
   });
   const response = assertCodexThreadStartResponse(threadStartResponse);


### PR DESCRIPTION
## Summary

Fixes #72574 by narrowing the Codex app-server startup-failure cleanup policy. Spawned/helper runs that fail for logical reasons (auth, thread/start 401) no longer retire the shared app-server client used by the main session. Only real transport/process failures still clear the shared singleton.

Closes #72812 (multi-app-server topology was the wrong direction per maintainer; this PR uses the requested cleanup-policy approach instead).

## Behavior change

`extensions/codex/src/app-server/attempt-startup.ts` — outer startup catch:
- **Before**: any error reaching the outer catch (auth, thread/start, transport) called `clearSharedCodexAppServerClientIfCurrent(startupClientForCleanup)`, wiping the main session's shared client.
- **After**: `clearSharedCodexAppServerClientIfCurrent` only fires when `isCodexAppServerConnectionClosedError(error)` (transport poisoned) OR the run is not spawned (`!params.spawnedBy?.trim()`). Spawned + logical failure → lease releases via the existing `finally`, shared singleton survives.

Inner retry-loop cleanup on connection-closed errors is unchanged (still clears + retries on real transport failure regardless of spawn topology).

`spawnedBy` is the only new field threaded through `startCodexAttemptThread`. No topology change, no new app-server processes, no isolated-client construction. Single shared leased Codex app-server is preserved.

## Diff size

```
extensions/codex/src/app-server/attempt-startup.ts |  7 ++-
extensions/codex/src/app-server/run-attempt.test.ts | 60 ++++++++++++++++++++++
extensions/codex/src/app-server/run-attempt.ts     |  1 +
3 files changed, 67 insertions(+), 1 deletion(-)
```

## Test plan

- [x] New regression test: spawned helper thread/start 401 leaves shared client current.
- [x] New regression test: top-level run thread/start 401 still retires shared client (baseline preserved for non-spawned runs).
- [x] Focused suite: `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts` → 67/67 passed.
- [x] Full app-server suite: `node scripts/run-vitest.mjs extensions/codex/src/app-server/` → 68 files / 949 tests passed.
- [ ] Live invalid-token spawn against real `@openai/codex` binary — see *What was not tested*.

## Real behavior proof

Behavior addressed: shared Codex app-server client retired by spawned helper run thread/start auth failure (#72574). After fix, a spawned helper's 401 only fails that attempt; the parent session's shared client and its in-flight turns are untouched.

Real environment tested: Node 24, vitest 4.1.7, macOS local checkout at `upstream/main@11ca150a1ba` + this PR's commit `cc424a24123`. Tests exercise the production `startCodexAttemptThread` path through `runCodexAppServerAttempt` with a stubbed `attemptClientFactory` whose returned client throws on `thread/start` (the same error shape Codex emits for invalid bearer tokens).

Exact steps or command run after this patch:
```
git checkout fix/72574-shared-client-cleanup-policy
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "logical thread/start error"
node scripts/run-vitest.mjs extensions/codex/src/app-server/
```

Evidence after fix:
- `-t "logical thread/start error"` → 2 tests pass (spawned does NOT clear shared; top-level still clears).
- Full app-server suite → 68 files / 949 tests pass.
- `vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent")` asserts `clearSpy.mock.calls.some(([arg]) => arg === failedClient)` is `false` for the spawned case and `true` for the top-level case. Same factory and error shape across both — only `params.spawnedBy` differs.

Observed result after fix: spawned helper thread/start 401 rejects its own attempt without invoking `clearSharedCodexAppServerClientIfCurrent(failedClient)`. Top-level thread/start 401 still invokes it (regression baseline for non-spawned runs preserved). Inner connection-closed retry loop unchanged.

What was not tested: live `@openai/codex` binary with a real invalid bearer token spawning a helper from a long-running parent session; relies on programmatic factory injection rather than a real `CodexAppServerClient.start` subprocess. Closed PR #72812 has live Fedora 43 proof for the bug repro itself — this PR's cleanup-policy narrowing is the maintainer-requested fix shape for the same bug.

## Refs

- Fixes #72574
- Closes/supersedes #72812 (multi-app-server topology rejected; this PR uses cleanup-policy narrowing per maintainer direction)