### PR TITLE
feat(sidebar): add Session Reset button alongside New Session

### DIFF
--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1101,6 +1101,7 @@ export const ar: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "تصدير",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1125,6 +1125,7 @@ export const de: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Exportieren",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1107,6 +1107,7 @@ export const en: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Export",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1122,6 +1122,7 @@ export const es: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Exportar",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1118,6 +1118,7 @@ export const fa: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "خروجی گرفتن",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1129,6 +1129,7 @@ export const fr: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Exporter",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1116,6 +1116,7 @@ export const id: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Ekspor",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1123,6 +1123,7 @@ export const it: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Esporta",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1120,6 +1120,7 @@ export const ja_JP: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "エクスポート",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1109,6 +1109,7 @@ export const ko: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "내보내기",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1121,6 +1121,7 @@ export const nl: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Exporteren",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1121,6 +1121,7 @@ export const pl: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Eksport",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1117,6 +1117,7 @@ export const pt_BR: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Exportar",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1086,6 +1086,7 @@ export const th: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "ส่งออก",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1122,6 +1122,7 @@ export const tr: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Dışa aktar",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1119,6 +1119,7 @@ export const uk: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Експорт",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1108,6 +1108,7 @@ export const vi: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "Xuất",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1081,6 +1081,7 @@ export const zh_CN: TranslationMap = {
     },
     runControls: {
       newSession: "新会话",
+      resetSession: "Reset session",
       export: "导出",
       exportChat: "导出聊天",
       queue: "排队",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1083,6 +1083,7 @@ export const zh_TW: TranslationMap = {
     },
     runControls: {
       newSession: "New session",
+      resetSession: "Reset session",
       export: "匯出",
       exportChat: "Export chat",
       queue: "Queue",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -668,6 +668,65 @@
   stroke-linejoin: round;
 }
 
+.sidebar-reset-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 38px;
+  box-sizing: border-box;
+  padding: 0 10px;
+  margin-top: 4px;
+  border: 1px solid color-mix(in srgb, var(--accent) 15%, var(--border) 85%);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    transform var(--duration-fast) ease;
+}
+
+.sidebar-reset-session:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-hover) 92%);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border) 72%);
+  color: var(--text-strong);
+  transform: translateY(-1px);
+}
+
+.sidebar-reset-session:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.sidebar-reset-session__icon,
+.sidebar-reset-session__icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.sidebar-reset-session__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: currentColor;
+}
+
+.sidebar-reset-session__icon svg {
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .sidebar-recent-sessions {
   display: grid;
   gap: 6px;

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -125,6 +125,7 @@ export function createChatSessionsLoadOverrides(
   return overrides;
 }
 export {
+  clearChatHistory,
   handleChatDraftChange,
   handleChatInputHistoryKey,
   navigateChatInputHistory,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,6 +1,6 @@
 import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
-import { createChatSessionsLoadOverrides, refreshChat, refreshChatAvatar } from "./app-chat.ts";
+import { clearChatHistory, createChatSessionsLoadOverrides, refreshChat, refreshChatAvatar } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
@@ -187,6 +187,32 @@ const NEW_CHAT_SESSIONS_LOADING_MESSAGE =
   "Session list is still refreshing. Try New Chat again in a moment.";
 const NEW_CHAT_CREATE_FAILED_MESSAGE =
   "New Chat could not create a new session. Try again in a moment.";
+const RESET_SESSION_CONFIRM_MESSAGE =
+  "Reset this session? This will clear all messages and start fresh.";
+
+/** Reset the current session via sessions.reset, reusing the same session key. */
+export async function resetChatSession(state: AppViewState): Promise<boolean> {
+  if (!state.client || !state.connected) {
+    return false;
+  }
+  if (!canSwitchToNewChatSession(state)) {
+    state.lastError = NEW_CHAT_ACTIVE_RUN_MESSAGE;
+    return false;
+  }
+  if (state.sessionsLoading) {
+    state.lastError = NEW_CHAT_SESSIONS_LOADING_MESSAGE;
+    return false;
+  }
+  if (
+    typeof globalThis.confirm === "function" &&
+    !globalThis.confirm(RESET_SESSION_CONFIRM_MESSAGE)
+  ) {
+    return false;
+  }
+  state.lastError = null;
+  await clearChatHistory(state as unknown as Parameters<typeof clearChatHistory>[0]);
+  return true;
+}
 
 export function renderTab(state: AppViewState, tab: Tab, opts?: { collapsed?: boolean }) {
   const href = pathForTab(tab, state.basePath);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -21,6 +21,7 @@ import {
   createChatSession,
   dismissChatError,
   switchChatSession,
+  resetChatSession,
 } from "./app-render.helpers.ts";
 import { warnQueryToken } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
@@ -297,6 +298,30 @@ function renderSidebarSessions(state: AppViewState) {
           ? nothing
           : html`<span class="sidebar-new-session__label"
               >${t("chat.runControls.newSession")}</span
+            >`}
+      </button>
+      <button
+        type="button"
+        class="sidebar-reset-session"
+        title=${newSessionDisabled
+          ? "Finish the active run before resetting the session"
+          : "Reset session"}
+        aria-label=${t("chat.runControls.resetSession")}
+        ?disabled=${newSessionDisabled}
+        @click=${async () => {
+          if (newSessionDisabled) {
+            return;
+          }
+          if (await resetChatSession(state)) {
+            state.setTab("chat" as import("./navigation.ts").Tab);
+          }
+        }}
+      >
+        <span class="sidebar-reset-session__icon" aria-hidden="true">${icons.refresh}</span>
+        ${collapsed
+          ? nothing
+          : html`<span class="sidebar-reset-session__label"
+              >${t("chat.runControls.resetSession")}</span
             >`}
       </button>
       ${collapsed || recent.length === 0


### PR DESCRIPTION
## Summary

Adds a **Reset session** button in the sidebar directly below the existing **New session** button. Unlike "New session" which creates a new session key, this button reuses the current session key by calling `sessions.reset` — clearing chat history without losing the session slot.

This is primarily useful for `agent:main:main` and similar single-session configurations where users want to reset context without cycling through session keys.

## Changes

1. **`ui/src/ui/app-chat.ts`** — Exported `clearChatHistory` (previously internal)
2. **`ui/src/ui/app-render.helpers.ts`** — Added `resetChatSession(state)` helper with connected/busy guard and confirmation dialog, reusing `clearChatHistory`
3. **`ui/src/ui/app-render.ts`** — Added reset button markup in `renderSidebarSessions()` using the existing `refresh` icon; imported `resetChatSession`
4. **`ui/src/styles/layout.css`** — Added `.sidebar-reset-session` styles (subtler than primary new-session — transparent background, muted text, same interaction pattern)
5. **`ui/src/i18n/locales/*.ts`** (all 19) — Added `resetSession: "Reset session"` to `runControls`

## Design

- Button is disabled under the same conditions as "New session" (disconnected, loading, active run in progress)
- Shows a `confirm()` dialog before resetting (same pattern as `/reset` slash command)
- Visually distinct from the primary New session button — transparent background, muted text color, lighter border — to avoid confusion
- Reuses the existing `refresh` (rotate-ccw) icon — no new icon assets needed
- Works in collapsed sidebar mode (icon-only)

## Motivation

Users with `agent:main:main` or similar fixed-session configurations need to clear chat history frequently but have no UI affordance to do so. The only options were:
- Type `/reset` (requires keyboard)
- Create a new session (wastes session slots)

This closes that gap with minimal code: no server-side changes, no new dependencies, just reusing existing `sessions.reset` logic.