### PR TITLE
fix(diagnostics): account stream deltas incrementally

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -233,7 +233,9 @@ Model-call diagnostics record bounded request/response measurements without
 capturing raw prompt or response content:
 
 - `requestPayloadBytes`: UTF-8 byte size of the final model request payload
-- `responseStreamBytes`: UTF-8 byte size of streamed model response events
+- `responseStreamBytes`: UTF-8 byte size of streamed model response payloads.
+  Delta events count only their incremental payload and exclude repeated
+  `partial` snapshots.
 - `timeToFirstByteMs`: elapsed time before the first streamed response event
 - `durationMs`: total model-call duration
 

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -263,6 +263,55 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     }
   });
 
+  it("accounts delta stream bytes without serializing repeated partial snapshots", async () => {
+    const chunks: Array<Record<string, unknown>> = [];
+    let accumulated = "";
+    for (let index = 0; index < 32; index += 1) {
+      const delta = `${index}: ${"token ".repeat(64)}`;
+      accumulated += delta;
+      chunks.push({
+        type: "text_delta",
+        contentIndex: 0,
+        delta,
+        partial: {
+          role: "assistant",
+          content: [{ type: "text", text: accumulated }],
+        },
+      });
+    }
+    async function* stream() {
+      yield* chunks;
+    }
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream()) as unknown as StreamFn,
+      {
+        runId: "run-1",
+        provider: "ollama",
+        model: "qwen/qwen3.5-9b",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-delta-accounting",
+      },
+    );
+
+    const events = await collectModelCallEvents(async () => {
+      await drain(wrapped({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
+    });
+
+    const completedEvent = getEvent(events, 1);
+    const deltaOnlyBytes = chunks.reduce((total, chunk) => {
+      const incrementalChunk = { ...chunk };
+      delete incrementalChunk.partial;
+      return total + Buffer.byteLength(JSON.stringify(incrementalChunk), "utf8");
+    }, 0);
+    const fullSnapshotBytes = chunks.reduce(
+      (total, chunk) => total + Buffer.byteLength(JSON.stringify(chunk), "utf8"),
+      0,
+    );
+    expect(completedEvent.type).toBe("model.call.completed");
+    expect(completedEvent.responseStreamBytes).toBe(deltaOnlyBytes);
+    expect(fullSnapshotBytes).toBeGreaterThan(deltaOnlyBytes * 10);
+  });
+
   it("does not retain stream progress activity when diagnostics are disabled", async () => {
     setDiagnosticsEnabledForProcess(false);
     const runProgressEvents: DiagnosticEventPayload[] = [];

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -106,6 +106,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function responseStreamChunkByteLength(chunk: unknown): number | undefined {
+  if (!isRecord(chunk)) {
+    return utf8JsonByteLength(chunk);
+  }
+  const type = chunk.type;
+  if (
+    (type === "text_delta" || type === "thinking_delta" || type === "toolcall_delta") &&
+    "partial" in chunk
+  ) {
+    // Delta events already carry the new bytes. The `partial` snapshot repeats
+    // the full answer-so-far, so counting it on every token turns diagnostics
+    // into quadratic work for fast local streams.
+    const incrementalChunk: Record<string, unknown> = { ...chunk };
+    delete incrementalChunk.partial;
+    return utf8JsonByteLength(incrementalChunk);
+  }
+  return utf8JsonByteLength(chunk);
+}
+
 function cloneDiagnosticContentValue(value: unknown): unknown {
   try {
     return structuredClone(value);
@@ -157,7 +176,7 @@ function observeResponseChunk(
 ): void {
   state.timeToFirstByteMs ??= Math.max(0, Date.now() - startedAt);
   observeOutputMessageContent(state, chunk);
-  const bytes = utf8JsonByteLength(chunk);
+  const bytes = responseStreamChunkByteLength(chunk);
   if (bytes !== undefined) {
     state.responseStreamBytes += bytes;
   }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -532,6 +532,10 @@ export type DiagnosticModelCallCompletedEvent = DiagnosticModelCallBaseEvent & {
   type: "model.call.completed";
   durationMs: number;
   requestPayloadBytes?: number;
+  /**
+   * Serialized streamed response payload bytes. Delta events count only their
+   * incremental payload and exclude repeated `partial` snapshots.
+   */
   responseStreamBytes?: number;
   timeToFirstByteMs?: number;
 };
@@ -543,6 +547,10 @@ export type DiagnosticModelCallErrorEvent = DiagnosticModelCallBaseEvent & {
   failureKind?: "aborted" | "connection_closed" | "connection_reset" | "terminated" | "timeout";
   memory?: DiagnosticMemoryUsage;
   requestPayloadBytes?: number;
+  /**
+   * Serialized streamed response payload bytes. Delta events count only their
+   * incremental payload and exclude repeated `partial` snapshots.
+   */
   responseStreamBytes?: number;
   timeToFirstByteMs?: number;
 };

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -260,6 +260,10 @@ export type PluginHookModelCallEndedEvent = PluginHookModelCallBaseEvent & {
   errorCategory?: string;
   failureKind?: "aborted" | "connection_closed" | "connection_reset" | "terminated" | "timeout";
   requestPayloadBytes?: number;
+  /**
+   * Serialized streamed response payload bytes. Delta events count only their
+   * incremental payload and exclude repeated `partial` snapshots.
+   */
   responseStreamBytes?: number;
   timeToFirstByteMs?: number;
   upstreamRequestIdHash?: string;

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -773,7 +773,7 @@
         "timeoutMs": {
           "description": "Provider timeout ms.",
           "minimum": 1,
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": ["text"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -809,7 +809,7 @@
         "timeoutMs": {
           "description": "Provider timeout ms.",
           "minimum": 1,
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": ["text"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -773,7 +773,7 @@
         "timeoutMs": {
           "description": "Provider timeout ms.",
           "minimum": 1,
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": ["text"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,7 +221,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40277,
+    "chars": 40278,
     "roughTokens": 10070
   },
   "openClawDeveloperInstructions": {
@@ -233,7 +233,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67979,
+    "chars": 67980,
     "roughTokens": 16995
   },
   "userInputText": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,7 +221,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 39998,
+    "chars": 39999,
     "roughTokens": 10000
   },
   "openClawDeveloperInstructions": {
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66176,
-    "roughTokens": 16544
+    "chars": 66177,
+    "roughTokens": 16545
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,7 +222,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41093,
+    "chars": 41094,
     "roughTokens": 10274
   },
   "openClawDeveloperInstructions": {
@@ -234,7 +234,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68214,
+    "chars": 68215,
     "roughTokens": 17054
   },
   "userInputText": {


### PR DESCRIPTION
## Summary
- stop model-call response byte accounting from serializing repeated `partial` snapshots on every text/thinking/tool-call delta
- keep request payload accounting, final/error output content capture, and normal diagnostic events intact
- document the intentional diagnostic/plugin-hook contract: delta events count incremental payload bytes and exclude repeated `partial` snapshots
- add a regression test for accumulated partial snapshots so the counter stays proportional to new delta payloads

Refs #86599.

## Diagnosis
The issue comment is directionally correct for the diagnostics path: commit `c6e98493511b3a18e6f2f402693ef7dc832a071f` added per-chunk `JSON.stringify(value)` accounting, and current streamed delta events can include a full `partial` assistant snapshot that grows with the answer. That makes diagnostics repeatedly serialize old output on every new delta. This PR fixes that confirmed multiplier, but it does not claim the whole issue is closed; Ollama dense-loop yielding and subscriber accumulated-text work remain separate follow-up surfaces.

## Verification
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/model-stream-delta-fix-$USER-$$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts` - 2 files / 24 tests passed on `dc30b0b998`
- `node scripts/format-docs.mjs --check docs/logging.md`
- `node scripts/check-docs-mdx.mjs docs/logging.md`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/infra/diagnostic-events.ts src/plugins/hook-types.ts`
- `./node_modules/.bin/oxlint src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/infra/diagnostic-events.ts src/plugins/hook-types.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings
- Previous AWS Crabbox Linux changed gate for this patch shape passed before the current rebase: `run_6475040d0e36`, lease `cbx_e279ac04cdc4`, provider `aws`, exit 0. Current broad changed-gate proof is waiting for current-main type gate unblocker #87750.
- Accounting probe from the same patch line: 2,000 accumulated-partial text deltas measured ~779.7 MB full-partial JSON work vs ~0.88 MB delta-accounting work, about 889x less serialized/countable payload in that shape.

Behavior addressed: model-call diagnostics now count incremental delta event payloads instead of repeatedly charging full assistant partial snapshots.
Real environment tested: focused local tests/lint/docs/probe and prior AWS Crabbox Linux changed gate for the same patch shape.
Exact steps or command run after this patch: listed in Verification.
Evidence after fix: regression test asserts response stream byte accounting excludes repeated `partial` snapshots for delta events while preserving proportional delta bytes; docs and exported diagnostic/plugin hook types now state that contract.
Observed result after fix: response stream accounting no longer grows quadratically with answer-so-far snapshots in plain delta streams.
What was not tested: live Windows/Ollama gateway reproduction for the full issue; this is the diagnostics multiplier slice only. Fresh broad changed-gate proof on latest SHA is pending #87750 or a stacked proof run with that prerequisite overlaid.
