### PR TITLE
fix(agents): honor ACP alias model.primary overrides (Fixes #87381)

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1002,6 +1002,9 @@ describe("spawnAcpDirect", () => {
         list: [
           {
             id: "reviewer",
+            model: {
+              primary: "openai/gpt-5.5-mini",
+            },
             runtime: {
               type: "acp",
               acp: {
@@ -1030,7 +1033,55 @@ describe("spawnAcpDirect", () => {
     );
 
     expectAcceptedSpawn(result);
+    const initInput = expectInitializeSessionFields({
+      agent: "codex",
+      runtimeOptions: {
+        model: "openai/gpt-5.5-mini",
+      },
+    });
+    expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
+  });
+
+  it("does not inherit configured alias model defaults for raw ACP harness ids", async () => {
+    replaceSpawnConfig({
+      ...createDefaultSpawnConfig(),
+      agents: {
+        list: [
+          {
+            id: "reviewer",
+            model: {
+              primary: "openai/gpt-5.5-mini",
+            },
+            runtime: {
+              type: "acp",
+              acp: {
+                agent: "codex",
+              },
+            },
+          },
+        ],
+        defaults: {
+          subagents: {
+            allowAgents: ["codex"],
+            maxSpawnDepth: 2,
+          },
+        },
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expectAcceptedSpawn(result);
     const initInput = expectInitializeSessionFields({ agent: "codex" });
+    expect(initInput.runtimeOptions).toBeUndefined();
     expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
   });
 

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -71,7 +71,12 @@ import {
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
-import { listAgentIds, resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentConfig,
+  resolveAgentEffectiveModelPrimary,
+  resolveDefaultAgentId,
+} from "./agent-scope.js";
 import {
   findAcpUnsupportedInheritedToolAllow,
   findAcpUnsupportedInheritedToolDeny,
@@ -444,6 +449,20 @@ function resolveTargetAcpAgentId(params: {
     error:
       "ACP target agent is not configured. Pass `agentId` in `sessions_spawn` or set `acp.defaultAgent` in config.",
   };
+}
+
+function resolveConfiguredAcpRuntimeAliasId(params: {
+  requestedAgentId?: string;
+  cfg: OpenClawConfig;
+}): string | undefined {
+  const requested = normalizeOptionalAgentId(params.requestedAgentId);
+  if (!requested) {
+    return undefined;
+  }
+  const configuredAgent = params.cfg.agents?.list?.find(
+    (agent) => normalizeOptionalAgentId(agent.id) === requested,
+  );
+  return configuredAgent?.runtime?.type === "acp" ? requested : undefined;
 }
 
 function isExplicitlyAllowedAcpAgent(cfg: OpenClawConfig, agentId: string): boolean {
@@ -1248,6 +1267,15 @@ export async function spawnAcpDirect(
     });
   }
   const targetAgentId = targetAgentResult.agentId;
+  const configuredAcpAliasId = resolveConfiguredAcpRuntimeAliasId({
+    requestedAgentId: params.agentId,
+    cfg,
+  });
+  const resolvedModel =
+    params.model ??
+    (configuredAcpAliasId
+      ? resolveAgentEffectiveModelPrimary(cfg, configuredAcpAliasId)
+      : undefined);
   const agentPolicyError = resolveAcpAgentPolicyError(cfg, targetAgentId);
   if (agentPolicyError) {
     return createAcpSpawnFailure({
@@ -1365,7 +1393,7 @@ export async function spawnAcpDirect(
       targetAgentId,
       runtimeMode,
       resumeSessionId: params.resumeSessionId,
-      model: params.model,
+      model: resolvedModel,
       thinking: params.thinking,
       runTimeoutSeconds: params.runTimeoutSeconds,
       cwd: runtimeCwd,


### PR DESCRIPTION
## Summary

Fixes #87381

When `sessions_spawn(runtime="acp")` targets an OpenClaw agent alias backed by `runtime.type="acp"`, ACP session initialization only forwarded an explicit `model` argument from the tool call. If the caller omitted `model`, the spawn path ignored the alias agent's configured `model.primary`, even though the alias had already resolved to the correct ACP harness id.

This patch keeps the fix narrow:

- preserve explicit `sessions_spawn.model` precedence
- when the requested `agentId` is a configured ACP alias, fall back to that alias agent's effective model before initializing the ACP session
- keep raw ACP harness ids like `codex` unchanged so unrelated ACP spawns do not start inheriting config from some other alias

I did not change the separate Claude startup-env/model-switch behavior discussed later on the issue. This PR only fixes the missing OpenClaw-side model routing on the ACP alias spawn path.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/acp-spawn.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed:
- ACP alias spawns now pass the configured alias model into ACP session initialization even when the caller does not send an explicit `model`.

Environment tested:
- macOS, Node v22, PR branch `dbac0720`

Exact validation:
- `node scripts/run-vitest.mjs src/agents/acp-spawn.test.ts --reporter=verbose`

Evidence after the fix:
- `spawnAcpDirect > maps OpenClaw ACP runtime agent aliases to their configured harness id` passes while asserting `runtimeOptions.model = "openai/gpt-5.5-mini"`
- `spawnAcpDirect > does not inherit configured alias model defaults for raw ACP harness ids` passes while asserting raw harness-id spawns still leave `runtimeOptions` unset
- the four invariant cases called out in the issue were also checked in a standalone logic reproduction: alias without explicit model, alias with explicit model, raw harness id, and a second alias resolving a different configured model

Observed result:
- the focused ACP spawn suite passed, and the updated proof covers both alias-model fallback and raw-harness isolation on the PR branch

What was not tested:
- I still did not run a live Claude/acpx process launch against a local ACP backend in this environment

Proof limitation:
- this remains source-level/runtime-harness proof rather than a live external Claude session repro

## Risk

Low to medium. The patch only changes ACP spawn model fallback when the requested `agentId` is a configured OpenClaw ACP alias and no explicit model was supplied. Explicit model overrides still win, and raw external harness ids keep their previous behavior.
