### PR TITLE
fix(memory-core): cap Dreaming short-term recall growth

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -234,9 +234,13 @@ function formatAuditCounts(audit: ShortTermAuditSummary): string {
 function formatRepairSummary(repair: RepairShortTermPromotionArtifactsResult): string {
   const actions: string[] = [];
   if (repair.rewroteStore) {
-    actions.push(
-      `rewrote store${repair.removedInvalidEntries > 0 ? ` (-${repair.removedInvalidEntries} invalid)` : ""}`,
-    );
+    const details = [
+      repair.removedInvalidEntries > 0 ? `-${repair.removedInvalidEntries} invalid` : null,
+      repair.removedOverflowEntries > 0 ? `-${repair.removedOverflowEntries} overflow` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    actions.push(`rewrote store${details ? ` (${details})` : ""}`);
   }
   if (repair.removedStaleLock) {
     actions.push("removed stale lock");

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -234,9 +234,10 @@ function formatAuditCounts(audit: ShortTermAuditSummary): string {
 function formatRepairSummary(repair: RepairShortTermPromotionArtifactsResult): string {
   const actions: string[] = [];
   if (repair.rewroteStore) {
+    const removedOverflowEntries = repair.removedOverflowEntries ?? 0;
     const details = [
       repair.removedInvalidEntries > 0 ? `-${repair.removedInvalidEntries} invalid` : null,
-      repair.removedOverflowEntries > 0 ? `-${repair.removedOverflowEntries} overflow` : null,
+      removedOverflowEntries > 0 ? `-${removedOverflowEntries} overflow` : null,
     ]
       .filter(Boolean)
       .join(", ");

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -132,14 +132,15 @@ type LegacyPhaseMigrationMode = "enabled" | "disabled";
 function formatRepairSummary(repair: {
   rewroteStore: boolean;
   removedInvalidEntries: number;
-  removedOverflowEntries: number;
+  removedOverflowEntries?: number;
   removedStaleLock: boolean;
 }): string {
   const actions: string[] = [];
   if (repair.rewroteStore) {
+    const removedOverflowEntries = repair.removedOverflowEntries ?? 0;
     const details = [
       repair.removedInvalidEntries > 0 ? `-${repair.removedInvalidEntries} invalid` : null,
-      repair.removedOverflowEntries > 0 ? `-${repair.removedOverflowEntries} overflow` : null,
+      removedOverflowEntries > 0 ? `-${removedOverflowEntries} overflow` : null,
     ]
       .filter(Boolean)
       .join(", ");

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -132,13 +132,18 @@ type LegacyPhaseMigrationMode = "enabled" | "disabled";
 function formatRepairSummary(repair: {
   rewroteStore: boolean;
   removedInvalidEntries: number;
+  removedOverflowEntries: number;
   removedStaleLock: boolean;
 }): string {
   const actions: string[] = [];
   if (repair.rewroteStore) {
-    actions.push(
-      `rewrote recall store${repair.removedInvalidEntries > 0 ? ` (-${repair.removedInvalidEntries} invalid)` : ""}`,
-    );
+    const details = [
+      repair.removedInvalidEntries > 0 ? `-${repair.removedInvalidEntries} invalid` : null,
+      repair.removedOverflowEntries > 0 ? `-${repair.removedOverflowEntries} overflow` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    actions.push(`rewrote recall store${details ? ` (${details})` : ""}`);
   }
   if (repair.removedStaleLock) {
     actions.push("removed stale promotion lock");

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -276,7 +276,7 @@ describe("short-term promotion", () => {
 
       const entries = Object.entries(await readRecallStoreEntries(workspaceDir));
       expect(entries).toHaveLength(1);
-      const [key, entry] = entries[0]!;
+      const [key, entry] = entries[0];
       expect(key.endsWith(`:${claimHash}`)).toBe(true);
       expect(entry.claimHash).toBe(claimHash);
       expect(entry.recallCount).toBe(1);

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -89,6 +89,14 @@ describe("short-term promotion", () => {
     return candidate.promotedAt;
   }
 
+  async function readRecallStoreEntries(
+    workspaceDir: string,
+  ): Promise<Record<string, { snippet?: unknown; totalScore?: unknown }>> {
+    const raw = await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8");
+    const store = JSON.parse(raw) as { entries?: Record<string, { snippet?: unknown }> };
+    return store.entries ?? {};
+  }
+
   async function expectEnoent(promise: Promise<unknown>): Promise<void> {
     await expect(promise).rejects.toHaveProperty("code", "ENOENT");
   }
@@ -176,6 +184,39 @@ describe("short-term promotion", () => {
       const raw = await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8");
       expect(raw).toContain("memory/daily notes/2026-04-03.md");
       expect(raw).toContain("memory/日记/2026-04-04.md");
+    });
+  });
+
+  it("caps short-term recall store entries and snippets during normal recording", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const maxEntries = __testing.SHORT_TERM_RECALL_MAX_ENTRIES as number;
+      const maxSnippetChars = __testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS as number;
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "bounded recall",
+        results: Array.from({ length: maxEntries + 5 }, (_, index) => ({
+          path: "memory/2026-04-03.md",
+          source: "memory" as const,
+          startLine: index + 1,
+          endLine: index + 1,
+          score: 0.1 + index / (maxEntries + 5),
+          snippet: `Recall entry ${index} ${"x".repeat(maxSnippetChars + 100)}`,
+        })),
+      });
+
+      const entries = Object.values(await readRecallStoreEntries(workspaceDir));
+      expect(entries).toHaveLength(maxEntries);
+      expect(entries.every((entry) => String(entry.snippet ?? "").length <= maxSnippetChars)).toBe(
+        true,
+      );
+      expect(
+        entries.some((entry) => String(entry.snippet ?? "").startsWith("Recall entry 0 ")),
+      ).toBe(false);
+      expect(
+        entries.some((entry) =>
+          String(entry.snippet ?? "").startsWith(`Recall entry ${maxEntries + 4} `),
+        ),
+      ).toBe(true);
     });
   });
 
@@ -1881,6 +1922,70 @@ describe("short-term promotion", () => {
       };
       expect(repairedRaw.entries.good?.conceptTags).toContain("router");
       expect(repairedRaw.entries.good?.recallDays).toEqual(["2026-04-04"]);
+    });
+  });
+
+  it("audits and repairs oversized recall stores", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const maxEntries = __testing.SHORT_TERM_RECALL_MAX_ENTRIES as number;
+      const maxSnippetChars = __testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS as number;
+      const storePath = resolveShortTermRecallStorePath(workspaceDir);
+      await fs.writeFile(
+        storePath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            updatedAt: "2026-04-04T00:00:00.000Z",
+            entries: Object.fromEntries(
+              Array.from({ length: maxEntries + 3 }, (_, index) => [
+                `entry-${index}`,
+                {
+                  key: `entry-${index}`,
+                  path: "memory/2026-04-01.md",
+                  startLine: index + 1,
+                  endLine: index + 1,
+                  source: "memory",
+                  snippet: `Oversized recall ${index} ${"x".repeat(maxSnippetChars + 100)}`,
+                  recallCount: 1,
+                  dailyCount: 0,
+                  groundedCount: 0,
+                  totalScore: index,
+                  maxScore: 0.75,
+                  firstRecalledAt: "2026-04-01T00:00:00.000Z",
+                  lastRecalledAt: new Date(
+                    Date.parse("2026-04-01T00:00:00.000Z") + index,
+                  ).toISOString(),
+                  queryHashes: [`q-${index}`],
+                  recallDays: ["2026-04-01"],
+                  conceptTags: [],
+                },
+              ]),
+            ),
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const auditBefore = await auditShortTermPromotionArtifacts({ workspaceDir });
+      expect(auditBefore.entryCount).toBe(maxEntries + 3);
+      expect(auditBefore.issues.map((issue) => issue.code)).toContain("recall-store-over-limit");
+
+      const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
+
+      expect(repair.changed).toBe(true);
+      expect(repair.rewroteStore).toBe(true);
+      expect(repair.removedOverflowEntries).toBe(3);
+
+      const entries = Object.values(await readRecallStoreEntries(workspaceDir));
+      expect(entries).toHaveLength(maxEntries);
+      expect(entries.every((entry) => String(entry.snippet ?? "").length <= maxSnippetChars)).toBe(
+        true,
+      );
+      expect(
+        entries.some((entry) => String(entry.snippet ?? "").startsWith("Oversized recall 0 ")),
+      ).toBe(false);
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1749,6 +1749,50 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("keeps rehydrated promotion snippets capped in the recall store", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
+      const longSnippet = `Moved backup policy ${"x".repeat(maxSnippetChars + 100)}`;
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", ["intro", longSnippet]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "backup policy",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.94,
+            snippet: longSnippet,
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const candidateKey = requireCandidateKey(ranked[0], "long rehydrated");
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.snippet.length).toBeGreaterThan(maxSnippetChars);
+      const entries = await readRecallStoreEntries(workspaceDir);
+      const storedSnippet = readEntrySnippet(entries[candidateKey] ?? {});
+      expect(storedSnippet.length).toBeLessThanOrEqual(maxSnippetChars);
+      expect(storedSnippet).toBe(applied.appliedCandidates[0]?.snippet.slice(0, maxSnippetChars));
+    });
+  });
+
   it("prefers the nearest matching snippet when the same text appears multiple times", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2053,6 +2053,51 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("rejects long contaminated legacy recall entries before truncating snippets", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
+      const storePath = resolveShortTermRecallStorePath(workspaceDir);
+      await fs.writeFile(
+        storePath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            updatedAt: "2026-04-04T00:00:00.000Z",
+            entries: {
+              contaminated: {
+                key: "contaminated",
+                path: "memory/2026-04-01.md",
+                startLine: 1,
+                endLine: 1,
+                source: "memory",
+                snippet: `Candidate: ${"x".repeat(maxSnippetChars + 100)} confidence: 9 evidence: memory/.dreams/session-corpus/2026-04-01.txt status: staged recalls: 1`,
+                recallCount: 1,
+                dailyCount: 0,
+                groundedCount: 0,
+                totalScore: 1,
+                maxScore: 0.75,
+                firstRecalledAt: "2026-04-01T00:00:00.000Z",
+                lastRecalledAt: "2026-04-01T00:00:00.000Z",
+                queryHashes: ["q"],
+                recallDays: ["2026-04-01"],
+                conceptTags: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
+
+      expect(repair.changed).toBe(true);
+      expect(repair.removedInvalidEntries).toBe(1);
+      expect(await readRecallStoreEntries(workspaceDir)).toEqual({});
+    });
+  });
+
   it("repairs empty recall-store files without throwing", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const storePath = resolveShortTermRecallStorePath(workspaceDir);

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -193,8 +193,8 @@ describe("short-term promotion", () => {
 
   it("caps short-term recall store entries and snippets during normal recording", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const maxEntries = __testing.SHORT_TERM_RECALL_MAX_ENTRIES;
-      const maxSnippetChars = __testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
+      const maxEntries = testing.SHORT_TERM_RECALL_MAX_ENTRIES;
+      const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
       await recordShortTermRecalls({
         workspaceDir,
         query: "bounded recall",
@@ -1931,8 +1931,8 @@ describe("short-term promotion", () => {
 
   it("audits and repairs oversized recall stores", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const maxEntries = __testing.SHORT_TERM_RECALL_MAX_ENTRIES;
-      const maxSnippetChars = __testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
+      const maxEntries = testing.SHORT_TERM_RECALL_MAX_ENTRIES;
+      const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
       const storePath = resolveShortTermRecallStorePath(workspaceDir);
       await fs.writeFile(
         storePath,

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2053,6 +2053,56 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("uses score tie-breakers when capping stores with invalid timestamps", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const maxEntries = testing.SHORT_TERM_RECALL_MAX_ENTRIES;
+      const storePath = resolveShortTermRecallStorePath(workspaceDir);
+      await fs.writeFile(
+        storePath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            updatedAt: "2026-04-04T00:00:00.000Z",
+            entries: Object.fromEntries(
+              Array.from({ length: maxEntries + 3 }, (_, index) => [
+                `entry-${index}`,
+                {
+                  key: `entry-${index}`,
+                  path: "memory/2026-04-01.md",
+                  startLine: index + 1,
+                  endLine: index + 1,
+                  source: "memory",
+                  snippet: `Invalid timestamp recall ${index}`,
+                  recallCount: 1,
+                  dailyCount: 0,
+                  groundedCount: 0,
+                  totalScore: index,
+                  maxScore: 0.75,
+                  firstRecalledAt: "not-a-date",
+                  lastRecalledAt: "not-a-date",
+                  queryHashes: [`q-${index}`],
+                  recallDays: ["2026-04-01"],
+                  conceptTags: [],
+                },
+              ]),
+            ),
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
+
+      expect(repair.removedOverflowEntries).toBe(3);
+      const entries = await readRecallStoreEntries(workspaceDir);
+      expect(Object.keys(entries)).toHaveLength(maxEntries);
+      expect(entries["entry-0"]).toBeUndefined();
+      expect(entries[`entry-${maxEntries + 2}`]).toBeDefined();
+    });
+  });
+
   it("rejects long contaminated legacy recall entries before truncating snippets", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -91,9 +91,19 @@ describe("short-term promotion", () => {
 
   async function readRecallStoreEntries(
     workspaceDir: string,
-  ): Promise<Record<string, { snippet?: unknown; totalScore?: unknown }>> {
+  ): Promise<
+    Record<
+      string,
+      { claimHash?: unknown; recallCount?: unknown; snippet?: unknown; totalScore?: unknown }
+    >
+  > {
     const raw = await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8");
-    const store = JSON.parse(raw) as { entries?: Record<string, { snippet?: unknown }> };
+    const store = JSON.parse(raw) as {
+      entries?: Record<
+        string,
+        { claimHash?: unknown; recallCount?: unknown; snippet?: unknown; totalScore?: unknown }
+      >;
+    };
     return store.entries ?? {};
   }
 
@@ -221,6 +231,56 @@ describe("short-term promotion", () => {
           readEntrySnippet(entry).startsWith(`Recall entry ${maxEntries + 4} `),
         ),
       ).toBe(true);
+    });
+  });
+
+  it("keeps long-snippet claim identity stable while storing capped snippets", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
+      const longSnippet = `Stable claim identity ${"x".repeat(maxSnippetChars + 100)}`;
+      const claimHash = testing.buildClaimHash(longSnippet);
+
+      await recordGroundedShortTermCandidates({
+        workspaceDir,
+        query: "__dreaming_grounded_backfill__",
+        items: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            snippet: longSnippet,
+            score: 0.9,
+            query: "__dreaming_grounded_backfill__:candidate",
+            signalCount: 1,
+            dayBucket: "2026-04-03",
+          },
+        ],
+        nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
+      });
+
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "stable claim",
+        nowMs: Date.parse("2026-04-03T11:00:00.000Z"),
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 1,
+            score: 0.8,
+            snippet: longSnippet,
+          },
+        ],
+      });
+
+      const entries = Object.entries(await readRecallStoreEntries(workspaceDir));
+      expect(entries).toHaveLength(1);
+      const [key, entry] = entries[0]!;
+      expect(key.endsWith(`:${claimHash}`)).toBe(true);
+      expect(entry.claimHash).toBe(claimHash);
+      expect(entry.recallCount).toBe(1);
+      expect(readEntrySnippet(entry).length).toBeLessThanOrEqual(maxSnippetChars);
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -97,6 +97,10 @@ describe("short-term promotion", () => {
     return store.entries ?? {};
   }
 
+  function readEntrySnippet(entry: { snippet?: unknown }): string {
+    return typeof entry.snippet === "string" ? entry.snippet : "";
+  }
+
   async function expectEnoent(promise: Promise<unknown>): Promise<void> {
     await expect(promise).rejects.toHaveProperty("code", "ENOENT");
   }
@@ -189,8 +193,8 @@ describe("short-term promotion", () => {
 
   it("caps short-term recall store entries and snippets during normal recording", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const maxEntries = __testing.SHORT_TERM_RECALL_MAX_ENTRIES as number;
-      const maxSnippetChars = __testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS as number;
+      const maxEntries = __testing.SHORT_TERM_RECALL_MAX_ENTRIES;
+      const maxSnippetChars = __testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
       await recordShortTermRecalls({
         workspaceDir,
         query: "bounded recall",
@@ -206,15 +210,15 @@ describe("short-term promotion", () => {
 
       const entries = Object.values(await readRecallStoreEntries(workspaceDir));
       expect(entries).toHaveLength(maxEntries);
-      expect(entries.every((entry) => String(entry.snippet ?? "").length <= maxSnippetChars)).toBe(
+      expect(entries.every((entry) => readEntrySnippet(entry).length <= maxSnippetChars)).toBe(
         true,
       );
-      expect(
-        entries.some((entry) => String(entry.snippet ?? "").startsWith("Recall entry 0 ")),
-      ).toBe(false);
+      expect(entries.some((entry) => readEntrySnippet(entry).startsWith("Recall entry 0 "))).toBe(
+        false,
+      );
       expect(
         entries.some((entry) =>
-          String(entry.snippet ?? "").startsWith(`Recall entry ${maxEntries + 4} `),
+          readEntrySnippet(entry).startsWith(`Recall entry ${maxEntries + 4} `),
         ),
       ).toBe(true);
     });
@@ -1927,8 +1931,8 @@ describe("short-term promotion", () => {
 
   it("audits and repairs oversized recall stores", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const maxEntries = __testing.SHORT_TERM_RECALL_MAX_ENTRIES as number;
-      const maxSnippetChars = __testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS as number;
+      const maxEntries = __testing.SHORT_TERM_RECALL_MAX_ENTRIES;
+      const maxSnippetChars = __testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
       const storePath = resolveShortTermRecallStorePath(workspaceDir);
       await fs.writeFile(
         storePath,
@@ -1980,11 +1984,11 @@ describe("short-term promotion", () => {
 
       const entries = Object.values(await readRecallStoreEntries(workspaceDir));
       expect(entries).toHaveLength(maxEntries);
-      expect(entries.every((entry) => String(entry.snippet ?? "").length <= maxSnippetChars)).toBe(
+      expect(entries.every((entry) => readEntrySnippet(entry).length <= maxSnippetChars)).toBe(
         true,
       );
       expect(
-        entries.some((entry) => String(entry.snippet ?? "").startsWith("Oversized recall 0 ")),
+        entries.some((entry) => readEntrySnippet(entry).startsWith("Oversized recall 0 ")),
       ).toBe(false);
     });
   });

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -570,9 +570,17 @@ function parseStoreTimestampMs(value: string | undefined): number {
   return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
 }
 
+function compareStoreTimestampDesc(left: string | undefined, right: string | undefined): number {
+  const leftMs = parseStoreTimestampMs(left);
+  const rightMs = parseStoreTimestampMs(right);
+  if (leftMs === rightMs) {
+    return 0;
+  }
+  return rightMs > leftMs ? 1 : -1;
+}
+
 function compareShortTermRecallRetention(a: ShortTermRecallEntry, b: ShortTermRecallEntry): number {
-  const lastDiff =
-    parseStoreTimestampMs(b.lastRecalledAt) - parseStoreTimestampMs(a.lastRecalledAt);
+  const lastDiff = compareStoreTimestampDesc(a.lastRecalledAt, b.lastRecalledAt);
   if (lastDiff !== 0) {
     return lastDiff;
   }
@@ -588,7 +596,7 @@ function compareShortTermRecallRetention(a: ShortTermRecallEntry, b: ShortTermRe
   if (maxScoreDiff !== 0) {
     return maxScoreDiff;
   }
-  const promotedDiff = parseStoreTimestampMs(b.promotedAt) - parseStoreTimestampMs(a.promotedAt);
+  const promotedDiff = compareStoreTimestampDesc(a.promotedAt, b.promotedAt);
   if (promotedDiff !== 0) {
     return promotedDiff;
   }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -508,13 +508,11 @@ function normalizeStore(raw: unknown, nowIso: string): ShortTermRecallStore {
         typeof entry.claimHash === "string" && entry.claimHash.trim().length > 0
           ? entry.claimHash.trim()
           : undefined;
-      const snippet =
-        typeof entry.snippet === "string"
-          ? truncateShortTermSnippet(normalizeSnippet(entry.snippet))
-          : "";
-      if (snippet && isContaminatedDreamingSnippet(snippet)) {
+      const fullSnippet = typeof entry.snippet === "string" ? normalizeSnippet(entry.snippet) : "";
+      if (fullSnippet && isContaminatedDreamingSnippet(fullSnippet)) {
         continue;
       }
+      const snippet = truncateShortTermSnippet(fullSnippet);
       const queryHashes = Array.isArray(entry.queryHashes)
         ? normalizeDistinctStrings(entry.queryHashes, MAX_QUERY_HASHES)
         : [];
@@ -530,7 +528,7 @@ function normalizeStore(raw: unknown, nowIso: string): ShortTermRecallStore {
             ),
             MAX_CONCEPT_TAGS,
           )
-        : deriveConceptTags({ path: entryPath, snippet });
+        : deriveConceptTags({ path: entryPath, snippet: fullSnippet });
 
       const normalizedKey =
         key || buildEntryKey({ path: entryPath, startLine, endLine, source, claimHash });

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -32,6 +32,8 @@ export const DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES = 2;
 const PROMOTION_MARKER_PREFIX = "openclaw-memory-promotion:";
 const MAX_QUERY_HASHES = 32;
 const MAX_RECALL_DAYS = 16;
+const SHORT_TERM_RECALL_MAX_ENTRIES = 512;
+const SHORT_TERM_RECALL_MAX_SNIPPET_CHARS = 800;
 const SHORT_TERM_STORE_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-recall.json");
 const SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH = path.join("memory", ".dreams", "phase-signals.json");
 const SHORT_TERM_LOCK_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-promotion.lock");
@@ -149,6 +151,7 @@ type ShortTermAuditIssue = {
     | "recall-store-unreadable"
     | "recall-store-empty"
     | "recall-store-invalid"
+    | "recall-store-over-limit"
     | "recall-lock-stale"
     | "recall-lock-unreadable"
     | "qmd-index-missing"
@@ -182,6 +185,7 @@ export type ShortTermAuditSummary = {
 export type RepairShortTermPromotionArtifactsResult = {
   changed: boolean;
   removedInvalidEntries: number;
+  removedOverflowEntries: number;
   rewroteStore: boolean;
   removedStaleLock: boolean;
 };
@@ -256,6 +260,13 @@ function normalizeSnippet(raw: string): string {
     return "";
   }
   return trimmed.replace(/\s+/g, " ");
+}
+
+function truncateShortTermSnippet(snippet: string): string {
+  if (snippet.length <= SHORT_TERM_RECALL_MAX_SNIPPET_CHARS) {
+    return snippet;
+  }
+  return snippet.slice(0, SHORT_TERM_RECALL_MAX_SNIPPET_CHARS).trimEnd();
 }
 
 function consumeDreamingLeadPrefix(snippet: string): string {
@@ -497,7 +508,10 @@ function normalizeStore(raw: unknown, nowIso: string): ShortTermRecallStore {
         typeof entry.claimHash === "string" && entry.claimHash.trim().length > 0
           ? entry.claimHash.trim()
           : undefined;
-      const snippet = typeof entry.snippet === "string" ? normalizeSnippet(entry.snippet) : "";
+      const snippet =
+        typeof entry.snippet === "string"
+          ? truncateShortTermSnippet(normalizeSnippet(entry.snippet))
+          : "";
       if (snippet && isContaminatedDreamingSnippet(snippet)) {
         continue;
       }
@@ -548,6 +562,51 @@ function normalizeStore(raw: unknown, nowIso: string): ShortTermRecallStore {
     updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : nowIso,
     entries,
   };
+}
+
+function parseStoreTimestampMs(value: string | undefined): number {
+  if (!value) {
+    return Number.NEGATIVE_INFINITY;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+function compareShortTermRecallRetention(a: ShortTermRecallEntry, b: ShortTermRecallEntry): number {
+  const lastDiff =
+    parseStoreTimestampMs(b.lastRecalledAt) - parseStoreTimestampMs(a.lastRecalledAt);
+  if (lastDiff !== 0) {
+    return lastDiff;
+  }
+  const signalDiff = totalSignalCountForEntry(b) - totalSignalCountForEntry(a);
+  if (signalDiff !== 0) {
+    return signalDiff;
+  }
+  const totalScoreDiff = b.totalScore - a.totalScore;
+  if (totalScoreDiff !== 0) {
+    return totalScoreDiff;
+  }
+  const maxScoreDiff = b.maxScore - a.maxScore;
+  if (maxScoreDiff !== 0) {
+    return maxScoreDiff;
+  }
+  const promotedDiff = parseStoreTimestampMs(b.promotedAt) - parseStoreTimestampMs(a.promotedAt);
+  if (promotedDiff !== 0) {
+    return promotedDiff;
+  }
+  return a.key.localeCompare(b.key);
+}
+
+function enforceShortTermRecallStoreRetention(store: ShortTermRecallStore): number {
+  const entries = Object.entries(store.entries);
+  if (entries.length <= SHORT_TERM_RECALL_MAX_ENTRIES) {
+    return 0;
+  }
+  const retained = entries
+    .toSorted(([, a], [, b]) => compareShortTermRecallRetention(a, b))
+    .slice(0, SHORT_TERM_RECALL_MAX_ENTRIES);
+  store.entries = Object.fromEntries(retained.toSorted(([a], [b]) => a.localeCompare(b)));
+  return entries.length - retained.length;
 }
 
 function toFinitePositive(value: unknown, fallback: number): number {
@@ -787,10 +846,12 @@ async function withShortTermLock<T>(workspaceDir: string, task: () => Promise<T>
 
 async function readStore(workspaceDir: string, nowIso: string): Promise<ShortTermRecallStore> {
   try {
-    return normalizeStore(
+    const store = normalizeStore(
       await privateFileStore(workspaceDir).readJsonIfExists(SHORT_TERM_STORE_RELATIVE_PATH),
       nowIso,
     );
+    enforceShortTermRecallStoreRetention(store);
+    return store;
   } catch (err) {
     if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
       return emptyStore(nowIso);
@@ -884,6 +945,7 @@ async function writePhaseSignalStore(
 }
 
 async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
+  enforceShortTermRecallStoreRetention(store);
   await ensureShortTermArtifactsDir(workspaceDir);
   await privateFileStore(workspaceDir).writeJson(SHORT_TERM_STORE_RELATIVE_PATH, store, {
     trailingNewline: true,
@@ -977,8 +1039,9 @@ export async function recordShortTermRecalls(params: {
 
     for (const result of relevant) {
       const normalizedPath = normalizeMemoryPath(result.path);
-      const snippet = normalizeSnippet(result.snippet);
-      if (!snippet || isContaminatedDreamingSnippet(snippet)) {
+      const rawSnippet = normalizeSnippet(result.snippet);
+      const snippet = truncateShortTermSnippet(rawSnippet);
+      if (!rawSnippet || isContaminatedDreamingSnippet(rawSnippet)) {
         continue;
       }
       const claimHash = snippet ? buildClaimHash(snippet) : undefined;
@@ -1082,11 +1145,12 @@ export async function recordGroundedShortTermCandidates(params: {
   }
   const relevant = params.items
     .map((item) => {
-      const snippet = normalizeSnippet(item.snippet);
+      const rawSnippet = normalizeSnippet(item.snippet);
+      const snippet = truncateShortTermSnippet(rawSnippet);
       const normalizedPath = normalizeMemoryPath(item.path);
       if (
-        !snippet ||
-        isContaminatedDreamingSnippet(snippet) ||
+        !rawSnippet ||
+        isContaminatedDreamingSnippet(rawSnippet) ||
         !normalizedPath ||
         !isShortTermMemoryPath(normalizedPath) ||
         !Number.isFinite(item.startLine) ||
@@ -1901,8 +1965,9 @@ export async function auditShortTermPromotionArtifacts(params: {
       const nowIso = new Date().toISOString();
       const parsed = JSON.parse(raw) as unknown;
       const store = normalizeStore(parsed, nowIso);
+      const normalizedEntryCount = Object.keys(store.entries).length;
       updatedAt = store.updatedAt;
-      entryCount = Object.keys(store.entries).length;
+      entryCount = normalizedEntryCount;
       promotedCount = Object.values(store.entries).filter((entry) =>
         Boolean(entry.promotedAt),
       ).length;
@@ -1923,6 +1988,14 @@ export async function auditShortTermPromotionArtifacts(params: {
           severity: "warn",
           code: "recall-store-invalid",
           message: `Short-term recall store contains ${invalidEntryCount} invalid entr${invalidEntryCount === 1 ? "y" : "ies"}.`,
+          fixable: true,
+        });
+      }
+      if (normalizedEntryCount > SHORT_TERM_RECALL_MAX_ENTRIES) {
+        issues.push({
+          severity: "warn",
+          code: "recall-store-over-limit",
+          message: `Short-term recall store contains ${normalizedEntryCount} entries; only the newest ${SHORT_TERM_RECALL_MAX_ENTRIES} are kept at runtime.`,
           fixable: true,
         });
       }
@@ -2028,6 +2101,7 @@ export async function repairShortTermPromotionArtifacts(params: {
   const nowIso = new Date().toISOString();
   let rewroteStore = false;
   let removedInvalidEntries = 0;
+  let removedOverflowEntries = 0;
   let removedStaleLock = false;
 
   try {
@@ -2080,6 +2154,7 @@ export async function repairShortTermPromotionArtifacts(params: {
         updatedAt: normalized.updatedAt,
         entries: nextEntries,
       };
+      removedOverflowEntries = enforceShortTermRecallStoreRetention(comparableStore);
       const comparableRaw = `${JSON.stringify(comparableStore, null, 2)}\n`;
       if (comparableRaw !== `${raw.trimEnd()}\n`) {
         await writeStore(workspaceDir, {
@@ -2098,6 +2173,7 @@ export async function repairShortTermPromotionArtifacts(params: {
   return {
     changed: rewroteStore || removedStaleLock,
     removedInvalidEntries,
+    removedOverflowEntries,
     rewroteStore,
     removedStaleLock,
   };
@@ -2158,5 +2234,7 @@ export const testing = {
   totalSignalCountForEntry,
   isContaminatedDreamingSnippet,
   lineRangeOverlapsDreamingFence,
+  SHORT_TERM_RECALL_MAX_ENTRIES,
+  SHORT_TERM_RECALL_MAX_SNIPPET_CHARS,
 };
 export { testing as __testing };

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1044,7 +1044,7 @@ export async function recordShortTermRecalls(params: {
       if (!rawSnippet || isContaminatedDreamingSnippet(rawSnippet)) {
         continue;
       }
-      const claimHash = snippet ? buildClaimHash(snippet) : undefined;
+      const claimHash = buildClaimHash(rawSnippet);
       const groundedKey = claimHash
         ? buildEntryKey({
             path: normalizedPath,
@@ -1163,6 +1163,7 @@ export async function recordGroundedShortTermCandidates(params: {
         startLine: Math.max(1, Math.floor(item.startLine)),
         endLine: Math.max(1, Math.floor(item.endLine)),
         snippet,
+        identitySnippet: rawSnippet,
         score: clampScore(item.score),
         query: normalizeSnippet(item.query ?? query),
         signalCount: Math.max(1, Math.floor(item.signalCount ?? 1)),
@@ -1187,7 +1188,7 @@ export async function recordGroundedShortTermCandidates(params: {
         continue;
       }
       const queryHash = hashQuery(effectiveQuery);
-      const claimHash = buildClaimHash(item.snippet);
+      const claimHash = buildClaimHash(item.identitySnippet);
       const key = buildEntryKey({
         path: item.path,
         startLine: item.startLine,

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -269,6 +269,12 @@ function truncateShortTermSnippet(snippet: string): string {
   return snippet.slice(0, SHORT_TERM_RECALL_MAX_SNIPPET_CHARS).trimEnd();
 }
 
+function enforceShortTermRecallSnippetCap(store: ShortTermRecallStore): void {
+  for (const entry of Object.values(store.entries)) {
+    entry.snippet = truncateShortTermSnippet(entry.snippet);
+  }
+}
+
 function consumeDreamingLeadPrefix(snippet: string): string {
   let index = 0;
   while (index < snippet.length) {
@@ -951,6 +957,7 @@ async function writePhaseSignalStore(
 }
 
 async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
+  enforceShortTermRecallSnippetCap(store);
   enforceShortTermRecallStoreRetention(store);
   await ensureShortTermArtifactsDir(workspaceDir);
   await privateFileStore(workspaceDir).writeJson(SHORT_TERM_STORE_RELATIVE_PATH, store, {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -135,6 +135,7 @@ function resetMemoryRecallMocks() {
   repairShortTermPromotionArtifacts.mockResolvedValue({
     changed: false,
     removedInvalidEntries: 0,
+    removedOverflowEntries: 0,
     rewroteStore: false,
     removedStaleLock: false,
   });
@@ -1041,6 +1042,7 @@ describe("memory recall doctor integration", () => {
     repairShortTermPromotionArtifacts.mockResolvedValueOnce({
       changed: true,
       removedInvalidEntries: 1,
+      removedOverflowEntries: 0,
       rewroteStore: true,
       removedStaleLock: true,
     });

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -307,13 +307,12 @@ export async function maybeRepairMemoryRecallHealth(params: {
       if (approved) {
         const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
         if (repair.changed) {
+          const removedOverflowEntries = repair.removedOverflowEntries ?? 0;
           const details = [
             repair.removedInvalidEntries > 0
               ? `-${repair.removedInvalidEntries} invalid entries`
               : null,
-            repair.removedOverflowEntries > 0
-              ? `-${repair.removedOverflowEntries} overflow entries`
-              : null,
+            removedOverflowEntries > 0 ? `-${removedOverflowEntries} overflow entries` : null,
           ]
             .filter(Boolean)
             .join(", ");

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -307,11 +307,19 @@ export async function maybeRepairMemoryRecallHealth(params: {
       if (approved) {
         const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
         if (repair.changed) {
+          const details = [
+            repair.removedInvalidEntries > 0
+              ? `-${repair.removedInvalidEntries} invalid entries`
+              : null,
+            repair.removedOverflowEntries > 0
+              ? `-${repair.removedOverflowEntries} overflow entries`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(", ");
           const lines = [
             "Memory recall artifacts repaired:",
-            repair.rewroteStore
-              ? `- rewrote recall store${repair.removedInvalidEntries > 0 ? ` (-${repair.removedInvalidEntries} invalid entries)` : ""}`
-              : null,
+            repair.rewroteStore ? `- rewrote recall store${details ? ` (${details})` : ""}` : null,
             repair.removedStaleLock ? "- removed stale promotion lock" : null,
             `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
           ].filter(Boolean);

--- a/src/plugin-sdk/memory-core-engine-runtime.test.ts
+++ b/src/plugin-sdk/memory-core-engine-runtime.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import type { ShortTermAuditIssue } from "./memory-core-engine-runtime.js";
+
+describe("memory-core engine runtime SDK facade", () => {
+  it("exposes the short-term recall overflow audit code", () => {
+    const issue = {
+      severity: "warn",
+      code: "recall-store-over-limit",
+      message: "Short-term recall store is over the retention limit.",
+      fixable: true,
+    } satisfies ShortTermAuditIssue;
+
+    expect(issue.code).toBe("recall-store-over-limit");
+  });
+});

--- a/src/plugin-sdk/memory-core-engine-runtime.ts
+++ b/src/plugin-sdk/memory-core-engine-runtime.ts
@@ -88,7 +88,7 @@ export type ShortTermAuditSummary = {
 export type RepairShortTermPromotionArtifactsResult = {
   changed: boolean;
   removedInvalidEntries: number;
-  removedOverflowEntries: number;
+  removedOverflowEntries?: number;
   rewroteStore: boolean;
   removedStaleLock: boolean;
 };

--- a/src/plugin-sdk/memory-core-engine-runtime.ts
+++ b/src/plugin-sdk/memory-core-engine-runtime.ts
@@ -55,6 +55,7 @@ export type ShortTermAuditIssue = {
     | "recall-store-unreadable"
     | "recall-store-empty"
     | "recall-store-invalid"
+    | "recall-store-over-limit"
     | "recall-lock-stale"
     | "recall-lock-unreadable"
     | "qmd-index-missing"

--- a/src/plugin-sdk/memory-core-engine-runtime.ts
+++ b/src/plugin-sdk/memory-core-engine-runtime.ts
@@ -88,6 +88,7 @@ export type ShortTermAuditSummary = {
 export type RepairShortTermPromotionArtifactsResult = {
   changed: boolean;
   removedInvalidEntries: number;
+  removedOverflowEntries: number;
   rewroteStore: boolean;
   removedStaleLock: boolean;
 };


### PR DESCRIPTION
## Summary

- cap memory-core Dreaming short-term recall retention at 512 entries
- truncate stored recall snippets to 800 chars during normal recording and legacy normalization
- surface over-limit recall stores in audit/doctor repair output and report overflow removals

Fixes #87095

## Real behavior proof

behavior: Dreaming `short-term-recall.json` no longer grows without bound during normal recall recording, and an existing oversized recall store is repaired down to the same cap.

environment: Local OpenClaw source checkout on Linux, Node 22.22.2, pnpm 11.1.0, real temporary workspaces under `/tmp`, real filesystem JSON writes.

steps:

1. Created a temporary workspace and recorded 517 short-term recall results through `recordShortTermRecalls`.
2. Read the persisted `memory/.dreams/short-term-recall.json`.
3. Created a second temporary workspace with a legacy 515-entry `short-term-recall.json`.
4. Ran `auditShortTermPromotionArtifacts` and `repairShortTermPromotionArtifacts`.
5. Read the repaired store from disk.

evidence:

```json
{
  "workspaceRoot": "/tmp/openclaw-recall-proof-yhNQXz",
  "normalRecord": {
    "maxEntries": 512,
    "beforeAttempted": 517,
    "afterEntries": 512,
    "maxSnippetLength": 800,
    "droppedOldest": true,
    "keptNewest": true
  },
  "repair": {
    "beforeEntries": 515,
    "issueCodes": [
      "recall-store-over-limit"
    ],
    "removedOverflowEntries": 3,
    "afterEntries": 512,
    "maxSnippetLength": 800,
    "droppedOldest": true
  }
}
```

observedResult: Normal recording attempted 517 recall entries and persisted 512. Legacy repair started from 515 entries, reported `recall-store-over-limit`, removed 3 overflow entries, and persisted 512 entries. Both paths capped stored snippets at 800 chars.

notTested: Full live Dreaming cron plus `/new` session-context E2E was not run locally. The focused proof covers the real memory-core recall store write/repair paths on filesystem workspaces; regression tests cover normal recording, repair/audit behavior, and doctor summary consumers.

## Verification

- `pnpm test extensions/memory-core/src/short-term-promotion.test.ts src/commands/doctor-memory-search.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
- `git diff --check`
