### PR TITLE
fix(plugin-state): preserve fresh writes at plugin cap

### DIFF
--- a/src/plugin-state/plugin-state-store.e2e.test.ts
+++ b/src/plugin-state/plugin-state-store.e2e.test.ts
@@ -4,6 +4,7 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   closePluginStateSqliteStore,
+  countPluginStateLiveEntries,
   createPluginStateKeyedStore,
   PluginStateStoreError,
   probePluginStateStore,
@@ -194,7 +195,7 @@ describe("limits", () => {
     });
   });
 
-  it("enforces the per-plugin live-row cap", async () => {
+  it("preserves fresh writes when the per-plugin live-row cap is full", async () => {
     await withOpenClawTestState({ label: "e2e-limit-plugin" }, async () => {
       // Fill the plugin budget outside the namespace that attempts the write.
       const nsCount = 10;
@@ -215,11 +216,18 @@ describe("limits", () => {
         namespace: "overflow-ns",
         maxEntries: 10,
       });
-
-      // One more row tips over the plugin-wide limit.
-      await expectPluginStateStoreError(store.register("overflow", { boom: true }), {
-        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+      const oldestNamespaceStore = createPluginStateKeyedStore("fixture-plugin", {
+        namespace: "ns-0",
+        maxEntries: perNs,
       });
+
+      // One more row tips over the plugin-wide limit; the fresh row stays alive.
+      await expect(store.register("overflow", { boom: true })).resolves.toBeUndefined();
+      await expect(store.lookup("overflow")).resolves.toEqual({ boom: true });
+      await expect(oldestNamespaceStore.lookup("k-0")).resolves.toBeUndefined();
+      expect(countPluginStateLiveEntries("fixture-plugin")).toBe(
+        MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN,
+      );
     });
   });
 

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -50,6 +50,7 @@ type PluginStateStatements = {
   countLiveNamespace: StatementSync;
   countLivePlugin: StatementSync;
   deleteOldestNamespace: StatementSync;
+  deleteOldestPlugin: StatementSync;
   sweepExpired: StatementSync;
 };
 
@@ -275,6 +276,18 @@ function createStatements(db: DatabaseSync): PluginStateStatements {
         LIMIT ?
       )
     `),
+    deleteOldestPlugin: db.prepare(`
+      DELETE FROM plugin_state_entries
+      WHERE rowid IN (
+        SELECT rowid
+        FROM plugin_state_entries
+        WHERE plugin_id = ?
+          AND entry_key <> ?
+          AND (expires_at IS NULL OR expires_at > ?)
+        ORDER BY created_at ASC, namespace ASC, entry_key ASC
+        LIMIT ?
+      )
+    `),
     sweepExpired: db.prepare(`
       DELETE FROM plugin_state_entries
       WHERE expires_at IS NOT NULL AND expires_at <= ?
@@ -426,7 +439,7 @@ function enforcePostRegisterLimits(params: {
     return;
   }
 
-  // Shed rows from the namespace that grew before failing the plugin write.
+  // Prefer shedding rows from the namespace that grew so sibling caches survive normal pressure.
   params.store.statements.deleteOldestNamespace.run(
     params.pluginId,
     params.namespace,
@@ -439,7 +452,24 @@ function enforcePostRegisterLimits(params: {
       | CountRow
       | undefined,
   );
-  if (remainingPluginCount > MAX_ENTRIES_PER_PLUGIN) {
+  if (remainingPluginCount <= MAX_ENTRIES_PER_PLUGIN) {
+    return;
+  }
+
+  // If the current namespace cannot shed enough rows, keep the fresh write alive by
+  // evicting the oldest live row for this plugin while still protecting the new key.
+  params.store.statements.deleteOldestPlugin.run(
+    params.pluginId,
+    params.protectedKey,
+    params.now,
+    remainingPluginCount - MAX_ENTRIES_PER_PLUGIN,
+  );
+  const finalPluginCount = countRow(
+    params.store.statements.countLivePlugin.get(params.pluginId, params.now) as
+      | CountRow
+      | undefined,
+  );
+  if (finalPluginCount > MAX_ENTRIES_PER_PLUGIN) {
     throw createPluginStateError({
       code: "PLUGIN_STATE_LIMIT_EXCEEDED",
       operation: "register",

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   clearPluginStateStoreForTests,
   closePluginStateSqliteStore,
+  countPluginStateLiveEntries,
   createCorePluginStateKeyedStore,
   createPluginStateKeyedStore,
   PluginStateStoreError,
@@ -433,7 +434,7 @@ describe("plugin state keyed store", () => {
     });
   });
 
-  it("rejects plugin overflow when the current namespace cannot shed old rows", async () => {
+  it("preserves fresh writes when the current namespace cannot shed old rows", async () => {
     await withPluginStateTestState(async () => {
       seedPluginStateEntriesForTests(
         Array.from({ length: 6_000 }, (_, entryIndex) => ({
@@ -453,11 +454,10 @@ describe("plugin state keyed store", () => {
         maxEntries: 6_000,
       });
 
-      await expectPluginStateStoreError(messageStore.register("new-message", { fresh: true }), {
-        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
-      });
-      await expect(messageStore.lookup("new-message")).resolves.toBeUndefined();
-      await expect(topicStore.lookup("topic-0")).resolves.toEqual({ entryIndex: 0 });
+      await expect(messageStore.register("new-message", { fresh: true })).resolves.toBeUndefined();
+      await expect(messageStore.lookup("new-message")).resolves.toEqual({ fresh: true });
+      await expect(topicStore.lookup("topic-0")).resolves.toBeUndefined();
+      expect(countPluginStateLiveEntries("telegram")).toBe(6_000);
     });
   });
 


### PR DESCRIPTION
## Summary

This builds on the existing plugin-state row-cap eviction behavior and closes one remaining Telegram-shaped edge case.

When a plugin is already at the plugin-wide live-row cap, the current implementation first tries to evict rows from the namespace that just received the write. That works when the write lands in a namespace that already has old rows, but it can still hard-fail when the write is for a brand-new or sparse namespace, because that namespace cannot shed enough rows.

This change keeps the current-namespace eviction preference, then falls back to evicting the oldest live row for the same plugin while protecting the just-written key. That preserves the fresh write and keeps the plugin under the cap instead of surfacing `PluginStateStoreError` to callers.

## Why

Telegram keeps several sibling caches under the same plugin, such as message, topic, and bot-info caches. In production, a full plugin budget can cause a new topic/cache write to fail even though old rows from another Telegram cache could safely be evicted.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/plugin-state/plugin-state-store.test.ts src/plugin-state/plugin-state-store.e2e.test.ts`
- Custom Telegram-shaped stress check:
  - message-cache write at plugin cap preserves the fresh message and evicts the oldest message row
  - brand-new topic/message namespace write at plugin cap preserves the fresh write and evicts the oldest plugin row

No config, auth, service wrapper, or LaunchAgent changes are included.