### PR TITLE
fix(agents): stream assistant deltas incrementally

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -687,6 +687,22 @@ describe("handleAgentEnd", () => {
     });
   });
 
+  it("final-flushes block replies before clearing pending fence fragments", async () => {
+    const ctx = createContext(undefined);
+    ctx.state.blockState.pendingFenceFragment = "```";
+    ctx.flushBlockReplyBuffer = vi.fn((options?: { final?: boolean }) => {
+      if (vi.mocked(ctx.flushBlockReplyBuffer).mock.calls.length === 1) {
+        expect(options).toEqual({ final: true });
+        expect(ctx.state.blockState.pendingFenceFragment).toBe("```");
+      }
+    });
+
+    await handleAgentEnd(ctx);
+
+    expect(ctx.flushBlockReplyBuffer).toHaveBeenNthCalledWith(1, { final: true });
+    expect(ctx.state.blockState.pendingFenceFragment).toBeUndefined();
+  });
+
   it("emits lifecycle end when block reply flush throws", () => {
     const onAgentEvent = vi.fn();
     const ctx = createContext(undefined, { onAgentEvent });

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -177,6 +177,9 @@ export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promi
     ctx.state.blockState.thinking = false;
     ctx.state.blockState.final = false;
     ctx.state.blockState.inlineCode = createInlineCodeState();
+    ctx.state.blockState.fence = undefined;
+    ctx.state.blockState.reasoningPendingFenceFragment = undefined;
+    ctx.state.blockState.pendingFenceFragment = undefined;
 
     if (ctx.state.pendingCompactionRetry > 0) {
       ctx.resolveCompactionRetry();
@@ -236,7 +239,7 @@ export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promi
   };
 
   try {
-    const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer();
+    const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer({ final: true });
     finalizeAgentEnd();
     const flushPendingMediaAndChannelResult = isPromiseLike<void>(flushBlockReplyBufferResult)
       ? Promise.resolve(flushBlockReplyBufferResult).then(() => flushPendingMediaAndChannel())

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -29,6 +29,7 @@ function createMessageUpdateContext(
     debug?: ReturnType<typeof vi.fn>;
     shouldEmitPartialReplies?: boolean;
     consumePartialReplyDirectives?: ReturnType<typeof vi.fn>;
+    stripBlockTags?: ReturnType<typeof vi.fn>;
     state?: Record<string, unknown>;
   } = {},
 ) {
@@ -64,7 +65,7 @@ function createMessageUpdateContext(
     },
     log: { debug: params.debug ?? vi.fn() },
     noteLastAssistant: vi.fn(),
-    stripBlockTags: (text: string) => text,
+    stripBlockTags: params.stripBlockTags ?? vi.fn((text: string) => text),
     consumePartialReplyDirectives: params.consumePartialReplyDirectives ?? vi.fn(() => null),
     emitReasoningStream: vi.fn(),
     flushBlockReplyBuffer: params.flushBlockReplyBuffer ?? vi.fn(),
@@ -289,6 +290,81 @@ describe("pending assistant reply directives", () => {
 });
 
 describe("handleMessageUpdate text signatures", () => {
+  it("uses incremental text deltas for non-phase streams", () => {
+    const onAgentEvent = vi.fn();
+    const stripBlockTags = vi.fn((text: string) => text);
+    const context = createMessageUpdateContext({ onAgentEvent, stripBlockTags });
+
+    const createNonPhaseEvent = (text: string, delta: string) =>
+      ({
+        type: "message_update",
+        message: { role: "assistant", content: [] },
+        assistantMessageEvent: {
+          type: "text_delta",
+          delta,
+          partial: {
+            role: "assistant",
+            content: [{ type: "text", text }],
+            stopReason: "stop",
+            provider: "test",
+            model: "local",
+            usage: {},
+            timestamp: 0,
+          },
+        },
+      }) as never;
+
+    handleMessageUpdate(context, createNonPhaseEvent("Hello ", "Hello "));
+    handleMessageUpdate(context, createNonPhaseEvent("Hello world", "world"));
+
+    expect(stripBlockTags.mock.calls.map(([text]) => text)).toEqual(["Hello ", "world"]);
+    expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject([
+      {
+        stream: "assistant",
+        data: { text: "Hello", delta: "Hello" },
+      },
+      {
+        stream: "assistant",
+        data: { text: "Hello world", delta: " world" },
+      },
+    ]);
+  });
+
+  it("uses full partial text for suffix deltas after a suppressed commentary item", () => {
+    const onAgentEvent = vi.fn();
+    const context = createMessageUpdateContext({ onAgentEvent });
+
+    handleMessageUpdate(
+      context,
+      createTextUpdateEvent({
+        type: "text_delta",
+        text: "Hello",
+        delta: "Hello",
+        id: "item-commentary",
+        signaturePhase: "commentary",
+        partialPhase: "commentary",
+      }),
+    );
+    handleMessageUpdate(
+      context,
+      createTextUpdateEvent({
+        type: "text_delta",
+        text: "Hello world",
+        delta: " world",
+        id: "item-final",
+        signaturePhase: "final_answer",
+        partialPhase: "final_answer",
+      }),
+    );
+
+    expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject([
+      {
+        stream: "assistant",
+        data: { text: "Hello world", delta: "Hello world", phase: "final_answer" },
+      },
+    ]);
+  });
+
   it("treats phased textSignature item changes as assistant-message boundaries", () => {
     const flushBlockReplyBuffer = vi.fn();
     const resetAssistantMessageState = vi.fn();

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -200,6 +200,47 @@ function resolveAssistantTextChunk(params: {
   return "";
 }
 
+const REASONING_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b/i;
+
+function resolveStreamVisibleText(params: {
+  previousRawText: string;
+  visibleDelta: string;
+  finalText?: string;
+}): { rawText: string; visibleText: string } {
+  if (params.finalText !== undefined) {
+    const rawText = params.finalText;
+    return { rawText, visibleText: rawText.trim() };
+  }
+  const rawText = `${params.previousRawText}${params.visibleDelta}`;
+  return { rawText, visibleText: rawText.trim() };
+}
+
+function copyPartialBlockState(
+  target: EmbeddedAgentSubscribeState["partialBlockState"],
+  source: EmbeddedAgentSubscribeState["partialBlockState"],
+) {
+  const copyFenceState = (fence?: typeof source.fence) =>
+    fence
+      ? {
+          atLineStart: fence.atLineStart,
+          ...(fence.open ? { open: { ...fence.open } } : {}),
+        }
+      : undefined;
+  target.thinking = source.thinking;
+  target.final = source.final;
+  target.inlineCode = { ...source.inlineCode };
+  target.fence = copyFenceState(source.fence);
+  target.reasoningInlineCode = source.reasoningInlineCode
+    ? { ...source.reasoningInlineCode }
+    : undefined;
+  target.reasoningFence = copyFenceState(source.reasoningFence);
+  target.reasoningPendingFenceFragment = source.reasoningPendingFenceFragment;
+  target.finalInlineCode = source.finalInlineCode ? { ...source.finalInlineCode } : undefined;
+  target.finalFence = copyFenceState(source.finalFence);
+  target.pendingFenceFragment = source.pendingFenceFragment;
+  target.pendingTagFragment = source.pendingTagFragment;
+}
+
 export function resolveSilentReplyFallbackText(params: {
   text: unknown;
   messagingToolSentTexts: string[];
@@ -551,9 +592,6 @@ export function handleMessageUpdate(
   if (isPhasePendingOpenAiResponsesTextItem) {
     return;
   }
-  const phaseAwareVisibleText = coerceChatContentText(
-    extractAssistantVisibleText(partialAssistant),
-  ).trim();
   const shouldUsePhaseAwareBlockReply = Boolean(deliveryPhase);
 
   if (chunk) {
@@ -567,27 +605,58 @@ export function handleMessageUpdate(
     // Handle partial <think> tags: stream whatever reasoning is visible so far.
     ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
   }
-  const next =
-    phaseAwareVisibleText ||
-    (deliveryPhase === "final_answer"
-      ? ""
-      : ctx
-          .stripBlockTags(
-            ctx.state.deltaBuffer,
-            {
-              thinking: false,
-              final: false,
-              inlineCode: createInlineCodeState(),
-            },
-            { final: evtType === "text_end" },
-          )
-          .trim());
+  const wasThinking = ctx.state.partialBlockState.thinking;
+  let visibleDelta = "";
+  let next = shouldUsePhaseAwareBlockReply
+    ? coerceChatContentText(extractAssistantVisibleText(partialAssistant)).trim()
+    : "";
+  let nextRawStreamText = next;
+  if (!next && deliveryPhase !== "final_answer") {
+    const pendingTagFragment = ctx.state.partialBlockState.pendingTagFragment;
+    const shouldRecomputeFullStream = Boolean(pendingTagFragment) || REASONING_TAG_RE.test(chunk);
+    if (shouldRecomputeFullStream) {
+      const recomputeState: EmbeddedAgentSubscribeState["partialBlockState"] = {
+        thinking: false,
+        final: false,
+        inlineCode: createInlineCodeState(),
+      };
+      const recomputedRawText = ctx.stripBlockTags(ctx.state.deltaBuffer, recomputeState, {
+        final: evtType === "text_end",
+      });
+      const previousRawText = ctx.state.lastStreamedAssistant ?? "";
+      const isFullStreamReplacement = !recomputedRawText.startsWith(previousRawText);
+      next = recomputedRawText.trim();
+      visibleDelta = isFullStreamReplacement
+        ? recomputedRawText
+        : recomputedRawText.slice(previousRawText.length);
+      nextRawStreamText = recomputedRawText;
+      copyPartialBlockState(ctx.state.partialBlockState, recomputeState);
+    } else {
+      visibleDelta =
+        chunk || evtType === "text_end"
+          ? ctx.stripBlockTags(chunk, ctx.state.partialBlockState, {
+              final: evtType === "text_end",
+            })
+          : "";
+      if (ctx.state.partialBlockState.pendingTagFragment) {
+        visibleDelta = "";
+        next = ctx.state.lastStreamedAssistantCleaned ?? "";
+        nextRawStreamText = ctx.state.lastStreamedAssistant ?? "";
+      } else {
+        const streamVisibleText = resolveStreamVisibleText({
+          previousRawText: ctx.state.lastStreamedAssistant ?? "",
+          visibleDelta,
+        });
+        next = streamVisibleText.visibleText;
+        nextRawStreamText = streamVisibleText.rawText;
+      }
+    }
+  } else if (next && (chunk || evtType === "text_end")) {
+    visibleDelta = ctx.stripBlockTags(chunk, ctx.state.partialBlockState, {
+      final: evtType === "text_end",
+    });
+  }
   if (next) {
-    const wasThinking = ctx.state.partialBlockState.thinking;
-    const visibleDelta =
-      chunk || evtType === "text_end"
-        ? ctx.stripBlockTags(chunk, ctx.state.partialBlockState, { final: evtType === "text_end" })
-        : "";
     if (!wasThinking && ctx.state.partialBlockState.thinking) {
       openReasoningStream(ctx);
     }
@@ -636,7 +705,7 @@ export function handleMessageUpdate(
       }
     }
 
-    ctx.state.lastStreamedAssistant = next;
+    ctx.state.lastStreamedAssistant = nextRawStreamText;
     ctx.state.lastStreamedAssistantCleaned = cleanedText;
 
     if (ctx.params.silentExpected || suppressDeterministicApprovalOutput) {
@@ -755,7 +824,21 @@ export function handleMessageEnd(
     ctx.state.blockState.thinking = false;
     ctx.state.blockState.final = false;
     ctx.state.blockState.inlineCode = createInlineCodeState();
+    ctx.state.blockState.fence = undefined;
+    ctx.state.blockState.reasoningInlineCode = undefined;
+    ctx.state.blockState.reasoningFence = undefined;
+    ctx.state.blockState.reasoningPendingFenceFragment = undefined;
+    ctx.state.blockState.finalInlineCode = undefined;
+    ctx.state.blockState.finalFence = undefined;
+    ctx.state.blockState.pendingFenceFragment = undefined;
     ctx.state.blockState.pendingTagFragment = undefined;
+    ctx.state.partialBlockState.fence = undefined;
+    ctx.state.partialBlockState.reasoningInlineCode = undefined;
+    ctx.state.partialBlockState.reasoningFence = undefined;
+    ctx.state.partialBlockState.reasoningPendingFenceFragment = undefined;
+    ctx.state.partialBlockState.finalInlineCode = undefined;
+    ctx.state.partialBlockState.finalFence = undefined;
+    ctx.state.partialBlockState.pendingFenceFragment = undefined;
     ctx.state.partialBlockState.pendingTagFragment = undefined;
     ctx.state.lastStreamedAssistant = undefined;
     ctx.state.lastStreamedAssistantCleaned = undefined;

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -2,6 +2,7 @@ import type { HeartbeatToolResponse } from "../auto-reply/heartbeat-tool-respons
 import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
+import type { FenceScanState } from "../markdown/fences.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import type { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
@@ -64,12 +65,26 @@ export type EmbeddedAgentSubscribeState = {
     thinking: boolean;
     final: boolean;
     inlineCode: InlineCodeState;
+    fence?: FenceScanState;
+    reasoningInlineCode?: InlineCodeState;
+    reasoningFence?: FenceScanState;
+    reasoningPendingFenceFragment?: string;
+    finalInlineCode?: InlineCodeState;
+    finalFence?: FenceScanState;
+    pendingFenceFragment?: string;
     pendingTagFragment?: string;
   };
   partialBlockState: {
     thinking: boolean;
     final: boolean;
     inlineCode: InlineCodeState;
+    fence?: FenceScanState;
+    reasoningInlineCode?: InlineCodeState;
+    reasoningFence?: FenceScanState;
+    reasoningPendingFenceFragment?: string;
+    finalInlineCode?: InlineCodeState;
+    finalFence?: FenceScanState;
+    pendingFenceFragment?: string;
     pendingTagFragment?: string;
   };
   lastStreamedAssistant?: string;
@@ -150,6 +165,13 @@ export type EmbeddedAgentSubscribeContext = {
       thinking: boolean;
       final: boolean;
       inlineCode?: InlineCodeState;
+      fence?: FenceScanState;
+      reasoningInlineCode?: InlineCodeState;
+      reasoningFence?: FenceScanState;
+      reasoningPendingFenceFragment?: string;
+      finalInlineCode?: InlineCodeState;
+      finalFence?: FenceScanState;
+      pendingFenceFragment?: string;
       pendingTagFragment?: string;
     },
     options?: { final?: boolean },

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -95,6 +95,115 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(requireFirstReplyPayload(onPartialReply).text).toBe("Hello world");
   });
 
+  it("keeps final tag literals inside streamed fenced code while enforcement is on", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedAgentSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "```xml\n" });
+    emitAssistantTextDelta({ emit, delta: "<final>literal</final>\n" });
+    emitAssistantTextDelta({ emit, delta: "```\n<final>Answer</final>" });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Answer");
+  });
+
+  it("does not keep stale fence state after a suppressed prefix closes before final text", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedAgentSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "```xml\n" });
+    emitAssistantTextDelta({ emit, delta: "```\n<final>Answer" });
+    emitAssistantTextDelta({ emit, delta: "</final><think>secret</think>" });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Answer");
+    expect(payloads.some((payload) => String(payload.text).includes("secret"))).toBe(false);
+  });
+
+  it("does not let suppressed inline code state hide later final tags", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedAgentSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "draft `" });
+    emitAssistantTextDelta({ emit, delta: "<final>Answer</final>" });
+
+    expect(onPartialReply).toHaveBeenCalledTimes(1);
+    expect(requireFirstReplyPayload(onPartialReply).text).toBe("Answer");
+  });
+
+  it("closes hidden reasoning fences split across deltas before final text", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedAgentSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "<think>\n```ts\nconst hidden = true;\n``" });
+    emitAssistantTextDelta({ emit, delta: "`\n</think><final>Answer</final>" });
+
+    expect(onPartialReply).toHaveBeenCalledTimes(1);
+    expect(requireFirstReplyPayload(onPartialReply).text).toBe("Answer");
+  });
+
+  it("strips nested final tag literals after suppressed fenced prefixes", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedAgentSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "```xml\n" });
+    emitAssistantTextDelta({
+      emit,
+      delta: "```\n<final>Answer <final>literal</final></final>",
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Answer literal");
+  });
+
   it("strips final tags split across streamed deltas without emitting tag remnants", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -78,6 +78,21 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
   }
 
