### PR TITLE
test: drop long iMessage image test timeouts

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -648,12 +648,14 @@ function installFastLocalImageProviderStubs(...providers: MediaUnderstandingProv
           fileName: path.basename(mediaUrl),
         };
       },
-      optimizeImageBufferForWebMedia: async ({ buffer, contentType, fileName }) => ({
-        buffer,
-        contentType: contentType ?? "image/png",
-        kind: "image",
-        fileName,
-      }),
+      optimizeImageBufferForWebMedia: async ({ buffer, contentType, fileName }) => {
+        return {
+          buffer,
+          contentType: contentType ?? "image/png",
+          kind: "image",
+          fileName,
+        };
+      },
     }),
   });
 }
@@ -1793,7 +1795,7 @@ describe("image tool implicit imageModel config", () => {
         await fs.rm(attachmentRoot, { recursive: true, force: true });
       }
     });
-  }, 240_000);
+  });
 
   it("allows image paths from current iMessage wildcard attachment roots", async () => {
     await withTempAgentDir(async (agentDir) => {
@@ -1852,7 +1854,7 @@ describe("image tool implicit imageModel config", () => {
         await fs.rm(attachmentRootParent, { recursive: true, force: true });
       }
     });
-  }, 240_000);
+  });
 
   it("allows workspace images via createOpenClawCodingTools when workspace root is explicit", async () => {
     await withTempWorkspacePng(async ({ workspaceDir, imagePath }) => {


### PR DESCRIPTION
## Summary
- Keep the iMessage image-tool attachment-root tests in place.
- Remove the two obsolete `240_000`ms per-test timeouts now that the channel inbound-root seam is mocked on main and these cases complete quickly.
- Leave production behavior unchanged.

## Verification
- `pnpm exec oxfmt --write --threads=1 src/agents/tools/image-tool.test.ts src/agents/tools/media-tool-shared.test.ts`
- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/image-tool.test.ts -t 'iMessage' --reporter=verbose --testTimeout=10000`
- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/image-tool.test.ts src/agents/tools/media-tool-shared.test.ts --reporter=verbose`
- `git diff --check`

## Real behavior proof
Behavior addressed: after main moved image-tool tests onto a mocked channel inbound-root seam, the two iMessage attachment-root image-tool tests no longer need `240000ms` timeouts that can hide a stall and make `checks-node-agentic-agents` run long.
Real environment tested: local Node 24.16.0 checkout with repo dependencies installed via pnpm.
Exact steps or command run after this patch: `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/image-tool.test.ts src/agents/tools/media-tool-shared.test.ts --reporter=verbose`.
Evidence after fix: after rebasing onto origin/main, the two touched test files passed together: 2 files, 87 tests, 6.90s. The two iMessage image-tool tests passed under a 10s timeout in a focused run, taking 128ms and 53ms in that run.
Observed result after fix: the iMessage image-tool coverage remains in place, and a future stall in those cases will fail on the normal test timeout instead of waiting 240s.
What was not tested: the full `checks-node-agentic-agents` CI shard was not run locally; this PR uses focused touched-file proof.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":17,"user":8,"assistant":8,"toolCalls":347,"toolOutputsDropped":346,"web":0,"redactions":0,"omittedUnsafe":0,"rawEntries":72}

[user]
look into  checks-node-agentic-agents, it's been flaky and long running lately

[assistant]
I’ll use the OpenClaw testing workflow here because this is a flaky/long-running check investigation. I’m going to inspect the repo state and find where `checks-node-agentic-agents` is defined before deciding whether this is CI config, test selection, or a specific test file issue.

I found the check name comes from the Node CI test plan, not a standalone workflow. Next I’m reading the relevant CI/test docs and the script/tests that define the shard so I can see why that shard grew or became unstable.

Recent `main` CI shows mixed success/failure and the current run is still active. I’m going to pull job-level timing for the recent runs, focusing only on the `checks-node-agentic-agents` job and adjacent agentic shards for comparison.

The timing pattern is clear: `checks-node-agentic-agents` is consistently one of the slowest Node shards, around 3-6.5 minutes wall time, and one recent failure happened after nearly 6 minutes of test execution. I’m pulling that failed job log now to identify whether it is a deterministic failing test, timeout, or worker instability.

The failed run is not a generic infrastructure timeout: `src/agents/tools/image-tool.test.ts` had one 240s timeout, then the adjacent wildcard attachment-root test observed the mocked image describe call twice. That points to test state leaking or duplicate work inside the image tool tests, and the long runtime is largely the timeout plus a single 22s image-auth test in the same shard.

The failure mode also explains the long-running symptom: when the first attachment-root test hangs, Vitest waits the full 240 seconds before the shard can finish. I’m going to reproduce just `image-tool.test.ts` with the repo’s node Vitest wrapper, then patch the narrow test/runtime cause instead of reshuffling the whole shard blindly.

The local worktree has no `node_modules`, so the wrapper cannot run. Per repo policy I’m hydrating dependencies once with the frozen lockfile, then I’ll rerun the narrow test.

The narrow local run has reproduced the bad behavior: it passed through `fsPolicy.workspaceOnly` and then stopped making progress at the iMessage attachment-root test. I’m stopping that run now rather than waiting four minutes for Vitest’s timeout, then I’ll patch the test to avoid the fallback path that is consuming the whole timeout.

The positive-only wildcard test also hangs, so the timeout is not caused by the negative assertion. I’m going to capture a process sample from the hung Vitest worker to see whether it is stuck in filesystem access, network/runtime discovery, or Vitest teardown.

I need a little more signal inside the hanging test. I’m going to add temporary instrumentation around that test path, run it once, and then replace the instrumentation with the actual fix.

The hang is before media loading: the image tool resolves compression metadata, then scans plugin manifests to decide whether a provider has runtime model augmentation. For a test-local custom provider with explicit `models.providers.ollama.models`, that broad manifest scan is unnecessary and can stall the whole image tool call. I’m going to make configured provider-model metadata short-circuit that plugin scan, then remove the temporary instrumentation.

The code path is now narrowed: configured provider models no longer trigger manifest runtime-augment discovery during image compression setup. I removed the debug logs and I’m rerunning the exact hanging test first.

I found the remaining stall: `ollama` is treated as a runtime-augmented bundled provider, so even an explicitly configured test model was entering runtime model augmentation. I changed image compression setup to skip that path when every candidate is declared in `models.providers`, unless the config actually sets image compression policy. Now I’m rerunning the exact hanging test.

The image-tool integration cases are the source of the 240s CI flake. They duplicate the resolver contract already owned by `media-tool-shared`, so I’m moving the wildcard coverage to that pure resolver test and removing the long-running image-tool integration assertions. That keeps the channel-root behavior covered without exercising the slow image runtime path in this shard.

The targeted run now gets past the former 240s iMessage area quickly, but my production shortcut changed image-compression behavior for configured provider models and broke an existing maxBytes test. I’m reverting that production shortcut and keeping the lower-risk test-routing fix: move the iMessage root coverage to the pure resolver test.

I’m resuming from the CI shard investigation. I’ll first confirm no Vitest processes are still running, then I’ll do one narrow validation pass and inspect the current diff before closing this out.

No stale Vitest process is left. I’m checking the exact patch now so I can validate the smallest relevant surface instead of re-running the whole slow shard.

The patch is exactly the intended test-scope change: two 240s image runtime cases removed, equivalent wildcard/root coverage added to the pure resolver test. I’m going to run just that resolver case first with a short no-output timeout so a local hang doesn’t waste another cycle.

The resolver-only run stalls before executing a test under the agents-tools config, so that looks like a local harness/import issue rather than the resolver assertion itself. I’m checking the config graph and runtime version now before deciding whether to use a more direct proof or leave this as a local proof gap.

The one-file startup is doing enough work that a 30s no-output guard kills it before Vitest reports the test. I’m giving the exact resolver case a longer window once; if it still does not produce output, I’ll treat that as a local runner proof gap and avoid masking it.

That longer run exposed something useful: the new pure resolver assertion itself times out when a wildcard inbound root is present. I’m going to inspect the inbound-root policy now; this suggests the old flake was not only test weight, but also a wildcard path pathologically interacting with root normalization/matching.

The timeout is from `media-tool-shared.test.ts` loading the real iMessage media contract through `channel-inbound-roots`, which is exactly the broad plugin path this shard should avoid. I’m going to keep the behavior coverage but mock that channel seam in the agent tool test, so the shard validates agent-side routing without bootstrapping bundled plugin code.

I’ve changed the agent-side resolver test to mock the channel inbound root contract instead of importing the real iMessage contract path. That keeps the assertion local to `src/agents/tools` and should take the 60s-plus startup out of this shard.

Formatting is clean. I’m rerunning the exact resolver case now; this should prove whether the mock removes the long-running plugin-load path.

The resolver case now passes in about 2 seconds, with the test body itself taking 5ms. I’m running the two touched files together once to make sure the image tool file no longer hits the old 240s iMessage cases and the shared test stays fast under the real shard config.

The two touched files now pass together in 11.4s under `vitest.agents-tools.config.ts`, and the prior iMessage-root area is gone from the image tool runtime path. I’m doing final diff sanity checks next: whitespace, status, and LOC impact.

Found the flake source and made a focused test cleanup.

`checks-node-agentic-agents` maps to the `agentic-agents` shard in `scripts/lib/ci-node-test-plan.mjs:362`, including `test/vitest/vitest.agents-tools.config.ts`. Recent CI failures were coming from two `src/agents/tools/image-tool.test.ts` iMessage attachment-root runtime tests with `240_000` timeouts. One timed out after 240s, and the adjacent wildcard case then saw duplicate provider mock calls.

Changed:
- Removed those two slow image-tool integration tests from `src/agents/tools/image-tool.test.ts`.
- Preserved the account-root and wildcard-root coverage in `src/agents/tools/media-tool-shared.test.ts:69`, but mocked `../../media/channel-inbound-roots.js` at `src/agents/tools/media-tool-shared.test.ts:5` so this agent shard no longer bootstraps the real iMessage media contract path.
- No production code changed.

Validation:
- `pnpm install --frozen-lockfile`
- `pnpm exec oxfmt --write --threads=1 src/agents/tools/image-tool.test.ts src/agents/tools/media-tool-shared.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/image-tool.test.ts src/agents/tools/media-tool-shared.test.ts --reporter=verbose`
  - Passed: 2 files, 85 tests, 11.43s.
- `git diff --check` passed.

I did not run the full `checks-node-agentic-agents` shard locally; that is broader than the touched files and should go through CI/Testbox if we want full-shard proof.

[user]
open a new PR with the fixes

[assistant]
I’ll use the OpenClaw PR preparation workflow and the transcript guidance before creating the branch/commit/PR, then I’ll push only the two touched test files.

The repo-local `prepare-pr` skill path is not present here, so I’m reading the global copy listed for this session. The worktree currently has only the two expected modified test files.

I’m checking branch/remotes and whether there is an existing PR for this branch before committing. If this branch already has an open PR, I’ll avoid creating a duplicate and update that path instead.

There’s no existing PR attached to this branch. I’m going to commit the two test-only changes with the repo committer wrapper, then create the PR against `main`.

The commit is made. I’m preparing the PR body now, and I’ll run the transcript finder per repo policy before deciding whether to include a redacted transcript section.

A high-confidence local session was found for this PR. Include a redacted agent transcript? It helps reviewers and can make the PR easier to prioritize; I can open a local preview first. I’m proceeding without a transcript unless you explicitly approve adding one, so the PR creation is not blocked.

Branch pushed. I’m creating the PR body with the scoped behavior/proof fields now, without a transcript section because there is no approval to include one.

PR created. I’m doing one final status/API check so I can hand you the exact state and URL.

Opened PR #87499 with commit `35c6bf7d7a`.

It removes the two 240s iMessage image-tool integration tests from `src/agents/tools/image-tool.test.ts` and keeps the inbound-root coverage in `src/agents/tools/media-tool-shared.test.ts` with the channel seam mocked. Focused proof passed: 2 files, 85 tests, 11.43s under `test/vitest/vitest.agents-tools.config.ts`; `git diff --check` also passed. I did not include a redacted transcript because that needs explicit approval.

https://github.com/openclaw/openclaw/pull/87499

[user]
include the transcript

[assistant]
I’ll add the redacted transcript section to PR #87499 using the local transcript helper, then update the existing PR body rather than creating a second comment.

The PR body was updated with the generated redacted transcript. I’m verifying the body now so the final answer can include the exact state.

Added the redacted `## Agent Transcript` section to PR #87499 and verified it is present in the PR body.

https://github.com/openclaw/openclaw/pull/87499

[user]
check clawsweeper feedback btw, anything actionable? And rebase main

[assistant]
I’ll check the PR’s ClawSweeper comments/reviews first, then fetch and rebase this branch onto latest `origin/main`. If feedback requires code changes, I’ll handle those before pushing the rebased branch.

I’ve loaded the ClawSweeper and PR maintainer workflows. The branch is clean and tracking `origin/node-agentic-agents-test`, so I’m gathering live PR feedback now before touching history.

ClawSweeper’s actionable feedback is procedural, not a code finding: rebase/refresh the dirty branch, then let CI or the agents-tools shard prove the refreshed head. I’m rebasing onto latest `origin/main` now.

The rebase hit one conflict in `src/agents/tools/media-tool-shared.test.ts`; `image-tool.test.ts` merged cleanly. I’m reading the conflict and current main side before resolving it.

`origin/main` already added the same general channel-seam mock, with a more useful config-driven implementation. I’m resolving by keeping main’s mock and applying only this PR’s wildcard-root coverage on top.

Conflict resolved: latest main already removed the broad plugin load from this test; this branch now only adds wildcard-root coverage to that current mock. I’m formatting, staging, and continuing the rebase.

The rebase completed and rewrote the commit to `7b10d652c6`. Because `pnpm exec` hydrated workspace packages during formatting, I’m checking the tracked tree and rerunning the focused agents-tools proof on the rebased head.

[user]
just to be clear is this pr even still needed given the changes on main

[assistant]
Yes, the PR is still doing work after the rebase. Latest `origin/main` already added the fast channel-inbound mock in `media-tool-shared.test.ts`, so that part of our patch collapsed, but `origin/main` still has the two `240_000`ms iMessage image-tool runtime tests; this PR still removes those and adds wildcard-root coverage to the now-existing shared helper test. I’m letting the focused test run finish now.

The focused proof still passes on the rebased head: 2 files, 85 tests, 11.10s. I’m force-pushing with an explicit lease against the previous PR branch SHA, then I’ll update the PR proof text to reflect the rebased run.

The PR branch is updated and the proof line in the PR body now reflects the rebased run. I’m checking GitHub’s current PR state and local cleanliness before final.

ClawSweeper feedback had no code-level finding. The actionable items were:

- Rebase/refresh because GitHub reported the branch as dirty.
- Let CI or the agents-tools shard prove the refreshed head.

I rebased onto latest `origin/main`, resolved the one conflict in `src/agents/tools/media-tool-shared.test.ts`, and force-pushed with lease. The PR is still needed: `main` already added a fast mocked channel-root seam, but it still had the two `240_000`ms image-tool runtime tests. This PR still removes those and keeps wildcard-root coverage in the shared helper test.

Verification after rebase:
`OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/image-tool.test.ts src/agents/tools/media-tool-shared.test.ts --reporter=verbose`

Result: 2 files, 85 tests passed, 11.10s.

GitHub now reports the PR as `MERGEABLE`; status is `UNSTABLE` because CI is still queued/in progress, including `checks-node-agentic-agents`. PR body proof was updated for the rebased run.

https://github.com/openclaw/openclaw/pull/87499

[user]
ok but like is the pr still useful given the similar changes on main?

And can we do an approach that doesn't just nuke the tests?

[assistant]
The PR is still useful, but narrower than when opened: latest `main` already fixed the shared-test plugin-load part, while this PR still removes the two slow image-tool runtime cases. I agree the better patch is to keep image-tool-level coverage and make those two cases cheap/deterministic instead of deleting them; I’m going to inspect the current rebased test setup and revise the PR that way.

One important detail from the rebase: `main` now has the mocked channel-inbound seam in `image-tool.test.ts` too, not just the shared test. That makes the original slow tests likely cheap now, so I’m going to restore them on top of current main with normal test timeouts and keep the wildcard assertion in the shared helper.

I’m revising the branch so it no longer deletes the two image-tool cases. The new shape will keep both tests, remove the long `240_000` timeout escape hatch, and rely on the mocked channel-root seam that now exists on `main`.

The image-tool tests are restored with normal timeouts. I’m formatting and running those two specific cases first to confirm they’re now fast instead of just less permissive.

The restored iMessage image-tool cases pass in 195ms total under a 10s test timeout. I’m checking the new diff now; if it’s only “remove long timeout” plus the shared wildcard assertion, I’ll amend and push that cleaner approach.

[user]
ok but isn't the pr basically nothing now?

[assistant]
After `main` absorbed the seam mock, yes: the PR is now small. The remaining useful bit is not a deflake architecture change anymore; it is “these two image-tool tests are now fast, so do not give them a 240s timeout,” plus one shared wildcard assertion. I’m finishing the non-nuking revision so the PR accurately reflects that smaller value instead of deleting coverage.

The revised two-file proof passes with the tests restored: 87 tests in 7.87s, and the two iMessage cases took 79ms and 2ms. I’m amending the PR commit and updating the PR body so it no longer claims we removed those tests.

The PR is now rewritten to the smaller non-deletion version: 13 insertions, 10 deletions, tests preserved. I’m doing final cleanliness and PR state checks.

Yes, after the latest `main` changes, the PR is basically a small cleanup, not the original deflake. `main` already added the important mocked channel-root seam that makes the iMessage tests fast.

I rewrote the PR so it does **not** delete the tests. It now:
- keeps both iMessage image-tool tests,
- removes their `240_000`ms custom timeouts,
- adds wildcard-root coverage to the shared resolver test.

That is still mildly useful because those tests now pass quickly, so keeping a 240s timeout would let a future stall waste minutes again. But it is no longer a high-impact PR. If you want to reduce queue noise, closing it would be defensible.

Current PR state:
- Diff: `+13/-10` across 2 test files.
- Focused proof: 2 files, 87 tests passed, 7.87s.
- PR is mergeable; CI still in progress.

https://github.com/openclaw/openclaw/pull/87499

[user]
ok are you SURE about that wildcard root fix?

[assistant]
I’m going to re-check the actual root resolution path and run the focused assertion again. The question is whether the shared resolver wildcard assertion proves a real contract or just mirrors the test mock.

After re-reading it, I’m not comfortable calling the shared-test wildcard line a “fix.” It proves that the current test mock passes a wildcard string through `resolveMediaToolInboundRoots`, but actual wildcard matching is already covered in `src/media/inbound-path-policy.test.ts`, and the restored image-tool wildcard case exercises the image-tool path. I’m going to remove that shared-test change and keep the PR to the defensible part: dropping the obsolete 240s timeouts.

I removed the questionable shared wildcard assertion. I’m running the focused iMessage cases and the two touched files once more, then I’ll amend the PR body/commit to reflect the smaller scope.

With that assertion removed, the shared test is back to `main`; the PR is only about the two iMessage test timeouts plus formatting from `oxfmt`. I’m amending/pushing that final version and updating the PR body again.

[tool summary]
134 read, 19 write, 194 execute; raw tool outputs dropped: 346
````

</details>
<!-- agent-transcript:end -->
