### PR TITLE
test(diffs): cover viewer client controls

### DIFF
--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -1,8 +1,8 @@
-/* @vitest-environment jsdom */
-
+/** @vitest-environment jsdom */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiffViewerPayload } from "./types.js";
 
 const disableAutoStartKey = Symbol.for("openclaw.diffs.disableAutoStart");
 (globalThis as typeof globalThis & Record<symbol, unknown>)[disableAutoStartKey] = true;
@@ -14,59 +14,120 @@ const VIEWER_CLIENT_SRC = readFileSync(
 
 const XSS_PATTERNS = ["onerror", "<script", "onclick", "javascript:", "onload"];
 
-const {
-  fileDiffHydrateMock,
-  fileDiffRerenderMock,
-  fileDiffSetOptionsMock,
-  preloadHighlighterMock,
-} = vi.hoisted(() => ({
-  fileDiffHydrateMock: vi.fn(),
-  fileDiffRerenderMock: vi.fn(),
-  fileDiffSetOptionsMock: vi.fn(),
-  preloadHighlighterMock: vi.fn(async () => undefined),
-}));
+const diffMocks = vi.hoisted(() => {
+  type MockFileDiffOptions = Record<string, unknown> & {
+    renderHeaderMetadata?: () => HTMLElement;
+  };
 
-vi.mock("@pierre/diffs", () => ({
-  FileDiff: class {
-    hydrate(params: unknown) {
-      return fileDiffHydrateMock(params);
-    }
-    rerender() {
-      return fileDiffRerenderMock();
-    }
-    setOptions(params: unknown) {
-      return fileDiffSetOptionsMock(params);
-    }
-  },
-  preloadHighlighter: preloadHighlighterMock,
-}));
+  class MockFileDiff {
+    static instances: MockFileDiff[] = [];
+    static throwNextHydrate = 0;
+    static throwNextSetOptions = 0;
 
-const viewerPayload = JSON.stringify({
-  prerenderedHTML: "<div>diff</div>",
-  options: {
-    theme: { light: "pierre-light", dark: "pierre-dark" },
-    diffStyle: "unified",
-    diffIndicators: "bars",
-    disableLineNumbers: false,
-    expandUnchanged: false,
-    themeType: "dark",
-    backgroundEnabled: true,
-    overflow: "wrap",
-    unsafeCSS: "",
-  },
-  langs: ["text"],
-  oldFile: { fileName: "a.ts", lang: "text", content: "old" },
-  newFile: { fileName: "a.ts", lang: "text", content: "new" },
+    hydrate = vi.fn((params: Record<string, unknown>) => {
+      hydrateSpy(params);
+      this.hydrateParams = params;
+      if (MockFileDiff.throwNextHydrate > 0) {
+        MockFileDiff.throwNextHydrate -= 1;
+        throw new Error("broken card");
+      }
+      const fileContainer = params.fileContainer as HTMLElement;
+      const toolbar = this.options.renderHeaderMetadata?.();
+      if (toolbar instanceof HTMLElement) {
+        (fileContainer.shadowRoot ?? fileContainer).append(toolbar);
+      }
+    });
+    hydrateParams: Record<string, unknown> | undefined;
+    options: MockFileDiffOptions;
+    rerender = vi.fn(() => {
+      rerenderSpy();
+    });
+    setOptions = vi.fn((options: MockFileDiffOptions) => {
+      setOptionsSpy(options);
+      if (MockFileDiff.throwNextSetOptions > 0) {
+        MockFileDiff.throwNextSetOptions -= 1;
+        throw new Error("broken options");
+      }
+      this.options = options;
+    });
+
+    constructor(options: MockFileDiffOptions) {
+      this.options = options;
+      MockFileDiff.instances.push(this);
+    }
+  }
+
+  const hydrateSpy = vi.fn();
+  const rerenderSpy = vi.fn();
+  const setOptionsSpy = vi.fn();
+
+  return {
+    MockFileDiff,
+    hydrateSpy,
+    preloadHighlighter: vi.fn(async () => {}),
+    rerenderSpy,
+    resolveLanguage: vi.fn(async (lang: string) => lang),
+    setOptionsSpy,
+  };
 });
 
+vi.mock("@pierre/diffs", () => ({
+  FileDiff: diffMocks.MockFileDiff,
+  preloadHighlighter: diffMocks.preloadHighlighter,
+  resolveLanguage: diffMocks.resolveLanguage,
+}));
+
+function payload(overrides: Partial<DiffViewerPayload> = {}): DiffViewerPayload {
+  return {
+    prerenderedHTML: "<div data-prerendered>diff</div>",
+    options: {
+      theme: {
+        light: "pierre-light",
+        dark: "pierre-dark",
+      },
+      diffStyle: "split",
+      diffIndicators: "bars",
+      disableLineNumbers: false,
+      expandUnchanged: false,
+      themeType: "light",
+      backgroundEnabled: false,
+      overflow: "scroll",
+      unsafeCSS: ".diff{}",
+    },
+    langs: ["text"],
+    oldFile: { name: "before.ts", contents: "const value = 1;\n", lang: "text" },
+    newFile: { name: "after.ts", contents: "const value = 2;\n", lang: "text" },
+    ...overrides,
+  };
+}
+
+function addCard(diffPayload: DiffViewerPayload, options: { withTemplate?: boolean } = {}) {
+  const card = document.createElement("section");
+  card.className = "oc-diff-card";
+  card.innerHTML = `
+    <div data-openclaw-diff-host>
+      ${
+        options.withTemplate
+          ? '<template shadowrootmode="open"><span data-shadow-template>shell</span></template>'
+          : ""
+      }
+    </div>
+    <script type="application/json" data-openclaw-diff-payload></script>
+  `;
+  const script = card.querySelector<HTMLScriptElement>("[data-openclaw-diff-payload]");
+  if (!script) {
+    throw new Error("missing payload script");
+  }
+  script.textContent = JSON.stringify(diffPayload);
+  document.body.append(card);
+  return {
+    card,
+    host: card.querySelector<HTMLElement>("[data-openclaw-diff-host]"),
+  };
+}
+
 function renderCard(): void {
-  document.body.insertAdjacentHTML(
-    "beforeend",
-    `<section class="oc-diff-card">
-      <div data-openclaw-diff-host></div>
-      <script type="application/json" data-openclaw-diff-payload>${viewerPayload}</script>
-    </section>`,
-  );
+  addCard(payload());
 }
 
 describe("createToolbarButton icon safety", () => {
@@ -99,10 +160,9 @@ describe("createToolbarButton icon safety", () => {
 
   it("SVG strings in toolbarIconSvg contain no XSS patterns", () => {
     for (const pattern of XSS_PATTERNS) {
-      expect(
-        VIEWER_CLIENT_SRC.includes(pattern),
-        `source must not contain "${pattern}"`,
-      ).toBe(false);
+      expect(VIEWER_CLIENT_SRC.includes(pattern), `source must not contain "${pattern}"`).toBe(
+        false,
+      );
     }
   });
 
@@ -122,25 +182,32 @@ describe("createToolbarButton icon safety", () => {
 
 describe("hydrateViewer", () => {
   beforeEach(() => {
+    (globalThis as typeof globalThis & Record<symbol, unknown>)[disableAutoStartKey] = true;
+    vi.resetModules();
+    diffMocks.MockFileDiff.instances.length = 0;
+    diffMocks.MockFileDiff.throwNextHydrate = 0;
+    diffMocks.MockFileDiff.throwNextSetOptions = 0;
+    diffMocks.hydrateSpy.mockClear();
+    diffMocks.preloadHighlighter.mockClear();
+    diffMocks.rerenderSpy.mockClear();
+    diffMocks.resolveLanguage.mockClear();
+    diffMocks.setOptionsSpy.mockClear();
     document.body.innerHTML = "";
-    delete document.documentElement.dataset.openclawDiffsError;
+    delete document.body.dataset.theme;
     delete document.documentElement.dataset.openclawDiffsReady;
-    vi.clearAllMocks();
+    delete document.documentElement.dataset.openclawDiffsError;
   });
 
   it("continues hydrating later cards when one card throws", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     renderCard();
     renderCard();
-    fileDiffHydrateMock.mockImplementationOnce(() => {
-      throw new Error("broken card");
-    });
+    diffMocks.MockFileDiff.throwNextHydrate = 1;
     const { controllers, hydrateViewer } = await import("./viewer-client.js");
-    controllers.splice(0);
 
     await hydrateViewer();
 
-    expect(fileDiffHydrateMock).toHaveBeenCalledTimes(2);
+    expect(diffMocks.hydrateSpy).toHaveBeenCalledTimes(2);
     expect(controllers).toHaveLength(1);
     expect(warn).toHaveBeenCalledWith(
       "Skipping diff card that failed to hydrate",
@@ -154,16 +221,13 @@ describe("hydrateViewer", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     renderCard();
     renderCard();
-    fileDiffSetOptionsMock.mockImplementationOnce(() => {
-      throw new Error("broken options");
-    });
+    diffMocks.MockFileDiff.throwNextSetOptions = 1;
     const { controllers, hydrateViewer } = await import("./viewer-client.js");
-    controllers.splice(0);
 
     await hydrateViewer();
 
-    expect(fileDiffHydrateMock).toHaveBeenCalledTimes(2);
-    expect(fileDiffSetOptionsMock).toHaveBeenCalledTimes(2);
+    expect(diffMocks.hydrateSpy).toHaveBeenCalledTimes(2);
+    expect(diffMocks.setOptionsSpy).toHaveBeenCalledTimes(2);
     expect(controllers).toHaveLength(1);
     expect(warn).toHaveBeenCalledWith(
       "Skipping diff card that failed to hydrate",
@@ -171,5 +235,97 @@ describe("hydrateViewer", () => {
     );
     expect(document.documentElement.dataset.openclawDiffsError).toBeUndefined();
     warn.mockRestore();
+  });
+
+  it("hydrates cards from payload scripts and seeds viewer state from the first card", async () => {
+    const first = addCard(payload(), { withTemplate: true });
+    const secondPayload = payload({
+      fileDiff: {
+        name: "new.txt",
+        prevName: "old.txt",
+        type: "change",
+        hunks: [],
+        splitLineCount: 0,
+        unifiedLineCount: 0,
+        isPartial: true,
+        deletionLines: ["old"],
+        additionLines: ["new"],
+      },
+      langs: ["text", "javascript"],
+      oldFile: undefined,
+      newFile: undefined,
+    });
+    const second = addCard(secondPayload);
+    const { controllers, hydrateViewer } = await import("./viewer-client.js");
+
+    await hydrateViewer();
+
+    expect(document.body.dataset.theme).toBe("light");
+    expect(diffMocks.preloadHighlighter).toHaveBeenCalledWith({
+      themes: ["pierre-light", "pierre-dark"],
+      langs: ["text", "javascript"],
+    });
+    expect(controllers).toHaveLength(2);
+    expect(diffMocks.MockFileDiff.instances).toHaveLength(2);
+
+    const [firstDiff, secondDiff] = diffMocks.MockFileDiff.instances;
+    expect(first.host?.shadowRoot?.querySelector("[data-shadow-template]")).not.toBeNull();
+    expect(first.host?.querySelector("template[shadowrootmode='open']")).toBeNull();
+    expect(firstDiff?.hydrate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileContainer: first.host,
+        oldFile: expect.objectContaining({ name: "before.ts" }),
+        newFile: expect.objectContaining({ name: "after.ts" }),
+        prerenderedHTML: "<div data-prerendered>diff</div>",
+      }),
+    );
+    expect(secondDiff?.hydrate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileContainer: second.host,
+        fileDiff: secondPayload.fileDiff,
+      }),
+    );
+    expect(firstDiff?.options).toEqual(
+      expect.objectContaining({
+        themeType: "light",
+        diffStyle: "split",
+        overflow: "scroll",
+        disableBackground: true,
+      }),
+    );
+  });
+
+  it("toolbar actions synchronize state across all hydrated controllers", async () => {
+    const first = addCard(payload(), { withTemplate: true });
+    addCard(payload());
+    const { hydrateViewer } = await import("./viewer-client.js");
+
+    await hydrateViewer();
+
+    const layoutButton = first.host?.shadowRoot?.querySelector<HTMLButtonElement>(
+      ".oc-diff-toolbar-button[aria-label='Switch to unified diff']",
+    );
+    expect(layoutButton).not.toBeNull();
+
+    layoutButton?.click();
+
+    for (const instance of diffMocks.MockFileDiff.instances) {
+      expect(instance.setOptions).toHaveBeenLastCalledWith(
+        expect.objectContaining({ diffStyle: "unified" }),
+      );
+      expect(instance.rerender).toHaveBeenCalledTimes(2);
+    }
+
+    const wrapButton = first.host?.shadowRoot?.querySelector<HTMLButtonElement>(
+      ".oc-diff-toolbar-button[aria-label='Enable word wrap']",
+    );
+    wrapButton?.click();
+
+    for (const instance of diffMocks.MockFileDiff.instances) {
+      expect(instance.setOptions).toHaveBeenLastCalledWith(
+        expect.objectContaining({ diffStyle: "unified", overflow: "wrap" }),
+      );
+      expect(instance.rerender).toHaveBeenCalledTimes(3);
+    }
   });
 });


### PR DESCRIPTION
Fixes #83915

## Summary
- keep the existing viewer-client icon safety and hydration error-path coverage
- add jsdom coverage for hydrating real diff card payloads, including declarative shadow root adoption and highlighter preloading
- cover toolbar layout and wrap actions synchronizing all hydrated FileDiff controllers

## Real behavior proof
- **Behavior or issue addressed:** The diffs viewer client now has after-patch coverage for real DOM diff-card hydration, shadow-root adoption, initial viewer state seeding, and toolbar control synchronization across hydrated controllers.
- **Real environment tested:** Local OpenClaw checkout `/media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-83915` on Linux with Node `v22.22.0`, using the repository test runner and repo-local tool binaries.
- **Exact steps or command run after this patch:** `CI=true node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-diffs.config.ts extensions/diffs/src/viewer-client.test.ts --reporter=dot --testTimeout=10000`
- **Evidence after fix:** Terminal output from the real local run:

```text
RUN  v4.1.7 /media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-83915

.........

Test Files  1 passed (1)
Tests  9 passed (9)
Duration  2.80s
```

- **Observed result after fix:** The real jsdom viewer-client test run completed successfully with all 9 tests passing, including the newly added hydration and toolbar synchronization scenarios.
- **What was not tested:** No browser screenshot or full packaged extension run was captured; this PR only changes unit coverage for the viewer client.

## Supplemental checks
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --pretty false --noEmit`
- `node_modules/.bin/oxfmt --check extensions/diffs/src/viewer-client.test.ts`
- `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json extensions/diffs/src/viewer-client.test.ts`
- `git diff --check origin/main...HEAD`