### PR TITLE
docs(plugins): clarify skill workshop tool policy

### DIFF
--- a/docs/plugins/skill-workshop.md
+++ b/docs/plugins/skill-workshop.md
@@ -84,10 +84,25 @@ Minimal safe config:
 
 With this config:
 
-- the `skill_workshop` tool is available
+- the `skill_workshop` tool is registered by the plugin
 - explicit reusable corrections are queued as pending proposals
 - threshold-based reviewer passes can propose skill updates
 - no skill file is written until a pending proposal is applied
+
+Manual `skill_workshop` calls still follow the active tool policy. If your
+agent uses `tools.profile: "coding"`, add the exact tool to the policy:
+
+```json5
+{
+  tools: {
+    profile: "coding",
+    alsoAllow: ["skill_workshop"],
+  },
+}
+```
+
+Use `alsoAllow: ["group:plugins"]` only when the agent should be allowed to use
+all currently loaded plugin-owned tools.
 
 Use automatic writes only in trusted workspaces:
 
@@ -646,15 +661,15 @@ Inspect quarantined proposals:
 
 Common symptoms:
 
-| Symptom                               | Likely cause                                                                        | Check                                                                |
-| ------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Tool is unavailable                   | Plugin entry is not enabled                                                         | `plugins.entries.skill-workshop.enabled` and `openclaw plugins list` |
-| No automatic proposal appears         | `autoCapture: false`, `reviewMode: "off"`, or thresholds not met                    | Config, proposal status, Gateway logs                                |
-| Heuristic did not capture             | User wording did not match correction patterns                                      | Use explicit `skill_workshop.suggest` or enable LLM reviewer         |
-| Reviewer did not create a proposal    | Reviewer returned `none`, invalid JSON, or timed out                                | Gateway logs, `reviewTimeoutMs`, thresholds                          |
-| Proposal is not applied               | `approvalPolicy: "pending"`                                                         | `list_pending`, then `apply`                                         |
-| Proposal disappeared from pending     | Duplicate proposal reused, max pending pruning, or was applied/rejected/quarantined | `status`, `list_pending` with status filters, `list_quarantine`      |
-| Skill file exists but model misses it | Skill snapshot not refreshed or skill gating excludes it                            | `openclaw skills` status and workspace skill eligibility             |
+| Symptom                               | Likely cause                                                                        | Check                                                                                                        |
+| ------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Tool is unavailable                   | Plugin entry is not enabled, or the active tool policy hides plugin tools           | `plugins.entries.skill-workshop.enabled`, `openclaw plugins list`, and `tools.alsoAllow: ["skill_workshop"]` |
+| No automatic proposal appears         | `autoCapture: false`, `reviewMode: "off"`, or thresholds not met                    | Config, proposal status, Gateway logs                                                                        |
+| Heuristic did not capture             | User wording did not match correction patterns                                      | Use explicit `skill_workshop.suggest` or enable LLM reviewer                                                 |
+| Reviewer did not create a proposal    | Reviewer returned `none`, invalid JSON, or timed out                                | Gateway logs, `reviewTimeoutMs`, thresholds                                                                  |
+| Proposal is not applied               | `approvalPolicy: "pending"`                                                         | `list_pending`, then `apply`                                                                                 |
+| Proposal disappeared from pending     | Duplicate proposal reused, max pending pruning, or was applied/rejected/quarantined | `status`, `list_pending` with status filters, `list_quarantine`                                              |
+| Skill file exists but model misses it | Skill snapshot not refreshed or skill gating excludes it                            | `openclaw skills` status and workspace skill eligibility                                                     |
 
 Relevant logs:
 


### PR DESCRIPTION
Fixes #87570

## Summary
- clarify that enabling Skill Workshop registers `skill_workshop`, but manual calls still depend on the active tool policy
- document the narrow `tools.alsoAllow: ["skill_workshop"]` fix for `tools.profile: "coding"` users
- update the troubleshooting table so a hidden tool points operators to both plugin enablement and tool-policy checks

## Real behavior proof
Behavior addressed: Skill Workshop could be enabled and loaded while manual `skill_workshop` calls remained unavailable under `tools.profile: "coding"`, with the docs saying the tool was available but not pointing to the required tool-policy grant.

Real environment tested: Source docs in this branch, based on `origin/main`, rendered from `docs/plugins/skill-workshop.md`.

Exact steps or command run after this patch: `nl -ba docs/plugins/skill-workshop.md | sed -n '86,112p;661,668p'`

Evidence after fix: Terminal capture from this branch after the patch:

```text
    87  - the `skill_workshop` tool is registered by the plugin
    92  Manual `skill_workshop` calls still follow the active tool policy. If your
    93  agent uses `tools.profile: "coding"`, add the exact tool to the policy:
    95  ```json5
    97    tools: {
    98      profile: "coding",
    99      alsoAllow: ["skill_workshop"],
   104  Use `alsoAllow: ["group:plugins"]` only when the agent should be allowed to use
   105  all currently loaded plugin-owned tools.
   666 | Tool is unavailable | Plugin entry is not enabled, or the active tool policy hides plugin tools | `plugins.entries.skill-workshop.enabled`, `openclaw plugins list`, and `tools.alsoAllow: ["skill_workshop"]` |
```

Observed result after fix: The Skill Workshop guide now distinguishes plugin registration from tool-policy exposure and gives operators an exact config for manual `status`, `list_pending`, and `apply` calls under `tools.profile: "coding"`.

What was not tested: I did not run a live Gateway or agent session; this is a docs-only clarification for an already source-reproduced tool-policy behavior.

## Verification
- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `git diff --check origin/main...HEAD`
