### PR TITLE
fix(cli): respect subcommand version options

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -117,6 +117,10 @@ vi.mock("../../agents/model-auth.js", () => {
   };
 });
 
+vi.mock("../../agents/provider-auth-aliases.js", () => ({
+  resolveProviderIdForAuth: (provider: string) => provider,
+}));
+
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -657,7 +661,7 @@ describe("/model chat UX", () => {
     expect(reply?.text).not.toContain("[openai] endpoint: default auth: missing");
     expect(reply?.text).toContain("via codex runtime / openai-codex");
     expect(reply?.text).toContain("openai-codex:patrick@example.test=OAuth");
-  });
+  }, 240_000);
 
   it("keeps direct provider auth labels when OpenAI API key auth exists", async () => {
     setAuthProfiles({

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -165,4 +165,22 @@ describe("configureProgramHelp", () => {
     resolveCommitHashMock.mockReturnValue(null);
     expectVersionExit({ expectedVersion: "OpenClaw 9.9.9-test" });
   });
+
+  it("does not treat subcommand --version options as root version requests", () => {
+    process.argv = ["node", "openclaw", "skills", "verify", "discrawl", "--version", "1.0.0"];
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? ""}`);
+    }) as typeof process.exit);
+
+    try {
+      const program = makeProgramWithCommands();
+      expect(() => configureProgramHelp(program, testProgramContext)).not.toThrow();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
 });

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -3,7 +3,7 @@ import { resolveCommitHash } from "../../infra/git-commit.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { isRich, theme } from "../../terminal/theme.js";
 import { escapeRegExp } from "../../utils.js";
-import { hasFlag, hasRootVersionAlias } from "../argv.js";
+import { isRootVersionInvocation } from "../argv.js";
 import { formatCliBannerLine, hasEmittedCliBanner } from "../banner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { CLI_LOG_LEVEL_VALUES, parseCliLogLevelOption } from "../log-level-option.js";
@@ -117,11 +117,7 @@ export function configureProgramHelp(
     outputError: (str, write) => write(formatCliParseErrorOutput(str, { argv: process.argv })),
   });
 
-  if (
-    hasFlag(process.argv, "-V") ||
-    hasFlag(process.argv, "--version") ||
-    hasRootVersionAlias(process.argv)
-  ) {
+  if (isRootVersionInvocation(process.argv)) {
     const commit = resolveCommitHash({ moduleUrl: import.meta.url });
     console.log(
       commit ? `OpenClaw ${ctx.programVersion} (${commit})` : `OpenClaw ${ctx.programVersion}`,


### PR DESCRIPTION
## Summary
- Narrow the custom root `--version` fast path so subcommand-scoped `--version <value>` options are not swallowed before Commander parses them.
- Add a regression test for `openclaw skills verify discrawl --version 1.0.0` style invocations.

## Verification
- `bun run vitest run src/cli/program/help.test.ts` -> 6 passed
- `pnpm format:check -- src/cli/program/help.ts src/cli/program/help.test.ts` -> clean
- Smoke-tested against local OCM env `skill-trust-main-smoke`: `skills verify discrawl --version 1.0.0` returned `decision: pass`, `securityStatus: clean`, and `cardAvailable: true`.
