### PR TITLE
perf: dedupe persisted skill prompts

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -97,6 +97,30 @@ vi.mock("../agent-tools.abort.js", () => ({
   wrapToolWithAbortSignal: vi.fn((tool) => tool),
 }));
 
+// Keep image-tool tests focused on root propagation; media-tool-shared
+// and channel-inbound tests cover the real bundled contract loader.
+vi.mock("../../media/channel-inbound-roots.js", () => ({
+  resolveChannelInboundAttachmentRootsForChannel: (params: {
+    cfg?: OpenClawConfig;
+    channelId?: string | null;
+    accountId?: string | null;
+  }) => {
+    const channelId = params.channelId?.trim();
+    if (!channelId) {
+      return undefined;
+    }
+    const channelConfig = params.cfg?.channels?.[channelId];
+    const accountConfig = params.accountId
+      ? channelConfig?.accounts?.[params.accountId]
+      : undefined;
+    const roots = [
+      ...(accountConfig?.attachmentRoots ?? []),
+      ...(channelConfig?.attachmentRoots ?? []),
+    ];
+    return channelId === "imessage" ? [...roots, "/Users/*/Library/Messages/Attachments"] : roots;
+  },
+}));
+
 vi.mock("../auth-profiles.js", () => ({
   externalCliDiscoveryForProviderAuth: () => undefined,
   ensureAuthProfileStore: (agentDir?: string) => {

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   hasGenerationToolAvailability,
   isCapabilityProviderConfigured,
@@ -9,6 +10,31 @@ import {
   resolveMediaToolLocalRoots,
   resolveModelFromRegistry,
 } from "./media-tool-shared.js";
+
+// Keep media-tool-shared tests focused on root separation; channel-inbound
+// tests cover the real bundled contract loader.
+vi.mock("../../media/channel-inbound-roots.js", () => ({
+  resolveChannelInboundAttachmentRootsForChannel: (params: {
+    cfg?: OpenClawConfig;
+    channelId?: string | null;
+    accountId?: string | null;
+  }) => {
+    const channelId = params.channelId?.trim();
+    if (!channelId) {
+      return undefined;
+    }
+
+    const channelConfig = params.cfg?.channels?.[channelId];
+    const accountConfig = params.accountId
+      ? channelConfig?.accounts?.[params.accountId]
+      : undefined;
+    const roots = [
+      ...(accountConfig?.attachmentRoots ?? []),
+      ...(channelConfig?.attachmentRoots ?? []),
+    ];
+    return channelId === "imessage" ? [...roots, "/Users/*/Library/Messages/Attachments"] : roots;
+  },
+}));
 
 function normalizeHostPath(value: string): string {
   return path.normalize(path.resolve(value));

--- a/src/commands/doctor-session-snapshots.test.ts
+++ b/src/commands/doctor-session-snapshots.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveSessionStore } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
@@ -293,6 +294,43 @@ describe("doctor session snapshot stale runtime metadata", () => {
     const [message] = note.mock.calls[0] as [string, string];
     expect(message).toContain("agent:main");
     expect(message).toContain("skillsSnapshot.resolvedSkills");
+    expect(message).toContain(stalePath);
+  });
+
+  it("hydrates blobbed skills prompts before scanning raw session stores", async () => {
+    const stalePath = path.join(
+      root,
+      "old-runtime",
+      "node_modules",
+      "openclaw",
+      "skills",
+      "doctor",
+      "SKILL.md",
+    );
+    const storePath = path.join(root, "state", "agents", "main", "sessions", "sessions.json");
+    const prompt = `${skillPrompt(stalePath)}\n${"padding\n".repeat(200)}`;
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main": sessionEntry({
+          skillsSnapshot: {
+            prompt,
+            skills: [{ name: "doctor" }],
+          },
+        }),
+      },
+      { skipMaintenance: true },
+    );
+    const raw = await fs.readFile(storePath, "utf-8");
+    expect(raw).not.toContain(stalePath);
+    expect(raw).toContain("promptRef");
+
+    await noteSessionSnapshotHealth({ storePaths: [storePath], bundledSkillsDir });
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const [message] = note.mock.calls[0] as [string, string];
+    expect(message).toContain("agent:main");
+    expect(message).toContain("skillsSnapshot.prompt");
     expect(message).toContain(stalePath);
   });
 

--- a/src/commands/doctor-session-snapshots.ts
+++ b/src/commands/doctor-session-snapshots.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveBundledSkillsDir } from "../agents/skills/bundled-dir.js";
 import { resolveStateDir } from "../config/paths.js";
+import { hydrateSessionStoreSkillPromptRefs } from "../config/sessions/skill-prompt-blobs.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -261,7 +262,12 @@ function resolveSessionStorePaths(params: {
 
 function loadSessionStoreForSnapshotScan(storePath: string): Record<string, SessionEntry> {
   const parsed = JSON.parse(fs.readFileSync(storePath, "utf-8")) as unknown;
-  return isRecord(parsed) ? (parsed as Record<string, SessionEntry>) : {};
+  if (!isRecord(parsed)) {
+    return {};
+  }
+  const store = parsed as Record<string, SessionEntry>;
+  hydrateSessionStoreSkillPromptRefs({ storePath, store });
+  return store;
 }
 
 export async function noteSessionSnapshotHealth(params?: {

--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -257,7 +257,12 @@ describe("Session Store Cache", () => {
     const parseSpy = vi.spyOn(JSON, "parse");
 
     try {
-      writeSessionStoreCache({ storePath, store: testStore, serialized });
+      writeSessionStoreCache({
+        storePath,
+        store: testStore,
+        serialized,
+        cloneSerialized: serialized,
+      });
 
       expect(parseSpy).not.toHaveBeenCalled();
 

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -273,6 +273,8 @@ describe("enforceSessionDiskBudget", () => {
       );
       await expectPathExists(oldBlob);
       await expectPathExists(activeBlob);
+      const staleBlobTime = new Date(Date.now() - 10 * 60 * 1000);
+      await fs.utimes(oldBlob, staleBlobTime, staleBlobTime);
 
       const result = await enforceSessionDiskBudget({
         store,
@@ -290,6 +292,37 @@ describe("enforceSessionDiskBudget", () => {
       expect(store).toHaveProperty(activeKey);
       await expectPathMissing(oldBlob);
       await expectPathExists(activeBlob);
+    });
+  });
+
+  it("preserves fresh unreferenced skills prompt blobs under pressure", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-fresh-prompt-blob-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const store: Record<string, SessionEntry> = {
+        "agent:main:active": { sessionId: "active", updatedAt: Date.now() },
+      };
+      const hash = "b".repeat(64);
+      const blobDir = path.join(dir, "skills-prompts", "sha256", hash.slice(0, 2));
+      const blobPath = path.join(blobDir, `${hash}.txt`);
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.mkdir(blobDir, { recursive: true });
+      await fs.writeFile(blobPath, "fresh unreferenced prompt blob".repeat(200), "utf-8");
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        activeSessionKey: "agent:main:active",
+        maintenance: {
+          maxDiskBytes: 1,
+          highWaterBytes: 1,
+        },
+        warnOnly: false,
+      });
+
+      expectBudgetResult(result);
+      expect(result.overBudget).toBe(true);
+      expect(result.removedFiles).toBe(0);
+      await expectPathExists(blobPath);
     });
   });
 
@@ -568,7 +601,7 @@ describe("pruneUnreferencedSessionArtifacts", () => {
       );
       await expectPathExists(oldBlob);
       await expectPathExists(keepBlob);
-      const oldMtime = new Date(Date.now() - 2 * 60 * 1000);
+      const oldMtime = new Date(Date.now() - 10 * 60 * 1000);
       await fs.utimes(oldBlob, oldMtime, oldMtime);
       delete store[oldKey];
 
@@ -581,6 +614,27 @@ describe("pruneUnreferencedSessionArtifacts", () => {
       await expectPathMissing(oldBlob);
       await expectPathExists(keepBlob);
       expect(result.removedFiles).toBe(1);
+    });
+  });
+
+  it("preserves fresh unreferenced skills prompt blobs during normal artifact cleanup", async () => {
+    await withTempDir({ prefix: "openclaw-prune-fresh-prompt-blob-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const hash = "c".repeat(64);
+      const blobDir = path.join(dir, "skills-prompts", "sha256", hash.slice(0, 2));
+      const blobPath = path.join(blobDir, `${hash}.txt`);
+      await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf-8");
+      await fs.mkdir(blobDir, { recursive: true });
+      await fs.writeFile(blobPath, "fresh unreferenced prompt blob".repeat(200), "utf-8");
+
+      const result = await pruneUnreferencedSessionArtifacts({
+        store: {},
+        storePath,
+        olderThanMs: 0,
+      });
+
+      await expectPathExists(blobPath);
+      expect(result.removedFiles).toBe(0);
     });
   });
 

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -1,6 +1,8 @@
+import nodeFs from "node:fs";
+import type { PathLike, StatOptions } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 import {
   resolveTrajectoryFilePath,
@@ -31,6 +33,23 @@ function expectBudgetResult(
   if (result === null) {
     throw new Error("expected disk budget enforcement result");
   }
+}
+
+function refreshPathBeforeSecondStat(targetPath: string): ReturnType<typeof vi.spyOn> {
+  const originalStat = nodeFs.promises.stat.bind(nodeFs.promises);
+  let statCalls = 0;
+  return vi
+    .spyOn(nodeFs.promises, "stat")
+    .mockImplementation(async (target: PathLike, options?: StatOptions) => {
+      if (target === targetPath) {
+        statCalls += 1;
+        if (statCalls === 2) {
+          const now = new Date();
+          await fs.utimes(targetPath, now, now);
+        }
+      }
+      return await originalStat(target, options);
+    });
 }
 
 describe("enforceSessionDiskBudget", () => {
@@ -323,6 +342,43 @@ describe("enforceSessionDiskBudget", () => {
       expect(result.overBudget).toBe(true);
       expect(result.removedFiles).toBe(0);
       await expectPathExists(blobPath);
+    });
+  });
+
+  it("revalidates stale prompt blobs before removing them under pressure", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-revalidate-prompt-blob-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const store: Record<string, SessionEntry> = {
+        "agent:main:active": { sessionId: "active", updatedAt: Date.now() },
+      };
+      const hash = "d".repeat(64);
+      const blobDir = path.join(dir, "skills-prompts", "sha256", hash.slice(0, 2));
+      const blobPath = path.join(blobDir, `${hash}.txt`);
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.mkdir(blobDir, { recursive: true });
+      await fs.writeFile(blobPath, "stale prompt blob".repeat(200), "utf-8");
+      const staleBlobTime = new Date(Date.now() - 10 * 60 * 1000);
+      await fs.utimes(blobPath, staleBlobTime, staleBlobTime);
+      const statSpy = refreshPathBeforeSecondStat(blobPath);
+      try {
+        const result = await enforceSessionDiskBudget({
+          store,
+          storePath,
+          activeSessionKey: "agent:main:active",
+          maintenance: {
+            maxDiskBytes: 1,
+            highWaterBytes: 1,
+          },
+          warnOnly: false,
+        });
+
+        expectBudgetResult(result);
+        expect(result.overBudget).toBe(true);
+        expect(result.removedFiles).toBe(0);
+        await expectPathExists(blobPath);
+      } finally {
+        statSpy.mockRestore();
+      }
     });
   });
 
