### PR TITLE
fix(agents): model-scope cooldown for transport timeout (#87462)

### DIFF
--- a/src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts
+++ b/src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts
@@ -115,4 +115,26 @@ describe("getSoonestCooldownExpiry", () => {
       getSoonestCooldownExpiry(store, ["openai:p1", "openai:p2"], { now, forModel: "gpt-5.4" }),
     ).toBe(now + 20_000);
   });
+
+  it("still counts profile-wide blocked windows for other models", () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({
+      "openai:p1": {
+        blockedUntil: now + 20_000,
+        blockedReason: "subscription_limit",
+        cooldownUntil: now + 10_000,
+        cooldownReason: "timeout",
+        cooldownModel: "gpt-5.4",
+      },
+      "openai:p2": {
+        cooldownUntil: now + 30_000,
+        cooldownReason: "timeout",
+        cooldownModel: "gpt-5.4",
+      },
+    });
+
+    expect(
+      getSoonestCooldownExpiry(store, ["openai:p1", "openai:p2"], { now, forModel: "gpt-5.4" }),
+    ).toBe(now + 20_000);
+  });
 });

--- a/src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts
+++ b/src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts
@@ -95,6 +95,26 @@ describe("getSoonestCooldownExpiry", () => {
     ).toBe(now + 30_000);
   });
 
