### PR TITLE
feat(volcengine): add allowPrivateNetwork option for TTS behind TUN proxy

### DIFF
--- a/extensions/volcengine/speech-provider.ts
+++ b/extensions/volcengine/speech-provider.ts
@@ -38,6 +38,8 @@ type VolcengineTtsProviderConfig = {
   baseUrl?: string;
   speedRatio?: number;
   emotion?: string;
+  /** When true, allow private-network (RFC 1918) connections for the TTS HTTP call. */
+  allowPrivateNetwork?: boolean;
 };
 
 type VolcengineTtsProviderOverrides = {
@@ -84,6 +86,7 @@ function normalizeVolcengineProviderConfig(
     baseUrl: trimToUndefined(raw?.baseUrl) ?? trimToUndefined(process.env.VOLCENGINE_TTS_BASE_URL),
     speedRatio: normalizeSpeedRatio(raw?.speedRatio),
     emotion: trimToUndefined(raw?.emotion),
+    allowPrivateNetwork: raw?.allowPrivateNetwork === true,
   };
 }
 
@@ -112,6 +115,8 @@ function readProviderConfig(config: SpeechProviderConfig): VolcengineTtsProvider
     baseUrl: trimToUndefined(config.baseUrl) ?? normalized.baseUrl,
     speedRatio: normalizeSpeedRatio(config.speedRatio) ?? normalized.speedRatio,
     emotion: trimToUndefined(config.emotion) ?? normalized.emotion,
+    allowPrivateNetwork:
+      config.allowPrivateNetwork === true || normalized.allowPrivateNetwork === true,
   };
 }
 
@@ -221,6 +226,7 @@ export function buildVolcengineSpeechProvider(): SpeechProviderPlugin {
         emotion: overrides.emotion ?? cfg.emotion,
         encoding,
         timeoutMs: req.timeoutMs,
+        allowPrivateNetwork: cfg.allowPrivateNetwork === true,
       });
 
       return {

--- a/extensions/volcengine/tts.test.ts
+++ b/extensions/volcengine/tts.test.ts
@@ -304,4 +304,89 @@ describe("volcengineTTS", () => {
     expect((error as Error).message).not.toContain("secret-token");
     expect(release).toHaveBeenCalledTimes(1);
   });
+
+  describe("allowPrivateNetwork SSRF policy", () => {
+    function makeSeedResponse() {
+      return {
+        response: new Response(
+          [
+            JSON.stringify({ code: 0, message: "" }),
+            JSON.stringify({ code: 0, data: Buffer.from("audio").toString("base64") }),
+            JSON.stringify({ code: 20000000, message: "ok", data: null }),
+          ].join("\n"),
+        ),
+        release: vi.fn(),
+      };
+    }
+
+    function makeLegacyResponse() {
+      return {
+        response: new Response(
+          JSON.stringify({ code: 3000, data: Buffer.from("audio").toString("base64") }),
+        ),
+        release: vi.fn(),
+      };
+    }
+
+    it("seed speech: omits fake-IP policy bits when allowPrivateNetwork is false (default)", async () => {
+      fetchWithSsrFGuardMock.mockResolvedValue(makeSeedResponse());
+      await volcengineTTS({
+        text: "hello",
+        apiKey: "test-api-key",
+        timeoutMs: 1000,
+        allowPrivateNetwork: false,
+      });
+      const call = requireFirstGuardedFetchCall() as { policy: Record<string, unknown> };
+      expect(call.policy).not.toHaveProperty("allowRfc2544BenchmarkRange");
+      expect(call.policy).not.toHaveProperty("allowIpv6UniqueLocalRange");
+    });
+
+    it("seed speech: adds narrow fake-IP policy bits when allowPrivateNetwork is true", async () => {
+      fetchWithSsrFGuardMock.mockResolvedValue(makeSeedResponse());
+      await volcengineTTS({
+        text: "hello",
+        apiKey: "test-api-key",
+        timeoutMs: 1000,
+        allowPrivateNetwork: true,
+      });
+      const call = requireFirstGuardedFetchCall() as { policy: Record<string, unknown> };
+      expect(call.policy).toMatchObject({
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      });
+      // Full RFC 1918 space must NOT be opened
+      expect(call.policy).not.toHaveProperty("allowPrivateNetwork");
+    });
+
+    it("legacy TTS: omits fake-IP policy bits when allowPrivateNetwork is false (default)", async () => {
+      fetchWithSsrFGuardMock.mockResolvedValue(makeLegacyResponse());
+      await volcengineTTS({
+        text: "hello",
+        appId: "app-id",
+        token: "test-token",
+        timeoutMs: 1000,
+        allowPrivateNetwork: false,
+      });
+      const call = requireFirstGuardedFetchCall() as { policy: Record<string, unknown> };
+      expect(call.policy).not.toHaveProperty("allowRfc2544BenchmarkRange");
+      expect(call.policy).not.toHaveProperty("allowIpv6UniqueLocalRange");
+    });
+
+    it("legacy TTS: adds narrow fake-IP policy bits when allowPrivateNetwork is true", async () => {
+      fetchWithSsrFGuardMock.mockResolvedValue(makeLegacyResponse());
+      await volcengineTTS({
+        text: "hello",
+        appId: "app-id",
+        token: "test-token",
+        timeoutMs: 1000,
+        allowPrivateNetwork: true,
+      });
+      const call = requireFirstGuardedFetchCall() as { policy: Record<string, unknown> };
+      expect(call.policy).toMatchObject({
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      });
+      expect(call.policy).not.toHaveProperty("allowPrivateNetwork");
+    });
+  });
 });

