### PR TITLE
fix(canvas): use focused number runtime helpers

### DIFF
--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -8,6 +8,10 @@ import {
   resolveNodeFromNodeList,
   type NodeMatchCandidate,
 } from "openclaw/plugin-sdk/gateway-runtime";
+import {
+  parseStrictFiniteNumber,
+  parseStrictPositiveInteger,
+} from "openclaw/plugin-sdk/number-runtime";
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -69,41 +73,6 @@ export type CanvasCliDependencies = {
 
 type CanvasNodeCandidate = NodeMatchCandidate;
 type CanvasSnapshotRequestFormat = "png" | "jpeg";
-
-function normalizeNumericString(value: string): string | undefined {
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-function parseStrictPositiveInteger(value: unknown): number | undefined {
-  if (typeof value === "number") {
-    return Number.isSafeInteger(value) && value > 0 ? value : undefined;
-  }
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = normalizeNumericString(value);
-  if (!normalized || !/^\+?\d+$/.test(normalized)) {
-    return undefined;
-  }
-  const parsed = Number(normalized);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-function parseStrictFiniteNumber(value: unknown): number | undefined {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : undefined;
-  }
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = normalizeNumericString(value);
-  if (!normalized || !/^[+-]?(?:(?:\d+\.?\d*)|(?:\.\d+))(?:e[+-]?\d+)?$/i.test(normalized)) {
-    return undefined;
-  }
-  const parsed = Number(normalized);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
 
 function parseCanvasSnapshotRequestFormat(raw: unknown): CanvasSnapshotRequestFormat {
   const format = normalizeLowercaseStringOrEmpty(normalizeOptionalString(raw) ?? "jpg");

--- a/src/plugin-sdk/number-runtime.ts
+++ b/src/plugin-sdk/number-runtime.ts
@@ -1,3 +1,7 @@
 // Numeric coercion helpers for plugin runtime inputs.
 
-export { parseFiniteNumber } from "../infra/parse-finite-number.js";
+export {
+  parseFiniteNumber,
+  parseStrictFiniteNumber,
+  parseStrictPositiveInteger,
+} from "../infra/parse-finite-number.js";


### PR DESCRIPTION
## Summary
- Move the Canvas CLI strict number parsing imports off the deprecated `openclaw/plugin-sdk/infra-runtime` barrel.
- Re-export the strict finite/positive integer helpers from the focused `openclaw/plugin-sdk/number-runtime` subpath.

## Verification
- `pnpm run lint:plugins:no-monolithic-plugin-sdk-entry-imports && pnpm check:deprecated-api-usage`
- `pnpm build:plugin-sdk:strict-smoke`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-canvas-number-pr node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts src/plugins/contracts/extension-package-project-boundaries.test.ts`

## Real behavior proof
Behavior addressed: Canvas plugin production code no longer imports a deprecated broad Plugin SDK runtime barrel.
Real environment tested: Local source checkout on macOS, Node/pnpm repo tooling.
Exact steps or command run after this patch: See Verification above.
Evidence after fix: Deprecated SDK usage guard and plugin SDK package contract guardrails pass locally.
Observed result after fix: Focused contract run passed 2 files / 30 tests; SDK declaration smoke completed successfully.
What was not tested: Full CI matrix and live Canvas CLI runtime.
