### PR TITLE
Fix gateway warning noise and empty embedded turns

### DIFF
--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -225,6 +225,47 @@ describe("registerTelegramNativeCommands", () => {
     });
   });
 
+  it("drops per-skill commands before truncating an over-limit Telegram menu", async () => {
+    const { bot, commandHandlers, setMyCommands } = createCommandBot();
+    const runtimeLog = vi.fn();
+    listSkillCommandsForAgents.mockReturnValue(
+      Array.from({ length: 120 }, (_, index) => ({
+        name: `demo_skill_${index}`,
+        skillName: `demo-skill-${index}`,
+        description: `Demo skill ${index}`,
+      })),
+    );
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      {
+        name: "demo_skill_0",
+        description: "Conflicting plugin command",
+      },
+    ] as never);
+
+    registerTelegramNativeCommands(
+      createNativeCommandTestParams(
+        {
+          commands: { native: true, nativeSkills: true },
+          agents: { list: [{ id: "main", default: true }] },
+        },
+        {
+          bot,
+          runtime: { log: runtimeLog } as unknown as RuntimeEnv,
+        },
+      ),
+    );
+
+    const registeredCommands = await waitForRegisteredCommands(setMyCommands);
+    expect(registeredCommands.length).toBeLessThanOrEqual(100);
+    expect(registeredCommands.some((entry) => entry.command.startsWith("demo_skill_"))).toBe(false);
+    expect(commandHandlers.has("demo_skill_0")).toBe(true);
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "commands exceeds limit; removing per-skill commands and keeping /skill.",
+      ),
+    );
+  });
+
   it("truncates Telegram command registration to 100 commands", async () => {
     const customCommands = Array.from({ length: 120 }, (_, index) => ({
       command: `cmd_${index}`,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -741,50 +741,109 @@ export const registerTelegramNativeCommands = ({
       "nativeSkillsEnabled is true but no agent route is bound for this Telegram account; skill commands will not appear in the native menu.",
     );
   }
-  const skillCommands =
+  let skillCommands =
     nativeEnabled && nativeSkillsEnabled && boundRoute
       ? telegramDeps.listSkillCommandsForAgents({
           cfg,
           agentIds: [boundRoute.agentId],
         })
       : [];
-  const nativeCommands = nativeEnabled
-    ? listNativeCommandSpecsForConfig(cfg, {
-        skillCommands,
-        provider: "telegram",
-      })
-    : [];
-  const reservedCommands = new Set(
-    listNativeCommandSpecs().map((command) => normalizeTelegramCommandName(command.name)),
-  );
-  for (const command of skillCommands) {
-    reservedCommands.add(normalizeLowercaseStringOrEmpty(command.name));
-  }
-  const customResolution = resolveTelegramCustomCommands({
-    commands: telegramCfg.customCommands,
-    reservedCommands,
-  });
-  for (const issue of customResolution.issues) {
-    runtime.error?.(danger(issue.message));
-  }
-  const customCommands = customResolution.commands;
   const pluginCommandSpecs =
     (
       telegramDeps.getPluginCommandSpecs ?? defaultTelegramNativeCommandDeps.getPluginCommandSpecs
     )?.("telegram", { config: cfg }) ?? [];
-  const existingCommands = new Set(
-    [
-      ...nativeCommands.map((command) => normalizeTelegramCommandName(command.name)),
-      ...customCommands.map((command) => command.command),
-    ].map((command) => normalizeLowercaseStringOrEmpty(command)),
-  );
-  const pluginCatalog = buildPluginTelegramMenuCommands({
-    specs: pluginCommandSpecs,
-    existingCommands,
-  });
-  for (const issue of pluginCatalog.issues) {
-    runtime.error?.(danger(issue));
+  const resolveTelegramMenuCommandCatalog = (
+    activeSkillCommands: typeof skillCommands,
+    reservedSkillCommands = activeSkillCommands,
+  ) => {
+    const nativeCommands = nativeEnabled
+      ? listNativeCommandSpecsForConfig(cfg, {
+          skillCommands: activeSkillCommands,
+          provider: "telegram",
+        })
+      : [];
+    const reservedCommands = new Set(
+      listNativeCommandSpecs().map((command) => normalizeTelegramCommandName(command.name)),
+    );
+    for (const command of reservedSkillCommands) {
+      reservedCommands.add(normalizeLowercaseStringOrEmpty(command.name));
+    }
+    const customResolution = resolveTelegramCustomCommands({
+      commands: telegramCfg.customCommands,
+      reservedCommands,
+    });
+    for (const issue of customResolution.issues) {
+      runtime.error?.(danger(issue.message));
+    }
+    const customCommands = customResolution.commands;
+    const existingCommands = new Set(
+      [
+        ...nativeCommands.map((command) => normalizeTelegramCommandName(command.name)),
+        ...customCommands.map((command) => command.command),
+      ].map((command) => normalizeLowercaseStringOrEmpty(command)),
+    );
+    for (const command of reservedSkillCommands) {
+      existingCommands.add(normalizeTelegramCommandName(command.name));
+    }
+    const pluginCatalog = buildPluginTelegramMenuCommands({
+      specs: pluginCommandSpecs,
+      existingCommands,
+    });
+    for (const issue of pluginCatalog.issues) {
+      runtime.error?.(danger(issue));
+    }
+    const allCommandsFull: TelegramMenuCommand[] = [
+      ...nativeCommands
+        .map((command): TelegramMenuCommand | null => {
+          const normalized = normalizeTelegramCommandName(command.name);
+          if (!TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
+            runtime.error?.(
+              danger(
+                `Native command "${command.name}" is invalid for Telegram (resolved to "${normalized}"). Skipping.`,
+              ),
+            );
+            return null;
+          }
+          const menuCommand: TelegramMenuCommand = {
+            command: normalized,
+            description: command.description,
+          };
+          if (command.isAlias) {
+            menuCommand.isAlias = true;
+          }
+          if (command.descriptionLocalizations) {
+            menuCommand.descriptionLocalizations = command.descriptionLocalizations;
+          }
+          return menuCommand;
+        })
+        .filter((cmd) => cmd !== null),
+      ...(nativeEnabled ? pluginCatalog.commands : []),
+      ...customCommands,
+    ];
+    return {
+      nativeCommands,
+      customCommands,
+      pluginCatalog,
+      ...buildCappedTelegramMenuCommands({
+        allCommands: allCommandsFull,
+      }),
+    };
+  };
+  const fullCommandCatalog = resolveTelegramMenuCommandCatalog(skillCommands);
+  let menuCommandCatalog = fullCommandCatalog;
+  if (
+    nativeEnabled &&
+    nativeSkillsEnabled &&
+    skillCommands.length > 0 &&
+    fullCommandCatalog.overflowCount > 0
+  ) {
+    const initialCommandCount = fullCommandCatalog.totalCommands;
+    menuCommandCatalog = resolveTelegramMenuCommandCatalog([], skillCommands);
+    runtime.log?.(
+      `Telegram: ${initialCommandCount} commands exceeds limit; removing per-skill commands and keeping /skill.`,
+    );
   }
+  const { nativeCommands, pluginCatalog } = fullCommandCatalog;
   const loadFreshRuntimeConfig = (): OpenClawConfig => telegramDeps.getRuntimeConfig();
   const resolveFreshTelegramConfig = (runtimeCfg: OpenClawConfig): TelegramAccountConfig => {
     try {
@@ -799,34 +858,6 @@ export const registerTelegramNativeCommands = ({
       return telegramCfg;
     }
   };
-  const allCommandsFull: TelegramMenuCommand[] = [
-    ...nativeCommands
-      .map((command): TelegramMenuCommand | null => {
-        const normalized = normalizeTelegramCommandName(command.name);
-        if (!TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
-          runtime.error?.(
-            danger(
-              `Native command "${command.name}" is invalid for Telegram (resolved to "${normalized}"). Skipping.`,
-            ),
-          );
-          return null;
-        }
-        const menuCommand: TelegramMenuCommand = {
-          command: normalized,
-          description: command.description,
-        };
-        if (command.isAlias) {
-          menuCommand.isAlias = true;
-        }
-        if (command.descriptionLocalizations) {
-          menuCommand.descriptionLocalizations = command.descriptionLocalizations;
-        }
-        return menuCommand;
-      })
-      .filter((cmd) => cmd !== null),
-    ...(nativeEnabled ? pluginCatalog.commands : []),
-    ...customCommands,
-  ];
   const {
     commandsToRegister,
     totalCommands,
@@ -835,9 +866,7 @@ export const registerTelegramNativeCommands = ({
     maxTotalChars,
     descriptionTrimmed,
     textBudgetDropCount,
-  } = buildCappedTelegramMenuCommands({
-    allCommands: allCommandsFull,
-  });
+  } = menuCommandCatalog;
   if (overflowCount > 0) {
     runtime.log?.(
       `Telegram limits bots to ${maxCommands} commands. ` +

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1340,6 +1340,23 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         }),
       }),
     ).toBe(false);
+    expect(
+      shouldRetryMissingAssistantTurn({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: undefined,
+          currentAttemptAssistant: undefined,
+          itemLifecycle: {
+            startedCount: 1,
+            completedCount: 0,
+            activeCount: 1,
+          },
+        }),
+      }),
+    ).toBe(false);
   });
 
   it("detects tool-use terminal turn with pre-tool text as incomplete (#76477)", () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -36,6 +36,7 @@ import {
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
   resolveSilentToolResultReplyPayload,
+  shouldRetryMissingAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
@@ -746,6 +747,43 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectWarnMessageWith("empty response detected");
   });
 
+  it("retries replay-safe missing terminal assistant turns once with the same prompt", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: undefined,
+        currentAttemptAssistant: undefined,
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Recovered answer."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "Recovered answer." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-missing-assistant-retry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(runAttemptCall(1).prompt).toBe(runAttemptCall(0).prompt);
+    expect(result.meta?.finalAssistantVisibleText).toBe("Recovered answer.");
+    expectWarnMessageWith("missing assistant terminal message detected");
+    expectNoWarnMessageWith("empty response detected");
+    expectNoWarnMessageWith("incomplete turn detected");
+  });
+
   it("retries zero-token empty Claude stop turns with a visible-answer continuation instruction", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
@@ -1272,6 +1310,36 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(explicitCancellationText).toBeNull();
+  });
+
+  it("allows a same-prompt retry only for replay-safe missing assistant turns", () => {
+    const replaySafeAttempt = makeAttemptResult({
+      assistantTexts: [],
+      lastAssistant: undefined,
+      currentAttemptAssistant: undefined,
+    });
+
+    expect(
+      shouldRetryMissingAssistantTurn({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: replaySafeAttempt,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRetryMissingAssistantTurn({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: undefined,
+          currentAttemptAssistant: undefined,
+          toolMetas: [{ toolName: "image_generate", asyncStarted: true }],
+        }),
+      }),
+    ).toBe(false);
   });
 
   it("detects tool-use terminal turn with pre-tool text as incomplete (#76477)", () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -173,6 +173,7 @@ import {
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
+  shouldRetryMissingAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./run/incomplete-turn.js";
 import type { RunEmbeddedAgentParams } from "./run/params.js";
@@ -1157,6 +1158,8 @@ export async function runEmbeddedAgent(
       // visible-answer retry instruction instead.
       const MAX_EMPTY_ERROR_RETRIES = 3;
       let emptyErrorRetries = 0;
+      const MAX_MISSING_ASSISTANT_RETRIES = 1;
+      let missingAssistantRetryAttempts = 0;
       const overloadFailoverBackoffMs = resolveOverloadFailoverBackoffMs(params.config);
       const overloadProfileRotationLimit = resolveOverloadProfileRotationLimit(params.config);
       const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit(params.config);
@@ -3062,6 +3065,24 @@ export async function runEmbeddedAgent(
             nextReasoningOnlyRetryInstruction &&
             reasoningOnlyRetryAttempts >= maxReasoningOnlyRetryAttempts;
           if (
+            !emptyAssistantReplyIsSilent &&
+            shouldRetryMissingAssistantTurn({
+              payloadCount,
+              aborted,
+              promptError,
+              timedOut,
+              attempt,
+            }) &&
+            missingAssistantRetryAttempts < MAX_MISSING_ASSISTANT_RETRIES
+          ) {
+            missingAssistantRetryAttempts += 1;
+            log.warn(
+              `missing assistant terminal message detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} with same prompt`,
+            );
+            continue;
+          }
+          if (
             !nextPlanningOnlyRetryInstruction &&
             !nextReasoningOnlyRetryInstruction &&
             nextEmptyResponseRetryInstruction &&
@@ -3288,9 +3309,17 @@ export async function runEmbeddedAgent(
               livenessState,
             });
             const incompleteStopReason = attempt.lastAssistant?.stopReason;
+            const replayMetadata = resolveAttemptReplayMetadata(attempt);
             log.warn(
               `incomplete turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `stopReason=${incompleteStopReason} payloads=${payloadCount} — surfacing error to user`,
+                `provider=${activeErrorContext.provider}/${activeErrorContext.model} ` +
+                `stopReason=${incompleteStopReason ?? "missing"} hasLastAssistant=${attempt.lastAssistant ? "yes" : "no"} ` +
+                `hasCurrentAttemptAssistant=${attempt.currentAttemptAssistant ? "yes" : "no"} payloads=${payloadCount} ` +
+                `tools=${attempt.toolMetas?.length ?? 0} replaySafe=${replayMetadata.replaySafe ? "yes" : "no"} ` +
+                `compactions=${attemptCompactionCount} planningRetries=${planningOnlyRetryAttempts}/${maxPlanningOnlyRetryAttempts} ` +
+                `reasoningRetries=${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
+                `emptyRetries=${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +
+                `missingAssistantRetries=${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} — surfacing error to user`,
             );
 
             // Mark the failing profile for cooldown so multi-profile setups

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4559,6 +4559,7 @@ export async function runEmbeddedAttempt(
           acceptedSessionSpawns,
           lastToolError,
           lastAssistant,
+          itemLifecycle: getItemLifecycle(),
           toolMetas: toolMetasNormalized,
           replayMetadata,
           promptErrorSource,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -306,6 +306,51 @@ export function resolveIncompleteTurnPayloadText(params: {
     : "⚠️ Agent couldn't generate a response. Please try again.";
 }
 
+export function shouldRetryMissingAssistantTurn(params: {
+  payloadCount: number;
+  aborted: boolean;
+  promptError?: unknown;
+  timedOut: boolean;
+  attempt: IncompleteTurnAttempt;
+}): boolean {
+  if (
+    params.payloadCount !== 0 ||
+    params.aborted ||
+    Boolean(params.promptError) ||
+    params.timedOut ||
+    params.attempt.clientToolCalls ||
+    params.attempt.currentAttemptAssistant ||
+    params.attempt.lastAssistant ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.lastToolError
+  ) {
+    return false;
+  }
+
+  if (hasOnlySilentAssistantReply(params.attempt.assistantTexts)) {
+    return false;
+  }
+
+  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+    return false;
+  }
+
+  if (hasCommittedMessagingToolDeliveryEvidence(params.attempt)) {
+    return false;
+  }
+
+  if (hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns)) {
+    return false;
+  }
+
+  if (hasAsyncStartedToolActivity(params.attempt.toolMetas)) {
+    return false;
+  }
+
+  return !resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects;
+}
+
 function joinAssistantTexts(assistantTexts?: readonly string[]): string {
   return (assistantTexts ?? []).join("\n\n").trim();
 }

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -46,6 +46,7 @@ type IncompleteTurnAttempt = Pick<
   | "messagingToolSentTargets"
   | "lastToolError"
   | "lastAssistant"
+  | "itemLifecycle"
   | "replayMetadata"
   | "promptErrorSource"
   | "timedOutDuringCompaction"
@@ -345,6 +346,13 @@ export function shouldRetryMissingAssistantTurn(params: {
   }
 
   if (hasAsyncStartedToolActivity(params.attempt.toolMetas)) {
+    return false;
+  }
+
+  if (
+    (params.attempt.itemLifecycle?.startedCount ?? 0) > 0 ||
+    (params.attempt.itemLifecycle?.activeCount ?? 0) > 0
+  ) {
     return false;
   }
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import type { DeviceAuthEntry } from "../shared/device-auth.js";
 import { captureEnv } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
@@ -23,6 +24,9 @@ const deviceIdentityState = vi.hoisted(() => ({
   } satisfies DeviceIdentity,
   throwOnLoad: false,
 }));
+const loadDeviceAuthTokenMock = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => DeviceAuthEntry | null>(() => null),
+);
 
 const eventLoopReadyState = vi.hoisted(() => ({
   calls: [] as Array<{ maxWaitMs?: number } | undefined>,
@@ -262,9 +266,17 @@ function resetGatewayCallMocks() {
       }
       return deviceIdentityState.value;
     },
+    loadDeviceAuthToken: loadDeviceAuthTokenMock,
     resolveGatewayPort: resolveGatewayPortForTests,
   });
   deviceIdentityState.throwOnLoad = false;
+  loadDeviceAuthTokenMock.mockReset();
+  loadDeviceAuthTokenMock.mockReturnValue({
+    token: "paired-device-token",
+    role: "operator",
+    scopes: ["operator.read"],
+    updatedAtMs: 123,
+  });
 }
 
 function setGatewayNetworkDefaults(port = 18789) {
@@ -425,6 +437,95 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.clientName).toBe(GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT);
     expect(lastClientOptions?.mode).toBe(GATEWAY_CLIENT_MODES.BACKEND);
     expect(lastClientOptions?.deviceIdentity).toBeNull();
+  });
+
+  it("fails before opening a websocket when backend token auth has no shared or paired credential", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", auth: { mode: "token" } },
+    });
+    setGatewayNetworkDefaults();
+    loadDeviceAuthTokenMock.mockReturnValue(null);
+
+    await expect(callGateway({ method: "sessions.list" })).rejects.toThrow(
+      "requires credentials before opening a websocket",
+    );
+
+    expect(lastClientOptions).toBeNull();
+    expect(startCalls).toBe(0);
+    expect(loadDeviceAuthTokenMock).toHaveBeenCalledWith({
+      deviceId: "test-device-identity",
+      role: "operator",
+      env: process.env,
+    });
+  });
+
+  it("fails before opening a websocket when default token auth has no shared or paired credential", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback" },
+    });
+    setGatewayNetworkDefaults();
+    loadDeviceAuthTokenMock.mockReturnValue(null);
+
+    await expect(callGateway({ method: "sessions.list" })).rejects.toThrow(
+      "requires credentials before opening a websocket",
+    );
+
+    expect(lastClientOptions).toBeNull();
+    expect(startCalls).toBe(0);
+  });
+
+  it("allows paired backend device auth without explicit shared credentials", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", auth: { mode: "token" } },
+    });
+    setGatewayNetworkDefaults();
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "paired-device-token",
+      role: "operator",
+      scopes: ["operator.read"],
+      updatedAtMs: 123,
+    });
+
+    await callGateway({ method: "sessions.list" });
+
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18789");
+    expect(lastClientOptions?.token).toBeUndefined();
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
+  });
+
+  it("allows Tailscale-authenticated backend calls without client-side credentials", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        remote: { url: "wss://openclaw.example.test" },
+        auth: { mode: "token", allowTailscale: true },
+      },
+    });
+    setGatewayNetworkDefaults();
+
+    await callGateway({ method: "sessions.list" });
+
+    expect(lastClientOptions?.url).toBe("wss://openclaw.example.test");
+    expect(lastClientOptions?.token).toBeUndefined();
+    expect(lastClientOptions?.password).toBeUndefined();
+  });
+
+  it("allows Tailscale Serve backend calls without explicit allowTailscale", async () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        remote: { url: "wss://openclaw.example.test" },
+        auth: { mode: "token" },
+        tailscale: { mode: "serve" },
+      },
+    });
+    setGatewayNetworkDefaults();
+
+    await callGateway({ method: "sessions.list" });
+
+    expect(lastClientOptions?.url).toBe("wss://openclaw.example.test");
+    expect(lastClientOptions?.token).toBeUndefined();
+    expect(lastClientOptions?.password).toBeUndefined();
   });
 
   it("keeps device identity enabled for explicit CLI loopback shared-token auth", async () => {
@@ -1299,6 +1400,7 @@ describe("callGateway error details", () => {
         }) as never,
       getRuntimeConfig: getRuntimeConfig as unknown as () => OpenClawConfig,
       loadOrCreateDeviceIdentity: () => deviceIdentityState.value,
+      loadDeviceAuthToken: loadDeviceAuthTokenMock,
       resolveGatewayPort: resolveGatewayPort as unknown as (
         cfg?: OpenClawConfig,
         env?: NodeJS.ProcessEnv,
@@ -1363,6 +1465,7 @@ describe("callGateway error details", () => {
         }) as never,
       getRuntimeConfig: getRuntimeConfig as unknown as () => OpenClawConfig,
       loadOrCreateDeviceIdentity: () => deviceIdentityState.value,
+      loadDeviceAuthToken: loadDeviceAuthTokenMock,
       resolveGatewayPort: resolveGatewayPort as unknown as (
         cfg?: OpenClawConfig,
         env?: NodeJS.ProcessEnv,
@@ -1448,6 +1551,7 @@ describe("callGateway error details", () => {
         }) as never,
       getRuntimeConfig: getRuntimeConfig as unknown as () => OpenClawConfig,
       loadOrCreateDeviceIdentity: () => deviceIdentityState.value,
+      loadDeviceAuthToken: loadDeviceAuthTokenMock,
       resolveGatewayPort: resolveGatewayPort as unknown as (
         cfg?: OpenClawConfig,
         env?: NodeJS.ProcessEnv,
@@ -1509,6 +1613,7 @@ describe("callGateway error details", () => {
         }) as never,
       getRuntimeConfig: getRuntimeConfig as unknown as () => OpenClawConfig,
       loadOrCreateDeviceIdentity: () => deviceIdentityState.value,
+      loadDeviceAuthToken: loadDeviceAuthTokenMock,
       resolveGatewayPort: resolveGatewayPort as unknown as (
         cfg?: OpenClawConfig,
         env?: NodeJS.ProcessEnv,

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -6,6 +6,7 @@ import {
   resolveStateDir as resolveStateDirFromPaths,
 } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadDeviceAuthToken } from "../infra/device-auth-store.js";
 import { loadOrCreateDeviceIdentity, type DeviceIdentity } from "../infra/device-identity.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import { isLoopbackIpAddress } from "../shared/net/ip.js";
@@ -19,6 +20,7 @@ import {
 } from "../utils/message-channel.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { VERSION } from "../version.js";
+import { resolveGatewayAuth } from "./auth-resolve.js";
 import { startGatewayClientWhenEventLoopReady } from "./client-start-readiness.js";
 import {
   GatewayClient,
@@ -205,6 +207,7 @@ const defaultGatewayCallDeps = {
   resolveConfigPath: resolveConfigPathFromPaths,
   resolveStateDir: resolveStateDirFromPaths,
   loadGatewayTlsRuntime,
+  loadDeviceAuthToken,
 };
 const gatewayCallDeps = {
   ...defaultGatewayCallDeps,
@@ -296,6 +299,8 @@ export const testing = {
       deps?.resolveStateDir ?? defaultGatewayCallDeps.resolveStateDir;
     gatewayCallDeps.loadGatewayTlsRuntime =
       deps?.loadGatewayTlsRuntime ?? defaultGatewayCallDeps.loadGatewayTlsRuntime;
+    gatewayCallDeps.loadDeviceAuthToken =
+      deps?.loadDeviceAuthToken ?? defaultGatewayCallDeps.loadDeviceAuthToken;
   },
   setCreateGatewayClientForTests(createGatewayClient?: typeof defaultCreateGatewayClient): void {
     gatewayCallDeps.createGatewayClient =
@@ -309,6 +314,7 @@ export const testing = {
     gatewayCallDeps.resolveConfigPath = defaultGatewayCallDeps.resolveConfigPath;
     gatewayCallDeps.resolveStateDir = defaultGatewayCallDeps.resolveStateDir;
     gatewayCallDeps.loadGatewayTlsRuntime = defaultGatewayCallDeps.loadGatewayTlsRuntime;
+    gatewayCallDeps.loadDeviceAuthToken = defaultGatewayCallDeps.loadDeviceAuthToken;
   },
 };
 
@@ -356,6 +362,61 @@ function resolveDeviceIdentityForGatewayCall(params: {
     // gateway with token/password auth without crashing before the RPC.
     return null;
   }
+}
+
+function hasStoredOperatorDeviceAuthToken(deviceIdentity: DeviceIdentity | null): boolean {
+  if (!deviceIdentity) {
+    return false;
+  }
+  try {
+    return Boolean(
+      gatewayCallDeps.loadDeviceAuthToken({
+        deviceId: deviceIdentity.deviceId,
+        role: "operator",
+        env: process.env,
+      })?.token,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function resolveGatewayCallAuth(config: OpenClawConfig) {
+  return resolveGatewayAuth({
+    authConfig: config.gateway?.auth,
+    env: process.env,
+    tailscaleMode: config.gateway?.tailscale?.mode,
+  });
+}
+
+function ensureGatewayCallCanAuthenticate(params: {
+  opts: CallGatewayBaseOptions;
+  context: ResolvedGatewayCallContext;
+  token?: string;
+  password?: string;
+  deviceIdentity: DeviceIdentity | null;
+}): void {
+  const resolvedAuth = resolveGatewayCallAuth(params.context.config);
+  const authMode = resolvedAuth.mode;
+  if (authMode !== "token" && authMode !== "password") {
+    return;
+  }
+  if (params.token || params.password || params.opts.approvalRuntimeToken) {
+    return;
+  }
+  if (resolvedAuth.allowTailscale) {
+    return;
+  }
+  if (hasStoredOperatorDeviceAuthToken(params.deviceIdentity)) {
+    return;
+  }
+  throw new Error(
+    [
+      `gateway ${params.opts.method} requires credentials before opening a websocket`,
+      "Fix: configure gateway.auth token/password, pair this device, or pass --token/--password.",
+      `Config: ${params.context.configPath}`,
+    ].join("\n"),
+  );
 }
 
 export type { ExplicitGatewayAuth } from "./credentials.js";
@@ -675,6 +736,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
   timeoutMs: number;
   safeTimerTimeoutMs: number;
   connectionDetails: GatewayConnectionDetails;
+  deviceIdentity: DeviceIdentity | null;
 }): Promise<T> {
   const {
     opts,
@@ -686,6 +748,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
     preauthHandshakeTimeoutMs,
     timeoutMs,
     safeTimerTimeoutMs,
+    deviceIdentity,
   } = params;
   return await new Promise<T>((resolve, reject) => {
     if (opts.signal?.aborted) {
@@ -771,10 +834,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       ...(opts.approvalRuntimeToken ? { approvalRuntimeToken: opts.approvalRuntimeToken } : {}),
       role: "operator",
       scopes,
-      deviceIdentity:
-        opts.deviceIdentity === undefined
-          ? resolveDeviceIdentityForGatewayCall({ opts, url, token, password })
-          : opts.deviceIdentity,
+      deviceIdentity,
       minProtocol: opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
       onHelloOk: async (hello) => {
@@ -888,6 +948,17 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
   const { token, password } = resolvedCredentials;
+  const deviceIdentity =
+    opts.deviceIdentity === undefined
+      ? resolveDeviceIdentityForGatewayCall({ opts, url, token, password })
+      : opts.deviceIdentity;
+  ensureGatewayCallCanAuthenticate({
+    opts,
+    context,
+    token,
+    password,
+    deviceIdentity,
+  });
   return await executeGatewayRequestWithScopes<T>({
     opts,
     scopes,
@@ -899,6 +970,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     timeoutMs,
     safeTimerTimeoutMs,
     connectionDetails,
+    deviceIdentity,
   });
 }
 

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -31,6 +31,7 @@ import { broadcastPresenceSnapshot } from "./presence-events.js";
 import {
   buildHandshakeAuthLogKey,
   HandshakeAuthLogLimiter,
+  shouldLimitMissingCredentialAuthLog,
 } from "./ws-connection/handshake-auth-log-limiter.js";
 import type {
   GatewayWsMessageHandlerParams,
@@ -400,7 +401,10 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         const authReason = stringMetaValue(closeMeta, "authReason");
         const shouldLimitMissingAuthClose =
           closeCause === "unauthorized" &&
-          (authReason === "token_missing" || authReason === "password_missing");
+          shouldLimitMissingCredentialAuthLog({
+            reason: authReason,
+            authProvided: "none",
+          });
         const closeLogDecision = shouldLimitMissingAuthClose
           ? unauthorizedCloseBeforeConnectLogLimiter.register(
               buildHandshakeAuthLogKey({

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -28,6 +28,10 @@ import { logWs } from "../ws-log.js";
 import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
 import type { PreauthConnectionBudget } from "./preauth-connection-budget.js";
 import { broadcastPresenceSnapshot } from "./presence-events.js";
+import {
+  buildHandshakeAuthLogKey,
+  HandshakeAuthLogLimiter,
+} from "./ws-connection/handshake-auth-log-limiter.js";
 import type {
   GatewayWsMessageHandlerParams,
   WsOriginCheckMetrics,
@@ -40,6 +44,7 @@ type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 const LOG_HEADER_MAX_LEN = 300;
 const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
 const MAX_QUEUED_MESSAGE_HANDLER_FRAMES = 16;
+const unauthorizedCloseBeforeConnectLogLimiter = new HandshakeAuthLogLimiter();
 
 function replaceControlChars(value: string): string {
   let cleaned = "";
@@ -55,6 +60,11 @@ function replaceControlChars(value: string): string {
     cleaned += char;
   }
   return cleaned;
+}
+
+function stringMetaValue(meta: Record<string, unknown>, key: string): string | undefined {
+  const value = meta[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 const sanitizeLogValue = (value: string | undefined): string | undefined => {
   if (!value) {
@@ -387,10 +397,33 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
           isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) || isExpectedStartupRetryClose
             ? logWsControl.debug
             : logWsControl.warn;
-        logFn(
-          `closed before connect conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"}`,
-          closeContext,
-        );
+        const authReason = stringMetaValue(closeMeta, "authReason");
+        const shouldLimitMissingAuthClose =
+          closeCause === "unauthorized" &&
+          (authReason === "token_missing" || authReason === "password_missing");
+        const closeLogDecision = shouldLimitMissingAuthClose
+          ? unauthorizedCloseBeforeConnectLogLimiter.register(
+              buildHandshakeAuthLogKey({
+                reason: authReason,
+                remoteAddr,
+                client:
+                  stringMetaValue(closeMeta, "clientDisplayName") ??
+                  stringMetaValue(closeMeta, "client"),
+                mode: stringMetaValue(closeMeta, "mode"),
+                authProvided: "none",
+              }),
+            )
+          : { shouldLog: true, suppressedSinceLastLog: 0 };
+        if (closeLogDecision.shouldLog) {
+          const suppressedText =
+            closeLogDecision.suppressedSinceLastLog > 0
+              ? ` suppressed=${closeLogDecision.suppressedSinceLastLog}`
+              : "";
+          logFn(
+            `closed before connect conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"}${suppressedText}`,
+            closeContext,
+          );
+        }
       }
       if (client && isWebchatClient(client.connect.client)) {
         logWsControl.info(

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -399,6 +399,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
             ? logWsControl.debug
             : logWsControl.warn;
         const authReason = stringMetaValue(closeMeta, "authReason");
+        // This pre-connect close path has no client object yet; treat only
+        // missing shared credentials as suppressible startup retry noise.
         const shouldLimitMissingAuthClose =
           closeCause === "unauthorized" &&
           shouldLimitMissingCredentialAuthLog({

--- a/src/gateway/server/ws-connection/handshake-auth-log-limiter.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-log-limiter.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildHandshakeAuthLogKey, HandshakeAuthLogLimiter } from "./handshake-auth-log-limiter.js";
+import {
+  buildHandshakeAuthLogKey,
+  HandshakeAuthLogLimiter,
+  shouldLimitMissingCredentialAuthLog,
+} from "./handshake-auth-log-limiter.js";
 
 describe("HandshakeAuthLogLimiter", () => {
-  it("suppresses repeated auth failures for the same client key within the interval", () => {
+  it("suppresses repeated selected failures for the same client key within the interval", () => {
     const limiter = new HandshakeAuthLogLimiter({ intervalMs: 1_000 });
     const key = buildHandshakeAuthLogKey({
       reason: "token_missing",
@@ -41,5 +45,41 @@ describe("HandshakeAuthLogLimiter", () => {
       shouldLog: true,
       suppressedSinceLastLog: 0,
     });
+  });
+
+  it("only rate-limits benign missing-credential startup retries", () => {
+    expect(
+      shouldLimitMissingCredentialAuthLog({
+        reason: "token_missing",
+        authProvided: "none",
+      }),
+    ).toBe(true);
+    expect(
+      shouldLimitMissingCredentialAuthLog({
+        reason: "password_missing",
+        authProvided: "none",
+      }),
+    ).toBe(true);
+
+    for (const reason of [
+      "token_mismatch",
+      "password_mismatch",
+      "device_token_mismatch",
+      "rate_limited",
+      "token_missing_config",
+    ]) {
+      expect(
+        shouldLimitMissingCredentialAuthLog({
+          reason,
+          authProvided: "none",
+        }),
+      ).toBe(false);
+    }
+    expect(
+      shouldLimitMissingCredentialAuthLog({
+        reason: "token_missing",
+        authProvided: "token",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/gateway/server/ws-connection/handshake-auth-log-limiter.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-log-limiter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildHandshakeAuthLogKey, HandshakeAuthLogLimiter } from "./handshake-auth-log-limiter.js";
+
+describe("HandshakeAuthLogLimiter", () => {
+  it("suppresses repeated auth failures for the same client key within the interval", () => {
+    const limiter = new HandshakeAuthLogLimiter({ intervalMs: 1_000 });
+    const key = buildHandshakeAuthLogKey({
+      reason: "token_missing",
+      remoteAddr: "127.0.0.1",
+      client: "gateway:sessions.list",
+      mode: "backend",
+      authProvided: "none",
+    });
+
+    expect(limiter.register(key, 10_000)).toEqual({
+      shouldLog: true,
+      suppressedSinceLastLog: 0,
+    });
+    expect(limiter.register(key, 10_100)).toEqual({
+      shouldLog: false,
+      suppressedSinceLastLog: 0,
+    });
+    expect(limiter.register(key, 10_200)).toEqual({
+      shouldLog: false,
+      suppressedSinceLastLog: 0,
+    });
+    expect(limiter.register(key, 11_001)).toEqual({
+      shouldLog: true,
+      suppressedSinceLastLog: 2,
+    });
+  });
+
+  it("does not suppress distinct clients", () => {
+    const limiter = new HandshakeAuthLogLimiter({ intervalMs: 1_000 });
+
+    expect(limiter.register("token_missing|127.0.0.1|gateway:sessions.list", 10)).toEqual({
+      shouldLog: true,
+      suppressedSinceLastLog: 0,
+    });
+    expect(limiter.register("token_missing|127.0.0.1|gateway:health", 20)).toEqual({
+      shouldLog: true,
+      suppressedSinceLastLog: 0,
+    });
+  });
+});

--- a/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
@@ -71,6 +71,8 @@ export function shouldLimitMissingCredentialAuthLog(params: {
   reason?: string;
   authProvided?: string;
 }): boolean {
+  // Only no-credential retries are startup/config churn. Credential mismatches
+  // and auth rate limits are security audit events and must log per attempt.
   return (
     params.authProvided === "none" &&
     (params.reason === "token_missing" || params.reason === "password_missing")

--- a/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
@@ -1,0 +1,68 @@
+export type HandshakeAuthLogDecision = {
+  shouldLog: boolean;
+  suppressedSinceLastLog: number;
+};
+
+type HandshakeAuthLogState = {
+  lastLoggedAtMs: number;
+  suppressedSinceLastLog: number;
+};
+
+export class HandshakeAuthLogLimiter {
+  private readonly intervalMs: number;
+  private readonly maxEntries: number;
+  private readonly entries = new Map<string, HandshakeAuthLogState>();
+
+  constructor(options?: { intervalMs?: number; maxEntries?: number }) {
+    this.intervalMs = Math.max(1, Math.floor(options?.intervalMs ?? 30_000));
+    this.maxEntries = Math.max(1, Math.floor(options?.maxEntries ?? 256));
+  }
+
+  register(key: string, nowMs = Date.now()): HandshakeAuthLogDecision {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      this.pruneIfNeeded();
+      this.entries.set(key, {
+        lastLoggedAtMs: nowMs,
+        suppressedSinceLastLog: 0,
+      });
+      return { shouldLog: true, suppressedSinceLastLog: 0 };
+    }
+
+    if (nowMs - entry.lastLoggedAtMs < this.intervalMs) {
+      entry.suppressedSinceLastLog += 1;
+      return { shouldLog: false, suppressedSinceLastLog: 0 };
+    }
+
+    const suppressedSinceLastLog = entry.suppressedSinceLastLog;
+    entry.lastLoggedAtMs = nowMs;
+    entry.suppressedSinceLastLog = 0;
+    return { shouldLog: true, suppressedSinceLastLog };
+  }
+
+  private pruneIfNeeded(): void {
+    if (this.entries.size < this.maxEntries) {
+      return;
+    }
+    const oldestKey = this.entries.keys().next().value;
+    if (oldestKey !== undefined) {
+      this.entries.delete(oldestKey);
+    }
+  }
+}
+
+export function buildHandshakeAuthLogKey(params: {
+  reason?: string;
+  remoteAddr?: string;
+  client?: string;
+  mode?: string;
+  authProvided?: string;
+}): string {
+  return [
+    params.reason ?? "unknown",
+    params.remoteAddr ?? "?",
+    params.client ?? "?",
+    params.mode ?? "?",
+    params.authProvided ?? "?",
+  ].join("|");
+}

--- a/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
@@ -66,3 +66,13 @@ export function buildHandshakeAuthLogKey(params: {
     params.authProvided ?? "?",
   ].join("|");
 }
+
+export function shouldLimitMissingCredentialAuthLog(params: {
+  reason?: string;
+  authProvided?: string;
+}): boolean {
+  return (
+    params.authProvided === "none" &&
+    (params.reason === "token_missing" || params.reason === "password_missing")
+  );
+}

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -152,7 +152,11 @@ import {
   shouldAllowSilentLocalPairing,
   shouldSkipLocalBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
-import { buildHandshakeAuthLogKey, HandshakeAuthLogLimiter } from "./handshake-auth-log-limiter.js";
+import {
+  buildHandshakeAuthLogKey,
+  HandshakeAuthLogLimiter,
+  shouldLimitMissingCredentialAuthLog,
+} from "./handshake-auth-log-limiter.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -761,15 +765,20 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             scopeCount: scopes.length,
             hasDeviceIdentity: Boolean(device),
           });
-          const authLogDecision = unauthorizedHandshakeLogLimiter.register(
-            buildHandshakeAuthLogKey({
-              reason: failedAuth.reason,
-              remoteAddr,
-              client: clientLabel,
-              mode: connectParams.client.mode,
-              authProvided,
-            }),
-          );
+          const authLogDecision = shouldLimitMissingCredentialAuthLog({
+            reason: failedAuth.reason,
+            authProvided,
+          })
+            ? unauthorizedHandshakeLogLimiter.register(
+                buildHandshakeAuthLogKey({
+                  reason: failedAuth.reason,
+                  remoteAddr,
+                  client: clientLabel,
+                  mode: connectParams.client.mode,
+                  authProvided,
+                }),
+              )
+            : { shouldLog: true, suppressedSinceLastLog: 0 };
           if (authLogDecision.shouldLog) {
             const suppressedText =
               authLogDecision.suppressedSinceLastLog > 0

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -152,6 +152,7 @@ import {
   shouldAllowSilentLocalPairing,
   shouldSkipLocalBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
+import { buildHandshakeAuthLogKey, HandshakeAuthLogLimiter } from "./handshake-auth-log-limiter.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -162,6 +163,7 @@ const DEVICE_CREDENTIAL_INVALIDATING_METHODS = new Set([
   "device.token.rotate",
   "device.token.revoke",
 ]);
+const unauthorizedHandshakeLogLimiter = new HandshakeAuthLogLimiter();
 
 /** Match production release versions (YYYY.M.D or YYYY.M.D-beta.N). */
 const RELEASED_VERSION_RE = /^\d{4}\.\d+\.\d+/;
@@ -759,9 +761,24 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             scopeCount: scopes.length,
             hasDeviceIdentity: Boolean(device),
           });
-          logWsControl.warn(
-            `unauthorized conn=${connId} peer=${formatForLog(peerLabel)} remote=${remoteAddr ?? "?"} client=${formatForLog(clientLabel)} ${connectParams.client.mode} v${formatForLog(connectParams.client.version)} role=${role} scopes=${scopes.length} auth=${authProvided} device=${device ? "yes" : "no"} platform=${formatForLog(connectParams.client.platform)} instance=${formatForLog(connectParams.client.instanceId ?? "n/a")} host=${formatForLog(requestHost ?? "n/a")} origin=${formatForLog(requestOrigin ?? "n/a")} ua=${formatForLog(requestUserAgent ?? "n/a")} reason=${failedAuth.reason ?? "unknown"}`,
+          const authLogDecision = unauthorizedHandshakeLogLimiter.register(
+            buildHandshakeAuthLogKey({
+              reason: failedAuth.reason,
+              remoteAddr,
+              client: clientLabel,
+              mode: connectParams.client.mode,
+              authProvided,
+            }),
           );
+          if (authLogDecision.shouldLog) {
+            const suppressedText =
+              authLogDecision.suppressedSinceLastLog > 0
+                ? ` suppressed=${authLogDecision.suppressedSinceLastLog}`
+                : "";
+            logWsControl.warn(
+              `unauthorized conn=${connId} peer=${formatForLog(peerLabel)} remote=${remoteAddr ?? "?"} client=${formatForLog(clientLabel)} ${connectParams.client.mode} v${formatForLog(connectParams.client.version)} role=${role} scopes=${scopes.length} auth=${authProvided} device=${device ? "yes" : "no"} platform=${formatForLog(connectParams.client.platform)} instance=${formatForLog(connectParams.client.instanceId ?? "n/a")} host=${formatForLog(requestHost ?? "n/a")} origin=${formatForLog(requestOrigin ?? "n/a")} ua=${formatForLog(requestUserAgent ?? "n/a")} reason=${failedAuth.reason ?? "unknown"}${suppressedText}`,
+            );
+          }
           const authMessage = formatGatewayAuthFailureMessage({
             authMode: resolvedAuth.mode,
             authProvided,

--- a/src/logging/logger-settings.test.ts
+++ b/src/logging/logger-settings.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let originalTestFileLog: string | undefined;
@@ -67,5 +68,10 @@ describe("getResolvedLoggerSettings", () => {
     const settings = logging.getResolvedLoggerSettings();
 
     expect(settings.level).toBe("info");
+    expect(settings.file).toContain(path.join(".artifacts", "test-logs"));
+    expect(path.basename(settings.file)).toMatch(/^openclaw-vitest-\d+-\d{4}-\d{2}-\d{2}\.log$/);
+    expect(settings.file).not.toBe(
+      `/tmp/openclaw/openclaw-${new Date().toISOString().slice(0, 10)}.log`,
+    );
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -473,6 +473,18 @@ function canUseSilentVitestFileLogFastPath(envLevel: LogLevel | undefined): bool
   );
 }
 
+function resolveDefaultActiveLogFile(): string {
+  if (process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG === "1") {
+    return path.join(
+      process.cwd(),
+      ".artifacts",
+      "test-logs",
+      `${LOG_PREFIX}-vitest-${process.pid}-${formatLocalDate(new Date())}${LOG_SUFFIX}`,
+    );
+  }
+  return defaultRollingPathForToday();
+}
+
 function resolveSettings(): ResolvedSettings {
   if (!canUseNodeFs()) {
     return {
@@ -499,7 +511,7 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
+  const file = cfg?.file ?? resolveDefaultActiveLogFile();
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }


### PR DESCRIPTION
## Summary

- Retry one replay-safe missing terminal assistant turn before surfacing incomplete-turn errors, with richer diagnostics for remaining failures.
- Keep explicit Vitest file logs out of the shared runtime log path.
- Fail fast for backend gateway calls that have no shared, paired-device, approval-runtime, or effective Tailscale auth path, and rate-limit repeated missing-auth websocket warnings.
- Drop Telegram per-skill commands from the visible menu before Telegram's command cap while keeping hidden handlers and plugin collision rules intact.

## Verification

- `pnpm test src/agents/embedded-agent-runner/run.incomplete-turn.test.ts -- --reporter=verbose`
- `pnpm test src/logging/logger-settings.test.ts extensions/telegram/src/bot-native-commands.test.ts -- --reporter=verbose`
- `pnpm test src/gateway/call.test.ts src/gateway/server/ws-connection/handshake-auth-log-limiter.test.ts -- --reporter=verbose`
- `pnpm test src/gateway/call.test.ts -- --reporter=verbose`
- `pnpm test extensions/telegram/src/bot-native-commands.test.ts -- --reporter=verbose`
- `pnpm test src/gateway/call.test.ts extensions/telegram/src/bot-native-commands.test.ts -- --reporter=verbose`
- `git diff --check`
- `autoreview --mode local` clean
- `pnpm check:changed` via Blacksmith Testbox `tbx_01kspx1bc1fmy1p1h7zaz6p4q2` exit 0

## Real behavior proof

Behavior addressed: gateway/watch warning noise and empty embedded-agent turn recovery.
Real environment tested: local source checkout plus Blacksmith Testbox changed checks.
Exact steps or command run after this patch: focused Vitest files above, local autoreview, git diff check, and Testbox `pnpm check:changed`.
Evidence after fix: focused tests passed; autoreview reported no accepted/actionable findings; Testbox `tbx_01kspx1bc1fmy1p1h7zaz6p4q2` completed with exit 0.
Observed result after fix: replay-safe missing assistant turns get one same-prompt retry; explicit test file logs write under `.artifacts/test-logs`; backend gateway calls without any usable credential fail before websocket unless paired, approval-runtime, or effective Tailscale auth can work; repeated missing-auth websocket logs are suppressed; Telegram drops per-skill menu entries before cap truncation while hidden handlers stay callable.
What was not tested: live Discord, Telegram, or Tailscale gateway session.
