### PR TITLE
feat: add task flow lifecycle observability with tags, hooks, and diagnostic events

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -62,6 +62,10 @@ openclaw hooks info session-memory
 | `message:transcribed`    | After audio transcription completes                        |
 | `message:preprocessed`   | After media and link preprocessing completes or is skipped |
 | `message:sent`           | Outbound message delivered                                 |
+| `task:flow:created`      | A new task flow record is created                          |
+| `task:flow:transition`   | A task flow's status changes                               |
+| `task:flow:deleted`      | A task flow record is removed                              |
+| `task`                   | Any task flow event (general listener)                     |
 
 ## Writing hooks
 
@@ -142,6 +146,12 @@ reply channel and ignore pushed messages.
 **Bootstrap events** (`agent:bootstrap`): `context.bootstrapFiles` (mutable array), `context.agentId`.
 
 **Session patch events** (`session:patch`): `context.sessionEntry`, `context.patch` (only changed fields), `context.cfg`. Only privileged clients can trigger patch events.
+
+**Task flow events** (`task:flow:created`): `context.flow` with `flowId`, `syncMode`, `ownerKey`, `status`, `goal`, `controllerId?`, `tags?`, `createdAt`.
+
+**Task flow events** (`task:flow:transition`): `context.flow` (same shape as created), `context.previousStatus`, `context.durationMs` (milliseconds since flow creation).
+
+**Task flow events** (`task:flow:deleted`): `context.flowId`, `context.previous` (flow snapshot before deletion including `tags`).
 
 **Compaction events**: `session:compact:before` includes `messageCount`, `tokenCount`. `session:compact:after` adds `compactedCount`, `summaryLength`, `tokensBefore`, `tokensAfter`.
 

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -296,6 +296,13 @@ Liveness warnings also emit:
 - `openclaw.tool.loop.iterations` (counter, attrs: `openclaw.toolName`, `openclaw.outcome`)
 - `openclaw.tool.loop.duration_ms` (histogram, attrs: `openclaw.toolName`, `openclaw.outcome`)
 
+### Task flow lifecycle
+
+- `openclaw.task.flow.created` (counter, attrs: `openclaw.task.flow.sync_mode`, `openclaw.task.flow.owner_key`, `openclaw.task.flow.tag.*`)
+- `openclaw.task.flow.transitions` (counter, attrs: `openclaw.task.flow.sync_mode`, `openclaw.task.flow.owner_key`, `openclaw.task.flow.status`, `openclaw.task.flow.previous_status`, `openclaw.task.flow.tag.*`)
+- `openclaw.task.flow.duration_ms` (histogram, attrs: same as `openclaw.task.flow.transitions`, recorded on terminal statuses only)
+- `openclaw.task.flow.deleted` (counter, attrs: `openclaw.task.flow.owner_key`, `openclaw.task.flow.previous_status`, `openclaw.task.flow.tag.*`)
+
 ## Exported spans
 
 - `openclaw.model.usage`

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -140,6 +140,10 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
 | `openclaw_memory_pressure_total`                 | counter   | `level`, `reason`                                                                         |
 | `openclaw_telemetry_exporter_total`              | counter   | `exporter`, `reason`, `signal`, `status`                                                  |
 | `openclaw_prometheus_series_dropped_total`       | counter   | none                                                                                      |
+| `openclaw_task_flow_created_total`               | counter   | `sync_mode`, `tag_*`                                                                      |
+| `openclaw_task_flow_transition_total`            | counter   | `previous_status`, `status`, `sync_mode`, `tag_*`                                         |
+| `openclaw_task_flow_duration_seconds`            | histogram | `previous_status`, `status`, `sync_mode`, `tag_*`                                         |
+| `openclaw_task_flow_deleted_total`               | counter   | `previous_status`, `sync_mode`, `tag_*`                                                   |
 
 ## Label policy
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -898,11 +898,7 @@ function assignOtelModelContentAttributes(
     );
   }
   if (policy.systemPrompt) {
-    assignOtelContentAttribute(
-      attributes,
-      "openclaw.content.system_prompt",
-      content?.systemPrompt,
-    );
+    assignOtelContentAttribute(attributes, "openclaw.content.system_prompt", content?.systemPrompt);
   }
 }
 
@@ -1475,13 +1471,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           description: "Tool execution duration",
         },
       );
