### PR TITLE
fix(media): restore compact WhatsApp terminal QR

### DIFF
--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -159,8 +159,8 @@ describe("loginWeb coverage", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith("terminal:initial-qr");
     expect(runtime.log).toHaveBeenCalledWith("terminal:restart-qr");
-    expect(renderQrTerminalMock).toHaveBeenCalledWith("initial-qr");
-    expect(renderQrTerminalMock).toHaveBeenCalledWith("restart-qr");
+    expect(renderQrTerminalMock).toHaveBeenCalledWith("initial-qr", { small: true });
+    expect(renderQrTerminalMock).toHaveBeenCalledWith("restart-qr", { small: true });
   });
 
   it("clears creds and throws when logged out", async () => {

--- a/extensions/whatsapp/src/login.ts
+++ b/extensions/whatsapp/src/login.ts
@@ -22,7 +22,7 @@ export async function loginWeb(
   const restoredFromBackup = await restoreCredsFromBackupIfNeeded(account.authDir);
   const onQr = (qr: string) => {
     runtime.log("Open the WhatsApp app, go to Linked Devices, then scan this QR:");
-    void renderQrTerminal(qr)
+    void renderQrTerminal(qr, { small: true })
       .then((output) => {
         runtime.log(output.endsWith("\n") ? output.slice(0, -1) : output);
       })

--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -40,6 +40,7 @@ const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
 let createWaSocket: typeof import("./session.js").createWaSocket;
 let formatError: typeof import("./session.js").formatError;
 let logWebSelfId: typeof import("./session.js").logWebSelfId;
+let renderQrTerminalMock: ReturnType<typeof vi.fn>;
 let waitForWaConnection: typeof import("./session.js").waitForWaConnection;
 let waitForCredsSaveQueue: typeof import("./session.js").waitForCredsSaveQueue;
 let writeCredsJsonAtomically: typeof import("./session.js").writeCredsJsonAtomically;
@@ -224,6 +225,7 @@ describe("web session", () => {
       waitForCredsSaveQueue,
       writeCredsJsonAtomically,
     } = await import("./session.js"));
+    renderQrTerminalMock = vi.mocked((await import("./qr-terminal.js")).renderQrTerminal);
     ({ DEFAULT_WHATSAPP_SOCKET_TIMING } = await import("./socket-timing.js"));
   });
 
@@ -269,6 +271,27 @@ describe("web session", () => {
     expect(write.options.mode).toBe(0o600);
     expect(write.options.flag).toBe("wx");
     openMock.restore();
+  });
+
+  it("prints compact terminal QR output when requested", async () => {
+    const authDir = createTempAuthDir("openclaw-wa-terminal-qr");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    try {
+      await createWaSocket(true, false, { authDir });
+      getLastSocket().ev.emit("connection.update", { qr: "qr-data" });
+      await flushCredsUpdate();
+
+      expect(logSpy).toHaveBeenCalledWith(
+        "Open the WhatsApp app, go to Linked Devices, then scan this QR:",
+      );
+      expect(renderQrTerminalMock).toHaveBeenCalledWith("qr-data", { small: true });
+      expect(stdoutSpy).toHaveBeenCalledWith("ASCII-QR\n");
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+    }
   });
 
   it.runIf(process.platform !== "win32")(

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -124,7 +124,7 @@ async function safeSaveCreds(
 }
 
 async function printTerminalQr(qr: string): Promise<void> {
-  const output = await renderQrTerminal(qr);
+  const output = await renderQrTerminal(qr, { small: true });
   process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 }
 

--- a/src/media/qr-terminal.render.test.ts
+++ b/src/media/qr-terminal.render.test.ts
@@ -1,11 +1,61 @@
+import QRCode from "qrcode";
 import { describe, expect, it } from "vitest";
 import { renderQrTerminal } from "./qr-terminal.ts";
+
+const ansiSgr = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
+const compactMarginModules = 1;
+
+function visibleLines(output: string): string[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.replace(ansiSgr, ""))
+    .filter((line) => line.length > 0);
+}
+
+function maxVisibleWidth(output: string): number {
+  return Math.max(...visibleLines(output).map((line) => line.length));
+}
+
+function decodeCompactBlock(char: string): [boolean, boolean] {
+  if (char === "█") {
+    return [true, true];
+  }
+  if (char === "▀") {
+    return [true, false];
+  }
+  if (char === "▄") {
+    return [false, true];
+  }
+  if (char === " ") {
+    return [false, false];
+  }
+  throw new Error(`Unexpected compact QR character: ${char}`);
+}
+
+function decodeCompactQr(output: string, size: number): boolean[] {
+  const decoded = Array.from({ length: size * size }, () => false);
+  visibleLines(output).forEach((line, lineIndex) => {
+    Array.from(line).forEach((char, columnIndex) => {
+      const x = columnIndex - compactMarginModules;
+      const topY = lineIndex * 2 - compactMarginModules;
+      const [top, bottom] = decodeCompactBlock(char);
+      for (const [y, value] of [
+        [topY, top],
+        [topY + 1, bottom],
+      ] as const) {
+        if (x >= 0 && x < size && y >= 0 && y < size) {
+          decoded[y * size + x] = value;
+        }
+      }
+    });
+  });
+  return decoded;
+}
 
 describe("renderQrTerminal (real qrcode runtime)", () => {
   it("keeps per-row ANSI sequence counts in line with typical rows", async () => {
     const sample = "https://wa.me/login/2@SAMPLE-TOKEN-1234567890ABCDEF";
     const rendered = await renderQrTerminal(sample);
-    const ansiSgr = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
     const escCounts = rendered
       .split(/\r?\n/)
       .map((line) => (line.match(ansiSgr) ?? []).length)
@@ -16,5 +66,15 @@ describe("renderQrTerminal (real qrcode runtime)", () => {
     const max = Math.max(...escCounts);
     expect(median).toBeGreaterThan(0);
     expect(max).toBeLessThanOrEqual(median * 6);
+  });
+
+  it("renders compact output from the same QR matrix", async () => {
+    const sample = "https://wa.me/login/2@SAMPLE-TOKEN-1234567890ABCDEF";
+    const qr = QRCode.create(sample);
+    const full = await renderQrTerminal(sample);
+    const compact = await renderQrTerminal(sample, { small: true });
+
+    expect(maxVisibleWidth(compact)).toBeLessThan(maxVisibleWidth(full));
+    expect(decodeCompactQr(compact, qr.modules.size)).toEqual(Array.from(qr.modules.data, Boolean));
   });
 });

--- a/src/media/qr-terminal.test.ts
+++ b/src/media/qr-terminal.test.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { toString } = vi.hoisted(() => ({
+const { create, toString } = vi.hoisted(() => ({
+  create: vi.fn(() => ({
+    modules: {
+      data: [1, 0, 0, 1],
+      size: 2,
+    },
+  })),
   toString: vi.fn(async () => "ASCII-QR"),
 }));
 
 vi.mock("qrcode", () => ({
   default: {
+    create,
     toString,
   },
 }));
@@ -14,6 +21,7 @@ import { renderQrTerminal } from "./qr-terminal.ts";
 
 describe("renderQrTerminal", () => {
   beforeEach(() => {
+    create.mockClear();
     toString.mockClear();
   });
 
@@ -23,6 +31,13 @@ describe("renderQrTerminal", () => {
       small: false,
       type: "terminal",
     });
+  });
+
+  it("renders compact QR output without qrcode terminal small mode", async () => {
+    const rendered = await renderQrTerminal("openclaw", { small: true });
+    expect(rendered).toContain("▄");
+    expect(create).toHaveBeenCalledWith("openclaw");
+    expect(toString).not.toHaveBeenCalled();
   });
 
   it("rejects empty QR text", async () => {

--- a/src/media/qr-terminal.ts
+++ b/src/media/qr-terminal.ts
@@ -1,12 +1,60 @@
 import { loadQrCodeRuntime, normalizeQrText } from "./qr-runtime.ts";
 
+type QrTerminalModules = {
+  data: ArrayLike<boolean | number>;
+  size: number;
+};
+
+const COMPACT_MARGIN_MODULES = 1;
+const TERMINAL_BLACK_ON_WHITE = "\x1b[47m\x1b[30m";
+const TERMINAL_RESET = "\x1b[0m";
+const FULL_BLOCK = "█";
+const UPPER_HALF_BLOCK = "▀";
+const LOWER_HALF_BLOCK = "▄";
+
+function readModule(modules: QrTerminalModules, x: number, y: number): boolean {
+  if (x < 0 || y < 0 || x >= modules.size || y >= modules.size) {
+    return false;
+  }
+  return Boolean(modules.data[y * modules.size + x]);
+}
+
+function compactBlock(top: boolean, bottom: boolean): string {
+  if (top && bottom) {
+    return FULL_BLOCK;
+  }
+  if (top) {
+    return UPPER_HALF_BLOCK;
+  }
+  if (bottom) {
+    return LOWER_HALF_BLOCK;
+  }
+  return " ";
+}
+
+function renderCompactTerminalQr(modules: QrTerminalModules): string {
+  const lines: string[] = [];
+  for (let y = -COMPACT_MARGIN_MODULES; y < modules.size + COMPACT_MARGIN_MODULES; y += 2) {
+    let line = TERMINAL_BLACK_ON_WHITE;
+    for (let x = -COMPACT_MARGIN_MODULES; x < modules.size + COMPACT_MARGIN_MODULES; x += 1) {
+      line += compactBlock(readModule(modules, x, y), readModule(modules, x, y + 1));
+    }
+    lines.push(`${line}${TERMINAL_RESET}`);
+  }
+  return lines.join("\n");
+}
+
 export async function renderQrTerminal(
   input: string,
   opts: { small?: boolean } = {},
 ): Promise<string> {
+  const text = normalizeQrText(input);
   const qrCode = await loadQrCodeRuntime();
-  return await qrCode.toString(normalizeQrText(input), {
-    small: opts.small ?? false,
+  if (opts.small === true) {
+    return renderCompactTerminalQr(qrCode.create(text).modules);
+  }
+  return await qrCode.toString(text, {
+    small: false,
     type: "terminal",
   });
 }

--- a/src/types/qrcode.d.ts
+++ b/src/types/qrcode.d.ts
@@ -24,6 +24,14 @@ declare module "qrcode" {
     width?: number;
   };
 
+  export type QrCodeSymbol = {
+    modules: {
+      data: ArrayLike<boolean | number>;
+      size: number;
+    };
+  };
+
+  export function create(text: string, options?: QrCodeRenderOptions): QrCodeSymbol;
   export function toString(text: string, options?: QrCodeRenderOptions): Promise<string>;
   export function toDataURL(text: string, options?: QrCodeRenderOptions): Promise<string>;
   export function toFile(
@@ -33,6 +41,7 @@ declare module "qrcode" {
   ): Promise<void>;
 
   const qrcode: {
+    create: typeof create;
     toString: typeof toString;
     toDataURL: typeof toDataURL;
     toFile: typeof toFile;


### PR DESCRIPTION
## Summary

- Add an OpenClaw compact terminal QR renderer backed by the `qrcode.create()` matrix.
- Keep the default full terminal QR renderer unchanged.
- Use compact QR output for WhatsApp login/session QR prompts again.
- Add tests that decode the compact terminal output back to the QR matrix and compare every cell.

## Linked context

Related: #77820
Related: #77844

#77844 fixed a real bug in the upstream `qrcode` terminal `small: true` renderer, but it also made WhatsApp use the full-size terminal QR. That made the WhatsApp login QR much larger than before. This PR keeps the safety goal from #77844 by not using upstream `small: true`; OpenClaw now compacts the QR from the raw matrix itself.

## Real behavior proof

Behavior addressed: WhatsApp terminal login QR is compact enough for normal terminals again, without using the broken upstream `qrcode` terminal small renderer.

Real environment tested: Windows Terminal and PowerShell against this branch. The renderer uses ANSI SGR color and standard block characters, so the QR value does not depend on Windows-only behavior.

Exact steps or command run after this patch: Ran `corepack pnpm openclaw channels login --channel whatsapp`, then scanned the printed QR from WhatsApp Linked Devices.

Evidence after fix: Terminal output from the real login showed the compact QR and then printed `Linked after restart; web session ready.` Screenshots were reviewed locally on dark and white terminal backgrounds. The scannable QR payload is not attached here because WhatsApp login QR contents are sensitive. A local size probe with a WhatsApp-style sample showed full render `70x35` and compact render `35x18`.

Observed result after fix: WhatsApp linked successfully after scanning the compact terminal QR.

What was not tested: Live WhatsApp pairing on macOS/Linux terminals was not run for this PR. Feishu and other QR call sites were not live-tested.

## Tests and validation

- `corepack pnpm test src/media/qr-terminal.test.ts src/media/qr-terminal.render.test.ts extensions/whatsapp/src/login.coverage.test.ts extensions/whatsapp/src/session.test.ts` passed: 3 shards, 29 passed, 6 skipped.
- `corepack pnpm exec oxfmt --check --threads=1 src/media/qr-terminal.ts src/media/qr-terminal.test.ts src/media/qr-terminal.render.test.ts src/types/qrcode.d.ts extensions/whatsapp/src/login.ts extensions/whatsapp/src/session.ts extensions/whatsapp/src/login.coverage.test.ts extensions/whatsapp/src/session.test.ts` passed on 8 files.
- `git diff --check` passed.
- `src/media/qr-terminal.render.test.ts` decodes compact block output back to QR cells and compares it to `QRCode.create(sample).modules.data`.

## Risk checklist

- [x] User-visible behavior change: WhatsApp terminal QR is compact again.
- [x] No config, migration, or credential format change.
- [x] No auth/session behavior change beyond terminal QR display.
- [x] QR value protected by matrix-equivalence test.

## Current review state

Ready for maintainer review.