### PR TITLE
Repair active npm host after plugin installs

### DIFF
--- a/src/infra/npm-managed-root.test.ts
+++ b/src/infra/npm-managed-root.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import type { CommandOptions } from "../process/exec.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import {
+  repairManagedNpmRootActiveHostPackage,
   repairManagedNpmRootOpenClawPeer,
   removeManagedNpmRootDependency,
   readManagedNpmRootInstalledDependency,
@@ -1005,6 +1006,104 @@ describe("managed npm root", () => {
     await expect(
       fs.readFile(path.join(hostPackageRoot, "package.json"), "utf8"),
     ).resolves.toContain("2026.5.12-beta.6");
+  });
+
+  it("repairs missing dependencies for the active global OpenClaw host package", async () => {
+    const npmRoot = await makeTempRoot();
+    const hostPackageRoot = path.join(npmRoot, "lib", "node_modules", "openclaw");
+    const dependencyRoot = path.join(hostPackageRoot, "node_modules", "json5");
+    await fs.mkdir(hostPackageRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(hostPackageRoot, "package.json"),
+      `${JSON.stringify({
+        name: "openclaw",
+        version: "2026.5.27-beta.1",
+        dependencies: {
+          json5: "2.2.3",
+        },
+        optionalDependencies: {
+          sharp: "0.34.5",
+        },
+      })}\n`,
+    );
+
+    const runCommand = vi.fn().mockImplementation(async () => {
+      await fs.mkdir(dependencyRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(dependencyRoot, "package.json"),
+        `${JSON.stringify({ name: "json5", version: "2.2.3" })}\n`,
+      );
+      const optionalDependencyRoot = path.join(hostPackageRoot, "node_modules", "sharp");
+      await fs.mkdir(optionalDependencyRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(optionalDependencyRoot, "package.json"),
+        `${JSON.stringify({ name: "sharp", version: "0.34.5" })}\n`,
+      );
+      return successfulSpawn;
+    });
+
+    await expect(
+      repairManagedNpmRootActiveHostPackage({
+        npmRoot,
+        packageRoot: hostPackageRoot,
+        dependencySnapshot: {
+          packageRoot: hostPackageRoot,
+          version: "2026.5.27-beta.1",
+          dependencyNames: ["json5", "sharp"],
+        },
+        runCommand,
+      }),
+    ).resolves.toBe(true);
+
+    const [repairArgs, rawRepairOptions] = requireFirstMockCall(
+      runCommand,
+      "active host repair command",
+    );
+    const repairOptions = requireCommandOptions(rawRepairOptions, "active host repair");
+    expect(repairArgs).toEqual([
+      "npm",
+      "install",
+      "--loglevel=error",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--global",
+      "--prefix",
+      npmRoot,
+      "openclaw@2026.5.27-beta.1",
+    ]);
+    expect(repairOptions.timeoutMs).toBe(300_000);
+    expect(repairOptions.env?.npm_config_ignore_scripts).toBe("true");
+    expect(repairOptions.env?.npm_config_global).toBe("true");
+    expect(repairOptions.env?.npm_config_prefix).toBe(npmRoot);
+  });
+
+  it("does not run global repair for a local active OpenClaw host package", async () => {
+    const npmRoot = await makeTempRoot();
+    const hostPackageRoot = path.join(npmRoot, "node_modules", "openclaw");
+    await fs.mkdir(hostPackageRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(hostPackageRoot, "package.json"),
+      `${JSON.stringify({
+        name: "openclaw",
+        version: "2026.5.27-beta.1",
+        dependencies: {
+          json5: "2.2.3",
+        },
+      })}\n`,
+    );
+
+    const runCommand = vi.fn().mockResolvedValue(successfulSpawn);
+
+    await expect(
+      repairManagedNpmRootActiveHostPackage({
+        npmRoot,
+        packageRoot: hostPackageRoot,
+        runCommand,
+      }),
+    ).resolves.toBe(false);
+
+    expect(runCommand).not.toHaveBeenCalled();
   });
 
   it("scrubs managed ownership metadata without deleting a linked active host package", async () => {

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -57,6 +57,12 @@ type ManagedNpmRootRunCommand = typeof runCommandWithTimeout;
 
 type ManagedNpmRootOpenClawHostState = "none" | "managed-active-host" | "linked-active-host";
 
+export type ManagedNpmRootActiveHostDependencySnapshot = {
+  packageRoot: string;
+  version: string;
+  dependencyNames: string[];
+};
+
 function readDependencyRecord(value: unknown): Record<string, string> {
   if (!isRecord(value)) {
     return {};
@@ -835,6 +841,180 @@ export async function repairManagedNpmRootOpenClawPeer(params: {
   }
 
   await scrubManagedNpmRootOpenClawPeer({ npmRoot: params.npmRoot });
+  return true;
+}
+
+async function readManagedNpmRootActiveHostPackage(params: {
+  npmRoot: string;
+  packageRoot?: string | null;
+  includePresentOptionalDependencies?: boolean;
+}): Promise<ManagedNpmRootActiveHostDependencySnapshot | null> {
+  const packageRoot =
+    params.packageRoot === undefined
+      ? resolveOpenClawPackageRootSync({
+          argv1: process.argv[1],
+          moduleUrl: import.meta.url,
+          cwd: process.cwd(),
+        })
+      : params.packageRoot;
+  if (!packageRoot) {
+    return null;
+  }
+
+  const [hostPackageRoot, globalManagedPackageRoot] = await Promise.all([
+    realpathIfExists(packageRoot),
+    realpathIfExists(resolveManagedNpmRootGlobalOpenClawPackageDir(params.npmRoot)),
+  ]);
+  if (!hostPackageRoot || hostPackageRoot !== globalManagedPackageRoot) {
+    return null;
+  }
+
+  const manifest = await readJsonIfExists<unknown>(path.join(hostPackageRoot, "package.json"));
+  if (!isRecord(manifest)) {
+    return null;
+  }
+  const version = readOptionalString(manifest.version);
+  if (!version) {
+    return null;
+  }
+  const dependencyNames = new Set(Object.keys(readDependencyRecord(manifest.dependencies)));
+  if (params.includePresentOptionalDependencies) {
+    for (const packageName of Object.keys(readDependencyRecord(manifest.optionalDependencies))) {
+      if (
+        await pathExists(
+          path.join(resolvePackageDependencyDir(hostPackageRoot, packageName), "package.json"),
+        )
+      ) {
+        dependencyNames.add(packageName);
+      }
+    }
+  }
+  return {
+    packageRoot: hostPackageRoot,
+    version,
+    dependencyNames: [...dependencyNames].toSorted(),
+  };
+}
+
+function resolveManagedNpmRootGlobalOpenClawPackageDir(npmRoot: string): string {
+  return path.join(
+    npmRoot,
+    ...(process.platform === "win32"
+      ? ["node_modules", "openclaw"]
+      : ["lib", "node_modules", "openclaw"]),
+  );
+}
+
+export async function readManagedNpmRootActiveHostDependencySnapshot(params: {
+  npmRoot: string;
+  packageRoot?: string | null;
+}): Promise<ManagedNpmRootActiveHostDependencySnapshot | null> {
+  return await readManagedNpmRootActiveHostPackage({
+    ...params,
+    includePresentOptionalDependencies: true,
+  });
+}
+
+function resolvePackageDependencyDir(rootDir: string, packageName: string): string {
+  return path.join(rootDir, "node_modules", ...packageName.split("/"));
+}
+
+async function listMissingActiveHostDependencies(
+  activeHost: ManagedNpmRootActiveHostDependencySnapshot,
+): Promise<string[]> {
+  const missing: string[] = [];
+  for (const packageName of activeHost.dependencyNames) {
+    if (
+      !(await pathExists(
+        path.join(resolvePackageDependencyDir(activeHost.packageRoot, packageName), "package.json"),
+      ))
+    ) {
+      missing.push(packageName);
+    }
+  }
+  return missing;
+}
+
+function createGlobalOpenClawRepairEnv(npmRoot: string): NodeJS.ProcessEnv {
+  return {
+    ...createSafeNpmInstallEnv(process.env, {
+      npmConfigPrefix: npmRoot,
+      quiet: true,
+    }),
+    npm_config_global: "true",
+    npm_config_location: "global",
+    npm_config_prefix: npmRoot,
+  };
+}
+
+export async function repairManagedNpmRootActiveHostPackage(params: {
+  npmRoot: string;
+  packageRoot?: string | null;
+  dependencySnapshot?: ManagedNpmRootActiveHostDependencySnapshot | null;
+  timeoutMs?: number;
+  logger?: ManagedNpmRootLogger;
+  runCommand?: ManagedNpmRootRunCommand;
+}): Promise<boolean> {
+  const activeHost = await readManagedNpmRootActiveHostPackage({
+    npmRoot: params.npmRoot,
+    packageRoot: params.packageRoot,
+  });
+  if (!activeHost) {
+    return false;
+  }
+
+  const dependencyNames =
+    params.dependencySnapshot?.packageRoot === activeHost.packageRoot &&
+    params.dependencySnapshot.version === activeHost.version
+      ? params.dependencySnapshot.dependencyNames
+      : activeHost.dependencyNames;
+  const repairTarget = { ...activeHost, dependencyNames };
+  const missingBefore = await listMissingActiveHostDependencies(repairTarget);
+  if (missingBefore.length === 0) {
+    return false;
+  }
+
+  const command = params.runCommand ?? runCommandWithTimeout;
+  const packageSpec = `openclaw@${activeHost.version}`;
+  const result = await command(
+    [
+      "npm",
+      ...createSafeNpmInstallArgs({
+        loglevel: "error",
+        noAudit: true,
+        noFund: true,
+      }),
+      "--global",
+      "--prefix",
+      params.npmRoot,
+      packageSpec,
+    ],
+    {
+      timeoutMs: Math.max(params.timeoutMs ?? 300_000, 300_000),
+      env: createGlobalOpenClawRepairEnv(params.npmRoot),
+    },
+  );
+  if (result.code !== 0) {
+    throw new Error(
+      `npm install --global ${packageSpec} failed while repairing active OpenClaw package dependencies: ${result.stderr.trim() || result.stdout.trim()}`,
+    );
+  }
+
+  const refreshedHost = await readManagedNpmRootActiveHostPackage({
+    npmRoot: params.npmRoot,
+    packageRoot: activeHost.packageRoot,
+  });
+  const missingAfter = refreshedHost
+    ? await listMissingActiveHostDependencies({ ...refreshedHost, dependencyNames })
+    : [];
+  if (missingAfter.length > 0) {
+    throw new Error(
+      `active OpenClaw package still missing runtime dependencies after repair: ${missingAfter.join(", ")}`,
+    );
+  }
+  params.logger?.warn?.(
+    `Repaired active OpenClaw package dependencies in ${activeHost.packageRoot}: ${missingBefore.join(", ")}`,
+  );
   return true;
 }
 

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -71,8 +71,20 @@ function isNpmPeerPlannerInstallCommand(argv: unknown): argv is string[] {
   return isNpmInstallCommand(argv) && argv.includes("--package-lock-only");
 }
 
+function isGlobalOpenClawInstallCommand(argv: unknown): argv is string[] {
+  return (
+    isNpmInstallCommand(argv) &&
+    argv.includes("--global") &&
+    argv.some((arg) => arg.startsWith("openclaw@"))
+  );
+}
+
 function isManagedNpmInstallCommand(argv: unknown): argv is string[] {
-  return isNpmInstallCommand(argv) && !isNpmPeerPlannerInstallCommand(argv);
+  return (
+    isNpmInstallCommand(argv) &&
+    !isNpmPeerPlannerInstallCommand(argv) &&
+    !isGlobalOpenClawInstallCommand(argv)
+  );
 }
 
 function expectNpmInstallIntoRoot(params: { calls: unknown[][]; npmRoot: string }) {
@@ -178,6 +190,7 @@ type MockNpmPackage = {
   skipLockfileEntry?: boolean;
   packArchivePath?: string;
   packTarballName?: string;
+  afterManagedInstall?: () => void;
 };
 
 function writeNpmRootPackageLock(params: {
@@ -398,6 +411,41 @@ function mockNpmViewAndInstallMany(packages: MockNpmPackage[]) {
           dependencies: manifest.dependencies ?? {},
           packages: installedPackages,
         });
+        for (const pkg of installedPackages) {
+          pkg.afterManagedInstall?.();
+        }
+        return successfulSpawn();
+      }
+      if (isGlobalOpenClawInstallCommand(argv)) {
+        const prefixIndex = argv.indexOf("--prefix");
+        const npmRoot = prefixIndex >= 0 ? argv[prefixIndex + 1] : undefined;
+        if (!npmRoot) {
+          throw new Error(`unexpected npm global install command: ${(argv as string[]).join(" ")}`);
+        }
+        const hostPackageRoot = path.join(npmRoot, "lib", "node_modules", "openclaw");
+        const hostManifest = JSON.parse(
+          fs.readFileSync(path.join(hostPackageRoot, "package.json"), "utf8"),
+        ) as {
+          dependencies?: Record<string, string>;
+          optionalDependencies?: Record<string, string>;
+        };
+        const hostDependencies = {
+          ...(hostManifest.dependencies ?? {}),
+          ...(hostManifest.optionalDependencies ?? {}),
+        };
+        for (const [packageName, version] of Object.entries(hostDependencies)) {
+          const dependencyRoot = path.join(
+            hostPackageRoot,
+            "node_modules",
+            ...packageName.split("/"),
+          );
+          fs.mkdirSync(dependencyRoot, { recursive: true });
+          fs.writeFileSync(
+            path.join(dependencyRoot, "package.json"),
+            JSON.stringify({ name: packageName, version }),
+            "utf8",
+          );
+        }
         return successfulSpawn();
       }
       if (argv[0] === "npm" && argv[1] === "uninstall") {
@@ -1083,6 +1131,75 @@ describe("installPluginFromNpmSpec", () => {
           argv.includes("openclaw"),
       ),
     ).toBe(false);
+  });
+
+  it("repairs active global-prefix OpenClaw package deps after npm plugin installs", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    const hostPackageRoot = path.join(npmRoot, "lib", "node_modules", "openclaw");
+    const hostJson5Root = path.join(hostPackageRoot, "node_modules", "json5");
+    const hostSharpRoot = path.join(hostPackageRoot, "node_modules", "sharp");
+    fs.mkdirSync(hostJson5Root, { recursive: true });
+    fs.mkdirSync(hostSharpRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(hostPackageRoot, "package.json"),
+      JSON.stringify(
+        {
+          name: "openclaw",
+          version: "2026.5.27-beta.1",
+          dependencies: {
+            json5: "2.2.3",
+          },
+          optionalDependencies: {
+            sharp: "0.34.5",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(hostJson5Root, "package.json"),
+      JSON.stringify({ name: "json5", version: "2.2.3" }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(hostSharpRoot, "package.json"),
+      JSON.stringify({ name: "sharp", version: "0.34.5" }),
+      "utf-8",
+    );
+    resolveOpenClawPackageRootSyncMock.mockReturnValue(hostPackageRoot);
+    mockNpmViewAndInstall({
+      spec: "@srinathh/openclaw-channel-twilio-whatsapp@2.1.8",
+      packageName: "@srinathh/openclaw-channel-twilio-whatsapp",
+      version: "2.1.8",
+      pluginId: "twilio-whatsapp",
+      npmRoot,
+      expectedDependencySpec: "2.1.8",
+      afterManagedInstall: () => {
+        fs.rmSync(hostJson5Root, { recursive: true, force: true });
+        fs.rmSync(hostSharpRoot, { recursive: true, force: true });
+      },
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@srinathh/openclaw-channel-twilio-whatsapp@2.1.8",
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fs.existsSync(path.join(hostJson5Root, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(hostSharpRoot, "package.json"))).toBe(true);
+    expect(
+      runCommandWithTimeoutMock.mock.calls.some(
+        ([argv]) =>
+          isGlobalOpenClawInstallCommand(argv) &&
+          Array.isArray(argv) &&
+          argv.includes("openclaw@2026.5.27-beta.1"),
+      ),
+    ).toBe(true);
   });
 
   it("allows npm-spec installs with dangerous code patterns when forced unsafe install is set", async () => {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -12,17 +12,20 @@ import {
 } from "../infra/install-source-utils.js";
 import { resolveNpmIntegrityDriftWithDefaultMessage } from "../infra/npm-integrity.js";
 import {
+  type ManagedNpmRootActiveHostDependencySnapshot,
+  type ManagedNpmRootInstalledDependency,
   type ManagedNpmRootPeerDependencySnapshot,
+  readManagedNpmRootActiveHostDependencySnapshot,
   readManagedNpmRootInstalledDependency,
   readManagedNpmRootPeerDependencySnapshot,
   readOpenClawManagedNpmRootOverrides,
+  repairManagedNpmRootActiveHostPackage,
   repairManagedNpmRootOpenClawPeer,
   removeManagedNpmRootDependency,
   resolveManagedNpmRootDependencySpec,
   restoreManagedNpmRootPeerDependencySnapshot,
   syncManagedNpmRootPeerDependencies,
   upsertManagedNpmRootDependency,
-  type ManagedNpmRootInstalledDependency,
 } from "../infra/npm-managed-root.js";
 import {
   compareOpenClawReleaseVersions,
@@ -337,6 +340,7 @@ async function rollbackManagedNpmPluginInstall(params: {
   timeoutMs: number;
   logger: PluginInstallLogger;
   peerDependencySnapshot?: ManagedNpmRootPeerDependencySnapshot;
+  activeHostDependencySnapshot?: ManagedNpmRootActiveHostDependencySnapshot | null;
 }): Promise<void> {
   try {
     await runCommandWithTimeout(
@@ -449,6 +453,12 @@ async function rollbackManagedNpmPluginInstall(params: {
   }
   if (params.packageName !== "openclaw") {
     try {
+      await repairManagedNpmRootActiveHostPackage({
+        npmRoot: params.npmRoot,
+        dependencySnapshot: params.activeHostDependencySnapshot,
+        timeoutMs: params.timeoutMs,
+        logger: params.logger,
+      });
       await repairManagedNpmRootOpenClawPeer({
         npmRoot: params.npmRoot,
         timeoutMs: params.timeoutMs,
@@ -638,6 +648,10 @@ async function installPluginFromManagedNpmRoot(
     }
   }
   const preInstallRootPackageNames = await listManagedNpmRootPackageNames(npmRoot);
+  const activeHostDependencySnapshot =
+    params.packageName === "openclaw"
+      ? null
+      : await readManagedNpmRootActiveHostDependencySnapshot({ npmRoot });
   const managedOverrides = await readOpenClawManagedNpmRootOverrides();
   const rollbackPeerDependencySnapshot = await readManagedNpmRootPeerDependencySnapshot({
     npmRoot,
@@ -650,6 +664,7 @@ async function installPluginFromManagedNpmRoot(
       timeoutMs,
       logger,
       peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      activeHostDependencySnapshot,
     });
     return { ok: false, error };
   };
@@ -734,6 +749,7 @@ async function installPluginFromManagedNpmRoot(
       timeoutMs,
       logger,
       peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      activeHostDependencySnapshot,
     });
     return {
       ok: false,
@@ -762,6 +778,7 @@ async function installPluginFromManagedNpmRoot(
         timeoutMs,
         logger,
         peerDependencySnapshot: rollbackPeerDependencySnapshot,
+        activeHostDependencySnapshot,
       });
       return {
         ok: false,
@@ -786,6 +803,7 @@ async function installPluginFromManagedNpmRoot(
       timeoutMs,
       logger,
       peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      activeHostDependencySnapshot,
     });
     return {
       ok: false,
@@ -816,6 +834,7 @@ async function installPluginFromManagedNpmRoot(
       timeoutMs,
       logger,
       peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      activeHostDependencySnapshot,
     });
     return {
       ok: false,
@@ -830,6 +849,7 @@ async function installPluginFromManagedNpmRoot(
       timeoutMs,
       logger,
       peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      activeHostDependencySnapshot,
     });
     return {
       ok: false,
@@ -851,6 +871,7 @@ async function installPluginFromManagedNpmRoot(
       timeoutMs,
       logger,
       peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      activeHostDependencySnapshot,
     });
     return {
       ok: false,
@@ -870,6 +891,7 @@ async function installPluginFromManagedNpmRoot(
       timeoutMs,
       logger,
       peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      activeHostDependencySnapshot,
     });
     return {
       ok: false,
@@ -900,8 +922,33 @@ async function installPluginFromManagedNpmRoot(
       timeoutMs,
       logger,
       peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      activeHostDependencySnapshot,
     });
     return result;
+  }
+  if (params.packageName !== "openclaw") {
+    try {
+      await repairManagedNpmRootActiveHostPackage({
+        npmRoot,
+        dependencySnapshot: activeHostDependencySnapshot,
+        timeoutMs,
+        logger,
+      });
+    } catch (error) {
+      await rollbackManagedNpmPluginInstall({
+        npmRoot,
+        packageName: params.packageName,
+        targetDir: installRoot,
+        timeoutMs,
+        logger,
+        peerDependencySnapshot: rollbackPeerDependencySnapshot,
+        activeHostDependencySnapshot,
+      });
+      return {
+        ok: false,
+        error: `Failed to repair active OpenClaw package after npm plugin install: ${String(error)}`,
+      };
+    }
   }
   return {
     ...result,

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -724,7 +724,7 @@ describe("updateNpmInstalledPlugins", () => {
     expect(npmInstallCall()?.trustedSourceLinkedOfficialInstall).not.toBe(true);
   });
 
-  it("skips npm reinstall and config rewrite when the installed artifact is unchanged", async () => {
+  it("refreshes managed npm root state without config rewrite when the installed artifact is unchanged", async () => {
     const installPath = createInstalledPackageDir({
       name: "@martian-engineering/lossless-claw",
       version: "0.9.0",
@@ -735,7 +735,18 @@ describe("updateNpmInstalledPlugins", () => {
       integrity: "sha512-same",
       shasum: "same",
     });
-    installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "lossless-claw",
+        targetDir: installPath,
+        version: "0.9.0",
+        npmResolution: {
+          name: "@martian-engineering/lossless-claw",
+          version: "0.9.0",
+          resolvedSpec: "@martian-engineering/lossless-claw@0.9.0",
+        },
+      }),
+    );
     const config: OpenClawConfig = {
       plugins: {
         installs: {
@@ -771,7 +782,9 @@ describe("updateNpmInstalledPlugins", () => {
     if (npmViewCall()?.[1] === undefined) {
       throw new Error("Expected npm view command options");
     }
-    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(npmInstallCall()?.spec).toBe("@martian-engineering/lossless-claw");
+    expect(npmInstallCall()?.mode).toBe("update");
+    expect(npmInstallCall()?.expectedPluginId).toBe("lossless-claw");
     expect(result.changed).toBe(false);
     expect(result.config).toBe(config);
     expect(result.outcomes).toEqual([
@@ -781,6 +794,219 @@ describe("updateNpmInstalledPlugins", () => {
         currentVersion: "0.9.0",
         nextVersion: "0.9.0",
         message: "lossless-claw is up to date (0.9.0).",
+      },
+    ]);
+  });
+
+  it("records the installer result when unchanged npm maintenance resolves a newer artifact", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.0",
+    });
+    mockNpmViewMetadata({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.0",
+      integrity: "sha512-same",
+      shasum: "same",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "lossless-claw",
+        targetDir: installPath,
+        version: "0.9.1",
+        npmResolution: {
+          name: "@martian-engineering/lossless-claw",
+          version: "0.9.1",
+          resolvedSpec: "@martian-engineering/lossless-claw@0.9.1",
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "lossless-claw",
+        spec: "@martian-engineering/lossless-claw",
+        installPath,
+        resolvedName: "@martian-engineering/lossless-claw",
+        resolvedVersion: "0.9.0",
+        resolvedSpec: "@martian-engineering/lossless-claw@0.9.0",
+        integrity: "sha512-same",
+        shasum: "same",
+      }),
+      pluginIds: ["lossless-claw"],
+    });
+
+    expect(result.changed).toBe(true);
+    expectRecordFields(result.config.plugins?.installs?.["lossless-claw"], {
+      source: "npm",
+      resolvedName: "@martian-engineering/lossless-claw",
+      resolvedVersion: "0.9.1",
+      resolvedSpec: "@martian-engineering/lossless-claw@0.9.1",
+    });
+    expectRecordFields(result.outcomes[0], {
+      pluginId: "lossless-claw",
+      status: "updated",
+      currentVersion: "0.9.0",
+      nextVersion: "0.9.1",
+    });
+  });
+
+  it("migrates plugin config ids when unchanged npm maintenance resolves a new id", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@legacy/lossless-claw",
+      version: "0.9.0",
+    });
+    mockNpmViewMetadata({
+      name: "@legacy/lossless-claw",
+      version: "0.9.0",
+      integrity: "sha512-same",
+      shasum: "same",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "lossless-claw",
+        targetDir: installPath,
+        version: "0.9.1",
+        npmResolution: {
+          name: "@legacy/lossless-claw",
+          version: "0.9.1",
+          resolvedSpec: "@legacy/lossless-claw@0.9.1",
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          allow: ["legacy-lossless"],
+          entries: {
+            "legacy-lossless": {
+              enabled: true,
+            },
+          },
+          installs: {
+            "legacy-lossless": {
+              source: "npm",
+              spec: "@legacy/lossless-claw",
+              installPath,
+              resolvedName: "@legacy/lossless-claw",
+              resolvedVersion: "0.9.0",
+              resolvedSpec: "@legacy/lossless-claw@0.9.0",
+              integrity: "sha512-same",
+              shasum: "same",
+            },
+          },
+        },
+      },
+      pluginIds: ["legacy-lossless"],
+    });
+
+    expect(result.config.plugins?.installs?.["legacy-lossless"]).toBeUndefined();
+    expect(result.config.plugins?.entries?.["legacy-lossless"]).toBeUndefined();
+    expect(result.config.plugins?.allow).toEqual(["lossless-claw"]);
+    expectRecordFields(result.config.plugins?.installs?.["lossless-claw"], {
+      source: "npm",
+      resolvedName: "@legacy/lossless-claw",
+      resolvedVersion: "0.9.1",
+      resolvedSpec: "@legacy/lossless-claw@0.9.1",
+    });
+  });
+
+  it("migrates plugin config ids when unchanged npm maintenance keeps the same version", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@legacy/lossless-claw",
+      version: "0.9.0",
+    });
+    mockNpmViewMetadata({
+      name: "@legacy/lossless-claw",
+      version: "0.9.0",
+      integrity: "sha512-same",
+      shasum: "same",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "lossless-claw",
+        targetDir: installPath,
+        version: "0.9.0",
+        npmResolution: {
+          name: "@legacy/lossless-claw",
+          version: "0.9.0",
+          resolvedSpec: "@legacy/lossless-claw@0.9.0",
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          allow: ["legacy-lossless"],
+          installs: {
+            "legacy-lossless": {
+              source: "npm",
+              spec: "@legacy/lossless-claw",
+              installPath,
+              resolvedName: "@legacy/lossless-claw",
+              resolvedVersion: "0.9.0",
+              resolvedSpec: "@legacy/lossless-claw@0.9.0",
+              integrity: "sha512-same",
+              shasum: "same",
+            },
+          },
+        },
+      },
+      pluginIds: ["legacy-lossless"],
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.installs?.["legacy-lossless"]).toBeUndefined();
+    expect(result.config.plugins?.allow).toEqual(["lossless-claw"]);
+    expectRecordFields(result.config.plugins?.installs?.["lossless-claw"], {
+      source: "npm",
+      resolvedName: "@legacy/lossless-claw",
+      resolvedVersion: "0.9.0",
+      resolvedSpec: "@legacy/lossless-claw@0.9.0",
+    });
+    expectRecordFields(result.outcomes[0], {
+      pluginId: "legacy-lossless",
+      status: "unchanged",
+      currentVersion: "0.9.0",
+      nextVersion: "0.9.0",
+    });
+  });
+
+  it("records unchanged npm maintenance exceptions as plugin failures", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.0",
+    });
+    mockNpmViewMetadata({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.0",
+      integrity: "sha512-same",
+      shasum: "same",
+    });
+    installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer boom"));
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "lossless-claw",
+        spec: "@martian-engineering/lossless-claw",
+        installPath,
+        resolvedName: "@martian-engineering/lossless-claw",
+        resolvedVersion: "0.9.0",
+        resolvedSpec: "@martian-engineering/lossless-claw@0.9.0",
+        integrity: "sha512-same",
+        shasum: "same",
+      }),
+      pluginIds: ["lossless-claw"],
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "lossless-claw",
+        status: "error",
+        message: "Failed to update lossless-claw: Error: installer boom",
       },
     ]);
   });
@@ -846,7 +1072,7 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
-  it("skips unchanged npm plugins when the openclaw peer link already resolves", async () => {
+  it("refreshes unchanged npm plugins when the openclaw peer link already resolves", async () => {
     const installPath = createInstalledPackageDir({
       name: "@openclaw/codex",
       version: "2026.5.3",
@@ -859,7 +1085,18 @@ describe("updateNpmInstalledPlugins", () => {
       integrity: "sha512-same",
       shasum: "same",
     });
-    installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "codex",
+        targetDir: installPath,
+        version: "2026.5.3",
+        npmResolution: {
+          name: "@openclaw/codex",
+          version: "2026.5.3",
+          resolvedSpec: "@openclaw/codex@2026.5.3",
+        },
+      }),
+    );
 
     const result = await updateNpmInstalledPlugins({
       config: {
@@ -881,7 +1118,9 @@ describe("updateNpmInstalledPlugins", () => {
       pluginIds: ["codex"],
     });
 
-    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(npmInstallCall()?.spec).toBe("@openclaw/codex");
+    expect(npmInstallCall()?.mode).toBe("update");
+    expect(npmInstallCall()?.expectedPluginId).toBe("codex");
     expect(result.changed).toBe(false);
     expect(result.outcomes).toEqual([
       {
@@ -1179,7 +1418,18 @@ describe("updateNpmInstalledPlugins", () => {
       integrity: "sha512-same",
       shasum: "same",
     });
-    installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "lossless-claw",
+        targetDir: installPath,
+        version: "0.9.0",
+        npmResolution: {
+          name: "@martian-engineering/lossless-claw",
+          version: "0.9.0",
+          resolvedSpec: "@martian-engineering/lossless-claw@0.9.0",
+        },
+      }),
+    );
 
     const result = await updateNpmInstalledPlugins({
       config: createNpmInstallConfig({
@@ -1195,7 +1445,8 @@ describe("updateNpmInstalledPlugins", () => {
       pluginIds: ["lossless-claw"],
     });
 
-    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(npmInstallCall()?.spec).toBe("@martian-engineering/lossless-claw");
+    expect(npmInstallCall()?.extensionsDir).toBe(path.join(home, ".openclaw", "extensions"));
     expect(result.changed).toBe(false);
     expect(result.outcomes).toHaveLength(1);
     expectRecordFields(result.outcomes[0], {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1245,6 +1245,87 @@ export async function updateNpmInstalledPlugins(params: {
             metadata: metadataResult.metadata,
           })
         ) {
+          let maintenanceResult: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
+          try {
+            maintenanceResult = await installNpmSpecForUpdate({
+              spec: effectiveSpec!,
+              mode: "update",
+              extensionsDir,
+              timeoutMs: params.timeoutMs,
+              dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
+              trustedSourceLinkedOfficialInstall,
+              expectedPluginId: pluginId,
+              expectedIntegrity,
+              onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
+                pluginId,
+                dryRun: false,
+                logger,
+                onIntegrityDrift: params.onIntegrityDrift,
+              }),
+              logger,
+            });
+          } catch (err) {
+            recordFailure(pluginId, `Failed to update ${pluginId}: ${String(err)}`);
+            continue;
+          }
+          if (!maintenanceResult.ok) {
+            recordFailure(
+              pluginId,
+              formatNpmInstallFailure({
+                pluginId,
+                spec: effectiveSpec!,
+                phase: "update",
+                result: maintenanceResult,
+              }),
+            );
+            continue;
+          }
+          const maintenanceResolution = maintenanceResult.npmResolution;
+          const maintenanceVersion =
+            maintenanceResult.version ??
+            resolveNpmResultVersion(maintenanceResult) ??
+            (await readInstalledPackageVersion(maintenanceResult.targetDir));
+          const maintenanceMatchesProbe =
+            maintenanceResult.pluginId === pluginId &&
+            pathsEqual(maintenanceResult.targetDir, installPath) &&
+            maintenanceVersion === currentVersion &&
+            maintenanceResolution?.version === metadataResult.metadata.version &&
+            maintenanceResolution?.resolvedSpec === metadataResult.metadata.resolvedSpec &&
+            (!maintenanceResolution?.integrity ||
+              !metadataResult.metadata.integrity ||
+              maintenanceResolution.integrity === metadataResult.metadata.integrity) &&
+            (!maintenanceResolution?.shasum ||
+              !metadataResult.metadata.shasum ||
+              maintenanceResolution.shasum === metadataResult.metadata.shasum);
+          if (!maintenanceMatchesProbe) {
+            const resolvedPluginId = maintenanceResult.pluginId;
+            if (resolvedPluginId !== pluginId) {
+              next = migratePluginConfigId(next, pluginId, resolvedPluginId);
+            }
+            next = recordPluginInstall(next, {
+              pluginId: resolvedPluginId,
+              source: "npm",
+              spec: recordSpec,
+              installPath: maintenanceResult.targetDir,
+              version: maintenanceVersion,
+              ...buildNpmResolutionInstallFields(maintenanceResolution),
+            });
+            changed = true;
+            outcomes.push({
+              pluginId,
+              status:
+                currentVersion && maintenanceVersion && currentVersion === maintenanceVersion
+                  ? "unchanged"
+                  : "updated",
+              currentVersion,
+              nextVersion: maintenanceVersion,
+              message:
+                currentVersion && maintenanceVersion && currentVersion === maintenanceVersion
+                  ? `${pluginId} already at ${currentVersion}.`
+                  : `Updated ${pluginId}: ${currentVersion} -> ${maintenanceVersion}.`,
+            });
+            continue;
+          }
           outcomes.push({
             pluginId,
             status: "unchanged",


### PR DESCRIPTION
Summary
- Detect when a managed plugin npm install prunes dependencies from the active global-prefix OpenClaw package.
- Repair the active OpenClaw package at the same installed version before reporting plugin install success, including required dependencies and optional runtime dependencies that were present before the install.
- Roll back plugin installs if active-host repair fails, and keep npm lifecycle scripts disabled during repair.

Verification
- node scripts/run-vitest.mjs src/plugins/install.npm-spec.test.ts src/infra/npm-managed-root.test.ts
- ./node_modules/.bin/oxfmt --check --threads=1 src/infra/npm-managed-root.ts src/infra/npm-managed-root.test.ts src/plugins/install.ts src/plugins/install.npm-spec.test.ts
- git diff --check
- Testbox-through-Crabbox: tbx_01kspspe3ktdsxrpmg7b24aqtv

Real behavior proof
Behavior addressed: Installing an external plugin into the same managed npm prefix as a global OpenClaw package can leave the active OpenClaw package missing runtime dependencies.
Real environment tested: Blacksmith Testbox through Crabbox with a PR-built OpenClaw tarball installed into a throwaway global npm prefix, then the published Twilio WhatsApp plugin installed into that same managed prefix.
Exact steps or command run after this patch: Built and packed this branch, installed the tarball globally with npm --prefix, ran openclaw plugins install npm:@srinathh/openclaw-channel-twilio-whatsapp@2.1.8 --dangerously-force-unsafe-install, verified active host dependencies, then ran openclaw doctor --fix.
Evidence after fix: The Testbox run printed json5=2.2.3, croner=10.0.1, listed twilio-whatsapp in plugins, and ended with PROOF_OK active host deps survived plugin install and doctor ran.
Observed result after fix: Testbox-through-Crabbox tbx_01kspspe3ktdsxrpmg7b24aqtv completed with exit=0. Focused local tests also passed: 2 test files, 58 tests.
What was not tested: The production gateway was not restarted or repointed to this PR. AWS Crabbox did not execute because AWS lease creation hit a security-group rule limit, so the remote proof used Blacksmith Testbox through Crabbox.
