### PR TITLE
ci: warm pnpm store before node fanout

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Whether to restore and save the pnpm store with actions/cache.
     required: false
     default: "true"
+  save-actions-cache:
+    description: Whether to save the pnpm store with actions/cache after install.
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -45,6 +49,7 @@ runs:
         openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
     - name: Setup pnpm
+      id: setup-pnpm
       uses: ./.github/actions/setup-pnpm-store-cache
       with:
         node-version: ${{ inputs.node-version }}
@@ -130,3 +135,10 @@ runs:
           ln -sfn "$PNPM_CONFIG_MODULES_DIR" node_modules
           ln -sfn . "$PNPM_CONFIG_MODULES_DIR/node_modules"
         fi
+
+    - name: Save pnpm store cache
+      if: ${{ inputs.install-deps == 'true' && inputs.use-actions-cache == 'true' && inputs.save-actions-cache == 'true' && runner.os != 'Windows' && steps.setup-pnpm.outputs.store-cache-hit != 'true' }}
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ steps.setup-pnpm.outputs.store-path }}
+        key: ${{ steps.setup-pnpm.outputs.store-cache-primary-key }}

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -20,11 +20,11 @@ inputs:
     required: false
     default: "true"
   use-actions-cache:
-    description: Whether to restore and save the pnpm store with actions/cache.
+    description: Whether to restore the pnpm store with actions/cache.
     required: false
     default: "true"
   save-actions-cache:
-    description: Whether to save the pnpm store with actions/cache after install.
+    description: Whether to save the pnpm store with actions/cache after install when no exact cache restored.
     required: false
     default: "false"
 runs:

--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: ""
   use-actions-cache:
-    description: Whether actions/cache should cache the pnpm store.
+    description: Whether actions/cache should restore the pnpm store.
     required: false
     default: "true"
 outputs:

--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -24,6 +24,15 @@ outputs:
   project-dir:
     description: Directory containing the packageManager file used for pnpm resolution.
     value: ${{ steps.setup-pnpm.outputs.project-dir }}
+  store-cache-hit:
+    description: Whether the pnpm store cache restored an exact key.
+    value: ${{ steps.pnpm-store-cache.outputs.cache-hit }}
+  store-cache-primary-key:
+    description: Exact pnpm store cache key used for restore/save.
+    value: ${{ steps.pnpm-store-cache.outputs.cache-primary-key }}
+  store-path:
+    description: Resolved pnpm store path.
+    value: ${{ steps.pnpm-store.outputs.path }}
 runs:
   using: composite
   steps:
@@ -81,14 +90,15 @@ runs:
         echo "path=$store_path" >> "$GITHUB_OUTPUT"
 
     - name: Restore pnpm store cache
+      id: pnpm-store-cache
       if: ${{ inputs.use-actions-cache == 'true' && runner.os != 'Windows' }}
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
-        key: pnpm-store-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles(inputs.lockfile-path) }}
+        key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}-${{ hashFiles(inputs.package-manager-file) }}-${{ hashFiles(inputs.lockfile-path) }}
         restore-keys: |
-          pnpm-store-${{ runner.os }}-${{ inputs.node-version }}-
-          pnpm-store-${{ runner.os }}-
+          pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}-${{ hashFiles(inputs.package-manager-file) }}-
+          pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}-
 
     - name: Record pnpm version
       id: pnpm-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,13 +414,73 @@ jobs:
       - name: Audit production dependencies
         run: node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high
 
