### PR TITLE
fix(plugins): reject incompatible package plugin API installs

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1216,8 +1216,12 @@ plugins are assumed to be co-versioned with the host checkout.
 plugin sources. Use it for the OpenClaw plugin SDK/runtime API floor that the
 package was built against. It can be stricter than `minHostVersion` when a
 plugin package needs a newer API but still keeps a lower install hint for other
-flows. `peerDependencies.openclaw` remains npm package metadata; OpenClaw uses
-the `openclaw.compat.pluginApi` contract for install compatibility decisions.
+flows. Official OpenClaw release sync bumps existing official plugin API floors
+to the OpenClaw release version by default, but plugin-only releases can keep a
+lower floor when the package intentionally supports older hosts. Do not use the
+package version alone as the compatibility contract. `peerDependencies.openclaw`
+remains npm package metadata; OpenClaw uses the `openclaw.compat.pluginApi`
+contract for install compatibility decisions.
 
 Official install-on-demand metadata should use `clawhubSpec` when the plugin is
 published on ClawHub; onboarding treats that as the preferred remote source and

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1197,6 +1197,7 @@ Important examples:
 | `openclaw.install.clawhubSpec` / `openclaw.install.npmSpec` / `openclaw.install.localPath` | Install/update hints for bundled and externally published plugins.                                                                                                                   |
 | `openclaw.install.defaultChoice`                                                           | Preferred install path when multiple install sources are available.                                                                                                                  |
 | `openclaw.install.minHostVersion`                                                          | Minimum supported OpenClaw host version, using a semver floor like `>=2026.3.22` or `>=2026.5.1-beta.1`.                                                                             |
+| `openclaw.compat.pluginApi`                                                                | Minimum OpenClaw plugin API range required by this package, using a semver floor like `>=2026.5.27`.                                                                                 |
 | `openclaw.install.expectedIntegrity`                                                       | Expected npm dist integrity string such as `sha512-...`; install and update flows verify the fetched artifact against it.                                                            |
 | `openclaw.install.allowInvalidConfigRecovery`                                              | Allows a narrow bundled-plugin reinstall recovery path when config is invalid.                                                                                                       |
 | `openclaw.startup.deferConfiguredChannelFullLoadUntilAfterListen`                          | Lets setup-only channel surfaces load before the full channel plugin during startup.                                                                                                 |
@@ -1210,6 +1211,13 @@ choices. Do not move install hints into `openclaw.plugin.json`.
 registry loading for non-bundled plugin sources. Invalid values are rejected;
 newer-but-valid values skip external plugins on older hosts. Bundled source
 plugins are assumed to be co-versioned with the host checkout.
