### PR TITLE
fix(doctor): report dreaming without memory search

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -192,6 +192,35 @@ describe("noteMemorySearchHealth", () => {
     resetMemoryRecallMocks();
   });
 
+  it("distinguishes enabled memory-core dreaming when embedding memory search is disabled (#87637)", async () => {
+    resolveMemorySearchConfig.mockReturnValue(null);
+    const cfgWithDreaming = {
+      agents: { defaults: { userTimezone: "America/Los_Angeles" } },
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: { dreaming: { enabled: true, frequency: "0 */4 * * *" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await noteMemorySearchHealth(cfgWithDreaming, {});
+
+    expect(note).toHaveBeenCalledTimes(2);
+    expect(note.mock.calls[0]).toEqual([
+      "Memory search is explicitly disabled (enabled: false).",
+      "Memory search",
+    ]);
+    expect(note.mock.calls[1][1]).toBe("Memory dreaming");
+    const message = String(note.mock.calls[1][0]);
+    expect(message).toContain(
+      "Memory-core dreaming is enabled independently of embedding memory search.",
+    );
+    expect(message).toContain("Dreaming schedule: 0 */4 * * * (America/Los_Angeles)");
+    expect(message).toContain("openclaw memory status --deep");
+  });
+
   it("does not warn when local provider is set with no explicit modelPath (default model fallback)", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -27,6 +27,10 @@ import {
 import { DEFAULT_LOCAL_MODEL } from "../memory-host-sdk/host/embedding-defaults.js";
 import { hasConfiguredMemorySecretInput } from "../memory-host-sdk/secret.js";
 import {
+  resolveMemoryDreamingConfig,
+  resolveMemoryDreamingPluginConfig,
+} from "../memory-host-sdk/dreaming.js";
+import {
   auditDreamingArtifacts,
   auditShortTermPromotionArtifacts,
   repairDreamingArtifacts,
@@ -395,6 +399,27 @@ function hasActiveAlternateMemoryPluginSlot(cfg: OpenClawConfig): boolean {
  * may spawn a short-lived probe process when `memory.backend=qmd` to verify
  * the configured `qmd` binary is available.
  */
+// Memory-core dreaming runs independently of embedding memory search, so surface its
+// status even when embedding memory search is disabled or unavailable (#87637).
+function noteIndependentDreamingStatus(cfg: OpenClawConfig): void {
+  const dreaming = resolveMemoryDreamingConfig({
+    pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
+    cfg,
+  });
+  if (!dreaming.enabled) {
+    return;
+  }
+  const timezone = dreaming.timezone ? ` (${dreaming.timezone})` : "";
+  note(
+    [
+      "Memory-core dreaming is enabled independently of embedding memory search.",
+      `Dreaming schedule: ${dreaming.frequency}${timezone}`,
+      `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+    ].join("\n"),
+    "Memory dreaming",
+  );
+}
+
 export async function noteMemorySearchHealth(
   cfg: OpenClawConfig,
   opts?: {
@@ -415,6 +440,7 @@ export async function noteMemorySearchHealth(
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");
+    noteIndependentDreamingStatus(cfg);
     return;
   }
   const provider =

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -266,6 +266,33 @@ describe("doctor.memory.status", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("keeps dreaming status visible when the memory search manager is missing (#87637)", async () => {
+    getMemorySearchManager.mockResolvedValue({ manager: null, error: "memory search disabled" });
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond);
+
+    const payload = respondPayload(respond);
+    expectRecordFields(payload.embedding, { ok: false, error: "memory search disabled" });
+    // Dreaming status is still reported even without an active embedding manager (#87637).
+    const dreaming = expectRecordFields(payload.dreaming, { enabled: false });
+    expectRecordFields(dreaming.phases, {});
+  });
+
+  it("resolves the requested agent's workspace from config when no manager is active (#87637)", async () => {
+    getMemorySearchManager.mockResolvedValue({ manager: null, error: "memory search disabled" });
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond, { params: { agentId: "research" } });
+
+    // Without a live manager to read the workspace from, the requested-agent scope must resolve
+    // its workspace from config — otherwise dreaming would report an empty selected-agent store.
+    expect(resolveAgentWorkspaceDir).toHaveBeenCalledWith(expect.anything(), "research");
+    expectRecordFields(respondPayload(respond).dreaming as Record<string, unknown>, {
+      enabled: false,
+    });
+  });
+
   it("returns gateway embedding probe status for the requested agent", async () => {
     const close = vi.fn().mockResolvedValue(undefined);
     getMemorySearchManager.mockResolvedValue({

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -839,6 +839,80 @@ async function resolveAllManagedDreamingCronStatuses(context: {
   };
 }
 
+// Builds the doctor memory-dreaming payload independently of the embedding memory
+// search manager, so dreaming status stays visible even when no manager is active
+// (memory-core dreaming runs separately from embedding memory search). #87637
+async function buildDoctorMemoryDreamingPayload(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  requestedAgentId: string | null;
+  context: {
+    cron?: { list?: (opts?: { includeDisabled?: boolean }) => Promise<unknown[]> };
+  };
+  managerWorkspaceDir?: string;
+}): Promise<DoctorMemoryDreamingPayload> {
+  const { cfg, agentId, requestedAgentId, context, managerWorkspaceDir } = params;
+  const nowMs = Date.now();
+  const dreamingConfig = resolveDreamingConfig(cfg);
+  const configuredWorkspaces = requestedAgentId
+    ? managerWorkspaceDir
+      ? [managerWorkspaceDir]
+      : []
+    : resolveMemoryDreamingWorkspaces(cfg, {
+        primaryWorkspaceDir: managerWorkspaceDir,
+        primaryAgentId: agentId,
+      }).map((entry) => entry.workspaceDir);
+  const allWorkspaces =
+    configuredWorkspaces.length > 0
+      ? configuredWorkspaces
+      : managerWorkspaceDir
+        ? [managerWorkspaceDir]
+        : [];
+  const storeStats =
+    allWorkspaces.length > 0
+      ? mergeDreamingStoreStats(
+          await Promise.all(
+            allWorkspaces.map((entry) =>
+              loadDreamingStoreStats(entry, nowMs, dreamingConfig.timezone),
+            ),
+          ),
+        )
+      : {
+          shortTermCount: 0,
+          recallSignalCount: 0,
+          dailySignalCount: 0,
+          groundedSignalCount: 0,
+          totalSignalCount: 0,
+          phaseSignalCount: 0,
+          lightPhaseHitCount: 0,
+          remPhaseHitCount: 0,
+          promotedTotal: 0,
+          promotedToday: 0,
+          shortTermEntries: [],
+          signalEntries: [],
+          promotedEntries: [],
+        };
+  const cronStatuses = await resolveAllManagedDreamingCronStatuses(context);
+  return {
+    ...dreamingConfig,
+    ...storeStats,
+    phases: {
+      light: {
+        ...dreamingConfig.phases.light,
+        ...cronStatuses.light,
+      },
+      deep: {
+        ...dreamingConfig.phases.deep,
+        ...cronStatuses.deep,
+      },
+      rem: {
+        ...dreamingConfig.phases.rem,
+        ...cronStatuses.rem,
+      },
+    },
+  };
+}
+
 async function readDreamDiary(
   workspaceDir: string,
 ): Promise<Omit<DoctorMemoryDreamDiaryPayload, "agentId">> {
@@ -908,12 +982,23 @@ export const doctorHandlers: GatewayRequestHandlers = {
       purpose: "status",
     });
     if (!manager) {
+      // Memory-core dreaming runs independently of embedding memory search, so keep
+      // reporting dreaming status even when no embedding manager is active (#87637).
       const payload: DoctorMemoryStatusPayload = {
         agentId,
         embedding: {
           ok: false,
           error: error ?? "memory search unavailable",
         },
+        dreaming: await buildDoctorMemoryDreamingPayload({
+          cfg,
+          agentId,
+          requestedAgentId,
+          // No live manager to read the workspace from, so resolve it from config — otherwise
+          // a requested-agent scope would have an empty workspace and report no dreaming store.
+          managerWorkspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+          context,
+        }),
       };
       respond(true, payload, undefined);
       return;
@@ -928,63 +1013,18 @@ export const doctorHandlers: GatewayRequestHandlers = {
       if (!embedding.ok && !embedding.error) {
         embedding = { ok: false, error: "memory embeddings unavailable" };
       }
-      const nowMs = Date.now();
-      const dreamingConfig = resolveDreamingConfig(cfg);
       const workspaceDir = normalizeTrimmedString((status as Record<string, unknown>).workspaceDir);
-      const configuredWorkspaces = requestedAgentId
-        ? workspaceDir
-          ? [workspaceDir]
-          : []
-        : resolveMemoryDreamingWorkspaces(cfg, {
-            primaryWorkspaceDir: workspaceDir,
-            primaryAgentId: agentId,
-          }).map((entry) => entry.workspaceDir);
-      const allWorkspaces =
-        configuredWorkspaces.length > 0 ? configuredWorkspaces : workspaceDir ? [workspaceDir] : [];
-      const storeStats =
-        allWorkspaces.length > 0
-          ? mergeDreamingStoreStats(
-              await Promise.all(
-                allWorkspaces.map((entry) =>
-                  loadDreamingStoreStats(entry, nowMs, dreamingConfig.timezone),
-                ),
-              ),
-            )
-          : {
-              shortTermCount: 0,
-              recallSignalCount: 0,
-              dailySignalCount: 0,
-              groundedSignalCount: 0,
-              totalSignalCount: 0,
-              phaseSignalCount: 0,
-              lightPhaseHitCount: 0,
-              remPhaseHitCount: 0,
-              promotedTotal: 0,
-              promotedToday: 0,
-            };
-      const cronStatuses = await resolveAllManagedDreamingCronStatuses(context);
       const payload: DoctorMemoryStatusPayload = {
         agentId,
         provider: status.provider,
         embedding,
-        dreaming: {
-          ...dreamingConfig,
-          ...storeStats,
-          phases: {
-            light: {
-              ...dreamingConfig.phases.light,
-              ...cronStatuses.light,
-            },
-            deep: {
-              ...dreamingConfig.phases.deep,
-              ...cronStatuses.deep,
-            },
-            rem: {
-              ...dreamingConfig.phases.rem,
-              ...cronStatuses.rem,
-            },
-          },
-        },
+        dreaming: await buildDoctorMemoryDreamingPayload({
+          cfg,
+          agentId,
+          requestedAgentId,
+          context,
+          managerWorkspaceDir: workspaceDir,
+        }),
       };
       respond(true, payload, undefined);
     } catch (err) {


### PR DESCRIPTION
Fixes #87637

## Summary
- keep `doctor.memory.status` dreaming diagnostics visible when embedding memory search has no active manager
- add a separate CLI doctor note for enabled memory-core dreaming when embedding memory search is disabled
- cover both source-repro paths with focused gateway-methods and command tests

## Verification
- `pnpm install --frozen-lockfile`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/doctor.test.ts -t 'keeps dreaming status visible when memory search manager is missing' --reporter=verbose --testTimeout=10000`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/doctor.test.ts --reporter=dot --testTimeout=10000`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/doctor-memory-search.test.ts -t 'distinguishes enabled memory-core dreaming when embedding memory search is disabled' --reporter=verbose --testTimeout=10000`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/doctor-memory-search.test.ts --reporter=dot --testTimeout=10000`
- `node_modules/.bin/oxfmt --check src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts src/gateway/server-methods/doctor.ts src/gateway/server-methods/doctor.test.ts`
- `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts src/gateway/server-methods/doctor.ts src/gateway/server-methods/doctor.test.ts`
- `git diff --check origin/main...HEAD`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --pretty false --noEmit`

## Real behavior proof

**Behavior addressed:** `openclaw doctor` and `doctor.memory.status` now keep embedding memory search unavailable/disabled diagnostics separate from memory-core dreaming, so dreaming state remains visible when memory search is disabled or unavailable.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, HEAD `4f16f0a615f5121cf0e3ea198a2bb50171ead5ec` based on `origin/main` `a25338f2b7b2676c64765e1e9ee202ae56210fc0`.

**Exact steps or command run after this patch:**

```bash
pnpm build
OPENCLAW_CONFIG_PATH=/tmp/test-openclaw-no-memory.json node openclaw.mjs doctor
```

The test config has `agents.defaults.memorySearch.enabled=false` and `plugins.entries.memory-core.config.dreaming.enabled=true, frequency="0 */4 * * *"`.

**Evidence after fix:**

```
$ OPENCLAW_CONFIG_PATH=/tmp/test-openclaw-no-memory.json node openclaw.mjs doctor

[...config warnings for unrelated stale plugins omitted...]

◇  Memory search ──────────────────────────────────────────╮
│                                                          │
│  Memory search is explicitly disabled (enabled: false).  │
│                                                          │
├──────────────────────────────────────────────────────────╯
│
◇  Memory dreaming ───────────────────────────────────────────────────╮
│                                                                     │
│  Memory-core dreaming is enabled independently of embedding memory  │
│  search.                                                            │
│  Dreaming schedule: 0 */4 * * *                                     │
│  Verify: openclaw memory status --deep                              │
│                                                                     │
├─────────────────────────────────────────────────────────────────────╯
```

**Observed result after fix:** `openclaw doctor` shows a dedicated `Memory dreaming` section after the `Memory search` disabled note, confirming dreaming state remains visible even when embedding memory search is explicitly disabled. The `Memory dreaming` section reports the dreaming schedule and instructs the user to run `openclaw memory status --deep` to inspect dreaming state further.

**What was not tested:** End-to-end `openclaw doctor` run against a live gateway with a real memory-core plugin and active dreaming session. The focused Vitest coverage exercises the source-repro paths (CLI disabled-memory-search path and gateway missing-manager path) directly.

