### PR TITLE
fix(codex): narrow legacy hook generation grace

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -527,6 +527,21 @@ describe("runCodexAppServerAttempt native hook relay", () => {
         },
       }),
     ).resolves.toMatchObject({ exitCode: 0 });
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        generation: "different-legacy-generation",
+        event: "pre_tool_use",
+        requireGeneration: true,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "unexpected-stale-generation",
+          tool_input: { command: "pwd" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
 
     await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
     await run;

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -772,6 +772,21 @@ describe("native hook relay registry", () => {
       runId: "run-1",
       event: "pre_tool_use",
     });
+
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: "different-stale-generation",
+        event: "pre_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
   });
 
   it("rejects bootstrap generation mismatches after the grace window", async () => {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -75,6 +75,7 @@ export type NativeHookRelayRegistration = {
   relayId: string;
   provider: NativeHookRelayProvider;
   generationMismatchGraceExpiresAtMs?: number;
+  generationMismatchGraceAcceptedGeneration?: string;
   agentId?: string;
   sessionId: string;
   sessionKey?: string;
@@ -540,7 +541,7 @@ export async function invokeNativeHookRelay(
   if (params.requireGeneration) {
     const generation = readNonEmptyString(params.generation, "generation");
     if (generation !== registration.generation) {
-      if (!canAcceptNativeHookRelayGenerationMismatch(registration)) {
+      if (!canAcceptNativeHookRelayGenerationMismatch(registration, generation)) {
         throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
       }
       log.debug("native hook relay accepted bootstrap generation mismatch", {
@@ -678,9 +679,17 @@ function removeNativeHookRelayInvocations(relayId: string): void {
 
 function canAcceptNativeHookRelayGenerationMismatch(
   registration: NativeHookRelayRegistration,
+  generation: string,
 ): boolean {
   const expiresAtMs = registration.generationMismatchGraceExpiresAtMs;
-  return typeof expiresAtMs === "number" && Date.now() <= expiresAtMs;
+  if (typeof expiresAtMs !== "number" || Date.now() > expiresAtMs) {
+    return false;
+  }
+  if (registration.generationMismatchGraceAcceptedGeneration) {
+    return registration.generationMismatchGraceAcceptedGeneration === generation;
+  }
+  registration.generationMismatchGraceAcceptedGeneration = generation;
+  return true;
 }
 
 function pruneExpiredNativeHookRelays(now = Date.now()): void {


### PR DESCRIPTION
## Summary
- Follow-up to #87272 after the native hook relay restart fix was merged.
- Narrows the legacy bootstrap generation grace so the first observed stale generation is pinned during the grace window.
- Adds regression coverage that a different mismatched generation is still rejected in both the generic relay and Codex resumed-thread path.

## Verification
- `node scripts/run-vitest.mjs src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts --run`
- `./node_modules/.bin/oxfmt --check src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts`

Refs #87272
