### PR TITLE
fix(telegram): avoid replaying long streamed replies

### DIFF
--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -115,6 +115,15 @@ function compactChunks(chunks: readonly string[]): string[] {
   return out;
 }
 
+function isDeliveredPrefix(params: { deliveredText: string | undefined; finalText: string }) {
+  if (!params.deliveredText || params.deliveredText.length === 0) {
+    return false;
+  }
+  return (
+    params.finalText === params.deliveredText || params.finalText.startsWith(params.deliveredText)
+  );
+}
+
 export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
   const followUpPayload = (payload: ReplyPayload, text: string) =>
     params.applyTextToFollowUpPayload
@@ -270,6 +279,53 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     if (!firstChunk || firstChunk.length > params.draftMaxChars) {
       return undefined;
     }
+    const finalText = text.trimEnd();
+    const deliveredStreamTextBeforeUpdate = stream.lastDeliveredText?.();
+    const deliveredPrefixBeforeUpdate =
+      isFinal &&
+      deliveredStreamTextBeforeUpdate !== undefined &&
+      isDeliveredPrefix({
+        deliveredText: deliveredStreamTextBeforeUpdate,
+        finalText,
+      }) &&
+      deliveredStreamTextBeforeUpdate.length > firstChunk.trimEnd().length;
+    const finalizeDeliveredPrefix = async (
+      deliveredStreamText: string,
+      messageId: number,
+    ): Promise<LaneDeliveryResult> => {
+      lane.finalized = true;
+      params.markDelivered();
+      let buttonsAttached = false;
+      if (buttons) {
+        const deliveredChunks = compactChunks(
+          params.splitFinalTextForStream?.(deliveredStreamText) ?? [],
+        );
+        const currentChunk = deliveredChunks.at(-1);
+        if (currentChunk && currentChunk.length <= params.draftMaxChars) {
+          try {
+            await params.editStreamMessage({ laneName, messageId, text: currentChunk, buttons });
+            buttonsAttached = true;
+          } catch (err) {
+            params.log(`telegram: ${laneName} stream button edit failed: ${String(err)}`);
+          }
+        }
+      }
+      const suffix = finalText.slice(deliveredStreamText.length);
+      if (suffix.trim().length > 0) {
+        for (const chunk of compactChunks(params.splitFinalTextForStream?.(suffix) ?? [])) {
+          if (chunk.trim().length === 0) {
+            continue;
+          }
+          await params.sendPayload(followUpPayload(payload, chunk));
+        }
+      }
+      return result("preview-finalized", {
+        content: text,
+        promptContextContent: deliveredStreamText,
+        messageId,
+        buttonsAttached,
+      });
+    };
 
     const retainedPreview =
       isFinal && remainingChunks.length === 0 && isPotentialTruncatedFinal(text)
@@ -296,8 +352,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         }
         return undefined;
       }
-      const deliveredStreamText = stream.lastDeliveredText?.();
-      if (deliveredStreamText !== undefined && deliveredStreamText !== previewText) {
+      const deliveredStreamTextAfterStop = stream.lastDeliveredText?.();
+      if (
+        deliveredStreamTextAfterStop !== undefined &&
+        deliveredStreamTextAfterStop !== previewText
+      ) {
         return undefined;
       }
       let buttonsAttached = false;
@@ -320,10 +379,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       return result("preview-finalized", { content: previewText, messageId, buttonsAttached });
     }
 
-    lane.lastPartialText = firstChunk;
-    lane.hasStreamedMessage = true;
-    lane.finalized = false;
-    stream.update(firstChunk);
+    if (!deliveredPrefixBeforeUpdate) {
+      lane.lastPartialText = firstChunk;
+      lane.hasStreamedMessage = true;
+      lane.finalized = false;
+      stream.update(firstChunk);
+    }
     if (isFinal) {
       await params.stopDraftLane(lane);
     } else {
@@ -340,13 +401,23 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       return undefined;
     }
 
-    const deliveredStreamText = stream.lastDeliveredText?.();
+    const deliveredStreamTextAfterStop = stream.lastDeliveredText?.();
     if (
       isFinal &&
-      deliveredStreamText !== undefined &&
-      deliveredStreamText !== firstChunk.trimEnd()
+      deliveredStreamTextAfterStop !== undefined &&
+      deliveredStreamTextAfterStop !== firstChunk.trimEnd()
     ) {
+      if (
+        isDeliveredPrefix({ deliveredText: deliveredStreamTextAfterStop, finalText }) &&
+        deliveredStreamTextAfterStop.length > firstChunk.trimEnd().length
+      ) {
+        return await finalizeDeliveredPrefix(deliveredStreamTextAfterStop, messageId);
+      }
       return undefined;
+    }
+
+    if (deliveredPrefixBeforeUpdate && deliveredStreamTextAfterStop === undefined) {
+      return await finalizeDeliveredPrefix(deliveredStreamTextBeforeUpdate, messageId);
     }
 
     params.markDelivered();

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -663,6 +663,137 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: " again" });
   });
 
