### PR TITLE
fix(qa): wire live fallback models

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -52,6 +52,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"
   OPENCLAW_CI_OPENAI_MODEL: ${{ vars.OPENCLAW_CI_OPENAI_MODEL || 'openai/gpt-5.5' }}
+  OPENCLAW_CI_OPENAI_FALLBACK_MODEL: ${{ vars.OPENCLAW_CI_OPENAI_FALLBACK_MODEL || 'openai/gpt-5.4' }}
   OPENCLAW_BUILD_PRIVATE_QA: "1"
   OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
 
@@ -288,7 +289,7 @@ jobs:
             --runtime-parity-tier live-only \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model "${OPENCLAW_CI_OPENAI_MODEL}" \
+            --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}" \
             --runtime-pair openclaw,codex \
             --fast \
             --allow-failures \
@@ -373,7 +374,7 @@ jobs:
             --output-dir "${output_dir}" \
             --provider-mode live-frontier \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model "${OPENCLAW_CI_OPENAI_MODEL}" \
+            --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}" \
             --profile "${INPUT_MATRIX_PROFILE}" \
             --fast
           )
@@ -457,7 +458,7 @@ jobs:
             --output-dir "${output_dir}" \
             --provider-mode live-frontier \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model "${OPENCLAW_CI_OPENAI_MODEL}" \
+            --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}" \
             --profile "${{ matrix.profile }}" \
             --fast
           )
@@ -555,7 +556,7 @@ jobs:
             --output-dir "${output_dir}" \
             --provider-mode live-frontier \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model "${OPENCLAW_CI_OPENAI_MODEL}" \
+            --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}" \
             --fast \
             --credential-source convex \
             --credential-role ci \
@@ -649,7 +650,7 @@ jobs:
             --output-dir "${output_dir}" \
             --provider-mode live-frontier \
             --model openai/gpt-5.5 \
-            --alt-model openai/gpt-5.5 \
+            --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}" \
             --fast \
             --credential-source convex \
             --credential-role ci \
@@ -746,7 +747,7 @@ jobs:
             --output-dir "${output_dir}" \
             --provider-mode live-frontier \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model "${OPENCLAW_CI_OPENAI_MODEL}" \
+            --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}" \
             --fast \
             --credential-source convex \
             --credential-role ci \
@@ -840,7 +841,7 @@ jobs:
             --output-dir "${output_dir}" \
             --provider-mode live-frontier \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model "${OPENCLAW_CI_OPENAI_MODEL}" \
+            --alt-model "${OPENCLAW_CI_OPENAI_FALLBACK_MODEL}" \
             --fast \
             --credential-source convex \
             --credential-role ci \

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -106,6 +106,27 @@ describe("Slack live QA runtime helpers", () => {
     expect(account?.channels?.C123456789?.users).toEqual(["U999999999"]);
   });
 
