### PR TITLE
fix(agents): keep before_prompt_build hook prependContext in user prompt on empty transcript (#87163)

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -417,6 +417,7 @@ import {
   buildCurrentInboundPrompt,
   buildRuntimeContextCustomMessage,
   type RuntimeContextCustomMessage,
+  resolveAttemptEmptyTranscriptMode,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
@@ -4003,9 +4004,10 @@ export async function runEmbeddedAttempt(
           const promptSubmission = resolveRuntimeContextPromptParts({
             effectivePrompt,
             transcriptPrompt: effectiveTranscriptPrompt,
-            emptyTranscriptMode: params.suppressNextUserMessagePersistence
-              ? "model-prompt"
-              : "runtime-event",
+            emptyTranscriptMode: resolveAttemptEmptyTranscriptMode({
+              suppressNextUserMessagePersistence: params.suppressNextUserMessagePersistence,
+              hookPromptBuildResult: hookResult,
+            }),
           });
           const promptForModel = buildCurrentInboundPrompt({
             context: params.currentInboundContext,

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -4,6 +4,7 @@ import {
   buildCurrentInboundPromptContextPrefix,
   buildRuntimeContextCustomMessage,
   buildRuntimeContextSystemContext,
+  resolveAttemptEmptyTranscriptMode,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
 
@@ -140,5 +141,69 @@ describe("runtime context prompt submission", () => {
 
     expect(buildRuntimeEventSystemContext("internal event")).toContain("OpenClaw runtime event.");
     expect(buildRuntimeEventSystemContext("internal event")).toContain("not user-authored");
+  });
+
+  describe("resolveAttemptEmptyTranscriptMode", () => {
+    // The runtime-event mode routes the trigger payload through
+    // `runtimeSystemContext` (the system prompt) because cron/heartbeat triggers
+    // have no user-authored content. When a `before_prompt_build` hook supplies
+    // `prependContext` or `appendContext`, that content is user-prompt by
+    // contract, so the empty-transcript fallback must switch to "model-prompt"
+    // or the hook's text leaks into the system prompt. (#87163)
+    it("returns runtime-event by default", () => {
+      expect(resolveAttemptEmptyTranscriptMode({})).toBe("runtime-event");
+    });
+
+    it("returns model-prompt when next-user persistence is suppressed", () => {
+      expect(resolveAttemptEmptyTranscriptMode({ suppressNextUserMessagePersistence: true })).toBe(
+        "model-prompt",
+      );
+    });
+
+    it("returns model-prompt when a hook supplied prependContext", () => {
+      expect(
+        resolveAttemptEmptyTranscriptMode({
+          hookPromptBuildResult: { prependContext: "user-visible note" },
+        }),
+      ).toBe("model-prompt");
+    });
+
+    it("returns model-prompt when a hook supplied appendContext", () => {
+      expect(
+        resolveAttemptEmptyTranscriptMode({
+          hookPromptBuildResult: { appendContext: "user-visible note" },
+        }),
+      ).toBe("model-prompt");
+    });
+
+    it("returns runtime-event when only system-prompt hook fields are present", () => {
+      expect(
+        resolveAttemptEmptyTranscriptMode({
+          hookPromptBuildResult: { prependContext: "", appendContext: "" },
+        }),
+      ).toBe("runtime-event");
+    });
+
+    it("chained with resolveRuntimeContextPromptParts: hook prependContext lands in user prompt on empty transcript (#87163)", () => {
+      // Heartbeat/cron-style trigger where params.prompt is empty. After the
+      // `before_prompt_build` hook runs, effectivePrompt contains the hook's
+      // prependContext. The transcript-prompt is empty (no user-authored
+      // message). Without the fix this hits the runtimeOnly branch and the
+      // hook contribution ends up in `runtimeSystemContext` (system prompt).
+      const hookResult = { prependContext: "Plugin context for THIS turn." };
+      const effectivePrompt = `${hookResult.prependContext}\n\n`;
+
+      const parts = resolveRuntimeContextPromptParts({
+        effectivePrompt,
+        transcriptPrompt: "",
+        emptyTranscriptMode: resolveAttemptEmptyTranscriptMode({
+          hookPromptBuildResult: hookResult,
+        }),
+      });
+
+      expect(parts.runtimeOnly).toBeUndefined();
+      expect(parts.runtimeSystemContext).toBeUndefined();
+      expect(parts.prompt).toContain("Plugin context for THIS turn.");
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -27,6 +27,33 @@ export type RuntimeContextCustomMessage = {
 
 type EmptyTranscriptMode = "model-prompt" | "runtime-event";
 
+/**
+ * Decide which empty-transcript fallback mode to use when calling
+ * `resolveRuntimeContextPromptParts`. When the request explicitly suppresses
+ * next-user-message persistence, or when a `before_prompt_build` hook has
+ * contributed visible user-prompt content via `prependContext` / `appendContext`,
+ * the prompt is no longer purely runtime-generated and must be submitted as a
+ * model prompt so the hook's contract holds: those fields land in the user
+ * prompt, not in `runtimeSystemContext` (the system prompt). (#87163)
+ */
+export function resolveAttemptEmptyTranscriptMode(params: {
+  suppressNextUserMessagePersistence?: boolean;
+  hookPromptBuildResult?: {
+    prependContext?: string;
+    appendContext?: string;
+  };
+}): EmptyTranscriptMode {
+  if (params.suppressNextUserMessagePersistence) {
+    return "model-prompt";
+  }
+  const prepend = params.hookPromptBuildResult?.prependContext;
+  const append = params.hookPromptBuildResult?.appendContext;
+  if ((prepend && prepend.length > 0) || (append && append.length > 0)) {
+    return "model-prompt";
+  }
+  return "runtime-event";
+}
+
 export function buildCurrentInboundPromptContextPrefix(
   context: CurrentInboundPromptContext | undefined,
 ): string {


### PR DESCRIPTION
## Summary

- **Problem.** A `before_prompt_build` hook that returns `prependContext` (or `appendContext`) lands the text on the **system prompt** instead of the **user prompt** on turns with an empty transcript (heartbeat, cron, and other runtime-driven triggers). This violates the documented contract for these fields and breaks plugins that rely on per-turn user-prompt injection. Reported as a 2026.4.12 → 2026.5.19 regression (#87163).
- **Root cause.** `attempt.ts` folds `hookResult.prependContext` / `hookResult.appendContext` into `effectivePrompt` before calling `resolveRuntimeContextPromptParts`. When `transcriptPrompt` is empty, that function's `"runtime-event"` mode treats the whole of `effectivePrompt` as runtime-generated, wraps it with `buildRuntimeEventSystemContext(...)`, and returns it via `runtimeSystemContext` (system prompt) plus a synthetic `"Continue the OpenClaw runtime event."` user prompt. The hook's user-prompt contribution rides along into the system slot.
- **Fix.** Introduce `resolveAttemptEmptyTranscriptMode` next to `resolveRuntimeContextPromptParts`. The helper returns `"model-prompt"` when either (a) `suppressNextUserMessagePersistence` is already set (existing behavior), or (b) the `before_prompt_build` hook contributed non-empty `prependContext` / `appendContext`. The embedded-runner call site now uses the helper, so on empty-transcript turns where a hook added user-prompt content, `resolveRuntimeContextPromptParts` returns `{ prompt: effectivePrompt }` and the hook's text stays where the contract puts it.
- **What did not change (scope boundary).** No change to `resolveRuntimeContextPromptParts` itself, the runtime-only/system-context labelling for true cron/heartbeat events without a hook contribution, the `prependSystemContext` / `appendSystemContext` path, the CLI runner (`src/agents/cli-runner/prepare.ts` already prepends directly to `preparedPrompt` and is unaffected), or any plugin-SDK type definitions. The change is one new exported helper plus the call-site swap.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #87163
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: `PluginHookBeforePromptBuildResult.prependContext` (and `appendContext`) returned from a `before_prompt_build` hook now stays in the user prompt on empty-transcript turns. It no longer gets folded into `runtimeSystemContext` and emitted as system-prompt content.
- Real environment tested: Local OpenClaw source checkout on macOS (Apple Silicon, Node v22.14, corepack pnpm 11.2.2). Verified by Vitest unit + integration tests against the helper and its caller pattern. No full LaunchAgent/Docker run; the fix is mechanical at a narrow boundary that the helper covers.
- Exact steps or command run after this patch:
  - `pnpm test src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts` — covers the new helper, the chained "hook prependContext lands in user prompt on empty transcript" integration case, and the existing runtime-event/marker-prompt suite.
  - `pnpm test src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts` — adjacent helper tests to confirm no caller-side regression.
  - `pnpm format:check <touched files>`, `pnpm lint <touched files>`, `pnpm tsgo:core`, `pnpm tsgo:core:test` — format/lint/typecheck on changed files.
- Evidence after fix:
  - New helper coverage (`src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts`):
    - `returns runtime-event by default` (pre-existing behavior preserved when no hook contribution)
    - `returns model-prompt when next-user persistence is suppressed` (existing branch preserved)
    - `returns model-prompt when a hook supplied prependContext`
    - `returns model-prompt when a hook supplied appendContext`
    - `returns runtime-event when only system-prompt hook fields are present` (no false trigger from `prependSystemContext` / `appendSystemContext`)
    - `chained with resolveRuntimeContextPromptParts: hook prependContext lands in user prompt on empty transcript (#87163)` — drives the helper plus `resolveRuntimeContextPromptParts` together and asserts `runtimeOnly` and `runtimeSystemContext` are unset and the hook text appears in `parts.prompt`.
  - Test run summary after fix:
    ```
    Test Files  1 passed (1)
    Tests       17 passed (17)   # runtime-context-prompt.test.ts (was 11; +6 new)
    Test Files  1 passed (1)
    Tests       12 passed (12)   # attempt.prompt-helpers.test.ts (no change)
    ```
  - Format / lint / typecheck on changed files: all clean.
- Observed result after fix: For the reporter's repro shape — `before_prompt_build` hook that sets `resp.prependContext = "user prompt"` on a turn whose transcript prompt is empty — the resulting `llm_input` event would now show that text in the user prompt and not on the system prompt. The pre-existing "runtime-event labels runtime-only events as system context" test continues to document the still-correct cron/heartbeat-only path.
- What was not tested: A full live LaunchAgent or Docker round-trip with a real `before_prompt_build` plugin and a heartbeat trigger. The proof here is at the helper + composition boundary, which is the exact decision the caller in `src/agents/embedded-agent-runner/run/attempt.ts:4006` makes for `emptyTranscriptMode`. The CLI runner path is not affected by this change because it already routes `hookResult.prependContext` directly into `preparedPrompt` without going through `resolveRuntimeContextPromptParts`.
