### PR TITLE
fix(telegram): clamp partial draft overflow

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -172,6 +172,21 @@ describe("createTelegramDraftStream", () => {
     },
   );
 
+  it("does not finalize stale preview text after a stopped send failure", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage.mockRejectedValueOnce(new Error("temporary send failure"));
+    const warn = vi.fn();
+    const stream = createDraftStream(api, { warn });
+
+    stream.update("Hello");
+    await stream.flush();
+    await stream.stop();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined);
+    expect(warn).toHaveBeenCalledWith("telegram stream preview failed: temporary send failure");
+  });
+
   it("keeps allow_sending_without_reply on message previews that target a reply", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -399,7 +399,42 @@ describe("createTelegramDraftStream", () => {
     });
   });
 
-  it("continues in a new message when rendered preview crosses maxChars", async () => {
+  it("keeps non-final overflow in one editable preview", async () => {
+    const api = createMockDraftApi();
+    const onSupersededPreview = vi.fn();
+    const stream = createDraftStream(api, { maxChars: 20, onSupersededPreview });
+
+    stream.update("Hello world");
+    await stream.flush();
+    stream.update("Hello world foo bar baz qux");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "Hello world", undefined);
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello world foo bar");
+    expect(onSupersededPreview).not.toHaveBeenCalled();
+    expect(stream.lastDeliveredText?.()).toBe("Hello world foo bar");
+  });
+
+  it("does not retain non-final overflow preview pages", async () => {
+    const api = createMockDraftApi();
+    const onSupersededPreview = vi.fn();
+    const stream = createDraftStream(api, {
+      maxChars: 20,
+      onSupersededPreview,
+    });
+
+    stream.update("Hello world");
+    await stream.flush();
+    stream.update("Hello world foo bar baz qux");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello world foo bar");
+    expect(onSupersededPreview).not.toHaveBeenCalled();
+  });
+
+  it("continues in a new message when a final rendered preview crosses maxChars", async () => {
     const api = createMockDraftApi();
     api.sendMessage
       .mockResolvedValueOnce({ message_id: 17 })
@@ -409,29 +444,53 @@ describe("createTelegramDraftStream", () => {
     stream.update("Hello world");
     await stream.flush();
     stream.update("Hello world foo bar baz qux");
-    await stream.flush();
+    await stream.stop();
 
     expect(api.sendMessage).toHaveBeenCalledTimes(2);
     expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "Hello world", undefined);
     expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "foo bar baz qux", undefined);
   });
 
-  it("splits a first oversized rendered preview into chained messages", async () => {
+  it("clamps a first oversized non-final preview", async () => {
     const api = createMockDraftApi();
-    api.sendMessage
-      .mockResolvedValueOnce({ message_id: 17 })
-      .mockResolvedValueOnce({ message_id: 42 });
     const stream = createDraftStream(api, { maxChars: 10 });
 
     stream.update("1234567890ABCDEFGHIJ");
     await stream.flush();
 
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "1234567890", undefined);
+    expect(stream.lastDeliveredText?.()).toBe("1234567890");
+  });
+
+  it("finalizes overflow that was hidden by a clamped non-final preview", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 });
+    const onSupersededPreview = vi.fn();
+    const stream = createDraftStream(api, {
+      maxChars: 10,
+      onSupersededPreview,
+    });
+
+    stream.update("1234567890ABCDEFGHIJ");
+    await stream.flush();
+    await stream.stop();
+
     expect(api.sendMessage).toHaveBeenCalledTimes(2);
     expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "1234567890", undefined);
     expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "ABCDEFGHIJ", undefined);
+    expect(stream.lastDeliveredText?.()).toBe("1234567890ABCDEFGHIJ");
+    expect(onSupersededPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 17,
+        retain: true,
+      }),
+    );
   });
 
