### PR TITLE
fix(agents): fall back to raw command when most exec stages are generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/tool display: fall back to the compact raw command when a multi-stage shell script is mostly unrecognized "run X" stages, instead of paraphrasing shell keywords (`then`, `fi`, `[`, `jq`, …) into a misleading step list. Prevents garbled cron-delivery summaries like `create folder X → run then set → run [ → run jq → run fi (agent) failed` from landing in Discord/etc. (#87426)
 - Security/CLI/runtime: harden hostname normalization for repeated trailing dots, block side-effecting command wrappers, reject unsafe Node runtime env overrides, reject loose numeric CLI and gateway options, require admin approval for node device-role pairing, and reject no-auth Tailscale exposure. (#87305, #87292, #87308, #87146) Thanks @pgondhi987.
 - Telegram: route `sendMessage` action replies through durable outbound delivery so completed agent responses remain retryable when the gateway send path times out. (#87261) Thanks @mbelinky.
 - Matrix/auto-reply: keep draft previews mention-inert, preserve final mention delivery, send mention finals normally, await shared DM notices, ignore filename-embedded MXIDs, and suppress reasoning-prefixed `NO_REPLY` responses.

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -295,6 +295,7 @@ type ExecSummary = {
   text: string;
   chdirPath?: string;
   allGeneric?: boolean;
+  mostlyGeneric?: boolean;
 };
 
 function normalizePathForDisplay(path: string): string {
@@ -361,9 +362,15 @@ function summarizeExecCommand(command: string): ExecSummary | undefined {
 
   const summaries = stages.map((stage) => summarizePipeline(stage));
   const text = summaries.length === 1 ? summaries[0] : summaries.join(" → ");
-  const allGeneric = summaries.every((summary) => isGenericSummary(summary));
+  const genericCount = summaries.filter((summary) => isGenericSummary(summary)).length;
+  const allGeneric = genericCount === summaries.length;
+  // If a multi-stage script is mostly unrecognized "run X" steps, the joined
+  // paraphrase reads as gibberish (e.g. `create folder X → run then set →
+  // run [ → run jq → run fi`). Prefer the compact raw command in that case.
+  const mostlyGeneric =
+    !allGeneric && summaries.length >= 3 && genericCount * 2 >= summaries.length;
 
-  return { text, chdirPath, allGeneric };
+  return { text, chdirPath, allGeneric, mostlyGeneric };
 }
 
 const KNOWN_SUMMARY_PREFIXES = [
@@ -466,7 +473,10 @@ export function resolveExecDetail(
 
   const compact = compactRawCommand(unwrapped);
   const cwdSuffix = cwd ? formatCwdSuffix(cwd) : undefined;
-  if (result?.allGeneric !== false && isGenericSummary(summary)) {
+  if (
+    result?.mostlyGeneric === true ||
+    (result?.allGeneric !== false && isGenericSummary(summary))
+  ) {
     return cwdSuffix ? `${compact} ${cwdSuffix}` : compact;
   }
 

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -357,6 +357,38 @@ describe("tool display details", () => {
     expect(detail).toMatch(/^run cargo build → run tests/);
   });
 
+  it("falls back to raw command when most stages of a multi-stage script are generic", () => {
+    // Simulates the multi-line shell scripts that produced garbled cron
+    // notifications (e.g. `create folder X → run then set → run [ → run jq →
+    // run fi`): the first stage paraphrases cleanly but later stages are just
+    // shell keywords. Prefer the compact raw command in that case.
+    const command =
+      "mkdir -p /tmp/x && set -u && if [ -f /tmp/x/y ]; then jq empty /tmp/x/y && true; fi && cat /tmp/x/y";
+    const detail = formatToolDetail(resolveToolDisplay({ name: "exec", args: { command } }));
+
+    // The detail should not be the gibberish stage list — instead the compact
+    // raw command (possibly with a recognized leading summary as context).
+    expect(detail).not.toMatch(/run then/);
+    expect(detail).not.toMatch(/run \[/);
+    expect(detail).not.toMatch(/run fi/);
+    expect(detail).toContain("mkdir -p /tmp/x");
+  });
+
+  it("keeps the paraphrase for short multi-stage commands with one generic stage", () => {
+    // Regression guard: a 3-stage command where only one stage is generic
+    // should still get the joined paraphrase, not the raw command fallback.
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "git fetch && cargo build && npm test" },
+      }),
+    );
+
+    // 1/3 generic — below the mostly-generic threshold — keep joined summary.
+    expect(detail).toMatch(/fetch git/);
+    expect(detail).toMatch(/run tests/);
+  });
+
   it("handles standalone cd as raw command", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({


### PR DESCRIPTION
## Summary

Fixes #87426.

When a multi-stage shell script has a few recognized stages mixed with many unrecognized "run X" stages, the previous joined paraphrase in `resolveExecDetail` reads as gibberish — e.g. a real

```bash
mkdir -p /tmp/x && set -u && if [ -f /tmp/x/y ]; then jq empty /tmp/x/y && true; fi && cat /tmp/x/y
```

rendered as ``create folder /tmp/x → run then set → run [ → run jq → run fi → run cat``. That string is what landed in cron-delivery Discord notifications as ``⚠️ 🛠️ `...` (agent) failed`` when agent turns ended in error without a final assistant message — looking like the agent had gone off the rails when really the underlying issue was upstream (HTTP 5xx, etc.).

This adds a `mostlyGeneric` heuristic in `summarizeExecCommand`: for scripts with **≥3 stages where ≥50% are unrecognized "run X" forms**, prefer the compact raw command in `resolveExecDetail` instead of joining the stages. Short pipelines and commands with only one generic stage out of two keep their existing paraphrased summary.

Before:
> ``⚠️ 🛠️ `create folder ~/.openclaw/workspace/.tmp → run then set → run true set → run [ → run then → run jq → run true) fi → run python3 scripts/birdweather.py → run sed transform (+2 steps) → run true) cat (agent)` failed``

After (typical):
> ``⚠️ 🛠️ `mkdir -p ~/.openclaw/workspace/.tmp && set -u && if [ -f ... ] (agent)` failed``

The compact raw command is still truncated to 120 chars by `compactRawCommand`, so the notification stays readable.

## Test plan

- [x] Added two tests in `src/agents/tool-display.test.ts`:
  - **`falls back to raw command when most stages of a multi-stage script are generic`** — repros the gibberish scenario and asserts the fallback path.
  - **`keeps the paraphrase for short multi-stage commands with one generic stage`** — regression guard so a 3-stage command with one unrecognized stage still gets the paraphrased summary, not the raw fallback.
- [x] Existing `keeps multi-stage summary when only some stages are generic` test continues to pass (2-stage case with one generic stage).
- [x] `pnpm tsgo:core` clean.
- [x] `pnpm tsgo:core:test` clean.
- [x] `pnpm lint:core` clean.
- [x] Full `vitest.agents-core.config.ts` suite: 299 test files passed, 4269 tests passed, 4 skipped.

## Scope

Intentionally narrow: only changes the `summarizeExecCommand` → `resolveExecDetail` decision for multi-stage exec details. The paraphraser itself, `KNOWN_SUMMARY_PREFIXES`, `summarizePipeline`, and `formatToolAggregate` are untouched. The fallback summary text format for cron delivery in `src/agents/embedded-agent-runner/run/payloads.ts` is unchanged — this PR just makes the meta string it consumes more readable when the command is a real script.

---

*PR developed with assistance from Claude (Anthropic) per CONTRIBUTING.md AI-disclosure guidance. Repro evidence (multiple cron-delivery Discord notifications from production), root cause analysis, and fix were authored by [@mogglemoss]; Claude helped with code edits, test scaffolding, and exposition.*