+
+`openclaw.compat.pluginApi` is enforced during package install for non-bundled
+plugin sources. Use it for the OpenClaw plugin SDK/runtime API floor that the
+package was built against. It can be stricter than `minHostVersion` when a
+plugin package needs a newer API but still keeps a lower install hint for other
+flows. `peerDependencies.openclaw` remains npm package metadata; OpenClaw uses
+the `openclaw.compat.pluginApi` contract for install compatibility decisions.
 
 Official install-on-demand metadata should use `clawhubSpec` when the plugin is
 published on ClawHub; onboarding treats that as the preferred remote source and

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -141,6 +141,12 @@ vYYYY.M.D-beta.N` from the matching `release/YYYY.M.D` branch. The helper runs
   exports, and plugin SDK API baseline. `pnpm release:check` re-runs those
   guards in check mode and reports every generated drift failure it finds in one
   pass before running package release checks.
+- Plugin version sync updates official plugin package versions and existing
+  `openclaw.compat.pluginApi` floors to the OpenClaw release version by
+  default. Treat that field as the plugin SDK/runtime API floor, not just a copy
+  of the package version: for plugin-only releases that intentionally remain
+  compatible with older OpenClaw hosts, keep the floor at the oldest supported
+  host API and document that choice in the plugin release proof.
 - Run the manual `Full Release Validation` workflow before release approval to
   kick off all pre-release test boxes from one entrypoint. It accepts a branch,
   tag, or full commit SHA, dispatches manual `CI`, and dispatches

--- a/src/agents/live-model-dynamic-candidates.test.ts
+++ b/src/agents/live-model-dynamic-candidates.test.ts
@@ -102,7 +102,7 @@ describe("appendPrioritizedDynamicLiveModels", () => {
     );
     expect(normalizeModel).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "opencode-go",
+        provider: DYNAMIC_PROVIDER,
         id: "glm-5",
       }),
       "/tmp/openclaw-agent",

--- a/src/agents/live-model-dynamic-candidates.test.ts
+++ b/src/agents/live-model-dynamic-candidates.test.ts
@@ -40,6 +40,7 @@ describe("appendPrioritizedDynamicLiveModels", () => {
         : undefined,
     );
     const prepareDynamicModel: DynamicModelPreparer = vi.fn(async () => undefined);
+    const normalizeModel = vi.fn((entry: Model) => entry);
     const config = {
       models: {
         providers: {
@@ -59,6 +60,7 @@ describe("appendPrioritizedDynamicLiveModels", () => {
       modelRegistry: REGISTRY,
       resolveDynamicModel,
       prepareDynamicModel,
+      normalizeModel,
       refs: [
         { provider: "anthropic", id: "claude-sonnet-4-6" },
         { provider: DYNAMIC_PROVIDER, id: "glm-5" },
@@ -97,6 +99,13 @@ describe("appendPrioritizedDynamicLiveModels", () => {
           providerConfig: config.models?.providers?.[DYNAMIC_PROVIDER],
         }),
       }),
+    );
+    expect(normalizeModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "opencode-go",
+        id: "glm-5",
+      }),
+      "/tmp/openclaw-agent",
     );
   });
 

--- a/src/agents/live-model-dynamic-candidates.ts
+++ b/src/agents/live-model-dynamic-candidates.ts
@@ -1,17 +1,36 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Model } from "../llm/types.js";
-import {
+import type {
   prepareProviderDynamicModel,
   runProviderDynamicModel,
 } from "../plugins/provider-runtime.js";
 import type { ProviderResolveDynamicModelContext } from "../plugins/types.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
-import { normalizeDiscoveredAgentModel } from "./agent-model-discovery.js";
 import { listPrioritizedHighSignalLiveModelRefs } from "./live-model-filter.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "./provider-id.js";
 
 type DynamicModelResolver = typeof runProviderDynamicModel;
 type DynamicModelPreparer = typeof prepareProviderDynamicModel;
+type DynamicModelNormalizer = (model: Model, agentDir: string) => Model | Promise<Model>;
+
+async function prepareProviderDynamicModelDefault(
+  params: Parameters<DynamicModelPreparer>[0],
+): Promise<void> {
+  const { prepareProviderDynamicModel } = await import("../plugins/provider-runtime.js");
+  await prepareProviderDynamicModel(params);
+}
+
+async function runProviderDynamicModelDefault(
+  params: Parameters<DynamicModelResolver>[0],
+): Promise<ReturnType<DynamicModelResolver>> {
+  const { runProviderDynamicModel } = await import("../plugins/provider-runtime.js");
+  return runProviderDynamicModel(params);
+}
+
+async function normalizeDynamicModelDefault(model: Model, agentDir: string): Promise<Model> {
+  const { normalizeDiscoveredAgentModel } = await import("./agent-model-discovery.js");
+  return normalizeDiscoveredAgentModel(model, agentDir);
+}
 
 function liveModelKey(provider: string, id: string): string | null {
   const normalizedProvider = normalizeProviderId(provider);
@@ -28,10 +47,12 @@ export async function appendPrioritizedDynamicLiveModels(params: {
   modelRegistry: ProviderResolveDynamicModelContext["modelRegistry"];
   resolveDynamicModel?: DynamicModelResolver;
   prepareDynamicModel?: DynamicModelPreparer;
+  normalizeModel?: DynamicModelNormalizer;
   refs?: Array<{ provider: string; id: string }>;
 }): Promise<{ models: Model[]; added: Model[] }> {
-  const resolveDynamicModel = params.resolveDynamicModel ?? runProviderDynamicModel;
-  const prepareDynamicModel = params.prepareDynamicModel ?? prepareProviderDynamicModel;
+  const resolveDynamicModel = params.resolveDynamicModel ?? runProviderDynamicModelDefault;
+  const prepareDynamicModel = params.prepareDynamicModel ?? prepareProviderDynamicModelDefault;
+  const normalizeModel = params.normalizeModel ?? normalizeDynamicModelDefault;
   const refs = params.refs ?? listPrioritizedHighSignalLiveModelRefs();
   const seen = new Set<string>();
   for (const model of params.models) {
@@ -68,7 +89,7 @@ export async function appendPrioritizedDynamicLiveModels(params: {
       env: params.env,
       context,
     });
-    const resolved = resolveDynamicModel({
+    const resolved = await resolveDynamicModel({
       provider: ref.provider,
       config: params.config,
       workspaceDir: params.workspaceDir,
@@ -78,7 +99,7 @@ export async function appendPrioritizedDynamicLiveModels(params: {
     if (!resolved) {
       continue;
     }
-    const model = normalizeDiscoveredAgentModel(resolved as Model, params.agentDir);
+    const model = await normalizeModel(resolved as Model, params.agentDir);
     const resolvedKey = liveModelKey(model.provider, model.id);
     if (!resolvedKey || seen.has(resolvedKey)) {
       continue;

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -148,6 +148,13 @@ describe("clawhub helpers", () => {
     expect(satisfiesPluginApiRange("2026.5.2-beta.1", ">=2026.5.3")).toBe(false);
   });
 
+  it("preserves prerelease ordering for explicit plugin API prerelease floors", () => {
+    expect(satisfiesPluginApiRange("2026.3.24-beta.1", ">=2026.3.24-beta.2")).toBe(false);
+    expect(satisfiesPluginApiRange("2026.3.24-beta.2", ">=2026.3.24-beta.2")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.3.24", ">=2026.3.24-beta.2")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.3.24-beta.1", ">=2026.3.24")).toBe(true);
+  });
+
   it("accepts legacy bare major.minor plugin api ranges as lower bounds", () => {
     expect(satisfiesPluginApiRange("2026.5.2", "2026.4")).toBe(true);
     expect(satisfiesPluginApiRange("2026.4.0", "2026.4")).toBe(true);

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -151,6 +151,7 @@ describe("clawhub helpers", () => {
   it("preserves prerelease ordering for explicit plugin API prerelease floors", () => {
     expect(satisfiesPluginApiRange("2026.3.24-beta.1", ">=2026.3.24-beta.2")).toBe(false);
     expect(satisfiesPluginApiRange("2026.3.24-beta.2", ">=2026.3.24-beta.2")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.3.24-1", ">=2026.3.24-beta.2")).toBe(true);
     expect(satisfiesPluginApiRange("2026.3.24", ">=2026.3.24-beta.2")).toBe(true);
     expect(satisfiesPluginApiRange("2026.3.24-beta.1", ">=2026.3.24")).toBe(true);
   });

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -142,7 +142,10 @@ describe("clawhub helpers", () => {
   it("treats OpenClaw CalVer correction versions as stable plugin API hosts", () => {
     expect(satisfiesPluginApiRange("2026.5.3-1", ">=2026.5.3")).toBe(true);
     expect(satisfiesPluginApiRange("2026.5.3-2", ">=2026.5.3")).toBe(true);
-    expect(satisfiesPluginApiRange("2026.5.3-beta.1", ">=2026.5.3")).toBe(false);
+    expect(satisfiesPluginApiRange("2026.5.3-beta.1", ">=2026.5.3")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.5.3-alpha.1", ">=2026.5.3")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.5.3-rc.1", ">=2026.5.3")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.5.2-beta.1", ">=2026.5.3")).toBe(false);
   });
 
   it("accepts legacy bare major.minor plugin api ranges as lower bounds", () => {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -541,6 +541,18 @@ function matchWildcardComparator(token: string): "any" | "none" | null {
   return operator === ">" || operator === "<" ? "none" : "any";
 }
 
+function shouldPreservePluginApiPrereleaseFloor(target: string): boolean {
+  return Boolean(
+    parseComparableSemver(normalizePartialComparableVersion(target).version)?.prerelease?.length,
+  );
+}
+
+function normalizePluginApiVersionForComparator(version: string, target: string): string {
+  return shouldPreservePluginApiPrereleaseFloor(target)
+    ? version
+    : normalizeCalVerCorrectionForPluginApi(version);
+}
+
 function satisfiesComparator(version: string, token: string): boolean {
   const trimmed = token.trim();
   if (!trimmed) {
@@ -553,8 +565,9 @@ function satisfiesComparator(version: string, token: string): boolean {
   if (trimmed.startsWith("^")) {
     const base = trimmed.slice(1).trim();
     const upperBound = upperBoundForCaret(base);
-    const lowerCmp = compareSemver(version, base);
-    const upperCmp = upperBound ? compareSemver(version, upperBound) : null;
+    const comparableVersion = normalizePluginApiVersionForComparator(version, base);
+    const lowerCmp = compareSemver(comparableVersion, base);
+    const upperCmp = upperBound ? compareSemver(comparableVersion, upperBound) : null;
     return lowerCmp != null && upperCmp != null && lowerCmp >= 0 && upperCmp < 0;
   }
 
@@ -567,8 +580,9 @@ function satisfiesComparator(version: string, token: string): boolean {
   if (!target) {
     return false;
   }
+  const comparableVersion = normalizePluginApiVersionForComparator(version, target);
   const normalizedTarget = normalizePartialComparableVersion(target);
-  const cmp = compareSemver(version, normalizedTarget.version);
+  const cmp = compareSemver(comparableVersion, normalizedTarget.version);
   if (cmp == null) {
     return false;
   }
@@ -1264,10 +1278,7 @@ export function satisfiesPluginApiRange(
   if (!pluginApiRange) {
     return true;
   }
-  return satisfiesSemverRange(
-    normalizeCalVerCorrectionForPluginApi(pluginApiVersion),
-    pluginApiRange,
-  );
+  return satisfiesSemverRange(pluginApiVersion, pluginApiRange);
 }
 
 export function satisfiesGatewayMinimum(

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -595,7 +595,8 @@ function satisfiesSemverRange(version: string, range: string): boolean {
   return tokens.every((token) => satisfiesComparator(version, token));
 }
 
-const OPENCLAW_CALVER_STABLE_CORRECTION_PATTERN = /^[vV]?(\d{4}\.\d{1,2}\.\d{1,2})-\d+$/;
+const OPENCLAW_CALVER_STABLE_CORRECTION_PATTERN =
+  /^[vV]?(\d{4}\.\d{1,2}\.\d{1,2})(?:-\d+|-(?:alpha|beta|rc)\.\d+)$/i;
 
 function normalizeCalVerCorrectionForPluginApi(pluginApiVersion: string): string {
   const match = OPENCLAW_CALVER_STABLE_CORRECTION_PATTERN.exec(pluginApiVersion.trim());

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -548,6 +548,10 @@ function shouldPreservePluginApiPrereleaseFloor(target: string): boolean {
 }
 
 function normalizePluginApiVersionForComparator(version: string, target: string): string {
+  const normalizedCorrection = normalizeCalVerNumericCorrectionForPluginApi(version);
+  if (normalizedCorrection) {
+    return normalizedCorrection;
+  }
   return shouldPreservePluginApiPrereleaseFloor(target)
     ? version
     : normalizeCalVerCorrectionForPluginApi(version);
@@ -611,6 +615,13 @@ function satisfiesSemverRange(version: string, range: string): boolean {
 
 const OPENCLAW_CALVER_STABLE_CORRECTION_PATTERN =
   /^[vV]?(\d{4}\.\d{1,2}\.\d{1,2})(?:-\d+|-(?:alpha|beta|rc)\.\d+)$/i;
+const OPENCLAW_CALVER_NUMERIC_CORRECTION_PATTERN = /^[vV]?(\d{4}\.\d{1,2}\.\d{1,2})-\d+$/;
+
+function normalizeCalVerNumericCorrectionForPluginApi(
+  pluginApiVersion: string,
+): string | undefined {
+  return OPENCLAW_CALVER_NUMERIC_CORRECTION_PATTERN.exec(pluginApiVersion.trim())?.[1];
+}
 
 function normalizeCalVerCorrectionForPluginApi(pluginApiVersion: string): string {
   const match = OPENCLAW_CALVER_STABLE_CORRECTION_PATTERN.exec(pluginApiVersion.trim());

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -16,6 +16,7 @@ export type NpmSpecResolution = {
   integrity?: string;
   shasum?: string;
   resolvedAt?: string;
+  packageOpenClaw?: Record<string, unknown>;
 };
 
 export type NpmResolutionFields = {
@@ -65,6 +66,7 @@ function normalizeNpmViewMetadata(value: unknown): NpmSpecResolution | null {
     resolvedSpec,
     integrity: toOptionalString(rec["dist.integrity"]) ?? toOptionalString(dist.integrity),
     shasum: toOptionalString(rec["dist.shasum"]) ?? toOptionalString(dist.shasum),
+    ...(isRecord(rec.openclaw) ? { packageOpenClaw: rec.openclaw } : {}),
   };
 }
 
@@ -79,7 +81,17 @@ export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?:
     }
 > {
   const res = await runCommandWithTimeout(
-    ["npm", "view", params.spec, "name", "version", "dist.integrity", "dist.shasum", "--json"],
+    [
+      "npm",
+      "view",
+      params.spec,
+      "name",
+      "version",
+      "dist.integrity",
+      "dist.shasum",
+      "openclaw",
+      "--json",
+    ],
     {
       timeoutMs: Math.max(params.timeoutMs ?? 60_000, 60_000),
       env: createNpmMetadataEnv(),
@@ -148,6 +160,10 @@ function toOptionalString(value: unknown): string | undefined {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseResolvedSpecFromId(id: string): string | undefined {

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -855,6 +855,32 @@ describe("installPluginFromClawHub", () => {
     expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
   });
 
+  it("installs when a beta runtime is on the same plugin API floor", async () => {
+    resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.27-beta.1");
+    fetchClawHubPackageVersionMock.mockResolvedValueOnce({
+      version: {
+        version: "2026.5.27",
+        createdAt: 0,
+        changelog: "",
+        sha256hash: "a9eac48c6129bc44b6f93c9a9f48f6c700d191b7279a1e1915f28df6f59bb1af",
+        compatibility: {
+          pluginApiRange: ">=2026.5.27",
+          minGatewayVersion: "2026.3.0",
+        },
+      },
+    });
+
+    const result = await installPluginFromClawHub({
+      spec: "clawhub:demo",
+      baseUrl: "https://clawhub.ai",
+    });
+
+    expectSuccessfulClawHubInstall(result);
+    expect(downloadClawHubPackageArchiveMock).toHaveBeenCalledTimes(1);
+    expect(archiveInstallCall().archivePath).toBe("/tmp/clawhub-demo/archive.zip");
+    expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not let a wildcard plugin API range hide an invalid runtime version", async () => {
     resolveCompatibilityHostVersionMock.mockReturnValueOnce("invalid");
     fetchClawHubPackageVersionMock.mockResolvedValueOnce({

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -138,6 +138,7 @@ function writePluginPackageManifest(params: {
   runtimeExtensions?: string[];
   setupEntry?: string;
   runtimeSetupEntry?: string;
+  compatPluginApi?: string;
 }) {
   fs.writeFileSync(
     path.join(params.packageDir, "package.json"),
@@ -148,6 +149,7 @@ function writePluginPackageManifest(params: {
         ...(params.runtimeExtensions ? { runtimeExtensions: params.runtimeExtensions } : {}),
         ...(params.setupEntry ? { setupEntry: params.setupEntry } : {}),
         ...(params.runtimeSetupEntry ? { runtimeSetupEntry: params.runtimeSetupEntry } : {}),
+        ...(params.compatPluginApi ? { compat: { pluginApi: params.compatPluginApi } } : {}),
       },
     }),
     "utf-8",
@@ -198,12 +200,14 @@ function createPackagePlugin(params: {
   packageName: string;
   extensions: string[];
   pluginId?: string;
+  compatPluginApi?: string;
 }) {
   mkdirSafe(params.packageDir);
   writePluginPackageManifest({
     packageDir: params.packageDir,
     packageName: params.packageName,
     extensions: params.extensions,
+    ...(params.compatPluginApi ? { compatPluginApi: params.compatPluginApi } : {}),
   });
   if (params.pluginId) {
     writePluginManifest({ pluginDir: params.packageDir, id: params.pluginId });
@@ -216,6 +220,7 @@ function createPackagePluginWithEntry(params: {
   pluginId?: string;
   entryPath?: string;
   writeBuiltRuntime?: boolean;
+  compatPluginApi?: string;
 }) {
   const entryPath = params.entryPath ?? "src/index.ts";
   mkdirSafe(path.dirname(path.join(params.packageDir, entryPath)));
@@ -224,6 +229,7 @@ function createPackagePluginWithEntry(params: {
     packageName: params.packageName,
     extensions: [`./${entryPath}`],
     ...(params.pluginId ? { pluginId: params.pluginId } : {}),
+    ...(params.compatPluginApi ? { compatPluginApi: params.compatPluginApi } : {}),
   });
   writePluginEntry(path.join(params.packageDir, entryPath));
   if (params.writeBuiltRuntime ?? listBuiltRuntimeEntryCandidates(entryPath).length > 0) {
@@ -1525,6 +1531,89 @@ describe("discoverOpenClawPlugins", () => {
     );
   });
 
+  it("skips incompatible non-bundled package plugin API candidates during discovery", () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions");
+    const pluginDir = path.join(globalExt, "future-channel");
+    createPackagePluginWithEntry({
+      packageDir: pluginDir,
+      packageName: "@openclaw/future-channel",
+      pluginId: "future-channel",
+      compatPluginApi: ">=2026.5.27-beta.2",
+    });
+
+    const { candidates, diagnostics } = discoverOpenClawPlugins({
+      env: buildDiscoveryEnvWithOverrides(stateDir, {
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.27-beta.1",
+      }),
+    });
+
+    expectCandidateIds(candidates, { excludes: ["future-channel"] });
+    expectDiagnostic({
+      diagnostics,
+      level: "warn",
+      pluginId: "future-channel",
+      source: path.join(pluginDir, "package.json"),
+      messageIncludes:
+        "plugin requires plugin API >=2026.5.27-beta.2, but this host is 2026.5.27-beta.1; skipping discovery",
+    });
+  });
+
+  it("checks non-bundled package plugin API before package entry validation", () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions");
+    const pluginDir = path.join(globalExt, "future-shape");
+    mkdirSafe(pluginDir);
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/future-shape",
+        openclaw: {
+          extensions: { runtime: "./src/index.ts" },
+          compat: { pluginApi: ">=2026.5.27-beta.2" },
+        },
+      }),
+      "utf-8",
+    );
+
+    const { candidates, diagnostics } = discoverOpenClawPlugins({
+      env: buildDiscoveryEnvWithOverrides(stateDir, {
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.27-beta.1",
+      }),
+    });
+
+    expectCandidateIds(candidates, { excludes: ["future-shape"] });
+    expectDiagnostic({
+      diagnostics,
+      level: "warn",
+      pluginId: "future-shape",
+      source: path.join(pluginDir, "package.json"),
+      messageIncludes:
+        "plugin requires plugin API >=2026.5.27-beta.2, but this host is 2026.5.27-beta.1; skipping discovery",
+    });
+    expectNoDiagnostic({ diagnostics, messageIncludes: "openclaw.extensions" });
+  });
+
+  it("discovers same-floor beta non-bundled package plugin API candidates", () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions");
+    createPackagePluginWithEntry({
+      packageDir: path.join(globalExt, "current-channel"),
+      packageName: "@openclaw/current-channel",
+      pluginId: "current-channel",
+      compatPluginApi: ">=2026.5.27-beta.1",
+    });
+
+    const { candidates, diagnostics } = discoverOpenClawPlugins({
+      env: buildDiscoveryEnvWithOverrides(stateDir, {
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.27-beta.1",
+      }),
+    });
+
+    expectCandidateIds(candidates, { includes: ["current-channel"] });
+    expect(diagnostics).toStrictEqual([]);
+  });
+
   it("discovers present bundled package plugins without package metadata gates", () => {
     const stateDir = makeTempDir();
     const bundledDir = path.join(stateDir, "bundled");
@@ -1536,6 +1625,7 @@ describe("discoverOpenClawPlugins", () => {
         name: "@openclaw/downloadable",
         openclaw: {
           extensions: ["./index.ts"],
+          compat: { pluginApi: ">=2099.1.1" },
         },
       }),
       "utf-8",

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -1559,6 +1559,42 @@ describe("discoverOpenClawPlugins", () => {
     });
   });
 
+  it("skips malformed non-bundled package plugin API candidates during discovery", () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions");
+    const pluginDir = path.join(globalExt, "malformed-channel");
+    mkdirSafe(pluginDir);
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/malformed-channel",
+        openclaw: {
+          extensions: ["./index.js"],
+          plugin: { id: "malformed-channel" },
+          compat: { pluginApi: 20260527 },
+        },
+      }),
+      "utf-8",
+    );
+    writePluginEntry(path.join(pluginDir, "index.js"));
+
+    const { candidates, diagnostics } = discoverOpenClawPlugins({
+      env: buildDiscoveryEnvWithOverrides(stateDir, {
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.27",
+      }),
+    });
+
+    expectCandidateIds(candidates, { excludes: ["malformed-channel"] });
+    expectDiagnostic({
+      diagnostics,
+      level: "warn",
+      pluginId: "malformed-channel",
+      source: path.join(pluginDir, "package.json"),
+      messageIncludes:
+        "invalid package plugin API metadata: package.json openclaw.compat.pluginApi must be a string; skipping discovery",
+    });
+  });
+
   it("checks non-bundled package plugin API before package entry validation", () => {
     const stateDir = makeTempDir();
     const globalExt = path.join(stateDir, "extensions");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -30,6 +30,7 @@ import {
   type PackageExtensionResolution,
   type PackageManifest,
 } from "./manifest.js";
+import { resolvePackagePluginApiRange } from "./package-compat.js";
 import {
   resolvePackageRuntimeExtensionSources,
   resolvePackageSetupSource,
@@ -879,7 +880,20 @@ function shouldSkipIncompatiblePackagePluginApi(params: {
     return false;
   }
   const packageManifest = getPackageManifestMetadata(params.manifest ?? undefined);
-  const packagePluginApiRange = normalizeOptionalString(packageManifest?.compat?.pluginApi);
+  const packagePluginApiRangeCheck = resolvePackagePluginApiRange(packageManifest);
+  if (!packagePluginApiRangeCheck.ok) {
+    const pluginId =
+      normalizeOptionalString(packageManifest?.plugin?.id) ??
+      derivePackagePluginIdHint({ packageName: params.manifest?.name });
+    params.diagnostics.push({
+      level: "warn",
+      source: path.join(params.packageDir, "package.json"),
+      message: `invalid package plugin API metadata: ${packagePluginApiRangeCheck.error}; skipping discovery`,
+      ...(pluginId ? { pluginId } : {}),
+    });
+    return true;
+  }
+  const packagePluginApiRange = packagePluginApiRangeCheck.range;
   if (!packagePluginApiRange) {
     return false;
   }

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { satisfiesPluginApiRange } from "../infra/clawhub.js";
 import { readRootJsonObjectSync } from "../infra/json-files.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
 import {
@@ -8,6 +9,7 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { resolveUserPath } from "../utils.js";
+import { resolveCompatibilityHostVersion } from "../version.js";
 import { detectBundleManifestFormat, loadBundleManifest } from "./bundle-manifest.js";
 import { resolveSourceCheckoutDependencyDiagnostic } from "./bundled-dir.js";
 import {
@@ -759,6 +761,7 @@ function addCandidate(params: {
   }
   params.seen.add(resolved);
   const manifest = params.manifest ?? null;
+  const packageManifest = getPackageManifestMetadata(manifest ?? undefined);
   const packageDependencies = normalizePluginDependencySpecs({
     dependencies: manifest?.dependencies,
     optionalDependencies: manifest?.optionalDependencies,
@@ -776,7 +779,7 @@ function addCandidate(params: {
     packageVersion: normalizeOptionalString(manifest?.version),
     packageDescription: normalizeOptionalString(manifest?.description),
     packageDir: params.packageDir,
-    packageManifest: getPackageManifestMetadata(manifest ?? undefined),
+    packageManifest,
     packageDependencies: packageDependencies.dependencies,
     packageOptionalDependencies: packageDependencies.optionalDependencies,
     rawPackageManifest: manifest ?? undefined,
@@ -861,6 +864,37 @@ function addLegacyNpmDeclarationDiagnostic(params: {
     pluginId: declaration.pluginId,
     source: declaration.source,
     message: `legacy npm plugin declaration ignored for "${declaration.pluginId}"; run "openclaw doctor --fix" to install ${declaration.npmSpec} into the managed plugin root`,
+  });
+  return true;
+}
+
+function shouldSkipIncompatiblePackagePluginApi(params: {
+  origin: PluginOrigin;
+  manifest: PackageManifest | null;
+  packageDir: string;
+  env: NodeJS.ProcessEnv;
+  diagnostics: PluginDiagnostic[];
+}): boolean {
+  if (params.origin === "bundled") {
+    return false;
+  }
+  const packageManifest = getPackageManifestMetadata(params.manifest ?? undefined);
+  const packagePluginApiRange = normalizeOptionalString(packageManifest?.compat?.pluginApi);
+  if (!packagePluginApiRange) {
+    return false;
+  }
+  const compatibilityHostVersion = resolveCompatibilityHostVersion(params.env);
+  if (satisfiesPluginApiRange(compatibilityHostVersion, packagePluginApiRange)) {
+    return false;
+  }
+  const pluginId =
+    normalizeOptionalString(packageManifest?.plugin?.id) ??
+    derivePackagePluginIdHint({ packageName: params.manifest?.name });
+  params.diagnostics.push({
+    level: "warn",
+    source: path.join(params.packageDir, "package.json"),
+    message: `plugin requires plugin API ${packagePluginApiRange}, but this host is ${compatibilityHostVersion}; skipping discovery`,
+    ...(pluginId ? { pluginId } : {}),
   });
   return true;
 }
@@ -963,6 +997,17 @@ function discoverInDirectory(params: {
       ...(fullPathRealPath !== undefined ? { rootRealPath: fullPathRealPath } : {}),
       packageManifestCache: params.packageManifestCache,
     });
+    if (
+      shouldSkipIncompatiblePackagePluginApi({
+        origin: params.origin,
+        manifest,
+        packageDir: fullPath,
+        env: params.env,
+        diagnostics: params.diagnostics,
+      })
+    ) {
+      continue;
+    }
     const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
     if (
       pushInvalidPackageExtensionDiagnostic({
@@ -1213,6 +1258,17 @@ function discoverFromPath(params: {
       ...(resolvedRealPath !== undefined ? { rootRealPath: resolvedRealPath } : {}),
       packageManifestCache: params.packageManifestCache,
     });
+    if (
+      shouldSkipIncompatiblePackagePluginApi({
+        origin: params.origin,
+        manifest,
+        packageDir: resolved,
+        env: params.env,
+        diagnostics: params.diagnostics,
+      })
+    ) {
+      return;
+    }
     const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
     if (
       pushInvalidPackageExtensionDiagnostic({

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -40,7 +40,17 @@ function successfulSpawn(stdout = "") {
 }
 
 function npmViewArgv(spec: string): string[] {
-  return ["npm", "view", spec, "name", "version", "dist.integrity", "dist.shasum", "--json"];
+  return [
+    "npm",
+    "view",
+    spec,
+    "name",
+    "version",
+    "dist.integrity",
+    "dist.shasum",
+    "openclaw",
+    "--json",
+  ];
 }
 
 function npmViewVersionsArgv(spec: string): string[] {
@@ -314,6 +324,7 @@ function mockNpmViewAndInstallMany(packages: MockNpmPackage[]) {
               integrity: viewPackage.integrity ?? "sha512-plugin-test",
               shasum: viewPackage.shasum ?? "pluginshasum",
             },
+            ...(viewPackage.openclaw ? { openclaw: viewPackage.openclaw } : {}),
           }),
         );
       }
@@ -913,10 +924,78 @@ describe("installPluginFromNpmSpec", () => {
     expect(result.error).toContain("runtime exposes 2026.5.10-beta.1");
     expect(result.error).toContain("install a compatible plugin version");
     expect(fs.existsSync(path.join(npmRoot, "node_modules", "@openclaw", "whatsapp"))).toBe(false);
+    expect(fs.existsSync(path.join(npmRoot, "package.json"))).toBe(false);
+    expect(
+      runCommandWithTimeoutMock.mock.calls.some(([argv]) => isManagedNpmInstallCommand(argv)),
+    ).toBe(false);
+  });
+
+  it("preserves an existing npm plugin when update metadata requires a newer host", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    fs.mkdirSync(npmRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(npmRoot, "package.json"),
+      JSON.stringify({
+        private: true,
+        dependencies: {
+          "@openclaw/whatsapp": "2026.5.26",
+        },
+      }),
+      "utf8",
+    );
+    writeInstalledNpmPlugin({
+      packageName: "@openclaw/whatsapp",
+      version: "2026.5.26",
+      pluginId: "whatsapp",
+      npmRoot,
+      openclaw: {
+        extensions: ["./dist/index.js"],
+        install: { minHostVersion: ">=2026.4.25" },
+        compat: { pluginApi: ">=2026.5.26" },
+      },
+    });
+    vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "2026.5.10-beta.1");
+    mockNpmViewAndInstall({
+      spec: "@openclaw/whatsapp",
+      packageName: "@openclaw/whatsapp",
+      version: "2026.5.27",
+      pluginId: "whatsapp",
+      npmRoot,
+      openclaw: {
+        extensions: ["./dist/index.js"],
+        install: { minHostVersion: ">=2026.4.25" },
+        compat: { pluginApi: ">=2026.5.27" },
+      },
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@openclaw/whatsapp",
+      npmDir: npmRoot,
+      mode: "update",
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_PLUGIN_API);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(npmRoot, "node_modules", "@openclaw", "whatsapp", "package.json"),
+          "utf8",
+        ),
+      ).version,
+    ).toBe("2026.5.26");
     const managedManifest = JSON.parse(
       fs.readFileSync(path.join(npmRoot, "package.json"), "utf8"),
     ) as { dependencies?: Record<string, string> };
-    expect(managedManifest.dependencies?.["@openclaw/whatsapp"]).toBeUndefined();
+    expect(managedManifest.dependencies?.["@openclaw/whatsapp"]).toBe("2026.5.26");
+    expect(
+      runCommandWithTimeoutMock.mock.calls.some(([argv]) => isManagedNpmInstallCommand(argv)),
+    ).toBe(false);
   });
 
   it.runIf(process.platform !== "win32")(

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -101,6 +101,7 @@ function writeInstalledNpmPlugin(params: {
   dependency?: { name: string; version: string };
   hoistedDependency?: { name: string; version: string };
   peerDependencies?: Record<string, string>;
+  openclaw?: Record<string, unknown>;
 }) {
   const pluginDir = path.join(params.npmRoot, "node_modules", params.packageName);
   fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
@@ -109,7 +110,7 @@ function writeInstalledNpmPlugin(params: {
     JSON.stringify({
       name: params.packageName,
       version: params.version,
-      openclaw: { extensions: ["./dist/index.js"] },
+      openclaw: params.openclaw ?? { extensions: ["./dist/index.js"] },
       ...(params.dependency
         ? { dependencies: { [params.dependency.name]: params.dependency.version } }
         : {}),
@@ -170,6 +171,7 @@ type MockNpmPackage = {
   dependency?: { name: string; version: string };
   hoistedDependency?: { name: string; version: string };
   peerDependencies?: Record<string, string>;
+  openclaw?: Record<string, unknown>;
   expectedDependencySpec?: string;
   versions?: string[];
   installedVersion?: string;
@@ -256,6 +258,7 @@ function mockNpmViewAndInstall(params: {
   dependency?: { name: string; version: string };
   hoistedDependency?: { name: string; version: string };
   peerDependencies?: Record<string, string>;
+  openclaw?: Record<string, unknown>;
   expectedDependencySpec?: string;
   versions?: string[];
   installedVersion?: string;
@@ -874,6 +877,46 @@ describe("installPluginFromNpmSpec", () => {
       fs.readFileSync(path.join(npmRoot, "package.json"), "utf8"),
     ) as { dependencies?: Record<string, string> };
     expect(managedManifest.dependencies?.["@openclaw/codex"]).toBeUndefined();
+  });
+
+  it("rejects npm plugins whose package compatibility requires a newer host", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "2026.5.10-beta.1");
+
+    mockNpmViewAndInstall({
+      spec: "@openclaw/whatsapp",
+      packageName: "@openclaw/whatsapp",
+      version: "2026.5.27",
+      pluginId: "whatsapp",
+      npmRoot,
+      peerDependencies: { openclaw: ">=2026.5.27" },
+      openclaw: {
+        extensions: ["./dist/index.js"],
+        install: { minHostVersion: ">=2026.4.25" },
+        compat: { pluginApi: ">=2026.5.27" },
+      },
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@openclaw/whatsapp",
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_PLUGIN_API);
+    expect(result.error).toContain("requires plugin API >=2026.5.27");
+    expect(result.error).toContain("runtime exposes 2026.5.10-beta.1");
+    expect(result.error).toContain("install a compatible plugin version");
+    expect(fs.existsSync(path.join(npmRoot, "node_modules", "@openclaw", "whatsapp"))).toBe(false);
+    const managedManifest = JSON.parse(
+      fs.readFileSync(path.join(npmRoot, "package.json"), "utf8"),
+    ) as { dependencies?: Record<string, string> };
+    expect(managedManifest.dependencies?.["@openclaw/whatsapp"]).toBeUndefined();
   });
 
   it.runIf(process.platform !== "win32")(

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -3674,6 +3674,36 @@ describe("installPluginFromDir", () => {
     expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
   });
 
+  it("rejects bundle package installs whose package plugin API range is newer than the current host", async () => {
+    resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.10-beta.1");
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "codex",
+      name: "Future Bundle",
+    });
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/future-bundle",
+        version: "2026.5.27",
+        openclaw: { compat: { pluginApi: ">=2026.5.27" } },
+      }),
+      "utf-8",
+    );
+
+    const result = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expectFailedInstallResult({
+      result,
+      code: PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_PLUGIN_API,
+      messageIncludes: ["requires plugin API >=2026.5.27", "runtime exposes 2026.5.10-beta.1"],
+    });
+    expect(fs.existsSync(path.join(extensionsDir, "future-bundle"))).toBe(false);
+    expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
+  });
+
   it("allows plugins when a beta host is on the package plugin API floor", async () => {
     resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.27-beta.1");
     const { pluginDir, extensionsDir } = setupInstallPluginFromDirFixture();

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -270,6 +270,21 @@ function setPluginMinHostVersion(pluginDir: string, minHostVersion: string) {
   fs.writeFileSync(packageJsonPath, JSON.stringify(manifest), "utf-8");
 }
 
+function setPluginPackageCompatibility(pluginDir: string, pluginApiRange: string) {
+  const packageJsonPath = path.join(pluginDir, "package.json");
+  const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+    openclaw?: { compat?: Record<string, unknown> };
+  };
+  manifest.openclaw = {
+    ...manifest.openclaw,
+    compat: {
+      ...manifest.openclaw?.compat,
+      pluginApi: pluginApiRange,
+    },
+  };
+  fs.writeFileSync(packageJsonPath, JSON.stringify(manifest), "utf-8");
+}
+
 function expectFailedInstallResult<
   TResult extends { ok: boolean; code?: string } & Partial<{ error: string }>,
 >(params: { result: TResult; code?: string; messageIncludes: readonly string[] }) {
@@ -3602,6 +3617,47 @@ describe("installPluginFromDir", () => {
       expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
     },
   );
+
+  it("rejects plugins whose package plugin API range is newer than the current host", async () => {
+    resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.10-beta.1");
+    const { pluginDir, extensionsDir } = setupInstallPluginFromDirFixture();
+    setPluginMinHostVersion(pluginDir, ">=2026.4.25");
+    setPluginPackageCompatibility(pluginDir, ">=2026.5.27");
+
+    const result = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expectFailedInstallResult({
+      result,
+      code: PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_PLUGIN_API,
+      messageIncludes: [
+        "requires plugin API >=2026.5.27",
+        "runtime exposes 2026.5.10-beta.1",
+        "install a compatible plugin version",
+      ],
+    });
+    expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
+  });
+
+  it("allows plugins when a beta host is on the package plugin API floor", async () => {
+    resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.27-beta.1");
+    const { pluginDir, extensionsDir } = setupInstallPluginFromDirFixture();
+    setPluginMinHostVersion(pluginDir, ">=2026.4.25");
+    setPluginPackageCompatibility(pluginDir, ">=2026.5.27");
+
+    const result = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.pluginId).toBe("@openclaw/test-plugin");
+  });
 
   it("uses openclaw.plugin.json id as install key when it differs from package name", async () => {
     const { pluginDir, extensionsDir } = setupManifestInstallFixture({

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -270,7 +270,7 @@ function setPluginMinHostVersion(pluginDir: string, minHostVersion: string) {
   fs.writeFileSync(packageJsonPath, JSON.stringify(manifest), "utf-8");
 }
 
-function setPluginPackageCompatibility(pluginDir: string, pluginApiRange: string) {
+function setPluginPackageCompatibility(pluginDir: string, pluginApiRange: unknown) {
   const packageJsonPath = path.join(pluginDir, "package.json");
   const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
     openclaw?: { compat?: Record<string, unknown> };
@@ -3637,6 +3637,24 @@ describe("installPluginFromDir", () => {
         "runtime exposes 2026.5.10-beta.1",
         "install a compatible plugin version",
       ],
+    });
+    expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
+  });
+
+  it("rejects plugins whose package plugin API metadata is malformed", async () => {
+    resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.27");
+    const { pluginDir, extensionsDir } = setupInstallPluginFromDirFixture();
+    setPluginPackageCompatibility(pluginDir, 20260527);
+
+    const result = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expectFailedInstallResult({
+      result,
+      code: PLUGIN_INSTALL_ERROR_CODE.INVALID_PLUGIN_API,
+      messageIncludes: ["openclaw.compat.pluginApi", "must be a string"],
     });
     expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
   });

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -3641,6 +3641,39 @@ describe("installPluginFromDir", () => {
     expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
   });
 
+  it("checks package plugin API before current-host extension shape validation", async () => {
+    resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.27-beta.1");
+    const { pluginDir, extensionsDir } = setupInstallPluginFromDirFixture();
+    const packageJsonPath = path.join(pluginDir, "package.json");
+    const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+      openclaw?: Record<string, unknown>;
+    };
+    manifest.openclaw = {
+      ...manifest.openclaw,
+      extensions: { runtime: "./src/index.ts" },
+      compat: { pluginApi: ">=2026.5.27-beta.2" },
+    };
+    fs.writeFileSync(packageJsonPath, JSON.stringify(manifest), "utf-8");
+
+    const result = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expectFailedInstallResult({
+      result,
+      code: PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_PLUGIN_API,
+      messageIncludes: [
+        "requires plugin API >=2026.5.27-beta.2",
+        "runtime exposes 2026.5.27-beta.1",
+      ],
+    });
+    if (!result.ok) {
+      expect(result.error).not.toContain("openclaw.extensions");
+    }
+    expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
+  });
+
   it("allows plugins when a beta host is on the package plugin API floor", async () => {
     resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.27-beta.1");
     const { pluginDir, extensionsDir } = setupInstallPluginFromDirFixture();

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -84,6 +84,7 @@ type PackageManifest = PluginPackageManifest & {
   optionalDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
 };
+type PluginInstallRuntime = Awaited<ReturnType<typeof loadPluginInstallRuntime>>;
 
 function formatUnresolvedOpenClawPeerLinkError(packageName: string): string {
   return `Installed plugin ${packageName} declares openclaw as a peer dependency, but OpenClaw could not create a plugin-local node_modules/openclaw link. Run from a packaged OpenClaw install or reinstall OpenClaw, then retry.`;
@@ -153,6 +154,64 @@ function validateOpenClawPackageCompatibility(params: {
   }
 
   return null;
+}
+
+function validateOpenClawPackageInstallCompatibility(params: {
+  runtime: PluginInstallRuntime;
+  pluginId: string;
+  packageMetadata?: OpenClawPackageManifest;
+}): PluginInstallFailureResult | null {
+  const currentHostVersion = params.runtime.resolveCompatibilityHostVersion();
+  const minHostVersionCheck = params.runtime.checkMinHostVersion({
+    currentVersion: currentHostVersion,
+    minHostVersion: params.packageMetadata?.install?.minHostVersion,
+  });
+  if (!minHostVersionCheck.ok) {
+    if (minHostVersionCheck.kind === "invalid") {
+      return {
+        ok: false,
+        error: `invalid package.json openclaw.install.minHostVersion: ${minHostVersionCheck.error}`,
+        code: PLUGIN_INSTALL_ERROR_CODE.INVALID_MIN_HOST_VERSION,
+      };
+    }
+    if (minHostVersionCheck.kind === "unknown_host_version") {
+      return {
+        ok: false,
+        error: `plugin "${params.pluginId}" requires OpenClaw >=${minHostVersionCheck.requirement.minimumLabel}, but this host version could not be determined. Re-run from a released build or set OPENCLAW_VERSION and retry.`,
+        code: PLUGIN_INSTALL_ERROR_CODE.UNKNOWN_HOST_VERSION,
+      };
+    }
+    return {
+      ok: false,
+      error: `plugin "${params.pluginId}" requires OpenClaw >=${minHostVersionCheck.requirement.minimumLabel}, but this host is ${minHostVersionCheck.currentVersion}. Upgrade OpenClaw and retry.`,
+      code: PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_HOST_VERSION,
+    };
+  }
+
+  return validateOpenClawPackageCompatibility({
+    pluginId: params.pluginId,
+    currentHostVersion,
+    packageMetadata: params.packageMetadata,
+  });
+}
+
+async function readOptionalPackageManifest(params: {
+  runtime: PluginInstallRuntime;
+  packageDir: string;
+}): Promise<{ ok: true; manifest?: PackageManifest } | PluginInstallFailureResult> {
+  const manifestPath = path.join(params.packageDir, "package.json");
+  if (!(await params.runtime.fileExists(manifestPath))) {
+    return { ok: true };
+  }
+
+  try {
+    return {
+      ok: true,
+      manifest: await params.runtime.readJsonFile<PackageManifest>(manifestPath),
+    };
+  } catch (err) {
+    return { ok: false, error: `invalid package.json: ${String(err)}` };
+  }
 }
 
 export type PluginNpmIntegrityDriftParams = {
@@ -1237,6 +1296,24 @@ async function installBundleFromSourceDir(
       code: PLUGIN_INSTALL_ERROR_CODE.PLUGIN_ID_MISMATCH,
     };
   }
+  const packageManifestResult = await readOptionalPackageManifest({
+    runtime,
+    packageDir: params.sourceDir,
+  });
+  if (!packageManifestResult.ok) {
+    return packageManifestResult;
+  }
+  const packageMetadata = packageManifestResult.manifest
+    ? runtime.getPackageManifestMetadata(packageManifestResult.manifest)
+    : undefined;
+  const compatibilityError = validateOpenClawPackageInstallCompatibility({
+    runtime,
+    pluginId,
+    packageMetadata,
+  });
+  if (compatibilityError) {
+    return compatibilityError;
+  }
 
   const targetResult = await resolvePreparedDirectoryInstallTarget({
     runtime,
@@ -1407,35 +1484,9 @@ async function validatePackagePluginInstallSource(params: {
   }
 
   const packageMetadata = params.runtime.getPackageManifestMetadata(manifest);
-  const currentHostVersion = params.runtime.resolveCompatibilityHostVersion();
-  const minHostVersionCheck = params.runtime.checkMinHostVersion({
-    currentVersion: currentHostVersion,
-    minHostVersion: packageMetadata?.install?.minHostVersion,
-  });
-  if (!minHostVersionCheck.ok) {
-    if (minHostVersionCheck.kind === "invalid") {
-      return {
-        ok: false,
-        error: `invalid package.json openclaw.install.minHostVersion: ${minHostVersionCheck.error}`,
-        code: PLUGIN_INSTALL_ERROR_CODE.INVALID_MIN_HOST_VERSION,
-      };
-    }
-    if (minHostVersionCheck.kind === "unknown_host_version") {
-      return {
-        ok: false,
-        error: `plugin "${pluginId}" requires OpenClaw >=${minHostVersionCheck.requirement.minimumLabel}, but this host version could not be determined. Re-run from a released build or set OPENCLAW_VERSION and retry.`,
-        code: PLUGIN_INSTALL_ERROR_CODE.UNKNOWN_HOST_VERSION,
-      };
-    }
-    return {
-      ok: false,
-      error: `plugin "${pluginId}" requires OpenClaw >=${minHostVersionCheck.requirement.minimumLabel}, but this host is ${minHostVersionCheck.currentVersion}. Upgrade OpenClaw and retry.`,
-      code: PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_HOST_VERSION,
-    };
-  }
-  const compatibilityError = validateOpenClawPackageCompatibility({
+  const compatibilityError = validateOpenClawPackageInstallCompatibility({
+    runtime: params.runtime,
     pluginId,
-    currentHostVersion,
     packageMetadata,
   });
   if (compatibilityError) {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { satisfiesPluginApiRange } from "../infra/clawhub.js";
 import { packageNameMatchesId } from "../infra/install-safe-path.js";
 import {
   resolveNpmPackArchiveMetadata,
@@ -56,6 +57,7 @@ import type { InstallSecurityScanResult } from "./install-security-scan.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.js";
 import {
   resolvePackageExtensionEntries,
+  type OpenClawPackageManifest,
   type PackageManifest as PluginPackageManifest,
 } from "./manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "./package-entry-resolution.js";
@@ -107,6 +109,7 @@ export const PLUGIN_INSTALL_ERROR_CODE = {
   INVALID_MIN_HOST_VERSION: "invalid_min_host_version",
   UNKNOWN_HOST_VERSION: "unknown_host_version",
   INCOMPATIBLE_HOST_VERSION: "incompatible_host_version",
+  INCOMPATIBLE_PLUGIN_API: "incompatible_plugin_api",
   MISSING_OPENCLAW_EXTENSIONS: "missing_openclaw_extensions",
   MISSING_PLUGIN_MANIFEST: "missing_plugin_manifest",
   EMPTY_OPENCLAW_EXTENSIONS: "empty_openclaw_extensions",
@@ -132,6 +135,23 @@ export type InstallPluginResult =
       integrityDrift?: NpmIntegrityDrift;
     }
   | { ok: false; error: string; code?: PluginInstallErrorCode };
+
+function validateOpenClawPackageCompatibility(params: {
+  pluginId: string;
+  currentHostVersion: string;
+  packageMetadata?: OpenClawPackageManifest;
+}): InstallPluginResult | null {
+  const pluginApiRange = normalizeOptionalString(params.packageMetadata?.compat?.pluginApi);
+  if (pluginApiRange && !satisfiesPluginApiRange(params.currentHostVersion, pluginApiRange)) {
+    return {
+      ok: false,
+      error: `plugin "${params.pluginId}" requires plugin API ${pluginApiRange}, but this OpenClaw runtime exposes ${params.currentHostVersion}. Upgrade OpenClaw or install a compatible plugin version and retry.`,
+      code: PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_PLUGIN_API,
+    };
+  }
+
+  return null;
+}
 
 export type PluginNpmIntegrityDriftParams = {
   spec: string;
@@ -1397,8 +1417,9 @@ async function validatePackagePluginInstallSource(params: {
   }
 
   const packageMetadata = params.runtime.getPackageManifestMetadata(manifest);
+  const currentHostVersion = params.runtime.resolveCompatibilityHostVersion();
   const minHostVersionCheck = params.runtime.checkMinHostVersion({
-    currentVersion: params.runtime.resolveCompatibilityHostVersion(),
+    currentVersion: currentHostVersion,
     minHostVersion: packageMetadata?.install?.minHostVersion,
   });
   if (!minHostVersionCheck.ok) {
@@ -1421,6 +1442,14 @@ async function validatePackagePluginInstallSource(params: {
       error: `plugin "${pluginId}" requires OpenClaw >=${minHostVersionCheck.requirement.minimumLabel}, but this host is ${minHostVersionCheck.currentVersion}. Upgrade OpenClaw and retry.`,
       code: PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_HOST_VERSION,
     };
+  }
+  const compatibilityError = validateOpenClawPackageCompatibility({
+    pluginId,
+    currentHostVersion,
+    packageMetadata,
+  });
+  if (compatibilityError) {
+    return compatibilityError;
   }
 
   const extensionValidation = await validatePackageExtensionEntriesForInstall({

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -60,6 +60,7 @@ import {
   type OpenClawPackageManifest,
   type PackageManifest as PluginPackageManifest,
 } from "./manifest.js";
+import { resolvePackagePluginApiRange } from "./package-compat.js";
 import { validatePackageExtensionEntriesForInstall } from "./package-entry-resolution.js";
 import {
   linkOpenClawPeerDependencies,
@@ -111,6 +112,7 @@ export const PLUGIN_INSTALL_ERROR_CODE = {
   UNKNOWN_HOST_VERSION: "unknown_host_version",
   INCOMPATIBLE_HOST_VERSION: "incompatible_host_version",
   INCOMPATIBLE_PLUGIN_API: "incompatible_plugin_api",
+  INVALID_PLUGIN_API: "invalid_plugin_api",
   MISSING_OPENCLAW_EXTENSIONS: "missing_openclaw_extensions",
   MISSING_PLUGIN_MANIFEST: "missing_plugin_manifest",
   EMPTY_OPENCLAW_EXTENSIONS: "empty_openclaw_extensions",
@@ -144,7 +146,15 @@ function validateOpenClawPackageCompatibility(params: {
   currentHostVersion: string;
   packageMetadata?: OpenClawPackageManifest;
 }): PluginInstallFailureResult | null {
-  const pluginApiRange = normalizeOptionalString(params.packageMetadata?.compat?.pluginApi);
+  const pluginApiRangeCheck = resolvePackagePluginApiRange(params.packageMetadata);
+  if (!pluginApiRangeCheck.ok) {
+    return {
+      ok: false,
+      error: `invalid package.json openclaw.compat.pluginApi: ${pluginApiRangeCheck.error}`,
+      code: PLUGIN_INSTALL_ERROR_CODE.INVALID_PLUGIN_API,
+    };
+  }
+  const pluginApiRange = pluginApiRangeCheck.range;
   if (pluginApiRange && !satisfiesPluginApiRange(params.currentHostVersion, pluginApiRange)) {
     return {
       ok: false,

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -136,11 +136,13 @@ export type InstallPluginResult =
     }
   | { ok: false; error: string; code?: PluginInstallErrorCode };
 
+type PluginInstallFailureResult = Extract<InstallPluginResult, { ok: false }>;
+
 function validateOpenClawPackageCompatibility(params: {
   pluginId: string;
   currentHostVersion: string;
   packageMetadata?: OpenClawPackageManifest;
-}): InstallPluginResult | null {
+}): PluginInstallFailureResult | null {
   const pluginApiRange = normalizeOptionalString(params.packageMetadata?.compat?.pluginApi);
   if (pluginApiRange && !satisfiesPluginApiRange(params.currentHostVersion, pluginApiRange)) {
     return {
@@ -1349,7 +1351,7 @@ async function validatePackagePluginInstallSource(params: {
       ok: true;
       plugin: ValidatedPackagePlugin;
     }
-  | Extract<InstallPluginResult, { ok: false }>
+  | PluginInstallFailureResult
 > {
   const manifestPath = path.join(params.packageDir, "package.json");
   if (!(await params.runtime.fileExists(manifestPath))) {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1365,18 +1365,6 @@ async function validatePackagePluginInstallSource(params: {
     return { ok: false, error: `invalid package.json: ${String(err)}` };
   }
 
-  const extensionsResult = ensureOpenClawExtensions({
-    manifest,
-  });
-  if (!extensionsResult.ok) {
-    return {
-      ok: false,
-      error: extensionsResult.error,
-      code: extensionsResult.code,
-    };
-  }
-  const extensions = extensionsResult.entries;
-
   const pkgName = normalizeOptionalString(manifest.name) ?? "";
   const npmPluginId = pkgName || "plugin";
   const ocManifestResult = params.runtime.loadPluginManifest(params.packageDir);
@@ -1453,6 +1441,18 @@ async function validatePackagePluginInstallSource(params: {
   if (compatibilityError) {
     return compatibilityError;
   }
+
+  const extensionsResult = ensureOpenClawExtensions({
+    manifest,
+  });
+  if (!extensionsResult.ok) {
+    return {
+      ok: false,
+      error: extensionsResult.error,
+      code: extensionsResult.code,
+    };
+  }
+  const extensions = extensionsResult.entries;
 
   const extensionValidation = await validatePackageExtensionEntriesForInstall({
     packageDir: params.packageDir,

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1939,6 +1939,14 @@ export async function installPluginFromNpmSpec(
   if (driftResult.error) {
     return { ok: false, error: driftResult.error };
   }
+  const compatibilityError = validateOpenClawPackageCompatibility({
+    pluginId: expectedPluginId ?? npmResolution.name ?? parsedSpec.name,
+    currentHostVersion: runtime.resolveCompatibilityHostVersion(),
+    packageMetadata: npmResolution.packageOpenClaw as OpenClawPackageManifest | undefined,
+  });
+  if (compatibilityError) {
+    return compatibilityError;
+  }
 
   return await installPluginFromManagedNpmRoot({
     dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -251,6 +251,35 @@ function loadRegistryForMinHostVersionCase(params: {
   });
 }
 
+function loadRegistryForPluginApiCase(params: {
+  rootDir: string;
+  pluginApi: string;
+  env?: NodeJS.ProcessEnv;
+  origin?: "bundled" | "global" | "workspace" | "config";
+  idHint?: string;
+}) {
+  return loadPluginManifestRegistry({
+    ...(params.env ? { env: params.env } : {}),
+    candidates: [
+      createPluginCandidate({
+        idHint: params.idHint ?? "synology-chat",
+        rootDir: params.rootDir,
+        packageDir: params.rootDir,
+        origin: params.origin ?? "global",
+        packageManifest: {
+          install: {
+            npmSpec: "@openclaw/synology-chat",
+            minHostVersion: ">=2026.4.25",
+          },
+          compat: {
+            pluginApi: params.pluginApi,
+          },
+        },
+      }),
+    ],
+  });
+}
+
 function hasUnsafeManifestDiagnostic(registry: ReturnType<typeof loadPluginManifestRegistry>) {
   return registry.diagnostics.some((diag) => diag.message.includes("unsafe plugin manifest path"));
 }
@@ -2229,6 +2258,54 @@ describe("loadPluginManifestRegistry", () => {
 
     expect(registry.plugins.map((plugin) => plugin.id)).toContain("codex");
     expectNoRegistryDiagnosticContains(registry, "requires OpenClaw");
+  });
+
+  it("skips installed plugins whose package plugin API range is newer than the current host", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "synology-chat", configSchema: { type: "object" } });
+
+    const registry = loadRegistryForPluginApiCase({
+      rootDir: dir,
+      pluginApi: ">=2026.5.27",
+      env: { OPENCLAW_VERSION: "2026.5.10-beta.1" } as NodeJS.ProcessEnv,
+    });
+
+    expect(registry.plugins).toStrictEqual([]);
+    expectRegistryDiagnosticContains(
+      registry,
+      "plugin requires plugin API >=2026.5.27, but this host is 2026.5.10-beta.1",
+    );
+    expect(registry.diagnostics.map((diag) => diag.level)).toContain("warn");
+  });
+
+  it("loads installed plugins when a beta host is on the package plugin API floor", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "synology-chat", configSchema: { type: "object" } });
+
+    const registry = loadRegistryForPluginApiCase({
+      rootDir: dir,
+      pluginApi: ">=2026.5.27",
+      env: { OPENCLAW_VERSION: "2026.5.27-beta.1" } as NodeJS.ProcessEnv,
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["synology-chat"]);
+    expectNoRegistryDiagnosticContains(registry, "requires plugin API");
+  });
+
+  it("does not runtime-gate bundled source plugins by package plugin API", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "codex", configSchema: { type: "object" } });
+
+    const registry = loadRegistryForPluginApiCase({
+      rootDir: dir,
+      pluginApi: ">=2026.5.27",
+      origin: "bundled",
+      idHint: "codex",
+      env: { OPENCLAW_VERSION: "2026.5.10-beta.1" } as NodeJS.ProcessEnv,
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toContain("codex");
+    expectNoRegistryDiagnosticContains(registry, "requires plugin API");
   });
 
   it.each([

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -253,7 +253,7 @@ function loadRegistryForMinHostVersionCase(params: {
 
 function loadRegistryForPluginApiCase(params: {
   rootDir: string;
-  pluginApi: string;
+  pluginApi: unknown;
   env?: NodeJS.ProcessEnv;
   origin?: "bundled" | "global" | "workspace" | "config";
   idHint?: string;
@@ -272,7 +272,7 @@ function loadRegistryForPluginApiCase(params: {
             minHostVersion: ">=2026.4.25",
           },
           compat: {
-            pluginApi: params.pluginApi,
+            pluginApi: params.pluginApi as string,
           },
         },
       }),
@@ -2276,6 +2276,24 @@ describe("loadPluginManifestRegistry", () => {
       "plugin requires plugin API >=2026.5.27, but this host is 2026.5.10-beta.1",
     );
     expect(registry.diagnostics.map((diag) => diag.level)).toContain("warn");
+  });
+
+  it("skips installed plugins whose package plugin API metadata is malformed", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "synology-chat", configSchema: { type: "object" } });
+
+    const registry = loadRegistryForPluginApiCase({
+      rootDir: dir,
+      pluginApi: 20260527,
+      env: { OPENCLAW_VERSION: "2026.5.27" } as NodeJS.ProcessEnv,
+    });
+
+    expect(registry.plugins).toStrictEqual([]);
+    expectRegistryDiagnosticContains(
+      registry,
+      "plugin manifest invalid | package.json openclaw.compat.pluginApi must be a string",
+    );
+    expect(registry.diagnostics.map((diag) => diag.level)).toContain("error");
   });
 
   it("loads installed plugins when a beta host is on the package plugin API floor", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -58,6 +58,7 @@ import {
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
+import { resolvePackagePluginApiRange } from "./package-compat.js";
 import { isPathInside, safeRealpathSync, safeStatSync } from "./path-safety.js";
 import type { PluginKind } from "./plugin-kind.types.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -1041,9 +1042,17 @@ export function loadPluginManifestRegistry(
         });
         continue;
       }
-      const packagePluginApiRange = normalizeOptionalString(
-        candidate.packageManifest?.compat?.pluginApi,
-      );
+      const packagePluginApiRangeCheck = resolvePackagePluginApiRange(candidate.packageManifest);
+      if (!packagePluginApiRangeCheck.ok) {
+        diagnostics.push({
+          level: "error",
+          pluginId: manifest.id,
+          source: packageManifestSource,
+          message: `plugin manifest invalid | ${packagePluginApiRangeCheck.error}`,
+        });
+        continue;
+      }
+      const packagePluginApiRange = packagePluginApiRangeCheck.range;
       if (
         packagePluginApiRange &&
         !satisfiesPluginApiRange(currentHostVersion, packagePluginApiRange)

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { satisfiesPluginApiRange } from "../infra/clawhub.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
@@ -1008,6 +1009,10 @@ export function loadPluginManifestRegistry(
     }
     const manifest = manifestRes.manifest;
     if (candidate.origin !== "bundled") {
+      const packageManifestSource = path.join(
+        candidate.packageDir ?? candidate.rootDir,
+        "package.json",
+      );
       const allowLegacyBareMinHostVersion =
         candidate.origin === "global" &&
         matchesInstalledPluginRecord({
@@ -1023,10 +1028,6 @@ export function loadPluginManifestRegistry(
         allowLegacyBareSemver: allowLegacyBareMinHostVersion,
       });
       if (!minHostVersionCheck.ok) {
-        const packageManifestSource = path.join(
-          candidate.packageDir ?? candidate.rootDir,
-          "package.json",
-        );
         diagnostics.push({
           level: minHostVersionCheck.kind === "invalid" ? "error" : "warn",
           pluginId: manifest.id,
@@ -1037,6 +1038,21 @@ export function loadPluginManifestRegistry(
               : minHostVersionCheck.kind === "unknown_host_version"
                 ? `plugin requires OpenClaw >=${minHostVersionCheck.requirement.minimumLabel}, but this host version could not be determined; skipping load`
                 : `plugin requires OpenClaw >=${minHostVersionCheck.requirement.minimumLabel}, but this host is ${minHostVersionCheck.currentVersion}; skipping load`,
+        });
+        continue;
+      }
+      const packagePluginApiRange = normalizeOptionalString(
+        candidate.packageManifest?.compat?.pluginApi,
+      );
+      if (
+        packagePluginApiRange &&
+        !satisfiesPluginApiRange(currentHostVersion, packagePluginApiRange)
+      ) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: packageManifestSource,
+          message: `plugin requires plugin API ${packagePluginApiRange}, but this host is ${currentHostVersion}; skipping load`,
         });
         continue;
       }

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1826,6 +1826,10 @@ export type OpenClawPackageSetupFeatures = {
   legacySessionSurfaces?: boolean;
 };
 
+export type OpenClawPackageCompat = {
+  pluginApi?: string;
+};
+
 export type OpenClawPackageManifest = {
   extensions?: string[];
   runtimeExtensions?: string[];
@@ -1837,6 +1841,7 @@ export type OpenClawPackageManifest = {
     label?: string;
   };
   channel?: PluginPackageChannel;
+  compat?: OpenClawPackageCompat;
   install?: PluginPackageInstall;
   startup?: OpenClawPackageStartup;
 };

--- a/src/plugins/package-compat.ts
+++ b/src/plugins/package-compat.ts
@@ -1,0 +1,38 @@
+import { isRecord } from "../shared/record-coerce.js";
+
+export type PackagePluginApiRangeResult =
+  | { ok: true; range?: string }
+  | { ok: false; error: string };
+
+export function resolvePackagePluginApiRange(
+  packageMetadata: unknown,
+): PackagePluginApiRangeResult {
+  if (packageMetadata === undefined || packageMetadata === null) {
+    return { ok: true };
+  }
+  if (!isRecord(packageMetadata)) {
+    return { ok: true };
+  }
+  if (!("compat" in packageMetadata)) {
+    return { ok: true };
+  }
+  const compat = packageMetadata.compat;
+  if (compat === undefined || compat === null) {
+    return { ok: true };
+  }
+  if (!isRecord(compat)) {
+    return { ok: false, error: "package.json openclaw.compat must be an object" };
+  }
+  if (!("pluginApi" in compat)) {
+    return { ok: true };
+  }
+  const pluginApi = compat.pluginApi;
+  if (typeof pluginApi !== "string") {
+    return { ok: false, error: "package.json openclaw.compat.pluginApi must be a string" };
+  }
+  const range = pluginApi.trim();
+  if (!range) {
+    return { ok: false, error: "package.json openclaw.compat.pluginApi must not be empty" };
+  }
+  return { ok: true, range };
+}


### PR DESCRIPTION
## Summary

- reject package installs when `package.json#openclaw.compat.pluginApi` requires a newer OpenClaw runtime than the current host
- reject malformed present `openclaw.compat.pluginApi` package metadata instead of treating it as absent
- preflight npm package metadata before mutating the managed npm root, so incompatible updates do not remove an existing installed plugin
- skip already-persisted non-bundled plugins at discovery/manifest-registry load time when their package `openclaw.compat.pluginApi` no longer matches the current host
- keep the direct package install path aligned with ClawHub's plugin API compatibility check, including OpenClaw alpha/beta/rc CalVer host labels on the same stable API floor
- preserve explicit prerelease API floor ordering, so `beta.1` does not satisfy a `beta.2` plugin API requirement
- document `openclaw.compat.pluginApi` as the OpenClaw-owned install compatibility contract and release-sync process

