### PR TITLE
chore: stop tracking generated diffs viewer runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,6 +249,7 @@ extensions/qa-lab/web/dist/
 # Generated bundled plugin runtime dependency manifests
 extensions/**/.openclaw-runtime-deps.json
 extensions/**/.openclaw-runtime-deps-stamp.json
+extensions/diffs/assets/viewer-runtime.js
 extensions/diffs-language-pack/assets/viewer-runtime.js
 
 # Output dir for scripts/run-opengrep.sh (local opengrep scans)

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -6,7 +6,7 @@ import {
   validateJsonSchemaValue,
   type JsonSchemaObject,
 } from "openclaw/plugin-sdk/json-schema-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_DIFFS_PLUGIN_SECURITY,
   DEFAULT_DIFFS_TOOL_DEFAULTS,
@@ -17,6 +17,7 @@ import {
   resolveDiffsPluginViewerBaseUrl,
 } from "./config.js";
 import { resolveDiffsLanguagePackAvailability } from "./plugin.js";
+import { ensureCuratedViewerRuntimeForTests } from "./test-helpers.js";
 import { buildViewerUrl, normalizeViewerBaseUrl } from "./url.js";
 import {
   getServedLanguagePackViewerAsset,
@@ -45,6 +46,10 @@ const FULL_DEFAULTS = {
   mode: "file",
   ttlSeconds: 21_600,
 } as const;
+
+beforeAll(async () => {
+  await ensureCuratedViewerRuntimeForTests();
+});
 
 function compileManifestConfigSchema() {
   const manifest = JSON.parse(

--- a/extensions/diffs/src/store.test.ts
+++ b/extensions/diffs/src/store.test.ts
@@ -2,10 +2,14 @@ import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import path from "node:path";
 import { createMockServerResponse } from "openclaw/plugin-sdk/test-env";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDiffsHttpHandler } from "./http.js";
 import { DiffArtifactStore } from "./store.js";
-import { createDiffStoreHarness } from "./test-helpers.js";
+import { createDiffStoreHarness, ensureCuratedViewerRuntimeForTests } from "./test-helpers.js";
+
+beforeAll(async () => {
+  await ensureCuratedViewerRuntimeForTests();
+});
 
 describe("DiffArtifactStore", () => {
   let rootDir: string;

--- a/extensions/diffs/src/test-helpers.ts
+++ b/extensions/diffs/src/test-helpers.ts
@@ -1,7 +1,38 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { resolvePreferredOpenClawTmpDir } from "../api.js";
 import { DiffArtifactStore } from "./store.js";
+
+const execFileAsync = promisify(execFile);
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export async function ensureCuratedViewerRuntimeForTests(): Promise<void> {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+  const runtimePath = path.join(repoRoot, "extensions", "diffs", "assets", "viewer-runtime.js");
+  if (await pathExists(runtimePath)) {
+    return;
+  }
+
+  // The curated runtime is generated output. Source tests that serve viewer
+  // assets need a clean-checkout fixture before the normal build hook runs.
+  await execFileAsync(process.execPath, ["scripts/build-diffs-viewer-runtime.mjs", "curated"], {
+    cwd: repoRoot,
+  });
+}
 
 export async function createTempDiffRoot(prefix: string): Promise<{
   rootDir: string;


### PR DESCRIPTION
## Summary

- Stop tracking the generated diffs viewer runtime bundle in git.
- Ignore `extensions/diffs/assets/viewer-runtime.js` alongside the generated language-pack runtime.
- Keep runtime generation covered by the existing diffs asset build hooks.

## Verification

- `node ../../scripts/build-diffs-viewer-runtime.mjs full` from `extensions/diffs-language-pack`
- `node scripts/run-vitest.mjs extensions/diffs/src/config.test.ts`
- `node scripts/run-vitest.mjs extensions/diffs/src/store.test.ts`
- `pnpm build`
- `git diff --check && git diff --cached --check`

## Real behavior proof

Behavior addressed: generated diffs viewer runtime is no longer checked in while the existing build hooks still generate runtime assets for builds and packaging.
Real environment tested: local Codex worktree on macOS, Node 24.16.0.
Exact steps or command run after this patch: `node ../../scripts/build-diffs-viewer-runtime.mjs full`; `node scripts/run-vitest.mjs extensions/diffs/src/config.test.ts`; `node scripts/run-vitest.mjs extensions/diffs/src/store.test.ts`; `pnpm build`; `git diff --check && git diff --cached --check`.
Evidence after fix: full language-pack runtime generation passed; focused diffs config/store tests passed; full build regenerated diffs assets through `plugins:assets:build` and completed successfully.
Observed result after fix: tracked diff removes `extensions/diffs/assets/viewer-runtime.js` and ignores it as generated output.
What was not tested: remote/Testbox packaging proof was not run; local `pnpm build` covered the relevant asset build and copy path.


## Follow-up for ClawSweeper

- Added a diffs test helper that generates the curated viewer runtime fixture when a clean checkout lacks the ignored generated asset.
- Verified both ClawSweeper-identified focused tests after deleting `extensions/diffs/assets/viewer-runtime.js` first:
  - `rm -f extensions/diffs/assets/viewer-runtime.js && node scripts/run-vitest.mjs extensions/diffs/src/config.test.ts`
  - `rm -f extensions/diffs/assets/viewer-runtime.js && node scripts/run-vitest.mjs extensions/diffs/src/store.test.ts`
