### PR TITLE
fix(ollama): yield during dense ndjson bursts

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1376,6 +1376,35 @@ describe("parseNdjsonStream", () => {
     expect(chunks[2].done).toBe(true);
   });
 
+  it("yields to timers while parsing dense NDJSON bursts", async () => {
+    const reader = mockNdjsonReader(
+      Array.from(
+        { length: 128 },
+        (_, index) =>
+          `{"model":"m","created_at":"t","message":{"role":"assistant","content":"${index}"},"done":false}`,
+      ),
+    );
+    let timerFired = false;
+    const timer = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        timerFired = true;
+        resolve();
+      }, 0);
+    });
+
+    let chunks = 0;
+    for await (const chunk of parseNdjsonStream(reader)) {
+      expect(chunk.message.role).toBe("assistant");
+      chunks += 1;
+      if (chunks === 65) {
+        expect(timerFired).toBe(true);
+      }
+    }
+
+    await timer;
+    expect(chunks).toBe(128);
+  });
+
   it("parses tool_calls from intermediate chunk (not final)", async () => {
     // Ollama sends tool_calls in done:false chunk, final done:true has no tool_calls
     const reader = mockNdjsonReader([

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -54,6 +54,8 @@ const GARBLED_VISIBLE_TEXT_MODEL_RE = /\b(?:glm|kimi)\b/i;
 const GARBLED_VISIBLE_TEXT_MIN_CHARS = 80;
 const GARBLED_VISIBLE_TEXT_SYMBOL_RE = /[$#%&="'_~`^|\\/*+\-[\]{}()<>:;,.!?]/gu;
 const LETTER_OR_DIGIT_RE = /[\p{L}\p{N}]/gu;
+const OLLAMA_NDJSON_COOPERATIVE_YIELD_MAX_RECORDS = 64;
+const OLLAMA_NDJSON_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 
 function countMatches(text: string, re: RegExp): number {
   re.lastIndex = 0;
@@ -1022,6 +1024,24 @@ export async function* parseNdjsonStream(
 ): AsyncGenerator<OllamaChatResponse> {
   const decoder = new TextDecoder();
   let buffer = "";
+  let recordsSinceYield = 0;
+  let lastYieldedAt = Date.now();
+
+  const maybeYieldToEventLoop = async () => {
+    recordsSinceYield += 1;
+    const now = Date.now();
+    if (
+      recordsSinceYield < OLLAMA_NDJSON_COOPERATIVE_YIELD_MAX_RECORDS &&
+      now - lastYieldedAt < OLLAMA_NDJSON_COOPERATIVE_YIELD_INTERVAL_MS
+    ) {
+      return;
+    }
+    recordsSinceYield = 0;
+    lastYieldedAt = now;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  };
 
   while (true) {
     const { done, value } = await reader.read();
@@ -1039,6 +1059,7 @@ export async function* parseNdjsonStream(
       }
       try {
         yield parseJsonPreservingUnsafeIntegers(trimmed) as OllamaChatResponse;
+        await maybeYieldToEventLoop();
       } catch {
         log.warn(`Skipping malformed NDJSON line: ${trimmed.slice(0, 120)}`);
       }


### PR DESCRIPTION
## Summary
- add cooperative event-loop yields while parsing large Ollama NDJSON bursts from one read
- mirror the existing OpenAI stream behavior with a 64-record / 12ms threshold
- add regression coverage proving timers can run mid-burst instead of waiting for the whole payload to parse

Refs #86599.

## Verification
- `node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts` - 1 file / 99 tests passed on `4159910`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean
- Previous AWS Crabbox Linux changed gate on the same patch shape: `node scripts/crabbox-wrapper.mjs run --timing-json --shell -- "corepack pnpm check:changed"`, run `run_08008110f420`, lease `cbx_aa144d583928`, slug `quick-prawn`, exit 0. Current SHA was rebased afterward; fresh broad gate is queued behind active AWS lanes.

Behavior addressed: Ollama provider parsing no longer monopolizes the Gateway event loop when a single read contains many NDJSON records.

Real environment tested: focused local Ollama runtime tests/lint after rebase, plus prior AWS Crabbox Linux changed gate for the same patch shape.

Exact steps or command run after this patch: listed in Verification.

Evidence after fix: regression test schedules a timer before parsing 128 same-read records and asserts the timer has fired by record 65.

Observed result after fix: dense Ollama stream bursts yield to timers during parsing, reducing Gateway timer/RPC starvation risk.

What was not tested: full live Windows/Ollama UI reproduction; current rebased SHA has not yet had a fresh broad Crabbox/Testbox `check:changed` because other AWS lanes are already active.
