### PR TITLE
fix(transport): preserve Anthropic-signed thinking block content

### DIFF
--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -292,9 +292,17 @@ function convertAnthropicMessages(
               text: sanitizeTransportPayloadText(block.thinking),
             });
           } else {
+            // BUGFIX (#87459): Do NOT sanitize Anthropic-signed thinking content.
+            // sanitizeTransportPayloadText() strips orphan UTF-16 surrogates, mutating
+            // the text and invalidating the cryptographic signature attached by
+            // Anthropic. The API then rejects the next turn with:
+            //   "thinking or redacted_thinking blocks in the latest assistant
+            //    message cannot be modified".
+            // Anthropic round-trips its own response bytes correctly; sanitization
+            // is not needed and is actively harmful here.
             blocks.push({
               type: "thinking",
-              thinking: sanitizeTransportPayloadText(block.thinking),
+              thinking: block.thinking,
               signature: block.thinkingSignature,
             });
           }


### PR DESCRIPTION
## Summary

Fixes #87459.

`sanitizeTransportPayloadText()` strips orphan UTF-16 surrogates from text. When applied to Anthropic `thinking` block content while preserving the `signature` field (which Anthropic computes against the original byte representation), the next API call fails with:

```
messages.N.content.M: thinking or redacted_thinking blocks in the latest
assistant message cannot be modified. These blocks must remain as they
were in the original response.
```

## Two corruption sites identified (running production has both)

This PR patches the **send path** (`anthropic-transport-stream.ts` lines ~290-300, branch where signature is preserved).

**A second corruption site exists in the receive path of the compiled `provider-stream-DRIaVJMo.js` (line ~843)**:
```js
if (contentBlock?.type === "thinking") {
    const thinking = typeof contentBlock.thinking === "string"
        ? sanitizeTransportPayloadText(contentBlock.thinking)  // ← CORRUPTS AT INGEST
        : "";
    output.content.push({ type: "thinking", thinking, thinkingSignature: contentBlock.signature, ... });
}
```

This site is in a newer file structure than what's currently on `main`. Whoever holds the source for this should also drop the `sanitizeTransportPayloadText` call there — it corrupts the session memory at ingestion time, before the message is ever sent back. Every signed thinking block in session history becomes permanently mismatched against its signature.

## Reproduction (production)

1. Claude model with extended thinking enabled (`claude-sonnet-4-6`, `claude-opus-4-7`)
2. Reasoning emits a thinking block containing a UTF-16 surrogate pair (emoji, non-BMP characters)
3. Continue the conversation
4. API fails with the error above
5. Session becomes unrecoverable until the corrupted block is dropped from history

## Impact in our deployment

- 4+ subagent crashes today during a parallel registry migration
- ~2 hours of work lost across crashed sessions
- Required falling back to background shell processes (no thinking)
- Long sessions become time bombs — any emoji in reasoning corrupts them

## Fix in this PR

Drop the sanitizer call for the signed-thinking branch in `anthropic-transport-stream.ts`. Anthropic round-trips its own response bytes safely.

## Required follow-up (NOT in this PR)

Apply equivalent fix at the receive path in the compiled provider-stream file. See issue #87459 comment for the exact location.

## Test recommendation

```ts
it("does not mutate Anthropic-signed thinking content on roundtrip", () => {
    const inputText = "Let me think about 🤔 this problem"; // emoji = surrogate pair
    const input = {
        role: "assistant",
        content: [{ type: "thinking", thinking: inputText, thinkingSignature: "REAL_ANTHROPIC_SIG" }]
    };
    const blocks = transformAssistantContent(input.content);
    expect(blocks[0].thinking).toBe(inputText); // byte-exact
    expect(blocks[0].signature).toBe("REAL_ANTHROPIC_SIG");
});
```