-      const toolExecutionBlockedCounter = meter.createCounter(
-        "openclaw.tool.execution.blocked",
-        {
-          unit: "1",
-          description: "Tool executions blocked by policy or sandbox diagnostics",
-        },
-      );
+      const toolExecutionBlockedCounter = meter.createCounter("openclaw.tool.execution.blocked", {
+        unit: "1",
+        description: "Tool executions blocked by policy or sandbox diagnostics",
+      });
       const execProcessDurationHistogram = meter.createHistogram("openclaw.exec.duration_ms", {
         unit: "ms",
         description: "Exec process duration",
@@ -1563,6 +1556,22 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const telemetryExporterCounter = meter.createCounter("openclaw.telemetry.exporter.events", {
         unit: "1",
         description: "Diagnostic telemetry exporter lifecycle and failure events",
+      });
+      const taskFlowCreatedCounter = meter.createCounter("openclaw.task.flow.created", {
+        unit: "1",
+        description: "Task flows created by sync mode",
+      });
+      const taskFlowTransitionCounter = meter.createCounter("openclaw.task.flow.transitions", {
+        unit: "1",
+        description: "Task flow status transitions",
+      });
+      const taskFlowDurationHistogram = meter.createHistogram("openclaw.task.flow.duration_ms", {
+        unit: "ms",
+        description: "Task flow duration from creation to terminal status",
+      });
+      const taskFlowDeletedCounter = meter.createCounter("openclaw.task.flow.deleted", {
+        unit: "1",
+        description: "Task flow deletions",
       });
 
       let recordLogRecord:
@@ -2897,6 +2906,73 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
       };
 
+      const TASK_FLOW_TERMINAL_STATUSES = new Set([
+        "succeeded",
+        "failed",
+        "cancelled",
+        "lost",
+        "blocked",
+      ]);
+
+      const taskFlowAttrs = (
+        evt: { syncMode: string; ownerKey: string; tags?: Record<string, string> },
+        extra?: Record<string, string>,
+      ): Record<string, string> => {
+        const attrs: Record<string, string> = {
+          "openclaw.task.flow.sync_mode": lowCardinalityAttr(evt.syncMode, "unknown"),
+          "openclaw.task.flow.owner_key": lowCardinalityAttr(evt.ownerKey, "unknown"),
+          ...extra,
+        };
+        if (evt.tags) {
+          for (const [key, value] of Object.entries(evt.tags)) {
+            if (
+              typeof key === "string" &&
+              typeof value === "string" &&
+              LOW_CARDINALITY_VALUE_RE.test(key) &&
+              LOW_CARDINALITY_VALUE_RE.test(value)
+            ) {
+              attrs[`openclaw.task.flow.tag.${key}`] = value;
+            }
+          }
+        }
+        return attrs;
+      };
+
+      const recordTaskFlowCreated = (
+        evt: Extract<DiagnosticEventPayload, { type: "task.flow.created" }>,
+      ) => {
+        taskFlowCreatedCounter.add(1, taskFlowAttrs(evt));
+      };
+
+      const recordTaskFlowTransition = (
+        evt: Extract<DiagnosticEventPayload, { type: "task.flow.transition" }>,
+      ) => {
+        const attrs = taskFlowAttrs(evt, {
+          "openclaw.task.flow.status": evt.status,
+          "openclaw.task.flow.previous_status": evt.previousStatus,
+        });
+        taskFlowTransitionCounter.add(1, attrs);
+        if (
+          TASK_FLOW_TERMINAL_STATUSES.has(evt.status) &&
+          typeof evt.durationMs === "number" &&
+          evt.durationMs >= 0
+        ) {
+          taskFlowDurationHistogram.record(evt.durationMs, attrs);
+        }
+      };
+
+      const recordTaskFlowDeleted = (
+        evt: Extract<DiagnosticEventPayload, { type: "task.flow.deleted" }>,
+      ) => {
+        taskFlowDeletedCounter.add(
+          1,
+          taskFlowAttrs(
+            { syncMode: "unknown", ownerKey: evt.ownerKey, tags: evt.tags },
+            { "openclaw.task.flow.previous_status": evt.previousStatus },
+          ),
+        );
+      };
+
       const recordExecProcessCompleted = (
         evt: Extract<DiagnosticEventPayload, { type: "exec.process.completed" }>,
       ) => {
@@ -3208,6 +3284,15 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "model.failover":
               recordModelFailover(evt, metadata);
+              return;
+            case "task.flow.created":
+              recordTaskFlowCreated(evt);
+              return;
+            case "task.flow.transition":
+              recordTaskFlowTransition(evt);
+              return;
+            case "task.flow.deleted":
+              recordTaskFlowDeleted(evt);
               return;
           }
         } catch (err) {

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -334,7 +334,9 @@ function modelCallLabels(evt: {
   };
 }
 
-function modelFailoverLabels(evt: Extract<DiagnosticEventPayload, { type: "model.failover" }>): LabelSet {
+function modelFailoverLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "model.failover" }>,
+): LabelSet {
   return {
     from_model: lowCardinalityLabel(evt.fromModel),
     from_provider: lowCardinalityLabel(evt.fromProvider),
@@ -429,7 +431,9 @@ function webhookLabels(
   };
 }
 
-function sessionStuckLabels(evt: Extract<DiagnosticEventPayload, { type: "session.stuck" }>): LabelSet {
+function sessionStuckLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "session.stuck" }>,
+): LabelSet {
   return {
     reason: lowCardinalityLabel(evt.reason, "none"),
     state: evt.state,
@@ -463,13 +467,56 @@ function livenessLabels(
   };
 }
 
-function payloadLargeLabels(evt: Extract<DiagnosticEventPayload, { type: "payload.large" }>): LabelSet {
+function payloadLargeLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "payload.large" }>,
+): LabelSet {
   return {
     action: evt.action,
     channel: lowCardinalityLabel(evt.channel, "none"),
     plugin: lowCardinalityLabel(evt.pluginId, "none"),
     reason: lowCardinalityLabel(evt.reason, "none"),
     surface: lowCardinalityLabel(evt.surface, "unknown"),
+  };
+}
+
+const TERMINAL_TASK_FLOW_STATUSES = new Set([
+  "succeeded",
+  "failed",
+  "cancelled",
+  "lost",
+  "blocked",
+]);
+
+function isTerminalTaskFlowStatus(status: string): boolean {
+  return TERMINAL_TASK_FLOW_STATUSES.has(status);
+}
+
+function taskFlowLabels(evt: { syncMode: string; tags?: Record<string, string> }): LabelSet {
+  const labels: LabelSet = {
+    sync_mode: lowCardinalityLabel(evt.syncMode),
+  };
+  if (evt.tags) {
+    for (const [key, value] of Object.entries(evt.tags)) {
+      if (
+        typeof key === "string" &&
+        typeof value === "string" &&
+        LOW_CARDINALITY_VALUE_RE.test(key) &&
+        LOW_CARDINALITY_VALUE_RE.test(value)
+      ) {
+        labels[`tag_${key}`] = value;
+      }
+    }
+  }
+  return labels;
+}
+
+function taskFlowTransitionLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "task.flow.transition" }>,
+): LabelSet {
+  return {
+    ...taskFlowLabels(evt),
+    status: lowCardinalityLabel(evt.status),
+    previous_status: lowCardinalityLabel(evt.previousStatus),
   };
 }
 
@@ -981,6 +1028,34 @@ function recordDiagnosticEvent(
         numericValue(evt.bytes),
         BYTE_BUCKETS,
       );
+      return;
+    case "task.flow.created":
+      store.counter(
+        "openclaw_task_flow_created_total",
+        "Task flows created by sync mode.",
+        taskFlowLabels(evt),
+      );
+      return;
+    case "task.flow.transition":
+      store.counter(
+        "openclaw_task_flow_transition_total",
+        "Task flow status transitions.",
+        taskFlowTransitionLabels(evt),
+      );
+      if (isTerminalTaskFlowStatus(evt.status)) {
+        store.histogram(
+          "openclaw_task_flow_duration_seconds",
+          "Task flow duration from creation to terminal status in seconds.",
+          taskFlowTransitionLabels(evt),
+          seconds(evt.durationMs),
+        );
+      }
+      return;
+    case "task.flow.deleted":
+      store.counter("openclaw_task_flow_deleted_total", "Task flow deletions.", {
+        ...taskFlowLabels({ syncMode: "unknown", tags: evt.tags }),
+        previous_status: lowCardinalityLabel(evt.previousStatus),
+      });
       return;
     default:
       return;

