### PR TITLE
test(cron): speed up isolated fallback tests

### DIFF
--- a/src/cron/isolated-agent/run.fast-mode.test.ts
+++ b/src/cron/isolated-agent/run.fast-mode.test.ts
@@ -25,7 +25,7 @@ function mockSuccessfulModelFallback() {
     return {
       result: {
         payloads: [{ text: "ok" }],
-        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+        meta: { agentMeta: {} },
       },
       provider,
       model,
@@ -126,7 +126,7 @@ async function runFastModeCase(params: {
 }
 
 describe("runCronIsolatedAgentTurn — fast mode", () => {
-  setupRunCronIsolatedAgentTurnSuite();
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
 
   it("passes config-driven fast mode into embedded cron runs", async () => {
     await runFastModeCase({

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -9,6 +9,7 @@ import {
   loadRunCronIsolatedAgentTurn,
   mockRunCronFallbackPassthrough,
   resolveConfiguredModelRefMock,
+  resolveCliRuntimeExecutionProviderMock,
   resolveAgentModelFallbacksOverrideMock,
   runCliAgentMock,
   runEmbeddedAgentMock,
@@ -50,7 +51,7 @@ function requireEmbeddedRunRequest(): {
 }
 
 describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
-  setupRunCronIsolatedAgentTurnSuite();
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
 
   it.each([
     {
@@ -92,13 +93,16 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
 
   it("plans Anthropic fallbacks canonically while executing compatible attempts through Claude CLI", async () => {
     isCliProviderMock.mockImplementation((provider: string) => provider === "claude-cli");
+    resolveCliRuntimeExecutionProviderMock.mockImplementation(
+      ({ provider }: { provider: string }) => (provider === "anthropic" ? "claude-cli" : undefined),
+    );
     resolveConfiguredModelRefMock.mockReturnValue({
       provider: "anthropic",
       model: "claude-opus-4-6",
     });
     runCliAgentMock.mockResolvedValue({
       payloads: [{ text: "fallback ok" }],
-      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      meta: { agentMeta: {} },
     });
     runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
       const firstResult = await run(provider, model);

--- a/src/cron/isolated-agent/run.suite-helpers.ts
+++ b/src/cron/isolated-agent/run.suite-helpers.ts
@@ -8,10 +8,13 @@ import {
   restoreFastTestEnv,
 } from "./run.test-harness.js";
 
-export function setupRunCronIsolatedAgentTurnSuite() {
+export function setupRunCronIsolatedAgentTurnSuite(options?: { fast?: boolean }) {
   let previousFastTestEnv: string | undefined;
   beforeEach(() => {
     previousFastTestEnv = clearFastTestEnv();
+    if (options?.fast) {
+      process.env.OPENCLAW_TEST_FAST = "1";
+    }
     resetRunCronIsolatedAgentTurnHarness();
     resolveCronSessionMock.mockReturnValue(makeCronSession());
   });

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -46,6 +46,7 @@ export const resolveAgentModelFallbacksOverrideMock = createMock();
 export const resolveAgentSkillsFilterMock = createMock();
 export const getModelRefStatusMock = createMock();
 export const isCliProviderMock = createMock();
+export const resolveCliRuntimeExecutionProviderMock = createMock();
 export const resolveAllowedModelRefMock = createMock();
 export const resolveConfiguredModelRefMock = createMock();
 export const resolveHooksGmailModelMock = createMock();
@@ -129,6 +130,13 @@ vi.mock("./run.runtime.js", () => ({
   isExternalHookSession: isExternalHookSessionMock,
   resolveHookExternalContentSource: resolveHookExternalContentSourceMock,
   getRemoteSkillEligibility: getRemoteSkillEligibilityMock,
+}));
+
+vi.mock("../../agents/model-runtime-aliases.js", async () => ({
+  ...(await vi.importActual<typeof import("../../agents/model-runtime-aliases.js")>(
+    "../../agents/model-runtime-aliases.js",
+  )),
+  resolveCliRuntimeExecutionProvider: resolveCliRuntimeExecutionProviderMock,
 }));
 
 vi.mock("./run-external-content.runtime.js", () => ({
@@ -296,7 +304,7 @@ function makeDefaultModelFallbackResult() {
   return {
     result: {
       payloads: [{ text: "test output" }],
-      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      meta: { agentMeta: {} },
     },
     provider: "openai",
     model: "gpt-5.4",
@@ -306,7 +314,7 @@ function makeDefaultModelFallbackResult() {
 function makeDefaultEmbeddedResult() {
   return {
     payloads: [{ text: "test output" }],
-    meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    meta: { agentMeta: {} },
   };
 }
 
@@ -379,6 +387,7 @@ function resetRunConfigMocks(): void {
   resolveAgentModelFallbacksOverrideMock.mockReturnValue(undefined);
   resolveAgentSkillsFilterMock.mockReturnValue(undefined);
   resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-5.4" });
+  resolveCliRuntimeExecutionProviderMock.mockReturnValue(undefined);
   resolveAllowedModelRefMock.mockReturnValue({ ref: { provider: "openai", model: "gpt-5.4" } });
   resolveHooksGmailModelMock.mockReturnValue(null);
   resolveThinkingDefaultMock.mockReturnValue("off");
@@ -389,7 +398,11 @@ function resetRunConfigMocks(): void {
   });
   resolveAgentTimeoutMsMock.mockReturnValue(60_000);
   deriveSessionTotalTokensMock.mockReturnValue(30);
-  hasNonzeroUsageMock.mockReturnValue(true);
+  hasNonzeroUsageMock.mockImplementation(
+    (usage: { input?: unknown; output?: unknown } | undefined) =>
+      (typeof usage?.input === "number" && usage.input > 0) ||
+      (typeof usage?.output === "number" && usage.output > 0),
+  );
   ensureAgentWorkspaceMock.mockResolvedValue({ dir: "/tmp/workspace" });
   normalizeThinkLevelMock.mockImplementation((value: unknown) => value);
   isThinkingLevelSupportedMock.mockReturnValue(true);


### PR DESCRIPTION
## Summary

This PR speeds up the isolated cron test hotspot shard without changing production runtime behavior.

- Adds a test-harness mock for `resolveCliRuntimeExecutionProvider` so the payload fallback tests can assert cron fallback planning without invoking real CLI runtime/backend discovery.
- Lets targeted mocked `runCronIsolatedAgentTurn` suites opt into `OPENCLAW_TEST_FAST=1` through `setupRunCronIsolatedAgentTurnSuite({ fast: true })`.
- Removes default fake usage from the run harness results so tests that do not assert usage avoid the unrelated usage/cost finalization path.

## Test Cost / Size Impact

- Planned hotspot group before: `166.17s` total, `143.35s` in tests.
- Planned hotspot group after: `3.55s` total, `1.18s` in tests.
- `src/cron/isolated-agent/run.payload-fallbacks.test.ts` after focused fix: `2.00s` total, `24ms` in tests. The former slow Claude CLI compatibility assertion now reports `0-1ms` in the grouped runs.
- Diff size: 4 files, +28/-8.

## Related Work Search

I searched GitHub and local repo tooling before implementing. I did not find an exact existing issue or PR covering this isolated cron test performance work.

Adjacent but not duplicate:
- #87410: embedded attempt runner helper test refactor, different surface.
- #86893: isolated cron cold runner setup timeout, runtime/timer surface.
- #82887: cron preflight fallback behavior, runtime behavior surface.

## Verification

- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run.fast-mode.test.ts src/cron/isolated-agent.hook-content-wrapping.test.ts src/cron/isolated-agent.delivery-awareness.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.*.test.ts --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 src/cron/isolated-agent/run.test-harness.ts src/cron/isolated-agent/run.suite-helpers.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run.fast-mode.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/cron/isolated-agent/run.test-harness.ts src/cron/isolated-agent/run.suite-helpers.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run.fast-mode.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Isolated cron test performance for payload fallback and fast-mode planning coverage; no production runtime behavior change intended.
Real environment tested: Local Codex worktree on macOS using repo Node/Vitest wrappers.
Exact steps or command run after this patch: The Verification commands listed above.
Evidence after fix: The planned four-file hotspot group passed 18 tests in `3.55s` after a baseline of `166.17s`; the broader `src/cron/isolated-agent/run.*.test.ts` wrapper run passed 16 files and 117 tests in `5.02s`; oxfmt, focused oxlint, test-source tsgo, and autoreview all exited cleanly.
Observed result after fix: The slow CLI compatibility fallback assertion is covered through the cron test harness mock instead of real runtime discovery, and the targeted mocked suites complete in seconds while preserving fallback ordering, compatible CLI execution attempts, fast-mode propagation, hook content wrapping, and delivery-awareness coverage.
What was not tested: Full `pnpm check`, full Vitest suite, and live provider behavior; this is a scoped test-only harness change in a Codex worktree.
