### PR TITLE
fix(agents): preserve signed thinking payloads

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -18,6 +18,7 @@ function bedrockModel(overrides: Record<string, unknown>) {
 }
 
 function signedThinkingContext(modelId: string) {
+  const highSurrogate = String.fromCharCode(0xd83d);
   return {
     messages: [
       {
@@ -25,7 +26,13 @@ function signedThinkingContext(modelId: string) {
         api: "bedrock-converse-stream",
         provider: "amazon-bedrock",
         model: modelId,
-        content: [{ type: "thinking", thinking: "private reasoning", thinkingSignature: "sig-1" }],
+        content: [
+          {
+            type: "thinking",
+            thinking: `private${highSurrogate}reasoning`,
+            thinkingSignature: "sig-1",
+          },
+        ],
       },
     ],
   } as never;
@@ -47,7 +54,10 @@ describe("Bedrock reasoning replay", () => {
     expect(messages[0]?.content).toEqual([
       {
         reasoningContent: {
-          reasoningText: { text: "private reasoning", signature: "sig-1" },
+          reasoningText: {
+            text: `private${String.fromCharCode(0xd83d)}reasoning`,
+            signature: "sig-1",
+          },
         },
       },
     ]);
@@ -61,7 +71,7 @@ describe("Bedrock reasoning replay", () => {
       "none",
     );
 
-    expect(messages[0]?.content).toEqual([{ text: "private reasoning" }]);
+    expect(messages[0]?.content).toEqual([{ text: "privatereasoning" }]);
   });
 });
 

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -662,7 +662,7 @@ function convertMessages(
                   contentBlocks.push({
                     reasoningContent: {
                       reasoningText: {
-                        text: sanitizeSurrogates(c.thinking),
+                        text: c.thinking,
                         signature: c.thinkingSignature,
                       },
                     },

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -708,6 +708,54 @@ describe("anthropic transport stream", () => {
     expect(result.usage.output).toBe(9);
   });
 
+  it("preserves provider-signed Anthropic thinking text on ingest", async () => {
+    const highSurrogate = String.fromCharCode(0xd83d);
+    const signedThinking = `keep${highSurrogate}signed`;
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: signedThinking, signature: "sig_1" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "signature_delta", signature: "sig_2" },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 6, output_tokens: 9 },
+        },
+      ]),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "think" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.content[0]).toMatchObject({
+      type: "thinking",
+      thinking: signedThinking,
+      thinkingSignature: "sig_2",
+    });
+  });
+
   it("captures OpenAI-style reasoning_content deltas from Anthropic-compatible streams", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
@@ -1090,6 +1138,7 @@ describe("anthropic transport stream", () => {
   });
 
   it("replays reasoning_content from compatible Anthropic thinking blocks", async () => {
+    const highSurrogate = String.fromCharCode(0xd83d);
     await runTransportStream(
       makeAnthropicTransportModel({
         id: "mimo-v2.6-pro",
@@ -1110,7 +1159,7 @@ describe("anthropic transport stream", () => {
             content: [
               {
                 type: "thinking",
-                thinking: "Need to answer politely.",
+                thinking: `Need${highSurrogate} to answer politely.`,
                 thinkingSignature: "reasoning_content",
               },
               { type: "text", text: "Hello!" },
@@ -1150,6 +1199,51 @@ describe("anthropic transport stream", () => {
         type: "thinking",
         thinking: "Then ask a follow-up.",
         signature: "reasoning_content",
+      },
+    ]);
+  });
+
+  it("preserves provider-signed Anthropic thinking text on replay", async () => {
+    const highSurrogate = String.fromCharCode(0xd83d);
+    const signedThinking = `keep${highSurrogate}signed`;
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "stop",
+            timestamp: 0,
+            content: [
+              {
+                type: "thinking",
+                thinking: signedThinking,
+                thinkingSignature: "sig_1",
+              },
+            ],
+          },
+          { role: "user", content: "again" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(assistantMessage.content).toEqual([
+      {
+        type: "thinking",
+        thinking: signedThinking,
+        signature: "sig_1",
       },
     ]);
   });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -380,7 +380,10 @@ function convertAnthropicMessages(
               text: sanitizeTransportPayloadText(block.thinking),
             });
           } else {
-            const thinking = sanitizeTransportPayloadText(block.thinking);
+            const thinking =
+              block.thinkingSignature === "reasoning_content"
+                ? sanitizeTransportPayloadText(block.thinking)
+                : block.thinking;
             if (block.thinkingSignature === "reasoning_content") {
               if (allowReasoningContentReplay) {
                 blocks.push({
@@ -1121,9 +1124,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             }
             if (contentBlock?.type === "thinking") {
               const thinking =
-                typeof contentBlock.thinking === "string"
-                  ? sanitizeTransportPayloadText(contentBlock.thinking)
-                  : "";
+                typeof contentBlock.thinking === "string" ? contentBlock.thinking : "";
               const block: TransportContentBlock = {
                 type: "thinking",
                 thinking,

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -21,27 +21,43 @@ vi.mock("@anthropic-ai/sdk", () => ({
 
 import { streamAnthropic } from "./anthropic.js";
 
+function createSseResponse(events: Record<string, unknown>[] = []): Response {
+  const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function makeAnthropicModel(overrides: Partial<Model<"anthropic-messages">> = {}) {
+  return {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    provider: "anthropic",
+    api: "anthropic-messages",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 4096,
+    ...overrides,
+  } satisfies Model<"anthropic-messages">;
+}
+
 describe("Anthropic provider", () => {
   beforeEach(() => {
     anthropicMockState.configs = [];
   });
 
   it("keeps Cloudflare AI Gateway upstream provider auth on the Anthropic API key", async () => {
-    const model = {
-      id: "claude-sonnet-4-6",
-      name: "Claude Sonnet 4.6",
+    const model = makeAnthropicModel({
       provider: "cloudflare-ai-gateway",
-      api: "anthropic-messages",
       baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/anthropic/v1/messages",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 200_000,
-      maxTokens: 4096,
       headers: {
         "cf-aig-authorization": "Bearer gateway-token",
       },
-    } satisfies Model<"anthropic-messages">;
+    });
     const context = {
       messages: [{ role: "user", content: "hello", timestamp: 1 }],
     } satisfies Context;
@@ -61,5 +77,94 @@ describe("Anthropic provider", () => {
     expect(config.authToken).toBeNull();
     expect(config.defaultHeaders?.["x-api-key"]).toBeUndefined();
     expect(config.defaultHeaders?.["cf-aig-authorization"]).toBe("Bearer gateway-token");
+  });
+
+  it("preserves provider-signed Anthropic thinking text on replay", async () => {
+    const highSurrogate = String.fromCharCode(0xd83d);
+    const signedThinking = `keep${highSurrogate}signed`;
+    let capturedPayload: unknown;
+    const client = {
+      messages: {
+        create: vi.fn(() => ({
+          asResponse: () =>
+            Promise.resolve(
+              createSseResponse([
+                {
+                  type: "message_start",
+                  message: { id: "msg_1", usage: { input_tokens: 1, output_tokens: 0 } },
+                },
+                {
+                  type: "message_delta",
+                  delta: { stop_reason: "end_turn" },
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+                { type: "message_stop" },
+              ]),
+            ),
+        })),
+      },
+    };
+
+    const stream = streamAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [
+          { role: "user", content: "hello", timestamp: 0 },
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "stop",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [
+              {
+                type: "thinking",
+                thinking: signedThinking,
+                thinkingSignature: "sig_1",
+              },
+              {
+                type: "thinking",
+                thinking: `sanitize${highSurrogate}synthetic`,
+                thinkingSignature: "reasoning_content",
+              },
+            ],
+          },
+          { role: "user", content: "again", timestamp: 0 },
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        client: client as never,
+        onPayload: (payload) => {
+          capturedPayload = payload;
+        },
+      },
+    );
+
+    await stream.result();
+
+    const payload = capturedPayload as { messages: Array<{ role: string; content: unknown[] }> };
+    const assistantMessage = payload.messages.find((message) => message.role === "assistant");
+    expect(assistantMessage?.content).toEqual([
+      {
+        type: "thinking",
+        thinking: signedThinking,
+        signature: "sig_1",
+      },
+      {
+        type: "thinking",
+        thinking: "sanitizesynthetic",
+        signature: "reasoning_content",
+      },
+    ]);
   });
 });

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1119,9 +1119,13 @@ function convertMessages(
               text: sanitizeSurrogates(block.thinking),
             });
           } else {
+            const thinking =
+              block.thinkingSignature === "reasoning_content"
+                ? sanitizeSurrogates(block.thinking)
+                : block.thinking;
             blocks.push({
               type: "thinking",
-              thinking: sanitizeSurrogates(block.thinking),
+              thinking,
               signature: block.thinkingSignature,
             });
           }


### PR DESCRIPTION
## Summary
- Preserve provider-owned signed Anthropic thinking text byte-for-byte on transport ingest and replay.
- Preserve signed Bedrock Anthropic reasoningText byte-for-byte on replay.
- Keep surrogate sanitation for unsigned fallback text and synthetic `reasoning_content` blocks.

Fixes #87459.

## Verification
- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.test.ts extensions/amazon-bedrock/stream.runtime.test.ts` - 4 files passed, 91 tests passed.
- `pnpm format:check -- src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts extensions/amazon-bedrock/stream.runtime.ts extensions/amazon-bedrock/stream.runtime.test.ts`
- `node scripts/run-oxlint.mjs src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts extensions/amazon-bedrock/stream.runtime.ts extensions/amazon-bedrock/stream.runtime.test.ts`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this OpenClaw fix for issue #87459 after the synthetic reasoning_content correction. Focus on provider-owned signed reasoning/thinking payload immutability, whether unsigned/synthetic sanitizer behavior is preserved, and whether sibling Anthropic/Bedrock surfaces are covered. Do not request broader refactors."` - clean, no accepted/actionable findings.
- AWS Crabbox `run_ce07acf3942c`, provider `aws`, lease `cbx_d4ae60080f6a`, PR head `fc08985ad977f72c0fd525a1751f73e45259c85c` - live Anthropic signed-thinking replay plus focused Linux regression tests passed.

## Real behavior proof
Behavior addressed: OpenClaw no longer mutates provider-owned signed Anthropic/Bedrock thinking payload text while retaining the original provider signature.

Real environment tested: AWS Crabbox Linux, provider `aws`, lease `cbx_d4ae60080f6a`, run `run_ce07acf3942c`, PR head `fc08985ad977f72c0fd525a1751f73e45259c85c`, live Anthropic Claude Sonnet 4.6 API credentials loaded from a local `/private/tmp` env profile without printing secrets.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider aws --env-from-profile /private/tmp/openclaw-87459-anthropic.env --allow-env ANTHROPIC_API_KEY --allow-env ANTHROPIC_MODEL --idle-timeout 90m --ttl 240m --timing-json --script /private/tmp/openclaw-87459-live-proof.sh`

Evidence after fix: The live portion requested a thinking-enabled Anthropic tool-use turn, received a signed `thinking` block plus `tool_use`, replayed the assistant content exactly with a `tool_result`, and received a successful second response. The same live script then intentionally corrupted the thinking signature and Anthropic rejected it, proving the replay path is signature-sensitive. The Linux regression portion then ran the focused tests covering Anthropic transport ingest, Anthropic transport replay, legacy Anthropic provider replay, Bedrock signed reasoning replay, and sanitizer retention for unsigned/synthetic paths.

Observed result after fix: Live first turn returned `stopReason: tool_use` with signed thinking (`signatureLen: 424`) and a tool call; exact live replay returned `stopReason: end_turn`; corrupted-signature replay was rejected; focused Linux regression tests passed with 4 files and 91 tests.

What was not tested: The original reporter's exact visible-thinking mutation was not reproduced live because current Anthropic behavior did not emit the reported sanitizer-sensitive payload in prior investigation. This proof validates the fixed signed-replay behavior live and validates the sanitizer-sensitive boundary synthetically in focused regression tests.
