### PR TITLE
fix(memory): show signalCount in dreaming promotion annotation (#87588)

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1924,7 +1924,13 @@ function buildPromotionSection(
 
   for (const candidate of candidates) {
     const source = `${candidate.path}:${candidate.startLine}-${candidate.endLine}`;
-    const metadata = `[score=${candidate.score.toFixed(3)} recalls=${candidate.recallCount} avg=${candidate.avgScore.toFixed(3)} source=${source}]`;
+    // "signals" = recallCount + dailyCount + groundedCount (the value checked
+    // against minRecallCount). Fall back to computing it when the field is absent
+    // for older entries that pre-date the signalCount property.
+    const signalCount =
+      candidate.signalCount ??
+      candidate.recallCount + (candidate.dailyCount ?? 0) + (candidate.groundedCount ?? 0);
+    const metadata = `[score=${candidate.score.toFixed(3)} signals=${signalCount} recalls=${candidate.recallCount} avg=${candidate.avgScore.toFixed(3)} source=${source}]`;
     lines.push(`<!-- ${PROMOTION_MARKER_PREFIX}${candidate.key} -->`);
     // Cap only the visible MEMORY.md text. The recall store keeps the full
     // rehydrated snippet so ranking, provenance, and dream narratives remain


### PR DESCRIPTION
## Problem

The promotion annotation written to `MEMORY.md` has shown `recalls=<recallCount>` since the feature shipped, but the actual promotion gate checks the *total signal count* (`recallCount + dailyCount + groundedCount`), not `recallCount` alone.

This produces confusing auditing output: entries that qualified entirely via daily-ingestion signals (`dailyCount`) show `recalls=0` in the annotation, giving the impression they bypassed the `minRecallCount` threshold when they actually satisfied it through accumulated daily signals.

Reported in #87588 — 58 of 79 promoted entries in the reporter's system have `recallCount=0` but passed via `dailyCount=5-7`.

## Fix

**`buildPromotionSection` annotation** — compute `signalCount` from the candidate's breakdown fields and emit `signals=<N>` alongside the existing `recalls=<N>` field:

```
Before: [score=0.832 recalls=0 avg=0.620 source=memory/2026-05-24-0003.md:9-10]
After:  [score=0.832 signals=6 recalls=0 avg=0.620 source=memory/2026-05-24-0003.md:9-10]
```

The `signals` value is `candidate.signalCount ?? (recallCount + dailyCount + groundedCount)`, matching exactly what `totalSignalCountForEntry` computes for the promotion gate.

**JSDoc on `minRecallCount` fields** — Clarify in `RankShortTermPromotionOptions` and `ApplyShortTermPromotionsOptions` that despite the name the parameter gates on total signal count, not `recallCount` alone. The parameter name is kept as-is for config backwards compatibility.

## Testing

- All 44 existing tests in `short-term-promotion.test.ts` pass (vitest run)
- No new TypeScript errors in the changed file
- Annotation change is additive — `recalls=` still present for anyone grepping existing logs

## Notes

The config parameter rename (`minRecallCount` → `minSignalCount`) suggested in the issue would be a breaking change for existing gateway configs. This PR takes the non-breaking approach: add JSDoc and fix the observable annotation. A separate migration/alias PR could address the rename if maintainers want to pursue it.

Closes #87588