@@ -635,6 +691,33 @@ describe("pruneUnreferencedSessionArtifacts", () => {
 
       await expectPathExists(blobPath);
       expect(result.removedFiles).toBe(0);
+    });
+  });
+
+  it("revalidates stale prompt blobs before removing them during normal artifact cleanup", async () => {
+    await withTempDir({ prefix: "openclaw-prune-revalidate-prompt-blob-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const hash = "e".repeat(64);
+      const blobDir = path.join(dir, "skills-prompts", "sha256", hash.slice(0, 2));
+      const blobPath = path.join(blobDir, `${hash}.txt`);
+      await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf-8");
+      await fs.mkdir(blobDir, { recursive: true });
+      await fs.writeFile(blobPath, "stale prompt blob".repeat(200), "utf-8");
+      const staleBlobTime = new Date(Date.now() - 10 * 60 * 1000);
+      await fs.utimes(blobPath, staleBlobTime, staleBlobTime);
+      const statSpy = refreshPathBeforeSecondStat(blobPath);
+      try {
+        const result = await pruneUnreferencedSessionArtifacts({
+          store: {},
+          storePath,
+          olderThanMs: 60_000,
+        });
+
+        await expectPathExists(blobPath);
+        expect(result.removedFiles).toBe(0);
+      } finally {
+        statSpy.mockRestore();
+      }
     });
   });
 

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../trajectory/paths.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import { enforceSessionDiskBudget, pruneUnreferencedSessionArtifacts } from "./disk-budget.js";
+import { saveSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
 
 async function expectPathExists(targetPath: string): Promise<void> {
@@ -219,6 +220,76 @@ describe("enforceSessionDiskBudget", () => {
       expect(result.overBudget).toBe(false);
       expect(result.removedEntries).toBe(0);
       expect(Object.keys(store)).toHaveLength(12);
+    });
+  });
+
+  it("removes unreferenced skills prompt blobs when evicting sessions", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const activeKey = "agent:main:active";
+      const oldKey = "agent:main:old";
+      const oldPrompt = `<available_skills>\n${"old prompt\n".repeat(200)}</available_skills>`;
+      const activePrompt = `<available_skills>\n${"active prompt\n".repeat(200)}</available_skills>`;
+      const store: Record<string, SessionEntry> = {
+        [oldKey]: {
+          sessionId: "old",
+          updatedAt: 1,
+          skillsSnapshot: {
+            prompt: oldPrompt,
+            skills: [{ name: "old" }],
+            version: 1,
+          },
+        },
+        [activeKey]: {
+          sessionId: "active",
+          updatedAt: 2,
+          skillsSnapshot: {
+            prompt: activePrompt,
+            skills: [{ name: "active" }],
+            version: 1,
+          },
+        },
+      };
+      await saveSessionStore(storePath, store, { skipMaintenance: true });
+      const raw = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, SessionEntry>;
+      const oldHash = raw[oldKey]?.skillsSnapshot?.promptRef?.hash;
+      const activeHash = raw[activeKey]?.skillsSnapshot?.promptRef?.hash;
+      if (!oldHash || !activeHash) {
+        throw new Error("expected prompt refs");
+      }
+      const oldBlob = path.join(
+        dir,
+        "skills-prompts",
+        "sha256",
+        oldHash.slice(0, 2),
+        `${oldHash}.txt`,
+      );
+      const activeBlob = path.join(
+        dir,
+        "skills-prompts",
+        "sha256",
+        activeHash.slice(0, 2),
+        `${activeHash}.txt`,
+      );
+      await expectPathExists(oldBlob);
+      await expectPathExists(activeBlob);
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        activeSessionKey: activeKey,
+        maintenance: {
+          maxDiskBytes: 1,
+          highWaterBytes: 1,
+        },
+        warnOnly: false,
+      });
+
+      expectBudgetResult(result);
+      expect(store).not.toHaveProperty(oldKey);
+      expect(store).toHaveProperty(activeKey);
+      await expectPathMissing(oldBlob);
+      await expectPathExists(activeBlob);
     });
   });
 

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -481,4 +481,71 @@ describe("pruneUnreferencedSessionArtifacts", () => {
       expect(result.removedFiles).toBeGreaterThanOrEqual(1);
     });
   });
+
+  it("reclaims unreferenced skills prompt blobs during normal artifact cleanup", async () => {
+    await withTempDir({ prefix: "openclaw-prune-prompt-blob-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const oldKey = "agent:main:old";
+      const keepKey = "agent:main:keep";
+      const oldPrompt = `<available_skills>\n${"old prompt\n".repeat(200)}</available_skills>`;
+      const keepPrompt = `<available_skills>\n${"keep prompt\n".repeat(200)}</available_skills>`;
+      const store: Record<string, SessionEntry> = {
+        [oldKey]: {
+          sessionId: "old",
+          updatedAt: 1,
+          skillsSnapshot: {
+            prompt: oldPrompt,
+            skills: [{ name: "old" }],
+            version: 1,
+          },
+        },
+        [keepKey]: {
+          sessionId: "keep",
+          updatedAt: 2,
+          skillsSnapshot: {
+            prompt: keepPrompt,
+            skills: [{ name: "keep" }],
+            version: 1,
+          },
+        },
+      };
+      await saveSessionStore(storePath, store, { skipMaintenance: true });
+
+      const raw = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, SessionEntry>;
+      const oldHash = raw[oldKey]?.skillsSnapshot?.promptRef?.hash;
+      const keepHash = raw[keepKey]?.skillsSnapshot?.promptRef?.hash;
+      if (!oldHash || !keepHash) {
+        throw new Error("expected prompt refs");
+      }
+      const oldBlob = path.join(
+        dir,
+        "skills-prompts",
+        "sha256",
+        oldHash.slice(0, 2),
+        `${oldHash}.txt`,
+      );
+      const keepBlob = path.join(
+        dir,
+        "skills-prompts",
+        "sha256",
+        keepHash.slice(0, 2),
+        `${keepHash}.txt`,
+      );
+      await expectPathExists(oldBlob);
+      await expectPathExists(keepBlob);
+      const oldMtime = new Date(Date.now() - 2 * 60 * 1000);
+      await fs.utimes(oldBlob, oldMtime, oldMtime);
+      delete store[oldKey];
+
+      const result = await pruneUnreferencedSessionArtifacts({
+        store,
+        storePath,
+        olderThanMs: 60_000,
+      });
+
+      await expectPathMissing(oldBlob);
+      await expectPathExists(keepBlob);
+      expect(result.removedFiles).toBe(1);
+    });
+  });
 });

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -293,6 +293,41 @@ describe("enforceSessionDiskBudget", () => {
     });
   });
 
+  it("reclaims stale skills prompt blob temps under pressure", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-prompt-temp-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const store: Record<string, SessionEntry> = {
+        "agent:main:main": { sessionId: "keep", updatedAt: Date.now() },
+      };
+      const hash = "a".repeat(64);
+      const tempDir = path.join(dir, "skills-prompts", "sha256", hash.slice(0, 2));
+      const tempPath = path.join(
+        tempDir,
+        `${hash}.txt.123.11111111-1111-4111-8111-111111111111.tmp`,
+      );
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.mkdir(tempDir, { recursive: true });
+      await fs.writeFile(tempPath, "t".repeat(2000), "utf-8");
+      const old = new Date(Date.now() - 30 * 60 * 1000);
+      await fs.utimes(tempPath, old, old);
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        maintenance: {
+          maxDiskBytes: 1000,
+          highWaterBytes: 500,
+        },
+        warnOnly: false,
+      });
+
+      await expectPathMissing(tempPath);
+      expectBudgetResult(result);
+      expect(result.removedFiles).toBe(1);
+      expect(result.removedEntries).toBe(0);
+    });
+  });
+
   it("removes unreferenced compaction checkpoint artifacts under pressure", async () => {
     await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
       const storePath = path.join(dir, "sessions.json");
@@ -545,6 +580,41 @@ describe("pruneUnreferencedSessionArtifacts", () => {
 
       await expectPathMissing(oldBlob);
       await expectPathExists(keepBlob);
+      expect(result.removedFiles).toBe(1);
+    });
+  });
+
+  it("reclaims stale skills prompt blob temps during normal artifact cleanup", async () => {
+    await withTempDir({ prefix: "openclaw-prune-prompt-temp-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const store: Record<string, SessionEntry> = {
+        "agent:main:main": { sessionId: "keep", updatedAt: Date.now() },
+      };
+      const hash = "b".repeat(64);
+      const tempDir = path.join(dir, "skills-prompts", "sha256", hash.slice(0, 2));
+      const staleTemp = path.join(
+        tempDir,
+        `${hash}.txt.123.22222222-2222-4222-8222-222222222222.tmp`,
+      );
+      const freshTemp = path.join(
+        tempDir,
+        `${hash}.txt.456.33333333-3333-4333-8333-333333333333.tmp`,
+      );
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.mkdir(tempDir, { recursive: true });
+      await fs.writeFile(staleTemp, "s".repeat(64), "utf-8");
+      await fs.writeFile(freshTemp, "f".repeat(64), "utf-8");
+      const old = new Date(Date.now() - 30 * 60 * 1000);
+      await fs.utimes(staleTemp, old, old);
+
+      const result = await pruneUnreferencedSessionArtifacts({
+        store,
+        storePath,
+        olderThanMs: 30 * 24 * 60 * 60 * 1000,
+      });
+
+      await expectPathMissing(staleTemp);
+      await expectPathExists(freshTemp);
       expect(result.removedFiles).toBe(1);
     });
   });

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -183,6 +183,45 @@ describe("enforceSessionDiskBudget", () => {
     });
   });
 
+  it("accounts for deduped skills prompt blobs before evicting sessions", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const prompt = `<available_skills>\n${"shared prompt\n".repeat(200)}</available_skills>`;
+      const now = Date.now();
+      const store: Record<string, SessionEntry> = Object.fromEntries(
+        Array.from({ length: 12 }, (_, index) => [
+          `agent:main:${index}`,
+          {
+            sessionId: `session-${index}`,
+            updatedAt: now + index,
+            skillsSnapshot: {
+              prompt,
+              skills: [{ name: "demo" }],
+              version: 1,
+            },
+          } satisfies SessionEntry,
+        ]),
+      );
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+
+      const inlineBytes = Buffer.byteLength(JSON.stringify(store, null, 2), "utf8");
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        maintenance: {
+          maxDiskBytes: Math.floor(inlineBytes / 2),
+          highWaterBytes: Math.floor(inlineBytes / 3),
+        },
+        warnOnly: false,
+      });
+
+      expectBudgetResult(result);
+      expect(result.overBudget).toBe(false);
+      expect(result.removedEntries).toBe(0);
+      expect(Object.keys(store)).toHaveLength(12);
+    });
+  });
+
   it("removes unreferenced compaction checkpoint artifacts under pressure", async () => {
     await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
       const storePath = path.join(dir, "sessions.json");

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -360,26 +360,45 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     Number.isFinite(params.olderThanMs) && params.olderThanMs > 0 ? params.olderThanMs : 0;
   const sessionsDir = path.dirname(params.storePath);
   const files = await readSessionsDirFiles(sessionsDir);
-  const fileSizesByPath = new Map(files.map((file) => [file.canonicalPath, file.size]));
+  const promptBlobFiles = await readSessionPromptBlobFiles(sessionsDir);
+  const fileSizesByPath = new Map(
+    [...files, ...promptBlobFiles].map((file) => [file.canonicalPath, file.size]),
+  );
   const simulatedRemovedPaths = new Set<string>();
   const referencedPaths = resolveReferencedSessionArtifactPaths({
     sessionsDir,
     store: params.store,
   });
+  const projectedPromptBlobRefCounts = buildProjectedPromptBlobRefCounts(
+    projectSessionStoreForPersistence({
+      storePath: params.storePath,
+      store: params.store,
+    }).store,
+  );
   const cutoffMs = Date.now() - olderThanMs;
   const tempCutoffMs = Date.now() - SESSION_STORE_TEMP_STALE_MS;
   const storeBasename = path.basename(params.storePath);
-  const removableFiles = files
+  const removableStoreFiles = files.filter((file) => {
+    if (params.excludeCanonicalPaths?.has(file.canonicalPath)) {
+      return false;
+    }
+    // Orphaned store atomic-write temps are reclaimed on their own short
+    // staleness window, independent of the unreferenced-artifact age (#56827).
+    if (isSessionStoreTempArtifactName(file.name, storeBasename)) {
+      return file.mtimeMs <= tempCutoffMs;
+    }
+    return file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths);
+  });
+  const removablePromptBlobFiles = promptBlobFiles.filter((file) => {
+    if (params.excludeCanonicalPaths?.has(file.canonicalPath) || file.mtimeMs > cutoffMs) {
+      return false;
+    }
+    const hash = resolvePromptBlobFileHash(file);
+    return hash ? !projectedPromptBlobRefCounts.has(hash) : false;
+  });
+  const removableFiles = [...removableStoreFiles, ...removablePromptBlobFiles]
     .filter((file) => {
-      if (params.excludeCanonicalPaths?.has(file.canonicalPath)) {
-        return false;
-      }
-      // Orphaned store atomic-write temps are reclaimed on their own short
-      // staleness window, independent of the unreferenced-artifact age (#56827).
-      if (isSessionStoreTempArtifactName(file.name, storeBasename)) {
-        return file.mtimeMs <= tempCutoffMs;
-      }
-      return file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths);
+      return !params.excludeCanonicalPaths?.has(file.canonicalPath);
     })
     .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
 
