### PR TITLE
fix(agents): clear legacy auto fallback pins

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -330,6 +330,7 @@ vi.mock("../utils/message-channel.js", () => ({
 vi.mock("./agent-scope.js", () => ({
   clearAutoFallbackPrimaryProbeSelection: vi.fn(),
   entryMatchesAutoFallbackPrimaryProbe: () => true,
+  hasLegacyAutoFallbackWithoutOrigin: () => false,
   hasSessionAutoModelFallbackProvenance: () => false,
   listAgentEntries: () => [],
   listAgentIds: () => ["default"],

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1642,9 +1642,7 @@ async function agentCommandInternal(
           agentId: sessionAgentId,
           sessionKey,
           hasSessionModelOverride:
-            hasExplicitRunOverride ||
-            (!hasLegacyAutoFallbackOverrideWithoutOrigin &&
-              Boolean(storedProviderOverride || storedModelOverride)),
+            hasExplicitRunOverride || Boolean(storedProviderOverride || storedModelOverride),
           modelOverrideSource: hasExplicitRunOverride ? "user" : storedModelOverrideSource,
           hasAutoFallbackProvenance: hasExplicitRunOverride
             ? false

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -66,6 +66,7 @@ import { resolveAgentRuntimeConfig } from "./agent-runtime-config.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
   entryMatchesAutoFallbackPrimaryProbe,
+  hasLegacyAutoFallbackWithoutOrigin,
   hasSessionAutoModelFallbackProvenance,
   listAgentIds,
   markAutoFallbackPrimaryProbe,
@@ -1197,6 +1198,8 @@ async function agentCommandInternal(
       : undefined;
     const hasStoredAutoFallbackProvenance =
       hasStoredOverride && hasSessionAutoModelFallbackProvenance(sessionEntry);
+    const hasLegacyAutoFallbackOverrideWithoutOrigin =
+      hasStoredOverride && hasLegacyAutoFallbackWithoutOrigin(sessionEntry);
     const explicitProviderOverride =
       typeof opts.provider === "string"
         ? normalizeExplicitOverrideInput(opts.provider, "provider")
@@ -1245,6 +1248,21 @@ async function agentCommandInternal(
       !suppressVisibleSessionEffects
     ) {
       const entry = sessionEntry;
+      if (hasLegacyAutoFallbackOverrideWithoutOrigin) {
+        const { updated } = applyModelOverrideToSessionEntry({
+          entry,
+          selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
+        });
+        if (updated) {
+          storedModelOverrideSource = undefined;
+          await persistSessionEntry({
+            sessionStore,
+            sessionKey,
+            storePath,
+            entry,
+          });
+        }
+      }
       const repaired = repairProviderWrappedModelOverride({
         entry,
         defaultProvider,
@@ -1285,8 +1303,12 @@ async function agentCommandInternal(
       }
     }
 
-    const storedProviderOverride = sessionEntry?.providerOverride?.trim();
-    let storedModelOverride = sessionEntry?.modelOverride?.trim();
+    const storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
+      ? undefined
+      : sessionEntry?.providerOverride?.trim();
+    let storedModelOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
+      ? undefined
+      : sessionEntry?.modelOverride?.trim();
     if (storedModelOverride) {
       const candidateProvider = storedProviderOverride || defaultProvider;
       const normalizedStored = normalizeAgentCommandModelRef(
@@ -1620,7 +1642,9 @@ async function agentCommandInternal(
           agentId: sessionAgentId,
           sessionKey,
           hasSessionModelOverride:
-            hasExplicitRunOverride || Boolean(storedProviderOverride || storedModelOverride),
+            hasExplicitRunOverride ||
+            (!hasLegacyAutoFallbackOverrideWithoutOrigin &&
+              Boolean(storedProviderOverride || storedModelOverride)),
           modelOverrideSource: hasExplicitRunOverride ? "user" : storedModelOverrideSource,
           hasAutoFallbackProvenance: hasExplicitRunOverride
             ? false

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -99,9 +99,9 @@ import { resolveAvailableAgentHarnessPolicy } from "./harness/selection.js";
 import { prepareInternalSessionEffectsTranscript } from "./internal-session-effects.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch.js";
-import { normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
 import { loadManifestModelCatalog } from "./model-catalog.js";
 import { runWithModelFallback } from "./model-fallback.js";
+import { normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
 import type { ModelManifestNormalizationContext } from "./model-selection-normalize.js";
 import {
   buildConfiguredModelCatalog,
@@ -1350,7 +1350,12 @@ async function agentCommandInternal(
             )
           : parseAgentCommandModelRef(cfg, explicitModelOverride, provider, modelManifestContext)
         : explicitProviderOverride
-          ? normalizeAgentCommandModelRef(cfg, explicitProviderOverride, model, modelManifestContext)
+          ? normalizeAgentCommandModelRef(
+              cfg,
+              explicitProviderOverride,
+              model,
+              modelManifestContext,
+            )
           : null;
       if (!explicitRef) {
         throw new Error("Invalid model override.");

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
+  hasLegacyAutoFallbackWithoutOrigin,
   markAutoFallbackPrimaryProbe,
   hasConfiguredModelFallbacks,
   resolveAgentConfig,
@@ -677,6 +678,28 @@ describe("resolveAgentConfig", () => {
         probeState: new Map(),
       }),
     ).toBeUndefined();
+  });
+
+  it("identifies legacy auto fallback overrides without origin metadata", () => {
+    expect(
+      hasLegacyAutoFallbackWithoutOrigin({
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "anthropic",
+        modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
+      }),
+    ).toBe(false);
+    expect(
+      hasLegacyAutoFallbackWithoutOrigin({
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: " ",
+        modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
+      }),
+    ).toBe(true);
+    expect(
+      hasLegacyAutoFallbackWithoutOrigin({
+        modelOverrideSource: "user",
+      }),
+    ).toBe(false);
   });
 
   it("recognizes recovered auto fallback provenance without a source marker", () => {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -697,9 +697,17 @@ describe("resolveAgentConfig", () => {
     ).toBe(true);
     expect(
       hasLegacyAutoFallbackWithoutOrigin({
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "anthropic",
+      }),
+    ).toBe(true);
+    expect(
+      hasLegacyAutoFallbackWithoutOrigin({
         modelOverrideSource: "user",
       }),
     ).toBe(false);
+    expect(hasLegacyAutoFallbackWithoutOrigin({})).toBe(false);
+    expect(hasLegacyAutoFallbackWithoutOrigin(undefined)).toBe(false);
   });
 
   it("recognizes recovered auto fallback provenance without a source marker", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -97,6 +97,24 @@ export type AutoFallbackPrimaryProbe = {
   fallbackAuthProfileIdSource?: "auto" | "user";
 };
 
+export function hasLegacyAutoFallbackWithoutOrigin(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "modelOverrideSource"
+        | "modelOverrideFallbackOriginProvider"
+        | "modelOverrideFallbackOriginModel"
+      >
+    | null
+    | undefined,
+): boolean {
+  return (
+    entry?.modelOverrideSource === "auto" &&
+    (!normalizeOptionalString(entry.modelOverrideFallbackOriginProvider) ||
+      !normalizeOptionalString(entry.modelOverrideFallbackOriginModel))
+  );
+}
+
 export function resolveAutoFallbackPrimaryProbe(params: {
   entry:
     | Pick<

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -3,6 +3,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   clearAutoFallbackPrimaryProbeSelection,
+  hasLegacyAutoFallbackWithoutOrigin,
   hasSessionAutoModelFallbackProvenance,
   type AutoFallbackPrimaryProbe,
 } from "../../agents/agent-scope.js";
@@ -1171,10 +1172,15 @@ export async function runPreparedReply(
     }
     resolveActiveRunAcceptsCurrentThread({ isActive });
   }
-  const runHasSessionModelOverride = Boolean(
+  const runHasStoredSessionModelOverride = Boolean(
     normalizeOptionalString(preparedSessionState.sessionEntry?.modelOverride) ||
     normalizeOptionalString(preparedSessionState.sessionEntry?.providerOverride),
   );
+  const runHasLegacyAutoFallbackWithoutOrigin =
+    runHasStoredSessionModelOverride &&
+    hasLegacyAutoFallbackWithoutOrigin(preparedSessionState.sessionEntry);
+  const runHasSessionModelOverride =
+    runHasStoredSessionModelOverride && !runHasLegacyAutoFallbackWithoutOrigin;
   const runModelOverrideSource = runHasSessionModelOverride
     ? preparedSessionState.sessionEntry?.modelOverrideSource
     : undefined;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
+  hasLegacyAutoFallbackWithoutOrigin,
   resolveAutoFallbackPrimaryProbe,
   resolveAgentConfig,
   resolveAgentDir,
@@ -610,10 +611,13 @@ export async function getReplyFromConfig(
     primaryProvider,
     primaryModel,
   });
+  const staleLegacyAutoFallbackWithoutOrigin =
+    storedModelOverride?.source === "session" && hasLegacyAutoFallbackWithoutOrigin(sessionEntry);
   if (
     storedModelOverride?.model &&
     !hasResolvedHeartbeatModelOverride &&
-    !staleHeartbeatAutoFallbackOverride
+    !staleHeartbeatAutoFallbackOverride &&
+    !staleLegacyAutoFallbackWithoutOrigin
   ) {
     provider = storedModelOverride.provider ?? defaultProvider;
     model = storedModelOverride.model;
@@ -629,7 +633,9 @@ export async function getReplyFromConfig(
       })
     : undefined;
   const hasEffectiveSessionModelOverride =
-    hasSessionModelOverride && !staleHeartbeatAutoFallbackOverride;
+    hasSessionModelOverride &&
+    !staleHeartbeatAutoFallbackOverride &&
+    !staleLegacyAutoFallbackWithoutOrigin;
   if (
     !hasResolvedHeartbeatModelOverride &&
     !hasEffectiveSessionModelOverride &&

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1120,19 +1120,20 @@ describe("createModelSelectionState auto-failover overrides", () => {
     return { state, sessionEntry, sessionStore };
   }
 
-  it("preserves auto-failover overrides across turns until reset", async () => {
+  it("clears legacy auto-failover overrides without origin metadata on normal turns", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
       modelOverrideSource: "auto",
     });
 
-    expect(state.provider).toBe("openrouter");
-    expect(state.model).toBe("minimax/minimax-m2.7");
-    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
-    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
-    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
-    expect(state.resetModelOverride).toBe(false);
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
   });
 
   it("clears stale auto-created legacy openai route pins when primary is canonical openai", async () => {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1136,6 +1136,42 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(state.resetModelOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
   });
 
+  it("preserves auto-failover overrides that still carry origin metadata on normal turns", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: defaultProvider,
+      modelOverrideFallbackOriginModel: defaultModel,
+      provider: "openrouter",
+      model: "minimax/minimax-m2.7",
+    });
+
+    expect(state.provider).toBe("openrouter");
+    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
+  });
+
+  it("keeps a legacy auto pin when the current selection already matches it", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      provider: "openrouter",
+      model: "minimax/minimax-m2.7",
+    });
+
+    expect(state.provider).toBe("openrouter");
+    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
+  });
+
   it("clears stale auto-created legacy openai route pins when primary is canonical openai", async () => {
     const sessionEntry = makeEntry({
       providerOverride: "openai",

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -219,9 +219,12 @@ export async function createModelSelectionState(params: {
     normalizeRuntimeModelRef(OPENAI_PROVIDER_ID, directStoredModelOverride.model).model ===
       normalizeRuntimeModelRef(OPENAI_PROVIDER_ID, primaryModel).model;
   const normalizedCurrentSelection = normalizeRuntimeModelRef(provider, model);
-  const normalizedDirectOverride = directStoredOverride
-    ? normalizeRuntimeModelRef(directStoredOverride.provider, directStoredOverride.model)
+  const normalizedDirectOverride = directStoredModelOverride
+    ? normalizeRuntimeModelRef(directStoredModelOverride.provider, directStoredModelOverride.model)
     : null;
+  // Only treat the legacy auto pin as stale when the current selection differs from the stored
+  // override. The current==stored case is the turn that deliberately re-applies the pin (e.g. an
+  // explicit run override); clearing there would fight that intent, so the guard must stay.
   const staleLegacyAutoFallbackWithoutOrigin =
     directStoredModelOverride?.source === "session" &&
     hasLegacyAutoFallbackWithoutOrigin(sessionEntry) &&

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,4 +1,7 @@
-import { resolveAgentConfig } from "../../agents/agent-scope.js";
+import {
+  hasLegacyAutoFallbackWithoutOrigin,
+  resolveAgentConfig,
+} from "../../agents/agent-scope.js";
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -215,8 +218,20 @@ export async function createModelSelectionState(params: {
     primaryHarnessPolicy.runtime === "codex" &&
     normalizeRuntimeModelRef(OPENAI_PROVIDER_ID, directStoredModelOverride.model).model ===
       normalizeRuntimeModelRef(OPENAI_PROVIDER_ID, primaryModel).model;
+  const normalizedCurrentSelection = normalizeRuntimeModelRef(provider, model);
+  const normalizedDirectOverride = directStoredOverride
+    ? normalizeRuntimeModelRef(directStoredOverride.provider, directStoredOverride.model)
+    : null;
+  const staleLegacyAutoFallbackWithoutOrigin =
+    directStoredModelOverride?.source === "session" &&
+    hasLegacyAutoFallbackWithoutOrigin(sessionEntry) &&
+    normalizedDirectOverride !== null &&
+    modelKey(normalizedCurrentSelection.provider, normalizedCurrentSelection.model) !==
+      modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model);
   const staleDirectStoredOverride =
-    staleHeartbeatAutoFallbackOverride || staleLegacyOpenAICodexAutoOverride;
+    staleHeartbeatAutoFallbackOverride ||
+    staleLegacyOpenAICodexAutoOverride ||
+    staleLegacyAutoFallbackWithoutOrigin;
 
   if (needsModelCatalog) {
     modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
@@ -283,14 +298,10 @@ export async function createModelSelectionState(params: {
     }
   }
   if (staleDirectStoredOverride) {
-    const normalizedCurrentSelection = normalizeRuntimeModelRef(provider, model);
     const currentSelectionKey = modelKey(
       normalizedCurrentSelection.provider,
       normalizedCurrentSelection.model,
     );
-    const normalizedDirectOverride = directStoredOverride
-      ? normalizeRuntimeModelRef(directStoredOverride.provider, directStoredOverride.model)
-      : null;
     const directStoredOverrideKey = normalizedDirectOverride
       ? modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model)
       : undefined;

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -865,6 +865,8 @@ describe("agentCommand", () => {
           providerOverride: "anthropic",
           modelOverride: "claude-opus-4-6",
           modelOverrideSource: "auto",
+          modelOverrideFallbackOriginProvider: "openai",
+          modelOverrideFallbackOriginModel: "gpt-4.1-mini",
         },
       });
 
@@ -907,9 +909,65 @@ describe("agentCommand", () => {
         .mocked(runEmbeddedAgent)
         .mock.calls.map((call) => ({ provider: call[0]?.provider, model: call[0]?.model }));
       expect(attempts).toEqual([
-        { provider: "anthropic", model: "claude-opus-4-6" },
+        { provider: "openai", model: "gpt-4.1-mini" },
         { provider: "openai", model: "gpt-5.4" },
       ]);
+    });
+  });
+
+  it("clears legacy auto session model overrides without origin metadata", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions-legacy-auto-override.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:subagent:legacy-auto": {
+          sessionId: "session-legacy-auto",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-6",
+          modelOverrideSource: "auto",
+        },
+      });
+
+      mockConfig(home, store, {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["openai/gpt-5.4"],
+        },
+        models: {
+          "anthropic/claude-opus-4-6": {},
+          "openai/gpt-4.1-mini": {},
+          "openai/gpt-5.4": {},
+        },
+      });
+
+      mockModelCatalogOnce([
+        { id: "claude-opus-4-6", name: "Opus", provider: "anthropic" },
+        { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
+        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+      ]);
+
+      await agentCommand(
+        {
+          message: "hi",
+          sessionKey: "agent:main:subagent:legacy-auto",
+        },
+        runtime,
+      );
+
+      const attempts = vi
+        .mocked(runEmbeddedAgent)
+        .mock.calls.map((call) => ({ provider: call[0]?.provider, model: call[0]?.model }));
+      expect(attempts).toEqual([{ provider: "openai", model: "gpt-4.1-mini" }]);
+
+      const cleared = readSessionStore<{
+        providerOverride?: string;
+        modelOverride?: string;
+        modelOverrideSource?: string;
+      }>(store);
+      const entry = cleared["agent:main:subagent:legacy-auto"];
+      expect(entry?.providerOverride).toBeUndefined();
+      expect(entry?.modelOverride).toBeUndefined();
+      expect(entry?.modelOverrideSource).toBeUndefined();
     });
   });
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -855,7 +855,7 @@ describe("agentCommand", () => {
     });
   });
 
-  it("uses default fallback list for auto session model overrides", async () => {
+  it("probes the configured primary first for origin-backed auto session model overrides", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
       writeSessionStoreSeed(store, {


### PR DESCRIPTION
## Summary

This PR fixes sessions that were left pinned to an auto-selected fallback model when the persisted session entry does not contain fallback-origin metadata.

- Root cause: `modelOverrideSource: "auto"` session entries without `modelOverrideFallbackOriginProvider` / `modelOverrideFallbackOriginModel` could still be treated as effective session overrides, so later normal turns reused the stale fallback instead of returning to the configured primary.
- The fix recognizes that missing-origin shape as legacy fallback state, clears it through the existing session override reset path, and prevents both reply and direct `openclaw agent` run metadata from treating it as an effective user/session override.
- Valid auto fallback selections with origin metadata keep their primary-probe behavior; user-selected overrides are unchanged.
- Intentionally out of scope: provider catalog/auth setup, new doctor migrations, UI screenshot proof, and broader fallback policy changes.
- Review focus: session override clearing, primary/fallback selection behavior, and the direct agent command path.

## Linked context

Closes #87467

Related #87467

Was this requested by a maintainer or owner? No direct owner request; this is a focused bug fix for the linked issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A session with a persisted `modelOverrideSource: "auto"` fallback but no fallback-origin metadata no longer stays pinned to the stale fallback model on later normal turns. The next turn clears the stale auto pin and starts from the configured primary model.
- Real environment tested: Local macOS OpenClaw Gateway, LaunchAgent-managed gateway, existing local Google/Gemini provider config. No OpenAI key was used.
- Exact steps or command run after this patch:
  1. Seeded a temporary affected session state for `agent:main:dashboard:fallback-proof`:
     - `providerOverride: "google"`
     - `modelOverride: "gemini-2.0-flash"`
     - `modelOverrideSource: "auto"`
     - no `modelOverrideFallbackOriginProvider`
     - no `modelOverrideFallbackOriginModel`
     - configured primary remained `google/gemini-2.5-flash`
  2. Restarted the managed Gateway from the patched build:
     - `pnpm build`
     - `pnpm openclaw gateway restart`
     - `pnpm openclaw gateway status --deep`
  3. Ran a real Gateway-backed agent turn:
     - `pnpm openclaw agent --session-key agent:main:dashboard:fallback-proof --message "Live proof after patch. Reply with exactly: proof-after" --json --timeout 120`
- Evidence after fix:

```json
{
  "time": "2026-05-27T22:33:18.649-04:00",
  "message": "model fallback decision",
  "event": "model_fallback_decision",
  "runId": "95d987b0-f6f0-4205-9fba-08d10cfc7687",
  "decision": "candidate_failed",
  "requestedProvider": "google",
  "requestedModel": "gemini-2.5-flash",
  "candidateProvider": "google",
  "candidateModel": "gemini-2.5-flash",
  "attempt": 1,
  "total": 1,
  "reason": "model_not_found",
  "errorPreview": "Unknown model: google/gemini-2.5-flash",
  "fallbackStepType": "fallback_step",
  "fallbackStepFromModel": "google/gemini-2.5-flash",
  "fallbackStepFromFailureReason": "model_not_found",
  "fallbackStepFinalOutcome": "chain_exhausted",
  "isPrimary": true,
  "requestedModelMatched": true,
  "fallbackConfigured": false
}
```

Before evidence from the same affected state before the final fix:

```json
{
  "time": "2026-05-27T22:24:50.280-04:00",
  "message": "model fallback decision",
  "event": "model_fallback_decision",
  "runId": "88613a50-285f-4236-a4ab-6b16da4ab1f4",
  "decision": "candidate_failed",
  "requestedProvider": "google",
  "requestedModel": "gemini-2.0-flash",
  "candidateProvider": "google",
  "candidateModel": "gemini-2.0-flash",
  "attempt": 1,
  "total": 1,
  "reason": "model_not_found",
  "errorPreview": "Unknown model: google/gemini-2.0-flash",
  "fallbackStepType": "fallback_step",
  "fallbackStepFromModel": "google/gemini-2.0-flash",
  "fallbackStepFromFailureReason": "model_not_found",
  "fallbackStepFinalOutcome": "chain_exhausted",
  "isPrimary": true,
  "requestedModelMatched": true,
  "fallbackConfigured": false
}
```

- Observed result after fix: The stale fallback pin was cleared before the run. The real Gateway turn no longer requested `google/gemini-2.0-flash`; it requested the configured primary `google/gemini-2.5-flash`.
- What was not tested: A successful provider completion was not tested because this local Google/Gemini setup rejected the selected model/catalog. That is separate from this bug; the proof here is the model-selection behavior changing from stale fallback to configured primary on a real Gateway turn.
- Proof limitations or environment constraints: No OpenAI key was available locally, so the live proof used Google/Gemini model ids. The Gateway/agent path was real; only the final provider completion was blocked by local provider catalog/auth setup.

## Tests and validation

Which commands did you run?

- `pnpm exec oxfmt --write --threads=1 src/agents/agent-command.ts src/agents/agent-scope.ts src/agents/agent-scope.test.ts src/commands/agent.test.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/model-selection.ts src/auto-reply/reply/model-selection.test.ts`
- `git diff --check`
- `pnpm test src/commands/agent.test.ts -t "uses default fallback list for auto session model overrides|clears legacy auto session model overrides without origin metadata"`
- `pnpm test src/auto-reply/reply/model-selection.test.ts -t "clears legacy auto-failover overrides without origin metadata on normal turns|can suppress a stored auto-failover override for a primary recovery probe|keeps pre-loaded fallback provider/model for an auto-failover override|keeps explicit user openai-codex route overrides"`
- `pnpm test src/agents/agent-scope.test.ts -t "identifies legacy auto fallback overrides without origin metadata|resolves throttled primary probes for auto fallback selections|skips primary probes for strict or stale fallback selections|recognizes recovered auto fallback provenance without a source marker"`
- `pnpm check:changed`
- `pnpm build`

What regression coverage was added or updated?

- Updated model-selection coverage to assert missing-origin auto fallback overrides clear back to the configured default and persist the reset side effects.
- Added direct `openclaw agent` command coverage for missing-origin auto fallback overrides, including the selected primary model and cleared persisted override fields.
- Added helper coverage for whitespace/missing origin metadata and for preserving user overrides.

What failed before this fix, if known?

- A seeded stale auto fallback entry without origin metadata caused real Gateway agent turns to request the stale fallback model (`google/gemini-2.0-flash`) instead of the configured primary (`google/gemini-2.5-flash`).

If no test was added, why not?

- Not applicable.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Legacy auto fallback pins without origin metadata now reset to the configured primary on the next normal turn.

Did config, environment, or migration behavior change? (`Yes/No`)

No config/default/environment surface changed. This is runtime session-state cleanup during existing model selection paths.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. Security/runtime controls are unchanged: provider auth, secret handling, network access, tool execution policy, and prompt/tool permissions are not modified. The fix relies on runtime-enforced session metadata checks, not prompt text.

What is the highest-risk area?

Model selection for sessions that currently have persisted auto fallback overrides.

How is that risk mitigated?

The reset only applies to `modelOverrideSource: "auto"` entries missing fallback-origin metadata. Entries with valid auto fallback provenance keep primary-probe behavior, and `modelOverrideSource: "user"` overrides remain effective.

## Current review state

What is the next action?

Waiting on CI and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI has not run yet. No additional author action is known.

Which bot or reviewer comments were addressed?

No bot or reviewer comments yet.

AI-assisted: yes.

Made with [Cursor](https://cursor.com)