--- a/extensions/volcengine/tts.ts
+++ b/extensions/volcengine/tts.ts
@@ -19,6 +19,10 @@ type VolcengineTTSParams = {
   emotion?: string;
   encoding?: VolcengineTtsEncoding;
   timeoutMs?: number;
+  /** When true, allow private-network (RFC 1918) connections. Required when
+   * running behind a TUN proxy that intercepts 198.18.x.x addresses for
+   * fast DNS resolution. Defaults to false for security. */
+  allowPrivateNetwork?: boolean;
 };
 
 const DEFAULT_SEED_VOICE = "en_female_anna_mars_bigtts";
@@ -121,6 +125,7 @@ async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): 
     emotion,
     encoding = "ogg_opus",
     timeoutMs = 30_000,
+    allowPrivateNetwork = false,
   } = params;
   const audioFormat = seedAudioFormat(encoding);
 
@@ -152,7 +157,10 @@ async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): 
       body: payload,
     },
     timeoutMs,
-    policy: { hostnameAllowlist: hostnameAllowlist(baseUrl) },
+    policy: {
+      hostnameAllowlist: hostnameAllowlist(baseUrl),
+      ...(allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+    },
     auditContext: "volcengine.tts",
   });
 
@@ -202,6 +210,7 @@ async function legacyVolcengineTTS(
     emotion,
     encoding = "ogg_opus",
     timeoutMs = 30_000,
+    allowPrivateNetwork = false,
   } = params;
 
   const payload = JSON.stringify({
@@ -234,7 +243,10 @@ async function legacyVolcengineTTS(
       body: payload,
     },
     timeoutMs,
-    policy: { hostnameAllowlist: hostnameAllowlist(baseUrl) },
+    policy: {
+      hostnameAllowlist: hostnameAllowlist(baseUrl),
+      ...(allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+    },
     auditContext: "volcengine.tts",
   });
 

--- a/extensions/volcengine/tts.ts
+++ b/extensions/volcengine/tts.ts
@@ -19,9 +19,11 @@ type VolcengineTTSParams = {
   emotion?: string;
   encoding?: VolcengineTtsEncoding;
   timeoutMs?: number;
-  /** When true, allow private-network (RFC 1918) connections. Required when
-   * running behind a TUN proxy that intercepts 198.18.x.x addresses for
-   * fast DNS resolution. Defaults to false for security. */
+  /** When true, allow connections to fake-IP ranges used by TUN proxy stacks
+   * (sing-box, Clash, Surge) for DNS resolution — specifically RFC 2544
+   * benchmark range 198.18.0.0/15 and IPv6 Unique Local addresses. This does
+   * NOT open up the full RFC 1918 private network space, so DNS-rebind attacks
+   * against metadata / intranet addresses remain blocked. Defaults to false. */
   allowPrivateNetwork?: boolean;
 };
 
@@ -159,7 +161,12 @@ async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): 
     timeoutMs,
     policy: {
       hostnameAllowlist: hostnameAllowlist(baseUrl),
-      ...(allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+      // Use narrow fake-IP policy flags rather than the broad allowPrivateNetwork
+      // flag, so only the 198.18/15 benchmark range (RFC 2544) and IPv6 ULA
+      // ranges used by TUN proxy stacks are opened — not the full RFC 1918 space.
+      ...(allowPrivateNetwork
+        ? { allowRfc2544BenchmarkRange: true, allowIpv6UniqueLocalRange: true }
+        : {}),
     },
     auditContext: "volcengine.tts",
   });