-  it("retains overflow preview pages", async () => {
+  it("retains final overflow preview pages", async () => {
     const api = createMockDraftApi();
     api.sendMessage
       .mockResolvedValueOnce({ message_id: 17 })
@@ -445,7 +504,7 @@ describe("createTelegramDraftStream", () => {
     stream.update("Hello world");
     await stream.flush();
     stream.update("Hello world foo bar baz qux");
-    await stream.flush();
+    await stream.stop();
 
     expect(onSupersededPreview).toHaveBeenCalledTimes(1);
     const [supersededPreview] = onSupersededPreview.mock.calls.at(0) ?? [];

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -505,6 +505,25 @@ describe("createTelegramDraftStream", () => {
     );
   });
 
+  it("continues finalizing more than two overflow chunks after a clamped preview", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 })
+      .mockResolvedValueOnce({ message_id: 43 });
+    const stream = createDraftStream(api, { maxChars: 10 });
+
+    stream.update("1234567890ABCDEFGHIJKLMNOPQRST");
+    await stream.flush();
+    await stream.stop();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(3);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "1234567890", undefined);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "ABCDEFGHIJ", undefined);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(3, 123, "KLMNOPQRST", undefined);
+    expect(stream.lastDeliveredText?.()).toBe("1234567890ABCDEFGHIJKLMNOPQRST");
+  });
+
   it("retains final overflow preview pages", async () => {
     const api = createMockDraftApi();
     api.sendMessage

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -112,6 +112,7 @@ export function createTelegramDraftStream(params: {
   let streamVisibleSinceMs: number | undefined;
   let lastSentText = "";
   let lastDeliveredText = "";
+  let lastRequestedText = "";
   let lastSentParseMode: "HTML" | undefined;
   let previewRevision = 0;
   let generation = 0;
@@ -184,6 +185,13 @@ export function createTelegramDraftStream(params: {
     streamVisibleSinceMs = visibleSinceMs;
     return true;
   };
+  const stopOversizedPreview = (renderedText: string): false => {
+    streamState.stopped = true;
+    params.warn?.(
+      `telegram stream preview stopped (text length ${renderedText.length} > ${maxChars})`,
+    );
+    return false;
+  };
 
   const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
     if (streamState.stopped && !streamState.final) {
@@ -204,6 +212,15 @@ export function createTelegramDraftStream(params: {
       return false;
     }
     if (renderedText.length > maxChars) {
+      const chunkLength = findTelegramDraftChunkLength(currentText, maxChars, params.renderText);
+      if (!streamState.final) {
+        if (chunkLength > 0) {
+          return await sendOrEditStreamMessage(
+            trimmed.slice(0, deliveredTextOffset) + currentText.slice(0, chunkLength),
+          );
+        }
+        return stopOversizedPreview(renderedText);
+      }
       if (lastDeliveredText.length > deliveredTextOffset) {
         const supersededMessageId = streamMessageId;
         const supersededTextSnapshot = lastSentText;
@@ -222,7 +239,6 @@ export function createTelegramDraftStream(params: {
         }
         return await sendOrEditStreamMessage(trimmed);
       }
-      const chunkLength = findTelegramDraftChunkLength(currentText, maxChars, params.renderText);
       if (chunkLength > 0) {
         const sent = await sendOrEditStreamMessage(
           trimmed.slice(0, deliveredTextOffset) + currentText.slice(0, chunkLength),
@@ -232,11 +248,7 @@ export function createTelegramDraftStream(params: {
         }
         return await sendOrEditStreamMessage(trimmed);
       }
-      streamState.stopped = true;
-      params.warn?.(
-        `telegram stream preview stopped (text length ${renderedText.length} > ${maxChars})`,
-      );
-      return false;
+      return stopOversizedPreview(renderedText);
     }
     if (renderedText === lastSentText && renderedParseMode === lastSentParseMode) {
       return true;
@@ -269,11 +281,33 @@ export function createTelegramDraftStream(params: {
     }
   };
 
-  const { loop, update, stop, stopForClear } = createFinalizableDraftStreamControlsForState({
+  const {
+    loop,
+    update: updateDraft,
+    stopForClear,
+  } = createFinalizableDraftStreamControlsForState({
     throttleMs,
     state: streamState,
     sendOrEditStreamMessage,
   });
+
+  const update = (text: string) => {
+    if (streamState.stopped || streamState.final) {
+      return;
+    }
+    lastRequestedText = text;
+    updateDraft(text);
+  };
+
+  const stop = async () => {
+    streamState.final = true;
+    await loop.flush();
+    const finalText = lastRequestedText.trimEnd();
+    if (finalText && finalText !== lastDeliveredText.trimEnd()) {
+      await sendOrEditStreamMessage(finalText);
+    }
+    streamState.final = true;
+  };
 
   resetStreamToNewMessage = (options) => {
     streamState.stopped = false;
@@ -286,6 +320,7 @@ export function createTelegramDraftStream(params: {
     lastSentParseMode = undefined;
     if (options?.resetOffset !== false) {
       deliveredTextOffset = 0;
+      lastRequestedText = "";
     }
     if (!options?.keepPending) {
       loop.resetPending();

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -302,6 +302,9 @@ export function createTelegramDraftStream(params: {
   const stop = async () => {
     streamState.final = true;
     await loop.flush();
+    if (streamState.stopped) {
+      return;
+    }
     const finalText = lastRequestedText.trimEnd();
     if (finalText && finalText !== lastDeliveredText.trimEnd()) {
       await sendOrEditStreamMessage(finalText);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -117,7 +117,11 @@ export function createTelegramDraftStream(params: {
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
-  let resetStreamToNewMessage: (options?: { keepPending?: boolean; resetOffset?: boolean }) => void;
+  let resetStreamToNewMessage: (options?: {
+    keepFinal?: boolean;
+    keepPending?: boolean;
+    resetOffset?: boolean;
+  }) => void;
   type PreviewSendParams = {
     renderedText: string;
     renderedParseMode: "HTML" | undefined;
@@ -227,7 +231,7 @@ export function createTelegramDraftStream(params: {
         const supersededParseMode = lastSentParseMode;
         const supersededVisibleSinceMs = streamVisibleSinceMs;
         deliveredTextOffset = lastDeliveredText.length;
-        resetStreamToNewMessage({ keepPending: true, resetOffset: false });
+        resetStreamToNewMessage({ keepFinal: true, keepPending: true, resetOffset: false });
         if (typeof supersededMessageId === "number") {
           params.onSupersededPreview?.({
             messageId: supersededMessageId,
@@ -314,7 +318,7 @@ export function createTelegramDraftStream(params: {
 
   resetStreamToNewMessage = (options) => {
     streamState.stopped = false;
-    streamState.final = false;
+    streamState.final = options?.keepFinal === true;
     generation += 1;
     messageSendAttempted = false;
     streamMessageId = undefined;


### PR DESCRIPTION
Summary:
- Keep Telegram partial draft overflow in one editable preview instead of retaining rollover preview pages.
- Preserve final overflow splitting so long final replies still deliver fully.
- Add regression coverage for non-final overflow clamping and stop-time finalization of hidden overflow.

Verification:
- `pnpm test extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/lane-delivery.test.ts`
- `git diff --check`
- Telegram bot-to-bot E2E with mock OpenAI on this branch

Real behavior proof:
Behavior addressed: Telegram partial draft streaming no longer emits multiple visible preview messages for one turn.
Real environment tested: Real Telegram bot-to-bot group transport with temp OpenClaw gateway and mock OpenAI.
Exact steps or command run after this patch: `REPRO_GATEWAY_PORT=19979 REPRO_MOCK_PORT=19982 REPO_HEAD=$(git rev-parse --short=12 HEAD) node /tmp/repro-84885-telegram-partial.mjs`
Evidence after fix: One mock `POST /v1/responses`; one reply-threaded SUT preview message; five edits to that preview; one final long-text overflow tail.
Observed result after fix: No preview rollover spam; only the final long reply tail used a second message.
What was not tested: Visual desktop recording.

Fixes #84885.
