### PR TITLE
fix(control-ui): prevent blur/click race that breaks session-picker buttons (#87554)

### DIFF
--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -201,6 +201,20 @@ function focusChatSessionPickerSearch(state: AppViewState) {
   setTimeout(focus, 0);
 }
 
+// Search input blur from clicks on sibling picker controls (option, submit, clear,
+// load-more) used to clear chatSessionPickerResult before the click dispatched. Lit's
+// microtask re-render then unmounted the option/button so the click target vanished
+// and no handler fired (#87554). The blur->apply contract only matters when focus
+// leaves the popover; in-popover focus moves keep the search state intact and let
+// the click handler take over.
+function isFocusMovingInsideChatSessionPicker(event: FocusEvent): boolean {
+  const next = event.relatedTarget;
+  if (!(next instanceof Element)) {
+    return false;
+  }
+  return next.closest(".chat-session-picker") !== null;
+}
+
 function openChatSessionPicker(state: AppViewState, surface: ChatSessionSelectSurface) {
   state.chatSessionPickerOpen = true;
   state.chatSessionPickerSurface = surface;
@@ -594,7 +608,12 @@ function renderChatSessionPickerPopover(
                 void applyChatSessionPickerSearch(state);
               }
             }}
-            @blur=${() => void applyChatSessionPickerSearch(state)}
+            @blur=${(event: FocusEvent) => {
+              if (isFocusMovingInsideChatSessionPicker(event)) {
+                return;
+              }
+              void applyChatSessionPickerSearch(state);
+            }}
           />
         </label>
         <button

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1433,6 +1433,46 @@ describe("chat session controls", () => {
     });
   });
 
