### PR TITLE
fix(gateway): preserve yielded status on replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **WebChat yielded status replay:** preserve user-visible `sessions_yield` wait messages across refresh while keeping raw tool results hidden by default. Fixes #87321. Thanks @giodl73-repo.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.
 - **Updater plugin convergence:** keep pre-plugin doctor passes from installing configured plugins before the updater's plugin sweep, while preserving the final post-plugin migration pass and preventing ambient update-phase state from leaking into fresh doctor processes.

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -22,6 +22,7 @@ import {
   sanitizeChatHistoryMessages,
   shouldDropAssistantHistoryMessage,
 } from "./chat-display-projection.sanitize.js";
+import { mirrorSessionsYieldVisibleMessages } from "./chat-display-projection.sessions-yield.js";
 import { stripEnvelopeFromMessages } from "./chat-sanitize.js";
 import { isSuppressedControlReplyText } from "./control-reply-text.js";
 import type {
@@ -306,7 +307,7 @@ export function projectChatDisplayMessagesWithState(
   options?: ChatDisplayProjectionOptions,
 ): ChatDisplayProjectionResult {
   const source = options?.stripEnvelope === false ? messages : stripEnvelopeFromMessages(messages);
-  const mirrored = mirrorMessageToolVisibleReplies(source);
+  const mirrored = mirrorSessionsYieldVisibleMessages(mirrorMessageToolVisibleReplies(source));
   const repairedStreamErrors = projectRepairedStreamErrorFallbackMessages(
     toProjectedMessages(mirrored),
     options?.streamErrorFallbackPending,

--- a/src/gateway/chat-display-projection.sessions-yield.ts
+++ b/src/gateway/chat-display-projection.sessions-yield.ts
@@ -1,0 +1,79 @@
+import { safeParseJsonRecord } from "@openclaw/normalization-core";
+import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
+import { extractAssistantTextForSilentCheck } from "./chat-display-projection.helpers.js";
+type YieldSource = { text: string; anchor: Record<string, unknown>; toolCallId?: string };
+function yieldSource(value: unknown): YieldSource | undefined {
+  const message = readRecord(value);
+  const details = readRecord(message?.details);
+  const current =
+    message?.role === "custom" &&
+    message.customType === "openclaw.sessions_yield" &&
+    message.display === false &&
+    details?.source === "sessions_yield"
+      ? readNonBlankString(details.message)
+      : undefined;
+  if (current && message) {
+    return { text: current, anchor: message };
+  }
+  if (
+    message?.role !== "toolResult" ||
+    message.toolName !== "sessions_yield" ||
+    message.isError === true
+  ) {
+    return undefined;
+  }
+  const nested = Array.isArray(message.content)
+    ? message.content.map((block) => readRecord(block)?.text)
+    : [];
+  for (const candidate of [message.details, message.text, message.content, ...nested]) {
+    const payload =
+      typeof candidate === "string" ? safeParseJsonRecord(candidate) : readRecord(candidate);
+    const text = payload?.status === "yielded" ? readNonBlankString(payload.message) : undefined;
+    if (text) {
+      return { text, anchor: message, toolCallId: readNonBlankString(message.toolCallId) };
+    }
+  }
+  return undefined;
+}
+function matchesMirror(value: unknown, source: YieldSource): boolean {
+  const message = readRecord(value);
+  const marker = readRecord(message?.openclawSessionsYieldMirror);
+  return (
+    message?.role === "assistant" &&
+    marker !== undefined &&
+    (!source.toolCallId || marker.toolCallId === source.toolCallId) &&
+    extractAssistantTextForSilentCheck(message) === source.text
+  );
+}
+function buildMirror(source: YieldSource): Record<string, unknown> {
+  const meta = readRecord(source.anchor["__openclaw"]);
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: source.text }],
+    openclawSessionsYieldMirror: source.toolCallId ? { toolCallId: source.toolCallId } : {},
+    timestamp: source.anchor.timestamp,
+    createdAt: source.anchor.createdAt,
+    agentId: source.anchor.agentId,
+    __openclaw: meta ? { ...meta } : undefined,
+  };
+}
+export function mirrorSessionsYieldVisibleMessages(messages: unknown[]): unknown[] {
+  return messages.flatMap((message, index) => {
+    let source = yieldSource(message);
+    if (!source) {
+      return [message];
+    }
+    const previous = yieldSource(messages[index - 1]);
+    const next = yieldSource(messages[index + 1]);
+    const current = source.anchor.role === "custom";
+    const nextIsCurrent = next?.anchor.role === "custom" && next.text === source.text;
+    const legacy = previous?.anchor.role === "toolResult" && previous.text === source.text;
+    source = current && legacy ? { ...source, toolCallId: previous.toolCallId } : source;
+    return (!current && nextIsCurrent) ||
+      matchesMirror(messages[index - 1], source) ||
+      matchesMirror(messages[index + 1], source)
+      ? [message]
+      : [message, buildMirror(source)];
+  });
+}

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -366,6 +366,107 @@ describe("transcript metadata projection", () => {
   });
 });
 
