### PR TITLE
ci: filter release workflow matrices

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -480,6 +480,35 @@ jobs:
           fi
           exit 1
 
+  plan_release_workflow_matrices:
+    needs: validate_selected_ref
+    runs-on: ubuntu-24.04
+    outputs:
+      docker_e2e_count: ${{ steps.plan.outputs.docker_e2e_count }}
+      docker_e2e_matrix: ${{ steps.plan.outputs.docker_e2e_matrix }}
+      docker_e2e_omitted_json: ${{ steps.plan.outputs.docker_e2e_omitted_json }}
+      live_models_count: ${{ steps.plan.outputs.live_models_count }}
+      live_models_matrix: ${{ steps.plan.outputs.live_models_matrix }}
+      live_models_omitted_json: ${{ steps.plan.outputs.live_models_omitted_json }}
+    steps:
+      - name: Checkout trusted release harness
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Plan release workflow matrices
+        id: plan
+        env:
+          DOCKER_LANES: ${{ inputs.docker_lanes }}
+          INCLUDE_LIVE_SUITES: ${{ inputs.include_live_suites }}
+          INCLUDE_RELEASE_PATH_SUITES: ${{ inputs.include_release_path_suites }}
+          LIVE_MODEL_PROVIDERS: ${{ inputs.live_model_providers }}
+          LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
+          RELEASE_TEST_PROFILE: ${{ inputs.release_test_profile }}
+        run: node scripts/plan-release-workflow-matrix.mjs >> "$GITHUB_OUTPUT"
+
   validate_release_live_cache:
     needs: validate_selected_ref
     if: inputs.include_live_suites && !inputs.live_models_only && (inputs.live_suite_filter == '' || inputs.live_suite_filter == 'live-cache')
@@ -636,72 +665,15 @@ jobs:
         run: ${{ matrix.command }}
 
   validate_docker_e2e:
-    needs: [validate_selected_ref, prepare_docker_e2e_image]
-    if: inputs.include_release_path_suites && inputs.docker_lanes == ''
+    needs: [validate_selected_ref, prepare_docker_e2e_image, plan_release_workflow_matrices]
+    if: inputs.include_release_path_suites && inputs.docker_lanes == '' && needs.plan_release_workflow_matrices.outputs.docker_e2e_count != '0'
     name: Docker E2E (${{ matrix.label }})
     continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - chunk_id: core
-            label: core
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: package-update-openai
-            label: package/update OpenAI install
-            timeout_minutes: 45
-            profiles: beta minimum stable full
-          - chunk_id: package-update-anthropic
-            label: package/update Anthropic install
-            timeout_minutes: 60
-            profiles: beta minimum stable full
-          - chunk_id: package-update-core
-            label: package/update core
-            timeout_minutes: 60
-            profiles: beta minimum stable full
-          - chunk_id: plugins-runtime-plugins
-            label: plugins/runtime plugins
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-services
-            label: plugins/runtime services
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-install-a
-            label: plugins/runtime install A
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-install-b
-            label: plugins/runtime install B
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-install-c
-            label: plugins/runtime install C
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-install-d
-            label: plugins/runtime install D
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-install-e
-            label: plugins/runtime install E
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-install-f
-            label: plugins/runtime install F
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-install-g
-            label: plugins/runtime install G
-            timeout_minutes: 60
-            profiles: stable full
-          - chunk_id: plugins-runtime-install-h
-            label: plugins/runtime install H
-            timeout_minutes: 60
-            profiles: stable full
+      matrix: ${{ fromJson(needs.plan_release_workflow_matrices.outputs.docker_e2e_matrix) }}
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
@@ -1631,42 +1603,14 @@ jobs:
 
   validate_live_models_docker:
     name: Docker live models (${{ matrix.provider_label }})
-    needs: [validate_selected_ref, prepare_live_test_image]
-    if: inputs.include_live_suites && inputs.live_model_providers == '' && (inputs.live_suite_filter == '' || inputs.live_suite_filter == 'docker-live-models')
+    needs: [validate_selected_ref, prepare_live_test_image, plan_release_workflow_matrices]
+    if: inputs.include_live_suites && inputs.live_model_providers == '' && (inputs.live_suite_filter == '' || inputs.live_suite_filter == 'docker-live-models') && needs.plan_release_workflow_matrices.outputs.live_models_count != '0'
     continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - provider_label: Anthropic
