### PR TITLE
feat(cli): add tool_use streaming to CLI JSONL parser

### DIFF
--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -398,6 +398,7 @@ export function createCliJsonlStreamingParser(params: {
   backend: CliBackendConfig;
   providerId: string;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUse?: (tool: { name: string; toolCallId?: string; args?: Record<string, unknown> }) => void;
 }) {
   let lineBuffer = "";
   let assistantText = "";
@@ -406,7 +407,45 @@ export function createCliJsonlStreamingParser(params: {
   let output: CliOutput | null = null;
   const texts: string[] = [];
 
+  let pendingToolName: string | undefined;
+  let pendingToolCallId: string | undefined;
+  let pendingToolInput = "";
+
   const handleParsedRecord = (parsed: Record<string, unknown>) => {
+    if (params.onToolUse) {
+      const evt = (isRecord(parsed.event) ? parsed.event : parsed) as Record<string, unknown>;
+      if (evt?.type === "content_block_start") {
+        const block = isRecord(evt.content_block) ? evt.content_block : undefined;
+        if (block?.type === "tool_use" && typeof block.name === "string") {
+          pendingToolName = block.name;
+          pendingToolCallId = typeof block.id === "string" ? block.id : undefined;
+          pendingToolInput = "";
+          params.onToolUse({
+            name: block.name,
+            toolCallId: pendingToolCallId,
+          });
+        }
+      } else if (evt?.type === "content_block_delta") {
+        const delta = isRecord(evt.delta) ? evt.delta : undefined;
+        if (delta?.type === "input_json_delta" && typeof delta.partial_json === "string") {
+          pendingToolInput += delta.partial_json;
+        }
+      } else if (evt?.type === "content_block_stop" && pendingToolName) {
+        if (pendingToolInput) {
+          try {
+            const args = JSON.parse(pendingToolInput) as Record<string, unknown>;
+            params.onToolUse({
+              name: pendingToolName,
+              toolCallId: pendingToolCallId,
+              args,
+            });
+          } catch {}
+        }
+        pendingToolName = undefined;
+        pendingToolCallId = undefined;
+        pendingToolInput = "";
+      }
+    }
     sessionId = pickCliSessionId(parsed, params.backend) ?? sessionId;
     if (!sessionId && typeof parsed.thread_id === "string") {
       sessionId = parsed.thread_id.trim();

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1,13 +1,13 @@
 import crypto from "node:crypto";
 import type { ReplyBackendHandle } from "../../auto-reply/reply/reply-run-registry.js";
 import type { CliBackendConfig } from "../../config/types.js";
-import { isRecord } from "../../shared/record-coerce.js";
 import {
   loadExecApprovals,
   maxAsk,
   minSecurity,
   resolveExecApprovalsFromFile,
 } from "../../infra/exec-approvals.js";
+import { isRecord } from "../../shared/record-coerce.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import {
   createCliJsonlStreamingParser,
@@ -204,8 +204,11 @@ export function buildClaudeLiveArgs(params: {
     upsertArgValue(
       upsertArgValue(
         upsertArgValue(
-          stripLiveProcessArgs(params.args, params.backend,
-            params.useResume && params.backend.systemPromptWhen !== "always"),
+          stripLiveProcessArgs(
+            params.args,
+            params.backend,
+            params.useResume && params.backend.systemPromptWhen !== "always",
+          ),
           "--input-format",
           "stream-json",
         ),
@@ -956,6 +959,7 @@ function createTurn(params: {
   context: PreparedCliRunContext;
   noOutputTimeoutMs: number;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUse?: (tool: { name: string; toolCallId?: string; args?: Record<string, unknown> }) => void;
   session: ClaudeLiveSession;
   resolve: (output: CliOutput) => void;
   reject: (error: unknown) => void;
@@ -972,6 +976,7 @@ function createTurn(params: {
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,
       onAssistantDelta: params.onAssistantDelta,
+      onToolUse: params.onToolUse,
     }),
     resolve: params.resolve,
     reject: params.reject,
@@ -1037,6 +1042,7 @@ export async function runClaudeLiveSessionTurn(params: {
   noOutputTimeoutMs: number;
   getProcessSupervisor: () => ProcessSupervisor;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolUse?: (tool: { name: string; toolCallId?: string; args?: Record<string, unknown> }) => void;
   cleanup: () => Promise<void>;
 }): Promise<ClaudeLiveRunResult> {
   const key = buildClaudeLiveKey(params.context);
@@ -1158,6 +1164,7 @@ export async function runClaudeLiveSessionTurn(params: {
       context: params.context,
       noOutputTimeoutMs: params.noOutputTimeoutMs,
       onAssistantDelta: params.onAssistantDelta,
+      onToolUse: params.onToolUse,
       session: liveSession,
       resolve,
       reject,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -483,6 +483,13 @@ export async function executePreparedCliRun(
                 },
               });
             },
+            onToolUse: ({ name, toolCallId, args }) => {
+              emitAgentEvent({
+                runId: params.runId,
+                stream: "tool",
+                data: { phase: args ? "update" : "start", name, toolCallId, args },
+              });
+            },
             cleanup: async () => {
               try {
                 await fallbackClaudeSkillsPlugin?.cleanup();
@@ -520,6 +527,13 @@ export async function executePreparedCliRun(
                       context.backendResolved.textTransforms?.output,
                     ),
                   },
+                });
+              },
+              onToolUse: ({ name, toolCallId, args }) => {
+                emitAgentEvent({
+                  runId: params.runId,
+                  stream: "tool",
+                  data: { phase: args ? "update" : "start", name, toolCallId, args },
                 });
               },
             })

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -11,6 +11,48 @@ function shouldBridgeCliAssistantTextToReasoning(provider: string): boolean {
   return normalizeLowercaseStringOrEmpty(provider) === "claude-cli";
 }
 
+function createToolEventBridge(params: {
+  runId: string;
+  deliver?: (evt: { phase: string; name?: string; toolCallId?: string; args?: Record<string, unknown> }) => Promise<void>;
+}) {
+  const deliver = params.deliver;
+  if (!deliver) {
+    return {
+      unsubscribe: () => undefined,
+      drain: async (): Promise<void> => undefined,
+    };
+  }
+  let unsubscribed = false;
+  let delivery = Promise.resolve();
+  const rawUnsubscribe = onAgentEvent((evt) => {
+    if (evt.runId !== params.runId || evt.stream !== "tool") {
+      return;
+    }
+    const phase = typeof evt.data.phase === "string" ? evt.data.phase : undefined;
+    if (!phase) {
+      return;
+    }
+    const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
+    const toolCallId = typeof evt.data.toolCallId === "string" ? evt.data.toolCallId : undefined;
+    const args = evt.data.args && typeof evt.data.args === "object"
+      ? (evt.data.args as Record<string, unknown>)
+      : undefined;
+    delivery = delivery.then(() => deliver({ phase, name, toolCallId, args })).catch(() => undefined);
+  });
+  return {
+    unsubscribe() {
+      if (unsubscribed) {
+        return;
+      }
+      unsubscribed = true;
+      rawUnsubscribe();
+    },
+    async drain(): Promise<void> {
+      await delivery;
+    },
+  };
+}
+
 function createAssistantTextBridge(params: {
   runId: string;
   suppressed?: boolean;
@@ -65,6 +107,7 @@ export async function runCliAgentWithLifecycle(params: {
   suppressAssistantBridge?: boolean;
   onAssistantText?: (text: string) => Promise<void>;
   onReasoningText?: (text: string) => Promise<void>;
+  onToolEvent?: (evt: { phase: string; name?: string; toolCallId?: string; args?: Record<string, unknown> }) => Promise<void>;
   onErrorBeforeLifecycle?: (err: unknown) => Promise<void>;
   transformResult?: (result: EmbeddedPiRunResult) => EmbeddedPiRunResult;
 }): Promise<EmbeddedPiRunResult> {
@@ -94,14 +137,20 @@ export async function runCliAgentWithLifecycle(params: {
       ? params.onReasoningText
       : undefined,
   });
+  const toolBridge = createToolEventBridge({
+    runId: params.runId,
+    deliver: params.onToolEvent,
+  });
   let lifecycleTerminalEmitted = false;
   try {
     const rawResult = await runCliAgent(params.runParams);
     const result = params.transformResult?.(rawResult) ?? rawResult;
     assistantBridge.unsubscribe();
     reasoningBridge.unsubscribe();
+    toolBridge.unsubscribe();
     await assistantBridge.drain();
     await reasoningBridge.drain();
+    await toolBridge.drain();
 
     const cliText = normalizeOptionalString(result.payloads?.[0]?.text);
     if (cliText) {
@@ -128,8 +177,10 @@ export async function runCliAgentWithLifecycle(params: {
   } catch (err) {
     assistantBridge.unsubscribe();
     reasoningBridge.unsubscribe();
+    toolBridge.unsubscribe();
     await assistantBridge.drain();
     await reasoningBridge.drain();
+    await toolBridge.drain();
     await params.onErrorBeforeLifecycle?.(err);
     if (emitLifecycleTerminal) {
       emitAgentEvent({
@@ -148,6 +199,7 @@ export async function runCliAgentWithLifecycle(params: {
   } finally {
     assistantBridge.unsubscribe();
     reasoningBridge.unsubscribe();
+    toolBridge.unsubscribe();
     if (emitLifecycleTerminal && !lifecycleTerminalEmitted) {
       emitAgentEvent({
         runId: params.runId,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2035,6 +2035,25 @@ export async function runAgentTurnWithFallback(params: {
                   onReasoningText: async (text) => {
                     await params.opts?.onReasoningStream?.({ text });
                   },
+                  onToolEvent: async ({ phase, name, args }) => {
+                    if (
+                      params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only"
+                    ) {
+                      return;
+                    }
+                    if (phase === "start" || phase === "update") {
+                      const toolStartProgressPromise = params.opts?.onToolStart?.({
+                        name,
+                        phase,
+                        args,
+                        detailMode: params.toolProgressDetail,
+                      });
+                      await Promise.all([
+                        params.typingSignals.signalToolStart(),
+                        toolStartProgressPromise,
+                      ]);
+                    }
+                  },
                   onErrorBeforeLifecycle: async () => {
                     if (!rollbackFallbackCandidateSelection) {
                       return;


### PR DESCRIPTION
## Summary

The shared CLI JSONL streaming parser (`createCliJsonlStreamingParser`) only extracted `thinking_delta` and `text_delta` — it completely ignored `tool_use` content blocks. This meant CLI backends (`claude-cli`, `claude-cli-interactive`) never emitted tool progress events, so interleaved tool names (e.g. "Using Read…") couldn't appear in Telegram/Discord/WhatsApp.

This PR adds tool event support across the full CLI pipeline, **including full tool argument forwarding** for channels that opt into `interleavedToolArgs`:

1. **Parser** (`cli-output.ts`): detect `content_block_start` with `type: "tool_use"`, call `onToolUse` immediately with name/toolCallId. Then accumulate `input_json_delta` chunks and emit a second `onToolUse` with parsed `args` on `content_block_stop`.
2. **Emitter** (`execute.ts`): first `onToolUse` call → `emitAgentEvent({ stream: "tool", phase: "start", name, toolCallId })`. Second call (with args) → `phase: "update"` with args attached.
3. **Live session** (`claude-live-session.ts`): thread `onToolUse` (including args) through `createTurn` / `runClaudeLiveSessionTurn`
4. **Bridge** (`agent-runner-cli-dispatch.ts`): `createToolEventBridge` subscribes to `stream: "tool"` events on the global agent event bus, extracting `phase`, `name`, `toolCallId`, and `args` — parallel to existing assistant text bridges
5. **Caller** (`agent-runner-execution.ts`): pass `onToolEvent` (with `args`) to `runCliAgentWithLifecycle` so CLI runs trigger `onToolStart` / `signalToolStart` identically to embedded PI agent runs — channels receive args for sanitized display. **`message_tool_only` suppression preserved**: when `sourceReplyDeliveryMode === "message_tool_only"`, CLI tool progress is suppressed to match existing embedded PI agent behavior.

## Depends on

- #87072 (interleaved progress renderer that consumes these events)
- #81851 (interactive backend that benefits from tool streaming)

## Test plan

- [x] Build passes (`tsdown` clean)
- [x] `message_tool_only` delivery mode suppresses CLI tool progress (matches embedded path)
- [ ] Telegram message triggering tool use shows interleaved tool names in streaming preview
- [ ] With `interleavedToolArgs: true`, sanitized tool arguments appear in the interleaved lane
- [ ] Embedded PI agent path unaffected (no regressions)
- [ ] Tool name appears immediately on `content_block_start`; args arrive on `content_block_stop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)