### PR TITLE
fix(webchat): add Content-Disposition header for assistant-media downloads

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -603,6 +603,15 @@ export async function handleControlUiAssistantMediaRequest(
     }
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Content-Length", String(opened.stat.size));
+    try {
+      const filename = path.basename(localPath);
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="${encodeURIComponent(filename)}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
+      );
+    } catch {
+      // filename extraction failure should not block the media response
+    }
     const stream = opened.handle.createReadStream({ start: 0, autoClose: false });
     const finishClose = () => {
       void closeOpenedHandle();


### PR DESCRIPTION
## Problem

When downloading files via webchat (`GET /__openclaw__/assistant-media?source=...`), the browser save dialog shows `assistant-media` (or `assistant-media (12)`) instead of the original filename (e.g. `script_v3.docx`).

## Root Cause

`handleControlUiAssistantMediaRequest` in `src/gateway/control-ui.ts` serves the file stream with `Content-Type`, `Cache-Control`, and `Content-Length` headers, but does not set a `Content-Disposition` header. Without it, the browser falls back to the URL path segment as the download filename.

## Fix

After setting `Content-Length`, extract the filename from `localPath` and set a `Content-Disposition: attachment` header with:
- `filename` — ASCII fallback (RFC 6266)
- `filename*` — UTF-8 encoded filename (RFC 5987), supports Chinese and other non-ASCII characters
- `encodeURIComponent` — safe encoding to prevent header injection

## Changes

- **File**: `src/gateway/control-ui.ts`
- **Function**: `handleControlUiAssistantMediaRequest`
- **Lines**: Added ~9 lines after `res.setHeader("Content-Length", ...)`

```diff
+    try {
+      const filename = path.basename(localPath);
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="${encodeURIComponent(filename)}"; filename*=UTF-8'${encodeURIComponent(filename)}`,
+      );
+    } catch {
+      // filename extraction failure should not block the media response
+    }
```

## Verification

1. Send a file through webchat with a recognizable name (e.g. `script_v3.docx`)
2. Click the download link in the browser
3. The save dialog should show `script_v3.docx` (not `assistant-media`)
4. Tested with Chinese filenames (e.g. `测试文档.pdf`) — UTF-8 encoding works correctly