### PR TITLE
fix(telegram): skip chat_window context for persistent DMs already in session transcript (#87566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: stop injecting the recent-conversation chat_window prompt-context block on Telegram private DMs that already route to a persistent session, eliminating ~5x token burn from duplicated transcript history on 1:1 DMs. Reply-chain, quote, forward, group, topic, and fresh-session paths retain the chat_window. (#87566)
 - Tighten phone-control mutation authorization [AI]. (#87150) Thanks @pgondhi987.
 - Clarify directive persistence authorization policy [AI]. (#86369) Thanks @pgondhi987.
 - Agents/Codex: keep spawned agent cwd/workspace state separated, keep hook context prompt-local, release session locks on timeout abort, avoid session event queue self-wait, preserve shared app-server state across startup or helper failures, keep native hook relay alive across restarts, route workspace memory through tools, resolve Codex runtime models first, report quarantined dynamic tools, format `skills` command output, and bound compaction/steering retries. (#87218, #86875, #86123, #87399, #87375, #87383, #87400) Thanks @mbelinky, @Alix-007, @luoyanglang, @yetval, and @sjf.

--- a/extensions/telegram/src/bot-message-context.prompt-context-filter.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context-filter.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterTelegramPromptContextForPersistentDm,
+  shouldSuppressTelegramChatWindowPromptContext,
+} from "./bot-message-context.prompt-context-filter.js";
+import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
+
+const baseChatWindow: TelegramPromptContextEntry = {
+  label: "Conversation context",
+  source: "telegram",
+  type: "chat_window",
+  payload: {
+    order: "chronological",
+    relation: "selected_for_current_message",
+    messages: [
+      {
+        message_id: "1",
+        sender: "Alice",
+        timestamp_ms: 1700000000000,
+        body: "hi",
+      },
+    ],
+  },
+} as unknown as TelegramPromptContextEntry;
+
+describe("shouldSuppressTelegramChatWindowPromptContext", () => {
+  it("suppresses chat_window for a persistent private DM (issue #87566 happy path)", () => {
+    expect(
+      shouldSuppressTelegramChatWindowPromptContext({
+        isGroup: false,
+        threadId: null,
+        previousTimestampMs: 1700000000000,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps chat_window for a fresh private DM session (no prior session activity)", () => {
+    expect(
+      shouldSuppressTelegramChatWindowPromptContext({
+        isGroup: false,
+        threadId: null,
+        previousTimestampMs: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps chat_window for group/supergroup chats even when session has prior activity", () => {
+    expect(
+      shouldSuppressTelegramChatWindowPromptContext({
+        isGroup: true,
+        threadId: null,
+        previousTimestampMs: 1700000000000,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps chat_window when the chat is a forum/topic thread", () => {
+    expect(
+      shouldSuppressTelegramChatWindowPromptContext({
+        isGroup: true,
+        threadId: 42,
+        previousTimestampMs: 1700000000000,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps chat_window for a private DM that has a topic/thread id (DM topic)", () => {
+    expect(
+      shouldSuppressTelegramChatWindowPromptContext({
+        isGroup: false,
+        threadId: 99,
+        previousTimestampMs: 1700000000000,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats previousTimestampMs <= 0 as fresh", () => {
+    expect(
+      shouldSuppressTelegramChatWindowPromptContext({
+        isGroup: false,
+        threadId: null,
+        previousTimestampMs: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("filterTelegramPromptContextForPersistentDm", () => {
+  it("drops chat_window entries for persistent DMs", () => {
+    const filtered = filterTelegramPromptContextForPersistentDm([baseChatWindow], {
+      isGroup: false,
+      threadId: null,
+      previousTimestampMs: 1700000000000,
+    });
+    expect(filtered).toEqual([]);
+  });
+
+  it("keeps chat_window entries when suppression does not apply", () => {
+    const filtered = filterTelegramPromptContextForPersistentDm([baseChatWindow], {
+      isGroup: false,
+      threadId: null,
+      previousTimestampMs: undefined,
+    });
+    expect(filtered).toEqual([baseChatWindow]);
+  });
+
+  it("returns the exact same array reference when suppression does not apply (zero-cost no-op)", () => {
+    const input = [baseChatWindow];
+    const out = filterTelegramPromptContextForPersistentDm(input, {
+      isGroup: true,
+      threadId: null,
+      previousTimestampMs: 1700000000000,
+    });
+    expect(out).toBe(input);
+  });
+
+  it("only drops chat_window entries and leaves other prompt-context types intact", () => {
+    const otherEntry = {
+      label: "Other",
+      source: "telegram",
+      type: "future_type_kept_for_forward_compat",
+      payload: {},
+    } as unknown as TelegramPromptContextEntry;
+    const filtered = filterTelegramPromptContextForPersistentDm([baseChatWindow, otherEntry], {
+      isGroup: false,
+      threadId: null,
+      previousTimestampMs: 1700000000000,
+    });
+    expect(filtered).toEqual([otherEntry]);
+  });
+
+  it("handles empty input gracefully", () => {
+    expect(
+      filterTelegramPromptContextForPersistentDm([], {
+        isGroup: false,
+        threadId: null,
+        previousTimestampMs: 1700000000000,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/extensions/telegram/src/bot-message-context.prompt-context-filter.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context-filter.ts
@@ -1,0 +1,68 @@
+import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
+
+/**
+ * Decide whether a Telegram inbound message should suppress the
+ * `chat_window` recent-conversation prompt-context block.
+ *
+ * The block injects the last ~10 cached Telegram messages on every inbound
+ * turn. For Telegram private DMs that route to a persistent OpenClaw session,
+ * the session transcript already contains that history, so the block
+ * duplicates content and burns tokens on every turn (see issue #87566).
+ *
+ * Suppression is applied only when ALL of the following hold:
+ *   - The chat is a private DM (not a group, supergroup, channel, or topic).
+ *   - The chat has no message thread id (no Telegram forum / topic routing).
+ *   - The route resolves to a session that already has prior activity
+ *     (`previousTimestampMs` is set). The first inbound message in a fresh
+ *     persistent session keeps the chat_window so the model still sees any
+ *     pre-existing cached context.
+ *
+ * The function intentionally targets only `chat_window` entries — other
+ * prompt-context kinds (if any are added later) flow through untouched.
+ *
+ * Reply / quote / forwarded context is propagated separately via
+ * `extra.ReplyChain` and `supplemental.quote` / `supplemental.forwarded`, so
+ * dropping `chat_window` here does NOT remove reply-chain context.
+ */
+export type TelegramPromptContextSuppressionInput = {
+  /** True when the inbound chat is a Telegram group/supergroup/channel. */
+  isGroup: boolean;
+  /**
+   * Resolved Telegram forum/topic id (if any). Topics behave like
+   * sub-conversations and may carry chat_window even for private DMs that
+   * have routed into a per-topic session.
+   */
+  threadId?: number | string | null;
+  /**
+   * Last-seen session timestamp for the resolved sessionKey. `undefined`
+   * means the session has never been written to (fresh / non-persistent).
+   */
+  previousTimestampMs?: number | null;
+};
+
+export function shouldSuppressTelegramChatWindowPromptContext(
+  input: TelegramPromptContextSuppressionInput,
+): boolean {
+  if (input.isGroup) return false;
+  if (input.threadId != null && input.threadId !== "") return false;
+  // No prior session activity → keep chat_window for fresh sessions.
+  if (!input.previousTimestampMs || input.previousTimestampMs <= 0) return false;
+  return true;
+}
+
+/**
+ * Apply DM-persistent-session suppression to a Telegram prompt-context list.
+ *
+ * Only entries with `type === "chat_window"` are filtered. Other entry kinds
+ * are returned unchanged. When suppression does not apply, the input array is
+ * returned as-is.
+ */
+export function filterTelegramPromptContextForPersistentDm(
+  entries: TelegramPromptContextEntry[],
+  input: TelegramPromptContextSuppressionInput,
+): TelegramPromptContextEntry[] {
+  if (!shouldSuppressTelegramChatWindowPromptContext(input)) {
+    return entries;
+  }
+  return entries.filter((entry) => entry?.type !== "chat_window");
+}

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -24,6 +24,7 @@ import { evaluateSupplementalContextVisibility } from "openclaw/plugin-sdk/secur
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { NormalizedAllowFrom } from "./bot-access.js";
 import { isSenderAllowed, normalizeAllowFrom } from "./bot-access.js";
+import { filterTelegramPromptContextForPersistentDm } from "./bot-message-context.prompt-context-filter.js";
 import type {
   TelegramMediaRef,
   TelegramMessageContextOptions,
@@ -360,6 +361,19 @@ export async function buildTelegramInboundContextPayload(params: {
     storePath,
     sessionKey: route.sessionKey,
   });
+  // Suppress the Telegram chat_window prompt-context block for private DMs
+  // routed to a persistent session that already has prior activity — the
+  // session transcript already covers that recent history (issue #87566).
+  const effectivePromptContext = filterTelegramPromptContextForPersistentDm(promptContext, {
+    isGroup,
+    threadId: threadSpec.id ?? null,
+    previousTimestampMs: previousTimestamp ?? null,
+  });
+  if (shouldLogVerbose() && effectivePromptContext.length !== promptContext.length) {
+    logVerbose(
+      `telegram: suppressed chat_window prompt-context for persistent DM session ${route.sessionKey} (chat ${chatId})`,
+    );
+  }
   const body = formatInboundEnvelope({
     channel: "Telegram",
     from: conversationLabel,
@@ -529,7 +543,7 @@ export async function buildTelegramInboundContextPayload(params: {
           }
         : undefined,
       groupSystemPrompt: isGroup || (!isGroup && groupConfig) ? groupSystemPrompt : undefined,
-      untrustedContext: promptContext.length > 0 ? promptContext : undefined,
+      untrustedContext: effectivePromptContext.length > 0 ? effectivePromptContext : undefined,
     },
     contextVisibility: contextVisibilityMode,
     extra: {

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -96,6 +96,10 @@ export function getLoadSessionStoreMock(): AnyMock {
   return loadSessionStoreMock;
 }
 
+export function getReadSessionUpdatedAtMock(): AnyMock {
+  return readSessionUpdatedAtMock;
+}
+
 export function setSessionStoreEntriesForTest(entries: SessionStore) {
   sessionStoreEntries.value = structuredClone(entries);
 }

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -20,6 +20,7 @@ const {
   getLoadConfigMock,
   getLoadWebMediaMock,
   getReadChannelAllowFromStoreMock,
+  getReadSessionUpdatedAtMock,
   getOnHandler,
   listSkillCommandsForAgents,
   onSpy,
@@ -3777,5 +3778,283 @@ describe("createTelegramBot", () => {
     });
 
     expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  // Regression tests for issue #87566 — Telegram DMs were duplicating recent
+  // conversation context inside every user turn, even when the session already
+  // contained the full transcript. The fix suppresses the chat_window
+  // prompt-context block for private DMs that route to a persistent session.
+  describe("Telegram chat_window suppression for persistent DMs (#87566)", () => {
+    const readSessionUpdatedAtMock = getReadSessionUpdatedAtMock();
+
+    function getInboundPayloadFromReplySpy() {
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      return mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    }
+
+    async function pumpDmMessage(
+      handler: (ctx: Record<string, unknown>) => Promise<void>,
+      params: {
+        messageId: number;
+        text: string;
+        date?: number;
+        chatId?: number;
+        chatType?: "private" | "group" | "supergroup";
+        chatTitle?: string;
+        threadId?: number;
+      },
+    ) {
+      const baseCtx = {
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      };
+      const chatId = params.chatId ?? 4242;
+      const chatType = params.chatType ?? "private";
+      const chat: Record<string, unknown> = { id: chatId, type: chatType };
+      if (params.chatTitle) {
+        chat.title = params.chatTitle;
+      }
+      if (params.threadId !== undefined && (chatType === "supergroup" || chatType === "group")) {
+        chat.is_forum = chatType === "supergroup" ? true : undefined;
+      }
+      const message: Record<string, unknown> = {
+        chat,
+        text: params.text,
+        date: params.date ?? 1736380800,
+        message_id: params.messageId,
+        from: { id: chatId, is_bot: false, first_name: "Ada" },
+      };
+      if (params.threadId !== undefined) {
+        message.message_thread_id = params.threadId;
+        message.is_topic_message = true;
+      }
+      await handler({ ...baseCtx, message });
+    }
+
+    beforeEach(() => {
+      loadConfig.mockReturnValue({
+        agents: { defaults: { envelopeTimezone: "utc" } },
+        channels: {
+          telegram: { dmPolicy: "open", allowFrom: ["*"] },
+        },
+      });
+    });
+
+    it("suppresses chat_window for a private DM routed to a persistent session", async () => {
+      // Simulate that the session has already been written to before (i.e.
+      // the persistent session transcript already contains earlier turns).
+      readSessionUpdatedAtMock.mockReturnValue(1736380000_000);
+
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      // Prime the message cache so buildTelegramConversationContext has
+      // recent messages to surface — these are exactly the ones that would
+      // otherwise duplicate the session transcript.
+      await pumpDmMessage(handler, { messageId: 1, text: "first", date: 1736380700 });
+      await pumpDmMessage(handler, { messageId: 2, text: "second", date: 1736380750 });
+
+      replySpy.mockClear();
+      await pumpDmMessage(handler, {
+        messageId: 3,
+        text: "third turn",
+        date: 1736380800,
+      });
+
+      const payload = getInboundPayloadFromReplySpy() as MsgContext & {
+        UntrustedStructuredContext?: unknown[];
+      };
+      // No chat_window block should be present — the persistent transcript
+      // covers this history.
+      const structured = payload.UntrustedStructuredContext ?? [];
+      const chatWindows = structured.filter((entry) => {
+        if (!entry || typeof entry !== "object") return false;
+        return (entry as Record<string, unknown>).type === "chat_window";
+      });
+      expect(chatWindows).toEqual([]);
+    });
+
+    it("keeps chat_window for a private DM whose session has no prior activity (fresh session)", async () => {
+      // No previousTimestamp → fresh session. We must NOT suppress, because
+      // the transcript does not yet cover the recent cached messages.
+      readSessionUpdatedAtMock.mockReturnValue(undefined);
+
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await pumpDmMessage(handler, { messageId: 10, text: "hi", date: 1736380700 });
+
+      replySpy.mockClear();
+      await pumpDmMessage(handler, {
+        messageId: 11,
+        text: "second hi",
+        date: 1736380800,
+      });
+
+      const payload = getInboundPayloadFromReplySpy() as MsgContext & {
+        UntrustedStructuredContext?: unknown[];
+      };
+      const structured = payload.UntrustedStructuredContext ?? [];
+      const chatWindows = structured.filter((entry) => {
+        if (!entry || typeof entry !== "object") return false;
+        return (entry as Record<string, unknown>).type === "chat_window";
+      });
+      expect(chatWindows.length).toBeGreaterThan(0);
+    });
+
+    it("keeps chat_window for a group chat even when the session has prior activity", async () => {
+      readSessionUpdatedAtMock.mockReturnValue(1736380000_000);
+      loadConfig.mockReturnValue({
+        agents: { defaults: { envelopeTimezone: "utc" } },
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      });
+
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await pumpDmMessage(handler, {
+        messageId: 20,
+        text: "first in group",
+        chatId: 7777,
+        chatType: "group",
+        chatTitle: "Ops",
+        date: 1736380700,
+      });
+
+      replySpy.mockClear();
+      await pumpDmMessage(handler, {
+        messageId: 21,
+        text: "second in group",
+        chatId: 7777,
+        chatType: "group",
+        chatTitle: "Ops",
+        date: 1736380800,
+      });
+
+      const payload = getInboundPayloadFromReplySpy() as MsgContext & {
+        UntrustedStructuredContext?: unknown[];
+      };
+      const structured = payload.UntrustedStructuredContext ?? [];
+      const chatWindows = structured.filter((entry) => {
+        if (!entry || typeof entry !== "object") return false;
+        return (entry as Record<string, unknown>).type === "chat_window";
+      });
+      expect(chatWindows.length).toBeGreaterThan(0);
+    });
+
+    it("keeps reply-chain context in private DMs even when chat_window is suppressed", async () => {
+      readSessionUpdatedAtMock.mockReturnValue(1736380000_000);
+
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const baseCtx = {
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      };
+
+      // First, an earlier message in the DM that the user will reply to.
+      await handler({
+        ...baseCtx,
+        message: {
+          chat: { id: 4242, type: "private" },
+          text: "What about deploys?",
+          date: 1736380700,
+          message_id: 30,
+          from: { id: 4242, is_bot: false, first_name: "Ada" },
+        },
+      });
+
+      replySpy.mockClear();
+
+      // Now a reply to msg 30. Reply-chain context must still surface even
+      // when chat_window is suppressed by the persistent-DM rule.
+      await handler({
+        ...baseCtx,
+        message: {
+          chat: { id: 4242, type: "private" },
+          text: "yes, deploys are next",
+          date: 1736380800,
+          message_id: 31,
+          from: { id: 4242, is_bot: false, first_name: "Ada" },
+          reply_to_message: {
+            chat: { id: 4242, type: "private" },
+            text: "What about deploys?",
+            date: 1736380700,
+            message_id: 30,
+            from: { id: 4242, is_bot: false, first_name: "Ada" },
+          },
+        },
+      });
+
+      const payload = getInboundPayloadFromReplySpy() as MsgContext & {
+        UntrustedStructuredContext?: unknown[];
+        ReplyChain?: Array<{ messageId?: string; body?: string }>;
+      };
+
+      const structured = payload.UntrustedStructuredContext ?? [];
+      const chatWindows = structured.filter((entry) => {
+        if (!entry || typeof entry !== "object") return false;
+        return (entry as Record<string, unknown>).type === "chat_window";
+      });
+      // chat_window is suppressed (persistent DM)…
+      expect(chatWindows).toEqual([]);
+      // …but the reply-chain context is preserved.
+      expect(payload.ReplyChain?.[0]?.messageId).toBe("30");
+      expect(payload.ReplyChain?.[0]?.body).toBe("What about deploys?");
+    });
+
+    it("keeps chat_window for a group topic (message_thread_id) even when session is persistent", async () => {
+      readSessionUpdatedAtMock.mockReturnValue(1736380000_000);
+      loadConfig.mockReturnValue({
+        agents: { defaults: { envelopeTimezone: "utc" } },
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      });
+
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      // Group chat with a topic thread — the suppression rule must NOT fire
+      // (different session per topic, recent-context still useful).
+      await pumpDmMessage(handler, {
+        messageId: 40,
+        text: "in topic",
+        chatId: 5555,
+        chatType: "group",
+        chatTitle: "Topic Group",
+        threadId: 7,
+        date: 1736380700,
+      });
+
+      replySpy.mockClear();
+      await pumpDmMessage(handler, {
+        messageId: 41,
+        text: "more in topic",
+        chatId: 5555,
+        chatType: "group",
+        chatTitle: "Topic Group",
+        threadId: 7,
+        date: 1736380800,
+      });
+
+      const payload = getInboundPayloadFromReplySpy() as MsgContext & {
+        UntrustedStructuredContext?: unknown[];
+      };
+      const structured = payload.UntrustedStructuredContext ?? [];
+      const chatWindows = structured.filter((entry) => {
+        if (!entry || typeof entry !== "object") return false;
+        return (entry as Record<string, unknown>).type === "chat_window";
+      });
+      expect(chatWindows.length).toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
Fixes #87566

## Summary

Telegram private DMs that route to a persistent OpenClaw session (e.g. `agent:main:main`) were receiving a duplicated `Conversation context (untrusted, chronological, selected for current message)` block on **every** inbound user turn. The block contains the last ~10 cached Telegram messages — but those messages are already in the persistent session transcript, so the model saw the same history twice and paid for it twice on every turn.

This change suppresses the `chat_window` prompt-context block when (and only when):

1. The chat is a Telegram **private DM** — no group, no supergroup, no channel.
2. The chat has **no topic/thread id** — DM-topics and forum topics still get the chat_window.
3. The route resolves to a session with **prior activity** (`readSessionUpdatedAt` returned a timestamp). Fresh sessions still get the chat_window.

No new config knob is introduced; the new behaviour is default-correct for the issue's repro and matches the clawsweeper "narrow session-aware suppression" recommendation.

## Root cause

`extensions/telegram/src/bot-handlers.runtime.ts` builds a `chat_window` entry from the Telegram message cache on every inbound message via `buildPromptContextForMessage` → `buildTelegramConversationContext({ recentLimit: 10, replyTargetWindowSize: 2 })`, then `extensions/telegram/src/bot-message-context.session.ts` unconditionally attaches it as `supplemental.untrustedContext`. The persistent session transcript already covers that history, so for 1:1 DMs the block is pure duplication.

The fix lands at the attachment site in `bot-message-context.session.ts`, where we already have:

- `isGroup` (from the route classifier)
- `threadSpec.id` (forum / DM topic id, if any)
- `previousTimestamp = sessionRuntime.readSessionUpdatedAt({ storePath, sessionKey: route.sessionKey })` — the per-session updated-at, which is exactly the "has this session already been written to?" signal we need to distinguish persistent-with-transcript from fresh.

The filtering logic lives in a tiny pure helper (`bot-message-context.prompt-context-filter.ts`) so it is unit-testable independent of the bot.

## Minimal reproduction

A two-turn Telegram DM into a persistent session (`agent:main:main`):

```
Turn 1 (cached): #6792  User    : "Can you finish the deploy?"
Turn 1 (cached): #6793  OpenClaw: "Update is running in the background…"
Turn 2 (inbound now): #6795 User: "and the release notes?"
```

### Before (every user turn duplicates recent history)

```
…
Conversation info (untrusted metadata): …
Sender (untrusted metadata): …
Conversation context (untrusted, chronological, selected for current message):
  #6792 Thu 2026-05-28 12:49 GMT+9 User    : Can you finish the deploy?
  #6793 Thu 2026-05-28 12:50 GMT+9 OpenClaw: Update is running in the background…
  #6795 Thu 2026-05-28 12:55 GMT+9 User    : and the release notes?
[/Conversation context]

and the release notes?
```

(Persistent session transcript already contains #6792 + #6793 → those two are now sent twice on every turn.)

### After

```
…
Conversation info (untrusted metadata): …
Sender (untrusted metadata): …

and the release notes?
```

Reply-chain / quote / forwarded context is preserved separately via `supplemental.quote`, `supplemental.forwarded`, and `extra.ReplyChain`, so dropping the `chat_window` does not lose reply context.

## Token-impact estimate

On long-lived 1:1 Telegram DMs the duplicated block grows linearly until it stabilises at `recentLimit: 10` messages. With OpenClaw's typical 200–400-token envelope per cached message, that is **~2–4k extra tokens per inbound turn** appended to user content (which also defeats prefix caching), in line with @piazzatron's "~5x token burn" comment on a 1:1 session that otherwise carries only a short transcript per turn. Group / topic / reply / fresh-session paths are unchanged.

## Architecture affected

Telegram inbound flow:

```
on("message")
  → bot-handlers.runtime.ts: processMessageWithReplyChain
      → buildPromptContextForMessage  ← still builds chat_window unchanged
      → processMessage
          → bot-message-context.session.ts: buildTelegramChannelInboundEventContext
              ↳ resolveTelegramConversationRoute → route.sessionKey, mainSessionKey
              ↳ sessionRuntime.readSessionUpdatedAt({ storePath, sessionKey })  ← persistent-vs-fresh signal
              ↳ filterTelegramPromptContextForPersistentDm(promptContext, { isGroup, threadId, previousTimestampMs })  ← NEW
              ↳ supplemental.untrustedContext = effectivePromptContext
                  → channel-inbound prompt formatter → "Conversation context (…)"
```

The decision lives entirely inside the Telegram extension; the channel-inbound formatter, prompt assembly, and session transcript paths are untouched.

## Behaviour matrix

| Scenario                                   | chat_window | Reason                                                    |
| ------------------------------------------ | :---------: | --------------------------------------------------------- |
| Private DM, persistent session (#87566)    |    ❌ off   | transcript already contains the history                   |
| Private DM, fresh session (first turn)     |    ✅ on    | no transcript yet → keep recent cached msgs               |
| Group / supergroup                         |    ✅ on    | groups don't share a single persistent main session       |
| Forum / group topic (`message_thread_id`)  |    ✅ on    | per-topic session window is still useful                  |
| Private DM with reply target               |    ❌ off   | reply context is preserved via `ReplyChain`/`quote`       |

## Tests

Two new test files exercise the fix; both fail without it and pass with it.

`extensions/telegram/src/bot-message-context.prompt-context-filter.test.ts` — 11 pure unit tests of the suppression decision and the entry filter (group vs private, topic vs no-topic, persistent vs fresh, mixed entry types, identity / no-op semantics, edge-case timestamps).

`extensions/telegram/src/bot.test.ts` — 5 new integration tests under `describe("Telegram chat_window suppression for persistent DMs (#87566)")`:

1. Private DM, persistent session → **no** `chat_window` in `UntrustedStructuredContext`.
2. Private DM, fresh session (no `previousTimestampMs`) → `chat_window` **present**.
3. Group chat, persistent session → `chat_window` **present**.
4. Private DM with reply target, persistent session → `chat_window` suppressed, but `ReplyChain` preserved.
5. Group topic (`message_thread_id`), persistent session → `chat_window` **present**.

### Acceptance criteria — `node scripts/run-vitest.mjs` output

`extensions/telegram/src/bot.test.ts`:

```
 ✓ extension-telegram ../../extensions/telegram/src/bot.test.ts (77 tests) 4513ms
 Test Files  1 passed (1)
      Tests  77 passed (77)
```

`extensions/telegram/src/message-cache.test.ts`:

```
 ✓ extension-telegram ../../extensions/telegram/src/message-cache.test.ts (16 tests) 14ms
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

New filter unit tests:

```
 ✓ extension-telegram ../../extensions/telegram/src/bot-message-context.prompt-context-filter.test.ts (11 tests) 1ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

## Out of scope

- This PR does **not** change `dmHistoryLimit` semantics; the issue notes that knob is on a separate code path. The new behaviour is the default and needs no config opt-in or opt-out.
- Named-account DMs that route to a per-account persistent session (e.g. `agent:main:telegram:atlas:direct:alice-shared`) are treated identically to default-account DMs because the suppression decision uses `previousTimestamp` on the resolved sessionKey, not the literal `mainSessionKey` value.
- The `chat_window` build itself in `buildPromptContextForMessage` is left intact (it is still cheap and used by groups/topics/fresh sessions); we only filter at the attachment site. This keeps the surgery minimal and the suppression decision in one place.

## CHANGELOG

Added under `## 2026.5.28` → `### Fixes`.
