### PR TITLE
perf(ci): instrument build artifacts phases - add timing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,9 +490,6 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
         run: pnpm build:ci-artifacts
 
-      - name: Build Control UI
-        run: pnpm ui:build
-
       - name: Check Control UI i18n
         if: needs.preflight.outputs.run_control_ui_i18n == 'true'
         run: pnpm ui:i18n:check

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
 import { resolvePnpmRunner } from "./pnpm-runner.mjs";
 
@@ -398,6 +399,32 @@ export function restoreBuildAllStepCacheOutputs(cacheState, params = {}) {
   return true;
 }
 
+export function formatBuildAllDuration(durationMs) {
+  const clampedMs = Math.max(0, durationMs);
+  if (clampedMs < 1000) {
+    return `${Math.round(clampedMs)}ms`;
+  }
+  if (clampedMs < 10000) {
+    return `${(clampedMs / 1000).toFixed(2)}s`;
+  }
+  return `${(clampedMs / 1000).toFixed(1)}s`;
+}
+
+export function formatBuildAllTimingSummary(timings) {
+  if (timings.length === 0) {
+    return "[build-all] phase timings: no phases ran";
+  }
+  const totalMs = timings.reduce((sum, timing) => sum + timing.durationMs, 0);
+  const phases = timings
+    .toSorted((left, right) => right.durationMs - left.durationMs)
+    .map((timing) => {
+      const status = timing.status === "ran" ? "" : ` (${timing.status})`;
+      return `${timing.label}${status} ${formatBuildAllDuration(timing.durationMs)}`;
+    })
+    .join("; ");
+  return `[build-all] phase timings: total ${formatBuildAllDuration(totalMs)}; slowest ${phases}`;
+}
+
 function isMainModule() {
   const argv1 = process.argv[1];
   if (!argv1) {
@@ -408,23 +435,43 @@ function isMainModule() {
 
 if (isMainModule()) {
   const profile = process.argv[2] ?? "full";
+  const timings = [];
+  let exitCode = 0;
   for (const step of resolveBuildAllSteps(profile)) {
+    const startedAt = performance.now();
     const cacheState = resolveBuildAllStepCacheState(step);
     if (process.env.OPENCLAW_BUILD_CACHE !== "0" && cacheState.fresh) {
       restoreBuildAllStepCacheOutputs(cacheState);
-      console.error(`[build-all] ${step.label} (cached)`);
+      const durationMs = performance.now() - startedAt;
+      timings.push({ label: step.label, status: "cached", durationMs });
+      console.error(`[build-all] ${step.label} (cached) ${formatBuildAllDuration(durationMs)}`);
       continue;
     }
     console.error(`[build-all] ${step.label}`);
     const invocation = resolveBuildAllStep(step);
     const result = spawnSync(invocation.command, invocation.args, invocation.options);
+    const durationMs = performance.now() - startedAt;
     if (typeof result.status === "number") {
       if (result.status !== 0) {
-        process.exit(result.status);
+        timings.push({ label: step.label, status: "failed", durationMs });
+        console.error(
+          `[build-all] ${step.label} failed after ${formatBuildAllDuration(durationMs)}`,
+        );
+        exitCode = result.status;
+        break;
       }
       writeBuildAllStepCacheStamp(step, resolveBuildAllStepCacheState(step));
+      timings.push({ label: step.label, status: "ran", durationMs });
+      console.error(`[build-all] ${step.label} done in ${formatBuildAllDuration(durationMs)}`);
       continue;
     }
-    process.exit(1);
+    timings.push({ label: step.label, status: "failed", durationMs });
+    console.error(`[build-all] ${step.label} failed after ${formatBuildAllDuration(durationMs)}`);
+    exitCode = 1;
+    break;
+  }
+  console.error(formatBuildAllTimingSummary(timings));
+  if (exitCode !== 0) {
+    process.exit(exitCode);
   }
 }

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 import {
   BUILD_ALL_PROFILES,
   BUILD_ALL_STEPS,
+  formatBuildAllDuration,
+  formatBuildAllTimingSummary,
   resolveBuildAllStepCacheState,
   resolveBuildAllStep,
   resolveBuildAllSteps,
@@ -255,6 +257,26 @@ describe("resolveBuildAllSteps", () => {
 
   it("rejects unknown build profiles", () => {
     expect(() => resolveBuildAllSteps("wat")).toThrow("Unknown build profile: wat");
+  });
+});
+
+describe("build-all timing output", () => {
+  it("formats short and long phase durations compactly", () => {
+    expect(formatBuildAllDuration(42.4)).toBe("42ms");
+    expect(formatBuildAllDuration(1234)).toBe("1.23s");
+    expect(formatBuildAllDuration(12345)).toBe("12.3s");
+  });
+
+  it("summarizes phases slowest first with total time and status", () => {
+    expect(
+      formatBuildAllTimingSummary([
+        { label: "tsdown", status: "ran", durationMs: 99000 },
+        { label: "plugins:assets:copy", status: "cached", durationMs: 12 },
+        { label: "build:plugin-sdk:dts", status: "ran", durationMs: 34567 },
+      ]),
+    ).toBe(
+      "[build-all] phase timings: total 133.6s; slowest tsdown 99.0s; build:plugin-sdk:dts 34.6s; plugins:assets:copy (cached) 12ms",
+    );
   });
 });
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1,5 +1,10 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+function readCiWorkflow() {
+  return parse(readFileSync(".github/workflows/ci.yml", "utf8"));
+}
 
 describe("ci workflow guards", () => {
   it("kills timed manual checkout fetches after the grace period", () => {
@@ -11,15 +16,11 @@ describe("ci workflow guards", () => {
 
     for (const workflowPath of workflowPaths) {
       const workflow = readFileSync(workflowPath, "utf8");
-      const fetchTimeouts = workflow.match(
-        /timeout --signal=TERM[^\n]* 30s git -C "\$workdir"/g,
-      );
+      const fetchTimeouts = workflow.match(/timeout --signal=TERM[^\n]* 30s git -C "\$workdir"/g);
 
       expect(fetchTimeouts?.length, workflowPath).toBeGreaterThan(0);
       expect(fetchTimeouts, workflowPath).toEqual(
-        fetchTimeouts?.map(
-          () => 'timeout --signal=TERM --kill-after=10s 30s git -C "$workdir"',
-        ),
+        fetchTimeouts?.map(() => 'timeout --signal=TERM --kill-after=10s 30s git -C "$workdir"'),
       );
     }
   });
@@ -34,6 +35,16 @@ describe("ci workflow guards", () => {
     expect(workflow).toContain("check-guards");
     expect(preflightGuards).toContain("pnpm deps:shrinkwrap:check");
     expect(preflightGuards).toContain("pnpm deps:patches:check");
+  });
+
+  it("does not rebuild Control UI after build:ci-artifacts", () => {
+    const workflow = readCiWorkflow();
+    const buildArtifactSteps = workflow.jobs["build-artifacts"].steps;
+    const buildDistStep = buildArtifactSteps.find((step) => step.name === "Build dist");
+
+    expect(buildDistStep.run).toBe("pnpm build:ci-artifacts");
+    expect(buildArtifactSteps.map((step) => step.name)).not.toContain("Build Control UI");
+    expect(buildArtifactSteps.some((step) => step.run === "pnpm ui:build")).toBe(false);
   });
 
   it("keeps push docs validation ClawHub-backed", () => {


### PR DESCRIPTION
## Summary

Adds lightweight phase timing instrumentation to `scripts/build-all.mjs` so `pnpm build:ci-artifacts` reports each build phase duration and a slowest-first summary in CI logs. Also removes the now-duplicate `Build Control UI` workflow step because the `ciArtifacts` build profile already runs `ui:build`.

This is instrumentation only; build optimization is intentionally deferred until CI timing data identifies the actual bottleneck.

## Related Work

- Related, not duplicate: #86010 made `build:ci-artifacts` responsible for `ui:build`.
- Related source issue: #85206.
- No exact open issue or PR was found for this timing instrumentation plus duplicate workflow-step removal.

## Verification

- `pnpm exec oxfmt --check scripts/build-all.mjs test/scripts/build-all.test.ts test/scripts/ci-workflow-guards.test.ts .github/workflows/ci.yml`
- `pnpm exec oxlint scripts/build-all.mjs test/scripts/build-all.test.ts test/scripts/ci-workflow-guards.test.ts`
- Direct Node probe for build profile order, timing summary formatting, and workflow duplicate removal
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Focused Vitest note: `node scripts/run-vitest.mjs ...` was attempted against `test/scripts/build-all.test.ts` and `test/scripts/ci-workflow-guards.test.ts`, but the local Vitest process hung without output twice in this Codex worktree. I stopped those local processes and used the direct probe plus formatter/lint/autoreview proof above.

## Real behavior proof

Behavior addressed: `build-artifacts` CI logs did not show which `build:ci-artifacts` phase was slow, and CI still ran a separate `pnpm ui:build` after `build:ci-artifacts` even though the profile already includes `ui:build`.

Real environment tested: Local Codex worktree on macOS, Node via repo wrappers, branch `codex/perf-build-artifacts` at commit `0963393da8`.

Exact steps or command run after this patch: Ran the formatter, oxlint, a direct Node probe that imports `scripts/build-all.mjs` and parses `.github/workflows/ci.yml`, and autoreview on the local diff.

Evidence after fix: The direct probe verified that `ciArtifacts` still includes `ui:build` before `write-build-info`, timing summary output sorts slowest phases first, and the `build-artifacts` workflow no longer contains the duplicate `Build Control UI` / `pnpm ui:build` step.

Observed result after fix: `build-all` now prints per-phase elapsed time and a compact final timing summary, while the CI workflow relies on `pnpm build:ci-artifacts` for Control UI artifacts without a second UI build.

What was not tested: A full GitHub Actions `build-artifacts` run was not triggered from this branch. Local focused Vitest did not complete due to the hung local runner described above.