+  it("overrides both owner and channel allowlists for block scenarios", () => {
+    const cfg = testing.buildSlackQaConfig(
+      {},
+      {
+        channelId: "C123456789",
+        driverBotUserId: "U999999999",
+        overrides: {
+          allowFrom: ["U_NEVER_ALLOWED"],
+          users: ["U_NEVER_ALLOWED"],
+        },
+        sutAccountId: "sut",
+        sutAppToken: "xapp-sut",
+        sutBotToken: "xoxb-sut",
+      },
+    );
+
+    const account = cfg.channels?.slack?.accounts?.sut;
+    expect(account?.allowFrom).toEqual(["U_NEVER_ALLOWED"]);
+    expect(account?.channels?.C123456789?.users).toEqual(["U_NEVER_ALLOWED"]);
+  });
+
   it("extracts Slack native approval button values from blocks", () => {
     expect(
       testing.collectSlackActionValues([

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts
@@ -97,6 +97,7 @@ type SlackQaBeforeRunResult =
     };
 
 type SlackQaConfigOverrides = {
+  allowFrom?: string[];
   approvals?: {
     exec?: boolean;
     plugin?: boolean;
@@ -334,7 +335,10 @@ const SLACK_QA_SCENARIOS: SlackQaScenarioDefinition[] = [
     standardId: "allowlist-block",
     title: "Slack non-allowlisted sender does not trigger",
     timeoutMs: 8_000,
-    configOverrides: { users: ["U_OPENCLAW_QA_NEVER_ALLOWED"] },
+    configOverrides: {
+      allowFrom: ["U_OPENCLAW_QA_NEVER_ALLOWED"],
+      users: ["U_OPENCLAW_QA_NEVER_ALLOWED"],
+    },
     buildRun: (sutUserId) => {
       const token = `SLACK_QA_BLOCK_${randomUUID().slice(0, 8).toUpperCase()}`;
       return {
@@ -656,7 +660,7 @@ function buildSlackQaConfig(
             mode: "socket",
             botToken: params.sutBotToken,
             appToken: params.sutAppToken,
-            allowFrom: [params.driverBotUserId],
+            allowFrom: params.overrides?.allowFrom ?? [params.driverBotUserId],
             groupPolicy: "allowlist",
             allowBots: true,
             replyToMode: params.overrides?.replyToMode ?? "off",

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -95,6 +95,16 @@ describe("WhatsApp QA live runtime", () => {
     ]);
   });
 
+  it("derives a stable non-secret credential fingerprint", () => {
+    expect(testing.fingerprintWhatsAppCredentialId("cred-stale-row")).toMatch(
+      /^sha256:[0-9a-f]{16}$/,
+    );
+    expect(testing.fingerprintWhatsAppCredentialId("cred-stale-row")).toBe(
+      testing.fingerprintWhatsAppCredentialId("cred-stale-row"),
+    );
+    expect(testing.fingerprintWhatsAppCredentialId(undefined)).toBeUndefined();
+  });
+
   it("unpacks auth archives into a caller-provided temp directory", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-qa-test-"));
     try {

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -105,6 +105,23 @@ describe("WhatsApp QA live runtime", () => {
     expect(testing.fingerprintWhatsAppCredentialId(undefined)).toBeUndefined();
   });
 
+  it("keeps credential fingerprints visible in redacted reports", () => {
+    const report = testing.renderWhatsAppQaMarkdown({
+      cleanupIssues: [],
+      credentialFingerprint: "sha256:1234567890abcdef",
+      credentialSource: "convex",
+      finishedAt: "2026-05-04T12:01:00.000Z",
+      redactMetadata: true,
+      scenarios: [],
+      startedAt: "2026-05-04T12:00:00.000Z",
+      sutPhoneE164: "+15550000002",
+    });
+
+    expect(report).toContain("Credential fingerprint: `sha256:1234567890abcdef`");
+    expect(report).toContain("SUT phone: `<redacted>`");
+    expect(report).not.toContain("+15550000002");
+  });
+
   it("unpacks auth archives into a caller-provided temp directory", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-qa-test-"));
     try {

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -983,15 +983,14 @@ export async function runWhatsAppQaLive(params: {
   const passed = scenarioResults.filter((entry) => entry.status === "pass").length;
   const failed = scenarioResults.filter((entry) => entry.status === "fail").length;
   const skipped = scenarioResults.filter((entry) => entry.status === "skip").length;
+  const credentialFingerprint = fingerprintWhatsAppCredentialId(credentialLease?.credentialId);
   const summary: WhatsAppQaSummary = {
     credentials: credentialLease
       ? {
           source: credentialLease.source,
           kind: credentialLease.kind,
           role: credentialLease.role,
-          credentialFingerprint: redactPublicMetadata
-            ? undefined
-            : fingerprintWhatsAppCredentialId(credentialLease.credentialId),
+          credentialFingerprint,
           credentialId: redactPublicMetadata ? undefined : credentialLease.credentialId,
           ownerId: redactPublicMetadata ? undefined : credentialLease.ownerId,
         }
@@ -1032,9 +1031,7 @@ export async function runWhatsAppQaLive(params: {
     reportPath,
     `${renderWhatsAppQaMarkdown({
       cleanupIssues,
-      credentialFingerprint: redactPublicMetadata
-        ? undefined
-        : fingerprintWhatsAppCredentialId(credentialLease?.credentialId),
+      credentialFingerprint,
       credentialSource: credentialLease?.source ?? requestedCredentialSource,
       finishedAt,
       gatewayDebugDirPath: preservedGatewayDebugArtifacts ? gatewayDebugDirPath : undefined,
@@ -1063,6 +1060,7 @@ export const testing = {
   fingerprintWhatsAppCredentialId,
   isTransientWhatsAppQaDriverError,
   parseWhatsAppQaCredentialPayload,
+  renderWhatsAppQaMarkdown,
   resolveWhatsAppQaRuntimeEnv,
   resolveWhatsAppMetadataRedaction,
   toObservedWhatsAppArtifacts,

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -132,6 +132,7 @@ type WhatsAppQaSummary = {
     total: number;
   };
   credentials: {
+    credentialFingerprint?: string;
     credentialId?: string;
     kind: string;
     ownerId?: string;
@@ -692,6 +693,7 @@ function toObservedWhatsAppArtifacts(params: {
 
 function renderWhatsAppQaMarkdown(params: {
   cleanupIssues: string[];
+  credentialFingerprint?: string;
   credentialSource: "convex" | "env";
   finishedAt: string;
   gatewayDebugDirPath?: string;
@@ -704,6 +706,9 @@ function renderWhatsAppQaMarkdown(params: {
     "# WhatsApp QA Report",
     "",
     `- Credential source: \`${params.credentialSource}\``,
+    ...(params.credentialFingerprint
+      ? [`- Credential fingerprint: \`${params.credentialFingerprint}\``]
+      : []),
     `- SUT phone: \`${params.redactMetadata ? "<redacted>" : (params.sutPhoneE164 ?? "<unavailable>")}\``,
     `- Metadata redaction: \`${params.redactMetadata ? "enabled" : "disabled"}\``,
     `- Started: ${params.startedAt}`,
@@ -729,6 +734,14 @@ function renderWhatsAppQaMarkdown(params: {
     lines.push("");
   }
   return lines.join("\n");
+}
+
+function fingerprintWhatsAppCredentialId(credentialId: string | undefined) {
+  if (!credentialId) {
+    return undefined;
+  }
+  const digest = createHash("sha256").update(credentialId).digest("hex").slice(0, 16);
+  return `sha256:${digest}`;
 }
 
 function createMissingGroupJidScenarioResult(params: {
@@ -976,6 +989,7 @@ export async function runWhatsAppQaLive(params: {
           source: credentialLease.source,
           kind: credentialLease.kind,
           role: credentialLease.role,
+          credentialFingerprint: fingerprintWhatsAppCredentialId(credentialLease.credentialId),
           credentialId: redactPublicMetadata ? undefined : credentialLease.credentialId,
           ownerId: redactPublicMetadata ? undefined : credentialLease.ownerId,
         }
@@ -1016,6 +1030,7 @@ export async function runWhatsAppQaLive(params: {
     reportPath,
     `${renderWhatsAppQaMarkdown({
       cleanupIssues,
+      credentialFingerprint: fingerprintWhatsAppCredentialId(credentialLease?.credentialId),
       credentialSource: credentialLease?.source ?? requestedCredentialSource,
       finishedAt,
       gatewayDebugDirPath: preservedGatewayDebugArtifacts ? gatewayDebugDirPath : undefined,
@@ -1041,6 +1056,7 @@ export const testing = {
   buildWhatsAppQaConfig,
   createMissingGroupJidScenarioResult,
   findScenarios,
+  fingerprintWhatsAppCredentialId,
   isTransientWhatsAppQaDriverError,
   parseWhatsAppQaCredentialPayload,
   resolveWhatsAppQaRuntimeEnv,

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -989,7 +989,9 @@ export async function runWhatsAppQaLive(params: {
           source: credentialLease.source,
           kind: credentialLease.kind,
           role: credentialLease.role,
-          credentialFingerprint: fingerprintWhatsAppCredentialId(credentialLease.credentialId),
+          credentialFingerprint: redactPublicMetadata
+            ? undefined
+            : fingerprintWhatsAppCredentialId(credentialLease.credentialId),
           credentialId: redactPublicMetadata ? undefined : credentialLease.credentialId,
           ownerId: redactPublicMetadata ? undefined : credentialLease.ownerId,
         }
@@ -1030,7 +1032,9 @@ export async function runWhatsAppQaLive(params: {
     reportPath,
     `${renderWhatsAppQaMarkdown({
       cleanupIssues,
-      credentialFingerprint: fingerprintWhatsAppCredentialId(credentialLease?.credentialId),
+      credentialFingerprint: redactPublicMetadata
+        ? undefined
+        : fingerprintWhatsAppCredentialId(credentialLease?.credentialId),
       credentialSource: credentialLease?.source ?? requestedCredentialSource,
       finishedAt,
       gatewayDebugDirPath: preservedGatewayDebugArtifacts ? gatewayDebugDirPath : undefined,

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -41,6 +41,16 @@ function getPrimaryModel(value: unknown): string | undefined {
   return undefined;
 }
 
+function getModelFallbacks(value: unknown): string[] | undefined {
+  if (value && typeof value === "object" && "fallbacks" in value) {
+    const fallbacks = (value as { fallbacks?: unknown }).fallbacks;
+    return Array.isArray(fallbacks)
+      ? fallbacks.filter((fallback): fallback is string => typeof fallback === "string")
+      : undefined;
+  }
+  return undefined;
+}
+
 describe("buildQaGatewayConfig", () => {
   it("keeps mock-openai as the default provider lane", () => {
     const cfg = buildQaGatewayConfig({
@@ -53,6 +63,8 @@ describe("buildQaGatewayConfig", () => {
     });
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("mock-openai/gpt-5.5");
+    expect(getModelFallbacks(cfg.agents?.defaults?.model)).toEqual(["mock-openai/gpt-5.5-alt"]);
+    expect(getModelFallbacks(cfg.agents?.list?.[0]?.model)).toEqual(["mock-openai/gpt-5.5-alt"]);
     expect(cfg.models?.providers?.["mock-openai"]?.baseUrl).toBe("http://127.0.0.1:44080/v1");
     expect(cfg.models?.providers?.["mock-openai"]?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.models?.providers?.["mock-openai"]?.models).toEqual(
@@ -100,6 +112,12 @@ describe("buildQaGatewayConfig", () => {
     });
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("openai/gpt-5.5");
+    expect(getModelFallbacks(cfg.agents?.defaults?.model)).toEqual([
+      "anthropic/claude-opus-4-7",
+    ]);
+    expect(getModelFallbacks(cfg.agents?.list?.[0]?.model)).toEqual([
+      "anthropic/claude-opus-4-7",
+    ]);
     expect(cfg.models?.providers?.openai?.api).toBe("openai-responses");
     expect(cfg.models?.providers?.openai?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.models?.providers?.openai?.models.map((model) => model.id)).toContain("gpt-5.5");
@@ -195,6 +213,8 @@ describe("buildQaGatewayConfig", () => {
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("openai/gpt-5.5");
     expect(getPrimaryModel(cfg.agents?.list?.[0]?.model)).toBe("openai/gpt-5.5");
+    expect(getModelFallbacks(cfg.agents?.defaults?.model)).toBeUndefined();
+    expect(getModelFallbacks(cfg.agents?.list?.[0]?.model)).toBeUndefined();
     expect(cfg.models).toBeUndefined();
     expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "openai", "qa-channel"]);
     expect(cfg.plugins?.entries?.openai).toEqual({ enabled: true });

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -35,6 +35,11 @@ function normalizeQaGatewayModelRef(input: string | undefined, fallback: string)
   return model && model.length > 0 ? model : fallback;
 }
 
+function buildQaModelSelection(primaryModel: string, alternateModel: string) {
+  const fallbacks = alternateModel !== primaryModel ? [alternateModel] : undefined;
+  return fallbacks ? { primary: primaryModel, fallbacks } : { primary: primaryModel };
+}
+
 export function buildQaGatewayConfig(params: {
   bind: "loopback" | "lan";
   gatewayPort: number;
@@ -144,9 +149,7 @@ export function buildQaGatewayConfig(params: {
     agents: {
       defaults: {
         workspace: params.workspaceDir,
-        model: {
-          primary: primaryModel,
-        },
+        model: buildQaModelSelection(primaryModel, alternateModel),
         ...(imageGenerationModelRef
           ? {
               imageGenerationModel: {
@@ -180,9 +183,7 @@ export function buildQaGatewayConfig(params: {
         {
           id: "qa",
           default: true,
-          model: {
-            primary: primaryModel,
-          },
+          model: buildQaModelSelection(primaryModel, alternateModel),
           identity: {
             name: "C-3PO QA",
             theme: "Flustered Protocol Droid",


### PR DESCRIPTION
## Summary
- Wire QA `--alt-model` into gateway model fallback config for defaults and the `qa` agent.
- Add a live QA fallback model variable, defaulting to `openai/gpt-5.4`, so secret-backed live lanes do not duplicate the gpt-5.5 primary as their only candidate.
- Fix Slack allowlist-block coverage so both account owner allowlist and channel users are blocked.
- Emit a short WhatsApp credential fingerprint in redacted artifacts while keeping raw credential ids, owners, phone numbers, and message ids redacted.

## Verification
- `CI=1 node scripts/run-vitest.mjs run extensions/qa-lab/src/qa-gateway-config.test.ts extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.test.ts extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts`
- `CI=1 node scripts/run-vitest.mjs run extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts`
- `git diff --check`
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean after fixes.
- AWS Crabbox changed gate: `node scripts/crabbox-wrapper.mjs run --timing-json --shell -- "pnpm check:changed"`
  - provider: `aws`
  - lease: `cbx_9dab74982b3e`
  - run: `run_0207de7d47aa`
- QA-Lab all-lanes, PR head with stale main workflow definition: https://github.com/openclaw/openclaw/actions/runs/26564896043
  - Matrix media/e2ee/smoke/deep/cli, Slack, Discord, Telegram, and parity cleared.
  - Matrix transport failed because the dispatch used `--ref main`, so the updated workflow did not pass the fallback model yet.
  - WhatsApp failed before scenarios with Baileys 401 Unauthorized.
- QA-Lab branch-defined transport rerun: https://github.com/openclaw/openclaw/actions/runs/26565521272
  - Matrix transport passed 56/56 with the updated fallback model wiring.
  - Slack, Discord, Telegram, and parity cleared.
  - WhatsApp again failed before scenarios with Baileys 401 Unauthorized, consistent with stale shared WhatsApp Web credential/session material.

## Real behavior proof
Behavior addressed: live QA gateway children now get a configured fallback model when `--alt-model` differs from `--model`; Slack block scenario now genuinely blocks the driver; WhatsApp public artifacts keep raw credential identifiers redacted while preserving a short correlation fingerprint.
Real environment tested: local focused Vitest, AWS Crabbox Linux changed gate, and GitHub Actions secret-backed QA-Lab live lanes.
Exact steps or command run after this patch: see Verification.
Evidence after fix: focused tests passed, autoreview passed, remote `pnpm check:changed` exited 0, and the branch-defined Matrix transport live lane passed 56/56.
Observed result after fix: gateway config includes fallback models without changing strict single-model behavior when primary and alternate match; Slack scenario config blocks both owner and channel allowlist paths; Matrix transport no longer fails on gpt-5.5 TPM cooldown when the updated workflow passes the fallback model; WhatsApp artifacts expose only the short fingerprint needed to identify stale rows.
What was not tested: WhatsApp cannot complete until stale shared Convex WhatsApp Web credential rows are disabled or refreshed; local maintainer/1Password/Blacksmith access is still unavailable in this shell.
