### PR TITLE
test(auto-reply): narrow directive model test dependencies

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { testing as cliBackendsTesting } from "../../agents/cli-backends.js";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.hoisted(() => {
   vi.resetModules();
@@ -16,6 +15,7 @@ const authProfilesStoreMock = vi.hoisted(() => ({
   >,
 }));
 const modelsCommandMock = vi.hoisted(() => ({
+  delegateToActual: false,
   resolveModelsCommandReply: vi.fn(),
 }));
 
@@ -33,6 +33,14 @@ function defaultModelsCommandReply() {
 
 function normalizeProviderForAuthTest(provider: string) {
   return provider.trim().toLowerCase();
+}
+
+function hasAllowedPluginForAuthTest(cfg: unknown, pluginId: string): boolean {
+  if (!cfg || typeof cfg !== "object" || !("plugins" in cfg)) {
+    return false;
+  }
+  const plugins = (cfg as { plugins?: { allow?: unknown } }).plugins;
+  return Array.isArray(plugins?.allow) && plugins.allow.includes(pluginId);
 }
 
 vi.mock("../../agents/auth-profiles.js", () => {
@@ -69,8 +77,17 @@ vi.mock("../../agents/auth-profiles.js", () => {
 });
 
 vi.mock("./commands-models.js", () => ({
-  resolveModelsCommandReply: (...args: unknown[]) =>
-    modelsCommandMock.resolveModelsCommandReply(...args),
+  resolveModelsCommandReply: async (
+    params: Parameters<typeof import("./commands-models.js").resolveModelsCommandReply>[0],
+  ) => {
+    modelsCommandMock.resolveModelsCommandReply(params);
+    if (modelsCommandMock.delegateToActual) {
+      const actual =
+        await vi.importActual<typeof import("./commands-models.js")>("./commands-models.js");
+      return actual.resolveModelsCommandReply(params);
+    }
+    return defaultModelsCommandReply();
+  },
 }));
 
 vi.mock("./directive-handling.auth.js", () => ({
@@ -82,7 +99,7 @@ vi.mock("./directive-handling.auth.js", () => ({
   },
   resolveAuthLabel: async (
     provider: string,
-    _cfg: unknown,
+    cfg: unknown,
     _modelsPath: string,
     _agentDir?: string,
     _mode?: unknown,
@@ -105,7 +122,10 @@ vi.mock("./directive-handling.auth.js", () => ({
     if (
       providerKey === "anthropic" &&
       workspaceDir &&
-      (process.env.WORKSPACE_MODEL_CREDENTIALS || process.env.WORKSPACE_MODEL_LIST_CREDENTIALS)
+      ((process.env.WORKSPACE_MODEL_CREDENTIALS &&
+        hasAllowedPluginForAuthTest(cfg, "workspace-model-auth")) ||
+        (process.env.WORKSPACE_MODEL_LIST_CREDENTIALS &&
+          hasAllowedPluginForAuthTest(cfg, "workspace-model-list")))
     ) {
       return {
         label: process.env.WORKSPACE_MODEL_CREDENTIALS
@@ -196,6 +216,50 @@ vi.mock("../../agents/provider-auth-aliases.js", () => ({
   resolveProviderIdForAuth: (provider: string) => provider,
 }));
 
+vi.mock("../../agents/harness/selection.js", () => ({
+  resolveAgentHarnessPolicy: ({
+    provider,
+    modelId,
+    config,
+  }: {
+    provider?: string;
+    modelId?: string;
+    config?: OpenClawConfig;
+  }) => {
+    const modelRuntime =
+      provider && modelId
+        ? config?.agents?.defaults?.models?.[`${provider}/${modelId}`]?.agentRuntime?.id
+        : undefined;
+    const providerRuntime = provider
+      ? config?.models?.providers?.[provider]?.agentRuntime?.id
+      : undefined;
+    const runtime =
+      modelRuntime === "default"
+        ? undefined
+        : (modelRuntime ??
+          (providerRuntime === "default" ? undefined : providerRuntime) ??
+          (provider === "openai" || provider === "openai-codex" ? "codex" : "auto"));
+    return {
+      runtime,
+      runtimeSource: modelRuntime ? "model" : providerRuntime ? "provider" : "implicit",
+    };
+  },
+}));
+
+vi.mock("../../agents/runtime-plan/auth.js", () => ({
+  buildAgentRuntimeAuthPlan: ({
+    provider,
+    harnessRuntime,
+  }: {
+    provider: string;
+    harnessRuntime?: string;
+  }) => ({
+    providerForAuth: provider,
+    authProfileProviderForAuth: provider,
+    ...(harnessRuntime === "codex" ? { harnessAuthProvider: "openai-codex" } : {}),
+  }),
+}));
+
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -215,13 +279,22 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { ProviderPlugin } from "../../plugins/types.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import type { ElevatedLevel } from "../thinking.js";
-import { handleDirectiveOnly } from "./directive-handling.impl.js";
-import {
-  maybeHandleModelDirectiveInfo,
-  resolveModelSelectionFromDirective,
-} from "./directive-handling.model.js";
-import { parseInlineDirectives } from "./directive-handling.parse.js";
-import { persistInlineDirectives } from "./directive-handling.persist.js";
+
+let handleDirectiveOnly: typeof import("./directive-handling.impl.js").handleDirectiveOnly;
+let cliBackendsTesting: typeof import("../../agents/cli-backends.js").testing;
+let maybeHandleModelDirectiveInfo: typeof import("./directive-handling.model.js").maybeHandleModelDirectiveInfo;
+let resolveModelSelectionFromDirective: typeof import("./directive-handling.model.js").resolveModelSelectionFromDirective;
+let parseInlineDirectives: typeof import("./directive-handling.parse.js").parseInlineDirectives;
+let persistInlineDirectives: typeof import("./directive-handling.persist.js").persistInlineDirectives;
+
+beforeAll(async () => {
+  ({ testing: cliBackendsTesting } = await import("../../agents/cli-backends.js"));
+  ({ handleDirectiveOnly } = await import("./directive-handling.impl.js"));
+  ({ maybeHandleModelDirectiveInfo, resolveModelSelectionFromDirective } =
+    await import("./directive-handling.model.js"));
+  ({ parseInlineDirectives } = await import("./directive-handling.parse.js"));
+  ({ persistInlineDirectives } = await import("./directive-handling.persist.js"));
+});
 
 const liveModelSwitchMocks = vi.hoisted(() => ({
   requestLiveSessionModelSwitch: vi.fn(),
@@ -341,6 +414,7 @@ beforeEach(() => {
   modelsCommandMock.resolveModelsCommandReply
     .mockReset()
     .mockResolvedValue(defaultModelsCommandReply());
+  modelsCommandMock.delegateToActual = false;
   clearRuntimeAuthProfileStoreSnapshots();
   replaceRuntimeAuthProfileStoreSnapshots([
     {
@@ -580,6 +654,7 @@ describe("/model chat UX", () => {
           WORKSPACE_MODEL_LIST_CREDENTIALS: credentialPath,
         },
         async () => {
+          modelsCommandMock.delegateToActual = true;
           const reply = await resolveModelInfoReply({
             directives: parseInlineDirectives("/model list"),
             workspaceDir,
@@ -744,7 +819,6 @@ describe("/model chat UX", () => {
         commands: { text: true },
         agents: {
           defaults: {
-            agentRuntime: { id: "codex" },
             model: { primary: "openai/gpt-5.5" },
             models: {
               "codex/gpt-5.5": {},
@@ -788,7 +862,6 @@ describe("/model chat UX", () => {
         commands: { text: true },
         agents: {
           defaults: {
-            agentRuntime: { id: "codex" },
             model: { primary: "openai/gpt-5.5" },
             models: {
               "openai/gpt-5.5": {},

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -3,6 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.js";
+
+vi.hoisted(() => {
+  vi.resetModules();
+});
+
 const authProfilesStoreMock = vi.hoisted(() => ({
   profiles: {} as Record<
     string,
@@ -10,6 +15,25 @@ const authProfilesStoreMock = vi.hoisted(() => ({
     | { type: "oauth"; provider: string; access: string; refresh: string; expires: number }
   >,
 }));
+const modelsCommandMock = vi.hoisted(() => ({
+  resolveModelsCommandReply: vi.fn(),
+}));
+
+function defaultModelsCommandReply() {
+  return {
+    text: [
+      "Providers:",
+      "- anthropic (1)",
+      "",
+      "Use: /models <provider>",
+      "Switch: /model <provider/model>",
+    ].join("\n"),
+  };
+}
+
+function normalizeProviderForAuthTest(provider: string) {
+  return provider.trim().toLowerCase();
+}
 
 vi.mock("../../agents/auth-profiles.js", () => {
   const store = () => ({
@@ -43,6 +67,56 @@ vi.mock("../../agents/auth-profiles.js", () => {
     resolveAuthStorePathForDisplay: () => "/tmp/auth-profiles.json",
   };
 });
+
+vi.mock("./commands-models.js", () => ({
+  resolveModelsCommandReply: (...args: unknown[]) =>
+    modelsCommandMock.resolveModelsCommandReply(...args),
+}));
+
+vi.mock("./directive-handling.auth.js", () => ({
+  formatAuthLabel: (auth: { label: string; source: string }) => {
+    if (!auth.source || auth.source === auth.label || auth.source === "missing") {
+      return auth.label;
+    }
+    return `${auth.label} (${auth.source})`;
+  },
+  resolveAuthLabel: async (
+    provider: string,
+    _cfg: unknown,
+    _modelsPath: string,
+    _agentDir?: string,
+    _mode?: unknown,
+    workspaceDir?: string,
+  ) => {
+    const providerKey = normalizeProviderForAuthTest(provider);
+    const matchingProfiles = Object.entries(authProfilesStoreMock.profiles).filter(
+      ([, profile]) => normalizeProviderForAuthTest(profile.provider) === providerKey,
+    );
+    if (matchingProfiles.length > 0) {
+      return {
+        label: matchingProfiles
+          .map(([profileId, profile]) =>
+            profile.type === "oauth" ? `${profileId}=OAuth` : `${profileId}=${profile.key}`,
+          )
+          .join(", "),
+        source: `auth-profiles.json: /tmp/auth-profiles.json`,
+      };
+    }
+    if (
+      providerKey === "anthropic" &&
+      workspaceDir &&
+      (process.env.WORKSPACE_MODEL_CREDENTIALS || process.env.WORKSPACE_MODEL_LIST_CREDENTIALS)
+    ) {
+      return {
+        label: process.env.WORKSPACE_MODEL_CREDENTIALS
+          ? "workspace model credentials"
+          : "workspace model list credentials",
+        source: "",
+      };
+    }
+    return { label: "missing", source: "missing" };
+  },
+}));
 
 vi.mock("../../agents/auth-profiles/store.js", () => {
   const store = () => ({
@@ -264,6 +338,9 @@ beforeEach(() => {
     resolveRuntimeCliBackends: () => [],
   });
   setDirectiveTestProviders([]);
+  modelsCommandMock.resolveModelsCommandReply
+    .mockReset()
+    .mockResolvedValue(defaultModelsCommandReply());
   clearRuntimeAuthProfileStoreSnapshots();
   replaceRuntimeAuthProfileStoreSnapshots([
     {
@@ -459,7 +536,7 @@ describe("/model chat UX", () => {
     expect(reply?.text).toContain("Switch: /model <provider/model>");
   });
 
-  it("uses workspace-scoped auth evidence in /model list provider visibility", async () => {
+  it("passes workspace scope through the /model list browser alias", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-list-auth-label-"));
     const workspaceDir = path.join(tempRoot, "workspace");
     const pluginDir = path.join(workspaceDir, ".openclaw", "extensions", "workspace-model-list");
@@ -513,6 +590,15 @@ describe("/model chat UX", () => {
           });
 
           expect(reply?.text).toContain("- anthropic");
+          expect(modelsCommandMock.resolveModelsCommandReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+              commandBodyNormalized: "/models",
+              workspaceDir,
+              cfg: expect.objectContaining({
+                plugins: { allow: ["workspace-model-list"] },
+              }),
+            }),
+          );
         },
       );
     } finally {


### PR DESCRIPTION
## Summary

- Narrow `directive-handling.model.test.ts` so unit-level `/model` directive assertions do not exercise broad `/models`, auth-label, CLI backend, harness-policy, or runtime-auth discovery paths.
- Keep `/model list` coverage focused on delegating to the models browser with the right workspace/config scope.
- Reset and dynamically import the modules under test so the narrowed mocks stay effective in shared-worker shard order.

## Verification

Behavior addressed: `src/auto-reply/reply/directive-handling.model.test.ts` was exercising broad `/models`, auth-label, CLI backend, harness-policy, and runtime-auth discovery paths for unit-level directive assertions, making the auto-reply dispatch shard slow and order-sensitive.

Real environment tested: Local Codex OpenClaw worktree on branch `codex/perf-auto-reply-tests` using repo wrappers, plus Blacksmith Testbox through Crabbox for the broad type lane.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.model.test.ts --run --reporter=verbose`
- `node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/dispatch-from-config.test.ts --run --reporter=verbose`
- `./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/directive-handling.model.test.ts`
- `git diff --check -- src/auto-reply/reply/directive-handling.model.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- corepack pnpm check:test-types`

Evidence after fix:
- Before patch: `directive-handling.model.test.ts` failed after one 120s timeout; Vitest duration `286.14s`; wall time `7:11.31`.
- After final patch: `directive-handling.model.test.ts` passed `60/60`; Vitest duration `1.83s`; status/auth cases ran in milliseconds.
- Hotspot shard proof passed `286/286` across `directive-handling.model.test.ts`, `followup-runner.test.ts`, and `dispatch-from-config.test.ts`; Vitest duration `87.71s`. The remaining slow work is in the broader shard/order path, especially `followup-runner`, not the isolated directive model test.
- Final autoreview: clean, no accepted/actionable findings.
- `check:test-types` passed on Testbox-through-Crabbox: provider `blacksmith-testbox`, id `tbx_01kspk4mg7qc4t25bp1as438c7`, Actions run `26557922178`, exit `0`.

Observed result after fix: The narrow `/model` directive test no longer pays the broad discovery cost in isolation, and the relevant auto-reply hotspot shard passes on the rebased branch. The ClawSweeper-reported `check-test-types` failure was in unrelated `src/agents/tools/pdf-native-providers.test.ts` on the old base; after rebasing onto current `main`, the lane passes in Testbox.

What was not tested: I did not run full local `pnpm check*` or the full auto-reply suite locally, per Codex-worktree guidance to avoid broad local pnpm gates.

## Related Work Search

- No exact existing issue or PR found for this test-shard cleanup.
- Nearby but not duplicate: #86229, #86635, #86547.
