### PR TITLE
chore(ui): mark generated locale artifacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 * text=auto eol=lf
 CLAUDE.md -text
 src/gateway/server-methods/CLAUDE.md -text
+ui/src/i18n/.i18n/* linguist-generated
+ui/src/i18n/locales/*.ts linguist-generated
+ui/src/i18n/locales/en.ts -linguist-generated


### PR DESCRIPTION
## Summary

- Mark generated Control UI locale metadata and non-English locale bundles as generated in Git attributes.
- Keep `ui/src/i18n/locales/en.ts` reviewable as the source-of-truth locale file.

## Verification

- `pnpm ui:i18n:check`
- `node scripts/run-vitest.mjs ui/src/i18n/test/translate.test.ts`
- `pnpm --dir ui build`
- `git diff --check`
- `git check-attr linguist-generated -- ui/src/i18n/locales/en.ts ui/src/i18n/locales/zh-CN.ts ui/src/i18n/.i18n/zh-CN.meta.json`

## Real behavior proof

Behavior addressed: Generated Control UI locale artifacts should stay in the repository for the existing i18n pipeline, but be hidden from ordinary GitHub source review.

Real environment tested: Local macOS worktree on branch `codex/cleanup-control-ui-locales`.

Exact steps or command run after this patch: `pnpm ui:i18n:check`; `node scripts/run-vitest.mjs ui/src/i18n/test/translate.test.ts`; `pnpm --dir ui build`; `git diff --check`; `git check-attr linguist-generated -- ui/src/i18n/locales/en.ts ui/src/i18n/locales/zh-CN.ts ui/src/i18n/.i18n/zh-CN.meta.json`.

Evidence after fix: `git check-attr` reports `ui/src/i18n/locales/zh-CN.ts` and `ui/src/i18n/.i18n/zh-CN.meta.json` as `linguist-generated: set`, while `ui/src/i18n/locales/en.ts` is unset.

Observed result after fix: Control UI i18n check, targeted i18n Vitest coverage, and UI production build all pass with runtime locale files preserved.

What was not tested: GitHub's rendered PR diff collapse cannot be observed until the PR is opened on GitHub.
