### PR TITLE
fix(session): normalize openai-codex provider to openai for session route persistence

### DIFF
--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -23,6 +23,17 @@ type RunResult = Awaited<ReturnType<(typeof import("../embedded-agent.js"))["run
 const usageFormatModuleLoader = createLazyImportLoader(() => import("../../utils/usage-format.js"));
 const contextModuleLoader = createLazyImportLoader(() => import("../context.js"));
 
+/**
+ * Normalize internal provider IDs to user-facing route names for session persistence.
+ * e.g., "openai-codex" → "openai" so doctor --fix doesn't report false legacy warnings.
+ */
+function normalizeSessionRouteProvider(provider: string | undefined): string | undefined {
+  if (provider === "openai-codex") {
+    return "openai";
+  }
+  return provider;
+}
+
 async function getUsageFormatModule() {
   return await usageFormatModuleLoader.load();
 }
@@ -99,7 +110,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
       : undefined;
   const compactionsThisRun = Math.max(0, result.meta.agentMeta?.compactionCount ?? 0);
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
-  const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
+  const providerUsed = normalizeSessionRouteProvider(
+    result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider,
+  );
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
   const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -110,9 +110,10 @@ export async function updateSessionStoreAfterAgentRun(params: {
       : undefined;
   const compactionsThisRun = Math.max(0, result.meta.agentMeta?.compactionCount ?? 0);
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
-  const providerUsed = normalizeSessionRouteProvider(
-    result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider,
-  );
+  const providerUsed =
+    normalizeSessionRouteProvider(
+      result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider,
+    ) ?? "openai";
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
   const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -110,10 +110,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
       : undefined;
   const compactionsThisRun = Math.max(0, result.meta.agentMeta?.compactionCount ?? 0);
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
-  const providerUsed =
-    normalizeSessionRouteProvider(
-      result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider,
-    ) ?? "openai";
+  const providerUsed = normalizeSessionRouteProvider(
+    result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider,
+  );
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
   const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1561,9 +1561,10 @@ export async function runReplyAgent(params: {
     const usage = runResult.meta?.agentMeta?.usage;
     const promptTokens = runResult.meta?.agentMeta?.promptTokens;
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
-    const providerUsed = normalizeSessionRouteProvider(
-      runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider,
-    );
+    const providerUsed =
+      normalizeSessionRouteProvider(
+        runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider,
+      ) ?? "openai";
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const preserveUserFacingSessionState = shouldPreserveUserFacingSessionStateForInputProvenance(
       followupRun.run.inputProvenance,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -141,6 +141,17 @@ function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
 }
 
+/**
+ * Normalize internal provider IDs to user-facing route names for session persistence.
+ * e.g., "openai-codex" → "openai" so doctor --fix doesn't report false legacy warnings.
+ */
+function normalizeSessionRouteProvider(provider: string | undefined): string | undefined {
+  if (provider === "openai-codex") {
+    return "openai";
+  }
+  return provider;
+}
+
 function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
   if (!Array.isArray(value)) {
     return false;
@@ -1550,8 +1561,9 @@ export async function runReplyAgent(params: {
     const usage = runResult.meta?.agentMeta?.usage;
     const promptTokens = runResult.meta?.agentMeta?.promptTokens;
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
-    const providerUsed =
-      runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
+    const providerUsed = normalizeSessionRouteProvider(
+      runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider,
+    );
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const preserveUserFacingSessionState = shouldPreserveUserFacingSessionStateForInputProvenance(
       followupRun.run.inputProvenance,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1561,10 +1561,9 @@ export async function runReplyAgent(params: {
     const usage = runResult.meta?.agentMeta?.usage;
     const promptTokens = runResult.meta?.agentMeta?.promptTokens;
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
-    const providerUsed =
-      normalizeSessionRouteProvider(
-        runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider,
-      ) ?? "openai";
+    const providerUsed = normalizeSessionRouteProvider(
+      runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider,
+    );
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const preserveUserFacingSessionState = shouldPreserveUserFacingSessionStateForInputProvenance(
       followupRun.run.inputProvenance,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -979,10 +979,9 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
-      const providerUsed =
-        normalizeSessionRouteProvider(
-          runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider,
-        ) ?? "openai";
+      const providerUsed = normalizeSessionRouteProvider(
+        runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider,
+      );
       const contextTokensUsed =
         resolveContextTokensForModel({
           cfg: queued.run.config,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -979,9 +979,10 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
-      const providerUsed = normalizeSessionRouteProvider(
-        runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider,
-      );
+      const providerUsed =
+        normalizeSessionRouteProvider(
+          runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider,
+        ) ?? "openai";
       const contextTokensUsed =
         resolveContextTokensForModel({
           cfg: queued.run.config,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -71,6 +71,17 @@ function filterStringArray(value: unknown): string[] | undefined {
     : undefined;
 }
 
+/**
+ * Normalize internal provider IDs to user-facing route names for session persistence.
+ * e.g., "openai-codex" → "openai" so doctor --fix doesn't report false legacy warnings.
+ */
+function normalizeSessionRouteProvider(provider: string | undefined): string | undefined {
+  if (provider === "openai-codex") {
+    return "openai";
+  }
+  return provider;
+}
+
 function hasFailedFollowupProgressEvent(evt: FollowupAgentEvent): boolean {
   if (evt.stream !== "item" && evt.stream !== "command_output") {
     return false;
@@ -968,8 +979,9 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
-      const providerUsed =
-        runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider;
+      const providerUsed = normalizeSessionRouteProvider(
+        runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider,
+      );
       const contextTokensUsed =
         resolveContextTokensForModel({
           cfg: queued.run.config,


### PR DESCRIPTION
Fixes #87436

## Summary
When Codex harness (openai-codex) runs, the internal provider ID "openai-codex" was being persisted directly to session route state. This caused `doctor --fix` to repeatedly report false legacy session-route warnings.

Added `normalizeSessionRouteProvider()` to convert "openai-codex" → "openai" when persisting session route state.

## Changes
- `src/agents/command/session-store.ts`: normalize provider before persisting
- `src/auto-reply/reply/agent-runner.ts`: normalize provider before persisting
- `src/auto-reply/reply/followup-runner.ts`: normalize provider before persisting