### PR TITLE
Fix Claude live tool progress for watchdog recovery

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -8,6 +8,14 @@ import {
   replyRunRegistry,
 } from "../auto-reply/reply/reply-run-registry.js";
 import { onAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
+import {
+  onInternalDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
+import {
+  getDiagnosticSessionActivitySnapshot,
+  resetDiagnosticRunActivityForTest,
+} from "../logging/diagnostic-run-activity.js";
 import type { getProcessSupervisor } from "../process/supervisor/index.js";
 import {
   makeBootstrapWarn as realMakeBootstrapWarn,
@@ -45,6 +53,7 @@ type SupervisorSpawnFn = ProcessSupervisor["spawn"];
 
 beforeEach(() => {
   resetAgentEventsForTest();
+  resetDiagnosticRunActivityForTest();
   resetClaudeLiveSessionsForTest();
   replyRunTesting.resetReplyRunRegistry();
   restoreCliRunnerPrepareTestDeps();
@@ -53,6 +62,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
+  resetDiagnosticRunActivityForTest();
   resetClaudeLiveSessionsForTest();
   replyRunTesting.resetReplyRunRegistry();
 });
@@ -73,6 +84,7 @@ function buildPreparedCliRunContext(params: {
   skillsSnapshot?: PreparedCliRunContext["params"]["skillsSnapshot"];
   thinkLevel?: PreparedCliRunContext["params"]["thinkLevel"];
   workspaceDir?: string;
+  timeoutMs?: number;
 }): PreparedCliRunContext {
   const workspaceDir = params.workspaceDir ?? "/tmp";
   const baseBackend =
@@ -116,7 +128,7 @@ function buildPreparedCliRunContext(params: {
       provider: params.provider,
       model: params.model,
       thinkLevel: params.thinkLevel,
-      timeoutMs: 1_000,
+      timeoutMs: params.timeoutMs ?? 1_000,
       runId: params.runId,
       skillsSnapshot: params.skillsSnapshot,
     },
@@ -1602,6 +1614,164 @@ ${JSON.stringify({
     expect(parsed.response.request_id).toBe("req-allow");
     expect(parsed.response.response.behavior).toBe("allow");
     expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
+  });
+
+  it("reports Claude live stream progress and keeps native tools fresh while they are running", async () => {
+    vi.useFakeTimers({
+      toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+    });
+    vi.setSystemTime(new Date("2026-05-28T00:00:00.000Z"));
+    const diagnosticEvents: string[] = [];
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      if (event.type === "run.progress" || event.type.startsWith("tool.execution.")) {
+        diagnosticEvents.push(event.type);
+      }
+    });
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        stdoutListener?.(
+          [
+            JSON.stringify({
+              type: "system",
+              subtype: "init",
+              session_id: "live-diagnostics",
+            }),
+            JSON.stringify({
+              type: "assistant",
+              session_id: "live-diagnostics",
+              message: {
+                role: "assistant",
+                content: [
+                  {
+                    type: "tool_use",
+                    id: "tool-live-1",
+                    name: "Bash",
+                    input: { command: "sleep 45" },
+                  },
+                ],
+              },
+            }),
+          ].join("\n") + "\n",
+        );
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-diagnostics",
+        pid: 3060,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    try {
+      const context = buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-live-diagnostics",
+        sessionId: "session-live-diagnostics",
+        sessionKey: "agent:main:diagnostics",
+        prompt: "hello",
+        backend: { liveSession: "claude-stdio" },
+        timeoutMs: 120_000,
+      });
+      const resultPromise = runClaudeLiveSessionTurn({
+        context,
+        args: context.preparedBackend.backend.args ?? [],
+        env: {},
+        prompt: "hello",
+        useResume: false,
+        noOutputTimeoutMs: 120_000,
+        getProcessSupervisor: () => ({
+          spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+            supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+          cancel: vi.fn(),
+          cancelScope: vi.fn(),
+          reconcileOrphans: vi.fn(),
+          getRecord: vi.fn(),
+        }),
+        onAssistantDelta: () => {},
+        cleanup: async () => {},
+      });
+
+      await waitForDiagnosticEventsDrained();
+      await vi.waitFor(() =>
+        expect(
+          getDiagnosticSessionActivitySnapshot({
+            sessionKey: "agent:main:diagnostics",
+          }).activeToolName,
+        ).toBe("Bash"),
+      );
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:diagnostics" })
+          .lastProgressReason,
+      ).toBe("cli_live:tool_started");
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await waitForDiagnosticEventsDrained();
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:diagnostics" })
+          .lastProgressReason,
+      ).toBe("cli_live:tool_running");
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:diagnostics" })
+          .lastProgressAgeMs,
+      ).toBeLessThan(100);
+
+      stdoutListener?.(
+        [
+          JSON.stringify({
+            type: "user",
+            session_id: "live-diagnostics",
+            message: {
+              role: "user",
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "tool-live-1",
+                  content: "done",
+                },
+              ],
+            },
+          }),
+          JSON.stringify({
+            type: "assistant",
+            session_id: "live-diagnostics",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "ok" }],
+            },
+          }),
+          JSON.stringify({
+            type: "result",
+            session_id: "live-diagnostics",
+            result: "ok",
+          }),
+        ].join("\n") + "\n",
+      );
+
+      await expect(resultPromise).resolves.toMatchObject({ output: { text: "ok" } });
+      await waitForDiagnosticEventsDrained();
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:diagnostics" })
+          .activeToolName,
+      ).toBeUndefined();
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:diagnostics" })
+          .lastProgressReason,
+      ).toBe("cli_live:result");
+      expect(diagnosticEvents).toContain("tool.execution.started");
+      expect(diagnosticEvents).toContain("tool.execution.completed");
+    } finally {
+      stopDiagnostics();
+    }
   });
 
   it("answers Claude live control_request can_use_tool with deny when exec policy is restrictive", async () => {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -2,6 +2,13 @@ import crypto from "node:crypto";
 import type { ReplyBackendHandle } from "../../auto-reply/reply/reply-run-registry.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import {
+  emitTrustedDiagnosticEvent,
+  type DiagnosticToolParamsSummary,
+  type DiagnosticToolSource,
+  type DiagnosticToolExecutionErrorEvent,
+  type DiagnosticToolExecutionCompletedEvent,
+} from "../../infra/diagnostic-events.js";
+import {
   loadExecApprovals,
   maxAsk,
   minSecurity,
@@ -29,6 +36,7 @@ type ProcessSupervisor = ReturnType<
 type ManagedRun = Awaited<ReturnType<ProcessSupervisor["spawn"]>>;
 type ClaudeLiveTurn = {
   backend: CliBackendConfig;
+  diagnosticRefs: ClaudeLiveDiagnosticRefs;
   outputLimits: ClaudeLiveOutputLimits;
   startedAtMs: number;
   rawLines: string[];
@@ -36,6 +44,8 @@ type ClaudeLiveTurn = {
   sessionId?: string;
   noOutputTimer: NodeJS.Timeout | null;
   timeoutTimer: NodeJS.Timeout | null;
+  activeToolTimer: NodeJS.Timeout | null;
+  activeTools: Map<string, ClaudeLiveActiveTool>;
   streamingParser: ReturnType<typeof createCliJsonlStreamingParser>;
   execPermission: ClaudeLiveExecPermission;
   resolve: (output: CliOutput) => void;
@@ -71,8 +81,24 @@ type ClaudeLiveExecPermission = {
   ask: ExecAsk;
   permissionMode: "bypassPermissions" | "default";
 };
+type ClaudeLiveDiagnosticRefs = {
+  runId: string;
+  sessionId: string;
+  sessionKey?: string;
+};
+type ClaudeLiveActiveTool = {
+  toolName: string;
+  toolCallId: string;
+  startedAt: number;
+};
+type ClaudeLiveToolUse = {
+  toolName: string;
+  toolCallId: string;
+  paramsSummary?: DiagnosticToolParamsSummary;
+};
 
 const CLAUDE_LIVE_IDLE_TIMEOUT_MS = 10 * 60 * 1_000;
+const CLAUDE_LIVE_ACTIVE_TOOL_PROGRESS_MS = 10_000;
 const CLAUDE_LIVE_MAX_SESSIONS = 16;
 const CLAUDE_LIVE_MAX_STDERR_CHARS = 64 * 1024;
 const CLAUDE_LIVE_DEFAULT_MAX_TURN_RAW_CHARS = 8 * 1024 * 1024;
@@ -329,6 +355,10 @@ function clearTurnTimers(turn: ClaudeLiveTurn): void {
     clearTimeout(turn.timeoutTimer);
     turn.timeoutTimer = null;
   }
+  if (turn.activeToolTimer) {
+    clearInterval(turn.activeToolTimer);
+    turn.activeToolTimer = null;
+  }
 }
 
 function clearDrainTimer(session: ClaudeLiveSession): void {
@@ -346,6 +376,7 @@ function finishTurn(session: ClaudeLiveSession, output: CliOutput): void {
   cliBackendLog.info(
     `claude live session turn: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} rawLines=${turn.rawLines.length}`,
   );
+  completeActiveClaudeLiveTools(turn);
   clearTurnTimers(turn);
   turn.streamingParser.finish();
   session.currentTurn = null;
@@ -362,6 +393,7 @@ function failTurn(session: ClaudeLiveSession, error: unknown): void {
   cliBackendLog.warn(
     `claude live session turn failed: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} error=${errorKind}`,
   );
+  failActiveClaudeLiveTools(turn, error);
   clearTurnTimers(turn);
   turn.streamingParser.finish();
   session.currentTurn = null;
@@ -438,6 +470,208 @@ function createOutputLimitError(session: ClaudeLiveSession, message: string): Fa
     model: session.modelId,
     status: resolveFailoverStatus("format"),
   });
+}
+
+function diagnosticToolSourceForClaudeLiveTool(toolName: string): DiagnosticToolSource {
+  return toolName.startsWith("mcp__") ? "mcp" : "core";
+}
+
+function claudeLiveDiagnosticBase(turn: ClaudeLiveTurn) {
+  return {
+    runId: turn.diagnosticRefs.runId,
+    sessionId: turn.diagnosticRefs.sessionId,
+    ...(turn.diagnosticRefs.sessionKey ? { sessionKey: turn.diagnosticRefs.sessionKey } : {}),
+  };
+}
+
+function emitClaudeLiveProgress(turn: ClaudeLiveTurn, reason: string): void {
+  emitTrustedDiagnosticEvent({
+    type: "run.progress",
+    ...claudeLiveDiagnosticBase(turn),
+    reason,
+  });
+}
+
+function summarizeClaudeLiveToolInput(input: unknown): DiagnosticToolParamsSummary | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+  if (input === null) {
+    return { kind: "null" };
+  }
+  if (Array.isArray(input)) {
+    return { kind: "array", length: input.length };
+  }
+  switch (typeof input) {
+    case "object":
+      return { kind: "object" };
+    case "string":
+      return { kind: "string", length: input.length };
+    case "number":
+      return { kind: "number" };
+    case "boolean":
+      return { kind: "boolean" };
+    case "undefined":
+      return { kind: "undefined" };
+    default:
+      return { kind: "other" };
+  }
+}
+
+function readClaudeLiveMessageContent(parsed: Record<string, unknown>): unknown[] {
+  const message = parsed.message;
+  if (!isRecord(message)) {
+    return [];
+  }
+  const content = message.content;
+  return Array.isArray(content) ? content : [];
+}
+
+function readClaudeLiveToolUses(parsed: Record<string, unknown>): ClaudeLiveToolUse[] {
+  const tools: ClaudeLiveToolUse[] = [];
+  for (const entry of readClaudeLiveMessageContent(parsed)) {
+    if (!isRecord(entry) || entry.type !== "tool_use") {
+      continue;
+    }
+    const toolName = typeof entry.name === "string" ? entry.name.trim() : "";
+    const toolCallId = typeof entry.id === "string" ? entry.id.trim() : "";
+    if (!toolName || !toolCallId) {
+      continue;
+    }
+    tools.push({
+      toolName,
+      toolCallId,
+      paramsSummary: summarizeClaudeLiveToolInput(entry.input),
+    });
+  }
+  return tools;
+}
+
+function readClaudeLiveToolResultIds(parsed: Record<string, unknown>): string[] {
+  const toolResultIds: string[] = [];
+  for (const entry of readClaudeLiveMessageContent(parsed)) {
+    if (!isRecord(entry) || entry.type !== "tool_result") {
+      continue;
+    }
+    const toolCallId = typeof entry.tool_use_id === "string" ? entry.tool_use_id.trim() : "";
+    if (toolCallId) {
+      toolResultIds.push(toolCallId);
+    }
+  }
+  return toolResultIds;
+}
+
+function startClaudeLiveActiveToolHeartbeat(turn: ClaudeLiveTurn): void {
+  if (turn.activeToolTimer || turn.activeTools.size === 0) {
+    return;
+  }
+  turn.activeToolTimer = setInterval(() => {
+    if (turn.activeTools.size === 0) {
+      if (turn.activeToolTimer) {
+        clearInterval(turn.activeToolTimer);
+        turn.activeToolTimer = null;
+      }
+      return;
+    }
+    emitClaudeLiveProgress(turn, "cli_live:tool_running");
+  }, CLAUDE_LIVE_ACTIVE_TOOL_PROGRESS_MS);
+  turn.activeToolTimer.unref?.();
+}
+
+function stopClaudeLiveActiveToolHeartbeatIfIdle(turn: ClaudeLiveTurn): void {
+  if (turn.activeTools.size > 0 || !turn.activeToolTimer) {
+    return;
+  }
+  clearInterval(turn.activeToolTimer);
+  turn.activeToolTimer = null;
+}
+
+function markClaudeLiveToolStarted(turn: ClaudeLiveTurn, tool: ClaudeLiveToolUse): void {
+  const now = Date.now();
+  turn.activeTools.set(tool.toolCallId, {
+    toolName: tool.toolName,
+    toolCallId: tool.toolCallId,
+    startedAt: now,
+  });
+  emitTrustedDiagnosticEvent({
+    type: "tool.execution.started",
+    ...claudeLiveDiagnosticBase(turn),
+    toolName: tool.toolName,
+    toolSource: diagnosticToolSourceForClaudeLiveTool(tool.toolName),
+    toolOwner: "claude-cli",
+    toolCallId: tool.toolCallId,
+    ...(tool.paramsSummary ? { paramsSummary: tool.paramsSummary } : {}),
+  });
+  emitClaudeLiveProgress(turn, "cli_live:tool_started");
+  startClaudeLiveActiveToolHeartbeat(turn);
+}
+
+function markClaudeLiveToolCompleted(turn: ClaudeLiveTurn, toolCallId: string): void {
+  const activeTool = turn.activeTools.get(toolCallId);
+  if (!activeTool) {
+    emitClaudeLiveProgress(turn, "cli_live:tool_result");
+    return;
+  }
+  turn.activeTools.delete(toolCallId);
+  const event: Omit<DiagnosticToolExecutionCompletedEvent, "seq" | "ts" | "type"> = {
+    ...claudeLiveDiagnosticBase(turn),
+    toolName: activeTool.toolName,
+    toolSource: diagnosticToolSourceForClaudeLiveTool(activeTool.toolName),
+    toolOwner: "claude-cli",
+    toolCallId: activeTool.toolCallId,
+    durationMs: Math.max(0, Date.now() - activeTool.startedAt),
+  };
+  emitTrustedDiagnosticEvent({
+    type: "tool.execution.completed",
+    ...event,
+  });
+  emitClaudeLiveProgress(turn, "cli_live:tool_result");
+  stopClaudeLiveActiveToolHeartbeatIfIdle(turn);
+}
+
+function completeActiveClaudeLiveTools(turn: ClaudeLiveTurn): void {
+  for (const toolCallId of [...turn.activeTools.keys()]) {
+    markClaudeLiveToolCompleted(turn, toolCallId);
+  }
+}
+
+function failActiveClaudeLiveTools(turn: ClaudeLiveTurn, error: unknown): void {
+  const errorCategory = error instanceof Error && error.name === "AbortError" ? "aborted" : "error";
+  for (const activeTool of turn.activeTools.values()) {
+    const event: Omit<DiagnosticToolExecutionErrorEvent, "seq" | "ts" | "type"> = {
+      ...claudeLiveDiagnosticBase(turn),
+      toolName: activeTool.toolName,
+      toolSource: diagnosticToolSourceForClaudeLiveTool(activeTool.toolName),
+      toolOwner: "claude-cli",
+      toolCallId: activeTool.toolCallId,
+      durationMs: Math.max(0, Date.now() - activeTool.startedAt),
+      errorCategory,
+    };
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.error",
+      ...event,
+    });
+  }
+  turn.activeTools.clear();
+}
+
+function noteClaudeLiveProgress(turn: ClaudeLiveTurn, parsed: Record<string, unknown>): void {
+  const toolUses = readClaudeLiveToolUses(parsed);
+  const toolResultIds = readClaudeLiveToolResultIds(parsed);
+  for (const tool of toolUses) {
+    markClaudeLiveToolStarted(turn, tool);
+  }
+  for (const toolCallId of toolResultIds) {
+    markClaudeLiveToolCompleted(turn, toolCallId);
+  }
+  if (parsed.type === "result") {
+    emitClaudeLiveProgress(turn, "cli_live:result");
+    return;
+  }
+  if (toolUses.length > 0 || toolResultIds.length > 0) {
+    return;
+  }
+  emitClaudeLiveProgress(turn, "cli_live:stream_progress");
 }
 
 function resetNoOutputTimer(session: ClaudeLiveSession): void {
@@ -669,6 +903,7 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   turn.rawLines.push(trimmed);
   turn.streamingParser.push(`${trimmed}\n`);
   turn.sessionId = parseSessionId(parsed) ?? turn.sessionId;
+  noteClaudeLiveProgress(turn, parsed);
   handleClaudeLiveControlRequest(session, turn, parsed);
   if (parsed.type !== "result") {
     return;
@@ -875,12 +1110,19 @@ function createTurn(params: {
 }): ClaudeLiveTurn {
   const turn: ClaudeLiveTurn = {
     backend: params.context.preparedBackend.backend,
+    diagnosticRefs: {
+      runId: params.context.params.runId,
+      sessionId: params.context.params.sessionId,
+      ...(params.context.params.sessionKey ? { sessionKey: params.context.params.sessionKey } : {}),
+    },
     outputLimits: resolveClaudeLiveOutputLimits(params.context.preparedBackend.backend),
     startedAtMs: Date.now(),
     rawLines: [],
     rawChars: 0,
     noOutputTimer: null,
     timeoutTimer: null,
+    activeToolTimer: null,
+    activeTools: new Map(),
     streamingParser: createCliJsonlStreamingParser({
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -630,7 +630,8 @@ function markClaudeLiveToolCompleted(turn: ClaudeLiveTurn, toolCallId: string): 
 }
 
 function completeActiveClaudeLiveTools(turn: ClaudeLiveTurn): void {
-  for (const toolCallId of [...turn.activeTools.keys()]) {
+  const activeToolCallIds = Array.from(turn.activeTools.keys());
+  for (const toolCallId of activeToolCallIds) {
     markClaudeLiveToolCompleted(turn, toolCallId);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #86895.

Claude live sessions now feed parsed `stream-json` progress into diagnostic run activity. The runner tracks Claude-native `tool_use` / `tool_result` lifecycle events, emits trusted diagnostic tool events for Claude CLI tools, and sends a bounded active-tool heartbeat while a native Claude tool is running silently.

This keeps the Gateway stuck-session watchdog from aborting a valid long-running Claude-native foreground tool as an apparently stale embedded run.

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts`
- `node scripts/run-oxlint.mjs src/agents/cli-runner/claude-live-session.ts src/agents/cli-runner.spawn.test.ts`
- AWS Crabbox canonical before/after proof: `run_311599d1ceae`, provider `aws`, lease `cbx_db022c6f0c82`, exit `0`

## Real behavior proof

Behavior addressed: Claude live `chat.send` turns that emit a native `tool_result` before a later silent foreground Claude-native `Bash` tool no longer get recovered as stale embedded runs while the later tool is still running.

Real environment tested: AWS Crabbox Linux, Claude Code CLI `2.1.152`, Claude Opus 4.6 via `claude-cli`, Gateway `chat.send` webchat path. The before/after proof compared current `main` at `744da7e6bdea60dc33fb96d2ca5c1739d6c2e73e` with this PR at `5b73eeb9cdcfb5f8891db172e9c00c8fab3fe761`.

Exact steps or command run after this patch: Ran the same live `chat.send` repro on current `main` and on this PR with diagnostics enabled, `stuckSessionWarnMs=5000`, and `stuckSessionAbortMs=15000`. The prompt required two Claude-native `Bash` calls: a quick first tool, then after that first tool result a foreground second tool: `python3 -c "import time; time.sleep(45); print('OC86895-SECOND-TOOL-DONE')"`.

Evidence after fix: AWS Crabbox `run_311599d1ceae` on `cbx_db022c6f0c82` exited `0`. On current `main`, the raw Claude stream showed `toolUseCount=2` and `toolResultCount=1`, while Gateway diagnostics showed `recoveryAbortEmbeddedRun=1`, `stalledEvents=1`, `streamProgress=0`, and `toolRunningProgress=0`. On this PR, the raw Claude stream showed `toolUseCount=2` and `toolResultCount=2`, while Gateway diagnostics showed `recoveryAbortEmbeddedRun=0`, `toolStarted=2`, `toolCompleted=2`, `toolErrored=0`, `toolRunningProgress=4`, `streamProgress=44`, `resultProgress=1`, and `stalledEvents=0`.

Observed result after fix: Current `main` aborted the live turn as a stuck embedded run after the second foreground Claude-native tool had started. This PR completed the same live turn in about 57s, classified the active work as Claude-native `Bash` tool work with recent `cli_live:tool_running` progress while the foreground tool was silent, and did not invoke stuck-session recovery.

What was not tested: Non-Claude live-session providers, and the exact reporter account/session data. This patch is scoped to the Claude live `stream-json` runner path.
