### PR TITLE
fix(agents): broadcast agent stream=thinking to gateway clients without channel callback (supersedes #79687)

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -413,11 +413,12 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Preview streaming is separate from block streaming. When block streaming is explicitly enabled for Telegram, OpenClaw skips the preview stream to avoid double-streaming.
 
-    Reasoning stream behavior:
+    Telegram reasoning stream surface:
 
     - `/reasoning stream` uses a supported channel's reasoning-preview path; on Telegram, it streams reasoning into the live preview while generating
     - the reasoning preview is deleted after final delivery; use `/reasoning on` when reasoning should remain visible
     - final answer is sent without reasoning text
+    - `/reasoning stream` is no longer Telegram-only at the runtime level: when the directive is active, OpenClaw also broadcasts `agent.stream === "thinking"` events on the agent event bus so gateway/WebSocket/webchat/ACP clients can render live thinking too. Telegram's own preview behavior described above is unchanged. See [Reasoning visibility (/reasoning)](/tools/thinking#reasoning-visibility-reasoning).
 
   </Accordion>
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -105,7 +105,11 @@ title: "Thinking levels"
 - Levels: `on|off|stream`.
 - Directive-only message toggles whether thinking blocks are shown in replies.
 - When enabled, reasoning is sent as a **separate message** prefixed with `Thinking`.
-- `stream`: streams reasoning while the reply is generating when the active channel supports reasoning previews, then sends the final answer without reasoning.
+- `stream`: streams reasoning to **all gateway clients in real time**.
+  - Channels with a streaming surface (Telegram, Mattermost) update an in-place draft bubble.
+  - WebSocket / webchat / Control UI / ACP / `chat.send`-originated runs (cron auto-reply, heartbeats, plain WS) receive `agent.stream === "thinking"` events on the agent event bus with `data.text` (cumulative) and `data.delta` (incremental). The directive no longer requires a channel-side `onReasoningStream` callback.
+  - `thinkingLevel: "off"` still hard-disables the broadcast: `streamReasoning` is only enabled when both `reasoningMode === "stream"` and `canShowReasoning` (i.e. `thinkingLevel !== "off"`) are true, so opting out of thinking blocks the live thinking stream as well.
+  - `silentExpected` runs (e.g. heartbeat probes that should stay quiet) still suppress the broadcast.
 - Alias: `/reason`.
 - Send `/reasoning` (or `/reasoning:`) with no argument to see the current reasoning level.
 - Resolution order: inline directive, then session override, then per-agent default (`agents.list[].reasoningDefault`), then global default (`agents.defaults.reasoningDefault`), then fallback (`off`).

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -1491,4 +1491,114 @@ describe("subscribeEmbeddedAgentSession", () => {
       summary: "Nothing needs attention.",
     });
   });
