### PR TITLE
fix(cron): complete jobs filters

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5458,6 +5458,8 @@ public struct CronListParams: Codable, Sendable {
     public let offset: Int?
     public let query: String?
     public let enabled: AnyCodable?
+    public let schedulekind: AnyCodable?
+    public let lastrunstatus: AnyCodable?
     public let sortby: AnyCodable?
     public let sortdir: AnyCodable?
     public let agentid: String?
@@ -5468,6 +5470,8 @@ public struct CronListParams: Codable, Sendable {
         offset: Int?,
         query: String?,
         enabled: AnyCodable?,
+        schedulekind: AnyCodable?,
+        lastrunstatus: AnyCodable?,
         sortby: AnyCodable?,
         sortdir: AnyCodable?,
         agentid: String?)
@@ -5477,6 +5481,8 @@ public struct CronListParams: Codable, Sendable {
         self.offset = offset
         self.query = query
         self.enabled = enabled
+        self.schedulekind = schedulekind
+        self.lastrunstatus = lastrunstatus
         self.sortby = sortby
         self.sortdir = sortdir
         self.agentid = agentid
@@ -5488,6 +5494,8 @@ public struct CronListParams: Codable, Sendable {
         case offset
         case query
         case enabled
+        case schedulekind = "scheduleKind"
+        case lastrunstatus = "lastRunStatus"
         case sortby = "sortBy"
         case sortdir = "sortDir"
         case agentid = "agentId"

--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createMockCronStateForJobs } from "./service.test-harness.js";
 import { listPage } from "./service/ops.js";
@@ -113,5 +116,43 @@ describe("cron listPage sort guards", () => {
     const page = await listPage(state, { query: "tax" });
 
     expect(page.jobs.map((job) => job.id)).toEqual(["tax-digest"]);
+  });
+
+  it("applies schedule and last-run status filters before paging", async () => {
+    const nextRunAtMs = Date.parse("2030-02-27T15:30:00.000Z");
+    const jobs = [
+      createBaseJob({
+        id: "at-unknown",
+        schedule: { kind: "at", at: "2030-02-27T15:30:00.000Z" },
+        state: { nextRunAtMs },
+      }),
+      createBaseJob({
+        id: "cron-error",
+        schedule: { kind: "cron", expr: "0 9 * * *" },
+        state: { nextRunAtMs, lastStatus: "error" },
+      }),
+      createBaseJob({
+        id: "cron-unknown",
+        schedule: { kind: "cron", expr: "0 10 * * *" },
+        state: { nextRunAtMs },
+      }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+    const storeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-list-page-"));
+    try {
+      state.deps.storePath = path.join(storeDir, "jobs.json");
+
+      const page = await listPage(state, {
+        scheduleKind: "cron",
+        lastRunStatus: "unknown",
+        limit: 1,
+      });
+
+      expect(page.jobs.map((job) => job.id)).toEqual(["cron-unknown"]);
+      expect(page.total).toBe(1);
+      expect(page.hasMore).toBe(false);
+    } finally {
+      await fs.rm(storeDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -102,4 +102,16 @@ describe("cron listPage sort guards", () => {
 
     expect(page.jobs.map((job) => job.id)).toEqual(["job-main", "job-ops"]);
   });
+
+  it("matches job ids in listPage text search", async () => {
+    const jobs = [
+      createBaseJob({ id: "daily-report", name: "Morning report" }),
+      createBaseJob({ id: "tax-digest", name: "Finance digest" }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+
+    const page = await listPage(state, { query: "tax" });
+
+    expect(page.jobs.map((job) => job.id)).toEqual(["tax-digest"]);
+  });
 });

--- a/src/cron/service/list-page-types.ts
+++ b/src/cron/service/list-page-types.ts
@@ -1,6 +1,8 @@
-import type { CronJob } from "../types.js";
+import type { CronJob, CronRunStatus } from "../types.js";
 
 export type CronJobsEnabledFilter = "all" | "enabled" | "disabled";
+export type CronJobsScheduleKindFilter = "all" | "at" | "every" | "cron";
+export type CronJobsLastRunStatusFilter = "all" | CronRunStatus | "unknown";
 export type CronJobsSortBy = "nextRunAtMs" | "updatedAtMs" | "name";
 export type CronSortDir = "asc" | "desc";
 
@@ -10,6 +12,8 @@ export type CronListPageOptions = {
   offset?: number;
   query?: string;
   enabled?: CronJobsEnabledFilter;
+  scheduleKind?: CronJobsScheduleKindFilter;
+  lastRunStatus?: CronJobsLastRunStatusFilter;
   sortBy?: CronJobsSortBy;
   sortDir?: CronSortDir;
   agentId?: string;

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -27,6 +27,8 @@ import {
 } from "./jobs.js";
 import type {
   CronJobsEnabledFilter,
+  CronJobsLastRunStatusFilter,
+  CronJobsScheduleKindFilter,
   CronJobsSortBy,
   CronListPageOptions,
   CronListPageResult,
@@ -275,6 +277,35 @@ function resolveEnabledFilter(opts?: CronListPageOptions): CronJobsEnabledFilter
   return opts?.includeDisabled ? "all" : "enabled";
 }
 
+function resolveScheduleKindFilter(opts?: CronListPageOptions): CronJobsScheduleKindFilter {
+  if (
+    opts?.scheduleKind === "all" ||
+    opts?.scheduleKind === "at" ||
+    opts?.scheduleKind === "every" ||
+    opts?.scheduleKind === "cron"
+  ) {
+    return opts.scheduleKind;
+  }
+  return "all";
+}
+
+function resolveLastRunStatusFilter(opts?: CronListPageOptions): CronJobsLastRunStatusFilter {
+  if (
+    opts?.lastRunStatus === "all" ||
+    opts?.lastRunStatus === "ok" ||
+    opts?.lastRunStatus === "error" ||
+    opts?.lastRunStatus === "skipped" ||
+    opts?.lastRunStatus === "unknown"
+  ) {
+    return opts.lastRunStatus;
+  }
+  return "all";
+}
+
+function resolveJobLastRunStatus(job: CronJob): CronJobsLastRunStatusFilter {
+  return job.state.lastRunStatus ?? job.state.lastStatus ?? "unknown";
+}
+
 function sortJobs(jobs: CronJob[], sortBy: CronJobsSortBy, sortDir: CronSortDir) {
   const dir = sortDir === "desc" ? -1 : 1;
   return jobs.toSorted((a, b) => {
@@ -320,6 +351,8 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
     await ensureLoadedForRead(state);
     const query = normalizeLowercaseStringOrEmpty(opts?.query);
     const enabledFilter = resolveEnabledFilter(opts);
+    const scheduleKindFilter = resolveScheduleKindFilter(opts);
+    const lastRunStatusFilter = resolveLastRunStatusFilter(opts);
     const sortBy = opts?.sortBy ?? "nextRunAtMs";
     const sortDir = opts?.sortDir ?? "asc";
     const requestedAgentId = normalizeOptionalAgentId(opts?.agentId);
@@ -335,6 +368,12 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
         requestedAgentId &&
         resolveEffectiveJobAgentId(job, state.deps.defaultAgentId) !== requestedAgentId
       ) {
+        return false;
+      }
+      if (scheduleKindFilter !== "all" && job.schedule.kind !== scheduleKindFilter) {
+        return false;
+      }
+      if (lastRunStatusFilter !== "all" && resolveJobLastRunStatus(job) !== lastRunStatusFilter) {
         return false;
       }
       if (!query) {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -341,7 +341,7 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
         return true;
       }
       const haystack = normalizeLowercaseStringOrEmpty(
-        [job.name, job.description ?? "", job.agentId ?? ""].join(" "),
+        [job.id, job.name, job.description ?? "", job.agentId ?? ""].join(" "),
       );
       return haystack.includes(query);
     });

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -117,6 +117,8 @@ describe("cron protocol validators", () => {
         offset: 0,
         query: "daily",
         enabled: "all",
+        scheduleKind: "cron",
+        lastRunStatus: "unknown",
         sortBy: "nextRunAtMs",
         sortDir: "asc",
         agentId: "ops",
@@ -124,6 +126,8 @@ describe("cron protocol validators", () => {
     ).toBe(true);
     expect(validateCronListParams({ offset: -1 })).toBe(false);
     expect(validateCronListParams({ agentId: "" })).toBe(false);
+    expect(validateCronListParams({ scheduleKind: "yearly" })).toBe(false);
+    expect(validateCronListParams({ lastRunStatus: "pending" })).toBe(false);
   });
 
   it("enforces runs limit minimum for id and jobId selectors", () => {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -40,6 +40,19 @@ const CronJobsEnabledFilterSchema = Type.Union([
   Type.Literal("enabled"),
   Type.Literal("disabled"),
 ]);
+const CronJobsScheduleKindFilterSchema = Type.Union([
+  Type.Literal("all"),
+  Type.Literal("at"),
+  Type.Literal("every"),
+  Type.Literal("cron"),
+]);
+const CronJobsLastRunStatusFilterSchema = Type.Union([
+  Type.Literal("all"),
+  Type.Literal("ok"),
+  Type.Literal("error"),
+  Type.Literal("skipped"),
+  Type.Literal("unknown"),
+]);
 const CronJobsSortBySchema = Type.Union([
   Type.Literal("nextRunAtMs"),
   Type.Literal("updatedAtMs"),
@@ -360,6 +373,8 @@ export const CronListParamsSchema = Type.Object(
     offset: Type.Optional(Type.Integer({ minimum: 0 })),
     query: Type.Optional(Type.String()),
     enabled: Type.Optional(CronJobsEnabledFilterSchema),
+    scheduleKind: Type.Optional(CronJobsScheduleKindFilterSchema),
+    lastRunStatus: Type.Optional(CronJobsLastRunStatusFilterSchema),
     sortBy: Type.Optional(CronJobsSortBySchema),
     sortDir: Type.Optional(CronSortDirSchema),
     agentId: Type.Optional(NonEmptyString),

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -213,6 +213,8 @@ export const cronHandlers: GatewayRequestHandlers = {
       offset?: number;
       query?: string;
       enabled?: "all" | "enabled" | "disabled";
+      scheduleKind?: "all" | "at" | "every" | "cron";
+      lastRunStatus?: "all" | "ok" | "error" | "skipped" | "unknown";
       sortBy?: "nextRunAtMs" | "updatedAtMs" | "name";
       sortDir?: "asc" | "desc";
       agentId?: string;
@@ -223,6 +225,8 @@ export const cronHandlers: GatewayRequestHandlers = {
       offset: p.offset,
       query: p.query,
       enabled: p.enabled,
+      scheduleKind: p.scheduleKind,
+      lastRunStatus: p.lastRunStatus,
       sortBy: p.sortBy,
       sortDir: p.sortDir,
       agentId: p.agentId,

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -183,9 +183,10 @@ function expectPluginRecordFields(record: unknown, expected: Record<string, unkn
 }
 
 function expectDiagnosticCodes(diagnostics: unknown, expectedCodes: string[]) {
-  const codes = requireArray(diagnostics, "diagnostics").map(
-    (diagnostic) => requireRecord(diagnostic, "diagnostic").code,
-  );
+  const codes: unknown[] = [];
+  for (const diagnostic of requireArray(diagnostics, "diagnostics")) {
+    codes.push(requireRecord(diagnostic, "diagnostic").code);
+  }
   expect(codes).toEqual(expectedCodes);
 }
 

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -167,9 +167,9 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function requireArray(value: unknown, label: string): unknown[] {
+function requireArray(value: unknown, label: string): Array<unknown> {
   expect(Array.isArray(value), label).toBe(true);
-  return value as unknown[];
+  return value as Array<unknown>;
 }
 
 function expectFields(record: Record<string, unknown>, expected: Record<string, unknown>) {
@@ -183,7 +183,7 @@ function expectPluginRecordFields(record: unknown, expected: Record<string, unkn
 }
 
 function expectDiagnosticCodes(diagnostics: unknown, expectedCodes: string[]) {
-  const codes: unknown[] = [];
+  const codes: Array<unknown> = [];
   for (const diagnostic of requireArray(diagnostics, "diagnostics")) {
     codes.push(requireRecord(diagnostic, "diagnostic").code);
   }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2261,16 +2261,18 @@ export function renderApp(state: AppViewState) {
                   updateCronRunsFilter(state, { cronRunsScope: "job" });
                   await loadCronRuns(state, jobId);
                 },
-                onLoadMoreJobs: () => loadCronJobsPage(state, { append: true }),
+                onLoadMoreJobs: () => loadCronJobsPage(state, { append: true, tableFilters: true }),
                 onJobsFiltersChange: async (patch) => {
                   updateCronJobsFilter(state, patch);
                   const shouldReload =
                     typeof patch.cronJobsQuery === "string" ||
                     Boolean(patch.cronJobsEnabledFilter) ||
+                    Boolean(patch.cronJobsScheduleKindFilter) ||
+                    Boolean(patch.cronJobsLastStatusFilter) ||
                     Boolean(patch.cronJobsSortBy) ||
                     Boolean(patch.cronJobsSortDir);
                   if (shouldReload) {
-                    await loadCronJobsPage(state, { append: false });
+                    await loadCronJobsPage(state, { append: false, tableFilters: true });
                   }
                 },
                 onJobsFiltersReset: async () => {
@@ -2282,7 +2284,7 @@ export function renderApp(state: AppViewState) {
                     cronJobsSortBy: "nextRunAtMs",
                     cronJobsSortDir: "asc",
                   });
-                  await loadCronJobsPage(state, { append: false });
+                  await loadCronJobsPage(state, { append: false, tableFilters: true });
                 },
                 onLoadMoreRuns: () => loadMoreCronRuns(state),
                 onRunsFiltersChange: async (patch) => {

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -250,7 +250,7 @@ describe("refreshActiveTab", () => {
     expectCommonAgentsTabRefresh(host);
     expect(mocks.loadChannelsMock).toHaveBeenCalledWith(host, false);
     expect(mocks.loadCronStatusMock).toHaveBeenCalledOnce();
-    expect(mocks.loadCronJobsPageMock).toHaveBeenCalledOnce();
+    expect(mocks.loadCronJobsPageMock).toHaveBeenCalledWith(host, { tableFilters: false });
     expect(mocks.loadCronRunsMock).toHaveBeenCalledWith(host, "job-123");
     expect(mocks.loadAgentFilesMock).not.toHaveBeenCalled();
     expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
@@ -451,7 +451,7 @@ describe("refreshActiveTab", () => {
     expect(outcome).toBe("resolved");
     expect(mocks.loadChannelsMock).toHaveBeenCalledWith(host, false);
     expect(mocks.loadCronStatusMock).toHaveBeenCalledOnce();
-    expect(mocks.loadCronJobsPageMock).toHaveBeenCalledOnce();
+    expect(mocks.loadCronJobsPageMock).toHaveBeenCalledWith(host, { tableFilters: true });
     expect(mocks.loadCronRunsMock).toHaveBeenCalledOnce();
   });
 

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -54,6 +54,7 @@ import { loadPresence, type PresenceState } from "./controllers/presence.ts";
 import { loadSessions, type SessionsState } from "./controllers/sessions.ts";
 import { loadSkills, type SkillsState } from "./controllers/skills.ts";
 import { loadUsage, type UsageState } from "./controllers/usage.ts";
+import { resolveCronJobLastRunStatus } from "./cron-status.ts";
 import { syncCustomThemeStyleTag } from "./custom-theme.ts";
 import { isMonitoredAuthProvider } from "./model-auth-helpers.ts";
 import {
@@ -865,7 +866,7 @@ function buildAttentionItems(host: SettingsAppHost) {
   }
 
   const cronJobs = host.cronJobs ?? [];
-  const failedCron = cronJobs.filter((j) => j.state?.lastStatus === "error");
+  const failedCron = cronJobs.filter((j) => resolveCronJobLastRunStatus(j) === "error");
   if (failedCron.length > 0) {
     items.push({
       severity: "error",
@@ -942,6 +943,7 @@ export async function loadCron(host: SettingsHost) {
   host.controlUiCronRefreshSeq = cronSeq;
   const isCurrentCronRefresh = () =>
     host.controlUiCronRefreshSeq === cronSeq && host.tab === "cron";
+  const useTableFilters = host.tab === "cron";
   const runsStartedAtMs = controlUiNowMs();
   const runsRefresh = loadCronRuns(app, activeCronJobId)
     .catch(() => "error" as const)
@@ -961,5 +963,9 @@ export async function loadCron(host: SettingsHost) {
       );
     });
   void runsRefresh;
-  await Promise.all([loadChannels(app, false), loadCronStatus(app), loadCronJobsPage(app)]);
+  await Promise.all([
+    loadChannels(app, false),
+    loadCronStatus(app),
+    loadCronJobsPage(app, { tableFilters: useTableFilters }),
+  ]);
 }

--- a/ui/src/ui/controllers/cron-filters.test.ts
+++ b/ui/src/ui/controllers/cron-filters.test.ts
@@ -56,6 +56,28 @@ describe("getVisibleCronJobs", () => {
     expect(visible.map((entry) => entry.id)).toEqual(["error"]);
   });
 
+  it("filters unknown and preferred last-run statuses", () => {
+    const jobs = [
+      job("preferred", { state: { lastRunStatus: "skipped", lastRunAtMs: 1 } }),
+      job("legacy", { state: { lastStatus: "skipped", lastRunAtMs: 2 } }),
+      job("missing"),
+    ];
+
+    const skipped = getVisibleCronJobs({
+      cronJobs: jobs,
+      cronJobsScheduleKindFilter: "all",
+      cronJobsLastStatusFilter: "skipped",
+    });
+    const unknown = getVisibleCronJobs({
+      cronJobs: jobs,
+      cronJobsScheduleKindFilter: "all",
+      cronJobsLastStatusFilter: "unknown",
+    });
+
+    expect(skipped.map((entry) => entry.id)).toEqual(["preferred", "legacy"]);
+    expect(unknown.map((entry) => entry.id)).toEqual(["missing"]);
+  });
+
   it("combines schedule and last-status filters", () => {
     const jobs = [
       job("a", {

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -1253,6 +1253,8 @@ describe("cron controller", () => {
           offset: 0,
           query: "daily",
           enabled: "enabled",
+          scheduleKind: "cron",
+          lastRunStatus: "error",
           sortBy: "updatedAtMs",
           sortDir: "desc",
         });
@@ -1281,15 +1283,44 @@ describe("cron controller", () => {
       client: { request } as unknown as CronState["client"],
       cronJobsQuery: "daily",
       cronJobsEnabledFilter: "enabled",
+      cronJobsScheduleKindFilter: "cron",
+      cronJobsLastStatusFilter: "error",
       cronJobsSortBy: "updatedAtMs",
       cronJobsSortDir: "desc",
     });
 
-    await loadCronJobsPage(state);
+    await loadCronJobsPage(state, { tableFilters: true });
 
     expect(state.cronJobs).toHaveLength(1);
     expect(state.cronJobsTotal).toBe(1);
     expect(state.cronJobsHasMore).toBe(false);
+  });
+
+  it("keeps table-only filters out of shared cron jobs loads", async () => {
+    const request = vi.fn(async (method: string, payload?: unknown) => {
+      if (method === "cron.list") {
+        const listPayload = requireRecord(payload, "cron.list payload");
+        expect(listPayload).not.toHaveProperty("scheduleKind");
+        expect(listPayload).not.toHaveProperty("lastRunStatus");
+        return { jobs: [], total: 0, hasMore: false, nextOffset: null };
+      }
+      return {};
+    });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronJobsScheduleKindFilter: "cron",
+      cronJobsLastStatusFilter: "error",
+    });
+
+    await loadCronJobsPage(state);
+
+    expect(request).toHaveBeenCalledWith(
+      "cron.list",
+      expect.not.objectContaining({
+        scheduleKind: expect.anything(),
+        lastRunStatus: expect.anything(),
+      }),
+    );
   });
 
   it("drops malformed cron jobs before they enter UI state", async () => {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -1,6 +1,7 @@
 import { t } from "../../i18n/index.ts";
 import { DEFAULT_CRON_FORM } from "../app-defaults.ts";
 import { getCronJobPayload, hasCronJobPayload } from "../cron-payload.ts";
+import { resolveCronJobLastRunStatus } from "../cron-status.ts";
 import { toNumber } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import { normalizeLowercaseStringOrEmpty, sortUniqueStrings } from "../string-coerce.ts";
@@ -275,7 +276,10 @@ function normalizeCronPageMeta(params: {
   return { total, hasMore, nextOffset };
 }
 
-export async function loadCronJobsPage(state: CronState, opts?: { append?: boolean }) {
+export async function loadCronJobsPage(
+  state: CronState,
+  opts?: { append?: boolean; tableFilters?: boolean },
+) {
   if (!state.client || !state.connected) {
     return;
   }
@@ -300,6 +304,12 @@ export async function loadCronJobsPage(state: CronState, opts?: { append?: boole
       offset,
       query: state.cronJobsQuery.trim() || undefined,
       enabled: state.cronJobsEnabledFilter,
+      ...(opts?.tableFilters
+        ? {
+            scheduleKind: state.cronJobsScheduleKindFilter,
+            lastRunStatus: state.cronJobsLastStatusFilter,
+          }
+        : {}),
       sortBy: state.cronJobsSortBy,
       sortDir: state.cronJobsSortDir,
     });
@@ -358,10 +368,6 @@ export function updateCronJobsFilter(
   state.cronJobsSortDir = patch.cronJobsSortDir ?? state.cronJobsSortDir;
 }
 
-function resolveCronJobLastStatus(job: CronJob): CronRunStatus | "unknown" {
-  return job.state?.lastRunStatus ?? job.state?.lastStatus ?? "unknown";
-}
-
 export function getVisibleCronJobs(
   state: Pick<CronState, "cronJobs" | "cronJobsScheduleKindFilter" | "cronJobsLastStatusFilter">,
 ): CronJob[] {
@@ -374,7 +380,7 @@ export function getVisibleCronJobs(
     }
     if (
       state.cronJobsLastStatusFilter !== "all" &&
-      resolveCronJobLastStatus(job) !== state.cronJobsLastStatusFilter
+      resolveCronJobLastRunStatus(job) !== state.cronJobsLastStatusFilter
     ) {
       return false;
     }
@@ -734,7 +740,7 @@ export async function addCronJob(state: CronState): Promise<boolean> {
       await client.request("cron.add", job);
       resetCronFormToDefaults(state);
     }
-    await loadCronJobsPage(state);
+    await loadCronJobsPage(state, { tableFilters: true });
     await loadCronStatus(state);
     saved = true;
   });
@@ -744,7 +750,7 @@ export async function addCronJob(state: CronState): Promise<boolean> {
 export async function toggleCronJob(state: CronState, job: CronJob, enabled: boolean) {
   await withCronBusy(state, async (client) => {
     await client.request("cron.update", { id: job.id, patch: { enabled } });
-    await loadCronJobsPage(state);
+    await loadCronJobsPage(state, { tableFilters: true });
     await loadCronStatus(state);
   });
 }
@@ -766,7 +772,7 @@ export async function removeCronJob(state: CronState, job: CronJob) {
       state.cronRunsJobId = null;
       clearCronRunsPage(state);
     }
-    await loadCronJobsPage(state);
+    await loadCronJobsPage(state, { tableFilters: true });
     await loadCronStatus(state);
   });
 }

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -10,6 +10,7 @@ import type {
   CronJobsEnabledFilter,
   CronJobsListResult,
   CronJobsSortBy,
+  CronRunStatus,
   CronRunScope,
   CronRunLogEntry,
   CronRunsResult,
@@ -42,7 +43,7 @@ export type CronFieldKey =
 export type CronFieldErrors = Partial<Record<CronFieldKey, string>>;
 
 export type CronJobsScheduleKindFilter = "all" | "at" | "every" | "cron";
-export type CronJobsLastStatusFilter = "all" | "ok" | "error" | "skipped";
+export type CronJobsLastStatusFilter = "all" | CronRunStatus | "unknown";
 export type CronRunsLoadStatus = "ok" | "error" | "skipped";
 
 export type CronState = {
@@ -357,6 +358,10 @@ export function updateCronJobsFilter(
   state.cronJobsSortDir = patch.cronJobsSortDir ?? state.cronJobsSortDir;
 }
 
+function resolveCronJobLastStatus(job: CronJob): CronRunStatus | "unknown" {
+  return job.state?.lastRunStatus ?? job.state?.lastStatus ?? "unknown";
+}
+
 export function getVisibleCronJobs(
   state: Pick<CronState, "cronJobs" | "cronJobsScheduleKindFilter" | "cronJobsLastStatusFilter">,
 ): CronJob[] {
@@ -369,7 +374,7 @@ export function getVisibleCronJobs(
     }
     if (
       state.cronJobsLastStatusFilter !== "all" &&
-      job.state?.lastStatus !== state.cronJobsLastStatusFilter
+      resolveCronJobLastStatus(job) !== state.cronJobsLastStatusFilter
     ) {
       return false;
     }

--- a/ui/src/ui/cron-status.ts
+++ b/ui/src/ui/cron-status.ts
@@ -1,0 +1,7 @@
+import type { CronJob, CronRunStatus } from "./types.ts";
+
+export type CronJobLastRunStatus = CronRunStatus | "unknown";
+
+export function resolveCronJobLastRunStatus(job: CronJob): CronJobLastRunStatus {
+  return job.state?.lastRunStatus ?? job.state?.lastStatus ?? "unknown";
+}

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -1,4 +1,5 @@
 import { t } from "../i18n/index.ts";
+import { resolveCronJobLastRunStatus } from "./cron-status.ts";
 import {
   formatRelativeTimestamp,
   formatDurationHuman,
@@ -52,7 +53,7 @@ export function formatCronState(job: CronJob) {
   const state = job.state ?? {};
   const next = state.nextRunAtMs ? formatMs(state.nextRunAtMs) : t("common.na");
   const last = state.lastRunAtMs ? formatMs(state.lastRunAtMs) : t("common.na");
-  const status = state.lastStatus ?? t("common.na");
+  const status = resolveCronJobLastRunStatus(job);
   return `${status} · next ${next} · last ${last}`;
 }
 

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -207,10 +207,16 @@ describe("cron view", () => {
       'select[data-test-id="cron-jobs-last-status-filter"]',
       HTMLSelectElement,
     );
+    expect(Array.from(lastRunSelect.options).map((option) => option.value)).toContain("unknown");
     lastRunSelect.value = "error";
     lastRunSelect.dispatchEvent(new Event("change", { bubbles: true }));
 
     expect(onJobsFiltersChange).toHaveBeenCalledWith({ cronJobsLastStatusFilter: "error" });
+
+    lastRunSelect.value = "unknown";
+    lastRunSelect.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(onJobsFiltersChange).toHaveBeenLastCalledWith({ cronJobsLastStatusFilter: "unknown" });
 
     render(
       renderCron(

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -9,6 +9,7 @@ import type {
   CronJobsScheduleKindFilter,
 } from "../controllers/cron.ts";
 import { getCronJobPayload } from "../cron-payload.ts";
+import { resolveCronJobLastRunStatus } from "../cron-status.ts";
 import { formatRelativeTimestamp, formatMs } from "../format.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
 import { pathForTab } from "../navigation.ts";
@@ -1751,7 +1752,7 @@ function formatRunNextLabel(nextRunAtMs: number, nowMs = Date.now()) {
 }
 
 function renderJobState(job: CronJob) {
-  const rawStatus = job.state?.lastRunStatus ?? job.state?.lastStatus;
+  const rawStatus = resolveCronJobLastRunStatus(job);
   const statusClass =
     rawStatus === "ok"
       ? "cron-job-status-ok"

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -542,6 +542,7 @@ export function renderCron(props: CronProps) {
                   <option value="ok">${t("cron.runs.runStatusOk")}</option>
                   <option value="error">${t("cron.runs.runStatusError")}</option>
                   <option value="skipped">${t("cron.runs.runStatusSkipped")}</option>
+                  <option value="unknown">${t("cron.runs.runStatusUnknown")}</option>
                 </select>
               </label>
               <label class="field">
@@ -1750,7 +1751,7 @@ function formatRunNextLabel(nextRunAtMs: number, nowMs = Date.now()) {
 }
 
 function renderJobState(job: CronJob) {
-  const rawStatus = job.state?.lastStatus;
+  const rawStatus = job.state?.lastRunStatus ?? job.state?.lastStatus;
   const statusClass =
     rawStatus === "ok"
       ? "cron-job-status-ok"
@@ -1766,7 +1767,7 @@ function renderJobState(job: CronJob) {
         ? t("cron.runs.runStatusError")
         : rawStatus === "skipped"
           ? t("cron.runs.runStatusSkipped")
-          : t("common.na");
+          : t("cron.runs.runStatusUnknown");
   const nextRunAtMs = job.state?.nextRunAtMs;
   const lastRunAtMs = job.state?.lastRunAtMs;
 

--- a/ui/src/ui/views/overview-cards.ts
+++ b/ui/src/ui/views/overview-cards.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
+import { resolveCronJobLastRunStatus } from "../cron-status.ts";
 import { formatCost, formatTokens, formatRelativeTimestamp } from "../format.ts";
 import { isMonitoredAuthProvider } from "../model-auth-helpers.ts";
 import { formatNextRun } from "../presenter.ts";
@@ -131,7 +132,9 @@ export function renderOverviewCards(props: OverviewCardsProps) {
   const cronEnabled = props.cronStatus?.enabled ?? null;
   const cronNext = props.cronStatus?.nextWakeAtMs ?? null;
   const cronJobCount = props.cronJobs.length;
-  const failedCronCount = props.cronJobs.filter((j) => j.state?.lastStatus === "error").length;
+  const failedCronCount = props.cronJobs.filter(
+    (j) => resolveCronJobLastRunStatus(j) === "error",
+  ).length;
   const authLoading = props.modelAuthStatus === null;
   const authProviders = props.modelAuthStatus?.providers ?? [];
   const monitoredProviders = authProviders.filter(isMonitoredAuthProvider);


### PR DESCRIPTION
Fixes #9455

## Summary
- Include cron job ids in cron.list text search so Jobs search can match IDs.
- Add an Unknown last-run status filter for Jobs and normalize preferred lastRunStatus, legacy lastStatus, and missing status in the UI.
- Cover the service, controller, and view surfaces with targeted checks.

## Real behavior proof
- **Behavior or issue addressed:** Cron Jobs list filtering from #9455 now matches job IDs during text search and lets the Jobs last-run status filter select Unknown while still recognizing preferred `lastRunStatus` and legacy `lastStatus` values.
- **Real environment tested:** Local OpenClaw checkout `/media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-9455` at `849f83bdf9` on Linux, Node `v22.22.0`, pnpm `11.2.2`, running repository code via `node --import tsx` against a temporary cron store JSON.
- **Exact steps or command run after this patch:** Created a temporary cron store with two cron job records, constructed `CronService` from `src/cron/service.ts`, ran `service.listPage({ query: "tax" })`, then imported `getVisibleCronJobs` from `ui/src/ui/controllers/cron.ts` and applied `skipped` and `unknown` last-status filters to three UI job records.
- **Evidence after fix:** Terminal output from the local run:

```text
{
  "command": "CronService.listPage({ query: \"tax\" }) and getVisibleCronJobs(...) ",
  "serviceJobIdsForTaxQuery": [
    "tax-digest"
  ],
  "uiSkippedStatusJobIds": [
    "preferred",
    "legacy"
  ],
  "uiUnknownStatusJobIds": [
    "missing"
  ]
}
```

- **Observed result after fix:** The `tax` search returned `tax-digest` by job ID even though its display name was `Finance digest`; the `skipped` filter returned both the preferred `lastRunStatus` job and the legacy `lastStatus` job; the `unknown` filter returned only the job with no last status.
- **What was not tested:** I did not run a browser control UI session; the local run exercised the same service and UI controller modules, and the supplemental view check covers the rendered Unknown option.

## Supplemental checks
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/service.list-page-sort-guards.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs ui/src/ui/controllers/cron-filters.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs ui/src/ui/views/cron.test.ts --reporter=verbose`
- `node_modules/.bin/oxfmt --check src/cron/service/ops.ts src/cron/service.list-page-sort-guards.test.ts ui/src/ui/controllers/cron.ts ui/src/ui/controllers/cron-filters.test.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts`
- `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/cron/service/ops.ts src/cron/service.list-page-sort-guards.test.ts ui/src/ui/controllers/cron.ts ui/src/ui/controllers/cron-filters.test.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts`
- `git diff --check origin/main...HEAD`

