### PR TITLE
fix(codex): backport shared app-server startup cleanup to .27

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -12546,7 +12546,7 @@ describe("runCodexAppServerAttempt", () => {
     clearSpy.mockRestore();
   });
 
-  it("retires the shared Codex client when a spawned helper hits a thread/start write failure", async () => {
+  it("retires the shared Codex client when a spawned helper hits a thread/start connection close", async () => {
     const clearSpy = vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent");
     clearSpy.mockClear();
     let failedClient: unknown;
@@ -12554,7 +12554,7 @@ describe("runCodexAppServerAttempt", () => {
       const c = {
         request: vi.fn(async (method: string) => {
           if (method === "thread/start") {
-            throw new Error("write EPIPE");
+            throw new Error("codex app-server client is closed");
           }
           return {};
         }),
@@ -12570,13 +12570,15 @@ describe("runCodexAppServerAttempt", () => {
     );
     params.spawnedBy = "agent:main:session-parent";
 
-    await expect(runCodexAppServerAttempt(params)).rejects.toThrow("write EPIPE");
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow(
+      "codex app-server client is closed",
+    );
     const calledWithFailedClient = clearSpy.mock.calls.some(([arg]) => arg === failedClient);
     expect(calledWithFailedClient).toBe(true);
     clearSpy.mockRestore();
   });
 
-  it("retires the shared Codex client when a top-level run fails with a logical thread/start error", async () => {
+  it("does not retire the shared Codex client when a top-level run fails with a logical thread/start error", async () => {
     const clearSpy = vi.spyOn(sharedClientModule, "clearSharedCodexAppServerClientIfCurrent");
     clearSpy.mockClear();
     let failedClient: unknown;
@@ -12604,7 +12606,7 @@ describe("runCodexAppServerAttempt", () => {
 
     await expect(runCodexAppServerAttempt(params)).rejects.toThrow("Invalid bearer token");
     const calledWithFailedClient = clearSpy.mock.calls.some(([arg]) => arg === failedClient);
-    expect(calledWithFailedClient).toBe(true);
+    expect(calledWithFailedClient).toBe(false);
     clearSpy.mockRestore();
   });
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -189,7 +189,6 @@ import {
   buildTurnStartParams,
   codexDynamicToolsFingerprint,
   isContextEngineBindingCompatible,
-  isCodexThreadStartRequestError,
   startOrResumeThread,
   type CodexAppServerThreadLifecycleBinding,
   type CodexContextEngineThreadBootstrapProjection,
@@ -1851,9 +1850,7 @@ export async function runCodexAppServerAttempt(
   } catch (error) {
     nativeHookRelay?.unregister();
     await releaseSandboxExecEnvironment();
-    const preserveSpawnedThreadStartFailureClient =
-      Boolean(params.spawnedBy?.trim()) && isCodexThreadStartRequestError(error);
-    if (!preserveSpawnedThreadStartFailureClient) {
+    if (runAbortController.signal.aborted || shouldClearSharedClientAfterStartupRace(error)) {
       clearSharedCodexAppServerClientIfCurrent(startupClientForCleanup);
     }
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
@@ -6561,6 +6558,15 @@ function waitForCodexNotificationDispatchTurn(): Promise<void> {
   return new Promise((resolve) => {
     setImmediate(resolve);
   });
+}
+
+function shouldClearSharedClientAfterStartupRace(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === "codex app-server startup timed out" ||
+      error.message === "codex app-server startup aborted" ||
+      error.message.endsWith(" timed out"))
+  );
 }
 
 function handleApprovalRequest(params: {

--- a/extensions/telegram/src/inline-buttons.test.ts
+++ b/extensions/telegram/src/inline-buttons.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
 import { buildTelegramInteractiveButtons } from "./button-types.js";
 import { describeTelegramInteractiveButtonBehavior } from "./button-types.test-helpers.js";

--- a/scripts/generate-npm-shrinkwrap.mjs
+++ b/scripts/generate-npm-shrinkwrap.mjs
@@ -305,9 +305,58 @@ function mergeOverrideEntry(merged, name, spec) {
     }
     return;
   }
+  if (
+    typeof current === "string" &&
+    isPlainObject(spec) &&
+    typeof spec["."] === "string" &&
+    exactOverrideVersionsMatch(current, spec["."])
+  ) {
+    merged[name] = { ".": preferredExactOverrideRootSpec(current, spec["."]) };
+    for (const [nestedName, nestedSpec] of Object.entries(spec)) {
+      if (nestedName === ".") {
+        continue;
+      }
+      mergeOverrideEntry(merged[name], nestedName, nestedSpec);
+    }
+    return;
+  }
+  if (
+    isPlainObject(current) &&
+    typeof spec === "string" &&
+    typeof current["."] === "string" &&
+    exactOverrideVersionsMatch(current["."], spec)
+  ) {
+    current["."] = preferredExactOverrideRootSpec(current["."], spec);
+    return;
+  }
   if (JSON.stringify(current) !== JSON.stringify(spec)) {
     throw new Error(`package.json overrides.${name} conflicts with pnpm lock policy for ${name}`);
   }
+}
+
+function preferredExactOverrideRootSpec(current, incoming) {
+  return incoming.startsWith("npm:") ? incoming : current;
+}
+
+function exactOverrideVersionsMatch(left, right) {
+  const leftVersion = exactVersionFromOverrideSpec(left);
+  if (leftVersion === null || leftVersion !== exactVersionFromOverrideSpec(right)) {
+    return false;
+  }
+  const leftAlias = parseNpmAliasOverrideSpec(left);
+  const rightAlias = parseNpmAliasOverrideSpec(right);
+  return !leftAlias || !rightAlias || leftAlias.name === rightAlias.name;
+}
+
+function parseNpmAliasOverrideSpec(spec) {
+  if (!spec.startsWith("npm:")) {
+    return null;
+  }
+  const versionIndex = spec.lastIndexOf("@");
+  if (versionIndex <= "npm:".length) {
+    return null;
+  }
+  return { name: spec.slice("npm:".length, versionIndex) };
 }
 
 function mergeOverrides(packageOverrides, workspaceOverrides, pnpmLockOverrides) {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { clearLoadInstalledPluginIndexInstallRecordsCache } from "../plugins/installed-plugin-index-records.js";
 import { validateConfigObjectWithPlugins } from "./validation.js";
 
 vi.unmock("../version.js");
@@ -833,6 +834,7 @@ describe("config plugin validation", () => {
   it("uses persisted installed-plugin records as stale channel evidence", async () => {
     const installedPluginIndexPath = path.join(suiteHome, ".openclaw", "plugins", "installs.json");
     await mkdirSafe(path.dirname(installedPluginIndexPath));
+    clearLoadInstalledPluginIndexInstallRecordsCache();
     await fs.writeFile(
       installedPluginIndexPath,
       JSON.stringify(
@@ -870,6 +872,7 @@ describe("config plugin validation", () => {
       });
     } finally {
       await fs.rm(installedPluginIndexPath, { force: true });
+      clearLoadInstalledPluginIndexInstallRecordsCache();
     }
   });
 


### PR DESCRIPTION
Summary:
- Backport #87399 to release/2026.5.27.
- Preserve the single shared Codex app-server after logical thread/start startup errors in the older run-attempt startup path.
- Keep cleanup for abandoned startup races: abort, startup timeout, and per-RPC startup timeout.
- Keep the installed-plugin ledger cache fixture isolated for the release branch config test.

Behavior addressed: Codex helper/auth app-level startup failures no longer tear down the shared parent Codex app-server on the .27 release branch.
Real environment tested: Testbox through Crabbox, provider=blacksmith-testbox, id=tbx_01ksnprx3pgh6d3a9fqcf6nnkb.
Exact steps or command run after this patch: corepack pnpm install --frozen-lockfile && node scripts/run-vitest.mjs run extensions/codex/src/app-server/run-attempt.test.ts -t 'shared Codex client|thread/start connection close|logical thread/start error' && node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/config.plugin-validation.test.ts
Evidence after fix: Codex run-attempt focused tests passed: 1 file, 4 tests. Config plugin validation passed: 1 file, 37 tests. Autoreview clean: no accepted/actionable findings.
Observed result after fix: Logical thread/start errors preserve the shared client; connection-close and timeout startup paths still retire abandoned clients.
What was not tested: Live Codex auth failure against a real operator account; coverage uses mocked app-server startup plus CI-parity Testbox runtime.

Backport of #87399 / commit 7f7eca1ad2baee222206d767d16b6f1bf86ea594.
