### PR TITLE
[codex] Key llama.cpp sessions for local reuse

### DIFF
--- a/src/agents/pi-embedded-runner/llamacpp-cache-key.test.ts
+++ b/src/agents/pi-embedded-runner/llamacpp-cache-key.test.ts
@@ -1,0 +1,89 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { createLlamaCppCacheKeyWrapper, resolveLlamaCppCacheKey } from "./llamacpp-cache-key.js";
+
+function runPayloadCase(params: {
+  provider: string;
+  sessionKey?: string;
+  sessionId?: string;
+  payload?: Record<string, unknown>;
+}) {
+  const payload = params.payload ?? { model: "qwen", messages: [] };
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return {} as ReturnType<StreamFn>;
+  };
+  const streamFn = createLlamaCppCacheKeyWrapper({
+    baseStreamFn,
+    provider: params.provider,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId ?? "session-123",
+  });
+  const model = {
+    api: "openai-completions",
+    provider: params.provider,
+    id: "qwen3.6-35b-a3b-turboquant",
+  } as Model<"openai-completions">;
+  const context: Context = { messages: [] };
+
+  void streamFn?.(model, context, {});
+  return payload;
+}
+
+describe("llama.cpp cache key wrapper", () => {
+  it("derives stable cache key from session key for llama-cpp-turboquant", () => {
+    expect(
+      resolveLlamaCppCacheKey({
+        provider: "llama-cpp-turboquant",
+        sessionKey: "agent:turboquant-test:main",
+        sessionId: "fallback-session",
+      }),
+    ).toBe("openclaw:agent:turboquant-test:main");
+  });
+
+  it("falls back to session id when session key is absent", () => {
+    expect(
+      resolveLlamaCppCacheKey({
+        provider: "llama-cpp-turboquant",
+        sessionId: "session-123",
+      }),
+    ).toBe("openclaw:session-123");
+  });
+
+  it("does not enable cache keys for unrelated OpenAI-compatible providers", () => {
+    expect(
+      resolveLlamaCppCacheKey({
+        provider: "openrouter",
+        sessionKey: "agent:turboquant-test:main",
+        sessionId: "session-123",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("injects cache_key and session_id into llama.cpp request payloads", () => {
+    const payload = runPayloadCase({
+      provider: "llama-cpp-turboquant",
+      sessionKey: "agent:turboquant-test:main",
+    });
+
+    expect(payload.cache_key).toBe("openclaw:agent:turboquant-test:main");
+    expect(payload.session_id).toBe("openclaw:agent:turboquant-test:main");
+  });
+
+  it("preserves explicit payload cache keys", () => {
+    const payload = runPayloadCase({
+      provider: "llama-cpp-turboquant",
+      sessionKey: "agent:turboquant-test:main",
+      payload: {
+        model: "qwen",
+        messages: [],
+        cache_key: "explicit-cache-key",
+        session_id: "explicit-session-id",
+      },
+    });
+
+    expect(payload.cache_key).toBe("explicit-cache-key");
+    expect(payload.session_id).toBe("explicit-session-id");
+  });
+});

--- a/src/agents/pi-embedded-runner/llamacpp-cache-key.ts
+++ b/src/agents/pi-embedded-runner/llamacpp-cache-key.ts
@@ -1,0 +1,45 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+
+const LLAMA_CPP_CACHE_KEY_PROVIDERS = new Set(["llama-cpp-turboquant"]);
+
+export function resolveLlamaCppCacheKey(params: {
+  provider: string;
+  sessionKey?: string;
+  sessionId: string;
+}): string | undefined {
+  if (!LLAMA_CPP_CACHE_KEY_PROVIDERS.has(params.provider)) {
+    return undefined;
+  }
+
+  const source = params.sessionKey?.trim() || params.sessionId.trim();
+  return source ? `openclaw:${source}` : undefined;
+}
+
+export function createLlamaCppCacheKeyWrapper(params: {
+  baseStreamFn: StreamFn | undefined;
+  provider: string;
+  sessionKey?: string;
+  sessionId: string;
+}): StreamFn | undefined {
+  const cacheKey = resolveLlamaCppCacheKey(params);
+  if (!cacheKey) {
+    return undefined;
+  }
+
+  const underlying = params.baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const body = payload as Record<string, unknown>;
+          body.cache_key ??= cacheKey;
+          body.session_id ??= cacheKey;
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -82,6 +82,7 @@ import {
   sanitizeToolsForGoogle,
 } from "../google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
+import { createLlamaCppCacheKeyWrapper } from "../llamacpp-cache-key.js";
 import { log } from "../logger.js";
 import { buildModelAliasLines } from "../model.js";
 import {
@@ -646,6 +647,15 @@ export async function runEmbeddedAttempt(
         params.modelId,
         params.streamParams,
       );
+      const llamaCppCacheKeyStreamFn = createLlamaCppCacheKeyWrapper({
+        baseStreamFn: activeSession.agent.streamFn,
+        provider: params.provider,
+        sessionKey: params.sessionKey,
+        sessionId: activeSession.sessionId,
+      });
+      if (llamaCppCacheKeyStreamFn) {
+        activeSession.agent.streamFn = llamaCppCacheKeyStreamFn;
+      }
 
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {


### PR DESCRIPTION
## Summary

Adds a narrow OpenClaw wrapper for the `llama-cpp-turboquant` provider that injects stable `cache_key` and `session_id` values into OpenAI-compatible request payloads. The key is derived from the OpenClaw session key when available, falling back to the Pi session ID.

This lets llama.cpp's keyed slot scheduler reuse the correct local model slot across turns instead of relying on incidental LCP selection.

## Details

- Enables keyed request payloads only for the `llama-cpp-turboquant` provider.
- Preserves explicit `cache_key` and `session_id` values if another caller already set them.
- Keeps other OpenAI-compatible providers untouched.
- Wraps after existing extraParams are applied, before cache trace / payload logging wrappers observe the payload.

## Validation

- `pnpm test src/agents/pi-embedded-runner/llamacpp-cache-key.test.ts`
- `pnpm tsgo --noEmit`

## Real behavior proof

- **Behavior or issue addressed:** OpenClaw local llama.cpp sessions should send stable keyed request payloads so the local server can reuse the correct session slot on follow-up turns.
- **Real environment tested:** macOS local OpenClaw source tree at `/Users/ben/dev/openclaw`, isolated local OpenClaw config, provider id `llama-cpp-turboquant`, model `qwen3.6-35b-a3b-turboquant`, and local llama.cpp TurboQuant PR #157 server on `127.0.0.1:8080`.
- **Exact steps or command run after this patch:** Ran a real OpenClaw local replay with the patched source against the local llama.cpp server: first a cold `turboquant-test` agent turn, then a warm same-session turn using the same OpenClaw session.
- **Evidence after fix:** Copied live terminal/runtime output from the local replay:

```text
cold OpenClaw turn:
reply: READY
wall: 26.027 s
usage: input 12022, output 2, total 12024
server selection: selected slot by LRU
server prefill: 12022 prompt tokens, 661.89 tok/s

warm same-session turn:
reply: READY
wall: 1.115 s
usage: input 20, cacheRead 12018, output 2, total 12040
server selection: selected slot by cache_key, sim 0.998, common 12018
server incremental prompt eval: 20 tokens, 70.84 tok/s
```

- **Observed result after fix:** The warm same-session OpenClaw request included the keyed payload, llama.cpp selected the slot by `cache_key`, OpenClaw reported `cacheRead=12018`, and wall time dropped from `26.027s` cold to `1.115s` warm.
- **What was not tested:** No hosted cloud provider behavior was tested because the wrapper is intentionally limited to provider id `llama-cpp-turboquant`; multi-user production traffic was not tested in this PR.

## Notes

This pairs with the llama.cpp TurboQuant server-side cache-key scheduling PR: https://github.com/TheTom/llama-cpp-turboquant/pull/157
