### PR TITLE
fix(ui): preserve session picker on empty search blur

### DIFF
--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -594,7 +594,11 @@ function renderChatSessionPickerPopover(
                 void applyChatSessionPickerSearch(state);
               }
             }}
-            @blur=${() => void applyChatSessionPickerSearch(state)}
+            @blur=${() => {
+              if (normalizeOptionalString(state.chatSessionPickerQuery)) {
+                void applyChatSessionPickerSearch(state);
+              }
+            }}
           />
         </label>
         <button

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1433,6 +1433,92 @@ describe("chat session controls", () => {
     });
   });
 
+  it("does not destroy picker result when blurring an initially empty search input", async () => {
+    const { state, request } = createChatHeaderState();
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    await vi.waitFor(() => expect(state.chatSessionPickerResult).not.toBeNull());
+    render(renderChatSessionSelect(state), container);
+    const pickerResultBefore = state.chatSessionPickerResult;
+    const optionsBefore = container.querySelectorAll(
+      'button[data-chat-session-picker-option="true"]',
+    );
+    expect(optionsBefore.length).toBeGreaterThan(0);
+
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-chat-session-picker-search="true"]',
+    );
+    expect(input!.value).toBe("");
+    const searchCallsBefore = request.mock.calls.filter(
+      ([method]) => method === "sessions.list",
+    ).length;
+
+    input!.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+    render(renderChatSessionSelect(state), container);
+
+    expect(state.chatSessionPickerResult).toBe(pickerResultBefore);
+    expect(state.chatSessionPickerOpen).toBe(true);
+    const optionsAfter = container.querySelectorAll(
+      'button[data-chat-session-picker-option="true"]',
+    );
+    expect(optionsAfter.length).toBe(optionsBefore.length);
+    const searchCallsAfter = request.mock.calls.filter(
+      ([method]) => method === "sessions.list",
+    ).length;
+    expect(searchCallsAfter).toBe(searchCallsBefore);
+  });
+
+  it("session option click still works after blurring an empty search input", async () => {
+    const { state } = createChatHeaderState();
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
+    state.sessionsResult = createSessionsResultFromRows([
+      { key: "main", kind: "direct", label: "Main", updatedAt: 2 },
+      { key: "agent:main:work", kind: "direct", label: "Work", updatedAt: 1 },
+    ]);
+    const request = vi.fn((method: string) => {
+      if (method === "sessions.list") {
+        return Promise.resolve(
+          createSessionsResultFromRows([
+            { key: "main", kind: "direct", label: "Main", updatedAt: 2 },
+            { key: "agent:main:work", kind: "direct", label: "Work", updatedAt: 1 },
+          ]),
+        );
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    state.client = { request } as unknown as GatewayBrowserClient;
+    const onSwitchSession = vi.fn();
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state, onSwitchSession), container);
+
+    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    await vi.waitFor(() => expect(state.chatSessionPickerResult).not.toBeNull());
+    render(renderChatSessionSelect(state, onSwitchSession), container);
+
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-chat-session-picker-search="true"]',
+    );
+    expect(input!.value).toBe("");
+    input!.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+    render(renderChatSessionSelect(state, onSwitchSession), container);
+
+    const options = container.querySelectorAll<HTMLButtonElement>(
+      'button[data-chat-session-picker-option="true"]',
+    );
+    const target = [...options].find(
+      (button) => button.dataset.sessionKey && button.dataset.sessionKey !== state.sessionKey,
+    );
+    expect(target).toBeTruthy();
+    target!.click();
+
+    expect(onSwitchSession).toHaveBeenCalledWith(state, target!.dataset.sessionKey);
+  });
+
   it("clears applied chat session picker search when the input is cleared", async () => {
     const { state } = createChatHeaderState();
     state.sessionsIncludeGlobal = false;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

* Fixes a Control UI bug where the chat session picker cannot switch sessions when the initially empty focused search input blurs before a picker option click completes.
* Fixes the same empty-blur state transition breaking keyboard navigation from the search input into the picker controls.
* Adds focused regression coverage for preserving picker state after empty blur and retaining native click activation.

Why does this matter now?

* This is a user-visible regression reproducible in the shipped Control UI and currently blocks normal session switching in Chromium-based browsers.
* Existing alternative fixes either change button activation semantics or rely on timing deferral, while this change addresses the destructive empty-query state transition directly.

What is the intended outcome?

* When the picker opens with an empty search query, blurring the search input no longer clears the current picker result or destroys the available option controls.
* When the query is non-empty, blur-triggered search continues to behave as before.
* Existing native pointer and keyboard activation paths remain intact.

What is intentionally out of scope?

* No changes to picker button activation events.
* No broader refactor of session picker state management.
* No changes to the native agent filter `<select>`, which uses a separate `@change` path and does not share this blur/search behavior.

What does success look like?

* Mouse selection works after opening the picker with its initially empty focused search field.
* Tab navigation and native keyboard activation remain usable.
* Non-empty blur-triggered search and clearing search continue to work.
* Regression tests fail without the fix and pass with it.

What should reviewers focus on?

* Whether guarding the blur handler is the appropriate boundary for preserving explicit Enter/search-action behavior.
* Whether the regression tests cover the destructive empty-blur path without changing native activation semantics.

AI-assisted: I used ChatGPT , Claude Code and Codex CLI to investigate the issue, prepare the source change and regression tests, and review validation steps. I manually verified the root cause, reviewed the final diff, ran the listed validation commands, and recorded before/after browser behavior using an isolated source-built test environment. I understand the change: the blur handler now skips `applyChatSessionPickerSearch(state)` only when the current query normalizes to empty, preventing the initial empty-picker result from being cleared while retaining explicit search and non-empty blur behavior.

## Linked context

Which issue does this close?

Closes #87554 

Was this requested by a maintainer or owner?

* No. This is a focused fix for a reported and reproduced user-visible bug.

## Real behavior proof (required for external PRs)

* Behavior or issue addressed: The Control UI chat session picker fails to switch sessions when its initially empty focused search input blurs before a session option click completes. The same empty-blur path also prevents normal Tab navigation into the picker controls.

* Real environment tested: Chromium on macOS, connected through VS Code port forwarding to an isolated `picker-proof` OpenClaw Gateway profile running from this source checkout inside a Dev Container on port `19789`.

* Exact steps or command run after this patch:

  ```bash
  pnpm ui:build
  pnpm openclaw --profile picker-proof setup
  export OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)"
  pnpm openclaw --profile picker-proof gateway --port 19789 --verbose
  ```

  In the Control UI, I then:

  1. Opened the chat session picker with the initially empty search input focused.
  2. Clicked another session option.
  3. Reopened the picker and pressed Tab from the empty focused search input.
  4. Activated a session option through keyboard interaction.
  5. Entered a non-empty search query and blurred the input.
  6. Cleared the search and verified that the full session list returned.

* Evidence after fix:

  Patch commit: `6c55ff0535` (`6c55ff0` shown by the running source checkout)

https://github.com/user-attachments/assets/bbdca7b4-889f-47ff-a2b7-d865f46cbbbf

* Observed result after fix:

  * Clicking another session while the initially empty search input is focused switches sessions successfully.
  * Pressing Tab from the initially empty focused search input preserves the picker controls and allows keyboard navigation.
  * Keyboard activation of a session option remains usable.
  * Blurring a non-empty search query still applies the search.
  * Clearing search restores the unfiltered session list.

* What was not tested:

  * Mobile browser interaction.
  * Safari and Firefox behavior.
  * A production profile containing real user sessions or configured channels.

* Proof limitations or environment constraints:

  * The browser proof used an isolated local Gateway profile with synthetic test sessions rather than an existing production profile.
  * The Gateway was run from a Dev Container with an ephemeral token for local port-forwarded browser access.

* Before evidence:

  Base commit: `e5a687f115`

  Using the same isolated `picker-proof` profile and interaction flow on the direct parent commit, I reproduced:

  * clicking another session from the initially empty focused search state failing to switch sessions;
  * Tab navigation from the initially empty focused search input failing to move normally into picker controls.

https://github.com/user-attachments/assets/3bfb0c77-2c4d-4307-ba36-fa82f482a91a

## Tests and validation

Which commands did you run?

```bash
git diff --check upstream/main...HEAD
pnpm test ui/src/ui/views/chat.test.ts
pnpm check:changed
pnpm ui:build
pnpm build
```

Results:

* `git diff --check upstream/main...HEAD`: passed.
* `pnpm test ui/src/ui/views/chat.test.ts`: passed, 60/60 tests.
* `pnpm ui:build`: passed and was used for the browser proof.
* `pnpm check:changed`: fails only in the zero-diagnostic `typecheck all` lane; the identical failure reproduces on clean updated `upstream/main` without this patch.
* `pnpm build`: attempted in the Dev Container, but `tsdown` was terminated with `SIGKILL` and emitted no source diagnostic. The focused Control UI build and focused test suite completed successfully.

What regression coverage was added or updated?

* Added a regression test verifying that blurring an initially empty search input does not destroy/reset the picker result state or its option controls.
* Added a regression test verifying that native session option click activation still works after the empty-input blur scenario.
* Existing test coverage continues to verify that a non-empty query is applied on blur.

What failed before this fix, if known?

Red validation was performed by retaining the new regression tests while temporarily restoring the unpatched source behavior:

```text
Tests: 2 failed, 58 passed
```

The failures confirmed that:

* empty-input blur nullified `chatSessionPickerResult`;
* session option buttons did not survive the destructive empty-blur re-render.

With the source fix restored:

```text
Tests: 60 passed
```

If no test was added, why not?

* Not applicable; focused regression tests were added.

Local AI review:

* Ran `codex review --base upstream/main`.
* Result: `No discrete correctness issues were identified in the reviewed changes.`

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

* Yes. The session picker now remains interactive when its initially empty focused search input blurs.

Did config, environment, or migration behavior change? (`Yes/No`)

* No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

* No.

What is the highest-risk area?

* The highest-risk area is changing when blur-triggered search runs, because blur is also used to flush pending non-empty searches.

How is that risk mitigated?

* The guard skips work only when `chatSessionPickerQuery` normalizes to empty.
* Non-empty blur-triggered search behavior remains covered by existing tests.
* New regression tests cover empty-blur state preservation and native session option activation.
* Manual browser proof verifies mouse switching, Tab navigation, keyboard activation, non-empty blur search, and clear-search behavior.

## Current review state

What is the next action?

* Await a fresh ClawSweeper review after the previous automated review timed out.

What is still waiting on author, maintainer, CI, or external proof?

* ClawSweeper: re-review requested because the previous Codex-backed review timed out before evaluating the patch and attached proof.
* CI: completed with failures that require separate triage.
* Maintainer: review the blur-handler boundary and focused regression coverage after automated review completes.

Which bot or reviewer comments were addressed?

* ClawSweeper's initial review did not complete because its internal Codex invocation timed out (`spawnSync codex ETIMEDOUT`); no code finding or inline review thread was produced.
* Before opening this PR, I checked the issue comment suggesting a separate `.value`-bound session select path. In current source, desktop and mobile use the same session picker implementation covered by this fix; the `.value`-bound native select is the agent filter and does not call the picker search or clear functions.