+  # Warm the lockfile- and pnpm-pinned store once before Linux Node shards fan out.
+  # On a cold key this job owns the save, so later shards restore the exact key.
+  pnpm-store-warmup:
+    permissions:
+      contents: read
+    needs: [preflight]
+    if: needs.preflight.outputs.run_node == 'true' || needs.preflight.outputs.run_check_docs == 'true'
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        shell: bash
+        env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+        run: |
+          set -euo pipefail
+
+          workdir="$GITHUB_WORKSPACE"
+          reset_checkout_dir() {
+            mkdir -p "$workdir"
+            find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          }
+
+          checkout_attempt() {
+            local attempt="$1"
+
+            reset_checkout_dir
+            git init "$workdir" >/dev/null
+            git config --global --add safe.directory "$workdir"
+            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
+            git -C "$workdir" config gc.auto 0
+
+            timeout --signal=TERM --kill-after=10s 30s git -C "$workdir" \
+              -c protocol.version=2 \
+              fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
+              "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
+
+            git -C "$workdir" checkout --force --detach "$CHECKOUT_SHA" || return 1
+            test -f "$workdir/.github/actions/setup-node-env/action.yml" || return 1
+            echo "checkout attempt ${attempt}/5 succeeded"
+          }
+
+          for attempt in 1 2 3 4 5; do
+            if checkout_attempt "$attempt"; then
+              exit 0
+            fi
+            echo "checkout attempt ${attempt}/5 failed"
+            sleep $((attempt * 5))
+          done
+
+          echo "checkout failed after 5 attempts" >&2
+          exit 1
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          save-actions-cache: "true"
+
   # Build dist once for Node-relevant changes and share it with downstream jobs.
   # Keep this overlapping with the fast correctness lanes so green PRs get heavy
   # test/build feedback sooner instead of waiting behind a full `check` pass.
   build-artifacts:
     permissions:
       contents: read
-    needs: [preflight]
+    needs: [preflight, pnpm-store-warmup]
     if: needs.preflight.outputs.run_build_artifacts == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
@@ -652,7 +712,7 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.check_name }}
-    needs: [preflight]
+    needs: [preflight, pnpm-store-warmup]
     if: needs.preflight.outputs.run_checks_fast_core == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
@@ -741,7 +801,7 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.checkName }}
-    needs: [preflight]
+    needs: [preflight, pnpm-store-warmup]
     if: needs.preflight.outputs.run_plugin_contracts_shards == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
@@ -821,7 +881,7 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.checkName }}
-    needs: [preflight]
+    needs: [preflight, pnpm-store-warmup]
     if: needs.preflight.outputs.run_checks_fast == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
@@ -973,7 +1033,7 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.check_name }}
-    needs: [preflight]
+    needs: [preflight, pnpm-store-warmup]
     if: needs.preflight.outputs.run_checks_node_core_nondist == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (matrix.runner || 'ubuntu-24.04') || 'ubuntu-24.04') }}
     timeout-minutes: 60
@@ -1079,8 +1139,8 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.check_name }}
-    needs: [preflight]
-    if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check == 'true' }}
+    needs: [preflight, pnpm-store-warmup]
+    if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check == 'true' && needs.pnpm-store-warmup.result == 'success' }}
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && matrix.runner || 'ubuntu-24.04') }}
     timeout-minutes: 20
     strategy:
@@ -1210,8 +1270,8 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.check_name }}
-    needs: [preflight]
-    if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check_additional == 'true' }}
+    needs: [preflight, pnpm-store-warmup]
+    if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check_additional == 'true' && needs.pnpm-store-warmup.result == 'success' }}
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     strategy:
@@ -1377,7 +1437,7 @@ jobs:
   check-docs:
     permissions:
       contents: read
