### PR TITLE
fix(imessage): backport native approval reactions to .27

### DIFF
--- a/extensions/imessage/src/approval-handler.runtime.ts
+++ b/extensions/imessage/src/approval-handler.runtime.ts
@@ -5,7 +5,10 @@ import {
   type ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
-import { buildApprovalReactionPendingContent } from "openclaw/plugin-sdk/approval-reaction-runtime";
+import {
+  buildApprovalReactionHint,
+  buildApprovalReactionPendingContent,
+} from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import {
   buildApprovalResolvedReplyPayload,
@@ -60,6 +63,19 @@ function buildPendingPayload(params: {
     view: params.view as never,
     nowMs: params.nowMs,
   });
+  if (params.approvalKind === "plugin") {
+    return {
+      text: [
+        pendingContent.manualFallbackPayload.text,
+        buildApprovalReactionHint({
+          allowedDecisions: pendingContent.reactionPayload.allowedDecisions,
+        }),
+      ]
+        .filter(Boolean)
+        .join("\n\n"),
+      allowedDecisions: pendingContent.reactionPayload.allowedDecisions,
+    };
+  }
   return {
     text: pendingContent.reactionPayload.text ?? "",
     allowedDecisions: pendingContent.reactionPayload.allowedDecisions,

--- a/extensions/imessage/src/approval-reaction-poller.test.ts
+++ b/extensions/imessage/src/approval-reaction-poller.test.ts
@@ -227,4 +227,121 @@ describe("iMessage approval reaction poller", () => {
       gatewayUrl: undefined,
     });
   });
+
+  it("continues scanning after an unauthorized reaction leaves the approval pending", async () => {
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { chatId: 42, chatGuid: "iMessage;+;chat-guid" },
+      messageId: "msg-1",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "messages.history") {
+        return {
+          messages: [
+            {
+              guid: "msg-1",
+              chat_id: 42,
+              chat_guid: "iMessage;+;chat-guid",
+              is_group: true,
+              is_from_me: true,
+              text: "Exec approval required\nID: exec-1",
+              reactions: [
+                {
+                  id: 8,
+                  sender: "+15550000000",
+                  type: "like",
+                  emoji: "👍",
+                  created_at: "2026-05-27T21:01:00.000Z",
+                },
+                {
+                  id: 9,
+                  sender: "+15551230000",
+                  type: "like",
+                  emoji: "👍",
+                  created_at: "2026-05-27T21:02:00.000Z",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    await pollPendingIMessageApprovalReactions({
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+    });
+
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      approvalId: "exec-1",
+      decision: "allow-once",
+      senderId: "+15551230000",
+      gatewayUrl: undefined,
+    });
+  });
+
+  it("stops scanning after an authorized resolver failure", async () => {
+    resolverMocks.resolveIMessageApproval.mockRejectedValueOnce(new Error("gateway down"));
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { chatId: 42, chatGuid: "iMessage;+;chat-guid" },
+      messageId: "msg-1",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "messages.history") {
+        return {
+          messages: [
+            {
+              guid: "msg-1",
+              chat_id: 42,
+              chat_guid: "iMessage;+;chat-guid",
+              is_group: true,
+              is_from_me: true,
+              text: "Exec approval required\nID: exec-1",
+              reactions: [
+                {
+                  id: 8,
+                  sender: "+15551230000",
+                  type: "like",
+                  emoji: "👍",
+                  created_at: "2026-05-27T21:01:00.000Z",
+                },
+                {
+                  id: 9,
+                  sender: "+15551230000",
+                  type: "dislike",
+                  emoji: "👎",
+                  created_at: "2026-05-27T21:02:00.000Z",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    await pollPendingIMessageApprovalReactions({
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+    });
+
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      approvalId: "exec-1",
+      decision: "allow-once",
+      senderId: "+15551230000",
+      gatewayUrl: undefined,
+    });
+  });
 });

--- a/extensions/imessage/src/approval-reaction-poller.ts
+++ b/extensions/imessage/src/approval-reaction-poller.ts
@@ -1,8 +1,8 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   extractIMessageApprovalPromptBinding,
+  handleIMessageApprovalReaction,
   listPendingIMessageApprovalReactionPollTargets,
-  maybeResolveIMessageApprovalReaction,
   registerIMessageApprovalReactionTarget,
   type PendingIMessageApprovalReactionPollTarget,
   type IMessageApprovalConversationKey,
@@ -263,14 +263,14 @@ export async function pollPendingIMessageApprovalReactions(params: {
         if (!reactionPayload) {
           continue;
         }
-        const handled = await maybeResolveIMessageApprovalReaction({
+        const handled = await handleIMessageApprovalReaction({
           cfg: params.cfg,
           accountId: params.accountId,
           message: reactionPayload,
           bodyText: reactionPayload.text ?? "",
           logVerboseMessage: params.logVerboseMessage,
         });
-        if (handled) {
+        if (handled.stopPolling) {
           return;
         }
       }

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -24,6 +24,9 @@ type IMessageApprovalReactionResolution = {
   approvalId: string;
   decision: ExecApprovalReplyDecision;
 };
+export type IMessageApprovalReactionHandleResult =
+  | { handled: false; stopPolling: false }
+  | { handled: true; stopPolling: boolean };
 
 type IMessageApprovalReactionTarget = ApprovalReactionTargetRecord;
 
@@ -469,17 +472,17 @@ function readApprovalReactionEvent(
   };
 }
 
-export async function maybeResolveIMessageApprovalReaction(params: {
+export async function handleIMessageApprovalReaction(params: {
   cfg: OpenClawConfig;
   accountId: string;
   message: IMessagePayload;
   bodyText: string;
   gatewayUrl?: string;
   logVerboseMessage?: (message: string) => void;
-}): Promise<boolean> {
+}): Promise<IMessageApprovalReactionHandleResult> {
   const event = readApprovalReactionEvent(params.message, params.bodyText);
   if (!event) {
-    return false;
+    return { handled: false, stopPolling: false };
   }
   // A removed tapback (user un-taps 👍 or switches to a different emoji) is
   // intentionally NOT a fresh resolve. We only want to clear the binding so
@@ -487,7 +490,7 @@ export async function maybeResolveIMessageApprovalReaction(params: {
   // would surface the un-tap as a noisy reaction system event; instead we
   // own the event and stay quiet.
   if (event.action === "removed") {
-    return false;
+    return { handled: false, stopPolling: false };
   }
   let target: IMessageApprovalReactionResolution | null = null;
   let matchedMessageId: string | null = null;
@@ -504,7 +507,7 @@ export async function maybeResolveIMessageApprovalReaction(params: {
     }
   }
   if (!target) {
-    return false;
+    return { handled: false, stopPolling: false };
   }
 
   const approvalKind = target.approvalId.startsWith("plugin:") ? "plugin" : "exec";
@@ -513,7 +516,7 @@ export async function maybeResolveIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction denied id=${target.approvalId}; reactions require explicit approvers`,
     );
-    return true;
+    return { handled: true, stopPolling: false };
   }
   const auth = imessageApprovalAuth.authorizeActorAction({
     cfg: params.cfg,
@@ -526,7 +529,7 @@ export async function maybeResolveIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction denied id=${target.approvalId} sender=${event.actorHandle}`,
     );
-    return true;
+    return { handled: true, stopPolling: false };
   }
 
   const { isApprovalNotFoundError, resolveIMessageApproval } = await loadApprovalResolver();
@@ -552,7 +555,7 @@ export async function maybeResolveIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction resolved id=${target.approvalId} sender=${event.actorHandle} decision=${target.decision} via messageId=${matchedMessageId ?? event.messageId}`,
     );
-    return true;
+    return { handled: true, stopPolling: true };
   } catch (error) {
     if (isApprovalNotFoundError(error)) {
       for (const candidate of event.messageIdCandidates) {
@@ -565,7 +568,7 @@ export async function maybeResolveIMessageApprovalReaction(params: {
       params.logVerboseMessage?.(
         `imessage: approval reaction ignored for expired approval id=${target.approvalId} sender=${event.actorHandle}`,
       );
-      return true;
+      return { handled: true, stopPolling: true };
     }
     // Surface non-NotFound errors at warn level so a gateway 5xx / network
     // outage / auth failure is visible without OPENCLAW_LOG_LEVEL=debug.
@@ -583,8 +586,19 @@ export async function maybeResolveIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction failed id=${target.approvalId} sender=${event.actorHandle}: ${String(error)}`,
     );
-    return true;
+    return { handled: true, stopPolling: true };
   }
+}
+
+export async function maybeResolveIMessageApprovalReaction(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  message: IMessagePayload;
+  bodyText: string;
+  gatewayUrl?: string;
+  logVerboseMessage?: (message: string) => void;
+}): Promise<boolean> {
+  return (await handleIMessageApprovalReaction(params)).handled;
 }
 
 export function clearIMessageApprovalReactionTargetsForTest(): void {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1243,10 +1243,11 @@ describe("package artifact reuse", () => {
     expect(npmWorkflow).toContain("preflight-manifest.json");
     expect(npmWorkflow).toContain("Verify full release validation run metadata");
     expect(npmWorkflow).toContain("Verify full release validation target");
-    expect(npmWorkflow).not.toContain("Verify Docker runtime-assets prune path");
+    expect(npmWorkflow).not.toContain("Build and smoke test final Docker runtime image");
     expect(fullReleaseWorkflow).toContain("docker_runtime_assets_preflight");
-    expect(fullReleaseWorkflow).toContain("Verify Docker runtime-assets prune path");
-    expect(fullReleaseWorkflow).toContain("--target runtime-assets");
+    expect(fullReleaseWorkflow).toContain("Build and smoke test final Docker runtime image");
+    expect(fullReleaseWorkflow).toContain('-t "${image_ref}"');
+    expect(fullReleaseWorkflow).toContain("test -f /app/src/agents/templates/HEARTBEAT.md");
     expect(fullReleaseWorkflow).toContain("inputs.rerun_group == 'all'");
     expect(fullReleaseWorkflow).toContain(
       "needs.docker_runtime_assets_preflight.result == 'success'",

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -541,9 +541,9 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     );
     expect(
       fullReleaseWorkflow.jobs.docker_runtime_assets_preflight.steps.find(
-        (step) => step.name === "Verify Docker runtime-assets prune path",
+        (step) => step.name === "Build and smoke test final Docker runtime image",
       ).run,
-    ).toContain("--target runtime-assets");
+    ).toContain("test -f /app/src/agents/templates/HEARTBEAT.md");
     expect(fullReleaseWorkflow.jobs.plugin_prerelease["timeout-minutes"]).toBe(
       "${{ inputs.release_profile == 'full' && 300 || inputs.release_profile == 'stable' && 240 || 60 }}",
     );


### PR DESCRIPTION
Summary:
- Backports #87324 to `release/2026.5.27`.
- Preserves `.27` plugin command-action prompt text while adding iMessage approval reaction binding/polling.
- Adds a release-branch poller fix so unauthorized reactions do not block later authorized reactions, while resolver failures still stop the current poll pass.

Verification:
- `node scripts/run-vitest.mjs extensions/imessage/src/approval-reaction-poller.test.ts extensions/imessage/src/approval-handler.runtime.test.ts extensions/imessage/src/send.test.ts extensions/imessage/src/approval-native.test.ts extensions/imessage/src/approval-reactions.test.ts extensions/imessage/src/test-plugin.test.ts src/plugin-sdk/approval-reaction-runtime.test.ts`
- `pnpm tsgo:extensions:test`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/release/2026.5.27`

Refs: #87324
