### PR TITLE
fix(ollama): promote plain text tool calls

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -106,6 +106,9 @@ describe("createOllamaStreamFn thinking events", () => {
   async function streamOllamaEvents(
     chunks: Array<Record<string, unknown>>,
     options: Parameters<ReturnType<typeof createOllamaStreamFn>>[2] = {},
+    context: Parameters<ReturnType<typeof createOllamaStreamFn>>[1] = {
+      messages: [{ role: "user", content: "test" }],
+    } as never,
   ): Promise<Array<{ type: string; [key: string]: unknown }>> {
     const body = makeNdjsonBody(chunks);
     fetchWithSsrFGuardMock.mockResolvedValue({
@@ -116,7 +119,7 @@ describe("createOllamaStreamFn thinking events", () => {
     const streamFn = createOllamaStreamFn("http://localhost:11434");
     const stream = streamFn(
       { api: "ollama", provider: "ollama", id: "qwen3.5", contextWindow: 65536 } as never,
-      { messages: [{ role: "user", content: "test" }] } as never,
+      context,
       options,
     );
 
@@ -247,6 +250,110 @@ describe("createOllamaStreamFn thinking events", () => {
       },
       timeoutMs: 2500,
       auditContext: "ollama-stream.chat",
+    });
+  });
+
+  it("promotes standalone bracketed local-model tool text to a structured tool call", async () => {
+    const rawToolText = [
+      "[mempalace_mempalace_search]",
+      '{"query":"codename","wing":"personal","room":"identities"}',
+      "[END_TOOL_REQUEST]",
+    ].join("\n");
+
+    const events = await streamOllamaEvents(
+      [
+        {
+          model: "qwen3.5",
+          created_at: "2026-01-01T00:00:00Z",
+          message: { role: "assistant", content: rawToolText },
+          done: false,
+        },
+        {
+          model: "qwen3.5",
+          created_at: "2026-01-01T00:00:01Z",
+          message: { role: "assistant", content: "" },
+          done: true,
+          done_reason: "stop",
+          prompt_eval_count: 10,
+          eval_count: 5,
+        },
+      ],
+      {},
+      {
+        messages: [{ role: "user", content: "test" }],
+        tools: [
+          {
+            name: "mempalace_mempalace_search",
+            description: "Search MemPalace",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as never,
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_delta",
+      "done",
+    ]);
+    const done = events.find((event) => event.type === "done") as {
+      message?: { content?: Array<Record<string, unknown>>; stopReason?: string };
+      reason?: string;
+    };
+    expect(done.reason).toBe("toolUse");
+    expect(done.message?.stopReason).toBe("toolUse");
+    expect(done.message?.content?.[0]).toMatchObject({
+      type: "toolCall",
+      name: "mempalace_mempalace_search",
+      arguments: { query: "codename", wing: "personal", room: "identities" },
+    });
+  });
+
+  it("promotes standalone Harmony local-model tool text to a structured tool call", async () => {
+    const rawToolText =
+      'commentary to=read code {"path":"/path/to/file","line_start":1,"line_end":400}';
+
+    const events = await streamOllamaEvents(
+      [
+        {
+          model: "qwen3.5",
+          created_at: "2026-01-01T00:00:00Z",
+          message: { role: "assistant", content: rawToolText },
+          done: false,
+        },
+        {
+          model: "qwen3.5",
+          created_at: "2026-01-01T00:00:01Z",
+          message: { role: "assistant", content: "" },
+          done: true,
+          done_reason: "stop",
+          prompt_eval_count: 10,
+          eval_count: 5,
+        },
+      ],
+      {},
+      {
+        messages: [{ role: "user", content: "test" }],
+        tools: [{ name: "read", description: "Read files", parameters: { type: "object" } }],
+      } as never,
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_delta",
+      "done",
+    ]);
+    const done = events.find((event) => event.type === "done") as {
+      message?: { content?: Array<Record<string, unknown>>; stopReason?: string };
+      reason?: string;
+    };
+    expect(done.reason).toBe("toolUse");
+    expect(done.message?.content?.[0]).toMatchObject({
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/path/to/file", line_start: 1, line_end: 400 },
     });
   });
 });

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -23,6 +23,7 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   createMoonshotThinkingWrapper,
+  createPlainTextToolCallCompatWrapper,
   resolveMoonshotThinkingType,
   streamWithPayloadPatch,
 } from "openclaw/plugin-sdk/provider-stream-shared";
@@ -1080,7 +1081,7 @@ function resolveOllamaRequestTimeoutMs(
   return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : undefined;
 }
 
-export function createOllamaStreamFn(
+function createRawOllamaStreamFn(
   baseUrl: string,
   defaultHeaders?: Record<string, string>,
 ): StreamFn {
@@ -1407,6 +1408,13 @@ export function createOllamaStreamFn(
     queueMicrotask(() => void run());
     return stream;
   };
+}
+
+export function createOllamaStreamFn(
+  baseUrl: string,
+  defaultHeaders?: Record<string, string>,
+): StreamFn {
+  return createPlainTextToolCallCompatWrapper(createRawOllamaStreamFn(baseUrl, defaultHeaders));
 }
 
 export function createConfiguredOllamaStreamFn(params: {


### PR DESCRIPTION
## Summary
- Wrap Ollama native streams with the shared plain-text tool-call compatibility wrapper.
- Promote bracketed and Harmony-style tool-call text from small/local Ollama models into structured `toolCall` events when matching tools are available.
- Add Ollama stream regressions for bracketed `[tool] ... [END_TOOL_REQUEST]` and `commentary to=tool` forms.

## Verification
- `node scripts/run-vitest.mjs extensions/ollama/src/stream.test.ts src/plugin-sdk/provider-stream.test.ts src/plugin-sdk/tool-payload.test.ts` - passed, 3 files / 29 tests on `5c1386e`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts` - passed
- `./node_modules/.bin/oxlint extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts` - passed
- `git diff --check` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings
- Previous AWS Crabbox `corepack pnpm check:changed` on the same patch shape: run `run_63007c8cd66f`, lease `cbx_9c760afc22c6`, slug `violet-barnacle`; it failed during `typecheck extensions` on existing current-main errors outside this branch. Current SHA was rebased afterward; fresh broad gate is queued behind the active AWS lane.

## Real behavior proof
Behavior addressed: Ollama models that emit tool requests as plain assistant text can now be recovered into structured tool calls through the shared provider compatibility path.

Real environment tested: Local linked OpenClaw worktree after rebase, plus previous AWS Crabbox Linux changed gate for the same patch shape.

Exact steps or command run after this patch: The Vitest, format, lint, diff, autoreview, and previous Crabbox commands listed above.

Evidence after fix: Focused Ollama/plugin-sdk tests passed and cover both bracketed and Harmony-style plain-text tool-call promotion.

Observed result after fix: Matching plain-text tool-call payloads are emitted as `toolCall` events and stream completion is marked `toolUse`.

What was not tested: Full live Windows/Ollama UI reproduction; current rebased SHA has not yet had a fresh broad Crabbox/Testbox `check:changed` because another AWS gate is already active.