Fixes #85869

## Compatibility model

This PR uses `openclaw.compat.pluginApi` as the contract that answers whether a given OpenClaw runtime can safely install and load a plugin package. The host exposes a compatibility API version, and the plugin package declares the supported range. If the range does not include the host version, OpenClaw now fails before install mutation, dependency linking, package copying, or later runtime load.

This is intentionally separate from package version equality. OpenClaw and official plugins usually share CalVer release numbers, but version numbers alone are not enough: a plugin can be newer than the installed host, prerelease floors need exact SemVer-style ordering, and package metadata is the place where the plugin can say which OpenClaw plugin API it needs. `openclaw.install.minHostVersion` remains a separate install UX floor, while `peerDependencies.openclaw` remains npm metadata and is not the OpenClaw install blocker.

Malformed present `openclaw.compat.pluginApi` metadata now fails closed. A missing field means no package API floor; a present non-string or empty value is invalid package metadata and is rejected/skipped at install, discovery, and manifest-registry load boundaries.

## Selection behavior

This PR does not yet implement best-compatible plugin version selection. For an npm spec such as `npm:@openclaw/whatsapp`, the resolver can still pick the registry's latest package; this patch makes that resolved package fail closed if its `openclaw.compat.pluginApi` is too new. That is the safe first step because it prevents older hosts from persisting a package that will crash later during plugin load.

