### PR TITLE
fix(discord): fence tool warning fallback delivery

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -236,6 +236,7 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
       ) => Promise<ReplyPayload | null> | ReplyPayload | null;
       deliver: (payload: unknown, info: { kind: "block" | "final" }) => Promise<void> | void;
       transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
+      onSettled?: () => Promise<unknown> | unknown;
     };
     ctx?: unknown;
     replyOptions?: DispatchInboundParams["replyOptions"];
@@ -261,17 +262,25 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
       pendingDeliveries.push(delivery);
       return true;
     };
-    return await dispatchInboundMessage({
-      ctx: params.ctx,
-      replyOptions: params.replyOptions,
-      dispatcher: {
-        sendBlockReply: vi.fn((payload: ReplyPayload) => queueDelivery(payload, { kind: "block" })),
-        sendFinalReply: vi.fn((payload: ReplyPayload) => queueDelivery(payload, { kind: "final" })),
-        waitForIdle: vi.fn(async () => {
-          await Promise.all(pendingDeliveries);
-        }),
-      },
-    });
+    try {
+      return await dispatchInboundMessage({
+        ctx: params.ctx,
+        replyOptions: params.replyOptions,
+        dispatcher: {
+          sendBlockReply: vi.fn((payload: ReplyPayload) =>
+            queueDelivery(payload, { kind: "block" }),
+          ),
+          sendFinalReply: vi.fn((payload: ReplyPayload) =>
+            queueDelivery(payload, { kind: "final" }),
+          ),
+          waitForIdle: vi.fn(async () => {
+            await Promise.all(pendingDeliveries);
+          }),
+        },
+      });
+    } finally {
+      await params.dispatcherOptions.onSettled?.();
+    }
   },
   dispatchInboundMessage: (params: DispatchInboundParams) => dispatchInboundMessage(params),
   settleReplyDispatcher: async (params: {
@@ -2252,6 +2261,7 @@ describe("processDiscordMessage draft streaming", () => {
     const draftStream = createMockDraftStreamForTest();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "delivery survived" });
+      await params?.dispatcher.waitForIdle();
       await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
       return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
     });
@@ -2273,6 +2283,7 @@ describe("processDiscordMessage draft streaming", () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
       await params?.dispatcher.sendFinalReply({ text: "delivery recovered" });
+      await params?.dispatcher.waitForIdle();
       return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
     });
 
@@ -2500,6 +2511,7 @@ describe("processDiscordMessage draft streaming", () => {
       await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
       await params?.replyOptions?.onItemEvent?.({ progressText: "exec done" });
       await params?.dispatcher.sendFinalReply({ text: "delivery survived" });
+      await params?.dispatcher.waitForIdle();
       await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
       return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
     });

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -238,6 +238,7 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
       onError?: (err: unknown, info: { kind: "block" | "final" }) => void;
       transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
       onSettled?: () => Promise<unknown> | unknown;
+      onFreshSettledDelivery?: () => Promise<unknown> | unknown;
     };
     ctx?: unknown;
     replyOptions?: DispatchInboundParams["replyOptions"];
@@ -283,6 +284,7 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
       });
     } finally {
       await params.dispatcherOptions.onSettled?.();
+      await params.dispatcherOptions.onFreshSettledDelivery?.();
     }
   },
   dispatchInboundMessage: (params: DispatchInboundParams) => dispatchInboundMessage(params),

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -235,6 +235,7 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
         info: { kind: "block" | "final" },
       ) => Promise<ReplyPayload | null> | ReplyPayload | null;
       deliver: (payload: unknown, info: { kind: "block" | "final" }) => Promise<void> | void;
+      onError?: (err: unknown, info: { kind: "block" | "final" }) => void;
       transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
       onSettled?: () => Promise<unknown> | unknown;
     };
@@ -258,7 +259,9 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
       await params.dispatcherOptions.deliver(deliverPayload, info);
     };
     const queueDelivery = (payload: ReplyPayload, info: { kind: "block" | "final" }) => {
-      const delivery = Promise.resolve(deliver(payload, info)).catch(() => undefined);
+      const delivery = Promise.resolve(deliver(payload, info)).catch((err: unknown) => {
+        params.dispatcherOptions.onError?.(err, info);
+      });
       pendingDeliveries.push(delivery);
       return true;
     };
