### PR TITLE
fix(active-memory): raise recall timeout ceiling

### DIFF
--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -683,7 +683,7 @@ The most important fields are:
 | `config.thinking`            | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "adaptive" \| "max"`                | Advanced thinking override for the blocking memory sub-agent; default `off` for speed                                                                                                                                                                    |
 | `config.promptOverride`      | `string`                                                                                             | Advanced full prompt replacement; not recommended for normal use                                                                                                                                                                                         |
 | `config.promptAppend`        | `string`                                                                                             | Advanced extra instructions appended to the default or overridden prompt                                                                                                                                                                                 |
-| `config.timeoutMs`           | `number`                                                                                             | Hard timeout for the blocking memory sub-agent, capped at 120000 ms                                                                                                                                                                                      |
+| `config.timeoutMs`           | `number`                                                                                             | Hard timeout for the blocking memory sub-agent, capped at 300000 ms. Higher values can delay the visible reply.                                                                                                                                          |
 | `config.setupGraceTimeoutMs` | `number`                                                                                             | Advanced extra setup budget before the recall timeout expires; defaults to 0 and is capped at 30000 ms. See [Cold-start grace](#cold-start-grace) for v2026.4.x upgrade guidance                                                                         |
 | `config.maxSummaryChars`     | `number`                                                                                             | Maximum total characters allowed in the active-memory summary                                                                                                                                                                                            |
 | `config.logging`             | `boolean`                                                                                            | Emits active memory logs while tuning                                                                                                                                                                                                                    |
@@ -799,6 +799,10 @@ If active memory is too slow:
 - lower `timeoutMs`
 - reduce recent turn counts
 - reduce per-turn char caps
+
+For slow local recall models, you can raise `config.timeoutMs` up to `300000`
+ms. This is an explicit trade-off: Active Memory may wait longer before the
+visible reply starts.
 
 ## Common issues
 

--- a/extensions/active-memory/config.test.ts
+++ b/extensions/active-memory/config.test.ts
@@ -60,7 +60,7 @@ describe("active-memory manifest config schema", () => {
       value: {
         enabled: true,
         agents: ["main"],
-        timeoutMs: 120_000,
+        timeoutMs: 300_000,
       },
     });
 
@@ -102,7 +102,7 @@ describe("active-memory manifest config schema", () => {
       value: {
         enabled: true,
         agents: ["main"],
-        timeoutMs: 120_001,
+        timeoutMs: 300_001,
       },
     });
 

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -381,11 +381,11 @@ describe("active-memory plugin", () => {
   it("registers before_prompt_build with the configured recall timeout", () => {
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 90_000,
+      timeoutMs: 180_000,
     };
     plugin.register(api as unknown as OpenClawPluginApi);
 
-    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(90_000);
+    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(180_000);
   });
 
   it("registers before_prompt_build with explicit setup grace when configured", () => {
@@ -3231,10 +3231,10 @@ describe("active-memory plugin", () => {
     expectLinesToContain(warnLines, "before_prompt_build");
   });
 
-  it("honors configured timeoutMs values above the former 60 000 ms ceiling", async () => {
+  it("honors configured timeoutMs values above the former 120 000 ms ceiling", async () => {
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 90_000,
+      timeoutMs: 180_000,
       logging: true,
     };
     plugin.register(api as unknown as OpenClawPluginApi);
@@ -3250,13 +3250,13 @@ describe("active-memory plugin", () => {
     );
 
     const passedTimeoutMs = lastEmbeddedRunParams().timeoutMs;
-    expect(passedTimeoutMs).toBe(90_000);
+    expect(passedTimeoutMs).toBe(180_000);
   });
 
-  it("clamps timeoutMs above the 120 000 ms ceiling to the ceiling", async () => {
+  it("clamps timeoutMs above the 300 000 ms ceiling to the ceiling", async () => {
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 200_000,
+      timeoutMs: 400_000,
       logging: true,
     };
     plugin.register(api as unknown as OpenClawPluginApi);
@@ -3272,7 +3272,7 @@ describe("active-memory plugin", () => {
     );
 
     const passedTimeoutMs = lastEmbeddedRunParams().timeoutMs;
-    expect(passedTimeoutMs).toBe(120_000);
+    expect(passedTimeoutMs).toBe(300_000);
   });
 
   it("sanitizes active-memory log fields onto a single line", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -39,6 +39,7 @@ const DEFAULT_CACHE_TTL_MS = 15_000;
 const DEFAULT_MAX_CACHE_ENTRIES = 1000;
 const CACHE_SWEEP_INTERVAL_MS = 1000;
 const DEFAULT_MIN_TIMEOUT_MS = 250;
+const MAX_ACTIVE_MEMORY_TIMEOUT_MS = 300_000;
 const DEFAULT_SETUP_GRACE_TIMEOUT_MS = 0;
 const DEFAULT_QUERY_MODE = "recent" as const;
 const DEFAULT_QMD_SEARCH_MODE = "search" as const;
@@ -894,7 +895,7 @@ function normalizePluginConfig(
       parseOptionalPositiveInt(raw.timeoutMs, DEFAULT_TIMEOUT_MS),
       DEFAULT_TIMEOUT_MS,
       minimumTimeoutMs,
-      120_000,
+      MAX_ACTIVE_MEMORY_TIMEOUT_MS,
     ),
     setupGraceTimeoutMs: clampInt(raw.setupGraceTimeoutMs, setupGraceTimeoutMs, 0, 30_000),
     queryMode:

--- a/extensions/active-memory/openclaw.plugin.json
+++ b/extensions/active-memory/openclaw.plugin.json
@@ -39,7 +39,7 @@
         "type": "string",
         "enum": ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive"]
       },
-      "timeoutMs": { "type": "integer", "minimum": 250, "maximum": 120000 },
+      "timeoutMs": { "type": "integer", "minimum": 250, "maximum": 300000 },
       "setupGraceTimeoutMs": { "type": "integer", "minimum": 0, "maximum": 30000 },
       "queryMode": {
         "type": "string",
@@ -123,7 +123,8 @@
       "help": "Optional explicit denylist of chat/user IDs. Sessions whose resolved conversation id matches the list are skipped even when the chat type is allowed. Applied after allowedChatIds."
     },
     "timeoutMs": {
-      "label": "Timeout (ms)"
+      "label": "Timeout (ms)",
+      "help": "Hard timeout for the blocking memory sub-agent. Default: 15000. Maximum: 300000. Higher values can delay the visible reply."
     },
     "setupGraceTimeoutMs": {
       "label": "Setup Grace Timeout (ms)",


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`). This PR was prepared with AI assistance.

