### PR TITLE
Fix heartbeat pending final delivery cleanup

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -171,6 +171,31 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+async function readStoredSessionEntry(
+  storePath: string,
+  sessionKey: string,
+  sessionId: string,
+): Promise<Record<string, unknown>> {
+  const store = requireRecord(JSON.parse(await fs.readFile(storePath, "utf-8")), "session store");
+  const directEntry = store[sessionKey];
+  if (directEntry) {
+    return requireRecord(directEntry, `session ${sessionKey}`);
+  }
+  for (const entry of Object.values(store)) {
+    const record = requireRecord(entry, "session entry");
+    if (record.sessionId === sessionId) {
+      return record;
+    }
+  }
+  const seen = Object.entries(store)
+    .map(([key, entry]) => {
+      const record = requireRecord(entry, "session entry");
+      return `${key}:${String(record.sessionId)}`;
+    })
+    .join(", ");
+  throw new Error(`expected session ${sessionKey} or sessionId ${sessionId}; saw ${seen}`);
+}
+
 function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
   for (const [key, value] of Object.entries(fields)) {
     expect(record[key]).toEqual(value);
@@ -1222,6 +1247,157 @@ describe("runHeartbeatOnce", () => {
       });
 
       expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
+  it("clears pending final delivery after sending a matching heartbeat payload", async () => {
+    const tmpDir = await createCaseDir("hb-pending-clear-sent");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.fn();
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      const pendingText = "Final alert";
+      const nowMs = Date.now();
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: nowMs - 30_000,
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+            pendingFinalDelivery: true,
+            pendingFinalDeliveryText: pendingText,
+            pendingFinalDeliveryCreatedAt: 1,
+            pendingFinalDeliveryLastAttemptAt: 2,
+            pendingFinalDeliveryAttemptCount: 3,
+            pendingFinalDeliveryLastError: "previous failure",
+            pendingFinalDeliveryContext: { source: "heartbeat" },
+            pendingFinalDeliveryIntentId: "intent-1",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: pendingText }]);
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp, {
+          nowMs,
+          getReplyFromConfig: replySpy,
+        }),
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      const stored = await readStoredSessionEntry(storePath, sessionKey, "sid");
+      expect(stored.pendingFinalDelivery).toBeUndefined();
+      expect(stored.pendingFinalDeliveryText).toBeUndefined();
+      expect(stored.pendingFinalDeliveryCreatedAt).toBeUndefined();
+      expect(stored.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
+      expect(stored.pendingFinalDeliveryAttemptCount).toBeUndefined();
+      expect(stored.pendingFinalDeliveryLastError).toBeUndefined();
+      expect(stored.pendingFinalDeliveryContext).toBeUndefined();
+      expect(stored.pendingFinalDeliveryIntentId).toBeUndefined();
+      expect(stored.lastHeartbeatText).toBe(pendingText);
+      expect(stored.lastHeartbeatSentAt).toBe(nowMs);
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
+  it("clears matching pending final delivery when duplicate heartbeat is skipped", async () => {
+    const tmpDir = await createCaseDir("hb-pending-clear-duplicate");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.fn();
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      const pendingText = "Final alert";
+      const nowMs = Date.now();
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: nowMs - 30_000,
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+            lastHeartbeatText: pendingText,
+            lastHeartbeatSentAt: nowMs - 60_000,
+            pendingFinalDelivery: true,
+            pendingFinalDeliveryText: pendingText,
+            pendingFinalDeliveryCreatedAt: 1,
+            pendingFinalDeliveryLastAttemptAt: 2,
+            pendingFinalDeliveryAttemptCount: 3,
+            pendingFinalDeliveryLastError: "previous failure",
+            pendingFinalDeliveryContext: { source: "heartbeat" },
+            pendingFinalDeliveryIntentId: "intent-1",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: pendingText }]);
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp, {
+          nowMs,
+          getReplyFromConfig: replySpy,
+        }),
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+      const stored = await readStoredSessionEntry(storePath, sessionKey, "sid");
+      expect(stored.pendingFinalDelivery).toBeUndefined();
+      expect(stored.pendingFinalDeliveryText).toBeUndefined();
+      expect(stored.pendingFinalDeliveryCreatedAt).toBeUndefined();
+      expect(stored.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
+      expect(stored.pendingFinalDeliveryAttemptCount).toBeUndefined();
+      expect(stored.pendingFinalDeliveryLastError).toBeUndefined();
+      expect(stored.pendingFinalDeliveryContext).toBeUndefined();
+      expect(stored.pendingFinalDeliveryIntentId).toBeUndefined();
+      expect(stored.lastHeartbeatText).toBe(pendingText);
     } finally {
       replySpy.mockReset();
     }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1643,6 +1643,43 @@ export async function runHeartbeatOnce(opts: {
     }
     consumeSelectedSystemEventEntries(sessionKey, inspectedSystemEventsToConsume);
   };
