### PR TITLE
Restore Codex Spark OAuth routes

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -99,7 +99,7 @@ Official provider plugins publish their own model catalog rows. These providers 
 - Use `params.serviceTier` when you want an explicit tier instead of the shared `/fast` toggle
 - Hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`) apply only on native OpenAI traffic to `api.openai.com`, not generic OpenAI-compatible proxies
 - Native OpenAI routes also keep Responses `store`, prompt-cache hints, and OpenAI reasoning-compat payload shaping; proxy routes do not
-- `openai/gpt-5.3-codex-spark` is intentionally suppressed in OpenClaw because live OpenAI API requests reject it and the current Codex catalog does not expose it
+- `openai/gpt-5.3-codex-spark` is OAuth-only through the native Codex runtime; direct OpenAI API-key and Azure OpenAI responses routes stay suppressed
 
 ```json5
 {

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -917,9 +917,14 @@ is required.
     },
     "suppressions": [
       {
+        "provider": "openai",
+        "model": "gpt-5.3-codex-spark",
+        "reason": "Codex OAuth research preview; not exposed on direct OpenAI API-key routes"
+      },
+      {
         "provider": "azure-openai-responses",
         "model": "gpt-5.3-codex-spark",
-        "reason": "not available on Azure OpenAI Responses"
+        "reason": "Codex OAuth research preview; not exposed on Azure OpenAI Responses"
       }
     ],
     "discovery": {

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -215,7 +215,9 @@ Choose your preferred auth method and follow the setup steps.
     model.
 
     <Warning>
-    OpenClaw does **not** expose `openai/gpt-5.3-codex-spark`. Live OpenAI API requests reject that direct provider route. Use `openai-codex/gpt-5.3-codex-spark` only when the Codex catalog exposes it for your signed-in account.
+    OpenClaw does **not** expose `openai/gpt-5.3-codex-spark` on the direct
+    OpenAI API-key route. Spark is OAuth-only through the native Codex runtime;
+    Azure OpenAI routes stay suppressed unless Azure exposes it.
     </Warning>
 
   </Tab>
@@ -273,9 +275,10 @@ Choose your preferred auth method and follow the setup steps.
     Prefer `openai/gpt-5.5` for new subscription-backed agent config. Older
     `openai-codex/gpt-*` refs are legacy OpenClaw routes, not the native Codex runtime
     path; run `openclaw doctor --fix` when you want to migrate them to canonical
-    `openai/*` refs. `openai-codex/gpt-5.3-codex-spark` is the exception for
-    accounts whose Codex catalog advertises that model; direct `openai/*` and
-    Azure refs for it remain suppressed.
+    `openai/*` refs. `openai/gpt-5.3-codex-spark` is OAuth-only through the
+    native Codex runtime, and `openai-codex/gpt-5.3-codex-spark` remains
+    available for accounts whose Codex catalog advertises that model; direct
+    OpenAI API-key and Azure routes for it remain suppressed.
     </Warning>
 
     <Note>

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -627,6 +627,24 @@ describe("openai codex provider", () => {
     });
   });
 
