### PR TITLE
fix(gateway): auto-approve metadata-upgrade for native local app clients

### DIFF
--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -72,6 +72,7 @@ describe("handshake auth helpers", () => {
         hasBrowserOriginHeader: false,
         isControlUi: false,
         isWebchat: false,
+        isNativeLocalApp: false,
         reason: "not-paired",
       }),
     ).toBe(true);
@@ -81,6 +82,45 @@ describe("handshake auth helpers", () => {
         hasBrowserOriginHeader: false,
         isControlUi: false,
         isWebchat: false,
+        isNativeLocalApp: false,
+        reason: "metadata-upgrade",
+      }),
+    ).toBe(false);
+  });
+
+  it("allows silent metadata-upgrade for native local app clients (macOS/iOS/Android)", () => {
+    // Native app on loopback with OS version bump: should auto-approve
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        isNativeLocalApp: true,
+        reason: "metadata-upgrade",
+      }),
+    ).toBe(true);
+
+    // Remote client (not loopback): must still require manual approval
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        isControlUi: false,
+        isWebchat: false,
+        isNativeLocalApp: true,
+        reason: "metadata-upgrade",
+      }),
+    ).toBe(false);
+
+    // Browser/webchat client on loopback: must still require manual approval
+    expect(
+      shouldAllowSilentLocalPairing({
+        isLocalClient: true,
+        hasBrowserOriginHeader: true,
+        isControlUi: false,
+        isWebchat: false,
+        isNativeLocalApp: false,
         reason: "metadata-upgrade",
       }),
     ).toBe(false);

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -50,13 +50,26 @@ export function shouldAllowSilentLocalPairing(params: {
   hasBrowserOriginHeader: boolean;
   isControlUi: boolean;
   isWebchat: boolean;
+  isNativeLocalApp: boolean;
   reason: "not-paired" | "role-upgrade" | "scope-upgrade" | "metadata-upgrade";
 }): boolean {
-  return (
-    params.isLocalClient &&
-    (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" || params.reason === "scope-upgrade")
-  );
+  if (!params.isLocalClient) {
+    return false;
+  }
+  if (params.hasBrowserOriginHeader && !params.isControlUi && !params.isWebchat) {
+    return false;
+  }
+  if (params.reason === "not-paired" || params.reason === "scope-upgrade") {
+    return true;
+  }
+  // For metadata-upgrade (e.g. OS version bump), allow silent re-approval only for
+  // trusted native app clients (macOS/iOS/Android) connecting from loopback.
+  // The device public key is unchanged — only the OS version string differs.
+  // Remote/browser clients still require explicit manual re-approval.
+  if (params.reason === "metadata-upgrade" && params.isNativeLocalApp) {
+    return true;
+  }
+  return false;
 }
 
 function resolveSignatureToken(connectParams: ConnectParams): string | null {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -26,6 +26,7 @@ import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import {
   isBrowserOperatorUiClient,
   isGatewayCliClient,
+  isNativeAppClient,
   isOperatorUiClient,
   isWebchatClient,
 } from "../../../utils/message-channel.js";
@@ -779,6 +780,7 @@ export function attachGatewayWsMessageHandler(params: {
               hasBrowserOriginHeader,
               isControlUi,
               isWebchat,
+              isNativeLocalApp: isNativeAppClient(connectParams.client),
               reason,
             });
             const pairing = await requestDevicePairing({

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -56,6 +56,15 @@ export function isInternalMessageChannel(raw?: string | null): raw is InternalMe
   return normalizeMessageChannel(raw) === INTERNAL_MESSAGE_CHANNEL;
 }
 
+export function isNativeAppClient(client?: GatewayClientInfoLike | null): boolean {
+  const clientId = normalizeGatewayClientName(client?.id);
+  return (
+    clientId === GATEWAY_CLIENT_NAMES.MACOS_APP ||
+    clientId === GATEWAY_CLIENT_NAMES.IOS_APP ||
+    clientId === GATEWAY_CLIENT_NAMES.ANDROID_APP
+  );
+}
+
 export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean {
   const mode = normalizeGatewayClientMode(client?.mode);
   if (mode === GATEWAY_CLIENT_MODES.WEBCHAT) {


### PR DESCRIPTION
## Problem

When a paired `openclaw-macos` (or iOS/Android) native app reconnects after an OS version bump, the gateway fires a `metadata-upgrade` security audit and requires re-approval. The fix in v2026.4.23 (#62176) only addressed the **client side** (adding `pauseReconnect` in `GatewayConnectionProblem.swift` for iOS), but left the **macOS desktop app** unaddressed.

The result: `openclaw-macos` enters a tight reconnect loop generating new `requestId`s every ~1–2 seconds — faster than any human can manually run `openclaw devices approve <requestId>`. The `nodes pending` command and agent tools also hide `isRepair: true` requests (they only appear in `openclaw devices list`), so there is no visible indication anything is wrong.

Ref: #87524, #62176

## Root Cause

`shouldAllowSilentLocalPairing()` correctly blocks `metadata-upgrade` from silent auto-approval for all clients. But this is **too broad**: for native app clients (`openclaw-macos`, `openclaw-ios`, `openclaw-android`) connecting from loopback, the device public key is **unchanged** — only the OS version string changed. There is no meaningful security risk in auto-approving this case.

Remote/browser clients triggering `metadata-upgrade` should still require explicit manual re-approval (unchanged).

## Changes

- **`src/utils/message-channel.ts`**: add `isNativeAppClient()` helper covering `openclaw-macos`, `openclaw-ios`, `openclaw-android`
- **`src/gateway/server/ws-connection/handshake-auth-helpers.ts`**: extend `shouldAllowSilentLocalPairing()` with `isNativeLocalApp` param; allow silent re-approval for `metadata-upgrade` when client is a trusted native app on loopback
- **`src/gateway/server/ws-connection/message-handler.ts`**: pass `isNativeLocalApp: isNativeAppClient(connectParams.client)` at the call site
- **`handshake-auth-helpers.test.ts`**: update existing test for new param; add new test cases asserting native-local auto-approves and remote/browser still requires manual approval

## Security Considerations

- Auto-approval is gated on **both** `isLocalClient` (loopback) **and** `isNativeLocalApp` — remote native app connections still require manual approval
- Browser/webchat clients are unaffected
- `role-upgrade` and `scope-upgrade` behaviour is unchanged

## Real Behavior Proof

### Before fix — gateway logs from a live Mac mini (macOS 26.3.1 → 26.5.0 update, today 2026-05-28)

The device `f8f00f95...` (`openclaw-macos` v2026.5.22, `clientMode: ui`) triggered repeated `metadata-upgrade` rejections in a tight loop immediately after macOS updated:

```
security audit: device metadata upgrade requested reason=metadata-upgrade 
  device=f8f00f958631877d2dc545d2059b5e215b190d97def25792af97b71577d385ad 
  ip=unknown-ip auth=token payload=v3 
  claimedPlatform=macOS 26.5.0 pinnedPlatform=macOS 26.3.1 
  claimedDeviceFamily=Mac pinnedDeviceFamily=Mac 
  client=openclaw-macos conn=50eb595a-d546-43a3-97e6-c2f463ff7043

closed before connect conn=d3f838e0-36e2-4209-a173-dfc6327fc0ba 
  peer=127.0.0.1:56509->127.0.0.1:18789 
  ua=OpenClaw/2026052290 CFNetwork/3860.600.21 Darwin/25.5.0 
  code=1008 reason=pairing required: device identity changed and must be re-approved 
  (requestId: 7a0bf886-9ae6-4847-87d1-e2b77177da09)

[repeated 3+ times within the same second with new requestIds each time]
```

`openclaw nodes pending` returned empty throughout. `openclaw devices list --json` showed the pending entry with `"isRepair": true` and `"platform": "macOS 26.5.0"` but each requestId expired in ~1–2 seconds.

### Workaround used (before this fix)

The only way to approve it was an atomic single-pipeline shell command to beat the expiry window:

```bash
ID=$(openclaw devices list --json | python3 -c \
  "import json,sys; p=json.load(sys.stdin); print(p[\"pending\"][0][\"requestId\"] if p[\"pending\"] else \"\")") \
  && [ -n "$ID" ] && openclaw devices approve "$ID" --json
```

Result after approval:
```json
{
  "requestId": "f154b42d-3512-4268-a4d1-4ae43526c5e9",
  "device": {
    "deviceId": "f8f00f958631877d2dc545d2059b5e215b190d97def25792af97b71577d385ad",
    "platform": "macOS 26.5.0",
    "approvedAtMs": 1779942960899
  }
}
```

Device reconnected successfully after the forced approval.

### After-fix runtime verification

After-fix live runtime verification (building from source and triggering a real metadata-upgrade on this setup) is not feasible here as the build environment requires `pnpm@10.32.1` which is not installed. The fix is a narrow, well-contained change: the new `metadata-upgrade` auto-approval path is only reachable when **both** `isLocalClient` and `isNativeLocalApp` are true, which is exactly the scenario demonstrated above in the before-fix logs.

A maintainer `proof: override` would be appropriate here given the real before-fix reproduction evidence above and the targeted nature of the change.