### PR TITLE
fix: forward quiet channel-owned progress callbacks in group chats

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1908,7 +1908,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses channel-owned group progress callbacks while verbose is off", async () => {
+  it("forwards channel-owned group progress callbacks while verbose is off", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       verboseLevel: "off",
@@ -1968,14 +1968,23 @@ describe("dispatchReplyFromConfig", () => {
       },
     });
 
-    expect(onToolStart).not.toHaveBeenCalled();
-    expect(onItemEvent).not.toHaveBeenCalled();
-    expect(onPlanUpdate).not.toHaveBeenCalled();
-    expect(onApprovalEvent).not.toHaveBeenCalled();
-    expect(onCommandOutput).not.toHaveBeenCalled();
-    expect(onPatchSummary).not.toHaveBeenCalled();
-    expect(onCompactionStart).not.toHaveBeenCalled();
-    expect(onCompactionEnd).not.toHaveBeenCalled();
+    expect(onToolStart).toHaveBeenCalledWith({ name: "exec", phase: "start" });
+    expect(onItemEvent).toHaveBeenCalledWith({
+      itemId: "1",
+      kind: "tool",
+      progressText: "running exec",
+    });
+    expect(onPlanUpdate).toHaveBeenCalledWith({ phase: "update", steps: ["Run command"] });
+    expect(onApprovalEvent).toHaveBeenCalledWith({ phase: "requested", command: "pnpm test" });
+    expect(onCommandOutput).toHaveBeenCalledWith({
+      phase: "end",
+      name: "exec",
+      status: "ok",
+      exitCode: 0,
+    });
+    expect(onPatchSummary).toHaveBeenCalledWith({ phase: "end", summary: "1 modified" });
+    expect(onCompactionStart).toHaveBeenCalledTimes(1);
+    expect(onCompactionEnd).toHaveBeenCalledTimes(1);
     expect(onToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2173,12 +2173,11 @@ export async function dispatchReplyFromConfig(
     const onPatchSummaryFromReplyOptions = params.replyOptions?.onPatchSummary;
     const allowSuppressedSourceProgressCallbacks =
       params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed === true;
-    const shouldAllowQuietDirectNativeProgressCallbacks = (options?: {
+    const shouldAllowQuietChannelOwnedProgressCallbacks = (options?: {
       requiresToolSummaryVisibility?: boolean;
     }) =>
       options?.requiresToolSummaryVisibility === true &&
-      params.replyOptions?.suppressDefaultToolProgressMessages === true &&
-      chatType === "direct";
+      params.replyOptions?.suppressDefaultToolProgressMessages === true;
     let hasPendingDirectBlockReplyDelivery = false;
     const waitForPendingDirectBlockReplyDelivery = async (abortSignal?: AbortSignal) => {
       if (!hasPendingDirectBlockReplyDelivery) {
@@ -2197,7 +2196,7 @@ export async function dispatchReplyFromConfig(
       if (
         options?.requiresToolSummaryVisibility === true &&
         !shouldSendToolSummaries() &&
-        !shouldAllowQuietDirectNativeProgressCallbacks(options)
+        !shouldAllowQuietChannelOwnedProgressCallbacks(options)
       ) {
         return false;
       }


### PR DESCRIPTION
## Summary

Fix #87612 by forwarding channel-owned progress callbacks in group and group-channel sessions even when `/verbose off` suppresses default tool-progress text.

This keeps native channel progress surfaces working for group chats while preserving the existing suppression of tool-result summary text.

## Verification

- node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts

Behavior addressed:
Group and group-channel sessions no longer drop channel-owned progress callbacks when verbose mode is off and default tool-progress text is suppressed.

Real environment tested:
Local source checkout with focused Vitest coverage for reply dispatch behavior.

Exact steps or command run after this patch:
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts

Evidence after fix:
The focused regression suite passed after updating the group verbose-off case to assert callback delivery while keeping tool-result summary text suppressed.

Observed result after fix:
Group-scoped channel-owned progress callbacks now fire under verbose off, and `onToolResult` / `sendToolResult` remain suppressed as before.

What was not tested:
No live Telegram/Discord/Slack channel run was exercised in this change; verification was limited to the focused dispatch test surface.
