### PR TITLE
fix(agents): isolate RTL lines on outbound assistant text

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -919,4 +919,43 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
       "🛠️ run git status",
     );
   });
+
+  // Regression for #68105: outbound delivery surfaces (Discord/Slack/Telegram/
+  // WhatsApp) receive assistant text without bidi isolation, so RTL lines that
+  // end with LTR punctuation render with the punctuation on the wrong visual
+  // side. The delivery profile now applies line-level RTL isolation; storage
+  // and runtime profiles still pass through unchanged so transcripts and
+  // internal inspection paths stay byte-for-byte with the model output.
+  describe("RTL bidi isolation on outbound delivery", () => {
+    const RLI = "\u2067";
+    const PDI = "\u2069";
+
+    it("wraps Hebrew lines on the delivery profile so trailing punctuation visually trails", () => {
+      const input = "שלום?";
+      expect(sanitizeAssistantVisibleText(input)).toBe(`${RLI}${input}${PDI}`);
+    });
+
+    it("wraps Arabic lines on the delivery profile and leaves LTR-only lines untouched", () => {
+      const input = ["مرحبا!", "Hello there.", "كيف حالك؟"].join("\n");
+      const expected = [`${RLI}مرحبا!${PDI}`, "Hello there.", `${RLI}كيف حالك؟${PDI}`].join("\n");
+      expect(sanitizeAssistantVisibleText(input)).toBe(expected);
+    });
+
+    it("does not wrap RTL lines on the history profile (transcript storage stays byte-clean)", () => {
+      const input = "שלום?";
+      expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe(input);
+    });
+
+    it("does not wrap RTL lines on the internal-scaffolding profile", () => {
+      const input = "שלום?";
+      expect(sanitizeAssistantVisibleTextWithProfile(input, "internal-scaffolding")).toBe(input);
+    });
+
+    it("is idempotent on the delivery profile (already-isolated text is not re-wrapped)", () => {
+      const input = "שלום?";
+      const once = sanitizeAssistantVisibleText(input);
+      const twice = sanitizeAssistantVisibleText(once);
+      expect(twice).toBe(once);
+    });
+  });
 });

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -2,12 +2,14 @@
 import { describe, expect, it } from "vitest";
 import {
   sanitizeAssistantVisibleText,
+  sanitizeAssistantVisibleTextWithOptions,
   sanitizeAssistantVisibleTextWithProfile,
   stripAssistantInternalScaffolding,
   stripMinimaxToolCallXml,
   stripToolCallXmlTags,
 } from "./assistant-visible-text.js";
 import { stripModelSpecialTokens } from "./model-special-tokens.js";
