### PR TITLE
fix(auth): harden Codex auth probes

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -781,17 +781,26 @@ export async function runEmbeddedAgent(
         pluginHarnessOwnsTransport &&
         provider === OPENAI_CODEX_PROVIDER_ID &&
         effectiveModel.api === "openai-codex-responses";
+      const openClawNativeCodexResponsesNeedsAuthBootstrap =
+        !pluginHarnessOwnsTransport &&
+        provider === OPENAI_CODEX_PROVIDER_ID &&
+        effectiveModel.api === "openai-codex-responses";
       let piExternalCliAuthScope = pluginHarnessOwnsTransport
         ? { ignoreAutoPreferredProfile: false }
-        : resolveExternalCliAuthOverlayScopeFromSelection({
-            provider,
-            cfg: params.config,
-            agentId: params.agentId,
-            modelId,
-            workspaceDir: resolvedWorkspace,
-            userLockedAuthProfileId:
-              params.authProfileIdSource === "user" ? params.authProfileId : undefined,
-          });
+        : openClawNativeCodexResponsesNeedsAuthBootstrap
+          ? {
+              providerIds: [OPENAI_CODEX_PROVIDER_ID],
+              ignoreAutoPreferredProfile: false,
+            }
+          : resolveExternalCliAuthOverlayScopeFromSelection({
+              provider,
+              cfg: params.config,
+              agentId: params.agentId,
+              modelId,
+              workspaceDir: resolvedWorkspace,
+              userLockedAuthProfileId:
+                params.authProfileIdSource === "user" ? params.authProfileId : undefined,
+            });
       let noExternalAuthStore: AuthProfileStore | undefined;
       if (
         !pluginHarnessOwnsTransport &&

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2293,6 +2293,65 @@ describe("openai transport stream", () => {
     expect(params.prompt_cache_key).toBeUndefined();
   });
 
+  it("adds fallback instructions for raw native Codex responses probes", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: "",
+        messages: [{ role: "user", content: "Reply OK", timestamp: 1 }],
+        tools: [],
+      } as never,
+      {
+        maxTokens: 16,
+        sessionId: "session-123",
+      },
+    ) as Record<string, unknown>;
+
+    expect(params.instructions).toBe("Follow the user request.");
+    expect(params.max_output_tokens).toBeUndefined();
+    expect(params.prompt_cache_retention).toBeUndefined();
+  });
+
+  it("does not add fallback instructions for custom Codex-compatible responses backends", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://proxy.example.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: "",
+        messages: [{ role: "user", content: "Reply OK", timestamp: 1 }],
+        tools: [],
+      } as never,
+      {
+        maxTokens: 16,
+        sessionId: "session-123",
+      },
+    ) as Record<string, unknown>;
+
+    expect(params.instructions).toBeUndefined();
+    expect(params.max_output_tokens).toBe(16);
+  });
+
   it("uses top-level instructions for Codex responses and preserves prompt cache identity", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -79,6 +79,7 @@ import {
 
 const DEFAULT_AZURE_OPENAI_API_VERSION = "preview";
 const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
+const OPENAI_CODEX_RESPONSES_DEFAULT_INSTRUCTIONS = "Follow the user request.";
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
 const AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS = 30_000;
 const MODEL_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
@@ -1992,6 +1993,19 @@ function buildOpenAICodexResponsesInstructions(context: Context): string | undef
   return sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt));
 }
 