@@ -401,7 +420,7 @@ export async function pruneUnreferencedSessionArtifacts(params: {
   }
 
   return {
-    scannedFiles: files.length,
+    scannedFiles: files.length + promptBlobFiles.length,
     removedFiles,
     freedBytes,
     olderThanMs,

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -16,6 +16,7 @@ import {
   isTrajectorySessionArtifactName,
 } from "./artifacts.js";
 import { resolveSessionFilePath } from "./paths.js";
+import { projectSessionStoreForPersistence } from "./skill-prompt-blobs.js";
 import { shouldPreserveMaintenanceEntry } from "./store-maintenance.js";
 import type { SessionEntry } from "./types.js";
 
@@ -88,6 +89,25 @@ function buildStoreEntryChunkSizeMap(store: Record<string, SessionEntry>): Map<s
     out.set(key, measureStoreEntryChunkBytes(key, entry));
   }
   return out;
+}
+
+function resolveProjectedPromptBlobHash(entry: SessionEntry | undefined): string | undefined {
+  const ref = entry?.skillsSnapshot?.promptRef;
+  return ref?.algorithm === "sha256" && typeof ref.hash === "string" ? ref.hash : undefined;
+}
+
+function buildProjectedPromptBlobRefCounts(
+  store: Record<string, SessionEntry>,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const entry of Object.values(store)) {
+    const hash = resolveProjectedPromptBlobHash(entry);
+    if (!hash) {
+      continue;
+    }
+    counts.set(hash, (counts.get(hash) ?? 0) + 1);
+  }
+  return counts;
 }
 
 function getEntryUpdatedAt(entry?: SessionEntry): number {
@@ -375,9 +395,26 @@ export async function enforceSessionDiskBudget(params: {
   const simulatedRemovedPaths = new Set<string>();
   const resolvedStorePath = canonicalizePathForComparison(params.storePath);
   const storeFile = files.find((file) => file.canonicalPath === resolvedStorePath);
-  let projectedStoreBytes = measureStoreBytes(params.store);
+  const projectedPersistence = projectSessionStoreForPersistence({
+    storePath: params.storePath,
+    store: params.store,
+  });
+  const projectedStore = projectedPersistence.store;
+  let projectedStoreBytes = measureStoreBytes(projectedStore);
+  const projectedPromptBlobBytesByHash = new Map<string, number>();
+  for (const [hash, blob] of projectedPersistence.promptBlobs) {
+    projectedPromptBlobBytesByHash.set(hash, blob.ref.bytes);
+  }
+  const projectedPromptBlobRefCounts = buildProjectedPromptBlobRefCounts(projectedStore);
+  const projectedPromptBlobBytes = [...projectedPromptBlobBytesByHash.values()].reduce(
+    (sum, bytes) => sum + bytes,
+    0,
+  );
   let total =
-    files.reduce((sum, file) => sum + file.size, 0) - (storeFile?.size ?? 0) + projectedStoreBytes;
+    files.reduce((sum, file) => sum + file.size, 0) -
+    (storeFile?.size ?? 0) +
+    projectedStoreBytes +
+    projectedPromptBlobBytes;
   const totalBefore = total;
   if (total <= maxBytes) {
     return {
@@ -449,7 +486,7 @@ export async function enforceSessionDiskBudget(params: {
   if (total > highWaterBytes) {
     const activeSessionKey = normalizeOptionalLowercaseString(params.activeSessionKey);
     const sessionIdRefCounts = buildSessionIdRefCounts(params.store);
-    const entryChunkBytesByKey = buildStoreEntryChunkSizeMap(params.store);
+    const entryChunkBytesByKey = buildStoreEntryChunkSizeMap(projectedStore);
     const keys = Object.keys(params.store).toSorted((a, b) => {
       const aTime = getEntryUpdatedAt(params.store[a]);
       const bTime = getEntryUpdatedAt(params.store[b]);
@@ -470,16 +507,28 @@ export async function enforceSessionDiskBudget(params: {
         continue;
       }
       const previousProjectedBytes = projectedStoreBytes;
+      const projectedEntry = projectedStore[key];
+      const promptBlobHash = resolveProjectedPromptBlobHash(projectedEntry);
       delete params.store[key];
+      delete projectedStore[key];
       const chunkBytes = entryChunkBytesByKey.get(key);
       entryChunkBytesByKey.delete(key);
       if (typeof chunkBytes === "number" && Number.isFinite(chunkBytes) && chunkBytes >= 0) {
         // Removing any one pretty-printed top-level entry always removes the entry chunk plus ",\n" (2 bytes).
         projectedStoreBytes = Math.max(2, projectedStoreBytes - (chunkBytes + 2));
       } else {
-        projectedStoreBytes = measureStoreBytes(params.store);
+        projectedStoreBytes = measureStoreBytes(projectedStore);
       }
       total += projectedStoreBytes - previousProjectedBytes;
+      if (promptBlobHash) {
+        const nextRefCount = (projectedPromptBlobRefCounts.get(promptBlobHash) ?? 1) - 1;
+        if (nextRefCount > 0) {
+          projectedPromptBlobRefCounts.set(promptBlobHash, nextRefCount);
+        } else {
+          projectedPromptBlobRefCounts.delete(promptBlobHash);
+          total -= projectedPromptBlobBytesByHash.get(promptBlobHash) ?? 0;
+        }
+      }
       removedEntries += 1;
 
       const sessionId = entry.sessionId;

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -237,6 +237,43 @@ async function readSessionsDirFiles(sessionsDir: string): Promise<SessionsDirFil
   return files;
 }
 
+async function readSessionPromptBlobFiles(sessionsDir: string): Promise<SessionsDirFileStat[]> {
+  const root = path.join(sessionsDir, "skills-prompts", "sha256");
+  const prefixEntries = await fs.promises.readdir(root, { withFileTypes: true }).catch(() => []);
+  const files: SessionsDirFileStat[] = [];
+  for (const prefixEntry of prefixEntries) {
+    if (!prefixEntry.isDirectory() || !/^[a-f0-9]{2}$/u.test(prefixEntry.name)) {
+      continue;
+    }
+    const prefixDir = path.join(root, prefixEntry.name);
+    const blobEntries = await fs.promises
+      .readdir(prefixDir, { withFileTypes: true })
+      .catch(() => []);
+    for (const blobEntry of blobEntries) {
+      if (!blobEntry.isFile() || !/^[a-f0-9]{64}\.txt$/u.test(blobEntry.name)) {
+        continue;
+      }
+      const filePath = path.join(prefixDir, blobEntry.name);
+      const stat = await fs.promises.stat(filePath).catch(() => null);
+      if (!stat?.isFile()) {
+        continue;
+      }
+      files.push({
+        path: filePath,
+        canonicalPath: canonicalizePathForComparison(filePath),
+        name: blobEntry.name,
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+      });
+    }
+  }
+  return files;
+}
+
+function resolvePromptBlobFileHash(file: Pick<SessionsDirFileStat, "name">): string | undefined {
+  return /^[a-f0-9]{64}\.txt$/u.test(file.name) ? file.name.slice(0, -4) : undefined;
+}
+
 function isUnreferencedSessionArtifactFile(
   file: Pick<SessionsDirFileStat, "canonicalPath" | "name">,
   referencedPaths: ReadonlySet<string>,
@@ -391,7 +428,10 @@ export async function enforceSessionDiskBudget(params: {
   const dryRun = params.dryRun === true;
   const sessionsDir = path.dirname(params.storePath);
   const files = await readSessionsDirFiles(sessionsDir);
-  const fileSizesByPath = new Map(files.map((file) => [file.canonicalPath, file.size]));
+  const promptBlobFiles = await readSessionPromptBlobFiles(sessionsDir);
+  const fileSizesByPath = new Map(
+    [...files, ...promptBlobFiles].map((file) => [file.canonicalPath, file.size]),
+  );
   const simulatedRemovedPaths = new Set<string>();
   const resolvedStorePath = canonicalizePathForComparison(params.storePath);
   const storeFile = files.find((file) => file.canonicalPath === resolvedStorePath);
@@ -402,8 +442,17 @@ export async function enforceSessionDiskBudget(params: {
   const projectedStore = projectedPersistence.store;
   let projectedStoreBytes = measureStoreBytes(projectedStore);
   const projectedPromptBlobBytesByHash = new Map<string, number>();
+  const existingPromptBlobFilesByHash = new Map<string, SessionsDirFileStat>();
+  for (const file of promptBlobFiles) {
+    const hash = resolvePromptBlobFileHash(file);
+    if (hash) {
+      existingPromptBlobFilesByHash.set(hash, file);
+    }
+  }
   for (const [hash, blob] of projectedPersistence.promptBlobs) {
-    projectedPromptBlobBytesByHash.set(hash, blob.ref.bytes);
+    if (!existingPromptBlobFilesByHash.has(hash)) {
+      projectedPromptBlobBytesByHash.set(hash, blob.ref.bytes);
+    }
   }
   const projectedPromptBlobRefCounts = buildProjectedPromptBlobRefCounts(projectedStore);
   const projectedPromptBlobBytes = [...projectedPromptBlobBytesByHash.values()].reduce(
@@ -411,7 +460,7 @@ export async function enforceSessionDiskBudget(params: {
     0,
   );
   let total =
-    files.reduce((sum, file) => sum + file.size, 0) -
+    [...files, ...promptBlobFiles].reduce((sum, file) => sum + file.size, 0) -
     (storeFile?.size ?? 0) +
     projectedStoreBytes +
     projectedPromptBlobBytes;
@@ -458,6 +507,32 @@ export async function enforceSessionDiskBudget(params: {
   });
   const tempStaleCutoffMs = Date.now() - SESSION_STORE_TEMP_STALE_MS;
   const storeBasename = path.basename(params.storePath);
+  const unreferencedPromptBlobQueue = promptBlobFiles
+    .filter((file) => {
+      const hash = resolvePromptBlobFileHash(file);
+      return hash ? !projectedPromptBlobRefCounts.has(hash) : false;
+    })
+    .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
+  for (const file of unreferencedPromptBlobQueue) {
+    if (total <= highWaterBytes) {
+      break;
+    }
+    const deletedBytes = await removeFileForBudget({
+      filePath: file.path,
+      canonicalPath: file.canonicalPath,
+      dryRun,
+      fileSizesByPath,
+      simulatedRemovedPaths,
+      onRemovedPath: params.onRemoveFile,
+    });
+    if (deletedBytes <= 0) {
+      continue;
+    }
+    total -= deletedBytes;
+    freedBytes += deletedBytes;
+    removedFiles += 1;
+  }
+
   const removableFileQueue = files
     .filter((file) =>
       isDiskBudgetRemovableSessionFile(file, referencedPaths, tempStaleCutoffMs, storeBasename),
@@ -526,7 +601,27 @@ export async function enforceSessionDiskBudget(params: {
           projectedPromptBlobRefCounts.set(promptBlobHash, nextRefCount);
         } else {
           projectedPromptBlobRefCounts.delete(promptBlobHash);
-          total -= projectedPromptBlobBytesByHash.get(promptBlobHash) ?? 0;
+          const virtualBlobBytes = projectedPromptBlobBytesByHash.get(promptBlobHash) ?? 0;
+          if (virtualBlobBytes > 0) {
+            total -= virtualBlobBytes;
+          } else {
+            const blobFile = existingPromptBlobFilesByHash.get(promptBlobHash);
+            if (blobFile) {
+              const deletedBytes = await removeFileForBudget({
+                filePath: blobFile.path,
+                canonicalPath: blobFile.canonicalPath,
+                dryRun,
+                fileSizesByPath,
+                simulatedRemovedPaths,
+                onRemovedPath: params.onRemoveFile,
+              });
+              if (deletedBytes > 0) {
+                total -= deletedBytes;
+                freedBytes += deletedBytes;
+                removedFiles += 1;
+              }
+            }
+          }
         }
       }
       removedEntries += 1;

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -319,6 +319,22 @@ function isUnreferencedPromptBlobFileRemovable(
   return hash ? !projectedPromptBlobRefCounts.has(hash) : false;
 }
 
+function isPromptBlobArtifactRemovable(
+  file: Pick<SessionsDirFileStat, "name" | "mtimeMs">,
+  projectedPromptBlobRefCounts: ReadonlyMap<string, number>,
+  promptBlobCutoffMs: number,
+  tempCutoffMs: number,
+): boolean {
+  if (isSessionPromptBlobTempArtifactName(file.name)) {
+    return file.mtimeMs <= tempCutoffMs;
+  }
+  return isUnreferencedPromptBlobFileRemovable(
+    file,
+    projectedPromptBlobRefCounts,
+    promptBlobCutoffMs,
+  );
+}
+
 function isDiskBudgetRemovableSessionFile(
   file: Pick<SessionsDirFileStat, "canonicalPath" | "name" | "mtimeMs">,
   referencedPaths: ReadonlySet<string>,
@@ -375,6 +391,48 @@ async function removeFileForBudget(params: {
   return size;
 }
 
+async function removePromptBlobFileForBudget(params: {
+  file: SessionsDirFileStat;
+  projectedPromptBlobRefCounts: ReadonlyMap<string, number>;
+  promptBlobCutoffMs: number;
+  tempCutoffMs: number;
+  dryRun: boolean;
+  fileSizesByPath: Map<string, number>;
+  simulatedRemovedPaths: Set<string>;
+  onRemovedPath?: (canonicalPath: string) => void;
+}): Promise<number> {
+  let file = params.file;
+  if (!params.dryRun) {
+    const stat = await fs.promises.stat(file.path).catch(() => null);
+    if (!stat?.isFile()) {
+      return 0;
+    }
+    file = {
+      ...file,
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    };
+  }
+  if (
+    !isPromptBlobArtifactRemovable(
+      file,
+      params.projectedPromptBlobRefCounts,
+      params.promptBlobCutoffMs,
+      params.tempCutoffMs,
+    )
+  ) {
+    return 0;
+  }
+  return await removeFileForBudget({
+    filePath: file.path,
+    canonicalPath: file.canonicalPath,
+    dryRun: params.dryRun,
+    fileSizesByPath: params.fileSizesByPath,
+    simulatedRemovedPaths: params.simulatedRemovedPaths,
+    onRemovedPath: params.onRemovedPath,
+  });
+}
+
 export async function pruneUnreferencedSessionArtifacts(params: {
   store: Record<string, SessionEntry>;
   storePath: string;
@@ -421,31 +479,44 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     if (params.excludeCanonicalPaths?.has(file.canonicalPath)) {
       return false;
     }
-    if (isSessionPromptBlobTempArtifactName(file.name)) {
-      return file.mtimeMs <= tempCutoffMs;
-    }
-    return isUnreferencedPromptBlobFileRemovable(
+    return isPromptBlobArtifactRemovable(
       file,
       projectedPromptBlobRefCounts,
       promptBlobCutoffMs,
+      tempCutoffMs,
     );
   });
-  const removableFiles = [...removableStoreFiles, ...removablePromptBlobFiles]
+  const removableFiles = [
+    ...removableStoreFiles.map((file) => ({ kind: "store" as const, file })),
+    ...removablePromptBlobFiles.map((file) => ({ kind: "promptBlob" as const, file })),
+  ]
     .filter((file) => {
-      return !params.excludeCanonicalPaths?.has(file.canonicalPath);
+      return !params.excludeCanonicalPaths?.has(file.file.canonicalPath);
     })
-    .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
+    .toSorted((a, b) => a.file.mtimeMs - b.file.mtimeMs);
 
   let removedFiles = 0;
   let freedBytes = 0;
-  for (const file of removableFiles) {
-    const deletedBytes = await removeFileForBudget({
-      filePath: file.path,
-      canonicalPath: file.canonicalPath,
-      dryRun: params.dryRun === true,
-      fileSizesByPath,
-      simulatedRemovedPaths,
-    });
+  const dryRun = params.dryRun === true;
+  for (const item of removableFiles) {
+    const deletedBytes =
+      item.kind === "promptBlob"
+        ? await removePromptBlobFileForBudget({
+            file: item.file,
+            projectedPromptBlobRefCounts,
+            promptBlobCutoffMs,
+            tempCutoffMs,
+            dryRun,
+            fileSizesByPath,
+            simulatedRemovedPaths,
+          })
+        : await removeFileForBudget({
+            filePath: item.file.path,
+            canonicalPath: item.file.canonicalPath,
+            dryRun,
+            fileSizesByPath,
+            simulatedRemovedPaths,
+          });
     if (deletedBytes <= 0) {
       continue;
     }
@@ -563,13 +634,11 @@ export async function enforceSessionDiskBudget(params: {
   const storeBasename = path.basename(params.storePath);
   const unreferencedPromptBlobQueue = promptBlobFiles
     .filter((file) => {
-      if (isSessionPromptBlobTempArtifactName(file.name)) {
-        return file.mtimeMs <= tempStaleCutoffMs;
-      }
-      return isUnreferencedPromptBlobFileRemovable(
+      return isPromptBlobArtifactRemovable(
         file,
         projectedPromptBlobRefCounts,
         promptBlobOrphanCutoffMs,
+        tempStaleCutoffMs,
       );
     })
     .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
@@ -577,9 +646,11 @@ export async function enforceSessionDiskBudget(params: {
     if (total <= highWaterBytes) {
       break;
     }
-    const deletedBytes = await removeFileForBudget({
-      filePath: file.path,
-      canonicalPath: file.canonicalPath,
+    const deletedBytes = await removePromptBlobFileForBudget({
+      file,
+      projectedPromptBlobRefCounts,
+      promptBlobCutoffMs: promptBlobOrphanCutoffMs,
+      tempCutoffMs: tempStaleCutoffMs,
       dryRun,
       fileSizesByPath,
       simulatedRemovedPaths,
@@ -668,15 +739,18 @@ export async function enforceSessionDiskBudget(params: {
             const blobFile = existingPromptBlobFilesByHash.get(promptBlobHash);
             if (
               blobFile &&
-              isUnreferencedPromptBlobFileRemovable(
+              isPromptBlobArtifactRemovable(
                 blobFile,
                 projectedPromptBlobRefCounts,
                 promptBlobOrphanCutoffMs,
+                tempStaleCutoffMs,
               )
             ) {
-              const deletedBytes = await removeFileForBudget({
-                filePath: blobFile.path,
-                canonicalPath: blobFile.canonicalPath,
+              const deletedBytes = await removePromptBlobFileForBudget({
+                file: blobFile,
+                projectedPromptBlobRefCounts,
+                promptBlobCutoffMs: promptBlobOrphanCutoffMs,
+                tempCutoffMs: tempStaleCutoffMs,
                 dryRun,
                 fileSizesByPath,
                 simulatedRemovedPaths,

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -250,7 +250,11 @@ async function readSessionPromptBlobFiles(sessionsDir: string): Promise<Sessions
       .readdir(prefixDir, { withFileTypes: true })
       .catch(() => []);
     for (const blobEntry of blobEntries) {
-      if (!blobEntry.isFile() || !/^[a-f0-9]{64}\.txt$/u.test(blobEntry.name)) {
+      if (
+        !blobEntry.isFile() ||
+        (!/^[a-f0-9]{64}\.txt$/u.test(blobEntry.name) &&
+          !isSessionPromptBlobTempArtifactName(blobEntry.name))
+      ) {
         continue;
       }
       const filePath = path.join(prefixDir, blobEntry.name);
@@ -272,6 +276,12 @@ async function readSessionPromptBlobFiles(sessionsDir: string): Promise<Sessions
 
 function resolvePromptBlobFileHash(file: Pick<SessionsDirFileStat, "name">): string | undefined {
   return /^[a-f0-9]{64}\.txt$/u.test(file.name) ? file.name.slice(0, -4) : undefined;
+}
+
+function isSessionPromptBlobTempArtifactName(name: string): boolean {
+  return /^[a-f0-9]{64}\.txt\.(?:\d+\.)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tmp$/u.test(
+    name,
+  );
 }
 
 function isUnreferencedSessionArtifactFile(
@@ -390,7 +400,13 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     return file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths);
   });
   const removablePromptBlobFiles = promptBlobFiles.filter((file) => {
-    if (params.excludeCanonicalPaths?.has(file.canonicalPath) || file.mtimeMs > cutoffMs) {
+    if (params.excludeCanonicalPaths?.has(file.canonicalPath)) {
+      return false;
+    }
+    if (isSessionPromptBlobTempArtifactName(file.name)) {
+      return file.mtimeMs <= tempCutoffMs;
+    }
+    if (file.mtimeMs > cutoffMs) {
       return false;
     }
     const hash = resolvePromptBlobFileHash(file);
@@ -528,6 +544,9 @@ export async function enforceSessionDiskBudget(params: {
   const storeBasename = path.basename(params.storePath);
   const unreferencedPromptBlobQueue = promptBlobFiles
     .filter((file) => {
+      if (isSessionPromptBlobTempArtifactName(file.name)) {
+        return file.mtimeMs <= tempStaleCutoffMs;
+      }
       const hash = resolvePromptBlobFileHash(file);
       return hash ? !projectedPromptBlobRefCounts.has(hash) : false;
     })

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -302,6 +302,22 @@ function isUnreferencedSessionArtifactFile(
 // atomic write (those rename within milliseconds), so it is safe to reclaim
 // regardless of the general unreferenced-artifact age threshold (#56827).
 const SESSION_STORE_TEMP_STALE_MS = 5 * 60 * 1000;
+// Prompt blobs are written or mtime-refreshed before sessions.json points at
+// them. Treat fresh unreferenced blobs as in-flight so cleanup cannot strand a
+// durable promptRef that is about to be committed by another writer.
+const SESSION_PROMPT_BLOB_UNREFERENCED_GRACE_MS = SESSION_STORE_TEMP_STALE_MS;
+
+function isUnreferencedPromptBlobFileRemovable(
+  file: Pick<SessionsDirFileStat, "name" | "mtimeMs">,
+  projectedPromptBlobRefCounts: ReadonlyMap<string, number>,
+  cutoffMs: number,
+): boolean {
+  if (file.mtimeMs > cutoffMs) {
+    return false;
+  }
+  const hash = resolvePromptBlobFileHash(file);
+  return hash ? !projectedPromptBlobRefCounts.has(hash) : false;
+}
 
 function isDiskBudgetRemovableSessionFile(
   file: Pick<SessionsDirFileStat, "canonicalPath" | "name" | "mtimeMs">,
@@ -387,6 +403,8 @@ export async function pruneUnreferencedSessionArtifacts(params: {
   );
   const cutoffMs = Date.now() - olderThanMs;
   const tempCutoffMs = Date.now() - SESSION_STORE_TEMP_STALE_MS;
+  const promptBlobCutoffMs =
+    Date.now() - Math.max(olderThanMs, SESSION_PROMPT_BLOB_UNREFERENCED_GRACE_MS);
   const storeBasename = path.basename(params.storePath);
   const removableStoreFiles = files.filter((file) => {
     if (params.excludeCanonicalPaths?.has(file.canonicalPath)) {
@@ -406,11 +424,11 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     if (isSessionPromptBlobTempArtifactName(file.name)) {
       return file.mtimeMs <= tempCutoffMs;
     }
-    if (file.mtimeMs > cutoffMs) {
-      return false;
-    }
-    const hash = resolvePromptBlobFileHash(file);
-    return hash ? !projectedPromptBlobRefCounts.has(hash) : false;
+    return isUnreferencedPromptBlobFileRemovable(
+      file,
+      projectedPromptBlobRefCounts,
+      promptBlobCutoffMs,
+    );
   });
   const removableFiles = [...removableStoreFiles, ...removablePromptBlobFiles]
     .filter((file) => {
@@ -541,14 +559,18 @@ export async function enforceSessionDiskBudget(params: {
     store: params.store,
   });
   const tempStaleCutoffMs = Date.now() - SESSION_STORE_TEMP_STALE_MS;
+  const promptBlobOrphanCutoffMs = Date.now() - SESSION_PROMPT_BLOB_UNREFERENCED_GRACE_MS;
   const storeBasename = path.basename(params.storePath);
   const unreferencedPromptBlobQueue = promptBlobFiles
     .filter((file) => {
       if (isSessionPromptBlobTempArtifactName(file.name)) {
         return file.mtimeMs <= tempStaleCutoffMs;
       }
-      const hash = resolvePromptBlobFileHash(file);
-      return hash ? !projectedPromptBlobRefCounts.has(hash) : false;
+      return isUnreferencedPromptBlobFileRemovable(
+        file,
+        projectedPromptBlobRefCounts,
+        promptBlobOrphanCutoffMs,
+      );
     })
     .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
   for (const file of unreferencedPromptBlobQueue) {
@@ -644,7 +666,14 @@ export async function enforceSessionDiskBudget(params: {
             total -= virtualBlobBytes;
           } else {
             const blobFile = existingPromptBlobFilesByHash.get(promptBlobHash);
-            if (blobFile) {
+            if (
+              blobFile &&
+              isUnreferencedPromptBlobFileRemovable(
+                blobFile,
+                projectedPromptBlobRefCounts,
+                promptBlobOrphanCutoffMs,
+              )
+            ) {
               const deletedBytes = await removeFileForBudget({
                 filePath: blobFile.path,
                 canonicalPath: blobFile.canonicalPath,

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -725,6 +725,7 @@ describe("session store writer queue", () => {
     expect(writtenText).toBeTypeOf("string");
     expect(writeOptions?.durable).toBe(false);
     expect(writeOptions?.mode).toBe(0o600);
+    expect(writeOptions?.beforeRename).toBeTypeOf("function");
     writeSpy.mockRestore();
   });
 

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -530,6 +530,43 @@ describe("session store writer queue", () => {
     writeSpy.mockRestore();
   });
 
+  it("skips unchanged writes after persisting blobbed skills prompts", async () => {
+    const key = "agent:main:no-op-blobbed-save";
+    const { storePath } = await makeTmpStore({
+      [key]: {
+        sessionId: "s-noop-blobbed",
+        updatedAt: Date.now(),
+        skillsSnapshot: {
+          prompt: `<available_skills>\n${"shared prompt\n".repeat(200)}</available_skills>`,
+          skills: [{ name: "demo" }],
+          version: 1,
+        },
+      },
+    });
+
+    const writeSpy = vi.spyOn(jsonFiles, "writeTextAtomic");
+    await updateSessionStore(
+      storePath,
+      async (store) => {
+        store[key]!.displayName = "saved once";
+      },
+      { skipMaintenance: true },
+    );
+    writeSpy.mockClear();
+
+    await updateSessionStore(
+      storePath,
+      async () => {
+        // Intentionally no-op mutation after the disk JSON has prompt refs.
+      },
+      { skipMaintenance: true },
+    );
+
+    const storeWrites = writeSpy.mock.calls.filter(([targetPath]) => targetPath === storePath);
+    expect(storeWrites).toHaveLength(0);
+    writeSpy.mockRestore();
+  });
+
   it("caches unchanged session stores from persisted JSON shape", async () => {
     const key = "agent:main:no-op-cache";
     const { storePath } = await makeTmpStore({

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -17,7 +17,12 @@ import {
 import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { readSessionStoreCache, writeSessionStoreCache } from "./store-cache.js";
-import { clearSessionStoreCacheForTest, loadSessionStore, updateSessionStore } from "./store.js";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  updateSessionStore,
+  updateSessionStoreEntry,
+} from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
 import { mergeSessionEntry, mergeSessionEntryWithPolicy, type SessionEntry } from "./types.js";
 
@@ -349,6 +354,7 @@ describe("session store writer queue", () => {
   it("drops non-object persisted session entries on load", async () => {
     const { storePath } = await makeTmpStore({
       "agent:main:good": { sessionId: "s-good", updatedAt: Date.now() },
+      "agent:main:null": null,
       "agent:main:string": "not-a-session-entry",
       "agent:main:array": [{ sessionId: "s-array", updatedAt: Date.now() }],
     } as unknown as Record<string, SessionEntry>);
@@ -356,6 +362,7 @@ describe("session store writer queue", () => {
     const store = loadSessionStore(storePath, { skipCache: true });
 
     expect(store["agent:main:good"]?.sessionId).toBe("s-good");
+    expect(store["agent:main:null"]).toBeUndefined();
     expect(store["agent:main:string"]).toBeUndefined();
     expect(store["agent:main:array"]).toBeUndefined();
   });
@@ -548,7 +555,7 @@ describe("session store writer queue", () => {
     await updateSessionStore(
       storePath,
       async (store) => {
-        store[key]!.displayName = "saved once";
+        store[key].displayName = "saved once";
       },
       { skipMaintenance: true },
     );
@@ -564,7 +571,84 @@ describe("session store writer queue", () => {
 
     const storeWrites = writeSpy.mock.calls.filter(([targetPath]) => targetPath === storePath);
     expect(storeWrites).toHaveLength(0);
+    writeSpy.mockClear();
+
+    await updateSessionStore(
+      storePath,
+      async () => {
+        // The first unchanged save must not clear the serialized comparison cache.
+      },
+      { skipMaintenance: true },
+    );
+
+    const secondStoreWrites = writeSpy.mock.calls.filter(
+      ([targetPath]) => targetPath === storePath,
+    );
+    expect(secondStoreWrites).toHaveLength(0);
     writeSpy.mockRestore();
+  });
+
+  it("keeps unchanged entry saves from clearing blobbed store comparison cache", async () => {
+    const now = Date.now();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const key = "agent:main:no-op-blobbed-entry-save";
+    let writeSpy:
+      | {
+          mock: { calls: WriteTextAtomicCall[] };
+          mockClear: () => void;
+          mockRestore: () => void;
+        }
+      | undefined;
+    try {
+      const { storePath } = await makeTmpStore({
+        [key]: {
+          sessionId: "s-noop-blobbed-entry",
+          updatedAt: now,
+          displayName: "entry",
+          skillsSnapshot: {
+            prompt: `<available_skills>\n${"entry prompt\n".repeat(200)}</available_skills>`,
+            skills: [{ name: "demo" }],
+            version: 1,
+          },
+        },
+      });
+
+      writeSpy = vi.spyOn(jsonFiles, "writeTextAtomic");
+      await updateSessionStore(
+        storePath,
+        async (store) => {
+          store[key].displayName = "saved once";
+        },
+        { skipMaintenance: true },
+      );
+      writeSpy.mockClear();
+
+      await updateSessionStoreEntry({
+        storePath,
+        sessionKey: key,
+        update: async (entry) => ({ displayName: entry.displayName, updatedAt: entry.updatedAt }),
+        skipMaintenance: true,
+      });
+      expect(
+        writeSpy.mock.calls.filter((call: WriteTextAtomicCall) => call[0] === storePath),
+      ).toHaveLength(0);
+      writeSpy.mockClear();
+
+      await updateSessionStore(
+        storePath,
+        async () => {
+          // The unchanged entry save must leave the serialized comparison cache hot.
+        },
+        { skipMaintenance: true },
+      );
+      expect(
+        writeSpy.mock.calls.filter((call: WriteTextAtomicCall) => call[0] === storePath),
+      ).toHaveLength(0);
+    } finally {
+      writeSpy?.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("caches unchanged session stores from persisted JSON shape", async () => {
@@ -605,6 +689,7 @@ describe("session store writer queue", () => {
       mtimeMs: 1,
       sizeBytes: serialized.length,
       serialized,
+      cloneSerialized: serialized,
       takeOwnership: true,
     });
     store[key].sessionId = "mutated-cache-object";

--- a/src/config/sessions/skill-prompt-blobs.ts
+++ b/src/config/sessions/skill-prompt-blobs.ts
@@ -16,6 +16,16 @@ type PersistedSessionStore = {
   changed: boolean;
 };
 
+export type SessionSkillPromptBlobProjection = {
+  ref: SessionSkillPromptRef;
+  path: string | null;
+  prompt: string;
+};
+
+export type SessionStorePersistenceProjection = PersistedSessionStore & {
+  promptBlobs: Map<string, SessionSkillPromptBlobProjection>;
+};
+
 function hashPrompt(prompt: string): string {
   return crypto.createHash(PROMPT_BLOB_ALGORITHM).update(prompt).digest("hex");
 }
@@ -24,7 +34,7 @@ function isSha256Hex(value: string): boolean {
   return /^[a-f0-9]{64}$/u.test(value);
 }
 
-function resolvePromptBlobPath(storePath: string, hash: string): string | null {
+export function resolveSessionSkillPromptBlobPath(storePath: string, hash: string): string | null {
   if (!isSha256Hex(hash)) {
     return null;
   }
@@ -63,7 +73,7 @@ function readValidPromptBlob(storePath: string, ref: SessionSkillPromptRef): str
   ) {
     return null;
   }
-  const blobPath = resolvePromptBlobPath(storePath, ref.hash);
+  const blobPath = resolveSessionSkillPromptBlobPath(storePath, ref.hash);
   if (!blobPath) {
     return null;
   }
@@ -83,7 +93,7 @@ function readValidPromptBlob(storePath: string, ref: SessionSkillPromptRef): str
 
 async function ensurePromptBlob(storePath: string, prompt: string): Promise<SessionSkillPromptRef> {
   const ref = buildPromptRef(prompt);
-  const blobPath = resolvePromptBlobPath(storePath, ref.hash);
+  const blobPath = resolveSessionSkillPromptBlobPath(storePath, ref.hash);
   if (!blobPath) {
     return ref;
   }
@@ -110,25 +120,42 @@ function stripPromptForPersistence(entry: SessionEntry, ref: SessionSkillPromptR
   };
 }
 
-export async function prepareSessionStoreForPersistence(params: {
+export function projectSessionStoreForPersistence(params: {
   storePath: string;
   store: Record<string, SessionEntry>;
-}): Promise<PersistedSessionStore> {
+}): SessionStorePersistenceProjection {
   let persisted = params.store;
   let changed = false;
+  const promptBlobs = new Map<string, SessionSkillPromptBlobProjection>();
   for (const [key, entry] of Object.entries(params.store)) {
     const prompt = entry.skillsSnapshot?.prompt;
     if (!prompt || !shouldStorePromptAsBlob(prompt)) {
       continue;
     }
-    const promptRef = await ensurePromptBlob(params.storePath, prompt);
+    const promptRef = buildPromptRef(prompt);
+    promptBlobs.set(promptRef.hash, {
+      ref: promptRef,
+      path: resolveSessionSkillPromptBlobPath(params.storePath, promptRef.hash),
+      prompt,
+    });
     if (persisted === params.store) {
       persisted = { ...params.store };
     }
     persisted[key] = stripPromptForPersistence(entry, promptRef);
     changed = true;
   }
-  return { store: persisted, changed };
+  return { store: persisted, changed, promptBlobs };
+}
+
+export async function prepareSessionStoreForPersistence(params: {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+}): Promise<PersistedSessionStore> {
+  const projected = projectSessionStoreForPersistence(params);
+  for (const blob of projected.promptBlobs.values()) {
+    await ensurePromptBlob(params.storePath, blob.prompt);
+  }
+  return projected;
 }
 
 function parsePromptRef(value: unknown): SessionSkillPromptRef | null {

--- a/src/config/sessions/skill-prompt-blobs.ts
+++ b/src/config/sessions/skill-prompt-blobs.ts
@@ -155,15 +155,13 @@ export function projectSessionStoreForPersistence(params: {
   return { store: persisted, changed, promptBlobs };
 }
 
-export async function prepareSessionStoreForPersistence(params: {
+export async function ensureSessionStorePromptBlobsForPersistence(params: {
   storePath: string;
-  store: Record<string, SessionEntry>;
-}): Promise<PersistedSessionStore> {
-  const projected = projectSessionStoreForPersistence(params);
-  for (const blob of projected.promptBlobs.values()) {
+  promptBlobs: Iterable<SessionSkillPromptBlobProjection>;
+}): Promise<void> {
+  for (const blob of params.promptBlobs) {
     await ensurePromptBlob(params.storePath, blob.prompt);
   }
-  return projected;
 }
 
 function parsePromptRef(value: unknown): SessionSkillPromptRef | null {

--- a/src/config/sessions/skill-prompt-blobs.ts
+++ b/src/config/sessions/skill-prompt-blobs.ts
@@ -9,7 +9,6 @@ const PROMPT_BLOB_ALGORITHM: SessionSkillPromptRef["algorithm"] = "sha256";
 const PROMPT_BLOB_VERSION: SessionSkillPromptRef["version"] = 1;
 const MIN_PROMPT_BLOB_CHARS = 512;
 const MAX_PROMPT_BLOB_BYTES = 512 * 1024;
-const verifiedPromptBlobPaths = new Set<string>();
 
 type PersistedSessionStore = {
   store: Record<string, SessionEntry>;
@@ -97,7 +96,7 @@ async function ensurePromptBlob(storePath: string, prompt: string): Promise<Sess
   if (!blobPath) {
     return ref;
   }
-  if (!verifiedPromptBlobPaths.has(blobPath) && readValidPromptBlob(storePath, ref) !== prompt) {
+  if (readValidPromptBlob(storePath, ref) !== prompt) {
     await fs.promises.mkdir(path.dirname(blobPath), { recursive: true });
     await writeTextAtomic(blobPath, prompt, {
       durable: false,
@@ -105,7 +104,6 @@ async function ensurePromptBlob(storePath: string, prompt: string): Promise<Sess
       tempPrefix: path.basename(blobPath),
     });
   }
-  verifiedPromptBlobPaths.add(blobPath);
   return ref;
 }
 

--- a/src/config/sessions/skill-prompt-blobs.ts
+++ b/src/config/sessions/skill-prompt-blobs.ts
@@ -176,10 +176,14 @@ function parsePromptRef(value: unknown): SessionSkillPromptRef | null {
 
 export function hydrateSessionStoreSkillPromptRefs(params: {
   storePath: string;
-  store: Record<string, SessionEntry>;
+  store: Record<string, unknown>;
 }): boolean {
   let changed = false;
-  for (const [key, entry] of Object.entries(params.store)) {
+  for (const [key, value] of Object.entries(params.store)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      continue;
+    }
+    const entry = value as SessionEntry;
     const snapshot = entry.skillsSnapshot;
     if (!snapshot || typeof snapshot.prompt === "string") {
       continue;
@@ -187,8 +191,9 @@ export function hydrateSessionStoreSkillPromptRefs(params: {
     const promptRef = parsePromptRef((snapshot as { promptRef?: unknown }).promptRef);
     const prompt = promptRef ? readValidPromptBlob(params.storePath, promptRef) : null;
     if (!prompt) {
-      params.store[key] = { ...entry };
-      delete params.store[key].skillsSnapshot;
+      const nextEntry = { ...entry };
+      delete nextEntry.skillsSnapshot;
+      params.store[key] = nextEntry;
       changed = true;
       continue;
     }

--- a/src/config/sessions/skill-prompt-blobs.ts
+++ b/src/config/sessions/skill-prompt-blobs.ts
@@ -96,14 +96,24 @@ async function ensurePromptBlob(storePath: string, prompt: string): Promise<Sess
   if (!blobPath) {
     return ref;
   }
-  if (readValidPromptBlob(storePath, ref) !== prompt) {
-    await fs.promises.mkdir(path.dirname(blobPath), { recursive: true });
-    await writeTextAtomic(blobPath, prompt, {
-      durable: false,
-      mode: 0o600,
-      tempPrefix: path.basename(blobPath),
-    });
+  if (readValidPromptBlob(storePath, ref) === prompt) {
+    try {
+      const now = new Date();
+      // Saving a store can reference an existing content-addressed blob before
+      // sessions.json is replaced. Refresh its mtime so orphan cleanup does not
+      // reclaim the blob while the store write is still in flight.
+      await fs.promises.utimes(blobPath, now, now);
+      return ref;
+    } catch {
+      // A concurrent cleanup may have removed it; rewrite below.
+    }
   }
+  await fs.promises.mkdir(path.dirname(blobPath), { recursive: true });
+  await writeTextAtomic(blobPath, prompt, {
+    durable: false,
+    mode: 0o600,
+    tempPrefix: path.basename(blobPath),
+  });
   return ref;
 }
 

--- a/src/config/sessions/skill-prompt-blobs.ts
+++ b/src/config/sessions/skill-prompt-blobs.ts
@@ -1,0 +1,183 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { writeTextAtomic } from "../../infra/json-files.js";
+import type { SessionEntry, SessionSkillPromptRef, SessionSkillSnapshot } from "./types.js";
+
+const PROMPT_BLOB_DIR = "skills-prompts";
+const PROMPT_BLOB_ALGORITHM: SessionSkillPromptRef["algorithm"] = "sha256";
+const PROMPT_BLOB_VERSION: SessionSkillPromptRef["version"] = 1;
+const MIN_PROMPT_BLOB_CHARS = 512;
+const MAX_PROMPT_BLOB_BYTES = 512 * 1024;
+const verifiedPromptBlobPaths = new Set<string>();
+
+type PersistedSessionStore = {
+  store: Record<string, SessionEntry>;
+  changed: boolean;
+};
+
+function hashPrompt(prompt: string): string {
+  return crypto.createHash(PROMPT_BLOB_ALGORITHM).update(prompt).digest("hex");
+}
+
+function isSha256Hex(value: string): boolean {
+  return /^[a-f0-9]{64}$/u.test(value);
+}
+
+function resolvePromptBlobPath(storePath: string, hash: string): string | null {
+  if (!isSha256Hex(hash)) {
+    return null;
+  }
+  return path.join(
+    path.dirname(path.resolve(storePath)),
+    PROMPT_BLOB_DIR,
+    PROMPT_BLOB_ALGORITHM,
+    hash.slice(0, 2),
+    `${hash}.txt`,
+  );
+}
+
+function buildPromptRef(prompt: string): SessionSkillPromptRef {
+  return {
+    version: PROMPT_BLOB_VERSION,
+    algorithm: PROMPT_BLOB_ALGORITHM,
+    hash: hashPrompt(prompt),
+    bytes: Buffer.byteLength(prompt, "utf8"),
+  };
+}
+
+function shouldStorePromptAsBlob(prompt: string): boolean {
+  const bytes = Buffer.byteLength(prompt, "utf8");
+  return prompt.length >= MIN_PROMPT_BLOB_CHARS && bytes <= MAX_PROMPT_BLOB_BYTES;
+}
+
+function readValidPromptBlob(storePath: string, ref: SessionSkillPromptRef): string | null {
+  if (
+    ref.version !== PROMPT_BLOB_VERSION ||
+    ref.algorithm !== PROMPT_BLOB_ALGORITHM ||
+    !isSha256Hex(ref.hash) ||
+    typeof ref.bytes !== "number" ||
+    !Number.isFinite(ref.bytes) ||
+    ref.bytes < 0 ||
+    ref.bytes > MAX_PROMPT_BLOB_BYTES
+  ) {
+    return null;
+  }
+  const blobPath = resolvePromptBlobPath(storePath, ref.hash);
+  if (!blobPath) {
+    return null;
+  }
+  try {
+    const stat = fs.statSync(blobPath);
+    if (!stat.isFile() || stat.size !== ref.bytes) {
+      return null;
+    }
+    const prompt = fs.readFileSync(blobPath, "utf8");
+    return hashPrompt(prompt) === ref.hash && Buffer.byteLength(prompt, "utf8") === ref.bytes
+      ? prompt
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensurePromptBlob(storePath: string, prompt: string): Promise<SessionSkillPromptRef> {
+  const ref = buildPromptRef(prompt);
+  const blobPath = resolvePromptBlobPath(storePath, ref.hash);
+  if (!blobPath) {
+    return ref;
+  }
+  if (!verifiedPromptBlobPaths.has(blobPath) && readValidPromptBlob(storePath, ref) !== prompt) {
+    await fs.promises.mkdir(path.dirname(blobPath), { recursive: true });
+    await writeTextAtomic(blobPath, prompt, {
+      durable: false,
+      mode: 0o600,
+      tempPrefix: path.basename(blobPath),
+    });
+  }
+  verifiedPromptBlobPaths.add(blobPath);
+  return ref;
+}
+
+function stripPromptForPersistence(entry: SessionEntry, ref: SessionSkillPromptRef): SessionEntry {
+  const { prompt: _prompt, ...snapshot } = entry.skillsSnapshot!;
+  return {
+    ...entry,
+    skillsSnapshot: {
+      ...snapshot,
+      promptRef: ref,
+    } as SessionSkillSnapshot,
+  };
+}
+
+export async function prepareSessionStoreForPersistence(params: {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+}): Promise<PersistedSessionStore> {
+  let persisted = params.store;
+  let changed = false;
+  for (const [key, entry] of Object.entries(params.store)) {
+    const prompt = entry.skillsSnapshot?.prompt;
+    if (!prompt || !shouldStorePromptAsBlob(prompt)) {
+      continue;
+    }
+    const promptRef = await ensurePromptBlob(params.storePath, prompt);
+    if (persisted === params.store) {
+      persisted = { ...params.store };
+    }
+    persisted[key] = stripPromptForPersistence(entry, promptRef);
+    changed = true;
+  }
+  return { store: persisted, changed };
+}
+
+function parsePromptRef(value: unknown): SessionSkillPromptRef | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const ref = value as Partial<SessionSkillPromptRef>;
+  return ref.version === PROMPT_BLOB_VERSION &&
+    ref.algorithm === PROMPT_BLOB_ALGORITHM &&
+    typeof ref.hash === "string" &&
+    typeof ref.bytes === "number"
+    ? {
+        version: ref.version,
+        algorithm: ref.algorithm,
+        hash: ref.hash,
+        bytes: ref.bytes,
+      }
+    : null;
+}
+
+export function hydrateSessionStoreSkillPromptRefs(params: {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+}): boolean {
+  let changed = false;
+  for (const [key, entry] of Object.entries(params.store)) {
+    const snapshot = entry.skillsSnapshot;
+    if (!snapshot || typeof snapshot.prompt === "string") {
+      continue;
+    }
+    const promptRef = parsePromptRef((snapshot as { promptRef?: unknown }).promptRef);
+    const prompt = promptRef ? readValidPromptBlob(params.storePath, promptRef) : null;
+    if (!prompt) {
+      params.store[key] = { ...entry };
+      delete params.store[key].skillsSnapshot;
+      changed = true;
+      continue;
+    }
+    const { promptRef: _promptRef, ...rest } = snapshot as typeof snapshot & {
+      promptRef?: SessionSkillPromptRef;
+    };
+    params.store[key] = {
+      ...entry,
+      skillsSnapshot: {
+        ...rest,
+        prompt,
+      },
+    };
+    changed = true;
+  }
+  return changed;
+}

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -404,6 +404,7 @@ export function writeSessionStoreCache(params: {
   mtimeMs?: number;
   sizeBytes?: number;
   serialized?: string;
+  cloneSerialized?: string;
   takeOwnership?: boolean;
 }): void {
   const store =
@@ -415,7 +416,7 @@ export function writeSessionStoreCache(params: {
     store,
     mtimeMs: params.mtimeMs,
     sizeBytes: params.sizeBytes,
-    serialized: params.serialized,
+    serialized: params.cloneSerialized,
   });
   setSerializedSessionStore(params.storePath, params.serialized, params.sizeBytes);
 }

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -10,6 +10,7 @@ import {
   normalizeSessionDeliveryFields,
 } from "../../utils/delivery-context.shared.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
+import { hydrateSessionStoreSkillPromptRefs } from "./skill-prompt-blobs.js";
 import {
   cloneSessionStoreRecord,
   cloneSessionStoreSnapshot,
@@ -398,9 +399,10 @@ export function loadSessionStore(
     }
   }
 
+  const hydratedPromptRefs = hydrateSessionStoreSkillPromptRefs({ storePath, store });
   const migrated = applySessionStoreMigrations(store);
   const normalized = normalizeSessionStore(store);
-  if (migrated || normalized) {
+  if (hydratedPromptRefs || migrated || normalized) {
     serializedFromDisk = undefined;
   }
   if (opts.runMaintenance) {

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -450,6 +450,7 @@ export function loadSessionStore(
       mtimeMs,
       sizeBytes: fileStat?.sizeBytes,
       serialized: serializedFromDisk,
+      cloneSerialized: serializedFromDisk,
       takeOwnership: serializedFromDisk !== undefined,
     });
   }

--- a/src/config/sessions/store.skills-stripping.test.ts
+++ b/src/config/sessions/store.skills-stripping.test.ts
@@ -258,6 +258,34 @@ describe("session store strips resolvedSkills from persistence", () => {
     expect(await fs.readFile(blobPath, "utf-8")).toBe(prompt);
   });
 
+  it("refreshes reused prompt blob mtimes before committing prompt refs", async () => {
+    const prompt = `<available_skills>\n${"refreshed prompt\n".repeat(200)}</available_skills>`;
+    const store = {
+      "agent:main:test:1": makeEntry("session-1", makeSnapshotWithPrompt(prompt)),
+    };
+    await saveSessionStore(storePath, store, { skipMaintenance: true });
+    const raw = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, SessionEntry>;
+    const hash = raw["agent:main:test:1"]?.skillsSnapshot?.promptRef?.hash;
+    if (!hash) {
+      throw new Error("expected prompt ref");
+    }
+    const blobPath = path.join(
+      testDir,
+      "skills-prompts",
+      "sha256",
+      hash.slice(0, 2),
+      `${hash}.txt`,
+    );
+    const oldTime = new Date(Date.now() - 10 * 60 * 1000);
+    await fs.utimes(blobPath, oldTime, oldTime);
+
+    await saveSessionStore(storePath, store, { skipMaintenance: true });
+
+    const refreshed = await fs.stat(blobPath);
+    expect(refreshed.mtimeMs).toBeGreaterThan(oldTime.getTime());
+    expect(await fs.readFile(blobPath, "utf-8")).toBe(prompt);
+  });
+
   it("keeps cache clones hydrated when disk JSON uses prompt refs", async () => {
     process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "45000";
     clearSessionStoreCacheForTest();

--- a/src/config/sessions/store.skills-stripping.test.ts
+++ b/src/config/sessions/store.skills-stripping.test.ts
@@ -9,7 +9,7 @@ import {
   hydrateResolvedSkillsAsync,
 } from "../../agents/skills/snapshot-hydration.js";
 import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
-import type { SessionEntry, SessionSkillSnapshot } from "./types.js";
+import type { SessionEntry, SessionSkillPromptRef, SessionSkillSnapshot } from "./types.js";
 
 vi.mock("../config.js", async () => ({
   ...(await vi.importActual<typeof import("../config.js")>("../config.js")),
@@ -45,6 +45,13 @@ function makeSnapshot(skillCount: number): SessionSkillSnapshot {
     skillFilter: undefined,
     resolvedSkills: resolved,
     version: 1,
+  };
+}
+
+function makeSnapshotWithPrompt(prompt: string): SessionSkillSnapshot {
+  return {
+    ...makeSnapshot(2),
+    prompt,
   };
 }
 
@@ -173,6 +180,124 @@ describe("session store strips resolvedSkills from persistence", () => {
     // Post-fix: only the lightweight `skills` array + prompt per entry.
     // Conservative budget that comfortably covers metadata growth.
     expect(stat.size).toBeLessThan(2 * 1024 * 1024);
+  });
+
+  it("stores duplicate large skills prompts as content-addressed blobs", async () => {
+    const prompt = `<available_skills>\n${"skill prompt body\n".repeat(200)}</available_skills>`;
+    const store = {
+      "agent:main:test:1": makeEntry("session-1", makeSnapshotWithPrompt(prompt)),
+      "agent:main:test:2": makeEntry("session-2", makeSnapshotWithPrompt(prompt)),
+    };
+
+    await saveSessionStore(storePath, store, { skipMaintenance: true });
+
+    const raw = await fs.readFile(storePath, "utf-8");
+    expect(raw).not.toContain("skill prompt body");
+    const parsed = JSON.parse(raw) as Record<string, SessionEntry>;
+    const firstRef = parsed["agent:main:test:1"]?.skillsSnapshot
+      ?.promptRef as SessionSkillPromptRef;
+    const secondRef = parsed["agent:main:test:2"]?.skillsSnapshot
+      ?.promptRef as SessionSkillPromptRef;
+    expect(firstRef).toMatchObject({
+      version: 1,
+      algorithm: "sha256",
+      bytes: Buffer.byteLength(prompt, "utf8"),
+    });
+    expect(secondRef).toEqual(firstRef);
+    expect(parsed["agent:main:test:1"]?.skillsSnapshot?.prompt).toBeUndefined();
+
+    const blobPath = path.join(
+      testDir,
+      "skills-prompts",
+      "sha256",
+      firstRef.hash.slice(0, 2),
+      `${firstRef.hash}.txt`,
+    );
+    expect(await fs.readFile(blobPath, "utf-8")).toBe(prompt);
+  });
+
+  it("hydrates content-addressed skills prompt blobs on load", async () => {
+    const prompt = `<available_skills>\n${"persisted prompt\n".repeat(200)}</available_skills>`;
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:test:1": makeEntry("session-1", makeSnapshotWithPrompt(prompt)),
+      },
+      { skipMaintenance: true },
+    );
+
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+
+    expect(loaded["agent:main:test:1"]?.skillsSnapshot?.prompt).toBe(prompt);
+    expect(loaded["agent:main:test:1"]?.skillsSnapshot?.promptRef).toBeUndefined();
+    expect(loaded["agent:main:test:1"]?.skillsSnapshot?.resolvedSkills).toBeUndefined();
+  });
+
+  it("keeps cache clones hydrated when disk JSON uses prompt refs", async () => {
+    process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "45000";
+    clearSessionStoreCacheForTest();
+    const prompt = `<available_skills>\n${"cached prompt\n".repeat(200)}</available_skills>`;
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:test:1": makeEntry("session-1", makeSnapshotWithPrompt(prompt)),
+      },
+      { skipMaintenance: true },
+    );
+
+    const loaded = loadSessionStore(storePath);
+
+    expect(loaded["agent:main:test:1"]?.skillsSnapshot?.prompt).toBe(prompt);
+    expect(loaded["agent:main:test:1"]?.skillsSnapshot?.promptRef).toBeUndefined();
+  });
+
+  it("keeps small skills prompts inline", async () => {
+    const prompt = "short prompt";
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:test:1": makeEntry("session-1", makeSnapshotWithPrompt(prompt)),
+      },
+      { skipMaintenance: true },
+    );
+
+    const raw = await fs.readFile(storePath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, SessionEntry>;
+
+    expect(parsed["agent:main:test:1"]?.skillsSnapshot?.prompt).toBe(prompt);
+    expect(parsed["agent:main:test:1"]?.skillsSnapshot?.promptRef).toBeUndefined();
+  });
+
+  it("drops stale prompt refs so missing blobs rebuild on the next turn", async () => {
+    await fs.mkdir(testDir, { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:test:1": {
+            sessionId: "session-1",
+            updatedAt: Date.now(),
+            skillsSnapshot: {
+              promptRef: {
+                version: 1,
+                algorithm: "sha256",
+                hash: "a".repeat(64),
+                bytes: 123,
+              },
+              skills: [{ name: "demo" }],
+              version: 1,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+
+    expect(loaded["agent:main:test:1"]?.skillsSnapshot).toBeUndefined();
   });
 });
 

--- a/src/config/sessions/store.skills-stripping.test.ts
+++ b/src/config/sessions/store.skills-stripping.test.ts
@@ -233,6 +233,31 @@ describe("session store strips resolvedSkills from persistence", () => {
     expect(loaded["agent:main:test:1"]?.skillsSnapshot?.resolvedSkills).toBeUndefined();
   });
 
+  it("rewrites a verified prompt blob when cleanup removed it in the same process", async () => {
+    const prompt = `<available_skills>\n${"rewritten prompt\n".repeat(200)}</available_skills>`;
+    const store = {
+      "agent:main:test:1": makeEntry("session-1", makeSnapshotWithPrompt(prompt)),
+    };
+    await saveSessionStore(storePath, store, { skipMaintenance: true });
+    const raw = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, SessionEntry>;
+    const hash = raw["agent:main:test:1"]?.skillsSnapshot?.promptRef?.hash;
+    if (!hash) {
+      throw new Error("expected prompt ref");
+    }
+    const blobPath = path.join(
+      testDir,
+      "skills-prompts",
+      "sha256",
+      hash.slice(0, 2),
+      `${hash}.txt`,
+    );
+    await fs.rm(blobPath);
+
+    await saveSessionStore(storePath, store, { skipMaintenance: true });
+
+    expect(await fs.readFile(blobPath, "utf-8")).toBe(prompt);
+  });
+
   it("keeps cache clones hydrated when disk JSON uses prompt refs", async () => {
     process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "45000";
     clearSessionStoreCacheForTest();

--- a/src/config/sessions/store.skills-stripping.test.ts
+++ b/src/config/sessions/store.skills-stripping.test.ts
@@ -1,3 +1,4 @@
+import type { MakeDirectoryOptions, Mode, PathLike } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -284,6 +285,52 @@ describe("session store strips resolvedSkills from persistence", () => {
     const refreshed = await fs.stat(blobPath);
     expect(refreshed.mtimeMs).toBeGreaterThan(oldTime.getTime());
     expect(await fs.readFile(blobPath, "utf-8")).toBe(prompt);
+  });
+
+  it("rewrites prompt blobs when the session dir is recreated before store commit", async () => {
+    const prompt = `<available_skills>\n${"recreated dir prompt\n".repeat(200)}</available_skills>`;
+    const store = {
+      "agent:main:test:1": makeEntry("session-1", makeSnapshotWithPrompt(prompt)),
+    };
+    const realMkdir = fs.mkdir.bind(fs);
+    let storeDirMkdirs = 0;
+    const mkdirSpy = vi
+      .spyOn(fs, "mkdir")
+      .mockImplementation(
+        async (dirPath: PathLike, options?: MakeDirectoryOptions | Mode | null) => {
+          if (typeof dirPath === "string" && path.resolve(dirPath) === path.resolve(testDir)) {
+            storeDirMkdirs += 1;
+            if (storeDirMkdirs === 2) {
+              await fs.rm(testDir, { recursive: true, force: true });
+            }
+          }
+          return await realMkdir(dirPath, options ?? undefined);
+        },
+      );
+
+    try {
+      await saveSessionStore(storePath, store, { skipMaintenance: true });
+    } finally {
+      mkdirSpy.mockRestore();
+    }
+
+    expect(storeDirMkdirs).toBeGreaterThanOrEqual(2);
+    const raw = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, SessionEntry>;
+    const hash = raw["agent:main:test:1"]?.skillsSnapshot?.promptRef?.hash;
+    if (!hash) {
+      throw new Error("expected prompt ref");
+    }
+    const blobPath = path.join(
+      testDir,
+      "skills-prompts",
+      "sha256",
+      hash.slice(0, 2),
+      `${hash}.txt`,
+    );
+    expect(await fs.readFile(blobPath, "utf-8")).toBe(prompt);
+    expect(
+      loadSessionStore(storePath, { skipCache: true })["agent:main:test:1"]?.skillsSnapshot?.prompt,
+    ).toBe(prompt);
   });
 
   it("keeps cache clones hydrated when disk JSON uses prompt refs", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -17,7 +17,11 @@ import { getRuntimeConfig } from "../io.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import { resolveStorePath } from "./paths.js";
-import { prepareSessionStoreForPersistence } from "./skill-prompt-blobs.js";
+import {
+  ensureSessionStorePromptBlobsForPersistence,
+  projectSessionStoreForPersistence,
+  type SessionSkillPromptBlobProjection,
+} from "./skill-prompt-blobs.js";
 import {
   cloneSessionStoreRecord,
   dropSessionStoreObjectCache,
@@ -502,10 +506,15 @@ async function saveSessionStoreUnlocked(
   }
 
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
-  const persisted = await prepareSessionStoreForPersistence({ storePath, store });
+  const persisted = projectSessionStoreForPersistence({ storePath, store });
+  const promptBlobs = [...persisted.promptBlobs.values()];
   const json = JSON.stringify(persisted.store, null, 2);
   const cloneSerialized = persisted.changed ? undefined : json;
   if (getSerializedSessionStore(storePath) === json) {
+    await ensureSessionStorePromptBlobsForPersistence({
+      storePath,
+      promptBlobs,
+    });
     updateSessionStoreWriteCaches({
       storePath,
       store,
@@ -525,6 +534,7 @@ async function saveSessionStoreUnlocked(
           store,
           serialized: json,
           cloneSerialized,
+          promptBlobs,
           takeOwnership: opts?.takeCacheOwnership,
         });
         return;
@@ -551,6 +561,7 @@ async function saveSessionStoreUnlocked(
       store,
       serialized: json,
       cloneSerialized,
+      promptBlobs,
       takeOwnership: opts?.takeCacheOwnership,
     });
   } catch (err) {
@@ -565,6 +576,7 @@ async function saveSessionStoreUnlocked(
           store,
           serialized: json,
           cloneSerialized,
+          promptBlobs,
           takeOwnership: opts?.takeCacheOwnership,
         });
       } catch (err2) {
@@ -680,6 +692,7 @@ async function writeSessionStoreAtomic(params: {
   store: Record<string, SessionEntry>;
   serialized: string;
   cloneSerialized?: string;
+  promptBlobs: Iterable<SessionSkillPromptBlobProjection>;
   takeOwnership?: boolean;
 }): Promise<void> {
   // Stage the temp as `sessions.json.<pid>.<uuid>.tmp` (not the generic
@@ -689,6 +702,12 @@ async function writeSessionStoreAtomic(params: {
     durable: false,
     mode: 0o600,
     tempPrefix: path.basename(params.storePath),
+    beforeRename: async () => {
+      await ensureSessionStorePromptBlobsForPersistence({
+        storePath: params.storePath,
+        promptBlobs: params.promptBlobs,
+      });
+    },
   });
   updateSessionStoreWriteCaches({
     storePath: params.storePath,

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -223,12 +223,10 @@ function updateSessionStoreWriteCaches(params: {
     store: params.store,
     mtimeMs: fileStat?.mtimeMs,
     sizeBytes: fileStat?.sizeBytes,
-    serialized: params.cloneSerialized,
+    serialized: params.serialized,
+    cloneSerialized: params.cloneSerialized,
     takeOwnership: params.takeOwnership,
   });
-  if (params.cloneSerialized === undefined) {
-    setSerializedSessionStore(params.storePath, params.serialized, fileStat?.sizeBytes);
-  }
   dropSessionStoreSnapshotCache(params.storePath);
 }
 
@@ -248,13 +246,20 @@ function restoreUnchangedSessionStoreCache(
     invalidateSessionStoreCache(storePath);
     return;
   }
+  const serialized = getSerializedSessionStore(storePath);
   writeSessionStoreCache({
     storePath,
     store,
     mtimeMs: loadedFileStat?.mtimeMs,
     sizeBytes: loadedFileStat?.sizeBytes,
+    serialized,
     takeOwnership: true,
   });
+  if (serialized !== undefined) {
+    // Keep hydrated blob prompts in the object cache, but preserve the disk JSON
+    // comparison string so repeated no-op saves do not rewrite sessions.json.
+    setSerializedSessionStore(storePath, serialized, loadedFileStat?.sizeBytes);
+  }
 }
 
 function loadMutableSessionStoreForWriter(storePath: string): Record<string, SessionEntry> {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -17,6 +17,7 @@ import { getRuntimeConfig } from "../io.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import { resolveStorePath } from "./paths.js";
+import { prepareSessionStoreForPersistence } from "./skill-prompt-blobs.js";
 import {
   cloneSessionStoreRecord,
   dropSessionStoreObjectCache,
@@ -207,6 +208,7 @@ function updateSessionStoreWriteCaches(params: {
   storePath: string;
   store: Record<string, SessionEntry>;
   serialized: string;
+  cloneSerialized?: string;
   takeOwnership?: boolean;
 }): void {
   const fileStat = getFileStatSnapshot(params.storePath);
@@ -221,7 +223,7 @@ function updateSessionStoreWriteCaches(params: {
     store: params.store,
     mtimeMs: fileStat?.mtimeMs,
     sizeBytes: fileStat?.sizeBytes,
-    serialized: params.serialized,
+    serialized: params.cloneSerialized,
     takeOwnership: params.takeOwnership,
   });
   dropSessionStoreSnapshotCache(params.storePath);
@@ -248,7 +250,6 @@ function restoreUnchangedSessionStoreCache(
     store,
     mtimeMs: loadedFileStat?.mtimeMs,
     sizeBytes: loadedFileStat?.sizeBytes,
-    serialized: getSerializedSessionStore(storePath),
     takeOwnership: true,
   });
 }
@@ -493,12 +494,15 @@ async function saveSessionStoreUnlocked(
   }
 
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
-  const json = JSON.stringify(store, null, 2);
+  const persisted = await prepareSessionStoreForPersistence({ storePath, store });
+  const json = JSON.stringify(persisted.store, null, 2);
+  const cloneSerialized = persisted.changed ? undefined : json;
   if (getSerializedSessionStore(storePath) === json) {
     updateSessionStoreWriteCaches({
       storePath,
       store,
       serialized: json,
+      cloneSerialized,
       takeOwnership: opts?.takeCacheOwnership,
     });
     return;
@@ -512,6 +516,7 @@ async function saveSessionStoreUnlocked(
           storePath,
           store,
           serialized: json,
+          cloneSerialized,
           takeOwnership: opts?.takeCacheOwnership,
         });
         return;
@@ -537,6 +542,7 @@ async function saveSessionStoreUnlocked(
       storePath,
       store,
       serialized: json,
+      cloneSerialized,
       takeOwnership: opts?.takeCacheOwnership,
     });
   } catch (err) {
@@ -550,6 +556,7 @@ async function saveSessionStoreUnlocked(
           storePath,
           store,
           serialized: json,
+          cloneSerialized,
           takeOwnership: opts?.takeCacheOwnership,
         });
       } catch (err2) {
@@ -664,6 +671,7 @@ async function writeSessionStoreAtomic(params: {
   storePath: string;
   store: Record<string, SessionEntry>;
   serialized: string;
+  cloneSerialized?: string;
   takeOwnership?: boolean;
 }): Promise<void> {
   // Stage the temp as `sessions.json.<pid>.<uuid>.tmp` (not the generic
@@ -678,6 +686,7 @@ async function writeSessionStoreAtomic(params: {
     storePath: params.storePath,
     store: params.store,
     serialized: params.serialized,
+    cloneSerialized: params.cloneSerialized,
     takeOwnership: params.takeOwnership,
   });
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -226,6 +226,9 @@ function updateSessionStoreWriteCaches(params: {
     serialized: params.cloneSerialized,
     takeOwnership: params.takeOwnership,
   });
+  if (params.cloneSerialized === undefined) {
+    setSerializedSessionStore(params.storePath, params.serialized, fileStat?.sizeBytes);
+  }
   dropSessionStoreSnapshotCache(params.storePath);
 }
 

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -609,8 +609,17 @@ export type GroupKeyResolution = {
   chatType?: SessionChatType;
 };
 
+export type SessionSkillPromptRef = {
+  version: 1;
+  algorithm: "sha256";
+  hash: string;
+  bytes: number;
+};
+
 export type SessionSkillSnapshot = {
   prompt: string;
+  /** Persisted stores may replace large duplicate prompts with a content-addressed blob ref. */
+  promptRef?: SessionSkillPromptRef;
   skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -4,7 +4,12 @@ import {
   readJson as readJsonImpl,
   readJsonIfExists as readJsonIfExistsImpl,
 } from "@openclaw/fs-safe/json";
-import { replaceFileAtomic, type ReplaceFileAtomicOptions } from "./replace-file.js";
+import { replaceFileAtomic } from "./replace-file.js";
+
+type WriteTextAtomicBeforeRename = (params: {
+  filePath: string;
+  tempPath: string;
+}) => Promise<void>;
 
 export {
   JsonFileReadError,
@@ -71,7 +76,7 @@ export type WriteTextAtomicOptions = {
   dirMode?: number;
   trailingNewline?: boolean;
   durable?: boolean;
-  beforeRename?: ReplaceFileAtomicOptions["beforeRename"];
+  beforeRename?: WriteTextAtomicBeforeRename;
   /**
    * Prefix for the staged `<prefix>.<pid>.<uuid>.tmp` file. Defaults to the
    * generic `.fs-safe-replace`; pass a target-specific prefix so an orphaned

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -4,7 +4,7 @@ import {
   readJson as readJsonImpl,
   readJsonIfExists as readJsonIfExistsImpl,
 } from "@openclaw/fs-safe/json";
-import { replaceFileAtomic } from "./replace-file.js";
+import { replaceFileAtomic, type ReplaceFileAtomicOptions } from "./replace-file.js";
 
 export {
   JsonFileReadError,
@@ -71,6 +71,7 @@ export type WriteTextAtomicOptions = {
   dirMode?: number;
   trailingNewline?: boolean;
   durable?: boolean;
+  beforeRename?: ReplaceFileAtomicOptions["beforeRename"];
   /**
    * Prefix for the staged `<prefix>.<pid>.<uuid>.tmp` file. Defaults to the
    * generic `.fs-safe-replace`; pass a target-specific prefix so an orphaned
@@ -93,6 +94,7 @@ export async function writeTextAtomic(
     copyFallbackOnPermissionError: true,
     syncTempFile: options?.durable !== false,
     syncParentDir: options?.durable !== false,
+    ...(options?.beforeRename ? { beforeRename: options.beforeRename } : {}),
     ...(options?.tempPrefix ? { tempPrefix: options.tempPrefix } : {}),
   });
 }


### PR DESCRIPTION
## Summary
- Store large repeated skills prompts as content-addressed blobs next to sessions.json while preserving hydrated runtime snapshots.
- Teach session loading, cache cloning, doctor raw scans, disk-budget accounting, and normal artifact cleanup to understand prompt refs.
- Add regression coverage for blob persistence, missing/stale blob recovery, disk-budget blob/temp cleanup, cache hydration, and doctor scans.

## Verification
- pnpm test src/config/sessions/disk-budget.test.ts src/config/sessions/store.skills-stripping.test.ts src/config/sessions.cache.test.ts src/config/sessions/sessions.test.ts src/commands/doctor-session-snapshots.test.ts -- --reporter=verbose
- pnpm exec oxlint src/config/sessions/skill-prompt-blobs.ts src/config/sessions/disk-budget.ts src/config/sessions/disk-budget.test.ts src/config/sessions/store.skills-stripping.test.ts --tsconfig config/tsconfig/oxlint.json
- rm -f .artifacts/tsgo-cache/core-test.tsbuildinfo .artifacts/tsgo-cache/extensions-test.tsbuildinfo && pnpm check:test-types
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main: clean, no accepted/actionable findings

Behavior addressed: Large duplicated skills prompts are no longer repeated inline in persisted session stores.
Real environment tested: Local macOS checkout.
Exact steps or command run after this patch: The verification commands above were run after the final patch.
Evidence after fix: Focused session/doctor tests pass, including prompt blob persistence/hydration, missing blob rewrite, disk-budget accounting, normal cleanup, and stale atomic temp cleanup.
Observed result after fix: Runtime loads hydrated skillsSnapshot.prompt values, persisted sessions.json stores large prompts by promptRef, and cleanup removes unreferenced or stale prompt blob artifacts without deleting fresh in-flight temps.
What was not tested: Full release CI and live production migration on a real user state directory.