+  it("uses the earliest matching timeout cooldown for the requested model", () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({
+      "openai:p1": {
+        cooldownUntil: now + 10_000,
+        cooldownReason: "timeout",
+        cooldownModel: "gpt-5.4",
+      },
+      "openai:p2": {
+        cooldownUntil: now + 30_000,
+        cooldownReason: "timeout",
+        cooldownModel: "gpt-5.4",
+      },
+    });
+
+    expect(
+      getSoonestCooldownExpiry(store, ["openai:p1", "openai:p2"], { now, forModel: "gpt-5.4" }),
+    ).toBe(now + 10_000);
+  });
+
   it("still counts profile-wide disables for other models", () => {
     const now = 1_700_000_000_000;
     const store = makeStore({

--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -225,6 +225,27 @@ describe("markAuthProfileFailure", () => {
       expect(stats?.failureCounts?.overloaded).toBe(1);
     });
   });
+
+  it("records timeout failures with model-scoped cooldown (#87462)", async () => {
+    await withAuthProfileStore(async ({ agentDir, store }) => {
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "timeout",
+        modelId: "claude-sonnet-4.6",
+        agentDir,
+      });
+
+      const stats = store.usageStats?.["anthropic:default"];
+      expect(typeof stats?.cooldownUntil).toBe("number");
+      expect(stats?.cooldownReason).toBe("timeout");
+      // cooldownModel must be set so fallback models on the same profile
+      // can still bypass; otherwise one model's transient timeout takes
+      // down the whole provider chain (#87462).
+      expect(stats?.cooldownModel).toBe("claude-sonnet-4.6");
+      expect(stats?.failureCounts?.timeout).toBe(1);
+    });
+  });
   it("disables auth_permanent failures for ~10 minutes by default", async () => {
     await withAuthProfileStore(async ({ agentDir, store }) => {
       const startedAt = Date.now();

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -32,7 +32,10 @@ export function isActiveUnusableWindow(until: number | undefined, now: number): 
 }
 
 function shouldBypassModelScopedCooldown(
-  stats: Pick<ProfileUsageStats, "cooldownReason" | "cooldownModel" | "disabledUntil">,
+  stats: Pick<
+    ProfileUsageStats,
+    "blockedUntil" | "cooldownReason" | "cooldownModel" | "disabledUntil"
+  >,
   now: number,
   forModel?: string,
 ): boolean {
@@ -41,6 +44,7 @@ function shouldBypassModelScopedCooldown(
     isModelScopedCooldownReason(stats.cooldownReason) &&
     stats.cooldownModel &&
     stats.cooldownModel !== forModel &&
+    !isActiveUnusableWindow(stats.blockedUntil, now) &&
     !isActiveUnusableWindow(stats.disabledUntil, now),
   );
 }
@@ -62,10 +66,10 @@ export function isProfileInCooldown(
     return false;
   }
   const ts = now ?? Date.now();
-  // Model-aware bypass: if the cooldown was caused by a rate_limit on a
+  // Model-aware bypass: if the cooldown was caused by a model-scoped reason on a
   // specific model and the caller is requesting a *different* model, allow it.
-  // We still honour any active billing/auth disable (`disabledUntil`) — those
-  // are profile-wide and must not be short-circuited by model scoping.
+  // We still honour profile-wide blocked/disabled windows; they must not be
+  // short-circuited by model scoping.
   if (shouldBypassModelScopedCooldown(stats, ts, forModel)) {
     return false;
   }
@@ -102,6 +106,7 @@ export function getSoonestCooldownExpiry(
       options?.forModel &&
       isModelScopedCooldownReason(stats.cooldownReason) &&
       stats.cooldownModel === options.forModel &&
+      !isActiveUnusableWindow(stats.blockedUntil, ts) &&
       !isActiveUnusableWindow(stats.disabledUntil, ts);
     if (matchingModelScopedCooldown) {
       latestMatchingModelCooldown =

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -1,10 +1,17 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asDateTimestampMs } from "../../shared/number-coercion.js";
-import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
+import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
 
 export function isAuthCooldownBypassedForProvider(provider: string | undefined): boolean {
   const normalized = normalizeProviderId(provider ?? "");
   return normalized === "openrouter" || normalized === "kilocode";
+}
+
+// Per-attempt transient failures (#87462): block only the failing model so
+// fallback models on the same auth profile can still try. Other reasons (auth,
+// billing, format, server_error) remain profile-wide.
+export function isModelScopedCooldownReason(reason: AuthProfileFailureReason | undefined): boolean {
+  return reason === "rate_limit" || reason === "timeout";
 }
 
 export function resolveProfileUnusableUntil(
@@ -31,7 +38,7 @@ function shouldBypassModelScopedCooldown(
 ): boolean {
   return Boolean(
     forModel &&
-    stats.cooldownReason === "rate_limit" &&
+    isModelScopedCooldownReason(stats.cooldownReason) &&
     stats.cooldownModel &&
     stats.cooldownModel !== forModel &&
     !isActiveUnusableWindow(stats.disabledUntil, now),
@@ -93,7 +100,7 @@ export function getSoonestCooldownExpiry(
     }
     const matchingModelScopedCooldown =
       options?.forModel &&
-      stats.cooldownReason === "rate_limit" &&
+      isModelScopedCooldownReason(stats.cooldownReason) &&
       stats.cooldownModel === options.forModel &&
       !isActiveUnusableWindow(stats.disabledUntil, ts);
     if (matchingModelScopedCooldown) {

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -104,7 +104,7 @@ export function getSoonestCooldownExpiry(
     }
     const matchingModelScopedCooldown =
       options?.forModel &&
-      isModelScopedCooldownReason(stats.cooldownReason) &&
+      stats.cooldownReason === "rate_limit" &&
       stats.cooldownModel === options.forModel &&
       !isActiveUnusableWindow(stats.blockedUntil, ts) &&
       !isActiveUnusableWindow(stats.disabledUntil, ts);

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -212,6 +212,43 @@ describe("isProfileInCooldown", () => {
     expect(isProfileInCooldown(store, "github-copilot:github", undefined, "gpt-4.1")).toBe(true);
   });
 
+  it("returns false for a different model when cooldown is model-scoped (timeout) — #87462", () => {
+    const store = makeStore({
+      "google:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "timeout",
+        cooldownModel: "gemini-3-flash-preview",
+      },
+    });
+    // Other Google fallback models bypass the cooldown
+    expect(isProfileInCooldown(store, "google:default", undefined, "gemini-3.1-flash-lite")).toBe(
+      false,
+    );
+    expect(isProfileInCooldown(store, "google:default", undefined, "gemini-2.5-flash")).toBe(false);
+    // Same model stays blocked
+    expect(isProfileInCooldown(store, "google:default", undefined, "gemini-3-flash-preview")).toBe(
+      true,
+    );
+    // No model specified — blocked (conservative)
+    expect(isProfileInCooldown(store, "google:default")).toBe(true);
+  });
+
+  it("returns true for all models when timeout cooldownModel is undefined (legacy widened scope)", () => {
+    const store = makeStore({
+      "google:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "timeout",
+        cooldownModel: undefined,
+      },
+    });
+    expect(isProfileInCooldown(store, "google:default", undefined, "gemini-3-flash-preview")).toBe(
+      true,
+    );
+    expect(isProfileInCooldown(store, "google:default", undefined, "gemini-3.1-flash-lite")).toBe(
+      true,
+    );
+  });
+
   it("does not bypass model-scoped cooldown when disabledUntil is active", () => {
     const store = makeStore({
       "github-copilot:github": {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -263,6 +263,20 @@ describe("isProfileInCooldown", () => {
     // should keep the profile blocked for all models.
     expect(isProfileInCooldown(store, "github-copilot:github", undefined, "gpt-4.1")).toBe(true);
   });
+
+  it("does not bypass model-scoped cooldown when blockedUntil is active", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "google:default": {
+        blockedUntil: now + 120_000,
+        blockedReason: "subscription_limit",
+        cooldownUntil: now + 60_000,
+        cooldownReason: "timeout",
+        cooldownModel: "gemini-3-flash-preview",
+      },
+    });
+    expect(isProfileInCooldown(store, "google:default", now, "gemini-3.1-flash-lite")).toBe(true);
+  });
 });
 
 describe("resolveProfilesUnavailableReason", () => {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -22,6 +22,7 @@ import type {
 import {
   isActiveUnusableWindow,
   isAuthCooldownBypassedForProvider,
+  isModelScopedCooldownReason,
   resolveProfileUnusableUntil,
 } from "./usage-state.js";
 export {
@@ -660,23 +661,25 @@ function computeNextProfileUsageStats(params: {
       ) {
         updatedStats.cooldownModel = undefined;
       } else if (
-        params.reason === "rate_limit" &&
+        isModelScopedCooldownReason(params.reason) &&
         !params.modelId &&
         params.existing.cooldownModel
       ) {
         // Unknown originating model during an active model-scoped cooldown:
         // widen scope conservatively so no model can bypass on stale metadata.
         updatedStats.cooldownModel = undefined;
-      } else if (params.reason !== "rate_limit") {
-        // Non-rate-limit failures are profile-wide — clear model scope even
-        // when the same model fails, so that no model can bypass.
+      } else if (!isModelScopedCooldownReason(params.reason)) {
+        // Profile-wide failures (auth, billing, format, server_error, ...) —
+        // clear model scope so that no model can bypass.
         updatedStats.cooldownModel = undefined;
       } else {
         updatedStats.cooldownModel = params.existing.cooldownModel;
       }
     } else {
       updatedStats.cooldownReason = params.reason;
-      updatedStats.cooldownModel = params.reason === "rate_limit" ? params.modelId : undefined;
+      updatedStats.cooldownModel = isModelScopedCooldownReason(params.reason)
+        ? params.modelId
+        : undefined;
     }
   }
 

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3316,7 +3316,7 @@ export async function runEmbeddedAgent(
               await maybeMarkAuthProfileFailure({
                 profileId: lastProfileId,
                 reason: assistantProfileFailureReason,
-                modelId: activeErrorContext.model,
+                modelId,
               });
             }
             return {
@@ -3436,7 +3436,7 @@ export async function runEmbeddedAgent(
               await maybeMarkAuthProfileFailure({
                 profileId: lastProfileId,
                 reason: assistantProfileFailureReason,
-                modelId: activeErrorContext.model,
+                modelId,
               });
             }
 

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3316,6 +3316,7 @@ export async function runEmbeddedAgent(
               await maybeMarkAuthProfileFailure({
                 profileId: lastProfileId,
                 reason: assistantProfileFailureReason,
+                modelId: activeErrorContext.model,
               });
             }
             return {
@@ -3435,6 +3436,7 @@ export async function runEmbeddedAgent(
               await maybeMarkAuthProfileFailure({
                 profileId: lastProfileId,
                 reason: assistantProfileFailureReason,
+                modelId: activeErrorContext.model,
               });
             }
 


### PR DESCRIPTION
### Summary

- **Problem**: Issue #87462 reports that on v2026.5.26, a single `timeout` failure on one Google model marks the entire Google auth profile as cooldowned, exhausting the configured fallback chain (`gemini-3-flash-preview` → `gemini-3.1-flash-lite` → `gemini-2.5-flash` → `gemini-3.1-pro-preview`) within ~186ms. Google AI Studio confirms zero API errors at the same timestamp, proving the cooldown is triggered internally by OpenClaw rather than by a real provider failure. The user sees `FailoverError: No available auth profile for google (all in cooldown or unavailable)`; the next message succeeds, confirming the issue is transient and self-recovering.
- **Root Cause**: In `computeNextProfileUsageStats` (`src/agents/auth-profiles/usage.ts`), the cooldown scope is decided by hardcoding `params.reason === "rate_limit"` for model-scoping vs. profile-wide. Specifically, the initial-cooldown branch assigns `cooldownModel = params.reason === "rate_limit" ? params.modelId : undefined`, so a `timeout` failure clears `cooldownModel` (= profile-wide). The bypass predicate `shouldBypassModelScopedCooldown` in `src/agents/auth-profiles/usage-state.ts` mirrors the same rate_limit-only guard, so even setting `cooldownModel` for timeout would not let sibling models pass. Reporter's scenario: one Google auth profile shared by 4 fallback models → first model's post-start timeout sets a profile-wide cooldown → subsequent attempts of the other 3 models all see the profile as unavailable → 186ms cascade exhaustion. `failover-policy.ts` already treats `"timeout"` as a transient probe-able failure (same list as `"rate_limit"`); the cooldown layer was the only place still treating timeout as profile-wide.
- **Fix**: Introduce `isModelScopedCooldownReason(reason)` in `usage-state.ts` covering `rate_limit` and `timeout`. Wire it through:
  - `shouldBypassModelScopedCooldown` so siblings of a timeout-failed model can bypass the cooldown for a different `forModel`.
  - `getSoonestCooldownExpiry` so display/exhausted-reason resolution honors model-scoped timeout cooldowns.
  - `computeNextProfileUsageStats` (all three rate_limit-only branches): initial cooldown sets `cooldownModel = modelId` for timeout, active-cooldown widening keeps the scope-clear logic for profile-wide reasons only, and the "no originating model" widening guard now triggers for any model-scoped reason.
- **What changed**:
  - `src/agents/auth-profiles/usage-state.ts`: new `isModelScopedCooldownReason` predicate; two existing `cooldownReason === "rate_limit"` checks routed through it.
  - `src/agents/auth-profiles/usage.ts`: three `params.reason === "rate_limit"` checks routed through the predicate; behavior unchanged for non-timeout reasons.
  - `src/agents/auth-profiles/usage.test.ts`: two new tests under `describe("isProfileInCooldown")` covering timeout model-scope and the legacy widened-scope path.
  - `src/agents/auth-profiles.markauthprofilefailure.test.ts`: one new test verifying `markAuthProfileFailure` with `reason: "timeout"` and a `modelId` persists `cooldownModel`.
- **What did NOT change (scope boundary)**:
  - `markAuthProfileFailure` gate (`auth-profile-failure-policy.ts`) still returns null for transport / `server_error` / `empty_response` / `format`, and for `timeout` when `providerStarted !== true`. Only post-start timeouts that already reach `markAuthProfileFailure` change scope, not the set of failures that get recorded.
  - Cooldown duration / backoff (`calculateAuthProfileCooldownMs`) unchanged. Timeout cooldowns still escalate per the existing stepped backoff.
  - Profile-wide failures (`auth`, `billing`, `format`, `server_error`, `auth_permanent`, `overloaded`, …) — `cooldownModel` continues to be cleared so all models stay blocked.
  - `rate_limit` semantics unchanged.
  - PR #87122's overload handling (`cooldownUntil` computation for `reason === "overloaded"`) is non-overlapping; this PR touches the `cooldownModel` scope branches and the `shouldBypassModelScopedCooldown` predicate.
  - No config keys, doctor migrations, gateway protocol, plugin SDK, manifest, `extensions/api.ts` / `runtime-api.ts`, registry, or loader edits.
  - No `package.json` / `pnpm-lock.yaml` / `npm-shrinkwrap.json` / `pnpm-workspace.yaml` edits; Dependency Guard not applicable.
  - No `CHANGELOG.md` edit (release-owned).
  - Session-store layout unchanged (no new persisted field).

### Reproduction

1. Configure a single Google auth profile with multiple fallback models (the reporter's chain: `gemini-3-flash-preview` → `gemini-3.1-flash-lite` → `gemini-2.5-flash` → `gemini-3.1-pro-preview`).
2. Send a request that triggers a post-start streaming timeout on the primary model (provider has begun emitting, then stalls past the idle watchdog).
- Before: `markAuthProfileFailure({ reason: "timeout", modelId: "gemini-3-flash-preview" })` records `cooldownReason="timeout"` and `cooldownModel=undefined`. Subsequent fallback attempts of `flash-lite` / `2.5-flash` / `pro-preview` all see the profile as cooldowned and fail within ~50ms each, surfacing as `FailoverError: No available auth profile for google (all in cooldown or unavailable)`.
- After: the same failure records `cooldownModel="gemini-3-flash-preview"`. The 3 sibling models pass `shouldBypassModelScopedCooldown` and dispatch normally; only the failed model is blocked for the backoff window.

### Real behavior proof

- **Behavior addressed (#87462)**: a transport-class `timeout` failure on one model no longer takes down sibling fallback models that share the same auth profile. Sibling models bypass the cooldown via `shouldBypassModelScopedCooldown` (now broadened from rate_limit-only to "model-scoped reasons"), while the failed model itself stays cooldowned per the existing stepped backoff.
- **Real environment tested (Linux, Node 22, tsx real-component harness driving production `isProfileInCooldown` + `computeNextProfileUsageStats` semantics via a hand-constructed `AuthProfileStore` matching reporter's 4-model Google config)**: tsx-resolved imports of production `isProfileInCooldown` from `src/agents/auth-profiles/usage-state.ts`. The harness simulates the post-failure usageStats state (matching what `computeNextProfileUsageStats` produces both before and after this fix) and probes the per-model bypass behavior.
- **Exact steps or command run after this patch (re-verified on the rebased head)**: `node_modules/.bin/tsx /tmp/qmd87462/repro.mts` (real-component cooldown-scope sweep), then `pnpm test src/agents/auth-profiles/usage.test.ts src/agents/auth-profiles.markauthprofilefailure.test.ts src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts`, then `pnpm tsgo:core` and `pnpm tsgo:core:test`, then `pnpm exec oxfmt --check --threads=1 src/agents/auth-profiles/usage-state.ts src/agents/auth-profiles/usage.ts src/agents/auth-profiles/usage.test.ts src/agents/auth-profiles.markauthprofilefailure.test.ts`.
- **Evidence after fix (verbatim real-component harness output)**:

```text
================ #87462 cooldown-scope contract sweep ================

--- CURRENT MAIN: timeout, cooldownModel=undefined (the bug — all 4 blocked) ---
  state: cooldownReason=timeout, cooldownModel=<undefined>
  gemini-3-flash-preview       → blocked=true ✓ expected
  gemini-3.1-flash-lite        → blocked=true
  gemini-2.5-flash             → blocked=true
  gemini-3.1-pro-preview       → blocked=true

--- AFTER FIX: timeout, cooldownModel=gemini-3-flash-preview (only failed model blocked) ---
  state: cooldownReason=timeout, cooldownModel=gemini-3-flash-preview
  gemini-3-flash-preview       → blocked=true ✓ expected
  gemini-3.1-flash-lite        → blocked=false
  gemini-2.5-flash             → blocked=false
  gemini-3.1-pro-preview       → blocked=false

--- BASELINE (rate_limit, already model-scoped — proves the bypass mechanism) ---
  state: cooldownReason=rate_limit, cooldownModel=gemini-3-flash-preview
  gemini-3-flash-preview       → blocked=true ✓ expected
  gemini-3.1-flash-lite        → blocked=false
  gemini-2.5-flash             → blocked=false
  gemini-3.1-pro-preview       → blocked=false

--- CONTROL: auth failure (profile-wide, all blocked — must NOT change after fix) ---
  state: cooldownReason=auth, cooldownModel=<undefined>
  gemini-3-flash-preview       → blocked=true ✓ expected
  gemini-3.1-flash-lite        → blocked=true
  gemini-2.5-flash             → blocked=true
  gemini-3.1-pro-preview       → blocked=true
```

- **Observed result after fix**: post-start timeout on model X cooldowns only model X on the shared profile. Sibling fallback models bypass and can dispatch. Auth / billing / format / server_error failures continue to block all models on the profile, matching their profile-wide reliability semantics. `rate_limit` semantics unchanged.
- **Code-path coverage**: `pnpm test src/agents/auth-profiles/usage.test.ts src/agents/auth-profiles.markauthprofilefailure.test.ts src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts` (92/92 across 3 files) pins the new model-scope branches for timeout, the persistence of `cooldownModel` through `markAuthProfileFailure`, the soonest-cooldown-expiry resolution, and the existing rate_limit / profile-wide branches (regression-protected). `pnpm tsgo:core` and `pnpm tsgo:core:test` both report 0 errors on the rebased head, and `pnpm exec oxfmt --check` on the 4 touched files is clean.
- **What was not tested**: a real live Google API request producing a streaming timeout. The harness exercises the cooldown-scope contract that `markAuthProfileFailure` produces; the upstream `auth-profile-failure-policy.ts` gate that routes only `providerStarted=true` timeouts into this code path is unchanged and covered by its existing tests.

### Risk / Mitigation

- **Risk**: the fix sits in `src/agents/auth-profiles/usage.ts` / `usage-state.ts`, a hot path consulted by every model dispatch and failover decision. **Mitigation**: the change is a single-predicate generalization (`rate_limit` → `rate_limit || timeout`) wired through one new helper, with five existing-call-site rewrites that all read the same boolean. No new state, no new persisted fields, no schema changes. The active-cooldown-widening path (different model fails during cooldown → widen to profile-wide) is preserved.
- **Risk**: overlap with PR #87122 ("Avoid profile cooldowns for provider overloads", cbcampos, open). **Mitigation**: #87122 changes `cooldownUntil` computation for `reason === "overloaded"`; this PR changes `cooldownModel` scope for `rate_limit || timeout`. Different conditionals, non-overlapping logic, no merge conflict expected.
- **Risk**: could mask a real provider outage where the timeout is genuinely Google-wide rather than per-model. **Mitigation**: when a second model fails during the active cooldown window, the existing widening logic clears `cooldownModel` and the cooldown reverts to profile-wide — exactly as it does today for rate_limit cascades.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Auth / tokens

### Linked Issue/PR

Fixes #87462