+  function emitAssistantTextEnd(
+    emit: (evt: unknown) => void,
+    content: string,
+    message: Record<string, unknown> = { role: "assistant" },
+  ) {
+    emit({
+      type: "message_update",
+      message,
+      assistantMessageEvent: {
+        type: "text_end",
+        content,
+      },
+    });
+  }
+
   function createWriteFailureHarness(params: {
     runId: string;
     path: string;
@@ -939,6 +954,137 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.text).toBe("Visible answer");
     expect(payloads[0]?.delta).toBe("Visible answer");
+  });
+
+  it("replaces malformed streamed reasoning when orphan close tags split across deltas", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "private chain of thought </thi");
+    emitAssistantTextDelta(emit, "nk> Visible answer");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Visible answer");
+    expect(payloads[0]?.replace).toBeUndefined();
+  });
+
+  it("preserves visible text before a split orphan close when no final text follows", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "Done ");
+    emitAssistantTextDelta(emit, "</thi");
+    emitAssistantTextDelta(emit, "nk>");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Done");
+  });
+
+  it("preserves media directives when orphan close replacement has no text", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "private chain of thought </thi");
+    emitAssistantTextDelta(emit, "nk>\nMEDIA:/tmp/a.png\n");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads.at(-1)).toMatchObject({
+      text: "",
+      mediaUrls: ["/tmp/a.png"],
+    });
+    expect(payloads.at(-1)?.replace).toBeUndefined();
+  });
+
+  it("preserves block tag literals inside fenced code split across deltas", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+    const finalText = "```xml\n<thinking>literal</thinking>\n```";
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "```xml\n");
+    emitAssistantTextDelta(emit, "<thinking>literal</thinking>\n");
+    emitAssistantTextDelta(emit, "```");
+    emitAssistantTextEnd(emit, finalText);
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads.at(-1)?.text).toBe(finalText);
+  });
+
+  it("does not infer a fence from a chunk-local line start before reasoning tags", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "abc");
+    emitAssistantTextDelta(emit, "~~~xml\n<think>secret");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads[0]?.text).toBe("abc");
+    expect(payloads.at(-1)?.text).toBe("abc~~~xml");
+    expect(payloads.some((payload) => String(payload.text).includes("secret"))).toBe(false);
+  });
+
+  it("preserves split fenced code openers while stripping later reasoning", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "``");
+    emitAssistantTextDelta(
+      emit,
+      "`xml\n<thinking>literal</thinking>\n```\n<think>secret</think>answer",
+    );
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads.at(-1)?.text).toBe("```xml\n<thinking>literal</thinking>\n```\nanswer");
+  });
+
+  it("preserves long fenced code openers split after three markers", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+    const finalText = "````\n<thinking>literal</thinking>\n```\n````";
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "```");
+    emitAssistantTextDelta(emit, "`\n<thinking>literal</thinking>\n```\n````");
+    emitAssistantTextEnd(emit, finalText);
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads.at(-1)?.text).toBe(finalText);
+  });
+
+  it("keeps close tag literals inside hidden fenced code stripped across deltas", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "<think>\n```ts\nliteral ");
+    emitAssistantTextDelta(emit, "</think> still private");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("does not carry hidden fenced code state into visible text", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "<think>\n```ts\nscratch");
+    emitAssistantTextDelta(emit, "\n```\n</think>Visible answer");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads.at(-1)?.text).toBe("Visible answer");
+  });
+
+  it("preserves block tag literals inside tilde fenced code split across deltas", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+    const finalText = "~~~xml\n<thinking>literal</thinking>\n~~~";
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "~~~xml\n");
+    emitAssistantTextDelta(emit, "<thinking>literal</thinking>\n");
+    emitAssistantTextDelta(emit, "~~~");
+    emitAssistantTextEnd(emit, finalText);
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads.at(-1)?.text).toBe(finalText);
   });
 
   it("emits agent events on message_end for non-streaming assistant text", () => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -7,6 +7,7 @@ import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
+import type { FenceScanState } from "../markdown/fences.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { findFinalTagMatches } from "../shared/text/final-tags.js";
 import { hasOrphanReasoningCloseBoundary } from "../shared/text/reasoning-tags.js";
@@ -102,6 +103,21 @@ function splitTrailingBlockTagFragment(
   return {
     text: text.slice(0, fragmentStart),
     pendingTagFragment: fragment,
+  };
+}
+
+function splitTrailingFenceFragment(
+  text: string,
+  startsAtLineStart: boolean,
+): { text: string; pendingFenceFragment?: string } {
+  const lineStart = text.lastIndexOf("\n") + 1;
+  const line = text.slice(lineStart);
+  if ((!startsAtLineStart && lineStart === 0) || !/^(?: {0,3})(?:`+|~+)$/.test(line)) {
+    return { text };
+  }
+  return {
+    text: text.slice(0, lineStart),
+    pendingFenceFragment: line,
   };
 }
 
@@ -289,10 +305,24 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.blockState.thinking = false;
     state.blockState.final = false;
     state.blockState.inlineCode = createInlineCodeState();
+    state.blockState.fence = undefined;
+    state.blockState.reasoningInlineCode = undefined;
+    state.blockState.reasoningFence = undefined;
+    state.blockState.reasoningPendingFenceFragment = undefined;
+    state.blockState.finalInlineCode = undefined;
+    state.blockState.finalFence = undefined;
+    state.blockState.pendingFenceFragment = undefined;
     state.blockState.pendingTagFragment = undefined;
     state.partialBlockState.thinking = false;
     state.partialBlockState.final = false;
     state.partialBlockState.inlineCode = createInlineCodeState();
+    state.partialBlockState.fence = undefined;
+    state.partialBlockState.reasoningInlineCode = undefined;
+    state.partialBlockState.reasoningFence = undefined;
+    state.partialBlockState.reasoningPendingFenceFragment = undefined;
+    state.partialBlockState.finalInlineCode = undefined;
+    state.partialBlockState.finalFence = undefined;
+    state.partialBlockState.pendingFenceFragment = undefined;
     state.partialBlockState.pendingTagFragment = undefined;
     state.lastStreamedAssistant = undefined;
     state.lastStreamedAssistantCleaned = undefined;
@@ -624,37 +654,97 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       thinking: boolean;
       final: boolean;
       inlineCode?: InlineCodeState;
+      fence?: FenceScanState;
+      reasoningInlineCode?: InlineCodeState;
+      reasoningFence?: FenceScanState;
+      reasoningPendingFenceFragment?: string;
+      finalInlineCode?: InlineCodeState;
+      finalFence?: FenceScanState;
+      pendingFenceFragment?: string;
       pendingTagFragment?: string;
     },
-    options?: { final?: boolean },
+    options?: { final?: boolean; completeMarkdownChunk?: boolean },
   ): string => {
-    const input = `${state.pendingTagFragment ?? ""}${text}`;
+    const input = `${state.pendingFenceFragment ?? ""}${state.pendingTagFragment ?? ""}${text}`;
+    state.pendingFenceFragment = undefined;
     state.pendingTagFragment = undefined;
     if (!input) {
       return text;
     }
 
+    const { text: fenceInput, pendingFenceFragment } = options?.final
+      ? { text: input, pendingFenceFragment: undefined }
+      : options?.completeMarkdownChunk
+        ? { text: input, pendingFenceFragment: undefined }
+        : splitTrailingFenceFragment(input, state.fence?.atLineStart ?? true);
+    state.pendingFenceFragment = pendingFenceFragment;
+    if (!fenceInput) {
+      return "";
+    }
+
     const inlineStateStart = state.inlineCode ?? createInlineCodeState();
-    const initialCodeSpans = buildCodeSpanIndex(input, inlineStateStart);
+    const fenceStateStart = state.fence;
+    const initialCodeSpans = buildCodeSpanIndex(fenceInput, inlineStateStart, fenceStateStart);
     const { text: scanText, pendingTagFragment } = options?.final
-      ? { text: input, pendingTagFragment: undefined }
-      : splitTrailingBlockTagFragment(input, initialCodeSpans.isInside);
+      ? { text: fenceInput, pendingTagFragment: undefined }
+      : splitTrailingBlockTagFragment(fenceInput, initialCodeSpans.isInside);
     state.pendingTagFragment = pendingTagFragment;
     if (!scanText) {
       return "";
     }
-    const codeSpans = buildCodeSpanIndex(scanText, inlineStateStart);
+    const codeSpans = buildCodeSpanIndex(scanText, inlineStateStart, fenceStateStart);
 
     let processed = "";
     THINKING_TAG_SCAN_RE.lastIndex = 0;
     let lastIndex = 0;
+    let lastCodeIndex = 0;
     let inThinking = state.thinking;
+    // Hidden reasoning has its own code state: malformed hidden fences must not
+    // mark later visible text as code, but literal close tags there stay hidden.
+    let hiddenInlineState: InlineCodeState = state.reasoningInlineCode
+      ? { ...state.reasoningInlineCode }
+      : createInlineCodeState();
+    let hiddenFenceState: FenceScanState | undefined = state.reasoningFence?.open
+      ? { atLineStart: state.reasoningFence.atLineStart, open: { ...state.reasoningFence.open } }
+      : state.reasoningFence
+        ? { atLineStart: state.reasoningFence.atLineStart }
+        : undefined;
+    let hiddenPendingFenceFragment = state.reasoningPendingFenceFragment;
+    state.reasoningPendingFenceFragment = undefined;
+    const advanceHiddenCodeState = (segment: string) => {
+      const hiddenInput = `${hiddenPendingFenceFragment ?? ""}${segment}`;
+      hiddenPendingFenceFragment = undefined;
+      if (!hiddenInput) {
+        return;
+      }
+      const { text: hiddenFenceInput, pendingFenceFragment } = options?.final
+        ? { text: hiddenInput, pendingFenceFragment: undefined }
+        : options?.completeMarkdownChunk
+          ? { text: hiddenInput, pendingFenceFragment: undefined }
+          : splitTrailingFenceFragment(hiddenInput, hiddenFenceState?.atLineStart ?? true);
+      hiddenPendingFenceFragment = pendingFenceFragment;
+      if (!hiddenFenceInput) {
+        return;
+      }
+      const next = buildCodeSpanIndex(hiddenFenceInput, hiddenInlineState, hiddenFenceState);
+      hiddenInlineState = next.inlineState;
+      hiddenFenceState = next.fenceState;
+    };
     for (const match of scanText.matchAll(THINKING_TAG_SCAN_RE)) {
       const idx = match.index ?? 0;
-      if (codeSpans.isInside(idx)) {
+      const isClose = match[1] === "/";
+      if (inThinking) {
+        advanceHiddenCodeState(scanText.slice(lastCodeIndex, idx));
+      }
+      const isInsideHiddenCode =
+        inThinking && (hiddenInlineState.open || Boolean(hiddenFenceState?.open));
+      lastCodeIndex = idx + match[0].length;
+      if ((!inThinking && codeSpans.isInside(idx)) || isInsideHiddenCode) {
+        if (inThinking) {
+          advanceHiddenCodeState(match[0]);
+        }
         continue;
       }
-      const isClose = match[1] === "/";
       if (!inThinking) {
         if (isClose) {
           const afterIndex = idx + match[0].length;
@@ -669,21 +759,36 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           continue;
         }
         processed += scanText.slice(lastIndex, idx);
+        hiddenInlineState = createInlineCodeState();
+        hiddenFenceState = undefined;
+        hiddenPendingFenceFragment = undefined;
       }
       inThinking = !isClose;
+      if (!inThinking) {
+        hiddenInlineState = createInlineCodeState();
+        hiddenFenceState = undefined;
+        hiddenPendingFenceFragment = undefined;
+      }
       lastIndex = idx + match[0].length;
+    }
+    if (inThinking) {
+      advanceHiddenCodeState(scanText.slice(lastCodeIndex));
     }
     if (!inThinking) {
       processed += scanText.slice(lastIndex);
     }
     state.thinking = inThinking;
+    state.reasoningInlineCode = inThinking ? hiddenInlineState : undefined;
+    state.reasoningFence = inThinking ? hiddenFenceState : undefined;
+    state.reasoningPendingFenceFragment = inThinking ? hiddenPendingFenceFragment : undefined;
 
     // If enforcement is disabled, we still strip the tags themselves to prevent
     // hallucinations (e.g. Minimax copying the style) from leaking, but we
     // do not enforce buffering/extraction logic.
-    const finalCodeSpans = buildCodeSpanIndex(processed, inlineStateStart);
+    const finalCodeSpans = buildCodeSpanIndex(processed, inlineStateStart, fenceStateStart);
     if (!params.enforceFinalTag) {
       state.inlineCode = finalCodeSpans.inlineState;
+      state.fence = finalCodeSpans.fenceState;
       return stripFinalTagsOutsideCodeSpans(processed, finalCodeSpans.isInside);
     }
 
@@ -732,13 +837,26 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // we have seen a <final> tag. Otherwise, we leak "thinking out loud" text
     // (e.g. "**Locating Manulife**...") that the model emitted without <think> tags.
     if (!everInFinal) {
+      state.inlineCode = createInlineCodeState();
+      state.fence = finalCodeSpans.fenceState;
+      state.finalInlineCode = undefined;
+      state.finalFence = undefined;
       return "";
     }
 
     // Hardened Cleanup: Remove any remaining <final> tags that might have been
     // missed (e.g. nested tags or hallucinations) to prevent leakage.
-    const resultCodeSpans = buildCodeSpanIndex(result, inlineStateStart);
-    state.inlineCode = resultCodeSpans.inlineState;
+    const finalResultInlineStateStart = state.finalInlineCode ?? createInlineCodeState();
+    const finalResultFenceStateStart = state.finalFence;
+    const resultCodeSpans = buildCodeSpanIndex(
+      result,
+      finalResultInlineStateStart,
+      finalResultFenceStateStart,
+    );
+    state.inlineCode = finalCodeSpans.inlineState;
+    state.fence = finalCodeSpans.fenceState;
+    state.finalInlineCode = inFinal ? resultCodeSpans.inlineState : undefined;
+    state.finalFence = inFinal ? resultCodeSpans.fenceState : undefined;
     return stripFinalTagsOutsideCodeSpans(result, resultCodeSpans.isInside);
   };
 
@@ -759,7 +877,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
 
   const emitBlockChunk = (
     text: string,
-    options?: { assistantMessageIndex?: number; final?: boolean },
+    options?: { assistantMessageIndex?: number; final?: boolean; completeMarkdownChunk?: boolean },
   ) => {
     if (state.suppressBlockChunks || params.silentExpected) {
       return;
@@ -767,7 +885,10 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
     const blockReplyText = stripDowngradedToolCallText(
-      stripBlockTags(text, state.blockState, { final: options?.final === true }),
+      stripBlockTags(text, state.blockState, {
+        final: options?.final === true,
+        completeMarkdownChunk: options?.completeMarkdownChunk === true,
+      }),
     ).trimEnd();
     if (!blockReplyText) {
       return;
@@ -896,6 +1017,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
             if (pendingChunk !== undefined) {
               emitBlockChunk(pendingChunk, {
                 assistantMessageIndex: options.assistantMessageIndex,
+                completeMarkdownChunk: true,
               });
             }
             pendingChunk = text;
@@ -904,6 +1026,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         if (pendingChunk !== undefined) {
           emitBlockChunk(pendingChunk, {
             assistantMessageIndex: options.assistantMessageIndex,
+            completeMarkdownChunk: true,
             final: true,
           });
         }

--- a/src/markdown/code-spans.ts
+++ b/src/markdown/code-spans.ts
@@ -1,4 +1,4 @@
-import { parseFenceSpans, type FenceSpan } from "./fences.js";
+import { scanFenceSpans, type FenceScanState, type FenceSpan } from "./fences.js";
 
 export type InlineCodeState = {
   open: boolean;
@@ -16,11 +16,16 @@ type InlineCodeSpansResult = {
 
 type CodeSpanIndex = {
   inlineState: InlineCodeState;
+  fenceState: FenceScanState;
   isInside: (index: number) => boolean;
 };
 
-export function buildCodeSpanIndex(text: string, inlineState?: InlineCodeState): CodeSpanIndex {
-  const fenceSpans = parseFenceSpans(text);
+export function buildCodeSpanIndex(
+  text: string,
+  inlineState?: InlineCodeState,
+  fenceState?: FenceScanState,
+): CodeSpanIndex {
+  const { spans: fenceSpans, state: nextFenceState } = scanFenceSpans(text, fenceState);
   const startState = inlineState
     ? { open: inlineState.open, ticks: inlineState.ticks }
     : createInlineCodeState();
@@ -32,6 +37,7 @@ export function buildCodeSpanIndex(text: string, inlineState?: InlineCodeState):
 
   return {
     inlineState: nextInlineState,
+    fenceState: nextFenceState,
     isInside: (index: number) =>
       isInsideFenceSpan(index, fenceSpans) || isInsideInlineSpan(index, inlineSpans),
   };

--- a/src/markdown/fences.ts
+++ b/src/markdown/fences.ts
@@ -6,8 +6,23 @@ export type FenceSpan = {
   indent: string;
 };
 
-export function parseFenceSpans(buffer: string): FenceSpan[] {
+export type FenceScanState = {
+  atLineStart?: boolean;
+  open?: {
+    markerChar: string;
+    markerLen: number;
+    openLine: string;
+    marker: string;
+    indent: string;
+  };
+};
+
+export function scanFenceSpans(
+  buffer: string,
+  state?: FenceScanState,
+): { spans: FenceSpan[]; state: FenceScanState } {
   const spans: FenceSpan[] = [];
+  const startsAtLineStart = state?.atLineStart ?? true;
   let open:
     | {
         start: number;
@@ -17,7 +32,7 @@ export function parseFenceSpans(buffer: string): FenceSpan[] {
         marker: string;
         indent: string;
       }
-    | undefined;
+    | undefined = state?.open ? { ...state.open, start: 0 } : undefined;
 
   let offset = 0;
   while (offset <= buffer.length) {
@@ -26,7 +41,7 @@ export function parseFenceSpans(buffer: string): FenceSpan[] {
     const line = buffer.slice(offset, lineEnd);
 
     const match = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
-    if (match) {
+    if (match && (offset > 0 || startsAtLineStart)) {
       const indent = match[1];
       const marker = match[2];
       const markerChar = marker[0];
@@ -69,7 +84,26 @@ export function parseFenceSpans(buffer: string): FenceSpan[] {
     });
   }
 
-  return spans;
+  const atLineStart = buffer.length === 0 ? startsAtLineStart : buffer.endsWith("\n");
+  const nextState: FenceScanState = {
+    atLineStart,
+    ...(open
+      ? {
+          open: {
+            markerChar: open.markerChar,
+            markerLen: open.markerLen,
+            openLine: open.openLine,
+            marker: open.marker,
+            indent: open.indent,
+          },
+        }
+      : {}),
+  };
+  return { spans, state: nextState };
+}
+
+export function parseFenceSpans(buffer: string): FenceSpan[] {
+  return scanFenceSpans(buffer).spans;
 }
 
 export function findFenceSpanAt(spans: FenceSpan[], index: number): FenceSpan | undefined {


### PR DESCRIPTION
## Summary

- stream ordinary non-phase assistant text deltas incrementally instead of stripping the accumulated `deltaBuffer` on every chunk
- keep full recompute behavior for split block-tag fragments and reasoning tags where chunk-local stripping is unsafe
- carry visible, hidden-reasoning, and enforced-final fenced-code state incrementally without letting stripped/suppressed text poison later visible parsing
- final-flush block replies on `agent_end` before clearing pending fence fragments
- add regressions for suffix streaming, split orphan close replacement, media-only replacement, hidden-code safety, split fence markers, strict-final fences, chunk-boundary fence context, agent-end final flush, and suppressed inline-code/fence edge cases

Fixes part of https://github.com/openclaw/openclaw/issues/86599.

## Verification

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/stream-subscriber-hiddenfence-$USER-$$ node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts` - 8 files / 266 tests passed on `bd46e30cb5`
- `./node_modules/.bin/oxfmt --check --threads=1 src/markdown/fences.ts src/markdown/code-spans.ts src/agents/embedded-agent-subscribe.handlers.types.ts src/agents/embedded-agent-subscribe.handlers.messages.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts src/agents/embedded-agent-subscribe.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts`
- `./node_modules/.bin/oxlint src/markdown/fences.ts src/markdown/code-spans.ts src/agents/embedded-agent-subscribe.handlers.types.ts src/agents/embedded-agent-subscribe.handlers.messages.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts src/agents/embedded-agent-subscribe.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings
- Earlier AWS Crabbox Linux `corepack pnpm check:changed`: run `run_1a882b49b2af`, lease `cbx_fdfa7ac4ecbd`, slug `jade-prawn`, passed for the current-main type gate unblocker #87750. Fresh broad changed-gate proof for this PR is waiting for #87750 to land or for a stacked proof run with #87750 overlaid.

## Real behavior proof

Behavior addressed: repeated subscriber work over accumulated streamed text during normal non-phase assistant deltas.

Real environment tested: focused local Vitest/static checks in a Codex worktree after rebase, autoreview after regression fixes, plus AWS Crabbox Linux changed gate proof for the current-main gate unblocker.

Exact steps or command run after this patch: commands listed in Verification.

Evidence after fix: focused tests pass with 8 files / 266 tests; autoreview reports no accepted/actionable findings after fixing agent-end fence flush, suppressed inline-code state, and hidden reasoning split-fence cases.

Observed result after fix: ordinary text deltas append from the new chunk, while split tag, orphan close, hidden reasoning, strict-final, and fenced-code cases avoid leaking reasoning, dropping final output, or stripping literal code content.

What was not tested: fresh full `check:changed` completion on this latest SHA until #87750 lands or is overlaid in a stacked proof run.
