### PR TITLE
Classify read-only Codex command failures

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1508,6 +1508,86 @@ describe("CodexAppServerEventProjector", () => {
     });
   });
 
+  it("marks read-only diagnostic command errors as non-mutating", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-readonly-failure",
+          command: `/bin/zsh -lc "jq '.agents | keys' ~/.openclaw/openclaw.json"`,
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "failed",
+          commandActions: [],
+          aggregatedOutput: "jq: error: null has no keys",
+          exitCode: 5,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toEqual({
+      toolName: "bash",
+      meta: "jq '.agents | keys' ~/.openclaw/openclaw.json (workspace)",
+      error: "jq: error: null has no keys",
+      mutatingAction: false,
+    });
+  });
+
+  it("does not let later read-only diagnostic failures clobber unresolved mutating errors", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-write-failure",
+          command: "pnpm install",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "failed",
+          commandActions: [],
+          aggregatedOutput: "install failed",
+          exitCode: 1,
+          durationMs: 42,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-readonly-failure",
+          command: "jq '.agents | keys' ~/.openclaw/openclaw.json",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "failed",
+          commandActions: [],
+          aggregatedOutput: "jq: error: null has no keys",
+          exitCode: 5,
+          durationMs: 42,
+        },
+      }),
+    );
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toEqual({
+      toolName: "bash",
+      meta: "install dependencies (workspace)",
+      error: "install failed",
+      mutatingAction: true,
+      actionFingerprint: JSON.stringify({
+        type: "commandExecution",
+        command: "pnpm install",
+        cwd: "/workspace",
+      }),
+    });
+  });
+
   it("does not duplicate native tool starts when the snapshot completes a started item", async () => {
     const onAgentEvent = vi.fn();
     const trajectoryRecorder = {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -22,6 +22,7 @@ import {
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import type { AssistantMessage, Usage } from "openclaw/plugin-sdk/llm";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
+import { classifyNativeCommandSideEffect } from "./native-command-side-effects.js";
 import {
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
@@ -980,13 +981,23 @@ export class CodexAppServerEventProjector {
       }
       return;
     }
+    const isMutatingAction = isMutatingNativeToolItem(params.item);
+    if (!isMutatingAction && this.lastNativeToolError?.mutatingAction) {
+      return;
+    }
     const error = itemToolError(params.item, params.status, this.toolResultOutputTextByItem);
-    const actionFingerprint = nativeToolActionFingerprint(params.item);
+    const actionFingerprint = isMutatingAction
+      ? nativeToolActionFingerprint(params.item)
+      : undefined;
     this.lastNativeToolError = {
       toolName: params.name,
       ...(params.meta ? { meta: params.meta } : {}),
       ...(error ? { error } : {}),
-      ...(isMutatingNativeToolItem(params.item) ? { mutatingAction: true } : {}),
+      ...(params.item.type === "commandExecution"
+        ? { mutatingAction: isMutatingAction }
+        : isMutatingAction
+          ? { mutatingAction: true }
+          : {}),
       ...(actionFingerprint ? { actionFingerprint } : {}),
     };
   }
@@ -1809,7 +1820,13 @@ function shouldRecordNativeToolTranscript(item: CodexThreadItem): boolean {
 }
 
 function isMutatingNativeToolItem(item: CodexThreadItem): boolean {
-  return item.type === "commandExecution" || item.type === "fileChange";
+  if (item.type === "fileChange") {
+    return true;
+  }
+  if (item.type === "commandExecution") {
+    return classifyNativeCommandSideEffect(item.command ?? "") !== "readOnlyDiagnostic";
+  }
+  return false;
 }
 
 function nativeToolActionFingerprint(item: CodexThreadItem): string | undefined {

--- a/extensions/codex/src/app-server/native-command-side-effects.test.ts
+++ b/extensions/codex/src/app-server/native-command-side-effects.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { classifyNativeCommandSideEffect } from "./native-command-side-effects.js";
+
+describe("classifyNativeCommandSideEffect", () => {
+  it.each([
+    "jq '.agents | keys' ~/.openclaw/openclaw.json",
+    `/bin/zsh -lc "jq '.agents | keys' ~/.openclaw/openclaw.json"`,
+    'rg -n "lastToolError" src',
+    "ls ~/.openclaw/skills",
+    "find src -name '*.ts'",
+    "sed -n '1,80p' src/file.ts",
+    "git status --short",
+    "git -C /repo diff -- src/file.ts",
+    "git branch --show-current",
+  ])("classifies read-only diagnostic command as non-mutating: %s", (command) => {
+    expect(classifyNativeCommandSideEffect(command)).toBe("readOnlyDiagnostic");
+  });
+
+  it.each([
+    "jq . file.json > out.json",
+    "tee file.txt",
+    "find . -delete",
+    "find . -exec rm {} \\;",
+    "sed -i '' 's/a/b/' file.txt",
+    "rm -rf dist",
+    "mv a b",
+    "touch file.txt",
+    "git checkout -- file.txt",
+    "git reset --hard",
+    "pnpm install",
+    "node -e \"require('fs').writeFileSync('x', 'y')\"",
+    "curl -X POST https://example.test",
+  ])("defaults mutating or ambiguous command to warning-relevant: %s", (command) => {
+    expect(classifyNativeCommandSideEffect(command)).toBe("mutatingOrUnknown");
+  });
+});

--- a/extensions/codex/src/app-server/native-command-side-effects.ts
+++ b/extensions/codex/src/app-server/native-command-side-effects.ts
@@ -1,0 +1,148 @@
+export type NativeCommandSideEffect = "readOnlyDiagnostic" | "mutatingOrUnknown";
+
+const READ_ONLY_COMMANDS = new Set([
+  "cat",
+  "date",
+  "file",
+  "grep",
+  "head",
+  "jq",
+  "ls",
+  "pwd",
+  "rg",
+  "stat",
+  "tail",
+  "wc",
+]);
+
+const READ_ONLY_GIT_COMMANDS = new Set([
+  "diff",
+  "grep",
+  "log",
+  "ls-files",
+  "rev-parse",
+  "show",
+  "status",
+]);
+
+const SHELL_WRAPPER_PATTERN =
+  /^(?:(?:\/usr\/bin\/env\s+)?(?:\/[^\s]+\/)?(?:bash|zsh|sh))\s+-lc\s+(.+)$/u;
+const REDIRECTION_PATTERN = /(^|[^<>])(?:>>?|<>)($|\s|\S)/u;
+const MUTATING_TOKEN_PATTERN =
+  /(^|[\s|;&()])(?:apply_patch|chmod|chown|cp|install|kill|mkdir|mv|rm|rmdir|rsync|tee|touch|truncate|unlink)(?=$|[\s|;&()])/u;
+const PACKAGE_MUTATION_PATTERN =
+  /(^|[\s|;&()])(?:npm|pnpm|yarn)\s+(?:add|i|install|remove|uninstall|update)(?=$|[\s|;&()])/u;
+const GIT_MUTATION_PATTERN =
+  /(^|[\s|;&()])git(?:\s+-C\s+\S+)?\s+(?:add|am|apply|checkout|clean|commit|merge|mv|push|rebase|reset|restore|rm|switch|tag)(?=$|[\s|;&()])/u;
+const CURL_MUTATION_PATTERN = /(^|[\s|;&()])curl\b[^\n]*(?:\s-X\s*(?:POST|PUT|PATCH|DELETE)\b)/iu;
+
+function stripWrappingQuotes(value: string): string {
+  if (value.length < 2) {
+    return value;
+  }
+  const first = value[0];
+  const last = value[value.length - 1];
+  if ((first === `"` && last === `"`) || (first === "'" && last === "'")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function unwrapShellCommand(command: string): string {
+  let current = command.trim();
+  for (let index = 0; index < 2; index += 1) {
+    const match = SHELL_WRAPPER_PATTERN.exec(current);
+    if (!match?.[1]) {
+      return current;
+    }
+    current = stripWrappingQuotes(match[1].trim());
+  }
+  return current;
+}
+
+function hasShellControlChain(command: string): boolean {
+  return /(?:^|[^|])(?:&&|\|\||;)(?:[^|]|$)/u.test(command);
+}
+
+function firstCommandToken(command: string): string | undefined {
+  const firstSegment = command.split("|", 1)[0]?.trim();
+  if (!firstSegment) {
+    return undefined;
+  }
+  const firstToken = firstSegment.split(/\s+/u)[0]?.trim();
+  if (!firstToken) {
+    return undefined;
+  }
+  return firstToken.replace(/^.*\//u, "");
+}
+
+function gitSubcommand(command: string): string | undefined {
+  const tokens = command.split(/\s+/u).filter(Boolean);
+  if (tokens[0]?.replace(/^.*\//u, "") !== "git") {
+    return undefined;
+  }
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "-C" || token === "-c") {
+      index += 1;
+      continue;
+    }
+    if (token?.startsWith("-")) {
+      continue;
+    }
+    return token;
+  }
+  return undefined;
+}
+
+function isReadOnlyFind(command: string): boolean {
+  return !/(^|\s)-(?:delete|exec|execdir)\b/u.test(command);
+}
+
+function isReadOnlySed(command: string): boolean {
+  return !/(^|\s)-[A-Za-z]*i[A-Za-z]*(?:\s|$)/u.test(command);
+}
+
+function isReadOnlyGit(command: string): boolean {
+  const subcommand = gitSubcommand(command);
+  if (!subcommand) {
+    return false;
+  }
+  if (subcommand === "branch") {
+    return /\s--(?:list|show-current)(?:\s|$)/u.test(command);
+  }
+  return READ_ONLY_GIT_COMMANDS.has(subcommand);
+}
+
+export function classifyNativeCommandSideEffect(command: string): NativeCommandSideEffect {
+  const unwrapped = unwrapShellCommand(command).trim();
+  if (!unwrapped) {
+    return "mutatingOrUnknown";
+  }
+  if (
+    REDIRECTION_PATTERN.test(unwrapped) ||
+    MUTATING_TOKEN_PATTERN.test(unwrapped) ||
+    PACKAGE_MUTATION_PATTERN.test(unwrapped) ||
+    GIT_MUTATION_PATTERN.test(unwrapped) ||
+    CURL_MUTATION_PATTERN.test(unwrapped)
+  ) {
+    return "mutatingOrUnknown";
+  }
+  if (hasShellControlChain(unwrapped)) {
+    return "mutatingOrUnknown";
+  }
+  const commandName = firstCommandToken(unwrapped);
+  if (!commandName) {
+    return "mutatingOrUnknown";
+  }
+  if (commandName === "find") {
+    return isReadOnlyFind(unwrapped) ? "readOnlyDiagnostic" : "mutatingOrUnknown";
+  }
+  if (commandName === "sed") {
+    return isReadOnlySed(unwrapped) ? "readOnlyDiagnostic" : "mutatingOrUnknown";
+  }
+  if (commandName === "git") {
+    return isReadOnlyGit(unwrapped) ? "readOnlyDiagnostic" : "mutatingOrUnknown";
+  }
+  return READ_ONLY_COMMANDS.has(commandName) ? "readOnlyDiagnostic" : "mutatingOrUnknown";
+}

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -614,6 +614,22 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadSummary(payloads, { text });
   });
 
+  it("suppresses recovered read-only native command failures when explicitly flagged non-mutating", () => {
+    const text = "Config loaded.";
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "bash",
+        meta: "jq '.agents | keys' ~/.openclaw/openclaw.json",
+        error: "jq: error: null has no keys",
+        mutatingAction: false,
+      },
+    });
+
+    expectSinglePayloadSummary(payloads, { text });
+  });
+
   it("does not treat session_status read failures as mutating when explicitly flagged", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Status loaded."],


### PR DESCRIPTION
## Summary

- classify Codex-native command executions with a conservative read-only vs mutating/unknown side-effect heuristic
- stop recovered read-only diagnostic command failures from surfacing as misleading final tool-warning payloads
- preserve warnings for file changes, unknown commands, mutating shell commands, and earlier unresolved mutating failures

## Why

Telegram users were seeing final warnings like `⚠️ 🛠️ jq ... failed` after otherwise successful answers. The RCA showed these warnings came from final payload assembly using `lastToolError`, while the Codex app-server projected every failed `commandExecution` as mutating. That made harmless read-only diagnostic failures warning-relevant even after the agent recovered.

## Verification

- `node scripts/test-projects.mjs extensions/codex/src/app-server/native-command-side-effects.test.ts extensions/codex/src/app-server/event-projector.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/native-command-side-effects.test.ts extensions/codex/src/app-server/event-projector.test.ts`
- `pnpm exec oxfmt --check extensions/codex/src/app-server/native-command-side-effects.ts extensions/codex/src/app-server/native-command-side-effects.test.ts extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts`
- `git diff --check origin/main..HEAD`

## Known unrelated check gap

`pnpm tsgo:extensions:test` still fails on current `origin/main` with:

`extensions/codex/src/app-server/attempt-startup.test.ts(59,39): error TS2741: Property 'effectiveCwd' is missing ...`

That typecheck failure is pre-existing relative to this PR branch and not introduced by this change.