The follow-up that makes most sense is a compatibility-aware resolver:

- ClawHub should answer latest-compatible for this host plugin API server-side, using the same `openclaw.compat.pluginApi` metadata.
- npm fallback can walk package versions and read package metadata when ClawHub cannot provide a catalog answer.
- The selector should prefer the newest package whose plugin API range includes the host version, rather than assuming matching package/OpenClaw version numbers.
- `openclaw.build.openclawVersion` can remain provenance/debug metadata, not the primary compatibility contract.

## Release sync

The docs now describe the existing release-sync process: `plugins:sync` updates official plugin package versions and bumps existing `openclaw.compat.pluginApi` floors to the OpenClaw release version by default. Plugin-only releases can intentionally keep a lower API floor when the package still supports older OpenClaw hosts, but that lower floor needs explicit proof. This avoids a separate release process while making the compatibility contract explicit.

## Real behavior proof

Behavior addressed: Direct package installs, npm package installs, bundle package installs, persisted external discovery, and manifest-registry load now fail closed when package plugin API metadata is incompatible or malformed.

Real environment tested: Local source checkout on macOS, Blacksmith Testbox-through-Crabbox Linux proof, and AWS Crabbox Linux live proof against the real npm registry.

Exact steps or command run after this patch:

```bash
CI=true OPENCLAW_HOME=<temp-openclaw-home> OPENCLAW_COMPATIBILITY_HOST_VERSION=2026.5.10-beta.1 node --import tsx src/index.ts plugins install npm:@openclaw/whatsapp
node scripts/run-vitest.mjs src/plugins/install.test.ts src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts src/agents/live-model-dynamic-candidates.test.ts src/infra/clawhub.test.ts
node scripts/run-vitest.mjs src/plugins/install.npm-spec.test.ts
node scripts/run-vitest.mjs src/plugin-sdk/fetch-runtime.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
./node_modules/.bin/oxfmt --check --threads=1 src/plugins/package-compat.ts src/plugins/install.ts src/plugins/discovery.ts src/plugins/manifest-registry.ts src/plugins/install.test.ts src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts src/agents/live-model-dynamic-candidates.test.ts
node scripts/format-docs.mjs --check docs/reference/RELEASING.md docs/plugins/manifest.md
node scripts/check-docs-mdx.mjs docs/reference/RELEASING.md docs/plugins/manifest.md
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Evidence after fix: AWS Crabbox run `run_e0c2d1ab3025` downloaded the current `@openclaw/whatsapp@2026.5.27` package from npm and rejected it on the older host before persistence:

```text
plugin "whatsapp" requires plugin API >=2026.5.27, but this OpenClaw runtime exposes 2026.5.10-beta.1. Upgrade OpenClaw or install a compatible plugin version and retry.
```

Focused regression proof passed locally: plugin install/discovery/registry/clawhub tests passed with 313 tests across 6 files, `install.npm-spec` passed 39 tests, core tsgo passed, docs checks passed, and final autoreview reported no accepted/actionable findings. Blacksmith Testbox-through-Crabbox proof `tbx_01ksqz9p7n2s8g06f4s21c87r9` verified the Linux Node 24.16 plugin SDK guard test after the main rebase.

Observed result after fix: Older hosts now get an actionable compatibility error instead of persisting a package that can fail later during plugin load. Incompatible npm updates leave an existing package directory and managed-root dependency unchanged, persisted non-bundled plugins with incompatible or malformed package API metadata are skipped before package entry validation, and bundle-style package installs with future `openclaw.compat.pluginApi` metadata fail before copying.

What was not tested: A clean same-floor live registry install was not claimed; same-floor acceptance is covered by fixture proof. The full test suite was not run.

## User-visible behavior

Operators get a clear install-time compatibility error that suggests upgrading OpenClaw or installing a compatible plugin version. Existing persisted plugins with incompatible or malformed package API metadata are skipped at load instead of failing later inside runtime code.
