### PR TITLE
fix(discord): read RadioGroup modal field values from raw interaction payload

### DIFF
--- a/extensions/discord/src/monitor/agent-components-data.ts
+++ b/extensions/discord/src/monitor/agent-components-data.ts
@@ -1,4 +1,6 @@
 import { logError } from "openclaw/plugin-sdk/logging-core";
+import type { ModalSubmitLabelComponent } from "discord-api-types/v10";
+import { ComponentType } from "discord-api-types/v10";
 import {
   parseDiscordComponentCustomId,
   parseDiscordModalCustomId,
@@ -139,6 +141,42 @@ export function mapSelectValues(entry: DiscordComponentEntry, values: string[]):
   return values;
 }
 
+/**
+ * Read a RadioGroup's selected value directly from the raw interaction payload.
+ * Carbon's FieldsHandler reads `.values` (array) for non-TextInput components,
+ * but Discord's RadioGroup submission uses `.value` (singular string | null).
+ * This bypasses Carbon to read the correct field.
+ */
+function resolveRadioGroupValueFromRaw(
+  interaction: ModalInteraction,
+  fieldId: string,
+): string | null {
+  const components =
+    interaction.rawData &&
+    typeof interaction.rawData === "object" &&
+    "data" in interaction.rawData &&
+    interaction.rawData.data &&
+    typeof interaction.rawData.data === "object" &&
+    "components" in interaction.rawData.data
+      ? (interaction.rawData.data as { components?: unknown[] }).components
+      : undefined;
+  for (const component of components ?? []) {
+    if (
+      component &&
+      typeof component === "object" &&
+      "type" in component &&
+      (component as { type: unknown }).type === ComponentType.Label
+    ) {
+      const sub = (component as ModalSubmitLabelComponent).component;
+      if (sub?.custom_id === fieldId && sub.type === ComponentType.RadioGroup) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Discord API type mismatch: .value is not in @types yet
+        return (sub as any).value ?? null;
+      }
+    }
+  }
+  return null;
+}
+
 export function resolveModalFieldValues(
   field: DiscordModalEntry["fields"][number],
   interaction: ModalInteraction,
@@ -155,9 +193,15 @@ export function resolveModalFieldValues(
         const value = required ? fields.getText(field.id, true) : fields.getText(field.id);
         return value ? [value] : [];
       }
-      case "select":
-      case "checkbox":
       case "radio": {
+        const value = resolveRadioGroupValueFromRaw(interaction, field.id);
+        if (required && !value) {
+          throw new Error(`Missing required field: ${field.id}`);
+        }
+        return value ? mapOptionLabels(optionLabels, [value]) : [];
+      }
+      case "select":
+      case "checkbox": {
         const values = required
           ? fields.getStringSelect(field.id, true)
           : (fields.getStringSelect(field.id) ?? []);


### PR DESCRIPTION
## Problem

Carbon's `FieldsHandler` reads `.values` (an array) for all non-TextInput modal components. Discord's `APIModalSubmitRadioGroupComponent`, however, uses a singular `.value` property (a `string | null`), not `.values`.

This mismatch causes every RadioGroup field in a modal submission to fail with `Missing required field` errors (when `required=true`) or silently return an empty array (when `required=false`), making RadioGroup fields completely unusable in modals.

## Fix

Add `resolveRadioGroupValueFromRaw()` that reads the raw interaction payload directly, bypassing Carbon's `FieldsHandler` for the `radio` field type. The `radio` case is split out of the shared `select`/`checkbox` branch so each path uses the correct Discord API shape.

The helper walks `interaction.rawData.data.components` looking for a `Label` wrapper whose inner component is a `RadioGroup` with a matching `custom_id`.

## Testing

- Tested locally against a live Discord bot with multi-option RadioGroup modals; field values now propagate correctly on submission.
- Ran the existing `monitor.agent-components.test.ts` suite; no regressions.

Reopens #60765