### PR TITLE
feat(skills): add SkillRouter abstraction for pre-routing

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-3682bfa2cc3e6253f70be831afffea9f14d6f343eb0b18e109f01457af524b9c  plugin-sdk-api-baseline.json
-5c7b4f20d9026ea5a0faf67e382b3ea3d60d4525b366e44c291519bd91548232  plugin-sdk-api-baseline.jsonl
+05ce13ad6d2ef72af943a61a023e26f58d01e37a04f76e279a933df9b6aed05b  plugin-sdk-api-baseline.json
+628a6ac85acd5ed71236b07d5760e211b9c0698ea529d5b3101c20579926b0ea  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-172fe4e143964c0a20525428ff3e6c7631856a7d51c6ad48959a35c72363a410  plugin-sdk-api-baseline.json
-a4c18ea9f0b0d2c22183bf8c082e757b7f9852b4c518c8b8cb62a21a9dd766e9  plugin-sdk-api-baseline.jsonl
+3682bfa2cc3e6253f70be831afffea9f14d6f343eb0b18e109f01457af524b9c  plugin-sdk-api-baseline.json
+5c7b4f20d9026ea5a0faf67e382b3ea3d60d4525b366e44c291519bd91548232  plugin-sdk-api-baseline.jsonl

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyEmbeddedAttemptToolsAllow,
   mergeForcedEmbeddedAttemptToolsAllow,
+  isRestrictiveEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
   shouldCreateBundleLspRuntimeForAttempt,
   shouldCreateBundleMcpRuntimeForAttempt,
@@ -177,6 +178,16 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
       "includeCoreTools",
       false,
     );
+  });
+});
+
+describe("isRestrictiveEmbeddedAttemptToolsAllow", () => {
+  it("matches the existing runtime allowlist wildcard semantics", () => {
+    expect(isRestrictiveEmbeddedAttemptToolsAllow(undefined)).toBe(false);
+    expect(isRestrictiveEmbeddedAttemptToolsAllow(["*"])).toBe(false);
+    expect(isRestrictiveEmbeddedAttemptToolsAllow([" * "])).toBe(false);
+    expect(isRestrictiveEmbeddedAttemptToolsAllow([])).toBe(true);
+    expect(isRestrictiveEmbeddedAttemptToolsAllow(["sessions_spawn"])).toBe(true);
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -100,8 +100,9 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
   it("keeps plugin-only allowlists on the shared tool policy path", () => {
     const tools = [{ name: "memory_search" }, { name: "plugin_extra" }];
 
-    expect(resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: ["memory_search"] }))
-      .toHaveProperty("includeCoreTools", false);
+    expect(
+      resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: ["memory_search"] }),
+    ).toHaveProperty("includeCoreTools", false);
     expect(
       applyEmbeddedAttemptToolsAllow(tools, ["memory_search"]).map((tool) => tool.name),
     ).toEqual(["memory_search"]);

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -85,6 +85,10 @@ function hasWildcardToolAllowlist(toolsAllow: string[]): boolean {
   return toolsAllow.some((entry) => normalizeToolName(entry) === "*");
 }
 
+export function isRestrictiveEmbeddedAttemptToolsAllow(toolsAllow?: string[]): boolean {
+  return toolsAllow !== undefined && !hasWildcardToolAllowlist(toolsAllow);
+}
+
 function isKnownLocalCodingToolName(normalized: string): boolean {
   // Unknown non-bundle names are treated as plugin tools so installed plugin
   // catalog entries still materialize under narrow allowlists.

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -23,12 +23,19 @@ import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-pr
 import { wrapPluginSystemContextSection } from "../../hook-system-context-boundary.js";
 import { buildActiveImageGenerationTaskPromptContextForSession } from "../../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import {
+  buildSessionContext as buildSessionContextFromEntries,
+  loadEntriesFromFile,
+  type SessionEntry,
+} from "../../sessions/index.js";
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { derivePromptTokens, type NormalizedUsage } from "../../usage.js";
 import { buildActiveVideoGenerationTaskPromptContextForSession } from "../../video-generation-task-status.js";
 import { buildEmbeddedCompactionRuntimeContext } from "../compaction-runtime-context.js";
 import { resolveContextEngineCapabilities } from "../context-engine-capabilities.js";
+import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
 import { log } from "../logger.js";
 import { shouldInjectHeartbeatPromptForTrigger } from "./trigger-policy.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
@@ -93,6 +100,28 @@ function rememberDrainedInjections(
 export function forgetPromptBuildDrainCacheForRun(runId: string | undefined): void {
   if (runId) {
     promptBuildDrainCache.delete(runId);
+  }
+}
+
+export function loadSkillRouteRecentMessages(params: {
+  config?: EmbeddedRunAttemptParams["config"];
+  sessionFile: string;
+  sessionKey?: string;
+}): AgentMessage[] {
+  try {
+    const entries = loadEntriesFromFile(params.sessionFile).filter(
+      (entry): entry is SessionEntry => entry.type !== "session",
+    );
+    if (entries.length === 0) {
+      return [];
+    }
+    const messages = buildSessionContextFromEntries(entries).messages;
+    return limitHistoryTurns(
+      messages,
+      getHistoryLimitFromSessionKey(params.sessionKey, params.config),
+    );
+  } catch {
+    return [];
   }
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1166,10 +1166,13 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         skillsSnapshot: undefined,
       },
     );
-    expectFields(mockParams(hoisted.resolveSkillsPromptForRunMock, 0, "skills prompt params"), {
-      workspaceDir: sandboxWorkspace,
-      skillsSnapshot: undefined,
-    });
+    expectFields(
+      mockParams(hoisted.resolveSkillsPromptStateForRunMock, 0, "skills prompt params"),
+      {
+        workspaceDir: sandboxWorkspace,
+        skillsSnapshot: undefined,
+      },
+    );
   });
 
   it("keeps before_prompt_build context in the model prompt and out of transcript messages", async () => {
@@ -2232,6 +2235,16 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       runBeforeAgentStart: vi.fn(async () => ({ prependContext: "legacy hook context" })),
       runLlmInput,
     });
+    hoisted.resolveSkillsPromptStateForRunMock.mockReturnValue({
+      prompt: "<available_skills></available_skills>",
+      resolvedSkills: [
+        {
+          name: "raw-run-skill",
+          description: "Should not be routed",
+          filePath: "/tmp/skills/raw-run-skill/SKILL.md",
+        },
+      ],
+    });
     const seen: { prompt?: string; messages?: unknown[]; systemPrompt?: string } = {};
 
     const result = await createContextEngineAttemptRunner({
@@ -2249,6 +2262,11 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       attemptOverrides: {
         promptMode: "none",
         disableTools: true,
+        config: {
+          skills: {
+            router: { name: "test-router" },
+          },
+        },
         inputProvenance: {
           kind: "inter_session",
           sourceSessionKey: "agent:main:discord:source",
@@ -2272,6 +2290,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(seen.systemPrompt ?? "").toBe("");
     expect(result.finalPromptText).toBe("hello");
     expect(result.systemPromptReport?.systemPrompt ?? "").toBe("");
+    expect(hoisted.resolveSkillRouteMock).not.toHaveBeenCalled();
     expect(result.messagesSnapshot).toHaveLength(1);
     expectFields(requireRecord(result.messagesSnapshot[0], "gateway model snapshot"), {
       role: "assistant",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2383,6 +2383,52 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(routeParams.recentMessages()).toStrictEqual([]);
   });
 
+  it("sends routed skill XML to the provider prompt without persisting it as user text", async () => {
+    const runLlmInput = vi.fn(async () => {});
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((name: string) => name === "llm_input"),
+      runLlmInput,
+    });
+    hoisted.resolveSkillsPromptStateForRunMock.mockReturnValue({
+      prompt: "<available_skills><skill><name>full-catalog</name></skill></available_skills>",
+      resolvedSkills: [
+        {
+          name: "routed-skill",
+          description: "Can be routed",
+          filePath: "/tmp/skills/routed-skill/SKILL.md",
+        },
+      ],
+    });
+    hoisted.resolveSkillRouteMock.mockResolvedValue({
+      xml: "<available_skills><skill><name>routed-skill</name></skill></available_skills>",
+      mode: "direct",
+    });
+    const seen: { prompt?: string } = {};
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        config: {
+          skills: {
+            router: { name: "test-router" },
+          },
+        },
+      },
+      sessionPrompt: async (_session, prompt) => {
+        seen.prompt = prompt;
+      },
+    });
+
+    expect(seen.prompt).toBe("hello");
+    expect(hoisted.systemPromptTexts.at(-1) ?? "").not.toContain("full-catalog");
+    const llmInput = mockParams(runLlmInput, 0, "llm input params");
+    expect(llmInput.prompt).toContain("<available_skills>");
+    expect(llmInput.prompt).toContain("routed-skill");
+    expect(llmInput.prompt).toContain("hello");
+  });
+
   it("passes recent session text into skill routing queries", async () => {
     hoisted.resolveSkillsPromptStateForRunMock.mockReturnValue({
       prompt: "<available_skills></available_skills>",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2304,6 +2304,82 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(runLlmInput).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { label: "non-empty allowlist", toolsAllow: ["sessions_spawn"] },
+    { label: "empty allowlist", toolsAllow: [] },
+  ])("skips skill routing for toolsAllow restricted runs: $label", async ({ toolsAllow }) => {
+    hoisted.resolveSkillsPromptStateForRunMock.mockReturnValue({
+      prompt: "<available_skills></available_skills>",
+      resolvedSkills: [
+        {
+          name: "restricted-run-skill",
+          description: "Should not be routed",
+          filePath: "/tmp/skills/restricted-run-skill/SKILL.md",
+        },
+      ],
+    });
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+        toolsAllow,
+        config: {
+          skills: {
+            router: { name: "test-router" },
+          },
+        },
+      },
+    });
+
+    expect(hoisted.resolveSkillsPromptStateForRunMock).toHaveBeenCalled();
+    expect(hoisted.systemPromptOverrideTexts.at(-1) ?? "").not.toContain("<available_skills>");
+    expect(hoisted.resolveSkillRouteMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps skill routing enabled for wildcard toolsAllow runs", async () => {
+    hoisted.resolveSkillsPromptStateForRunMock.mockReturnValue({
+      prompt: "<available_skills></available_skills>",
+      resolvedSkills: [
+        {
+          name: "wildcard-run-skill",
+          description: "Can be routed",
+          filePath: "/tmp/skills/wildcard-run-skill/SKILL.md",
+        },
+      ],
+    });
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+        toolsAllow: ["*"],
+        config: {
+          skills: {
+            router: { name: "test-router" },
+          },
+        },
+      },
+    });
+
+    expect(hoisted.resolveSkillRouteMock).toHaveBeenCalledWith({
+      routerName: "test-router",
+      routerConfig: undefined,
+      resolvedSkills: [
+        {
+          name: "wildcard-run-skill",
+          description: "Can be routed",
+          filePath: "/tmp/skills/wildcard-run-skill/SKILL.md",
+        },
+      ],
+      query: "hello",
+    });
+  });
+
   it("forwards sessionKey to bootstrap, assemble, and afterTurn", async () => {
     const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
     const afterTurn = vi.fn(async (_params: { sessionKey?: string }) => {});

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2335,7 +2335,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     });
 
     expect(hoisted.resolveSkillsPromptStateForRunMock).toHaveBeenCalled();
