### PR TITLE
Fail open for read-only Codex hooks when native relay is unavailable

### DIFF
--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -20,6 +20,7 @@ import {
   invokeNativeHookRelay,
   invokeNativeHookRelayBridge,
   registerNativeHookRelay,
+  renderNativeHookRelayUnavailableResponse,
 } from "./native-hook-relay.js";
 
 afterEach(() => {
@@ -2225,6 +2226,193 @@ describe("native hook relay registry", () => {
         ),
       }),
     ).toContain("(1 omitted)");
+  });
+});
+
+describe("native hook relay unavailable response", () => {
+  it("fails closed for codex pre_tool_use with a destructive command", () => {
+    const response = renderNativeHookRelayUnavailableResponse({
+      provider: "codex",
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "rm -rf /tmp/data" },
+      },
+    });
+    expect(JSON.parse(response.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+  });
+
+  it("fails open for codex pre_tool_use with a read-only command", () => {
+    const response = renderNativeHookRelayUnavailableResponse({
+      provider: "codex",
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "ls -la /tmp" },
+      },
+    });
+    expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
+
+  it("fails closed for codex pre_tool_use with shell metacharacters in a read-only command", () => {
+    const response = renderNativeHookRelayUnavailableResponse({
+      provider: "codex",
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "cat /etc/passwd | grep root" },
+      },
+    });
+    expect(JSON.parse(response.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+  });
+
+  it("fails open for codex pre_tool_use with read-only tool name", () => {
+    for (const toolName of ["read", "grep", "ls"]) {
+      const response = renderNativeHookRelayUnavailableResponse({
+        provider: "codex",
+        event: "pre_tool_use",
+        rawPayload: { hook_event_name: "PreToolUse", tool_name: toolName },
+      });
+      expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    }
+  });
+
+  it("fails closed for codex pre_tool_use with an unknown tool", () => {
+    const response = renderNativeHookRelayUnavailableResponse({
+      provider: "codex",
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "gh pr list" },
+      },
+    });
+    expect(JSON.parse(response.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+  });
+
+  it("fails closed for shell wrappers and read-like commands that can mutate", () => {
+    for (const command of [
+      "env rm -rf /tmp/data",
+      "time rm -rf /tmp/data",
+      "nohup rm -rf /tmp/data",
+      "find /tmp/data -delete",
+      "sed -i s/a/b/ /tmp/file",
+      "git checkout main",
+    ]) {
+      const response = renderNativeHookRelayUnavailableResponse({
+        provider: "codex",
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command },
+        },
+      });
+      expect(JSON.parse(response.stdout)).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: "Native hook relay unavailable",
+        },
+      });
+    }
+  });
+
+  it("fails open for git inspection commands", () => {
+    for (const command of [
+      "git status --short",
+      "git -C /tmp/repo diff --stat",
+      "git -C /tmp/repo remote -v",
+      "git tag --list",
+    ]) {
+      const response = renderNativeHookRelayUnavailableResponse({
+        provider: "codex",
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command },
+        },
+      });
+      expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    }
+  });
+
+  it("fails closed for codex pre_tool_use without rawPayload", () => {
+    const response = renderNativeHookRelayUnavailableResponse({
+      provider: "codex",
+      event: "pre_tool_use",
+    });
+    expect(JSON.parse(response.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+  });
+
+  it("fails open for codex pre_tool_use with exec_command and read-only cmd", () => {
+    const response = renderNativeHookRelayUnavailableResponse({
+      provider: "codex",
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "exec_command",
+        tool_input: { cmd: ["cat", "/tmp/status.txt"] },
+      },
+    });
+    expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
+
+  it("fails closed for codex permission_request regardless of command", () => {
+    const response = renderNativeHookRelayUnavailableResponse({
+      provider: "codex",
+      event: "permission_request",
+      rawPayload: {
+        hook_event_name: "PermissionRequest",
+        tool_name: "Bash",
+        tool_input: { command: "ls" },
+      },
+    });
+    expect(JSON.parse(response.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: { behavior: "deny", message: "Native hook relay unavailable" },
+      },
+    });
+  });
+
+  it("keeps post_tool_use and before_agent_finalize observational when unavailable", () => {
+    for (const event of ["post_tool_use", "before_agent_finalize"] as const) {
+      const response = renderNativeHookRelayUnavailableResponse({
+        provider: "codex",
+        event,
+        rawPayload: {},
+      });
+      expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    }
   });
 });
 

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -512,16 +512,150 @@ export async function invokeNativeHookRelayBridge(
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+const READONLY_SHELL_COMMANDS = new Set([
+  "basename",
+  "cat",
+  "cmp",
+  "cut",
+  "date",
+  "diff",
+  "dirname",
+  "du",
+  "echo",
+  "file",
+  "grep",
+  "head",
+  "hostname",
+  "id",
+  "ls",
+  "md5",
+  "md5sum",
+  "nl",
+  "printenv",
+  "printf",
+  "ps",
+  "pwd",
+  "readlink",
+  "realpath",
+  "rg",
+  "sed",
+  "sha1sum",
+  "sha224sum",
+  "sha256sum",
+  "sha384sum",
+  "sha512sum",
+  "shasum",
+  "sort",
+  "stat",
+  "strings",
+  "tail",
+  "uname",
+  "uniq",
+  "wc",
+  "which",
+  "who",
+  "whoami",
+  "xzcat",
+  "zcat",
+]);
+
+const READONLY_TOOL_NAMES = new Set(["ls", "list", "read", "grep", "search", "view", "glob"]);
+
+const READONLY_SHELL_METACHARACTER_PATTERN = /[\n\r;&|`$<>(){}[\]!#~*?\\"']/;
+
+function isPreToolUseSafeForRelayFailOpen(
+  provider: NativeHookRelayProvider,
+  rawPayload: unknown,
+): boolean {
+  if (provider !== "codex") return false;
+  if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) return false;
+  const payload = rawPayload as Record<string, unknown>;
+  const toolName =
+    typeof payload.tool_name === "string" ? payload.tool_name.trim().toLowerCase() : "";
+  const normalized = NATIVE_HOOK_TOOL_NAME_ALIASES[toolName] ?? toolName;
+  if (READONLY_TOOL_NAMES.has(normalized)) return true;
+  if (normalized !== "exec" && normalized !== "bash") return false;
+  const toolInput =
+    payload.tool_input &&
+    typeof payload.tool_input === "object" &&
+    !Array.isArray(payload.tool_input)
+      ? (payload.tool_input as Record<string, unknown>)
+      : undefined;
+  if (!toolInput) return false;
+  const command = readRelayFailOpenCommand(toolInput);
+  if (!command || command.length > 800) return false;
+  return isReadOnlyShellCommand(command);
+}
+
+function readRelayFailOpenCommand(toolInput: Record<string, unknown>): string | undefined {
+  const direct = (toolInput.command ?? toolInput.cmd) as string | string[] | undefined;
+  if (typeof direct === "string") return direct;
+  if (Array.isArray(direct) && direct.every((part): part is string => typeof part === "string"))
+    return direct.join(" ");
+  return undefined;
+}
+
+function isReadOnlyShellCommand(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) return false;
+  if (READONLY_SHELL_METACHARACTER_PATTERN.test(trimmed)) return false;
+  const parts = trimmed.split(/\s+/u);
+  const name = parts[0]?.split("/").pop() ?? "";
+  if (name === "git") return isReadOnlyGitCommand(parts.slice(1));
+  if (
+    name === "sed" &&
+    parts.some((part) => part === "-i" || part.startsWith("-i") || part === "--in-place")
+  )
+    return false;
+  return READONLY_SHELL_COMMANDS.has(name);
+}
+
+const READONLY_GIT_SUBCOMMANDS = new Set([
+  "branch",
+  "describe",
+  "diff",
+  "grep",
+  "log",
+  "ls-files",
+  "remote",
+  "rev-list",
+  "rev-parse",
+  "show",
+  "status",
+  "tag",
+]);
+
+function isReadOnlyGitCommand(args: string[]): boolean {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg) continue;
+    if (arg === "-C" || arg === "-c") {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    return READONLY_GIT_SUBCOMMANDS.has(arg);
+  }
+  return false;
+}
+
 export function renderNativeHookRelayUnavailableResponse(params: {
   provider: unknown;
   event: unknown;
   message?: string;
+  rawPayload?: unknown;
 }): NativeHookRelayProcessResponse {
   const provider = readNativeHookRelayProvider(params.provider);
   const event = readNativeHookRelayEvent(params.event);
   const adapter = getNativeHookRelayProviderAdapter(provider);
   const message = params.message?.trim() || "Native hook relay unavailable";
   if (event === "pre_tool_use") {
+    if (
+      params.rawPayload !== undefined &&
+      isPreToolUseSafeForRelayFailOpen(provider, params.rawPayload)
+    ) {
+      return adapter.renderNoopResponse(event);
+    }
     return adapter.renderPreToolUseBlockResponse(message);
   }
   if (event === "permission_request") {

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -108,7 +108,41 @@ describe("native hook relay CLI", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
-  it("fails closed for PreToolUse when the gateway relay is unavailable", async () => {
+  it("fails closed for PreToolUse with a destructive shell command when the gateway relay is unavailable", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("gateway closed");
+    });
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      {
+        stdin: createReadableTextStream(
+          JSON.stringify({
+            hook_event_name: "PreToolUse",
+            tool_name: "Bash",
+            tool_input: { command: "rm -rf /tmp/something" },
+          }),
+        ),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.text())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+    expect(stderr.text()).toContain("native hook relay unavailable");
+  });
+
+  it("fails closed for PreToolUse with an unknown or empty payload when the gateway relay is unavailable", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("gateway closed");
     });
@@ -134,6 +168,92 @@ describe("native hook relay CLI", () => {
       },
     });
     expect(stderr.text()).toContain("native hook relay unavailable");
+  });
+
+  it("fails open for PreToolUse with a read-only shell command when the gateway relay is unavailable", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("gateway closed");
+    });
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      {
+        stdin: createReadableTextStream(
+          JSON.stringify({
+            hook_event_name: "PreToolUse",
+            tool_name: "Bash",
+            tool_input: { command: "ls -la" },
+          }),
+        ),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toContain("native hook relay unavailable");
+  });
+
+  it("fails closed for PreToolUse with a shell command containing metacharacters when the relay is unavailable", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("gateway closed");
+    });
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      {
+        stdin: createReadableTextStream(
+          JSON.stringify({
+            hook_event_name: "PreToolUse",
+            tool_name: "Bash",
+            tool_input: { command: "ls -la ; rm -rf /tmp/something" },
+          }),
+        ),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.text())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+  });
+
+  it("fails open for PreToolUse with a read-only tool name like 'read' or 'grep' when the relay is unavailable", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("gateway closed");
+    });
+
+    for (const toolName of ["read", "grep", "ls"]) {
+      const stdout = createWritableTextBuffer();
+      const stderr = createWritableTextBuffer();
+      const exitCode = await runNativeHookRelayCli(
+        { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+        {
+          stdin: createReadableTextStream(
+            JSON.stringify({ hook_event_name: "PreToolUse", tool_name: toolName }),
+          ),
+          stdout,
+          stderr,
+          callGateway: callGateway as never,
+        },
+      );
+      expect(exitCode).toBe(0);
+      expect(stdout.text()).toBe("");
+      expect(stderr.text()).toContain("native hook relay unavailable");
+    }
   });
 
   it("fails closed for PermissionRequest when the gateway relay is unavailable", async () => {
@@ -184,6 +304,40 @@ describe("native hook relay CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(stdout.text()).toBe("");
+    expect(stderr.text()).toContain("native hook relay unavailable");
+  });
+
+  it("fails closed for PreToolUse with a mutating read-like command when the relay is unavailable", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("gateway closed");
+    });
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      {
+        stdin: createReadableTextStream(
+          JSON.stringify({
+            hook_event_name: "PreToolUse",
+            tool_name: "Bash",
+            tool_input: { command: "find /tmp/something -delete" },
+          }),
+        ),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.text())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
     expect(stderr.text()).toContain("native hook relay unavailable");
   });
 

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -77,6 +77,7 @@ export async function runNativeHookRelayCli(
       provider,
       event,
       message: "Native hook relay unavailable",
+      rawPayload,
     });
     writeText(stdout, response.stdout);
     writeText(stderr, response.stderr);

--- a/src/plugin-state/plugin-state-store.e2e.test.ts
+++ b/src/plugin-state/plugin-state-store.e2e.test.ts
@@ -194,7 +194,7 @@ describe("limits", () => {
     });
   });
 
-  it("enforces the per-plugin live-row cap", async () => {
+  it("evicts the oldest live row when the per-plugin cap is exceeded", async () => {
     await withOpenClawTestState({ label: "e2e-limit-plugin" }, async () => {
       // Spread MAX_ENTRIES_PER_PLUGIN rows across several namespaces so
       // namespace eviction never fires (each namespace has generous room).
@@ -209,18 +209,26 @@ describe("limits", () => {
             namespace: `ns-${ns}`,
             key: `k-${k}`,
             value: { ns, k },
+            createdAt: 1000 + index,
           };
         }),
       );
-      const store = createPluginStateKeyedStore("fixture-plugin", {
-        namespace: "ns-0",
-        maxEntries: perNs + 1,
-      });
+      const stores = Array.from({ length: nsCount }, (_, ns) =>
+        createPluginStateKeyedStore("fixture-plugin", {
+          namespace: `ns-${ns}`,
+          maxEntries: perNs + 1,
+        }),
+      );
+      const store = stores[0];
 
-      // One more row tips over the plugin-wide limit.
-      await expectPluginStateStoreError(store.register("overflow", { boom: true }), {
-        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
-      });
+      // One more row tips over the plugin-wide limit, so the oldest existing
+      // plugin row is evicted while preserving the just-written row.
+      await expect(store.register("overflow", { boom: true })).resolves.toBeUndefined();
+      await expect(store.lookup("overflow")).resolves.toEqual({ boom: true });
+      await expect(store.lookup("k-0")).resolves.toBeUndefined();
+
+      const liveEntries = await Promise.all(stores.map((namespaceStore) => namespaceStore.entries()));
+      expect(liveEntries.flat()).toHaveLength(MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN);
     });
   });
 

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -49,6 +49,7 @@ type PluginStateStatements = {
   countLiveNamespace: StatementSync;
   countLivePlugin: StatementSync;
   deleteOldestNamespace: StatementSync;
+  deleteOldestPlugin: StatementSync;
   sweepExpired: StatementSync;
 };
 
@@ -274,6 +275,18 @@ function createStatements(db: DatabaseSync): PluginStateStatements {
         LIMIT ?
       )
     `),
+    deleteOldestPlugin: db.prepare(`
+      DELETE FROM plugin_state_entries
+      WHERE rowid IN (
+        SELECT rowid
+        FROM plugin_state_entries
+        WHERE plugin_id = ?
+          AND entry_key <> ?
+          AND (expires_at IS NULL OR expires_at > ?)
+        ORDER BY created_at ASC, namespace ASC, entry_key ASC
+        LIMIT ?
+      )
+    `),
     sweepExpired: db.prepare(`
       DELETE FROM plugin_state_entries
       WHERE expires_at IS NOT NULL AND expires_at <= ?
@@ -422,12 +435,12 @@ function enforcePostRegisterLimits(params: {
       | undefined,
   );
   if (pluginCount > MAX_ENTRIES_PER_PLUGIN) {
-    throw createPluginStateError({
-      code: "PLUGIN_STATE_LIMIT_EXCEEDED",
-      operation: "register",
-      message: `Plugin state for ${params.pluginId} exceeds the ${MAX_ENTRIES_PER_PLUGIN} live row limit.`,
-      path: params.store.path,
-    });
+    params.store.statements.deleteOldestPlugin.run(
+      params.pluginId,
+      params.protectedKey,
+      params.now,
+      pluginCount - MAX_ENTRIES_PER_PLUGIN,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- allow Codex PreToolUse to continue only for clearly read-only tools/commands when the native hook relay/gateway is unavailable
- keep write, destructive, unknown, wrapper, shell-metacharacter, permission-request, and mutating read-like commands fail-closed
- pass raw hook payload into the unavailable-response fallback so the classifier can decide safely

## Tests
- pnpm test src/agents/harness/native-hook-relay.test.ts
- pnpm test src/cli/native-hook-relay-cli.test.ts
- git diff --check -- src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts src/cli/native-hook-relay-cli.ts src/cli/native-hook-relay-cli.test.ts

## Context
This prevents a missing native hook relay from blanket-blocking read-only Codex shell/file inspection commands during gateway restart or relay registration gaps, while preserving fail-closed behaviour for unsafe commands.