### PR TITLE
fix(images): skip CLI image cache refs

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -39,6 +39,22 @@ describe("loadPromptRefImages", () => {
     expect(sanitizeImageBlocksSpy).not.toHaveBeenCalled();
   });
 
+  it("does not reload OpenClaw CLI image cache paths from prior prompt text", async () => {
+    const loadImageFromRefSpy = vi.spyOn(promptImageUtils, "loadImageFromRef");
+    const sanitizeImageBlocksSpy = vi.spyOn(toolImages, "sanitizeImageBlocks");
+
+    await expect(
+      loadPromptRefImages({
+        prompt:
+          'Called the Read tool with {"file_path":"/workspace/.openclaw-cli-images/stale.png"}',
+        workspaceDir: "/workspace",
+      }),
+    ).resolves.toStrictEqual([]);
+
+    expect(loadImageFromRefSpy).not.toHaveBeenCalled();
+    expect(sanitizeImageBlocksSpy).not.toHaveBeenCalled();
+  });
+
   it("passes the max-byte guardrail through load and sanitize", async () => {
     const loadedImage: ImageContent = {
       type: "image",

--- a/src/agents/embedded-agent-runner/run/images.test.ts
+++ b/src/agents/embedded-agent-runner/run/images.test.ts
@@ -81,6 +81,35 @@ describe("detectImageReferences", () => {
     });
   });
 
+  it("ignores OpenClaw CLI image cache paths from prior prompt transcripts", () => {
+    const refs = detectImageReferences(
+      [
+        '<system-reminder>Called the Read tool with {"file_path":"/Users/ada/.openclaw/workspace/.openclaw-cli-images/stale.png"}</system-reminder>',
+        "Compare it with /Users/ada/Pictures/current.png",
+      ].join("\n"),
+    );
+
+    expect(refs).toStrictEqual([
+      {
+        raw: "/Users/ada/Pictures/current.png",
+        type: "path",
+        resolved: "/Users/ada/Pictures/current.png",
+      },
+    ]);
+  });
+
+  it("ignores temporary OpenClaw CLI image cache paths", () => {
+    expectNoImageReferences(
+      `Prior turn wrote ${path.join(os.tmpdir(), "openclaw-cli-images", "stale.jpg")}`,
+    );
+  });
+
+  it("ignores file URLs into the OpenClaw CLI image cache", () => {
+    const stalePath = path.join(os.tmpdir(), "openclaw-cli-images", "stale.png");
+
+    expectNoImageReferences(`Prior turn wrote ${pathToFileURL(stalePath).href}`);
+  });
+
   it("detects multiple image references in a prompt", () => {
     const refs = expectImageReferenceCount(
       `

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -102,6 +102,13 @@ function normalizeRefForDedupe(raw: string): string {
   return process.platform === "win32" ? normalizeLowercaseStringOrEmpty(raw) : raw;
 }
 
+function isOpenClawCliImageCachePath(filePath: string): boolean {
+  const normalized = filePath.replaceAll("\\", "/");
+  return normalized.split("/").some((part) => {
+    return part === ".openclaw-cli-images" || part === "openclaw-cli-images";
+  });
+}
+
 export function mergePromptAttachmentImages(params: {
   imageOrder?: PromptImageOrderEntry[];
   existingImages?: ImageContent[];
@@ -321,8 +328,11 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     } catch {
       return;
     }
-    seen.add(dedupeKey);
     const resolved = trimmed.startsWith("~") ? resolveUserPath(trimmed) : trimmed;
+    if (isOpenClawCliImageCachePath(resolved)) {
+      return;
+    }
+    seen.add(dedupeKey);
     refs.push({ raw: trimmed, type: "path", resolved });
   };
 
@@ -388,6 +398,9 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     // Use fileURLToPath for proper handling (e.g., file://localhost/path)
     try {
       const resolved = safeFileURLToPath(raw);
+      if (isOpenClawCliImageCachePath(resolved)) {
+        continue;
+      }
       refs.push({ raw, type: "path", resolved });
     } catch {
       // Skip malformed file:// URLs


### PR DESCRIPTION
Fixes the sticky-image reattachment portion of #86687.

## Summary
- skip OpenClaw-written `.openclaw-cli-images` and `openclaw-cli-images` paths during prompt image-reference detection
- cover direct parser behavior for prior transcript cache paths, temporary cache paths, and file URLs
- add a CLI helper regression proving prior `.openclaw-cli-images` prompt text is not reloaded through `loadImageFromRef`

## Scope note
This intentionally does not change the group-chat selective-reply policy. The issue review marks that half as needing a maintainer/product decision, while the sticky-image loop has a narrow source-proven fix.

## Real behavior proof
Behavior or issue addressed: Prior OpenClaw-written CLI image cache paths in prompt history should not be detected or loaded as fresh user image references on later turns.

Real environment tested: Local OpenClaw checkout at `/Users/andy/openclaw/openclaw-86687`, branch `fix/skip-cli-image-cache-86687`, dependencies installed with `pnpm install --frozen-lockfile`.

Exact steps or command run after this patch: Ran `pnpm exec tsx -e ...` against the real `detectImageReferences` and `loadPromptRefImages` helpers using prior prompt text containing `/workspace/.openclaw-cli-images/stale.png`, then ran ClawSweeper's requested surrounding test suite.

Evidence after fix:
```json
{
  "refs": [
    {
      "raw": "/workspace/current.png",
      "type": "path",
      "resolved": "/workspace/current.png"
    }
  ],
  "cacheOnlyLoadCount": 0,
  "cachePathDetected": false
}
```

Additional command output:
- `node scripts/run-vitest.mjs src/agents/cli-runner.helpers.test.ts src/agents/embedded-agent-runner/run/images.test.ts src/auto-reply/reply/groups.test.ts src/config/silent-reply.test.ts --reporter dot` -> 6 test files passed, 132 tests passed.

Observed result after fix: The stale `.openclaw-cli-images` transcript path was ignored, `loadPromptRefImages` returned zero images for a cache-only prompt, and an unrelated normal image path remained detectable.

What was not tested: I did not run a live Discord channel replay; the fix is scoped to the shared prompt image-reference detector used by the CLI image reload path.

## Author attribution
If this PR is squash-merged or reworked, please preserve author attribution for `Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>` or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`