### PR TITLE
fix(agents): release compaction session lock on every exit path (#84193)

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -35,6 +35,10 @@ export const hookRunner = {
 };
 
 export const ensureRuntimePluginsLoaded: Mock<(params?: unknown) => void> = vi.fn();
+export const sessionLockReleaseMock: Mock<() => Promise<void>> = vi.fn(async () => {});
+export const repairSessionFileIfNeededMock: Mock<(params?: unknown) => Promise<void>> = vi.fn(
+  async () => {},
+);
 export const resolveContextEngineMock = vi.fn(async () => ({
   info: { ownsCompaction: true as boolean },
   compact: contextEngineCompactMock,
@@ -308,6 +312,10 @@ export function resetCompactHooksHarnessMocks(): void {
   hookRunner.runAfterCompaction.mockResolvedValue(undefined);
 
   ensureRuntimePluginsLoaded.mockReset();
+  sessionLockReleaseMock.mockReset();
+  sessionLockReleaseMock.mockResolvedValue(undefined);
+  repairSessionFileIfNeededMock.mockReset();
+  repairSessionFileIfNeededMock.mockResolvedValue(undefined);
 
   resolveContextEngineMock.mockReset();
   resolveContextEngineMock.mockResolvedValue({
@@ -524,11 +532,11 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../session-file-repair.js", () => ({
-    repairSessionFileIfNeeded: vi.fn(async () => {}),
+    repairSessionFileIfNeeded: repairSessionFileIfNeededMock,
   }));
 
   vi.doMock("../session-write-lock.js", () => ({
-    acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+    acquireSessionWriteLock: vi.fn(async () => ({ release: sessionLockReleaseMock })),
     resolveSessionLockMaxHoldFromTimeout: vi.fn(() => 0),
     resolveSessionWriteLockAcquireTimeoutMs: vi.fn(() => 60_000),
     resolveSessionWriteLockOptions: vi.fn(() => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -18,6 +18,7 @@ import {
   maybeCompactAgentHarnessSessionMock,
   resolveAgentHarnessPolicyMock,
   registerProviderStreamForModelMock,
+  repairSessionFileIfNeededMock,
   resolveContextWindowInfoMock,
   resolveContextEngineMock,
   resolveEmbeddedAgentStreamFnMock,
@@ -30,6 +31,7 @@ import {
   resetCompactHooksHarnessMocks,
   resetCompactSessionStateMocks,
   sessionAbortCompactionMock,
+  sessionLockReleaseMock,
   sessionMessages,
   sessionCompactImpl,
   triggerInternalHook,
@@ -832,6 +834,25 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       code: "rate_limit_exceeded",
       rawError: "primary compaction rate limited",
     });
+  });
+
+  it("releases the session write lock when the compaction body throws (#84193)", async () => {
+    repairSessionFileIfNeededMock.mockImplementationOnce(async () => {
+      throw new Error("synthetic compaction failure");
+    });
+
+    const result = await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expectRecordFields(result, {
+      ok: false,
+      compacted: false,
+    });
+    expect(sessionLockReleaseMock).toHaveBeenCalledTimes(1);
   });
 
   it("emits internal + plugin compaction hooks with counts", async () => {

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -637,6 +637,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
   let compactionSessionManager: unknown = null;
   let checkpointSnapshot: CapturedCompactionCheckpointSnapshot | null = null;
   let checkpointSnapshotRetained = false;
+  let releaseSessionLockOnce: (() => Promise<void>) | undefined;
   try {
     const skillsSnapshotForRun =
       sandbox?.enabled && sandbox.workspaceAccess !== "rw" ? undefined : params.skillsSnapshot;
@@ -1021,6 +1022,17 @@ async function compactEmbeddedAgentSessionDirectOnce(
         }),
       }),
     });
+    // Idempotent so outer finally is safe after happy-path release (#84193).
+    let sessionLockReleased = false;
+    releaseSessionLockOnce = async (): Promise<void> => {
+      if (sessionLockReleased) {
+        return;
+      }
+      sessionLockReleased = true;
+      await sessionLock.release().catch((err) => {
+        log.warn(`failed to release compaction session lock: ${formatErrorMessage(err)}`);
+      });
+    };
     try {
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
@@ -1476,7 +1488,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       } catch {
         /* best-effort */
       }
-      await sessionLock.release();
+      await releaseSessionLockOnce();
     }
   } catch (err) {
     const reason = resolveCompactionFailureReason({
@@ -1485,6 +1497,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
     });
     return fail(reason, err);
   } finally {
+    await releaseSessionLockOnce?.();
     if (!checkpointSnapshotRetained) {
       await cleanupCompactionCheckpointSnapshot(checkpointSnapshot);
     }


### PR DESCRIPTION
### Summary

- **Problem**: Issue #84193 reports that after a long Anthropic/Opus Discord run, post-run auto-compaction can hold the session JSONL write lock indefinitely (until gateway restart). Every subsequent Discord turn on the same session fails with `SessionWriteLockTimeoutError: session file locked (timeout 60000ms)`. The in-process watchdog eventually reclaims the lock after `compactionTimeoutMs + grace`, but operators restart sooner so the leak looks permanent.
- **Root Cause**: `compactEmbeddedAgentSessionDirectOnce` in `src/agents/embedded-agent-runner/compact.ts` acquires the session write lock and only releases it on the happy path inside the outer `try`. The `catch (err)` branch calls `fail(reason, err)` without releasing. The outer `finally` runs `cleanupCompactionCheckpointSnapshot` and `restoreSkillEnv` but also does not release the lock. So any exception thrown anywhere inside the compaction body — model call rejection, transcript repair failure, session-manager guard error, harness teardown error — leaks the lock until the watchdog reclaims. This is the same shape as the embedded-attempt session lock leak fixed in PR #86427 (#86014) and PR #87278 (#86816), but in a different function that did not get the same outer-finally cleanup pattern.
- **Fix**: Hoist a `releaseSessionLockOnce` reference declared before the outer `try`, assigned to an idempotent helper immediately after the lock is acquired, and awaited in the outer `finally` via optional-chain (so a throw before assignment is still safe). The happy-path release at the tail of the outer `try` calls the same helper so the finally is a no-op when the run already cleaned up. Mirrors the pattern already in use in sibling lock holders (`tool-result-truncation.ts`, `transcript-rewrite.ts`).
- **What changed**:
  - `src/agents/embedded-agent-runner/compact.ts` — hoist `releaseSessionLockOnce`; define idempotent body after acquire; replace happy-path `sessionLock.release()` with helper call; add `await releaseSessionLockOnce?.()` to the outer `finally`.
  - `src/agents/embedded-agent-runner/compact.hooks.harness.ts` — expose `sessionLockReleaseMock` and `repairSessionFileIfNeededMock` as named exports so tests can drive synthetic failures and assert release.
  - `src/agents/embedded-agent-runner/compact.hooks.test.ts` — regression test "releases the session write lock when the compaction body throws (#84193)" pins the contract.
- **What did NOT change (scope boundary)**:
  - Sibling lock-holder paths (`tool-result-truncation.ts`, `transcript-rewrite.ts`, `attempt.session-lock.ts`) — they already release in `finally`. Verified by inspection; no edits.
  - `acquireSessionWriteLock` / `session-write-lock.ts` watchdog behavior — unchanged.
  - Cooldown / failover / channel surface — unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config` edits).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/api.ts` / `runtime-api.ts`, registry, or loader edits).
  - Session store unchanged.

### Reproduction

1. On a Gateway with Discord enabled, run an Anthropic/Opus session with a file-producing task large enough to cross the auto-compaction threshold.
2. Let the assistant finish; observe post-run auto-compaction start.
3. While compaction is in flight, induce any failure inside the compaction body (model rejection, transcript repair issue, etc.) — the catch path returns `fail` without releasing the JSONL lock.
4. Send another user request in the same Discord channel.
5. **Before this PR**: the new request waits for the JSONL lock and fails after `60000ms` with `SessionWriteLockTimeoutError`. Restart is the only recovery within the window.
6. **After this PR**: the outer `finally` releases the lock eagerly on the failure path; the next user request acquires the lock immediately and the channel recovers without restart.

### Real behavior proof

**Behavior addressed (#84193)**: post-run auto-compaction in `compactEmbeddedAgentSessionDirectOnce` now releases the session write lock on every exit path (success, exception, abort). Subsequent writes on the same session no longer have to wait for the in-process watchdog or for a gateway restart.

**Real environment tested (Linux, Node 22, tsx real-component harness driving production `acquireSessionWriteLock`)**: tsx-resolved import of production `acquireSessionWriteLock` from `src/agents/session-write-lock.ts`. The harness creates a real session file, exercises both the pre-fix shape (acquire, throw, do not release in catch) and the post-fix shape (acquire, throw, release via idempotent helper in outer finally), and probes the lock state via same-process re-acquire with a 1.5s timeout.

**Exact steps or command run after this patch**:

1. `node_modules/.bin/tsx /tmp/qmd84193/repro.mts` (real-component lock-release sweep)
2. `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compact.hooks.test.ts` (110/110 pass, including new regression)
3. `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/compact.hooks.harness.ts src/agents/embedded-agent-runner/compact.hooks.test.ts`

**Evidence after fix (verbatim real-component harness output)**:

```text
================ #84193 compaction lock-release sweep ================

--- Scenario A: BEFORE FIX (acquire, throw, no release in catch path) ---
    BEFORE FIX: re-acquire blocked at 1505ms (expected=held) — SessionWriteLockTimeoutError: session file locked (timeout 1500ms): pid=... /tmp/openclaw-84193-...
    (lock IS still held — subsequent writes would block 60s)

--- Scenario B: AFTER FIX (acquire, throw, release in outer finally) ---
    AFTER FIX: re-acquire succeeded in 0ms (expected=released)
    (lock released eagerly — no 60s blocking)
```

**Observed result after fix**: the post-fix shape releases the JSONL write lock immediately when the compaction body throws; same-process re-acquire succeeds in `0ms`. Without the fix, re-acquire times out at the configured wait budget, matching the reporter's `SessionWriteLockTimeoutError: timeout 60000ms`.

**What was not tested**: a real Anthropic/Opus Discord run with a forced compaction-body exception. The reporter's live setup involves a long-context model call inside compaction that is not easy to deterministically fail in isolation; the harness instead exercises the lock-lifecycle contract directly against the production `acquireSessionWriteLock`, which is the layer the fix changes. The regression test in `compact.hooks.test.ts` drives `compactEmbeddedAgentSessionDirect` with a synthetic `repairSessionFileIfNeeded` failure and asserts the underlying release mock fires exactly once — covering the exact catch path that was leaking.

### Risk / Mitigation

- **Risk**: The fix lives in `src/agents/embedded-agent-runner/compact.ts`, a hot path for every embedded-agent compaction. **Mitigation**: change is additive — one variable hoisted, one idempotent helper assigned after acquire, one happy-path call replaced, one optional-chain call added to the outer `finally`. The lock state machine itself is untouched; the helper is a single-shot guard. All 110 tests in `compact.hooks.test.ts` (the file covering this function's behavior) pass, including the new regression that asserts the catch path now releases.
- **Risk**: Overlap with Peter's recent session-lock ownership refactor (`#87409`, 11h before this PR). **Mitigation**: `#87409` moved `attempt.session-lock` ownership into the owned session runtime — it did not touch `compact.ts`'s direct `acquireSessionWriteLock` call site, which lives outside the embedded-attempt controller. Verified by `git diff` against current main: this PR's three files have no overlap with `#87409`.
- **Risk**: Double-release if the underlying `lock.release()` is not idempotent. **Mitigation**: the helper guards with a `sessionLockReleased` boolean before delegating; second call is a no-op. The happy-path release at the tail of the outer `try` and the outer-finally release reuse the same helper, so even on the success path the finally call is a no-op.

### Change Type

`fix(agents)` — release the session write lock on every exit path in queued/auto-compaction.

### Scope

`src/agents/embedded-agent-runner/` only. 3 files, +45 / −3.

### Linked Issue

Fixes #84193.