+function resolveOpenAICodexResponsesInstructions(
+  model: Model,
+  context: Context,
+): string | undefined {
+  const instructions = buildOpenAICodexResponsesInstructions(context);
+  if (instructions && instructions.trim().length > 0) {
+    return instructions;
+  }
+  return usesNativeOpenAICodexResponsesBackend(model)
+    ? OPENAI_CODEX_RESPONSES_DEFAULT_INSTRUCTIONS
+    : undefined;
+}
+
 function ensureOpenAICodexResponsesInput(messages: ResponseInput, context: Context): void {
   if (messages.length > 0 || !context.systemPrompt) {
     return;
@@ -2063,7 +2077,9 @@ export function buildOpenAIResponsesParams(
     stream: true,
     prompt_cache_key: promptCacheKey,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
-    ...(isCodexResponses ? { instructions: buildOpenAICodexResponsesInstructions(context) } : {}),
+    ...(isCodexResponses
+      ? { instructions: resolveOpenAICodexResponsesInstructions(model, context) }
+      : {}),
     ...(metadata ? { metadata } : {}),
   };
   const effectiveMaxTokens = options?.maxTokens || model.maxTokens;

--- a/src/commands/models/list.probe.test.ts
+++ b/src/commands/models/list.probe.test.ts
@@ -38,3 +38,75 @@ describe("mapFailoverReasonToProbeStatus", () => {
     expect(mapFailoverReasonToProbeStatus("something_else")).toBe("unknown");
   });
 });