+  it("does not resend a long final when streaming already delivered it", async () => {
+    const fullAnswer = "Hello world again";
+    const answer = createTestDraftStream({ messageId: 999 });
+    answer.lastDeliveredText.mockReturnValue(fullAnswer);
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: () => ["Hello", " world", " again"],
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, fullAnswer);
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe(fullAnswer);
+    expect(delivery.promptContextContent).toBe(fullAnswer);
+    expect(delivery.messageId).toBe(999);
+    expect(answer.update).not.toHaveBeenCalled();
+    expect(harness.stopDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.clearDraftLane).not.toHaveBeenCalled();
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends only the missing suffix when a long final extends the streamed prefix", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    answer.lastDeliveredText.mockReturnValue("Hello world");
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: (text) =>
+        text === " again" ? [" again"] : ["Hello", " world", " again"],
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe("Hello world again");
+    expect(delivery.promptContextContent).toBe("Hello world");
+    expect(answer.update).not.toHaveBeenCalled();
+    expect(harness.clearDraftLane).not.toHaveBeenCalled();
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " again" });
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send a suffix already flushed while stopping a long streamed final", async () => {
+    let deliveredText = "Hello world";
+    const answer = createTestDraftStream({
+      messageId: 999,
+      onStop: () => {
+        deliveredText = "Hello world again";
+      },
+    });
+    answer.lastDeliveredText.mockImplementation(() => deliveredText);
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: (text) =>
+        text === " again" ? [" again"] : ["Hello", " world", " again"],
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.promptContextContent).toBe("Hello world again");
+    expect(answer.update).not.toHaveBeenCalled();
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a long final when stop advances the stream past the first chunk", async () => {
+    let deliveredText = "Hello";
+    const answer = createTestDraftStream({
+      messageId: 999,
+      onStop: () => {
+        deliveredText = "Hello world again";
+      },
+    });
+    answer.lastDeliveredText.mockImplementation(() => deliveredText);
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: (text) =>
+        text === "Hello world again" ? ["Hello", " world", " again"] : ["Hello"],
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.promptContextContent).toBe("Hello world again");
+    expect(answer.update).toHaveBeenCalledWith("Hello");
+    expect(harness.clearDraftLane).not.toHaveBeenCalled();
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps inline buttons on the current chunk of an already-streamed long final", async () => {
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+    const fullAnswer = "Hello world again";
+    const answer = createTestDraftStream({ messageId: 999 });
+    answer.lastDeliveredText.mockReturnValue(fullAnswer);
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 6,
+      splitFinalTextForStream: () => ["Hello", " world", " again"],
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: fullAnswer,
+      payload: { text: fullAnswer, channelData: { telegram: { buttons } } },
+      infoKind: "final",
+      buttons,
+    });
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.buttonsAttached).toBe(true);
+    expect(harness.editStreamMessage).toHaveBeenCalledWith({
+      laneName: "answer",
+      messageId: 999,
+      text: " again",
+      buttons,
+    });
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+  });
+
   it("retains the streamed message when stop may have landed without a message id", async () => {
     const answer = createTestDraftStream();
     answer.sendMayHaveLanded.mockReturnValue(true);


### PR DESCRIPTION
## Summary
- Finalize already-streamed long Telegram replies instead of falling back to a fresh durable send from byte zero.
- Send only the missing suffix when a final response extends the streamed prefix.
- Add regression coverage for full replay, pending flush, suffix-only follow-up, and inline-button preservation.

Refs #86519.

## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/lane-delivery.test.ts -- --reporter=verbose` -> 32 passed
- Telegram bot-to-bot E2E with mocked SSE: one-delta long response -> `bugExists: false`, `mockRequests: 1`, `restartedReplyIds: []`
- Telegram bot-to-bot E2E with mocked SSE: multi-delta long response -> `bugExists: false`, `mockRequests: 1`, `restartedReplyIds: []`
- `pnpm check:changed` currently fails in untouched `src/plugin-sdk/approval-reaction-runtime.ts:300` on latest `origin/main` (`ApprovalActionView.kind`), outside this diff.

Behavior addressed: duplicate Telegram replay after long streamed replies
Real environment tested: real Telegram bot-to-bot group with mocked OpenAI SSE
Exact steps or command run after this patch: focused Vitest, changed check, Telegram E2E long-response probes
Evidence after fix: no restarted segment-01 reply in either E2E run
Observed result after fix: long replies continue as Telegram chunks without replaying the beginning
What was not tested: full suite / Testbox