### PR TITLE
test(discord): use reply payload SDK test helper

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -5,9 +5,9 @@ import {
   type ChannelBotLoopProtectionFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import * as runtimeEnvModule from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { setReplyPayloadMetadata } from "../../../../src/auto-reply/reply-payload.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
 
 const sendMocks = vi.hoisted(() => ({

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "!dist/plugin-sdk/provider-http-test-mocks.d.ts",
     "!dist/plugin-sdk/provider-test-contracts.js",
     "!dist/plugin-sdk/provider-test-contracts.d.ts",
+    "!dist/plugin-sdk/reply-payload-testing.js",
+    "!dist/plugin-sdk/reply-payload-testing.d.ts",
     "!dist/plugin-sdk/test-env.js",
     "!dist/plugin-sdk/test-env.d.ts",
     "!dist/plugin-sdk/test-fixtures.js",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -46,6 +46,7 @@
   "reply-reference",
   "reply-chunking",
   "reply-payload",
+  "reply-payload-testing",
   "agent-media-payload",
   "inbound-reply-dispatch",
   "inbound-envelope",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -13,6 +13,7 @@
   "qa-channel-protocol",
   "qa-lab",
   "qa-runtime",
+  "reply-payload-testing",
   "ssrf-runtime-internal",
   "test-env",
   "test-fixtures",

--- a/src/plugin-sdk/reply-payload-testing.ts
+++ b/src/plugin-sdk/reply-payload-testing.ts
@@ -1,0 +1,1 @@
+export { setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";


### PR DESCRIPTION
## Summary

- Move the Discord regression test metadata helper from a core-internal import to a focused plugin SDK test subpath.
- Mark the new `reply-payload-testing` subpath local-only and exclude it from packaged npm artifacts.

## Verification

- `pnpm lint:plugins:no-extension-test-core-imports`
- `pnpm test extensions/discord/src/monitor/message-handler.process.test.ts -- --reporter=dot` (78 passed)
- `$autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: fixes the boundary-check failure introduced by #87451 without changing Discord production delivery behavior.
Real environment tested: local focused boundary lint and Discord Vitest shard.
Exact steps or command run after this patch: `pnpm lint:plugins:no-extension-test-core-imports`; `pnpm test extensions/discord/src/monitor/message-handler.process.test.ts -- --reporter=dot`; `$autoreview --mode branch --base origin/main`.
Evidence after fix: boundary lint passed; focused Discord shard passed 78 tests; autoreview clean.
Observed result after fix: extension tests stay on public plugin SDK test surfaces, and the test-only helper stays out of npm package files.
What was not tested: live Discord production message send.