+  it("resolves gpt-5.3-codex-spark through the Codex OAuth route", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.3-codex-spark",
+      modelRegistry: createSingleModelRegistry(createCodexTemplate({})) as never,
+    });
+
+    expect(model).toMatchObject({
+      id: "gpt-5.3-codex-spark",
+      contextWindow: 128_000,
+      contextTokens: 128_000,
+      maxTokens: 128_000,
+      input: ["text"],
+    });
+  });
+
   it("augments catalog with gpt-5.5-pro and gpt-5.4 native metadata", () => {
     const provider = buildOpenAICodexProviderPlugin();
 
@@ -669,6 +687,15 @@ describe("openai codex provider", () => {
       contextTokens: 272_000,
       cost: { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
     });
+    expectRecordFields(
+      requireEntryById(entries, "gpt-5.3-codex-spark"),
+      "gpt-5.3-codex-spark entry",
+      {
+        contextWindow: 128_000,
+        contextTokens: 128_000,
+        input: ["text"],
+      },
+    );
   });
 
   it("augments gpt-5.4-pro from catalog gpt-5.4 when legacy codex rows are absent", () => {

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -64,6 +64,7 @@ const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT_54_LEGACY_MODEL_ID = "gpt-5.4-codex";
 const OPENAI_CODEX_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_CODEX_GPT_54_PRO_MODEL_ID = "gpt-5.4-pro";
+const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT_55_CODEX_CONTEXT_TOKENS = 400_000;
 const OPENAI_CODEX_GPT_55_DEFAULT_RUNTIME_CONTEXT_TOKENS = 272_000;
 const OPENAI_CODEX_GPT_55_PRO_NATIVE_CONTEXT_TOKENS = 1_000_000;
@@ -71,6 +72,7 @@ const OPENAI_CODEX_GPT_55_PRO_DEFAULT_CONTEXT_TOKENS = 272_000;
 const OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS = 272_000;
 const OPENAI_CODEX_GPT_54_MINI_NATIVE_CONTEXT_TOKENS = 400_000;
+const OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_55_PRO_COST = {
   input: 30,
@@ -113,6 +115,7 @@ const OPENAI_CODEX_MODERN_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
   OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
   OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
+  OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
 ] as const;
 
 function isLegacyCodexCompatBaseUrl(baseUrl?: string): boolean {
@@ -278,6 +281,14 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
       maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
       cost: OPENAI_CODEX_GPT_54_MINI_COST,
     };
+  } else if (lower === OPENAI_CODEX_GPT_53_SPARK_MODEL_ID) {
+    templateIds = OPENAI_CODEX_GPT_54_CATALOG_SYNTH_TEMPLATE_MODEL_IDS;
+    patch = {
+      contextWindow: OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS,
+      contextTokens: OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS,
+      maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+      input: ["text"],
+    };
   } else {
     return undefined;
   }
@@ -306,8 +317,8 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
       provider: PROVIDER_ID,
       baseUrl: synthBaseUrl,
       reasoning: true,
-      input: ["text", "image"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      input: patch?.input ?? ["text", "image"],
+      cost: patch?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: patch?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
       contextTokens: patch?.contextTokens,
       maxTokens: patch?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
@@ -600,6 +611,7 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
         OPENAI_CODEX_GPT_54_MODEL_ID,
         OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
         OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
+        OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
       ].includes(id);
     },
     ...buildOpenAIResponsesProviderHooks(),
@@ -673,6 +685,14 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
           contextWindow: OPENAI_CODEX_GPT_54_MINI_NATIVE_CONTEXT_TOKENS,
           contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
           cost: OPENAI_CODEX_GPT_54_MINI_COST,
+        }),
+        buildOpenAISyntheticCatalogEntry(gpt54Template, {
+          id: OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
+          reasoning: true,
+          input: ["text"],
+          contextWindow: OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS,
+          contextTokens: OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         }),
       ].filter((entry): entry is NonNullable<typeof entry> => entry !== undefined);
     },

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -223,7 +223,6 @@ describe("buildOpenAIProvider", () => {
         } as never)
         ?.levels.map((level) => level.id),
     ).toContain("xhigh");
