### PR TITLE
[AI-assisted] fix(nostr): keep DM subscriptions alive until abort

### DIFF
--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -90,13 +90,24 @@ async function startGatewayHarness(params: {
   const bus = createMockBus();
   setNostrRuntime(harness.runtime);
   mocks.startNostrBus.mockResolvedValueOnce(bus as never);
+  const abort = new AbortController();
 
-  const cleanup = (await startNostrGatewayAccount(
+  const task = startNostrGatewayAccount(
     createStartAccountContext({
       account: params.account,
       cfg: params.cfg,
+      abortSignal: abort.signal,
     }),
-  )) as { stop: () => void };
+  );
+  await vi.waitFor(() => {
+    expect(mocks.startNostrBus).toHaveBeenCalledTimes(1);
+  });
+  const cleanup = {
+    stop: async () => {
+      abort.abort();
+      await task;
+    },
+  };
 
   return { harness, bus, cleanup };
 }
@@ -139,7 +150,7 @@ describe("nostr inbound gateway path", () => {
     expect(sendPairingReply).toHaveBeenCalledTimes(1);
     expect(mockCallArg(sendPairingReply)).toContain("Pairing code:");
 
-    cleanup.stop();
+    await cleanup.stop();
   });
 
   it("routes allowed DMs through the standard reply pipeline", async () => {
@@ -182,6 +193,6 @@ describe("nostr inbound gateway path", () => {
     expect(ctx?.CommandAuthorized).toBe(true);
     expect(sendReply).toHaveBeenCalledWith("converted:|a|b|");
 
-    cleanup.stop();
+    await cleanup.stop();
   });
 });

--- a/extensions/nostr/src/channel.lifecycle.test.ts
+++ b/extensions/nostr/src/channel.lifecycle.test.ts
@@ -1,11 +1,13 @@
 import {
   createStartAccountContext,
+  createPluginRuntimeMock,
   expectStopPendingUntilAbort,
   startAccountAndTrackLifecycle,
   waitForStartedMocks,
 } from "openclaw/plugin-sdk/channel-test-helpers";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getActiveNostrBuses, startNostrGatewayAccount } from "./gateway.js";