+describe("sessions_yield display projection", () => {
+  it("prefers the current hidden context record and retains its legacy tool result", () => {
+    const rawResult = {
+      role: "toolResult",
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+      details: { status: "yielded", message: "Waiting for the subagent." },
+      timestamp: 10,
+      __openclaw: { seq: 2 },
+    };
+    const hiddenContext = {
+      role: "custom",
+      customType: "openclaw.sessions_yield",
+      content: "internal continuation context",
+      display: false,
+      details: { source: "sessions_yield", message: "Waiting for the subagent." },
+      timestamp: 11,
+      createdAt: "yield-created",
+      agentId: "main",
+      __openclaw: { seq: 3, id: "yield-context" },
+    };
+
+    const projected = projectChatDisplayMessages([rawResult, hiddenContext]);
+
+    expect(projected).toHaveLength(2);
+    expect(projected[0]).toMatchObject({
+      role: "toolResult",
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+      timestamp: 10,
+      __openclaw: { seq: 2 },
+    });
+    expect(projected.some((message) => message.role === "custom")).toBe(false);
+    expect(projected[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Waiting for the subagent." }],
+      openclawSessionsYieldMirror: { toolCallId: "call-yield" },
+      timestamp: 11,
+      createdAt: "yield-created",
+      agentId: "main",
+      __openclaw: { seq: 3, id: "yield-context" },
+    });
+  });
+
+  it("projects shipped text-JSON results without hiding the raw result", () => {
+    const result = {
+      role: "toolResult",
+      toolName: "sessions_yield",
+      toolCallId: "call-legacy-yield",
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ status: "yielded", message: "Legacy wait status." }),
+        },
+      ],
+      __openclaw: { seq: 4 },
+    };
+
+    const projected = projectChatDisplayMessages([result]);
+
+    expect(projected[0]).toMatchObject(result);
+    expect(projected[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Legacy wait status." }],
+      openclawSessionsYieldMirror: { toolCallId: "call-legacy-yield" },
+      __openclaw: { seq: 4 },
+    });
+    expect(projectChatDisplayMessages([{ ...result, isError: true }])).toEqual([
+      expect.objectContaining({ role: "toolResult", isError: true }),
+    ]);
+  });
+
+  it("dedupes only an adjacent marked mirror, not ordinary assistant text", () => {
+    const text = "Same visible wait status.";
+    const result = {
+      role: "toolResult",
+      toolName: "sessions_yield",
+      toolCallId: "call-adjacent-yield",
+      details: { status: "yielded", message: text },
+    };
+    const ordinaryAssistant = { role: "assistant", content: [{ type: "text", text }] };
+    const existingMirror = {
+      ...ordinaryAssistant,
+      openclawSessionsYieldMirror: { toolCallId: "call-adjacent-yield" },
+    };
+
+    expect(
+      projectChatDisplayMessages([ordinaryAssistant, result]).filter(
+        (message) => message.role === "assistant",
+      ),
+    ).toHaveLength(2);
+    expect(projectChatDisplayMessages([result, existingMirror])).toEqual([
+      expect.objectContaining({ role: "toolResult" }),
+      expect.objectContaining({
+        role: "assistant",
+        openclawSessionsYieldMirror: { toolCallId: "call-adjacent-yield" },
+      }),
+    ]);
+  });
+});
+
 describe("current user profile display projection", () => {
   it("dedupes sender lookups per batch and enriches only resolved sender ids", () => {
     const messages = [

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -74,6 +74,14 @@ function hasGatewayHistoryMessageToolMirror(message: unknown) {
   );
 }
 
+function hasGatewaySessionsYieldMirror(message: unknown) {
+  return Boolean(
+    message &&
+    typeof message === "object" &&
+    (message as { openclawSessionsYieldMirror?: unknown }).openclawSessionsYieldMirror,
+  );
+}
+
 installGatewayTestHooks({ scope: "suite" });
 const CHAT_RESPONSE_TIMEOUT_MS = 10_000;
 
@@ -1124,6 +1132,53 @@ describe("gateway server chat", () => {
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["Evo, you there?", replyText]);
     expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(true);
+  });
+
+  test("chat.history replays one sessions_yield status while retaining the raw result", async () => {
+    const waitText = "Waiting for the subagent to finish.";
+    const historyMessages = await loadChatHistoryWithMessages([
+      createGatewayHistoryText("user", "start worker", 1),
+      {
+        role: "toolResult",
+        toolName: "sessions_yield",
+        toolCallId: "call-yield-status",
+        details: { status: "yielded", message: waitText },
+        timestamp: 2,
+      },
+      {
+        role: "custom",
+        customType: "openclaw.sessions_yield",
+        content: "internal continuation context",
+        display: false,
+        details: { source: "sessions_yield", message: waitText },
+        timestamp: 3,
+      },
+    ]);
+
+    expect(historyMessages.filter(hasGatewaySessionsYieldMirror)).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: waitText }],
+        openclawSessionsYieldMirror: { toolCallId: "call-yield-status" },
+        timestamp: 3,
+      }),
+    ]);
+    expect(
+      historyMessages.some(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          (message as { role?: unknown }).role === "toolResult",
+      ),
+    ).toBe(true);
+    expect(
+      historyMessages.some(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          (message as { role?: unknown }).role === "custom",
+      ),
+    ).toBe(false);
   });
 
   test.each([

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -347,6 +347,47 @@ describe("SessionHistorySseState", () => {
     ).toBe("Cursor-visible reply.");
   });
 
+  test("keeps one sessions_yield mirror across current inline context persistence", () => {
+    const state = newStateWithUserText("start worker");
+    const waitText = "Waiting for child completion.";
+
+    expect(
+      state.appendInlineMessage({
+        message: {
+          role: "toolResult",
+          toolName: "sessions_yield",
+          toolCallId: "call-yield-inline",
+          details: { status: "yielded", message: waitText },
+        },
+        messageSeq: 2,
+      }),
+    ).toEqual({ shouldRefresh: true });
+    expect(
+      state.appendInlineMessage({
+        message: {
+          role: "custom",
+          customType: "openclaw.sessions_yield",
+          content: "internal continuation context",
+          display: false,
+          details: { source: "sessions_yield", message: waitText },
+        },
+        messageSeq: 3,
+      }),
+    ).toEqual({ shouldRefresh: true });
+
+    const messages = state.snapshot().messages;
+    expect(messages.filter((message) => message.role === "toolResult")).toHaveLength(1);
+    expect(messages.some((message) => message.role === "custom")).toBe(false);
+    expect(messages.filter((message) => message.openclawSessionsYieldMirror !== undefined)).toEqual(
+      [
+        expect.objectContaining({
+          content: [{ type: "text", text: waitText }],
+          openclawSessionsYieldMirror: { toolCallId: "call-yield-inline" },
+        }),
+      ],
+    );
+  });
+
   test("does not coerce partial cursor values", () => {
     const snapshot = buildSessionHistorySnapshot({
       rawMessages: [assistantTextMessage("first", 1), assistantTextMessage("second", 2)],

--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -15,6 +15,47 @@ import {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
+  it("replays a sessions_yield mirror while raw tool results stay hidden", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 720, width: 1280 },
+    });
+    await context.addInitScript((settingsKey) => {
+      localStorage.setItem(settingsKey, JSON.stringify({ chatShowToolCalls: false }));
+    }, controlUiBundledSettingsStorageKey(suite.server.baseUrl));
+    const page = await context.newPage();
+    const waitText = "Waiting for the subagent to finish.";
+    const rawResult = JSON.stringify({ status: "yielded", message: waitText });
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "toolResult",
+          toolName: "sessions_yield",
+          toolCallId: "call-yield-status",
+          content: [{ type: "text", text: rawResult }],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: waitText }],
+          openclawSessionsYieldMirror: { toolCallId: "call-yield-status" },
+          timestamp: 2,
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByText(waitText, { exact: true }).waitFor();
+      expect(await page.getByText(waitText, { exact: true }).count()).toBe(1);
+      expect(await page.getByText(rawResult, { exact: true }).count()).toBe(0);
+      expect(await page.locator(".chat-group--activity").count()).toBe(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("coalesces persisted same-session split panes during cold startup", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
Fixes #87321.

## Summary

- replay successful `sessions_yield` status messages as one marked assistant-visible row
- prefer the current hidden continuation record while supporting shipped legacy tool-result transcripts
- retain raw tool results and keep hidden custom rows filtered
- preserve timestamp, agent, and transcript provenance metadata
- leave message-tool projection, UI runtime, persistence, config, protocol, and plugin surfaces unchanged

## Root cause

Live `sessions_yield` status text was user-visible, but persisted replay exposed it only through a hidden custom continuation record or a legacy tool result. The gateway display projection filtered the hidden record and WebChat hid raw tool results by default, so refresh silently removed the status.

## Fix

The gateway display-projection owner now recognizes only:

- current hidden records with `customType: "openclaw.sessions_yield"`, `display: false`, `details.source: "sessions_yield"`, and a nonblank `details.message`
- successful legacy `sessions_yield` results with `{ status: "yielded", message }` in `details` or text JSON

It emits one adjacent assistant mirror with an `openclawSessionsYieldMirror` marker, carries a call ID when available, and deduplicates only adjacent marked mirrors. Raw tool-result rows remain in projected history; existing visibility filtering still controls their rendering.

Production delta: `+81/-1`, net `+80`. Tests and changelog are counted separately.

## Real behavior proof

Blacksmith Testbox mock Gateway/WebChat replay, with `chatShowToolCalls: false`:

```json
{
  "durableRows": ["toolResult", "assistant"],
  "visibleYieldStatusCount": 1,
  "rawToolPayloadVisible": false,
  "toolActivityVisible": false,
  "result": "passed"
}
```

## Validation

- focused gateway Vitest: 3 files, 5 passed
- `pnpm check:changed`: passed on Testbox `tbx_01kztjh3nt087m4n16n4ww7drp`
- mock WebChat replay: 1 passed on Testbox `tbx_01kztjzzst4jpyy6g7xy3qa5mn`
- `pnpm build`: passed on Testbox `tbx_01kztjzzst4jpyy6g7xy3qa5mn`
- `oxfmt`, `oxlint`, and `git diff --check`: passed
- branch autoreview through P1: no actionable findings

Contributor credit is preserved with `Co-authored-by: Gio Della-Libera <giodl73@gmail.com>`.
