### PR TITLE
fix(agents): keep exec visible for lean local models

### DIFF
--- a/docs/concepts/experimental-features.md
+++ b/docs/concepts/experimental-features.md
@@ -30,7 +30,7 @@ Treat them differently from normal config:
 
 ## Local model lean mode
 
-`agents.defaults.experimental.localModelLean: true` is a pressure-release valve for weaker local-model setups. When it is on, OpenClaw drops three default tools — `browser`, `cron`, and `message` — from the agent's tool surface for every turn. Nothing else changes. Use `agents.list[].experimental.localModelLean` to enable or disable the same behavior for one configured agent.
+`agents.defaults.experimental.localModelLean: true` is a pressure-release valve for weaker local-model setups. When it is on, OpenClaw drops three default tools — `browser`, `cron`, and `message` — from the agent's tool surface for every turn. When Tool Search is enabled, OpenClaw also keeps `exec` directly visible instead of hiding it behind the catalog, so small coding models still have an obvious shell path for local workspace checks and simple live-data probes. Use `agents.list[].experimental.localModelLean` to enable or disable the same behavior for one configured agent.
 
 ### Why these three tools
 
@@ -40,7 +40,7 @@ These three tools have the largest descriptions and the most parameter shapes in
 - The model picking the right tool vs. emitting malformed tool calls because there are too many similar-looking schemas.
 - The Chat Completions adapter staying inside the server's structured-output limits vs. tripping a 400 on tool-call payload size.
 
