### PR TITLE
fix(agents): validate context engine assemble result shape

### DIFF
--- a/src/agents/harness/context-engine-lifecycle.test.ts
+++ b/src/agents/harness/context-engine-lifecycle.test.ts
@@ -113,6 +113,67 @@ describe("harness context engine lifecycle", () => {
     expect(afterTurnParams?.prePromptMessageCount).toBe(2);
   });
 
+  describe("assembleHarnessContextEngine result validation", () => {
+    // Regression for #75541: plugins that return a malformed assemble result
+    // previously poisoned activeSession.messages with `undefined`, which then
+    // crashed downstream with "Cannot read properties of undefined (reading
+    // 'length')". The harness wrapper now throws a descriptive error so the
+    // runner's existing assemble try/catch can log the engine id and fall
+    // back to the pipeline messages instead of corrupting session state.
+    const visibleUser = textMessage("user", "ping", 1);
+
+    async function runAssembleWithEngineResult(result: unknown) {
+      return assembleHarnessContextEngine({
+        contextEngine: createContextEngine({
+          info: { id: "broken-engine", name: "Broken engine" },
+          assemble: vi.fn(async () => result as never),
+        }),
+        sessionId: sessionParams.sessionId,
+        sessionKey: sessionParams.sessionKey,
+        messages: [visibleUser],
+        modelId: "gpt-test",
+      });
+    }
+
+    it("passes through a well-formed AssembleResult unchanged", async () => {
+      const wellFormed = { messages: [visibleUser], estimatedTokens: 0 };
+      await expect(runAssembleWithEngineResult(wellFormed)).resolves.toBe(wellFormed);
+    });
+
+    it("rejects an undefined assemble result with the engine id", async () => {
+      await expect(runAssembleWithEngineResult(undefined)).rejects.toThrow(
+        /context engine "broken-engine"[\s\S]*messages/,
+      );
+    });
+
+    it("rejects a null assemble result with the engine id", async () => {
+      await expect(runAssembleWithEngineResult(null)).rejects.toThrow(
+        /context engine "broken-engine"[\s\S]*messages/,
+      );
+    });
+
+    it("rejects an assemble result missing the messages array (lossless-claw shape)", async () => {
+      // Mirrors the malformed shape reported in #75541, where the plugin
+      // returned an object that satisfied the truthy `if (!assembled)` guard
+      // but omitted the required `messages` field.
+      await expect(runAssembleWithEngineResult({ estimatedTokens: 0 })).rejects.toThrow(
+        /assemble\(\) returned an invalid result[\s\S]*messages of type undefined/,
+      );
+    });
+
+    it("rejects an assemble result whose messages field is not an array", async () => {
+      await expect(
+        runAssembleWithEngineResult({ messages: "all of them", estimatedTokens: 0 }),
+      ).rejects.toThrow(/messages of type string/);
+    });
+
+    it("rejects an assemble result whose messages field is null", async () => {
+      await expect(
+        runAssembleWithEngineResult({ messages: null, estimatedTokens: 0 }),
+      ).rejects.toThrow(/messages of type null/);
+    });
+  });
+
   it("keeps hidden runtime-context custom messages out of ingestBatch fallbacks", async () => {
     const beforePromptUser = textMessage("user", "old ask", 1);
     const beforePromptRuntimeContext = runtimeContextMessage("old hidden context", 2);

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -1,5 +1,9 @@
 import type { MemoryCitationsMode } from "../../config/types.memory.js";
-import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
+import type {
+  AssembleResult,
+  ContextEngine,
+  ContextEngineRuntimeContext,
+} from "../../context-engine/types.js";
 import { runContextEngineMaintenance } from "../embedded-agent-runner/context-engine-maintenance.js";
 import {
   buildAfterTurnRuntimeContext,
@@ -73,7 +77,7 @@ export async function assembleHarnessContextEngine(params: {
     return undefined;
   }
   const messages = stripRuntimeContextCustomMessages(params.messages);
-  return await params.contextEngine.assemble({
+  const result = await params.contextEngine.assemble({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     messages,
@@ -83,6 +87,42 @@ export async function assembleHarnessContextEngine(params: {
     model: params.modelId,
     ...(params.prompt !== undefined ? { prompt: params.prompt } : {}),
   });
+  return ensureAssembleResultShape(result, params.contextEngine.info.id);
+}
+
+/**
+ * Validate that a context engine's assemble() return value matches the
+ * AssembleResult contract before the runner consumes it. Engines that omit
+ * `messages` or return a non-array previously crashed the runner downstream
+ * when prompt assembly tried to read `activeSession.messages.length` (#75541).
+ *
+ * Throws a descriptive error so the runner's existing assemble try/catch can
+ * log the offending engine id and fall back to the unmodified pipeline
+ * messages instead of poisoning session state.
+ */
+function ensureAssembleResultShape(result: unknown, engineId: string): AssembleResult {
+  if (!result || typeof result !== "object") {
+    throw new Error(
+      `context engine "${engineId}" assemble() returned an invalid result: expected an object with a "messages" array (got ${describeAssembleResultType(result)})`,
+    );
+  }
+  const candidate = result as { messages?: unknown };
+  if (!Array.isArray(candidate.messages)) {
+    throw new Error(
+      `context engine "${engineId}" assemble() returned an invalid result: expected an object with a "messages" array (got messages of type ${describeAssembleResultType(candidate.messages)})`,
+    );
+  }
+  return result as AssembleResult;
+}
+
+function describeAssembleResultType(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  return typeof value;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Guard the harness `assembleHarnessContextEngine` boundary against context engine plugins that return a malformed assemble result, so a buggy plugin can no longer poison `activeSession.messages` with `undefined` and crash the prompt assembly stage with `Cannot read properties of undefined (reading 'length')`.
- Throw a descriptive error naming the offending engine id; the runner's existing assemble try/catch in `attempt.ts` already logs the failure and falls back to the unmodified pipeline messages, so behavior on a well-formed plugin is unchanged.
- Out of scope: the third-party plugin's own bug, native runtime compaction, the broader context-engine RFC (#82137), and any change to provider transports.

## Linked context

Closes #75541

Was this requested by a maintainer or owner?

No direct maintainer request; ClawSweeper triage on the issue flagged this as a `safe repair candidate` at the harness boundary.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: With a third-party context engine (lossless-claw v0.9.2 in the report) that returns `{ estimatedTokens: 0 }` without a `messages` array, OpenClaw previously assigned `undefined` to `activeSession.agent.state.messages` and then crashed inside `attempt.ts` when it read `activeSession.messages.length`.
- Real environment tested: Local OpenClaw source checkout on Linux with Node `v22.22.3`, pnpm `11.2.2` via corepack.
- Exact steps or command run after this patch: Ran two local OpenClaw source smokes with `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" node --import tsx --input-type=module -e '...'` against the real `assembleHarnessContextEngine`, once before the patch (via `git stash` of the change) and once after, using a `lossless-claw`-shaped plugin that omits `messages`.
- Evidence after fix: Copied console output from those local OpenClaw source smokes.

  Before-fix (with the patch temporarily stashed on the same branch):

  ```
  BEFORE-FIX BEHAVIOR: assemble returned truthy: true
  assembled.messages: undefined
  Array.isArray(assembled.messages): false
  DOWNSTREAM CRASH: Cannot read properties of undefined (reading 'length')
  ```

  After-fix (working tree restored to this patch):

  ```
  AFTER-FIX BEHAVIOR: caught descriptive error before downstream crash
  error: context engine \"lossless-claw\" assemble() returned an invalid result: expected an object with a \"messages\" array (got messages of type undefined)
  VALID RESULT PASSTHROUGH: messages.length = 1 estimatedTokens = 1
  ```

- Observed result after fix: The malformed plugin payload throws a descriptive error at the harness boundary before any state assignment, naming the engine id. A well-formed `AssembleResult` still passes through unchanged. The runner's existing `try { ... } catch (assembleErr) { log.warn('context engine assemble failed, using pipeline messages: ...') }` in `src/agents/embedded-agent-runner/run/attempt.ts` then logs the failure and falls back to the unmodified pipeline messages.
- What was not tested: A live OpenClaw session that actually installs and runs lossless-claw v0.9.2 against the embedded runner. The fix targets the runtime boundary, not the third-party plugin itself.
- Proof limitations or environment constraints: The after-fix proof uses the real OpenClaw harness wrapper on the real `AssembleResult` consumer path, but it does not install the lossless-claw plugin because this environment is not configured with that plugin's runtime. The malformed shape used in the smoke matches the exact shape ClawSweeper identified as crash-prone in the issue triage.
- Before evidence (optional but encouraged): Captured directly above via the same script after `git stash`-ing this patch.

## Tests and validation

Which commands did you run?

- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" node scripts/test-projects.mjs src/agents/harness/context-engine-lifecycle.test.ts`
- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" corepack pnpm exec oxfmt --check src/agents/harness/context-engine-lifecycle.ts src/agents/harness/context-engine-lifecycle.test.ts`
- `git diff --check`

Outputs:

- `context-engine-lifecycle.test.ts`: `Test Files 1 passed (1)` / `Tests 9 passed (9)` (3 existing + 6 new shape-validation cases).
- `attempt.spawn-workspace.context-engine.test.ts`: `Test Files 1 passed (1)` / `Tests 53 passed (53)` — no regression in the existing adjacent assemble integration coverage.
- `oxfmt --check`: `All matched files use the correct format.`

What regression coverage was added or updated?

Added a `describe(\"assembleHarnessContextEngine result validation\")` block covering: well-formed passthrough, `undefined` result, `null` result, `{ estimatedTokens: 0 }` missing `messages` (the exact lossless-claw shape from #75541), `messages: \"string\"` (wrong type), and `messages: null`. Each rejection asserts that the engine id appears in the thrown message so the runner's existing assemble-failure log carries actionable context.

What failed before this fix, if known?

The before-fix smoke above reproduces `Cannot read properties of undefined (reading 'length')`. Without this guard, the new tests' rejection assertions would not be possible because the wrapper previously returned the malformed object unchanged.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes (recovery semantics). A plugin returning a malformed assemble result now produces a runtime warning naming the engine and falls back to pipeline messages, instead of crashing the turn. Behavior on a well-formed `AssembleResult` is unchanged.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

A previously crashing plugin will now silently fall back to pipeline messages, potentially masking a real plugin bug behind a single warn log.

How is that risk mitigated?

The thrown error string is descriptive and names the offending engine id, so the existing `log.warn(\"context engine assemble failed, using pipeline messages: ...\")` in `attempt.ts` surfaces both the engine id and the exact shape mismatch. Validation is strict enough to reject the failure mode in #75541 but only enforces what the public `AssembleResult` type already requires.

## Current review state

What is the next action?

Await maintainer / ClawSweeper review on whether the validator scope (only `messages` shape) is the preferred boundary, or whether `estimatedTokens` should also be validated.

What is still waiting on author, maintainer, CI, or external proof?

A live install of the third-party lossless-claw plugin is still not provided from this environment.

Which bot or reviewer comments were addressed?

Initial PR; no PR comments yet.

AI-assisted: yes. I reviewed the touched code path and ran the focused validation commands above.

Made with [Cursor](https://cursor.com)