### PR TITLE
Fix Discord task notify default

### DIFF
--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2863,6 +2863,74 @@ describe("task-registry", () => {
     });
   });
 
+  it("defaults Discord-originated deliverable tasks to state-change notifications", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:123",
+        },
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-discord-default-notify",
+        task: "Investigate issue",
+        status: "queued",
+      });
+
+      expectRecordFields(requireTaskByRunId("run-discord-default-notify"), {
+        deliveryStatus: "pending",
+        notifyPolicy: "state_changes",
+      });
+    });
+  });
+
+  it("keeps explicit and non-Discord task notify defaults unchanged", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:123",
+        },
+        childSessionKey: "agent:codex:acp:explicit",
+        runId: "run-discord-explicit-notify",
+        task: "Investigate silently",
+        status: "queued",
+        notifyPolicy: "silent",
+      });
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "guildchat",
+          to: "guildchat:123",
+        },
+        childSessionKey: "agent:codex:acp:guildchat",
+        runId: "run-guildchat-default-notify",
+        task: "Investigate issue",
+        status: "queued",
+      });
+
+      expectRecordFields(requireTaskByRunId("run-discord-explicit-notify"), {
+        notifyPolicy: "silent",
+      });
+      expectRecordFields(requireTaskByRunId("run-guildchat-default-notify"), {
+        notifyPolicy: "done_only",
+      });
+    });
+  });
+
   it("delivers concise state-change updates only when notify policy requests them", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -348,6 +348,7 @@ function ensureDeliveryStatus(params: {
 function ensureNotifyPolicy(params: {
   notifyPolicy?: TaskNotifyPolicy;
   deliveryStatus?: TaskDeliveryStatus;
+  requesterOrigin?: TaskDeliveryState["requesterOrigin"];
   ownerKey: string;
   scopeKind: TaskScopeKind;
 }): TaskNotifyPolicy {
@@ -360,7 +361,13 @@ function ensureNotifyPolicy(params: {
       ownerKey: params.ownerKey,
       scopeKind: params.scopeKind,
     });
-  return deliveryStatus === "not_applicable" ? "silent" : "done_only";
+  if (deliveryStatus === "not_applicable") {
+    return "silent";
+  }
+  if (params.requesterOrigin?.channel === "discord") {
+    return "state_changes";
+  }
+  return "done_only";
 }
 
 function resolveTaskScopeKind(params: {
@@ -804,6 +811,7 @@ function mergeExistingTaskForCreate(
   const notifyPolicy = ensureNotifyPolicy({
     notifyPolicy: params.notifyPolicy,
     deliveryStatus: params.deliveryStatus,
+    requesterOrigin,
     ownerKey: existing.ownerKey,
     scopeKind: existing.scopeKind,
   });
@@ -1561,9 +1569,11 @@ export function createTaskRecord(params: {
       ownerKey,
       scopeKind,
     });
+  const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   const notifyPolicy = ensureNotifyPolicy({
     notifyPolicy: params.notifyPolicy,
     deliveryStatus,
+    requesterOrigin,
     ownerKey,
     scopeKind,
   });
@@ -1603,7 +1613,7 @@ export function createTaskRecord(params: {
   tasks.set(taskId, record);
   upsertTaskDeliveryState({
     taskId,
-    requesterOrigin: normalizeDeliveryContext(params.requesterOrigin),
+    requesterOrigin,
   });
   addRunIdIndex(taskId, record.runId);
   addOwnerKeyIndex(taskId, record);


### PR DESCRIPTION
## Summary
- default deliverable Discord-originated task records to state-change notifications when no explicit notify policy is supplied
- preserve explicit notify policies, not_applicable silent behavior, and non-Discord done_only defaults
- add regression coverage for Discord defaulting and unchanged explicit/non-Discord behavior

Fixes #87665

## Real behavior proof
- **Behavior or issue addressed:** Discord-originated ACP/subagent task records created without an explicit `notifyPolicy` now surface state-change notifications instead of staying on `done_only`, so Discord operators get progress/state updates instead of only a typing indicator until terminal status.
- **Real environment tested:** Local OpenClaw checkout on macOS from PR branch `vector/fix-87665-discord-notify-policy`, Node 22 runtime, isolated temporary `OPENCLAW_STATE_DIR`, real `src/tasks/task-registry.ts` imported through `node --import tsx`.
- **Exact steps or command run after the patch:** Ran a local OpenClaw task-registry smoke command that creates one Discord-originated ACP task and one non-Discord ACP task without explicit `notifyPolicy`, then reads both records through `findTaskByRunId`.
- **Evidence after fix:** Terminal output from the patched branch:

```console
$ STATE_DIR=$(mktemp -d) OPENCLAW_STATE_DIR="$STATE_DIR" node --import tsx -e '...createTaskRecord smoke...'
{
  "discord": {
    "deliveryStatus": "pending",
    "notifyPolicy": "state_changes"
  },
  "guildchat": {
    "deliveryStatus": "pending",
    "notifyPolicy": "done_only"
  }
}
```

- **Observed result after fix:** The real task-registry path assigns `notifyPolicy: "state_changes"` to the Discord-originated deliverable task and keeps the non-Discord deliverable task at `notifyPolicy: "done_only"`.
- **What was not tested:** I did not run a live Discord channel end-to-end because this environment does not have a disposable Discord bot/channel setup for live message delivery.

## Verification
- RED: `pnpm exec vitest run src/tasks/task-registry.test.ts --testNamePattern "defaults Discord-originated deliverable tasks to state-change notifications|keeps explicit and non-Discord task notify defaults unchanged"` failed with expected `done_only` vs `state_changes`
- GREEN: same focused command passed after the fix
- `pnpm exec vitest run src/tasks/task-registry.test.ts` passed 73/73
- `git diff --check` passed
- `pnpm tsgo:core` currently fails on existing unrelated errors in `src/plugin-sdk/approval-reaction-runtime.ts` and `src/plugins/discovery.ts`

## Clawpatch
- `clawpatch_doctor` passed for `/Users/miya/Desktop/openclaw`
- `clawpatch_map --provider codex` completed
- `clawpatch_review --provider codex --limit 3 --jobs 1` could not complete because the Codex provider returned 401 Unauthorized; `clawpatch_report` showed 0 findings because no review results were produced