-            providers: anthropic
-            profiles: stable full
-          - provider_label: Google
-            providers: google
-            profiles: stable full
-          - provider_label: MiniMax
-            providers: minimax
-            profiles: stable full
-          - provider_label: OpenAI
-            providers: openai
-            profiles: beta minimum stable full
-          - provider_label: OpenCode
-            providers: opencode-go
-            profiles: full
-          - provider_label: OpenRouter
-            providers: openrouter
-            profiles: full
-          - provider_label: xAI
-            providers: xai
-            profiles: full
-          - provider_label: Z.ai
-            providers: zai
-            profiles: full
-          - provider_label: Fireworks
-            providers: fireworks
-            profiles: full
+      matrix: ${{ fromJson(needs.plan_release_workflow_matrices.outputs.live_models_matrix) }}
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
@@ -1744,6 +1688,8 @@ jobs:
       - name: Validate provider credential
         if: contains(matrix.profiles, inputs.release_test_profile)
         shell: bash
+        env:
+          LIVE_MODEL_PROVIDERS: ${{ matrix.providers }}
         run: |
           set -euo pipefail
 
@@ -1760,7 +1706,7 @@ jobs:
             exit 1
           }
 
-          case "${{ matrix.providers }}" in
+          case "${LIVE_MODEL_PROVIDERS}" in
             anthropic) require_any Anthropic ANTHROPIC_API_KEY ANTHROPIC_API_KEY_OLD ANTHROPIC_API_TOKEN ;;
             google) require_any Google GEMINI_API_KEY GOOGLE_API_KEY ;;
             minimax) require_any MiniMax MINIMAX_API_KEY ;;
@@ -1771,7 +1717,7 @@ jobs:
             zai) require_any Z.ai ZAI_API_KEY Z_AI_API_KEY ;;
             fireworks) require_any Fireworks FIREWORKS_API_KEY ;;
             *)
-              echo "Unhandled live model provider shard: ${{ matrix.providers }}" >&2
+              echo "Unhandled live model provider shard: ${LIVE_MODEL_PROVIDERS}" >&2
               exit 1
               ;;
           esac