-    needs: [preflight]
+    needs: [preflight, pnpm-store-warmup]
     if: needs.preflight.outputs.run_check_docs == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -96,7 +96,7 @@ describe("package acceptance workflow", () => {
       "if: ${{ inputs.use-actions-cache == 'true' && runner.os != 'Windows' }}",
     );
     expect(setupPnpmAction).toContain(
-      "key: pnpm-store-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles(inputs.lockfile-path) }}",
+      "key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}-${{ hashFiles(inputs.package-manager-file) }}-${{ hashFiles(inputs.lockfile-path) }}",
     );
     expect(setupPnpmAction).not.toContain("pnpm/action-setup");
     expect(setupPnpmAction).not.toContain("shasum");


### PR DESCRIPTION
## Summary

- Adds a `pnpm-store-warmup` job before the Linux Node CI matrix fans out.
- Splits pnpm store restore/save so the shared setup action restores with `actions/cache/restore@v5`, while only the warmup job saves after install.
- Keeps dependency correctness tied to runner OS/arch, requested Node selector, `package.json` packageManager, and `pnpm-lock.yaml`.

## Verification

- `node scripts/check-workflows.mjs`
- `git diff --check -- .github/actions/setup-node-env/action.yml .github/actions/setup-pnpm-store-cache/action.yml .github/workflows/ci.yml`

## Matrix/cache validation proof

Behavior addressed: Linux Node CI shards no longer all race to populate the same cold pnpm store cache key; `pnpm-store-warmup` owns the initial save, and dependent matrix jobs restore that exact key.

Real environment tested: GitHub Actions `CI` workflow on branch `codex/perf-pnpm-cache-setup`, head `1b739c613da0c0ff0b40efa4311a2baee8e169a6`.

Exact steps or command run after this patch: dispatched `ci.yml` twice with `include_android=false`; inspected `pnpm-store-warmup`, `check-docs`, and cache API evidence; cancelled proof runs after cache behavior was proven to avoid spending the full matrix.

Evidence after fix: run `26555070823` had `pnpm-store-warmup` miss key `pnpm-store-Linux-X64-24.x-8e847ee68eabecfe672090b626620cd18487c600ebcbf156d29a4b35f04c1538-100b2b72ad614c04caf65407fe2ca5c5dd16b5dc222bf700599ece8592f0eb47`, then `actions/cache/save@v5` saved 529,790,606 bytes. In the same run, downstream matrix job `check-docs` restored that exact key successfully before running.

Observed result after fix: run `26555146813` proved the second-run path: `pnpm-store-warmup` restored the exact same key successfully and completed install in 6.6s. The GitHub cache API showed one cache entry for the branch with that key, size 529,790,606 bytes, last accessed during the proof run.

What was not tested: the proof runs were intentionally cancelled after cache save/restore and dependent matrix restore behavior were confirmed; the full CI matrix was not allowed to run to completion.

## Related work checked

- Prior exact attempt found but closed/unmerged: #47645
- Related pnpm setup work, not cache fanout coverage: #85468
- Related package-manager hardening, not exact cache warmup coverage: #72358
- Closed broad cache request: #8089



## Cache storage policy

The shared setup action restores pnpm-store caches when `use-actions-cache` is enabled, but saving new pnpm-store caches is now opt-in. `save-actions-cache` defaults to `false`, and `ci.yml` enables it only in `pnpm-store-warmup`.

This keeps the PR scoped to one Linux CI cache producer before fanout. Downstream Linux Node jobs restore the warmed exact key but do not save competing caches, and other workflows/OS lanes that use `setup-node-env` do not silently start producing pnpm-store cache entries just because they call the shared action.

This matters because live cache metadata showed the repository already above the default GitHub Actions cache budget, with large BuildKit, Swift, Gradle, and proof-branch pnpm-store entries. The lockfile is also high-churn, so unconstrained pnpm-store saving would risk cache thrash. The intended tradeoff is explicit: one warmed Linux CI pnpm-store cache per relevant lockfile key, not broad cache creation across every shared setup action call.

## Expected CI impact

This affects the Linux Node fanout behind `pnpm-store-warmup`, not Windows, macOS, Android, or Python-only lanes. In the workflow-dispatch proof run at `1b739c613da0c0ff0b40efa4311a2baee8e169a6`, 54 downstream Linux Node jobs were gated behind the warmup job: `build-artifacts`, fast contract/core checks, check shards, additional check shards, docs, and the Node test shards.

How many runs were tested: two corrected GitHub Actions CI dispatches proved the intended behavior. Run `26555070823` proved cold-key behavior: one warmup miss installed dependencies and saved the exact pnpm-store key; downstream matrix jobs then restored that key. Run `26555146813` proved warm-key behavior: the warmup job itself restored the exact key on the next run. Two earlier dispatches on the pre-fix implementation were cancelled after proving the old composite `actions/cache@v5` shape restored but did not save the cache.

Observed timing in the proof runs: the cold warmup install took 15.2s and saved a 529,790,606-byte cache. A downstream exact-cache restore in `check-docs` took about 6.7s, and its following `pnpm install` completed in 7.6s. The second-run warmup exact-cache path restored the same key and completed `pnpm install` in 6.6s.

Expected speedup: for this sampled Blacksmith run, the direct per-shard wall-clock win is modest because restoring a 505 MB cache also costs several seconds. Compared with a cold no-cache install of about 15-18s, an exact-cache restore plus install was about 14s in the sampled logs, so the immediate wall-clock gain is roughly 0-4s per affected shard on this runner class. The larger benefit is reducing repeated registry downloads and cache-save races across roughly 54 Linux Node jobs: the expensive cold population happens once, dependent jobs use the exact key, and future runs start from the warm-key path. In practice this should reduce setup variance and wasted network/CPU more than it will remove the whole setup phase.

