### PR TITLE
fix(discord): suppress recovered tool warnings

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -7,6 +7,7 @@ import {
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import * as runtimeEnvModule from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { setReplyPayloadMetadata } from "../../../../src/auto-reply/reply-payload.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
 
 const sendMocks = vi.hoisted(() => ({
@@ -50,6 +51,16 @@ const deliveryMocks = vi.hoisted(() => ({
 const editMessageDiscord = deliveryMocks.editMessageDiscord;
 const deliverDiscordReply = deliveryMocks.deliverDiscordReply;
 const createDiscordDraftStream = deliveryMocks.createDiscordDraftStream;
+
+function createNonTerminalToolWarningPayload(): ReplyPayload {
+  return setReplyPayloadMetadata(
+    {
+      text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+      isError: true,
+    },
+    { nonTerminalToolErrorWarning: true },
+  );
+}
 
 vi.mock("../send.js", () => ({
   reactMessageDiscord: async (
@@ -2237,14 +2248,11 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps finalized previews when later tool warning finals are delivered", async () => {
+  it("drops later tool warning finals after preview final replies", async () => {
     const draftStream = createMockDraftStreamForTest();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "delivery survived" });
-      await params?.dispatcher.sendFinalReply({
-        text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
-        isError: true,
-      } as never);
+      await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
       return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
     });
 
@@ -2257,24 +2265,13 @@ describe("processDiscordMessage draft streaming", () => {
     expectPreviewEditContent("delivery survived");
     expect(draftStream.clear).not.toHaveBeenCalled();
     expect(draftStream.messageId()).toBe("preview-1");
-    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
-    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
-      replies: [
-        {
-          text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
-          isError: true,
-        },
-      ],
-    });
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
-  it("keeps draft previews when tool warning finals arrive before recovered replies", async () => {
+  it("drops earlier tool warning finals when recovered replies arrive", async () => {
     const draftStream = createMockDraftStreamForTest();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendFinalReply({
-        text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
-        isError: true,
-      } as never);
+      await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
       await params?.dispatcher.sendFinalReply({ text: "delivery recovered" });
       return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
     });
@@ -2288,11 +2285,59 @@ describe("processDiscordMessage draft streaming", () => {
     expectPreviewEditContent("delivery recovered");
     expect(draftStream.clear).not.toHaveBeenCalled();
     expect(draftStream.messageId()).toBe("preview-1");
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers tool warning finals when no recovered reply is available", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
     expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
       replies: [
         {
           text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+          isError: true,
+        },
+      ],
+    });
+  });
+
+  it("keeps mutating tool warning finals after successful-looking replies", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "Done." });
+      await params?.dispatcher.sendFinalReply({
+        text: "⚠️ 🛠️ `write file (agent)` failed",
+        isError: true,
+      } as never);
+      return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expectPreviewEditContent("Done.");
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [
+        {
+          text: "⚠️ 🛠️ `write file (agent)` failed",
           isError: true,
         },
       ],
@@ -2448,17 +2493,14 @@ describe("processDiscordMessage draft streaming", () => {
     expectPreviewEditContent("done");
   });
 
-  it("keeps finalized progress previews when later tool warning finals are delivered", async () => {
+  it("drops later tool warning finals after progress preview final replies", async () => {
     const draftStream = createMockDraftStreamForTest();
 
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
       await params?.replyOptions?.onItemEvent?.({ progressText: "exec done" });
       await params?.dispatcher.sendFinalReply({ text: "delivery survived" });
-      await params?.dispatcher.sendFinalReply({
-        text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
-        isError: true,
-      } as never);
+      await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
       return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
     });
 
@@ -2479,15 +2521,7 @@ describe("processDiscordMessage draft streaming", () => {
     expectPreviewEditContent("delivery survived");
     expect(draftStream.clear).not.toHaveBeenCalled();
     expect(draftStream.messageId()).toBe("preview-1");
-    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
-    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
-      replies: [
-        {
-          text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
-          isError: true,
-        },
-      ],
-    });
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
   it("uses raw tool-progress detail in Discord progress drafts", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -37,6 +37,7 @@ import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import {
   buildTtsSupplementMediaPayload,
   getReplyPayloadTtsSupplement,
+  isReplyPayloadNonTerminalToolErrorWarning,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
@@ -102,6 +103,13 @@ function formatDiscordReplyDeliveryFailure(params: {
     .filter(Boolean)
     .join(" ");
   return `discord ${params.kind} reply failed (${context}): ${String(params.err)}`;
+}
+
+function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
+  if (payload.isError !== true || !isReplyPayloadNonTerminalToolErrorWarning(payload)) {
+    return false;
+  }
+  return !resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
 type DiscordReplySkipReason = "aborted before delivery" | "reasoning payload";
@@ -537,6 +545,16 @@ export async function processDiscordMessage(
     draftPreview.markFinalReplyStarted();
     observer?.onFinalReplyStart?.();
   };
+  let userFacingFinalDelivered = false;
+  let pendingToolWarningFinal:
+    | { payload: ReplyPayload; info: { kind: ReplyDispatchKind } }
+    | undefined;
+  const markUserFacingFinalDelivered = () => {
+    userFacingFinalDelivered = true;
+    pendingToolWarningFinal = undefined;
+    draftPreview.markFinalReplyDelivered();
+    observer?.onFinalReplyDelivered?.();
+  };
   const beforeDiscordPayloadDelivery = (
     payload: ReplyPayload,
     info: { kind: ReplyDispatchKind },
@@ -570,7 +588,7 @@ export async function processDiscordMessage(
         return null;
       }
     }
-    if (info.kind === "final") {
+    if (info.kind === "final" && !isFallbackOnlyToolWarningFinal(payload)) {
       draftPreview.markFinalReplyStarted();
     }
     return payload;
@@ -579,6 +597,7 @@ export async function processDiscordMessage(
   const deliverDiscordPayload = async (
     payload: ReplyPayload,
     info: { kind: ReplyDispatchKind },
+    options?: { allowFallbackOnlyToolWarning?: boolean },
   ) => {
     if (isProcessAborted(abortSignal)) {
       // Surface so operators don't chase missing replies when an abort
@@ -604,6 +623,16 @@ export async function processDiscordMessage(
           sessionKey: ctxPayload.SessionKey,
         }),
       );
+      return { visibleReplySent: false };
+    }
+    if (
+      isFinal &&
+      !options?.allowFallbackOnlyToolWarning &&
+      isFallbackOnlyToolWarningFinal(payload)
+    ) {
+      if (!userFacingFinalDelivered) {
+        pendingToolWarningFinal = { payload, info };
+      }
       return { visibleReplySent: false };
     }
     if (isFinal) {
@@ -679,10 +708,9 @@ export async function processDiscordMessage(
             });
           },
           onPreviewFinalized: () => {
-            draftPreview.markFinalReplyDelivered();
+            markUserFacingFinalDelivered();
             draftPreview.markPreviewFinalized();
             replyReference.markSent();
-            observer?.onFinalReplyDelivered?.();
           },
           buildSupplementalPayload: () =>
             ttsSupplement ? buildTtsSupplementMediaPayload(effectivePayload) : undefined,
@@ -759,9 +787,8 @@ export async function processDiscordMessage(
           return true;
         },
         onNormalDelivered: () => {
-          draftPreview.markFinalReplyDelivered();
+          markUserFacingFinalDelivered();
           replyReference.markSent();
-          observer?.onFinalReplyDelivered?.();
         },
       });
       if (result.kind !== "normal-skipped") {
@@ -807,8 +834,7 @@ export async function processDiscordMessage(
     });
     replyReference.markSent();
     if (isFinal && payload.isError !== true) {
-      draftPreview.markFinalReplyDelivered();
-      observer?.onFinalReplyDelivered?.();
+      markUserFacingFinalDelivered();
     }
     return { visibleReplySent: true };
   };
@@ -837,6 +863,21 @@ export async function processDiscordMessage(
     null;
   let dispatchError = false;
   let dispatchAborted = false;
+  const deliverPendingToolWarningFinalIfNeeded = async () => {
+    if (!pendingToolWarningFinal || userFacingFinalDelivered || isProcessAborted(abortSignal)) {
+      return;
+    }
+    const pending = pendingToolWarningFinal;
+    pendingToolWarningFinal = undefined;
+    try {
+      await deliverDiscordPayload(pending.payload, pending.info, {
+        allowFallbackOnlyToolWarning: true,
+      });
+    } catch (err) {
+      dispatchError = true;
+      onDiscordDeliveryError(err, pending.info);
+    }
+  };
   try {
     if (isProcessAborted(abortSignal)) {
       dispatchAborted = true;
@@ -1026,6 +1067,7 @@ export async function processDiscordMessage(
       dispatchAborted = true;
       return;
     }
+    await deliverPendingToolWarningFinalIfNeeded();
   } catch (err) {
     if (isProcessAborted(abortSignal)) {
       dispatchAborted = true;

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -184,6 +184,10 @@ export function getReplyPayloadMetadata(payload: object): ReplyPayloadMetadata |
   return replyPayloadMetadata.get(payload);
 }
 
+export function isReplyPayloadNonTerminalToolErrorWarning(payload: object): boolean {
+  return getReplyPayloadMetadata(payload)?.nonTerminalToolErrorWarning === true;
+}
+
 export function copyReplyPayloadMetadata<T extends object>(source: object, payload: T): T {
   const metadata = getReplyPayloadMetadata(source);
   return metadata ? setReplyPayloadMetadata(payload, metadata) : payload;

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -13,6 +13,7 @@ export type { ReplyPayloadTtsSupplement } from "../auto-reply/reply-payload.js";
 export {
   buildTtsSupplementMediaPayload,
   getReplyPayloadTtsSupplement,
+  isReplyPayloadNonTerminalToolErrorWarning,
   isReplyPayloadTtsSupplement,
   markReplyPayloadAsTtsSupplement,
 } from "../auto-reply/reply-payload.js";


### PR DESCRIPTION
## Summary

- Defer Discord delivery of metadata-marked non-terminal tool warning finals until the turn has no user-facing final reply.
- Preserve ordinary and mutating tool failure warnings, including successful-looking assistant replies followed by real mutating failures.
- Expose the existing reply-payload metadata predicate through the plugin SDK for channel delivery decisions.

## Verification

- `pnpm test extensions/discord/src/monitor/message-handler.process.test.ts -- --reporter=dot` (78 passed)
- `pnpm check:changed` via Blacksmith Testbox `tbx_01ksnw1ngdzgz4qkm6yeq3jrdf`, Actions run `26544657655`
- `$autoreview --mode local`: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: Discord no longer posts a compact non-terminal tool failure warning after a useful final answer already appears.
Real environment tested: local focused Vitest plus Blacksmith Testbox changed gate.
Exact steps or command run after this patch: `pnpm test extensions/discord/src/monitor/message-handler.process.test.ts -- --reporter=dot`; `pnpm check:changed`; `$autoreview --mode local`.
Evidence after fix: focused Discord shard passed 78 tests; Testbox `tbx_01ksnw1ngdzgz4qkm6yeq3jrdf` exited 0; autoreview clean.
Observed result after fix: recovered final replies suppress metadata-marked non-terminal warnings, warning-only turns still deliver the warning, and mutating failure warnings remain visible.
What was not tested: live Discord production message send against Hetzner.
