### PR TITLE
fix(daemon): preserve explicit systemd unit during refresh

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -685,6 +685,33 @@ describe("buildServiceEnvironment", () => {
     }
   });
 
+  it("preserves explicit systemd unit overrides", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        OPENCLAW_PROFILE: "work",
+        OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-maintenance",
+      },
+      port: 18789,
+      platform: "linux",
+    });
+
+    expect(env.OPENCLAW_SYSTEMD_UNIT).toBe("openclaw-gateway-maintenance.service");
+  });
+
+  it("preserves explicit systemd unit overrides with service suffix", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-maintenance.service",
+      },
+      port: 18789,
+      platform: "linux",
+    });
+
+    expect(env.OPENCLAW_SYSTEMD_UNIT).toBe("openclaw-gateway-maintenance.service");
+  });
+
   it("sets a profile-specific launchd marker for macOS gateway services", () => {
     const env = buildServiceEnvironment({
       env: { HOME: "/Users/user", OPENCLAW_PROFILE: "work" },

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -391,6 +391,14 @@ export function buildMinimalServicePath(options: BuildServicePathOptions = {}): 
   return getMinimalServicePathPartsFromEnv({ ...options, env }).join(path.posix.delimiter);
 }
 
+function resolveGatewaySystemdUnitEnv(env: Record<string, string | undefined>): string {
+  const override = normalizeOptionalString(env.OPENCLAW_SYSTEMD_UNIT);
+  if (override) {
+    return override.endsWith(".service") ? override : `${override}.service`;
+  }
+  return `${resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
+}
+
 export function buildServiceEnvironment(params: {
   env: Record<string, string | undefined>;
   port: number;
@@ -411,7 +419,7 @@ export function buildServiceEnvironment(params: {
   const wrapperPath = normalizeOptionalString(env.OPENCLAW_WRAPPER);
   const resolvedLaunchdLabel =
     launchdLabel || (platform === "darwin" ? resolveGatewayLaunchAgentLabel(profile) : undefined);
-  const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
+  const systemdUnit = resolveGatewaySystemdUnitEnv(env);
   return {
     ...buildCommonServiceEnvironment(env, sharedEnv),
     OPENCLAW_PROFILE: profile,

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -112,6 +112,32 @@ describe("readGatewayServiceState", () => {
     expect(state.running).toBe(true);
     expect(state.env.OPENCLAW_GATEWAY_PORT).toBe("18789");
   });
+
+  it("keeps the caller-selected service identity when merging persisted env", async () => {
+    const readRuntime = vi.fn(async () => ({ status: "running" }));
+    const service = createService({
+      isLoaded: vi.fn(async () => true),
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "run"],
+        environment: {
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service",
+        },
+      })),
+      readRuntime,
+    });
+
+    const state = await readGatewayServiceState(service, {
+      env: { OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-maintenance.service" },
+    });
+
+    expect(state.env.OPENCLAW_SYSTEMD_UNIT).toBe("openclaw-gateway-maintenance.service");
+    expect(readRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-maintenance.service",
+      }),
+    );
+  });
 });
 
 describe("startGatewayService", () => {

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -91,10 +91,21 @@ function mergeGatewayServiceEnv(
   if (!command?.environment) {
     return baseEnv;
   }
-  return {
+  const merged = {
     ...baseEnv,
     ...command.environment,
   };
+  for (const key of [
+    "OPENCLAW_LAUNCHD_LABEL",
+    "OPENCLAW_SYSTEMD_UNIT",
+    "OPENCLAW_WINDOWS_TASK_NAME",
+  ]) {
+    const value = baseEnv[key]?.trim();
+    if (value) {
+      merged[key] = value;
+    }
+  }
+  return merged;
 }
 
 const TEMP_PROGRAM_ROOTS = [os.tmpdir(), "/tmp", "/private/tmp", "/var/tmp"].map((entry) =>


### PR DESCRIPTION
## Summary

- preserve explicit `OPENCLAW_SYSTEMD_UNIT` values when rendering the managed gateway service environment
- keep caller-selected service identity env (`OPENCLAW_SYSTEMD_UNIT`, launchd label, Windows task name) ahead of stale persisted service env during service-state inspection
- add regression coverage for explicit systemd unit preservation and stale persisted-unit merge behavior

Fixes #87490

## Verification

- `node scripts/run-vitest.mjs src/daemon/service-env.test.ts src/daemon/service.test.ts src/cli/update-cli.test.ts src/cli/update-cli/restart-helper.test.ts src/cli/daemon-cli/install.test.ts src/daemon/systemd.test.ts` (6 files / 347 tests passed)
- `git diff --check`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`

## Real behavior proof

Behavior addressed: package/update refresh can keep using the explicitly selected systemd unit instead of drifting back to `openclaw-gateway.service` from a stale persisted service environment.
Real environment tested: local source checkout running the real OpenClaw TypeScript service-env/state code with Node 24 on macOS; the probe used Linux service-env rendering inputs for the systemd unit behavior.
Exact steps or command run after this patch: ran `node --import tsx --input-type=module` to render a Linux gateway service env with `OPENCLAW_SYSTEMD_UNIT=openclaw-gateway-maintenance.service`, then read gateway service state from an existing unit command whose persisted env still contained `OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service`.
Evidence after fix: terminal output from the behavior probe was:

```json
{
  "renderedSystemdUnit": "openclaw-gateway-maintenance.service",
  "mergedSystemdUnit": "openclaw-gateway-maintenance.service",
  "runtimeSystemdUnit": "openclaw-gateway-maintenance.service"
}
```

Observed result after fix: both rendered service env and post-inspection runtime env retained the selected `openclaw-gateway-maintenance.service` unit despite the stale persisted default unit.
What was not tested: a live Linux `systemctl --user` package-update smoke, because Blacksmith/Testbox required `blacksmith auth login` and local Docker was unavailable in this environment.

If maintainers squash or rework this PR, please preserve author attribution or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
