### PR TITLE
fix(sessions): avoid stale restart continuation reuse

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -588,7 +588,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
-  it("starts a fresh session instead of reusing a terminal entry", async () => {
+  it("reuses a completed run entry while the session is still fresh", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const sessionKey = "agent:main:explicit:terminal-cli-session";
       const existingSessionId = "terminal-cli-session-old";
@@ -621,9 +621,11 @@ describe("updateSessionStoreAfterAgentRun", () => {
         sessionKey,
       });
 
-      expect(result.isNewSession).toBe(true);
-      expect(result.sessionId).not.toBe(existingSessionId);
+      expect(result.isNewSession).toBe(false);
+      expect(result.sessionId).toBe(existingSessionId);
       expect(result.sessionEntry?.sessionId).toBe(existingSessionId);
+      expect(result.sessionEntry?.status).toBe("done");
+      expect(result.sessionEntry?.endedAt).toBe(now - 100);
     });
   });
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -588,6 +588,45 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("starts a fresh session instead of reusing a terminal entry", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const sessionKey = "agent:main:explicit:terminal-cli-session";
+      const existingSessionId = "terminal-cli-session-old";
+      const now = Date.now();
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            [sessionKey]: {
+              sessionId: existingSessionId,
+              updatedAt: now,
+              status: "done",
+              startedAt: now - 1_000,
+              endedAt: now - 100,
+              runtimeMs: 900,
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = resolveSession({
+        cfg: {
+          session: {
+            store: storePath,
+            mainKey: "main",
+          },
+        } as OpenClawConfig,
+        sessionKey,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionId).not.toBe(existingSessionId);
+      expect(result.sessionEntry?.sessionId).toBe(existingSessionId);
+    });
+  });
+
   it("preserves previous totalTokens when provider returns no usage data (#67667)", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -19,7 +19,7 @@ import {
 import { resolveChannelResetConfig, resolveSessionResetType } from "../../config/sessions/reset.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { loadSessionStore } from "../../config/sessions/store-load.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import { hasTerminalSessionLifecycle, type SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   buildAgentMainSessionKey,
@@ -332,18 +332,19 @@ export function resolveSession(opts: {
     resetType,
     resetOverride: channelReset,
   });
-  const fresh = sessionEntry
-    ? evaluateSessionFreshness({
-        updatedAt: sessionEntry.updatedAt,
-        ...resolveSessionLifecycleTimestamps({
-          entry: sessionEntry,
-          agentId: opts.agentId,
-          storePath,
-        }),
-        now,
-        policy: resetPolicy,
-      }).fresh
-    : false;
+  const fresh =
+    sessionEntry && !hasTerminalSessionLifecycle(sessionEntry)
+      ? evaluateSessionFreshness({
+          updatedAt: sessionEntry.updatedAt,
+          ...resolveSessionLifecycleTimestamps({
+            entry: sessionEntry,
+            agentId: opts.agentId,
+            storePath,
+          }),
+          now,
+          policy: resetPolicy,
+        }).fresh
+      : false;
   const sessionId =
     opts.sessionId?.trim() || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
   const isNewSession = !fresh && !opts.sessionId;

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -19,7 +19,7 @@ import {
 import { resolveChannelResetConfig, resolveSessionResetType } from "../../config/sessions/reset.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { loadSessionStore } from "../../config/sessions/store-load.js";
-import { hasTerminalSessionLifecycle, type SessionEntry } from "../../config/sessions/types.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   buildAgentMainSessionKey,
@@ -332,19 +332,18 @@ export function resolveSession(opts: {
     resetType,
     resetOverride: channelReset,
   });
-  const fresh =
-    sessionEntry && !hasTerminalSessionLifecycle(sessionEntry)
-      ? evaluateSessionFreshness({
-          updatedAt: sessionEntry.updatedAt,
-          ...resolveSessionLifecycleTimestamps({
-            entry: sessionEntry,
-            agentId: opts.agentId,
-            storePath,
-          }),
-          now,
-          policy: resetPolicy,
-        }).fresh
-      : false;
+  const fresh = sessionEntry
+    ? evaluateSessionFreshness({
+        updatedAt: sessionEntry.updatedAt,
+        ...resolveSessionLifecycleTimestamps({
+          entry: sessionEntry,
+          agentId: opts.agentId,
+          storePath,
+        }),
+        now,
+        policy: resetPolicy,
+      }).fresh
+    : false;
   const sessionId =
     opts.sessionId?.trim() || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
   const isNewSession = !fresh && !opts.sessionId;

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1555,6 +1555,44 @@ describe("initSessionState reset policy", () => {
     expect(peekSystemEvents(existingSessionId)).toStrictEqual([]);
   });
 
+  it("rotates terminal session entries without carrying lifecycle markers forward", async () => {
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 30, 0));
+    const root = await makeCaseDir("openclaw-reset-terminal-entry-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:whatsapp:dm:terminal-entry";
+    const existingSessionId = "terminal-entry-old";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        startedAt: Date.now() - 10_000,
+        endedAt: Date.now() - 1_000,
+        runtimeMs: 9_000,
+        status: "done",
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(persisted[sessionKey]?.sessionId).toBe(result.sessionId);
+    expect(persisted[sessionKey]?.status).toBeUndefined();
+    expect(persisted[sessionKey]?.startedAt).toBeUndefined();
+    expect(persisted[sessionKey]?.endedAt).toBeUndefined();
+    expect(persisted[sessionKey]?.runtimeMs).toBeUndefined();
+  });
+
   it("keeps the existing stale session for /reset soft", async () => {
     vi.setSystemTime(new Date(2026, 0, 18, 5, 30, 0));
     const root = await makeCaseDir("openclaw-reset-soft-stale-");

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1555,7 +1555,7 @@ describe("initSessionState reset policy", () => {
     expect(peekSystemEvents(existingSessionId)).toStrictEqual([]);
   });
 
-  it("rotates terminal session entries without carrying lifecycle markers forward", async () => {
+  it("reuses completed run entries while the session is still fresh", async () => {
     vi.setSystemTime(new Date(2026, 0, 18, 5, 30, 0));
     const root = await makeCaseDir("openclaw-reset-terminal-entry-");
     const storePath = path.join(root, "sessions.json");
@@ -1579,18 +1579,18 @@ describe("initSessionState reset policy", () => {
       commandAuthorized: true,
     });
 
-    expect(result.isNewSession).toBe(true);
-    expect(result.sessionId).not.toBe(existingSessionId);
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
 
     const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
       SessionEntry
     >;
-    expect(persisted[sessionKey]?.sessionId).toBe(result.sessionId);
-    expect(persisted[sessionKey]?.status).toBeUndefined();
-    expect(persisted[sessionKey]?.startedAt).toBeUndefined();
-    expect(persisted[sessionKey]?.endedAt).toBeUndefined();
-    expect(persisted[sessionKey]?.runtimeMs).toBeUndefined();
+    expect(persisted[sessionKey]?.sessionId).toBe(existingSessionId);
+    expect(persisted[sessionKey]?.status).toBe("done");
+    expect(persisted[sessionKey]?.startedAt).toBe(Date.now() - 10_000);
+    expect(persisted[sessionKey]?.endedAt).toBe(Date.now() - 1_000);
+    expect(persisted[sessionKey]?.runtimeMs).toBe(9_000);
   });
 
   it("keeps the existing stale session for /reset soft", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -28,6 +28,7 @@ import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js
 import {
   DEFAULT_RESET_TRIGGERS,
   type GroupKeyResolution,
+  hasTerminalSessionLifecycle,
   type SessionEntry,
   type SessionScope,
 } from "../../config/sessions/types.js";
@@ -432,7 +433,8 @@ export async function initSessionState(params: {
   const canReuseExistingEntry =
     Boolean(entry?.sessionId) &&
     typeof entry?.updatedAt === "number" &&
-    Number.isFinite(entry.updatedAt);
+    Number.isFinite(entry.updatedAt) &&
+    !hasTerminalSessionLifecycle(entry);
   const skipImplicitExpiry = hasProviderOwnedSession(entry) && resetPolicy.configured !== true;
   const lifecycleTimestamps = resolveSessionLifecycleTimestamps({
     entry,
@@ -440,15 +442,17 @@ export async function initSessionState(params: {
     storePath,
   });
   const entryFreshness = entry
-    ? skipImplicitExpiry
-      ? ({ fresh: true } satisfies SessionFreshness)
-      : evaluateSessionFreshness({
-          updatedAt: entry.updatedAt,
-          sessionStartedAt: lifecycleTimestamps.sessionStartedAt,
-          lastInteractionAt: lifecycleTimestamps.lastInteractionAt,
-          now,
-          policy: resetPolicy,
-        })
+    ? hasTerminalSessionLifecycle(entry)
+      ? undefined
+      : skipImplicitExpiry
+        ? ({ fresh: true } satisfies SessionFreshness)
+        : evaluateSessionFreshness({
+            updatedAt: entry.updatedAt,
+            sessionStartedAt: lifecycleTimestamps.sessionStartedAt,
+            lastInteractionAt: lifecycleTimestamps.lastInteractionAt,
+            now,
+            policy: resetPolicy,
+          })
     : undefined;
   const softResetAllowed =
     softReset.matched &&
@@ -782,6 +786,10 @@ export async function initSessionState(params: {
     // Clear stale context hash so the first flush in the new session is not
     // incorrectly skipped due to a hash match with the old transcript (#30115).
     sessionEntry.memoryFlushContextHash = undefined;
+    sessionEntry.startedAt = undefined;
+    sessionEntry.endedAt = undefined;
+    sessionEntry.runtimeMs = undefined;
+    sessionEntry.status = undefined;
     // Clear stale token metrics from previous session so /status doesn't
     // display the old session's context usage after /new or /reset.
     sessionEntry.totalTokens = undefined;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -28,7 +28,6 @@ import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js
 import {
   DEFAULT_RESET_TRIGGERS,
   type GroupKeyResolution,
-  hasTerminalSessionLifecycle,
   type SessionEntry,
   type SessionScope,
 } from "../../config/sessions/types.js";
@@ -433,8 +432,7 @@ export async function initSessionState(params: {
   const canReuseExistingEntry =
     Boolean(entry?.sessionId) &&
     typeof entry?.updatedAt === "number" &&
-    Number.isFinite(entry.updatedAt) &&
-    !hasTerminalSessionLifecycle(entry);
+    Number.isFinite(entry.updatedAt);
   const skipImplicitExpiry = hasProviderOwnedSession(entry) && resetPolicy.configured !== true;
   const lifecycleTimestamps = resolveSessionLifecycleTimestamps({
     entry,
@@ -442,17 +440,15 @@ export async function initSessionState(params: {
     storePath,
   });
   const entryFreshness = entry
-    ? hasTerminalSessionLifecycle(entry)
-      ? undefined
-      : skipImplicitExpiry
-        ? ({ fresh: true } satisfies SessionFreshness)
-        : evaluateSessionFreshness({
-            updatedAt: entry.updatedAt,
-            sessionStartedAt: lifecycleTimestamps.sessionStartedAt,
-            lastInteractionAt: lifecycleTimestamps.lastInteractionAt,
-            now,
-            policy: resetPolicy,
-          })
+    ? skipImplicitExpiry
+      ? ({ fresh: true } satisfies SessionFreshness)
+      : evaluateSessionFreshness({
+          updatedAt: entry.updatedAt,
+          sessionStartedAt: lifecycleTimestamps.sessionStartedAt,
+          lastInteractionAt: lifecycleTimestamps.lastInteractionAt,
+          now,
+          policy: resetPolicy,
+        })
     : undefined;
   const softResetAllowed =
     softReset.matched &&

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -396,6 +396,22 @@ export type SessionEntry = {
   acp?: SessionAcpMeta;
 };
 
+export function isTerminalSessionStatus(
+  status: unknown,
+): status is Exclude<NonNullable<SessionEntry["status"]>, "running"> {
+  return status === "done" || status === "failed" || status === "killed" || status === "timeout";
+}
+
+export function hasTerminalSessionLifecycle(entry: SessionEntry | undefined): boolean {
+  if (!entry) {
+    return false;
+  }
+  return (
+    isTerminalSessionStatus(entry.status) ||
+    (typeof entry.endedAt === "number" && Number.isFinite(entry.endedAt))
+  );
+}
+
 function isSessionPluginTraceLine(line: string): boolean {
   const trimmed = line.trim();
   return trimmed.startsWith("🔎 ") || /(?:^|\s)(?:Debug|Trace):/.test(trimmed);

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -402,16 +402,6 @@ export function isTerminalSessionStatus(
   return status === "done" || status === "failed" || status === "killed" || status === "timeout";
 }
 
-export function hasTerminalSessionLifecycle(entry: SessionEntry | undefined): boolean {
-  if (!entry) {
-    return false;
-  }
-  return (
-    isTerminalSessionStatus(entry.status) ||
-    (typeof entry.endedAt === "number" && Number.isFinite(entry.endedAt))
-  );
-}
-
 function isSessionPluginTraceLine(line: string): boolean {
   const trimmed = line.trim();
   return trimmed.startsWith("🔎 ") || /(?:^|\s)(?:Debug|Trace):/.test(trimmed);

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -619,7 +619,7 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
   });
 
-  it("does not dispatch agentTurn continuation into a terminal session entry", async () => {
+  it("dispatches agentTurn continuation for a completed run entry", async () => {
     mocks.readRestartSentinel.mockResolvedValue({
       payload: {
         sessionKey: "agent:main:main",
@@ -652,33 +652,36 @@ describe("scheduleRestartSentinelWake", () => {
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
-    expect(mocks.enqueueSessionDelivery).not.toHaveBeenCalled();
-    expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
-    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
-      sessionKey: "agent:main:main",
-      deliveryContext: {
-        channel: "whatsapp",
-        to: "+15550002",
-        accountId: "acct-2",
-        threadId: "thread-42",
-      },
-    });
-    expect(mocks.logWarn).toHaveBeenCalledWith(
-      "restart summary: continuation skipped: session is terminal",
-      {
+    expect(mocks.enqueueSessionDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "agentTurn",
         sessionKey: "agent:main:main",
-        continuationKind: "agentTurn",
-        status: "done",
-        endedAt: expect.any(Number),
-      },
+        message: "continue after restart",
+        messageId: "restart-sentinel:agent:main:main:agentTurn:123",
+        expectedSessionId: "agent:main:main",
+        route: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+          threadId: "thread-42",
+          chatType: "direct",
+        },
+      }),
     );
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledTimes(1);
+    expectContinuationDispatchFields(
+      { routeSessionKey: "agent:main:main" },
+      { Body: "continue after restart" },
+    );
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.logWarn).not.toHaveBeenCalled();
   });
 
-  it("does not dispatch a queued agentTurn continuation after the session becomes terminal", async () => {
+  it("does not dispatch a queued agentTurn continuation after the session key changes", async () => {
     const activeEntry: LoadedSessionEntry = {
       cfg: {},
       entry: {
-        sessionId: "agent:main:main",
+        sessionId: "old-session-id",
         updatedAt: Date.now(),
       },
       store: {},
@@ -686,10 +689,10 @@ describe("scheduleRestartSentinelWake", () => {
       canonicalKey: "agent:main:main",
       legacyKey: undefined,
     };
-    const terminalEntry: LoadedSessionEntry = {
+    const replacementEntry: LoadedSessionEntry = {
       cfg: {},
       entry: {
-        sessionId: "agent:main:main",
+        sessionId: "new-session-id",
         updatedAt: Date.now(),
         status: "done",
         endedAt: Date.now() - 1_000,
@@ -715,7 +718,7 @@ describe("scheduleRestartSentinelWake", () => {
         },
       },
     } as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
-    mocks.loadSessionEntry.mockReturnValueOnce(activeEntry).mockReturnValue(terminalEntry);
+    mocks.loadSessionEntry.mockReturnValueOnce(activeEntry).mockReturnValue(replacementEntry);
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -736,18 +739,15 @@ describe("scheduleRestartSentinelWake", () => {
       reason: "wake",
       sessionKey: "agent:main:main",
     });
-    expect(mocks.logWarn).toHaveBeenCalledWith(
-      "restart continuation skipped: session is terminal",
-      {
-        sessionKey: "agent:main:main",
-        queueId: "session-delivery-1",
-        status: "done",
-        endedAt: expect.any(Number),
-      },
-    );
+    expect(mocks.logWarn).toHaveBeenCalledWith("restart continuation skipped: session changed", {
+      sessionKey: "agent:main:main",
+      queueId: "session-delivery-1",
+      expectedSessionId: "old-session-id",
+      actualSessionId: "new-session-id",
+    });
   });
 
-  it("still delivers systemEvent continuations for terminal session entries", async () => {
+  it("still delivers systemEvent continuations for completed run entries", async () => {
     mocks.readRestartSentinel.mockResolvedValue({
       payload: {
         sessionKey: "agent:main:main",
@@ -791,7 +791,7 @@ describe("scheduleRestartSentinelWake", () => {
     });
     expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
     expect(mocks.logWarn).not.toHaveBeenCalledWith(
-      "restart summary: continuation skipped: session is terminal",
+      "restart continuation skipped: session changed",
       expect.anything(),
     );
   });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -674,6 +674,128 @@ describe("scheduleRestartSentinelWake", () => {
     );
   });
 
+  it("does not dispatch a queued agentTurn continuation after the session becomes terminal", async () => {
+    const activeEntry: LoadedSessionEntry = {
+      cfg: {},
+      entry: {
+        sessionId: "agent:main:main",
+        updatedAt: Date.now(),
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      legacyKey: undefined,
+    };
+    const terminalEntry: LoadedSessionEntry = {
+      cfg: {},
+      entry: {
+        sessionId: "agent:main:main",
+        updatedAt: Date.now(),
+        status: "done",
+        endedAt: Date.now() - 1_000,
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      legacyKey: undefined,
+    };
+    mocks.readRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        threadId: "thread-42",
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue after restart",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
+    mocks.loadSessionEntry.mockReturnValueOnce(activeEntry).mockReturnValue(terminalEntry);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSessionDelivery).toHaveBeenCalledTimes(1);
+    expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("continue after restart", {
+      sessionKey: "agent:main:main",
+      deliveryContext: {
+        channel: "whatsapp",
+        to: "+15550002",
+        accountId: "acct-2",
+        threadId: "thread-42",
+      },
+    });
+    expect(mocks.requestHeartbeat).toHaveBeenCalledWith({
+      source: "restart-sentinel",
+      intent: "immediate",
+      reason: "wake",
+      sessionKey: "agent:main:main",
+    });
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      "restart continuation skipped: session is terminal",
+      {
+        sessionKey: "agent:main:main",
+        queueId: "session-delivery-1",
+        status: "done",
+        endedAt: expect.any(Number),
+      },
+    );
+  });
+
+  it("still delivers systemEvent continuations for terminal session entries", async () => {
+    mocks.readRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        threadId: "thread-42",
+        ts: 123,
+        continuation: {
+          kind: "systemEvent",
+          text: "continue after restart",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      entry: {
+        sessionId: "agent:main:main",
+        updatedAt: Date.now(),
+        status: "done",
+        endedAt: Date.now() - 1_000,
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      legacyKey: undefined,
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenNthCalledWith(2, "continue after restart", {
+      sessionKey: "agent:main:main",
+      deliveryContext: {
+        channel: "whatsapp",
+        to: "+15550002",
+        accountId: "acct-2",
+        threadId: "thread-42",
+      },
+    });
+    expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
+    expect(mocks.logWarn).not.toHaveBeenCalledWith(
+      "restart summary: continuation skipped: session is terminal",
+      expect.anything(),
+    );
+  });
+
   it("preserves the session chat type for agentTurn continuations", async () => {
     mocks.readRestartSentinel.mockResolvedValue({
       payload: {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -619,6 +619,61 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
   });
 
+  it("does not dispatch agentTurn continuation into a terminal session entry", async () => {
+    mocks.readRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        threadId: "thread-42",
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue after restart",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      entry: {
+        sessionId: "agent:main:main",
+        updatedAt: Date.now(),
+        status: "done",
+        endedAt: Date.now() - 1_000,
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      legacyKey: undefined,
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSessionDelivery).not.toHaveBeenCalled();
+    expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
+      sessionKey: "agent:main:main",
+      deliveryContext: {
+        channel: "whatsapp",
+        to: "+15550002",
+        accountId: "acct-2",
+        threadId: "thread-42",
+      },
+    });
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      "restart summary: continuation skipped: session is terminal",
+      {
+        sessionKey: "agent:main:main",
+        continuationKind: "agentTurn",
+        status: "done",
+        endedAt: expect.any(Number),
+      },
+    );
+  });
+
   it("preserves the session chat type for agentTurn continuations", async () => {
     mocks.readRestartSentinel.mockResolvedValue({
       payload: {

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -10,7 +10,6 @@ import { dispatchAssembledChannelTurn } from "../channels/turn/kernel.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { parseSessionThreadInfo } from "../config/sessions/thread-info.js";
-import { hasTerminalSessionLifecycle } from "../config/sessions/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "../infra/outbound/delivery-queue.js";
@@ -263,12 +262,15 @@ async function deliverQueuedSessionDelivery(params: {
     return;
   }
 
-  if (hasTerminalSessionLifecycle(entry)) {
-    log.warn("restart continuation skipped: session is terminal", {
+  if (
+    params.entry.expectedSessionId &&
+    (!entry?.sessionId || entry.sessionId !== params.entry.expectedSessionId)
+  ) {
+    log.warn("restart continuation skipped: session changed", {
       sessionKey: canonicalKey,
       queueId: params.entry.id,
-      status: entry?.status ?? null,
-      endedAt: entry?.endedAt ?? null,
+      expectedSessionId: params.entry.expectedSessionId,
+      actualSessionId: entry?.sessionId ?? null,
     });
     enqueueRestartSentinelWake(params.entry.message, canonicalKey, queuedDeliveryContext);
     return;
@@ -397,6 +399,7 @@ function buildQueuedRestartContinuation(params: {
   sessionKey: string;
   continuation: RestartSentinelContinuation;
   route?: SessionDeliveryRoute;
+  expectedSessionId?: string | undefined;
   ts: number;
   deliveryContext?: {
     channel?: string;
@@ -425,6 +428,7 @@ function buildQueuedRestartContinuation(params: {
     sessionKey: params.sessionKey,
     message: params.continuation.message,
     messageId: idempotencyKey,
+    ...(params.expectedSessionId ? { expectedSessionId: params.expectedSessionId } : {}),
     maxRetries: RESTART_CONTINUATION_BUSY_MAX_ATTEMPTS,
     ...(params.route ? { route: params.route } : {}),
     ...(params.deliveryContext ? { deliveryContext: params.deliveryContext } : {}),
@@ -532,7 +536,6 @@ async function loadRestartSentinelStartupTask(params: {
     const { baseSessionKey, threadId: sessionThreadId } = parseSessionThreadInfo(sessionKey);
 
     const { cfg, entry, canonicalKey } = loadSessionEntry(sessionKey);
-    const terminalSessionEntry = hasTerminalSessionLifecycle(entry);
 
     const sentinelContext = payload.deliveryContext;
     let sessionDeliveryContext = deliveryContextFromSession(entry);
@@ -591,9 +594,7 @@ async function loadRestartSentinelStartupTask(params: {
       }
     }
 
-    const terminalAgentTurnContinuation =
-      payload.continuation?.kind === "agentTurn" && terminalSessionEntry;
-    if (payload.continuation && !terminalAgentTurnContinuation) {
+    if (payload.continuation) {
       continuationRoute = resolveRestartContinuationRoute({
         channel: channel ?? undefined,
         to: resolvedTo,
@@ -608,6 +609,7 @@ async function loadRestartSentinelStartupTask(params: {
           continuation: payload.continuation,
           ts: payload.ts,
           route: continuationRoute,
+          expectedSessionId: entry?.sessionId,
           deliveryContext:
             resolvedTo && channel
               ? {
@@ -619,13 +621,6 @@ async function loadRestartSentinelStartupTask(params: {
               : wakeDeliveryContext,
         }),
       );
-    } else if (terminalAgentTurnContinuation) {
-      log.warn(`${summary}: continuation skipped: session is terminal`, {
-        sessionKey: canonicalKey,
-        continuationKind: "agentTurn",
-        status: entry?.status ?? null,
-        endedAt: entry?.endedAt ?? null,
-      });
     }
 
     await removeRestartSentinelFile(sentinelPath);

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -10,6 +10,7 @@ import { dispatchAssembledChannelTurn } from "../channels/turn/kernel.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { parseSessionThreadInfo } from "../config/sessions/thread-info.js";
+import { hasTerminalSessionLifecycle } from "../config/sessions/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "../infra/outbound/delivery-queue.js";
@@ -550,6 +551,7 @@ async function loadRestartSentinelStartupTask(params: {
     const { baseSessionKey, threadId: sessionThreadId } = parseSessionThreadInfo(sessionKey);
 
     const { cfg, entry, canonicalKey } = loadSessionEntry(sessionKey);
+    const terminalSessionEntry = hasTerminalSessionLifecycle(entry);
 
     const sentinelContext = payload.deliveryContext;
     let sessionDeliveryContext = deliveryContextFromSession(entry);
@@ -608,7 +610,7 @@ async function loadRestartSentinelStartupTask(params: {
       }
     }
 
-    if (payload.continuation) {
+    if (payload.continuation && !terminalSessionEntry) {
       continuationRoute = resolveRestartContinuationRoute({
         channel: channel ?? undefined,
         to: resolvedTo,
@@ -634,6 +636,13 @@ async function loadRestartSentinelStartupTask(params: {
               : wakeDeliveryContext,
         }),
       );
+    } else if (payload.continuation) {
+      log.warn(`${summary}: continuation skipped: session is terminal`, {
+        sessionKey: canonicalKey,
+        continuationKind: payload.continuation.kind,
+        status: entry?.status ?? null,
+        endedAt: entry?.endedAt ?? null,
+      });
     }
 
     await removeRestartSentinelFile(sentinelPath);

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -255,46 +255,27 @@ async function deliverQueuedSessionDelivery(params: {
   deps: CliDeps;
   entry: QueuedSessionDelivery;
 }) {
-  const { cfg, storePath, canonicalKey } = loadSessionEntry(params.entry.sessionKey);
+  const { cfg, entry, storePath, canonicalKey } = loadSessionEntry(params.entry.sessionKey);
   const queuedDeliveryContext = resolveQueuedSessionDeliveryContext(params.entry);
 
   if (params.entry.kind === "systemEvent") {
-    enqueueSystemEvent(params.entry.text, {
+    enqueueRestartSentinelWake(params.entry.text, canonicalKey, queuedDeliveryContext);
+    return;
+  }
+
+  if (hasTerminalSessionLifecycle(entry)) {
+    log.warn("restart continuation skipped: session is terminal", {
       sessionKey: canonicalKey,
-      ...(queuedDeliveryContext
-        ? {
-            deliveryContext: {
-              ...queuedDeliveryContext,
-            },
-          }
-        : {}),
+      queueId: params.entry.id,
+      status: entry?.status ?? null,
+      endedAt: entry?.endedAt ?? null,
     });
-    requestHeartbeat({
-      source: "restart-sentinel",
-      intent: "immediate",
-      reason: "wake",
-      sessionKey: canonicalKey,
-    });
+    enqueueRestartSentinelWake(params.entry.message, canonicalKey, queuedDeliveryContext);
     return;
   }
 
   if (!params.entry.route) {
-    enqueueSystemEvent(params.entry.message, {
-      sessionKey: canonicalKey,
-      ...(queuedDeliveryContext
-        ? {
-            deliveryContext: {
-              ...queuedDeliveryContext,
-            },
-          }
-        : {}),
-    });
-    requestHeartbeat({
-      source: "restart-sentinel",
-      intent: "immediate",
-      reason: "wake",
-      sessionKey: canonicalKey,
-    });
+    enqueueRestartSentinelWake(params.entry.message, canonicalKey, queuedDeliveryContext);
     return;
   }
 
@@ -610,7 +591,9 @@ async function loadRestartSentinelStartupTask(params: {
       }
     }
 
-    if (payload.continuation && !terminalSessionEntry) {
+    const terminalAgentTurnContinuation =
+      payload.continuation?.kind === "agentTurn" && terminalSessionEntry;
+    if (payload.continuation && !terminalAgentTurnContinuation) {
       continuationRoute = resolveRestartContinuationRoute({
         channel: channel ?? undefined,
         to: resolvedTo,
@@ -636,10 +619,10 @@ async function loadRestartSentinelStartupTask(params: {
               : wakeDeliveryContext,
         }),
       );
-    } else if (payload.continuation) {
+    } else if (terminalAgentTurnContinuation) {
       log.warn(`${summary}: continuation skipped: session is terminal`, {
         sessionKey: canonicalKey,
-        continuationKind: payload.continuation.kind,
+        continuationKind: "agentTurn",
         status: entry?.status ?? null,
         endedAt: entry?.endedAt ?? null,
       });

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -53,6 +53,7 @@ export type QueuedSessionDeliveryPayload =
       sessionKey: string;
       message: string;
       messageId: string;
+      expectedSessionId?: string;
       route?: SessionDeliveryRoute;
       deliveryContext?: SessionDeliveryContext;
       idempotencyKey?: string;


### PR DESCRIPTION
## Summary
- keep normal completed-run lifecycle fields (`status`, `endedAt`, `runtimeMs`) out of session freshness decisions so ordinary follow-up turns continue the existing conversation
- clear stale lifecycle markers when a new reply session row is intentionally created over an existing row
- make queued restart `agentTurn` deliveries carry the session id they were queued for, then fall back to a system wake if the session key now points at a different session

Closes #86593.

## Validation
- `node scripts/run-vitest.mjs src/gateway/server-restart-sentinel.test.ts src/auto-reply/reply/session.test.ts src/agents/command/session-store.test.ts`
- `node_modules/.bin/oxfmt --check src/config/sessions/types.ts src/agents/command/session.ts src/auto-reply/reply/session.ts src/infra/session-delivery-queue-storage.ts src/gateway/server-restart-sentinel.ts src/agents/command/session-store.test.ts src/auto-reply/reply/session.test.ts src/gateway/server-restart-sentinel.test.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof
Behavior addressed: stale restart continuation delivery must not dispatch an `agentTurn` into a session key after that key has rotated to a different session id. Completed run metadata alone must not force normal fresh sessions to rotate.

Real environment tested: Real local OpenClaw checkout on branch `pr-87378`, head SHA `4521a0119da537b91d7402e8f07898785f3f7d9e`, using a temporary JSON session store and the real `resolveSession` implementation.

Exact steps or command run after this patch: Created a temporary `sessions.json` containing a fresh row for `agent:main:explicit:proof-completed-entry` with `sessionId=proof-completed-session`, `status=done`, numeric `startedAt`, numeric `endedAt`, and `runtimeMs`. Then ran `resolveSession` against that real store path and printed the resolved session state.

Evidence after fix:

```text
sessionKey=agent:main:explicit:proof-completed-entry
existingSessionId=proof-completed-session
resolvedSessionId=proof-completed-session
isNewSession=false
reusedExistingSession=true
completedStatusSeen=done
completedEndedAtSeen=true
```

Observed result after fix: A fresh completed-run row continues with its existing session id (`reusedExistingSession=true`) instead of rotating just because `status=done` and `endedAt` are present. The restart-sentinel fallback path is covered by the focused test suite and now keys queued agent turns by `expectedSessionId`.

What was not tested: No live Telegram Desktop restart was run locally. The focused restart-sentinel test exercises the routing and fallback behavior with preserved delivery context.

## Attribution
If maintainers squash/rework this PR, please preserve author attribution or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
