### PR TITLE
fix(codex): format skills using Codex skills response shape

### DIFF
--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -448,9 +448,32 @@ export type CodexSkillsListParams = {
   forceReload?: boolean;
 };
 
+export type CodexSkillScope = "user" | "repo" | "system" | "admin";
+
+export type CodexSkillMetadata = {
+  name: string;
+  description: string;
+  shortDescription?: string;
+  interface?: JsonObject;
+  dependencies?: JsonObject;
+  path: string;
+  scope: CodexSkillScope;
+  enabled: boolean;
+};
+
+export type CodexSkillErrorInfo = {
+  path: string;
+  message: string;
+};
+
+export type CodexSkillsListEntry = {
+  cwd: string;
+  skills: CodexSkillMetadata[];
+  errors: CodexSkillErrorInfo[];
+};
+
 export type CodexSkillsListResponse = {
-  data: JsonValue[];
-  nextCursor?: string | null;
+  data: CodexSkillsListEntry[];
 };
 
 export type CodexHooksListParams = {

--- a/extensions/codex/src/command-formatters.ts
+++ b/extensions/codex/src/command-formatters.ts
@@ -57,7 +57,7 @@ export function formatCodexStatus(probes: CodexStatusProbes): string {
   lines.push(
     `Skills: ${
       probes.skills.ok
-        ? summarizeArrayLike(probes.skills.value)
+        ? summarizeCodexSkills(probes.skills.value)
         : formatCodexDisplayText(probes.skills.error)
     }`,
   );
@@ -197,6 +197,48 @@ export function formatList(response: JsonValue | undefined, label: string): stri
       )}`;
     }),
   ].join("\n");
+}
+
+export function formatSkills(response: JsonValue | undefined): string {
+  const groups = isJsonObject(response) && Array.isArray(response.data) ? response.data : [];
+  if (groups.length === 0) {
+    return "Codex skills: none returned.";
+  }
+  const lines = ["Codex skills:"];
+  let renderedSkills = 0;
+  let loadErrors = 0;
+  for (const group of groups) {
+    const record = isJsonObject(group) ? group : {};
+    if (Array.isArray(record.errors)) {
+      loadErrors += record.errors.length;
+    }
+    const skills = Array.isArray(record.skills) ? record.skills : [];
+    if (skills.length === 0) {
+      continue;
+    }
+    for (const skill of skills) {
+      if (isJsonObject(skill) && skill.enabled === false) {
+        continue;
+      }
+      lines.push(`- ${formatCodexSkillEntry(skill)}`);
+      renderedSkills += 1;
+    }
+  }
+  if (renderedSkills === 0) {
+    if (loadErrors > 0) {
+      return `Codex skills: none returned (${loadErrors} load ${
+        loadErrors === 1 ? "error" : "errors"
+      }).`;
+    }
+    return "Codex skills: none returned.";
+  }
+  return lines.join("\n");
+}
+
+function formatCodexSkillEntry(entry: JsonValue): string {
+  const record = isJsonObject(entry) ? entry : {};
+  const name = readString(record, "name") ?? "<unknown>";
+  return `\`${formatCodexDisplayText(name)}\``;
 }
 
 const CODEX_RESUME_SAFE_THREAD_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
@@ -348,6 +390,36 @@ function summarizeArrayLike(value: JsonValue | undefined): string {
     return "none returned";
   }
   return `${entries.length}`;
