### PR TITLE
fix(skill-workshop): align agent_end hook timeout with max reviewer timeout

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import {
   testing as replyRunTesting,
@@ -17,6 +17,7 @@ import {
   createUserTurnTranscriptRecorder,
   type UserTurnTranscriptRecorder,
 } from "../sessions/user-turn-transcript.js";
+import { runSkillResearchAutoCapture } from "../skills/research/autocapture.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { runPreparedCliAgent } from "./cli-runner.js";
 import {
@@ -39,11 +40,16 @@ vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: vi.fn(() => null),
 }));
 
+vi.mock("../skills/research/autocapture.js", () => ({
+  runSkillResearchAutoCapture: vi.fn(),
+}));
+
 vi.mock("../tts/tts.js", () => ({
   buildTtsSystemPromptHint: vi.fn(() => undefined),
 }));
 
 const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+const mockSkillResearchAutoCapture = vi.mocked(runSkillResearchAutoCapture);
 const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
 let sessionFileEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
 
@@ -140,11 +146,13 @@ function buildPreparedContext(params?: {
   cliSessionId?: string;
   runId?: string;
   lane?: string;
+  trigger?: PreparedCliRunContext["params"]["trigger"];
   openClawHistoryPrompt?: string;
   provider?: string;
   model?: string;
   executionMode?: PreparedCliRunContext["params"]["executionMode"];
   allowEmptyAssistantReplyAsSilent?: boolean;
+  config?: OpenClawConfig;
 }): PreparedCliRunContext {
   // Common prepared context fixture for runPreparedCliAgent reliability branches.
   const provider = params?.provider ?? "codex-cli";
@@ -172,7 +180,9 @@ function buildPreparedContext(params?: {
       runId: params?.runId ?? "run-2",
       lane: params?.lane,
       executionMode: params?.executionMode,
+      trigger: params?.trigger,
       allowEmptyAssistantReplyAsSilent: params?.allowEmptyAssistantReplyAsSilent,
+      ...(params?.config ? { config: params.config } : {}),
     },
     started: Date.now(),
     workspaceDir: "/tmp",
@@ -278,8 +288,14 @@ const CLI_RESEED_PROMPT =
   "Continue this conversation using the OpenClaw transcript below as prior session history.\n\n<conversation_history>\nUser: earlier context\n</conversation_history>\n\n<next_user_message>\nhi\n</next_user_message>";
 
 describe("runCliAgent reliability", () => {
+  beforeEach(() => {
+    mockSkillResearchAutoCapture.mockReset();
+    mockSkillResearchAutoCapture.mockResolvedValue(undefined);
+  });
+
   afterEach(() => {
     replyRunTesting.resetReplyRunRegistry();
+    mockSkillResearchAutoCapture.mockReset();
     mockGetGlobalHookRunner.mockReset();
     setHookRunnerForTest(null);
     vi.unstubAllEnvs();
@@ -1248,6 +1264,59 @@ describe("runCliAgent reliability", () => {
     expect(resolved).toBe(false);
 
     releaseAgentEnd();
+    await expect(run).resolves.toMatchObject({
+      payloads: [{ text: "hello from cli" }],
+    });
+    expect(resolved).toBe(true);
+  });
+
+  it("waits for Skill Research auto-capture before resolving direct CLI runs", async () => {
+    let releaseCapture: () => void = () => undefined;
+    const captureSettled = new Promise<void>((resolve) => {
+      releaseCapture = resolve;
+    });
+    mockSkillResearchAutoCapture.mockReturnValueOnce(captureSettled);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from cli",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    let resolved = false;
+    const run = runPreparedCliAgent(
+      buildPreparedContext({
+        sessionKey: "manual-proof-87504",
+        trigger: "manual",
+        config: {
+          skills: {
+            workshop: {
+              autonomous: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      }),
+    ).then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await vi.waitFor(() => {
+      expect(mockSkillResearchAutoCapture).toHaveBeenCalledTimes(1);
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releaseCapture();
     await expect(run).resolves.toMatchObject({
       payloads: [{ text: "hello from cli" }],
     });

--- a/src/agents/harness/agent-end-side-effects.test.ts
+++ b/src/agents/harness/agent-end-side-effects.test.ts
@@ -90,6 +90,32 @@ describe("agent end side effects", () => {
     resolveCapture?.();
   });
 
+  it("does not wait for Skill Research auto-capture when awaiting plugin hooks", async () => {
+    let resolveCapture: (() => void) | undefined;
+    mockAutoCapture.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveCapture = resolve;
+      }),
+    );
+
+    await expect(
+      awaitAgentEndSideEffects({
+        event: {
+          messages: [],
+          success: true,
+        },
+        ctx: {
+          runId: "run-1",
+          workspaceDir: "/workspace",
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockAutoCapture).toHaveBeenCalledTimes(1);
+    expect(mockAwaitAgentEndHook).toHaveBeenCalledTimes(1);
+    resolveCapture?.();
+  });
+
   it("still runs agent_end hooks when Skill Research auto-capture fails", async () => {
     mockAutoCapture.mockRejectedValueOnce(new Error("capture failed"));
 

--- a/src/agents/harness/agent-end-side-effects.test.ts
+++ b/src/agents/harness/agent-end-side-effects.test.ts
@@ -90,7 +90,7 @@ describe("agent end side effects", () => {
     resolveCapture?.();
   });
 
-  it("does not wait for Skill Research auto-capture when awaiting plugin hooks", async () => {
+  it("waits for Skill Research auto-capture when awaiting side effects", async () => {
     let resolveCapture: (() => void) | undefined;
     mockAutoCapture.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -98,22 +98,30 @@ describe("agent end side effects", () => {
       }),
     );
 
-    await expect(
-      awaitAgentEndSideEffects({
-        event: {
-          messages: [],
-          success: true,
-        },
-        ctx: {
-          runId: "run-1",
-          workspaceDir: "/workspace",
-        },
-      }),
-    ).resolves.toBeUndefined();
+    let resolved = false;
+    const run = awaitAgentEndSideEffects({
+      event: {
+        messages: [],
+        success: true,
+      },
+      ctx: {
+        runId: "run-1",
+        workspaceDir: "/workspace",
+      },
+    }).then(() => {
+      resolved = true;
+    });
 
-    expect(mockAutoCapture).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(mockAutoCapture).toHaveBeenCalledTimes(1);
+    });
     expect(mockAwaitAgentEndHook).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
     resolveCapture?.();
+    await expect(run).resolves.toBeUndefined();
+    expect(resolved).toBe(true);
   });
 
   it("still runs agent_end hooks when Skill Research auto-capture fails", async () => {

--- a/src/agents/harness/agent-end-side-effects.ts
+++ b/src/agents/harness/agent-end-side-effects.ts
@@ -1,8 +1,8 @@
 /**
  * Agent-end side effect runner.
  *
- * Harnesses use this to trigger core research capture and plugin agent_end hooks
- * either fire-and-forget or awaited during tests/shutdown.
+ * Harnesses use this to trigger core research capture and plugin agent_end hooks.
+ * Awaited callers wait for plugin hooks while auto-capture stays opportunistic.
  */
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runSkillResearchAutoCapture } from "../../skills/research/autocapture.js";
@@ -15,27 +15,24 @@ const log = createSubsystemLogger("agents/harness");
 
 type AgentEndSideEffectsParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];
 
-async function runCoreAgentEndSideEffects(params: AgentEndSideEffectsParams): Promise<void> {
-  try {
-    await runSkillResearchAutoCapture({
-      event: params.event,
-      ctx: params.ctx,
-      ...(params.ctx.config ? { config: params.ctx.config } : {}),
-    });
-  } catch (error) {
-    // Side effects are observational; failures must not change the completed run result.
+function runCoreAgentEndSideEffects(params: AgentEndSideEffectsParams): void {
+  void runSkillResearchAutoCapture({
+    event: params.event,
+    ctx: params.ctx,
+    ...(params.ctx.config ? { config: params.ctx.config } : {}),
+  }).catch((error: unknown) => {
     log.warn(`skill research auto-capture failed: ${String(error)}`);
-  }
+  });
 }
 
 /** Starts agent-end side effects without waiting for completion. */
 export function runAgentEndSideEffects(params: AgentEndSideEffectsParams): void {
-  void runCoreAgentEndSideEffects(params);
+  runCoreAgentEndSideEffects(params);
   runAgentHarnessAgentEndHook(params);
 }
 
-/** Runs agent-end side effects and waits for plugin/core completion. */
+/** Runs agent-end side effects and waits for plugin hook completion. */
 export async function awaitAgentEndSideEffects(params: AgentEndSideEffectsParams): Promise<void> {
-  await runCoreAgentEndSideEffects(params);
+  runCoreAgentEndSideEffects(params);
   await awaitAgentHarnessAgentEndHook(params);
 }

--- a/src/agents/harness/agent-end-side-effects.ts
+++ b/src/agents/harness/agent-end-side-effects.ts
@@ -2,7 +2,7 @@
  * Agent-end side effect runner.
  *
  * Harnesses use this to trigger core research capture and plugin agent_end hooks.
- * Awaited callers wait for plugin hooks while auto-capture stays opportunistic.
+ * Fire-and-forget callers keep auto-capture opportunistic.
  */
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runSkillResearchAutoCapture } from "../../skills/research/autocapture.js";
@@ -15,8 +15,8 @@ const log = createSubsystemLogger("agents/harness");
 
 type AgentEndSideEffectsParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];
 
-function runCoreAgentEndSideEffects(params: AgentEndSideEffectsParams): void {
-  void runSkillResearchAutoCapture({
+function startSkillResearchAutoCapture(params: AgentEndSideEffectsParams): Promise<void> {
+  return runSkillResearchAutoCapture({
     event: params.event,
     ctx: params.ctx,
     ...(params.ctx.config ? { config: params.ctx.config } : {}),
@@ -27,12 +27,13 @@ function runCoreAgentEndSideEffects(params: AgentEndSideEffectsParams): void {
 
 /** Starts agent-end side effects without waiting for completion. */
 export function runAgentEndSideEffects(params: AgentEndSideEffectsParams): void {
-  runCoreAgentEndSideEffects(params);
+  void startSkillResearchAutoCapture(params);
   runAgentHarnessAgentEndHook(params);
 }
 
-/** Runs agent-end side effects and waits for plugin hook completion. */
+/** Runs agent-end side effects and waits for completion. */
 export async function awaitAgentEndSideEffects(params: AgentEndSideEffectsParams): Promise<void> {
-  runCoreAgentEndSideEffects(params);
-  await awaitAgentHarnessAgentEndHook(params);
+  const captureSettled = startSkillResearchAutoCapture(params);
+  const hookSettled = awaitAgentHarnessAgentEndHook(params);
+  await Promise.all([captureSettled, hookSettled]);
 }

--- a/src/skills/research/autocapture.test.ts
+++ b/src/skills/research/autocapture.test.ts
@@ -165,6 +165,102 @@ describe("skill research auto-capture", () => {
     expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
   });
 
+  it("skips Active Memory helper sessions with manual triggers", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content: "Remember to always verify generated screenshots before replying.",
+          },
+        ],
+      },
+      ctx: {
+        workspaceDir,
+        trigger: "manual",
+        sessionKey: "agent:main:active-memory:recall-1",
+      },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+  });
+
+  it("skips unscoped Active Memory helper session ids with manual triggers", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content: "Remember to always verify generated screenshots before replying.",
+          },
+        ],
+      },
+      ctx: {
+        workspaceDir,
+        trigger: "manual",
+        sessionKey: "active-memory-recall-1",
+      },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+  });
+
+  it("skips agent-scoped Active Memory helper session ids with manual triggers", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content: "Remember to always verify generated screenshots before replying.",
+          },
+        ],
+      },
+      ctx: {
+        workspaceDir,
+        trigger: "manual",
+        sessionKey: "agent:main:active-memory-recall-1",
+      },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+  });
+
   it("preserves existing skill content when auto-capturing an update", async () => {
     const workspaceDir = await makeWorkspace();
     const skillFile = path.join(workspaceDir, "skills", "github-pr-workflow", "SKILL.md");

--- a/src/skills/research/autocapture.test.ts
+++ b/src/skills/research/autocapture.test.ts
@@ -101,6 +101,70 @@ describe("skill research auto-capture", () => {
     expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
   });
 
+  it("skips automatic agent_end sessions before creating workshop proposals", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content: "Remember to always verify generated screenshots before replying.",
+          },
+        ],
+      },
+      ctx: {
+        workspaceDir,
+        trigger: "cron",
+        sessionKey: "cron:daily-summary",
+      },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+  });
+
+  it("skips hook-scoped helper sessions before creating workshop proposals", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content: "Remember to always verify generated screenshots before replying.",
+          },
+        ],
+      },
+      ctx: {
+        workspaceDir,
+        trigger: "user",
+        sessionKey: "hook:gmail:msg-1",
+      },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+  });
+
   it("preserves existing skill content when auto-capturing an update", async () => {
     const workspaceDir = await makeWorkspace();
     const skillFile = path.join(workspaceDir, "skills", "github-pr-workflow", "SKILL.md");

--- a/src/skills/research/autocapture.ts
+++ b/src/skills/research/autocapture.ts
@@ -38,6 +38,16 @@ function isHookScopedSessionKey(sessionKey: string | undefined): boolean {
   );
 }
 
+function isActiveMemoryHelperSessionKey(sessionKey: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  const agentSessionRest = normalizeLowercaseStringOrEmpty(parseAgentSessionKey(sessionKey)?.rest);
+  return (
+    normalized.startsWith("active-memory-") ||
+    normalized.includes(":active-memory:") ||
+    agentSessionRest.startsWith("active-memory-")
+  );
+}
+
 function shouldSkipSkillResearchAutoCapture(ctx: SkillResearchAgentContext): boolean {
   const trigger = normalizeLowercaseStringOrEmpty(ctx.trigger);
   if (AUTOMATIC_CAPTURE_TRIGGERS.has(trigger)) {
@@ -46,7 +56,8 @@ function shouldSkipSkillResearchAutoCapture(ctx: SkillResearchAgentContext): boo
   return (
     isCronSessionKey(ctx.sessionKey) ||
     isSubagentSessionKey(ctx.sessionKey) ||
-    isHookScopedSessionKey(ctx.sessionKey)
+    isHookScopedSessionKey(ctx.sessionKey) ||
+    isActiveMemoryHelperSessionKey(ctx.sessionKey)
   );
 }
 

--- a/src/skills/research/autocapture.ts
+++ b/src/skills/research/autocapture.ts
@@ -1,6 +1,12 @@
 // Research autocapture helpers decide when skill research signals should be captured.
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  isCronSessionKey,
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+} from "../../sessions/session-key-utils.js";
 import { readWorkspaceSkillFile } from "../lifecycle/workspace-skill-write.js";
 import { resolveSkillWorkshopConfig } from "../workshop/config.js";
 import { listSkillProposals, proposeCreateSkill, proposeUpdateSkill } from "../workshop/service.js";
@@ -15,9 +21,34 @@ type SkillResearchAgentEndEvent = {
 type SkillResearchAgentContext = {
   agentId?: string;
   workspaceDir?: string;
+  trigger?: string;
+  sessionKey?: string;
 };
 
 const log = createSubsystemLogger("skills/research");
+const AUTOMATIC_CAPTURE_TRIGGERS = new Set(["cron", "heartbeat", "memory", "overflow"]);
+
+function isHookScopedSessionKey(sessionKey: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  if (normalized.startsWith("hook:") || normalized.startsWith("cron:")) {
+    return true;
+  }
+  return normalizeLowercaseStringOrEmpty(parseAgentSessionKey(sessionKey)?.rest).startsWith(
+    "hook:",
+  );
+}
+
+function shouldSkipSkillResearchAutoCapture(ctx: SkillResearchAgentContext): boolean {
+  const trigger = normalizeLowercaseStringOrEmpty(ctx.trigger);
+  if (AUTOMATIC_CAPTURE_TRIGGERS.has(trigger)) {
+    return true;
+  }
+  return (
+    isCronSessionKey(ctx.sessionKey) ||
+    isSubagentSessionKey(ctx.sessionKey) ||
+    isHookScopedSessionKey(ctx.sessionKey)
+  );
+}
 
 // Captured updates append below existing skill text so learned context stays auditable.
 function buildAutoCaptureUpdateContent(existingSkill: string, capturedContent: string): string {
@@ -37,6 +68,9 @@ export async function runSkillResearchAutoCapture(params: {
     return;
   }
   if (params.event.success === false) {
+    return;
+  }
+  if (shouldSkipSkillResearchAutoCapture(params.ctx)) {
     return;
   }
   const workspaceDir = params.ctx.workspaceDir;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Skill Research auto-capture was still eligible on automatic/helper `agent_end` sessions, including cron, hook-scoped, and Active Memory helper session keys, so routine automation could queue Skill Workshop proposals from sessions that should not produce durable user-correction proposals.
- The harness keeps Skill Research auto-capture detached for fire-and-forget/channel-backed lifecycle paths, but direct local CLI runs now await auto-capture settlement so an eligible proposal is persisted before the command returns.
- Fix classification: root-cause fix at the active Skill Research auto-capture owner and agent lifecycle side-effect boundary.
- Root cause: the Skill Research lifecycle invariant was missing at the proposal-capture source; every successful `agent_end` could be treated as a durable instruction source, so automatic/helper session state reached Skill Workshop proposal extraction and writes.
- Why this is root-cause fix: the eligibility decision now runs inside `src/skills/research/autocapture.ts` before signal extraction or workshop writes, because that file is the source-of-truth boundary that turns session messages into persisted Skill Workshop proposals. Rejected automation/helper sessions never enter proposal creation, rather than timing out later, relying on a fallback, or masking the symptom downstream.
- Architecture / source-of-truth check: the source-of-truth owner for proposal creation is Skill Research auto-capture; the agent harness only schedules lifecycle side effects; plugin hook settlement remains owned by the agent harness hook contract; the model-consumed transcript and raw session history are unchanged.
- What did NOT change: this PR does not change public config, schema, protocol, data format, storage layout, provider routing, model defaults, model-consumed transcript, plugin SDK contract, or user/manual capture eligibility. The changed boundary is optional proposal-capture eligibility plus caller-sensitive lifecycle settlement: fire-and-forget/channel-backed paths remain detached, while direct local CLI awaited side effects settle proposal capture before return.
- Patch quality notes: the `catch` in the harness is not a broad failure mask for plugin hooks; it only logs failures from optional Skill Research capture while plugin hook settlement stays on its own path. Fire-and-forget callers still do not wait for capture; direct local CLI callers now wait for the same capture promise before returning. The session classifier guards reject hook/cron/Active Memory helper keys before proposal creation and do not add a fallback path or mask the timeout symptom.
- Related open PR scan: this update repairs existing open PR #87504 for linked issue #87352 rather than creating a replacement or narrow competing PR; no public contract expansion is introduced.

Why does this matter now?

- The linked report observed `@openclaw/skill-workshop` autoCapture timeouts on routine `agent_end` sessions; disabling autoCapture stopped new timeout errors.
- In current main, the old Skill Workshop extension boundary has migrated into Skill Research auto-capture plus agent harness `agent_end` side effects. The live failure boundary is therefore the auto-capture eligibility and scheduling path, not an old extension timeout constant.

What is the intended outcome?

- Automatic/helper runs such as cron, heartbeat, memory, overflow, subagent, hook-scoped, and Active Memory helper sessions do not create Skill Workshop proposals.
- Normal user/manual sessions still capture durable corrections into pending Skill Workshop proposals when autonomous workshop capture is enabled.
- Skill Research auto-capture stays opportunistic for fire-and-forget/channel-backed lifecycle paths, while direct local CLI runs wait for eligible proposal capture before returning.

What is intentionally out of scope?

- Timeout budget changes, public config/schema/protocol changes, storage/data format changes, provider behavior changes, Desktop/Mantis/private CI/external channel coverage, and third-party account flows.
- This does not restore the old `extensions/skill-workshop` runtime; it repairs the current main architecture boundary.

What does success look like?

- Focused auto-capture regressions prove automatic, hook-scoped, and Active Memory helper sessions stay inert before proposal creation.
- Focused harness and CLI regressions prove fire-and-forget paths stay detached, direct local CLI waits for pending Skill Research auto-capture, and awaited side effects settle both auto-capture and plugin hooks.
- Real gateway-backed CLI proof shows hook/cron/Active Memory helper `agent_end` sessions produce zero proposals, while a manual user session still produces `github-pr-workflow`.

What should reviewers focus on?

- `src/skills/research/autocapture.ts`: the session eligibility gate using current `trigger` and canonical session-key classification.
- `src/agents/harness/agent-end-side-effects.ts`: fire-and-forget side effects remain detached, while awaited side effects now settle both Skill Research auto-capture and plugin hooks.
- The behavior boundary: optional Skill Research proposal capture is not a routine automation side effect, but remains active for user/manual durable corrections.

## Linked context

Which issue does this close?

Closes #87352

Which issues, PRs, or discussions are related?

Related #87504

Was this requested by a maintainer or owner?

This is an existing PR repair. ClawSweeper review reported RF-001/RF-003 against #87504, asking for Active Memory helper-session skip coverage and stronger real behavior proof.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Skill Research/Skill Workshop auto-capture should not run proposal creation for automatic, hook-scoped, or Active Memory helper `agent_end` sessions, and normal manual user sessions should continue to capture durable instructions.
- Real environment tested: Linux OpenClaw worktree on the updated PR branch; real `openclaw gateway run` plus gateway-backed `openclaw agent`; isolated state/workspace; configured provider/model from local runtime config; `skills.workshop.autonomous.enabled=true`; loopback gateway with auth disabled only inside the isolated proof run.
- Exact steps or command run after this patch:
  - `openclaw gateway run --auth none --bind loopback --allow-unconfigured`
  - `openclaw skills workshop --agent main list --json`
  - `openclaw agent --agent main --session-key hook:gmail:msg-87504 --message "Remember to always verify generated screenshots before replying. Reply only with: OK." --json --timeout 120`
  - `openclaw skills workshop --agent main list --json`
  - `openclaw agent --agent main --session-key cron:daily-summary --message "Remember to always record QA scenario decisions before replying. Reply only with: OK." --json --timeout 120`
  - `openclaw skills workshop --agent main list --json`
  - `openclaw agent --agent main --session-key agent:main:active-memory:recall-87504 --message "Remember to always capture maintainer review proof before replying. Reply only with: OK." --json --timeout 120`
  - `openclaw skills workshop --agent main list --json`
  - `openclaw agent --agent main --session-key active-memory-recall-87504 --message "Remember to always collect runtime evidence before replying. Reply only with: OK." --json --timeout 120`
  - `openclaw skills workshop --agent main list --json`
  - `openclaw agent --agent main --session-key manual-proof-87504 --message "From now on, when working on GitHub PRs, always check CI before final response. Reply only with: OK." --json --timeout 120`
  - `openclaw skills workshop --agent main list --json`
  - Stop the loopback gateway process
  - `openclaw agent --local --agent main --session-key direct-local-proof-87504 --message "From now on, when preparing screenshots, always verify screen capture assets before final response. Reply only with: OK." --json --timeout 120`
  - `openclaw skills workshop --agent main list --json`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from real `openclaw gateway run`, `openclaw agent`, and `openclaw skills workshop list --json` execution:

  ```text
  Runtime proof: Skill Research auto-capture uses real gateway-backed and direct local CLI agent_end surfaces
  Config: skills.workshop.autonomous.enabled=true, agent=main, provider=<configured>, gateway=loopback auth none for gateway segment
  Setup: building current worktree CLI once before runtime steps
  Gateway: starting long-lived local gateway so fire-and-forget auto-capture can complete
  initial proposals: count=0 keys=none
  hook-scoped agent_end: sessionKey=hook:gmail:msg-87504 agent_status=completed proposals_after_wait=0 keys=none
  automatic agent_end: sessionKey=cron:daily-summary agent_status=completed proposals_after_wait=0 keys=none
  active-memory helper agent_end: sessionKey=agent:main:active-memory:recall-87504 agent_status=completed proposals_after_wait=0 keys=none
  active-memory helper id agent_end: sessionKey=active-memory-recall-87504 agent_status=completed proposals_after_wait=0 keys=none
  manual user agent_end: sessionKey=manual-proof-87504 agent_status=completed proposals_after_wait=1 keys=github-pr-workflow
  direct local CLI agent_end: mode=--local gateway_running=false channel_args=none sessionKey=direct-local-proof-87504 agent_status=completed proposals_immediate_after_return=2 keys=github-pr-workflow,screenshot-asset-workflow
  PASS: hook/cron/active-memory helper agent_end sessions produced no workshop proposals, gateway-backed manual capture produced github-pr-workflow, and direct local CLI --local returned only after screenshot-asset-workflow was immediately listed.
  ```

- Observed result after fix: hook-scoped, cron-style, and both Active Memory helper `agent_end` sessions stayed at zero proposals after the agent run completed; the gateway-backed manual user session created one pending `github-pr-workflow` proposal; after the gateway was stopped, the direct local CLI `--local` run returned with `screenshot-asset-workflow` immediately visible in the proposal list.
- What was not tested: Desktop, Mantis, private CI, external channel delivery, third-party account flows, and real hosted gateway deployments were not exercised.
- Proof limitations or environment constraints: The runtime proof uses an isolated loopback gateway and local runtime credentials so the real Gateway/agent/session/autocapture path runs without exposing external accounts. It validates the `agent_end` auto-capture eligibility and scheduling behavior, not provider network quality or external channel delivery.
- Before evidence (optional but encouraged): The new TDD regressions failed before the auto-capture eligibility gate because Active Memory helper inputs created one proposal instead of zero. The gateway runtime proof also failed once before the agent-scoped `active-memory-...` helper id form was covered.

## Tests and validation

Which commands did you run?

- `pnpm exec vitest run --config test/vitest/vitest.unit.config.ts src/skills/research/autocapture.test.ts`
- `pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/harness/agent-end-side-effects.test.ts`
- `pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/cli-runner.reliability.test.ts`
- Gateway-backed and direct local CLI runtime proof using `openclaw gateway run`, `openclaw agent`, `openclaw agent --local`, and `openclaw skills workshop list --json`.

What regression coverage was added or updated?

- Added `src/skills/research/autocapture.test.ts` coverage showing automatic cron-style sessions do not create proposals.
- Added `src/skills/research/autocapture.test.ts` coverage showing hook-scoped helper sessions do not create proposals.
- Added `src/skills/research/autocapture.test.ts` coverage showing `:active-memory:`, `active-memory-...`, and agent-scoped `active-memory-...` helper sessions with manual triggers do not create proposals.
- Updated `src/agents/harness/agent-end-side-effects.test.ts` coverage showing fire-and-forget side effects do not wait for capture, while awaited side effects wait for pending Skill Research auto-capture and plugin hooks.

What failed before this fix, if known?

- Before the auto-capture eligibility gate, the new automatic/hook-scoped and Active Memory helper regression cases produced one proposal instead of zero.
- The gateway runtime proof initially reproduced the remaining Active Memory helper-id gap: `active-memory-recall-87504` produced one `learned-workflows` proposal instead of zero until the agent-scoped helper-id form was covered.
- Before the direct CLI settlement repair, the awaited helper started Skill Research auto-capture but did not wait for it, so a direct local CLI command could return before an eligible proposal was persisted.

If no test was added, why not?

- Not applicable; focused regression coverage was added and passed on the updated PR branch.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Skill Research proposal capture is now skipped for automatic/helper `agent_end` sessions; fire-and-forget/channel-backed captures remain detached; direct local CLI user/manual capture is awaited before the command returns.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Highest-risk area: agent lifecycle scheduling and Skill Workshop proposal capture eligibility.
- Risk labels considered: `merge-risk: availability`, `merge-risk: session-state`, and `merge-risk: compatibility`.
- Architecture / source-of-truth check: current main uses Skill Research auto-capture from `src/skills/research/autocapture.ts` and agent harness side effects from `src/agents/harness/agent-end-side-effects.ts`; plugin hook completion remains owned by `awaitAgentHarnessAgentEndHook`.
- Architecture boundary: this change affects when and whether optional Skill Research proposal capture runs, not the model-consumed transcript source of truth, public config, schema, protocol, storage format, or plugin SDK contract.

How is that risk mitigated?

- The eligibility gate stays at the Skill Research proposal-capture owner and uses existing run context plus canonical session-key parsing where needed, so helper sessions are rejected before signal extraction or workshop writes.
- The diff keeps normal manual/user capture intact and proves that path through real gateway-backed CLI behavior.
- Capture failures remain caught/logged, fire-and-forget paths stay detached, and direct local CLI awaited side effects now wait for both capture and plugin hook settlement.

## Current review state

What is the next action?

- Maintainer-ready confidence: 92/100.
- Next action: remote CI and maintainer/ClawSweeper review should evaluate the updated root-cause boundary, including the direct local CLI settlement repair and the helper-session skip coverage.

What is still waiting on author, maintainer, CI, or external proof?

- Author: RF-001 `status: ⏳ waiting on author` is addressed by this update; no known remaining local code or proof blocker after focused regressions plus gateway-backed and direct local CLI proof.
- Maintainer/ClawSweeper: re-review should clear the waiting-on-author label if the direct CLI settlement repair and helper-session skip coverage satisfy the review.
- CI: remote checks need to run on the updated branch after submit.
- External proof: Desktop, Mantis, external channel, private CI, and third-party account flows remain out of scope.

Which bot or reviewer comments were addressed?

- RF-001: Addressed by updating the PR with the requested author-side fix/proof; the `status: ⏳ waiting on author` label should clear after remote re-review.
- RF-002/RF-003/RF-006: Addressed with a direct local CLI regression that holds Skill Research auto-capture pending and proves the command does not resolve until capture settles, plus the awaited side-effects repair.
- RF-004: Addressed with real `openclaw agent --local` proof showing no gateway running, no channel args, and `screenshot-asset-workflow` visible immediately after command return.
- RF-005: Addressed as a narrow caller-sensitive lifecycle repair: fire-and-forget/channel-backed paths stay detached, while direct local CLI awaited side effects settle capture before return.
- RF-007/RF-008/RF-009: Addressed with refreshed `agent-end-side-effects`, `autocapture`, and `cli-runner.reliability` validation on the updated branch.
- Previous Active Memory helper-session findings remain addressed with skip logic and regressions for `:active-memory:`, unscoped `active-memory-...`, and agent-scoped `active-memory-...` forms.