-    expect(hoisted.systemPromptOverrideTexts.at(-1) ?? "").not.toContain("<available_skills>");
+    expect(hoisted.systemPromptTexts.at(-1) ?? "").not.toContain("<available_skills>");
     expect(hoisted.resolveSkillRouteMock).not.toHaveBeenCalled();
   });
 
@@ -2377,7 +2377,105 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         },
       ],
       query: "hello",
+      recentMessages: expect.any(Function),
     });
+    const routeParams = mockParams(hoisted.resolveSkillRouteMock, 0, "skill route params");
+    expect(routeParams.recentMessages()).toStrictEqual([]);
+  });
+
+  it("passes recent session text into skill routing queries", async () => {
+    hoisted.resolveSkillsPromptStateForRunMock.mockReturnValue({
+      prompt: "<available_skills></available_skills>",
+      resolvedSkills: [
+        {
+          name: "github-skill",
+          description: "GitHub PR work",
+          filePath: "/tmp/skills/github-skill/SKILL.md",
+        },
+      ],
+    });
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      sessionFileEntries: [
+        {
+          type: "session",
+          version: 1,
+          id: "session-with-router-context",
+          timestamp: "2026-05-29T00:00:00.000Z",
+          cwd: "/tmp/openclaw",
+        },
+        {
+          type: "message",
+          id: "u1",
+          parentId: null,
+          timestamp: "2026-05-29T00:00:01.000Z",
+          message: {
+            role: "user",
+            content: "I need to review a GitHub pull request.",
+            timestamp: 1,
+          },
+        },
+        {
+          type: "message",
+          id: "a1",
+          parentId: "u1",
+          timestamp: "2026-05-29T00:00:02.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Use the GitHub workflow for that review." }],
+            api: "test",
+            provider: "test",
+            model: "test",
+            stopReason: "stop",
+            timestamp: 2,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+        },
+      ],
+      attemptOverrides: {
+        prompt: "do that",
+        config: {
+          skills: {
+            router: { name: "test-router" },
+          },
+        },
+      },
+    });
+
+    const routeParams = mockParams(hoisted.resolveSkillRouteMock, 0, "skill route params");
+    expect(routeParams.query).toBe("do that");
+    expect(routeParams.recentMessages()).toStrictEqual([
+      {
+        role: "user",
+        content: "I need to review a GitHub pull request.",
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Use the GitHub workflow for that review." }],
+        api: "test",
+        provider: "test",
+        model: "test",
+        stopReason: "stop",
+        timestamp: 2,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+    ]);
   });
 
   it("forwards sessionKey to bootstrap, assemble, and afterTurn", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -85,6 +85,8 @@ type AttemptSpawnWorkspaceHoisted = {
   resolveEmbeddedRunSkillEntriesMock: UnknownMock;
   resolveSkillsPromptStateForRunMock: UnknownMock;
   resolveSkillRouteMock: UnknownMock;
+  loadEntriesFromFileMock: UnknownMock;
+  buildSessionContextFromEntriesMock: UnknownMock;
   supportsModelToolsMock: Mock<(model?: unknown) => boolean>;
   getGlobalHookRunnerMock: Mock<() => unknown>;
   initializeGlobalHookRunnerMock: UnknownMock;
@@ -184,6 +186,8 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   }));
   const resolveSkillsPromptStateForRunMock = vi.fn(() => ({ prompt: "", resolvedSkills: [] }));
   const resolveSkillRouteMock = vi.fn(async () => undefined);
+  const loadEntriesFromFileMock = vi.fn(() => []);
+  const buildSessionContextFromEntriesMock = vi.fn(() => ({ messages: [] }));
   const supportsModelToolsMock = vi.fn<(model?: unknown) => boolean>(() => true);
   const getGlobalHookRunnerMock = vi.fn<() => unknown>(() => undefined);
   const initializeGlobalHookRunnerMock = vi.fn();
@@ -237,6 +241,8 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     resolveEmbeddedRunSkillEntriesMock,
     resolveSkillsPromptStateForRunMock,
     resolveSkillRouteMock,
+    loadEntriesFromFileMock,
+    buildSessionContextFromEntriesMock,
     supportsModelToolsMock,
     getGlobalHookRunnerMock,
     initializeGlobalHookRunnerMock,