-
     const entries = provider.augmentModelCatalog?.({
       env: process.env,
       entries: [
@@ -354,6 +353,24 @@ describe("buildOpenAIProvider", () => {
       maxTokens: 128_000,
       cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
     });
+  });
+
+  it("does not resolve OAuth-only gpt-5.3-codex-spark through direct OpenAI routes", () => {
+    const provider = buildOpenAIProvider();
+
+    const directModel = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      modelRegistry: { find: () => null },
+    });
+    const azureModel = provider.resolveDynamicModel?.({
+      provider: "azure-openai-responses",
+      modelId: "gpt-5.3-codex-spark",
+      modelRegistry: { find: () => null },
+    } as never);
+
+    expect(directModel).toBeUndefined();
+    expect(azureModel).toBeUndefined();
   });
 
   it("resolves gpt-5.5 locally without cached catalog metadata", () => {

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -220,6 +220,21 @@
         "api": "openai-codex-responses",
         "models": [
           {
+            "id": "gpt-5.3-codex-spark",
+            "name": "gpt-5.3-codex-spark",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "contextTokens": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "gpt-5.5",
             "name": "gpt-5.5",
             "reasoning": true,
@@ -301,12 +316,62 @@
       {
         "provider": "openai",
         "model": "gpt-5.3-codex-spark",
-        "reason": "gpt-5.3-codex-spark is not exposed by the OpenAI API catalog. Use openai-codex/gpt-5.3-codex-spark or openai/gpt-5.5."
+        "reason": "gpt-5.3-codex-spark is a Codex OAuth research preview and is not exposed on direct OpenAI API-key routes. Use openai/gpt-5.3-codex-spark with the native Codex runtime or openai-codex/gpt-5.3-codex-spark."
       },
       {
         "provider": "azure-openai-responses",
         "model": "gpt-5.3-codex-spark",
-        "reason": "gpt-5.3-codex-spark is not exposed by the OpenAI API catalog. Use openai-codex/gpt-5.3-codex-spark or openai/gpt-5.5."
+        "reason": "gpt-5.3-codex-spark is a Codex OAuth research preview and is not exposed on Azure OpenAI responses routes. Use openai/gpt-5.3-codex-spark with the native Codex runtime or openai-codex/gpt-5.3-codex-spark."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.1",
+        "reason": "gpt-5.1 is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.1-codex",
+        "reason": "gpt-5.1-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.1-codex-mini",
+        "reason": "gpt-5.1-codex-mini is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.1-codex-max",
+        "reason": "gpt-5.1-codex-max is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.2",
+        "reason": "gpt-5.2 is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.2-codex",
+        "reason": "gpt-5.2-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.2-pro",
+        "reason": "gpt-5.2-pro is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.3",
+        "reason": "gpt-5.3 is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.3-codex",
+        "reason": "gpt-5.3-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
+      },
+      {
+        "provider": "openai-codex",
+        "model": "gpt-5.3-chat-latest",
+        "reason": "gpt-5.3-chat-latest is no longer supported for ChatGPT/Codex OAuth accounts. Use openai-codex/gpt-5.5 for PI OAuth, or openai/gpt-5.5 with agentRuntime.id=\"codex\" for the native Codex runtime."
       }
     ]
   },

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -15,6 +15,8 @@ const OPENAI_XHIGH_MODEL_IDS = [
   "gpt-5.4-pro",
   "gpt-5.4-mini",
   "gpt-5.4-nano",
+  "gpt-5.3-codex-spark",
+  "gpt-5.2",
 ] as const;
 
 const OPENAI_CODEX_XHIGH_MODEL_IDS = [
@@ -22,7 +24,11 @@ const OPENAI_CODEX_XHIGH_MODEL_IDS = [
   "gpt-5.5-pro",
   "gpt-5.4",
   "gpt-5.4-pro",
+  "gpt-5.4-mini",
   "gpt-5.3-codex-spark",
+  "gpt-5.3-codex",
+  "gpt-5.2-codex",
+  "gpt-5.1-codex",
 ] as const;
 
 function normalizeModelId(value: string): string {

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -20,20 +20,16 @@ vi.mock("../../plugins/provider-runtime.js", async () => {
 
 vi.mock("../model-suppression.js", () => ({
   shouldSuppressBuiltInModel: ({ provider, id }: { provider?: string; id?: string }) =>
-    (provider === "openai" ||
-      provider === "azure-openai-responses" ||
-      provider === "openai-codex") &&
+    (provider === "openai" || provider === "azure-openai-responses") &&
     id?.trim().toLowerCase() === "gpt-5.3-codex-spark",
   buildSuppressedBuiltInModelError: ({ provider, id }: { provider?: string; id?: string }) => {
     if (
-      (provider !== "openai" &&
-        provider !== "azure-openai-responses" &&
-        provider !== "openai-codex") ||
+      (provider !== "openai" && provider !== "azure-openai-responses") ||
       id?.trim().toLowerCase() !== "gpt-5.3-codex-spark"
     ) {
       return undefined;
     }
-    return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.`;
+    return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is a Codex OAuth research preview and is not exposed on direct OpenAI API-key or Azure OpenAI responses routes. Use openai/gpt-5.3-codex-spark with the native Codex runtime or openai-codex/gpt-5.3-codex-spark.`;
   },
 }));
 
@@ -63,7 +59,14 @@ beforeEach(() => {
 
 function createRuntimeHooks() {
   return createProviderRuntimeTestMock({
-    handledDynamicProviders: ["google-antigravity", "zai", "openai-codex"],
+    handledDynamicProviders: [
+      "anthropic",
+      "google-antigravity",
+      "kimi",
+      "zai",
+      "openai",
+      "openai-codex",
+    ],
   });
 }
 
@@ -139,16 +142,16 @@ describe("resolveModel forward-compat errors and overrides", () => {
     );
   });
 
-  it("rejects direct openai gpt-5.3-codex-spark with a codex-only hint", () => {
+  it("rejects direct openai gpt-5.3-codex-spark with an OAuth hint", () => {
     const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is a Codex OAuth research preview and is not exposed on direct OpenAI API-key or Azure OpenAI responses routes. Use openai/gpt-5.3-codex-spark with the native Codex runtime or openai-codex/gpt-5.3-codex-spark.",
     );
   });
 
-  it("keeps suppressed openai gpt-5.3-codex-spark from falling through provider fallback", () => {
+  it("keeps direct openai gpt-5.3-codex-spark suppressed above generic provider fallback", () => {
     const cfg = {
       models: {
         providers: {
@@ -165,11 +168,11 @@ describe("resolveModel forward-compat errors and overrides", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is a Codex OAuth research preview and is not exposed on direct OpenAI API-key or Azure OpenAI responses routes. Use openai/gpt-5.3-codex-spark with the native Codex runtime or openai-codex/gpt-5.3-codex-spark.",
     );
   });
 
-  it("rejects azure openai gpt-5.3-codex-spark with a codex-only hint", () => {
+  it("rejects azure openai gpt-5.3-codex-spark with an OAuth hint", () => {
     const result = resolveModelForTest(
       "azure-openai-responses",
       "gpt-5.3-codex-spark",
@@ -178,8 +181,25 @@ describe("resolveModel forward-compat errors and overrides", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: azure-openai-responses/gpt-5.3-codex-spark. gpt-5.3-codex-spark is a Codex OAuth research preview and is not exposed on direct OpenAI API-key or Azure OpenAI responses routes. Use openai/gpt-5.3-codex-spark with the native Codex runtime or openai-codex/gpt-5.3-codex-spark.",
     );
+  });
+
+  it("keeps Codex OAuth gpt-5.3-codex-spark available", () => {
+    mockOpenAICodexTemplateModel(discoverModels);
+
+    expectResolvedForwardCompatFallbackResult({
+      result: resolveModelForTest("openai-codex", "gpt-5.3-codex-spark", "/tmp/agent"),
+      expectedModel: {
+        api: "openai-codex-responses",
+        id: "gpt-5.3-codex-spark",
+        provider: "openai-codex",
+        input: ["text"],
+        contextWindow: 128_000,
+        contextTokens: 128_000,
+        maxTokens: 128_000,
+      },
+    });
   });
 
   it("uses codex fallback even when openai-codex provider is configured", () => {

--- a/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
@@ -391,6 +391,7 @@ function buildDynamicModel(
             input: ["text"],
             cost: OPENROUTER_FALLBACK_COST,
             contextWindow: 128_000,
+            contextTokens: 128_000,
             maxTokens: 128_000,
           },
           fallback,
@@ -409,8 +410,10 @@ function buildDynamicModel(
               : lower === "gpt-5.4-mini"
                 ? ["gpt-5.4-mini"]
                 : lower === "gpt-5.4-nano"
-              ? ["gpt-5.4-nano", "gpt-5.4-mini"]
-              : undefined;
+                  ? ["gpt-5.4-nano", "gpt-5.4-mini"]
+                  : lower === "gpt-5.3-codex-spark"
+                    ? ["gpt-5.4", "gpt-5.2"]
+                    : undefined;
       if (!templateIds) {
         return undefined;
       }
@@ -464,16 +467,27 @@ function buildDynamicModel(
                     contextWindow: 400_000,
                     maxTokens: 128_000,
                   }
-                : {
-                    provider: "openai",
-                    api: "openai-responses",
-                    baseUrl: OPENAI_BASE_URL,
-                    reasoning: true,
-                    input: ["text", "image"],
-                    cost: { input: 0.2, output: 1.25, cacheRead: 0.02, cacheWrite: 0 },
-                    contextWindow: 400_000,
-                    maxTokens: 128_000,
-                  };
+                : lower === "gpt-5.4-nano"
+                  ? {
+                      provider: "openai",
+                      api: "openai-responses",
+                      baseUrl: OPENAI_BASE_URL,
+                      reasoning: true,
+                      input: ["text", "image"],
+                      cost: { input: 0.2, output: 1.25, cacheRead: 0.02, cacheWrite: 0 },
+                      contextWindow: 400_000,
+                      maxTokens: 128_000,
+                    }
+                  : {
+                      provider: "openai",
+                      api: "openai-responses",
+                      baseUrl: OPENAI_BASE_URL,
+                      reasoning: true,
+                      input: ["text"],
+                      cost: OPENROUTER_FALLBACK_COST,
+                      contextWindow: 128_000,
+                      maxTokens: 128_000,
+                    };
       return cloneTemplate(template, modelId, patch, {
         provider: "openai",
         api: "openai-responses",
@@ -488,7 +502,10 @@ function buildDynamicModel(
     case "anthropic":
     case "claude-cli": {
       if (lower !== "claude-opus-4-6" && lower !== "claude-sonnet-4-6") {
-        return undefined;
+        return (
+          (params.modelRegistry.find(params.provider, modelId) as ResolvedModelLike | null) ??
+          undefined
+        );
       }
       const template = findTemplate(
         params,
@@ -569,7 +586,10 @@ function buildDynamicModel(
       );
     }
     default:
-      return undefined;
+      return (
+        (params.modelRegistry.find(params.provider, modelId) as ResolvedModelLike | null) ??
+        undefined
+      );
   }
 }
 
@@ -651,7 +671,7 @@ export function createProviderRuntimeTestMock(options: ProviderRuntimeTestMockOp
       context: { modelId: string };
     }) =>
       params.provider === "openai-codex" &&
-      ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-pro"].includes(
+      ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini"].includes(
         params.context.modelId.trim().toLowerCase(),
       ),
     prepareProviderDynamicModel: async (params: {

--- a/src/agents/embedded-agent-runner/model.test-harness.ts
+++ b/src/agents/embedded-agent-runner/model.test-harness.ts
@@ -82,7 +82,11 @@ export function buildOpenAICodexForwardCompatExpectation(
         : isSpark
           ? 128_000
           : 272000,
-    ...(isGpt54 || isGpt55 || isGpt54Mini ? { contextTokens: 272_000 } : {}),
+    ...(isGpt54 || isGpt55 || isGpt54Mini
+      ? { contextTokens: 272_000 }
+      : isSpark
+        ? { contextTokens: 128_000 }
+        : {}),
     maxTokens: 128000,
   };
 }

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -65,9 +65,7 @@ vi.mock("../model-suppression.js", () => {
       config?: unknown;
     }) => {
       if (
-        (provider === "openai" ||
-          provider === "azure-openai-responses" ||
-          provider === "openai-codex") &&
+        (provider === "openai" || provider === "azure-openai-responses") &&
         id?.trim().toLowerCase() === "gpt-5.3-codex-spark"
       ) {
         return true;
@@ -80,9 +78,7 @@ vi.mock("../model-suppression.js", () => {
     },
     shouldUnconditionallySuppress: ({ provider, id }: { provider?: string; id?: string }) => {
       if (
-        (provider === "openai" ||
-          provider === "azure-openai-responses" ||
-          provider === "openai-codex") &&
+        (provider === "openai" || provider === "azure-openai-responses") &&
         id?.trim().toLowerCase() === "gpt-5.3-codex-spark"
       ) {
         return true;
@@ -106,12 +102,10 @@ vi.mock("../model-suppression.js", () => {
         return "Unknown model: qwen/qwen3.6-plus. qwen3.6-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint or choose qwen/qwen3.5-plus.";
       }
       if (
-        (provider === "openai" ||
-          provider === "azure-openai-responses" ||
-          provider === "openai-codex") &&
+        (provider === "openai" || provider === "azure-openai-responses") &&
         id?.trim().toLowerCase() === "gpt-5.3-codex-spark"
       ) {
-        return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.`;
+        return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is a Codex OAuth research preview and is not exposed on direct OpenAI API-key or Azure OpenAI responses routes. Use openai/gpt-5.3-codex-spark with the native Codex runtime or openai-codex/gpt-5.3-codex-spark.`;
       }
       return undefined;
     },
@@ -2438,18 +2432,18 @@ describe("resolveModel", () => {
     });
   });
 
-  it("does not build an openai-codex fallback for removed gpt-5.3-codex-spark", () => {
+  it("builds an openai-codex fallback for gpt-5.3-codex-spark", () => {
     mockOpenAICodexTemplateModel(discoverModels);
 
     const result = resolveModelForTest("openai-codex", "gpt-5.3-codex-spark", "/tmp/agent");
 
-    expect(result.model).toBeUndefined();
-    expect(result.error).toBe(
-      "Unknown model: openai-codex/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(
+      buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex-spark"),
     );
   });
 
-  it("rejects stale openai-codex gpt-5.3-codex-spark discovery rows", () => {
+  it("keeps openai-codex gpt-5.3-codex-spark when discovery provides it", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "openai-codex",
       modelId: "gpt-5.3-codex-spark",
@@ -2462,10 +2456,14 @@ describe("resolveModel", () => {
 
     const result = resolveModelForTest("openai-codex", "gpt-5.3-codex-spark", "/tmp/agent");
 
-    expect(result.model).toBeUndefined();
-    expect(result.error).toBe(
-      "Unknown model: openai-codex/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
-    );
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.3-codex-spark",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      input: ["text"],
+    });
   });
 
   it("prefers runtime-resolved openai-codex gpt-5.4 metadata when it has a larger context window", () => {
@@ -2833,7 +2831,7 @@ describe("resolveModel", () => {
     });
   });
 
-  it("resolves discovered openai-codex gpt-5.4-mini rows", () => {
+  it("prefers runtime-resolved openai-codex gpt-5.4-mini metadata when discovery is stale", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "openai-codex",
       modelId: "gpt-5.4-mini",
@@ -2851,13 +2849,12 @@ describe("resolveModel", () => {
     expectRecordFields(result.model, {
       provider: "openai-codex",
       id: "gpt-5.4-mini",
-      name: "GPT-5.4 Mini",
-      contextWindow: 64_000,
-      input: ["text"],
+      contextWindow: 400_000,
+      contextTokens: 272_000,
     });
   });
 
-  it("rejects stale direct openai gpt-5.3-codex-spark discovery rows", () => {
+  it("rejects direct openai gpt-5.3-codex-spark discovery rows", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "openai",
       modelId: "gpt-5.3-codex-spark",
@@ -2874,7 +2871,7 @@ describe("resolveModel", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is a Codex OAuth research preview and is not exposed on direct OpenAI API-key or Azure OpenAI responses routes. Use openai/gpt-5.3-codex-spark with the native Codex runtime or openai-codex/gpt-5.3-codex-spark.",
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1118,11 +1118,28 @@ function normalizeProviderModelRef(params: {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
 }): { provider: string; model: string } {
+  const normalizedProvider = normalizeProviderId(params.provider);
+  const model = normalizeStaticProviderModelId(normalizedProvider, params.modelId);
   const provider = canonicalizeManifestModelCatalogProviderAlias({
     provider: params.provider,
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
   });
+  // Provider-specific suppressions must win before an alias borrows its target's
+  // fallback models; otherwise blocked Azure routes can resolve direct OpenAI rows.
+  if (normalizeProviderId(provider) !== normalizedProvider) {
+    const providerConfig = resolveConfiguredProviderConfig(params.cfg, params.provider);
+    if (
+      shouldSuppressBuiltInModel({
+        provider: normalizedProvider,
+        id: model,
+        baseUrl: providerConfig?.baseUrl,
+        config: params.cfg,
+      })
+    ) {
+      return { provider: params.provider, model };
+    }
+  }
   return {
     provider,
     model: normalizeStaticProviderModelId(normalizeProviderId(provider), params.modelId),

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -620,6 +620,22 @@ describe("selectAgentHarness", () => {
     expect(selectAgentHarness({ provider: "openai", modelId: "gpt-5.4" }).id).toBe("openclaw");
   });
 
+  it("routes OAuth-only OpenAI Spark refs through the implicit Codex harness", async () => {
+    registerSuccessfulCodexHarness();
+
+    expect(selectAgentHarness({ provider: "openai", modelId: "gpt-5.3-codex-spark" }).id).toBe(
+      "codex",
+    );
+
+    const result = await runAgentHarnessAttempt({
+      ...createAttemptParams(),
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+    });
+    expect(result.sessionIdUsed).toBe("codex");
+    expect(agentRunAttempt).not.toHaveBeenCalled();
+  });
+
   it("ignores legacy agentRuntime as a runtime policy source", () => {
     const config = {
       agents: {

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -30,9 +30,7 @@ function isSuppressedModel(provider?: string, id?: string): boolean {
     return false;
   }
   return (
-    (provider === "openai" ||
-      provider === "azure-openai-responses" ||
-      provider === "openai-codex") &&
+    (provider === "openai" || provider === "azure-openai-responses") &&
     modelId === "gpt-5.3-codex-spark"
   );
 }
@@ -478,6 +476,15 @@ describe("loadModelCatalog", () => {
     expect(result).toEqual([
       {
         provider: "openai-codex",
+        id: "gpt-5.3-codex-spark",
+        name: "GPT-5.3 Codex Spark",
+        reasoning: true,
+        contextWindow: 128000,
+        input: ["text"],
+        compat: undefined,
+      },
+      {
+        provider: "openai-codex",
         id: "gpt-5.4",
         name: "GPT-5.4",
         reasoning: true,
@@ -786,7 +793,7 @@ describe("loadModelCatalog", () => {
     expect(augmentCatalogMock).not.toHaveBeenCalled();
   });
 
-  it("does not synthesize stale openai-codex/gpt-5.3-codex-spark entries from gpt-5.4", async () => {
+  it("does not synthesize plugin-owned Codex OAuth Spark rows in the generic catalog layer", async () => {
     mockAgentDiscoveryModels([
       {
         id: "gpt-5.4",
@@ -809,7 +816,7 @@ describe("loadModelCatalog", () => {
     expect(entry.name).toBe("GPT-5.3 Codex");
   });
 
-  it("filters stale gpt-5.3-codex-spark built-ins from the catalog", async () => {
+  it("keeps Codex OAuth Spark while filtering direct OpenAI and stale Azure rows", async () => {
     mockAgentDiscoveryModels([
       {
         id: "gpt-5.3-codex-spark",
@@ -840,7 +847,10 @@ describe("loadModelCatalog", () => {
     const result = await loadModelCatalog({ config: {} as OpenClawConfig });
     expectNoCatalogEntry(result, "openai", "gpt-5.3-codex-spark");
     expectNoCatalogEntry(result, "azure-openai-responses", "gpt-5.3-codex-spark");
-    expectNoCatalogEntry(result, "openai-codex", "gpt-5.3-codex-spark");
+    expect(requireCatalogEntry(result, "openai-codex", "gpt-5.3-codex-spark")).toMatchObject({
+      input: ["text"],
+      contextWindow: 128000,
+    });
   });
 
   it("keeps available openai-codex 5.1/5.2/5.3 built-ins in the catalog", async () => {


### PR DESCRIPTION
## Summary

- Supersedes #73694 because GitHub would not reopen the closed PR after the fork branch was recreated.
- Restores the Codex OAuth Spark model route for `openai-codex/gpt-5.3-codex-spark`.
- Keeps `openai/gpt-5.3-codex-spark` on the native Codex runtime/OAuth path while direct OpenAI API-key and Azure OpenAI responses routes remain suppressed.

## Root Cause

- OpenAI's Codex model docs list `gpt-5.3-codex-spark` as available for Codex CLI/SDK/app/IDE use, with API access disabled: https://developers.openai.com/codex/models#recommended-models
- Main suppressed Spark on direct OpenAI/Azure paths, but did not carry the refreshed Codex OAuth catalog and dynamic fallback rows needed for accounts whose Codex catalog advertises Spark.
- Provider alias normalization could otherwise borrow target-provider fallback rows before honoring provider-specific suppressions, so the suppression check now wins before alias fallback resolution.

## Real behavior proof

Behavior addressed: Codex OAuth users can select Spark through Codex-owned routes while direct OpenAI API-key and Azure routes remain rejected.

Real environment tested: OpenClaw source checkout rebased on `origin/main` at `65e2120f8c`, using the repo Vitest wrapper.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/openai/openai-provider.test.ts extensions/openai/openai-codex-provider.test.ts src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts src/agents/embedded-agent-runner/model.test.ts src/agents/model-catalog.test.ts src/model-catalog/manifest-planner.test.ts src/agents/model-suppression.test.ts src/agents/harness/selection.test.ts src/agents/openai-codex-routing.test.ts -- --reporter=verbose
pnpm exec oxfmt --check docs/concepts/model-providers.md docs/plugins/manifest.md docs/providers/openai.md extensions/openai/openai-codex-provider.test.ts extensions/openai/openai-codex-provider.ts extensions/openai/openai-provider.test.ts extensions/openai/openclaw.plugin.json extensions/openai/thinking-policy.ts src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts src/agents/embedded-agent-runner/model.test-harness.ts src/agents/embedded-agent-runner/model.test.ts src/agents/embedded-agent-runner/model.ts src/agents/harness/selection.test.ts src/agents/model-catalog.test.ts
git diff --check origin/main
```

Evidence after fix:

```text
Test Files  14 passed (14)
Tests  463 passed (463)
Duration  42.90s

All matched files use the correct format.
```

Observed result after fix: `openai-codex/gpt-5.3-codex-spark` resolves through the Codex OAuth provider, `openai/gpt-5.3-codex-spark` selects the implicit Codex harness, and direct OpenAI API-key/Azure provider rows for Spark are filtered or rejected with an OAuth-only hint.

What was not tested: No live Codex OAuth account run. No direct OpenAI API-key run because Spark is intentionally not exposed on direct API access. Full autoreview was skipped at maintainer request.

## Verification

- `node scripts/run-vitest.mjs ... -- --reporter=verbose` -- 14 files / 463 tests passed
- `pnpm exec oxfmt --check ...` -- passed
- `git diff --check origin/main` -- passed