@@ -245,7 +252,12 @@ async function legacyVolcengineTTS(
     timeoutMs,
     policy: {
       hostnameAllowlist: hostnameAllowlist(baseUrl),
-      ...(allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+      // Use narrow fake-IP policy flags rather than the broad allowPrivateNetwork
+      // flag, so only the 198.18/15 benchmark range (RFC 2544) and IPv6 ULA
+      // ranges used by TUN proxy stacks are opened — not the full RFC 1918 space.
+      ...(allowPrivateNetwork
+        ? { allowRfc2544BenchmarkRange: true, allowIpv6UniqueLocalRange: true }
+        : {}),
     },
     auditContext: "volcengine.tts",
   });


### PR DESCRIPTION
## Summary
Adds `allowPrivateNetwork` boolean option to Volcengine TTS provider to support TUN proxy stacks that use RFC 2544 fake-IP ranges for DNS resolution.

**Security approach (revised from original PR):** Instead of passing the broad `allowPrivateNetwork: true` SSRF flag (which would open all of RFC 1918), this PR uses two narrow policy bits already in `SsrfPolicy`:
- `allowRfc2544BenchmarkRange: true` — opens 198.18.0.0/15 (RFC 2544, the fake-IP range used by Surge/Clash/sing-box)
- `allowIpv6UniqueLocalRange: true` — opens IPv6 ULA (same use case)

Full RFC 1918 space (10.x, 172.16.x, 192.168.x) and metadata addresses remain blocked.

## Motivation
When running behind a TUN proxy (Surge, Clash, sing-box) that uses fake-IP DNS (198.18.0.0/15), the SSRF guard blocks the resolved Volcengine API hostname. This makes TTS fail silently.

## Changes
| File | Change |
|------|--------|
| `extensions/volcengine/tts.ts` | Add `allowPrivateNetwork` to both `seedSpeechTTS` and `legacyVolcengineTTS`; spread narrow fake-IP bits conditionally in `policy` |
| `extensions/volcengine/speech-provider.ts` | Read flag from config, propagate through `readProviderConfig`, forward to `volcengineTTS()` |

## Behavior proof

### Real-world reproduction

Cherry voice (OpenClaw STT-TTS) behind Surge TUN proxy on macOS. Surge uses fake-IP DNS; API hostnames resolve to 198.18.x.x. Without `allowPrivateNetwork`, the SSRF guard blocked the outbound TTS call.

After setting `allowPrivateNetwork: true` in the Cherry voice config, TTS resumed:

```
# gateway.log — 2026-05-16
[reload] config change detected (channels.discord.accounts.cherry.voice.tts.providers.volcengine.allowPrivateNetwork)
[reload] config hot reload applied
```

### Unit test proof (2026-05-29 addition — all 4 pass)

New tests in `volcengineTTS > allowPrivateNetwork SSRF policy` (`tts.test.ts`):

```
✓ seed speech: omits fake-IP policy bits when allowPrivateNetwork is false (default)
✓ seed speech: adds narrow fake-IP policy bits when allowPrivateNetwork is true
✓ legacy TTS: omits fake-IP policy bits when allowPrivateNetwork is false (default)
✓ legacy TTS: adds narrow fake-IP policy bits when allowPrivateNetwork is true
```

These tests confirm:
- Default (`false`): `allowRfc2544BenchmarkRange` and `allowIpv6UniqueLocalRange` are NOT present in policy
- Opt-in (`true`): both narrow bits ARE present; the broad `allowPrivateNetwork` flag is NOT present (full RFC 1918 stays blocked)

## Test plan
- [x] Default: SSRF guard blocks fake-IP range (policy does not contain fake-IP bits)  
- [x] Opt-in: only 198.18.0.0/15 + IPv6 ULA opened; RFC 1918 metadata addresses remain blocked
- [x] TypeScript compiles without errors
- [x] Lint passes (oxlint)

🤖 Updated with [Claude Code](https://claude.com/claude-code)