### PR TITLE
fix(daemon): detect system-scope systemd gateway units on Linux (#87577)

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -54,6 +54,15 @@ const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() 
 const loadConfig = vi.hoisted(() => vi.fn(() => ({})));
 const recoverInstalledLaunchAgent = vi.hoisted(() => vi.fn());
 const repairLoadedGatewayServiceForStart = vi.hoisted(() => vi.fn());
+const findInstalledSystemdGatewayScope = vi.hoisted(() =>
+  vi.fn<() => Promise<{ scope: "user" | "system"; unitName: string; unitPath: string } | null>>(
+    async () => null,
+  ),
+);
+const restartSystemdService = vi.hoisted(() =>
+  vi.fn<() => Promise<{ outcome: "completed" }>>(async () => ({ outcome: "completed" })),
+);
+const stopSystemdService = vi.hoisted(() => vi.fn<() => Promise<void>>(async () => {}));
 
 function requireMockCallArg(
   mockFn: { mock: { calls: unknown[][] } },
@@ -111,6 +120,12 @@ vi.mock("../../config/commands.js", () => ({
 
 vi.mock("../../daemon/service.js", () => ({
   resolveGatewayService: () => service,
+}));
+
+vi.mock("../../daemon/systemd.js", () => ({
+  findInstalledSystemdGatewayScope: () => findInstalledSystemdGatewayScope(),
+  restartSystemdService: () => restartSystemdService(),
+  stopSystemdService: () => stopSystemdService(),
 }));
 
 vi.mock("./launchd-recovery.js", () => ({
@@ -208,6 +223,12 @@ describe("runDaemonRestart health checks", () => {
     service.restart.mockResolvedValue({ outcome: "completed" });
     runServiceStart.mockResolvedValue(undefined);
     recoverInstalledLaunchAgent.mockResolvedValue(null);
+    findInstalledSystemdGatewayScope.mockReset();
+    findInstalledSystemdGatewayScope.mockResolvedValue(null);
+    restartSystemdService.mockReset();
+    restartSystemdService.mockResolvedValue({ outcome: "completed" });
+    stopSystemdService.mockReset();
+    stopSystemdService.mockResolvedValue(undefined);
 
     runServiceRestart.mockImplementation(async (params: RestartParams) => {
       const fail = (message: string, hints?: string[]) => {
@@ -605,6 +626,89 @@ describe("runDaemonRestart health checks", () => {
     await expect(runDaemonRestart({ json: true })).rejects.toThrow(
       "Gateway restart is disabled in the running gateway config",
     );
+  });
+
+  it("delegates system-scope restart to systemctl without unmanaged signaling when root (openclaw#87577)", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    findInstalledSystemdGatewayScope.mockResolvedValue({
+      scope: "system",
+      unitName: "openclaw.service",
+      unitPath: "/etc/systemd/system/openclaw.service",
+    });
+    restartSystemdService.mockResolvedValue({ outcome: "completed" });
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    mockUnmanagedRestart();
+
+    await expect(runDaemonRestart({ json: true })).resolves.toBe(true);
+
+    expect(restartSystemdService).toHaveBeenCalled();
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    expect(probeGateway).not.toHaveBeenCalled();
+  });
+
+  it("surfaces systemd sudo guidance and never signals when restarting a system-scope unit as non-root (openclaw#87577)", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    findInstalledSystemdGatewayScope.mockResolvedValue({
+      scope: "system",
+      unitName: "openclaw.service",
+      unitPath: "/etc/systemd/system/openclaw.service",
+    });
+    restartSystemdService.mockRejectedValue(
+      new Error(
+        "openclaw.service is a system-scope unit (/etc/systemd/system/openclaw.service); run `sudo systemctl restart openclaw.service` to restart it",
+      ),
+    );
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    mockUnmanagedRestart();
+
+    await expect(runDaemonRestart({ json: true })).rejects.toThrow(
+      /sudo systemctl restart openclaw\.service/,
+    );
+
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    expect(probeGateway).not.toHaveBeenCalled();
+  });
+
+  it("delegates system-scope stop to systemctl without unmanaged signaling when root (openclaw#87577)", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    findInstalledSystemdGatewayScope.mockResolvedValue({
+      scope: "system",
+      unitName: "openclaw-gateway.service",
+      unitPath: "/etc/systemd/system/openclaw-gateway.service",
+    });
+    stopSystemdService.mockResolvedValue(undefined);
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    runServiceStop.mockImplementation(async (params: { onNotLoaded?: () => Promise<unknown> }) => {
+      await params.onNotLoaded?.();
+    });
+
+    await expect(runDaemonStop({ json: true })).resolves.toBeUndefined();
+    expect(stopSystemdService).toHaveBeenCalled();
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+  });
+
+  it("surfaces systemd sudo guidance and never signals when stopping a system-scope unit as non-root (openclaw#87577)", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    findInstalledSystemdGatewayScope.mockResolvedValue({
+      scope: "system",
+      unitName: "openclaw-gateway.service",
+      unitPath: "/etc/systemd/system/openclaw-gateway.service",
+    });
+    stopSystemdService.mockRejectedValue(
+      new Error(
+        "openclaw-gateway.service is a system-scope unit (/etc/systemd/system/openclaw-gateway.service); run `sudo systemctl stop openclaw-gateway.service` to stop it",
+      ),
+    );
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    runServiceStop.mockImplementation(async (params: { onNotLoaded?: () => Promise<unknown> }) => {
+      await params.onNotLoaded?.();
+    });
+
+    await expect(runDaemonStop({ json: true })).rejects.toThrow(
+      /sudo systemctl stop openclaw-gateway\.service/,
+    );
+    expect(stopSystemdService).toHaveBeenCalled();
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
   });
 
   it("skips unmanaged signaling for pids that are not live gateway processes", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -3,6 +3,11 @@ import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
 import { resolveGatewayService } from "../../daemon/service.js";
+import {
+  findInstalledSystemdGatewayScope,
+  restartSystemdService,
+  stopSystemdService,
+} from "../../daemon/systemd.js";
 import { callGatewayCli } from "../../gateway/call.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
@@ -16,6 +21,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { parseDurationMs } from "../parse-duration.js";
 import { recoverInstalledLaunchAgent } from "./launchd-recovery.js";
+import { createNullWriter } from "./response.js";
 import {
   runServiceRestart,
   runServiceStart,
@@ -112,7 +118,36 @@ function resolveVerifiedGatewayListenerPids(port: number): number[] {
   );
 }
 
+async function handleSystemScopeSystemdGateway(
+  action: "stop" | "restart",
+): Promise<{ result: "stopped" | "restarted"; message: string } | null> {
+  if (process.platform !== "linux") {
+    return null;
+  }
+  const installed = await findInstalledSystemdGatewayScope(process.env).catch(() => null);
+  if (installed?.scope !== "system") {
+    return null;
+  }
+  const stdout = createNullWriter();
+  if (action === "stop") {
+    await stopSystemdService({ stdout, env: process.env });
+    return {
+      result: "stopped",
+      message: `Gateway stopped via system-scope systemd unit ${installed.unitName}.`,
+    };
+  }
+  await restartSystemdService({ stdout, env: process.env });
+  return {
+    result: "restarted",
+    message: `Gateway restarted via system-scope systemd unit ${installed.unitName}.`,
+  };
+}
+
 async function stopGatewayWithoutServiceManager(port: number) {
+  const managed = await handleSystemScopeSystemdGateway("stop");
+  if (managed) {
+    return managed;
+  }
   const pids = resolveVerifiedGatewayListenerPids(port);
   if (pids.length === 0) {
     return null;
@@ -196,6 +231,10 @@ async function restartGatewayWithoutServiceManager(
   port: number,
   restartIntent?: GatewayRestartIntent,
 ) {
+  const managed = await handleSystemScopeSystemdGateway("restart");
+  if (managed) {
+    return managed;
+  }
   await assertUnmanagedGatewayRestartEnabled(port);
   const pids = resolveVerifiedGatewayListenerPids(port);
   if (pids.length === 0) {

--- a/src/cli/daemon-cli/response.ts
+++ b/src/cli/daemon-cli/response.ts
@@ -90,7 +90,7 @@ export function buildDaemonServiceSnapshot(service: GatewayService, loaded: bool
   };
 }
 
-function createNullWriter(): Writable {
+export function createNullWriter(): Writable {
   return new Writable({
     write(_chunk, _encoding, callback) {
       callback();

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1,14 +1,10 @@
+import type { ExecFileException, ExecFileOptionsWithStringEncoding } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { ExecFileException, ExecFileOptionsWithStringEncoding } from "node:child_process";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-type ExecFileCallback = (
-  error: ExecFileException | null,
-  stdout: string,
-  stderr: string,
-) => void;
+type ExecFileCallback = (error: ExecFileException | null, stdout: string, stderr: string) => void;
 type ExecFileMock = (
   command: string,
   args: string[],
@@ -18,6 +14,24 @@ type ExecFileMock = (
 
 const execFileMock = vi.hoisted(() => vi.fn<ExecFileMock>());
 const existsSyncMock = vi.hoisted(() => vi.fn(() => false));
+const findSystemGatewayServicesMock = vi.hoisted(() =>
+  vi.fn<
+    () => Promise<
+      Array<{
+        platform: "linux";
+        label: string;
+        detail: string;
+        scope: "user" | "system";
+        marker?: "openclaw" | "clawdbot";
+        legacy?: boolean;
+      }>
+    >
+  >(async () => []),
+);
+
+vi.mock("./inspect.js", () => ({
+  findSystemGatewayServices: () => findSystemGatewayServicesMock(),
+}));
 
 vi.mock("node:fs", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:fs")>()),
@@ -58,6 +72,7 @@ vi.mock("./exec-file.js", () => {
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import { parseSystemdEnvAssignments, parseSystemdExecStart } from "./systemd-unit.js";
 import {
+  findInstalledSystemdGatewayScope,
   installSystemdService,
   isNonFatalSystemdInstallProbeError,
   isSystemdServiceEnabled,
@@ -509,6 +524,219 @@ describe("isSystemdUnitActive", () => {
     await expect(
       isSystemdUnitActive({ HOME: TEST_MANAGED_HOME }, GATEWAY_SERVICE, "system"),
     ).resolves.toBe(false);
+  });
+});
+
+describe("system-scope gateway unit detection (openclaw#87577)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    execFileMock.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockUnitFileLayout(layout: { user?: boolean; system?: string | false }) {
+    vi.spyOn(fs, "access").mockImplementation(async (pathArg) => {
+      const p = pathLikeToString(pathArg);
+      if (layout.user && p.includes("/.config/systemd/user/")) {
+        return undefined;
+      }
+      if (typeof layout.system === "string" && p === layout.system) {
+        return undefined;
+      }
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    });
+  }
+
+  it("findInstalledSystemdGatewayScope prefers user scope when both exist", async () => {
+    mockUnitFileLayout({
+      user: true,
+      system: "/etc/systemd/system/openclaw-gateway.service",
+    });
+    const result = await findInstalledSystemdGatewayScope({ HOME: TEST_MANAGED_HOME });
+    expect(result?.scope).toBe("user");
+    expect(result?.unitName).toBe(GATEWAY_SERVICE);
+    expect(result?.unitPath).toContain("/.config/systemd/user/openclaw-gateway.service");
+  });
+
+  it("findInstalledSystemdGatewayScope detects system-scope unit in /etc/systemd/system", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
+    const result = await findInstalledSystemdGatewayScope({ HOME: TEST_MANAGED_HOME });
+    expect(result).toEqual({
+      scope: "system",
+      unitName: GATEWAY_SERVICE,
+      unitPath: "/etc/systemd/system/openclaw-gateway.service",
+    });
+  });
+
+  it("findInstalledSystemdGatewayScope falls back to /usr/lib/systemd/system", async () => {
+    mockUnitFileLayout({ system: "/usr/lib/systemd/system/openclaw-gateway.service" });
+    const result = await findInstalledSystemdGatewayScope({ HOME: TEST_MANAGED_HOME });
+    expect(result?.scope).toBe("system");
+    expect(result?.unitPath).toBe("/usr/lib/systemd/system/openclaw-gateway.service");
+  });
+
+  it("findInstalledSystemdGatewayScope returns null when no unit file exists", async () => {
+    mockUnitFileLayout({ system: false });
+    findSystemGatewayServicesMock.mockResolvedValueOnce([]);
+    const result = await findInstalledSystemdGatewayScope({ HOME: TEST_MANAGED_HOME });
+    expect(result).toBeNull();
+  });
+
+  it("findInstalledSystemdGatewayScope falls back to marker-owned system unit with custom name", async () => {
+    mockUnitFileLayout({ system: false });
+    findSystemGatewayServicesMock.mockResolvedValueOnce([
+      {
+        platform: "linux",
+        label: "openclaw.service",
+        detail: "unit: /etc/systemd/system/openclaw.service",
+        scope: "system",
+        marker: "openclaw",
+      },
+    ]);
+    const result = await findInstalledSystemdGatewayScope({ HOME: TEST_MANAGED_HOME });
+    expect(result).toEqual({
+      scope: "system",
+      unitName: "openclaw.service",
+      unitPath: "/etc/systemd/system/openclaw.service",
+    });
+  });
+
+  it("findInstalledSystemdGatewayScope ignores legacy clawdbot system units in the marker fallback", async () => {
+    mockUnitFileLayout({ system: false });
+    findSystemGatewayServicesMock.mockResolvedValueOnce([
+      {
+        platform: "linux",
+        label: "clawdbot.service",
+        detail: "unit: /etc/systemd/system/clawdbot.service",
+        scope: "system",
+        marker: "clawdbot",
+        legacy: true,
+      },
+    ]);
+    const result = await findInstalledSystemdGatewayScope({ HOME: TEST_MANAGED_HOME });
+    expect(result).toBeNull();
+  });
+
+  it("isSystemdServiceEnabled queries the marker-owned custom system unit name", async () => {
+    mockUnitFileLayout({ system: false });
+    findSystemGatewayServicesMock.mockResolvedValueOnce([
+      {
+        platform: "linux",
+        label: "openclaw.service",
+        detail: "unit: /etc/systemd/system/openclaw.service",
+        scope: "system",
+        marker: "openclaw",
+      },
+    ]);
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(args).toEqual(["is-enabled", "openclaw.service"]);
+      cb(null, "enabled\n", "");
+    });
+    await expect(isSystemdServiceEnabled({ env: { HOME: TEST_MANAGED_HOME } })).resolves.toBe(true);
+  });
+
+  it("restartSystemdService surfaces sudo guidance using the marker-owned custom unit name", async () => {
+    mockUnitFileLayout({ system: false });
+    findSystemGatewayServicesMock.mockResolvedValueOnce([
+      {
+        platform: "linux",
+        label: "openclaw.service",
+        detail: "unit: /etc/systemd/system/openclaw.service",
+        scope: "system",
+        marker: "openclaw",
+      },
+    ]);
+    mockEffectiveUid(1000);
+    const { stdout, write } = createWritableStreamMock();
+    await expect(
+      restartSystemdService({ stdout, env: { HOME: TEST_MANAGED_HOME } }),
+    ).rejects.toThrow(
+      /openclaw\.service is a system-scope unit \(\/etc\/systemd\/system\/openclaw\.service\); run `sudo systemctl restart openclaw\.service`/,
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("isSystemdServiceEnabled reports true for an enabled system-scope unit", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(args).toEqual(["is-enabled", GATEWAY_SERVICE]);
+      cb(null, "enabled\n", "");
+    });
+    await expect(isSystemdServiceEnabled({ env: { HOME: TEST_MANAGED_HOME } })).resolves.toBe(true);
+  });
+
+  it("isSystemdServiceEnabled reports false for a disabled system-scope unit", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(args).toEqual(["is-enabled", GATEWAY_SERVICE]);
+      cb(createExecFileError("disabled", { code: 1 }), "disabled\n", "");
+    });
+    await expect(isSystemdServiceEnabled({ env: { HOME: TEST_MANAGED_HOME } })).resolves.toBe(
+      false,
+    );
+  });
+
+  it("readSystemdServiceRuntime queries the system manager for system-scope units", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(args[0]).toBe("show");
+      expect(args).not.toContain("--user");
+      cb(
+        null,
+        [
+          "Id=openclaw-gateway.service",
+          "ActiveState=active",
+          "SubState=running",
+          "MainPID=4242",
+        ].join("\n"),
+        "",
+      );
+    });
+    const runtime = await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
+    expect(runtime.status).toBe("running");
+    expect(runtime.pid).toBe(4242);
+    expect(runtime.systemd?.unit).toBe("openclaw-gateway.service");
+  });
+
+  it("restartSystemdService refuses to use the user manager when the unit is system-scope and the caller is not root", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
+    mockEffectiveUid(1000);
+    const { stdout, write } = createWritableStreamMock();
+    await expect(
+      restartSystemdService({ stdout, env: { HOME: TEST_MANAGED_HOME } }),
+    ).rejects.toThrow(
+      /system-scope unit .* run `sudo systemctl restart openclaw-gateway\.service`/,
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("restartSystemdService restarts the system unit directly when running as root", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
+    mockEffectiveUid(0);
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(args).toEqual(["restart", GATEWAY_SERVICE]);
+      cb(null, "", "");
+    });
+    const { stdout, write } = createWritableStreamMock();
+    const result = await restartSystemdService({ stdout, env: { HOME: TEST_MANAGED_HOME } });
+    expect(result).toEqual({ outcome: "completed" });
+    expect(requireFirstWrite(write)).toContain("Restarted systemd service");
+  });
+
+  it("stopSystemdService surfaces sudo guidance for system-scope units without root", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
+    mockEffectiveUid(1000);
+    const { stdout } = createWritableStreamMock();
+    await expect(stopSystemdService({ stdout, env: { HOME: TEST_MANAGED_HOME } })).rejects.toThrow(
+      /sudo systemctl stop openclaw-gateway\.service/,
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -78,6 +78,85 @@ export function resolveSystemdUserUnitPath(env: GatewayServiceEnv): string {
   return resolveSystemdUnitPath(env);
 }
 
+const SYSTEM_SYSTEMD_UNIT_DIRS = [
+  "/etc/systemd/system",
+  "/usr/lib/systemd/system",
+  "/lib/systemd/system",
+] as const;
+
+async function findSystemSystemdUnitPath(env: GatewayServiceEnv): Promise<string | null> {
+  const serviceFile = `${resolveSystemdServiceName(env)}.service`;
+  for (const dir of SYSTEM_SYSTEMD_UNIT_DIRS) {
+    const candidate = path.posix.join(dir, serviceFile);
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export type InstalledSystemdGatewayScope = {
+  scope: SystemdUnitScope;
+  unitName: string;
+  unitPath: string;
+};
+
+async function findMarkerOwnedSystemSystemdUnit(): Promise<{
+  unitName: string;
+  unitPath: string;
+} | null> {
+  const { findSystemGatewayServices } = await import("./inspect.js");
+  let services: Awaited<ReturnType<typeof findSystemGatewayServices>>;
+  try {
+    services = await findSystemGatewayServices();
+  } catch {
+    return null;
+  }
+  for (const svc of services) {
+    if (
+      svc.platform !== "linux" ||
+      svc.scope !== "system" ||
+      svc.marker !== "openclaw" ||
+      !svc.label?.endsWith(".service")
+    ) {
+      continue;
+    }
+    const match = /^unit:\s*(.+)$/.exec(svc.detail.trim());
+    const unitPath = match?.[1]?.trim();
+    if (unitPath) {
+      return { unitName: svc.label, unitPath };
+    }
+  }
+  return null;
+}
+
+export async function findInstalledSystemdGatewayScope(
+  env: GatewayServiceEnv,
+): Promise<InstalledSystemdGatewayScope | null> {
+  const canonicalUnitName = `${resolveSystemdServiceName(env)}.service`;
+  let userPath: string | null = null;
+  try {
+    userPath = resolveSystemdUnitPath(env);
+  } catch {
+    userPath = null;
+  }
+  if (userPath) {
+    try {
+      await fs.access(userPath);
+      return { scope: "user", unitName: canonicalUnitName, unitPath: userPath };
+    } catch {}
+  }
+  const systemPath = await findSystemSystemdUnitPath(env);
+  if (systemPath) {
+    return { scope: "system", unitName: canonicalUnitName, unitPath: systemPath };
+  }
+  const owned = await findMarkerOwnedSystemSystemdUnit();
+  return owned ? { scope: "system", unitName: owned.unitName, unitPath: owned.unitPath } : null;
+}
+
 export { enableSystemdUserLinger, readSystemdUserLingerStatus };
 
 // Unit file parsing/rendering: see systemd-unit.ts
@@ -1037,6 +1116,17 @@ export async function uninstallSystemdService({
   }
 }
 
+function isRunningAsRoot(): boolean {
+  if (typeof process.geteuid === "function") {
+    try {
+      return process.geteuid() === 0;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 async function runSystemdServiceAction(params: {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
@@ -1044,9 +1134,22 @@ async function runSystemdServiceAction(params: {
   label: string;
 }) {
   const env = params.env ?? process.env;
+  const installed = await findInstalledSystemdGatewayScope(env);
+  const unitName = installed?.unitName ?? `${resolveSystemdServiceName(env)}.service`;
+  if (installed?.scope === "system") {
+    if (!isRunningAsRoot()) {
+      throw new Error(
+        `${unitName} is a system-scope unit (${installed.unitPath}); run \`sudo systemctl ${params.action} ${unitName}\` to ${params.action} it`,
+      );
+    }
+    const res = await execSystemctl([params.action, unitName], env);
+    if (res.code !== 0) {
+      throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
+    }
+    params.stdout.write(`${formatLine(params.label, unitName)}\n`);
+    return;
+  }
   await assertSystemdAvailable(env);
-  const serviceName = resolveSystemdServiceName(env);
-  const unitName = `${serviceName}.service`;
   const res = await execSystemctlUser(env, [params.action, unitName]);
   if (res.code !== 0) {
     throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
@@ -1081,18 +1184,14 @@ export async function restartSystemdService({
 
 export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Promise<boolean> {
   const env = args.env ?? process.env;
-  try {
-    await fs.access(resolveSystemdUnitPath(env));
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-    throw error;
+  const installed = await findInstalledSystemdGatewayScope(env);
+  if (!installed) {
+    return false;
   }
-
-  const serviceName = resolveSystemdServiceName(env);
-  const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, ["is-enabled", unitName]);
+  const res =
+    installed.scope === "system"
+      ? await execSystemctl(["is-enabled", installed.unitName], env)
+      : await execSystemctlUser(env, ["is-enabled", installed.unitName]);
   if (res.code === 0) {
     return true;
   }
@@ -1106,23 +1205,29 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
 export async function readSystemdServiceRuntime(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<GatewayServiceRuntime> {
-  try {
-    await assertSystemdAvailable(env);
-  } catch (err) {
-    return {
-      status: "unknown",
-      detail: formatErrorMessage(err),
-    };
+  const installed = await findInstalledSystemdGatewayScope(env).catch(() => null);
+  if (installed?.scope !== "system") {
+    try {
+      await assertSystemdAvailable(env);
+    } catch (err) {
+      return {
+        status: "unknown",
+        detail: formatErrorMessage(err),
+      };
+    }
   }
-  const serviceName = resolveSystemdServiceName(env);
-  const unitName = `${serviceName}.service`;
-  const res = await execSystemctlUser(env, [
+  const unitName = installed?.unitName ?? `${resolveSystemdServiceName(env)}.service`;
+  const showArgs = [
     "show",
     unitName,
     "--no-page",
     "--property",
     "Id,ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
-  ]);
+  ];
+  const res =
+    installed?.scope === "system"
+      ? await execSystemctl(showArgs, env)
+      : await execSystemctlUser(env, showArgs);
   if (res.code !== 0) {
     const detail = (res.stderr || res.stdout).trim();
     const missing = normalizeLowercaseStringOrEmpty(detail).includes("not found");


### PR DESCRIPTION
## Summary

Fixes #87577 by teaching the Linux gateway service code to recognize **system-scope** systemd units in three forms — the canonical user-scope path, the canonical system-scope path (`/etc/systemd/system/openclaw-gateway.service` and siblings), and **any non-canonically named** system unit that carries the OpenClaw gateway marker (the reporter's `/etc/systemd/system/openclaw.service` shape). `openclaw status` now reports system-managed gateways correctly through the system manager, and `openclaw gateway restart` no longer drops to an unmanaged SIGUSR1 against a process the system supervisor owns.

Reuses two existing patterns already shipping in main:
- `findSystemGatewayServices` in `src/daemon/inspect.ts:357` (the marker scanner doctor and inspect already use to find arbitrary OpenClaw-marked system units).
- The sudo-guidance shape from `src/cli/update-cli/restart-helper.ts:98`.

## Maintainer decision requested (clawsweeper P1)

The **non-root** stop/restart behavior for a detected system-scope unit is an intentional operator-policy change that clawsweeper flagged as a compatibility risk (root `AGENTS.md`: removed fallbacks / fail-closed changes / new operator action are merge-sensitive). Requesting explicit maintainer acceptance of this policy:

- **Before:** `openclaw gateway stop` / `restart` fell through to unmanaged SIGTERM/SIGUSR1 against whatever PID held the gateway port — including a process systemd owns. That signal-an-unmanaged-pid path *is* the #87577 bug.
- **After (this PR):** when a system-scope unit is detected, **root** runs `systemctl <action> <unit>` directly; **non-root** gets actionable `sudo systemctl <action> <unit>` guidance that names the real installed unit, and no signal is sent.

This matches the operator guidance already shipping for the update-restart path (`src/cli/update-cli/restart-helper.ts:98`) and AGENTS.md's "one canonical path, no buggy-fallback compat" rule. The old fallback is the bug, not a shipped contract, so it is removed rather than preserved. If a maintainer would instead prefer (a) silent sudo escalation, (b) polkit integration, or (c) keeping the SIGUSR1 fallback for system-scope units behind an explicit flag, say which and I'll revise.

## Behavior change

`src/daemon/systemd.ts` — added `findInstalledSystemdGatewayScope(env)` returning `{ scope: "user" | "system", unitName, unitPath }`. Three call sites now use it:

- **`isSystemdServiceEnabled`** — falls through to system-scope `systemctl is-enabled` (no `--user`) for system units, using `installed.unitName` so non-canonical names (like `openclaw.service`) are queried correctly. Before: returned `false` whenever the canonical user unit file was absent, regardless of system units.
- **`readSystemdServiceRuntime`** — queries the system manager (no `--user`) when the unit is system-scope, using `installed.unitName`. Before: always went through the user manager and surfaced `Failed to connect to bus` on headless servers.
- **`runSystemdServiceAction` (stop/restart)** — when the unit is system-scope and the caller is not root, throws ``sudo systemctl <action> <installed.unitName>`` guidance (no silent privilege escalation). When root, runs `systemctl <action>` directly. Custom-name units get the real unit name in the hint, not a hardcoded canonical one.

`src/cli/daemon-cli/lifecycle.ts` — `stopGatewayWithoutServiceManager` and `restartGatewayWithoutServiceManager` now route a detected system-scope unit through the canonical `stopSystemdService` / `restartSystemdService` helpers instead of the unmanaged SIGUSR1/SIGTERM fallback. This makes the lifecycle fallback and the systemd action path **consistent**: root runs `systemctl <action> <installed.unitName>` directly, non-root gets the *same* sudo-guidance message `runSystemdServiceAction` already emits (one canonical hint string, no duplicate). Net effect: the unmanaged signal fallback can never reach a systemd-managed gateway process, and a root operator is never told to `sudo` a command it can already run. (The earlier revision threw unconditionally here, including for root — that inconsistency is removed.)

`findInstalledSystemdGatewayScope` resolution order:
1. Canonical user-scope unit file (`$HOME/.config/systemd/user/openclaw-gateway[-<profile>].service`).
2. Canonical system-scope unit file (`/etc/systemd/system/`, `/usr/lib/systemd/system/`, `/lib/systemd/system/`).
3. **Marker-based fallback** for any other name: delegates to `findSystemGatewayServices` (`src/daemon/inspect.ts`) which scans the same three system dirs and recognizes any `.service` file carrying the `OPENCLAW_SERVICE_MARKER` / `OPENCLAW_SERVICE_KIND` env markers (or a marker-bearing ExecStart). The returned unit name is used verbatim by every downstream `systemctl` call.

User-scope behavior is unchanged.

## Diff size

```
 src/cli/daemon-cli/lifecycle.test.ts | 104 ++++++++++++++
 src/cli/daemon-cli/lifecycle.ts      |  39 ++++++
 src/cli/daemon-cli/response.ts       |   2 +-
 src/daemon/systemd.test.ts           | 242 +++++++++++++++++++++++++++++++-
 src/daemon/systemd.ts                | 153 +++++++++++++++-----
 5 files changed, 508 insertions(+), 32 deletions(-)
```

(`response.ts` change: export the existing `createNullWriter` helper so the lifecycle fallback can discard the delegated `systemctl` status line and surface its own message.)

## Test plan

- [x] New unit tests for `findInstalledSystemdGatewayScope`: user-scope preferred when both exist; canonical `/etc/systemd/system/openclaw-gateway.service`; canonical `/usr/lib/systemd/system/openclaw-gateway.service`; returns null when nothing is installed; **marker fallback to custom-name `openclaw.service`**; legacy `clawdbot.service` marker units ignored.
- [x] `isSystemdServiceEnabled` against custom-name marker unit.
- [x] `restartSystemdService` raises sudo guidance with the marker-owned unit's real name; root path runs `systemctl restart <unit>` directly.
- [x] `readSystemdServiceRuntime` queries the system manager for custom-name marker units.
- [x] Lifecycle restart/stop tests cover **both** operator paths for a detected system-scope unit: **root** delegates to `systemctl` with no unmanaged signal; **non-root** surfaces `sudo systemctl <action> <installed.unitName>` guidance and never signals.
- [x] Focused acceptance suite (local Linux, Node 22.19): `src/daemon/systemd.test.ts` (84), `src/cli/daemon-cli/lifecycle.test.ts` (24), `src/daemon/inspect.test.ts`, `src/cli/daemon-cli/lifecycle-core.test.ts`, `src/cli/daemon-cli/status.gather.test.ts`, `src/cli/daemon-cli/response.test.ts`, `src/commands/doctor-gateway-daemon-flow.test.ts`, `src/cli/update-cli/restart-helper.test.ts` — all green. `tsgo -p tsconfig.core.json` + core test-types clean; oxlint clean on changed files.
- [ ] CI checks + clawsweeper re-review.

## Real behavior proof

Behavior addressed: openclaw#87577 — on Linux the gateway service code only checked the user-scope systemd unit, so a system-scope unit (including the reporter's custom-named `/etc/systemd/system/openclaw.service`) was reported wrong by `openclaw status`, and `openclaw gateway restart`/`stop` dropped to an unmanaged SIGUSR1/SIGTERM against the systemd-owned process. After the patch the code detects the system-scope unit (canonical or marker-named), reports it through the system manager, and routes stop/restart through systemd: root runs `systemctl <action>`, non-root fails closed with `sudo systemctl <action> <unit>` guidance and never signals.

Real environment tested: real systemd host — Linux 6.8.0-71-generic, systemd 255 (255.4-1ubuntu8.14), Node v22.19 — against a transient custom-name unit `/etc/systemd/system/openclaw.service` carrying the reporter's marker env (`OPENCLAW_SERVICE_MARKER=openclaw`, `OPENCLAW_SERVICE_KIND=gateway`) and a dedicated non-root `User=` (uid 1000). The unit was `systemctl start`ed (not enabled) and fully removed after the run.

Exact steps or command run after this patch: ran the real `openclaw` CLI straight from the source checkout at PR head `e2ec15c` — `node scripts/run-node.mjs gateway stop` and `node scripts/run-node.mjs gateway restart` (this builds and runs the patched TypeScript; not a copy, not a stub) — as root (uid 0) and as the non-root unit user (uid 1000), against the live custom-name unit. Separately exercised the real exported functions (`findInstalledSystemdGatewayScope`, `isSystemdServiceEnabled`, `readSystemdServiceRuntime`, `stopSystemdService`, `restartSystemdService`) from an esbuild bundle of `src/daemon/systemd.ts` at the same head, wrapped by a verbatim copy of `src/cli/daemon-cli/lifecycle.ts:handleSystemScopeSystemdGateway`.

Evidence after fix:

Actual patched CLI from the source checkout (`node scripts/run-node.mjs gateway <action>`):

```
# root (uid 0)
$ node scripts/run-node.mjs gateway stop
Gateway stopped via system-scope systemd unit openclaw.service.        # unit: active -> inactive

$ node scripts/run-node.mjs gateway restart
# MainPID 179861 -> 179973  (systemd actually restarted the unit via `systemctl restart`)
Timed out after 60s waiting for gateway port 18789 to become healthy.  # expected: stand-in listener is a plain `python -m http.server`, not a real gateway WS endpoint — the restart itself succeeded

# non-root (uid 1000)
$ node scripts/run-node.mjs gateway stop
Gateway stop failed: Error: openclaw.service is a system-scope unit (/etc/systemd/system/openclaw.service); run `sudo systemctl stop openclaw.service` to stop it
# unit stayed active — no signal sent

$ node scripts/run-node.mjs gateway restart
Gateway restart failed: Error: openclaw.service is a system-scope unit (/etc/systemd/system/openclaw.service); run `sudo systemctl restart openclaw.service` to restart it
# MainPID unchanged — no signal sent
```

Real exported functions from `src/daemon/systemd.ts` (esbuild bundle of the actual source, same host):

```
=== findInstalledSystemdGatewayScope ===
{ "scope": "system", "unitName": "openclaw.service", "unitPath": "/etc/systemd/system/openclaw.service" }
=== readSystemdServiceRuntime ===   # queried via the system manager, no --user
{ "status": "running", "state": "active", "subState": "running", "pid": 178463,
  "systemd": { "unit": "openclaw.service", "killMode": "control-group", ... } }
```

| function-level action | root (uid 0) | non-root (uid 1000) |
|---|---|---|
| restart | `{ result: "restarted" }`; MainPID **178463 -> 178808** | THREW `… sudo systemctl restart openclaw.service`; MainPID unchanged, no signal |
| stop | `{ result: "stopped" }`; **active -> inactive** | THREW `… sudo systemctl stop openclaw.service`; stayed active, no signal |

Observed result after fix: the system-scope custom-name unit is detected via the marker fallback (`{ scope: "system", unitName: "openclaw.service" }`), status is read through the **system manager** (no `--user`), and stop/restart route through systemd — root drives a real `systemctl` action (stop → inactive, restart → new MainPID), while non-root fails closed with the real-unit `sudo systemctl <action> openclaw.service` hint and never signals the systemd-owned process. The only non-patch noise is the post-restart health check timing out because the stand-in listener is a plain HTTP server rather than a real gateway. User-scope and canonical-name deployments are unchanged (existing tests stay green).

What was not tested: a fully packaged `openclaw` release binary (as opposed to the source checkout used above). The published 2026.5.26 tarball ships a broken `npm-shrinkwrap.json` (omits `json5`, `tslog`, …) so it cannot materialize working `node_modules/`; the source-checkout CLI run above reaches the identical changed `src/cli/daemon-cli/lifecycle.ts` path. Happy to rerun against a maintainer-built tarball.

## Refs

- Fixes #87577
- Addresses clawsweeper review on #87618 (custom-name `openclaw.service` shape; non-root system-scope fail-closed policy gated for maintainer acceptance; real source-checkout CLI proof on a live systemd host).
- Reuses existing marker scan from `src/daemon/inspect.ts:357` (`findSystemGatewayServices`) and the sudo-guidance shape from `src/cli/update-cli/restart-helper.ts:98`.