--- a/src/hooks/internal-hook-types.ts
+++ b/src/hooks/internal-hook-types.ts
@@ -1,4 +1,10 @@
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "task";
 
 export interface InternalHookEvent {
   /** The type of event (command, session, agent, gateway, etc.) */

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -176,6 +176,81 @@ export type SessionPatchHookEvent = InternalHookEvent & {
   context: SessionPatchHookContext;
 };
 
+// ============================================================================
+// Task Flow Hook Events
+// ============================================================================
+
+export type TaskFlowCreatedHookContext = {
+  /** The created flow record. */
+  flow: {
+    flowId: string;
+    syncMode: string;
+    ownerKey: string;
+    status: string;
+    goal: string;
+    currentStep?: string;
+    controllerId?: string;
+    tags?: Record<string, string>;
+    createdAt: number;
+  };
+};
+
+export type TaskFlowCreatedHookEvent = InternalHookEvent & {
+  type: "task";
+  action: "flow:created";
+  context: TaskFlowCreatedHookContext;
+};
+
+export type TaskFlowTransitionHookContext = {
+  /** The flow record after the transition. */
+  flow: {
+    flowId: string;
+    syncMode: string;
+    ownerKey: string;
+    status: string;
+    goal: string;
+    currentStep?: string;
+    controllerId?: string;
+    tags?: Record<string, string>;
+    createdAt: number;
+    updatedAt: number;
+    endedAt?: number;
+  };
+  /** The status before the transition. */
+  previousStatus: string;
+  /** Elapsed time since flow creation in milliseconds. */
+  durationMs: number;
+};
+
+export type TaskFlowTransitionHookEvent = InternalHookEvent & {
+  type: "task";
+  action: "flow:transition";
+  context: TaskFlowTransitionHookContext;
+};
+
+export type TaskFlowDeletedHookContext = {
+  /** The ID of the deleted flow. */
+  flowId: string;
+  /** The flow record before deletion. */
+  previous: {
+    flowId: string;
+    syncMode: string;
+    ownerKey: string;
+    status: string;
+    goal: string;
+    tags?: Record<string, string>;
+    createdAt: number;
+    updatedAt: number;
+    endedAt?: number;
+  };
+};
+
+export type TaskFlowDeletedHookEvent = InternalHookEvent & {
+  type: "task";
+  action: "flow:deleted";
+  context: TaskFlowDeletedHookContext;
+};
+
 /**
  * Registry of hook handlers by event key.
  *
@@ -459,4 +534,38 @@ export function isSessionPatchEvent(event: InternalHookEvent): event is SessionP
     typeof context.sessionEntry === "object" &&
     context.sessionEntry !== null
   );
+}
+
+export function isTaskFlowCreatedEvent(
+  event: InternalHookEvent,
+): event is TaskFlowCreatedHookEvent {
+  if (!isHookEventTypeAndAction(event, "task", "flow:created")) {
+    return false;
+  }
+  const context = getHookContext<TaskFlowCreatedHookContext>(event);
+  return context?.flow != null && typeof context.flow.flowId === "string";
+}
+
+export function isTaskFlowTransitionEvent(
+  event: InternalHookEvent,
+): event is TaskFlowTransitionHookEvent {
+  if (!isHookEventTypeAndAction(event, "task", "flow:transition")) {
+    return false;
+  }
+  const context = getHookContext<TaskFlowTransitionHookContext>(event);
+  return (
+    context?.flow != null &&
+    typeof context.flow.flowId === "string" &&
+    typeof context.previousStatus === "string"
+  );
+}
+
+export function isTaskFlowDeletedEvent(
+  event: InternalHookEvent,
+): event is TaskFlowDeletedHookEvent {
+  if (!isHookEventTypeAndAction(event, "task", "flow:deleted")) {
+    return false;
+  }
+  const context = getHookContext<TaskFlowDeletedHookContext>(event);
+  return context != null && typeof context.flowId === "string" && context.previous != null;
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -643,6 +643,38 @@ export type DiagnosticAsyncQueueDroppedEvent = DiagnosticBaseEvent & {
   drainBatchSize: number;
 };
 
+export type DiagnosticTaskFlowCreatedEvent = DiagnosticBaseEvent & {
+  type: "task.flow.created";
+  flowId: string;
+  syncMode: string;
+  ownerKey: string;
+  goal: string;
+  controllerId?: string;
+  tags?: Record<string, string>;
+};
+
+export type DiagnosticTaskFlowTransitionEvent = DiagnosticBaseEvent & {
+  type: "task.flow.transition";
+  flowId: string;
+  syncMode: string;
+  ownerKey: string;
+  goal: string;
+  previousStatus: string;
+  status: string;
+  currentStep?: string;
+  controllerId?: string;
+  tags?: Record<string, string>;
+  durationMs?: number;
+};
+
+export type DiagnosticTaskFlowDeletedEvent = DiagnosticBaseEvent & {
+  type: "task.flow.deleted";
+  flowId: string;
+  ownerKey: string;
+  previousStatus: string;
+  tags?: Record<string, string>;
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
   | DiagnosticWebhookReceivedEvent
@@ -693,7 +725,10 @@ export type DiagnosticEventPayload =
   | DiagnosticLogRecordEvent
   | DiagnosticTelemetryExporterEvent
   | DiagnosticAsyncQueueDroppedEvent
-  | DiagnosticFailoverEvent;
+  | DiagnosticFailoverEvent
+  | DiagnosticTaskFlowCreatedEvent
+  | DiagnosticTaskFlowTransitionEvent
+  | DiagnosticTaskFlowDeletedEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -536,6 +536,21 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.model = event.fromModel;
       assignReasonCode(record, event.reason);
       break;
+    case "task.flow.created":
+      record.source = event.flowId;
+      record.action = event.syncMode;
+      break;
+    case "task.flow.transition":
+      record.source = event.flowId;
+      record.action = event.syncMode;
+      record.outcome = event.status;
+      record.durationMs = event.durationMs;
+      assignReasonCode(record, event.previousStatus);
+      break;
+    case "task.flow.deleted":
+      record.source = event.flowId;
+      assignReasonCode(record, event.previousStatus);
+      break;
   }
 
   return record;

--- a/src/plugins/runtime/runtime-taskflow.ts
+++ b/src/plugins/runtime/runtime-taskflow.ts
@@ -113,6 +113,7 @@ function createBoundTaskFlowRuntime(params: {
         currentStep: input.currentStep,
         stateJson: input.stateJson,
         waitJson: input.waitJson,
+        tags: input.tags,
         cancelRequestedAt: input.cancelRequestedAt,
         createdAt: input.createdAt,
         updatedAt: input.updatedAt,

--- a/src/plugins/runtime/runtime-taskflow.types.ts
+++ b/src/plugins/runtime/runtime-taskflow.types.ts
@@ -60,6 +60,7 @@ export type BoundTaskFlowRuntime = {
     currentStep?: string | null;
     stateJson?: JsonValue | null;
     waitJson?: JsonValue | null;
+    tags?: Record<string, string> | null;
     cancelRequestedAt?: number | null;
     createdAt?: number;
     updatedAt?: number;

--- a/src/tasks/task-flow-registry.hooks.test.ts
+++ b/src/tasks/task-flow-registry.hooks.test.ts
@@ -1,0 +1,670 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearInternalHooks,
+  createInternalHookEvent,
+  isTaskFlowCreatedEvent,
+  isTaskFlowDeletedEvent,
+  isTaskFlowTransitionEvent,
+  registerInternalHook,
+  type InternalHookEvent,
+} from "../hooks/internal-hooks.js";
+import {
+  onInternalDiagnosticEvent,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  createFlowRecord,
+  createManagedTaskFlow,
+  createTaskFlowForTask,
+  deleteTaskFlowRecordById,
+  failFlow,
+  finishFlow,
+  resetTaskFlowRegistryForTests,
+  resumeFlow,
+  setFlowWaiting,
+  syncFlowFromTask,
+  updateFlowRecordByIdExpectedRevision,
+} from "./task-flow-registry.js";
+
+async function withFlowRegistryTempDir<T>(run: (root: string) => Promise<T>): Promise<T> {
+  return await withOpenClawTestState(
+    { layout: "state-only", prefix: "openclaw-task-flow-hooks-" },
+    async (state) => {
+      resetTaskFlowRegistryForTests();
+      try {
+        return await run(state.stateDir);
+      } finally {
+        resetTaskFlowRegistryForTests();
+      }
+    },
+  );
+}
+
+describe("task-flow-registry hook events", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearInternalHooks();
+    resetTaskFlowRegistryForTests();
+  });
+
+  // =========================================================================
+  // Hook events (task:flow:created, task:flow:transition, task:flow:deleted)
+  // =========================================================================
+
+  it("emits task:flow:created hook when a managed flow is created", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const hookEvents: InternalHookEvent[] = [];
+      registerInternalHook("task:flow:created", (event) => {
+        hookEvents.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/hooks",
+        goal: "Test hook creation",
+        tags: { env: "test", priority: "high" },
+      });
+
+      // Wait for fire-and-forget hooks to settle.
+      await vi.waitFor(() => expect(hookEvents).toHaveLength(1));
+
+      const event = hookEvents[0];
+      expect(event.type).toBe("task");
+      expect(event.action).toBe("flow:created");
+      expect(event.sessionKey).toBe("agent:main:main");
+
+      const context = event.context as { flow: Record<string, unknown> };
+      expect(context.flow.flowId).toBe(created.flowId);
+      expect(context.flow.syncMode).toBe("managed");
+      expect(context.flow.status).toBe("queued");
+      expect(context.flow.goal).toBe("Test hook creation");
+      expect(context.flow.tags).toEqual({ env: "test", priority: "high" });
+    });
+  });
+
+  it("emits task:flow:transition hook on status changes", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const transitionEvents: InternalHookEvent[] = [];
+      registerInternalHook("task:flow:transition", (event) => {
+        transitionEvents.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/hooks",
+        goal: "Lifecycle transitions",
+        tags: { workflow: "deploy" },
+      });
+
+      resumeFlow({
+        flowId: created.flowId,
+        expectedRevision: 0,
+        status: "running",
+      });
+
+      finishFlow({
+        flowId: created.flowId,
+        expectedRevision: 1,
+      });
+
+      await vi.waitFor(() => expect(transitionEvents).toHaveLength(2));
+
+      const runningTransition = transitionEvents[0];
+      const ctx0 = runningTransition.context as {
+        flow: Record<string, unknown>;
+        previousStatus: string;
+        durationMs: number;
+      };
+      expect(ctx0.previousStatus).toBe("queued");
+      expect(ctx0.flow.status).toBe("running");
+      expect(ctx0.flow.tags).toEqual({ workflow: "deploy" });
+      expect(ctx0.durationMs).toBeGreaterThanOrEqual(0);
+
+      const succeededTransition = transitionEvents[1];
+      const ctx1 = succeededTransition.context as {
+        flow: Record<string, unknown>;
+        previousStatus: string;
+      };
+      expect(ctx1.previousStatus).toBe("running");
+      expect(ctx1.flow.status).toBe("succeeded");
+    });
+  });
+
+  it("emits task:flow:deleted hook when a flow is deleted", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const deletedEvents: InternalHookEvent[] = [];
+      registerInternalHook("task:flow:deleted", (event) => {
+        deletedEvents.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/hooks",
+        goal: "Test deletion",
+        tags: { env: "staging" },
+      });
+
+      deleteTaskFlowRecordById(created.flowId);
+
+      await vi.waitFor(() => expect(deletedEvents).toHaveLength(1));
+
+      const event = deletedEvents[0];
+      expect(event.type).toBe("task");
+      expect(event.action).toBe("flow:deleted");
+
+      const context = event.context as {
+        flowId: string;
+        previous: Record<string, unknown>;
+      };
+      expect(context.flowId).toBe(created.flowId);
+      expect(context.previous.goal).toBe("Test deletion");
+      expect(context.previous.tags).toEqual({ env: "staging" });
+    });
+  });
+
+  it("does not emit transition hook when status stays the same", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const transitionEvents: InternalHookEvent[] = [];
+      registerInternalHook("task:flow:transition", (event) => {
+        transitionEvents.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/hooks",
+        goal: "Same status update",
+      });
+
+      // Update stateJson without changing status — should NOT trigger transition.
+      setFlowWaiting({
+        flowId: created.flowId,
+        expectedRevision: 0,
+        stateJson: { phase: "waiting" },
+      });
+
+      // The waiting status IS a change from queued, so one transition is expected.
+      await vi.waitFor(() => expect(transitionEvents).toHaveLength(1));
+
+      // Now update within waiting — no transition.
+      setFlowWaiting({
+        flowId: created.flowId,
+        expectedRevision: 1,
+        stateJson: { phase: "still-waiting" },
+      });
+
+      // Give hooks time to settle — no extra transition should appear.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(transitionEvents).toHaveLength(1);
+    });
+  });
+
+  it("emits hook for failure transitions with tags propagated", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const transitions: InternalHookEvent[] = [];
+      registerInternalHook("task:flow:transition", (event) => {
+        transitions.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/hooks",
+        goal: "Failure path",
+        tags: { pipeline: "ci" },
+      });
+
+      failFlow({
+        flowId: created.flowId,
+        expectedRevision: 0,
+        blockedSummary: "Runner crashed.",
+      });
+
+      await vi.waitFor(() => expect(transitions).toHaveLength(1));
+
+      const ctx = transitions[0].context as {
+        flow: Record<string, unknown>;
+        previousStatus: string;
+      };
+      expect(ctx.flow.status).toBe("failed");
+      expect(ctx.previousStatus).toBe("queued");
+      expect(ctx.flow.tags).toEqual({ pipeline: "ci" });
+    });
+  });
+
+  // =========================================================================
+  // Diagnostic event bus bridge
+  // =========================================================================
+
+  it("emits task.flow.created diagnostic event on flow creation", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const diagnosticEvents: DiagnosticEventPayload[] = [];
+      const unsubscribe = onInternalDiagnosticEvent((event) => {
+        if (event.type === "task.flow.created") {
+          diagnosticEvents.push(event);
+        }
+      });
+
+      try {
+        createManagedTaskFlow({
+          ownerKey: "agent:main:main",
+          controllerId: "tests/diag",
+          goal: "Diagnostic test",
+          tags: { env: "test" },
+        });
+
+        expect(diagnosticEvents).toHaveLength(1);
+        const evt = diagnosticEvents[0];
+        expect(evt.type).toBe("task.flow.created");
+        if (evt.type !== "task.flow.created") {
+          throw new Error("Wrong type");
+        }
+        expect(evt.syncMode).toBe("managed");
+        expect(evt.ownerKey).toBe("agent:main:main");
+        expect(evt.goal).toBe("Diagnostic test");
+        expect(evt.tags).toEqual({ env: "test" });
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("emits task.flow.transition diagnostic events through full lifecycle", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const transitions: DiagnosticEventPayload[] = [];
+      const unsubscribe = onInternalDiagnosticEvent((event) => {
+        if (event.type === "task.flow.transition") {
+          transitions.push(event);
+        }
+      });
+
+      try {
+        const flow = createManagedTaskFlow({
+          ownerKey: "agent:main:main",
+          controllerId: "tests/diag",
+          goal: "Full lifecycle",
+          tags: { team: "platform" },
+        });
+
+        resumeFlow({
+          flowId: flow.flowId,
+          expectedRevision: 0,
+          status: "running",
+        });
+
+        finishFlow({
+          flowId: flow.flowId,
+          expectedRevision: 1,
+        });
+
+        expect(transitions).toHaveLength(2);
+
+        const running = transitions[0];
+        if (running.type !== "task.flow.transition") {
+          throw new Error("Wrong type");
+        }
+        expect(running.previousStatus).toBe("queued");
+        expect(running.status).toBe("running");
+        expect(running.tags).toEqual({ team: "platform" });
+        expect(running.durationMs).toBeGreaterThanOrEqual(0);
+
+        const succeeded = transitions[1];
+        if (succeeded.type !== "task.flow.transition") {
+          throw new Error("Wrong type");
+        }
+        expect(succeeded.previousStatus).toBe("running");
+        expect(succeeded.status).toBe("succeeded");
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("emits task.flow.deleted diagnostic event on deletion", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const deletedEvents: DiagnosticEventPayload[] = [];
+      const unsubscribe = onInternalDiagnosticEvent((event) => {
+        if (event.type === "task.flow.deleted") {
+          deletedEvents.push(event);
+        }
+      });
+
+      try {
+        const flow = createManagedTaskFlow({
+          ownerKey: "agent:main:main",
+          controllerId: "tests/diag",
+          goal: "Delete diag",
+          tags: { env: "prod" },
+        });
+
+        deleteTaskFlowRecordById(flow.flowId);
+
+        expect(deletedEvents).toHaveLength(1);
+        const evt = deletedEvents[0];
+        if (evt.type !== "task.flow.deleted") {
+          throw new Error("Wrong type");
+        }
+        expect(evt.flowId).toBe(flow.flowId);
+        expect(evt.ownerKey).toBe("agent:main:main");
+        expect(evt.previousStatus).toBe("queued");
+        expect(evt.tags).toEqual({ env: "prod" });
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  // =========================================================================
+  // Tags field
+  // =========================================================================
+
+  it("persists tags on TaskFlowRecord through create", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/tags",
+        goal: "Tag persistence",
+        tags: { env: "test", service: "api", priority: "p1" },
+      });
+
+      expect(created.tags).toEqual({ env: "test", service: "api", priority: "p1" });
+
+      // Verify getTaskFlowById returns the same tags from the in-memory store.
+      const { getTaskFlowById } = await import("./task-flow-registry.js");
+      const fetched = getTaskFlowById(created.flowId);
+      expect(fetched?.tags).toEqual({ env: "test", service: "api", priority: "p1" });
+    });
+  });
+
+  it("creates flows without tags when none are provided", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/no-tags",
+        goal: "No tags flow",
+      });
+
+      expect(created.tags).toBeUndefined();
+    });
+  });
+
+  it("normalizes empty and null tags to undefined", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const withNull = createFlowRecord({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/null-tags",
+        goal: "Null tags",
+        tags: null,
+      });
+      expect(withNull.tags).toBeUndefined();
+
+      const withEmpty = createFlowRecord({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/empty-tags",
+        goal: "Empty tags",
+        tags: {},
+      });
+      expect(withEmpty.tags).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Broad hook type listener (task:*)
+  // =========================================================================
+
+  it("broad task type listener receives all flow hook events", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const allTaskEvents: InternalHookEvent[] = [];
+      registerInternalHook("task", (event) => {
+        allTaskEvents.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/broad",
+        goal: "Broad listener",
+      });
+
+      resumeFlow({
+        flowId: created.flowId,
+        expectedRevision: 0,
+        status: "running",
+      });
+
+      deleteTaskFlowRecordById(created.flowId);
+
+      await vi.waitFor(() => expect(allTaskEvents).toHaveLength(3));
+
+      expect(allTaskEvents[0].action).toBe("flow:created");
+      expect(allTaskEvents[1].action).toBe("flow:transition");
+      expect(allTaskEvents[2].action).toBe("flow:deleted");
+    });
+  });
+
+  // =========================================================================
+  // Tag update via patch
+  // =========================================================================
+
+  it("updates tags via patch and emits no transition when status is unchanged", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const transitions: InternalHookEvent[] = [];
+      registerInternalHook("task:flow:transition", (event) => {
+        transitions.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/patch-tags",
+        goal: "Patch tags",
+        tags: { env: "dev" },
+      });
+
+      const result = updateFlowRecordByIdExpectedRevision({
+        flowId: created.flowId,
+        expectedRevision: 0,
+        patch: { tags: { env: "staging", region: "us-east" } },
+      });
+
+      expect(result.applied).toBe(true);
+      if (!result.applied) {
+        throw new Error("Expected update to apply");
+      }
+      expect(result.flow.tags).toEqual({ env: "staging", region: "us-east" });
+
+      // No status change, so no transition hook.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(transitions).toHaveLength(0);
+    });
+  });
+
+  it("clears tags by patching to null", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/clear-tags",
+        goal: "Clear tags",
+        tags: { env: "prod" },
+      });
+
+      const result = updateFlowRecordByIdExpectedRevision({
+        flowId: created.flowId,
+        expectedRevision: 0,
+        patch: { tags: null },
+      });
+
+      expect(result.applied).toBe(true);
+      if (!result.applied) {
+        throw new Error("Expected update to apply");
+      }
+      expect(result.flow.tags).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Task-mirrored flow events
+  // =========================================================================
+
+  it("emits hook events for task-mirrored flow creation and sync transitions", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const allTaskEvents: InternalHookEvent[] = [];
+      registerInternalHook("task", (event) => {
+        allTaskEvents.push(event);
+      });
+
+      const mirroredFlow = createTaskFlowForTask({
+        task: {
+          ownerKey: "agent:main:main",
+          taskId: "task-1",
+          notifyPolicy: "done_only",
+          status: "running",
+          terminalOutcome: undefined,
+          label: "Mirrored job",
+          task: "Run mirrored job",
+          createdAt: Date.now() - 1000,
+          lastEventAt: Date.now(),
+          endedAt: undefined,
+          terminalSummary: undefined,
+          progressSummary: undefined,
+        },
+      });
+
+      await vi.waitFor(() => expect(allTaskEvents).toHaveLength(1));
+      expect(allTaskEvents[0].action).toBe("flow:created");
+
+      // Sync the flow with a status change via syncFlowFromTask.
+      syncFlowFromTask({
+        parentFlowId: mirroredFlow.flowId,
+        status: "succeeded",
+        terminalOutcome: "succeeded",
+        notifyPolicy: "done_only",
+        label: "Mirrored job",
+        task: "Run mirrored job",
+        lastEventAt: Date.now(),
+        endedAt: Date.now(),
+        taskId: "task-1",
+        terminalSummary: "Done.",
+        progressSummary: undefined,
+      });
+
+      await vi.waitFor(() => expect(allTaskEvents).toHaveLength(2));
+      expect(allTaskEvents[1].action).toBe("flow:transition");
+
+      const ctx = allTaskEvents[1].context as {
+        flow: Record<string, unknown>;
+        previousStatus: string;
+      };
+      expect(ctx.flow.syncMode).toBe("task_mirrored");
+      expect(ctx.flow.status).toBe("succeeded");
+      expect(ctx.previousStatus).toBe("running");
+    });
+  });
+
+  // =========================================================================
+  // Type guards
+  // =========================================================================
+
+  it("isTaskFlowCreatedEvent correctly identifies created events", () => {
+    const valid = createInternalHookEvent("task", "flow:created", "agent:main:main", {
+      flow: {
+        flowId: "f-1",
+        syncMode: "managed",
+        ownerKey: "agent:main:main",
+        status: "queued",
+        goal: "Test",
+        createdAt: Date.now(),
+      },
+    });
+    expect(isTaskFlowCreatedEvent(valid)).toBe(true);
+
+    const wrongAction = createInternalHookEvent("task", "flow:transition", "agent:main:main", {
+      flow: { flowId: "f-1" },
+    });
+    expect(isTaskFlowCreatedEvent(wrongAction)).toBe(false);
+
+    const wrongType = createInternalHookEvent("command", "flow:created", "agent:main:main", {});
+    expect(isTaskFlowCreatedEvent(wrongType)).toBe(false);
+
+    const missingFlow = createInternalHookEvent("task", "flow:created", "agent:main:main", {});
+    expect(isTaskFlowCreatedEvent(missingFlow)).toBe(false);
+  });
+
+  it("isTaskFlowTransitionEvent correctly identifies transition events", () => {
+    const valid = createInternalHookEvent("task", "flow:transition", "agent:main:main", {
+      flow: { flowId: "f-1", status: "running" },
+      previousStatus: "queued",
+      durationMs: 100,
+    });
+    expect(isTaskFlowTransitionEvent(valid)).toBe(true);
+
+    const missingPrev = createInternalHookEvent("task", "flow:transition", "agent:main:main", {
+      flow: { flowId: "f-1" },
+    });
+    expect(isTaskFlowTransitionEvent(missingPrev)).toBe(false);
+  });
+
+  it("isTaskFlowDeletedEvent correctly identifies deleted events", () => {
+    const valid = createInternalHookEvent("task", "flow:deleted", "agent:main:main", {
+      flowId: "f-1",
+      previous: { flowId: "f-1", status: "running" },
+    });
+    expect(isTaskFlowDeletedEvent(valid)).toBe(true);
+
+    const missingPrevious = createInternalHookEvent("task", "flow:deleted", "agent:main:main", {
+      flowId: "f-1",
+    });
+    expect(isTaskFlowDeletedEvent(missingPrevious)).toBe(false);
+
+    const missingFlowId = createInternalHookEvent("task", "flow:deleted", "agent:main:main", {
+      previous: { flowId: "f-1" },
+    });
+    expect(isTaskFlowDeletedEvent(missingFlowId)).toBe(false);
+  });
+});

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -28,6 +28,7 @@ type FlowRegistryRow = {
   blocked_summary: string | null;
   state_json: string | null;
   wait_json: string | null;
+  tags_json: string | null;
   cancel_requested_at: number | bigint | null;
   created_at: number | bigint;
   updated_at: number | bigint;
@@ -68,6 +69,7 @@ const FLOW_RUNS_COLUMNS = `
   blocked_summary TEXT,
   state_json TEXT,
   wait_json TEXT,
+  tags_json TEXT,
   cancel_requested_at INTEGER,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
@@ -126,6 +128,7 @@ function rowToFlowRecord(row: FlowRegistryRow): TaskFlowRecord {
   const requesterOrigin = parseDeliveryContextJson(row.requester_origin_json);
   const stateJson = parseJsonValue<JsonValue>(row.state_json);
   const waitJson = parseJsonValue<JsonValue>(row.wait_json);
+  const tags = parseJsonValue<Record<string, string>>(row.tags_json);
   return {
     flowId: row.flow_id,
     syncMode: rowToSyncMode(row),
@@ -141,6 +144,7 @@ function rowToFlowRecord(row: FlowRegistryRow): TaskFlowRecord {
     ...(row.blocked_summary ? { blockedSummary: row.blocked_summary } : {}),
     ...(stateJson !== undefined ? { stateJson } : {}),
     ...(waitJson !== undefined ? { waitJson } : {}),
+    ...(tags ? { tags } : {}),
     ...(cancelRequestedAt != null ? { cancelRequestedAt } : {}),
     createdAt: normalizeNumber(row.created_at) ?? 0,
     updatedAt: normalizeNumber(row.updated_at) ?? 0,
@@ -164,6 +168,7 @@ function bindFlowRecord(record: TaskFlowRecord) {
     blocked_summary: record.blockedSummary ?? null,
     state_json: serializeJson(record.stateJson),
     wait_json: serializeJson(record.waitJson),
+    tags_json: serializeJson(record.tags),
     cancel_requested_at: record.cancelRequestedAt ?? null,
     created_at: record.createdAt,
     updated_at: record.updatedAt,
@@ -190,6 +195,7 @@ function createStatements(db: DatabaseSync): FlowRegistryStatements {
         blocked_summary,
         state_json,
         wait_json,
+        tags_json,
         cancel_requested_at,
         created_at,
         updated_at,
@@ -213,6 +219,7 @@ function createStatements(db: DatabaseSync): FlowRegistryStatements {
         blocked_summary,
         state_json,
         wait_json,
+        tags_json,
         cancel_requested_at,
         created_at,
         updated_at,
@@ -232,6 +239,7 @@ function createStatements(db: DatabaseSync): FlowRegistryStatements {
         @blocked_summary,
         @state_json,
         @wait_json,
+        @tags_json,
         @cancel_requested_at,
         @created_at,
         @updated_at,
@@ -251,6 +259,7 @@ function createStatements(db: DatabaseSync): FlowRegistryStatements {
         blocked_summary = excluded.blocked_summary,
         state_json = excluded.state_json,
         wait_json = excluded.wait_json,
+        tags_json = excluded.tags_json,
         cancel_requested_at = excluded.cancel_requested_at,
         created_at = excluded.created_at,
         updated_at = excluded.updated_at,
@@ -290,6 +299,7 @@ function rebuildLegacyFlowRunsTable(db: DatabaseSync) {
       blocked_summary,
       state_json,
       wait_json,
+      tags_json,
       cancel_requested_at,
       created_at,
       updated_at,
@@ -316,6 +326,8 @@ function rebuildLegacyFlowRunsTable(db: DatabaseSync) {
       blocked_summary,
       state_json,
       wait_json,
+      CASE WHEN EXISTS (SELECT 1 FROM pragma_table_info('flow_runs') WHERE name = 'tags_json')
+        THEN tags_json ELSE NULL END,
       cancel_requested_at,
       created_at,
       updated_at,
@@ -393,6 +405,9 @@ function ensureSchema(db: DatabaseSync) {
   }
   if (!hasFlowRunsColumn(db, "cancel_requested_at")) {
     db.exec(`ALTER TABLE flow_runs ADD COLUMN cancel_requested_at INTEGER;`);
+  }
+  if (!hasFlowRunsColumn(db, "tags_json")) {
+    db.exec(`ALTER TABLE flow_runs ADD COLUMN tags_json TEXT;`);
   }
   if (hasFlowRunsColumn(db, "owner_session_key")) {
     // Populate the canonical fields before rebuilding so existing rows survive the legacy-column

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -1,4 +1,11 @@
 import crypto from "node:crypto";
+import { fireAndForgetHook } from "../hooks/fire-and-forget.js";
+import {
+  createInternalHookEvent,
+  hasInternalHookListeners,
+  triggerInternalHook,
+} from "../hooks/internal-hooks.js";
+import { emitTrustedDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -54,6 +61,7 @@ type FlowRecordPatch = Omit<
   controllerId?: string | null;
   stateJson?: JsonValue | null;
   waitJson?: JsonValue | null;
+  tags?: Record<string, string> | null;
   cancelRequestedAt?: number | null;
   endedAt?: number | null;
 };
@@ -69,6 +77,7 @@ type FlowRecordCreateFields = {
   blockedSummary?: string | null;
   stateJson?: JsonValue | null;
   waitJson?: JsonValue | null;
+  tags?: Record<string, string> | null;
   cancelRequestedAt?: number | null;
   createdAt?: number;
   updatedAt?: number;
@@ -109,6 +118,7 @@ function cloneFlowRecord(record: TaskFlowRecord): TaskFlowRecord {
       ? { stateJson: cloneStructuredValue(record.stateJson)! }
       : {}),
     ...(record.waitJson !== undefined ? { waitJson: cloneStructuredValue(record.waitJson)! } : {}),
+    ...(record.tags ? { tags: { ...record.tags } } : {}),
   };
 }
 
@@ -133,6 +143,7 @@ function normalizeRestoredFlowRecord(record: TaskFlowRecord): TaskFlowRecord {
       ? { stateJson: cloneStructuredValue(record.stateJson)! }
       : {}),
     ...(record.waitJson !== undefined ? { waitJson: cloneStructuredValue(record.waitJson)! } : {}),
+    ...(record.tags ? { tags: { ...record.tags } } : {}),
     revision: Math.max(0, record.revision),
     cancelRequestedAt: record.cancelRequestedAt ?? undefined,
     endedAt: record.endedAt ?? undefined,
@@ -159,8 +170,124 @@ function ensureNotifyPolicy(notifyPolicy?: TaskNotifyPolicy): TaskNotifyPolicy {
   return notifyPolicy ?? "done_only";
 }
 
+function flowRecordToHookSnapshot(flow: TaskFlowRecord) {
+  return {
+    flowId: flow.flowId,
+    syncMode: flow.syncMode,
+    ownerKey: flow.ownerKey,
+    status: flow.status,
+    goal: flow.goal,
+    ...(flow.currentStep ? { currentStep: flow.currentStep } : {}),
+    ...(flow.controllerId ? { controllerId: flow.controllerId } : {}),
+    ...(flow.tags ? { tags: { ...flow.tags } } : {}),
+    createdAt: flow.createdAt,
+    updatedAt: flow.updatedAt,
+    ...(flow.endedAt != null ? { endedAt: flow.endedAt } : {}),
+  };
+}
+
+function emitTaskFlowHookEvents(next: TaskFlowRecord, previous?: TaskFlowRecord): void {
+  const isNew = !previous;
+  const statusChanged = previous != null && previous.status !== next.status;
+
+  if (isNew) {
+    emitTrustedDiagnosticEvent({
+      type: "task.flow.created",
+      flowId: next.flowId,
+      syncMode: next.syncMode,
+      ownerKey: next.ownerKey,
+      goal: next.goal,
+      ...(next.controllerId ? { controllerId: next.controllerId } : {}),
+      ...(next.tags ? { tags: { ...next.tags } } : {}),
+    });
+
+    if (hasInternalHookListeners("task", "flow:created")) {
+      fireAndForgetHook(
+        triggerInternalHook(
+          createInternalHookEvent("task", "flow:created", next.ownerKey, {
+            flow: flowRecordToHookSnapshot(next),
+          }),
+        ),
+        "task:flow:created hook",
+        (msg) => log.warn(msg),
+      );
+    }
+  }
+
+  if (statusChanged) {
+    const durationMs = (next.updatedAt || Date.now()) - next.createdAt;
+
+    emitTrustedDiagnosticEvent({
+      type: "task.flow.transition",
+      flowId: next.flowId,
+      syncMode: next.syncMode,
+      ownerKey: next.ownerKey,
+      goal: next.goal,
+      previousStatus: previous.status,
+      status: next.status,
+      ...(next.currentStep ? { currentStep: next.currentStep } : {}),
+      ...(next.controllerId ? { controllerId: next.controllerId } : {}),
+      ...(next.tags ? { tags: { ...next.tags } } : {}),
+      durationMs,
+    });
+
+    if (hasInternalHookListeners("task", "flow:transition")) {
+      fireAndForgetHook(
+        triggerInternalHook(
+          createInternalHookEvent("task", "flow:transition", next.ownerKey, {
+            flow: flowRecordToHookSnapshot(next),
+            previousStatus: previous.status,
+            durationMs,
+          }),
+        ),
+        "task:flow:transition hook",
+        (msg) => log.warn(msg),
+      );
+    }
+  }
+}
+
+function emitTaskFlowDeletedHookEvent(flowId: string, previous: TaskFlowRecord): void {
+  emitTrustedDiagnosticEvent({
+    type: "task.flow.deleted",
+    flowId,
+    ownerKey: previous.ownerKey,
+    previousStatus: previous.status,
+    ...(previous.tags ? { tags: { ...previous.tags } } : {}),
+  });
+
+  if (!hasInternalHookListeners("task", "flow:deleted")) {
+    return;
+  }
+  fireAndForgetHook(
+    triggerInternalHook(
+      createInternalHookEvent("task", "flow:deleted", previous.ownerKey, {
+        flowId,
+        previous: flowRecordToHookSnapshot(previous),
+      }),
+    ),
+    "task:flow:deleted hook",
+    (msg) => log.warn(msg),
+  );
+}
+
 function normalizeJsonBlob(value: JsonValue | null | undefined): JsonValue | undefined {
   return value === undefined ? undefined : cloneStructuredValue(value);
+}
+
+function normalizeTags(
+  value: Record<string, string> | null | undefined,
+): Record<string, string> | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (typeof key === "string" && typeof val === "string") {
+      result[key] = val;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function assertFlowOwnerKey(ownerKey: string): string {
@@ -289,6 +416,7 @@ function buildFlowRecord(params: CreateFlowRecordParams): TaskFlowRecord {
   const now = params.createdAt ?? Date.now();
   const syncMode = params.syncMode ?? "managed";
   const controllerId = syncMode === "managed" ? assertControllerId(params.controllerId) : undefined;
+  const tags = normalizeTags(params.tags);
   return {
     flowId: crypto.randomUUID(),
     syncMode,
@@ -310,6 +438,7 @@ function buildFlowRecord(params: CreateFlowRecordParams): TaskFlowRecord {
     ...(normalizeJsonBlob(params.waitJson) !== undefined
       ? { waitJson: normalizeJsonBlob(params.waitJson)! }
       : {}),
+    ...(tags ? { tags } : {}),
     ...(params.cancelRequestedAt != null ? { cancelRequestedAt: params.cancelRequestedAt } : {}),
     createdAt: now,
     updatedAt: params.updatedAt ?? now,
@@ -346,6 +475,7 @@ function applyFlowPatch(current: TaskFlowRecord, patch: FlowRecordPatch): TaskFl
     stateJson:
       patch.stateJson === undefined ? current.stateJson : normalizeJsonBlob(patch.stateJson),
     waitJson: patch.waitJson === undefined ? current.waitJson : normalizeJsonBlob(patch.waitJson),
+    tags: patch.tags === undefined ? current.tags : normalizeTags(patch.tags),
     cancelRequestedAt:
       patch.cancelRequestedAt === undefined
         ? current.cancelRequestedAt
@@ -364,6 +494,7 @@ function writeFlowRecord(next: TaskFlowRecord, previous?: TaskFlowRecord): TaskF
     flow: cloneFlowRecord(next),
     ...(previous ? { previous: cloneFlowRecord(previous) } : {}),
   }));
+  emitTaskFlowHookEvents(next, previous);
   return cloneFlowRecord(next);
 }
 
@@ -690,6 +821,7 @@ export function deleteTaskFlowRecordById(flowId: string): boolean {
     flowId,
     previous: cloneFlowRecord(current),
   }));
+  emitTaskFlowDeletedHookEvent(flowId, current);
   return true;
 }
 

--- a/src/tasks/task-flow-registry.types.ts
+++ b/src/tasks/task-flow-registry.types.ts
@@ -36,6 +36,7 @@ export type TaskFlowRecord = {
   blockedSummary?: string;
   stateJson?: JsonValue;
   waitJson?: JsonValue;
+  tags?: Record<string, string>;
   cancelRequestedAt?: number;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
## Summary

Adds comprehensive observability for the task flow lifecycle via diagnostic events, internal hooks, and OTel/Prometheus metrics. Also introduces a `tags` field on `TaskFlowRecord` for arbitrary user-defined metadata that propagates through all observability surfaces.

Closes #87362

## Changes

### Core (`src/tasks/`)
- `TaskFlowRecord.tags` — optional `Record<string, string>` for user-defined metadata
- `normalizeTags()` — filters non-string entries, returns `undefined` for empty/null
- `flowRecordToHookSnapshot()` — creates a minimal safe projection (excludes `stateJson`, `waitJson`, `blockedSummary`)
- `emitTaskFlowHookEvents()` / `emitTaskFlowDeletedHookEvent()` — emit diagnostic events synchronously and hook events via fire-and-forget
- SQLite: `tags_json` column with `ALTER TABLE` migration and safe `rebuildLegacyFlowRunsTable` support

### Hooks (`src/hooks/`)
- `"task"` added to `InternalHookEventType` union
- 3 hook event types: `task:flow:created`, `task:flow:transition`, `task:flow:deleted`
- 3 type guards: `isTaskFlowCreatedEvent`, `isTaskFlowTransitionEvent`, `isTaskFlowDeletedEvent`

### Diagnostic events (`src/infra/`)
- `DiagnosticTaskFlowCreatedEvent` (`task.flow.created`)
- `DiagnosticTaskFlowTransitionEvent` (`task.flow.transition`)
- `DiagnosticTaskFlowDeletedEvent` (`task.flow.deleted`)

### OTel (`extensions/diagnostics-otel/`)
- `openclaw.task.flow.created` counter
- `openclaw.task.flow.transitions` counter
- `openclaw.task.flow.duration_ms` histogram (terminal statuses only)
- `openclaw.task.flow.deleted` counter
- Per-tag attributes via `openclaw.task.flow.tag.*`

### Prometheus (`extensions/diagnostics-prometheus/`)
- `openclaw_task_flow_created_total`, `openclaw_task_flow_transition_total`, `openclaw_task_flow_duration_seconds`, `openclaw_task_flow_deleted_total`
- Labels: `sync_mode`, `status`, `previous_status`, `tag_*`

### Plugin SDK (`src/plugins/runtime/`)
- `tags` param added to `BoundTaskFlowRuntime.createManaged`

### Docs
- `docs/automation/hooks.md` — event types table + context highlights
- `docs/gateway/prometheus.md` — 4 new metrics
- `docs/gateway/opentelemetry.md` — task flow lifecycle subsection

## Verification

```
pnpm test src/tasks/task-flow-registry.hooks.test.ts    # 18 passed
pnpm test src/tasks/task-flow-registry.test.ts           # 6 passed
pnpm test extensions/diagnostics-otel/src/service.test.ts # 73 passed
pnpm test extensions/diagnostics-prometheus/src/service.test.ts # 17 passed
```

All 114 tests pass, zero regressions.