+  it("keeps chat session picker results when the search input blurs onto a sibling control", async () => {
+    // Regression for #87554: a blur whose relatedTarget is inside the picker (option, submit,
+    // clear, load-more) must not tear down picker state before the click handler dispatches.
+    // Reproduces the previously-broken scenario where blurring with an empty query would call
+    // clearChatSessionPickerSearch, null chatSessionPickerResult, and schedule a Lit re-render
+    // that removed the click target before its handler ran.
+    const { state, request } = createChatHeaderState();
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    await vi.waitFor(() =>
+      expect(state.chatSessionPickerResult?.sessions.length ?? 0).toBeGreaterThan(0),
+    );
+    render(renderChatSessionSelect(state), container);
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-chat-session-picker-search="true"]',
+    );
+    const option = container.querySelector<HTMLButtonElement>(
+      'button[data-chat-session-picker-option="true"]',
+    );
+    expect(input).not.toBeNull();
+    expect(option).not.toBeNull();
+    const populatedResult = state.chatSessionPickerResult;
+    expect(populatedResult).not.toBeNull();
+    request.mockClear();
+
+    // Simulate the browser focus shift that triggers the blur/click race: focus moves from
+    // the search input to a picker option button before the option's click handler dispatches.
+    // The search query is empty here, so the pre-fix blur handler would have called
+    // clearChatSessionPickerSearch and nulled chatSessionPickerResult.
+    input!.dispatchEvent(new FocusEvent("blur", { bubbles: false, relatedTarget: option }));
+
+    expect(state.chatSessionPickerResult).toBe(populatedResult);
+    expect(state.chatSessionPickerAppliedQuery).toBe("");
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("clears applied chat session picker search when the input is cleared", async () => {
     const { state } = createChatHeaderState();
     state.sessionsIncludeGlobal = false;


### PR DESCRIPTION
## Summary

- Search input blur in the Control UI chat-session-picker fired `applyChatSessionPickerSearch` unconditionally. With an empty query that calls `clearChatSessionPickerSearch`, nulls `chatSessionPickerResult`, and `requestUpdate()`s the host. Lit re-renders on the next microtask, so the option / search submit / clear / load-more buttons unmount before the click dispatches. Result: every interactive button in the popover silently fails.
- Fix: skip the blur apply when `event.relatedTarget` resolves inside `.chat-session-picker`. Focus moves to a sibling picker control are treated as in-popover; the click handler runs normally. Focus moves outside still flush a pending search, preserving the existing blur contract.
- Sibling-surface check (requested by the maintainer comment): the "simpler session select in the chat controls bar" is `renderChatAgentSelect` / `renderChatModelSelect` / `renderChatThinkingSelect`. All three are native `<select>` elements bound via `.value` with `@change`; they have no popover state teardown and no blur handler, so the race does not apply. No change needed there.
- Other `@blur` handlers in the Control UI (`ui/src/ui/views/usage-render-overview.ts:488`, `ui/src/ui/views/agents-panels-overview.ts:202`) are tooltip toggle and chip-list parse respectively — neither nukes a rendered list of click targets, so they are unaffected.

Closes #87554

## Files

- `ui/src/ui/chat/session-controls.ts` — guarded `@blur` handler + new `isFocusMovingInsideChatSessionPicker` helper with inline rationale.
- `ui/src/ui/views/chat.test.ts` — regression test "keeps chat session picker results when the search input blurs onto a sibling control". Reproduces the empty-query case and asserts `chatSessionPickerResult` is preserved and no `sessions.list` reload fires.

## Real behavior proof

Behavior addressed: Blur on the picker's search input no longer tears down picker state when focus is moving to a sibling button inside the popover, so the four affected click handlers (switch session, search submit, clear search, load more) reliably fire.

Real environment tested: Local Control UI vitest jsdom lane in this worktree (Node 25.8.2, pnpm 11.2.2). No Control UI dev server screenshot — the dev server is not wired into this worktree's mocked Gateway scenario, and the deterministic jsdom test directly exercises the blur/click sequence with `relatedTarget` set.

Exact steps or command run after this patch:

1. `pnpm install --frozen-lockfile`
2. `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts` — full file
3. `node scripts/run-vitest.mjs ui/src/ui/chat/` — surrounding chat lane
4. `pnpm exec oxfmt --check ui/src/ui/chat/session-controls.ts ui/src/ui/views/chat.test.ts`
5. `pnpm exec oxlint ui/src/ui/chat/session-controls.ts ui/src/ui/views/chat.test.ts`
6. Verified the new regression test FAILS without the fix (stashed `session-controls.ts`, ran the single test) with the exact failure mode from #87554 — `state.chatSessionPickerResult` becomes `null` because the blur handler synchronously runs `clearChatSessionPickerSearch`. Restored the fix, test passes.

Evidence after fix:

- `ui/src/ui/views/chat.test.ts`: 59 passed (59), including the new "keeps chat session picker results when the search input blurs onto a sibling control" case.
- `ui/src/ui/chat/`: 255 passed (255) across 19 files.
- Pre-fix failure on the new test (with fix stashed): `AssertionError: expected null to be { ts: +0, path: '', count: 1, ... }` on `expect(state.chatSessionPickerResult).toBe(populatedResult)` — reproduces the bug exactly.
- `pnpm exec oxfmt --check` and `pnpm exec oxlint` both clean on the two touched files.

Observed result after fix: Picker option / search submit / clear / load-more buttons retain their handlers across the blur/click sequence in jsdom; pre-existing "flushes pending chat session picker search on blur" test (which has no `relatedTarget`, simulating focus leaving the popover) continues to pass, so the blur-to-outside flush contract is preserved.

What was not tested:

- Live Playwright run against a real Chromium build of the Control UI for this branch — the worktree does not have a fully wired-up dev server with mocked Gateway scenarios, and the existing `ui/src/ui/e2e/chat-picker-pagination.e2e.test.ts` lane (which depends on `OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM`) was not executed in this session. The e2e test's existing submit and load-more click paths exercise the same surface, so a green e2e lane in CI is a useful additional signal.
- Manual interactive smoke in the desktop / mobile Control UI shells. The fix is a single guard inside one Lit-template `@blur` callback with no styling, layout, or routing impact, so visual regressions are not expected.
- Touch / pointer event paths. The fix only changes `@blur` behavior; touch-driven focus shifts still receive a `blur` with `relatedTarget`, which the helper handles via standard DOM semantics.