### PR TITLE
fix(web-search): preserve runtime-only provider config

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.merge.test.ts
+++ b/extensions/brave/src/brave-web-search-provider.merge.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { createBraveWebSearchProvider } from "./brave-web-search-provider.js";
+
+const runtimeMock = vi.hoisted(() => {
+  const searchConfigs: Array<Record<string, unknown> | undefined> = [];
+  return {
+    searchConfigs,
+    executeBraveSearch: vi.fn(async (_args: unknown, searchConfig?: Record<string, unknown>) => {
+      searchConfigs.push(searchConfig);
+      return { results: [] };
+    }),
+  };
+});
+
+vi.mock("./brave-web-search-provider.runtime.js", () => ({
+  executeBraveSearch: runtimeMock.executeBraveSearch,
+}));
+
+describe("brave web search config merge", () => {
+  it("keeps plugin webSearch runtime-only after merging it for the tool", async () => {
+    const provider = createBraveWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            brave: {
+              config: {
+                webSearch: {
+                  apiKey: "brave-test-key",
+                  mode: "llm-context",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: { provider: "brave" },
+    });
+
+    await tool?.execute({ query: "OpenClaw docs" });
+
+    const [searchConfig] = runtimeMock.searchConfigs;
+    expect(searchConfig?.brave).toEqual({
+      apiKey: "brave-test-key",
+      mode: "llm-context",
+    });
+    expect(searchConfig?.apiKey).toBe("brave-test-key");
+    expect(Object.keys(searchConfig ?? {})).toEqual(["provider", "apiKey"]);
+    expect(Object.getOwnPropertyDescriptor(searchConfig ?? {}, "brave")?.enumerable).toBe(false);
+  });
+});

--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -1,10 +1,15 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
 import type {
   SearchConfigRecord,
   WebSearchProviderPlugin,
   WebSearchProviderToolDefinition,
 } from "openclaw/plugin-sdk/provider-web-search";
-import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-config-contract";
+import {
+  createWebSearchProviderContractFields,
+  mergeScopedSearchConfig,
+  resolveProviderWebSearchPluginConfig,
+} from "openclaw/plugin-sdk/provider-web-search-config-contract";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const BRAVE_CREDENTIAL_PATH = "plugins.entries.brave.config.webSearch.apiKey";
@@ -62,22 +67,8 @@ const BraveSearchSchema = {
   },
 } satisfies Record<string, unknown>;
 