Fixes #86065.

## Summary

- Raises the Active Memory `config.timeoutMs` ceiling from `120000` ms to `300000` ms in the runtime clamp and plugin manifest schema.
- Keeps the existing config key and default behavior intact: operators still opt in by setting `config.timeoutMs`, and the default remains `15000` ms.
- Documents the trade-off that higher values can delay the visible reply, and adds plugin UI help for the new maximum.
- Updates schema and runtime regression tests for the new ceiling.

## Compatibility and safety

This keeps the existing configuration surface instead of adding a new knob. Existing valid configs remain valid, and values above the new production ceiling are still bounded rather than making Active Memory wait indefinitely.

The safety limit moves from 2 minutes to 5 minutes. That is enough room for slow local recall models without turning the hidden recall run into an unbounded pre-response stall.

## Real behavior proof

Behavior addressed: Active Memory operators can configure recall timeouts above `120000` ms, up to `300000` ms, while invalid values above the ceiling are still rejected by schema validation and clamped at runtime.

Real environment tested: Local OpenClaw source checkout on branch `codex/86065-active-memory-timeout-cap`.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/active-memory/config.test.ts extensions/active-memory/index.test.ts --reporter=verbose
pnpm check:changed
pnpm exec oxfmt --check --threads=1 extensions/active-memory/index.ts extensions/active-memory/config.test.ts extensions/active-memory/index.test.ts extensions/active-memory/openclaw.plugin.json docs/concepts/active-memory.md
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix: The focused Active Memory suite passed with 2 test files and 135 tests. `pnpm check:changed`, formatting, whitespace checks, and autoreview all exited cleanly.

Observed result after fix: The manifest schema accepts `timeoutMs: 300000` and rejects `300001`; the runtime passes configured values above the former 120-second cap and clamps values above `300000` to `300000`.

What was not tested: A live slow vLLM/local-model recall workload was not available, so this PR proves the config/schema/runtime/docs path rather than provider-specific latency behavior.