+import { setNostrRuntime } from "./runtime.js";
 import { buildResolvedNostrAccount } from "./test-fixtures.js";
 
 const mocks = vi.hoisted(() => ({
@@ -28,6 +30,10 @@ function createMockBus() {
 }
 
 describe("nostr gateway lifecycle", () => {
+  beforeEach(() => {
+    setNostrRuntime(createPluginRuntimeMock());
+  });
+
   afterEach(() => {
     mocks.startNostrBus.mockReset();
   });

--- a/extensions/nostr/src/channel.lifecycle.test.ts
+++ b/extensions/nostr/src/channel.lifecycle.test.ts
@@ -1,0 +1,90 @@
+import {
+  createStartAccountContext,
+  expectStopPendingUntilAbort,
+  startAccountAndTrackLifecycle,
+  waitForStartedMocks,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getActiveNostrBuses, startNostrGatewayAccount } from "./gateway.js";
+import { buildResolvedNostrAccount } from "./test-fixtures.js";
+
+const mocks = vi.hoisted(() => ({
+  startNostrBus: vi.fn(),
+}));
+
+vi.mock("./nostr-bus.js", () => ({
+  DEFAULT_RELAYS: ["wss://relay.example.com"],
+  startNostrBus: mocks.startNostrBus,
+}));
+
+function createMockBus() {
+  return {
+    sendDm: vi.fn(async () => {}),
+    close: vi.fn(),
+    getMetrics: vi.fn(() => ({ counters: {} })),
+    publishProfile: vi.fn(),
+    getProfileState: vi.fn(async () => null),
+  };
+}
+
+describe("nostr gateway lifecycle", () => {
+  afterEach(() => {
+    mocks.startNostrBus.mockReset();
+  });
+
+  it("keeps startAccount pending until abort, then closes the bus", async () => {
+    const bus = createMockBus();
+    mocks.startNostrBus.mockResolvedValueOnce(bus as never);
+
+    const { abort, task, isSettled } = startAccountAndTrackLifecycle({
+      startAccount: startNostrGatewayAccount,
+      account: buildResolvedNostrAccount(),
+    });
+
+    await expectStopPendingUntilAbort({
+      waitForStarted: waitForStartedMocks(mocks.startNostrBus),
+      isSettled,
+      abort,
+      task,
+      stop: bus.close,
+    });
+  });
+
+  it("keeps the active bus registered while pending and removes it after abort", async () => {
+    const bus = createMockBus();
+    mocks.startNostrBus.mockResolvedValueOnce(bus as never);
+
+    const { abort, task, isSettled } = startAccountAndTrackLifecycle({
+      startAccount: startNostrGatewayAccount,
+      account: buildResolvedNostrAccount(),
+    });
+
+    await vi.waitFor(() => {
+      expect(getActiveNostrBuses().get("default")).toBe(bus);
+    });
+    expect(isSettled()).toBe(false);
+
+    abort.abort();
+    await task;
+
+    expect(bus.close).toHaveBeenCalledOnce();
+    expect(getActiveNostrBuses().has("default")).toBe(false);
+  });
+
+  it("stops immediately when startAccount receives an already-aborted signal", async () => {
+    const bus = createMockBus();
+    mocks.startNostrBus.mockResolvedValueOnce(bus as never);
+    const abort = new AbortController();
+    abort.abort();
+
+    await startNostrGatewayAccount(
+      createStartAccountContext({
+        account: buildResolvedNostrAccount(),
+        abortSignal: abort.signal,
+      }),
+    );
+
+    expect(mocks.startNostrBus).toHaveBeenCalledOnce();
+    expect(bus.close).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -57,12 +57,23 @@ async function startOutboundAccount(accountId?: string) {
     getProfileState: vi.fn(async () => null),
   };
   mocks.startNostrBus.mockResolvedValueOnce(bus as unknown);
+  const abort = new AbortController();
 
-  const cleanup = (await startNostrGatewayAccount(
+  const task = startNostrGatewayAccount(
     createStartAccountContext({
       account: buildResolvedNostrAccount(accountId ? { accountId } : undefined),
+      abortSignal: abort.signal,
     }),
-  )) as { stop: () => void };
+  );
+  await vi.waitFor(() => {
+    expect(mocks.startNostrBus).toHaveBeenCalledTimes(1);
+  });
+  const cleanup = {
+    stop: async () => {
+      abort.abort();
+      await task;
+    },
+  };
 
   return { cleanup, sendDm };
 }
@@ -96,7 +107,7 @@ describe("nostr outbound cfg threading", () => {
     expect(mocks.normalizePubkey).toHaveBeenCalledWith("NPUB123");
     expect(sendDm).toHaveBeenCalledWith("normalized-npub123", "converted:|a|b|");
 
-    cleanup.stop();
+    await cleanup.stop();
   });
 
   it("uses the configured defaultAccount when accountId is omitted", async () => {
@@ -125,7 +136,7 @@ describe("nostr outbound cfg threading", () => {
     });
     expect(sendDm).toHaveBeenCalledWith("normalized-npub123", "hello");
 
-    cleanup.stop();
+    await cleanup.stop();
   });
 
   it("backs declared message adapter capabilities with outbound sends", async () => {
@@ -158,6 +169,6 @@ describe("nostr outbound cfg threading", () => {
       },
     });
 
-    cleanup.stop();
+    await cleanup.stop();
   });
 });

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -5,6 +5,7 @@ import {
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { runStoppablePassiveMonitor } from "openclaw/plugin-sdk/extension-shared";
 import { type ChannelOutboundAdapter, type ChannelPlugin } from "./channel-api.js";
 import type { MetricEvent, MetricsSnapshot } from "./metrics.js";
 import { startNostrBus, type NostrBusHandle } from "./nostr-bus.js";
@@ -143,118 +144,133 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
     return "block";
   };
 
-  const bus = await startNostrBus({
-    accountId: account.accountId,
-    privateKey: account.privateKey,
-    relays: account.relays,
-    authorizeSender: async ({ senderPubkey, reply }) =>
-      await authorizeSender({ senderId: senderPubkey, reply }),
-    onMessage: async (senderPubkey, text, reply, meta) => {
-      const resolvedAccess = await resolveInboundAccess(senderPubkey, text);
-      if (resolvedAccess.senderAccess.decision !== "allow") {
-        ctx.log?.warn?.(
-          `[${account.accountId}] dropping Nostr DM after preflight drift (${senderPubkey}, ${resolvedAccess.senderAccess.reasonCode})`,
-        );
-        return;
-      }
-
-      const { dispatchInboundDirectDmWithRuntime } = await import("./inbound-direct-dm-runtime.js");
-      await dispatchInboundDirectDmWithRuntime({
-        cfg: ctx.cfg,
-        runtime,
-        channel: "nostr",
-        channelLabel: "Nostr",
+  await runStoppablePassiveMonitor({
+    abortSignal: ctx.abortSignal,
+    start: async () => {
+      const bus = await startNostrBus({
         accountId: account.accountId,
-        peer: {
-          kind: "direct",
-          id: senderPubkey,
-        },
-        senderId: senderPubkey,
-        senderAddress: `nostr:${senderPubkey}`,
-        recipientAddress: `nostr:${account.publicKey}`,
-        conversationLabel: senderPubkey,
-        rawBody: text,
-        messageId: meta.eventId,
-        timestamp: meta.createdAt * 1000,
-        commandAuthorized: resolvedAccess.commandAccess.requested
-          ? resolvedAccess.commandAccess.authorized
-          : undefined,
-        deliver: async (payload) => {
-          const outboundText =
-            payload && typeof payload === "object" && "text" in payload
-              ? ((payload as { text?: string }).text ?? "")
-              : "";
-          if (!outboundText.trim()) {
+        privateKey: account.privateKey,
+        relays: account.relays,
+        authorizeSender: async ({ senderPubkey, reply }) =>
+          await authorizeSender({ senderId: senderPubkey, reply }),
+        onMessage: async (senderPubkey, text, reply, meta) => {
+          const resolvedAccess = await resolveInboundAccess(senderPubkey, text);
+          if (resolvedAccess.senderAccess.decision !== "allow") {
+            ctx.log?.warn?.(
+              `[${account.accountId}] dropping Nostr DM after preflight drift (${senderPubkey}, ${resolvedAccess.senderAccess.reasonCode})`,
+            );
             return;
           }
-          const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+
+          const { dispatchInboundDirectDmWithRuntime } =
+            await import("./inbound-direct-dm-runtime.js");
+          await dispatchInboundDirectDmWithRuntime({
             cfg: ctx.cfg,
+            runtime,
             channel: "nostr",
+            channelLabel: "Nostr",
             accountId: account.accountId,
+            peer: {
+              kind: "direct",
+              id: senderPubkey,
+            },
+            senderId: senderPubkey,
+            senderAddress: `nostr:${senderPubkey}`,
+            recipientAddress: `nostr:${account.publicKey}`,
+            conversationLabel: senderPubkey,
+            rawBody: text,
+            messageId: meta.eventId,
+            timestamp: meta.createdAt * 1000,
+            commandAuthorized: resolvedAccess.commandAccess.requested
+              ? resolvedAccess.commandAccess.authorized
+              : undefined,
+            deliver: async (payload) => {
+              const outboundText =
+                payload && typeof payload === "object" && "text" in payload
+                  ? ((payload as { text?: string }).text ?? "")
+                  : "";
+              if (!outboundText.trim()) {
+                return;
+              }
+              const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+                cfg: ctx.cfg,
+                channel: "nostr",
+                accountId: account.accountId,
+              });
+              await reply(runtime.channel.text.convertMarkdownTables(outboundText, tableMode));
+            },
+            onRecordError: (err) => {
+              ctx.log?.error?.(
+                `[${account.accountId}] failed recording Nostr inbound session: ${String(err)}`,
+              );
+            },
+            onDispatchError: (err, info) => {
+              ctx.log?.error?.(
+                `[${account.accountId}] Nostr ${info.kind} reply failed: ${String(err)}`,
+              );
+            },
           });
-          await reply(runtime.channel.text.convertMarkdownTables(outboundText, tableMode));
         },
-        onRecordError: (err) => {
-          ctx.log?.error?.(
-            `[${account.accountId}] failed recording Nostr inbound session: ${String(err)}`,
-          );
+        onError: (error, context) => {
+          ctx.log?.error?.(`[${account.accountId}] Nostr error (${context}): ${error.message}`);
         },
-        onDispatchError: (err, info) => {
-          ctx.log?.error?.(
-            `[${account.accountId}] Nostr ${info.kind} reply failed: ${String(err)}`,
-          );
+        onConnect: (relay) => {
+          ctx.log?.debug?.(`[${account.accountId}] Connected to relay: ${relay}`);
+        },
+        onDisconnect: (relay) => {
+          ctx.log?.debug?.(`[${account.accountId}] Disconnected from relay: ${relay}`);
+        },
+        onEose: (relays) => {
+          ctx.log?.debug?.(`[${account.accountId}] EOSE received from relays: ${relays}`);
+        },
+        onMetric: (event: MetricEvent) => {
+          if (event.name.startsWith("event.rejected.")) {
+            ctx.log?.debug?.(
+              `[${account.accountId}] Metric: ${event.name} ${JSON.stringify(event.labels)}`,
+            );
+          } else if (event.name === "relay.circuit_breaker.open") {
+            ctx.log?.warn?.(
+              `[${account.accountId}] Circuit breaker opened for relay: ${event.labels?.relay}`,
+            );
+          } else if (event.name === "relay.circuit_breaker.close") {
+            ctx.log?.info?.(
+              `[${account.accountId}] Circuit breaker closed for relay: ${event.labels?.relay}`,
+            );
+          } else if (event.name === "relay.error") {
+            ctx.log?.debug?.(`[${account.accountId}] Relay error: ${event.labels?.relay}`);
+          }
+          if (busHandle) {
+            metricsSnapshots.set(account.accountId, busHandle.getMetrics());
+          }
         },
       });
-    },
-    onError: (error, context) => {
-      ctx.log?.error?.(`[${account.accountId}] Nostr error (${context}): ${error.message}`);
-    },
-    onConnect: (relay) => {
-      ctx.log?.debug?.(`[${account.accountId}] Connected to relay: ${relay}`);
-    },
-    onDisconnect: (relay) => {
-      ctx.log?.debug?.(`[${account.accountId}] Disconnected from relay: ${relay}`);
-    },
-    onEose: (relays) => {
-      ctx.log?.debug?.(`[${account.accountId}] EOSE received from relays: ${relays}`);
-    },
-    onMetric: (event: MetricEvent) => {
-      if (event.name.startsWith("event.rejected.")) {
-        ctx.log?.debug?.(
-          `[${account.accountId}] Metric: ${event.name} ${JSON.stringify(event.labels)}`,
-        );
-      } else if (event.name === "relay.circuit_breaker.open") {
-        ctx.log?.warn?.(
-          `[${account.accountId}] Circuit breaker opened for relay: ${event.labels?.relay}`,
-        );
-      } else if (event.name === "relay.circuit_breaker.close") {
-        ctx.log?.info?.(
-          `[${account.accountId}] Circuit breaker closed for relay: ${event.labels?.relay}`,
-        );
-      } else if (event.name === "relay.error") {
-        ctx.log?.debug?.(`[${account.accountId}] Relay error: ${event.labels?.relay}`);
-      }
-      if (busHandle) {
-        metricsSnapshots.set(account.accountId, busHandle.getMetrics());
-      }
+      let stopped = false;
+      busHandle = bus;
+      activeBuses.set(account.accountId, bus);
+
+      ctx.log?.info?.(
+        `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
+      );
+
+      return {
+        stop: () => {
+          if (stopped) {
+            return;
+          }
+          stopped = true;
+          bus.close();
+          if (busHandle === bus) {
+            busHandle = null;
+          }
+          if (activeBuses.get(account.accountId) === bus) {
+            activeBuses.delete(account.accountId);
+          }
+          metricsSnapshots.delete(account.accountId);
+          ctx.log?.info?.(`[${account.accountId}] Nostr provider stopped`);
+        },
+      };
     },
   });
-
-  busHandle = bus;
-  activeBuses.set(account.accountId, bus);
-
-  ctx.log?.info?.(
-    `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
-  );
-
-  return {
-    stop: () => {
-      bus.close();
-      activeBuses.delete(account.accountId);
-      metricsSnapshots.delete(account.accountId);
-      ctx.log?.info?.(`[${account.accountId}] Nostr provider stopped`);
-    },
-  };
 };
 
 export const nostrPairingTextAdapter = {

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -12,6 +12,7 @@ const mockState = vi.hoisted(() => ({
   } | null,
   subscribeMany: vi.fn(),
   close: vi.fn(),
+  subscriptionClose: vi.fn(),
   verifyEvent: vi.fn(() => true),
   decrypt: vi.fn(() => "plaintext"),
   publishProfile: vi.fn(async () => ({
@@ -36,7 +37,7 @@ vi.mock("nostr-tools", () => {
       mockState.subscribeMany(relays, filters, handlers);
       mockState.handlers = handlers;
       return {
-        close: vi.fn(),
+        close: mockState.subscriptionClose,
       };
     }
 
@@ -100,6 +101,7 @@ describe("startNostrBus inbound guards", () => {
     mockState.handlers = null;
     mockState.subscribeMany.mockClear();
     mockState.close.mockClear();
+    mockState.subscriptionClose.mockReset();
     mockState.verifyEvent.mockClear();
     mockState.verifyEvent.mockReturnValue(true);
     mockState.decrypt.mockClear();
@@ -139,6 +141,32 @@ describe("startNostrBus inbound guards", () => {
 
     bus.close();
 
+    await vi.waitFor(() => {
+      expect(mockState.close).toHaveBeenCalledWith(["wss://relay.example"]);
+    });
+  });
+
+  it("closes the relay pool after the active subscription closes", async () => {
+    let releaseClose = () => {};
+    const subscriptionClosed = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    mockState.subscriptionClose.mockImplementationOnce(async () => {
+      await subscriptionClosed;
+    });
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      relays: ["wss://relay.example"],
+      onMessage: vi.fn(async () => {}),
+      onMetric: () => {},
+    });
+
+    bus.close();
+
+    expect(mockState.subscriptionClose).toHaveBeenCalledWith("closed by caller");
+    expect(mockState.close).not.toHaveBeenCalled();
+
+    releaseClose();
     await vi.waitFor(() => {
       expect(mockState.close).toHaveBeenCalledWith(["wss://relay.example"]);
     });

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -10,6 +10,8 @@ const mockState = vi.hoisted(() => ({
     oneose?: () => void;
     onclose?: (reason: string[]) => void;
   } | null,
+  subscribeMany: vi.fn(),
+  close: vi.fn(),
   verifyEvent: vi.fn(() => true),
   decrypt: vi.fn(() => "plaintext"),
   publishProfile: vi.fn(async () => ({
@@ -23,14 +25,15 @@ const mockState = vi.hoisted(() => ({
 vi.mock("nostr-tools", () => {
   class MockSimplePool {
     subscribeMany(
-      _relays: string[],
-      _filters: unknown,
+      relays: string[],
+      filters: unknown,
       handlers: {
         onevent: (event: Record<string, unknown>) => void | Promise<void>;
         oneose?: () => void;
         onclose?: (reason: string[]) => void;
       },
     ) {
+      mockState.subscribeMany(relays, filters, handlers);
       mockState.handlers = handlers;
       return {
         close: vi.fn(),
@@ -38,6 +41,10 @@ vi.mock("nostr-tools", () => {
     }
 
     publish = vi.fn(async () => {});
+
+    close(relays: string[]) {
+      mockState.close(relays);
+    }
   }
 
   return {
@@ -91,6 +98,8 @@ async function emitEvent(event: Record<string, unknown>) {
 describe("startNostrBus inbound guards", () => {
   beforeEach(() => {
     mockState.handlers = null;
+    mockState.subscribeMany.mockClear();
+    mockState.close.mockClear();
     mockState.verifyEvent.mockClear();
     mockState.verifyEvent.mockReturnValue(true);
     mockState.decrypt.mockClear();
@@ -99,6 +108,40 @@ describe("startNostrBus inbound guards", () => {
 
   afterEach(() => {
     mockState.handlers = null;
+  });
+
+  it("subscribes to DMs with a single Nostr filter object", async () => {
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      onMessage: vi.fn(async () => {}),
+      onMetric: () => {},
+    });
+
+    expect(mockState.subscribeMany).toHaveBeenCalledTimes(1);
+    const filters = mockState.subscribeMany.mock.calls[0]?.[1];
+    expect(Array.isArray(filters)).toBe(false);
+    expect(filters).toMatchObject({
+      kinds: [4],
+      "#p": [BOT_PUBKEY],
+      since: 0,
+    });
+
+    bus.close();
+  });
+
+  it("closes the relay pool when the bus closes", async () => {
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      relays: ["wss://relay.example"],
+      onMessage: vi.fn(async () => {}),
+      onMetric: () => {},
+    });
+
+    bus.close();
+
+    await vi.waitFor(() => {
+      expect(mockState.close).toHaveBeenCalledWith(["wss://relay.example"]);
+    });
   });
 
   it("checks sender authorization after verify and before decrypt", async () => {

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -138,7 +138,7 @@ function createFixedWindowRateLimiter(params: {
 }
 
 export interface NostrBusHandle {
-  /** Stop the bus and close connections */
+  /** Stop the bus and close relay connections */
   close: () => void;
   /** Get the bot's public key */
   publicKey: string;
@@ -617,6 +617,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
   const dmFilter = { kinds: [4], "#p": [pk], since } satisfies Parameters<
     typeof pool.subscribeMany
   >[1];
+  const relayAbort = new AbortController();
   const sub = pool.subscribeMany(relays, dmFilter, {
     onevent: handleEvent,
     oneose: () => {
@@ -634,6 +635,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
       }
       onError?.(new Error(`Subscription closed: ${reason.join(", ")}`), "subscription");
     },
+    abort: relayAbort.signal,
   });
 
   // Public sendDm function
@@ -692,8 +694,12 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
 
   return {
     close: () => {
-      sub.close();
-      setTimeout(() => pool.close(relays), 0);
+      relayAbort.abort("closed by caller");
+      void Promise.resolve(sub.close("closed by caller"))
+        .catch((err) => onError?.(err as Error, "close subscription"))
+        .finally(() => {
+          pool.close(relays);
+        });
       seen.stop();
       perSenderRateLimiter.clear();
       globalRateLimiter.clear();

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -614,28 +614,27 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
     }
   }
 
-  const sub = pool.subscribeMany(
-    relays,
-    [{ kinds: [4], "#p": [pk], since }] as unknown as Parameters<typeof pool.subscribeMany>[1],
-    {
-      onevent: handleEvent,
-      oneose: () => {
-        // EOSE handler - called when all stored events have been received
-        for (const relay of relays) {
-          metrics.emit("relay.message.eose", 1, { relay });
-        }
-        onEose?.(relays.join(", "));
-      },
-      onclose: (reason) => {
-        // Handle subscription close
-        for (const relay of relays) {
-          metrics.emit("relay.message.closed", 1, { relay });
-          options.onDisconnect?.(relay);
-        }
-        onError?.(new Error(`Subscription closed: ${reason.join(", ")}`), "subscription");
-      },
+  const dmFilter = { kinds: [4], "#p": [pk], since } satisfies Parameters<
+    typeof pool.subscribeMany
+  >[1];
+  const sub = pool.subscribeMany(relays, dmFilter, {
+    onevent: handleEvent,
+    oneose: () => {
+      // EOSE handler - called when all stored events have been received
+      for (const relay of relays) {
+        metrics.emit("relay.message.eose", 1, { relay });
+      }
+      onEose?.(relays.join(", "));
     },
-  );
+    onclose: (reason) => {
+      // Handle subscription close
+      for (const relay of relays) {
+        metrics.emit("relay.message.closed", 1, { relay });
+        options.onDisconnect?.(relay);
+      }
+      onError?.(new Error(`Subscription closed: ${reason.join(", ")}`), "subscription");
+    },
+  });
 
   // Public sendDm function
   const sendDm = async (toPubkey: string, text: string): Promise<void> => {
@@ -694,6 +693,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
   return {
     close: () => {
       sub.close();
+      setTimeout(() => pool.close(relays), 0);
       seen.stop();
       perSenderRateLimiter.clear();
       globalRateLimiter.clear();

--- a/extensions/nostr/src/nostr-profile-import.test.ts
+++ b/extensions/nostr/src/nostr-profile-import.test.ts
@@ -2,14 +2,69 @@
  * Tests for Nostr Profile Import
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { NostrProfile } from "./config-schema.js";
-import { mergeProfiles } from "./nostr-profile-import.js";
+import { importProfileFromRelays, mergeProfiles } from "./nostr-profile-import.js";
 
-// Note: importProfileFromRelays requires real network calls or complex mocking
-// of nostr-tools SimplePool, so we focus on unit testing mergeProfiles
+const mockState = vi.hoisted(() => ({
+  subscribeMany: vi.fn(),
+}));
+
+vi.mock("nostr-tools", () => {
+  class MockSimplePool {
+    subscribeMany(
+      relays: string[],
+      filters: unknown,
+      handlers: {
+        onevent: (event: Record<string, unknown>) => void;
+        oneose?: () => void;
+        onclose?: () => void;
+      },
+    ) {
+      mockState.subscribeMany(relays, filters, handlers);
+      queueMicrotask(() => handlers.oneose?.());
+      return {
+        close: vi.fn(),
+      };
+    }
+
+    close = vi.fn();
+  }
+
+  return {
+    SimplePool: MockSimplePool,
+    verifyEvent: vi.fn(() => true),
+  };
+});
+
+// Mock SimplePool so importProfileFromRelays can assert the relay subscription shape.
 
 describe("nostr-profile-import", () => {
+  beforeEach(() => {
+    mockState.subscribeMany.mockClear();
+  });
+
+  describe("importProfileFromRelays", () => {
+    it("subscribes to profiles with a single Nostr filter object", async () => {
+      const pubkey = "a".repeat(64);
+
+      await importProfileFromRelays({
+        pubkey,
+        relays: ["wss://relay.example"],
+        timeoutMs: 1,
+      });
+
+      expect(mockState.subscribeMany).toHaveBeenCalledTimes(1);
+      const filters = mockState.subscribeMany.mock.calls[0]?.[1];
+      expect(Array.isArray(filters)).toBe(false);
+      expect(filters).toMatchObject({
+        kinds: [0],
+        authors: [pubkey],
+        limit: 1,
+      });
+    });
+  });
+
   describe("mergeProfiles", () => {
     it("returns empty object when both are undefined", () => {
       const result = mergeProfiles(undefined, undefined);

--- a/extensions/nostr/src/nostr-profile-import.ts
+++ b/extensions/nostr/src/nostr-profile-import.ts
@@ -122,33 +122,29 @@ export async function importProfileFromRelays(
       for (const relay of relays) {
         relaysQueried.push(relay);
 
-        const sub = pool.subscribeMany(
-          [relay],
-          [
-            {
-              kinds: [0],
-              authors: [pubkey],
-              limit: 1,
-            },
-          ] as unknown as Parameters<typeof pool.subscribeMany>[1],
-          {
-            onevent(event) {
-              events.push({ event, relay });
-            },
-            oneose() {
-              completed++;
-              if (completed >= relays.length) {
-                resolve();
-              }
-            },
-            onclose() {
-              completed++;
-              if (completed >= relays.length) {
-                resolve();
-              }
-            },
+        const profileFilter = {
+          kinds: [0],
+          authors: [pubkey],
+          limit: 1,
+        } satisfies Parameters<typeof pool.subscribeMany>[1];
+
+        const sub = pool.subscribeMany([relay], profileFilter, {
+          onevent(event) {
+            events.push({ event, relay });
           },
-        );
+          oneose() {
+            completed++;
+            if (completed >= relays.length) {
+              resolve();
+            }
+          },
+          onclose() {
+            completed++;
+            if (completed >= relays.length) {
+              resolve();
+            }
+          },
+        });
 
         // Clean up subscription after timeout
         setTimeout(() => {


### PR DESCRIPTION
## Summary

- Problem: the Nostr channel could restart-loop because the DM subscription passed an array-wrapped filter to `nostr-tools` and the gateway account task returned immediately after startup.
- Solution: pass single NIP-01 filter objects to `subscribeMany`, keep the Nostr gateway account task pending until abort, and close the relay pool after subscription shutdown.
- What changed: updated the Nostr DM subscription shape, aligned profile-import subscriptions with the same single-filter contract, wrapped gateway startup in `runStoppablePassiveMonitor`, and added regression coverage for subscription shape, abort-driven lifecycle cleanup, and relay-pool shutdown.
- What did NOT change (scope boundary): no generated dist patch, raw media fallback, config shape, migration, relay policy, auth, or plugin API behavior changes.

## Motivation

Issue #53858 is a P1 message-loss/crash-loop bug. Strict Nostr relays reject the nested filter shape, so affected accounts cannot reliably receive DMs, and the immediately resolved account task can feed the generic gateway supervisor restart path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53858
- Related #86141
- Related #42832
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Nostr account startup no longer sends an array-wrapped DM subscription filter, profile import uses the same single-filter contract, the gateway account task no longer resolves immediately into the supervisor restart path, and abort cleanup closes the relay pool.
- Real environment tested: disposable Linux OpenClaw checkout based on `origin/main` `5846878924`, Node `v24.15.0`, pnpm `11.2.2`.
- Live relay proof type: disposable strict NIP-01 WebSocket relay process on loopback plus public third-party relay smoke using disposable generated Nostr keys, with real `nostr-tools` `SimplePool` WebSocket traffic through the OpenClaw Nostr bus, gateway, profile-import, and reply paths.
- Exact steps or command run after this patch:

```text
pnpm install --frozen-lockfile --store-dir /root/openclaw-pr-tests/pnpm-store
git diff --check
pnpm exec oxfmt --check --threads=1 extensions/nostr/src/channel.inbound.test.ts extensions/nostr/src/channel.lifecycle.test.ts extensions/nostr/src/channel.outbound.test.ts extensions/nostr/src/gateway.ts extensions/nostr/src/nostr-bus.inbound.test.ts extensions/nostr/src/nostr-bus.ts extensions/nostr/src/nostr-profile-import.test.ts extensions/nostr/src/nostr-profile-import.ts strict-relay-proof.ts
pnpm test:extension nostr
pnpm test:contracts:channels
node --import tsx strict-relay-proof.ts
timeout 180s node --import tsx public-relay-smoke.ts
```

- Evidence after fix (redacted terminal output from the strict relay proof):

```text
OpenClaw Nostr strict relay live proof
relay=ws://127.0.0.1:<redacted>
dmDirect.accepted=true
dmDirect.filterIsArray=false
dmDirect.kinds=4
dmDirect.closeSeenAfterAbort=true
gateway.accepted=true
gateway.filterIsArray=false
gateway.kinds=4
gateway.pendingBeforeAbort=true
gateway.closeSeenAfterAbort=true
profileImport.accepted=true
profileImport.filterIsArray=false
profileImport.kinds=0
profileImport.resultOk=false
arrayFilterRejected=false
noticeCount=0
result=STRICT_RELAY_LIVE_PROOF_PASS
```

- Evidence after fix (redacted terminal output from the public third-party relay smoke):

```text
OpenClaw Nostr public relay smoke proof
relay=wss://<public-third-party-relay-redacted>
relayAttempt=1/5
publishAccepted=true
inboundDmReceived=true
inboundSenderMatches=true
outboundReplyReceived=true
outboundReplyMatches=true
botPublicKey=03bb5684...848e167c
senderPublicKey=5deecee9...a335ef06
privateKeysPrinted=false
realUserAccountUsed=false
result=PUBLIC_RELAY_DM_ROUNDTRIP_PASS
```

- Observed result after fix: the strict relay accepted both DM and profile-import subscriptions as one filter object, emitted no notices, observed gateway startup staying pending before abort, observed subscription close after abort, and the public relay smoke delivered a real encrypted DM into OpenClaw and a real encrypted reply back out.
- What was not tested: no real user Nostr account, long-lived private key, private relay, or operator account was used. The public-relay proof used disposable generated keys and redacted the relay endpoint.
- Before evidence (optional but encouraged):

```text
#53858 relay log before fix:
invalid type: sequence, expected struct Filter

Malformed request shape:
["REQ","sub:1",[{"kinds":[4],"#p":["..."],"since":1774430972}]]

Expected request shape:
["REQ","sub:1",{"kinds":[4],"#p":["..."],"since":1774430972}]
```

## Root Cause (if applicable)

- Root cause: `startNostrBus` passed an array-shaped DM filter into the pinned `nostr-tools` `subscribeMany(relays, filter, params)` contract, and `startNostrGatewayAccount` returned a stop handle immediately after bus startup.
- Related optional cleanup: `importProfileFromRelays` used the same array-wrapped `subscribeMany` shape for kind:0 profile lookups, so this PR aligns that sibling Nostr path too.
- Missing detection / guardrail: existing tests covered inbound/outbound behavior, but did not assert the exact `subscribeMany` filter shape, that the gateway account task remains pending until abort, or that bus close shuts down the relay pool.
- Contributing context (if known): ClawSweeper identified the same focused fix shape on #53858, and previous related repair PR #86141 was closed unmerged by automation rather than rejected for direction.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/nostr/src/nostr-bus.inbound.test.ts`
  - `extensions/nostr/src/channel.lifecycle.test.ts`
  - `extensions/nostr/src/channel.inbound.test.ts`
  - `extensions/nostr/src/channel.outbound.test.ts`
  - `extensions/nostr/src/nostr-profile-import.test.ts`
- Scenario the test should lock in: Nostr DM and profile-import subscriptions are sent as one filter object, `startAccount` does not resolve until abort, the active bus is removed on abort, and bus close closes the relay pool after subscription close.
- Why this is the smallest reliable guardrail: it covers the dependency-contract boundary that creates the malformed REQ payload and the gateway lifecycle boundary that can trigger restarts or leave relay sockets open.
- Existing test that already covers this (if any): no existing test asserted the nested-array subscription shape or pending-until-abort account lifecycle.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Affected Nostr accounts should stay running and receive strict-relay DM subscriptions instead of restart-looping after startup. Profile import should also interoperate with strict relays that require one filter object per REQ entry, and abort cleanup should close relay-pool connections after subscription shutdown.

## Diagram (if applicable)

```text
Before:
startAccount -> start bus -> return stop handle -> supervisor sees clean exit
subscribeMany(relays, [{ filter }], params) -> relay receives nested filter array

After:
startAccount -> start bus -> wait for abort -> close bus once -> close relay pool
subscribeMany(relays, { filter }, params) -> relay receives one NIP-01 filter object
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux disposable checkout
- Runtime/container: Node `v24.15.0`, pnpm `11.2.2`
- Model/provider: N/A
- Integration/channel (if any): Nostr bundled extension
- Relevant config (redacted): no real user Nostr account or long-lived private key used; public relay endpoint redacted; public smoke used disposable generated keys and synthetic DM text

### Steps

1. Install dependencies in a fresh OpenClaw checkout based on `origin/main` `5846878924`.
2. Copy the patched Nostr source and test files into the checkout.
3. Run diff/format checks.
4. Run the full Nostr extension test lane.
5. Run shared channel contract tests.
6. Run the strict WebSocket relay proof against the real Nostr bus, gateway, and profile-import code paths.
7. Run the public third-party relay smoke with disposable generated Nostr keys against the real Nostr inbound and reply paths.

### Expected

- The subscription regression test observes a single filter object passed to `subscribeMany`.
- The profile-import regression test observes a single kind:0 filter object passed to `subscribeMany`.
- The lifecycle regression tests observe `startAccount` pending until abort, closing the bus on abort, removing the active bus entry, and closing the relay pool.
- The strict relay proof accepts DM/profile subscriptions and emits no invalid-filter notice.
- The public relay smoke observes a real encrypted inbound DM and real encrypted outbound reply.
- The full Nostr extension lane and channel contract shards pass.

### Actual

- After this patch, matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification on PR head `2f1f1dc4c2`:

```text
git diff --check
passed

pnpm exec oxfmt --check --threads=1 <8 touched Nostr files> strict-relay-proof.ts public-relay-smoke.ts
All matched files use the correct format.

pnpm test:extension nostr
13 test files passed / 276 tests passed

pnpm test:contracts:channels
4 Vitest shards passed / 45 test files passed / 162 tests passed

node --import tsx strict-relay-proof.ts
result=STRICT_RELAY_LIVE_PROOF_PASS

timeout 180s node --import tsx public-relay-smoke.ts
result=PUBLIC_RELAY_DM_ROUNDTRIP_PASS
```

## Human Verification (required)

- Verified scenarios: single-object DM subscription filter, single-object profile-import filter, Nostr account task remains pending until abort, abort closes the active subscription, active bus entry is removed after abort, relay pool closes after bus close, already-aborted startup closes the bus, inbound reply pipeline still routes allowed DMs, outbound sends still route through the Nostr gateway adapter, and public third-party relay DM/reply roundtrip works with disposable keys.
- Edge cases checked: already-aborted signal after bus startup, idempotent cleanup of active bus/metrics state, direct inbound/outbound harness shutdown through abort, strict relay emits no invalid-filter notice for patched DM/profile subscriptions, public relay process exits cleanly after bus close.
- What you did **not** verify: real user Nostr private keys, private relay traffic, operator accounts, or generated dist artifacts.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: keeping `startAccount` pending could leak bus state if abort cleanup does not run.
  - Mitigation: the fix uses the existing `runStoppablePassiveMonitor` helper and adds lifecycle coverage for normal abort, already-aborted startup, active bus removal, and relay-pool close.
- Risk: changing the Nostr subscription shape could affect tolerant relays that accepted the old nested filter.
  - Mitigation: the new shape matches the pinned `nostr-tools` contract and NIP-01 REQ filter structure; strict-relay behavior in #53858 requires this shape.
