### PR TITLE
[codex] Expire Telegram message-cache plugin state

### DIFF
--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -1,6 +1,7 @@
 import { readFile, rm, writeFile } from "node:fs/promises";
 import type { Message } from "grammy/types";
-import { describe, expect, it } from "vitest";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
@@ -8,8 +9,12 @@ import {
   resetTelegramMessageCacheBucketsForTest,
   resolveTelegramMessageCachePath,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+  TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
+  TELEGRAM_MESSAGE_CACHE_PERSISTENT_TTL_MS,
   type TelegramMessageCachePersistentStore,
 } from "./message-cache.js";
+import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
+import type { TelegramRuntime } from "./runtime.types.js";
 
 type PersistedCacheEntry = {
   key: string;
@@ -73,6 +78,51 @@ function unscopedPersistentKeys(entries: Map<string, PersistedCacheValue>): stri
 }
 
 describe("telegram message cache", () => {
+  afterEach(() => {
+    clearTelegramRuntime();
+  });
+
+  it("opens the default plugin-state store with bounded entries and ttl", async () => {
+    let openedOptions:
+      | {
+          namespace: string;
+          maxEntries: number;
+          defaultTtlMs?: number;
+        }
+      | undefined;
+    const { store } = createMemoryPersistentStore();
+    const runtime = createPluginRuntimeMock({
+      state: {
+        openKeyedStore: ((options) => {
+          openedOptions = options;
+          return store;
+        }) as TelegramRuntime["state"]["openKeyedStore"],
+      },
+    }) as unknown as TelegramRuntime;
+    setTelegramRuntime(runtime);
+
+    const cache = createTelegramMessageCache({
+      bucketKey: `plugin-state-defaults:${process.pid}:${Date.now()}`,
+    });
+    await cache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat: { id: 7, type: "group", title: "Ops" },
+        message_id: 9200,
+        date: 1736389200,
+        text: "ttl-backed",
+        from: { id: 9200, is_bot: false, first_name: "TTL" },
+      } as Message,
+    });
+
+    expect(openedOptions).toMatchObject({
+      namespace: TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
+      maxEntries: TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+      defaultTtlMs: TELEGRAM_MESSAGE_CACHE_PERSISTENT_TTL_MS,
+    });
+  });
+
   it("hydrates reply chains from persisted cached messages", async () => {
     const storePath = `/tmp/openclaw-telegram-message-cache-${process.pid}-${Date.now()}.json`;
     const persistedPath = resolveTelegramMessageCachePath(storePath);

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -83,6 +83,7 @@ type TelegramEmbeddedReplyMessage = NonNullable<Message["reply_to_message"]>;
 
 const DEFAULT_MAX_MESSAGES = 5000;
 export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES = 3000;
+export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE = "telegram.message-cache";
 const PERSISTENT_BUCKET_KEY = `plugin-state:${TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE}`;
 const COMPACT_THRESHOLD_RATIO = 2;
@@ -556,6 +557,7 @@ function resolveDefaultPersistentStore(): TelegramMessageCachePersistentStore | 
     return runtime.state.openKeyedStore<PersistedTelegramMessageCacheValue>({
       namespace: TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
       maxEntries: TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+      defaultTtlMs: TELEGRAM_MESSAGE_CACHE_PERSISTENT_TTL_MS,
     });
   } catch (error) {
     logVerbose(`telegram: failed to open message cache plugin state: ${String(error)}`);

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -47,6 +47,7 @@ type PluginStateStatements = {
   deleteEntry: StatementSync;
   clearNamespace: StatementSync;
   pruneExpiredNamespace: StatementSync;
+  expireImmortalNamespaceEntries: StatementSync;
   countLiveNamespace: StatementSync;
   countLivePlugin: StatementSync;
   deleteOldestNamespace: StatementSync;
@@ -248,6 +249,13 @@ function createStatements(db: DatabaseSync): PluginStateStatements {
         AND namespace = ?
         AND expires_at IS NOT NULL
         AND expires_at <= ?
+    `),
+    expireImmortalNamespaceEntries: db.prepare(`
+      UPDATE plugin_state_entries
+      SET expires_at = ?
+      WHERE plugin_id = ?
+        AND namespace = ?
+        AND expires_at IS NULL
     `),
     countLiveNamespace: db.prepare(`
       SELECT COUNT(*) AS count
@@ -470,6 +478,13 @@ export function pluginStateRegister(params: {
         created_at: now,
         expires_at: expiresAt,
       });
+      if (expiresAt != null) {
+        store.statements.expireImmortalNamespaceEntries.run(
+          expiresAt,
+          params.pluginId,
+          params.namespace,
+        );
+      }
       enforcePostRegisterLimits({
         store,
         pluginId: params.pluginId,
@@ -510,6 +525,13 @@ export function pluginStateRegisterIfAbsent(params: {
         created_at: now,
         expires_at: expiresAt,
       });
+      if (expiresAt != null) {
+        store.statements.expireImmortalNamespaceEntries.run(
+          expiresAt,
+          params.pluginId,
+          params.namespace,
+        );
+      }
       if (result.changes === 0) {
         return false;
       }

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -290,6 +290,65 @@ describe("plugin state keyed store", () => {
     });
   });
 
+  it("normalizes existing no-expiry namespace rows when default TTL is introduced", async () => {
+    await withPluginStateTestState(async () => {
+      vi.useFakeTimers();
+      seedPluginStateEntriesForTests([
+        {
+          pluginId: "telegram",
+          namespace: "telegram.message-cache",
+          key: "old-message",
+          value: { kind: "message", old: true },
+          createdAt: 100,
+          expiresAt: null,
+        },
+        {
+          pluginId: "telegram",
+          namespace: "telegram.topic-name-cache",
+          key: "old-topic",
+          value: { kind: "topic", old: true },
+          createdAt: 100,
+          expiresAt: null,
+        },
+      ]);
+
+      vi.setSystemTime(1000);
+      const messageStore = createPluginStateKeyedStore("telegram", {
+        namespace: "telegram.message-cache",
+        maxEntries: 10,
+        defaultTtlMs: 7_000,
+      });
+      const topicStore = createPluginStateKeyedStore("telegram", {
+        namespace: "telegram.topic-name-cache",
+        maxEntries: 10,
+      });
+
+      await messageStore.register("new-message", { kind: "message", old: false });
+
+      await expect(messageStore.entries()).resolves.toEqual([
+        {
+          key: "old-message",
+          value: { kind: "message", old: true },
+          createdAt: 100,
+          expiresAt: 8_000,
+        },
+        {
+          key: "new-message",
+          value: { kind: "message", old: false },
+          createdAt: 1_000,
+          expiresAt: 8_000,
+        },
+      ]);
+      await expect(topicStore.entries()).resolves.toEqual([
+        {
+          key: "old-topic",
+          value: { kind: "topic", old: true },
+          createdAt: 100,
+        },
+      ]);
+    });
+  });
+
   it("evicts oldest live entries over maxEntries", async () => {
     await withPluginStateTestState(async () => {
       vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- gives Telegram prompt-context message-cache plugin-state rows a seven-day TTL
- normalizes existing no-expiry rows in a TTL-enabled namespace on the next write so upgraded `telegram.message-cache` rows can age out too
- preserves sibling namespace budgets and adds focused coverage for the Telegram message-cache persistent store options

Refs openclaw/openclaw#87332 and openclaw/openclaw#87357.

## Notes
Current `main` already contains the generic plugin-state cap fix from `e3395867507` (`fix(plugin-state): evict current namespace on plugin row cap`). This PR addresses the remaining `telegram.message-cache` permanence angle from #87332.

The follow-up commit also addresses the review concern about pre-existing `expires_at = NULL` rows. When a namespace writes with a TTL, plugin state now updates live rows in that same namespace that were previously immortal to expire at the same deadline as the write. That keeps the upgrade path bounded without touching sibling namespaces.

## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts -t 'plugin-state store|persistent'`
- `node scripts/run-vitest.mjs src/plugin-state/plugin-state-store.test.ts -t 'default TTL|Telegram sibling|plugin row cap|plugin overflow'`
- `pnpm exec oxfmt --check --threads=1 src/plugin-state/plugin-state-store.sqlite.ts src/plugin-state/plugin-state-store.test.ts extensions/telegram/src/message-cache.ts extensions/telegram/src/message-cache.test.ts`

Behavior addressed: Telegram message-cache plugin-state entries now get a TTL instead of being permanent live rows, and old no-expiry message-cache rows receive a bounded expiry after the namespace writes under the new TTL policy.
Real environment tested: local macOS source worktree at `upstream/main`.
Exact steps or command run after this patch: focused Vitest and oxfmt commands above.
Evidence after fix: Telegram message-cache tests passed for persistent/default store coverage; plugin-state tests passed for TTL normalization, sibling namespace budget, and plugin cap behavior.
Observed result after fix: default Telegram message-cache plugin state opens with namespace `telegram.message-cache`, max entries `3000`, and a seven-day default TTL; existing no-expiry rows in that namespace are assigned the new expiry deadline on the next TTL write.
What was not tested: live Telegram traffic or a production SQLite file from a real user profile.