@@ -2316,6 +2319,39 @@ describe("processDiscordMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
     expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [
+        {
+          text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+          isError: true,
+        },
+      ],
+    });
+  });
+
+  it("delivers tool warning finals when the recovered reply fails to send", async () => {
+    deliverDiscordReply.mockRejectedValueOnce(new Error("send failed"));
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "delivery failed" });
+      await params?.dispatcher.waitForIdle();
+      await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
+      return {
+        queuedFinal: true,
+        counts: { final: 2, tool: 0, block: 0 },
+        failedCounts: { final: 1 },
+      };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "off" },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(2);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [{ text: "delivery failed" }],
+    });
+    expect(deliverDiscordReply.mock.calls[1]?.[0]).toMatchObject({
       replies: [
         {
           text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -907,7 +907,7 @@ export async function processDiscordMessage(
         humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
         beforeDeliver: beforeDiscordPayloadDelivery,
         onReplyStart: onDiscordReplyStart,
-        onSettled: deliverPendingToolWarningFinalIfNeeded,
+        onFreshSettledDelivery: deliverPendingToolWarningFinalIfNeeded,
       },
       delivery: {
         deliver: deliverDiscordPayload,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -630,7 +630,7 @@ export async function processDiscordMessage(
       !options?.allowFallbackOnlyToolWarning &&
       isFallbackOnlyToolWarningFinal(payload)
     ) {
-      if (!userFacingFinalDelivered) {
+      if (!userFacingFinalDelivered && !finalReplyStartNotified) {
         pendingToolWarningFinal = { payload, info };
       }
       return { visibleReplySent: false };
@@ -865,17 +865,18 @@ export async function processDiscordMessage(
   let dispatchAborted = false;
   const deliverPendingToolWarningFinalIfNeeded = async () => {
     if (!pendingToolWarningFinal || userFacingFinalDelivered || isProcessAborted(abortSignal)) {
-      return;
+      return undefined;
     }
     const pending = pendingToolWarningFinal;
     pendingToolWarningFinal = undefined;
     try {
-      await deliverDiscordPayload(pending.payload, pending.info, {
+      return await deliverDiscordPayload(pending.payload, pending.info, {
         allowFallbackOnlyToolWarning: true,
       });
     } catch (err) {
       dispatchError = true;
       onDiscordDeliveryError(err, pending.info);
+      return { visibleReplySent: false };
     }
   };
   try {
@@ -898,6 +899,7 @@ export async function processDiscordMessage(
         humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
         beforeDeliver: beforeDiscordPayloadDelivery,
         onReplyStart: onDiscordReplyStart,
+        onSettled: deliverPendingToolWarningFinalIfNeeded,
       },
       delivery: {
         deliver: deliverDiscordPayload,
@@ -1067,7 +1069,6 @@ export async function processDiscordMessage(
       dispatchAborted = true;
       return;
     }
-    await deliverPendingToolWarningFinalIfNeeded();
   } catch (err) {
     if (isProcessAborted(abortSignal)) {
       dispatchAborted = true;

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -546,11 +546,13 @@ export async function processDiscordMessage(
     observer?.onFinalReplyStart?.();
   };
   let userFacingFinalDelivered = false;
+  let userFacingFinalDeliveryFailed = false;
   let pendingToolWarningFinal:
     | { payload: ReplyPayload; info: { kind: ReplyDispatchKind } }
     | undefined;
   const markUserFacingFinalDelivered = () => {
     userFacingFinalDelivered = true;
+    userFacingFinalDeliveryFailed = false;
     pendingToolWarningFinal = undefined;
     draftPreview.markFinalReplyDelivered();
     observer?.onFinalReplyDelivered?.();
@@ -630,7 +632,10 @@ export async function processDiscordMessage(
       !options?.allowFallbackOnlyToolWarning &&
       isFallbackOnlyToolWarningFinal(payload)
     ) {
-      if (!userFacingFinalDelivered && !finalReplyStartNotified) {
+      if (
+        !userFacingFinalDelivered &&
+        (!finalReplyStartNotified || userFacingFinalDeliveryFailed)
+      ) {
         pendingToolWarningFinal = { payload, info };
       }
       return { visibleReplySent: false };
@@ -839,6 +844,9 @@ export async function processDiscordMessage(
     return { visibleReplySent: true };
   };
   const onDiscordDeliveryError = (err: unknown, info: { kind: string }) => {
+    if (info.kind === "final" && finalReplyStartNotified && !userFacingFinalDelivered) {
+      userFacingFinalDeliveryFailed = true;
+    }
     runtime.error(
       danger(
         formatDiscordReplyDeliveryFailure({

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -64,6 +64,7 @@ function dispatchWithDeliveries(
     beforeDeliver?: ReplyDispatchBeforeDeliver;
     deliver?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => Promise<unknown>;
     onSettled?: () => Promise<unknown> | unknown;
+    onFreshSettledDelivery?: () => Promise<unknown> | unknown;
   } = {},
 ) {
   return dispatchInboundMessageWithBufferedDispatcher({
@@ -476,7 +477,7 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([]);
   });
 
-  it("suppresses an older settled delivery after a newer visible reply", async () => {
+  it("still runs stale generic settled hooks after a newer visible reply", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();
     const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
@@ -484,10 +485,7 @@ describe("foreground reply freshness", () => {
       beforeDeliverStarted.resolve();
       return releaseBeforeDeliver.promise;
     });
-    const olderSettled = vi.fn(() => {
-      deliveries.push({ kind: "final", text: "old settled fallback" });
-      return { visibleReplySent: true };
-    });
+    const olderSettled = vi.fn();
 
     hoisted.dispatchReplyFromConfigMock.mockImplementation(
       async (params: DispatchReplyFromConfigParams) => {
@@ -519,7 +517,62 @@ describe("foreground reply freshness", () => {
     const olderResult = await olderDispatch;
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(olderSettled).not.toHaveBeenCalled();
+    expect(olderSettled).toHaveBeenCalledTimes(1);
+    expect(newerResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(olderResult).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+  });
+
+  it("suppresses an older fresh settled delivery after a newer visible reply", async () => {
+    const deliveries: Delivery[] = [];
+    const beforeDeliverStarted = createDeferred<void>();
+    const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
+    const beforeDeliver = vi.fn(() => {
+      beforeDeliverStarted.resolve();
+      return releaseBeforeDeliver.promise;
+    });
+    const olderFreshDelivery = vi.fn(() => {
+      deliveries.push({ kind: "final", text: "old settled fallback" });
+      return { visibleReplySent: true };
+    });
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      { beforeDeliver, onFreshSettledDelivery: olderFreshDelivery },
+    );
+    await beforeDeliverStarted.promise;
+
+    const newerResult = await dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+    );
+
+    releaseBeforeDeliver.resolve({ text: "old rewritten final" });
+    const olderResult = await olderDispatch;
+
+    expect(beforeDeliver).toHaveBeenCalledTimes(1);
+    expect(olderFreshDelivery).not.toHaveBeenCalled();
     expect(newerResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -63,7 +63,7 @@ function dispatchWithDeliveries(
   dispatcherOptions: {
     beforeDeliver?: ReplyDispatchBeforeDeliver;
     deliver?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => Promise<unknown>;
-    onSettled?: () => unknown;
+    onSettled?: () => Promise<unknown> | unknown;
   } = {},
 ) {
   return dispatchInboundMessageWithBufferedDispatcher({
@@ -474,6 +474,61 @@ describe("foreground reply freshness", () => {
       counts: { tool: 0, block: 0, final: 0 },
     });
     expect(deliveries).toEqual([]);
+  });
+
+  it("suppresses an older settled delivery after a newer visible reply", async () => {
+    const deliveries: Delivery[] = [];
+    const beforeDeliverStarted = createDeferred<void>();
+    const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
+    const beforeDeliver = vi.fn(() => {
+      beforeDeliverStarted.resolve();
+      return releaseBeforeDeliver.promise;
+    });
+    const olderSettled = vi.fn(() => {
+      deliveries.push({ kind: "final", text: "old settled fallback" });
+      return { visibleReplySent: true };
+    });
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      { beforeDeliver, onSettled: olderSettled },
+    );
+    await beforeDeliverStarted.promise;
+
+    const newerResult = await dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+    );
+
+    releaseBeforeDeliver.resolve({ text: "old rewritten final" });
+    const olderResult = await olderDispatch;
+
+    expect(beforeDeliver).toHaveBeenCalledTimes(1);
+    expect(olderSettled).not.toHaveBeenCalled();
+    expect(newerResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(olderResult).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
   });
 
   it("runs the settled delivery hook when dispatch fails after queueing a reply", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -213,18 +213,18 @@ function isVisiblePartialDeliveryError(error: unknown): boolean {
   );
 }
 
-async function runForegroundReplyFenceSettledDelivery(
+async function runForegroundReplyFenceFreshSettledDelivery(
   snapshot: ForegroundReplyFenceSnapshot | undefined,
-  onSettled: (() => unknown) | undefined,
+  onFreshSettledDelivery: (() => unknown) | undefined,
 ): Promise<void> {
-  if (!onSettled) {
+  if (!onFreshSettledDelivery) {
     return;
   }
   if (await shouldCancelForegroundReplyDelivery(snapshot)) {
     return;
   }
   try {
-    const deliveryResult = await onSettled();
+    const deliveryResult = await onFreshSettledDelivery();
     if (isExplicitlyVisibleDelivery(deliveryResult)) {
       markForegroundReplyFenceVisibleDeliveryGeneration(snapshot);
     }
@@ -491,9 +491,13 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     });
   } finally {
     try {
-      await runForegroundReplyFenceSettledDelivery(
+      const settledResult = await params.dispatcherOptions.onSettled?.();
+      if (isExplicitlyVisibleDelivery(settledResult)) {
+        markForegroundReplyFenceVisibleDeliveryGeneration(foregroundReplyFence);
+      }
+      await runForegroundReplyFenceFreshSettledDelivery(
         foregroundReplyFence,
-        params.dispatcherOptions.onSettled,
+        params.dispatcherOptions.onFreshSettledDelivery,
       );
     } finally {
       if (foregroundReplyFence) {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -220,6 +220,9 @@ async function runForegroundReplyFenceSettledDelivery(
   if (!onSettled) {
     return;
   }
+  if (await shouldCancelForegroundReplyDelivery(snapshot)) {
+    return;
+  }
   try {
     const deliveryResult = await onSettled();
     if (isExplicitlyVisibleDelivery(deliveryResult)) {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -82,6 +82,7 @@ export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onI
   onReplyStart?: () => Promise<void> | void;
   onIdle?: () => void;
   onSettled?: () => unknown;
+  onFreshSettledDelivery?: () => unknown;
   /** Called when the typing controller is cleaned up (e.g., on NO_REPLY). */
   onCleanup?: () => void;
 };
@@ -282,7 +283,15 @@ export async function waitForReplyDispatcherIdle(
 export function createReplyDispatcherWithTyping(
   options: ReplyDispatcherWithTypingOptions,
 ): ReplyDispatcherWithTypingResult {
-  const { typingCallbacks, onReplyStart, onIdle, onCleanup, ...dispatcherOptions } = options;
+  const {
+    typingCallbacks,
+    onReplyStart,
+    onIdle,
+    onSettled: _onSettled,
+    onFreshSettledDelivery: _onFreshSettledDelivery,
+    onCleanup,
+    ...dispatcherOptions
+  } = options;
   const resolvedOnReplyStart = onReplyStart ?? typingCallbacks?.onReplyStart;
   const resolvedOnIdle = onIdle ?? typingCallbacks?.onIdle;
   const resolvedOnCleanup = onCleanup ?? typingCallbacks?.onCleanup;


### PR DESCRIPTION
## Summary

- keep fallback-only Discord tool warnings behind the foreground reply freshness fence
- deliver that compact warning only when no useful/recovered final was delivered, including failed recovered sends
- preserve generic reply dispatcher settled cleanup semantics with a separate fresh settled delivery hook

## Verification

Behavior addressed: Discord no longer shows the compact non-terminal tool warning after a useful final reply succeeds.
Real environment tested: local focused OpenClaw test lanes on main branch.
Exact steps or command run after this patch: pnpm test extensions/discord/src/monitor/message-handler.process.test.ts -- --reporter=dot; pnpm test src/auto-reply/dispatch.freshness.test.ts -- --reporter=dot; pnpm lint:plugins:no-extension-test-core-imports; /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main.
Evidence after fix: Discord message-handler tests passed 79/79; foreground freshness tests passed 11/11; extension boundary lint passed; autoreview reported no accepted/actionable findings.
Observed result after fix: fallback-only tool warning finals are dropped after delivered/recovered final replies, retained when they are the only visible fallback, and cancelled if a newer foreground reply wins.
What was not tested: live Discord send against Hetzner; covered here with the focused channel dispatcher tests.
