### PR TITLE
fix(docs): render onboarding CLI info callout

### DIFF
--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -79,7 +79,9 @@ Onboarding requests TCC permissions needed for:
 
 </Step>
 <Step title="CLI">
-  <Info>This step is optional</Info>
+  <Info>
+  This step is optional
+  </Info>
   The app can install the global `openclaw` CLI via npm, pnpm, or bun.
   It prefers npm first, then pnpm, then bun if that is the only detected
   package manager. For the Gateway runtime, Node remains the recommended path.


### PR DESCRIPTION
## Summary

- Problem: the onboarding docs page renders the CLI step `<Info>` callout with garbled text on `/start/onboarding`.
- Why it matters: readers can see mojibake instead of the optional-step note during onboarding.
- What changed: rewrote the inline `<Info>This step is optional</Info>` callout as the multiline Mintlify component style used elsewhere in the docs.
- Scope boundary: docs-only change; no runtime, CLI, gateway, config, or product behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] Docs / website

## Verification

- [x] `pnpm docs:check-mdx docs/start/onboarding.md`
- [x] `git diff --check`
- [x] `pnpm docs:dev`, then checked `/start/onboarding`

## Real behavior proof

Behavior addressed: The CLI step on `/start/onboarding` displayed garbled text inside the Info callout.

Real environment tested: Local Mintlify docs preview.

Exact steps or command run after this patch: `pnpm docs:dev`, then opened `/start/onboarding`.

Evidence after fix: The Info callout displays `This step is optional`.Evidence after fix: [After-fix screenshot](https://github.com/user-attachments/assets/fe8d08bb-2ea7-4b59-9ce7-680bc4b493e4)

Observed result after fix: No garbled characters appear in the CLI step callout.

What was not tested: Full production docs deployment.