### PR TITLE
test(agents): cover quota prompt takeover regression

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1294,7 +1294,6 @@ describe("embedded attempt session lock lifecycle", () => {
         }),
       },
     };
-
     installPromptSubmissionLockRelease({
       session,
       waitForSessionEvents: (sessionToDrain) => controller.waitForSessionEvents(sessionToDrain),
@@ -1311,6 +1310,58 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
     await expect(fs.readFile(sessionFile, "utf8")).resolves.toContain(
       "mirrored message-tool delivery",
+    );
+  });
+
+  it("preserves provider quota errors after prompt-stream error transcript writes (#85103)", async () => {
+    const sessionFile = await createTempSessionFile();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: {
+        ...lockOptions,
+        sessionFile,
+        timeoutMs: 1_000,
+      },
+    });
+    const quotaError = Object.assign(new Error("429 The usage limit has been reached"), {
+      status: 429,
+      type: "usage_limit_reached",
+    });
+    const session = {
+      agent: {
+        streamFn: vi.fn(async (..._args: unknown[]) => {
+          await appendSessionTranscriptMessage({
+            transcriptPath: sessionFile,
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "429 The usage limit has been reached" }],
+            },
+          });
+          throw quotaError;
+        }),
+      },
+    };
+    const streamFn = session.agent.streamFn;
+
+    installPromptSubmissionLockRelease({
+      session,
+      waitForSessionEvents: (sessionToDrain) => controller.waitForSessionEvents(sessionToDrain),
+      releaseForPrompt: () => controller.releaseForPrompt(),
+      reacquireAfterPrompt: () => controller.reacquireAfterPrompt(),
+      sessionFile,
+      withSessionWriteLock: (run) => controller.withSessionWriteLock(run),
+    });
+
+    await expect(session.agent.streamFn("openai-codex/gpt-5.5", "context")).rejects.toBe(
+      quotaError,
+    );
+    const cleanupLock = await controller.acquireForCleanup({ session });
+    await cleanupLock.release();
+
+    expect(controller.hasSessionTakeover()).toBe(false);
+    expect(streamFn).toHaveBeenCalledWith("openai-codex/gpt-5.5", "context");
+    await expect(fs.readFile(sessionFile, "utf8")).resolves.toContain(
+      "429 The usage limit has been reached",
     );
   });
 


### PR DESCRIPTION
Summary:
- Adds a focused regression for the #85103 path where an OpenAI Codex quota error writes an assistant error transcript during prompt streaming.
- Asserts the original usage_limit_reached provider error survives and cleanup does not mark the session as an EmbeddedAttemptSessionTakeoverError.
- Locks in the owned prompt transcript write handling already present on main.

Testing:
- corepack pnpm exec vitest run src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts

Refs #85103