+
+  describe("agent stream=thinking emission without onReasoningStream callback", () => {
+    // Regression coverage for the gateway / WebSocket path. chat.send-originated
+    // runs (webchat, control UI, ACP, cron tick auto-replies, plain WS clients)
+    // do not supply onReasoningStream. Previously streamReasoning required the
+    // callback to be a function, so live thinking events never reached gateway
+    // subscribers even when reasoningMode === "stream".
+
+    function emitThinkingDelta(emit: (evt: unknown) => void, fullText: string, deltaText: string) {
+      emit({
+        type: "message_update",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: fullText }],
+        },
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          delta: deltaText,
+        },
+      });
+    }
+
+    it("broadcasts agent stream=thinking to gateway clients with no callback supplied", () => {
+      const emitAgentEventSpy = vi
+        .spyOn(agentEvents, "emitAgentEvent")
+        .mockImplementation(() => {});
+      const { emit } = createSubscribedHarness({
+        runId: "run-no-callback",
+        reasoningMode: "stream",
+        // intentionally no onReasoningStream — chat.send / WS path
+      });
+
+      emitThinkingDelta(emit, "Step 1", "Step 1");
+      emitThinkingDelta(emit, "Step 1 and Step 2", " and Step 2");
+
+      const thinkingEvents = emitAgentEventSpy.mock.calls
+        .map((call) => call[0])
+        .filter((evt) => evt?.stream === "thinking");
+
+      expect(thinkingEvents.length).toBe(2);
+      expect(thinkingEvents[0]?.runId).toBe("run-no-callback");
+      expect(thinkingEvents[0]?.data?.text).toBe("Step 1");
+      expect(thinkingEvents[0]?.data?.delta).toBe("Step 1");
+      expect(thinkingEvents[1]?.data?.text).toBe("Step 1 and Step 2");
+      expect(thinkingEvents[1]?.data?.delta).toBe(" and Step 2");
+      emitAgentEventSpy.mockRestore();
+    });
+
+    it("does not leak reasoning when thinkingLevel is 'off' even without a callback", () => {
+      const emitAgentEventSpy = vi
+        .spyOn(agentEvents, "emitAgentEvent")
+        .mockImplementation(() => {});
+      const { emit } = createSubscribedHarness({
+        runId: "run-thinking-off",
+        reasoningMode: "stream",
+        thinkingLevel: "off",
+      });
+
+      emitThinkingDelta(emit, "Should never leak", "Should never leak");
+
+      const thinkingEvents = emitAgentEventSpy.mock.calls
+        .map((call) => call[0])
+        .filter((evt) => evt?.stream === "thinking");
+      expect(thinkingEvents).toEqual([]);
+      emitAgentEventSpy.mockRestore();
+    });
+
+    it("respects silentExpected and emits no thinking events even without a callback", () => {
+      const emitAgentEventSpy = vi
+        .spyOn(agentEvents, "emitAgentEvent")
+        .mockImplementation(() => {});
+      const { emit } = createSubscribedHarness({
+        runId: "run-silent",
+        reasoningMode: "stream",
+        silentExpected: true,
+      });
+
+      emitThinkingDelta(emit, "Suppressed", "Suppressed");
+
+      const thinkingEvents = emitAgentEventSpy.mock.calls
+        .map((call) => call[0])
+        .filter((evt) => evt?.stream === "thinking");
+      expect(thinkingEvents).toEqual([]);
+      emitAgentEventSpy.mockRestore();
+    });
+
+    it("still invokes onReasoningStream when supplied (Telegram / Mattermost path)", () => {
+      const emitAgentEventSpy = vi
+        .spyOn(agentEvents, "emitAgentEvent")
+        .mockImplementation(() => {});
+      const onReasoningStream = vi.fn();
+      const { emit } = createSubscribedHarness({
+        runId: "run-with-callback",
+        reasoningMode: "stream",
+        onReasoningStream,
+      });
+
+      emitThinkingDelta(emit, "Telegram still works", "Telegram still works");
+
+      const thinkingEvents = emitAgentEventSpy.mock.calls
+        .map((call) => call[0])
+        .filter((evt) => evt?.stream === "thinking");
+      expect(thinkingEvents.length).toBe(1);
+      expect(onReasoningStream).toHaveBeenCalledTimes(1);
+      expect(onReasoningStream).toHaveBeenCalledWith({
+        text: "Telegram still works",
+      });
+      emitAgentEventSpy.mockRestore();
+    });
+  });
 });

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -177,10 +177,11 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     reasoningMode,
     includeReasoning: reasoningMode === "on" && canShowReasoning,
     shouldEmitPartialReplies: !(reasoningMode === "on" && !params.onBlockReply),
-    streamReasoning:
-      reasoningMode === "stream" &&
-      canShowReasoning &&
-      typeof params.onReasoningStream === "function",
+    // Gates `agent stream=thinking` broadcast and the optional
+    // onReasoningStream callback. canShowReasoning preserves the
+    // thinkingLevel:"off" visibility gate so reasoning never leaks
+    // when the user opted out.
+    streamReasoning: reasoningMode === "stream" && canShowReasoning,
     deltaBuffer: "",
     blockBuffer: "",
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
@@ -1164,7 +1165,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     if (params.silentExpected) {
       return;
     }
-    if (!state.streamReasoning || !params.onReasoningStream) {
+    if (!state.streamReasoning) {
       return;
     }
     const trimmed = text.trim();
@@ -1190,7 +1191,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       },
     });
 
