### PR TITLE
[Fix] Prefer external session delivery context

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -96,6 +96,12 @@ afterAll(() => {
   vi.resetModules();
 });
 
+describe("feishuPlugin metadata", () => {
+  it("opts announce delivery into persisted session lookup", () => {
+    expect(feishuPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
+  });
+});
+
 describe("feishuPlugin.status.probeAccount", () => {
   it("uses current account credentials for multi-account config", async () => {
     const cfg = {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -139,6 +139,7 @@ const meta: ChannelMeta = {
   blurb: "飞书/Lark enterprise messaging.",
   aliases: ["lark"],
   order: 70,
+  preferSessionLookupForAnnounceTarget: true,
 };
 
 const loadFeishuChannelRuntime = createLazyRuntimeNamedExport(

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -408,6 +408,43 @@ describe("resolveAnnounceTarget", () => {
     });
   });
 
+  it("hydrates announce delivery from explicit external context over stale webchat session fields", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:feishu:direct:ou_user",
+          channel: "webchat",
+          lastChannel: "webchat",
+          lastTo: "session:dashboard",
+          route: {
+            channel: "webchat",
+            target: { to: "session:dashboard" },
+          },
+          deliveryContext: {
+            channel: "feishu",
+            to: "user:ou_user",
+          },
+          origin: {
+            provider: "feishu",
+            accountId: "work",
+            threadId: "thread-77",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:feishu:direct:ou_user",
+      displayKey: "agent:main:feishu:direct:ou_user",
+    });
+    expect(target).toEqual({
+      channel: "feishu",
+      to: "user:ou_user",
+      accountId: "work",
+      threadId: "thread-77",
+    });
+  });
+
   it("preserves threaded Slack session keys when sessions.list lacks stored thread metadata", async () => {
     callGatewayMock.mockResolvedValueOnce({
       sessions: [

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -112,6 +112,30 @@ const installRegistry = async () => {
         },
       },
       {
+        pluginId: "feishu",
+        source: "test",
+        plugin: {
+          id: "feishu",
+          meta: {
+            id: "feishu",
+            label: "Feishu",
+            selectionLabel: "Feishu",
+            docsPath: "/channels/feishu",
+            blurb: "Feishu test stub.",
+            preferSessionLookupForAnnounceTarget: true,
+          },
+          capabilities: { chatTypes: ["direct", "group"] },
+          messaging: {
+            resolveSessionConversation: resolveSessionConversationStub,
+            resolveSessionTarget: resolveSessionTargetStub,
+          },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
+      {
         pluginId: "whatsapp",
         source: "test",
         plugin: {

--- a/src/cron/schedule-identity.ts
+++ b/src/cron/schedule-identity.ts
@@ -1,6 +1,5 @@
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { coerceFiniteScheduleNumber } from "./schedule-number.js";
-import type { CronJob } from "./types.js";
 
 function readString(record: Record<string, unknown>, key: string): string | undefined {
   return normalizeOptionalString(record[key]);
@@ -76,8 +75,8 @@ export function tryCronScheduleIdentity(
 }
 
 export function cronSchedulingInputsEqual(
-  previous: Pick<CronJob, "schedule"> & { enabled?: unknown },
-  next: Pick<CronJob, "schedule"> & { enabled?: unknown },
+  previous: { schedule?: unknown; enabled?: unknown },
+  next: { schedule?: unknown; enabled?: unknown },
 ): boolean {
   const previousIdentity = tryCronScheduleIdentity(previous as Record<string, unknown>);
   const nextIdentity = tryCronScheduleIdentity(next as Record<string, unknown>);

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -1,16 +1,20 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, type Mock } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { testing as agentStepTesting } from "../agents/tools/agent-step.js";
+import { runSessionsSendA2AFlow } from "../agents/tools/sessions-send-tool.a2a.js";
 import { resolveSessionTranscriptPath } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { captureEnv } from "../test-utils/env.js";
 import {
   agentCommand,
   getFreePort,
   installGatewayTestHooks,
   startGatewayServer,
+  setTestPluginRegistry,
   testState,
   writeSessionStore,
 } from "./test-helpers.js";
@@ -171,6 +175,114 @@ describe("sessions_send gateway loopback", () => {
     expect(firstCall?.inputProvenance?.kind).toBe("inter_session");
     expect(firstCall?.inputProvenance?.sourceTool).toBe("sessions_send");
   });
+
+  it(
+    "announces through gateway send using external deliveryContext over stale webchat session fields",
+    { timeout: SESSION_SEND_E2E_TIMEOUT_MS },
+    async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-route-"));
+      const sendCalls: Array<{
+        to?: string;
+        text?: string;
+        accountId?: string | null;
+        threadId?: string | number | null;
+      }> = [];
+      setTestPluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "whatsapp",
+            source: "test",
+            plugin: createOutboundTestPlugin({
+              id: "whatsapp",
+              label: "WhatsApp",
+              outbound: {
+                deliveryMode: "direct",
+                resolveTarget: ({ to }) => {
+                  const target = to?.trim();
+                  return target
+                    ? { ok: true, to: target }
+                    : { ok: false, error: new Error("missing target") };
+                },
+                sendText: async (ctx) => {
+                  sendCalls.push({
+                    to: ctx.to,
+                    text: ctx.text,
+                    accountId: ctx.accountId,
+                    threadId: ctx.threadId,
+                  });
+                  return { channel: "whatsapp", messageId: "wa-proof-msg" };
+                },
+              },
+              messaging: {
+                normalizeTarget: (raw) => raw,
+              },
+            }),
+          },
+        ]),
+      );
+
+      testState.sessionStorePath = path.join(dir, "sessions.json");
+      try {
+        await writeSessionStore({
+          entries: {
+            "agent:main:whatsapp:direct:peer-1": {
+              sessionId: "sess-whatsapp-peer",
+              updatedAt: Date.now(),
+              channel: "webchat",
+              lastChannel: "webchat",
+              lastTo: "session:dashboard",
+              route: {
+                channel: "webchat",
+                target: { to: "session:dashboard" },
+              },
+              deliveryContext: {
+                channel: "whatsapp",
+                to: "peer-1",
+              },
+              origin: {
+                provider: "whatsapp",
+                accountId: "work",
+                threadId: "thread-77",
+              },
+            },
+          },
+        });
+
+        agentStepTesting.setDepsForTest({
+          agentCommandFromIngress: async () => ({
+            payloads: [{ text: "announce through channel", mediaUrl: null }],
+            meta: { durationMs: 1 },
+          }),
+        });
+
+        await runSessionsSendA2AFlow({
+          targetSessionKey: "agent:main:whatsapp:direct:peer-1",
+          displayKey: "agent:main:whatsapp:direct:peer-1",
+          message: "ping",
+          announceTimeoutMs: 5_000,
+          maxPingPongTurns: 0,
+          roundOneReply: "target response",
+        });
+
+        await vi.waitFor(
+          () =>
+            expect(sendCalls).toEqual([
+              {
+                to: "peer-1",
+                text: "announce through channel",
+                accountId: "work",
+                threadId: "thread-77",
+              },
+            ]),
+          { timeout: 5_000 },
+        );
+      } finally {
+        agentStepTesting.setDepsForTest();
+        testState.sessionStorePath = undefined;
+        await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      }
+    },
+  );
 });
 
 describe("sessions_send label lookup", () => {

--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -8,7 +8,12 @@ import {
 } from "../plugin-sdk/channel-route.js";
 import { normalizeAccountId } from "./account-id.js";
 import type { DeliveryContext, DeliveryContextSessionSource } from "./delivery-context.types.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isInternalNonDeliveryChannel,
+} from "./message-channel-constants.js";
 import { normalizeMessageChannel } from "./message-channel-core.js";
+import { isDeliverableMessageChannel } from "./message-channel-normalize.js";
 export type { DeliveryContext, DeliveryContextSessionSource } from "./delivery-context.types.js";
 
 export function normalizeDeliveryContext(context?: DeliveryContext): DeliveryContext | undefined {
@@ -93,6 +98,30 @@ function mergeRouteMetadataWithDeliveryContext(
   });
 }
 
+function isInternalRouteContext(context?: DeliveryContext): boolean {
+  const channel = context?.channel;
+  return Boolean(
+    channel && (channel === INTERNAL_MESSAGE_CHANNEL || isInternalNonDeliveryChannel(channel)),
+  );
+}
+
+function hasExternalDeliveryTarget(context?: DeliveryContext): boolean {
+  const channel = normalizeMessageChannel(context?.channel);
+  return Boolean(channel && isDeliverableMessageChannel(channel) && context?.to);
+}
+
+function mergeExternalDeliveryContextOverInternalRoute(
+  deliveryContext?: DeliveryContext,
+  internalContext?: DeliveryContext,
+): DeliveryContext | undefined {
+  return normalizeDeliveryContext({
+    channel: deliveryContext?.channel,
+    to: deliveryContext?.to,
+    accountId: deliveryContext?.accountId ?? internalContext?.accountId,
+    threadId: deliveryContext?.threadId ?? internalContext?.threadId,
+  });
+}
+
 export function normalizeSessionDeliveryFields(source?: DeliveryContextSessionSource): {
   route?: ChannelRouteRef;
   deliveryContext?: DeliveryContext;
@@ -120,10 +149,17 @@ export function normalizeSessionDeliveryFields(source?: DeliveryContextSessionSo
     accountId: source.lastAccountId,
     threadId: source.lastThreadId,
   });
-  const merged = mergeDeliveryContext(
-    routeContext,
-    mergeDeliveryContext(legacyContext, normalizeDeliveryContext(source.deliveryContext)),
-  );
+  const deliveryContext = normalizeDeliveryContext(source.deliveryContext);
+  const sessionContext =
+    isInternalRouteContext(legacyContext) && hasExternalDeliveryTarget(deliveryContext)
+      ? mergeExternalDeliveryContextOverInternalRoute(deliveryContext, legacyContext)
+      : mergeDeliveryContext(legacyContext, deliveryContext);
+  const routeInternalContext = mergeDeliveryContext(routeContext, legacyContext);
+  const routeIsInternalFallback =
+    isInternalRouteContext(routeContext) && hasExternalDeliveryTarget(deliveryContext);
+  const merged = routeIsInternalFallback
+    ? mergeExternalDeliveryContextOverInternalRoute(deliveryContext, routeInternalContext)
+    : mergeDeliveryContext(routeContext, sessionContext);
 
   if (!merged) {
     return {
@@ -137,7 +173,10 @@ export function normalizeSessionDeliveryFields(source?: DeliveryContextSessionSo
   }
 
   return {
-    route: mergeRouteMetadataWithDeliveryContext(normalizedRoute, merged),
+    route: mergeRouteMetadataWithDeliveryContext(
+      routeIsInternalFallback ? undefined : normalizedRoute,
+      merged,
+    ),
     deliveryContext: merged,
     lastChannel: merged.channel,
     lastTo: merged.to,

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -261,6 +261,131 @@ describe("delivery context helpers", () => {
     });
   });
 
+  it("prefers explicit external delivery context over stale webchat legacy fields", () => {
+    expect(
+      deliveryContextFromSession({
+        channel: "webchat",
+        deliveryContext: {
+          channel: "room-chat",
+          to: " peer-1 ",
+          accountId: " acct-1 ",
+          threadId: " thread-1 ",
+        },
+      }),
+    ).toEqual({
+      channel: "room-chat",
+      to: "peer-1",
+      accountId: "acct-1",
+      threadId: "thread-1",
+    });
+
+    expect(
+      deliveryContextFromSession({
+        channel: "webchat",
+        lastChannel: "webchat",
+        lastTo: "session:dashboard",
+        lastAccountId: "work",
+        lastThreadId: "thread-2",
+        deliveryContext: {
+          channel: "room-chat",
+          to: "peer-2",
+        },
+      }),
+    ).toEqual({
+      channel: "room-chat",
+      to: "peer-2",
+      accountId: "work",
+      threadId: "thread-2",
+    });
+
+    expect(
+      deliveryContextFromSession({
+        lastChannel: "heartbeat",
+        lastTo: "heartbeat",
+        deliveryContext: {
+          channel: "telegram",
+          to: "-100123",
+        },
+      }),
+    ).toEqual({
+      channel: "telegram",
+      to: "-100123",
+      accountId: undefined,
+    });
+
+    const routeNormalized = normalizeSessionDeliveryFields({
+      route: {
+        channel: "webchat",
+        accountId: "work",
+        target: { to: "session:dashboard" },
+        thread: { id: "thread-route" },
+      },
+      deliveryContext: {
+        channel: "room-chat",
+        to: "peer-route",
+      },
+    });
+    expect(routeNormalized.deliveryContext).toEqual({
+      channel: "room-chat",
+      to: "peer-route",
+      accountId: "work",
+      threadId: "thread-route",
+    });
+    expect(routeNormalized.route).toEqual({
+      channel: "room-chat",
+      accountId: "work",
+      target: { to: "peer-route" },
+      thread: { id: "thread-route" },
+    });
+  });
+
+  it("does not promote tool-only context over internal session delivery", () => {
+    const normalized = normalizeSessionDeliveryFields({
+      route: {
+        channel: "webchat",
+        accountId: "work",
+        target: { to: "session:dashboard" },
+      },
+      deliveryContext: {
+        channel: "sessions_send",
+        to: "session:handoff",
+      },
+    });
+
+    expect(normalized.deliveryContext).toEqual({
+      channel: "webchat",
+      to: "session:dashboard",
+      accountId: "work",
+    });
+    expect(normalized.route).toEqual({
+      channel: "webchat",
+      accountId: "work",
+      target: { to: "session:dashboard" },
+    });
+
+    const staleLegacyExternal = normalizeSessionDeliveryFields({
+      route: {
+        channel: "webchat",
+        accountId: "work",
+        target: { to: "session:dashboard" },
+      },
+      lastChannel: "room-chat",
+      lastTo: "peer-old",
+      lastAccountId: "old-workspace",
+    });
+
+    expect(staleLegacyExternal.deliveryContext).toEqual({
+      channel: "webchat",
+      to: "session:dashboard",
+      accountId: "work",
+    });
+    expect(staleLegacyExternal.route).toEqual({
+      channel: "webchat",
+      accountId: "work",
+      target: { to: "session:dashboard" },
+    });
+  });
+
   it("normalizes delivery fields, mirrors session fields, and avoids cross-channel carryover", () => {
     const normalized = normalizeSessionDeliveryFields({
       deliveryContext: {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `sessions_send` announce delivery could fall back to stale internal WebChat route fields even when the persisted session row had an external delivery context.

Why does this matter now?

- Issue #76104 reports Feishu-originated `sessions_send` replies being routed to WebChat instead of the originating external conversation.

What is the intended outcome?

- A deliverable external `deliveryContext` wins over stale internal route data, while preserving account and thread metadata.

What is intentionally out of scope?

- No Feishu-specific branch.
- No new config flag.
- No broader channel routing rewrite.

What does success look like?

- A row with stale `webchat` route state and external delivery context resolves to the external target and sends through that channel.
- Tool-only contexts such as `sessions_send` are not treated as channel delivery targets.

What should reviewers focus on?

- The precedence rule in `src/utils/delivery-context.shared.ts`.
- The `sessions_send` announce path through `src/agents/tools/sessions-announce-target.ts`.
- Whether the fix stays generic instead of special-casing one channel.

## Linked context

Which issue does this close?

Closes #76104

Which issues, PRs, or discussions are related?

Related #33786, #47797, #63143, #63506, #66073, #72806

Was this requested by a maintainer or owner?

Issue #76104 came from user-reported behavior and maintainer triage.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `sessions_send` announce target resolution no longer lets stale internal `webchat` route state override a deliverable external `deliveryContext`.
- Real environment tested: Local OpenClaw Gateway child process with a temp config/state dir, real WebSocket Gateway RPC, real `sessions.list`, production `resolveAnnounceTarget`, real `send` RPC, bundled `qa-channel` plugin loaded through the OpenClaw plugin loader, and qa-lab HTTP bus outbound capture. `qa-channel` is OpenClaw's deterministic transport for exercising the same channel plugin boundary as external transports.
- Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` from the repo root with a proof script that started qa-lab bus, wrote a temp OpenClaw config, loaded the clickclack and qa-channel plugin registry entries through `loadOpenClawPlugins`, seeded `sessions.json` with `channel=webchat`, `lastTo=session:dashboard`, and `deliveryContext.channel=qa-channel`, started `node scripts/run-node.mjs gateway run --port <port> --auth token --token <token> --allow-unconfigured --ws-log compact`, called `sessions.list`, called production `resolveAnnounceTarget`, called Gateway `send`, and waited for the qa-lab bus outbound message.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  Config warnings:
  - plugins: plugin: ignored plugins.load.paths entry that points at OpenClaw's legacy bundled plugin directory; remove this redundant path or run openclaw doctor --fix
  [proof] gateway health ok version=unknown port=49308
  [proof] qa-channel bus=http://127.0.0.1:49309
  [proof] qa-channel ready accountStatus=running
  [proof] sessions.list row key=agent:main:clickclack:channel:proof-room channel=webchat lastChannel=qa-channel lastTo=group:qa-proof-room route.channel=undefined route.to=undefined deliveryContext.channel=qa-channel deliveryContext.to=group:qa-proof-room deliveryContext.threadId=thread-77
  [proof] resolveAnnounceTarget channel=qa-channel to=group:qa-proof-room accountId=default threadId=thread-77
  [proof] send RPC ok channel=qa-channel messageId=7a28b92b-50c8-406c-92a6-6eeff7799046
  [proof] qa-bus outbound direction=outbound conversation.kind=channel conversation.id=qa-proof-room threadId=thread-77 text=real-proof-76104-31e07741
  [proof] PASS external deliveryContext won over stale webchat route and delivered through qa-channel outbound bus
  ```

- Observed result after fix: The announce target resolved to `qa-channel/group:qa-proof-room/thread-77`, and the Gateway `send` RPC produced an outbound qa-bus message for that conversation and thread. It did not target `session:dashboard` or WebChat.
- What was not tested: Live Feishu delivery with real Feishu credentials was not run in this local environment.
- Proof limitations or environment constraints: The proof uses OpenClaw's bundled deterministic `qa-channel` transport in place of Feishu while keeping the changed Gateway/session route-resolution boundary real. The warning about `plugins.load.paths` is from intentionally pointing the temp config at a bundled plugin directory for the local proof run; the plugin still loaded and ran.
- Before evidence (optional but encouraged): No live pre-patch capture was kept. The proof seeded the stale `webchat` route shape from the reported failure and captured the after-fix Gateway behavior on this PR head.

## Tests and validation

Which commands did you run?

- `node --import tsx --input-type=module` real Gateway/qa-channel proof command above.
- `node scripts/run-vitest.mjs src/gateway/server.sessions-send.test.ts`
- `node scripts/run-vitest.mjs src/utils/delivery-context.test.ts src/agents/tools/sessions.test.ts`
- `pnpm exec oxfmt --check src/gateway/server.sessions-send.test.ts src/utils/delivery-context.shared.ts src/utils/delivery-context.test.ts src/agents/tools/sessions.test.ts`
- `git diff --cached --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

What regression coverage was added or updated?

- Added coverage for external delivery context winning over stale internal WebChat route state in the session delivery-context merge logic.
- Added coverage for `sessions_send` announce delivery through Gateway send using the external delivery context.
- Updated session target coverage so tool-only contexts are not promoted as channel delivery targets.

What failed before this fix, if known?

- The reported failure mode was that a Feishu-originated `sessions_send` reply could route to WebChat because stale internal session route fields won over the persisted external delivery context.

If no test was added, why not?

- Regression coverage was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Session delivery-context precedence for channel replies and `sessions_send` announce delivery.

How is that risk mitigated?

The change is scoped to internal/non-delivery route fallback handling, keeps external route-first behavior intact, and is covered by focused regression tests plus the real Gateway/qa-channel proof above.

## Current review state

What is the next action?

Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on GitHub CI and maintainer review.

Which bot or reviewer comments were addressed?

The PR body was rewritten to follow the template's Real behavior proof format with real Gateway behavior proof instead of using unit-test output as proof.
