### PR TITLE
fix(agents): expose bundle MCP structured content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1083,6 +1083,8 @@ jobs:
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check == 'true' }}
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && matrix.runner || 'ubuntu-24.04') }}
     timeout-minutes: 20
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
     strategy:
       fail-fast: false
       matrix:

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -22,9 +22,18 @@ function toAgentToolResult(params: {
   const content = Array.isArray(params.result.content)
     ? (params.result.content as AgentToolResult<unknown>["content"])
     : [];
+  const structuredContentBlock =
+    params.result.structuredContent !== undefined
+      ? ({
+          type: "text",
+          text: `structuredContent:\n${JSON.stringify(params.result.structuredContent, null, 2)}`,
+        } as const)
+      : undefined;
   const normalizedContent: AgentToolResult<unknown>["content"] =
     content.length > 0
-      ? content
+      ? structuredContentBlock !== undefined
+        ? [...content, structuredContentBlock]
+        : content
       : params.result.structuredContent !== undefined
         ? [
             {

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -1,3 +1,4 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { validateToolArguments } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { getPluginToolMeta } from "../plugins/tools.js";
@@ -19,6 +20,7 @@ function makeToolRuntime(
     tools?: McpCatalogTool[];
     serverName?: string;
     resultText?: string;
+    structuredContent?: Record<string, unknown>;
   } = {},
 ): SessionMcpRuntime {
   const serverName = params.serverName ?? "bundleProbe";
@@ -51,10 +53,16 @@ function makeToolRuntime(
       },
       tools,
     }),
-    callTool: async () => ({
-      content: [{ type: "text", text: params.resultText ?? "FROM-BUNDLE" }],
-      isError: false,
-    }),
+    callTool: async () => {
+      const result: CallToolResult = {
+        content: [{ type: "text", text: params.resultText ?? "FROM-BUNDLE" }],
+        isError: false,
+      };
+      if (params.structuredContent !== undefined) {
+        result.structuredContent = params.structuredContent;
+      }
+      return result;
+    },
     dispose: async () => {},
   };
 }
@@ -72,6 +80,35 @@ describe("createBundleMcpToolRuntime", () => {
     expect(result.details).toEqual({
       mcpServer: "bundleProbe",
       mcpTool: "bundle_probe",
+    });
+  });
+
+  it("exposes MCP structuredContent alongside normal text content", async () => {
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        resultText: "pong",
+        structuredContent: {
+          threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
+          content: "pong",
+        },
+      }),
+    });
+
+    const result = await runtime.tools[0].execute("call-codex-probe", {}, undefined, undefined);
+
+    expectTextContentBlock(result.content[0], "pong");
+    expect(result.content).toHaveLength(2);
+    expectTextContentBlock(
+      result.content[1],
+      'structuredContent:\n{\n  "threadId": "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",\n  "content": "pong"\n}',
+    );
+    expect(result.details).toEqual({
+      mcpServer: "bundleProbe",
+      mcpTool: "bundle_probe",
+      structuredContent: {
+        threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
+        content: "pong",
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- Surface inbound bundle-MCP `structuredContent` as a model-visible text block when an MCP server also returns normal content.
- Preserve the existing structured details payload for logs/UI and keep the empty-content structured fallback unchanged.
- Add regression coverage for the Codex-style `content` plus `structuredContent.threadId` response shape.
- Give CI check shards the same Node heap budget used by other heavy CI jobs so the plugin SDK dts smoke can complete instead of hitting the default heap limit.

Refs #87511.

## Verification
- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/agent-bundle-mcp-tools.request-boundary.test.ts`
- `pnpm tsgo:test:src --pretty false`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-bundle-mcp-materialize.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm build:plugin-sdk:dts`
- `pnpm check:workflows`
- `git diff --check`

## Real behavior proof
Behavior addressed: Inbound bundle-MCP tool results that include both `content[]` and `structuredContent` no longer hide structured identifiers like Codex `threadId` from the model-facing tool result.
Real environment tested: Local OpenClaw source checkout on macOS, running the production `materializeBundleMcpToolsForRun` boundary with a Codex-shaped MCP tool result.
Exact steps or command run after this patch: Ran `node --import tsx` against `src/agents/agent-bundle-mcp-materialize.ts`, materialized a bundle-MCP tool whose `callTool` returned `content: [{type:"text", text:"pong"}]` plus `structuredContent: {threadId:"019e6cdb-8e7f-7cb2-891f-9edb689f6fc7", content:"pong"}`, and executed the materialized agent tool.
Evidence after fix: The after-fix terminal probe printed this live output from the patched OpenClaw materializer:
```json
{
  "contentLength": 2,
  "firstText": "pong",
  "secondTextIncludesThreadId": true,
  "detailsThreadId": "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7"
}
```
Observed result after fix: The model-facing tool content now includes the original text result plus a second text block containing the serialized `structuredContent.threadId`, so an agent can read the thread id needed for a later `codex-reply` call.
What was not tested: A live external `codex mcp-server` model call was not run; the proof used the production OpenClaw materialization boundary with the same MCP result shape from the issue.

