### PR TITLE
test: narrow rejected provider errors

### DIFF
--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -2,6 +2,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import { isMinimaxVlmModel, minimaxUnderstandImage } from "./minimax-vlm.js";
 
+async function mustRejectWithError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (caught) {
+    if (caught instanceof Error) {
+      return caught;
+    }
+    throw new Error("expected promise to reject with an Error");
+  }
+  throw new Error("expected promise to reject");
+}
+
 describe("minimaxUnderstandImage apiKey normalization", () => {
   const priorFetch = global.fetch;
   const priorMinimaxApiHost = process.env.MINIMAX_API_HOST;
@@ -173,12 +185,14 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
     });
     global.fetch = withFetchPreconnect(fetchSpy);
 
-    const error = await minimaxUnderstandImage({
-      apiKey: "minimax-test-key",
-      prompt: "hi",
-      imageDataUrl: "data:image/png;base64,AAAA",
-      apiHost: "https://api.minimax.io",
-    }).catch((caught: unknown) => caught as Error);
+    const error = await mustRejectWithError(
+      minimaxUnderstandImage({
+        apiKey: "minimax-test-key",
+        prompt: "hi",
+        imageDataUrl: "data:image/png;base64,AAAA",
+        apiHost: "https://api.minimax.io",
+      }),
+    );
 
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toContain("MiniMax VLM request failed");

--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -9,7 +9,7 @@ async function mustRejectWithError(promise: Promise<unknown>): Promise<Error> {
     if (caught instanceof Error) {
       return caught;
     }
-    throw new Error("expected promise to reject with an Error");
+    throw new Error("expected promise to reject with an Error", { cause: caught });
   }
   throw new Error("expected promise to reject");
 }

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -8,6 +8,18 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
 
 const TEST_PDF_INPUT = { base64: "dGVzdA==", filename: "doc.pdf" } as const;
 
+async function mustRejectWithError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (caught) {
+    if (caught instanceof Error) {
+      return caught;
+    }
+    throw new Error("expected promise to reject with an Error");
+  }
+  throw new Error("expected promise to reject");
+}
+
 function makeAnthropicAnalyzeParams(
   overrides: Partial<{
     apiKey: string;
@@ -129,9 +141,9 @@ describe("native PDF provider API calls", () => {
       }),
     );
 
-    const error = await pdfNativeProviders
-      .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
-      .catch((caught: unknown) => caught as Error);
+    const error = await mustRejectWithError(
+      pdfNativeProviders.anthropicAnalyzePdf(makeAnthropicAnalyzeParams()),
+    );
 
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toContain("Anthropic PDF request failed");
@@ -158,9 +170,7 @@ describe("native PDF provider API calls", () => {
     );
 
     const error = await Promise.race([
-      pdfNativeProviders
-        .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
-        .catch((caught: unknown) => caught as Error),
+      mustRejectWithError(pdfNativeProviders.anthropicAnalyzePdf(makeAnthropicAnalyzeParams())),
       new Promise<Error>((_resolve, reject) => {
         setTimeout(() => reject(new Error("timed out waiting for bounded error body")), 500);
       }),

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -15,7 +15,7 @@ async function mustRejectWithError(promise: Promise<unknown>): Promise<Error> {
     if (caught instanceof Error) {
       return caught;
     }
-    throw new Error("expected promise to reject with an Error");
+    throw new Error("expected promise to reject with an Error", { cause: caught });
   }
   throw new Error("expected promise to reject");
 }


### PR DESCRIPTION
## Summary
- Replace test-only `.catch((caught) => caught as Error)` patterns with local helpers that only return after `instanceof Error` narrowing.
- Fix the `check-test-types` failure from the provider error-body tests on current `main`.

## Provenance
- Failing job: https://github.com/openclaw/openclaw/actions/runs/26555675502/job/78226949187?pr=87518
- `src/agents/tools/pdf-native-providers.test.ts` type errors were introduced by direct-main commit `c841218ace3a9da06f78059bfdde3d2c8efb5526` (`fix(agents): bound native pdf error bodies`), authored and committed by Vincent Koc (`@vincentkoc`) on 2026-05-28. GitHub returned no associated PR for that commit.
- `src/agents/minimax-vlm.normalizes-api-key.test.ts` type errors were introduced by direct-main commit `4f26cc9090d06e23f8aa1a306f707a449c5fdc69` (`fix(agents): bound minimax vlm error bodies`), authored and committed by Vincent Koc (`@vincentkoc`) on 2026-05-28. GitHub returned no associated PR for that commit.

## Verification
- `pnpm tsgo:test`
- `node scripts/run-vitest.mjs src/agents/minimax-vlm.normalizes-api-key.test.ts src/agents/tools/pdf-native-providers.test.ts`
- `git diff --check origin/main...HEAD`

## Real behavior proof
Behavior addressed: `check-test-types` fails because rejected provider-error values are typed as `string | Error` before reading `.message`.
Real environment tested: local macOS checkout rebased on `origin/main` at `8f6a2f0f6b119e8eb3e63d53800207fabe78e735`.
Exact steps or command run after this patch: `pnpm tsgo:test`; `node scripts/run-vitest.mjs src/agents/minimax-vlm.normalizes-api-key.test.ts src/agents/tools/pdf-native-providers.test.ts`; `git diff --check origin/main...HEAD`.
Evidence after fix: `pnpm tsgo:test` exited 0; focused Vitest wrapper reported 4 files and 48 tests passed; diff check exited 0.
Observed result after fix: the typecheck no longer reports `Property 'message' does not exist on type 'string | Error'` for the changed tests.
What was not tested: full CI matrix and built artifact checks were not rerun locally.
