### PR TITLE
fix(plugin-sdk): type approval command actions

### DIFF
--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -10,12 +10,22 @@ import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-app
 
 type ApprovalPhase = "pending" | "resolved" | "expired";
 
-export type ApprovalActionView = {
+export type ApprovalDecisionActionView = {
+  kind?: "decision";
   decision: ExecApprovalDecision;
   label: string;
   style: NonNullable<InteractiveReplyButton["style"]>;
   command: string;
 };
+
+export type ApprovalCommandActionView = {
+  kind: "command";
+  label: string;
+  style: NonNullable<InteractiveReplyButton["style"]>;
+  command: string;
+};
+
+export type ApprovalActionView = ApprovalDecisionActionView | ApprovalCommandActionView;
 
 export type ApprovalMetadataView = {
   label: string;

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -187,27 +187,14 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
         request: {
           ...pluginRequest.request,
           title: "World proof required for exec",
-          actions: [
-            {
-              kind: "command",
-              label: "Verify once",
-              command: "/agentkit approve plugin:agentkit allow-once",
-              style: "success",
-            },
-            {
-              kind: "decision",
-              label: "Deny",
-              command: "/approve plugin:agentkit deny",
-              decision: "deny",
-              style: "danger",
-            },
-          ],
         },
       },
       view: {
         approvalKind: "plugin",
         approvalId: "plugin:agentkit",
+        phase: "pending",
         title: "World proof required for exec",
+        metadata: [],
         severity: "warning",
         actions: [
           {
@@ -224,7 +211,8 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
             style: "danger",
           },
         ],
-      } as never,
+        expiresAtMs: 61_000,
+      },
       nowMs: 1_000,
     });
 


### PR DESCRIPTION
## Summary
- type approval action views as decision actions or command-only actions
- remove the approval reaction test's `as never` workaround and keep the command action in the explicit pending view
- restore plugin SDK declaration/type checks that read `action.kind` for command-only approval prompt actions

## Verification
- `pnpm install --frozen-lockfile`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --pretty false --noEmit`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false --noEmit`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.plugin-sdk.config.ts --reporter=dot --testTimeout=10000`
- `node_modules/.bin/oxfmt --check src/infra/approval-view-model.types.ts src/plugin-sdk/approval-reaction-runtime.test.ts`
- `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/infra/approval-view-model.types.ts src/plugin-sdk/approval-reaction-runtime.test.ts src/plugin-sdk/approval-reaction-runtime.ts`
- `pnpm build:plugin-sdk:dts`
- `git diff --check origin/main...HEAD`

## Real behavior proof
Behavior addressed:
Approval reaction prompts now have a typed command-action branch, matching the runtime path that renders command-only approval instructions while excluding them from reaction bindings.

Real environment tested:
Local checkout `/media/vdc/0668001470/workSpace/claw-campaign/openclaw-approval-action-view` on Linux, Node `v22.22.0`, based on `origin/main` head `bda924b639`, patch head `a501e1d6a2`.

Exact steps or command run after this patch:
The verification commands above were run after applying the patch.

Evidence after fix:
The previously failing type/declaration path passed:

```text
$ pnpm build:plugin-sdk:dts
$ node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true
```

Plugin SDK tests also passed:

```text
RUN v4.1.7 ... openclaw-approval-action-view
Test Files 55 passed (55)
Tests 332 passed (332)
```

Observed result after fix:
`ApprovalActionView` accepts command-only actions with `kind: "command"` and decision actions with `kind: "decision"` or no kind, so `approval-reaction-runtime.ts` can safely read `action.kind` and `action.decision` without casts.

What was not tested:
No live channel approval flow was exercised; this is a type/SDK declaration repair covered by focused type checks, declaration build, and plugin SDK unit tests.