+import { RTL_ISOLATION_MARKERS } from "./rtl-isolation.js";
 
 describe("stripAssistantInternalScaffolding", () => {
   function expectVisibleText(input: string, expected: string) {
@@ -927,8 +929,7 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
   // and runtime profiles still pass through unchanged so transcripts and
   // internal inspection paths stay byte-for-byte with the model output.
   describe("RTL bidi isolation on outbound delivery", () => {
-    const RLI = "\u2067";
-    const PDI = "\u2069";
+    const { start: RLI, end: PDI } = RTL_ISOLATION_MARKERS;
 
     it("wraps Hebrew lines on the delivery profile so trailing punctuation visually trails", () => {
       const input = "שלום?";
@@ -944,6 +945,11 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
     it("does not wrap RTL lines on the history profile (transcript storage stays byte-clean)", () => {
       const input = "שלום?";
       expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe(input);
+    });
+
+    it("does not wrap RTL lines through the legacy trim-none history wrapper", () => {
+      const input = "שלום?";
+      expect(sanitizeAssistantVisibleTextWithOptions(input, { trim: "none" })).toBe(input);
     });
 
     it("does not wrap RTL lines on the internal-scaffolding profile", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -942,6 +942,16 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
       expect(sanitizeAssistantVisibleText(input)).toBe(expected);
     });
 
+    it("does not wrap RTL examples inside fenced code blocks on the delivery profile", () => {
+      const input = ["Example:", "```text", "שלום?", "```"].join("\n");
+      expect(sanitizeAssistantVisibleText(input)).toBe(input);
+    });
+
+    it("does not wrap lines where RTL appears only inside inline code on the delivery profile", () => {
+      const input = "Use `שלום?` as the example.";
+      expect(sanitizeAssistantVisibleText(input)).toBe(input);
+    });
+
     it("does not wrap RTL lines on the history profile (transcript storage stays byte-clean)", () => {
       const input = "שלום?";
       expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe(input);

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -8,6 +8,7 @@ import {
   type ReasoningTagMode,
   type ReasoningTagTrim,
 } from "./reasoning-tags.js";
+import { applyRtlIsolation } from "./rtl-isolation.js";
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
@@ -815,6 +816,14 @@ type AssistantVisibleTextPipelineOptions = {
   reasoningMode: ReasoningTagMode;
   reasoningTrim: ReasoningTagTrim;
   stageOrder: "reasoning-first" | "reasoning-last";
+  /**
+   * Apply Unicode bidi isolation to RTL-script lines as the final stage so
+   * trailing LTR punctuation renders on the correct side on Discord/Slack/
+   * Telegram/WhatsApp. Only enabled for the delivery profile because history
+   * and internal-scaffolding pipelines feed transcript storage and runtime
+   * inspection paths that should stay byte-for-byte with the model output.
+   */
+  applyRtlIsolation?: boolean;
 };
 
 const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
@@ -827,6 +836,7 @@ const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
     reasoningMode: "strict",
     reasoningTrim: "both",
     stageOrder: "reasoning-last",
+    applyRtlIsolation: true,
   },
   history: {
     finalTrim: "none",
@@ -896,11 +906,12 @@ function applyAssistantVisibleTextStagePipeline(
     return cleaned;
   };
 
-  if (options.stageOrder === "reasoning-first") {
-    return applyFinalTrim(stripNonReasoningStages(stripReasoning(text)));
-  }
+  const trimmed =
+    options.stageOrder === "reasoning-first"
+      ? applyFinalTrim(stripNonReasoningStages(stripReasoning(text)))
+      : applyFinalTrim(stripReasoning(stripNonReasoningStages(text)));
 
-  return applyFinalTrim(stripReasoning(stripNonReasoningStages(text)));
+  return options.applyRtlIsolation ? applyRtlIsolation(trimmed) : trimmed;
 }
 
 export function sanitizeAssistantVisibleTextWithProfile(

--- a/src/shared/text/rtl-isolation.test.ts
+++ b/src/shared/text/rtl-isolation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { RTL_ISOLATION_MARKERS, RTL_ISOLATION_REGEX, applyRtlIsolation } from "./rtl-isolation.js";
+
+const { start: RLI, end: PDI } = RTL_ISOLATION_MARKERS;
+
+describe("applyRtlIsolation", () => {
+  it("returns input unchanged when no RTL-script characters are present", () => {
+    expect(applyRtlIsolation("Hello, world!")).toBe("Hello, world!");
+  });
+
+  it("wraps a single Hebrew line so trailing LTR punctuation stays on the visual right", () => {
+    const input = "שלום?";
+    const expected = `${RLI}${input}${PDI}`;
+    expect(applyRtlIsolation(input)).toBe(expected);
+  });
+
+  it("wraps Arabic lines line-by-line and leaves LTR-only lines untouched", () => {
+    const input = ["مرحبا!", "English line.", "كيف حالك؟"].join("\n");
+    const expected = [`${RLI}مرحبا!${PDI}`, "English line.", `${RLI}كيف حالك؟${PDI}`].join("\n");
+    expect(applyRtlIsolation(input)).toBe(expected);
+  });
+
+  it("is idempotent: re-wrapping already-isolated text is a no-op", () => {
+    const input = "שלום?";
+    const once = applyRtlIsolation(input);
+    const twice = applyRtlIsolation(once);
+    expect(twice).toBe(once);
+  });
+
+  it("skips lines that already contain bidi control characters", () => {
+    const lineWithEmbed = `\u202aforced ltr שלום\u202c`;
+    expect(applyRtlIsolation(lineWithEmbed)).toBe(lineWithEmbed);
+  });
+
+  it("exposes the underlying regex and marker constants for downstream guards", () => {
+    expect(RTL_ISOLATION_REGEX.rtlScript.test("שלום")).toBe(true);
+    expect(RTL_ISOLATION_REGEX.bidiControl.test(RLI)).toBe(true);
+    expect(RLI).toBe("\u2067");
+    expect(PDI).toBe("\u2069");
+  });
+});

--- a/src/shared/text/rtl-isolation.test.ts
+++ b/src/shared/text/rtl-isolation.test.ts
@@ -20,6 +20,21 @@ describe("applyRtlIsolation", () => {
     expect(applyRtlIsolation(input)).toBe(expected);
   });
 
+  it("leaves RTL text inside fenced code blocks unchanged", () => {
+    const input = ["Before", "```text", "שלום?", "```", "After"].join("\n");
+    expect(applyRtlIsolation(input)).toBe(input);
+  });
+
+  it("does not wrap lines where RTL text appears only inside inline code", () => {
+    const input = "Use `שלום?` as the example.";
+    expect(applyRtlIsolation(input)).toBe(input);
+  });
+
+  it("still wraps RTL prose lines that also contain inline code", () => {
+    const input = "שלום `code`?";
+    expect(applyRtlIsolation(input)).toBe(`${RLI}${input}${PDI}`);
+  });
+
   it("is idempotent: re-wrapping already-isolated text is a no-op", () => {
     const input = "שלום?";
     const once = applyRtlIsolation(input);

--- a/src/shared/text/rtl-isolation.ts
+++ b/src/shared/text/rtl-isolation.ts
@@ -1,0 +1,43 @@
+/**
+ * Wrap RTL-script lines in Unicode bidirectional isolate controls (FSI-style)
+ * so trailing LTR punctuation (".", "?", "!", parentheses, etc.) renders on
+ * the visually-correct side of the line on Discord, Slack, Telegram,
+ * WhatsApp, terminals, and any other surface that honors the bidi algorithm.
+ *
+ * Extracted from the TUI renderer so the same isolation can be applied to
+ * the canonical outbound assistant-visible text sanitizer (#68105). The
+ * line-level guard against existing bidi control characters keeps the
+ * function idempotent: re-wrapping already-isolated text is a no-op.
+ */
+
+const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
+const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
+const RTL_ISOLATE_START = "\u2067";
+const RTL_ISOLATE_END = "\u2069";
+
+function isolateRtlLine(line: string): string {
+  if (!RTL_SCRIPT_RE.test(line) || BIDI_CONTROL_RE.test(line)) {
+    return line;
+  }
+  return `${RTL_ISOLATE_START}${line}${RTL_ISOLATE_END}`;
+}
+
+export function applyRtlIsolation(text: string): string {
+  if (!RTL_SCRIPT_RE.test(text)) {
+    return text;
+  }
+  return text
+    .split("\n")
+    .map((line) => isolateRtlLine(line))
+    .join("\n");
+}
+
+export const RTL_ISOLATION_REGEX = {
+  rtlScript: RTL_SCRIPT_RE,
+  bidiControl: BIDI_CONTROL_RE,
+} as const;
+
+export const RTL_ISOLATION_MARKERS = {
+  start: RTL_ISOLATE_START,
+  end: RTL_ISOLATE_END,
+} as const;

--- a/src/shared/text/rtl-isolation.ts
+++ b/src/shared/text/rtl-isolation.ts
@@ -10,13 +10,31 @@
  * function idempotent: re-wrapping already-isolated text is a no-op.
  */
 
+import { findCodeRegions, isInsideCode, type CodeRegion } from "./code-regions.js";
+
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
 const RTL_ISOLATE_START = "\u2067";
 const RTL_ISOLATE_END = "\u2069";
 
-function isolateRtlLine(line: string): string {
-  if (!RTL_SCRIPT_RE.test(line) || BIDI_CONTROL_RE.test(line)) {
+function hasRtlScriptOutsideCode(
+  line: string,
+  lineStart: number,
+  codeRegions: CodeRegion[],
+): boolean {
+  if (!RTL_SCRIPT_RE.test(line)) {
+    return false;
+  }
+  for (let idx = 0; idx < line.length; idx += 1) {
+    if (RTL_SCRIPT_RE.test(line[idx] ?? "") && !isInsideCode(lineStart + idx, codeRegions)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isolateRtlLine(line: string, lineStart: number, codeRegions: CodeRegion[]): string {
+  if (!hasRtlScriptOutsideCode(line, lineStart, codeRegions) || BIDI_CONTROL_RE.test(line)) {
     return line;
   }
   return `${RTL_ISOLATE_START}${line}${RTL_ISOLATE_END}`;
@@ -26,10 +44,19 @@ export function applyRtlIsolation(text: string): string {
   if (!RTL_SCRIPT_RE.test(text)) {
     return text;
   }
-  return text
-    .split("\n")
-    .map((line) => isolateRtlLine(line))
-    .join("\n");
+  const codeRegions = findCodeRegions(text);
+  const lines: string[] = [];
+  let lineStart = 0;
+  while (lineStart <= text.length) {
+    const newlineIndex = text.indexOf("\n", lineStart);
+    const lineEnd = newlineIndex === -1 ? text.length : newlineIndex;
+    lines.push(isolateRtlLine(text.slice(lineStart, lineEnd), lineStart, codeRegions));
+    if (newlineIndex === -1) {
+      break;
+    }
+    lineStart = newlineIndex + 1;
+  }
+  return lines.join("\n");
 }
 
 export const RTL_ISOLATION_REGEX = {

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -5,6 +5,7 @@ import type { SessionGoal } from "../config/sessions/types.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
+import { applyRtlIsolation } from "../shared/text/rtl-isolation.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
 const REPLACEMENT_CHAR_RE = /\uFFFD/g;
@@ -18,11 +19,7 @@ const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
 const EDGE_PUNCTUATION_RE = /^[`"'([{<]+|[`"')\]}>.,:;!?]+$/g;
 const ALPHANUMERIC_RE = /[A-Za-z0-9]/;
 const TOKENISH_MIN_LENGTH = 24;
-const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const CJK_SCRIPT_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
-const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
-const RTL_ISOLATE_START = "\u2067";
-const RTL_ISOLATE_END = "\u2069";
 // Fenced code blocks (``` or ~~~). Lazy on content; tolerates info string after
 // the opening fence. Closing fence must sit on its own line.
 const FENCED_CODE_RE = /(```|~~~)[^\n]*\n[\s\S]*?\n\1[^\n]*/g;
@@ -170,23 +167,6 @@ function redactBinaryLikeLine(line: string): string {
     return "[binary data omitted]";
   }
   return line;
-}
-
-function isolateRtlLine(line: string): string {
-  if (!RTL_SCRIPT_RE.test(line) || BIDI_CONTROL_RE.test(line)) {
-    return line;
-  }
-  return `${RTL_ISOLATE_START}${line}${RTL_ISOLATE_END}`;
-}
-
-function applyRtlIsolation(text: string): string {
-  if (!RTL_SCRIPT_RE.test(text)) {
-    return text;
-  }
-  return text
-    .split("\n")
-    .map((line) => isolateRtlLine(line))
-    .join("\n");
 }
 
 export function sanitizeRenderableText(text: string): string {


### PR DESCRIPTION
## Summary

- Extract the existing TUI-only `applyRtlIsolation` helper into a shared module so the canonical outbound assistant-visible text sanitizer can reuse it.
- Apply U+2067/U+2069 line-level isolation in the `delivery` profile of `sanitizeAssistantVisibleText`, so Hebrew/Arabic/other RTL prose delivered through Discord, WhatsApp, Slack, Telegram, and any other channel plugin keeps trailing LTR punctuation on the visually-correct side.
- Keep the `history` and `internal-scaffolding` profiles byte-for-byte with the model output (transcript storage and runtime inspection stay clean); keep the TUI behavior unchanged.

## Linked context

Closes #68105

Was this requested by a maintainer or owner?

No direct maintainer request; this follows ClawSweeper's triage that flagged the issue as a queueable source-reproducible fix with the existing TUI implementation as the precedent.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Outbound delivery sanitizer drops bidi isolation that the TUI already applies, so Hebrew/Arabic text such as `שלום?` reaches Discord/Slack/Telegram/WhatsApp without RLI/PDI wrappers and renders trailing LTR punctuation on the wrong visual side.
- Real environment tested: Local OpenClaw source checkout on Linux with Node `v22.22.3`, pnpm `11.2.2` via corepack.
- Exact steps or command run after this patch: Ran two local OpenClaw source smokes with `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" node --import tsx --input-type=module -e '...'` against the real shared sanitizers, once with the patch temporarily stashed on the same branch and once with it restored.
- Evidence after fix: Copied console output from those local OpenClaw source smokes.

  Before-fix (patch stashed):

  ```
  === BEFORE-FIX BEHAVIOR (RTL bidi missing on outbound) ===
  TUI sanitizeRenderableText  : \"⁧שלום?⁩\" wraps? true
  Outbound sanitizeVisibleText: \"שלום?\" wraps? false
  bug repro confirmed: true
  ```

  After-fix (patch restored):

  ```
  === AFTER-FIX BEHAVIOR ===
  TUI sanitizeRenderableText still wraps: \"⁧שלום?⁩\"
  Outbound delivery now wraps:            \"⁧שלום?⁩\"
  Outbound delivery (Arabic):             \"⁧كيف حالك؟⁩\"
  History profile stays byte-clean:       \"שלום?\"
  Internal-scaffolding stays clean:       \"שלום?\"
  Idempotent (delivery twice === once):   true
  Mixed LTR/RTL outbound:
  \"Hello there.\n⁧مرحبا!⁩\nSee you.\"
  ```

- Observed result after fix: The outbound sanitizer now wraps RTL-script lines line-by-line; LTR-only lines pass through unchanged; mixed-direction text wraps only the RTL lines; the `history` and `internal-scaffolding` profiles intentionally remain byte-for-byte with the model output; the function is idempotent against already-isolated text.
- What was not tested: A live screenshot from Discord/Slack/Telegram showing the visual punctuation move. The fix is at the sanitizer boundary that those channels already call, so the proof above demonstrates the byte-level change at the exact seam those clients consume.
- Proof limitations or environment constraints: The after-fix proof uses the real OpenClaw shared sanitizers (`sanitizeAssistantVisibleText`, `sanitizeAssistantVisibleTextWithProfile`, `sanitizeRenderableText`) imported from the source checkout, but does not run a full channel send because this environment is not configured with messaging credentials.
- Before evidence (optional but encouraged): Captured above via `git stash`-ing this patch.

## Tests and validation

Which commands did you run?

- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" node scripts/test-projects.mjs src/shared/text/rtl-isolation.test.ts src/shared/text/assistant-visible-text.test.ts src/tui/tui-formatters.test.ts`
- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" corepack pnpm exec oxfmt --check src/shared/text/rtl-isolation.ts src/shared/text/rtl-isolation.test.ts src/shared/text/assistant-visible-text.ts src/shared/text/assistant-visible-text.test.ts src/tui/tui-formatters.ts`
- `git diff --check`

Outputs:

- `rtl-isolation.test.ts` + `assistant-visible-text.test.ts`: `Test Files 2 passed (2)` / `Tests 111 passed (111)` (6 new RTL isolation cases + 5 new delivery-vs-history profile cases land alongside the existing assistant-visible-text and tool-call XML coverage).
- `tui-formatters.test.ts`: `Test Files 1 passed (1)` / `Tests 47 passed (47)` — TUI rendering behavior is unchanged after the helper moved to the shared module.
- `oxfmt --check`: `All matched files use the correct format.`

What regression coverage was added or updated?

- New `src/shared/text/rtl-isolation.test.ts` covers Hebrew/Arabic wrapping, LTR passthrough, line-by-line behavior, double-wrap idempotency, and skipping lines that already carry bidi controls.
- New `RTL bidi isolation on outbound delivery` describe block in `src/shared/text/assistant-visible-text.test.ts` covers the delivery profile wrap, history and internal-scaffolding profiles staying byte-clean, mixed LTR/RTL line handling, and idempotency at the delivery boundary.

What failed before this fix, if known?

The before-fix smoke above reproduces the missing isolation at the outbound sanitizer boundary; without this patch the new delivery-profile assertions would fail because `sanitizeAssistantVisibleText` returned the raw RTL string.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes (delivery-only). Hebrew, Arabic, and other RTL-script lines now reach messaging surfaces wrapped in U+2067/U+2069, so trailing LTR punctuation visually trails the line as the user expects. LTR-only text and transcript storage are unchanged.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Bidi control characters leaking into surfaces that do not strip them and then echoing back through history or copy/paste paths.

How is that risk mitigated?

The isolation is applied only to the `delivery` profile, so the `history` profile (transcript storage) and `internal-scaffolding` profile (runtime/UI inspection) continue to receive the raw model output. The line-level guard against existing bidi controls keeps the function idempotent, so messages that re-enter delivery sanitization (e.g. tool result roundtrips) are not re-wrapped.

## Current review state

What is the next action?

Await maintainer / ClawSweeper review on whether the chosen canonical boundary (delivery profile of `sanitizeAssistantVisibleText`) is the preferred seam, or whether additional channel-specific sanitizers (for example `sanitizeForPlainText`) should also opt in.

What is still waiting on author, maintainer, CI, or external proof?

A live Discord/Slack/Telegram screenshot showing the visual punctuation move is still not provided from this environment.

Which bot or reviewer comments were addressed?

Initial PR; no PR comments yet.

AI-assisted: yes. I reviewed the touched code paths, extracted the shared helper, and ran the focused validation commands above.

Made with [Cursor](https://cursor.com)