### PR TITLE
fix: audit and repair hooks token reuse with Gateway auth

### DIFF
--- a/docs/cli/security.md
+++ b/docs/cli/security.md
@@ -32,7 +32,7 @@ This is for cooperative/shared inbox hardening. A single Gateway shared by mutua
 It also emits `security.trust_model.multi_user_heuristic` when config suggests likely shared-user ingress (for example open DM/group policy, configured group targets, or wildcard sender rules), and reminds you that OpenClaw is a personal-assistant trust model by default.
 For intentional shared-user setups, the audit guidance is to sandbox all sessions, keep filesystem access workspace-scoped, and keep personal/private identities or credentials off that runtime.
 It also warns when small models (`<=300B`) are used without sandboxing and with web/browser tools enabled.
-For webhook ingress, Gateway startup rejects `hooks.token` reuse of active Gateway shared-secret auth values, including `gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` and `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`. The audit also warns when:
+For webhook ingress, startup logs a non-fatal security warning and audit flags `hooks.token` reuse of active Gateway shared-secret auth values, including `gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` and `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`. It also warns when:
 
 - `hooks.token` is short
 - `hooks.path="/"`
@@ -42,7 +42,7 @@ For webhook ingress, Gateway startup rejects `hooks.token` reuse of active Gatew
 - overrides are enabled without `hooks.allowedSessionKeyPrefixes`
 
 If Gateway password auth is supplied only at startup, pass the same value to `openclaw security audit --auth password --password <password>` so the audit can check it against `hooks.token`.
-Rotate one of the secrets before restarting if the audit reports reuse.
+Run `openclaw doctor --fix` to rotate a persisted reused `hooks.token`, then update external hook senders to use the new hook token.
 
 It also warns when sandbox Docker settings are configured while sandbox mode is off, when `gateway.nodes.denyCommands` uses ineffective pattern-like/unknown entries (exact node command-name matching only, not shell-text filtering), when `gateway.nodes.allowCommands` explicitly enables dangerous node commands, when global `tools.profile="minimal"` is overridden by agent tool profiles, when write/edit tools are disabled but `exec` is still available without a constraining sandbox filesystem boundary, when open groups expose runtime/filesystem tools without sandbox/workspace guards, and when installed plugin tools may be reachable under permissive tool policy.
 It also flags `gateway.allowRealIpFallback=true` (header-spoofing risk if proxies are misconfigured) and `discovery.mdns.mode="full"` (metadata leakage via mDNS TXT records).

--- a/docs/cli/security.md
+++ b/docs/cli/security.md
@@ -32,9 +32,8 @@ This is for cooperative/shared inbox hardening. A single Gateway shared by mutua
 It also emits `security.trust_model.multi_user_heuristic` when config suggests likely shared-user ingress (for example open DM/group policy, configured group targets, or wildcard sender rules), and reminds you that OpenClaw is a personal-assistant trust model by default.
 For intentional shared-user setups, the audit guidance is to sandbox all sessions, keep filesystem access workspace-scoped, and keep personal/private identities or credentials off that runtime.
 It also warns when small models (`<=300B`) are used without sandboxing and with web/browser tools enabled.
-For webhook ingress, it warns when:
+For webhook ingress, Gateway startup rejects `hooks.token` reuse of active Gateway shared-secret auth values, including `gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` and `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`. The audit also warns when:
 
-- `hooks.token` reuses an active Gateway shared-secret auth value (`gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` or `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`)
 - `hooks.token` is short
 - `hooks.path="/"`
 - `hooks.defaultSessionKey` is unset
@@ -43,7 +42,7 @@ For webhook ingress, it warns when:
 - overrides are enabled without `hooks.allowedSessionKeyPrefixes`
 
 If Gateway password auth is supplied only at startup, pass the same value to `openclaw security audit --auth password --password <password>` so the audit can check it against `hooks.token`.
-Password-mode reuse is an audit finding for compatibility; rotate one of the secrets instead of expecting Gateway startup to reject that configuration.
+Rotate one of the secrets before restarting if the audit reports reuse.
 
 It also warns when sandbox Docker settings are configured while sandbox mode is off, when `gateway.nodes.denyCommands` uses ineffective pattern-like/unknown entries (exact node command-name matching only, not shell-text filtering), when `gateway.nodes.allowCommands` explicitly enables dangerous node commands, when global `tools.profile="minimal"` is overridden by agent tool profiles, when write/edit tools are disabled but `exec` is still available without a constraining sandbox filesystem boundary, when open groups expose runtime/filesystem tools without sandbox/workspace guards, and when installed plugin tools may be reachable under permissive tool policy.
 It also flags `gateway.allowRealIpFallback=true` (header-spoofing risk if proxies are misconfigured) and `discovery.mdns.mode="full"` (metadata leakage via mDNS TXT records).

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -730,8 +730,8 @@ Query-string hook tokens are rejected.
 Validation and safety notes:
 
 - `hooks.enabled=true` requires a non-empty `hooks.token`.
-- `hooks.token` must be distinct from `gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN`; reusing the Gateway token fails startup validation.
-- `openclaw security audit` also flags `hooks.token` reuse of active Gateway password auth (`gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`, or `--auth password --password <password>`) as a critical finding; password-mode reuse stays startup-compatible and should be repaired by rotating one of the secrets.
+- `hooks.token` must be distinct from active Gateway shared-secret auth (`gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` or `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`); reuse fails startup validation.
+- `openclaw security audit` also flags `hooks.token` reuse of Gateway password auth supplied only at audit time (`--auth password --password <password>`) as a critical finding. Repair reuse by rotating one of the secrets.
 - `hooks.path` cannot be `/`; use a dedicated subpath such as `/hooks`.
 - If `hooks.allowRequestSessionKey=true`, constrain `hooks.allowedSessionKeyPrefixes` (for example `["hook:"]`).
 - If a mapping or preset uses a templated `sessionKey`, set `hooks.allowedSessionKeyPrefixes` and `hooks.allowRequestSessionKey=true`. Static mapping keys do not require that opt-in.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -730,8 +730,8 @@ Query-string hook tokens are rejected.
 Validation and safety notes:
 
 - `hooks.enabled=true` requires a non-empty `hooks.token`.
