### PR TITLE
fix(agents): preserve reasoning_content replay across DeepSeek tier suffixes

### DIFF
--- a/extensions/opencode/opencode.live.test.ts
+++ b/extensions/opencode/opencode.live.test.ts
@@ -65,7 +65,6 @@ describeLive("opencode plugin live", () => {
       apiKey: OPENCODE_API_KEY,
       reasoning: "low",
       maxTokens: 128,
-      toolChoice: "required",
     } as const;
 
     const first = await completeSimple(
@@ -74,7 +73,7 @@ describeLive("opencode plugin live", () => {
         messages: [
           {
             role: "user",
-            content: "Use live_echo with value ok. Do not answer directly.",
+            content: "You must call the live_echo tool with value ok. Do not answer directly.",
             timestamp: Date.now(),
           },
         ],
@@ -96,7 +95,7 @@ describeLive("opencode plugin live", () => {
         messages: [
           {
             role: "user",
-            content: "Use live_echo with value ok. Do not answer directly.",
+            content: "You must call the live_echo tool with value ok. Do not answer directly.",
             timestamp: Date.now() - 3,
           },
           first,

--- a/extensions/opencode/opencode.live.test.ts
+++ b/extensions/opencode/opencode.live.test.ts
@@ -1,0 +1,132 @@
+import {
+  completeSimple,
+  type AssistantMessage,
+  type Model,
+  type Tool,
+} from "openclaw/plugin-sdk/llm";
+import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+
+const OPENCODE_API_KEY =
+  process.env.OPENCODE_API_KEY?.trim() || process.env.OPENCODE_ZEN_API_KEY?.trim() || "";
+const LIVE_MODEL_ID =
+  process.env.OPENCLAW_LIVE_OPENCODE_DEEPSEEK_MODEL?.trim() || "deepseek-v4-flash-free";
+const LIVE = isLiveTestEnabled(["OPENCODE_LIVE_TEST"]) && OPENCODE_API_KEY.length > 0;
+const describeLive = LIVE ? describe : describe.skip;
+
+function resolveOpencodeDeepSeekLiveModel(): Model<"openai-completions"> {
+  return {
+    id: LIVE_MODEL_ID,
+    name: LIVE_MODEL_ID,
+    api: "openai-completions",
+    provider: "opencode",
+    baseUrl: "https://opencode.ai/zen/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 65_536,
+    maxTokens: 8192,
+  };
+}
+
+function liveEchoTool(): Tool {
+  return {
+    name: "live_echo",
+    description: "Return the supplied value.",
+    parameters: Type.Object(
+      {
+        value: Type.String(),
+      },
+      { additionalProperties: false },
+    ),
+  };
+}
+
+function requireToolCall(message: AssistantMessage) {
+  const toolCall = message.content.find((block) => block.type === "toolCall");
+  if (toolCall?.type !== "toolCall") {
+    throw new Error(`OpenCode DeepSeek live model did not call a tool: ${message.stopReason}`);
+  }
+  return toolCall;
+}
+
+function hasReasoningContentReplay(message: AssistantMessage): boolean {
+  return message.content.some(
+    (block) => block.type === "thinking" && block.thinkingSignature === "reasoning_content",
+  );
+}
+
+describeLive("opencode plugin live", () => {
+  it("accepts DeepSeek V4 tier-suffixed thinking replay after a tool call", async () => {
+    const model = resolveOpencodeDeepSeekLiveModel();
+    const tool = liveEchoTool();
+    const firstOptions = {
+      apiKey: OPENCODE_API_KEY,
+      reasoning: "low",
+      maxTokens: 128,
+      toolChoice: "required",
+    } as const;
+
+    const first = await completeSimple(
+      model,
+      {
+        messages: [
+          {
+            role: "user",
+            content: "Use live_echo with value ok. Do not answer directly.",
+            timestamp: Date.now(),
+          },
+        ],
+        tools: [tool],
+      },
+      firstOptions,
+    );
+
+    if (first.stopReason === "error") {
+      throw new Error(first.errorMessage || "OpenCode DeepSeek first turn returned an error");
+    }
+
+    const toolCall = requireToolCall(first);
+    expect(hasReasoningContentReplay(first)).toBe(true);
+
+    const second = await completeSimple(
+      model,
+      {
+        messages: [
+          {
+            role: "user",
+            content: "Use live_echo with value ok. Do not answer directly.",
+            timestamp: Date.now() - 3,
+          },
+          first,
+          {
+            role: "toolResult",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: Date.now() - 1,
+          },
+          {
+            role: "user",
+            content: "Reply with exactly: ok",
+            timestamp: Date.now(),
+          },
+        ],
+        tools: [tool],
+      },
+      {
+        apiKey: OPENCODE_API_KEY,
+        reasoning: "low",
+        maxTokens: 64,
+      },
+    );
+
+    if (second.stopReason === "error") {
+      throw new Error(second.errorMessage || "OpenCode DeepSeek replay returned an error");
+    }
+
+    expect(extractNonEmptyAssistantText(second.content)).toMatch(/^ok[.!]?$/i);
+  }, 120_000);
+});

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -8154,6 +8154,51 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
     expect(assistant.reasoning_content).toBe("Need to answer politely.");
   });
 
+  // Regression for #87575: OpenCode Zen exposes DeepSeek V4 with a `-free`
+  // tier suffix that does not change the upstream replay contract. Without
+  // matching the base id we stripped reasoning_content from the follow-up
+  // request and DeepSeek rejected the assistant turn with HTTP 400.
+  it.each([
+    [
+      "OpenCode Zen DeepSeek V4 Flash Free",
+      {
+        id: "deepseek-v4-flash-free",
+        name: "DeepSeek V4 Flash Free",
+        api: "openai-completions" as const,
+        provider: "opencode",
+        baseUrl: "https://opencode.ai/zen/v1",
+        reasoning: true,
+        input: ["text"] as ("text" | "image")[],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 65_536,
+        maxTokens: 8192,
+      },
+    ],
+    [
+      "OpenRouter MiMo V2 Pro Free",
+      {
+        ...customMiMoProxyModel,
+        id: "xiaomi/mimo-v2-pro-free",
+      },
+    ],
+    [
+      "OpenRouter Kimi K2 Thinking Free",
+      {
+        ...customKimiProxyModel,
+        id: "moonshotai/kimi-k2-thinking-free",
+      },
+    ],
+  ] as const)("preserves reasoning_content replay despite the %s tier suffix", (_label, model) => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(model as Model<"openai-completions">, "reasoning_content"),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
   it("preserves OpenRouter array reasoning_details from tool-call signatures", () => {
     const reasoningDetail = { type: "reasoning.encrypted", id: "rs_1", data: "ciphertext" };
     const params = buildOpenAICompletionsParams(

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3398,6 +3398,23 @@ const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
   "mimo-v2.6-pro",
 ]);
 
+// Tier/access suffixes that some providers append to otherwise identical model
+// ids (OpenCode Zen exposes `deepseek-v4-flash-free`, OpenRouter exposes
+// `:free` / `:cloud`, etc.). The base model id before the suffix still owns
+// the same DeepSeek-style reasoning_content replay contract, so reasoning
+// replay must not be stripped just because the catalog id grew a marketing
+// suffix (#87575).
+const REASONING_CONTENT_REPLAY_TIER_SUFFIXES = ["-free", "-paid", "-trial"] as const;
+
+function stripReasoningContentReplayTierSuffix(modelId: string): string {
+  for (const suffix of REASONING_CONTENT_REPLAY_TIER_SUFFIXES) {
+    if (modelId.length > suffix.length && modelId.endsWith(suffix)) {
+      return modelId.slice(0, -suffix.length);
+    }
+  }
+  return modelId;
+}
+
 function getReasoningContentReplayModelIdCandidates(modelId: unknown): string[] {
   if (typeof modelId !== "string") {
     return [];
@@ -3412,6 +3429,12 @@ function getReasoningContentReplayModelIdCandidates(modelId: unknown): string[] 
   const colonParts = finalPart.split(":").filter(Boolean);
   if (colonParts.length > 1) {
     candidates.push(colonParts[0] ?? "", colonParts[colonParts.length - 1] ?? "");
+  }
+  for (const candidate of [...candidates]) {
+    const stripped = stripReasoningContentReplayTierSuffix(candidate);
+    if (stripped !== candidate) {
+      candidates.push(stripped);
+    }
   }
   return uniqueStrings(candidates.filter(Boolean));
 }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3430,7 +3430,12 @@ function getReasoningContentReplayModelIdCandidates(modelId: unknown): string[] 
   if (colonParts.length > 1) {
     candidates.push(colonParts[0] ?? "", colonParts[colonParts.length - 1] ?? "");
   }
-  for (const candidate of [...candidates]) {
+  const baseCount = candidates.length;
+  for (let index = 0; index < baseCount; index += 1) {
+    const candidate = candidates[index];
+    if (typeof candidate !== "string") {
+      continue;
+    }
     const stripped = stripReasoningContentReplayTierSuffix(candidate);
     if (stripped !== candidate) {
       candidates.push(stripped);


### PR DESCRIPTION
## Summary

- Strip well-known tier suffixes (`-free`, `-paid`, `-trial`) when building the `REASONING_CONTENT_REPLAY_MODEL_IDS` allowlist candidates so OpenCode Zen's `deepseek-v4-flash-free` (and any other tier-suffixed DeepSeek/MiMo/Kimi route) matches the base model id and keeps its DeepSeek-style `reasoning_content` replay.
- Out of scope: making `isDeepSeek` recognise OpenCode-native endpoints, adding an OpenCode Zen `wrapStreamFn`, or changing the replay sanitizer for non-DeepSeek-style providers. The minimal fix removes the 400 without expanding the replay contract.

## Linked context

Closes #87575

Was this requested by a maintainer or owner?

No direct maintainer request; the issue is `clawsweeper:fix-shape-clear` + `queueable-fix` + `source-repro`, and the reporter included a 4-step root cause analysis that points at exactly this allowlist gap.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenCode Zen exposes DeepSeek V4 Flash Free as `deepseek-v4-flash-free`. The shared OpenAI-compatible replay sanitizer used the bare allowlist (`deepseek-v4-flash`, etc.) so the tier-suffixed id never matched. The follow-up request to DeepSeek therefore had `reasoning_content` stripped from the assistant turn and DeepSeek rejected it with `400: \`reasoning_content\` in the thinking mode must be passed back to the API`, deadlocking the session.
- Real environment tested: Local OpenClaw source checkout on Linux with Node `v22.22.3`, pnpm `11.2.2` via corepack.
- Exact steps or command run after this patch: Ran a local OpenClaw source smoke against the real `buildOpenAICompletionsParams` with an OpenCode-routed `deepseek-v4-flash-free` model and a transcript that includes a thinking block carrying `reasoning_content`, then re-ran the same smoke after `git stash`-ing this patch on the same branch.
- Evidence after fix: Copied console output from the smoke.

  Before-fix (patch stashed):

  ```
  === BEFORE-FIX BEHAVIOR ===
  assistant.reasoning_content present: false
  assistant keys: [ 'role', 'content' ]
  bug repro: DeepSeek API would reject follow-up since reasoning_content missing
  ```

  After-fix (patch restored):

  ```
  === AFTER-FIX BEHAVIOR ===
  assistant.reasoning_content present: true
  assistant.reasoning_content value: \"Need to answer politely.\"
  ```

- Observed result after fix: The OpenCode-routed `deepseek-v4-flash-free` follow-up assistant payload now carries the original `reasoning_content` instead of being stripped down to bare role+content. The same matching path keeps preserving other tier-suffixed routes (MiMo `-free`, Kimi K2 `-free`).
- What was not tested: A live OpenCode Zen call against `https://opencode.ai/zen/v1`. The fix is at the sanitizer boundary that consumes the same OpenAI-compatible request shape; the smoke exercises that boundary directly using the model+context the live provider produces.
- Proof limitations or environment constraints: The after-fix proof uses the real shared sanitizer in a local checkout but does not call the OpenCode Zen endpoint because this environment is not configured with OpenCode credentials. The reporter's 400 capture in the issue documents the upstream side of the same boundary.
- Before evidence (optional but encouraged): Captured above via `git stash`-ing this patch.

## Tests and validation

Which commands did you run?

- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts`
- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" corepack pnpm exec oxfmt --check src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check`

Outputs:

- `openai-transport-stream.test.ts`: `Test Files 1 passed (1)` / `Tests 204 passed (204)` — the existing reasoning replay coverage plus a new parameterised case for OpenCode Zen DeepSeek V4 Flash Free, OpenRouter MiMo V2 Pro Free, and OpenRouter Kimi K2 Thinking Free.
- `oxfmt --check`: `All matched files use the correct format.`

What regression coverage was added or updated?

Added an `it.each([...])` block under `buildOpenAICompletionsParams sanitizes reasoning replay fields` that asserts `reasoning_content` survives the replay sanitizer for three tier-suffixed model ids while still stripping `reasoning_details`, `reasoning`, and `reasoning_text`. The before-fix smoke above demonstrates the new assertions would not have passed without this patch.

What failed before this fix, if known?

The OpenCode-routed `deepseek-v4-flash-free` follow-up assistant payload had `reasoning_content` stripped, so any DeepSeek API call after the first turn returned HTTP 400 and the session deadlocked.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes (positive). Tier-suffixed DeepSeek-style routes can now complete multi-turn sessions instead of failing the second request with HTTP 400.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

A provider that ships a model id ending in `-free`/`-paid`/`-trial` that does *not* honour the DeepSeek-style replay contract would now receive `reasoning_content` it did not expect.

How is that risk mitigated?

The base id (after suffix strip) still has to be in `REASONING_CONTENT_REPLAY_MODEL_IDS`, which only lists DeepSeek V4, Kimi/MiMo, and friends that all document the same replay contract. The suffix list is intentionally narrow (three known tier markers) and only applied to allowlist candidate matching — the wire-level sanitizer behavior is unchanged for any base id that is not on the allowlist.

## Current review state

What is the next action?

Await maintainer / ClawSweeper review on (a) whether suffix-stripping is preferred over enumerating every `-free` variant in the allowlist, and (b) whether the OpenCode Zen plugin should also wire `wrapStreamFn` for parity with `opencode-go`.

What is still waiting on author, maintainer, CI, or external proof?

A live OpenCode Zen call producing the 400 → success transition is still not provided from this environment.

Which bot or reviewer comments were addressed?

Initial PR; no PR comments yet.

AI-assisted: yes. I reviewed the touched code paths, designed the candidate-stripping change, and ran the focused validation commands above.

Made with [Cursor](https://cursor.com)