### PR TITLE
fix(agents): surface MCP structured content in tool results

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -34,6 +34,8 @@ function toAgentToolResult(params: {
           text: `structuredContent:\n${JSON.stringify(params.result.structuredContent, null, 2)}`,
         } as const)
       : null;
+  // Structured MCP results are the canonical model payload here; replacing
+  // mirrored content avoids duplicating large tool output in the prompt.
   const normalizedContent: AgentToolResult<unknown>["content"] = structuredContentBlock
     ? [structuredContentBlock]
     : content.length > 0

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -34,27 +34,24 @@ function toAgentToolResult(params: {
           text: `structuredContent:\n${JSON.stringify(params.result.structuredContent, null, 2)}`,
         } as const)
       : null;
-  const normalizedContent: AgentToolResult<unknown>["content"] =
-    content.length > 0
-      ? structuredContentBlock
-        ? [...content, structuredContentBlock]
-        : content
-      : structuredContentBlock
-        ? [structuredContentBlock]
-        : ([
-            {
-              type: "text",
-              text: JSON.stringify(
-                {
-                  status: params.result.isError === true ? "error" : "ok",
-                  server: params.serverName,
-                  tool: params.toolName,
-                },
-                null,
-                2,
-              ),
-            },
-          ] as AgentToolResult<unknown>["content"]);
+  const normalizedContent: AgentToolResult<unknown>["content"] = structuredContentBlock
+    ? [structuredContentBlock]
+    : content.length > 0
+      ? content
+      : ([
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                status: params.result.isError === true ? "error" : "ok",
+                server: params.serverName,
+                tool: params.toolName,
+              },
+              null,
+              2,
+            ),
+          },
+        ] as AgentToolResult<unknown>["content"]);
   const details: Record<string, unknown> = {
     mcpServer: params.serverName,
     mcpTool: params.toolName,

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -27,16 +27,20 @@ function toAgentToolResult(params: {
   const content = Array.isArray(params.result.content)
     ? (params.result.content as AgentToolResult<unknown>["content"])
     : [];
+  const structuredContentBlock =
+    params.result.structuredContent !== undefined
+      ? ({
+          type: "text",
+          text: `structuredContent:\n${JSON.stringify(params.result.structuredContent, null, 2)}`,
+        } as const)
+      : null;
   const normalizedContent: AgentToolResult<unknown>["content"] =
     content.length > 0
-      ? content
-      : params.result.structuredContent !== undefined
-        ? [
-            {
-              type: "text",
-              text: JSON.stringify(params.result.structuredContent, null, 2),
-            },
-          ]
+      ? structuredContentBlock
+        ? [...content, structuredContentBlock]
+        : content
+      : structuredContentBlock
+        ? [structuredContentBlock]
         : ([
             {
               type: "text",

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -1,3 +1,4 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { validateToolArguments } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { getPluginToolMeta } from "../plugins/tools.js";
@@ -18,6 +19,7 @@ function makeToolRuntime(
   params: {
     tools?: McpCatalogTool[];
     serverName?: string;
+    result?: CallToolResult;
     resultText?: string;
   } = {},
 ): SessionMcpRuntime {
@@ -63,10 +65,11 @@ function makeToolRuntime(
       },
       tools,
     }),
-    callTool: async () => ({
-      content: [{ type: "text", text: params.resultText ?? "FROM-BUNDLE" }],
-      isError: false,
-    }),
+    callTool: async () =>
+      params.result ?? {
+        content: [{ type: "text", text: params.resultText ?? "FROM-BUNDLE" }],
+        isError: false,
+      },
     dispose: async () => {},
   };
 }
@@ -84,6 +87,44 @@ describe("createBundleMcpToolRuntime", () => {
     expect(result.details).toEqual({
       mcpServer: "bundleProbe",
       mcpTool: "bundle_probe",
+    });
+  });
+
+  it("keeps structuredContent visible when MCP tools also return text content", async () => {
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        result: {
+          content: [{ type: "text", text: "pong" }],
+          structuredContent: {
+            threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
+            content: "pong",
+          },
+          isError: false,
+        },
+      }),
+    });
+
+    const result = await runtime.tools[0].execute("call-bundle-probe", {}, undefined, undefined);
+
+    expectTextContentBlock(result.content[0], "pong");
+    expectTextContentBlock(
+      result.content[1],
+      `structuredContent:\n${JSON.stringify(
+        {
+          threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
+          content: "pong",
+        },
+        null,
+        2,
+      )}`,
+    );
+    expect(result.details).toEqual({
+      mcpServer: "bundleProbe",
+      mcpTool: "bundle_probe",
+      structuredContent: {
+        threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
+        content: "pong",
+      },
     });
   });
 

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -106,9 +106,8 @@ describe("createBundleMcpToolRuntime", () => {
 
     const result = await runtime.tools[0].execute("call-bundle-probe", {}, undefined, undefined);
 
-    expectTextContentBlock(result.content[0], "pong");
     expectTextContentBlock(
-      result.content[1],
+      result.content[0],
       `structuredContent:\n${JSON.stringify(
         {
           threadId: "019e6cdb-8e7f-7cb2-891f-9edb689f6fc7",
@@ -118,6 +117,7 @@ describe("createBundleMcpToolRuntime", () => {
         2,
       )}`,
     );
+    expect(result.content).toHaveLength(1);
     expect(result.details).toEqual({
       mcpServer: "bundleProbe",
       mcpTool: "bundle_probe",

--- a/src/secrets/path-utils.ts
+++ b/src/secrets/path-utils.ts
@@ -2,10 +2,6 @@ import { isDeepStrictEqual } from "node:util";
 import { parseConfigPathArrayIndex } from "../shared/path-array-index.js";
 import { isRecord } from "./shared.js";
 
-function isArrayIndexSegment(segment: string): boolean {
-  return parseArrayIndexSegment(segment) !== undefined;
-}
-
 function looksLikeArrayIndexSegment(segment: string): boolean {
   return /^\d+$/.test(segment);
 }


### PR DESCRIPTION
## Summary

- Surface inbound bundle-MCP `structuredContent` in model-visible tool output when an MCP server also returns normal text content.
- When `structuredContent` is present, show only the serialized structured block to the model and keep `details.structuredContent` for UI/log consumers.
- Keep the change scoped to the bundle-MCP materialization boundary; provider transports, Codex runtime behavior, and MCP server behavior are intentionally out of scope.
- Also remove an unused local secrets path helper that was failing the latest `check-prod-types` gate on main.

## Linked context

Closes #87511

Related #77024
Related #57461

Was this requested by a maintainer or owner?

Yes. Maintainer follow-up requested that only structured content be shown to the model when `structuredContent` is present.

## Real behavior proof (required for external PRs)

- Behavior addressed: MCP servers such as Codex can return `content` plus `structuredContent.threadId`; OpenClaw previously hid the structured fields from the model-facing tool result whenever `content` was non-empty.
- Real environment tested: Local OpenClaw source checkout on macOS with real `codex-cli 0.134.0` / `codex mcp-server`.
- Exact steps or command run after this patch: Ran `node --import tsx --input-type=module -`, created a real `createSessionMcpRuntime` with `mcp.servers.codex.command = codex` and `args = ["mcp-server"]`, materialized bundle-MCP tools, called `codex__codex`, extracted `details.structuredContent.threadId`, then called `codex__codex-reply` with that thread id.
- Evidence after fix: Redacted/shape-only console output from the live Codex MCP smoke:

```json
{
  "tools": [
    "codex__codex",
    "codex__codex-reply"
  ],
  "firstResult": {
    "contentBlocks": 1,
    "visibleStructuredContent": true,
    "visibleThreadId": true,
    "detailsThreadId": "019e6f51-516e-7c20-8807-35fa47e24a16"
  },
  "replyResult": {
    "contentBlocks": 1,
    "detailsThreadId": "019e6f51-516e-7c20-8807-35fa47e24a16",
    "sameThread": true
  }
}
```

- Observed result after fix: The first Codex MCP call produced one model-visible `structuredContent:` block containing the thread id, without duplicating the original text block. A real `codex__codex-reply` call then continued on the same thread id.
- What was not tested: Full interactive OpenClaw agent UI/session flow; the smoke exercises the real bundle-MCP runtime, real Codex MCP server, and materialized OpenClaw tool execution boundary directly.
- Before evidence: Current source only serialized `structuredContent` in the empty-content fallback path, so the same Codex-style response previously exposed only the normal text block to the model.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-tools.materialize.test.ts`
- `pnpm exec oxfmt --check src/secrets/path-utils.ts src/agents/agent-bundle-mcp-materialize.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts`
- `pnpm tsgo:prod`
- `git diff --check`
- `node --import tsx --input-type=module -` live Codex MCP smoke described above

What regression coverage was added or updated?

Added focused bundle-MCP materialization coverage for a tool response that includes both normal text content and structuredContent with a Codex-style `threadId`; updated it to assert the model-visible result contains only the structured block. Also removed an unused secrets path helper to restore the prod-type gate on the latest base.

What failed before this fix, if known?

The model-visible result only included the normal text content, so continuation identifiers stored in `structuredContent` were unavailable to the agent.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Agents can now see serialized structured MCP result fields in tool output.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Model-visible result shape changes for MCP tools that return both normal content and structuredContent.

How is that risk mitigated?

The change is limited to the existing bundle-MCP result boundary, preserves `details.structuredContent`, and avoids duplicating large normal content plus structured JSON by showing only the structured block when structuredContent is present.

## Current review state

What is the next action?

Await maintainer review and CI after the branch update.

What is still waiting on author, maintainer, CI, or external proof?

Maintainer/CI only; live Codex MCP continuation smoke has been provided.

Which bot or reviewer comments were addressed?

Addressed the maintainer/ClawSweeper request to show only structured content to the model when `structuredContent` is present.

AI-assisted: yes. I reviewed the touched code path and ran the focused validation commands above.