-- `hooks.token` must be distinct from active Gateway shared-secret auth (`gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` or `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`); reuse fails startup validation.
-- `openclaw security audit` also flags `hooks.token` reuse of Gateway password auth supplied only at audit time (`--auth password --password <password>`) as a critical finding. Repair reuse by rotating one of the secrets.
+- `hooks.token` should be distinct from active Gateway shared-secret auth (`gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` or `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`); startup logs a non-fatal security warning when it detects reuse.
+- `openclaw security audit` flags hook/Gateway auth reuse as a critical finding, including Gateway password auth supplied only at audit time (`--auth password --password <password>`). Run `openclaw doctor --fix` to rotate a persisted reused `hooks.token`, then update external hook senders to use the new hook token.
 - `hooks.path` cannot be `/`; use a dedicated subpath such as `/hooks`.
 - If `hooks.allowRequestSessionKey=true`, constrain `hooks.allowedSessionKeyPrefixes` (for example `["hook:"]`).
 - If a mapping or preset uses a templated `sessionKey`, set `hooks.allowedSessionKeyPrefixes` and `hooks.allowRequestSessionKey=true`. Static mapping keys do not require that opt-in.

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1578,6 +1578,54 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("previews and repairs hooks token reuse of gateway auth", async () => {
+    const config = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "shared-gateway-token-1234567890",
+        },
+      },
+      hooks: {
+        enabled: true,
+        token: "shared-gateway-token-1234567890",
+      },
+    };
+    const previewNotes = resetTerminalNoteMock();
+    const preview = await runDoctorConfigWithInput({
+      config,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(preview.shouldWriteConfig).toBe(false);
+    expect(preview.cfg.hooks?.token).toBe("shared-gateway-token-1234567890");
+    expect(
+      previewNotes.mock.calls.some(
+        ([message, title]) =>
+          title === "Doctor changes preview" &&
+          message.includes("Rotated hooks.token because it reused active Gateway"),
+      ),
+    ).toBe(true);
+    expect(
+      previewNotes.mock.calls.some(
+        ([message, title]) =>
+          title === "Doctor" &&
+          message.includes("openclaw doctor --fix") &&
+          message.includes("rotate hooks.token"),
+      ),
+    ).toBe(true);
+
+    const repair = await runDoctorConfigWithInput({
+      config,
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(repair.shouldWriteConfig).toBe(true);
+    expect(repair.cfg.hooks?.token).toMatch(/^[0-9a-f]{48}$/);
+    expect(repair.cfg.hooks?.token).not.toBe("shared-gateway-token-1234567890");
+  });
+
   it("does not warn on mutable account allowlists when dangerous name matching is inherited", async () => {
     const doctorWarnings = await collectDoctorWarnings({
       channels: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -131,7 +131,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     shouldRepair,
     doctorFixCommand,
   });
-  ({ cfg, candidate, pendingChanges, fixHints } = legacyStep.state);
+  cfg = legacyStep.state.cfg;
+  candidate = legacyStep.state.candidate;
+  pendingChanges = pendingChanges || legacyStep.state.pendingChanges;
+  fixHints = legacyStep.state.fixHints;
   const legacyMigrationPartiallyValid = legacyStep.partiallyValid === true;
   const pluginLegacyIssues = await (async () => {
     if (snapshot.parsed === snapshot.sourceConfig) {
@@ -160,7 +163,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     !shouldRepair &&
     !fixHints.includes(`Run "${doctorFixCommand}" to migrate legacy config keys.`)
   ) {
-    fixHints = [...fixHints, `Run "${doctorFixCommand}" to migrate legacy config keys.`];
+    fixHints.push(`Run "${doctorFixCommand}" to migrate legacy config keys.`);
   }
   if (legacyIssueLines.length > 0) {
     note(legacyIssueLines.join("\n"), "Legacy config keys detected");

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -259,6 +259,17 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note(missingExplicitDefaultWarnings.join("\n"), "Doctor warnings");
   }
 
+  const { repairHooksTokenReuseGatewayAuth } =
+    await import("./doctor/shared/hooks-token-reuse-repair.js");
+  const hooksTokenReuseRepair = await repairHooksTokenReuseGatewayAuth(candidate, process.env);
+  emitDoctorChangesPanel(hooksTokenReuseRepair.changes, shouldRepair);
+  ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
+    state: { cfg, candidate, pendingChanges, fixHints },
+    mutation: hooksTokenReuseRepair,
+    shouldRepair,
+    fixHint: `Run "${doctorFixCommand}" to rotate hooks.token away from Gateway auth.`,
+  }));
+
   if (shouldRepair) {
     const { runDoctorRepairSequence } = await import("./doctor/repair-sequencing.js");
     const repairSequence = await runDoctorRepairSequence({

--- a/src/commands/doctor/shared/hooks-token-reuse-repair.test.ts
+++ b/src/commands/doctor/shared/hooks-token-reuse-repair.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { repairHooksTokenReuseGatewayAuth } from "./hooks-token-reuse-repair.js";
+
+const ROTATED_HOOKS_TOKEN = "rotated-hooks-token-1234567890";
+
+function repair(cfg: OpenClawConfig, env: NodeJS.ProcessEnv = {}) {
+  return repairHooksTokenReuseGatewayAuth(cfg, env, () => ROTATED_HOOKS_TOKEN);
+}
+
+describe("repairHooksTokenReuseGatewayAuth", () => {
+  it("rotates hooks.token when it reuses active gateway token auth from env", async () => {
+    const result = await repair(
+      {
+        hooks: {
+          enabled: true,
+          token: "shared-gateway-token-1234567890",
+        },
+      },
+      {
+        OPENCLAW_GATEWAY_TOKEN: "shared-gateway-token-1234567890",
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(result.config.hooks?.token).toBe(ROTATED_HOOKS_TOKEN);
+    expect(result.changes).toContain(
+      "Rotated hooks.token because it reused active Gateway shared-secret auth. Update external hook senders to use the new hooks.token.",
+    );
+  });
+
+  it("rotates hooks.token when it reuses gateway password auth", async () => {
+    const result = await repair({
+      gateway: {
+        auth: {
+          mode: "password",
+          password: "shared-gateway-password-1234567890", // pragma: allowlist secret
+        },
+      },
+      hooks: {
+        enabled: true,
+        token: "shared-gateway-password-1234567890",
+      },
+    });
+
+    expect(result.config.hooks?.token).toBe(ROTATED_HOOKS_TOKEN);
+  });
+
+  it("rotates hooks.token when it reuses gateway password auth from a SecretRef", async () => {
+    const result = await repair(
+      {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "password",
+            password: { source: "env", provider: "default", id: "GW_PASSWORD" },
+          },
+        },
+        hooks: {
+          enabled: true,
+          token: "shared-gateway-password-1234567890",
+        },
+      },
+      {
+        GW_PASSWORD: "shared-gateway-password-1234567890", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(result.config.hooks?.token).toBe(ROTATED_HOOKS_TOKEN);
+  });
+
+  it("does not abort when active gateway auth SecretRef is unavailable", async () => {
+    const cfg = {
+      secrets: {
+        providers: {
+          default: { source: "env" },
+        },
+      },
+      gateway: {
+        auth: {
+          mode: "password",
+          password: { source: "env", provider: "default", id: "MISSING_GW_PASSWORD" },
+        },
+      },
+      hooks: {
+        enabled: true,
+        token: "shared-gateway-password-1234567890",
+      },
+    } satisfies OpenClawConfig;
+
+    await expect(repair(cfg, {} as NodeJS.ProcessEnv)).resolves.toEqual({
+      config: cfg,
+      changes: [],
+    });
+  });
+
+  it("does not execute gateway auth SecretRefs during repair", async () => {
+    const cfg = {
+      secrets: {
+        providers: {
+          vault: {
+            source: "exec",
+            command: "node",
+            args: ["-e", "process.stdout.write('shared-gateway-password-1234567890')"],
+          },
+        },
+      },
+      gateway: {
+        auth: {
+          mode: "password",
+          password: { source: "exec", provider: "vault", id: "GW_PASSWORD" },
+        },
+      },
+      hooks: {
+        enabled: true,
+        token: "shared-gateway-password-1234567890",
+      },
+    } satisfies OpenClawConfig;
+
+    await expect(repair(cfg, {} as NodeJS.ProcessEnv)).resolves.toEqual({
+      config: cfg,
+      changes: [],
+    });
+  });
+
+  it("rotates hooks.token when it reuses trusted-proxy local password fallback", async () => {
+    const result = await repair({
+      gateway: {
+        auth: {
+          mode: "trusted-proxy",
+          trustedProxy: { userHeader: "x-forwarded-user" },
+          password: "trusted-proxy-local-password-1234567890", // pragma: allowlist secret
+        },
+      },
+      hooks: {
+        enabled: true,
+        token: "trusted-proxy-local-password-1234567890",
+      },
+    });
+
+    expect(result.config.hooks?.token).toBe(ROTATED_HOOKS_TOKEN);
+  });
+
+  it("rotates hooks.token when it reuses trusted-proxy password auth from a SecretRef", async () => {
+    const result = await repair(
+      {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "trusted-proxy",
+            trustedProxy: { userHeader: "x-forwarded-user" },
+            password: { source: "env", provider: "default", id: "GW_PASSWORD" },
+          },
+        },
+        hooks: {
+          enabled: true,
+          token: "trusted-proxy-local-password-1234567890",
+        },
+      },
+      {
+        GW_PASSWORD: "trusted-proxy-local-password-1234567890", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(result.config.hooks?.token).toBe(ROTATED_HOOKS_TOKEN);
+  });
+
+  it("does not rotate disabled hooks or distinct hook tokens", async () => {
+    const disabled = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "shared-gateway-token-1234567890",
+        },
+      },
+      hooks: {
+        enabled: false,
+        token: "shared-gateway-token-1234567890",
+      },
+    } satisfies OpenClawConfig;
+    const distinct = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "shared-gateway-token-1234567890",
+        },
+      },
+      hooks: {
+        enabled: true,
+        token: "distinct-hooks-token-1234567890",
+      },
+    } satisfies OpenClawConfig;
+
+    await expect(repair(disabled)).resolves.toEqual({ config: disabled, changes: [] });
+    await expect(repair(distinct)).resolves.toEqual({ config: distinct, changes: [] });
+  });
+});

--- a/src/commands/doctor/shared/hooks-token-reuse-repair.ts
+++ b/src/commands/doctor/shared/hooks-token-reuse-repair.ts
@@ -1,0 +1,83 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import {
+  canMaterializeGatewayAuthSecretRefsWithoutExec,
+  materializeGatewayAuthSecretRefs,
+} from "../../../gateway/auth-config-utils.js";
+import { resolveGatewayAuth, type ResolvedGatewayAuth } from "../../../gateway/auth.js";
+import { randomToken } from "../../random-token.js";
+import type { DoctorConfigMutationResult } from "./config-mutation-state.js";
+
+function activeGatewaySharedSecret(auth: ResolvedGatewayAuth): string {
+  if (auth.mode === "token") {
+    return normalizeOptionalString(auth.token) ?? "";
+  }
+  if (auth.mode === "password" || auth.mode === "trusted-proxy") {
+    return normalizeOptionalString(auth.password) ?? "";
+  }
+  return "";
+}
+
+export function repairHooksTokenReuseGatewayAuth(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv = process.env,
+  createToken: () => string = randomToken,
+): Promise<DoctorConfigMutationResult> {
+  return repairHooksTokenReuseGatewayAuthAfterMaterializingRefs(cfg, env, createToken);
+}
+
+async function materializeDoctorGatewayAuthRefs(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): Promise<OpenClawConfig> {
+  const materializeParams = {
+    cfg,
+    env,
+    mode: cfg.gateway?.auth?.mode,
+    hasTokenCandidate: Boolean(normalizeOptionalString(env.OPENCLAW_GATEWAY_TOKEN)),
+    hasPasswordCandidate: Boolean(normalizeOptionalString(env.OPENCLAW_GATEWAY_PASSWORD)),
+  };
+  if (!canMaterializeGatewayAuthSecretRefsWithoutExec(materializeParams)) {
+    return cfg;
+  }
+  try {
+    return await materializeGatewayAuthSecretRefs(materializeParams);
+  } catch {
+    return cfg;
+  }
+}
+
+async function repairHooksTokenReuseGatewayAuthAfterMaterializingRefs(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  createToken: () => string,
+): Promise<DoctorConfigMutationResult> {
+  const hooksToken = normalizeOptionalString(cfg.hooks?.token) ?? "";
+  if (cfg.hooks?.enabled !== true || !hooksToken) {
+    return { config: cfg, changes: [] };
+  }
+
+  const materializedCfg = await materializeDoctorGatewayAuthRefs(cfg, env);
+  const auth = resolveGatewayAuth({
+    authConfig: materializedCfg.gateway?.auth,
+    tailscaleMode: materializedCfg.gateway?.tailscale?.mode ?? "off",
+    env,
+  });
+  if (hooksToken !== activeGatewaySharedSecret(auth)) {
+    return { config: cfg, changes: [] };
+  }
+
+  const nextHooksToken = createToken();
+  return {
+    config: {
+      ...cfg,
+      hooks: {
+        ...cfg.hooks,
+        token: nextHooksToken,
+      },
+    },
+    changes: [
+      "Rotated hooks.token because it reused active Gateway shared-secret auth. Update external hook senders to use the new hooks.token.",
+    ],
+  };
+}

--- a/src/gateway/auth-config-utils.ts
+++ b/src/gateway/auth-config-utils.ts
@@ -1,6 +1,6 @@
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { hasConfiguredSecretInput } from "../config/types.secrets.js";
+import { hasConfiguredSecretInput, resolveSecretInputRef } from "../config/types.secrets.js";
 import { resolveRequiredConfiguredSecretRefInputString } from "./resolve-configured-secret-input-string.js";
 import {
   assignResolvedGatewaySecretInput,
@@ -44,7 +44,10 @@ function shouldResolveGatewayAuthSecretRef(params: {
   if (params.mode === (isTokenPath ? "token" : "password")) {
     return true;
   }
-  if (params.mode === "token" || params.mode === "none" || params.mode === "trusted-proxy") {
+  if (params.mode === "trusted-proxy") {
+    return !isTokenPath;
+  }
+  if (params.mode === "token" || params.mode === "none") {
     return false;
   }
   if (params.mode === "password") {
@@ -75,6 +78,39 @@ function shouldResolveGatewayPasswordSecretRef(
     hasPasswordCandidate: params.hasPasswordCandidate,
     hasTokenCandidate: params.hasTokenCandidate,
   });
+}
+
+function hasActiveExecGatewayAuthSecretRef(params: {
+  cfg: OpenClawConfig;
+  path: GatewayAuthSecretInputPath;
+  shouldResolve: boolean;
+}): boolean {
+  if (!params.shouldResolve) {
+    return false;
+  }
+  const { ref } = resolveSecretInputRef({
+    value: readGatewaySecretInputValue(params.cfg, params.path),
+    defaults: params.cfg.secrets?.defaults,
+  });
+  return ref?.source === "exec";
+}
+
+/** Check whether active local Gateway auth refs can be read without invoking exec providers. */
+export function canMaterializeGatewayAuthSecretRefsWithoutExec(
+  params: GatewayAuthSecretRefResolutionParams,
+): boolean {
+  return !(
+    hasActiveExecGatewayAuthSecretRef({
+      cfg: params.cfg,
+      path: "gateway.auth.token",
+      shouldResolve: shouldResolveGatewayTokenSecretRef(params),
+    }) ||
+    hasActiveExecGatewayAuthSecretRef({
+      cfg: params.cfg,
+      path: "gateway.auth.password",
+      shouldResolve: shouldResolveGatewayPasswordSecretRef(params),
+    })
+  );
 }
 
 async function resolveGatewayAuthSecretRefValue(params: {

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -435,6 +435,7 @@ export async function prepareGatewayStartupConfig(params: {
   tailscaleOverride?: GatewayTailscaleConfig;
   activateRuntimeSecrets: ActivateRuntimeSecrets;
   persistStartupAuth?: boolean;
+  log?: GatewayStartupLog;
   measure?: GatewayStartupConfigMeasure;
 }): Promise<Awaited<ReturnType<typeof ensureGatewayStartupAuth>>> {
   const measure = params.measure ?? (async (_name, run) => await run());
@@ -510,6 +511,7 @@ export async function prepareGatewayStartupConfig(params: {
       env: process.env,
       authOverride: preflightAuthOverride,
       tailscaleOverride: params.tailscaleOverride,
+      warn: params.log?.warn,
       persist: params.persistStartupAuth ?? false,
       baseHash: params.configSnapshot.hash,
     }),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -622,6 +622,7 @@ export async function startGatewayServer(
         authOverride: opts.auth,
         tailscaleOverride: opts.tailscale,
         activateRuntimeSecrets,
+        log,
         measure: (name, run, measureOptions) => startupTrace.measure(name, run, measureOptions),
       }),
     { omitErrorMessage: true },

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -377,12 +377,31 @@ describe("ensureGatewayStartupAuth", () => {
     ).rejects.toThrow(/hooks\.token must not match gateway auth token/i);
   });
 
-  it("does not block startup when hooks token reuses gateway password auth", async () => {
+  it("throws when hooks token reuses gateway password auth during startup", async () => {
+    await expect(
+      runStartupAuth({
+        cfg: {
+          hooks: {
+            enabled: true,
+            token: "shared-gateway-password-1234567890",
+          },
+          gateway: {
+            auth: {
+              mode: "password",
+              password: "shared-gateway-password-1234567890", // pragma: allowlist secret
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(/hooks\.token must not match gateway auth token or password/i);
+  });
+
+  it("allows distinct hooks token with gateway password auth during startup", async () => {
     const result = await runStartupAuth({
       cfg: {
         hooks: {
           enabled: true,
-          token: "shared-gateway-password-1234567890",
+          token: "distinct-hooks-token-1234567890",
         },
         gateway: {
           auth: {
@@ -557,29 +576,43 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
     ).toThrow(/hooks\.token must not match gateway auth token/i);
   });
 
-  it("allows hooks token reuse of gateway password auth", () => {
-    expectHooksGatewayAuthAllowed({
-      hooksToken: "shared-gateway-password-1234567890",
-      auth: {
-        mode: "password",
-        modeSource: "config",
-        password: "shared-gateway-password-1234567890", // pragma: allowlist secret
-        allowTailscale: false,
-      },
-    });
+  it("throws when hooks token reuses gateway password auth", () => {
+    expect(() =>
+      assertHooksTokenSeparateFromGatewayAuth({
+        cfg: {
+          hooks: {
+            enabled: true,
+            token: "shared-gateway-password-1234567890",
+          },
+        },
+        auth: {
+          mode: "password",
+          modeSource: "config",
+          password: "shared-gateway-password-1234567890", // pragma: allowlist secret
+          allowTailscale: false,
+        },
+      }),
+    ).toThrow(/hooks\.token must not match gateway auth token or password/i);
   });
 
-  it("allows hooks token reuse of trusted-proxy local password fallback", () => {
-    expectHooksGatewayAuthAllowed({
-      hooksToken: "trusted-proxy-local-password-1234567890",
-      auth: {
-        mode: "trusted-proxy",
-        modeSource: "config",
-        trustedProxy: { userHeader: "x-forwarded-user" },
-        password: "trusted-proxy-local-password-1234567890", // pragma: allowlist secret
-        allowTailscale: false,
-      },
-    });
+  it("throws when hooks token reuses trusted-proxy local password fallback", () => {
+    expect(() =>
+      assertHooksTokenSeparateFromGatewayAuth({
+        cfg: {
+          hooks: {
+            enabled: true,
+            token: "trusted-proxy-local-password-1234567890",
+          },
+        },
+        auth: {
+          mode: "trusted-proxy",
+          modeSource: "config",
+          trustedProxy: { userHeader: "x-forwarded-user" },
+          password: "trusted-proxy-local-password-1234567890", // pragma: allowlist secret
+          allowTailscale: false,
+        },
+      }),
+    ).toThrow(/hooks\.token must not match gateway auth token or password/i);
   });
 
   it("allows distinct hooks token when gateway auth is password mode", () => {

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -3,7 +3,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import { KNOWN_WEAK_GATEWAY_TOKEN_PLACEHOLDERS } from "./known-weak-gateway-secrets.js";
 import {
   assertGatewayAuthNotKnownWeak,
-  assertHooksTokenSeparateFromGatewayAuth,
   ensureGatewayStartupAuth,
   mergeGatewayTailscaleConfig,
 } from "./startup-auth.js";
@@ -28,7 +27,6 @@ type StartupAuthInput = Parameters<typeof ensureGatewayStartupAuth>[0];
 type StartupAuthResult = Awaited<ReturnType<typeof ensureGatewayStartupAuth>>;
 type GatewayAuthConfig = NonNullable<NonNullable<OpenClawConfig["gateway"]>["auth"]>;
 type GatewayAuthCheck = Parameters<typeof assertGatewayAuthNotKnownWeak>[0];
-type HooksGatewayAuthCheck = Parameters<typeof assertHooksTokenSeparateFromGatewayAuth>[0]["auth"];
 
 function emptyEnv(): NodeJS.ProcessEnv {
   return {} as NodeJS.ProcessEnv;
@@ -361,42 +359,52 @@ describe("ensureGatewayStartupAuth", () => {
     });
   });
 
-  it("throws when hooks token reuses gateway token resolved from env", async () => {
-    await expect(
-      runStartupAuth({
-        cfg: {
-          hooks: {
-            enabled: true,
-            token: "shared-gateway-token-1234567890",
-          },
+  it("keeps startup non-breaking when hooks token reuses gateway token resolved from env", async () => {
+    const warn = vi.fn();
+    const result = await runStartupAuth({
+      cfg: {
+        hooks: {
+          enabled: true,
+          token: "shared-gateway-token-1234567890",
         },
-        env: {
-          OPENCLAW_GATEWAY_TOKEN: "shared-gateway-token-1234567890",
-        } as NodeJS.ProcessEnv,
-      }),
-    ).rejects.toThrow(/hooks\.token must not match gateway auth token/i);
+      },
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "shared-gateway-token-1234567890",
+      } as NodeJS.ProcessEnv,
+      warn,
+    });
+
+    expectNoGeneratedToken(result);
+    expect(result.auth.mode).toBe("token");
+    expect(result.auth.token).toBe("shared-gateway-token-1234567890");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Security warning"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("openclaw security audit"));
   });
 
-  it("throws when hooks token reuses gateway password auth during startup", async () => {
-    await expect(
-      runStartupAuth({
-        cfg: {
-          hooks: {
-            enabled: true,
-            token: "shared-gateway-password-1234567890",
-          },
-          gateway: {
-            auth: {
-              mode: "password",
-              password: "shared-gateway-password-1234567890", // pragma: allowlist secret
-            },
+  it("keeps startup non-breaking when hooks token reuses gateway password auth", async () => {
+    const warn = vi.fn();
+    const result = await runStartupAuth({
+      cfg: {
+        hooks: {
+          enabled: true,
+          token: "shared-gateway-password-1234567890",
+        },
+        gateway: {
+          auth: {
+            mode: "password",
+            password: "shared-gateway-password-1234567890", // pragma: allowlist secret
           },
         },
-      }),
-    ).rejects.toThrow(/hooks\.token must not match gateway auth token or password/i);
+      },
+      warn,
+    });
+
+    expectResolvedPassword(result, "shared-gateway-password-1234567890");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Security warning"));
   });
 
   it("allows distinct hooks token with gateway password auth during startup", async () => {
+    const warn = vi.fn();
     const result = await runStartupAuth({
       cfg: {
         hooks: {
@@ -410,10 +418,12 @@ describe("ensureGatewayStartupAuth", () => {
           },
         },
       },
+      warn,
     });
 
     expect(result.auth.mode).toBe("password");
     expectNoGeneratedToken(result);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it.each(KNOWN_WEAK_GATEWAY_TOKEN_PLACEHOLDERS)(
@@ -534,109 +544,6 @@ describe("assertGatewayAuthNotKnownWeak", () => {
       mode: "none",
       modeSource: "default",
       allowTailscale: false,
-    });
-  });
-});
-
-describe("assertHooksTokenSeparateFromGatewayAuth", () => {
-  function expectHooksGatewayAuthAllowed(params: {
-    enabled?: boolean;
-    hooksToken: string;
-    auth: HooksGatewayAuthCheck;
-  }) {
-    expect(
-      assertHooksTokenSeparateFromGatewayAuth({
-        cfg: {
-          hooks: {
-            enabled: params.enabled ?? true,
-            token: params.hooksToken,
-          },
-        },
-        auth: params.auth,
-      }),
-    ).toBeUndefined();
-  }
-
-  it("throws when hooks token reuses gateway token auth", () => {
-    expect(() =>
-      assertHooksTokenSeparateFromGatewayAuth({
-        cfg: {
-          hooks: {
-            enabled: true,
-            token: "shared-gateway-token-1234567890",
-          },
-        },
-        auth: {
-          mode: "token",
-          modeSource: "config",
-          token: "shared-gateway-token-1234567890",
-          allowTailscale: false,
-        },
-      }),
-    ).toThrow(/hooks\.token must not match gateway auth token/i);
-  });
-
-  it("throws when hooks token reuses gateway password auth", () => {
-    expect(() =>
-      assertHooksTokenSeparateFromGatewayAuth({
-        cfg: {
-          hooks: {
-            enabled: true,
-            token: "shared-gateway-password-1234567890",
-          },
-        },
-        auth: {
-          mode: "password",
-          modeSource: "config",
-          password: "shared-gateway-password-1234567890", // pragma: allowlist secret
-          allowTailscale: false,
-        },
-      }),
-    ).toThrow(/hooks\.token must not match gateway auth token or password/i);
-  });
-
-  it("throws when hooks token reuses trusted-proxy local password fallback", () => {
-    expect(() =>
-      assertHooksTokenSeparateFromGatewayAuth({
-        cfg: {
-          hooks: {
-            enabled: true,
-            token: "trusted-proxy-local-password-1234567890",
-          },
-        },
-        auth: {
-          mode: "trusted-proxy",
-          modeSource: "config",
-          trustedProxy: { userHeader: "x-forwarded-user" },
-          password: "trusted-proxy-local-password-1234567890", // pragma: allowlist secret
-          allowTailscale: false,
-        },
-      }),
-    ).toThrow(/hooks\.token must not match gateway auth token or password/i);
-  });
-
-  it("allows distinct hooks token when gateway auth is password mode", () => {
-    expectHooksGatewayAuthAllowed({
-      hooksToken: "hook-token-1234567890",
-      auth: {
-        mode: "password",
-        modeSource: "config",
-        password: "gateway-password-1234567890", // pragma: allowlist secret
-        allowTailscale: false,
-      },
-    });
-  });
-
-  it("allows matching values when hooks are disabled", () => {
-    expectHooksGatewayAuthAllowed({
-      enabled: false,
-      hooksToken: "shared-gateway-token-1234567890",
-      auth: {
-        mode: "token",
-        modeSource: "config",
-        token: "shared-gateway-token-1234567890",
-        allowTailscale: false,
-      },
     });
   });
 });

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -18,6 +18,9 @@ import { assertGatewayAuthNotKnownWeak } from "./known-weak-gateway-secrets.js";
 
 export { assertGatewayAuthNotKnownWeak } from "./known-weak-gateway-secrets.js";
 
+const HOOKS_GATEWAY_AUTH_REUSE_WARNING =
+  "Security warning: hooks.token matches active Gateway shared-secret auth. Startup continues for compatibility; rotate hooks.token or Gateway auth. Run openclaw security audit for a full report, and run openclaw doctor --fix when the reused hooks.token is persisted in config.";
+
 /** Merge sparse runtime auth overrides into persisted Gateway auth config. */
 export function mergeGatewayAuthConfig(
   base?: GatewayAuthConfig,
@@ -90,6 +93,31 @@ function resolveGatewayAuthFromConfig(params: {
   });
 }
 
+function findActiveGatewaySharedSecret(auth: ResolvedGatewayAuth): string {
+  if (auth.mode === "token") {
+    return normalizeOptionalString(auth.token) ?? "";
+  }
+  if (auth.mode === "password" || auth.mode === "trusted-proxy") {
+    return normalizeOptionalString(auth.password) ?? "";
+  }
+  return "";
+}
+
+function warnHooksTokenReuseGatewayAuth(params: {
+  cfg: OpenClawConfig;
+  auth: ResolvedGatewayAuth;
+  warn?: (message: string) => void;
+}): void {
+  if (params.cfg.hooks?.enabled !== true || !params.warn) {
+    return;
+  }
+  const hooksToken = normalizeOptionalString(params.cfg.hooks.token) ?? "";
+  if (!hooksToken || hooksToken !== findActiveGatewaySharedSecret(params.auth)) {
+    return;
+  }
+  params.warn(HOOKS_GATEWAY_AUTH_REUSE_WARNING);
+}
+
 /** Check every source that can satisfy token auth before startup generates one. */
 function hasGatewayTokenCandidate(params: {
   cfg: OpenClawConfig;
@@ -134,6 +162,7 @@ export async function ensureGatewayStartupAuth(params: {
   env?: NodeJS.ProcessEnv;
   authOverride?: GatewayAuthConfig;
   tailscaleOverride?: GatewayTailscaleConfig;
+  warn?: (message: string) => void;
   /**
    * Legacy startup option retained for external callers. Startup-generated auth
    * is runtime-only; durable auth changes must go through explicit config tools.
@@ -194,7 +223,7 @@ export async function ensureGatewayStartupAuth(params: {
   });
   if (resolved.mode !== "token" || (resolved.token?.trim().length ?? 0) > 0) {
     assertGatewayAuthNotKnownWeak(resolved);
-    assertHooksTokenSeparateFromGatewayAuth({ cfg: params.cfg, auth: resolved });
+    warnHooksTokenReuseGatewayAuth({ cfg: params.cfg, auth: resolved, warn: params.warn });
     return { cfg: params.cfg, auth: resolved, persistedGeneratedToken: false };
   }
 
@@ -221,40 +250,11 @@ export async function ensureGatewayStartupAuth(params: {
   // the rule applies uniformly and guards against any future path that might
   // feed a non-generated value through nextAuth.
   assertGatewayAuthNotKnownWeak(nextAuth);
-  assertHooksTokenSeparateFromGatewayAuth({ cfg: nextCfg, auth: nextAuth });
+  warnHooksTokenReuseGatewayAuth({ cfg: nextCfg, auth: nextAuth, warn: params.warn });
   return {
     cfg: nextCfg,
     auth: nextAuth,
     generatedToken,
     persistedGeneratedToken: false,
   };
-}
-
-/** Prevent hook ingress and Gateway shared-secret auth from sharing a secret. */
-export function assertHooksTokenSeparateFromGatewayAuth(params: {
-  cfg: OpenClawConfig;
-  auth: ResolvedGatewayAuth;
-}): void {
-  if (params.cfg.hooks?.enabled !== true) {
-    return;
-  }
-  const hooksToken = normalizeOptionalString(params.cfg.hooks.token) ?? "";
-  if (!hooksToken) {
-    return;
-  }
-  const gatewaySecret =
-    params.auth.mode === "token"
-      ? (normalizeOptionalString(params.auth.token) ?? "")
-      : params.auth.mode === "password" || params.auth.mode === "trusted-proxy"
-        ? (normalizeOptionalString(params.auth.password) ?? "")
-        : "";
-  if (!gatewaySecret) {
-    return;
-  }
-  if (hooksToken !== gatewaySecret) {
-    return;
-  }
-  throw new Error(
-    "Invalid config: hooks.token must not match gateway auth token or password. Set a distinct hooks.token for hook ingress.",
-  );
 }

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -230,7 +230,7 @@ export async function ensureGatewayStartupAuth(params: {
   };
 }
 
-/** Prevent hook ingress and Gateway auth from sharing the same bearer token. */
+/** Prevent hook ingress and Gateway shared-secret auth from sharing a secret. */
 export function assertHooksTokenSeparateFromGatewayAuth(params: {
   cfg: OpenClawConfig;
   auth: ResolvedGatewayAuth;
@@ -242,15 +242,19 @@ export function assertHooksTokenSeparateFromGatewayAuth(params: {
   if (!hooksToken) {
     return;
   }
-  const gatewayToken =
-    params.auth.mode === "token" ? (normalizeOptionalString(params.auth.token) ?? "") : "";
-  if (!gatewayToken) {
+  const gatewaySecret =
+    params.auth.mode === "token"
+      ? (normalizeOptionalString(params.auth.token) ?? "")
+      : params.auth.mode === "password" || params.auth.mode === "trusted-proxy"
+        ? (normalizeOptionalString(params.auth.password) ?? "")
+        : "";
+  if (!gatewaySecret) {
     return;
   }
-  if (hooksToken !== gatewayToken) {
+  if (hooksToken !== gatewaySecret) {
     return;
   }
   throw new Error(
-    "Invalid config: hooks.token must not match gateway auth token. Set a distinct hooks.token for hook ingress.",
+    "Invalid config: hooks.token must not match gateway auth token or password. Set a distinct hooks.token for hook ingress.",
   );
 }

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -48,6 +48,10 @@ export type GatewayHttpNoAuthAuditOptions = {
 };
 
 type GatewayAuthSharedSecretLabel = "gateway auth token" | "gateway auth password";
+type GatewayAuthSharedSecretReuse = {
+  label: GatewayAuthSharedSecretLabel;
+  source: "config" | "override";
+};
 type ActiveGatewaySharedSecret = {
   label: GatewayAuthSharedSecretLabel;
   value?: string;
@@ -115,25 +119,36 @@ function findGatewayAuthLabelMatchingHooksToken(params: {
   )?.label;
 }
 
-function findHooksTokenGatewayAuthReuseLabel(params: {
+function findHooksTokenGatewayAuthReuse(params: {
   hooksToken: string;
   configGatewayAuth: ResolvedGatewayAuth;
   overrideGatewayAuth?: ResolvedGatewayAuth;
-}): GatewayAuthSharedSecretLabel | undefined {
+}): GatewayAuthSharedSecretReuse | undefined {
   const configReuseLabel = findGatewayAuthLabelMatchingHooksToken({
     hooksToken: params.hooksToken,
     auth: params.configGatewayAuth,
   });
   if (configReuseLabel) {
-    return configReuseLabel;
+    return { label: configReuseLabel, source: "config" };
   }
 
-  return params.overrideGatewayAuth
+  const overrideReuseLabel = params.overrideGatewayAuth
     ? findGatewayAuthLabelMatchingHooksToken({
         hooksToken: params.hooksToken,
         auth: params.overrideGatewayAuth,
       })
     : undefined;
+  if (!overrideReuseLabel) {
+    return undefined;
+  }
+  return { label: overrideReuseLabel, source: "override" };
+}
+
+function formatHooksTokenReuseRemediation(reuse: GatewayAuthSharedSecretReuse): string {
+  if (reuse.source === "override") {
+    return "Rotate hooks.token or the runtime Gateway shared-secret auth value used for this audit; doctor can only repair reuse that is present in persisted config or process env.";
+  }
+  return `Run ${formatCliCommand("openclaw doctor --fix")} to rotate a persisted hooks.token, then update external hook senders to use the new hook token.`;
 }
 
 function hasResolvedGatewayHttpAuth(auth: ResolvedGatewayAuth): boolean {
@@ -610,19 +625,18 @@ export function collectHooksHardeningFindings(
         env,
       })
     : undefined;
-  const reusedGatewayAuthLabel = findHooksTokenGatewayAuthReuseLabel({
+  const reusedGatewayAuth = findHooksTokenGatewayAuthReuse({
     hooksToken: token,
     configGatewayAuth,
     overrideGatewayAuth,
   });
-  if (reusedGatewayAuthLabel) {
+  if (reusedGatewayAuth) {
     findings.push({
       checkId: "hooks.token_reuse_gateway_token",
       severity: "critical",
-      title: `Hooks token reuses the ${formatGatewayAuthDisplayLabel(reusedGatewayAuthLabel)}`,
-      detail: formatHooksTokenReuseDetail(reusedGatewayAuthLabel),
-      remediation:
-        "Use a separate hooks.token dedicated to hook ingress and keep it distinct from Gateway token/password shared-secret auth.",
+      title: `Hooks token reuses the ${formatGatewayAuthDisplayLabel(reusedGatewayAuth.label)}`,
+      detail: formatHooksTokenReuseDetail(reusedGatewayAuth.label),
+      remediation: formatHooksTokenReuseRemediation(reusedGatewayAuth),
     });
   }
 

--- a/src/security/audit-hooks-routing.test.ts
+++ b/src/security/audit-hooks-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { collectHooksHardeningFindings } from "./audit-extra.sync.js";
+import { runSecurityAudit } from "./audit.js";
 
 function hasFinding(
   findings: ReturnType<typeof collectHooksHardeningFindings>,
@@ -138,7 +139,7 @@ describe("security audit hooks ingress findings", () => {
     const finding = getFinding(findings, "hooks.token_reuse_gateway_token");
     expect(finding?.title).toContain("Gateway password");
     expect(finding?.detail).toContain("gateway.auth password");
-    expect(finding?.remediation).toContain("Gateway token/password");
+    expect(finding?.remediation).toContain("openclaw doctor --fix");
   });
 
   it("flags hooks token reuse of trusted-proxy local password fallback as critical", () => {
@@ -184,6 +185,7 @@ describe("security audit hooks ingress findings", () => {
     const finding = getFinding(findings, "hooks.token_reuse_gateway_token");
     expect(finding?.title).toContain("Gateway password");
     expect(finding?.detail).toContain("gateway.auth password");
+    expect(finding?.remediation).toContain("doctor can only repair reuse");
   });
 
   it("does not flag inactive explicit audit password when config mode is token", () => {
@@ -268,5 +270,184 @@ describe("security audit hooks ingress findings", () => {
     const finding = getFinding(findings, "hooks.token_reuse_gateway_token");
     expect(finding?.title).toContain("Gateway password");
     expect(finding?.detail).toContain("gateway.auth password");
+  });
+
+  it("flags hooks token reuse of SecretRef-backed gateway password auth in full audit", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "password",
+            password: { source: "env", provider: "default", id: "GW_PASSWORD" },
+          },
+        },
+        hooks: {
+          enabled: true,
+          token: "shared-gateway-password-1234567890",
+        },
+      },
+      env: {
+        GW_PASSWORD: "shared-gateway-password-1234567890", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(hasFinding(report.findings, "hooks.token_reuse_gateway_token", "critical")).toBe(true);
+  });
+
+  it("keeps persisted SecretRef reuse findings when audit password override differs", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "password",
+            password: { source: "env", provider: "default", id: "GW_PASSWORD" },
+          },
+        },
+        hooks: {
+          enabled: true,
+          token: "config-gateway-password-1234567890",
+        },
+      },
+      env: {
+        GW_PASSWORD: "config-gateway-password-1234567890", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+      auditGatewayAuthOverride: {
+        mode: "password",
+        password: "different-runtime-password-1234567890", // pragma: allowlist secret
+      },
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const finding = getFinding(report.findings, "hooks.token_reuse_gateway_token");
+    expect(finding?.severity).toBe("critical");
+    expect(finding?.remediation).toContain("openclaw doctor --fix");
+  });
+
+  it("flags hooks token reuse of SecretRef-backed trusted-proxy password fallback", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "trusted-proxy",
+            trustedProxy: { userHeader: "x-forwarded-user" },
+            password: { source: "env", provider: "default", id: "GW_PASSWORD" },
+          },
+        },
+        hooks: {
+          enabled: true,
+          token: "trusted-proxy-local-password-1234567890",
+        },
+      },
+      env: {
+        GW_PASSWORD: "trusted-proxy-local-password-1234567890", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(hasFinding(report.findings, "hooks.token_reuse_gateway_token", "critical")).toBe(true);
+  });
+
+  it("does not resolve gateway auth SecretRefs when hooks are disabled", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "password",
+            password: { source: "env", provider: "default", id: "MISSING_GW_PASSWORD" },
+          },
+        },
+        hooks: {
+          enabled: false,
+          token: "shared-gateway-password-1234567890",
+        },
+      },
+      env: {} as NodeJS.ProcessEnv,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(hasFinding(report.findings, "hooks.token_reuse_gateway_token", "critical")).toBe(false);
+  });
+
+  it("skips unavailable gateway auth SecretRefs when auditing hooks token reuse", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "password",
+            password: { source: "env", provider: "default", id: "MISSING_GW_PASSWORD" },
+          },
+        },
+        hooks: {
+          enabled: true,
+          token: "shared-gateway-password-1234567890",
+        },
+      },
+      env: {} as NodeJS.ProcessEnv,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(hasFinding(report.findings, "hooks.token_reuse_gateway_token", "critical")).toBe(false);
+  });
+
+  it("does not execute gateway auth SecretRefs during hooks token reuse audit", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        secrets: {
+          providers: {
+            vault: {
+              source: "exec",
+              command: "node",
+              args: ["-e", "process.stdout.write('shared-gateway-password-1234567890')"],
+            },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "password",
+            password: { source: "exec", provider: "vault", id: "GW_PASSWORD" },
+          },
+        },
+        hooks: {
+          enabled: true,
+          token: "shared-gateway-password-1234567890",
+        },
+      },
+      env: {} as NodeJS.ProcessEnv,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(hasFinding(report.findings, "hooks.token_reuse_gateway_token", "critical")).toBe(false);
   });
 });

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveExecDefaults } from "../agents/exec-defaults.js";
@@ -12,6 +15,10 @@ import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { CliBackendConfig } from "../config/types.agent-defaults.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import type { SecurityAuditSuppression } from "../config/types.openclaw.js";
+import {
+  canMaterializeGatewayAuthSecretRefsWithoutExec,
+  materializeGatewayAuthSecretRefs,
+} from "../gateway/auth-config-utils.js";
 import { isInterpreterLikeAllowlistPattern } from "../infra/command-analysis/inline-eval.js";
 import {
   type ExecApprovalsFile,
@@ -217,6 +224,31 @@ function countBySeverity(findings: SecurityAuditFinding[]): SecurityAuditSummary
 
 function normalizeSuppressionText(value: string | undefined): string {
   return (value ?? "").trim().toLowerCase();
+}
+
+async function materializeAuditGatewayAuthRefs(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<OpenClawConfig> {
+  const materializeParams = {
+    cfg: params.cfg,
+    env: params.env,
+    mode: params.cfg.gateway?.auth?.mode,
+    hasTokenCandidate: Boolean(normalizeOptionalString(params.env.OPENCLAW_GATEWAY_TOKEN)),
+    hasPasswordCandidate: Boolean(normalizeOptionalString(params.env.OPENCLAW_GATEWAY_PASSWORD)),
+  };
+  if (!canMaterializeGatewayAuthSecretRefsWithoutExec(materializeParams)) {
+    return params.cfg;
+  }
+  try {
+    return await materializeGatewayAuthSecretRefs(materializeParams);
+  } catch {
+    return params.cfg;
+  }
+}
+
+function shouldMaterializeHooksGatewayAuthRefs(cfg: OpenClawConfig): boolean {
+  return cfg.hooks?.enabled === true && Boolean(normalizeOptionalString(cfg.hooks.token));
 }
 
 function findingMatchesSuppression(
@@ -1210,8 +1242,14 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...collectLoggingFindings(cfg));
   findings.push(...collectElevatedFindings(cfg));
   findings.push(...collectExecRuntimeFindings(cfg));
+  const hooksGatewayAuthCfg = shouldMaterializeHooksGatewayAuthRefs(cfg)
+    ? await materializeAuditGatewayAuthRefs({
+        cfg,
+        env,
+      })
+    : cfg;
   findings.push(
-    ...auditNonDeep.collectHooksHardeningFindings(cfg, env, {
+    ...auditNonDeep.collectHooksHardeningFindings(hooksGatewayAuthCfg, env, {
       gatewayAuthOverride: context.auditGatewayAuthOverride,
     }),
   );


### PR DESCRIPTION
## Summary

- Keep existing installs startup-compatible when `hooks.token` reuses active Gateway shared-secret auth; startup now logs a non-fatal security warning instead of rejecting the config.
- Add `openclaw security audit` coverage for hook/Gateway token reuse, including Gateway password, trusted-proxy password fallback, env/file SecretRefs, and audit-time auth overrides.
- Add `openclaw doctor --fix` repair that rotates a persisted reused `hooks.token`, with docs updated to point operators at audit plus doctor repair.

## Linked context

- Closes #87376
- Requested by a maintainer or owner: maintainer follow-up to avoid breaking existing installs and add doctor/audit handling.

## Real behavior proof (required for external PRs)

- Behavior addressed: Reusing `hooks.token` as Gateway shared-secret auth no longer becomes a silent auth-boundary collapse; startup warns, audit reports a critical finding, and doctor can rotate persisted `hooks.token` reuse without blocking existing installs.
- Real environment tested: local OpenClaw source checkout on this PR branch, targeted Vitest lanes through the repo wrapper.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/startup-auth.test.ts src/gateway/server-startup-config.secrets.test.ts src/security/audit-hooks-routing.test.ts src/commands/doctor/shared/hooks-token-reuse-repair.test.ts src/commands/doctor-config-flow.test.ts`.
- Evidence after fix: 3 Vitest shards passed; coverage includes non-breaking startup warning, full security audit SecretRef reuse findings, audit override behavior, doctor preview, doctor repair, missing SecretRef no-op, exec SecretRef no-op, and trusted-proxy fallback reuse.
- Observed result after fix: reused hook/Gateway credentials are accepted at startup for compatibility with a security warning; `openclaw security audit` reports the critical reuse when it can safely prove it; `openclaw doctor --fix` rotates a persisted reused `hooks.token` and leaves Gateway auth unchanged.
- What was not tested: browser Control UI interaction and live external hook delivery; this change is limited to startup auth validation, security audit, doctor config repair, and docs.
- Proof limitations or environment constraints: exec-backed Gateway SecretRefs are not executed by audit/doctor; startup warning covers the already-resolved runtime auth path. Startup remains non-fatal by design to preserve existing installs.
- Before evidence: the original branch rejected reused credentials at startup, which would break existing installs; current `main` did not cover Gateway password/trusted-proxy reuse consistently.

## Tests and validation

- Commands run:
  - `node scripts/run-vitest.mjs src/gateway/startup-auth.test.ts src/gateway/server-startup-config.secrets.test.ts src/security/audit-hooks-routing.test.ts src/commands/doctor/shared/hooks-token-reuse-repair.test.ts src/commands/doctor-config-flow.test.ts` -> passed, 3 Vitest shards, 109 tests.
  - `pnpm exec oxfmt --check --threads=1 src/gateway/auth-config-utils.ts src/security/audit.ts src/security/audit-hooks-routing.test.ts src/commands/doctor/shared/hooks-token-reuse-repair.ts src/commands/doctor/shared/hooks-token-reuse-repair.test.ts src/commands/doctor-config-flow.ts src/commands/doctor-config-flow.test.ts src/gateway/startup-auth.ts src/gateway/startup-auth.test.ts src/gateway/server-startup-config.ts src/gateway/server.impl.ts src/security/audit-extra.sync.ts` -> passed.
  - `git diff --check` -> passed.
  - `pnpm lint --threads=8` -> passed after lint fixup.
  - `pnpm docs:list` -> passed.
  - `.agents/skills/autoreview/scripts/autoreview --mode local` -> final remaining finding requested fail-closed startup; not accepted because the maintainer requirement is explicitly non-breaking existing installs.
- Regression coverage added or updated: startup warning tests, security audit hooks routing tests, doctor repair unit tests, doctor config-flow integration test.
- What failed before this fix, if known: the branch would have failed startup for existing reused-secret installs; audit/doctor did not provide the requested compatibility-preserving repair path.
- If no test was added, why not: N/A.
- Validation result: focused tests, docs routing, formatting, diff whitespace, and maintainer-directed review loop completed.
- AI-assisted: yes.
- Changed files:
  - `src/gateway/startup-auth.ts`
  - `src/gateway/server-startup-config.ts`
  - `src/gateway/server.impl.ts`
  - `src/gateway/auth-config-utils.ts`
  - `src/security/audit.ts`
  - `src/security/audit-extra.sync.ts`
  - `src/commands/doctor-config-flow.ts`
  - `src/commands/doctor/shared/hooks-token-reuse-repair.ts`
  - `docs/cli/security.md`
  - `docs/gateway/configuration-reference.md`

## Risk checklist

- Did user-visible behavior change? (`Yes/No`): Yes - startup warning, security audit finding, and doctor repair behavior changed for hook/Gateway shared-secret reuse.
- Did config, environment, or migration behavior change? (`Yes/No`): Yes - `openclaw doctor --fix` can rotate a persisted reused `hooks.token`; operators must update external hook senders afterward.
- Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`): Yes - hook ingress and Gateway operator shared-secret reuse is surfaced and repairable without failing startup.
- Highest-risk area: startup remains permissive for compatibility, so operators must act on the warning/audit finding.
- Risk mitigation: startup warning uses resolved runtime auth, audit detects safely resolvable config/env/file reuse, doctor rotates persisted hook tokens, and docs describe the required sender update.

## Current review state

- Next action: CI/proof run on pushed commit `50eb38194cbbd2f93b6c19f4e13ee00694bf7a4f`.
- Still waiting on author, maintainer, CI, or external proof: GitHub checks triggered by the latest push.
- Bot or reviewer comments addressed: replaced fail-closed startup behavior with maintainer-requested doctor/audit path and fixed SecretRef/dependency review gaps.