+
+describe("runAuthProbes", () => {
+  it("runs Codex auth probes through raw OpenClaw model-run mode", async () => {
+    const runEmbeddedAgent = vi.fn(async () => ({ text: "OK" }));
+    vi.doMock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent }));
+    vi.doMock("../../agents/auth-profiles.js", () => ({
+      externalCliDiscoveryScoped: () => undefined,
+      ensureAuthProfileStore: () => ({
+        version: 1,
+        profiles: {
+          "openai-codex:profile": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+        order: {},
+      }),
+      listProfilesForProvider: () => ["openai-codex:profile"],
+      resolveAuthProfileDisplayLabel: ({ profileId }: { profileId: string }) => profileId,
+      resolveAuthProfileEligibility: () => ({ eligible: true }),
+      resolveAuthProfileOrder: () => ["openai-codex:profile"],
+    }));
+    vi.doMock("../../agents/model-auth.js", () => ({
+      hasUsableCustomProviderApiKey: () => false,
+      resolveEnvApiKey: () => null,
+    }));
+    vi.doMock("../../agents/model-catalog.js", () => ({
+      loadModelCatalog: async () => [{ provider: "openai-codex", id: "gpt-5.5" }],
+    }));
+    try {
+      const module = await importFreshModule<typeof import("./list.probe.js")>(
+        import.meta.url,
+        `./list.probe.js?scope=${Math.random().toString(36).slice(2)}`,
+      );
+      const result = await module.runAuthProbes({
+        cfg: {} as never,
+        agentId: "probe-agent",
+        agentDir: "/tmp/openclaw-probe-agent",
+        workspaceDir: "/tmp/openclaw-probe-workspace",
+        providers: ["openai-codex"],
+        modelCandidates: ["openai-codex/gpt-5.5"],
+        options: {
+          provider: "openai-codex",
+          profileIds: ["openai-codex:profile"],
+          timeoutMs: 5_000,
+          concurrency: 1,
+          maxTokens: 8,
+        },
+      });
+
+      expect(result.results[0]?.status).toBe("ok");
+      expect(runEmbeddedAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentHarnessId: "openclaw",
+          agentHarnessRuntimeOverride: "openclaw",
+          modelRun: true,
+          disableTools: true,
+          authProfileId: "openai-codex:profile",
+          authProfileIdSource: "user",
+        }),
+      );
+    } finally {
+      vi.doUnmock("../../agents/embedded-agent.js");
+      vi.doUnmock("../../agents/auth-profiles.js");
+      vi.doUnmock("../../agents/model-auth.js");
+      vi.doUnmock("../../agents/model-catalog.js");
+    }
+  });
+});

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -522,6 +522,9 @@ async function probeTarget(params: {
       model: target.model.model,
       authProfileId: target.profileId,
       authProfileIdSource: target.profileId ? "user" : undefined,
+      ...(target.provider === "openai-codex"
+        ? { agentHarnessId: "openclaw", agentHarnessRuntimeOverride: "openclaw" }
+        : {}),
       timeoutMs,
       runId: `probe-${crypto.randomUUID()}`,
       lane: `auth-probe:${target.provider}:${target.profileId ?? target.source}`,
@@ -530,6 +533,7 @@ async function probeTarget(params: {
       verboseLevel: "off",
       streamParams: { maxTokens },
       disableTools: true,
+      modelRun: true,
       cleanupBundleMcpOnRunEnd: true,
     });
     return buildResult("ok");


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Makes `models status --probe --probe-provider openai-codex --probe-profile <id>` run as a raw OpenClaw model probe with the selected OAuth profile instead of inheriting the normal Codex harness/session path.
- Ensures native Codex Responses probe payloads still send non-empty instructions when raw probe mode suppresses the normal system prompt.
- Keeps the change narrow: no stream-resolution changes, no config/schema changes, no generated output.

Why does this matter now?

The auth probe is meant to answer whether a selected profile can complete a minimal model round-trip. If the probe runs through the normal session harness or sends an empty native Responses instruction field, it can fail or exercise a different path than the status command is trying to validate.

What is the intended outcome?

A selected `openai-codex` OAuth profile can be probed through the built-in OpenClaw model-run path, while native Codex Responses receives a small default instruction only when the raw probe would otherwise produce no instructions.

What is intentionally out of scope?

- Existing session continuation and stream-resolution ownership.
- General provider discovery or credential-store migration behavior.
- Non-native/custom Codex-compatible Responses backends.

What does success look like?

The CLI probe reports `status: "ok"` for the selected profile, focused regression tests cover the call shape and payload fallback, and existing stream-resolution tests continue to pass.

What should reviewers focus on?

The runtime/auth fields passed by the probe (`agentHarnessRuntimeOverride`, `modelRun`, `authProfileId`) and the native-only scoping of the default instructions fallback.

## Linked context

Which issue does this close?

Does not close an issue.

Which issues, PRs, or discussions are related?

Related #75272. This branch is a current-main narrow implementation for the auth-probe path and intentionally avoids changing stream resolution.

Was this requested by a maintainer or owner?

No maintainer request.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:

`models status --probe` for a selected `openai-codex` OAuth profile should exercise a raw OpenClaw model-run probe and complete a minimal round-trip.

- Real environment tested:

Local synthetic-current-main checkout: this patch applied cleanly on top of `upstream/main` `bd6a404aa32357c21d6588a35b18e1034fe4b610` at proof time, using an existing local OAuth profile and a minimal config file at `/tmp/openclaw-empty-config.json` to avoid unrelated legacy config fields. Final pre-push fetch later moved `upstream/main` to `05f357b13bb348f408b9a13a84e675ffe5dbd38f`; the branch still had zero touched-file overlap with base changes and `git merge-tree --write-tree upstream/main HEAD` was clean.

- Exact steps or command run after this patch:

```bash
OPENCLAW_CONFIG_PATH=/tmp/openclaw-empty-config.json \
  node --import tsx src/entry.ts models status \
    --agent main \
    --probe \
    --probe-provider openai-codex \
    --probe-profile openai-codex:default \
    --probe-timeout 90000 \
    --probe-max-tokens 16 \
    --json
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Terminal capture from the synthetic-current-main checkout, copied live output with secrets redacted and only the public-safe probe result included:

```text
exit 0
duration_s 88.61
stdout_bytes 6802
stderr_bytes 77
stdout_prefix_lines ['[agents/auth-profiles] using external OAuth credential after refresh [REDACTED]']
probe_summary.results[0]:
{
  "provider": "openai-codex",
  "model": "openai-codex/gpt-5.4",
  "profileId": "openai-codex:default",
  "label": "openai-codex:default",
  "source": "profile",
  "mode": "oauth",
  "status": "ok",
  "latencyMs": 12958
}
proof_ok True
```

- Observed result after fix:

The command exited 0 and the parsed probe result for `openai-codex:default` reported `status: "ok"` on a checkout with this patch applied to `upstream/main` at proof time. The later final pre-push fresh-base check found no touched-file overlap and a clean merge-tree against `05f357b13bb348f408b9a13a84e675ffe5dbd38f`.

- What was not tested:

I did not test every provider profile combination, expired/invalid OAuth recovery, or hosted CI before opening. The real run used one local `openai-codex:default` OAuth profile.

- Proof limitations or environment constraints:

The local raw stdout also contained one auth-profile refresh warning before the JSON object, so the evidence above is the sanitized terminal summary and probe-result excerpt rather than the full raw status output. The warning was unrelated to this patch and the parsed probe result completed successfully.

- Before evidence (optional but encouraged):

Before the patch, focused RED checks showed the raw Codex Responses payload could have `instructions === undefined`, and the probe runner did not pass raw model-run/runtime override fields for the `openai-codex` probe path.

## Tests and validation

Which commands did you run?

```bash
git diff --check -- src/commands/models/list.probe.ts src/commands/models/list.probe.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts
node_modules/.bin/oxfmt --check src/commands/models/list.probe.ts src/commands/models/list.probe.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts
node scripts/run-vitest.mjs src/commands/models/list.probe.test.ts src/agents/openai-transport-stream.test.ts src/agents/embedded-agent-runner/stream-resolution.test.ts --root /tmp/openclaw-codex-auth-probe-20260528135601
node scripts/run-vitest.mjs src/agents/harness/selection.test.ts src/agents/harness/runtime-plugin.test.ts --root /tmp/openclaw-codex-auth-probe-20260528135601

# Additional drift proof on upstream/main at proof time (bd6a404aa3) with this patch applied:
git apply --check /tmp/openclaw-codex-auth-probe-current-main.patch
git diff --check --cached -- src/commands/models/list.probe.ts src/commands/models/list.probe.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts
node_modules/.bin/oxfmt --check src/commands/models/list.probe.ts src/commands/models/list.probe.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts
node scripts/run-vitest.mjs src/commands/models/list.probe.test.ts src/agents/openai-transport-stream.test.ts src/agents/embedded-agent-runner/stream-resolution.test.ts --root /tmp/openclaw-codex-auth-probe-mergeproof-20260528150011
node scripts/run-vitest.mjs src/agents/harness/selection.test.ts src/agents/harness/runtime-plugin.test.ts --root /tmp/openclaw-codex-auth-probe-mergeproof-20260528150011
```

What regression coverage was added or updated?

- `list.probe.test.ts` now asserts the selected `openai-codex` profile is forwarded with raw OpenClaw model-run fields.
- `openai-transport-stream.test.ts` covers native fallback instructions and confirms custom/proxy Codex-compatible Responses backends are not changed.

What failed before this fix, if known?

The new focused checks failed before the production changes: the probe call lacked the raw model-run/runtime override fields, and the native raw Responses payload had no instructions.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, for `models status --probe` when probing selected `openai-codex` profiles.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, auth probe execution now pins the built-in runtime path and preserves the selected OAuth profile explicitly. It does not add new credential storage or logging.

What is the highest-risk area?

Accidentally changing normal Codex session stream ownership or applying the fallback instructions to custom/proxy backends.

How is that risk mitigated?

The patch does not touch `stream-resolution.ts`; existing stream-resolution tests still pass. The fallback instructions are gated by native backend detection, with a regression test proving custom/proxy backends still omit the fallback.

## Current review state

What is the next action?

Maintainer review and CI after the PR is opened.

What is still waiting on author, maintainer, CI, or external proof?

No known author-side code blocker. CI has not run on this branch yet; local drift proof applied this patch to `upstream/main` at proof time and reran the focused checks plus real CLI probe. Final pre-push fresh-base check against `05f357b13bb348f408b9a13a84e675ffe5dbd38f` had zero touched-file overlap and a clean merge-tree.

Which bot or reviewer comments were addressed?

No comments on this PR yet.