-    void params.onReasoningStream({
+    void params.onReasoningStream?.({
       text: trimmed,
     });
   };

--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -1,4 +1,3 @@
-// Covers MiniMax VLM auth/header normalization and provider-specific routing.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import { isMinimaxVlmModel, minimaxUnderstandImage } from "./minimax-vlm.js";
@@ -22,8 +21,6 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
   });
 
   async function runNormalizationCase(apiKey: string) {
-    // Headers must be Latin-1 and line-break free; normalize user/API-key
-    // input before constructing the Authorization header.
     const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const auth = (init?.headers as Record<string, string> | undefined)?.Authorization;
       expect(auth).toBe("Bearer minimax-test-key");
@@ -158,8 +155,6 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
   });
 
   it("bounds large provider error response bodies", async () => {
-    // Provider error bodies can be large. Read enough for diagnostics, then
-    // cancel the stream so failures stay bounded.
     let canceled = false;
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -183,15 +178,14 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
       prompt: "hi",
       imageDataUrl: "data:image/png;base64,AAAA",
       apiHost: "https://api.minimax.io",
-    }).catch((caught: unknown) => caught);
+    }).catch((caught: unknown) => caught as Error);
 
-    if (!(error instanceof Error)) {
-      throw new Error("expected MiniMax VLM request to throw an Error");
-    }
-    expect(error.message).toContain("MiniMax VLM request failed");
-    expect(error.message).toContain("Trace-Id: trace-123");
-    expect(error.message).not.toContain("tail-marker");
-    expect(error.message.length).toBeLessThan(520);
+    expect(error).toBeInstanceOf(Error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    expect(errorMessage).toContain("MiniMax VLM request failed");
+    expect(errorMessage).toContain("Trace-Id: trace-123");
+    expect(errorMessage).not.toContain("tail-marker");
+    expect(errorMessage.length).toBeLessThan(520);
     expect(canceled).toBe(true);
   });
 });

--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -178,14 +178,15 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
       prompt: "hi",
       imageDataUrl: "data:image/png;base64,AAAA",
       apiHost: "https://api.minimax.io",
-    }).catch((caught: unknown) => caught as Error);
+    }).catch((caught: unknown) => caught);
 
-    expect(error).toBeInstanceOf(Error);
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    expect(errorMessage).toContain("MiniMax VLM request failed");
-    expect(errorMessage).toContain("Trace-Id: trace-123");
-    expect(errorMessage).not.toContain("tail-marker");
-    expect(errorMessage.length).toBeLessThan(520);
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to throw an Error");
+    }
+    expect(error.message).toContain("MiniMax VLM request failed");
+    expect(error.message).toContain("Trace-Id: trace-123");
+    expect(error.message).not.toContain("tail-marker");
+    expect(error.message.length).toBeLessThan(520);
     expect(canceled).toBe(true);
   });
 });

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -1,5 +1,3 @@
-// Native PDF provider tests cover direct Anthropic and Gemini request shapes,
-// base URL handling, and bounded API error reporting.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
 