-function resolveProviderWebSearchPluginConfig(
-  config: unknown,
-  pluginId: string,
-): Record<string, unknown> | undefined {
-  if (!isRecord(config)) {
-    return undefined;
-  }
-  const plugins = isRecord(config.plugins) ? config.plugins : undefined;
-  const entries = isRecord(plugins?.entries) ? plugins.entries : undefined;
-  const entry = isRecord(entries?.[pluginId]) ? entries[pluginId] : undefined;
-  const pluginConfig = isRecord(entry?.config) ? entry.config : undefined;
-  return isRecord(pluginConfig?.webSearch) ? pluginConfig.webSearch : undefined;
-}
-
 function resolveLegacyTopLevelBraveCredential(
-  config: unknown,
+  config: OpenClawConfig | undefined,
 ): { path: string; value: unknown } | undefined {
   if (!isRecord(config)) {
     return undefined;
@@ -91,37 +82,11 @@ function resolveLegacyTopLevelBraveCredential(
   return { path: "tools.web.search.apiKey", value: search.apiKey };
 }
 
-function resolveConfiguredBraveCredential(config: unknown): unknown {
+function resolveConfiguredBraveCredential(config: OpenClawConfig | undefined): unknown {
   return (
     resolveProviderWebSearchPluginConfig(config, "brave")?.apiKey ??
     resolveLegacyTopLevelBraveCredential(config)?.value
   );
-}
-
-function mergeScopedSearchConfig(
-  searchConfig: Record<string, unknown> | undefined,
-  key: string,
-  pluginConfig: Record<string, unknown> | undefined,
-  options?: { mirrorApiKeyToTopLevel?: boolean },
-): Record<string, unknown> | undefined {
-  if (!pluginConfig) {
-    return searchConfig;
-  }
-
-  const currentScoped = isRecord(searchConfig?.[key]) ? searchConfig?.[key] : {};
-  const next: Record<string, unknown> = {
-    ...searchConfig,
-    [key]: {
-      ...currentScoped,
-      ...pluginConfig,
-    },
-  };
-
-  if (options?.mirrorApiKeyToTopLevel && pluginConfig.apiKey !== undefined) {
-    next.apiKey = pluginConfig.apiKey;
-  }
-
-  return next;
 }
 
 function resolveBraveMode(searchConfig?: Record<string, unknown>): "web" | "llm-context" {

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -92,17 +92,25 @@ function withGoogleModelProviderFallbacks(
     return searchConfig;
   }
   const gemini = isRecord(searchConfig?.gemini) ? { ...searchConfig.gemini } : {};
-  const mergedSearchConfig = searchConfig ? { ...searchConfig } : {};
+  const mergedSearchConfig: Record<string, unknown> = searchConfig
+    ? Object.defineProperties({}, Object.getOwnPropertyDescriptors(searchConfig))
+    : {};
+  const geminiDescriptor = searchConfig
+    ? Object.getOwnPropertyDescriptor(searchConfig, "gemini")
+    : undefined;
   if (provider.apiKey !== undefined) {
     gemini.providerApiKey = provider.apiKey;
   }
   if (provider.baseUrl !== undefined) {
     gemini.providerBaseUrl = provider.baseUrl;
   }
-  return {
-    ...mergedSearchConfig,
-    gemini,
-  };
+  Object.defineProperty(mergedSearchConfig, "gemini", {
+    value: gemini,
+    enumerable: geminiDescriptor?.enumerable ?? false,
+    configurable: true,
+    writable: true,
+  });
+  return mergedSearchConfig;
 }
 
 export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
@@ -144,5 +152,6 @@ export const testing = {
   resolveGeminiApiKey,
   resolveGeminiBaseUrl,
   resolveGeminiModel,
+  withGoogleModelProviderFallbacks,
 } as const;
 export { testing as __testing };

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -133,6 +133,34 @@ describe("google web search provider", () => {
     expect(provider.getConfiguredCredentialValue?.(config)).toBe("AIza-plugin-test");
   });
 
+  it("keeps model-provider fallback config runtime-only when Gemini config was injected", () => {
+    const searchConfig = Object.defineProperty({ provider: "gemini" }, "gemini", {
+      value: { apiKey: "AIza-plugin-test" },
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+
+    const merged = testing.withGoogleModelProviderFallbacks(searchConfig, {
+      models: {
+        providers: {
+          google: createGoogleModelProviderConfig({
+            apiKey: "AIza-provider-test",
+            baseUrl: "https://generativelanguage.googleapis.com/proxy/v1beta/",
+          }),
+        },
+      },
+    });
+
+    expect(merged?.gemini).toEqual({
+      apiKey: "AIza-plugin-test",
+      providerApiKey: "AIza-provider-test",
+      providerBaseUrl: "https://generativelanguage.googleapis.com/proxy/v1beta/",
+    });
+    expect(Object.keys(merged ?? {})).toEqual(["provider"]);
+    expect(Object.getOwnPropertyDescriptor(merged, "gemini")?.enumerable).toBe(false);
+  });
+
   it("defaults the Gemini web search model and trims explicit overrides", () => {
     expect(testing.resolveGeminiModel()).toBe("gemini-2.5-flash");
     expect(testing.resolveGeminiModel({ model: "  gemini-2.5-pro  " })).toBe("gemini-2.5-pro");

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -145,6 +145,20 @@ describe("web_search scoped config merge", () => {
     });
   });
 
+  it("keeps mirrored Brave plugin config runtime-only when newly injected", () => {
+    const merged = mergeScopedSearchConfig(
+      { provider: "brave" },
+      "brave",
+      { apiKey: "brave-test-key" },
+      { mirrorApiKeyToTopLevel: true },
+    );
+
+    expect(merged?.brave).toEqual({ apiKey: "brave-test-key" });
+    expect(merged?.apiKey).toBe("brave-test-key");
+    expect(Object.keys(merged ?? {})).toEqual(["provider", "apiKey"]);
+    expect(Object.getOwnPropertyDescriptor(merged, "brave")?.enumerable).toBe(false);
+  });
+
   it("keeps newly injected legacy provider config runtime-only for validation", () => {
     const merged = mergeScopedSearchConfig({ enabled: true, provider: "gemini" }, "perplexity", {
       apiKey: "perplexity-test-key",


### PR DESCRIPTION
## Summary

- route Brave plugin webSearch merging through the shared provider config helper so injected legacy Brave config stays runtime-only
- preserve the non-enumerable Gemini descriptor when adding Google model-provider fallback values
- add regressions for Brave runtime merge, Gemini fallback merge, and mirrored Brave helper validation shape

Fixes #87191

## Verification

Behavior addressed: PR #86818 hid runtime-injected legacy provider config in the shared merge helper, but Brave still had an inline enumerable merge copy and Gemini fallback code re-enumerated injected Gemini config.
Real environment tested: Local OpenClaw source checkout on macOS, branch fix/87191-web-search-legacy-merge, commit d37a418af8.
Exact steps or command run after this patch: pnpm test src/agents/tools/web-search.test.ts extensions/google/web-search-provider.test.ts extensions/brave/src/brave-web-search-provider.merge.test.ts; env -u OPENCLAW_TESTBOX pnpm check:changed; git diff --check; node --import tsx runtime validation probe; autoreview --mode local.
Evidence after fix: Focused Vitest passed 3 shards with 20 core tests, 1 Brave merge test, and 21 Google provider tests. Local check:changed completed typecheck, lint, guards, and import-cycle checks with exit 0. Autoreview rerun reported no accepted/actionable findings.
Observed result after fix: Runtime-injected Brave and Gemini provider config remains readable by provider runtime code but does not appear in Object.keys, so config validation no longer sees legacy tools.web.search.brave or tools.web.search.gemini shapes.
What was not tested: I did not run a packaged gateway container against v2026.5.26-beta.1; this patch verifies the source-level merge, validation, typecheck, lint, and provider regressions.
