### PR TITLE
fix(ui): defer chat session picker blur handler to next animation frame

### DIFF
--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -594,7 +594,7 @@ function renderChatSessionPickerPopover(
                 void applyChatSessionPickerSearch(state);
               }
             }}
-            @blur=${() => void applyChatSessionPickerSearch(state)}
+            @blur=${() => requestAnimationFrame(() => void applyChatSessionPickerSearch(state))}
           />
         </label>
         <button


### PR DESCRIPTION
## Bug Description

All interactive buttons inside the chat-session-picker dropdown (switch session, load more, search submit, clear search) silently fail because the search input's `@blur` handler destroys the DOM between the `blur` and `click` events via a Lit microtask re-render.

## Steps to Reproduce

1. Open the Control UI dashboard (tested with Chrome).
2. Navigate to the Chat tab.
3. Open the session picker dropdown.
4. The search input auto-focuses.
5. Click any session option button to switch sessions.
6. Observe the picker options flash but the session does not switch.
7. The same failure applies to "Load more", search submit, and clear search buttons.

## Root Cause

`@blur=${() => void applyChatSessionPickerSearch(state)}` synchronously triggers:
1. `applyChatSessionPickerSearch()` → `loadChatSessionPickerPage()`
2. `loadChatSessionPickerPage()` sets `chatSessionPickerLoading = true` and calls `requestHostUpdate(state)`
3. Lit schedules a microtask re-render, which rebuilds the picker DOM
4. The clicked button element is destroyed before the `click` event fires
5. Result: buttons appear to flash but no action is performed

## Fix

Defer the blur handler with `requestAnimationFrame` so the `click` event is processed before the DOM is rebuilt:

```diff
- @blur=${() => void applyChatSessionPickerSearch(state)}
+ @blur=${() => requestAnimationFrame(() => void applyChatSessionPickerSearch(state))}
```

## Test Environment

- OS: Linux 6.8.0 (VM)
- Browser: Chromium-based
- OpenClaw version: v2026.5.22

## Real Behavior Proof

### Before fix
1. Open Control UI Chat tab
2. Open session picker
3. Click any session option
4. **Expected**: session switches
5. **Actual**: picker flashes, session remains unchanged, no console error

### After fix
1. Same steps
2. **Result**: session switches correctly, "Load more" loads additional sessions, search/clear buttons work

## Regression Test

The change is a single-line defensive timing adjustment in `ui/src/ui/chat/session-controls.ts`. No other blur handlers in the codebase use the same pattern, so this is a targeted fix. The `@keydown` handler for Enter still triggers synchronously, preserving immediate keyboard search behavior.

Fixes #87554