@@ -66,7 +64,6 @@ describe("native PDF provider API calls", () => {
 
   afterEach(() => {
     global.fetch = priorFetch;
-    vi.unstubAllEnvs();
   });
 
   it("anthropicAnalyzePdf sends correct request shape", async () => {
@@ -102,21 +99,6 @@ describe("native PDF provider API calls", () => {
     expect(body.messages[0].content[1].type).toBe("text");
   });
 
-  it("anthropicAnalyzePdf honors ANTHROPIC_BASE_URL when no base URL is configured", async () => {
-    vi.stubEnv("ANTHROPIC_BASE_URL", "https://anthropic-pdf-proxy.example/v1");
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        content: [{ type: "text", text: "Analysis of PDF" }],
-      }),
-    });
-
-    await pdfNativeProviders.anthropicAnalyzePdf(makeAnthropicAnalyzeParams());
-
-    const [url] = firstFetchCall(fetchMock) as [string];
-    expect(url).toBe("https://anthropic-pdf-proxy.example/v1/messages");
-  });
-
   it("anthropicAnalyzePdf throws on API error", async () => {
     mockFetchResponse({
       ok: false,
@@ -131,8 +113,6 @@ describe("native PDF provider API calls", () => {
   });
 
   it("bounds large Anthropic API error bodies", async () => {
-    // Provider errors can contain large or sensitive payloads; surface a compact
-    // diagnostic and cancel the stream once the cap is reached.
     let canceled = false;
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -151,14 +131,13 @@ describe("native PDF provider API calls", () => {
 
     const error = await pdfNativeProviders
       .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
-      .catch((caught: unknown) => caught);
+      .catch((caught: unknown) => caught as Error);
 
-    if (!(error instanceof Error)) {
-      throw new Error("expected Anthropic PDF request to throw an Error");
-    }
-    expect(error.message).toContain("Anthropic PDF request failed");
-    expect(error.message).not.toContain("tail-marker");
-    expect(error.message.length).toBeLessThan(500);
+    expect(error).toBeInstanceOf(Error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    expect(errorMessage).toContain("Anthropic PDF request failed");
+    expect(errorMessage).not.toContain("tail-marker");
+    expect(errorMessage.length).toBeLessThan(500);
     expect(canceled).toBe(true);
   });
 
@@ -182,16 +161,15 @@ describe("native PDF provider API calls", () => {
     const error = await Promise.race([
       pdfNativeProviders
         .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
-        .catch((caught: unknown) => caught),
+        .catch((caught: unknown) => caught as Error),
       new Promise<Error>((_resolve, reject) => {
         setTimeout(() => reject(new Error("timed out waiting for bounded error body")), 500);
       }),
     ]);
 
-    if (!(error instanceof Error)) {
-      throw new Error("expected Anthropic PDF request to throw an Error");
-    }
-    expect(error.message).toContain("Anthropic PDF request failed");
+    expect(error).toBeInstanceOf(Error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    expect(errorMessage).toContain("Anthropic PDF request failed");
     expect(canceled).toBe(true);
   });
 
@@ -209,8 +187,6 @@ describe("native PDF provider API calls", () => {
   });
 
   it("geminiAnalyzePdf sends correct request shape", async () => {
-    // Gemini API keys belong in headers here, not query strings that are more
-    // likely to leak through logs and URL diagnostics.
     const fetchMock = mockFetchResponse({
       ok: true,
       json: async () => ({

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -131,13 +131,14 @@ describe("native PDF provider API calls", () => {
 
     const error = await pdfNativeProviders
       .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
-      .catch((caught: unknown) => caught as Error);
+      .catch((caught: unknown) => caught);
 
-    expect(error).toBeInstanceOf(Error);
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    expect(errorMessage).toContain("Anthropic PDF request failed");
-    expect(errorMessage).not.toContain("tail-marker");
-    expect(errorMessage.length).toBeLessThan(500);
+    if (!(error instanceof Error)) {
+      throw new Error("expected Anthropic PDF request to throw an Error");
+    }
+    expect(error.message).toContain("Anthropic PDF request failed");
+    expect(error.message).not.toContain("tail-marker");
+    expect(error.message.length).toBeLessThan(500);
     expect(canceled).toBe(true);
   });
 
@@ -161,15 +162,16 @@ describe("native PDF provider API calls", () => {
     const error = await Promise.race([
       pdfNativeProviders
         .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
-        .catch((caught: unknown) => caught as Error),
+        .catch((caught: unknown) => caught),
       new Promise<Error>((_resolve, reject) => {
         setTimeout(() => reject(new Error("timed out waiting for bounded error body")), 500);
       }),
     ]);
 
-    expect(error).toBeInstanceOf(Error);
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    expect(errorMessage).toContain("Anthropic PDF request failed");
+    if (!(error instanceof Error)) {
+      throw new Error("expected Anthropic PDF request to throw an Error");
+    }
+    expect(error.message).toContain("Anthropic PDF request failed");
     expect(canceled).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Decouple `streamReasoning` from the optional `onReasoningStream` channel callback so `chat.send`-originated runs (webchat / Control UI / WebSocket / ACP / cron auto-reply / heartbeat) receive live `agent.stream === "thinking"` events when `reasoningMode === "stream"`.

Supersedes #79687, #47613. Closes #42261, #5086.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Why this is needed

On `upstream/main` (`src/agents/embedded-agent-subscribe.ts:146-150`), `streamReasoning` is gated on `typeof params.onReasoningStream === "function"`. Telegram / Mattermost integrations supply that callback, so they get live thinking; every other surface that goes through `chat.send` (webchat, Control UI, plain WS clients, ACP, cron auto-reply, heartbeats) does **not** supply a callback, so `emitReasoningStream` short-circuits before reaching `emitAgentEvent`. The result is the symptom reported in #42261 and #5086: agents look frozen during reasoning for every non-Telegram subscriber.

This has been attempted multiple times before (#47613, #52642, #61469, #79687, #80543, #80956). #79687 is the most complete prior attempt — ClawSweeper judged its patch correct (0.86 confidence); the only outstanding gap was that `docs/tools/thinking.md` still described `/reasoning stream` as Telegram-only. This PR carries that doc fix in the same commit, plus regression tests that #47613 was missing, so the entire surface is closed in one PR.

## What changed

### Runtime

- `src/agents/embedded-agent-subscribe.ts`
  - `streamReasoning` now requires only `reasoningMode === "stream" && canShowReasoning`. The optional channel callback no longer participates in the gate.
  - `emitReasoningStream` no longer early-returns when `onReasoningStream` is absent; the callback is invoked with optional chaining when supplied.

### Documentation

- `docs/tools/thinking.md`
  - Replace the "Telegram only" note with the actual cross-client behavior.
  - Document the `thinkingLevel: "off"` hard-gate guarantee explicitly.
- `docs/channels/telegram.md`
  - Drop the "Telegram-only reasoning stream" framing.
  - Add a pointer back to the canonical reasoning-visibility section.

### Tests

- `src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts`
  - 4 new regression tests under a new `describe("agent stream=thinking emission without onReasoningStream callback")`:
    1. broadcasts `agent stream=thinking` to gateway clients with no callback supplied (covers chat.send / WS / webchat / ACP / cron paths)
    2. does not leak reasoning when `thinkingLevel` is `"off"` even without a callback (visibility hard-gate)
    3. respects `silentExpected` and emits no thinking events even without a callback
    4. still invokes `onReasoningStream` when supplied (Telegram / Mattermost path remains unchanged)

## Visibility / safety guarantees preserved

- `streamReasoning` still requires `canShowReasoning`, so `thinkingLevel: "off"` continues to **hard-disable** the broadcast — opting out of thinking still blocks the live thinking stream. This is what #47613 missed and is one of the reasons that PR was closed.
- `silentExpected` runs (heartbeat probes etc.) still suppress the broadcast.
- `onReasoningStream` is now optional: Telegram / Mattermost integrations still receive the callback exactly as before when they supply it.

## How this addresses prior PR blockers

| Prior PR | Reason it was closed | How this PR resolves it |
| --- | --- | --- |
| #79687 | ClawSweeper said patch is correct (0.86); only gap was `docs/tools/thinking.md` not matching the new runtime behavior. No human maintainer approval, no assignee. | Doc fix is included in the same commit. PR description carries `Real behavior proof` directly so the proof gate passes. |
| #47613 | (a) missing `canShowReasoning` gate after rebase — could leak reasoning when `thinkingLevel:"off"`; (b) no Gateway/WebSocket regression tests; (c) `docs/tools/thinking.md` still Telegram-only. | (a) `canShowReasoning` is preserved on line 146; (b) 4 new tests cover no-callback / thinkingLevel:"off" / silentExpected / Telegram callback paths; (c) doc fix included. |
| #42261, #5086 | Closed as duplicate / not planned by triage bots, not on technical merit. | Linked via `Closes` so they auto-close on merge. |

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  When `/reasoning stream` is active and `chat.send` is invoked **without** an `onReasoningStream` callback (the path used by webchat / Control UI / plain WebSocket / ACP / cron auto-reply / heartbeat), the gateway broadcasts `agent.stream === "thinking"` events on the agent event bus as the model thinks. Each event carries `runId`, `data.text` (cumulative reasoning), and `data.delta` (incremental). On `upstream/main`, the same path emits zero thinking events because `streamReasoning` short-circuits when `onReasoningStream` is undefined.

- Real environment tested:
  - OS: macOS 14
  - Node: v22
  - pnpm: 10.32.1
  - OpenClaw: `upstream/main` @ HEAD with this branch (`fix/reasoning-stream-supersede-79687`) applied
  - Test runner: `vitest` via `scripts/run-vitest.mjs` with `test/vitest/vitest.agents-core.config.ts`
  - End-to-end client: a downstream Electron WebSocket client subscribed to the gateway agent event bus

- Exact steps or command run after this patch:
  1. Check out `upstream/main`, apply this branch, run `pnpm install`.
  2. Run the new regression suite scoped to the no-callback path:
     ```
     node scripts/run-vitest.mjs run \
       --config test/vitest/vitest.agents-core.config.ts \
       src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts \
       -t "agent stream=thinking emission without onReasoningStream callback"
     ```
  3. For end-to-end, start the gateway, send a `chat.send` directive `/reasoning stream`, then send a normal user prompt that requires reasoning.
  4. Observe the agent event bus on a non-Telegram WebSocket subscriber.
  5. Repeat with `thinkingLevel: "off"` to confirm the visibility hard-gate.

- Evidence after fix:
  Terminal capture of the new regression suite (`4 passed | 39 skipped`):

<img width="1080" height="150" alt="Clipboard_Screenshot_1779944143" src="https://github.com/user-attachments/assets/28595eb8-bf61-4390-8870-1a67d644821d" />

  End-to-end capture of a non-Telegram WebSocket client rendering streamed thinking inline (`agent.stream === "thinking"` events delivered before final assistant text):

<img width="1080" height="734" alt="Clipboard_Screenshot_1779944129" src="https://github.com/user-attachments/assets/3a965c73-be45-42fc-97c0-86c96aeb8fb2" />

- Observed result after fix:
  - Step 2: `4 passed | 39 skipped` — covers no-callback emission, `thinkingLevel:"off"` suppression, `silentExpected` suppression, and the existing Telegram callback path.
  - Step 3: the WebSocket client receives `agent.stream === "thinking"` events incrementally and renders them inline before any final assistant text is sent.
  - Step 4: zero `agent.stream === "thinking"` events are emitted when thinking is disabled, confirming the `thinkingLevel:"off"` gate remains intact.

- What was not tested:
  - Live Telegram channel: author does not have channel credentials. The new regression test `still invokes onReasoningStream when supplied` plus the unchanged Telegram code path should keep that surface safe.
  - Live Mattermost channel: same as Telegram.
  - ACP transport end-to-end: covered at the unit level via the no-callback `chat.send` test, not against a real ACP client.
  - Cron auto-reply end-to-end: covered at the unit level via the no-callback test, not against a live cron run.

## Backwards compatibility

- Telegram / Mattermost: unchanged — they still pass `onReasoningStream` and still get the callback. The Telegram preview-bubble UX described in `docs/channels/telegram.md` is unchanged.
- `chat.send` / WebSocket / webchat / Control UI / ACP / cron auto-reply / heartbeat: previously received zero thinking events when `/reasoning stream` was active; now receive `agent.stream === "thinking"` events on the agent event bus. This is additive behavior gated behind an existing opt-in directive.
- Users who do not opt in to `/reasoning stream` (default `off`, or `on` for non-streamed thinking blocks) see no behavior change.
- `thinkingLevel: "off"` still hard-disables thinking on every surface, including this stream.

## Test plan

- [x] `vitest` agents-core suite passes locally (`43 passed`, including 4 new cases).
- [x] Lint clean (`oxlint` runs in pre-commit hook, no findings).
- [x] Manual end-to-end against a downstream WS client confirms `agent.stream === "thinking"` events arrive incrementally with both `text` (cumulative) and `delta` (incremental) populated.
- [x] Manual end-to-end with `thinkingLevel: "off"` confirms zero thinking events are emitted (visibility gate intact).
- [ ] CI: full agents test matrix (delegated to GitHub Actions).

## Risk / rollback

Runtime change is 1 expression rewrite + 1 optional-chaining call. If a regression surfaces in Telegram / Mattermost, reverting just `src/agents/embedded-agent-subscribe.ts` restores prior behavior; the doc and test changes are independently safe to keep.

## Reviewer notes

- The runtime diff is intentionally minimal — same shape as #79687, plus the doc fix that was its only ClawSweeper blocker, plus the regression tests that #47613 was closed for missing.
- Happy to add ACP / cron-specific integration tests if reviewers want explicit coverage at those surfaces, but the new unit tests already exercise the exact code path those surfaces hit (`chat.send` without `onReasoningStream`).
- Author has limited ability to test Telegram / Mattermost end-to-end; the existing Telegram callback test (#4 above) plus the unchanged Telegram code path should keep that surface safe, but a maintainer with channel credentials confirming live behavior would be appreciated.

## Linked issues

Closes #42261
Closes #5086
Related #79687
Related #47613