--- a/scripts/plan-release-workflow-matrix.mjs
+++ b/scripts/plan-release-workflow-matrix.mjs
@@ -1,0 +1,250 @@
+const DOCKER_E2E_CHUNKS = [
+  {
+    chunk_id: "core",
+    label: "core",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "package-update-openai",
+    label: "package/update OpenAI install",
+    timeout_minutes: 45,
+    profiles: "beta minimum stable full",
+  },
+  {
+    chunk_id: "package-update-anthropic",
+    label: "package/update Anthropic install",
+    timeout_minutes: 60,
+    profiles: "beta minimum stable full",
+  },
+  {
+    chunk_id: "package-update-core",
+    label: "package/update core",
+    timeout_minutes: 60,
+    profiles: "beta minimum stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-plugins",
+    label: "plugins/runtime plugins",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-services",
+    label: "plugins/runtime services",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-install-a",
+    label: "plugins/runtime install A",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-install-b",
+    label: "plugins/runtime install B",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-install-c",
+    label: "plugins/runtime install C",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-install-d",
+    label: "plugins/runtime install D",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-install-e",
+    label: "plugins/runtime install E",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-install-f",
+    label: "plugins/runtime install F",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-install-g",
+    label: "plugins/runtime install G",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+  {
+    chunk_id: "plugins-runtime-install-h",
+    label: "plugins/runtime install H",
+    timeout_minutes: 60,
+    profiles: "stable full",
+  },
+];
+
+const LIVE_MODEL_PROVIDERS = [
+  {
+    provider_label: "Anthropic",
+    providers: "anthropic",
+    profiles: "stable full",
+  },
+  {
+    provider_label: "Google",
+    providers: "google",
+    profiles: "stable full",
+  },
+  {
+    provider_label: "MiniMax",
+    providers: "minimax",
+    profiles: "stable full",
+  },
+  {
+    provider_label: "OpenAI",
+    providers: "openai",
+    profiles: "beta minimum stable full",
+  },
+  {
+    provider_label: "OpenCode",
+    providers: "opencode-go",
+    profiles: "full",
+  },
+  {
+    provider_label: "OpenRouter",
+    providers: "openrouter",
+    profiles: "full",
+  },
+  {
+    provider_label: "xAI",
+    providers: "xai",
+    profiles: "full",
+  },
+  {
+    provider_label: "Z.ai",
+    providers: "zai",
+    profiles: "full",
+  },
+  {
+    provider_label: "Fireworks",
+    providers: "fireworks",
+    profiles: "full",
+  },
+];
+
+function isEnabled(value) {
+  return value === true || value === "true";
+}
+
+function isBlank(value) {
+  return String(value ?? "").trim() === "";
+}
+
+function profileIncludes(entry, profile) {
+  return entry.profiles.split(/\s+/u).includes(profile);
+}
+
+function planProfileMatrix(entries, profile, enabled, disabledReason, labelForEntry) {
+  const selected = enabled ? entries.filter((entry) => profileIncludes(entry, profile)) : [];
+  const omitted = entries
+    .filter((entry) => !selected.includes(entry))
+    .map((entry) => ({
+      id: labelForEntry(entry),
+      label: entry.label ?? entry.provider_label ?? labelForEntry(entry),
+      reason: enabled ? `requires one of: ${entry.profiles}` : disabledReason,
+    }));
+
+  return {
+    count: selected.length,
+    matrix: { include: selected },
+    omitted,
+  };
+}
+
+export function createReleaseWorkflowMatrixPlan(options = {}) {
+  const releaseProfile = options.releaseProfile ?? "stable";
+  const dockerE2eEnabled =
+    isEnabled(options.includeReleasePathSuites) && isBlank(options.dockerLanes);
+  const liveModelsEnabled =
+    isEnabled(options.includeLiveSuites) &&
+    isBlank(options.liveModelProviders) &&
+    (isBlank(options.liveSuiteFilter) || options.liveSuiteFilter === "docker-live-models");
+
+  return {
+    dockerE2e: planProfileMatrix(
+      DOCKER_E2E_CHUNKS,
+      releaseProfile,
+      dockerE2eEnabled,
+      "release-path Docker E2E chunks disabled by input selection",
+      (entry) => entry.chunk_id,
+    ),
+    liveModels: planProfileMatrix(
+      LIVE_MODEL_PROVIDERS,
+      releaseProfile,
+      liveModelsEnabled,
+      "Docker live model matrix disabled by input selection",
+      (entry) => entry.providers,
+    ),
+    releaseProfile,
+  };
+}
+
+function markdownForPlan(plan) {
+  const sections = [
+    ["Docker E2E release chunks", plan.dockerE2e],
+    ["Docker live model providers", plan.liveModels],
+  ];
+  const lines = [
+    `## Release workflow matrix plan`,
+    "",
+    `Release profile: \`${plan.releaseProfile}\``,
+  ];
+
+  for (const [title, section] of sections) {
+    lines.push("", `### ${title}`, "", `Selected lanes: ${section.count}`);
+    if (section.omitted.length === 0) {
+      lines.push("", "No lanes omitted.");
+      continue;
+    }
+    lines.push("", "| Omitted lane | Reason |", "| --- | --- |");
+    for (const omitted of section.omitted) {
+      lines.push(`| \`${omitted.id}\` | ${omitted.reason} |`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function writeOutputs(plan) {
+  const outputs = {
+    docker_e2e_count: String(plan.dockerE2e.count),
+    docker_e2e_matrix: JSON.stringify(plan.dockerE2e.matrix),
+    docker_e2e_omitted_json: JSON.stringify(plan.dockerE2e.omitted),
+    live_models_count: String(plan.liveModels.count),
+    live_models_matrix: JSON.stringify(plan.liveModels.matrix),
+    live_models_omitted_json: JSON.stringify(plan.liveModels.omitted),
+  };
+
+  for (const [key, value] of Object.entries(outputs)) {
+    console.log(`${key}=${value}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const plan = createReleaseWorkflowMatrixPlan({
+    dockerLanes: process.env.DOCKER_LANES,
+    includeLiveSuites: process.env.INCLUDE_LIVE_SUITES,
+    includeReleasePathSuites: process.env.INCLUDE_RELEASE_PATH_SUITES,
+    liveModelProviders: process.env.LIVE_MODEL_PROVIDERS,
+    liveSuiteFilter: process.env.LIVE_SUITE_FILTER,
+    releaseProfile: process.env.RELEASE_TEST_PROFILE,
+  });
+
+  writeOutputs(plan);
+  const summary = markdownForPlan(plan);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+  }
+}

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { createReleaseWorkflowMatrixPlan } from "../../scripts/plan-release-workflow-matrix.mjs";
+
+function workflow() {
+  return parse(readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"));
+}
+
+const PROFILE_GATED_STATIC_MATRIX_ALLOWLIST = [
+  "validate_live_provider_suites",
+  "validate_live_docker_provider_suites",
+  "validate_live_media_provider_suites",
+];
+
+const PROFILE_EXPECTATIONS = [
+  {
+    profile: "minimum",
+    dockerE2eChunks: ["package-update-openai", "package-update-anthropic", "package-update-core"],
+    liveModelProviders: ["openai"],
+  },
+  {
+    profile: "beta",
+    dockerE2eChunks: ["package-update-openai", "package-update-anthropic", "package-update-core"],
+    liveModelProviders: ["openai"],
+  },
+  {
+    profile: "stable",
+    dockerE2eChunks: [
+      "core",
+      "package-update-openai",
+      "package-update-anthropic",
+      "package-update-core",
+      "plugins-runtime-plugins",
+      "plugins-runtime-services",
+      "plugins-runtime-install-a",
+      "plugins-runtime-install-b",
+      "plugins-runtime-install-c",
+      "plugins-runtime-install-d",
+      "plugins-runtime-install-e",
+      "plugins-runtime-install-f",
+      "plugins-runtime-install-g",
+      "plugins-runtime-install-h",
+    ],
+    liveModelProviders: ["anthropic", "google", "minimax", "openai"],
+  },
+  {
+    profile: "full",
+    dockerE2eChunks: [
+      "core",
+      "package-update-openai",
+      "package-update-anthropic",
+      "package-update-core",
+      "plugins-runtime-plugins",
+      "plugins-runtime-services",
+      "plugins-runtime-install-a",
+      "plugins-runtime-install-b",
+      "plugins-runtime-install-c",
+      "plugins-runtime-install-d",
+      "plugins-runtime-install-e",
+      "plugins-runtime-install-f",
+      "plugins-runtime-install-g",
+      "plugins-runtime-install-h",
+    ],
+    liveModelProviders: [
+      "anthropic",
+      "google",
+      "minimax",
+      "openai",
+      "opencode-go",
+      "openrouter",
+      "xai",
+      "zai",
+      "fireworks",
+    ],
+  },
+];
+
+function staticProfileMatrixJobs() {
+  return Object.entries(workflow().jobs)
+    .filter(([, job]) => {
+      const entries = job.strategy?.matrix?.include;
+      return Array.isArray(entries) && entries.some((entry) => "profiles" in entry);
+    })
+    .map(([jobName]) => jobName)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+describe("scripts/plan-release-workflow-matrix.mjs", () => {
+  it.each(PROFILE_EXPECTATIONS)(
+    "keeps $profile release jobs to profile-enabled Docker E2E chunks and live model providers",
+    ({ profile, dockerE2eChunks, liveModelProviders }) => {
+      const plan = createReleaseWorkflowMatrixPlan({
+        includeLiveSuites: true,
+        includeReleasePathSuites: true,
+        releaseProfile: profile,
+      });
+
+      expect(plan.dockerE2e.matrix.include.map((entry) => entry.chunk_id)).toEqual(dockerE2eChunks);
+      expect(plan.liveModels.matrix.include.map((entry) => entry.providers)).toEqual(
+        liveModelProviders,
+      );
+    },
+  );
+
+  it("reports omitted lanes for release jobs excluded by the selected profile", () => {
+    const plan = createReleaseWorkflowMatrixPlan({
+      includeLiveSuites: true,
+      includeReleasePathSuites: true,
+      releaseProfile: "beta",
+    });
+
+    expect(plan.dockerE2e.omitted.map((entry) => entry.id)).toContain("core");
+    expect(plan.liveModels.omitted.map((entry) => entry.id)).toContain("anthropic");
+  });
+
+  it("keeps stable release jobs broad enough for stable-required lanes", () => {
+    const plan = createReleaseWorkflowMatrixPlan({
+      includeLiveSuites: true,
+      includeReleasePathSuites: true,
+      releaseProfile: "stable",
+    });
+
+    expect(plan.dockerE2e.count).toBe(14);
+    expect(plan.liveModels.matrix.include.map((entry) => entry.providers)).toEqual([
+      "anthropic",
+      "google",
+      "minimax",
+      "openai",
+    ]);
+    expect(plan.liveModels.omitted.map((entry) => entry.id)).toEqual([
+      "opencode-go",
+      "openrouter",
+      "xai",
+      "zai",
+      "fireworks",
+    ]);
+  });
+
+  it("disables live model planning when focused recovery targets another live suite", () => {
+    const plan = createReleaseWorkflowMatrixPlan({
+      includeLiveSuites: true,
+      includeReleasePathSuites: true,
+      liveSuiteFilter: "live-cache",
+      releaseProfile: "full",
+    });
+
+    expect(plan.liveModels.count).toBe(0);
+    expect(plan.liveModels.omitted).toHaveLength(9);
+    expect(plan.liveModels.omitted[0]?.reason).toBe(
+      "Docker live model matrix disabled by input selection",
+    );
+  });
+
+  it("wires filtered matrices into the reusable live and E2E workflow", () => {
+    const jobs = workflow().jobs;
+    const planner = jobs.plan_release_workflow_matrices;
+
+    expect(planner.outputs.docker_e2e_matrix).toBe("${{ steps.plan.outputs.docker_e2e_matrix }}");
+    expect(planner.outputs.live_models_matrix).toBe("${{ steps.plan.outputs.live_models_matrix }}");
+    expect(jobs.validate_docker_e2e.needs).toContain("plan_release_workflow_matrices");
+    expect(jobs.validate_live_models_docker.needs).toContain("plan_release_workflow_matrices");
+    expect(jobs.validate_docker_e2e.strategy.matrix).toBe(
+      "${{ fromJson(needs.plan_release_workflow_matrices.outputs.docker_e2e_matrix) }}",
+    );
+    expect(jobs.validate_live_models_docker.strategy.matrix).toBe(
+      "${{ fromJson(needs.plan_release_workflow_matrices.outputs.live_models_matrix) }}",
+    );
+  });
+
+  it("requires new release-profile matrices to use a planner or an explicit allowlist", () => {
+    expect(staticProfileMatrixJobs()).toEqual(PROFILE_GATED_STATIC_MATRIX_ALLOWLIST.toSorted());
+  });
+});


### PR DESCRIPTION
## Summary

- add a release workflow matrix planner for profile-gated Docker E2E chunks and Docker live model provider shards
- wire `openclaw-live-and-e2e-checks-reusable.yml` to use generated matrices with empty-plan guards
- add focused planner/workflow wiring coverage for minimum, beta, stable, full, and focused live-suite selection
- add a workflow guard so future static release-profile matrices must use a planner or be explicitly allowlisted

Related issue search: no exact open issue/PR found. Local gitcrawl surfaced #59727 as a broad CI matrix refactor, but this PR is the narrower skip-only job reduction.

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/check-workflows.mjs`
- `git diff --check`
- `pnpm exec oxfmt --check scripts/plan-release-workflow-matrix.mjs test/scripts/release-workflow-matrix-plan.test.ts`
- `node scripts/run-vitest.mjs run test/scripts/release-workflow-matrix-plan.test.ts --reporter=verbose`
- Node assertion probe for beta/stable planner output and workflow wiring
- `uvx zizmor==1.22.0 --config .github/zizmor.yml --persona=regular --min-severity=medium --min-confidence=medium .github/workflows/openclaw-live-and-e2e-checks-reusable.yml`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
- PR CI on `bc965c03c0`: `security-fast`, CI `build-artifacts`, Blacksmith `build-artifacts`, `actionlint`, Real behavior proof, and `check-guards` passed

## Real behavior proof

Behavior addressed: release workflow matrix entries that were guaranteed to skip due to `release_test_profile` are filtered before matrix expansion for Docker E2E chunks and Docker live model provider shards.

Real environment tested: local OpenClaw Codex worktree on macOS with Node 24 and repo workflow/parser tooling, plus PR CI on GitHub Actions for head `bc965c03c0`.

Exact steps or command run after this patch: `INCLUDE_RELEASE_PATH_SUITES=true INCLUDE_LIVE_SUITES=true RELEASE_TEST_PROFILE=beta node scripts/plan-release-workflow-matrix.mjs`, the verification commands listed above, and PR CI after rebasing on `origin/main`.

Evidence after fix: beta planning emits 3 Docker E2E chunk jobs instead of 14 and 1 Docker live model provider job instead of 9, with omitted-lane reasons in the planner output. Focused Vitest coverage now asserts exact planned Docker E2E and live-model entries for `minimum`, `beta`, `stable`, and `full`. The related CI failures were fixed: `security-fast` passed after moving `matrix.providers` through env, and both build-artifacts lanes passed after fixing the planner guard ordering expectation.

Observed result after fix: workflow syntax sanity, focused planner assertions, Vitest planner coverage, zizmor, autoreview, and the related PR CI checks passed.

What was not tested: full manual release validation dispatch was not run; this PR relies on focused planner proof plus PR workflow sanity/security/build-artifact CI.