@@ -320,10 +326,13 @@ vi.mock("../../sessions/index.js", () => {
 
   return {
     AuthStorage,
+    buildSessionContext: (...args: unknown[]) =>
+      hoisted.buildSessionContextFromEntriesMock(...args),
     createAgentSession: (...args: unknown[]) => hoisted.createAgentSessionMock(...args),
     DefaultResourceLoader,
     estimateTokens,
     generateSummary: async () => "",
+    loadEntriesFromFile: (...args: unknown[]) => hoisted.loadEntriesFromFileMock(...args),
     ModelRegistry,
     SessionManager: {
       open: (...args: unknown[]) => hoisted.sessionManagerOpenMock(...args),
@@ -1021,6 +1030,8 @@ export function resetEmbeddedAttemptHarness(
     .mockReset()
     .mockReturnValue({ prompt: "", resolvedSkills: [] });
   hoisted.resolveSkillRouteMock.mockReset().mockResolvedValue(undefined);
+  hoisted.loadEntriesFromFileMock.mockReset().mockReturnValue([]);
+  hoisted.buildSessionContextFromEntriesMock.mockReset().mockReturnValue({ messages: [] });
   hoisted.supportsModelToolsMock.mockReset().mockReturnValue(true);
   hoisted.getGlobalHookRunnerMock.mockReset().mockReturnValue(undefined);
   hoisted.runContextEngineMaintenanceMock.mockReset().mockResolvedValue(undefined);
@@ -1223,6 +1234,7 @@ export async function createContextEngineAttemptRunner(params: {
   attemptOverrides?: Partial<Parameters<Awaited<ReturnType<typeof loadRunEmbeddedAttempt>>>[0]>;
   createSession?: () => MutableSession;
   sessionMessages?: AgentMessage[];
+  sessionFileEntries?: Array<Record<string, unknown>>;
   sessionPrompt?: SessionPromptOverride;
   sessionKey: string;
   tempPaths: string[];
@@ -1233,9 +1245,28 @@ export async function createContextEngineAttemptRunner(params: {
   const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ctx-engine-agent-"));
   const sessionFile = path.join(workspaceDir, "session.jsonl");
   params.tempPaths.push(workspaceDir, agentDir);
-  await fs.writeFile(sessionFile, "", "utf8");
+  await fs.writeFile(
+    sessionFile,
+    params.sessionFileEntries?.length
+      ? `${params.sessionFileEntries.map((entry) => JSON.stringify(entry)).join("\n")}\n`
+      : "",
+    "utf8",
+  );
   const seedMessages: AgentMessage[] =
     params.sessionMessages ?? ([{ role: "user", content: "seed", timestamp: 1 }] as AgentMessage[]);
+  hoisted.loadEntriesFromFileMock.mockImplementation((target: unknown) =>
+    target === sessionFile ? (params.sessionFileEntries ?? []) : [],
+  );
+  hoisted.buildSessionContextFromEntriesMock.mockImplementation((entries: unknown) => ({
+    messages: Array.isArray(entries)
+      ? entries
+          .filter(
+            (entry): entry is { type: "message"; message: AgentMessage } =>
+              entry?.type === "message",
+          )
+          .map((entry) => entry.message)
+      : [],
+  }));
   const infoId = params.contextEngine.info?.id ?? "test-context-engine";
   const infoName = params.contextEngine.info?.name ?? "Test Context Engine";
   const infoVersion = params.contextEngine.info?.version ?? "0.0.1";

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -83,7 +83,8 @@ type AttemptSpawnWorkspaceHoisted = {
   resolveContextInjectionModeMock: Mock<() => "always" | "continuation-skip">;
   hasCompletedBootstrapTurnMock: Mock<() => Promise<boolean>>;
   resolveEmbeddedRunSkillEntriesMock: UnknownMock;
-  resolveSkillsPromptForRunMock: UnknownMock;
+  resolveSkillsPromptStateForRunMock: UnknownMock;
+  resolveSkillRouteMock: UnknownMock;
   supportsModelToolsMock: Mock<(model?: unknown) => boolean>;
   getGlobalHookRunnerMock: Mock<() => unknown>;
   initializeGlobalHookRunnerMock: UnknownMock;
@@ -181,7 +182,8 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     shouldLoadSkillEntries: false,
     skillEntries: undefined,
   }));
-  const resolveSkillsPromptForRunMock = vi.fn(() => "");
+  const resolveSkillsPromptStateForRunMock = vi.fn(() => ({ prompt: "", resolvedSkills: [] }));
+  const resolveSkillRouteMock = vi.fn(async () => undefined);
   const supportsModelToolsMock = vi.fn<(model?: unknown) => boolean>(() => true);
   const getGlobalHookRunnerMock = vi.fn<() => unknown>(() => undefined);
   const initializeGlobalHookRunnerMock = vi.fn();
@@ -233,7 +235,8 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     resolveContextInjectionModeMock,
     hasCompletedBootstrapTurnMock,
     resolveEmbeddedRunSkillEntriesMock,
-    resolveSkillsPromptForRunMock,
+    resolveSkillsPromptStateForRunMock,
+    resolveSkillRouteMock,
     supportsModelToolsMock,
     getGlobalHookRunnerMock,
     initializeGlobalHookRunnerMock,
@@ -398,7 +401,12 @@ vi.mock("../../../skills/runtime/env-overrides.js", () => ({
 }));
 
 vi.mock("../../../skills/loading/workspace.js", () => ({
-  resolveSkillsPromptForRun: (...args: unknown[]) => hoisted.resolveSkillsPromptForRunMock(...args),
+  resolveSkillsPromptStateForRun: (...args: unknown[]) =>
+    hoisted.resolveSkillsPromptStateForRunMock(...args),
+}));
+
+vi.mock("../../../skills/loading/router-integration.js", () => ({
+  resolveSkillRoute: (...args: unknown[]) => hoisted.resolveSkillRouteMock(...args),
 }));
 
 vi.mock("../../../skills/runtime/embedded-run-entries.js", () => ({
@@ -1009,7 +1017,10 @@ export function resetEmbeddedAttemptHarness(
     shouldLoadSkillEntries: false,
     skillEntries: undefined,
   });
-  hoisted.resolveSkillsPromptForRunMock.mockReset().mockReturnValue("");
+  hoisted.resolveSkillsPromptStateForRunMock
+    .mockReset()
+    .mockReturnValue({ prompt: "", resolvedSkills: [] });
+  hoisted.resolveSkillRouteMock.mockReset().mockResolvedValue(undefined);
   hoisted.supportsModelToolsMock.mockReset().mockReturnValue(true);
   hoisted.getGlobalHookRunnerMock.mockReset().mockReturnValue(undefined);
   hoisted.runContextEngineMaintenanceMock.mockReset().mockResolvedValue(undefined);

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1144,7 +1144,7 @@ export async function runEmbeddedAttempt(
               config: params.config,
               sessionFile: params.sessionFile,
               sessionKey: params.sessionKey,
-            })
+            });
           },
         });
 
@@ -4022,9 +4022,11 @@ export async function runEmbeddedAttempt(
           }
         }
         // Apply skill router result to prompt (narrowed match or full fallback).
+        let skillRoutePromptInjected = false;
         if (skillRoute && typeof skillRoute === "object") {
           if ("xml" in skillRoute && !isRawModelRun) {
             effectivePrompt = skillRoute.xml + "\n\n" + effectivePrompt;
+            skillRoutePromptInjected = true;
             log.debug(`skill router: injected ${skillRoute.mode} match`);
           } else if ("error" in skillRoute) {
             log.warn(`skill router: ${skillRoute.reason}, falling back to full catalog`);
@@ -4230,9 +4232,10 @@ export async function runEmbeddedAttempt(
           const promptSubmission = resolveRuntimeContextPromptParts({
             effectivePrompt: promptForRuntimeContextSplit,
             transcriptPrompt: transcriptPromptForRuntimeSplit,
-            modelPrompt: hasPromptBuildContext
-              ? promptForModelBeforeRuntimeContextSplit
-              : undefined,
+            modelPrompt:
+              hasPromptBuildContext || skillRoutePromptInjected
+                ? promptForModelBeforeRuntimeContextSplit
+                : undefined,
             emptyTranscriptMode: params.suppressNextUserMessagePersistence
               ? "model-prompt"
               : "runtime-event",

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -71,7 +71,7 @@ import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
 import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
 import { resolveSkillRoute } from "../../../skills/loading/router-integration.js";
-import { resolveSkillsPromptForRun } from "../../../skills/loading/workspace.js";
+import { resolveSkillsPromptStateForRun } from "../../../skills/loading/workspace.js";
 import { resolveEmbeddedRunSkillEntries } from "../../../skills/runtime/embedded-run-entries.js";
 import {
   applySkillEnvOverrides,
@@ -1114,7 +1114,7 @@ export async function runEmbeddedAttempt(
       skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
     });
 
-    const skillsPrompt = resolveSkillsPromptForRun({
+    const skillsPromptState = resolveSkillsPromptStateForRun({
       skillsSnapshot: skillsSnapshotForRun,
       entries: promptSkillEntries,
       config: params.config,
@@ -1122,23 +1122,25 @@ export async function runEmbeddedAttempt(
       agentId: sessionAgentId,
       eligibility: skillsEligibility,
     });
+    const skillsPrompt = skillsPromptState.prompt;
+    const isRawModelRun = params.modelRun === true || params.promptMode === "none";
 
     // Pre-filter: call configured skill router before building the system prompt.
     // When a router matches, its narrowed result replaces the full skills catalog.
     const skillRouterConfig = params.config?.skills?.router;
-    const skillRoute = await resolveSkillRoute({
-      routerName: skillRouterConfig?.name,
-      routerConfig: skillRouterConfig?.config,
-      resolvedSkills: skillsSnapshotForRun?.resolvedSkills,
-      entries: skillEntries,
-      query: params.prompt,
-    });
+    const skillRoute = isRawModelRun
+      ? undefined
+      : await resolveSkillRoute({
+          routerName: skillRouterConfig?.name,
+          routerConfig: skillRouterConfig?.config,
+          resolvedSkills: skillsPromptState.resolvedSkills,
+          query: params.prompt,
+        });
 
     prepStages.mark("skills");
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const contextInjectionMode = resolveContextInjectionMode(params.config, sessionAgentId);
-    const isRawModelRun = params.modelRun === true || params.promptMode === "none";
     if (isRawModelRun && log.isEnabled("debug")) {
       log.debug(
         `raw model run enabled: modelRun=${params.modelRun === true} promptMode=${params.promptMode ?? "unset"}`,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -70,6 +70,7 @@ import { getPluginToolMeta } from "../../../plugins/tools.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
 import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
+import { resolveSkillRoute } from "../../../skills/loading/router-integration.js";
 import { resolveSkillsPromptForRun } from "../../../skills/loading/workspace.js";
 import { resolveEmbeddedRunSkillEntries } from "../../../skills/runtime/embedded-run-entries.js";
 import {
@@ -1121,6 +1122,18 @@ export async function runEmbeddedAttempt(
       agentId: sessionAgentId,
       eligibility: skillsEligibility,
     });
+
+    // Pre-filter: call configured skill router before building the system prompt.
+    // When a router matches, its narrowed result replaces the full skills catalog.
+    const skillRouterConfig = params.config?.skills?.router;
+    const skillRoute = await resolveSkillRoute({
+      routerName: skillRouterConfig?.name,
+      routerConfig: skillRouterConfig?.config,
+      resolvedSkills: skillsSnapshotForRun?.resolvedSkills,
+      entries: skillEntries,
+      query: params.prompt,
+    });
+
     prepStages.mark("skills");
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
@@ -1939,7 +1952,14 @@ export async function runEmbeddedAttempt(
 
     // When toolsAllow is set, use minimal prompt and strip skills catalog
     const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;
-    const effectiveSkillsPrompt = params.toolsAllow?.length ? undefined : skillsPrompt;
+    // Suppress full skills catalog when:
+    // - toolsAllow is set (minimal mode)
+    // - router returned a match (narrowed result goes into user prompt)
+    // - router explicitly said nomatch (no skill applies)
+    // Fall back to full catalog when no router is configured or router failed.
+    const suppressSkillsCatalog =
+      params.toolsAllow?.length || (typeof skillRoute === "object" && !("error" in skillRoute));
+    const effectiveSkillsPrompt = suppressSkillsCatalog ? undefined : skillsPrompt;
     const openClawReferences = await resolveOpenClawReferencePaths({
       workspaceDir: effectiveWorkspace,
       argv1: process.argv[1],
@@ -3985,6 +4005,17 @@ export async function runEmbeddedAttempt(
             );
           }
         }
+        // Apply skill router result to prompt (narrowed match or full fallback).
+        if (skillRoute && typeof skillRoute === "object") {
+          if ("xml" in skillRoute && !isRawModelRun) {
+            effectivePrompt = skillRoute.xml + "\n\n" + effectivePrompt;
+            log.debug(`skill router: injected ${skillRoute.mode} match`);
+          } else if ("error" in skillRoute) {
+            log.warn(`skill router: ${skillRoute.reason}, falling back to full catalog`);
+          }
+          // { mode: "nomatch" } — no injection, no log. Router said no skill applies.
+        }
+
         // The model identity line is appended below; for a marker-free hook systemPrompt
         // override ensure the cache boundary first so the identity lands in the dynamic
         // suffix, not the cached prefix — otherwise an idle turn's prefix (O + identity)

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -396,6 +396,7 @@ import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagn
 import {
   buildAfterTurnRuntimeContext,
   buildAfterTurnRuntimeContextFromUsage,
+  loadSkillRouteRecentMessages,
   prependSystemPromptAddition,
   resolveAttemptFsWorkspaceOnly,
   resolveAttemptMediaTaskSystemPromptAddition,
@@ -1138,6 +1139,13 @@ export async function runEmbeddedAttempt(
           routerConfig: skillRouterConfig?.config,
           resolvedSkills: skillsPromptState.resolvedSkills,
           query: params.prompt,
+          recentMessages: () => {
+            return loadSkillRouteRecentMessages({
+              config: params.config,
+              sessionFile: params.sessionFile,
+              sessionKey: params.sessionKey,
+            })
+          },
         });
 
     prepStages.mark("skills");

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -353,6 +353,7 @@ import {
 import { buildAttemptSystemPrompt } from "./attempt-system-prompt.js";
 import {
   applyEmbeddedAttemptToolsAllow,
+  isRestrictiveEmbeddedAttemptToolsAllow,
   mergeForcedEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
   shouldCreateBundleLspRuntimeForAttempt,
@@ -1124,11 +1125,13 @@ export async function runEmbeddedAttempt(
     });
     const skillsPrompt = skillsPromptState.prompt;
     const isRawModelRun = params.modelRun === true || params.promptMode === "none";
+    const skipSkillRouting =
+      isRawModelRun || isRestrictiveEmbeddedAttemptToolsAllow(params.toolsAllow);
 
     // Pre-filter: call configured skill router before building the system prompt.
     // When a router matches, its narrowed result replaces the full skills catalog.
     const skillRouterConfig = params.config?.skills?.router;
-    const skillRoute = isRawModelRun
+    const skillRoute = skipSkillRouting
       ? undefined
       : await resolveSkillRoute({
           routerName: skillRouterConfig?.name,
@@ -1952,15 +1955,18 @@ export async function runEmbeddedAttempt(
       (isRawModelRun ? "none" : resolvePromptModeForSession(params.sessionKey));
     const promptSurface = resolveAgentPromptSurfaceForSessionKey(params.sessionKey);
 
-    // When toolsAllow is set, use minimal prompt and strip skills catalog
-    const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;
+    // Restrictive toolsAllow runs use minimal prompt and strip skills catalog.
+    const effectivePromptMode = isRestrictiveEmbeddedAttemptToolsAllow(params.toolsAllow)
+      ? ("minimal" as const)
+      : promptMode;
     // Suppress full skills catalog when:
-    // - toolsAllow is set (minimal mode)
+    // - restrictive toolsAllow is set (minimal mode)
     // - router returned a match (narrowed result goes into user prompt)
     // - router explicitly said nomatch (no skill applies)
     // Fall back to full catalog when no router is configured or router failed.
     const suppressSkillsCatalog =
-      params.toolsAllow?.length || (typeof skillRoute === "object" && !("error" in skillRoute));
+      isRestrictiveEmbeddedAttemptToolsAllow(params.toolsAllow) ||
+      (typeof skillRoute === "object" && !("error" in skillRoute));
     const effectiveSkillsPrompt = suppressSkillsCatalog ? undefined : skillsPrompt;
     const openClawReferences = await resolveOpenClawReferencePaths({
       workspaceDir: effectiveWorkspace,

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -82,4 +82,11 @@ export type SkillsConfig = {
   limits?: SkillsLimitsConfig;
   workshop?: SkillsWorkshopConfig;
   entries?: Record<string, SkillConfig>;
+  /** Skill router configuration for pre-routing. */
+  router?: {
+    /** Registered router name (must match a plugin's registerSkillRouter name). */
+    name: string;
+    /** Router-specific configuration passed to the factory. */
+    config?: Record<string, unknown>;
+  };
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1295,6 +1295,13 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         entries: z.record(z.string(), SkillEntrySchema).optional(),
+        router: z
+          .object({
+            name: z.string(),
+            config: z.record(z.string(), z.unknown()).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/plugin-sdk/skills-runtime.ts
+++ b/src/plugin-sdk/skills-runtime.ts
@@ -8,3 +8,12 @@ export {
   shouldRefreshSnapshotForVersion,
   type SkillsChangeEvent,
 } from "../skills/runtime/refresh-state.js";
+
+export {
+  registerSkillRouter,
+  resolveSkillRouter,
+  listRegisteredSkillRouters,
+} from "../skills/loading/router-registry.js";
+
+export type { SkillRouteResult, SkillRouter } from "../skills/loading/router-types.js";
+export type { SkillForPrompt } from "../skills/loading/skill-contract.js";

--- a/src/plugin-sdk/skills-runtime.ts
+++ b/src/plugin-sdk/skills-runtime.ts
@@ -15,5 +15,10 @@ export {
   listRegisteredSkillRouters,
 } from "../skills/loading/router-registry.js";
 
-export type { SkillRouteResult, SkillRouter } from "../skills/loading/router-types.js";
+export type {
+  SkillRouteContext,
+  SkillRouteContextMessage,
+  SkillRouteResult,
+  SkillRouter,
+} from "../skills/loading/router-types.js";
 export type { SkillForPrompt } from "../skills/loading/skill-contract.js";

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { registerSkillRouter, resolveSkillRouter } from "../skills/loading/router-registry.js";
 import { getCompactionProvider, registerCompactionProvider } from "./compaction-provider.js";
 import { getEmbeddingProvider, registerEmbeddingProvider } from "./embedding-providers.js";
 import {
@@ -767,6 +768,10 @@ describe("clearPluginLoaderCache", () => {
         },
       },
     });
+    registerSkillRouter("stale-router", () => ({
+      name: "stale-router",
+      route: async () => ({ mode: "nomatch" }),
+    }));
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
       "stale memory section",
       "stale wiki supplement",
@@ -778,6 +783,7 @@ describe("clearPluginLoaderCache", () => {
     ).toEqual({ backend: "builtin" });
     expect(getEmbeddingProvider("stale-embedding")?.id).toBe("stale-embedding");
     expect(requireMemoryEmbeddingProvider("stale").id).toBe("stale");
+    expect(resolveSkillRouter("stale-router")?.name).toBe("stale-router");
 
     clearPluginLoaderCache();
 
@@ -787,6 +793,7 @@ describe("clearPluginLoaderCache", () => {
     expect(resolveMemoryFlushPlan({})).toBeNull();
     expect(getMemoryRuntime()).toBeUndefined();
     expect(getMemoryEmbeddingProvider("stale")).toBeUndefined();
+    expect(resolveSkillRouter("stale-router")).toBeNull();
   });
 });
 
@@ -805,12 +812,17 @@ describe("loadOpenClawPlugins active runtime clearing", () => {
       id: "stale-memory",
       create: async () => ({ provider: null }),
     });
+    registerSkillRouter("stale-router", () => ({
+      name: "stale-router",
+      route: async () => ({ mode: "nomatch" }),
+    }));
 
     loadOpenClawPlugins({ onlyPluginIds: [] });
 
     expect(getEmbeddingProvider("stale-embedding")).toBeUndefined();
     expect(getCompactionProvider("stale-compaction")).toBeUndefined();
     expect(getMemoryEmbeddingProvider("stale-memory")).toBeUndefined();
+    expect(resolveSkillRouter("stale-router")).toBeNull();
   });
 });
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -23,6 +23,11 @@ import {
 } from "../memory-host-sdk/dreaming.js";
 import { toSafeImportPath } from "../shared/import-specifier.js";
 import {
+  clearSkillRouterRegistry,
+  restoreSkillRouterRegistry,
+  snapshotSkillRouterRegistry,
+} from "../skills/loading/router-registry.js";
+import {
   clearDetachedTaskLifecycleRuntimeRegistration,
   getDetachedTaskLifecycleRuntimeRegistration,
   restoreDetachedTaskLifecycleRuntimeRegistration,
@@ -376,6 +381,7 @@ type CachedPluginState = {
   embeddingProviders: ReturnType<typeof listRegisteredEmbeddingProviders>;
   memoryEmbeddingProviders: ReturnType<typeof listRegisteredMemoryEmbeddingProviders>;
   memoryPromptSupplements: ReturnType<typeof listMemoryPromptSupplements>;
+  skillRouterRegistry: ReturnType<typeof snapshotSkillRouterRegistry>;
 };
 
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
@@ -436,6 +442,7 @@ export function clearActivatedPluginRuntimeState(): void {
   clearEmbeddingProviders();
   clearMemoryEmbeddingProviders();
   clearMemoryPluginState();
+  clearSkillRouterRegistry();
 }
 
 export function clearPluginRegistryLoadCache(): void {
@@ -1883,6 +1890,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           corpusSupplements: cached.state.memoryCorpusSupplements,
           promptSupplements: cached.state.memoryPromptSupplements,
         });
+        restoreSkillRouterRegistry(cached.state.skillRouterRegistry);
         activatePluginRegistry(
           cached.state.registry,
           cached.cacheKey,
@@ -2676,10 +2684,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             );
             continue;
           }
+          const setupSkillRouterRegistrySnapshot = snapshotSkillRouterRegistry();
           if (!runtimeSetterApplied) {
             try {
               mergedSetupRegistration.setChannelRuntime?.(api.runtime);
             } catch (err) {
+              restoreSkillRouterRegistry(setupSkillRouterRegistrySnapshot);
               recordPluginError({
                 logger,
                 registry,
@@ -2707,6 +2717,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                 );
               } catch (err) {
                 restorePluginRegistry(registry, registrySnapshot);
+                restoreSkillRouterRegistry(setupSkillRouterRegistrySnapshot);
                 recordPluginError({
                   logger,
                   registry,
@@ -2728,6 +2739,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           try {
             api.registerChannel(mergedSetupPlugin);
           } catch (err) {
+            restoreSkillRouterRegistry(setupSkillRouterRegistrySnapshot);
             recordPluginError({
               logger,
               registry,
@@ -2742,6 +2754,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
               diagnosticCode: "channel-setup-failure",
             });
             continue;
+          }
+          if (!shouldActivate) {
+            restoreSkillRouterRegistry(setupSkillRouterRegistrySnapshot);
           }
           registry.plugins.push(record);
           seenIds.set(pluginId, candidate.origin);
@@ -2852,6 +2867,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
+      const previousSkillRouterRegistry = snapshotSkillRouterRegistry();
 
       const beforeRegister = performance.now();
       let registerFailed = false;
@@ -2873,6 +2889,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             corpusSupplements: previousMemoryCorpusSupplements,
             promptSupplements: previousMemoryPromptSupplements,
           });
+          restoreSkillRouterRegistry(previousSkillRouterRegistry);
         }
         registry.plugins.push(record);
         seenIds.set(pluginId, candidate.origin);
@@ -2889,6 +2906,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           corpusSupplements: previousMemoryCorpusSupplements,
           promptSupplements: previousMemoryPromptSupplements,
         });
+        restoreSkillRouterRegistry(previousSkillRouterRegistry);
         recordPluginError({
           logger,
           registry,
@@ -2965,6 +2983,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           embeddingProviders: listRegisteredEmbeddingProviders(),
           memoryEmbeddingProviders: listRegisteredMemoryEmbeddingProviders(),
           memoryPromptSupplements: listMemoryPromptSupplements(),
+          skillRouterRegistry: snapshotSkillRouterRegistry(),
         },
         onlyPluginIds,
       );

--- a/src/skills/loading/prompt-resolution.test.ts
+++ b/src/skills/loading/prompt-resolution.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
-import { resolveSkillsPromptForRun } from "./workspace.js";
+import { resolveSkillsPromptForRun, resolveSkillsPromptStateForRun } from "./workspace.js";
 
 describe("resolveSkillsPromptForRun", () => {
   it("prefers snapshot prompt when available", () => {
@@ -12,6 +12,29 @@ describe("resolveSkillsPromptForRun", () => {
     });
     expect(prompt).toBe("SNAPSHOT");
   });
+
+  it("returns snapshot resolved skills with the snapshot prompt", () => {
+    const skill = createCanonicalFixtureSkill({
+      name: "snapshot-skill",
+      description: "Snapshot",
+      filePath: "/app/skills/snapshot-skill/SKILL.md",
+      baseDir: "/app/skills/snapshot-skill",
+      source: "openclaw-workspace",
+    });
+
+    const state = resolveSkillsPromptStateForRun({
+      skillsSnapshot: {
+        prompt: "SNAPSHOT",
+        skills: [{ name: "snapshot-skill" }],
+        resolvedSkills: [skill],
+      },
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(state.prompt).toBe("SNAPSHOT");
+    expect(state.resolvedSkills).toStrictEqual([skill]);
+  });
+
   it("builds prompt from entries when snapshot is missing", () => {
     const entry: SkillEntry = {
       skill: createCanonicalFixtureSkill({
@@ -29,6 +52,52 @@ describe("resolveSkillsPromptForRun", () => {
     });
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
+  });
+
+  it("returns resolved skills from the same filtered entries used for the prompt", () => {
+    const visible: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "visible-skill",
+        description: "Visible",
+        filePath: "/app/skills/visible-skill/SKILL.md",
+        baseDir: "/app/skills/visible-skill",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    };
+    const hidden: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "hidden-skill",
+        description: "Hidden",
+        filePath: "/app/skills/hidden-skill/SKILL.md",
+        baseDir: "/app/skills/hidden-skill",
+        source: "openclaw-workspace",
+        disableModelInvocation: true,
+      }),
+      frontmatter: {},
+    };
+
+    const state = resolveSkillsPromptStateForRun({
+      skillsSnapshot: {
+        prompt: " ",
+        skills: [{ name: "stale-snapshot-skill" }],
+        resolvedSkills: [
+          createCanonicalFixtureSkill({
+            name: "stale-snapshot-skill",
+            description: "Stale",
+            filePath: "/app/skills/stale-snapshot-skill/SKILL.md",
+            baseDir: "/app/skills/stale-snapshot-skill",
+            source: "openclaw-workspace",
+          }),
+        ],
+      },
+      entries: [visible, hidden],
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(state.prompt).toContain("/app/skills/visible-skill/SKILL.md");
+    expect(state.prompt).not.toContain("/app/skills/hidden-skill/SKILL.md");
+    expect(state.resolvedSkills.map((skill) => skill.name)).toStrictEqual(["visible-skill"]);
   });
 
   it("keeps legacy entries with disableModelInvocation hidden when exposure metadata is absent", () => {
@@ -90,6 +159,47 @@ describe("resolveSkillsPromptForRun", () => {
 
     expect(prompt).toContain("/app/skills/github/SKILL.md");
     expect(prompt).not.toContain("/app/skills/hidden-skill/SKILL.md");
+  });
+
+  it("returns resolved skills after applying the agent skill filter", () => {
+    const visible: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "github",
+        description: "GitHub",
+        filePath: "/app/skills/github/SKILL.md",
+        baseDir: "/app/skills/github",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    };
+    const hidden: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "hidden-skill",
+        description: "Hidden",
+        filePath: "/app/skills/hidden-skill/SKILL.md",
+        baseDir: "/app/skills/hidden-skill",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    };
+
+    const state = resolveSkillsPromptStateForRun({
+      entries: [visible, hidden],
+      config: {
+        agents: {
+          defaults: {
+            skills: ["github"],
+          },
+          list: [{ id: "writer" }],
+        },
+      },
+      workspaceDir: "/tmp/openclaw",
+      agentId: "writer",
+    });
+
+    expect(state.prompt).toContain("/app/skills/github/SKILL.md");
+    expect(state.prompt).not.toContain("/app/skills/hidden-skill/SKILL.md");
+    expect(state.resolvedSkills.map((skill) => skill.name)).toStrictEqual(["github"]);
   });
 
   it("uses agents.list[].skills as a full replacement for defaults", () => {

--- a/src/skills/loading/router-context.test.ts
+++ b/src/skills/loading/router-context.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../../agents/runtime/index.js";
+import { buildSkillRouteContext } from "./router-context.js";
+
+describe("buildSkillRouteContext", () => {
+  it("returns an empty recent message list when there is no recent text context", () => {
+    expect(buildSkillRouteContext({ query: "  summarize this  " })).toStrictEqual({
+      recentMessages: [],
+    });
+  });
+
+  it("includes recent user and assistant text for short follow-up prompts", () => {
+    const ctx = buildSkillRouteContext({
+      query: "use that one",
+      recentMessages: [
+        message("user", "I need to update a Figma mockup."),
+        message("assistant", "Use the design skill for this."),
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "large tool output" }],
+          isError: false,
+          timestamp: 3,
+        },
+      ],
+    });
+
+    expect(ctx.recentMessages).toStrictEqual([
+      { role: "user", text: "I need to update a Figma mockup." },
+      { role: "assistant", text: "Use the design skill for this." },
+    ]);
+  });
+
+  it("keeps prior repeated short prompts as real routing context", () => {
+    const ctx = buildSkillRouteContext({
+      query: "same short prompt",
+      recentMessages: [
+        message("user", "Earlier context"),
+        message("assistant", "Earlier answer"),
+        message("user", "same short prompt"),
+      ],
+    });
+
+    expect(ctx.recentMessages).toStrictEqual([
+      { role: "user", text: "Earlier context" },
+      { role: "assistant", text: "Earlier answer" },
+      { role: "user", text: "same short prompt" },
+    ]);
+  });
+
+  it("keeps only the latest six recent route context messages", () => {
+    const longText = "x".repeat(2_000);
+    const ctx = buildSkillRouteContext({
+      query: "continue",
+      recentMessages: [
+        message("user", "oldest dropped"),
+        message("user", longText),
+        message("assistant", longText),
+        message("user", longText),
+        message("assistant", longText),
+        message("user", longText),
+        message("assistant", longText),
+      ],
+    });
+
+    expect(ctx.recentMessages).toHaveLength(6);
+    expect(ctx.recentMessages[0]?.text).toBe(longText);
+    expect(
+      ctx.recentMessages.some((recentMessage) => recentMessage.text === "oldest dropped"),
+    ).toBe(false);
+    expect(ctx.recentMessages.every((recentMessage) => recentMessage.text === longText)).toBe(true);
+  });
+});
+
+function message(role: "user" | "assistant", content: string): AgentMessage {
+  if (role === "user") {
+    return { role, content, timestamp: 1 };
+  }
+  return {
+    role,
+    content: [{ type: "text", text: content }],
+    api: "test",
+    provider: "test",
+    model: "test",
+    stopReason: "stop",
+    timestamp: 1,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}

--- a/src/skills/loading/router-context.ts
+++ b/src/skills/loading/router-context.ts
@@ -1,0 +1,69 @@
+import type { AgentMessage } from "../../agents/runtime/index.js";
+import type { SkillRouteContext, SkillRouteContextMessage } from "./router-types.js";
+
+const MAX_RECENT_ROUTE_CONTEXT_MESSAGES = 6;
+
+function normalizeRouteText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function extractRouteMessageText(message: AgentMessage): string {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return normalizeRouteText(content);
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const text = (block as { text?: unknown }).text;
+    if (typeof text === "string") {
+      parts.push(text);
+    }
+  }
+  return normalizeRouteText(parts.join(" "));
+}
+
+function collectRecentRouteContextMessages(params: {
+  messages: AgentMessage[];
+}): SkillRouteContextMessage[] {
+  const collected: SkillRouteContextMessage[] = [];
+
+  for (let index = params.messages.length - 1; index >= 0; index--) {
+    const message = params.messages[index];
+    if (message.role !== "user" && message.role !== "assistant") {
+      continue;
+    }
+    const text = extractRouteMessageText(message);
+    if (!text) {
+      continue;
+    }
+
+    if (collected.length >= MAX_RECENT_ROUTE_CONTEXT_MESSAGES) {
+      break;
+    }
+
+    collected.unshift({ role: message.role, text });
+  }
+
+  return collected;
+}
+
+export function buildSkillRouteContext(params: {
+  query?: string;
+  recentMessages?: AgentMessage[];
+}): SkillRouteContext {
+  const currentQuery = normalizeRouteText(params.query ?? "");
+  const recentMessages =
+    currentQuery && params.recentMessages?.length
+      ? collectRecentRouteContextMessages({
+          messages: params.recentMessages,
+        })
+      : [];
+  return { recentMessages };
+}

--- a/src/skills/loading/router-integration.test.ts
+++ b/src/skills/loading/router-integration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveSkillRoute } from "./router-integration.js";
+import { registerSkillRouter } from "./router-registry.js";
+
+describe("resolveSkillRoute", () => {
+  it("passes structured routing context to the configured router", async () => {
+    const route = vi.fn(async () => ({ mode: "nomatch" as const }));
+    registerSkillRouter("structured-context-router", () => ({
+      name: "structured-context-router",
+      route,
+    }));
+
+    await resolveSkillRoute({
+      routerName: "structured-context-router",
+      resolvedSkills: [
+        {
+          name: "github",
+          description: "GitHub workflows",
+          filePath: "/tmp/skills/github/SKILL.md",
+        },
+      ],
+      query: "do that",
+      recentMessages: [{ role: "user", content: "Review a GitHub PR.", timestamp: 1 }],
+    });
+
+    expect(route).toHaveBeenCalledWith(
+      "do that",
+      [
+        {
+          name: "github",
+          description: "GitHub workflows",
+          filePath: "/tmp/skills/github/SKILL.md",
+        },
+      ],
+      {
+        recentMessages: [{ role: "user", text: "Review a GitHub PR." }],
+      },
+    );
+  });
+});

--- a/src/skills/loading/router-integration.ts
+++ b/src/skills/loading/router-integration.ts
@@ -1,0 +1,94 @@
+import { resolveSkillRouter } from "./router-registry.js";
+import type { SkillRouteResult } from "./router-types.js";
+import type { SkillForPrompt } from "./skill-contract.js";
+import { formatSkillsForPrompt } from "./skill-contract.js";
+import type { SkillEntry } from "./types.js";
+import { isSkillVisibleInAvailableSkillsPrompt } from "./workspace.js";
+
+/**
+ * Build the candidate list for router matching.
+ * Prefers resolvedSkills from snapshot (already filtered); falls back to raw entries.
+ */
+function buildSkillRouteCandidates(
+  resolvedSkills?: Array<{ name: string; description: string; filePath: string }>,
+  entries?: SkillEntry[],
+): SkillForPrompt[] {
+  if (resolvedSkills) {
+    return resolvedSkills.map((s) => ({
+      name: s.name,
+      description: s.description,
+      filePath: s.filePath,
+    }));
+  }
+  return (entries ?? [])
+    .filter(isSkillVisibleInAvailableSkillsPrompt)
+    .map((e) => ({
+      name: e.skill.name,
+      description: e.skill.description,
+      filePath: e.skill.filePath,
+    }));
+}
+
+/**
+ * Resolve skill routing: call the configured router, then resolve the result
+ * to an <available_skills> XML string.
+ *
+ * Returns:
+ * - `{ xml, mode }` — valid match found, inject into user prompt
+ * - `{ mode: "nomatch" }` — router explicitly said no skill matches, suppress full catalog
+ * - `{ error, reason }` — router was configured but failed; caller should log and fall back
+ * - `undefined` — no router configured, no candidates; caller uses full catalog as-is
+ */
+export async function resolveSkillRoute(ctx: {
+  routerName?: string;
+  routerConfig?: Record<string, unknown>;
+  resolvedSkills?: Array<{ name: string; description: string; filePath: string }>;
+  entries?: SkillEntry[];
+  query?: string;
+}): Promise<
+  | { xml: string; mode: "direct" | "ambiguous" }
+  | { mode: "nomatch" }
+  | { error: true; reason: "registry_miss" | "route_failed" | "lookup_failed" }
+  | undefined
+> {
+  // 1. Guard: no router configured
+  if (!ctx.routerName) return undefined;
+
+  // 2. Resolve router from registry
+  const router = resolveSkillRouter(ctx.routerName, ctx.routerConfig);
+  if (!router) return { error: true, reason: "registry_miss" };
+
+  // 3. Build candidates from resolved skills or raw entries
+  const candidates = buildSkillRouteCandidates(ctx.resolvedSkills, ctx.entries);
+  if (candidates.length === 0 || !ctx.query) return undefined;
+
+  // 4. Call the router
+  let result: SkillRouteResult;
+  try {
+    result = await router.route(ctx.query, candidates);
+  } catch {
+    return { error: true, reason: "route_failed" };
+  }
+
+  // 5. Resolve result to XML
+  if (result.mode === "direct") {
+    const matched = candidates.find((c) => c.name === result.name);
+    if (matched) {
+      const xml = formatSkillsForPrompt([matched]);
+      if (xml) return { xml, mode: "direct" };
+    }
+  } else if (result.mode === "ambiguous" && result.candidates.length > 0) {
+    const matched = result.candidates
+      .map((c) => candidates.find((m) => m.name === c.name))
+      .filter((c): c is NonNullable<typeof c> => c != null);
+    if (matched.length > 0) {
+      const xml = formatSkillsForPrompt(matched);
+      if (xml) return { xml, mode: "ambiguous" };
+    }
+  } else if (result.mode === "nomatch") {
+    return { mode: "nomatch" };
+  }
+
+  // 6. Lookup failed — router returned direct/ambiguous but name not in candidates
+  return { error: true, reason: "lookup_failed" };
+}

--- a/src/skills/loading/router-integration.ts
+++ b/src/skills/loading/router-integration.ts
@@ -2,31 +2,19 @@ import { resolveSkillRouter } from "./router-registry.js";
 import type { SkillRouteResult } from "./router-types.js";
 import type { SkillForPrompt } from "./skill-contract.js";
 import { formatSkillsForPrompt } from "./skill-contract.js";
-import type { SkillEntry } from "./types.js";
-import { isSkillVisibleInAvailableSkillsPrompt } from "./workspace.js";
 
 /**
  * Build the candidate list for router matching.
- * Prefers resolvedSkills from snapshot (already filtered); falls back to raw entries.
+ * resolvedSkills already matches the prompt-visible filtered skill set.
  */
 function buildSkillRouteCandidates(
   resolvedSkills?: Array<{ name: string; description: string; filePath: string }>,
-  entries?: SkillEntry[],
 ): SkillForPrompt[] {
-  if (resolvedSkills) {
-    return resolvedSkills.map((s) => ({
-      name: s.name,
-      description: s.description,
-      filePath: s.filePath,
-    }));
-  }
-  return (entries ?? [])
-    .filter(isSkillVisibleInAvailableSkillsPrompt)
-    .map((e) => ({
-      name: e.skill.name,
-      description: e.skill.description,
-      filePath: e.skill.filePath,
-    }));
+  return (resolvedSkills ?? []).map((s) => ({
+    name: s.name,
+    description: s.description,
+    filePath: s.filePath,
+  }));
 }
 
 /**
@@ -43,7 +31,6 @@ export async function resolveSkillRoute(ctx: {
   routerName?: string;
   routerConfig?: Record<string, unknown>;
   resolvedSkills?: Array<{ name: string; description: string; filePath: string }>;
-  entries?: SkillEntry[];
   query?: string;
 }): Promise<
   | { xml: string; mode: "direct" | "ambiguous" }
@@ -58,8 +45,8 @@ export async function resolveSkillRoute(ctx: {
   const router = resolveSkillRouter(ctx.routerName, ctx.routerConfig);
   if (!router) return { error: true, reason: "registry_miss" };
 
-  // 3. Build candidates from resolved skills or raw entries
-  const candidates = buildSkillRouteCandidates(ctx.resolvedSkills, ctx.entries);
+  // 3. Build candidates from the same prompt-visible skills used by the catalog.
+  const candidates = buildSkillRouteCandidates(ctx.resolvedSkills);
   if (candidates.length === 0 || !ctx.query) return undefined;
 
   // 4. Call the router

--- a/src/skills/loading/router-integration.ts
+++ b/src/skills/loading/router-integration.ts
@@ -1,7 +1,13 @@
+import type { AgentMessage } from "../../agents/runtime/index.js";
+import type { SkillEntry } from "../types.js";
+import { buildSkillRouteContext } from "./router-context.js";
 import { resolveSkillRouter } from "./router-registry.js";
 import type { SkillRouteResult } from "./router-types.js";
 import type { SkillForPrompt } from "./skill-contract.js";
 import { formatSkillsForPrompt } from "./skill-contract.js";
+import { isSkillVisibleInAvailableSkillsPrompt } from "./workspace.js";
+
+type RecentRouteMessages = AgentMessage[] | (() => AgentMessage[]);
 
 /**
  * Build the candidate list for router matching.
@@ -9,11 +15,19 @@ import { formatSkillsForPrompt } from "./skill-contract.js";
  */
 function buildSkillRouteCandidates(
   resolvedSkills?: Array<{ name: string; description: string; filePath: string }>,
+  entries?: SkillEntry[],
 ): SkillForPrompt[] {
-  return (resolvedSkills ?? []).map((s) => ({
-    name: s.name,
-    description: s.description,
-    filePath: s.filePath,
+  if (resolvedSkills) {
+    return resolvedSkills.map((s) => ({
+      name: s.name,
+      description: s.description,
+      filePath: s.filePath,
+    }));
+  }
+  return (entries ?? []).filter(isSkillVisibleInAvailableSkillsPrompt).map((e) => ({
+    name: e.skill.name,
+    description: e.skill.description,
+    filePath: e.skill.filePath,
   }));
 }
 
@@ -31,7 +45,9 @@ export async function resolveSkillRoute(ctx: {
   routerName?: string;
   routerConfig?: Record<string, unknown>;
   resolvedSkills?: Array<{ name: string; description: string; filePath: string }>;
+  entries?: SkillEntry[];
   query?: string;
+  recentMessages?: RecentRouteMessages;
 }): Promise<
   | { xml: string; mode: "direct" | "ambiguous" }
   | { mode: "nomatch" }
@@ -39,20 +55,40 @@ export async function resolveSkillRoute(ctx: {
   | undefined
 > {
   // 1. Guard: no router configured
-  if (!ctx.routerName) return undefined;
+  if (!ctx.routerName) {
+    return undefined;
+  }
 
   // 2. Resolve router from registry
-  const router = resolveSkillRouter(ctx.routerName, ctx.routerConfig);
-  if (!router) return { error: true, reason: "registry_miss" };
+  let router: ReturnType<typeof resolveSkillRouter>;
+  try {
+    router = resolveSkillRouter(ctx.routerName, ctx.routerConfig);
+    if (!router) {
+      return { error: true, reason: "registry_miss" };
+    }
+  } catch {
+    return { error: true, reason: "registry_miss" };
+  }
 
   // 3. Build candidates from the same prompt-visible skills used by the catalog.
-  const candidates = buildSkillRouteCandidates(ctx.resolvedSkills);
-  if (candidates.length === 0 || !ctx.query) return undefined;
+  const candidates = buildSkillRouteCandidates(ctx.resolvedSkills, ctx.entries);
+  if (candidates.length === 0 || !ctx.query) {
+    return undefined;
+  }
 
   // 4. Call the router
   let result: SkillRouteResult;
   try {
-    result = await router.route(ctx.query, candidates);
+    const recentMessages =
+      typeof ctx.recentMessages === "function" ? ctx.recentMessages() : ctx.recentMessages;
+    result = await router.route(
+      ctx.query,
+      candidates,
+      buildSkillRouteContext({
+        query: ctx.query,
+        recentMessages,
+      }),
+    );
   } catch {
     return { error: true, reason: "route_failed" };
   }
@@ -62,7 +98,9 @@ export async function resolveSkillRoute(ctx: {
     const matched = candidates.find((c) => c.name === result.name);
     if (matched) {
       const xml = formatSkillsForPrompt([matched]);
-      if (xml) return { xml, mode: "direct" };
+      if (xml) {
+        return { xml, mode: "direct" };
+      }
     }
   } else if (result.mode === "ambiguous" && result.candidates.length > 0) {
     const matched = result.candidates
@@ -70,7 +108,9 @@ export async function resolveSkillRoute(ctx: {
       .filter((c): c is NonNullable<typeof c> => c != null);
     if (matched.length > 0) {
       const xml = formatSkillsForPrompt(matched);
-      if (xml) return { xml, mode: "ambiguous" };
+      if (xml) {
+        return { xml, mode: "ambiguous" };
+      }
     }
   } else if (result.mode === "nomatch") {
     return { mode: "nomatch" };

--- a/src/skills/loading/router-registry.ts
+++ b/src/skills/loading/router-registry.ts
@@ -1,0 +1,36 @@
+import type { SkillRouter } from "./router-types.js";
+
+type SkillRouterFactory = (config: Record<string, unknown>) => SkillRouter;
+
+const registry = new Map<string, SkillRouterFactory>();
+
+/**
+ * Register a skill router implementation.
+ * Plugins call this at install time to declare which router they provide.
+ *
+ * @example
+ * registerSkillRouter("my-router", (config) => new MyRouter(config));
+ */
+export function registerSkillRouter(name: string, factory: SkillRouterFactory): void {
+  registry.set(name, factory);
+}
+
+/**
+ * Resolve a registered skill router by name.
+ * Returns null if no router with that name is registered.
+ */
+export function resolveSkillRouter(
+  name: string,
+  config?: Record<string, unknown>,
+): SkillRouter | null {
+  const factory = registry.get(name);
+  return factory ? factory(config ?? {}) : null;
+}
+
+/**
+ * List all registered skill router names.
+ * Useful for diagnostics and `openclaw skills check`.
+ */
+export function listRegisteredSkillRouters(): string[] {
+  return Array.from(registry.keys());
+}

--- a/src/skills/loading/router-registry.ts
+++ b/src/skills/loading/router-registry.ts
@@ -4,6 +4,8 @@ type SkillRouterFactory = (config: Record<string, unknown>) => SkillRouter;
 
 const registry = new Map<string, SkillRouterFactory>();
 
+export type SkillRouterRegistrySnapshot = Array<readonly [string, SkillRouterFactory]>;
+
 /**
  * Register a skill router implementation.
  * Plugins call this at install time to declare which router they provide.
@@ -13,6 +15,21 @@ const registry = new Map<string, SkillRouterFactory>();
  */
 export function registerSkillRouter(name: string, factory: SkillRouterFactory): void {
   registry.set(name, factory);
+}
+
+export function clearSkillRouterRegistry(): void {
+  registry.clear();
+}
+
+export function snapshotSkillRouterRegistry(): SkillRouterRegistrySnapshot {
+  return Array.from(registry.entries());
+}
+
+export function restoreSkillRouterRegistry(snapshot: SkillRouterRegistrySnapshot): void {
+  registry.clear();
+  for (const [name, factory] of snapshot) {
+    registry.set(name, factory);
+  }
 }
 
 /**

--- a/src/skills/loading/router-types.ts
+++ b/src/skills/loading/router-types.ts
@@ -1,0 +1,27 @@
+/**
+ * SkillRouter abstraction — core type definitions.
+ *
+ * Plugins implement `SkillRouter` and register via `registerSkillRouter`.
+ * The agent runner calls the configured router before building the LLM request;
+ * results are injected as tool results, keeping the system prompt static.
+ */
+
+import type { SkillForPrompt } from "./skill-contract.js";
+
+/**
+ * Discriminated union for routing outcomes.
+ *
+ * - `direct`: single high-confidence match — framework loads SKILL.md directly
+ * - `ambiguous`: multiple candidates — framework injects list for LLM/user to choose
+ * - `nomatch`: no match — skip skill, LLM handles on its own
+ */
+export type SkillRouteResult =
+  | { mode: "direct"; name: string }
+  | { mode: "ambiguous"; candidates: { name: string; score: number }[] }
+  | { mode: "nomatch" };
+
+/** Router interface that plugins implement. */
+export interface SkillRouter {
+  readonly name: string;
+  route(query: string, candidates: SkillForPrompt[]): Promise<SkillRouteResult>;
+}

--- a/src/skills/loading/router-types.ts
+++ b/src/skills/loading/router-types.ts
@@ -8,6 +8,15 @@
 
 import type { SkillForPrompt } from "./skill-contract.js";
 
+export type SkillRouteContextMessage = {
+  role: "user" | "assistant";
+  text: string;
+};
+
+export type SkillRouteContext = {
+  recentMessages: SkillRouteContextMessage[];
+};
+
 /**
  * Discriminated union for routing outcomes.
  *
@@ -23,5 +32,9 @@ export type SkillRouteResult =
 /** Router interface that plugins implement. */
 export interface SkillRouter {
   readonly name: string;
-  route(query: string, candidates: SkillForPrompt[]): Promise<SkillRouteResult>;
+  route(
+    query: string,
+    candidates: SkillForPrompt[],
+    ctx?: SkillRouteContext,
+  ): Promise<SkillRouteResult>;
 }

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -25,13 +25,15 @@ function escapeXml(str: string): string {
     .replace(/'/g, "&apos;");
 }
 
+export type SkillForPrompt = Pick<Skill, "name" | "description" | "filePath">;
+
 /**
  * Keep this formatter's XML layout byte-for-byte aligned with the upstream
  * Agent Skills formatter so we can avoid importing the full session runtime
  * package root on the cold skills path. Visibility policy is applied upstream
  * before calling this helper.
  */
-export function formatSkillsForPrompt(skills: Skill[]): string {
+export function formatSkillsForPrompt(skills: SkillForPrompt[]): string {
   if (skills.length === 0) {
     return "";
   }

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -25,7 +25,7 @@ function escapeXml(str: string): string {
     .replace(/'/g, "&apos;");
 }
 
-export type SkillForPrompt = Pick<Skill, "name" | "description" | "filePath">;
+export type SkillForPrompt = Pick<Skill, "name" | "description" | "filePath" | "promptVersion">;
 
 /**
  * Keep this formatter's XML layout byte-for-byte aligned with the upstream

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -166,6 +166,16 @@ function compactPathForConsoleMessage(filePath: string): string {
   return compactHomePath(filePath, resolveCompactHomePrefixes());
 }
 
+export function isSkillVisibleInAvailableSkillsPrompt(entry: SkillEntry): boolean {
+  if (entry.exposure) {
+    return entry.exposure.includeInAvailableSkillsPrompt !== false;
+  }
+  if (entry.invocation) {
+    return entry.invocation.disableModelInvocation !== true;
+  }
+  return entry.skill.disableModelInvocation !== true;
+}
+
 function filterSkillEntries(
   entries: SkillEntry[],
   config?: OpenClawConfig,

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1518,20 +1518,40 @@ export function resolveSkillsPromptForRun(params: {
   agentId?: string;
   eligibility?: SkillEligibilityContext;
 }): string {
-  const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
-  if (snapshotPrompt) {
-    return snapshotPrompt;
-  }
+  return resolveSkillsPromptStateForRun(params).prompt;
+}
+
+export function resolveSkillsPromptStateForRun(params: {
+  skillsSnapshot?: SkillSnapshot;
+  entries?: SkillEntry[];
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  agentId?: string;
+}): { prompt: string; resolvedSkills: Skill[] } {
+  const snapshotPrompt = params.skillsSnapshot?.prompt?.trim() ?? "";
+  const snapshotResolvedSkills = params.skillsSnapshot?.resolvedSkills;
   if (params.entries && params.entries.length > 0) {
-    const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
+    const state = resolveWorkspaceSkillPromptState(params.workspaceDir, {
       entries: params.entries,
       config: params.config,
       agentId: params.agentId,
       eligibility: params.eligibility,
     });
-    return prompt.trim() ? prompt : "";
+    if (!snapshotPrompt) {
+      return {
+        prompt: state.prompt.trim() ? state.prompt : "",
+        resolvedSkills: state.resolvedSkills,
+      };
+    }
+    return {
+      prompt: snapshotPrompt,
+      resolvedSkills: snapshotResolvedSkills ?? state.resolvedSkills,
+    };
   }
-  return "";
+  return {
+    prompt: snapshotPrompt,
+    resolvedSkills: snapshotResolvedSkills ?? [],
+  };
 }
 
 export function loadWorkspaceSkillEntries(

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -64,8 +64,8 @@ function resolveNativeUserHomeDir(): string | undefined {
 }
 
 function resolveCompactHomePrefixes(): string[] {
-  const homes = [resolveUserHomeDir(), resolveNativeUserHomeDir()].filter(
-    (home): home is string => Boolean(home),
+  const homes = [resolveUserHomeDir(), resolveNativeUserHomeDir()].filter((home): home is string =>
+    Boolean(home),
   );
   const resolvedHomes = homes.map((home) => path.resolve(home));
   const realHomes = resolvedHomes
@@ -111,15 +111,15 @@ function resolvePromptTildeRoots(): string[] {
     return [];
   }
   const realNativeHome = tryRealpath(resolvedNativeHome);
-  return uniqueStrings([
-    resolvedNativeHome,
-    ...(realNativeHome ? [realNativeHome] : []),
-  ]);
+  return uniqueStrings([resolvedNativeHome, ...(realNativeHome ? [realNativeHome] : [])]);
 }
 
 function isContainerStateHomeWherePromptTildeEscapes(home: string): boolean {
   const configDir = path.resolve(resolveConfigDir());
-  return home === "/data" && (configDir === "/data/.openclaw" || isPathInside("/data/.openclaw", configDir));
+  return (
+    home === "/data" &&
+    (configDir === "/data/.openclaw" || isPathInside("/data/.openclaw", configDir))
+  );
 }
 
 function shouldPreservePromptSkillPath(
@@ -168,12 +168,12 @@ function compactPathForConsoleMessage(filePath: string): string {
 
 export function isSkillVisibleInAvailableSkillsPrompt(entry: SkillEntry): boolean {
   if (entry.exposure) {
-    return entry.exposure.includeInAvailableSkillsPrompt !== false;
+    return entry.exposure.includeInAvailableSkillsPrompt ?? true;
   }
   if (entry.invocation) {
-    return entry.invocation.disableModelInvocation !== true;
+    return !entry.invocation.disableModelInvocation;
   }
-  return entry.skill.disableModelInvocation !== true;
+  return !entry.skill.disableModelInvocation;
 }
 
 function filterSkillEntries(
@@ -1527,6 +1527,7 @@ export function resolveSkillsPromptStateForRun(params: {
   config?: OpenClawConfig;
   workspaceDir: string;
   agentId?: string;
+  eligibility?: SkillEligibilityContext;
 }): { prompt: string; resolvedSkills: Skill[] } {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim() ?? "";
   const snapshotResolvedSkills = params.skillsSnapshot?.resolvedSkills;


### PR DESCRIPTION
## Summary

- Introduces a pluggable `SkillRouter` interface that lets plugins pre-filter skills before the final model request is built.
- Keeps core strategy-agnostic: core defines the router protocol, registry, config surface, lifecycle handling, and prompt integration; plugins provide concrete routing strategies.
- Aligns router candidates with the same prompt-visible skill state used for `<available_skills>`, so disabled skills, agent skill filters, and restrictive runtime tool allowlists cannot leak into routing.
- When a router matches, suppresses the full `<available_skills>` catalog from the static system prompt and injects the narrowed `<available_skills>` XML as prompt-local model context, preserving prefix-cache stability without persisting routed XML as user-authored transcript text.
- Passes a structured recent-message context to routers so short follow-up prompts can be routed without forcing plugin authors into a pre-rendered transcript string.
- Skips skill routing for raw model runs and restrictive `toolsAllow` runs, while preserving routing for wildcard `toolsAllow: ["*"]` runs that existing tool policy treats as unrestricted.
- Binds router registrations to the plugin loader lifecycle so stale routers are cleared/restored across cache restore, non-activating loads, reloads, and registration rollback.

This is a draft implementation of the updated [SkillRouter Abstraction Layer Proposal](https://github.com/lanzhi-lee/openclaw/blob/self/skill-router-abstraction/xiaomi/proposal/skill-router-abstraction-proposal-en.md).

## Design

**Router interface** (`router-types.ts`):
```typescript
interface SkillRouter {
  readonly name: string;
  route(
    query: string,
    candidates: SkillForPrompt[],
    ctx?: SkillRouteContext,
  ): Promise<SkillRouteResult>;
}
```

`SkillRouteContext` currently exposes `recentMessages: Array<{ role: "user" | "assistant"; text: string }>`.

**Routing outcome** (`router-integration.ts`):
- `{ xml, mode }` — valid direct/ambiguous match; inject narrowed skill XML as prompt-local model context.
- `{ mode: "nomatch" }` — router said no skill applies; suppress the full catalog.
- `{ error, reason }` — router failed or returned an invalid skill; fall back to the full catalog.
- `undefined` — no router configured, no candidates, or no query; use the full catalog as-is.

**Plugin registration** (`router-registry.ts`):
```typescript
registerSkillRouter("my-router", (config) => new MyRouter(config));
```

Router factories are process-global at runtime, but now participate in the plugin loader clear/snapshot/restore lifecycle.

**Configuration**:
```json
{ "skills": { "router": { "name": "my-router", "config": {} } } }
```

## Files Changed

| File | Change |
|------|--------|
| `router-types.ts` | `SkillRouter`, `SkillRouteResult`, `SkillRouteContext` types |
| `router-registry.ts` | router registration, resolution, listing, clear/snapshot/restore lifecycle helpers |
| `router-context.ts` | builds bounded structured recent-message context for routers |
| `router-integration.ts` | pure `resolveSkillRoute` with candidate filtering, context passing, 4-way return, and fallback handling |
| `attempt.ts` | pre-routing, prompt-local routed XML injection, catalog suppression, raw/restricted run skips, recent-message loading |
| `attempt.prompt-helpers.ts` | loads recent session messages for router context using existing session context construction |
| `attempt-tool-construction-plan.ts` | shared helper for existing restrictive runtime `toolsAllow` semantics |
| `workspace.ts` / `skill-contract.ts` | expose prompt-visible resolved skill state and prompt formatting for router candidates |
| `types.skills.ts` / `zod-schema.ts` | `skills.router` config typing and schema validation |
| `skills-runtime.ts` | plugin SDK exports for router registration and router types |
| `loader.ts` | includes skill router registry in plugin runtime clear/cache/rollback/non-activating-load lifecycle |
| tests | focused coverage for prompt-visible candidates, tool allowlists, recent context, model-visible routed XML, and router lifecycle cleanup |

## Verification

- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/plugins/loader.ts src/plugins/loader.runtime-registry.test.ts src/skills/loading/router-registry.ts src/skills/loading/router-integration.test.ts` — passed
- `node scripts/run-vitest.mjs src/plugins/loader.runtime-registry.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/skills/loading/router-integration.test.ts` — 3 shards passed; 90 tests passed
- `node scripts/run-vitest.mjs src/skills/loading/router-context.test.ts src/skills/loading/router-integration.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/skills/loading/prompt-resolution.test.ts` — 3 shards passed; focused router/prompt coverage passed before the lifecycle follow-up
- `pnpm plugin-sdk:api:check` — passed
- `git diff --cached --check` / `git diff --check` — passed at the relevant pre-commit points
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean after fixes; no accepted/actionable findings reported

## Real behavior proof

Behavior addressed: router candidate selection now matches the same filtered skill set shown in `<available_skills>`; raw model probe runs do not invoke skill routing; restrictive runtime `toolsAllow` runs use minimal prompt, suppress the skills catalog, and skip router execution; wildcard `toolsAllow: ["*"]` keeps existing unrestricted behavior and can still route skills; routed skill XML is model-visible without being persisted as user-authored transcript text; router registrations are cleared/restored with plugin runtime lifecycle state.

Real environment tested: local OpenClaw checkout with focused Vitest coverage and structured autoreview closeout.

Exact steps or command run after this patch: `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/plugins/loader.ts src/plugins/loader.runtime-registry.test.ts src/skills/loading/router-registry.ts src/skills/loading/router-integration.test.ts`; `node scripts/run-vitest.mjs src/plugins/loader.runtime-registry.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/skills/loading/router-integration.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode local`.

Evidence after fix: focused tests cover snapshot state, entries fallback, hidden skill filtering, agent skill filters, raw-run routing suppression, restrictive `toolsAllow` routing suppression for non-empty and empty allowlists, wildcard `toolsAllow` preserving routing, recent-message router context, prompt-local routed XML reaching the provider prompt without transcript persistence, and plugin loader router registry cleanup/restore.

Observed result after fix: Vitest reported passing focused shards; oxlint passed; plugin SDK API check passed; autoreview reported `autoreview clean: no accepted/actionable findings reported`.

What was not tested: no live external plugin package implementing a production router yet; no accuracy benchmark for a concrete routing strategy. This PR establishes the core abstraction and lifecycle-safe runtime path.

## Next Steps

- [ ] Community alignment on the abstraction/API design
- [ ] Add public docs for `skills.router` and plugin router integration
- [ ] Add a low-cost reference router plugin for real end-to-end plugin proof
- [ ] Add router diagnostic events
