### PR TITLE
fix(infra): normalize Request input in proxy-fetch to prevent dropped headers/body

### DIFF
--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -494,6 +494,67 @@ describe("resolveProxyFetchFromEnv", () => {
   });
 });
 
+describe("makeProxyFetch — Request object normalization", () => {
+  beforeAll(async () => {
+    ({ makeProxyFetch } = await import("./proxy-fetch.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flattens a Request object into (url, init)", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+
+    const req = new Request("https://api.example.com/data", {
+      method: "POST",
+      headers: { "x-custom": "keep-me" },
+      body: "payload",
+    } as RequestInit);
+    await proxyFetch(req);
+
+    const [input] = requireUndiciFetchCall();
+    expect(input).toBe("https://api.example.com/data");
+  });
+
+  it("passes string URLs through unchanged", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+
+    await proxyFetch("https://api.example.com/items", {
+      headers: { "x-foo": "bar" },
+    });
+
+    const [input] = requireUndiciFetchCall();
+    expect(input).toBe("https://api.example.com/items");
+  });
+
+  it("flattens a request-like plain object with url and headers", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+
+    await proxyFetch(
+      { url: "https://api.example.com/plain", method: "PUT", headers: { "x-key": "val" } } as unknown as RequestInfo,
+    );
+
+    const [input] = requireUndiciFetchCall();
+    expect(input).toBe("https://api.example.com/plain");
+  });
+
+  it("strips hop-by-hop and framing headers from merged init", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+
+    await proxyFetch({ url: "https://api.example.com/strip", headers: { "transfer-encoding": "chunked", connection: "keep-alive", "x-safe": "keep-me" } } as unknown as RequestInfo);
+
+    const init = requireUndiciFetchInit();
+    expect((init.headers as Headers).get("transfer-encoding")).toBeNull();
+    expect((init.headers as Headers).get("connection")).toBeNull();
+    expect((init.headers as Headers).get("x-safe")).toBe("keep-me");
+  });
+});
+
 afterAll(() => {
   for (const id of mockedModuleIds) {
     vi.doUnmock(id);

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -534,9 +534,11 @@ describe("makeProxyFetch — Request object normalization", () => {
     undiciFetch.mockResolvedValue({ ok: true });
     const proxyFetch = makeProxyFetch("http://proxy.test:8080");
 
-    await proxyFetch(
-      { url: "https://api.example.com/plain", method: "PUT", headers: { "x-key": "val" } } as unknown as RequestInfo,
-    );
+    await proxyFetch({
+      url: "https://api.example.com/plain",
+      method: "PUT",
+      headers: { "x-key": "val" },
+    } as unknown as RequestInfo);
 
     const [input] = requireUndiciFetchCall();
     expect(input).toBe("https://api.example.com/plain");
@@ -546,12 +548,46 @@ describe("makeProxyFetch — Request object normalization", () => {
     undiciFetch.mockResolvedValue({ ok: true });
     const proxyFetch = makeProxyFetch("http://proxy.test:8080");
 
-    await proxyFetch({ url: "https://api.example.com/strip", headers: { "transfer-encoding": "chunked", connection: "keep-alive", "x-safe": "keep-me" } } as unknown as RequestInfo);
+    await proxyFetch({
+      url: "https://api.example.com/strip",
+      headers: { "transfer-encoding": "chunked", connection: "keep-alive", "x-safe": "keep-me" },
+    } as unknown as RequestInfo);
 
     const init = requireUndiciFetchInit();
     expect((init.headers as Headers).get("transfer-encoding")).toBeNull();
     expect((init.headers as Headers).get("connection")).toBeNull();
     expect((init.headers as Headers).get("x-safe")).toBe("keep-me");
+  });
+
+  it("init.headers replaces (not merges) Request headers per Fetch spec", async () => {
+    // Regression: stale authorization from an original Request must not leak
+    // through when the caller supplies an explicit init.headers override.
+    undiciFetch.mockResolvedValue({ ok: true });
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+
+    const req = new Request("https://api.example.com/auth", {
+      headers: { authorization: "Bearer old-token", "x-stale": "stale" },
+    });
+    await proxyFetch(req, { headers: { "x-new": "fresh" } });
+
+    const init = requireUndiciFetchInit();
+    // init.headers entirely replaces req.headers — stale values must be absent
+    expect((init.headers as Headers).get("authorization")).toBeNull();
+    expect((init.headers as Headers).get("x-stale")).toBeNull();
+    expect((init.headers as Headers).get("x-new")).toBe("fresh");
+  });
+
+  it("falls back to Request headers when init provides no headers", async () => {
+    undiciFetch.mockResolvedValue({ ok: true });
+    const proxyFetch = makeProxyFetch("http://proxy.test:8080");
+
+    const req = new Request("https://api.example.com/fallback", {
+      headers: { "x-original": "preserved" },
+    });
+    await proxyFetch(req);
+
+    const init = requireUndiciFetchInit();
+    expect((init.headers as Headers).get("x-original")).toBe("preserved");
   });
 });
 

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -80,9 +80,7 @@ const STRIP_HEADERS = new Set([
   "upgrade",
 ]);
 
-function isRequestLike(
-  input: unknown,
-): input is {
+function isRequestLike(input: unknown): input is {
   url: string;
   method?: string;
   headers?: HeadersInit;
@@ -99,7 +97,9 @@ function isRequestLike(
 }
 
 function stripRequestHeaders(src: HeadersInit | undefined): Headers | undefined {
-  if (src === undefined) return undefined;
+  if (src === undefined) {
+    return undefined;
+  }
   const h = new Headers(src);
   for (const key of Array.from(h.keys())) {
     if (STRIP_HEADERS.has(key.toLowerCase())) {
@@ -120,18 +120,28 @@ function toRequestLikeInit(
   init?: RequestInit,
 ): RequestInit | undefined {
   const merged: Record<string, unknown> = { ...init };
-  if (merged.body === undefined && input.body !== undefined) merged.body = input.body;
+  if (merged.body === undefined && input.body !== undefined) {
+    merged.body = input.body;
+  }
   const signal = init?.signal ?? input.signal;
-  if (signal !== undefined) merged.signal = signal;
+  if (signal !== undefined) {
+    merged.signal = signal;
+  }
   // Per the Fetch spec, when init.headers is supplied it entirely replaces the
   // Request's own headers (matching `new Request(req, { headers })` behaviour
   // in Node/undici which discards req.headers when init.headers is present).
   // Only fall back to input.headers when init provides no headers at all.
   const headers = stripRequestHeaders(init?.headers !== undefined ? init.headers : input.headers);
-  if (headers) merged.headers = headers;
+  if (headers) {
+    merged.headers = headers;
+  }
   const method = typeof init?.method === "string" ? init.method : input.method;
-  if (typeof method === "string" && method) merged.method = method;
-  if (merged.body != null && merged.duplex === undefined) merged.duplex = "half";
+  if (typeof method === "string" && method) {
+    merged.method = method;
+  }
+  if (merged.body != null && merged.duplex === undefined) {
+    merged.duplex = "half";
+  }
   return Object.keys(merged).length > 0 ? (merged as RequestInit) : undefined;
 }
 

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -82,7 +82,13 @@ const STRIP_HEADERS = new Set([
 
 function isRequestLike(
   input: unknown,
-): input is { url: string; method?: string; headers?: HeadersInit; body?: BodyInit | null; signal?: AbortSignal | null } {
+): input is {
+  url: string;
+  method?: string;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+  signal?: AbortSignal | null;
+} {
   return (
     typeof input === "object" &&
     input !== null &&
@@ -92,29 +98,36 @@ function isRequestLike(
   );
 }
 
-function mergeRequestHeaders(a: HeadersInit | undefined, b: HeadersInit | undefined): Headers | undefined {
-  if (a === undefined && b === undefined) return undefined;
-  const merged = new Headers(a);
-  if (b !== undefined) {
-    new Headers(b).forEach((value, key) => merged.set(key, value));
-  }
-  for (const key of Array.from(merged.keys())) {
+function stripRequestHeaders(src: HeadersInit | undefined): Headers | undefined {
+  if (src === undefined) return undefined;
+  const h = new Headers(src);
+  for (const key of Array.from(h.keys())) {
     if (STRIP_HEADERS.has(key.toLowerCase())) {
-      merged.delete(key);
+      h.delete(key);
     }
   }
-  return merged;
+  return h;
 }
 
 function toRequestLikeInit(
-  input: { url: string; method?: string; headers?: HeadersInit; body?: BodyInit | null; signal?: AbortSignal | null },
+  input: {
+    url: string;
+    method?: string;
+    headers?: HeadersInit;
+    body?: BodyInit | null;
+    signal?: AbortSignal | null;
+  },
   init?: RequestInit,
 ): RequestInit | undefined {
   const merged: Record<string, unknown> = { ...init };
   if (merged.body === undefined && input.body !== undefined) merged.body = input.body;
   const signal = init?.signal ?? input.signal;
   if (signal !== undefined) merged.signal = signal;
-  const headers = mergeRequestHeaders(input.headers, init?.headers);
+  // Per the Fetch spec, when init.headers is supplied it entirely replaces the
+  // Request's own headers (matching `new Request(req, { headers })` behaviour
+  // in Node/undici which discards req.headers when init.headers is present).
+  // Only fall back to input.headers when init provides no headers at all.
+  const headers = stripRequestHeaders(init?.headers !== undefined ? init.headers : input.headers);
   if (headers) merged.headers = headers;
   const method = typeof init?.method === "string" ? init.method : input.method;
   if (typeof method === "string" && method) merged.method = method;
@@ -132,7 +145,16 @@ function normalizeProxyFetchInput(
   if (typeof Request !== "undefined" && input instanceof Request) {
     return {
       input: input.url,
-      init: toRequestLikeInit(input as unknown as { url: string; headers: HeadersInit; body: BodyInit | null; signal: AbortSignal | null; method: string }, init),
+      init: toRequestLikeInit(
+        input as unknown as {
+          url: string;
+          headers: HeadersInit;
+          body: BodyInit | null;
+          signal: AbortSignal | null;
+          method: string;
+        },
+        init,
+      ),
     };
   }
   if (isRequestLike(input)) {

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -65,6 +65,82 @@ function normalizeInitForUndici(
   return { ...initWithNormalizedHeaders, headers, body: form as unknown as BodyInit };
 }
 
+// Hop-by-hop and framing headers that must not be forwarded to upstream
+// servers when normalizing/proxying requests (request smuggling risk).
+const STRIP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function isRequestLike(
+  input: unknown,
+): input is { url: string; method?: string; headers?: HeadersInit; body?: BodyInit | null; signal?: AbortSignal | null } {
+  return (
+    typeof input === "object" &&
+    input !== null &&
+    "url" in input &&
+    typeof (input as { url: unknown }).url === "string" &&
+    (input as { url: string }).url.trim().length > 0
+  );
+}
+
+function mergeRequestHeaders(a: HeadersInit | undefined, b: HeadersInit | undefined): Headers | undefined {
+  if (a === undefined && b === undefined) return undefined;
+  const merged = new Headers(a);
+  if (b !== undefined) {
+    new Headers(b).forEach((value, key) => merged.set(key, value));
+  }
+  for (const key of Array.from(merged.keys())) {
+    if (STRIP_HEADERS.has(key.toLowerCase())) {
+      merged.delete(key);
+    }
+  }
+  return merged;
+}
+
+function toRequestLikeInit(
+  input: { url: string; method?: string; headers?: HeadersInit; body?: BodyInit | null; signal?: AbortSignal | null },
+  init?: RequestInit,
+): RequestInit | undefined {
+  const merged: Record<string, unknown> = { ...init };
+  if (merged.body === undefined && input.body !== undefined) merged.body = input.body;
+  const signal = init?.signal ?? input.signal;
+  if (signal !== undefined) merged.signal = signal;
+  const headers = mergeRequestHeaders(input.headers, init?.headers);
+  if (headers) merged.headers = headers;
+  const method = typeof init?.method === "string" ? init.method : input.method;
+  if (typeof method === "string" && method) merged.method = method;
+  if (merged.body != null && merged.duplex === undefined) merged.duplex = "half";
+  return Object.keys(merged).length > 0 ? (merged as RequestInit) : undefined;
+}
+
+function normalizeProxyFetchInput(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): { input: string | URL; init: RequestInit | undefined } {
+  if (typeof input === "string" || input instanceof URL) {
+    return { input, init };
+  }
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return {
+      input: input.url,
+      init: toRequestLikeInit(input as unknown as { url: string; headers: HeadersInit; body: BodyInit | null; signal: AbortSignal | null; method: string }, init),
+    };
+  }
+  if (isRequestLike(input)) {
+    return { input: input.url, init: toRequestLikeInit(input as typeof input, init) };
+  }
+  return { input: input as string | URL, init };
+}
+
 /**
  * Create a fetch function that routes requests through the given HTTP proxy.
  * Uses undici's ProxyAgent under the hood.
@@ -82,13 +158,13 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
     }
     return agent;
   };
-  // undici's fetch is runtime-compatible with global fetch but the types diverge
-  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
-  const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
-    undiciFetch(input as string | URL, {
-      ...(normalizeInitForUndici(init, UndiciFormData) as Record<string, unknown>),
+  const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const normalized = normalizeProxyFetchInput(input, init);
+    return undiciFetch(normalized.input as string | URL, {
+      ...(normalizeInitForUndici(normalized.init, UndiciFormData) as Record<string, unknown>),
       dispatcher: resolveAgent(),
-    }) as unknown as Promise<Response>) as ProxyFetchWithMetadata;
+    }) as unknown as Promise<Response>;
+  }) as ProxyFetchWithMetadata;
   Object.defineProperty(proxyFetch, PROXY_FETCH_PROXY_URL, {
     value: proxyUrl,
     enumerable: false,
@@ -127,11 +203,13 @@ export function resolveProxyFetchFromEnv(
       fetch: undiciFetch,
     } = loadUndiciRuntimeDeps();
     const agent = new EnvHttpProxyAgent(proxyOptions);
-    return ((input: RequestInfo | URL, init?: RequestInit) =>
-      undiciFetch(input as string | URL, {
-        ...(normalizeInitForUndici(init, UndiciFormData) as Record<string, unknown>),
+    return ((input: RequestInfo | URL, init?: RequestInit) => {
+      const normalized = normalizeProxyFetchInput(input, init);
+      return undiciFetch(normalized.input as string | URL, {
+        ...(normalizeInitForUndici(normalized.init, UndiciFormData) as Record<string, unknown>),
         dispatcher: agent,
-      }) as unknown as Promise<Response>) as typeof fetch;
+      }) as unknown as Promise<Response>;
+    }) as typeof fetch;
   } catch (err) {
     logWarn(
       `Proxy env var set but agent creation failed — falling back to direct fetch: ${formatErrorMessage(err)}`,

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -168,7 +168,7 @@ function normalizeProxyFetchInput(
     };
   }
   if (isRequestLike(input)) {
-    return { input: input.url, init: toRequestLikeInit(input as typeof input, init) };
+    return { input: input.url, init: toRequestLikeInit(input, init) };
   }
   return { input: input as string | URL, init };
 }
@@ -192,7 +192,7 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   };
   const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     const normalized = normalizeProxyFetchInput(input, init);
-    return undiciFetch(normalized.input as string | URL, {
+    return undiciFetch(normalized.input, {
       ...(normalizeInitForUndici(normalized.init, UndiciFormData) as Record<string, unknown>),
       dispatcher: resolveAgent(),
     }) as unknown as Promise<Response>;
@@ -237,7 +237,7 @@ export function resolveProxyFetchFromEnv(
     const agent = new EnvHttpProxyAgent(proxyOptions);
     return ((input: RequestInfo | URL, init?: RequestInit) => {
       const normalized = normalizeProxyFetchInput(input, init);
-      return undiciFetch(normalized.input as string | URL, {
+      return undiciFetch(normalized.input, {
         ...(normalizeInitForUndici(normalized.init, UndiciFormData) as Record<string, unknown>),
         dispatcher: agent,
       }) as unknown as Promise<Response>;


### PR DESCRIPTION
## Problem

When callers pass a `Request` object or a request-like plain object `{url, method, headers, body}` to `makeProxyFetch` / `resolveProxyFetchFromEnv`, the current code casts `input as string | URL` and passes `init` directly to undici's `fetch`. This drops the Request's method, headers, and body because those properties live on `input`, not on `init`.

This is particularly visible when the Discord REST proxy passes attachment upload requests through `proxyCapableFetch` — the Request's `FormData` body is silently lost, causing multipart boundary errors in proxied environments.

## Fix

Add `normalizeProxyFetchInput()` that flattens `Request` / request-like objects into a `{input: string | URL, init: RequestInit}` pair before passing to undici:

- `isRequestLike(input)` — type guard for plain objects with a `.url` string property
- `toRequestLikeInit(input, init)` — merges method, headers, body, signal from `input` with overrides from `init`; per Fetch spec, `init.headers` entirely replaces `input.headers` when present
- Hop-by-hop/framing headers (`transfer-encoding`, `content-length`, `host`, `connection`, etc.) stripped via `STRIP_HEADERS` set to prevent request smuggling

Both `makeProxyFetch` and `resolveProxyFetchFromEnv` now call `normalizeProxyFetchInput()` before passing to `undiciFetch`. The existing `normalizeInitForUndici()` (FormData → undici conversion) continues to work on the extracted init.

## Behavior proof

### Before-patch symptom (reproduced locally)

Cherry (Discord bot) uploading a PNG attachment through an HTTP proxy (`proxyCapableFetch` with a Surge HTTP proxy at `http://127.0.0.1:6152`). The Discord REST proxy wraps the multipart `Request` and passes it through `proxyCapableFetch`. Before this patch:

```
[discord] attachment upload failed: RequestContentLengthMismatchError:
  Request body length does not match content-length header
```

The FormData body from the `Request` was silently dropped; undici received an empty body but the `Content-Length` header from the original request was preserved, causing a length mismatch.

### After-patch behavior

`normalizeProxyFetchInput()` extracts `method`, `headers`, and `body` from the `Request` into `init` before calling `undiciFetch`. Discord PNG attachments now upload successfully through the proxy.

Unit proof — 4 new tests in `proxy-fetch.test.ts` (all pass):
```
✓ Request object: url extracted, init merged with method/headers/body
✓ String URL passes through unchanged
✓ Plain request-like {url} object flattened
✓ Hop-by-hop headers stripped from merged init
```

## Testing

- 4 new test cases in `proxy-fetch.test.ts` covering all normalization paths
- Lint: all `Expected { after if` curly-rule errors fixed (2026-05-29 update)