+  const clearDeliveredPendingFinalDelivery = async (deliveredText: string) => {
+    const normalizedDeliveredText = deliveredText.trim();
+    if (!normalizedDeliveredText) {
+      return false;
+    }
+    let cleared = false;
+    await updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey];
+      const pendingText =
+        typeof current?.pendingFinalDeliveryText === "string"
+          ? current.pendingFinalDeliveryText.trim()
+          : "";
+      if (
+        current?.pendingFinalDelivery !== true ||
+        !pendingText ||
+        pendingText !== normalizedDeliveredText
+      ) {
+        return;
+      }
+      store[sessionKey] = {
+        ...current,
+        pendingFinalDelivery: undefined,
+        pendingFinalDeliveryText: undefined,
+        pendingFinalDeliveryCreatedAt: undefined,
+        pendingFinalDeliveryLastAttemptAt: undefined,
+        pendingFinalDeliveryAttemptCount: undefined,
+        pendingFinalDeliveryLastError: undefined,
+        pendingFinalDeliveryContext: undefined,
+        pendingFinalDeliveryIntentId: undefined,
+      };
+      cleared = true;
+    });
+    if (cleared) {
+      log.info("heartbeat: cleared delivered pending final delivery", { sessionKey });
+    }
+    return cleared;
+  };
 
   const ctx = {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
@@ -1922,6 +1959,7 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
+      await clearDeliveredPendingFinalDelivery(normalized.text);
 
       emitHeartbeatEvent({
         status: "skipped",
@@ -2055,6 +2093,7 @@ export async function runHeartbeatOnce(opts: {
           lastHeartbeatSentAt: startedAt,
         };
       });
+      await clearDeliveredPendingFinalDelivery(normalized.text);
     }
 
     const sentStatus = deliveredAgentRunFailure ? "failed" : "sent";


### PR DESCRIPTION
## Problem

Heartbeat runs can persist non-ack final output in `pendingFinalDelivery*` so the final user-visible message can be retried. Normal reply dispatch clears that pending state after successful delivery, but `runHeartbeatOnce` sends heartbeat output through `sendDurableMessageBatch` directly and bypasses the normal cleanup path.

That leaves a stale `pendingFinalDeliveryText` in the session store after the heartbeat message was already delivered. On later heartbeat wakes, the pending text can be replayed or re-classified before fresh work runs, which is why an old heartbeat report can keep resurfacing instead of disappearing after a successful delivery.

## Relationship to #83187

[#83187](https://github.com/openclaw/openclaw/pull/83187) covers the heartbeat send-success cleanup path and already has strong proof for that narrower case.

This PR additionally covers the duplicate-suppression path: if the same heartbeat payload was already delivered recently (`lastHeartbeatText` / `lastHeartbeatSentAt`) but matching stale `pendingFinalDelivery*` fields remain, the duplicate branch currently returns before the send-success store write and therefore needs its own cleanup. If maintainers prefer #83187 as the canonical landing branch, the duplicate-suppression cleanup and regression coverage from this PR can be ported there.

## Fix

- Add heartbeat-runner cleanup for delivered pending final delivery state.
- Clear `pendingFinalDelivery*` only when the stored pending text exactly matches the heartbeat text that was delivered.
- Run the cleanup after a successful heartbeat send.
- Also run it when duplicate suppression skips the same payload, because `lastHeartbeatText`/`lastHeartbeatSentAt` show that exact heartbeat payload was already sent recently.

## Safety

The cleanup is intentionally narrow: it requires `pendingFinalDelivery === true` and a trimmed exact text match. It does not clear unrelated pending delivery state, and it does not run on failed sends, no-target skips, or alerts-disabled skips.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/heartbeat-runner.returns-default-unset.test.ts` — 41 tests passed.
- `pnpm exec oxfmt --check --threads=1 src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.returns-default-unset.test.ts` — clean.

## Real behavior proof

Environment: disposable local OpenClaw source-runtime run on branch `codex/fix-heartbeat-pending-replay`, head `9497a7a032cf`. The run used a temporary config/workspace/session store and the actual `runHeartbeatOnce` + `sendDurableMessageBatch` heartbeat path with a Telegram outbound adapter registered in the plugin registry. The model reply was stubbed to deterministic text so the proof isolates heartbeat delivery/session-state behavior. No production OpenClaw data or real chat credentials were used.

Command shape:

```sh
node --import tsx --input-type=module <<'EOF'
# imports runHeartbeatOnce from src/infra/heartbeat-runner.ts
# registers Telegram outbound adapter
# seeds temp sessions.json with matching pendingFinalDelivery* fields
# runs send-success and duplicate-suppression heartbeat scenarios
# prints before/after pending field states
EOF
```

Observed runtime logs:

```text
[heartbeat] cleared delivered pending final delivery
[heartbeat] cleared delivered pending final delivery
```

Send-success scenario:

```json
{
  "scenario": "send-success",
  "branch": "codex/fix-heartbeat-pending-replay",
  "head": "9497a7a032cf",
  "result": { "status": "ran", "durationMs": 387 },
  "sendCallCount": 1,
  "sends": [
    {
      "to": "proof-chat",
      "text": "PR87583 send-success heartbeat payload",
      "accountId": null
    }
  ],
  "before": {
    "pendingFinalDelivery": true,
    "pendingFinalDeliveryText": "PR87583 send-success heartbeat payload",
    "pendingFinalDeliveryCreatedAt": 1779957645636,
    "pendingFinalDeliveryLastAttemptAt": 1779957705636,
    "pendingFinalDeliveryAttemptCount": 2,
    "pendingFinalDeliveryLastError": "redacted prior delivery failure",
    "pendingFinalDeliveryContext": { "channel": "telegram", "to": "proof-chat" },
    "pendingFinalDeliveryIntentId": "intent-send-success",
    "lastHeartbeatText": "<absent>",
    "lastHeartbeatSentAt": "<absent>"
  },
  "after": {
    "pendingFinalDelivery": "<absent>",
    "pendingFinalDeliveryText": "<absent>",
    "pendingFinalDeliveryCreatedAt": "<absent>",
    "pendingFinalDeliveryLastAttemptAt": "<absent>",
    "pendingFinalDeliveryAttemptCount": "<absent>",
    "pendingFinalDeliveryLastError": "<absent>",
    "pendingFinalDeliveryContext": "<absent>",
    "pendingFinalDeliveryIntentId": "<absent>",
    "lastHeartbeatText": "PR87583 send-success heartbeat payload",
    "lastHeartbeatSentAt": 1779957765636
  },
  "clearedAllPendingFields": true,
  "deliveryEvidence": "sendDurableMessageBatch reached Telegram outbound adapter"
}
```

Duplicate-suppression scenario:

```json
{
  "scenario": "duplicate-skip",
  "branch": "codex/fix-heartbeat-pending-replay",
  "head": "9497a7a032cf",
  "result": { "status": "ran", "durationMs": 51 },
  "sendCallCount": 0,
  "before": {
    "pendingFinalDelivery": true,
    "pendingFinalDeliveryText": "PR87583 duplicate-skip heartbeat payload",
    "pendingFinalDeliveryCreatedAt": 1779957646044,
    "pendingFinalDeliveryLastAttemptAt": 1779957706044,
    "pendingFinalDeliveryAttemptCount": 2,
    "pendingFinalDeliveryLastError": "redacted prior delivery failure",
    "pendingFinalDeliveryContext": { "channel": "telegram", "to": "proof-chat" },
    "pendingFinalDeliveryIntentId": "intent-duplicate-skip",
    "lastHeartbeatText": "PR87583 duplicate-skip heartbeat payload",
    "lastHeartbeatSentAt": 1779957706044
  },
  "after": {
    "pendingFinalDelivery": "<absent>",
    "pendingFinalDeliveryText": "<absent>",
    "pendingFinalDeliveryCreatedAt": "<absent>",
    "pendingFinalDeliveryLastAttemptAt": "<absent>",
    "pendingFinalDeliveryAttemptCount": "<absent>",
    "pendingFinalDeliveryLastError": "<absent>",
    "pendingFinalDeliveryContext": "<absent>",
    "pendingFinalDeliveryIntentId": "<absent>",
    "lastHeartbeatText": "PR87583 duplicate-skip heartbeat payload",
    "lastHeartbeatSentAt": 1779957706044
  },
  "clearedAllPendingFields": true,
  "deliveryEvidence": "duplicate suppression skipped outbound send because lastHeartbeatText matched within 24h"
}
```