### PR TITLE
fix(openrouter): apply strict9 tool_call_id sanitisation for Mistral routes

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -82,6 +82,57 @@ describe("openrouter provider hooks", () => {
     });
   });
 
+  // Regression for #58012: OpenRouter proxies Mistral, which requires the
+  // strict9 tool_call_id mode the direct `mistral` provider already applies.
+  // Without strict9, replayed assistant turns fail with HTTP 400
+  // `invalid_function_call` 3280. Other OpenRouter-routed models (Gemini,
+  // OpenAI, Anthropic, etc.) must keep the existing passthrough policy.
+  describe("OpenRouter Mistral tool_call_id strict9 (#58012)", () => {
+    it.each([
+      ["bare mistralai prefix", "mistralai/mistral-large-latest"],
+      ["nested openrouter/mistralai", "openrouter/mistralai/mistral-small"],
+      ["bare mistral provider prefix", "mistral/mistral-medium"],
+    ])("applies strict9 sanitisation for %s", async (_label, modelId) => {
+      const provider = await registerSingleProviderPlugin(openrouterPlugin);
+      const policy = provider.buildReplayPolicy?.({
+        provider: "openrouter",
+        modelApi: "openai-completions",
+        modelId,
+      } as never);
+
+      expect(policy?.sanitizeToolCallIds).toBe(true);
+      expect(policy?.toolCallIdMode).toBe("strict9");
+    });
+
+    it.each([
+      ["Gemini", "gemini-2.5-pro"],
+      ["OpenAI", "openai/gpt-5.4"],
+      ["Anthropic", "anthropic/claude-sonnet-4-6"],
+      ["DeepSeek", "deepseek/deepseek-v4-flash"],
+    ])("keeps passthrough policy for %s (no strict9)", async (_label, modelId) => {
+      const provider = await registerSingleProviderPlugin(openrouterPlugin);
+      const policy = provider.buildReplayPolicy?.({
+        provider: "openrouter",
+        modelApi: "openai-completions",
+        modelId,
+      } as never);
+
+      expect(policy?.sanitizeToolCallIds).toBeUndefined();
+      expect(policy?.toolCallIdMode).toBeUndefined();
+    });
+
+    it("preserves Gemini thought-signature sanitisation alongside strict9 logic", async () => {
+      const provider = await registerSingleProviderPlugin(openrouterPlugin);
+      const geminiPolicy = provider.buildReplayPolicy?.({
+        provider: "openrouter",
+        modelApi: "openai-completions",
+        modelId: "google/gemini-2.5-pro",
+      } as never);
+
+      expect(geminiPolicy).toHaveProperty("sanitizeThoughtSignatures");
+    });
+  });
+
   it("owns native reasoning output mode", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
 

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -89,6 +89,9 @@ describe("openrouter provider hooks", () => {
   // OpenAI, Anthropic, etc.) must keep the existing passthrough policy.
   describe("OpenRouter Mistral tool_call_id strict9 (#58012)", () => {
     it.each([
+      ["unprefixed Mistral", "mistral-large-latest"],
+      ["unprefixed Codestral", "codestral-latest"],
+      ["unprefixed Devstral", "devstral-small-latest"],
       ["bare mistralai prefix", "mistralai/mistral-large-latest"],
       ["nested openrouter/mistralai", "openrouter/mistralai/mistral-small"],
       ["bare mistral provider prefix", "mistral/mistral-medium"],

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -1,5 +1,7 @@
 import {
   definePluginEntry,
+  type ProviderReplayPolicy,
+  type ProviderReplayPolicyContext,
   type ProviderResolveDynamicModelContext,
   type ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
@@ -92,6 +94,40 @@ export default definePluginEntry({
       return OPENROUTER_CACHE_TTL_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
     }
 
+    function isOpenRouterMistralModelId(modelId: string | undefined): boolean {
+      const normalized = (modelId ?? "").trim().toLowerCase();
+      if (!normalized) {
+        return false;
+      }
+      // OpenRouter exposes Mistral-family routes as `mistralai/<model>` and a
+      // few `openrouter/mistralai/<model>` mirrors. Use a prefix match instead
+      // of an enumerated list so future Mistral models inherit the same
+      // strict9 tool_call_id contract by default.
+      return (
+        normalized.startsWith("mistralai/") ||
+        normalized.startsWith("openrouter/mistralai/") ||
+        normalized.startsWith("mistral/") ||
+        normalized.startsWith("openrouter/mistral/")
+      );
+    }
+
+    const passthroughReplayHook = PASSTHROUGH_GEMINI_REPLAY_HOOKS.buildReplayPolicy;
+    function buildOpenRouterReplayPolicy(ctx: ProviderReplayPolicyContext): ProviderReplayPolicy {
+      const base = passthroughReplayHook?.(ctx) ?? {};
+      // OpenRouter proxies Mistral, which uses non-base62 tool_call_ids and
+      // requires the 9-char id contract that direct `mistral` provider already
+      // applies. Without strict9, replayed assistant turns fail with HTTP 400
+      // `invalid_function_call` 3280 (#58012).
+      if (isOpenRouterMistralModelId(ctx.modelId)) {
+        return {
+          ...base,
+          sanitizeToolCallIds: true,
+          toolCallIdMode: "strict9",
+        };
+      }
+      return base;
+    }
+
     api.registerProvider({
       id: PROVIDER_ID,
       label: "OpenRouter",
@@ -162,6 +198,7 @@ export default definePluginEntry({
           : undefined;
       },
       ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+      buildReplayPolicy: buildOpenRouterReplayPolicy,
       resolveReasoningOutputMode: () => "native",
       supportsXHighThinking: ({ modelId }) => supportsOpenRouterXHighThinking(modelId),
       resolveThinkingProfile: ({ modelId }) => resolveOpenRouterThinkingProfile(modelId),

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -16,6 +16,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-family";
 import { buildOpenRouterImageGenerationProvider } from "./image-generation-provider.js";
 import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
+import { isOpenRouterMistralModelId } from "./models.js";
 import { buildOpenRouterMusicGenerationProvider } from "./music-generation-provider.js";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
 import {
@@ -92,23 +93,6 @@ export default definePluginEntry({
 
     function isOpenRouterCacheTtlModel(modelId: string): boolean {
       return OPENROUTER_CACHE_TTL_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
-    }
-
-    function isOpenRouterMistralModelId(modelId: string | undefined): boolean {
-      const normalized = (modelId ?? "").trim().toLowerCase();
-      if (!normalized) {
-        return false;
-      }
-      // OpenRouter exposes Mistral-family routes as `mistralai/<model>` and a
-      // few `openrouter/mistralai/<model>` mirrors. Use a prefix match instead
-      // of an enumerated list so future Mistral models inherit the same
-      // strict9 tool_call_id contract by default.
-      return (
-        normalized.startsWith("mistralai/") ||
-        normalized.startsWith("openrouter/mistralai/") ||
-        normalized.startsWith("mistral/") ||
-        normalized.startsWith("openrouter/mistral/")
-      );
     }
 
     const passthroughReplayHook = PASSTHROUGH_GEMINI_REPLAY_HOOKS.buildReplayPolicy;

--- a/extensions/openrouter/models.ts
+++ b/extensions/openrouter/models.ts
@@ -1,11 +1,30 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+const OPENROUTER_MISTRAL_MODEL_PREFIXES = [
+  "mistralai/",
+  "mistral/",
+  "mistral-",
+  "codestral-",
+  "devstral-",
+  "ministral-",
+  "mixtral-",
+  "pixtral-",
+  "voxtral-",
+] as const;
+
 export function normalizeOpenRouterModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
   }
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
   return normalized.startsWith("openrouter/") ? normalized.slice("openrouter/".length) : normalized;
+}
+
+export function isOpenRouterMistralModelId(modelId: unknown): boolean {
+  const normalized = normalizeOpenRouterModelId(modelId);
+  return Boolean(
+    normalized && OPENROUTER_MISTRAL_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix)),
+  );
 }
 
 export function isOpenRouterDeepSeekV4ModelId(modelId: unknown): boolean {

--- a/extensions/openrouter/openrouter.live.test.ts
+++ b/extensions/openrouter/openrouter.live.test.ts
@@ -7,17 +7,24 @@ import {
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 
+const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+const OPENROUTER_MISTRAL_PROVIDER_PREFIX = "mistralai/";
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? "";
 const LIVE_MODEL_ID =
   process.env.OPENCLAW_LIVE_OPENROUTER_PLUGIN_MODEL?.trim() || "openai/gpt-5.4-nano";
 const LIVE_CACHE_MODEL_ID =
   process.env.OPENCLAW_LIVE_OPENROUTER_CACHE_MODEL?.trim() || "deepseek/deepseek-v3.2";
 const liveEnabled = OPENROUTER_API_KEY.trim().length > 0 && process.env.OPENCLAW_LIVE_TEST === "1";
+const liveCatalogEnabled = process.env.OPENCLAW_LIVE_TEST === "1";
 const describeLive = liveEnabled ? describe : describe.skip;
+const describeCatalogLive = liveCatalogEnabled ? describe : describe.skip;
 const describeCacheLive =
   liveEnabled && process.env.OPENCLAW_LIVE_CACHE_TEST === "1" ? describe : describe.skip;
 const ModelRegistryCtor = ModelRegistry as unknown as {
   new (authStorage: AuthStorage, modelsJsonPath?: string): ModelRegistry;
+};
+type OpenRouterModelsResponse = {
+  data?: Array<{ id?: unknown }>;
 };
 
 const registerOpenRouterPlugin = async () =>
@@ -47,6 +54,17 @@ async function completeOpenRouterChat(params: {
     messages: params.messages,
     max_tokens: 8,
   });
+}
+
+async function fetchOpenRouterModelIds(): Promise<string[]> {
+  const response = await fetch(OPENROUTER_MODELS_URL, {
+    headers: { "accept-encoding": "identity" },
+  });
+  expect(response.ok).toBe(true);
+  const json = (await response.json()) as OpenRouterModelsResponse;
+  return (json.data ?? [])
+    .map((model) => model.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
 }
 
 describeLive("openrouter plugin live", () => {
@@ -79,6 +97,28 @@ describeLive("openrouter plugin live", () => {
     });
 
     expect(response.choices[0]?.message?.content?.trim()).toMatch(/^OK[.!]?$/);
+  }, 30_000);
+});
+
+describeCatalogLive("openrouter plugin live model catalog", () => {
+  it("applies strict9 replay policy to current OpenRouter Mistral-family routes", async () => {
+    const liveMistralModelIds = (await fetchOpenRouterModelIds()).filter((id) =>
+      id.startsWith(OPENROUTER_MISTRAL_PROVIDER_PREFIX),
+    );
+    expect(liveMistralModelIds.length).toBeGreaterThan(0);
+
+    const { providers } = await registerOpenRouterPlugin();
+    const provider = requireRegisteredProvider(providers, "openrouter");
+
+    for (const modelId of liveMistralModelIds) {
+      const policy = provider.buildReplayPolicy?.({
+        provider: "openrouter",
+        modelApi: "openai-completions",
+        modelId,
+      } as never);
+      expect.soft(policy?.sanitizeToolCallIds, modelId).toBe(true);
+      expect.soft(policy?.toolCallIdMode, modelId).toBe("strict9");
+    }
   }, 30_000);
 });
 

--- a/src/agents/agent-tools-parameter-schema.ts
+++ b/src/agents/agent-tools-parameter-schema.ts
@@ -24,9 +24,9 @@ function resolveToolParameterSchemaCacheKey(
 ): string {
   const normalizedProvider = normalizeLowercaseStringOrEmpty(options?.modelProvider);
   const normalizedModelId = normalizeLowercaseStringOrEmpty(options?.modelId);
-  const unsupportedKeywords = [
-    ...resolveUnsupportedToolSchemaKeywords(options?.modelCompat),
-  ].sort();
+  const unsupportedKeywords = Array.from(
+    resolveUnsupportedToolSchemaKeywords(options?.modelCompat),
+  ).toSorted();
   const omitEmptyArrayItems = shouldOmitEmptyArrayItems(options?.modelCompat);
   return JSON.stringify([
     normalizedProvider,


### PR DESCRIPTION
## Summary

- Override `buildReplayPolicy` on the OpenRouter plugin so Mistral-targeted ids (`mistralai/...`, `openrouter/mistralai/...`, `mistral/...`) extend the existing passthrough policy with `sanitizeToolCallIds: true, toolCallIdMode: \"strict9\"` — the same contract the direct `mistral` provider already enforces.
- Out of scope: changing the shared `buildPassthroughGeminiSanitizingReplayPolicy`, touching non-Mistral OpenRouter routes (Gemini / OpenAI / Anthropic / DeepSeek keep their current passthrough policy), or altering Gemini thought-signature sanitisation.

## Linked context

Closes #58012

Was this requested by a maintainer or owner?

No direct maintainer request. The issue is `clawsweeper:fix-shape-clear` + `queueable-fix` + `source-repro`. Multiple earlier PRs (#58014, #58015, #57805, #47714) targeted the same gap and were closed without merging; ClawSweeper's most recent review encourages a fresh attempt against current main.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenRouter proxies Mistral but composed `PASSTHROUGH_GEMINI_REPLAY_HOOKS` straight through, so the replay sanitizer never converted tool_call_ids to Mistral's required 9-char format. Replayed assistant turns therefore failed with HTTP 400 `invalid_function_call` 3280 the moment the agent reused a stored tool_call_id.
- Real environment tested: Local OpenClaw source checkout on Linux with Node `v22.22.3`, pnpm `11.2.2` via corepack.
- Exact steps or command run after this patch: Ran a local OpenClaw source smoke against the registered OpenRouter plugin via `registerSingleProviderPlugin` and inspected the returned `ProviderReplayPolicy` for representative model ids, then re-ran the same smoke after `git stash`-ing this patch on the same branch.
- Evidence after fix: Copied console output from the smoke.

  Before-fix (patch stashed):

  ```
  === BEFORE-FIX BEHAVIOR ===
  mistralai/mistral-large-latest                strict? <none>    sanitizeToolCallIds: false
  openrouter/mistralai/mistral-small            strict? <none>    sanitizeToolCallIds: false
  google/gemini-2.5-pro                         strict? <none>    sanitizeToolCallIds: false
  bug repro: Mistral via OpenRouter has no strict9, will hit HTTP 400 invalid_function_call 3280 on tool replay
  ```

  After-fix (patch restored):

  ```
  === AFTER-FIX BEHAVIOR ===
  mistralai/mistral-large-latest                strict? strict9    sanitizeToolCallIds: true
  openrouter/mistralai/mistral-small            strict? strict9    sanitizeToolCallIds: true
  google/gemini-2.5-pro                         strict? <none>    sanitizeToolCallIds: false
  openai/gpt-5.4                                strict? <none>    sanitizeToolCallIds: false
  anthropic/claude-sonnet-4-6                   strict? <none>    sanitizeToolCallIds: false
  ```

- Observed result after fix: OpenRouter-routed Mistral now matches the direct `mistral` provider on the replay sanitisation contract. Every other OpenRouter route keeps the existing passthrough behavior unchanged, and Gemini-backed routes still receive the `sanitizeThoughtSignatures` extension from the shared passthrough policy.
- What was not tested: A live OpenRouter call against `mistralai/mistral-large-latest` exercising the tool_call replay. The fix is at the replay policy boundary that produces the wire-level ids, so the smoke exercises the exact transformation that the live request would consume.
- Proof limitations or environment constraints: The smoke uses the real registered plugin in a local checkout but does not call OpenRouter because this environment is not configured with OpenRouter credentials. The reporter and the chain of closed PRs document the live 400 behavior.
- Before evidence (optional but encouraged): Captured above via `git stash`-ing this patch.

## Tests and validation

Which commands did you run?

- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" node scripts/test-projects.mjs extensions/openrouter/index.test.ts`
- `PATH=\"\$HOME/.nvm/versions/node/v22.22.3/bin:\$PATH\" corepack pnpm exec oxfmt --check extensions/openrouter/index.ts extensions/openrouter/index.test.ts`
- `git diff --check`

Outputs:

- `extensions/openrouter/index.test.ts`: `Test Files 1 passed (1)` / `Tests 27 passed (27)` — the existing OpenRouter plugin coverage plus a new `OpenRouter Mistral tool_call_id strict9 (#58012)` describe block.
- `oxfmt --check`: `All matched files use the correct format.`

What regression coverage was added or updated?

Added a parameterised `describe` covering: three Mistral id shapes get `strict9` (`mistralai/...`, `openrouter/mistralai/...`, `mistral/...`); four non-Mistral routes (Gemini, OpenAI, Anthropic, DeepSeek) keep the passthrough (no `strict9`); and Gemini routes still receive `sanitizeThoughtSignatures` from the shared passthrough policy.

What failed before this fix, if known?

The before-fix smoke above shows the new Mistral assertions had no `sanitizeToolCallIds`/`toolCallIdMode`, which is exactly the wire-level shape that produced the reported HTTP 400.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes (positive). OpenRouter-routed Mistral conversations can now replay tool calls instead of failing with HTTP 400 `invalid_function_call` 3280.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No (tool_call_ids are rewritten in-flight only; nothing is persisted differently).

What is the highest-risk area?

A future Mistral-family id outside the `mistralai/...` / `openrouter/mistralai/...` / `mistral/...` prefix set would not pick up `strict9` automatically.

How is that risk mitigated?

The prefix list mirrors OpenRouter's existing Mistral routing conventions and is centralized in one helper (`isOpenRouterMistralModelId`) so any future route added to OpenRouter just needs an extra prefix here. Non-Mistral routes are explicitly verified by the parameterised passthrough test to ensure we did not over-broaden the strict9 contract.

## Current review state

What is the next action?

Await maintainer / ClawSweeper review on (a) the chosen prefix set and (b) whether the strict9 policy should live in `extensions/openrouter/` as it does here or be pushed into a shared helper alongside `buildPassthroughGeminiSanitizingReplayPolicy`.

What is still waiting on author, maintainer, CI, or external proof?

A live OpenRouter call demonstrating the 400 → success transition is still not provided from this environment.

Which bot or reviewer comments were addressed?

Initial PR; no PR comments yet. The earlier closed PRs (#58014, #58015, #57805, #47714) are referenced for context.

AI-assisted: yes. I reviewed the touched code paths, designed the override, and ran the focused validation commands above.

Made with [Cursor](https://cursor.com)