### PR TITLE
AI-assisted: recover message-tool-only replies written as private finals

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -23,6 +23,7 @@ import {
   EMPTY_RESPONSE_RETRY_INSTRUCTION,
   extractPlanningOnlyPlanDetails,
   isLikelyExecutionAckPrompt,
+  MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION,
   PLANNING_ONLY_RETRY_INSTRUCTION,
   REASONING_ONLY_RETRY_INSTRUCTION,
   resolveAckExecutionFastPathInstruction,
@@ -744,6 +745,274 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
     expectWarnMessageWith("empty response detected");
+  });
+
+  it("retries message-tool-only final answers that were only written privately", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Private final that the source channel will not receive."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            { type: "text", text: "Private final that the source channel will not receive." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Private final should stay private after message send."],
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["Visible via message tool."],
+        messagingToolSourceReplyPayloads: [{ text: "Visible via message tool." }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            { type: "text", text: "Private final should stay private after message send." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-private-final-retry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toContain(MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION);
+    expect(result.payloads).toBeUndefined();
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["Visible via message tool."]);
+    expectWarnMessageWith("message-tool-only final reply was private");
+  });
+
+  it("surfaces a visible runtime error if message-tool-only final answers never call message", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        assistantTexts: ["Still private only."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "Still private only." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-private-final-exhausted",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("private final answer");
+  });
+
+  it("accepts committed default-route message sends as source replies", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Private final should stay private after visible delivery."],
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["Visible via default-route message tool."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            { type: "text", text: "Private final should stay private after visible delivery." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-default-route-delivered",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads).toBeUndefined();
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["Visible via default-route message tool."]);
+  });
+
+  it("accepts default-route source replies even when the turn also sends elsewhere", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Private final should stay private after visible delivery."],
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["Visible via default-route message tool.", "Sent somewhere else."],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "telegram",
+            to: "other-session",
+            text: "Sent somewhere else.",
+          },
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            { type: "text", text: "Private final should stay private after visible delivery." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-default-route-and-explicit-route",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads).toBeUndefined();
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTargets).toHaveLength(1);
+  });
+
+  it("does not treat explicit-route message sends as source replies", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Private final for the current source chat."],
+        didSendViaMessagingTool: true,
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "telegram",
+            to: "other-session",
+            text: "Sent somewhere else.",
+          },
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "Private final for the current source chat." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-explicit-route-still-missing-source",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("private final answer");
+    expect(result.payloads?.[0]?.text).toContain("verify before retrying");
+    expect(result.messagingToolSentTargets).toEqual([
+      {
+        tool: "message",
+        provider: "telegram",
+        to: "other-session",
+        text: "Sent somewhere else.",
+      },
+    ]);
+  });
+
+  it("preserves NO_REPLY as silent in message-tool-only mode", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["NO_REPLY"],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "NO_REPLY" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-no-reply-silent",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads).toBeUndefined();
+    expectNoWarnMessageWith("incomplete/no-output assistant response");
+    expectNoWarnMessageWith("message-tool-only final reply was private");
+  });
+
+  it("preserves planning-only retries before message-tool-only private-final recovery", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["I'll inspect the files now, then patch the issue."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "I'll inspect the files now, then patch the issue." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Private final should stay private after message send."],
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["Visible after acting."],
+        messagingToolSourceReplyPayloads: [{ text: "Visible after acting." }],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      prompt: "Please inspect the files and patch the issue.",
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-planning-only-first",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toContain(PLANNING_ONLY_RETRY_INSTRUCTION);
+    expect(secondCall.prompt).not.toContain(MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION);
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["Visible after acting."]);
   });
 
   it("retries zero-token empty Claude stop turns with a visible-answer continuation instruction", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1,8 +1,11 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  markReplyPayloadForSourceSuppressionDelivery,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import {
   resolveContextEngine,
@@ -161,6 +164,7 @@ import {
 import {
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
+  MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION,
   resolveAckExecutionFastPathInstruction,
   resolveAttemptReplayMetadata,
   extractPlanningOnlyPlanDetails,
@@ -202,11 +206,110 @@ type ApiKeyInfo = ResolvedProviderAuth;
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 const EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS = 30_000;
+const MESSAGE_TOOL_ONLY_MISSING_REPLY_TEXT =
+  "⚠️ Agent wrote a private final answer instead of sending the source reply through the message tool. Please try again.";
+const MESSAGE_TOOL_ONLY_REPLAY_UNSAFE_MISSING_REPLY_TEXT =
+  "⚠️ Agent wrote a private final answer instead of sending the source reply through the message tool. Note: some tool actions may have already been executed — please verify before retrying.";
 const MID_TURN_PRECHECK_CONTINUATION_PROMPT =
   "Continue from the current transcript after the latest tool result. Do not repeat the original user request, and do not rerun completed tools unless the transcript shows they are still needed.";
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
+
+function hasVisibleReplyPayloadContent(payload: ReplyPayload): boolean {
+  return Boolean(
+    payload.text?.trim() ||
+    payload.mediaUrl?.trim() ||
+    (payload.mediaUrls?.length ?? 0) > 0 ||
+    payload.presentation ||
+    payload.interactive ||
+    payload.channelData,
+  );
+}
+
+function buildMessageToolOnlyMissingReplyPayload(text: string): ReplyPayload {
+  return markReplyPayloadForSourceSuppressionDelivery({
+    text,
+    isError: true,
+  });
+}
+
+function hasMessageToolOnlySourceReplyEvidence(attempt: EmbeddedRunAttemptForRunner): boolean {
+  if ((attempt.messagingToolSourceReplyPayloads ?? []).length > 0) {
+    return true;
+  }
+  if (!attempt.didSendViaMessagingTool) {
+    return false;
+  }
+  const targetedTextCounts = new Map<string, number>();
+  const targetedMediaUrlCounts = new Map<string, number>();
+  for (const target of attempt.messagingToolSentTargets ?? []) {
+    const text = target.text?.trim();
+    if (text) {
+      targetedTextCounts.set(text, (targetedTextCounts.get(text) ?? 0) + 1);
+    }
+    for (const mediaUrl of target.mediaUrls ?? []) {
+      const trimmed = mediaUrl.trim();
+      if (trimmed) {
+        targetedMediaUrlCounts.set(trimmed, (targetedMediaUrlCounts.get(trimmed) ?? 0) + 1);
+      }
+    }
+  }
+  for (const text of attempt.messagingToolSentTexts ?? []) {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const targetedCount = targetedTextCounts.get(trimmed) ?? 0;
+    if (targetedCount <= 0) {
+      return true;
+    }
+    targetedTextCounts.set(trimmed, targetedCount - 1);
+  }
+  for (const mediaUrl of attempt.messagingToolSentMediaUrls ?? []) {
+    const trimmed = mediaUrl.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const targetedCount = targetedMediaUrlCounts.get(trimmed) ?? 0;
+    if (targetedCount <= 0) {
+      return true;
+    }
+    targetedMediaUrlCounts.set(trimmed, targetedCount - 1);
+  }
+  return false;
+}
+
+function isVisiblePrivateFinalText(text: string | undefined): boolean {
+  return Boolean(text?.trim()) && !isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN);
+}
+
+function hasVisiblePrivateFinalText(texts: readonly string[] | undefined): boolean {
+  return (texts ?? []).some(isVisiblePrivateFinalText);
+}
+
+function hasPrivateFinalReplyText(params: {
+  attempt: EmbeddedRunAttemptForRunner;
+  finalAssistantVisibleText: string | undefined;
+  finalAssistantRawText: string | undefined;
+  payloads: ReplyPayload[] | undefined;
+}): boolean {
+  if (hasVisiblePrivateFinalText(params.attempt.assistantTexts)) {
+    return true;
+  }
+  if (
+    isVisiblePrivateFinalText(params.finalAssistantVisibleText) ||
+    isVisiblePrivateFinalText(params.finalAssistantRawText)
+  ) {
+    return true;
+  }
+  return (params.payloads ?? []).some(
+    (payload) =>
+      payload.isError !== true &&
+      payload.isReasoning !== true &&
+      hasVisibleReplyPayloadContent(payload),
+  );
+}
 
 function resolveAttemptDispatchApiKey(params: {
   apiKeyInfo: ApiKeyInfo | null;
@@ -1140,6 +1243,7 @@ export async function runEmbeddedAgent(
       let planningOnlyRetryInstruction: string | null = null;
       let reasoningOnlyRetryInstruction: string | null = null;
       let emptyResponseRetryInstruction: string | null = null;
+      let messageToolOnlyRetryInstruction: string | null = null;
       let compactionContinuationRetryInstruction: string | null = null;
       let nextAttemptPromptOverride: string | null = null;
       const ackExecutionFastPathInstruction = resolveAckExecutionFastPathInstruction({
@@ -1156,7 +1260,9 @@ export async function runEmbeddedAgent(
       // for errored turns; stopReason="stop" empty zero-token turns use the
       // visible-answer retry instruction instead.
       const MAX_EMPTY_ERROR_RETRIES = 3;
+      const MAX_MESSAGE_TOOL_ONLY_RETRIES = 1;
       let emptyErrorRetries = 0;
+      let messageToolOnlyRetries = 0;
       const overloadFailoverBackoffMs = resolveOverloadFailoverBackoffMs(params.config);
       const overloadProfileRotationLimit = resolveOverloadProfileRotationLimit(params.config);
       const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit(params.config);
@@ -1407,6 +1513,7 @@ export async function runEmbeddedAgent(
             planningOnlyRetryInstruction,
             reasoningOnlyRetryInstruction,
             emptyResponseRetryInstruction,
+            messageToolOnlyRetryInstruction,
             compactionContinuationRetryInstruction,
           ].filter(
             (value): value is string => typeof value === "string" && value.trim().length > 0,
@@ -3043,6 +3150,77 @@ export async function runEmbeddedAgent(
             );
             continue;
           }
+          const messageToolOnlyMissingSourceReply =
+            params.sourceReplyDeliveryMode === "message_tool_only" &&
+            !aborted &&
+            !timedOut &&
+            !attempt.didSendDeterministicApprovalPrompt &&
+            !hasMessageToolOnlySourceReplyEvidence(attempt) &&
+            hasPrivateFinalReplyText({
+              attempt,
+              finalAssistantVisibleText,
+              finalAssistantRawText,
+              payloads: payloadsWithToolMedia,
+            });
+          if (messageToolOnlyMissingSourceReply) {
+            const replayMetadata = resolveAttemptReplayMetadata(attempt);
+            if (
+              replayMetadata.replaySafe &&
+              messageToolOnlyRetries < MAX_MESSAGE_TOOL_ONLY_RETRIES
+            ) {
+              messageToolOnlyRetries += 1;
+              messageToolOnlyRetryInstruction = MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION;
+              log.warn(
+                `message-tool-only final reply was private: runId=${params.runId} sessionId=${params.sessionId} ` +
+                  `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ` +
+                  `${messageToolOnlyRetries}/${MAX_MESSAGE_TOOL_ONLY_RETRIES} with message-tool delivery steer`,
+              );
+              continue;
+            }
+
+            const messageToolOnlyMissingReplyText = replayMetadata.hadPotentialSideEffects
+              ? MESSAGE_TOOL_ONLY_REPLAY_UNSAFE_MISSING_REPLY_TEXT
+              : MESSAGE_TOOL_ONLY_MISSING_REPLY_TEXT;
+            const replayInvalid = resolveReplayInvalidForAttempt(messageToolOnlyMissingReplyText);
+            const livenessState = resolveRunLivenessState({
+              payloadCount: 0,
+              aborted,
+              timedOut,
+              attempt,
+              incompleteTurnText: messageToolOnlyMissingReplyText,
+            });
+            attempt.setTerminalLifecycleMeta?.({
+              replayInvalid,
+              livenessState,
+            });
+            return {
+              payloads: [buildMessageToolOnlyMissingReplyPayload(messageToolOnlyMissingReplyText)],
+              meta: {
+                durationMs: Date.now() - started,
+                agentMeta,
+                aborted,
+                systemPromptReport: attempt.systemPromptReport,
+                finalPromptText: attempt.finalPromptText,
+                finalAssistantVisibleText,
+                finalAssistantRawText,
+                replayInvalid,
+                livenessState,
+                toolSummary: attemptToolSummary,
+                ...(failureSignal ? { failureSignal } : {}),
+                agentHarnessResultClassification: attempt.agentHarnessResultClassification,
+              },
+              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+              messagingToolSentTexts: attempt.messagingToolSentTexts,
+              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+              messagingToolSentTargets: attempt.messagingToolSentTargets,
+              messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
+              heartbeatToolResponse: attempt.heartbeatToolResponse,
+              successfulCronAdds: attempt.successfulCronAdds,
+              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
+            };
+          }
+          messageToolOnlyRetryInstruction = null;
           if (
             !nextPlanningOnlyRetryInstruction &&
             nextReasoningOnlyRetryInstruction &&

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -206,6 +206,8 @@ export const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
+export const MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION =
+  "The previous assistant turn wrote the visible reply in the private final answer. This source conversation is message-tool-only: send the user-visible answer now with message(action=send). Do not repeat completed work or put the answer only in final.";
 export const ACK_EXECUTION_FAST_PATH_INSTRUCTION =
   "The latest user message is a short approval to proceed. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
 export const STRICT_AGENTIC_BLOCKED_TEXT =

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1552,7 +1552,7 @@ describe("messaging tool media URL tracking", () => {
       type: "tool_execution_start",
       toolName: "message",
       toolCallId: "tool-dry-run-source-reply",
-      args: { action: "send", message: "preview" },
+      args: { action: "send", message: "preview", dryRun: true },
     });
     await handleToolExecutionEnd(ctx, {
       type: "tool_execution_end",
@@ -1567,6 +1567,34 @@ describe("messaging tool media URL tracking", () => {
           sourceReply: { text: "preview" },
         },
       },
+    });
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-nested-dry-run",
+      args: { action: "send", message: "nested preview" },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-nested-dry-run",
+      isError: false,
+      result: { details: { payload: { deliveryStatus: "dry_run" } } },
+    });
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-json-content-dry-run",
+      args: { action: "send", message: "json preview" },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-json-content-dry-run",
+      isError: false,
+      result: { content: [{ type: "text", text: '{"deliveryStatus":"dry_run"}' }] },
     });
 
     await handleToolExecutionStart(ctx, {
@@ -1590,6 +1618,37 @@ describe("messaging tool media URL tracking", () => {
     });
 
     expect(ctx.state.messagingToolSourceReplyPayloads).toHaveLength(0);
+    expect(ctx.state.messagingToolSentTexts).toEqual(["sent externally"]);
+    expect(ctx.state.messagingToolSentTargets).toHaveLength(1);
+  });
+
+  it("tracks sessions_send as targeted cross-session delivery evidence", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "sessions_send",
+      toolCallId: "tool-session-send",
+      args: {
+        sessionKey: "agent:main:subagent:worker",
+        message: "sent to worker",
+      },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "sessions_send",
+      toolCallId: "tool-session-send",
+      isError: false,
+      result: { ok: true },
+    });
+
+    expect(ctx.state.messagingToolSentTexts).toEqual(["sent to worker"]);
+    expectRecordFields(requireSingleMessagingTarget(ctx), "messaging target", {
+      tool: "sessions_send",
+      provider: "session",
+      to: "agent:main:subagent:worker",
+      text: "sent to worker",
+    });
   });
 
   it("commits sendAttachment args as message delivery evidence", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -26,6 +26,7 @@ import {
 import { normalizeOptionalLowercaseString, readStringValue } from "../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
+import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
@@ -53,7 +54,6 @@ import {
 import { inferToolMetaFromArgs } from "./embedded-agent-utils.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
 import type { AgentEvent } from "./runtime/index.js";
-import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 
@@ -76,6 +76,15 @@ const beforeToolCallModuleLoader = createLazyImportLoader<BeforeToolCallModule>(
 );
 const LIVE_EXEC_OUTPUT_MAX_CHARS = 8000;
 const LIVE_EXEC_UPDATE_MIN_INTERVAL_MS = 250;
+const DRY_RUN_DELIVERY_STATUS = "dry_run";
+const RESULT_ENVELOPE_KEYS = [
+  "details",
+  "payload",
+  "result",
+  "results",
+  "sendResult",
+  "toolResult",
+];
 const TRACE_REQUIRED_PARAM_GROUPS = {
   read: [{ keys: ["path", "file_path"], label: "path" }],
   write: REQUIRED_PARAM_GROUPS.write,
@@ -289,6 +298,56 @@ function readToolResultDetailsRecord(result: unknown): Record<string, unknown> |
 function isAsyncStartedToolResult(result: unknown): boolean {
   const details = readToolResultDetailsRecord(result);
   return details?.async === true && details.status === "started";
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function deliveryEnvelopeIndicatesDryRun(value: unknown, depth = 0): boolean {
+  if (!value || typeof value !== "object" || depth > 4) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => deliveryEnvelopeIndicatesDryRun(item, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    record.dryRun === true ||
+    normalizeOptionalLowercaseString(record.deliveryStatus) === DRY_RUN_DELIVERY_STATUS
+  ) {
+    return true;
+  }
+
+  const content = record.content;
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (deliveryEnvelopeIndicatesDryRun(item, depth + 1)) {
+        return true;
+      }
+      if (item && typeof item === "object" && !Array.isArray(item)) {
+        const text = (item as Record<string, unknown>).text;
+        if (typeof text === "string") {
+          const parsed = parseJsonRecord(text);
+          if (parsed && deliveryEnvelopeIndicatesDryRun(parsed, depth + 1)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return RESULT_ENVELOPE_KEYS.some((key) =>
+    deliveryEnvelopeIndicatesDryRun(record[key], depth + 1),
+  );
 }
 
 function readExecToolDetails(result: unknown): ExecToolDetails | null {
@@ -1225,13 +1284,17 @@ export async function handleToolExecutionEnd(
   const isMessagingSend =
     pendingMediaUrls.length > 0 ||
     (isMessagingTool(toolName) && isMessagingToolSendAction(toolName, startArgs));
+  const isMessagingDryRun =
+    isMessagingTool(toolName) &&
+    isMessagingToolSendAction(toolName, startArgs) &&
+    (startArgs.dryRun === true || deliveryEnvelopeIndicatesDryRun(result));
   const committedMediaUrls =
-    !isToolError && isMessagingSend
+    !isToolError && isMessagingSend && !isMessagingDryRun
       ? [...pendingMediaUrls, ...collectMessagingMediaUrlsFromToolResult(result)]
       : [];
   if (pendingText) {
     ctx.state.pendingMessagingTexts.delete(toolCallId);
-    if (!isToolError) {
+    if (!isToolError && !isMessagingDryRun) {
       ctx.state.messagingToolSentTexts.push(pendingText);
       ctx.state.messagingToolSentTextsNormalized.push(normalizeTextForComparison(pendingText));
       ctx.log.debug(`Committed messaging text: tool=${toolName} len=${pendingText.length}`);
@@ -1240,7 +1303,7 @@ export async function handleToolExecutionEnd(
   }
   if (pendingTarget) {
     ctx.state.pendingMessagingTargets.delete(toolCallId);
-    if (!isToolError) {
+    if (!isToolError && !isMessagingDryRun) {
       ctx.state.messagingToolSentTargets.push({
         ...pendingTarget,
         ...(pendingText ? { text: pendingText } : {}),
@@ -1250,7 +1313,7 @@ export async function handleToolExecutionEnd(
     }
   }
   ctx.state.pendingMessagingMediaUrls.delete(toolCallId);
-  if (!isToolError && isMessagingSend) {
+  if (!isToolError && isMessagingSend && !isMessagingDryRun) {
     if (committedMediaUrls.length > 0) {
       ctx.state.messagingToolSentMediaUrls.push(...committedMediaUrls);
       ctx.trimMessagingToolSent();

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -681,6 +681,21 @@ export function extractMessagingToolSend(
         }
       : undefined;
   }
+  if (toolName === "sessions_send") {
+    const toRaw =
+      normalizeOptionalString(args.sessionKey) ??
+      normalizeOptionalString(args.sessionId) ??
+      normalizeOptionalString(args.label);
+    const to = normalizeTargetForProvider("session", toRaw);
+    return to
+      ? {
+          tool: toolName,
+          provider: "session",
+          accountId,
+          to,
+        }
+      : undefined;
+  }
   const providerId = normalizeChannelId(toolName);
   if (!providerId) {
     return undefined;

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -948,6 +948,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("use `message(action=send)` for visible source-channel output");
+    expect(prompt).toContain("Final-only answers are private in this mode");
     expect(prompt).toContain("Attach media with message-tool attachment fields");
     expect(prompt).not.toContain("Attach media: `MEDIA:<path-or-url>`");
     expect(prompt).toContain("The target defaults to the current source channel");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -529,6 +529,9 @@ function buildMessagingSection(params: {
     messageToolOnly
       ? "- Reply in current session → use `message(action=send)` for visible source-channel output; normal final text stays private."
       : "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",
+    messageToolOnly
+      ? "- Final-only answers are private in this mode. If the current user should see the answer, send it with `message(action=send)` before ending the turn."
+      : "",
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
     subagentOrchestrationGuidance,
     completionEventGuidance,


### PR DESCRIPTION
## Summary
- Retry once when a `message_tool_only` source reply is written as private final text instead of being sent with the message tool.
- If the retry still does not produce a current source reply, return a small visible runtime error instead of letting the turn look like a silent success.
- Tighten the source-reply prompt wording so final-only answers are called out as private in this mode.

## Linked context
I hit this on a Telegram direct Codex app-server turn on v2026.5.26. The run was correctly in `sourceReplyDeliveryMode: "message_tool_only"`, but the assistant answered only in final text. That final answer stayed private, so the source chat saw nothing and the turn looked stuck even though the model had produced an answer.

This PR keeps the message tool as the delivery path. It does not auto-publish the private final answer; it gives the agent one chance to send the reply through the intended tool, then fails visibly if it still does not produce a current source reply.

## Review follow-up
- Tightened the recovery predicate so a routed/cross-session `message(action=send)` no longer counts as delivery to the current source conversation. The guard now requires `messagingToolSourceReplyPayloads`, matching the existing default-route/source-reply evidence path.
- Moved the recovery check behind the existing planning-only retry path, so plan-only text like “I'll inspect the files now” still gets the normal act-now retry instead of being steered to send a message immediately.
- Added regressions for both cases.

## Relationship to #84485
This complements #84485 rather than replacing it.

#84485 is Discord-specific and explores a source-delivery guard around `runReplyAgent` behavior. This PR stays in the embedded-agent runner and keeps the strict `message_tool_only` privacy boundary: ordinary final text remains private and is not republished as the source reply. The only visible fallback here is a runtime error payload after the model has already had one replay-safe chance to use `message(action=send)` for the current source conversation.

## Behavior proof
The runner regressions cover the failure mode directly:
- first attempt writes ordinary assistant/final text with no source-reply message-tool evidence;
- the runner retries once with a message-tool-only delivery steer;
- a successful retry with default-route source reply evidence ends without duplicate final payloads;
- an exhausted retry returns a visible runtime error payload;
- explicit-route/cross-session message sends do not mask the missing current source reply;
- planning-only text still follows the planning-only retry path first.

Live transport proof for the PR head is still pending. I requested Mantis Telegram proof after pushing the review-fix commit so the PR can get real source-channel evidence without exposing private setup details.

## Tests and validation
- `corepack pnpm format:check -- src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/incomplete-turn.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts`
- `corepack pnpm test:changed -- src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.test.ts`
- `corepack pnpm prompt:snapshots:check`
- `CI=1 corepack pnpm check:changed -- src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/incomplete-turn.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts`

I did not run the full `pnpm build && pnpm check && pnpm test` suite locally.

## Risk checklist
- [x] No secrets, private IDs, logs, or local config included.
- [x] Keeps successful current-source `message(action=send)` delivery as the normal path.
- [x] Does not treat explicit-route/cross-session sends as current source replies.
- [x] Does not turn private final text into an automatic source-channel message.
- [x] Preserves planning-only retries before message-tool-only recovery.
- [x] Fails visibly after one retry instead of reporting a quiet terminal success.
- [x] I’m okay with maintainers editing this branch.

## Current review state
AI-assisted change. I traced the delivery path, wrote the patch, addressed the automated review feedback, and ran the validation above locally.
