### PR TITLE
fix(auto-reply): forward channel-owned progress callbacks in group sessions when /verbose off (#87612)

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2208,6 +2208,8 @@ describe("dispatchReplyFromConfig", () => {
       },
     });
 
+    // Channel-owned native progress callbacks drive embeds/typing/progress UIs;
+    // /verbose off must still let them fire so groups get live tool progress.
     expect(onToolStart).toHaveBeenCalledWith({ name: "exec", phase: "start" });
     expect(onItemEvent).toHaveBeenCalledWith({
       itemId: "1",
@@ -2228,6 +2230,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(onPatchSummary).toHaveBeenCalledWith({ phase: "end", summary: "1 modified" });
     expect(onCompactionStart).toHaveBeenCalledTimes(1);
     expect(onCompactionEnd).toHaveBeenCalledTimes(1);
+    // Message-level tool summary text stays silenced by /verbose off.
     expect(onToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2371,6 +2371,10 @@ export async function dispatchReplyFromConfig(
     const onPatchSummaryFromReplyOptions = params.replyOptions?.onPatchSummary;
     const allowSuppressedSourceProgressCallbacks =
       params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed === true;
+    // Channel-owned native progress callbacks (onToolStart/onItemEvent/onPlanUpdate/
+    // onApprovalEvent/onCommandOutput/onPatchSummary/onCompaction*) drive embeds,
+    // typing indicators, and progress bars. /verbose off only silences message-level
+    // tool summary text; channels still need these regardless of chatType.
     const shouldAllowQuietChannelOwnedProgressCallbacks = (options?: {
       requiresToolSummaryVisibility?: boolean;
     }) =>


### PR DESCRIPTION
## Summary

What problem does this PR solve?

The `/verbose off` directive in group and group-channel sessions incorrectly suppressed channel-owned native progress callbacks (`onToolStart`, `onItemEvent`, `onPlanUpdate`, `onApprovalEvent`, `onCommandOutput`, `onPatchSummary`, `onCompactionStart/End`). These callbacks drive channel-native UIs (Discord embeds, Telegram typing indicators, Slack progress messages). Direct sessions were unaffected because the guard only allowed callbacks for `chatType === "direct"`. See `src/auto-reply/reply/dispatch-from-config.ts:2176-2181`.

Why does this matter now?

- This is an impact:message-loss regression. Channel users on `/verbose off` lose all native progress UI even though they only asked to suppress the message-level tool summary text.
- Channels (Discord, Telegram, Slack, iMessage, Feishu, Zalo) all route through the single `dispatchReplyFromConfig` path, so this one guard silences live progress UI across every channel.

What is the intended outcome?

- Drop the `chatType === "direct"` restriction so channel-owned progress callbacks fire in group, group-channel, and direct sessions whenever the caller asked for the quiet (`suppressDefaultToolProgressMessages: true`) path.
- Keep message-level tool summary text silenced. `onToolResult` and `dispatcher.sendToolResult` remain gated by `shouldSendToolSummaries()` and `shouldSuppressDefaultToolProgressMessages()` (`src/auto-reply/reply/dispatch-from-config.ts:2316`, `src/auto-reply/reply/dispatch-from-config.ts:2353`).
- Rename the helper to `shouldAllowQuietChannelOwnedProgressCallbacks` since it no longer gates by `chatType`.

What is intentionally out of scope?

- No changes to message-level tool summary gating, send policy denial paths, or source delivery suppression.
- No formatting churn outside the touched guard, helper, and matching test.

What does success look like?

- Group/group-channel sessions with `/verbose off` receive all eight channel-owned progress callbacks; only `onToolResult` (message-level text) is silenced.
- The existing direct-session "forwards direct native progress callbacks while verbose is off" test continues to pass.

What should reviewers focus on?

- The single-line guard change in `src/auto-reply/reply/dispatch-from-config.ts:2176-2184` plus consult site at `src/auto-reply/reply/dispatch-from-config.ts:2200`.
- The flipped test in `src/auto-reply/reply/dispatch-from-config.test.ts:1911-1993`.
- Whether the rename of `shouldAllowQuietDirectNativeProgressCallbacks` -> `shouldAllowQuietChannelOwnedProgressCallbacks` (local symbol, no external callers) matches the file's naming style.

## Linked context

Which issue does this close?

Closes #87612

Which issues, PRs, or discussions are related?

Related #87612

Was this requested by a maintainer or owner?

The issue carries `P2`, `clawsweeper:fix-shape-clear`, `clawsweeper:queueable-fix`, `clawsweeper:source-repro`, and `impact:message-loss` labels; the reporter's source-level repro pointed at this exact guard.

## Real behavior proof (required for external PRs)

Behavior addressed: `/verbose off` in groups suppressed channel-owned native progress callbacks (`onToolStart`, `onItemEvent`, `onPlanUpdate`, `onApprovalEvent`, `onCommandOutput`, `onPatchSummary`, `onCompactionStart/End`), breaking channel-native progress UIs.

Real environment tested: Local checkout of `openclaw/openclaw` at `upstream/main` (`dab3152e0e fix(telegram): bound proof command output`) in worktree `wt-87612`. Source-level repro per the issue: the helper at `src/auto-reply/reply/dispatch-from-config.ts:2176` gated callback forwarding on `chatType === "direct"`, and the consult site at `src/auto-reply/reply/dispatch-from-config.ts:2200` calls it before deciding to drop the callback. With the fix, the same trace forwards channel-owned callbacks in group sessions while the message-level `onToolResult` and `dispatcher.sendToolResult` stay silent through the unchanged guards at `src/auto-reply/reply/dispatch-from-config.ts:2316` and `src/auto-reply/reply/dispatch-from-config.ts:2353`.

Exact steps or command run after this patch:

```
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "forwards channel-owned group progress callbacks while verbose is off"
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "progress"
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
pnpm exec oxfmt --check src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts
```

Evidence after fix:

```
$ node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "forwards channel-owned group progress callbacks while verbose is off"
 RUN  v4.1.7 /Users/cornna/project/openclaw_work/wt-87612

 Test Files  1 passed (1)
      Tests  1 passed | 170 skipped (171)
   Start at  22:37:49
   Duration  6.83s

$ node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "progress"
 Test Files  1 passed (1)
      Tests  16 passed | 155 skipped (171)

$ node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts
 Test Files  1 passed (1)
      Tests  171 passed (171)

$ node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
 Test Files  2 passed (2)
      Tests  20 passed (20)

$ pnpm exec oxfmt --check src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts
All matched files use the correct format.
```

Observed result after fix: With `verboseLevel: "off"` and `suppressDefaultToolProgressMessages: true` in a group chat (`ChatType: "group"`), the flipped test confirms each channel-owned callback receives its payload (`onToolStart` with `{ name: "exec", phase: "start" }`, `onItemEvent` with `{ itemId: "1", kind: "tool", progressText: "running exec" }`, `onPlanUpdate`, `onApprovalEvent`, `onCommandOutput`, `onPatchSummary`, `onCompactionStart`, `onCompactionEnd`). The message-level `onToolResult` and `dispatcher.sendToolResult` stay silent; `dispatcher.sendFinalReply` still fires exactly once.

What was not tested: Live end-to-end Discord/Telegram/Slack roundtrip with a real bot account. Sibling channels share the same `dispatchReplyFromConfig` consult site (`grep -rln dispatchReplyFromConfig src/channels/` and `extensions/{discord,feishu,zalouser}/` confirms this), so the one-guard fix benefits all of them; no per-channel divergence observed.

Proof limitations or environment constraints: Source-level repro plus targeted vitest only. The `clawsweeper:source-repro` label flags this issue as one where the reporter's source-level evidence is the canonical proof; the matching test now codifies the corrected contract.

## Tests and validation

Which commands did you run?

```
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
pnpm exec oxfmt --check src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts
```

What regression coverage was added or updated?

- Flipped `src/auto-reply/reply/dispatch-from-config.test.ts:1911` from "suppresses channel-owned group progress callbacks while verbose is off" to "forwards channel-owned group progress callbacks while verbose is off", asserting each callback fires with its exact payload while `onToolResult` and `dispatcher.sendToolResult` stay silent.

What failed before this fix, if known?

- The flipped test would have caught the bug: with the old `chatType === "direct"` guard, every channel-owned `onTool*` / `onPlanUpdate` / `onApprovalEvent` / `onCommandOutput` / `onPatchSummary` / `onCompaction*` callback was dropped for group sessions.

If no test was added, why not?

- Existing test in the same area covered the bug shape; flipping its expectation matches the maintainer's directional preference in the issue body and keeps regression coverage in one place.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes - groups on `/verbose off` now receive channel-owned progress UI callbacks again. Message-level tool summary text remains silenced.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No.

What is the highest-risk area?

A channel plugin that intentionally relied on the dropped callbacks staying silent on `/verbose off` in groups would see them resurface. None observed; the call sites (`src/auto-reply/reply/dispatch-from-config.ts:2270-2305`, `src/auto-reply/reply/dispatch-from-config.ts:2371-2459`) all already pass `requiresToolSummaryVisibility: true` because the channel UI was supposed to render them.

How is that risk mitigated?

Message-level tool text is still gated by `shouldSendToolSummaries()` and `shouldSuppressDefaultToolProgressMessages()`. Only the channel-owned native callbacks (used for embeds/typing/progress UIs) flip from "always dropped on group + verbose off" to "delivered". The full `dispatch-from-config.test.ts` suite (171 tests) passes; the direct-session forwarding test is unchanged.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI run on `openclaw/main` after PR is opened.

Which bot or reviewer comments were addressed?

None yet.
