### PR TITLE
fix(agents): enforce subagent run timeouts

### DIFF
--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -475,6 +475,23 @@ describe("subagent announce timeout config", () => {
     expect(internalEvents[0]?.result).not.toContain("data");
   });
 
+  it("keeps delete-mode timeout retryable while the embedded child request is still active", async () => {
+    sessionStore["agent:main:subagent:worker"] = {
+      sessionId: "child-session",
+    };
+    isEmbeddedAgentRunActiveMock.mockReturnValue(true);
+    waitForEmbeddedAgentRunEndMock.mockResolvedValue(false);
+
+    const didAnnounce = await runAnnounceFlowForTest("run-timeout-delete-still-active", {
+      cleanup: "delete",
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+    });
+
+    expect(didAnnounce).toBe(false);
+    expect(findFinalDirectAgentCall()).toBeUndefined();
+  });
+
   it("does not announce cached reply text when the child run terminally failed", async () => {
     chatHistoryMessages = [
       { role: "assistant", content: [{ type: "text", text: "stale history output" }] },

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -273,7 +273,10 @@ export async function runSubagentAnnounceFlow(params: {
       const settled = await waitForEmbeddedAgentRunEnd(childSessionId, settleTimeoutMs);
       if (!settled && isEmbeddedAgentRunActive(childSessionId)) {
         shouldDeleteChildSession = false;
-        return false;
+        // Keep delete cleanup retryable until the active child can be removed.
+        if (outcome?.status !== "timeout" || params.cleanup === "delete") {
+          return false;
+        }
       }
     }
 

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -75,6 +75,53 @@ async function loadCleanupBrowserSessionsForLifecycleEnd(): Promise<
   return (await browserCleanupLoader.load()).cleanupBrowserSessionsForLifecycleEnd;
 }
 
+function resolveSubagentRunDeadlineMs(
+  entry: SubagentRunRecord,
+  observedStartedAt?: number,
+): number | undefined {
+  const timeoutSeconds = entry.runTimeoutSeconds;
+  if (
+    typeof timeoutSeconds !== "number" ||
+    !Number.isFinite(timeoutSeconds) ||
+    timeoutSeconds <= 0
+  ) {
+    return undefined;
+  }
+  const startedAt =
+    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
+      ? observedStartedAt
+      : typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
+        ? entry.startedAt
+        : entry.createdAt;
+  return Number.isFinite(startedAt) ? startedAt + Math.floor(timeoutSeconds * 1000) : undefined;
+}
+
+function shouldPreserveExplicitRunTimeout(params: { entry: SubagentRunRecord }): boolean {
+  if (params.entry.outcome?.status !== "timeout" || typeof params.entry.endedAt !== "number") {
+    return false;
+  }
+  if (
+    params.entry.cleanupHandled ||
+    typeof params.entry.cleanupCompletedAt === "number" ||
+    typeof params.entry.endedHookEmittedAt === "number" ||
+    params.entry.delivery?.status === "delivered" ||
+    typeof params.entry.delivery?.announcedAt === "number"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function resolveExpiredExplicitRunDeadlineMs(params: {
+  entry: SubagentRunRecord;
+  nextOutcome: SubagentRunOutcome;
+  nextEndedAt: number;
+  observedStartedAt?: number;
+}): number | undefined {
+  const deadlineMs = resolveSubagentRunDeadlineMs(params.entry, params.observedStartedAt);
+  return deadlineMs !== undefined && params.nextEndedAt > deadlineMs ? deadlineMs : undefined;
+}
+
 export function createSubagentRegistryLifecycleController(params: {
   runs: Map<string, SubagentRunRecord>;
   resumedRuns: Set<string>;
@@ -1016,6 +1063,7 @@ export function createSubagentRegistryLifecycleController(params: {
     sendFarewell?: boolean;
     accountId?: string;
     triggerCleanup: boolean;
+    startedAt?: number;
   }) => {
     params.clearPendingLifecycleError(completeParams.runId);
     const entry = params.runs.get(completeParams.runId);
@@ -1036,8 +1084,40 @@ export function createSubagentRegistryLifecycleController(params: {
       mutated = true;
     }
 
-    const endedAt =
-      typeof completeParams.endedAt === "number" ? completeParams.endedAt : Date.now();
+    let endedAt = typeof completeParams.endedAt === "number" ? completeParams.endedAt : Date.now();
+    let completionOutcome = completeParams.outcome;
+    let completionReason = completeParams.reason;
+    if (
+      shouldPreserveExplicitRunTimeout({
+        entry,
+      })
+    ) {
+      return;
+    }
+
+    const observedStartedAt =
+      typeof completeParams.startedAt === "number" && Number.isFinite(completeParams.startedAt)
+        ? completeParams.startedAt
+        : undefined;
+    if (observedStartedAt !== undefined && entry.startedAt !== observedStartedAt) {
+      entry.startedAt = observedStartedAt;
+      if (typeof entry.sessionStartedAt !== "number") {
+        entry.sessionStartedAt = observedStartedAt;
+      }
+      mutated = true;
+    }
+
+    const expiredDeadlineMs = resolveExpiredExplicitRunDeadlineMs({
+      entry,
+      nextOutcome: completionOutcome,
+      nextEndedAt: endedAt,
+      observedStartedAt,
+    });
+    if (expiredDeadlineMs !== undefined) {
+      endedAt = expiredDeadlineMs;
+      completionOutcome = { status: "timeout" };
+      completionReason = SUBAGENT_ENDED_REASON_COMPLETE;
+    }
     if (entry.endedAt !== endedAt) {
       entry.endedAt = endedAt;
       entry.execution = {
@@ -1048,7 +1128,7 @@ export function createSubagentRegistryLifecycleController(params: {
       };
       mutated = true;
     }
-    const outcome = withSubagentOutcomeTiming(completeParams.outcome, {
+    const outcome = withSubagentOutcomeTiming(completionOutcome, {
       startedAt: entry.startedAt,
       endedAt,
     });
@@ -1070,8 +1150,8 @@ export function createSubagentRegistryLifecycleController(params: {
       };
       mutated = true;
     }
-    if (entry.endedReason !== completeParams.reason) {
-      entry.endedReason = completeParams.reason;
+    if (entry.endedReason !== completionReason) {
+      entry.endedReason = completionReason;
       mutated = true;
     }
     if (entry.pauseReason !== undefined) {
@@ -1114,7 +1194,7 @@ export function createSubagentRegistryLifecycleController(params: {
       !suppressedForSteerRestart &&
       params.shouldEmitEndedHookForRun({
         entry,
-        reason: completeParams.reason,
+        reason: completionReason,
       });
     const shouldDeferEndedHook =
       shouldEmitEndedHook &&
@@ -1124,7 +1204,7 @@ export function createSubagentRegistryLifecycleController(params: {
     if (!shouldDeferEndedHook && shouldEmitEndedHook) {
       await params.emitSubagentEndedHookForRun({
         entry,
-        reason: completeParams.reason,
+        reason: completionReason,
         sendFarewell: completeParams.sendFarewell,
         accountId: completeParams.accountId,
       });

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -96,12 +96,11 @@ function resolveSubagentRunDeadlineMs(
   return Number.isFinite(startedAt) ? startedAt + Math.floor(timeoutSeconds * 1000) : undefined;
 }
 
-function shouldPreserveExplicitRunTimeout(params: { entry: SubagentRunRecord }): boolean {
+function shouldPreservePublishedExplicitRunTimeout(params: { entry: SubagentRunRecord }): boolean {
   if (params.entry.outcome?.status !== "timeout" || typeof params.entry.endedAt !== "number") {
     return false;
   }
   if (
-    params.entry.cleanupHandled ||
     typeof params.entry.cleanupCompletedAt === "number" ||
     typeof params.entry.endedHookEmittedAt === "number" ||
     params.entry.delivery?.status === "delivered" ||
@@ -1088,7 +1087,7 @@ export function createSubagentRegistryLifecycleController(params: {
     let completionOutcome = completeParams.outcome;
     let completionReason = completeParams.reason;
     if (
-      shouldPreserveExplicitRunTimeout({
+      shouldPreservePublishedExplicitRunTimeout({
         entry,
       })
     ) {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -111,6 +111,7 @@ function shouldPreservePublishedExplicitRunTimeout(params: { entry: SubagentRunR
     return false;
   }
   if (
+    params.entry.cleanupHandled ||
     typeof params.entry.cleanupCompletedAt === "number" ||
     typeof params.entry.endedHookEmittedAt === "number" ||
     params.entry.delivery?.status === "delivered" ||

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -106,6 +106,10 @@ function shouldPreservePublishedExplicitRunTimeout(params: { entry: SubagentRunR
   ) {
     return false;
   }
+  const deadlineMs = resolveSubagentRunDeadlineMs(params.entry);
+  if (deadlineMs === undefined || params.entry.endedAt < deadlineMs) {
+    return false;
+  }
   if (
     typeof params.entry.cleanupCompletedAt === "number" ||
     typeof params.entry.endedHookEmittedAt === "number" ||

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -567,6 +567,26 @@ export function createSubagentRegistryLifecycleController(params: {
     delivery.payload = payload;
   };
 
+  const refreshPendingFinalDeliveryPayload = (entry: SubagentRunRecord): boolean => {
+    const delivery = entry.delivery;
+    if (
+      !delivery?.payload ||
+      delivery.status === "delivered" ||
+      typeof delivery.announcedAt === "number"
+    ) {
+      return false;
+    }
+    delivery.payload = {
+      ...delivery.payload,
+      startedAt: entry.startedAt,
+      endedAt: entry.endedAt,
+      outcome: entry.outcome,
+      frozenResultText: entry.completion?.resultText,
+      fallbackFrozenResultText: entry.completion?.fallbackResultText,
+    };
+    return true;
+  };
+
   const suspendPendingFinalDelivery = (args: {
     runId: string;
     entry: SubagentRunRecord;
@@ -1165,6 +1185,9 @@ export function createSubagentRegistryLifecycleController(params: {
     }
 
     if (await freezeRunResultAtCompletion(entry, outcome)) {
+      mutated = true;
+    }
+    if (refreshPendingFinalDeliveryPayload(entry)) {
       mutated = true;
     }
 

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -97,7 +97,13 @@ function resolveSubagentRunDeadlineMs(
 }
 
 function shouldPreservePublishedExplicitRunTimeout(params: { entry: SubagentRunRecord }): boolean {
-  if (params.entry.outcome?.status !== "timeout" || typeof params.entry.endedAt !== "number") {
+  if (
+    typeof params.entry.runTimeoutSeconds !== "number" ||
+    !Number.isFinite(params.entry.runTimeoutSeconds) ||
+    params.entry.runTimeoutSeconds <= 0 ||
+    params.entry.outcome?.status !== "timeout" ||
+    typeof params.entry.endedAt !== "number"
+  ) {
     return false;
   }
   if (

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -46,7 +46,10 @@ function shouldDeleteAttachments(entry: SubagentRunRecord) {
   return entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep;
 }
 
-function resolveSubagentRunDeadlineMs(entry: SubagentRunRecord): number | undefined {
+function resolveSubagentRunDeadlineMs(
+  entry: SubagentRunRecord,
+  observedStartedAt?: number,
+): number | undefined {
   const timeoutSeconds = entry.runTimeoutSeconds;
   if (
     typeof timeoutSeconds !== "number" ||
@@ -56,9 +59,11 @@ function resolveSubagentRunDeadlineMs(entry: SubagentRunRecord): number | undefi
     return undefined;
   }
   const startedAt =
-    typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
-      ? entry.startedAt
-      : entry.createdAt;
+    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
+      ? observedStartedAt
+      : typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
+        ? entry.startedAt
+        : entry.createdAt;
   if (!Number.isFinite(startedAt)) {
     return undefined;
   }
@@ -68,12 +73,30 @@ function resolveSubagentRunDeadlineMs(entry: SubagentRunRecord): number | undefi
 function resolveHardRunTimeoutEndedAt(
   entry: SubagentRunRecord,
   now: number,
+  observedStartedAt?: number,
 ): number | undefined {
-  const deadlineMs = resolveSubagentRunDeadlineMs(entry);
+  const deadlineMs = resolveSubagentRunDeadlineMs(entry, observedStartedAt);
   if (deadlineMs === undefined) {
     return undefined;
   }
   return now + WAIT_TIMEOUT_DEADLINE_SKEW_MS >= deadlineMs ? deadlineMs : undefined;
+}
+
+function resolveCompletionAfterHardRunDeadline(params: {
+  entry: SubagentRunRecord;
+  observedStartedAt?: number;
+  observedEndedAt?: number;
+  now: number;
+}): number | undefined {
+  const deadlineMs = resolveSubagentRunDeadlineMs(params.entry, params.observedStartedAt);
+  if (deadlineMs === undefined) {
+    return undefined;
+  }
+  const observedEndedAt =
+    typeof params.observedEndedAt === "number" && Number.isFinite(params.observedEndedAt)
+      ? params.observedEndedAt
+      : params.now;
+  return observedEndedAt > deadlineMs ? deadlineMs : undefined;
 }
 
 function resolveWaitTimeoutMsForRun(
@@ -203,6 +226,7 @@ export function createSubagentRunManager(params: {
     sendFarewell?: boolean;
     accountId?: string;
     triggerCleanup: boolean;
+    startedAt?: number;
   }): Promise<void>;
 }) {
   const waitForSubagentCompletion = async (
@@ -268,23 +292,72 @@ export function createSubagentRunManager(params: {
         scheduleWaitRetry(entry, "subagent wait interrupted; scheduling recovery", wait.error);
         return;
       }
+      const completeAsRunTimeout = async (endedAt?: number, startedAt?: number) => {
+        if (typeof startedAt === "number" && Number.isFinite(startedAt)) {
+          entry.startedAt = startedAt;
+          if (typeof entry.sessionStartedAt !== "number") {
+            entry.sessionStartedAt = startedAt;
+          }
+        }
+        const timeoutCompletion: Parameters<typeof params.completeSubagentRun>[0] = {
+          runId,
+          outcome: { status: "timeout" },
+          reason: SUBAGENT_ENDED_REASON_COMPLETE,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
+        };
+        if (typeof endedAt === "number") {
+          timeoutCompletion.endedAt = endedAt;
+        }
+        if (typeof startedAt === "number" && Number.isFinite(startedAt)) {
+          timeoutCompletion.startedAt = startedAt;
+        }
+        completionForRetry = timeoutCompletion;
+        await params.completeSubagentRun(completionForRetry);
+      };
       if (waitStatus === "timeout") {
         const isTerminalWaitTimeout =
           typeof wait.endedAt === "number" ||
           typeof wait.stopReason === "string" ||
           typeof wait.livenessState === "string";
         const now = Date.now();
+        const observedStartedAt =
+          typeof wait.startedAt === "number" && Number.isFinite(wait.startedAt)
+            ? wait.startedAt
+            : undefined;
+        if (observedStartedAt !== undefined && entry.startedAt !== observedStartedAt) {
+          entry.startedAt = observedStartedAt;
+          if (typeof entry.sessionStartedAt !== "number") {
+            entry.sessionStartedAt = observedStartedAt;
+          }
+          params.persist();
+        }
         // A plain agent.wait timeout has no terminal snapshot. For explicit
         // subagent run timeouts, the stored run deadline is the completion
         // contract so parent sessions are woken instead of retrying forever.
-        const hardRunTimeoutEndedAt = resolveHardRunTimeoutEndedAt(entry, now);
+        const hardRunTimeoutEndedAt = resolveHardRunTimeoutEndedAt(entry, now, observedStartedAt);
         const completion = params.resolveSubagentSessionCompletion({
           childSessionKey: entry.childSessionKey,
           fallbackEndedAt:
             typeof wait.endedAt === "number" ? wait.endedAt : (hardRunTimeoutEndedAt ?? now),
-          notBeforeMs: entry.startedAt ?? entry.createdAt,
+          notBeforeMs: observedStartedAt ?? entry.startedAt ?? entry.createdAt,
         });
         if (completion) {
+          const completionStartedAt = observedStartedAt;
+          const completionAfterDeadline =
+            completionStartedAt === undefined
+              ? undefined
+              : resolveCompletionAfterHardRunDeadline({
+                  entry,
+                  observedStartedAt: completionStartedAt,
+                  observedEndedAt: completion.endedAt,
+                  now,
+                });
+          if (completionAfterDeadline !== undefined) {
+            await completeAsRunTimeout(completionAfterDeadline, completionStartedAt);
+            return;
+          }
           completionForRetry = {
             runId,
             endedAt: completion.endedAt,
@@ -293,27 +366,40 @@ export function createSubagentRunManager(params: {
             sendFarewell: true,
             accountId: entry.requesterOrigin?.accountId,
             triggerCleanup: true,
+            startedAt: completionStartedAt,
           };
           await params.completeSubagentRun(completionForRetry);
           return;
         }
         if (isTerminalWaitTimeout || hardRunTimeoutEndedAt !== undefined) {
-          completionForRetry = {
-            runId,
-            endedAt: typeof wait.endedAt === "number" ? wait.endedAt : hardRunTimeoutEndedAt,
-            outcome: { status: "timeout" },
-            reason: SUBAGENT_ENDED_REASON_COMPLETE,
-            sendFarewell: true,
-            accountId: entry.requesterOrigin?.accountId,
-            triggerCleanup: true,
-          };
-          await params.completeSubagentRun(completionForRetry);
+          let timeoutEndedAt =
+            typeof wait.endedAt === "number" ? wait.endedAt : hardRunTimeoutEndedAt;
+          const timeoutAfterDeadline = resolveCompletionAfterHardRunDeadline({
+            entry,
+            observedStartedAt: wait.startedAt,
+            observedEndedAt: timeoutEndedAt,
+            now,
+          });
+          if (timeoutAfterDeadline !== undefined) {
+            timeoutEndedAt = timeoutAfterDeadline;
+          }
+          await completeAsRunTimeout(timeoutEndedAt, wait.startedAt);
           return;
         }
         scheduleWaitRetry(
           entry,
           "subagent wait timed out; deferring terminal state until session reconciliation",
         );
+        return;
+      }
+      const completionAfterDeadline = resolveCompletionAfterHardRunDeadline({
+        entry,
+        observedStartedAt: wait.startedAt,
+        observedEndedAt: wait.endedAt,
+        now: Date.now(),
+      });
+      if (completionAfterDeadline !== undefined) {
+        await completeAsRunTimeout(completionAfterDeadline, wait.startedAt);
         return;
       }
       let mutated = false;
@@ -363,6 +449,7 @@ export function createSubagentRunManager(params: {
         sendFarewell: true,
         accountId: entry.requesterOrigin?.accountId,
         triggerCleanup: true,
+        startedAt: wait.startedAt,
       };
       await params.completeSubagentRun(completionForRetry);
     } catch (error) {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -352,15 +352,12 @@ export function createSubagentRunManager(params: {
         });
         if (completion) {
           const completionStartedAt = observedStartedAt ?? completion.startedAt;
-          const completionAfterDeadline =
-            completionStartedAt === undefined
-              ? undefined
-              : resolveCompletionAfterHardRunDeadline({
-                  entry,
-                  observedStartedAt: completionStartedAt,
-                  observedEndedAt: completion.endedAt,
-                  now,
-                });
+          const completionAfterDeadline = resolveCompletionAfterHardRunDeadline({
+            entry,
+            observedStartedAt: completionStartedAt,
+            observedEndedAt: completion.endedAt,
+            now,
+          });
           if (completionAfterDeadline !== undefined) {
             await completeAsRunTimeout(completionAfterDeadline, completionStartedAt);
             return;

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -40,9 +40,53 @@ import type { SubagentSessionCompletion } from "./subagent-session-reconciliatio
 
 const log = createSubsystemLogger("agents/subagent-registry");
 const RECOVERABLE_WAIT_RETRY_DELAY_MS = process.env.OPENCLAW_TEST_FAST === "1" ? 25 : 5_000;
+const WAIT_TIMEOUT_DEADLINE_SKEW_MS = 250;
 
 function shouldDeleteAttachments(entry: SubagentRunRecord) {
   return entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep;
+}
+
+function resolveSubagentRunDeadlineMs(entry: SubagentRunRecord): number | undefined {
+  const timeoutSeconds = entry.runTimeoutSeconds;
+  if (
+    typeof timeoutSeconds !== "number" ||
+    !Number.isFinite(timeoutSeconds) ||
+    timeoutSeconds <= 0
+  ) {
+    return undefined;
+  }
+  const startedAt =
+    typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
+      ? entry.startedAt
+      : entry.createdAt;
+  if (!Number.isFinite(startedAt)) {
+    return undefined;
+  }
+  return startedAt + Math.floor(timeoutSeconds * 1000);
+}
+
+function resolveHardRunTimeoutEndedAt(
+  entry: SubagentRunRecord,
+  now: number,
+): number | undefined {
+  const deadlineMs = resolveSubagentRunDeadlineMs(entry);
+  if (deadlineMs === undefined) {
+    return undefined;
+  }
+  return now + WAIT_TIMEOUT_DEADLINE_SKEW_MS >= deadlineMs ? deadlineMs : undefined;
+}
+
+function resolveWaitTimeoutMsForRun(
+  entry: SubagentRunRecord,
+  waitTimeoutMs: number,
+  now: number,
+): number {
+  const normalizedWaitTimeoutMs = Math.max(1, Math.floor(waitTimeoutMs));
+  const deadlineMs = resolveSubagentRunDeadlineMs(entry);
+  if (deadlineMs === undefined) {
+    return normalizedWaitTimeoutMs;
+  }
+  return Math.max(1, Math.min(normalizedWaitTimeoutMs, deadlineMs - now));
 }
 
 export function markSubagentRunPausedAfterYield(params: {
@@ -165,6 +209,7 @@ export function createSubagentRunManager(params: {
     runId: string,
     waitTimeoutMs: number,
     expectedEntry?: SubagentRunRecord,
+    capWaitToStoredDeadline = false,
   ) => {
     let completionForRetry: Parameters<typeof params.completeSubagentRun>[0] | undefined;
     const scheduleWaitRetry = (entry: SubagentRunRecord, reason: string, error?: string) => {
@@ -175,7 +220,7 @@ export function createSubagentRunManager(params: {
         if (!current || current !== scheduledEntry || typeof current.endedAt === "number") {
           return;
         }
-        void waitForSubagentCompletion(runId, waitTimeoutMs, scheduledEntry);
+        void waitForSubagentCompletion(runId, waitTimeoutMs, scheduledEntry, true);
       }, RECOVERABLE_WAIT_RETRY_DELAY_MS).unref?.();
       log.info(reason, {
         runId,
@@ -184,9 +229,17 @@ export function createSubagentRunManager(params: {
       });
     };
     try {
+      const entryBeforeWait = params.runs.get(runId);
+      if (!entryBeforeWait || (expectedEntry && entryBeforeWait !== expectedEntry)) {
+        return;
+      }
+      const waitStartedAt = Date.now();
+      const timeoutMs = capWaitToStoredDeadline
+        ? resolveWaitTimeoutMsForRun(entryBeforeWait, waitTimeoutMs, waitStartedAt)
+        : Math.max(1, Math.floor(waitTimeoutMs));
       const wait = await waitForAgentRun({
         runId,
-        timeoutMs: Math.max(1, Math.floor(waitTimeoutMs)),
+        timeoutMs,
         callGateway: params.callGateway,
       });
       const entry = params.runs.get(runId);
@@ -220,9 +273,15 @@ export function createSubagentRunManager(params: {
           typeof wait.endedAt === "number" ||
           typeof wait.stopReason === "string" ||
           typeof wait.livenessState === "string";
+        const now = Date.now();
+        // A plain agent.wait timeout has no terminal snapshot. For explicit
+        // subagent run timeouts, the stored run deadline is the completion
+        // contract so parent sessions are woken instead of retrying forever.
+        const hardRunTimeoutEndedAt = resolveHardRunTimeoutEndedAt(entry, now);
         const completion = params.resolveSubagentSessionCompletion({
           childSessionKey: entry.childSessionKey,
-          fallbackEndedAt: typeof wait.endedAt === "number" ? wait.endedAt : Date.now(),
+          fallbackEndedAt:
+            typeof wait.endedAt === "number" ? wait.endedAt : (hardRunTimeoutEndedAt ?? now),
           notBeforeMs: entry.startedAt ?? entry.createdAt,
         });
         if (completion) {
@@ -238,10 +297,10 @@ export function createSubagentRunManager(params: {
           await params.completeSubagentRun(completionForRetry);
           return;
         }
-        if (isTerminalWaitTimeout) {
+        if (isTerminalWaitTimeout || hardRunTimeoutEndedAt !== undefined) {
           completionForRetry = {
             runId,
-            endedAt: wait.endedAt,
+            endedAt: typeof wait.endedAt === "number" ? wait.endedAt : hardRunTimeoutEndedAt,
             outcome: { status: "timeout" },
             reason: SUBAGENT_ENDED_REASON_COMPLETE,
             sendFarewell: true,

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -296,6 +296,13 @@ export function createSubagentRunManager(params: {
         scheduleWaitRetry(entry, "subagent wait interrupted; scheduling recovery", wait.error);
         return;
       }
+      const observedStartedAt =
+        typeof wait.startedAt === "number" && Number.isFinite(wait.startedAt)
+          ? wait.startedAt
+          : params.resolveSubagentSessionStartedAt({
+              childSessionKey: entry.childSessionKey,
+              notBeforeMs: entry.startedAt ?? entry.createdAt,
+            });
       const completeAsRunTimeout = async (endedAt?: number, startedAt?: number) => {
         if (typeof startedAt === "number" && Number.isFinite(startedAt)) {
           entry.startedAt = startedAt;
@@ -326,13 +333,6 @@ export function createSubagentRunManager(params: {
           typeof wait.stopReason === "string" ||
           typeof wait.livenessState === "string";
         const now = Date.now();
-        const observedStartedAt =
-          typeof wait.startedAt === "number" && Number.isFinite(wait.startedAt)
-            ? wait.startedAt
-            : params.resolveSubagentSessionStartedAt({
-                childSessionKey: entry.childSessionKey,
-                notBeforeMs: entry.startedAt ?? entry.createdAt,
-              });
         if (observedStartedAt !== undefined && entry.startedAt !== observedStartedAt) {
           entry.startedAt = observedStartedAt;
           if (typeof entry.sessionStartedAt !== "number") {
@@ -380,14 +380,14 @@ export function createSubagentRunManager(params: {
             typeof wait.endedAt === "number" ? wait.endedAt : hardRunTimeoutEndedAt;
           const timeoutAfterDeadline = resolveCompletionAfterHardRunDeadline({
             entry,
-            observedStartedAt: wait.startedAt,
+            observedStartedAt,
             observedEndedAt: timeoutEndedAt,
             now,
           });
           if (timeoutAfterDeadline !== undefined) {
             timeoutEndedAt = timeoutAfterDeadline;
           }
-          await completeAsRunTimeout(timeoutEndedAt, wait.startedAt);
+          await completeAsRunTimeout(timeoutEndedAt, observedStartedAt);
           return;
         }
         scheduleWaitRetry(
@@ -398,19 +398,19 @@ export function createSubagentRunManager(params: {
       }
       const completionAfterDeadline = resolveCompletionAfterHardRunDeadline({
         entry,
-        observedStartedAt: wait.startedAt,
+        observedStartedAt,
         observedEndedAt: wait.endedAt,
         now: Date.now(),
       });
       if (completionAfterDeadline !== undefined) {
-        await completeAsRunTimeout(completionAfterDeadline, wait.startedAt);
+        await completeAsRunTimeout(completionAfterDeadline, observedStartedAt);
         return;
       }
       let mutated = false;
-      if (typeof wait.startedAt === "number") {
-        entry.startedAt = wait.startedAt;
+      if (typeof observedStartedAt === "number") {
+        entry.startedAt = observedStartedAt;
         if (typeof entry.sessionStartedAt !== "number") {
-          entry.sessionStartedAt = wait.startedAt;
+          entry.sessionStartedAt = observedStartedAt;
         }
         mutated = true;
       }
@@ -453,7 +453,7 @@ export function createSubagentRunManager(params: {
         sendFarewell: true,
         accountId: entry.requesterOrigin?.accountId,
         triggerCleanup: true,
-        startedAt: wait.startedAt,
+        startedAt: observedStartedAt,
       };
       await params.completeSubagentRun(completionForRetry);
     } catch (error) {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -206,6 +206,10 @@ export function createSubagentRunManager(params: {
     fallbackEndedAt: number;
     notBeforeMs?: number;
   }): SubagentSessionCompletion | null;
+  resolveSubagentSessionStartedAt(args: {
+    childSessionKey: string;
+    notBeforeMs?: number;
+  }): number | undefined;
   notifyContextEngineSubagentEnded(args: {
     childSessionKey: string;
     reason: "completed" | "deleted" | "released";
@@ -325,7 +329,10 @@ export function createSubagentRunManager(params: {
         const observedStartedAt =
           typeof wait.startedAt === "number" && Number.isFinite(wait.startedAt)
             ? wait.startedAt
-            : undefined;
+            : params.resolveSubagentSessionStartedAt({
+                childSessionKey: entry.childSessionKey,
+                notBeforeMs: entry.startedAt ?? entry.createdAt,
+              });
         if (observedStartedAt !== undefined && entry.startedAt !== observedStartedAt) {
           entry.startedAt = observedStartedAt;
           if (typeof entry.sessionStartedAt !== "number") {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -344,7 +344,7 @@ export function createSubagentRunManager(params: {
           notBeforeMs: observedStartedAt ?? entry.startedAt ?? entry.createdAt,
         });
         if (completion) {
-          const completionStartedAt = observedStartedAt;
+          const completionStartedAt = observedStartedAt ?? completion.startedAt;
           const completionAfterDeadline =
             completionStartedAt === undefined
               ? undefined

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1318,6 +1318,56 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores stale session-store start time for fresh terminal completions", async () => {
+    const createdAt = Date.parse("2026-03-24T12:00:00Z");
+    const staleSessionStartedAt = createdAt - 60_000;
+    vi.setSystemTime(createdAt);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        vi.setSystemTime(createdAt + 61_000);
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: staleSessionStartedAt,
+        updatedAt: createdAt + 30_000,
+        endedAt: createdAt + 30_000,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-ignore-stale-session-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "ignore stale session store start",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-ignore-stale-session-start");
+      expect(run?.endedAt).toBe(createdAt + 30_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "ok",
+          startedAt: createdAt,
+          endedAt: createdAt + 30_000,
+          elapsedMs: 30_000,
+        },
+        "fresh terminal completion ignores stale session start",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
   it("caps restored waits to the remaining explicit run timeout", async () => {
     const startedAt = Date.parse("2026-03-24T11:59:00Z");
     const runTimeoutSeconds = 60;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -728,6 +728,70 @@ describe("subagent registry seam flow", () => {
     });
   });
 
+  it("allows in-flight cleanup timeout to be corrected by observed lifecycle start", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    mod.registerSubagentRun({
+      runId: "run-cleanup-lock-observed-success",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "cleanup lock should not freeze stale timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+    const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
+    expect(run).not.toBeNull();
+    Object.assign(run ?? {}, {
+      createdAt,
+      startedAt: createdAt,
+      sessionStartedAt: createdAt,
+      endedAt: createdAt + 60_000,
+      outcome: {
+        status: "timeout",
+        startedAt: createdAt,
+        endedAt: createdAt + 60_000,
+        elapsedMs: 60_000,
+      },
+      cleanupHandled: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-cleanup-lock-observed-success",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: createdAt + 10_000,
+        endedAt: createdAt + 65_000,
+      },
+    });
+
+    await waitForFast(() => {
+      const correctedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-cleanup-lock-observed-success");
+      expect(correctedRun?.endedAt).toBe(createdAt + 65_000);
+      expectRecordFields(
+        correctedRun?.outcome,
+        {
+          status: "ok",
+          startedAt: createdAt + 10_000,
+          endedAt: createdAt + 65_000,
+          elapsedMs: 55_000,
+        },
+        "cleanup lock corrected lifecycle outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
   it("caps lifecycle timeout events to the explicit run deadline", async () => {
     const startedAt = Date.now();
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -940,6 +940,72 @@ describe("subagent registry seam flow", () => {
     });
   });
 
+  it("allows pre-deadline lifecycle timeouts to be corrected by lifecycle success", async () => {
+    const startedAt = Date.parse("2026-03-24T11:59:00Z");
+    mod.registerSubagentRun({
+      runId: "run-predeadline-timeout-corrected",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "pre-deadline timeout remains correctable",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+    const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
+    expect(run).not.toBeNull();
+    Object.assign(run ?? {}, {
+      startedAt,
+      sessionStartedAt: startedAt,
+      endedAt: startedAt + 30_000,
+      outcome: {
+        status: "timeout",
+        startedAt,
+        endedAt: startedAt + 30_000,
+        elapsedMs: 30_000,
+      },
+      delivery: {
+        status: "delivered",
+        announcedAt: startedAt + 30_000,
+        deliveredAt: startedAt + 30_000,
+      },
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-predeadline-timeout-corrected",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt,
+        endedAt: startedAt + 35_000,
+      },
+    });
+
+    await waitForFast(() => {
+      const correctedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-predeadline-timeout-corrected");
+      expect(correctedRun?.endedAt).toBe(startedAt + 35_000);
+      expectRecordFields(
+        correctedRun?.outcome,
+        {
+          status: "ok",
+          startedAt,
+          endedAt: startedAt + 35_000,
+          elapsedMs: 35_000,
+        },
+        "pre-deadline published timeout corrected outcome",
+      );
+    });
+  });
+
   it("caps lifecycle timeout events to the explicit run deadline", async () => {
     const startedAt = Date.now();
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1516,6 +1516,54 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
+  it("applies explicit timeout to terminal session rows without startedAt", async () => {
+    const createdAt = Date.parse("2026-03-24T12:00:00Z");
+    vi.setSystemTime(createdAt);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        vi.setSystemTime(createdAt + 61_000);
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        updatedAt: createdAt + 61_000,
+        endedAt: createdAt + 61_000,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-session-row-no-start-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "terminal row without start still honors timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-session-row-no-start-timeout");
+      expect(run?.endedAt).toBe(createdAt + 60_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt: createdAt,
+          endedAt: createdAt + 60_000,
+          elapsedMs: 60_000,
+        },
+        "terminal session row without start timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
   it("caps restored waits to the remaining explicit run timeout", async () => {
     const startedAt = Date.parse("2026-03-24T11:59:00Z");
     const runTimeoutSeconds = 60;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1731,6 +1731,59 @@ describe("subagent registry seam flow", () => {
     expect(run?.cleanupCompletedAt).toBeTypeOf("number");
   });
 
+  it("uses session-store start time when sweeping stale explicit-timeout runs", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const sessionStartedAt = createdAt + 10_000;
+    const sessionEndedAt = createdAt + 65_000;
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: sessionEndedAt,
+        status: "done",
+        startedAt: sessionStartedAt,
+        endedAt: sessionEndedAt,
+      },
+    });
+
+    vi.setSystemTime(createdAt);
+    mod.registerSubagentRun({
+      runId: "run-sweep-session-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "sweep should respect session store start",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    vi.setSystemTime(createdAt + 120_000);
+    await mod.testing.sweepOnceForTests();
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-sweep-session-start");
+      expect(run?.endedAt).toBe(sessionEndedAt);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "ok",
+          startedAt: sessionStartedAt,
+          endedAt: sessionEndedAt,
+          elapsedMs: 55_000,
+        },
+        "swept session store observed start outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
   it("requeues orphan recovery instead of keeping restart-aborted stale runs stuck as running", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -728,7 +728,7 @@ describe("subagent registry seam flow", () => {
     });
   });
 
-  it("allows in-flight cleanup timeout to be corrected by observed lifecycle start", async () => {
+  it("keeps in-flight explicit deadline timeout stable during cleanup", async () => {
     const createdAt = Date.parse("2026-03-24T11:59:00Z");
     mod.registerSubagentRun({
       runId: "run-cleanup-lock-observed-success",
@@ -777,16 +777,16 @@ describe("subagent registry seam flow", () => {
       const correctedRun = mod
         .listSubagentRunsForRequester("agent:main:main")
         .find((entry) => entry.runId === "run-cleanup-lock-observed-success");
-      expect(correctedRun?.endedAt).toBe(createdAt + 65_000);
+      expect(correctedRun?.endedAt).toBe(createdAt + 60_000);
       expectRecordFields(
         correctedRun?.outcome,
         {
-          status: "ok",
-          startedAt: createdAt + 10_000,
-          endedAt: createdAt + 65_000,
-          elapsedMs: 55_000,
+          status: "timeout",
+          startedAt: createdAt,
+          endedAt: createdAt + 60_000,
+          elapsedMs: 60_000,
         },
-        "cleanup lock corrected lifecycle outcome",
+        "in-flight cleanup timeout outcome",
       );
     });
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1296,6 +1296,59 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
+  it("uses session-store start time for successful agent.wait results without a start", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const sessionStartedAt = createdAt + 10_000;
+    vi.setSystemTime(createdAt);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        vi.setSystemTime(createdAt + 65_000);
+        return {
+          status: "ok",
+          endedAt: createdAt + 65_000,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: sessionStartedAt,
+        updatedAt: createdAt + 65_000,
+        endedAt: createdAt + 65_000,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-ok-session-store-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "respect restored success start",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-ok-session-store-start");
+      expect(completedRun?.endedAt).toBe(createdAt + 65_000);
+      expectRecordFields(
+        completedRun?.outcome,
+        {
+          status: "ok",
+          startedAt: sessionStartedAt,
+          endedAt: createdAt + 65_000,
+          elapsedMs: 55_000,
+        },
+        "restored wait success uses session store start",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
   it("does not terminally time out plain agent.wait timeouts before the observed run deadline", async () => {
     const createdAt = Date.parse("2026-03-24T11:59:00Z");
     const observedStartedAt = createdAt + 10_000;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -197,6 +197,8 @@ describe("subagent registry seam flow", () => {
       onSubagentEnded: mocks.onSubagentEnded,
     });
     mocks.scheduleOrphanRecovery.mockReset();
+    mocks.resolveAgentTimeoutMs.mockReturnValue(1_000);
+    mocks.restoreSubagentRunsFromDisk.mockReturnValue(0);
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
         return {
@@ -395,6 +397,172 @@ describe("subagent registry seam flow", () => {
       expect(waitAttempts).toBeGreaterThanOrEqual(2);
       expect(completedRun?.endedAt).toBe(222);
       expectRecordFields(completedRun?.outcome, { status: "ok" }, "completed run outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("terminally times out explicit runTimeoutSeconds when agent.wait has no terminal snapshot", async () => {
+    const startedAt = Date.now();
+    let waitAttempts = 0;
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        waitAttempts += 1;
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-explicit-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "respect explicit timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 1,
+    });
+
+    await waitForFast(() => {
+      expect(waitAttempts).toBeGreaterThanOrEqual(1);
+    });
+    const activeRun = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-explicit-timeout");
+    expect(activeRun?.endedAt).toBeUndefined();
+    expect(activeRun?.outcome).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-explicit-timeout");
+      expect(waitAttempts).toBeGreaterThanOrEqual(2);
+      expect(completedRun?.endedAt).toBe(startedAt + 1_000);
+      expectRecordFields(
+        completedRun?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 1_000,
+          elapsedMs: 1_000,
+        },
+        "explicit run timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats boundary agent.wait timeouts as explicit run timeouts before child abort errors win", async () => {
+    const startedAt = Date.now();
+    let waitAttempts = 0;
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        waitAttempts += 1;
+        vi.setSystemTime(startedAt + 999);
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-boundary-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "deadline skew should still timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 1,
+    });
+
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-boundary-timeout");
+      expect(waitAttempts).toBe(1);
+      expect(completedRun?.endedAt).toBe(startedAt + 1_000);
+      expectRecordFields(
+        completedRun?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 1_000,
+          elapsedMs: 1_000,
+        },
+        "boundary explicit run timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps restored waits to the remaining explicit run timeout", async () => {
+    const startedAt = Date.parse("2026-03-24T11:59:00Z");
+    const runTimeoutSeconds = 60;
+    vi.setSystemTime(startedAt + 59_000);
+    mocks.resolveAgentTimeoutMs.mockReturnValue(60_000);
+    mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
+      runs: Map<string, unknown>;
+      mergeOnly?: boolean;
+    }) => {
+      params.runs.set("run-resumed-near-deadline", {
+        runId: "run-resumed-near-deadline",
+        childSessionKey: "agent:main:subagent:child",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "resume near explicit timeout",
+        cleanup: "keep",
+        runTimeoutSeconds,
+        createdAt: startedAt,
+        startedAt,
+        sessionStartedAt: startedAt,
+      });
+      return 1;
+    }) as never);
+    const waitTimeouts: unknown[] = [];
+    mocks.callGateway.mockImplementation(async (request: {
+      method?: string;
+      params?: Record<string, unknown>;
+    }) => {
+      if (request.method === "agent.wait") {
+        waitTimeouts.push(request.params?.timeoutMs);
+        vi.setSystemTime(startedAt + 60_000);
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    mod.initSubagentRegistry();
+
+    await waitForFast(() => {
+      expect(waitTimeouts).toEqual([1_000]);
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-resumed-near-deadline");
+      expect(completedRun?.endedAt).toBe(startedAt + 60_000);
+      expectRecordFields(
+        completedRun?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 60_000,
+          elapsedMs: 60_000,
+        },
+        "restored explicit run timeout outcome",
+      );
     });
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -398,7 +398,9 @@ describe("subagent registry seam flow", () => {
       expect(completedRun?.endedAt).toBe(222);
       expectRecordFields(completedRun?.outcome, { status: "ok" }, "completed run outcome");
     });
-    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("terminally times out explicit runTimeoutSeconds when agent.wait has no terminal snapshot", async () => {
@@ -457,6 +459,404 @@ describe("subagent registry seam flow", () => {
         "explicit run timeout outcome",
       );
     });
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("keeps explicit run timeout terminal when late lifecycle success arrives", async () => {
+    const startedAt = Date.now();
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-late-lifecycle-ok",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout should stay terminal",
+      cleanup: "keep",
+      runTimeoutSeconds: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-late-lifecycle-ok");
+      expect(completedRun?.endedAt).toBe(startedAt + 1_000);
+      expect(completedRun?.outcome?.status).toBe("timeout");
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-late-lifecycle-ok",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        endedAt: startedAt + 2_000,
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-late-lifecycle-ok");
+      expect(run?.endedAt).toBe(startedAt + 1_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 1_000,
+          elapsedMs: 1_000,
+        },
+        "late lifecycle timeout outcome",
+      );
+    });
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("keeps published explicit timeout stable when pre-deadline lifecycle success arrives late", async () => {
+    const startedAt = Date.now();
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-late-lifecycle-predeadline-ok",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "published timeout should stay stable",
+      cleanup: "keep",
+      runTimeoutSeconds: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-late-lifecycle-predeadline-ok");
+      expect(completedRun?.endedAt).toBe(startedAt + 1_000);
+      expect(completedRun?.outcome?.status).toBe("timeout");
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-late-lifecycle-predeadline-ok",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: startedAt + 10,
+        endedAt: startedAt + 500,
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-late-lifecycle-predeadline-ok");
+      expect(run?.endedAt).toBe(startedAt + 1_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 1_000,
+          elapsedMs: 1_000,
+        },
+        "stable published timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    expect(mocks.captureSubagentCompletionReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("converts first lifecycle success after the explicit run deadline into timeout", async () => {
+    const startedAt = Date.now();
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-lifecycle-success-after-deadline",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "post-deadline lifecycle success should timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 1,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-lifecycle-success-after-deadline",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt,
+        endedAt: startedAt + 2_000,
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-lifecycle-success-after-deadline");
+      expect(run?.endedAt).toBe(startedAt + 1_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 1_000,
+          elapsedMs: 1_000,
+        },
+        "late first lifecycle timeout outcome",
+      );
+    });
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("uses observed lifecycle start time when applying explicit run deadline", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const observedStartedAt = createdAt + 10_000;
+    vi.setSystemTime(createdAt);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-lifecycle-observed-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "respect observed lifecycle start",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-lifecycle-observed-start",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: observedStartedAt,
+        endedAt: createdAt + 65_000,
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-lifecycle-observed-start");
+      expect(run?.endedAt).toBe(createdAt + 65_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "ok",
+          startedAt: observedStartedAt,
+          endedAt: createdAt + 65_000,
+          elapsedMs: 55_000,
+        },
+        "observed lifecycle start success outcome",
+      );
+    });
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("caps lifecycle timeout events to the explicit run deadline", async () => {
+    const startedAt = Date.now();
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-lifecycle-timeout-after-deadline",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "post-deadline lifecycle timeout should cap",
+      cleanup: "keep",
+      runTimeoutSeconds: 1,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-lifecycle-timeout-after-deadline",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt,
+        endedAt: startedAt + 2_000,
+        aborted: true,
+      },
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-lifecycle-timeout-after-deadline");
+      expect(run?.endedAt).toBe(startedAt + 1_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 1_000,
+          elapsedMs: 1_000,
+        },
+        "capped lifecycle timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps published explicit timeout stable when late lifecycle timeout arrives", async () => {
+    const startedAt = Date.now();
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-late-lifecycle-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "published timeout should ignore late timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-late-lifecycle-timeout");
+      expect(completedRun?.endedAt).toBe(startedAt + 1_000);
+      expect(completedRun?.outcome?.status).toBe("timeout");
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-late-lifecycle-timeout",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: startedAt + 10,
+        endedAt: startedAt + 2_000,
+        aborted: true,
+      },
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-late-lifecycle-timeout");
+      expect(run?.endedAt).toBe(startedAt + 1_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 1_000,
+          elapsedMs: 1_000,
+        },
+        "stable published lifecycle timeout outcome",
+      );
+    });
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
@@ -509,6 +909,235 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
+  it("prefers explicit run timeout over late restored agent.wait success", async () => {
+    const startedAt = Date.parse("2026-03-24T11:59:00Z");
+    vi.setSystemTime(startedAt + 61_000);
+    mocks.resolveAgentTimeoutMs.mockReturnValue(60_000);
+    mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
+      runs: Map<string, unknown>;
+      mergeOnly?: boolean;
+    }) => {
+      params.runs.set("run-resumed-late-success", {
+        runId: "run-resumed-late-success",
+        childSessionKey: "agent:main:subagent:child",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "resume after explicit timeout",
+        cleanup: "keep",
+        runTimeoutSeconds: 60,
+        createdAt: startedAt,
+        startedAt,
+        sessionStartedAt: startedAt,
+      });
+      return 1;
+    }) as never);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+          startedAt,
+          endedAt: startedAt + 61_000,
+        };
+      }
+      return {};
+    });
+
+    mod.initSubagentRegistry();
+
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-resumed-late-success");
+      expect(completedRun?.endedAt).toBe(startedAt + 60_000);
+      expectRecordFields(
+        completedRun?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 60_000,
+          elapsedMs: 60_000,
+        },
+        "late restored wait success timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses observed agent.wait start time when applying explicit run deadline", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const observedStartedAt = createdAt + 10_000;
+    vi.setSystemTime(createdAt + 65_000);
+    mocks.resolveAgentTimeoutMs.mockReturnValue(60_000);
+    mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
+      runs: Map<string, unknown>;
+      mergeOnly?: boolean;
+    }) => {
+      params.runs.set("run-resumed-observed-start", {
+        runId: "run-resumed-observed-start",
+        childSessionKey: "agent:main:subagent:child",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "respect observed start",
+        cleanup: "keep",
+        runTimeoutSeconds: 60,
+        createdAt,
+        startedAt: createdAt,
+        sessionStartedAt: createdAt,
+      });
+      return 1;
+    }) as never);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+          startedAt: observedStartedAt,
+          endedAt: createdAt + 65_000,
+        };
+      }
+      return {};
+    });
+
+    mod.initSubagentRegistry();
+
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-resumed-observed-start");
+      expect(completedRun?.endedAt).toBe(createdAt + 65_000);
+      expectRecordFields(
+        completedRun?.outcome,
+        {
+          status: "ok",
+          startedAt: observedStartedAt,
+          endedAt: createdAt + 65_000,
+          elapsedMs: 55_000,
+        },
+        "observed start success outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not terminally time out plain agent.wait timeouts before the observed run deadline", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const observedStartedAt = createdAt + 10_000;
+    vi.setSystemTime(createdAt + 61_000);
+    let waitAttempts = 0;
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        waitAttempts += 1;
+        return {
+          status: "timeout",
+          startedAt: observedStartedAt,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: createdAt,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-plain-timeout-observed-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do not timeout before observed start deadline",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    let run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-plain-timeout-observed-start");
+    await waitForFast(() => {
+      expect(waitAttempts).toBeGreaterThanOrEqual(1);
+      run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-plain-timeout-observed-start");
+      expect(run?.endedAt).toBeUndefined();
+      expect(run?.outcome).toBeUndefined();
+      expect(run?.startedAt).toBe(observedStartedAt);
+    });
+
+    vi.setSystemTime(observedStartedAt + 60_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await waitForFast(() => {
+      run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-plain-timeout-observed-start");
+      expect(run?.endedAt).toBe(observedStartedAt + 60_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt: observedStartedAt,
+          endedAt: observedStartedAt + 60_000,
+          elapsedMs: 60_000,
+        },
+        "observed start plain wait timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers agent.wait start time over stale session-store start time", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const observedStartedAt = createdAt + 10_000;
+    vi.setSystemTime(createdAt + 61_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          startedAt: observedStartedAt,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: createdAt,
+        updatedAt: createdAt + 65_000,
+        endedAt: createdAt + 65_000,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-wait-start-over-session-store-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "prefer wait observed start",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-wait-start-over-session-store-start");
+      expect(run?.endedAt).toBe(createdAt + 65_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "ok",
+          startedAt: observedStartedAt,
+          endedAt: createdAt + 65_000,
+          elapsedMs: 55_000,
+        },
+        "wait observed start beats stale session store start",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
   it("caps restored waits to the remaining explicit run timeout", async () => {
     const startedAt = Date.parse("2026-03-24T11:59:00Z");
     const runTimeoutSeconds = 60;
@@ -533,17 +1162,16 @@ describe("subagent registry seam flow", () => {
       return 1;
     }) as never);
     const waitTimeouts: unknown[] = [];
-    mocks.callGateway.mockImplementation(async (request: {
-      method?: string;
-      params?: Record<string, unknown>;
-    }) => {
-      if (request.method === "agent.wait") {
-        waitTimeouts.push(request.params?.timeoutMs);
-        vi.setSystemTime(startedAt + 60_000);
-        return { status: "timeout" };
-      }
-      return {};
-    });
+    mocks.callGateway.mockImplementation(
+      async (request: { method?: string; params?: Record<string, unknown> }) => {
+        if (request.method === "agent.wait") {
+          waitTimeouts.push(request.params?.timeoutMs);
+          vi.setSystemTime(startedAt + 60_000);
+          return { status: "timeout" };
+        }
+        return {};
+      },
+    );
 
     mod.initSubagentRegistry();
 
@@ -602,6 +1230,108 @@ describe("subagent registry seam flow", () => {
         .find((entry) => entry.runId === "run-terminal-timeout");
       expect(run?.endedAt).toBe(222);
       expectRecordFields(run?.outcome, { status: "timeout" }, "terminal timeout outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps terminal agent.wait timeouts to the explicit run deadline", async () => {
+    const startedAt = Date.now();
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 2_000,
+          stopReason: "rpc",
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-terminal-timeout-capped",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "cap terminal timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 1,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-terminal-timeout-capped");
+      expect(run?.endedAt).toBe(startedAt + 1_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + 1_000,
+          elapsedMs: 1_000,
+        },
+        "capped terminal timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses observed agent.wait start time when capping terminal timeout", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const observedStartedAt = createdAt + 10_000;
+    vi.setSystemTime(createdAt + 75_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          startedAt: observedStartedAt,
+          endedAt: createdAt + 75_000,
+          stopReason: "rpc",
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: createdAt,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-terminal-timeout-observed-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "cap timeout using observed start",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-terminal-timeout-observed-start");
+      expect(run?.endedAt).toBe(observedStartedAt + 60_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt: observedStartedAt,
+          endedAt: observedStartedAt + 60_000,
+          elapsedMs: 60_000,
+        },
+        "observed start capped terminal timeout outcome",
+      );
     });
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -792,6 +792,89 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
   });
 
+  it("refreshes unpublished timeout delivery payloads after lifecycle correction", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    mocks.runSubagentAnnounceFlow.mockResolvedValueOnce(false);
+    mod.registerSubagentRun({
+      runId: "run-refresh-pending-timeout-payload",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "pending timeout payload should refresh",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+    const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
+    expect(run).not.toBeNull();
+    Object.assign(run ?? {}, {
+      createdAt,
+      startedAt: createdAt,
+      sessionStartedAt: createdAt,
+      endedAt: createdAt + 60_000,
+      outcome: {
+        status: "timeout",
+        startedAt: createdAt,
+        endedAt: createdAt + 60_000,
+        elapsedMs: 60_000,
+      },
+      delivery: {
+        status: "pending",
+        payload: {
+          requesterSessionKey: "agent:main:main",
+          childSessionKey: "agent:main:subagent:child",
+          childRunId: "run-refresh-pending-timeout-payload",
+          task: "pending timeout payload should refresh",
+          startedAt: createdAt,
+          endedAt: createdAt + 60_000,
+          outcome: { status: "timeout" },
+        },
+      },
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-refresh-pending-timeout-payload",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: createdAt + 10_000,
+        endedAt: createdAt + 65_000,
+      },
+    });
+
+    await waitForFast(() => {
+      const announceParams = findRecordCallArg(
+        mocks.runSubagentAnnounceFlow,
+        0,
+        "refreshed pending delivery announce",
+        (record) => record.childRunId === "run-refresh-pending-timeout-payload",
+      );
+      expectRecordFields(
+        announceParams.outcome,
+        {
+          status: "ok",
+          startedAt: createdAt + 10_000,
+          endedAt: createdAt + 65_000,
+          elapsedMs: 55_000,
+        },
+        "refreshed pending delivery outcome",
+      );
+    });
+  });
+
   it("allows non-explicit published timeouts to be corrected by lifecycle success", async () => {
     const startedAt = Date.parse("2026-03-24T11:59:00Z");
     mod.registerSubagentRun({

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -792,6 +792,71 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
   });
 
+  it("allows non-explicit published timeouts to be corrected by lifecycle success", async () => {
+    const startedAt = Date.parse("2026-03-24T11:59:00Z");
+    mod.registerSubagentRun({
+      runId: "run-non-explicit-timeout-corrected",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "non-explicit timeout remains correctable",
+      cleanup: "keep",
+    });
+    const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
+    expect(run).not.toBeNull();
+    Object.assign(run ?? {}, {
+      startedAt,
+      sessionStartedAt: startedAt,
+      endedAt: startedAt + 30_000,
+      outcome: {
+        status: "timeout",
+        startedAt,
+        endedAt: startedAt + 30_000,
+        elapsedMs: 30_000,
+      },
+      delivery: {
+        status: "delivered",
+        announcedAt: startedAt + 30_000,
+        deliveredAt: startedAt + 30_000,
+      },
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-non-explicit-timeout-corrected",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt,
+        endedAt: startedAt + 35_000,
+      },
+    });
+
+    await waitForFast(() => {
+      const correctedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-non-explicit-timeout-corrected");
+      expect(correctedRun?.endedAt).toBe(startedAt + 35_000);
+      expectRecordFields(
+        correctedRun?.outcome,
+        {
+          status: "ok",
+          startedAt,
+          endedAt: startedAt + 35_000,
+          elapsedMs: 35_000,
+        },
+        "non-explicit published timeout corrected outcome",
+      );
+    });
+  });
+
   it("caps lifecycle timeout events to the explicit run deadline", async () => {
     const startedAt = Date.now();
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -490,7 +490,7 @@ describe("subagent registry seam flow", () => {
       runTimeoutSeconds: 1,
     });
 
-    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(10_000);
     await waitForFast(() => {
       const completedRun = mod
         .listSubagentRunsForRequester("agent:main:main")
@@ -1145,6 +1145,72 @@ describe("subagent registry seam flow", () => {
           elapsedMs: 60_000,
         },
         "observed start plain wait timeout outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses running session-store start time for plain agent.wait timeouts", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const sessionStartedAt = createdAt + 10_000;
+    vi.setSystemTime(createdAt);
+    let waitAttempts = 0;
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        waitAttempts += 1;
+        if (waitAttempts === 1) {
+          vi.setSystemTime(createdAt + 61_000);
+        }
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: createdAt + 61_000,
+        status: "running",
+        startedAt: sessionStartedAt,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-plain-timeout-session-store-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do not timeout before session store start deadline",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-plain-timeout-session-store-start");
+      expect(waitAttempts).toBeGreaterThanOrEqual(1);
+      expect(run?.endedAt).toBeUndefined();
+      expect(run?.outcome).toBeUndefined();
+      expect(run?.startedAt).toBe(sessionStartedAt);
+    });
+
+    vi.setSystemTime(sessionStartedAt + 60_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-plain-timeout-session-store-start");
+      expect(run?.endedAt).toBe(sessionStartedAt + 60_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt: sessionStartedAt,
+          endedAt: sessionStartedAt + 60_000,
+          elapsedMs: 60_000,
+        },
+        "session store start plain wait timeout outcome",
       );
     });
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1202,6 +1202,56 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
+  it("uses session-store start time when agent.wait times out without a start", async () => {
+    const createdAt = Date.parse("2026-03-24T11:59:00Z");
+    const sessionStartedAt = createdAt + 10_000;
+    vi.setSystemTime(createdAt);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        vi.setSystemTime(createdAt + 61_000);
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: sessionStartedAt,
+        updatedAt: createdAt + 65_000,
+        endedAt: createdAt + 65_000,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-session-store-start-after-wait-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "use session store observed start",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-session-store-start-after-wait-timeout");
+      expect(run?.endedAt).toBe(createdAt + 65_000);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "ok",
+          startedAt: sessionStartedAt,
+          endedAt: createdAt + 65_000,
+          elapsedMs: 55_000,
+        },
+        "session store observed start beats stale registry start",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
   it("caps restored waits to the remaining explicit run timeout", async () => {
     const startedAt = Date.parse("2026-03-24T11:59:00Z");
     const runTimeoutSeconds = 60;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -295,6 +295,7 @@ const pendingLifecycleErrorByRunId = new Map<
   {
     timer: NodeJS.Timeout;
     endedAt: number;
+    startedAt?: number;
     error?: string;
   }
 >();
@@ -303,6 +304,7 @@ const pendingLifecycleTimeoutByRunId = new Map<
   {
     timer: NodeJS.Timeout;
     endedAt: number;
+    startedAt?: number;
   }
 >();
 
@@ -346,6 +348,7 @@ type CompleteSubagentRunParams = {
   sendFarewell?: boolean;
   accountId?: string;
   triggerCleanup: boolean;
+  startedAt?: number;
 };
 
 async function completeSubagentRunWithRecovery(params: CompleteSubagentRunParams, source: string) {
@@ -402,7 +405,12 @@ function completeSubagentRunInBackground(params: CompleteSubagentRunParams, sour
   void completeSubagentRunWithRecovery(params, source);
 }
 
-function schedulePendingLifecycleError(params: { runId: string; endedAt: number; error?: string }) {
+function schedulePendingLifecycleError(params: {
+  runId: string;
+  endedAt: number;
+  startedAt?: number;
+  error?: string;
+}) {
   clearPendingLifecycleTimeout(params.runId);
   clearPendingLifecycleError(params.runId);
   const timer = setTimeout(() => {
@@ -429,6 +437,7 @@ function schedulePendingLifecycleError(params: { runId: string; endedAt: number;
       sendFarewell: true,
       accountId: entry.requesterOrigin?.accountId,
       triggerCleanup: true,
+      startedAt: pending.startedAt,
     };
     completeSubagentRunInBackground(completionParams, "lifecycle-error-grace");
   }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
@@ -436,11 +445,16 @@ function schedulePendingLifecycleError(params: { runId: string; endedAt: number;
   pendingLifecycleErrorByRunId.set(params.runId, {
     timer,
     endedAt: params.endedAt,
+    startedAt: params.startedAt,
     error: params.error,
   });
 }
 
-function schedulePendingLifecycleTimeout(params: { runId: string; endedAt: number }) {
+function schedulePendingLifecycleTimeout(params: {
+  runId: string;
+  endedAt: number;
+  startedAt?: number;
+}) {
   clearPendingLifecycleError(params.runId);
   clearPendingLifecycleTimeout(params.runId);
   const timer = setTimeout(() => {
@@ -466,6 +480,7 @@ function schedulePendingLifecycleTimeout(params: { runId: string; endedAt: numbe
       sendFarewell: true,
       accountId: entry.requesterOrigin?.accountId,
       triggerCleanup: true,
+      startedAt: pending.startedAt,
     };
     completeSubagentRunInBackground(completionParams, "lifecycle-timeout-grace");
   }, LIFECYCLE_TIMEOUT_RETRY_GRACE_MS);
@@ -473,6 +488,7 @@ function schedulePendingLifecycleTimeout(params: { runId: string; endedAt: numbe
   pendingLifecycleTimeoutByRunId.set(params.runId, {
     timer,
     endedAt: params.endedAt,
+    startedAt: params.startedAt,
   });
 }
 
@@ -1062,6 +1078,7 @@ function ensureListener() {
         return;
       }
       const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+      const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
       const livenessState =
         typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
@@ -1070,6 +1087,7 @@ function ensureListener() {
         schedulePendingLifecycleError({
           runId: evt.runId,
           endedAt,
+          startedAt,
           error,
         });
         return;
@@ -1089,6 +1107,7 @@ function ensureListener() {
             sendFarewell: true,
             accountId: entry.requesterOrigin?.accountId,
             triggerCleanup: true,
+            startedAt,
           },
           "lifecycle-killed-event",
         );
@@ -1108,6 +1127,7 @@ function ensureListener() {
           sendFarewell: true,
           accountId: entry.requesterOrigin?.accountId,
           triggerCleanup: true,
+          startedAt,
         };
         await completeSubagentRunWithRecovery(blockedParams, "lifecycle-blocked-event");
         return;
@@ -1116,6 +1136,7 @@ function ensureListener() {
         schedulePendingLifecycleTimeout({
           runId: evt.runId,
           endedAt,
+          startedAt,
         });
         return;
       }
@@ -1124,8 +1145,7 @@ function ensureListener() {
           markSubagentRunPausedAfterYield({
             entry,
             endedAt,
-            startedAt:
-              typeof evt.data?.startedAt === "number" ? evt.data.startedAt : entry.startedAt,
+            startedAt: startedAt ?? entry.startedAt,
           })
         ) {
           persistSubagentRuns();
@@ -1142,6 +1162,7 @@ function ensureListener() {
         sendFarewell: true,
         accountId: entry.requesterOrigin?.accountId,
         triggerCleanup: true,
+        startedAt,
       };
       await completeSubagentRunWithRecovery(completionParams, "lifecycle-ok-event");
     })().catch((err) => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -674,7 +674,7 @@ function resumeSubagentRun(runId: string) {
   // Wait for completion again after restart.
   const cfg = subagentRegistryDeps.getRuntimeConfig();
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, entry.runTimeoutSeconds);
-  void subagentRunManager.waitForSubagentCompletion(runId, waitTimeoutMs, entry);
+  void subagentRunManager.waitForSubagentCompletion(runId, waitTimeoutMs, entry, true);
   resumedRuns.add(runId);
 }
 

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -928,6 +928,7 @@ async function sweepSubagentRuns() {
             await completeSubagentRunWithRecovery(
               {
                 runId,
+                startedAt: completion.startedAt,
                 endedAt: completion.endedAt,
                 outcome: completion.outcome,
                 reason: completion.reason,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -74,6 +74,7 @@ import {
   loadSubagentSessionEntry,
   resolveCompletionFromSessionEntry,
   resolveSubagentSessionCompletion,
+  resolveSubagentSessionStartedAt,
   type SubagentSessionStoreCache,
 } from "./subagent-session-reconciliation.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
@@ -1193,6 +1194,7 @@ const subagentRunManager = createSubagentRunManager({
   resolveSubagentWaitTimeoutMs,
   scheduleOrphanRecovery: (args) => scheduleSubagentOrphanRecovery(args),
   resolveSubagentSessionCompletion,
+  resolveSubagentSessionStartedAt,
   notifyContextEngineSubagentEnded,
   completeCleanupBookkeeping,
   completeSubagentRun,

--- a/src/agents/subagent-session-reconciliation.ts
+++ b/src/agents/subagent-session-reconciliation.ts
@@ -43,6 +43,17 @@ function isFreshForRun(
   return terminalAt !== undefined && terminalAt >= notBeforeMs;
 }
 
+function freshSessionStartedAt(
+  sessionEntry: SessionEntry | undefined,
+  notBeforeMs: number | undefined,
+): number | undefined {
+  const startedAt = finiteTimestamp(sessionEntry?.startedAt);
+  if (startedAt === undefined) {
+    return undefined;
+  }
+  return notBeforeMs === undefined || startedAt >= notBeforeMs ? startedAt : undefined;
+}
+
 function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
   const direct = store[sessionKey];
   if (direct) {
@@ -83,7 +94,7 @@ export function resolveCompletionFromSessionEntry(
   opts?: { notBeforeMs?: number },
 ): SubagentSessionCompletion | null {
   const status = sessionEntry?.status;
-  const startedAt = finiteTimestamp(sessionEntry?.startedAt);
+  const startedAt = freshSessionStartedAt(sessionEntry, opts?.notBeforeMs);
   const endedAt =
     finiteTimestamp(sessionEntry?.endedAt) ??
     finiteTimestamp(sessionEntry?.updatedAt) ??
@@ -177,6 +188,6 @@ export function resolveSubagentSessionStartedAt(params: {
     cfg: params.cfg,
   });
   return isFreshForRun(sessionEntry, params.notBeforeMs)
-    ? finiteTimestamp(sessionEntry?.startedAt)
+    ? freshSessionStartedAt(sessionEntry, params.notBeforeMs)
     : undefined;
 }

--- a/src/agents/subagent-session-reconciliation.ts
+++ b/src/agents/subagent-session-reconciliation.ts
@@ -164,3 +164,19 @@ export function resolveSubagentSessionCompletion(params: {
     { notBeforeMs: params.notBeforeMs },
   );
 }
+
+export function resolveSubagentSessionStartedAt(params: {
+  childSessionKey: string;
+  notBeforeMs?: number;
+  storeCache?: SubagentSessionStoreCache;
+  cfg?: OpenClawConfig;
+}): number | undefined {
+  const sessionEntry = loadSubagentSessionEntry({
+    childSessionKey: params.childSessionKey,
+    storeCache: params.storeCache,
+    cfg: params.cfg,
+  });
+  return isFreshForRun(sessionEntry, params.notBeforeMs)
+    ? finiteTimestamp(sessionEntry?.startedAt)
+    : undefined;
+}

--- a/src/agents/subagent-session-reconciliation.ts
+++ b/src/agents/subagent-session-reconciliation.ts
@@ -18,6 +18,7 @@ import {
 export type SubagentSessionStoreCache = Map<string, Record<string, SessionEntry>>;
 
 export type SubagentSessionCompletion = {
+  startedAt?: number;
   endedAt: number;
   outcome: SubagentRunOutcome;
   reason: SubagentLifecycleEndedReason;
@@ -82,6 +83,7 @@ export function resolveCompletionFromSessionEntry(
   opts?: { notBeforeMs?: number },
 ): SubagentSessionCompletion | null {
   const status = sessionEntry?.status;
+  const startedAt = finiteTimestamp(sessionEntry?.startedAt);
   const endedAt =
     finiteTimestamp(sessionEntry?.endedAt) ??
     finiteTimestamp(sessionEntry?.updatedAt) ??
@@ -92,6 +94,7 @@ export function resolveCompletionFromSessionEntry(
       return null;
     }
     return {
+      startedAt,
       endedAt,
       outcome: { status: "ok" },
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
@@ -102,6 +105,7 @@ export function resolveCompletionFromSessionEntry(
       return null;
     }
     return {
+      startedAt,
       endedAt,
       outcome: { status: "timeout" },
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
@@ -112,6 +116,7 @@ export function resolveCompletionFromSessionEntry(
       return null;
     }
     return {
+      startedAt,
       endedAt,
       outcome: { status: "error", error: "session completed before registry settled" },
       reason: SUBAGENT_ENDED_REASON_ERROR,
@@ -122,6 +127,7 @@ export function resolveCompletionFromSessionEntry(
       return null;
     }
     return {
+      startedAt,
       endedAt,
       outcome: { status: "error", error: "subagent run terminated" },
       reason: SUBAGENT_ENDED_REASON_KILLED,
@@ -132,6 +138,7 @@ export function resolveCompletionFromSessionEntry(
       return null;
     }
     return {
+      startedAt,
       endedAt,
       outcome: { status: "ok" },
       reason: SUBAGENT_ENDED_REASON_COMPLETE,

--- a/src/cron/schedule-identity.test.ts
+++ b/src/cron/schedule-identity.test.ts
@@ -26,4 +26,33 @@ describe("tryCronScheduleIdentity", () => {
       ),
     ).toBe(true);
   });
+
+  it("normalizes cron stagger identity like execution does", () => {
+    expect(
+      cronSchedulingInputsEqual(
+        { schedule: { kind: "cron", expr: "*/5 * * * *", staggerMs: 42 } },
+        { schedule: { kind: "cron", expr: "*/5 * * * *", staggerMs: 42.8 } },
+      ),
+    ).toBe(true);
+
+    expect(
+      cronSchedulingInputsEqual(
+        { schedule: { kind: "cron", expr: "*/5 * * * *", staggerMs: 0 } },
+        { schedule: { kind: "cron", expr: "*/5 * * * *", staggerMs: -10 } },
+      ),
+    ).toBe(true);
+
+    expect(
+      cronSchedulingInputsEqual(
+        { schedule: { kind: "cron", expr: "*/5 * * * *" } },
+        {
+          schedule: {
+            kind: "cron",
+            expr: "*/5 * * * *",
+            staggerMs: "1e3" as unknown as number,
+          },
+        },
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: `sessions_spawn` accepted `runTimeoutSeconds`, but a plain non-terminal `agent.wait` timeout could keep the subagent run active after the stored deadline.
- Intended outcome: explicit subagent run timeouts become terminal timeout outcomes at the stored deadline, including restored/retried runs near that deadline.
- Cleanup behavior: keep-mode parent wake can proceed while child abort is still unwinding; delete-mode cleanup stays retryable while an active child cannot yet be removed.
- Intentionally out of scope: manual kill/reap behavior remains tracked by #87445.

## Linked context

Which issue does this close?

Closes #87444

Which issues, PRs, or discussions are related?

Related #87445

Was this requested by a maintainer or owner?

Requested through the maintainer workflow for #87444.

## Real behavior proof (required for external PRs)

Behavior addressed: `sessions_spawn` child runs with explicit `runTimeoutSeconds` no longer remain active after the stored deadline when `agent.wait` only reports a non-terminal timeout; restored/retried waits now use only the remaining stored deadline budget before completing the timeout path.

Real environment tested: local OpenClaw source worktree running a real gateway/server and real `agent` RPC against a loopback OpenAI Responses-compatible provider harness. The parent model turn called `sessions_spawn`, then `sessions_yield`; the child provider request was held open past `runTimeoutSeconds: 1`.

Exact steps or command run after this patch: `node --import tsx /private/tmp/openclaw-issue-87444-proof.mts`; `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts src/agents/subagent-announce.timeout.test.ts`; `node scripts/run-vitest.mjs src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts src/gateway/server-methods/agent.test.ts`; `git diff --check`. After the latest deadline-before-wait amendment, reran `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts src/agents/subagent-announce.timeout.test.ts`, `node scripts/run-vitest.mjs src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts src/gateway/server-methods/agent.test.ts`, and `git diff --check`.

Evidence after fix: copied terminal output from the real gateway proof run:

```text
ISSUE_87444_PARENT_WOKE_C7A617
ISSUE_87444_REAL_BEHAVIOR_PROOF pass
{
  "sessionKey": "agent:main:issue-87444-c7a617",
  "taskName": "proof_child_timeout",
  "runId": "6298edb3-70e5-4926-91f3-9e98ebdb4ed1",
  "runTimeoutSeconds": 1,
  "outcomeStatus": "timeout",
  "elapsedMs": 1000,
  "deadlineDeltaMs": 0,
  "activeChildrenAfterTimeout": 0,
  "parentWakeDispatchCompleted": true,
  "providerRequestLabels": [
    "parent:function_call:sessions_spawn",
    "parent:function_call:sessions_yield",
    "child:provider_request_held_open",
    "parent:message:timeout_observed"
  ],
  "childProviderLateResponseServedBeforeParentWake": false
}
ISSUE_87444_PROOF_REQUEST_LOG ["parent:function_call:sessions_spawn","parent:function_call:sessions_yield","child:provider_request_held_open","parent:message:timeout_observed"]
```

Observed result after fix: the real gateway run accepted `sessions_spawn` with `runTimeoutSeconds: 1`, the held-open child recorded `outcomeStatus: "timeout"` at exactly `elapsedMs: 1000`, `activeChildrenAfterTimeout` was `0`, and the parent continuation produced the redacted wake token `ISSUE_87444_PARENT_WOKE_C7A617`.

What was not tested: external hosted provider credentials, external channel delivery, GitHub Actions CI completion, and the separate manual kill/reap path tracked by #87445.

Proof limitations or environment constraints: the provider endpoint was a loopback deterministic OpenAI Responses-compatible harness so no API keys or external messages were used; the exercised OpenClaw path was still the real gateway, real agent RPC, real `sessions_spawn`, real `sessions_yield`, registry timeout completion, and parent wake dispatch.

Before evidence (optional but encouraged): before the original registry change, the focused regression kept `completedRun?.endedAt` undefined after a plain `agent.wait` timeout. Before the deadline-before-wait amendment, a restored run 59s into a 60s timeout still passed a full 60s budget to `agent.wait`.

## Tests and validation

Which commands did you run?

- `node --import tsx /private/tmp/openclaw-issue-87444-proof.mts`
- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts src/agents/subagent-announce.timeout.test.ts`
- `node scripts/run-vitest.mjs src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts src/gateway/server-methods/agent.test.ts`
- `git diff --check`

What regression coverage was added or updated?

Added registry coverage for non-terminal `agent.wait` timeouts at and near the stored explicit run deadline, restored-run coverage proving a resumed run near its deadline waits only for the remaining budget, and announce coverage proving `cleanup: "delete"` timeout cleanup remains retryable while the embedded child request is still active.

What failed before this fix, if known?

The new restored-run regression failed before the latest production change because a run restored 59s into a 60s timeout still passed `timeoutMs: 60000` to `agent.wait` instead of `timeoutMs: 1000`. ClawSweeper also found that the previous announce branch could mark delete cleanup complete while deletion was skipped.

If no test was added, why not?

N/A; focused regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Prematurely marking a still-running child as timed out if the gateway wait path returns a plain timeout before the configured child deadline, or finalizing delete cleanup while the child is still active.

How is that risk mitigated?

Fresh subagent waits keep the existing initial wait budget. Resumed/retried waits are capped to the stored deadline, session-store reconciliation still wins before synthetic timeout completion, and focused tests cover pre-deadline retry, boundary timeout completion, restored near-deadline wait capping, and delete-cleanup retryability.

## Current review state

What is the next action?

Wait for GitHub CI and ClawSweeper re-review on the updated head/body.

What is still waiting on author, maintainer, CI, or external proof?

GitHub CI has not completed on the latest forced-pushed head; external hosted provider/channel proof was not run.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper’s deadline-before-wait finding, real-behavior proof request, and cleanup-delete finding.