### PR TITLE
Recover message-tool-only private final replies

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1,4 +1,8 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+} from "../../auto-reply/reply-payload.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
@@ -7,6 +11,7 @@ import {
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedBuildEmbeddedRunPayloads,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedLog,
@@ -23,6 +28,7 @@ import {
   EMPTY_RESPONSE_RETRY_INSTRUCTION,
   extractPlanningOnlyPlanDetails,
   isLikelyExecutionAckPrompt,
+  MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION,
   PLANNING_ONLY_RETRY_INSTRUCTION,
   REASONING_ONLY_RETRY_INSTRUCTION,
   resolveAckExecutionFastPathInstruction,
@@ -782,6 +788,219 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectWarnMessageWith("missing assistant terminal message detected");
     expectNoWarnMessageWith("empty response detected");
     expectNoWarnMessageWith("incomplete turn detected");
+  });
+
+  it("retries message-tool-only final answers that were only written privately", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    const sourceReplyMirrorPayload = setReplyPayloadMetadata(
+      { text: "Visible via message tool." },
+      {
+        deliverDespiteSourceReplySuppression: true,
+        sourceReplyTranscriptMirror: {
+          sessionKey: overflowBaseRunParams.sessionKey,
+          text: "Visible via message tool.",
+          idempotencyKey: "run-message-tool-only-private-final-retry:internal-source-reply:0",
+        },
+      },
+    );
+    mockedBuildEmbeddedRunPayloads.mockImplementation((params) =>
+      (params.messagingToolSourceReplyPayloads?.length ?? 0) > 0 ? [sourceReplyMirrorPayload] : [],
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Private final that the source channel will not receive."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            { type: "text", text: "Private final that the source channel will not receive." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Private final should stay private after message send."],
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["Visible via message tool."],
+        messagingToolSourceReplyPayloads: [{ text: "Visible via message tool." }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            { type: "text", text: "Private final should stay private after message send." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-private-final-retry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toContain(MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION);
+    expect(mockedBuildEmbeddedRunPayloads).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sourceReplyDeliveryMode: "message_tool_only",
+        messagingToolSourceReplyPayloads: [{ text: "Visible via message tool." }],
+      }),
+    );
+    expect(result.payloads).toHaveLength(1);
+    expect(result.payloads?.[0]).toMatchObject({ text: "Visible via message tool." });
+    expect(getReplyPayloadMetadata(result.payloads?.[0] as object)).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        sessionKey: overflowBaseRunParams.sessionKey,
+        text: "Visible via message tool.",
+        idempotencyKey: "run-message-tool-only-private-final-retry:internal-source-reply:0",
+      },
+    });
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["Visible via message tool."]);
+    expectWarnMessageWith("message-tool-only final reply was private");
+  });
+
+  it("surfaces a visible runtime error if message-tool-only final answers never call message", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        assistantTexts: ["Still private only."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "Still private only." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-private-final-exhausted",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("private final answer");
+  });
+
+  it("does not treat explicit-route message sends as source replies", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        assistantTexts: ["Private final for the current source."],
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["Sent elsewhere."],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "telegram",
+            to: "other-chat",
+            text: "Sent elsewhere.",
+          },
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "Private final for the current source." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-explicit-route-not-source",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("private final answer");
+  });
+
+  it("preserves planning-only retries before message-tool-only recovery", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            { type: "text", text: "I'll inspect the code, make the change, and run the checks." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Visible via message tool."],
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["Visible via message tool."],
+        messagingToolSourceReplyPayloads: [{ text: "Visible via message tool." }],
+      }),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      prompt: "Please inspect the code, make the change, and run the checks.",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-planning-first",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toContain(PLANNING_ONLY_RETRY_INSTRUCTION);
+    expect(secondCall.prompt).not.toContain(MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it("preserves NO_REPLY as silent in message-tool-only mode", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["NO_REPLY"],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "NO_REPLY" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runId: "run-message-tool-only-no-reply-silent",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expectNoWarnMessageWith("message-tool-only final reply was private");
   });
 
   it("retries zero-token empty Claude stop turns with a visible-answer continuation instruction", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1,8 +1,11 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  markReplyPayloadForSourceSuppressionDelivery,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { resolveStorePath, updateSessionStoreEntry } from "../../config/sessions.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import {
@@ -162,6 +165,7 @@ import {
 import {
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
+  MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION,
   resolveAckExecutionFastPathInstruction,
   resolveAttemptReplayMetadata,
   extractPlanningOnlyPlanDetails,
@@ -204,6 +208,8 @@ type ApiKeyInfo = ResolvedProviderAuth;
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 const EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS = 30_000;
+const MESSAGE_TOOL_ONLY_MISSING_REPLY_TEXT =
+  "⚠️ Agent wrote a private final answer instead of sending the source reply through the message tool. Please try again.";
 const MID_TURN_PRECHECK_CONTINUATION_PROMPT =
   "Continue from the current transcript after the latest tool result. Do not repeat the original user request, and do not rerun completed tools unless the transcript shows they are still needed.";
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
@@ -255,6 +261,62 @@ async function resetNoRealConversationTokenSnapshot(params: {
         `${params.sessionKey}: ${String(err)}`,
     );
   }
+}
+
+function hasVisibleReplyPayloadContent(payload: ReplyPayload): boolean {
+  return Boolean(
+    payload.text?.trim() ||
+    payload.mediaUrl?.trim() ||
+    (payload.mediaUrls?.length ?? 0) > 0 ||
+    payload.presentation ||
+    payload.interactive ||
+    payload.channelData,
+  );
+}
+
+function buildMessageToolOnlyMissingReplyPayload(): ReplyPayload {
+  return markReplyPayloadForSourceSuppressionDelivery({
+    text: MESSAGE_TOOL_ONLY_MISSING_REPLY_TEXT,
+    isError: true,
+  });
+}
+
+function hasMessageToolOnlySourceReplyEvidence(attempt: EmbeddedRunAttemptForRunner): boolean {
+  return (attempt.messagingToolSourceReplyPayloads ?? []).some(hasVisibleReplyPayloadContent);
+}
+
+function isVisiblePrivateFinalText(text: string | undefined): boolean {
+  return Boolean(text?.trim() && !isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN));
+}
+
+function hasPrivateFinalReplyText(params: {
+  attempt: EmbeddedRunAttemptForRunner;
+  finalAssistantVisibleText: string | undefined;
+  finalAssistantRawText: string | undefined;
+  payloads: ReplyPayload[] | undefined;
+}): boolean {
+  if ((params.attempt.assistantTexts ?? []).some(isVisiblePrivateFinalText)) {
+    return true;
+  }
+  if (
+    isVisiblePrivateFinalText(params.finalAssistantVisibleText) ||
+    isVisiblePrivateFinalText(params.finalAssistantRawText)
+  ) {
+    return true;
+  }
+  return (params.payloads ?? []).some(
+    (payload) =>
+      payload.isError !== true &&
+      payload.isReasoning !== true &&
+      (Boolean(
+        payload.text?.trim() && !isSilentReplyPayloadText(payload.text, SILENT_REPLY_TOKEN),
+      ) ||
+        Boolean(payload.mediaUrl?.trim()) ||
+        (payload.mediaUrls?.length ?? 0) > 0 ||
+        Boolean(payload.presentation) ||
+        Boolean(payload.interactive) ||
+        Boolean(payload.channelData)),
+  );
 }
 
 function resolveAttemptDispatchApiKey(params: {
@@ -1200,6 +1262,7 @@ export async function runEmbeddedAgent(
       let planningOnlyRetryInstruction: string | null = null;
       let reasoningOnlyRetryInstruction: string | null = null;
       let emptyResponseRetryInstruction: string | null = null;
+      let messageToolOnlyRetryInstruction: string | null = null;
       let compactionContinuationRetryInstruction: string | null = null;
       let nextAttemptPromptOverride: string | null = null;
       const ackExecutionFastPathInstruction = resolveAckExecutionFastPathInstruction({
@@ -1216,9 +1279,11 @@ export async function runEmbeddedAgent(
       // for errored turns; stopReason="stop" empty zero-token turns use the
       // visible-answer retry instruction instead.
       const MAX_EMPTY_ERROR_RETRIES = 3;
+      const MAX_MESSAGE_TOOL_ONLY_RETRIES = 1;
       let emptyErrorRetries = 0;
       const MAX_MISSING_ASSISTANT_RETRIES = 1;
       let missingAssistantRetryAttempts = 0;
+      let messageToolOnlyRetries = 0;
       const overloadFailoverBackoffMs = resolveOverloadFailoverBackoffMs(params.config);
       const overloadProfileRotationLimit = resolveOverloadProfileRotationLimit(params.config);
       const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit(params.config);
@@ -1469,6 +1534,7 @@ export async function runEmbeddedAgent(
             planningOnlyRetryInstruction,
             reasoningOnlyRetryInstruction,
             emptyResponseRetryInstruction,
+            messageToolOnlyRetryInstruction,
             compactionContinuationRetryInstruction,
           ].filter(
             (value): value is string => typeof value === "string" && value.trim().length > 0,
@@ -3266,6 +3332,76 @@ export async function runEmbeddedAgent(
               acceptedSessionSpawns: attempt.acceptedSessionSpawns,
             };
           }
+          const messageToolOnlyMissingSourceReply =
+            params.sourceReplyDeliveryMode === "message_tool_only" &&
+            !aborted &&
+            !timedOut &&
+            !attempt.didSendDeterministicApprovalPrompt &&
+            !hasMessageToolOnlySourceReplyEvidence(attempt) &&
+            hasPrivateFinalReplyText({
+              attempt,
+              finalAssistantVisibleText,
+              finalAssistantRawText,
+              payloads: payloadsWithToolMedia,
+            });
+          if (messageToolOnlyMissingSourceReply) {
+            const replayMetadata = resolveAttemptReplayMetadata(attempt);
+            if (
+              replayMetadata.replaySafe &&
+              messageToolOnlyRetries < MAX_MESSAGE_TOOL_ONLY_RETRIES
+            ) {
+              messageToolOnlyRetries += 1;
+              messageToolOnlyRetryInstruction = MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION;
+              log.warn(
+                `message-tool-only final reply was private: runId=${params.runId} sessionId=${params.sessionId} ` +
+                  `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ` +
+                  `${messageToolOnlyRetries}/${MAX_MESSAGE_TOOL_ONLY_RETRIES} with message-tool delivery steer`,
+              );
+              continue;
+            }
+
+            const replayInvalid = resolveReplayInvalidForAttempt(
+              MESSAGE_TOOL_ONLY_MISSING_REPLY_TEXT,
+            );
+            const livenessState = resolveRunLivenessState({
+              payloadCount: 0,
+              aborted,
+              timedOut,
+              attempt,
+              incompleteTurnText: MESSAGE_TOOL_ONLY_MISSING_REPLY_TEXT,
+            });
+            attempt.setTerminalLifecycleMeta?.({
+              replayInvalid,
+              livenessState,
+            });
+            return {
+              payloads: [buildMessageToolOnlyMissingReplyPayload()],
+              meta: {
+                durationMs: Date.now() - started,
+                agentMeta,
+                aborted,
+                systemPromptReport: attempt.systemPromptReport,
+                finalPromptText: attempt.finalPromptText,
+                finalAssistantVisibleText,
+                finalAssistantRawText,
+                replayInvalid,
+                livenessState,
+                toolSummary: attemptToolSummary,
+                ...(failureSignal ? { failureSignal } : {}),
+                agentHarnessResultClassification: attempt.agentHarnessResultClassification,
+              },
+              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+              messagingToolSentTexts: attempt.messagingToolSentTexts,
+              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+              messagingToolSentTargets: attempt.messagingToolSentTargets,
+              messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
+              heartbeatToolResponse: attempt.heartbeatToolResponse,
+              successfulCronAdds: attempt.successfulCronAdds,
+              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
+            };
+          }
+          messageToolOnlyRetryInstruction = null;
           if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
             const replayInvalid = resolveReplayInvalidForAttempt(
               "⚠️ Agent couldn't generate a response. Please try again.",

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -207,6 +207,8 @@ export const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
+export const MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION =
+  "The previous assistant turn wrote the visible reply in the private final answer. This source conversation is message-tool-only: send the user-visible answer now with message(action=send). Do not repeat completed work or put the answer only in final.";
 export const ACK_EXECUTION_FAST_PATH_INSTRUCTION =
   "The latest user message is a short approval to proceed. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
 export const STRICT_AGENTIC_BLOCKED_TEXT =

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -947,6 +947,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("use `message(action=send)` for visible source-channel output");
+    expect(prompt).toContain("Final-only answers are private in this mode");
     expect(prompt).toContain("Attach media with message-tool attachment fields");
     expect(prompt).not.toContain("Attach media: `MEDIA:<path-or-url>`");
     expect(prompt).toContain("The target defaults to the current source channel");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -503,6 +503,9 @@ function buildMessagingSection(params: {
     messageToolOnly
       ? "- Reply in current session → use `message(action=send)` for visible source-channel output; normal final text stays private."
       : "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",
+    messageToolOnly
+      ? "- Final-only answers are private in this mode. If the current user should see the answer, send it with `message(action=send)` before ending the turn."
+      : "",
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
     subagentOrchestrationGuidance,
     completionEventGuidance,


### PR DESCRIPTION
## Summary

- Recover `message_tool_only` turns where the assistant wrote the source reply only as private final text.
- Retry once with an explicit `message(action="send")` steer when the current source reply is missing.
- If the retry still does not produce current-source delivery evidence, return a visible runtime error payload instead of leaving the source chat silent.
- Preserve existing planning-only retry behavior and deliberate `NO_REPLY` silence.

## Problem

In `message_tool_only` delivery mode, private final text is not delivered to the source conversation. Before this change, an agent could produce the user-facing answer as private final text and the source channel would appear stuck.

The fix must not treat unrelated message sends as success. A message sent to another explicit target or session does not prove the current source conversation was answered.

## Fix

- Add a `message_tool_only` missing-source-reply recovery path in `runEmbeddedAgent`.
- Require current-source reply evidence via `messagingToolSourceReplyPayloads` before suppressing recovery.
- Add one replay-safe retry with `MESSAGE_TOOL_ONLY_RETRY_INSTRUCTION`.
- Add a source-suppressed visible error payload when retry is unavailable or exhausted.
- Clarify the system prompt so final-only answers are explicitly described as private in `message_tool_only` mode.

## Guardrails

- Explicit-route or cross-session `message` sends do not count as current-source replies.
- Planning-only turns still take the existing planning retry path before message-tool-only recovery.
- `NO_REPLY` remains silent and does not trigger retry/error recovery.
- Private final text is not republished as a source reply; the agent must use the message tool.

## Real behavior proof

**Behavior or issue addressed:** A `message_tool_only` source chat must not stay silent when the assistant only writes private final text. The runtime retries once with a message-tool delivery instruction and then surfaces a visible error if the source reply still was not sent.

**Real environment tested:** Local OpenClaw repository worktree on Ubuntu, using the repo's actual Node/Corepack/pnpm validation path against the runner implementation and prompt snapshot contract.

**Exact steps or command run after this patch:**

```console
$ corepack pnpm format:check -- src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/incomplete-turn.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts
All matched files use the correct format.

$ corepack pnpm test:changed -- src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.test.ts
Test Files 2 passed (2)
Tests 196 passed (196)

$ corepack pnpm prompt:snapshots:check
Prompt snapshots are current (7 files).

$ CI=1 corepack pnpm check:changed -- src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/incomplete-turn.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts
$ node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/incomplete-turn.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts
[check:changed] lanes=core, coreTests
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
(exit 0)
```

**Evidence after fix:** Terminal output above from the patched worktree. The regression tests exercise the source-channel failure mode directly: private-final-only retries, exhausted retry returns visible error, explicit-route sends do not count as source replies, planning-only retry wins first, and `NO_REPLY` stays silent.

**Observed result after fix:** The patched runner no longer treats broad message-tool delivery evidence as proof of source delivery, preserves existing silent/planning paths, and passes the targeted runner tests plus full changed-file validation.

**What was not tested:** Native Telegram Desktop visual proof was not captured in this PR body. The repository's Mantis Telegram proof job attempted that path separately but failed before Desktop start because the Crabbox/AWS capture environment could not launch, not because this patch's runner checks failed.

## Validation

- `corepack pnpm format:check -- src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/incomplete-turn.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts`
- `corepack pnpm test:changed -- src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.test.ts`
- `corepack pnpm prompt:snapshots:check`
- `CI=1 corepack pnpm check:changed -- src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/incomplete-turn.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts`

## Replaces

Replaces #87455 with a smaller branch focused on the original runtime failure, while keeping the relevant guard coverage that ClawSweeper flagged on the first version of this replacement PR.