### PR TITLE
fix(bash-tools): default stdin to pipe-closed in service-managed mode

### DIFF
--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -38,18 +38,19 @@ export async function createChildAdapter(params: {
     env: baseEnv,
   });
 
+  const serviceManaged = isServiceManagedRuntime();
+  // In service-managed mode (launchd / systemd), stdin is pipe-closed rather
+  // than inherited: the service manager closes fd 0 before exec, so inheriting
+  // it would give child processes a closed fd that triggers EBADF on Node 26.
+  // Outside service mode, inherit lets the existing POSIX detached behaviour
+  // work correctly for interactive shells and sub-shells.
   const stdinMode =
-    params.stdinMode ??
-    (params.input !== undefined
-      ? "pipe-closed"
-      : isServiceManagedRuntime()
-        ? "pipe-closed"
-        : "inherit");
+    params.stdinMode ?? (params.input !== undefined || serviceManaged ? "pipe-closed" : "inherit");
 
   // In service-managed mode keep children attached so systemd/launchd can
   // stop the full process tree reliably. Outside service mode preserve the
   // existing POSIX detached behavior.
-  const useDetached = process.platform !== "win32" && !isServiceManagedRuntime();
+  const useDetached = process.platform !== "win32" && !serviceManaged;
 
   const options: SpawnOptions = {
     cwd: params.cwd,

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -38,7 +38,13 @@ export async function createChildAdapter(params: {
     env: baseEnv,
   });
 
-  const stdinMode = params.stdinMode ?? (params.input !== undefined ? "pipe-closed" : "inherit");
+  const stdinMode =
+    params.stdinMode ??
+    (params.input !== undefined
+      ? "pipe-closed"
+      : isServiceManagedRuntime()
+        ? "pipe-closed"
+        : "inherit");
 
   // In service-managed mode keep children attached so systemd/launchd can
   // stop the full process tree reliably. Outside service mode preserve the


### PR DESCRIPTION
## Problem

When OpenClaw runs as a launchd service (`OPENCLAW_SERVICE_MODE=launchd`), spawned child processes inherit fd 0 (stdin) from the service manager process. On Node 26, launchd closes fd 0 before exec. The child process inherits a closed file descriptor; when Node.js tries to set up the inherited stream, it throws `EBADF` (bad file descriptor) during child startup.

## Fix

In `createChildAdapter`, extract `isServiceManagedRuntime()` into a local `serviceManaged` boolean (avoiding two calls), then apply it to the `stdinMode` default:

```ts
const serviceManaged = isServiceManagedRuntime();
const stdinMode =
  params.stdinMode ?? (params.input !== undefined || serviceManaged ? "pipe-closed" : "inherit");
const useDetached = process.platform !== "win32" && !serviceManaged;
```

When `serviceManaged` is `true`, stdin defaults to `"pipe-closed"` (a closed pipe) instead of `"inherit"`. This avoids giving children a closed fd 0 and eliminates the EBADF.

Outside service mode the existing POSIX detached behavior is preserved: `stdinMode` defaults to `"inherit"` for interactive shells and sub-shells.

## Behavior proof

### Before-patch symptom (OpenClaw on macOS launchd, Node 26)

```
[supervisor] spawn error account=cherry
Error: EBADF: bad file descriptor, read
    at ChildProcess.<anonymous> (node:child_process:...)
    at ChildProcess.emit (node:events:...)
```

The error appears immediately on `createChildAdapter` when launchd has closed fd 0 and `stdinMode` defaults to `"inherit"`.

### After-patch behavior

With `serviceManaged = true`, stdin is set to `"pipe-closed"`. The child process never tries to inherit the closed fd. No EBADF on startup; children spawn cleanly.

```
# gateway.log — launchd service boot (2026-05-28)
[gateway] starting account=cherry
[discord] provider started account=cherry
[discord] gateway connected account=cherry
```

The cherry agent connected without any EBADF errors after the patch was applied to the local runtime via `reapply-openclaw-discord-patches.sh`.

## Notes on `checks-node-agentic-control-plane-runtime` CI failure

The failing tests (`server.shared-token-hot-reload.test.ts`, `server.shared-token-session-rotation.test.ts`) are in a different package and not touched by this PR. The failure is a Vitest `EnvironmentTeardownError` in the `gateway-server` test suite — a known intermittent issue unrelated to `child.ts`. See [PR comment](https://github.com/openclaw/openclaw/pull/87527#issuecomment-4569705966).

🤖 Updated with [Claude Code](https://claude.com/claude-code)