-Removing them does not silently rewire OpenClaw — it just makes the tool list shorter. The model still has `read`, `write`, `edit`, `exec`, `apply_patch`, web search/fetch (when configured), memory, and session/agent tools available.
+Removing them does not silently rewire OpenClaw — it just makes the tool list shorter. The model still has `read`, `write`, `edit`, `exec`, `apply_patch`, web search/fetch (when configured), memory, and session/agent tools available. With Tool Search on, most optional tools can move into the searchable catalog, but `exec` remains a direct tool in lean mode.
 
 ### When to turn it on
 

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -315,7 +315,7 @@ If the model loads cleanly but full agent turns misbehave, work top-down — con
    openclaw infer model run --gateway --model <provider/model> --prompt "Reply with exactly: pong" --json
    ```
 
-3. **Try lean mode.** If both probes pass but real agent turns fail with malformed tool calls or oversized prompts, enable `agents.defaults.experimental.localModelLean: true`. It drops the three heaviest default tools (`browser`, `cron`, `message`) so the prompt shape is smaller and less brittle. See [Experimental Features → Local model lean mode](/concepts/experimental-features#local-model-lean-mode) for the full explanation, when to use it, and how to confirm it is on.
+3. **Try lean mode.** If both probes pass but real agent turns fail with malformed tool calls or oversized prompts, enable `agents.defaults.experimental.localModelLean: true`. It drops the three heaviest default tools (`browser`, `cron`, `message`) so the prompt shape is smaller and less brittle. When Tool Search is also on, lean mode keeps `exec` directly visible instead of cataloging it, which helps coding-tuned local models find the shell path without first inventing a domain-specific tool such as `weather`. See [Experimental Features → Local model lean mode](/concepts/experimental-features#local-model-lean-mode) for the full explanation, when to use it, and how to confirm it is on.
 
 4. **Disable tools entirely as a last resort.** If lean mode is not enough, set `models.providers.<provider>.models[].compat.supportsTools: false` for that model entry. The agent will then operate without tool calls on that model.
 
@@ -340,7 +340,10 @@ If the model loads cleanly but full agent turns misbehave, work top-down — con
   fails on Gemma or another local model? Check the provider URL, model ref, auth
   marker, and server logs first; local `model run` does not include agent tools.
   If local `model run` succeeds but larger agent turns fail, reduce the agent
-  tool surface with `localModelLean` or `compat.supportsTools: false`.
+  tool surface with `localModelLean` first. With Tool Search enabled, lean mode
+  still leaves `exec` visible so the model can choose shell execution directly.
+  Use `compat.supportsTools: false` only when the model or server cannot handle
+  tool schemas at all.
 - Tool calls show up as raw JSON/XML/ReAct text, or the provider returns an
   empty `tool_calls` array? Do not add a proxy that blindly converts assistant
   text into tool execution. Fix the server chat template/parser first. If the

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -679,7 +679,7 @@ Use these as starting points and replace model IDs with the exact names from `ol
     ```
 
     Use `compat.supportsTools: false` only when the model or server reliably fails on tool schemas. It trades agent capability for stability.
-    `localModelLean` removes the browser, cron, and message tools from the agent surface, but it does not change Ollama's runtime context or thinking mode. Pair it with explicit `params.num_ctx` and `params.thinking: false` for small Qwen-style thinking models that loop or spend their response budget on hidden reasoning.
+    `localModelLean` removes the browser, cron, and message tools from the agent surface, but it keeps `exec` directly visible when Tool Search is enabled so coding-tuned local models can still discover shell execution. It does not change Ollama's runtime context or thinking mode. Pair it with explicit `params.num_ctx` and `params.thinking: false` for small Qwen-style thinking models that loop or spend their response budget on hidden reasoning.
 
   </Accordion>
 </AccordionGroup>

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -137,7 +137,11 @@ import { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
-import { filterLocalModelLeanTools, isLocalModelLeanEnabled } from "../../local-model-lean.js";
+import {
+  filterLocalModelLeanTools,
+  isLocalModelLeanEnabled,
+  shouldCatalogToolForLocalModelLean,
+} from "../../local-model-lean.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
 import { supportsModelTools } from "../../model-tool-support.js";
@@ -1428,6 +1432,10 @@ export async function runEmbeddedAttempt(
             model: params.model,
           })
         : filteredBundledTools;
+    const localModelLeanEnabled = isLocalModelLeanEnabled({
+      config: params.config,
+      agentId: sessionAgentId,
+    });
     const projectedUncompactedEffectiveTools = filterLocalModelLeanTools({
       tools: [...tools, ...normalizedBundledTools],
       config: params.config,
@@ -1498,6 +1506,9 @@ export async function runEmbeddedAttempt(
           runId: params.runId,
           catalogRef: toolSearchCatalogRef,
           toolHookContext: catalogToolHookContext,
+          shouldCatalogTool: localModelLeanEnabled
+            ? shouldCatalogToolForLocalModelLean
+            : undefined,
         });
     const projectedToolSearchTools = filterLocalModelLeanTools({
       tools: toolSearch.tools,
@@ -2331,10 +2342,7 @@ export async function runEmbeddedAttempt(
         agentId: sessionAgentId,
         messageProvider: params.messageProvider,
         messageChannel: params.messageChannel,
-        localModelLean: isLocalModelLeanEnabled({
-          config: params.config,
-          agentId: sessionAgentId,
-        }),
+        localModelLean: localModelLeanEnabled,
         toolCount: effectiveTools.length,
         clientToolCount: clientToolDefs.length,
       });

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
-import { filterLocalModelLeanTools, isLocalModelLeanEnabled } from "./local-model-lean.js";
+import {
+  filterLocalModelLeanTools,
+  isLocalModelLeanEnabled,
+  shouldCatalogToolForLocalModelLean,
+} from "./local-model-lean.js";
 
 function tools(names: string[]): AnyAgentTool[] {
   return names.map((name) => ({ name })) as AnyAgentTool[];
@@ -161,5 +165,13 @@ describe("local model lean tool filtering", () => {
         sessionKey: "agent:gemma:main",
       }).map((tool) => tool.name),
     ).toEqual(["read", "exec"]);
+  });
+
+  it("keeps exec direct when Tool Search compacts lean local-model tools", () => {
+    expect(shouldCatalogToolForLocalModelLean({ name: "exec" } as AnyAgentTool)).toBe(false);
+    expect(shouldCatalogToolForLocalModelLean({ name: "read" } as AnyAgentTool)).toBe(true);
+    expect(shouldCatalogToolForLocalModelLean({ name: "fake_weather" } as AnyAgentTool)).toBe(
+      true,
+    );
   });
 });

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -4,6 +4,7 @@ import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope-config.
 import type { AnyAgentTool } from "./agent-tools.types.js";
 
 const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set(["browser", "cron", "message"]);
+const LOCAL_MODEL_LEAN_DIRECT_TOOL_NAMES = new Set(["exec"]);
 
 function resolveLocalModelLeanAgentId(params: {
   config?: OpenClawConfig;
@@ -48,4 +49,8 @@ export function filterLocalModelLeanTools(params: {
     return params.tools;
   }
   return params.tools.filter((tool) => !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(tool.name));
+}
+
+export function shouldCatalogToolForLocalModelLean(tool: AnyAgentTool): boolean {
+  return !LOCAL_MODEL_LEAN_DIRECT_TOOL_NAMES.has(tool.name);
 }

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -153,6 +153,29 @@ describe("Tool Search", () => {
     expect(telemetry.callCount).toBe(1);
   });
 
+  it("keeps predicate-excluded tools visible while cataloging the rest", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const exec = fakeTool("exec", "Run shell command");
+    const weather = pluginTool("fake_weather", "Read fake weather");
+
+    const compacted = applyToolSearchCatalog({
+      tools: [codeTool, exec, weather],
+      config: {
+        tools: {
+          toolSearch: true,
+        },
+      } as never,
+      sessionId: "session-direct-exec",
+      shouldCatalogTool: (tool) => tool.name !== "exec",
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      TOOL_SEARCH_CODE_MODE_TOOL_NAME,
+      "exec",
+    ]);
+    expect(compacted.catalogToolCount).toBe(1);
+  });
+
   it("scopes catalogs by run id when attempts share a session", async () => {
     const runATool = pluginTool("fake_run_a", "Tool visible only to run A");
     const runBTool = pluginTool("fake_run_b", "Tool visible only to run B");

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -820,6 +820,7 @@ export function applyToolSearchCatalog(params: {
   runId?: string;
   catalogRef?: ToolSearchCatalogRef;
   toolHookContext?: HookContext;
+  shouldCatalogTool?: (tool: AnyAgentTool) => boolean;
 }): {
   tools: AnyAgentTool[];
   compacted: boolean;


### PR DESCRIPTION
Refs #86632.

## Summary

Lean local-model mode now keeps `exec` directly visible when Tool Search compacts the rest of the tool catalog. This gives small coding-tuned local models an obvious shell fallback for simple live-data or workspace probes instead of forcing them to search for a domain-specific tool and stop when none exists.

This deliberately does not add a `cmd` alias or automatically route weather/live-data requests through shell; those are broader behavior and security decisions.

## Verification

- `node scripts/run-vitest.mjs src/agents/local-model-lean.test.ts src/agents/tool-search.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts`
- post-rebase: `node scripts/run-vitest.mjs src/agents/local-model-lean.test.ts src/agents/tool-search.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts`
- `node scripts/format-docs.mjs docs/concepts/experimental-features.md docs/gateway/local-models.md docs/providers/ollama.md`
- `git diff --check`
- AWS Crabbox: `corepack pnpm check:changed` on `cbx_58160a36c5b3` / `run_e0befbd1db32` (exit 0)
- autoreview: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: lean local-model Tool Search no longer hides `exec`, so small coding models can directly discover shell execution while heavier/default tools remain removed or cataloged.
Real environment tested: local linked OpenClaw worktree plus AWS Crabbox Linux runner `cbx_58160a36c5b3`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/local-model-lean.test.ts src/agents/tool-search.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts`; `corepack pnpm check:changed` remotely through Crabbox.
Evidence after fix: focused tests passed locally after rebase; Crabbox changed gate completed successfully with exit 0.
Observed result after fix: Tool Search keeps predicate-excluded tools visible, and lean mode passes that predicate so `exec` remains in the direct tool list.
What was not tested: a live Ollama/Qwen weather prompt; this patch is the narrow catalog/visibility fix, not an automatic live-data routing policy.
