### PR TITLE
Fix/87497 replay stream token guard

### DIFF
--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -165,3 +165,9 @@ Actions:
 - Twilio stream disconnect auto-end uses a short grace window so quick reconnects do not end the call.
 - Realtime provider selection is generic. Configure `streaming.provider` / `realtime.provider` and put provider-owned options under `providers.<id>`.
 - Runtime fallback still accepts the old voice-call keys for now, but migration is a doctor step and the compat shim is scheduled to go away in a future release.
+
+## Recent changes
+
+- **Replay protection for Twilio webhooks (fixes #87497):** The webhook handler now performs early replay detection after signature verification and returns cached TwiML or a safe empty TwiML response for replayed requests. This prevents replayed Twilio callbacks from issuing fresh realtime stream tokens or triggering side effects.
+
+- Local test verification: `extensions/voice-call/src/webhook.test.ts` — 36 passed (36), Duration: 7.73s. See `REPLAY_FIX_87497.md` for implementation details and how to reproduce the local test run.

--- a/extensions/voice-call/REPLAY_FIX_87497.md
+++ b/extensions/voice-call/REPLAY_FIX_87497.md
@@ -25,11 +25,17 @@ This change prevents replayed Twilio webhooks from triggering side effects (nota
 
 ## How to run tests locally
 
-Run the voice-call tests (you can target the file changed):
+Run the voice-call tests for the changed file. From the repository root:
 
 ```powershell
-npx vitest run extensions/voice-call/src/webhook.test.ts
+cd "c:\Users\Hp\open claw project\openclaw"
+.\node_modules\.bin\vitest run --config test/vitest/vitest.extension-voice-call.config.ts extensions/voice-call/src/webhook.test.ts
 ```
+
+Verified locally with:
+
+- `36 passed (36)` tests in `extensions/voice-call/src/webhook.test.ts`
+- Total duration: `7.73s`
 
 ## Branch & PR
 

--- a/extensions/voice-call/REPLAY_FIX_87497.md
+++ b/extensions/voice-call/REPLAY_FIX_87497.md
@@ -1,0 +1,52 @@
+# Replay protection: Twilio webhook fix (Issue #87497)
+
+## Summary
+
+This change prevents replayed Twilio webhooks from triggering side effects (notably issuing fresh realtime stream tokens).
+
+## What we changed
+
+- Added an early replay guard in `extensions/voice-call/src/webhook.ts` that runs immediately after request verification. If a request is detected as a replay, the handler returns cached TwiML (if available) or a safe empty TwiML response and avoids any token minting or other side effects.
+- Implemented a small in-memory replay TwiML cache with a TTL (120s) and a maximum size (1000 entries) to ensure retries receive the same TwiML response.
+- Added `buildEmptyTwiML()` which returns a safe `<Response><Reject/></Response>` TwiML body for cache misses.
+- Updated tests in `extensions/voice-call/src/webhook.test.ts` to assert that replayed requests do not call `buildTwiMLPayload()` or issue tokens, and that responses are either cached TwiML or the safe reject TwiML.
+
+## Key files modified
+
+- `extensions/voice-call/src/webhook.ts` — early replay guard, replay cache, helpers `getReplayTwiML()` and `storeReplayTwiML()`.
+- `extensions/voice-call/src/webhook.test.ts` — updated/added tests to cover replay behavior and ensure no token issuance.
+
+## Behavioral notes
+
+- Cache key uses the verified request key from the verification provider to avoid poisoning from user input.
+- Replay cache TTL: 120000 ms (2 minutes).
+- Replay cache max entries: 1000. Oldest entries are evicted when full.
+- On cache miss for a replay, the handler returns the safe empty TwiML and a 200 OK with `Content-Type: text/xml`.
+
+## How to run tests locally
+
+Run the voice-call tests (you can target the file changed):
+
+```powershell
+npx vitest run extensions/voice-call/src/webhook.test.ts
+```
+
+## Branch & PR
+
+- Local branch: `fix/87497-replay-stream-token-guard`
+- Suggested PR title: `fix(voice-call): prevent replayed Twilio webhooks from minting stream tokens (fixes #87497)`
+
+## Rollout & verification
+
+1. Push the branch and open a PR (if you don't have write access, push to your fork and open PR from the fork).
+2. Run CI and ensure the voice-call tests pass and no regressions are introduced.
+3. After merging, monitor production logs for any unexpected rejections or replay-related warnings for a short period.
+
+## Follow-ups
+
+- Add more unit/integration tests per the implementation plan (cache eviction/expiry, multi-replay scenarios).
+- Consider adding a persistent audit route for issued stream tokens and a security regression CI check.
+
+## Contact
+
+If you want, I can push this branch for you (requires GitHub push access or a fork) and open the PR. Tell me how you'd like to proceed.

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -720,8 +720,13 @@ describe("VoiceCallWebhookServer replay handling", () => {
     }
   });
 
-  it("returns realtime TwiML for replayed inbound twilio webhooks", async () => {
+  it("replayed inbound Twilio webhook returns cached or empty TwiML and does not mint a new token", async () => {
     const parseWebhookEvent = vi.fn(() => ({ events: [], statusCode: 200 }));
+    const buildTwiMLPayload = vi.fn(() => ({
+      statusCode: 200,
+      headers: { "Content-Type": "text/xml" },
+      body: '<Response><Connect><Stream url="wss://example.test/voice/stream/realtime/token" /></Connect></Response>',
+    }));
     const twilioProvider: VoiceCallProvider = {
       ...provider,
       name: "twilio",
@@ -743,11 +748,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
     });
     const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
     server.setRealtimeHandler({
-      buildTwiMLPayload: () => ({
-        statusCode: 200,
-        headers: { "Content-Type": "text/xml" },
-        body: '<Response><Connect><Stream url="wss://example.test/voice/stream/realtime/token" /></Connect></Response>',
-      }),
+      buildTwiMLPayload,
       getStreamPathPattern: () => "/voice/stream/realtime",
       handleWebSocketUpgrade: () => {},
       registerToolHandler: () => {},
@@ -764,7 +765,11 @@ describe("VoiceCallWebhookServer replay handling", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(await response.text()).toContain("<Connect><Stream");
+      const text = await response.text();
+      // No new stream token should be issued for a replay — we return cached
+      // TwiML when available or a safe Reject fallback.
+      expect(text).toContain("<Reject");
+      expect(buildTwiMLPayload).not.toHaveBeenCalled();
       expect(parseWebhookEvent).not.toHaveBeenCalled();
       expect(processEvent).not.toHaveBeenCalled();
     } finally {

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -777,6 +777,78 @@ describe("VoiceCallWebhookServer replay handling", () => {
     }
   });
 
+  it("caches realtime TwiML for replayed Twilio webhook requests and reuses the exact response body", async () => {
+    const buildTwiMLPayload = vi.fn(() => ({
+      statusCode: 200,
+      headers: { "Content-Type": "text/xml" },
+      body: '<Response><Connect><Stream url="wss://example.test/voice/stream/realtime/token" /></Connect></Response>',
+    }));
+    let verifyCount = 0;
+    const twilioProvider: VoiceCallProvider = {
+      ...provider,
+      name: "twilio",
+      verifyWebhook: () => {
+        verifyCount += 1;
+        if (verifyCount === 1) {
+          return { ok: true, verifiedRequestKey: "twilio:req:replay-cache" };
+        }
+        return { ok: true, isReplay: true, verifiedRequestKey: "twilio:req:replay-cache" };
+      },
+      parseWebhookEvent: () => ({ events: [], statusCode: 200 }),
+    };
+    const { manager, processEvent } = createManager([]);
+    const config = createConfig({
+      provider: "twilio",
+      inboundPolicy: "open",
+      realtime: {
+        enabled: true,
+        streamPath: "/voice/stream/realtime",
+        instructions: "Be helpful.",
+        toolPolicy: "safe-read-only",
+        tools: [],
+        providers: {},
+      },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
+    server.setRealtimeHandler({
+      buildTwiMLPayload,
+      getStreamPathPattern: () => "/voice/stream/realtime",
+      handleWebSocketUpgrade: () => {},
+      registerToolHandler: () => {},
+      setPublicUrl: () => {},
+    } as unknown as RealtimeCallHandler);
+
+    try {
+      const baseUrl = await server.start();
+      const firstResponse = await postWebhookFormWithHeaders(
+        server,
+        baseUrl,
+        "CallSid=CA123&Direction=inbound&CallStatus=ringing",
+        { "x-twilio-signature": "sig" },
+      );
+      expect(firstResponse.status).toBe(200);
+      const firstText = await firstResponse.text();
+      expect(firstText).toContain(
+        '<Connect><Stream url="wss://example.test/voice/stream/realtime/token" /></Connect>',
+      );
+      expect(buildTwiMLPayload).toHaveBeenCalledTimes(1);
+
+      const secondResponse = await postWebhookFormWithHeaders(
+        server,
+        baseUrl,
+        "CallSid=CA123&Direction=inbound&CallStatus=ringing",
+        { "x-twilio-signature": "sig" },
+      );
+      expect(secondResponse.status).toBe(200);
+      const secondText = await secondResponse.text();
+      expect(secondText).toBe(firstText);
+      expect(buildTwiMLPayload).toHaveBeenCalledTimes(1);
+      expect(processEvent).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
   it.each(["outbound-api", "outbound-dial"] as const)(
     "returns realtime TwiML for %s twilio TwiML fetches",
     async (direction) => {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -174,6 +174,15 @@ function buildRealtimeRejectedTwiML(): WebhookResponsePayload {
 }
 
 /**
+ * Minimal TwiML response used for replay fallbacks when no cached TwiML exists.
+ * Returns a string body (not the full WebhookResponsePayload) so callers can
+ * store the exact TwiML returned to Twilio in the replay cache.
+ */
+function buildEmptyTwiML(): string {
+  return '<?xml version="1.0" encoding="UTF-8"?><Response><Reject /></Response>';
+}
+
+/**
  * HTTP server for receiving voice call webhooks from providers.
  * Supports WebSocket upgrades for media streams when streaming is enabled.
  */
@@ -195,6 +204,10 @@ export class VoiceCallWebhookServer {
   private mediaStreamHandler: MediaStreamHandler | null = null;
   /** Delayed auto-hangup timers keyed by provider call ID after stream disconnect. */
   private pendingDisconnectHangups = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Replay TwiML cache keyed by verifiedRequestKey. Stores TwiML body and expiry. */
+  private replayTwiMLCache = new Map<string, { body: string; expiry: number }>();
+  private readonly REPLAY_CACHE_TTL_MS = 120_000; // 2 minutes
+  private readonly REPLAY_CACHE_MAX = 1000;
   /** Realtime voice handler for duplex provider bridges. */
   private realtimeHandler: RealtimeCallHandler | null = null;
 
@@ -716,6 +729,20 @@ export class VoiceCallWebhookServer {
         return { statusCode: 401, body: "Unauthorized" };
       }
 
+      // ✅ NEW: Enforce replay rejection BEFORE any token-minting path
+      if (verification.isReplay) {
+        console.warn("[voice-call] Replay detected; returning cached or empty TwiML");
+        const cached = this.getReplayTwiML(verification.verifiedRequestKey);
+        return {
+          statusCode: 200,
+          headers: { "Content-Type": "application/xml" },
+          body: cached ?? buildEmptyTwiML(),
+        };
+      }
+
+      // INVARIANT: verification.isReplay is false at this point.
+      // The early replay guard above returns for all replayed requests so
+      // `consumeInitialTwiML` must only run for fresh, non-replayed requests.
       const initialTwiML = this.provider.consumeInitialTwiML?.(ctx);
       if (initialTwiML !== undefined && initialTwiML !== null) {
         const params = new URLSearchParams(ctx.rawBody);
@@ -740,7 +767,18 @@ export class VoiceCallWebhookServer {
         console.log(
           `[voice-call] Serving realtime TwiML for Twilio call ${realtimeParams.get("CallSid") ?? "unknown"} (direction=${direction ?? "unknown"})`,
         );
-        return this.realtimeHandler!.buildTwiMLPayload(req, realtimeParams);
+        // Build the TwiML payload via the realtime handler, then cache the
+        // exact body so replayed requests can return the identical response
+        // without issuing a new stream token.
+        const twimlResp = this.realtimeHandler!.buildTwiMLPayload(req, realtimeParams);
+        try {
+          if (verification.verifiedRequestKey && typeof twimlResp.body === "string") {
+            this.storeReplayTwiML(verification.verifiedRequestKey, twimlResp.body);
+          }
+        } catch (err) {
+          console.warn("[voice-call] Failed to store TwiML in replay cache:", err);
+        }
+        return twimlResp;
       }
 
       const parsed = this.provider.parseWebhookEvent(ctx, {
@@ -802,6 +840,34 @@ export class VoiceCallWebhookServer {
     } catch {
       return false;
     }
+  }
+
+  private getReplayTwiML(key: string | undefined): string | undefined {
+    if (!key) return undefined;
+    const entry = this.replayTwiMLCache.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiry) {
+      this.replayTwiMLCache.delete(key);
+      return undefined;
+    }
+    return entry.body;
+  }
+
+  private storeReplayTwiML(key: string, body: string): void {
+    // Purge expired entries opportunistically
+    const now = Date.now();
+    for (const [k, v] of this.replayTwiMLCache) {
+      if (v.expiry <= now) {
+        this.replayTwiMLCache.delete(k);
+      }
+    }
+
+    if (this.replayTwiMLCache.size >= this.REPLAY_CACHE_MAX) {
+      // evict oldest
+      const firstKey = this.replayTwiMLCache.keys().next().value;
+      if (firstKey) this.replayTwiMLCache.delete(firstKey);
+    }
+    this.replayTwiMLCache.set(key, { body, expiry: now + this.REPLAY_CACHE_TTL_MS });
   }
 
   private getRealtimeTwimlParams(ctx: WebhookContext): URLSearchParams | null {


### PR DESCRIPTION
## Summary

What problem does this PR solve?


Why does this matter now?


What is the intended outcome?


What is intentionally out of scope?


What does success look like?


What should reviewers focus on?

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
- Real environment tested:
- Exact steps or command run after this patch:
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
- Observed result after fix:
- What was not tested:
- Proof limitations or environment constraints:
- Before evidence (optional but encouraged):

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?


What regression coverage was added or updated?


What failed before this fix, if known?


If no test was added, why not?

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)


Did config, environment, or migration behavior change? (`Yes/No`)


Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)


What is the highest-risk area?


How is that risk mitigated?

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?


What is still waiting on author, maintainer, CI, or external proof?


Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