+}
+
+function summarizeCodexSkills(value: JsonValue | undefined): string {
+  const groups = isJsonObject(value) && Array.isArray(value.data) ? value.data : [];
+  if (groups.length === 0) {
+    return "none returned";
+  }
+  let enabledSkills = 0;
+  let loadErrors = 0;
+  for (const group of groups) {
+    if (!isJsonObject(group)) {
+      continue;
+    }
+    if (Array.isArray(group.errors)) {
+      loadErrors += group.errors.length;
+    }
+    if (!Array.isArray(group.skills)) {
+      continue;
+    }
+    enabledSkills += group.skills.filter(
+      (skill) => !isJsonObject(skill) || skill.enabled !== false,
+    ).length;
+  }
+  if (enabledSkills > 0) {
+    return `${enabledSkills}`;
+  }
+  if (loadErrors > 0) {
+    return `none returned (${loadErrors} load ${loadErrors === 1 ? "error" : "errors"})`;
+  }
+  return "none returned";
 }
 
 function formatCodexRateLimitSummary(value: JsonValue | undefined): string {

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -30,6 +30,7 @@ import {
   formatCodexStatus,
   formatList,
   formatModels,
+  formatSkills,
   formatThreads,
   readString,
 } from "./command-formatters.js";
@@ -380,9 +381,8 @@ export async function handleCodexSubcommand(
       return { text: "Usage: /codex skills" };
     }
     return {
-      text: formatList(
+      text: formatSkills(
         await deps.codexControlRequest(options.pluginConfig, CODEX_CONTROL_METHODS.listSkills, {}),
-        "Codex skills",
       ),
     };
   }

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import type { CodexComputerUseStatus } from "./app-server/computer-use.js";
 import type { CodexAppServerStartOptions } from "./app-server/config.js";
+import type { JsonValue } from "./app-server/protocol.js";
 import {
   readRecentCodexRateLimits,
   resetCodexRateLimitCacheForTests,
@@ -910,6 +911,62 @@ describe("codex command", () => {
     expect(result.text).not.toContain("<@U123>");
     expect(result.text).not.toContain("[trusted](https://evil)");
     expect(result.text).not.toContain("@here");
+  });
+
+  it("summarizes Codex status skill groups by enabled nested skills", async () => {
+    const deps = createDeps({
+      readCodexStatusProbes: vi.fn(async () => ({
+        models: { ok: true as const, value: { models: [] } },
+        account: { ok: true as const, value: {} },
+        limits: { ok: true as const, value: { rateLimits: null, rateLimitsByLimitId: null } },
+        mcps: { ok: true as const, value: { data: [] } },
+        skills: {
+          ok: true as const,
+          value: {
+            data: [
+              {
+                cwd: "/repo-a",
+                skills: [
+                  {
+                    name: "enabled-one",
+                    description: "",
+                    path: "/repo-a/.codex/skills/enabled-one/SKILL.md",
+                    scope: "repo" as const,
+                    enabled: true,
+                  },
+                  {
+                    name: "disabled-one",
+                    description: "",
+                    path: "/repo-a/.codex/skills/disabled-one/SKILL.md",
+                    scope: "repo" as const,
+                    enabled: false,
+                  },
+                ],
+                errors: [],
+              },
+              {
+                cwd: "/repo-b",
+                skills: [
+                  {
+                    name: "enabled-two",
+                    description: "",
+                    path: "/repo-b/.codex/skills/enabled-two/SKILL.md",
+                    scope: "repo" as const,
+                    enabled: true,
+                  },
+                ],
+                errors: [{ path: "/repo-b/bad/SKILL.md", message: "bad skill" }],
+              },
+            ],
+          },
+        },
+      })),
+    });
+
+    const result = await handleCodexCommand(createContext("status"), { deps });
+
+    expect(result.text).toContain("Skills: 2");
+    expect(result.text).not.toContain("Skills: 1");
   });
 
   it("summarizes generated Codex rate-limit payloads", async () => {
@@ -3085,17 +3142,118 @@ describe("codex command", () => {
     const codexControlRequest = vi
       .fn()
       .mockResolvedValueOnce({ data: [{ name: "<@U123> [mcp](https://evil)" }] })
-      .mockResolvedValueOnce({ data: [{ id: "skill_1 @here" }] });
+      .mockResolvedValueOnce({
+        data: [
+          {
+            cwd: "/repo",
+            skills: [
+              {
+                name: "skill_1 @here",
+                description: "",
+                path: "/repo/.codex/skills/skill_1/SKILL.md",
+                scope: "repo",
+                enabled: true,
+              },
+            ],
+            errors: [],
+          },
+        ],
+      });
     const deps = createDeps({ codexControlRequest });
 
     const mcp = await handleCodexCommand(createContext("mcp"), { deps });
     const skills = await handleCodexCommand(createContext("skills"), { deps });
 
     expect(mcp.text).toContain("&lt;\uff20U123&gt; \uff3bmcp\uff3d\uff08https://evil\uff09");
-    expect(skills.text).toContain("skill\uff3f1 \uff20here");
+    expect(skills.text).toContain("- `skill\uff3f1 \uff20here`");
     expect(`${mcp.text}\n${skills.text}`).not.toContain("<@U123>");
     expect(`${mcp.text}\n${skills.text}`).not.toContain("[mcp](https://evil)");
     expect(`${mcp.text}\n${skills.text}`).not.toContain("@here");
+  });
+
+  it("formats every Codex skill as a code-styled bullet and tolerates malformed entries", async () => {
+    const malformedSkillEntries: JsonValue[] = [
+      null,
+      { description: "missing name" },
+      {
+        name: "final-skill",
+        description: "Final skill",
+        path: "/repo-b/.codex/skills/final-skill/SKILL.md",
+        scope: "repo",
+        enabled: true,
+      },
+    ];
+    const codexControlRequest = vi.fn(async () => ({
+      data: [
+        {
+          cwd: "/repo-a",
+          skills: Array.from({ length: 26 }, (_, index) => ({
+            name: `skill-${index + 1}`,
+            description: `Skill ${index + 1}`,
+            path: `/repo-a/.codex/skills/skill-${index + 1}/SKILL.md`,
+            scope: "repo",
+            enabled: true,
+          })).concat({
+            name: "disabled-skill",
+            description: "Disabled skill",
+            path: "/repo-a/.codex/skills/disabled-skill/SKILL.md",
+            scope: "repo",
+            enabled: false,
+          }),
+          errors: [{ path: "/repo-a/bad/SKILL.md", message: "bad skill" }],
+        },
+        {
+          cwd: "/repo-b",
+          skills: malformedSkillEntries,
+          errors: [],
+        },
+        "malformed group",
+      ],
+    }));
+    const deps = createDeps({ codexControlRequest });
+
+    const result = await handleCodexCommand(createContext("skills"), { deps });
+
+    expect(result.text).toContain("- `skill-1`");
+    expect(result.text).toContain("- `skill-26`");
+    expect(result.text).toContain("- `&lt;unknown&gt;`");
+    expect(result.text).toContain("- `final-skill`");
+    expect(result.text).not.toContain("Workspace:");
+    expect(result.text).not.toContain("Error:");
+    expect(result.text).not.toContain("More skills available");
+    expect(result.text).not.toContain("Skill 1");
+    expect(result.text).not.toContain("/repo-a/.codex/skills");
+    expect(result.text).not.toContain("disabled-skill");
+  });
+
+  it("reports Codex skill load errors when no skills render", async () => {
+    const codexControlRequest = vi.fn(async () => ({
+      data: [
+        {
+          cwd: "/repo-a",
+          skills: [
+            {
+              name: "disabled-skill",
+              description: "Disabled skill",
+              path: "/repo-a/.codex/skills/disabled-skill/SKILL.md",
+              scope: "repo",
+              enabled: false,
+            },
+          ],
+          errors: [
+            { path: "/repo-a/bad/SKILL.md", message: "bad skill <@U123>" },
+            { path: "/repo-a/other/SKILL.md", message: "other bad skill @here" },
+          ],
+        },
+      ],
+    }));
+    const deps = createDeps({ codexControlRequest });
+
+    const result = await handleCodexCommand(createContext("skills"), { deps });
+
+    expect(result.text).toBe("Codex skills: none returned (2 load errors).");
+    expect(result.text).not.toContain("<@U123>");
+    expect(result.text).not.toContain("@here");
   });
 
   it("returns sanitized command failures instead of leaking app-server errors", async () => {


### PR DESCRIPTION
Before
<img width="2394" height="1864" alt="Screenshot 2026-05-27 at 14 32 24" src="https://github.com/user-attachments/assets/d1149ec1-b70c-4496-9ca8-e3bb93a8935e" />

After
<img width="2362" height="1832" alt="Screenshot 2026-05-27 at 14 49 40" src="https://github.com/user-attachments/assets/a3a0f585-ca73-40e1-bdad-3af134935cfc" />

## Summary

- Format `/codex skills` with a skill-aware renderer instead of the generic list formatter.
- Type `skills/list` to match Codex's current schema: `data[]` workspace groups containing `cwd`, `skills[]`, and `errors[]`.
- Render `/codex skills` as a compact untruncated bullet list containing only code-styled enabled skill names.
- Count nested enabled skills in `/codex status` instead of counting workspace groups.
- Normalize each workspace and skill independently so one malformed skill entry does not derail the whole `/codex skills` response.
- Keep the existing chat-display escaping so mentions and markdown-like text are still neutralized.
- Report a sanitized load-error count when Codex returns only failed skill groups.

## Verification

- `git diff --check -- extensions/codex/src/app-server/protocol.ts extensions/codex/src/command-formatters.ts extensions/codex/src/command-handlers.ts extensions/codex/src/commands.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/commands.test.ts`