### PR TITLE
fix(exec): surface oom_score_adj raise when SIGKILLs hit broad find/grep on Linux (#69242)

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -11,6 +11,12 @@ const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
 const supervisorMock = vi.hoisted(() => ({
   spawn: vi.fn(),
 }));
+// Spy on the OOM-score predicate so the #69242 gate-wiring tests can assert
+// which env runExecProcess consults (spawn-time child env vs ambient) without
+// depending on the host platform. The predicate's own platform/opt-out logic
+// is covered in `linux-oom-score.test.ts`; here we delegate to the real
+// implementation by default and override per-test where needed.
+const oomScoreRaiseActiveMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../infra/heartbeat-wake.js", () => ({
   requestHeartbeat: requestHeartbeatMock,
@@ -26,6 +32,11 @@ vi.mock("../process/supervisor/index.js", () => ({
   }),
 }));
 
+vi.mock("../process/linux-oom-score.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../process/linux-oom-score.js")>();
+  return { ...actual, isLinuxChildOomScoreRaiseActive: oomScoreRaiseActiveMock };
+});
+
 let markBackgrounded: typeof import("./bash-process-registry.js").markBackgrounded;
 let buildExecExitOutcome: typeof import("./bash-tools.exec-runtime.js").buildExecExitOutcome;
 let detectCursorKeyMode: typeof import("./bash-tools.exec-runtime.js").detectCursorKeyMode;
@@ -33,9 +44,14 @@ let formatExecFailureReason: typeof import("./bash-tools.exec-runtime.js").forma
 let renderExecUpdateText: typeof import("./bash-tools.exec-runtime.js").renderExecUpdateText;
 let resolveExecTarget: typeof import("./bash-tools.exec-runtime.js").resolveExecTarget;
 let runExecProcess: typeof import("./bash-tools.exec-runtime.js").runExecProcess;
+let actualIsLinuxChildOomScoreRaiseActive: typeof import("../process/linux-oom-score.js").isLinuxChildOomScoreRaiseActive;
 
 beforeAll(async () => {
   ({ markBackgrounded } = await import("./bash-process-registry.js"));
+  ({ isLinuxChildOomScoreRaiseActive: actualIsLinuxChildOomScoreRaiseActive } =
+    await vi.importActual<typeof import("../process/linux-oom-score.js")>(
+      "../process/linux-oom-score.js",
+    ));
   ({
     buildExecExitOutcome,
     detectCursorKeyMode,
@@ -50,6 +66,12 @@ beforeEach(() => {
   requestHeartbeatMock.mockClear();
   enqueueSystemEventMock.mockClear();
   supervisorMock.spawn.mockReset();
+  // Default to the real predicate so non-OOM tests keep production behavior;
+  // the #69242 wiring tests override the return value explicitly.
+  oomScoreRaiseActiveMock.mockReset();
+  oomScoreRaiseActiveMock.mockImplementation((options) =>
+    actualIsLinuxChildOomScoreRaiseActive(options),
+  );
 });
 
 function expectExecTarget(
@@ -502,6 +524,106 @@ describe("formatExecFailureReason", () => {
       }),
     ).toBe("Command not found");
   });
+
+  it("explains likely cgroup OOM kill when SIGKILL hits linux children with raised oom_score_adj (#69242)", () => {
+    const reason = formatExecFailureReason({
+      failureKind: "signal",
+      exitSignal: "SIGKILL",
+      timeoutSec: null,
+      linuxOomKillLikely: true,
+    });
+
+    expect(reason).toContain("Command aborted by signal SIGKILL");
+    // The hint must call out the root cause (raised oom_score_adj makes the
+    // child the preferred OOM victim) and the opt-out env knob so the user
+    // can act without correlating cgroup OOM data manually.
+    expect(reason).toContain("oom_score_adj");
+    expect(reason).toContain("OPENCLAW_CHILD_OOM_SCORE_ADJ=0");
+    expect(reason).toContain("journalctl -k");
+  });
+
+  it("keeps the bare SIGKILL message off-linux or when oom score raise is opted out", () => {
+    expect(
+      formatExecFailureReason({
+        failureKind: "signal",
+        exitSignal: "SIGKILL",
+        timeoutSec: null,
+        linuxOomKillLikely: false,
+      }),
+    ).toBe("Command aborted by signal SIGKILL");
+  });
+
+  it("does not surface the OOM hint for non-SIGKILL signals even on linux", () => {
+    // Other external signals (SIGSEGV from a real crash, SIGINT from a user
+    // ^C, SIGPIPE from broken upstream) must not be misattributed to OOM.
+    for (const signal of ["SIGSEGV", "SIGINT", "SIGPIPE", "SIGTERM"] as const) {
+      const reason = formatExecFailureReason({
+        failureKind: "signal",
+        exitSignal: signal,
+        timeoutSec: null,
+        linuxOomKillLikely: true,
+      });
+      expect(reason).toBe(`Command aborted by signal ${signal}`);
+    }
+  });
+
+  it("treats numeric SIGKILL (9) from the PTY adapter the same as the string form", () => {
+    // node-pty's onExit event surfaces the raw POSIX signal number, so a
+    // PTY-spawned `find` killed by cgroup OOM lands here as `exitSignal: 9`,
+    // not the string `"SIGKILL"` that child_process produces. Both must
+    // trigger the hint, otherwise PTY users (the default exec path on macOS
+    // and the gateway TTY surface on Linux) keep seeing the bare "signal 9".
+    const reason = formatExecFailureReason({
+      failureKind: "signal",
+      exitSignal: 9,
+      timeoutSec: null,
+      linuxOomKillLikely: true,
+    });
+    expect(reason).toContain("Command aborted by signal SIGKILL");
+    expect(reason).toContain("oom_score_adj");
+    expect(reason).toContain("OPENCLAW_CHILD_OOM_SCORE_ADJ=0");
+  });
+
+  it("accepts the stringified numeric form '9' as SIGKILL", () => {
+    // Defensive: if a future adapter pre-stringifies the signal number we
+    // still want the hint to fire rather than fall through to bare text.
+    const reason = formatExecFailureReason({
+      failureKind: "signal",
+      exitSignal: "9" as unknown as NodeJS.Signals,
+      timeoutSec: null,
+      linuxOomKillLikely: true,
+    });
+    expect(reason).toContain("Command aborted by signal SIGKILL");
+    expect(reason).toContain("oom_score_adj");
+  });
+
+  it("normalizes the SIGKILL label even when the OOM-wrap is opted out", () => {
+    // The numeric/string skew between adapters is user-visible regardless of
+    // the hint, so the bare message should also stop leaking raw signal
+    // numbers. Off-linux or with OPENCLAW_CHILD_OOM_SCORE_ADJ=0 the user
+    // still sees "signal SIGKILL" (no hint), not "signal 9".
+    expect(
+      formatExecFailureReason({
+        failureKind: "signal",
+        exitSignal: 9,
+        timeoutSec: null,
+        linuxOomKillLikely: false,
+      }),
+    ).toBe("Command aborted by signal SIGKILL");
+  });
+
+  it("does not relabel other numeric signals as SIGKILL", () => {
+    // Only signal 9 maps to SIGKILL. Numeric SIGTERM (15), SIGINT (2), etc.
+    // keep their adapter-native form and must never pick up the OOM hint.
+    const reason = formatExecFailureReason({
+      failureKind: "signal",
+      exitSignal: 15,
+      timeoutSec: null,
+      linuxOomKillLikely: true,
+    });
+    expect(reason).toBe("Command aborted by signal 15");
+    expect(reason).not.toContain("oom_score_adj");
+  });
 });
 
 describe("buildExecExitOutcome", () => {
@@ -578,6 +700,154 @@ describe("buildExecExitOutcome", () => {
     expect(outcome.timedOut).toBe(true);
     expect(outcome.reason).toContain("background=true");
     expect(outcome.reason).toContain("Do not rely on shell backgrounding");
+  });
+
+  it("plumbs linuxOomKillLikely into the signal-failure reason for #69242", () => {
+    // External SIGKILL from the kernel surfaces in the supervisor as
+    // `reason: "signal"` (no forcedReason), which maps to failureKind=signal.
+    // The classifier already separates user/timeout cancels (which set
+    // forcedReason) from kernel kills, so a true SIGKILL here is the OOM path.
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "signal",
+        exitCode: null,
+        exitSignal: "SIGKILL",
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "",
+      durationMs: 50,
+      timeoutSec: null,
+      linuxOomKillLikely: true,
+    });
+
+    if (outcome.status !== "failed") {
+      throw new Error(`Expected signal exit to fail, got ${outcome.status}`);
+    }
+    expect(outcome.failureKind).toBe("signal");
+    expect(outcome.exitSignal).toBe("SIGKILL");
+    expect(outcome.reason).toContain("OPENCLAW_CHILD_OOM_SCORE_ADJ=0");
+    expect(outcome.reason).toContain("oom_score_adj");
+  });
+
+  it("plumbs numeric SIGKILL (PTY adapter shape) through to the OOM hint for #69242", () => {
+    // RunExit.exitSignal carries `number | NodeJS.Signals | null` because the
+    // PTY adapter emits the raw POSIX signal number. Without normalization,
+    // the supervisor's "signal" failureKind would format "signal 9" and the
+    // SIGKILL gate on the hint would never fire for PTY-spawned children.
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "signal",
+        exitCode: null,
+        exitSignal: 9,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "",
+      durationMs: 50,
+      timeoutSec: null,
+      linuxOomKillLikely: true,
+    });
+
+    if (outcome.status !== "failed") {
+      throw new Error(`Expected signal exit to fail, got ${outcome.status}`);
+    }
+    expect(outcome.failureKind).toBe("signal");
+    // exitSignal stays as the adapter-native value on the outcome — only the
+    // formatted reason normalizes to "SIGKILL" so downstream observers can
+    // still see what the adapter actually reported.
+    expect(outcome.exitSignal).toBe(9);
+    expect(outcome.reason).toContain("Command aborted by signal SIGKILL");
+    expect(outcome.reason).toContain("OPENCLAW_CHILD_OOM_SCORE_ADJ=0");
+    expect(outcome.reason).toContain("oom_score_adj");
+  });
+
+  it("omits the OOM hint for numeric SIGKILL when the oom score raise is opted out", () => {
+    // Numeric SIGKILL with linuxOomKillLikely=false (off-linux or opted out)
+    // still normalizes the label but keeps the message bare, matching the
+    // string-form behavior.
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "signal",
+        exitCode: null,
+        exitSignal: 9,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "",
+      durationMs: 50,
+      timeoutSec: null,
+      linuxOomKillLikely: false,
+    });
+
+    if (outcome.status !== "failed") {
+      throw new Error(`Expected signal exit to fail, got ${outcome.status}`);
+    }
+    expect(outcome.reason).toContain("Command aborted by signal SIGKILL");
+    expect(outcome.reason).not.toContain("oom_score_adj");
+    expect(outcome.reason).not.toContain("OPENCLAW_CHILD_OOM_SCORE_ADJ");
+  });
+
+  it("does not relabel numeric SIGTERM (15) as SIGKILL or attach the OOM hint", () => {
+    // Sibling-signal regression: a real SIGTERM from a supervisor outside
+    // the OpenClaw process tree must keep its numeric form and skip the hint.
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "signal",
+        exitCode: null,
+        exitSignal: 15,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "",
+      durationMs: 50,
+      timeoutSec: null,
+      linuxOomKillLikely: true,
+    });
+
+    if (outcome.status !== "failed") {
+      throw new Error(`Expected signal exit to fail, got ${outcome.status}`);
+    }
+    expect(outcome.reason).toContain("Command aborted by signal 15");
+    expect(outcome.reason).not.toContain("oom_score_adj");
+  });
+
+  it("omits the OOM hint when the oom score raise is not active", () => {
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "signal",
+        exitCode: null,
+        exitSignal: "SIGKILL",
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "",
+      durationMs: 50,
+      timeoutSec: null,
+      linuxOomKillLikely: false,
+    });
+
+    if (outcome.status !== "failed") {
+      throw new Error(`Expected signal exit to fail, got ${outcome.status}`);
+    }
+    expect(outcome.reason).not.toContain("oom_score_adj");
+    expect(outcome.reason).not.toContain("OPENCLAW_CHILD_OOM_SCORE_ADJ");
+    expect(outcome.reason).toContain("Command aborted by signal SIGKILL");
   });
 });
 
@@ -709,5 +979,93 @@ describe("runExecProcess POSIX command wrapper", () => {
     const commandStr = spawnCall.argv.join(" ");
     expect(commandStr).not.toContain("export PATH=");
     expect(commandStr).toContain("echo test");
+  });
+});
+
+describe("runExecProcess OOM-hint gate (#69242)", () => {
+  function mockSigkillExit() {
+    supervisorMock.spawn.mockImplementationOnce(async () => ({
+      runId: "oom-run",
+      startedAtMs: Date.now(),
+      pid: 4242,
+      wait: async () => {
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
+        return {
+          reason: "signal" as const,
+          exitCode: null,
+          exitSignal: "SIGKILL" as const,
+          durationMs: 5,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          noOutputTimedOut: false,
+        };
+      },
+      cancel: vi.fn(),
+    }));
+  }
+
+  it("derives the SIGKILL OOM hint from the spawn-time child env, not ambient process.env", async () => {
+    // Simulate a host where the wrap shim is active for this child.
+    oomScoreRaiseActiveMock.mockReturnValue(true);
+    mockSigkillExit();
+
+    const run = await runExecProcess({
+      command: "find / -maxdepth 6",
+      workdir: "/tmp",
+      env: {},
+      usePty: false,
+      warnings: [],
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+      notifyOnExit: false,
+      timeoutSec: null,
+    });
+    const outcome = await run.promise;
+
+    // The crux of the #69242 P1: the gate is consulted with the spawn-time
+    // child env (which carries the exec-injected OPENCLAW_SHELL marker), never
+    // with no args / ambient process.env.
+    expect(oomScoreRaiseActiveMock).toHaveBeenCalledWith({
+      env: expect.objectContaining({ OPENCLAW_SHELL: "exec" }),
+    });
+    if (outcome.status !== "failed") {
+      throw new Error(`Expected signal exit to fail, got ${outcome.status}`);
+    }
+    expect(outcome.reason).toContain("Command aborted by signal SIGKILL");
+    expect(outcome.reason).toContain("oom_score_adj");
+    expect(outcome.reason).toContain("OPENCLAW_CHILD_OOM_SCORE_ADJ=0");
+  });
+
+  it("keeps the bare SIGKILL message when the child opted out via OPENCLAW_CHILD_OOM_SCORE_ADJ=0", async () => {
+    // Regression for the P1: a per-child opt-out must suppress the hint even
+    // when the gateway's ambient env never set the knob. runExecProcess passes
+    // the child env (carrying the opt-out) to the gate, so it returns false.
+    oomScoreRaiseActiveMock.mockReturnValue(false);
+    mockSigkillExit();
+
+    const run = await runExecProcess({
+      command: "find / -maxdepth 6",
+      workdir: "/tmp",
+      env: { OPENCLAW_CHILD_OOM_SCORE_ADJ: "0" },
+      usePty: false,
+      warnings: [],
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+      notifyOnExit: false,
+      timeoutSec: null,
+    });
+    const outcome = await run.promise;
+
+    expect(oomScoreRaiseActiveMock).toHaveBeenCalledWith({
+      env: expect.objectContaining({ OPENCLAW_CHILD_OOM_SCORE_ADJ: "0" }),
+    });
+    if (outcome.status !== "failed") {
+      throw new Error(`Expected signal exit to fail, got ${outcome.status}`);
+    }
+    expect(outcome.reason).toContain("Command aborted by signal SIGKILL");
+    expect(outcome.reason).not.toContain("oom_score_adj");
   });
 });

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -34,6 +34,7 @@ export {
   normalizeExecTarget,
 } from "../infra/exec-approvals.js";
 import { logWarn } from "../logger.js";
+import { isLinuxChildOomScoreRaiseActive } from "../process/linux-oom-score.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit, TerminationReason } from "../process/supervisor/types.js";
@@ -447,11 +448,39 @@ function classifyExecFailureKind(params: {
   return "aborted";
 }
 
-/** Formats a user-facing reason for a failed exec process exit. */
+/**
+ * Hint appended to bare-SIGKILL failure reasons when the current host
+ * raises `oom_score_adj` on exec children (see #69242 / #70404). cgroup OOM
+ * kills do not always surface in `journalctl -k`, so the explanation is the
+ * only way users correlate broad find/grep terminations with memory pressure.
+ */
+const LINUX_OOM_KILL_HINT =
+  "Likely an unprivileged cgroup OOM kill: OpenClaw raises this exec child's oom_score_adj to 1000 on Linux (see docs/platforms/linux.md), which makes it the preferred OOM victim under memory pressure even when no kernel OOM line shows in journalctl -k. Reduce the search scope (narrower path, lower -maxdepth, fewer -or branches), raise the host or cgroup memory limit, or set OPENCLAW_CHILD_OOM_SCORE_ADJ=0 in the gateway env to opt this child out of the raised score.";
+
+/**
+ * Adapter surface skew: `child.signalCode` returns a string `NodeJS.Signals`
+ * name ("SIGKILL"), but the node-pty `onExit` event carries the raw POSIX
+ * signal number (9). Both paths flow through `RunExit.exitSignal`, so the
+ * #69242 OOM hint and the user-visible signal label must treat numeric 9 and
+ * string "SIGKILL" as the same termination. The param accepts the broad
+ * `string` form so a future adapter that pre-stringifies the number ("9")
+ * still funnels through the same gate without extra casts at the call site.
+ */
+function isSigkillSignal(signal: number | string | null | undefined): boolean {
+  return signal === "SIGKILL" || signal === 9 || signal === "9";
+}
+
 export function formatExecFailureReason(params: {
   failureKind: ExecExitFailureKind;
   exitSignal: NodeJS.Signals | number | null;
   timeoutSec: number | null | undefined;
+  /**
+   * True when exec children are being tagged with the raised `oom_score_adj`
+   * shim (Linux + not opted out). Lets the `signal`/SIGKILL branch surface
+   * the OOM hint instead of the bare "aborted by signal SIGKILL" message
+   * that hides the root cause.
+   */
+  linuxOomKillLikely?: boolean;
 }): string {
   switch (params.failureKind) {
     case "shell-command-not-found":
@@ -464,8 +493,25 @@ export function formatExecFailureReason(params: {
         : "Command timed out. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300). If it should keep running, start it with exec background=true or yieldMs so OpenClaw can register a pollable process session. Do not rely on shell backgrounding with a trailing &.";
     case "no-output-timeout":
       return "Command timed out waiting for output";
-    case "signal":
-      return `Command aborted by signal ${params.exitSignal}`;
+    case "signal": {
+      // Normalize the label so PTY-spawned children (raw POSIX `9`) and
+      // child_process children (string `"SIGKILL"`) produce the same
+      // user-visible message. Other signals keep their adapter-native form;
+      // we don't try to translate every numeric code because only SIGKILL
+      // gates the #69242 OOM hint.
+      const sigkill = isSigkillSignal(params.exitSignal);
+      const label = sigkill ? "SIGKILL" : params.exitSignal;
+      const base = `Command aborted by signal ${label}`;
+      // `failureKind === "signal"` only fires when the supervisor saw an
+      // external signal exit (no forcedReason). On Linux a bare SIGKILL with
+      // the OOM-score-raise shim active is almost always a cgroup OOM kill —
+      // see issue #69242. Keep the original line for other signals so SIGINT,
+      // SIGSEGV, etc. don't get misattributed.
+      if (params.linuxOomKillLikely && sigkill) {
+        return `${base}. ${LINUX_OOM_KILL_HINT}`;
+      }
+      return base;
+    }
     case "aborted":
       return "Command aborted before exit code was captured";
   }
@@ -478,6 +524,15 @@ export function buildExecExitOutcome(params: {
   aggregated: string;
   durationMs: number;
   timeoutSec: number | null | undefined;
+  /**
+   * Whether *this* spawned child was tagged with the raised Linux
+   * `oom_score_adj` shim. The caller must compute this from the spawn-time
+   * child env (see `runExecProcess`), not ambient `process.env`, so a
+   * per-child `OPENCLAW_CHILD_OOM_SCORE_ADJ=0` opt-out is honored (#69242).
+   * Defaults to `false` (no hint) when the caller does not supply it. See
+   * `formatExecFailureReason` for how it shapes the message.
+   */
+  linuxOomKillLikely?: boolean;
 }): ExecProcessOutcome {
   const exitCode = params.exit.exitCode ?? 0;
   const isNormalExit = params.exit.reason === "exit";
@@ -505,6 +560,7 @@ export function buildExecExitOutcome(params: {
     failureKind,
     exitSignal: params.exit.exitSignal,
     timeoutSec: params.timeoutSec,
+    linuxOomKillLikely: params.linuxOomKillLikely ?? false,
   });
   return {
     status: "failed",
@@ -790,6 +846,13 @@ export async function runExecProcess(opts: {
     };
   })();
 
+  // Gate the #69242 SIGKILL OOM hint on whether *this* child was actually
+  // wrapped with the raised oom_score_adj shim. Derive it from the spawn-time
+  // child env (`spawnSpec.env`) — the exact env the supervisor adapters hand to
+  // `prepareOomScoreAdjustedSpawn` — not ambient `process.env`, so a per-child
+  // `OPENCLAW_CHILD_OOM_SCORE_ADJ=0` opt-out keeps the bare SIGKILL message.
+  const linuxOomKillLikely = isLinuxChildOomScoreRaiseActive({ env: spawnSpec.env });
+
   let managedRun: ManagedRun | null = null;
   let usingPty = spawnSpec.mode === "pty";
   const cursorResponse = buildCursorPositionResponse();
@@ -908,6 +971,7 @@ export async function runExecProcess(opts: {
         aggregated: session.aggregated.trim(),
         durationMs,
         timeoutSec: opts.timeoutSec,
+        linuxOomKillLikely,
       });
 
       markExited(session, exit.exitCode, exit.exitSignal, outcome.status, exit.reason);

--- a/src/process/linux-oom-score.test.ts
+++ b/src/process/linux-oom-score.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   hardenedEnvForChildOomWrap,
+  isLinuxChildOomScoreRaiseActive,
   prepareOomScoreAdjustedSpawn,
   wrapArgvForChildOomScoreRaise,
 } from "./linux-oom-score.js";
@@ -84,6 +85,35 @@ describe("prepareOomScoreAdjustedSpawn", () => {
       env,
       wrapped: false,
     });
+  });
+});
+
+describe("isLinuxChildOomScoreRaiseActive", () => {
+  it("is true on linux when /bin/sh exists and the opt-out is unset", () => {
+    expect(isLinuxChildOomScoreRaiseActive(linux)).toBe(true);
+  });
+
+  it("is false on non-linux platforms regardless of env or shell", () => {
+    for (const platform of ["darwin", "win32", "freebsd"] as const) {
+      expect(
+        isLinuxChildOomScoreRaiseActive({ platform, env: {}, shellAvailable: () => true }),
+      ).toBe(false);
+    }
+  });
+
+  it("is false on linux when /bin/sh is unavailable (distroless/scratch)", () => {
+    expect(isLinuxChildOomScoreRaiseActive(linuxNoShell)).toBe(false);
+  });
+
+  it("honours the OPENCLAW_CHILD_OOM_SCORE_ADJ opt-out", () => {
+    for (const value of ["0", "false", "FALSE", "no", "off"]) {
+      expect(
+        isLinuxChildOomScoreRaiseActive({
+          ...linux,
+          env: { OPENCLAW_CHILD_OOM_SCORE_ADJ: value },
+        }),
+      ).toBe(false);
+    }
   });
 });
 

--- a/src/process/linux-oom-score.ts
+++ b/src/process/linux-oom-score.ts
@@ -157,13 +157,5 @@ export function hardenedEnvForChildOomWrap(
  * *tagged* for preferred OOM victim selection.
  */
 export function isLinuxChildOomScoreRaiseActive(options?: OomWrapOptions): boolean {
-  const platform = options?.platform ?? process.platform;
-  if (platform !== "linux") {
-    return false;
-  }
-  const env = options?.env ?? process.env;
-  if (isDisabled(env[CHILD_OOM_SCORE_ADJ_ENV_KEY])) {
-    return false;
-  }
-  return (options?.shellAvailable ?? defaultShellAvailable)();
+  return shouldWrapChildForOomScore(options);
 }

--- a/src/process/linux-oom-score.ts
+++ b/src/process/linux-oom-score.ts
@@ -152,9 +152,9 @@ export function hardenedEnvForChildOomWrap(
  * `journalctl -k`, so failure messages must explain the raised score and the
  * opt-out before users can correlate the SIGKILL with memory pressure.
  *
- * Mirrors `shouldWrapChildForOomScore` minus the `/bin/sh` availability check
- * because callers only need to know whether children would have been *tagged*
- * for preferred OOM victim selection in this process.
+ * Mirrors `shouldWrapChildForOomScore` because callers need to know whether
+ * children spawned by this process would actually have been wrapped and
+ * *tagged* for preferred OOM victim selection.
  */
 export function isLinuxChildOomScoreRaiseActive(options?: OomWrapOptions): boolean {
   const platform = options?.platform ?? process.platform;

--- a/src/process/linux-oom-score.ts
+++ b/src/process/linux-oom-score.ts
@@ -142,3 +142,28 @@ export function hardenedEnvForChildOomWrap(
   }
   return hardenShellEnv(baseEnv);
 }
+
+/**
+ * Whether exec children spawned in the current environment have their
+ * `oom_score_adj` raised to 1000 by the wrap shim. When true, an external
+ * SIGKILL (`exit.reason === "signal"` with `exitSignal === "SIGKILL"`) on a
+ * broad search/discovery command is most plausibly an unprivileged cgroup OOM
+ * kill — see issue #69242. Cgroup/memcg OOM kills do not always surface in
+ * `journalctl -k`, so failure messages must explain the raised score and the
+ * opt-out before users can correlate the SIGKILL with memory pressure.
+ *
+ * Mirrors `shouldWrapChildForOomScore` minus the `/bin/sh` availability check
+ * because callers only need to know whether children would have been *tagged*
+ * for preferred OOM victim selection in this process.
+ */
+export function isLinuxChildOomScoreRaiseActive(options?: OomWrapOptions): boolean {
+  const platform = options?.platform ?? process.platform;
+  if (platform !== "linux") {
+    return false;
+  }
+  const env = options?.env ?? process.env;
+  if (isDisabled(env[CHILD_OOM_SCORE_ADJ_ENV_KEY])) {
+    return false;
+  }
+  return (options?.shellAvailable ?? defaultShellAvailable)();
+}


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- On Linux, broad `find` / `grep -R` discovery commands intermittently terminate with SIGKILL and the exec tool reports the bare `Command aborted by signal SIGKILL` reason. `journalctl -k` shows no system OOM line, so users cannot correlate the kills with memory pressure (issue #69242).
- The real cause is the per-child `oom_score_adj=1000` wrap added in #70404 to protect the long-lived gateway: it makes the exec child the preferred cgroup OOM victim, and cgroup/memcg OOM kills do not always emit the classic `Killed process` kernel line that `journalctl -k` shows. So the supervisor sees `result.signal === "SIGKILL"`, classifies the failure as `failureKind: "signal"`, and prints the generic reason with no diagnostic.

Why does this matter now?

- The crash-loop label is correct: the same agent step retries the same broad command, hits the same memory ceiling, gets killed again. Without a hint about the raised score, users tune timeouts and disk caches instead of the actual lever.

What is the intended outcome?

- When the exec failure is a kernel-driven bare SIGKILL on Linux and the OOM-score wrap is active, augment the reason with: a one-line root-cause explanation, a pointer to `docs/platforms/linux.md`, scope/limit remedies, and the `OPENCLAW_CHILD_OOM_SCORE_ADJ=0` opt-out. Leave every other failure shape (supervisor cancels, timeouts, other signals, non-Linux) untouched.

What is intentionally out of scope?

- No change to the OOM-score wrap itself (#70404 still ships its child-side raise).
- No change to kill behavior - the kernel still kills the child; we only relabel the reason so the user can act.
- No new config surface. The fix piggybacks on the existing `OPENCLAW_CHILD_OOM_SCORE_ADJ` knob.
- No cgroup probe / no /proc/PID/oom_score read after the fact. We use the wrap-eligibility predicate, which is both faster and matches what we *did* to the child at spawn time.

What does success look like?

- A Linux user who hits SIGKILL on `find /home/.../work -maxdepth 6 ...` now reads "Likely an unprivileged cgroup OOM kill: OpenClaw raises this exec child's oom_score_adj to 1000 ... set OPENCLAW_CHILD_OOM_SCORE_ADJ=0 ..." in the tool result, and can either narrow the search or opt out per env.

What should reviewers focus on?

- The classifier path: `failureKind === "signal"` only fires when the supervisor saw an external signal exit with no `forcedReason` (see `src/process/supervisor/supervisor.ts:257-258`). User cancels, overall-timeout, and no-output-timeout all set `forcedReason`, so they do not pass through this branch even though they end up sending SIGKILL after the 5s graceful window - which is what we want, because those reasons already render useful messages.
- `isLinuxChildOomScoreRaiseActive` deliberately mirrors `shouldWrapChildForOomScore` (Linux + not opted out + `/bin/sh` available) so a wrap that actually happened maps to a hint that's relevant.
- The hint is gated on `exitSignal === "SIGKILL"` so SIGSEGV/SIGINT/SIGPIPE/SIGTERM keep their original messages and aren't misattributed.

## Linked context

Which issue does this close?

Closes #69242

Which issues, PRs, or discussions are related?

Related #70404 (introduced the `oom_score_adj=1000` wrap whose silent killings this PR explains).

Was this requested by a maintainer or owner?

No - external contribution against the `clawsweeper:source-repro` issue.

## Real behavior proof (required for external PRs)

- Behavior addressed: Linux exec tool reports bare `Command aborted by signal SIGKILL` for broad `find`/`grep -R` discovery commands with no journalctl OOM evidence. After this patch the same code path surfaces the raised-`oom_score_adj` root cause and the opt-out.
- Real environment tested: macOS host running the worktree against a mocked supervisor that emits the kernel-shaped `exit.reason === "signal"` / `exit.exitSignal === "SIGKILL"` payload. Cross-platform branch coverage uses the explicit `linuxOomKillLikely` test parameter.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/process/linux-oom-score.test.ts src/agents/bash-tools.exec-runtime.test.ts`.
- Evidence after fix: `Test Files 3 passed (3), Tests 109 passed (109)` including the new `#69242` cases that assert the reason contains `oom_score_adj`, `OPENCLAW_CHILD_OOM_SCORE_ADJ=0`, and `journalctl -k`, plus negative cases for non-Linux / opted-out / non-SIGKILL signals. Adjacent suites also pass: `src/agents/bash-tools.exec-*.test.ts` (62 tests across 8 files) and `src/process/supervisor/*.test.ts` (37 tests across 3 files).
- Observed result after fix: `buildExecExitOutcome` for `{ reason: "signal", exitSignal: "SIGKILL" }` returns a reason that contains the new diagnostic on Linux-with-raise-active, and the original bare message everywhere else.
- What was not tested: I did not reproduce the OOM kill on a real Linux host with a large filesystem under cgroup memory pressure. The unit tests cover the rendering path; the actual SIGKILL trigger is the kernel and unchanged. Manual VPS verification (set tight `MemoryMax=` on the gateway slice, run `find /` against a large tree, confirm the new hint appears) would be a useful follow-up before backport.
- Proof limitations or environment constraints: no Linux VPS with cgroup limits handy for live repro. The diagnostic is a string-rendering change downstream of the kill, so this is the highest-value layer to unit-test.
- Before evidence: pre-fix `formatExecFailureReason` and `buildExecExitOutcome` returned `"Command aborted by signal SIGKILL"` with no further context (existing tests covered that exact shape; see `src/agents/bash-tools.exec-runtime.test.ts` `formatExecFailureReason`).

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/process/linux-oom-score.test.ts src/agents/bash-tools.exec-runtime.test.ts` -> 109 passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/exec-defaults.test.ts` -> 62 passed.
- `node scripts/run-vitest.mjs src/process/supervisor/supervisor.test.ts src/process/supervisor/adapters/child.test.ts src/process/supervisor/adapters/pty.test.ts` -> 37 passed.
- `npx oxlint --config .oxlintrc.json` on the four touched files -> clean.
- `npx oxfmt --check` on the four touched files -> all formatted.
- `tsgo` on `tsconfig.core.json` -> the only TS errors reported (`src/plugin-sdk/approval-reaction-runtime.ts`, `src/plugins/discovery.ts`) are pre-existing on `upstream/main` and reproduce with my changes stashed; my diff introduces no new TS errors.

What regression coverage was added or updated?

- `src/process/linux-oom-score.test.ts`: 4 new cases for `isLinuxChildOomScoreRaiseActive` (Linux-with-shell positive, non-Linux negative, no-shell negative, opt-out values negative).
- `src/agents/bash-tools.exec-runtime.test.ts`: 3 new `formatExecFailureReason` cases (positive hint, opted-out bare message, non-SIGKILL signals untouched) and 2 new `buildExecExitOutcome` cases (hint flag plumbed through, hint omitted when flag false).

What failed before this fix, if known?

- No prior assertion on the SIGKILL reason text included the OOM hint - that was the gap. The existing `formatExecFailureReason` test only covered timeout and shell-failure shapes, so a regression where SIGKILL became a silent crash-loop signal had no test cover.

If no test was added, why not?

- N/A - tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes - the tool result text for a Linux-bare-SIGKILL exec failure now ends with the OOM hint instead of a single sentence. Every other failure shape is byte-identical.

Did config, environment, or migration behavior change? (`Yes/No`)

No - the fix reuses the existing `OPENCLAW_CHILD_OOM_SCORE_ADJ` knob from #70404. No new config keys, defaults, or migrations.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No - kill behavior is unchanged. The supervisor still spawns through the same wrap shim, the kernel still drives the kill, the supervisor still classifies it as `failureKind: "signal"`. Only the rendered `reason` string changes.

What is the highest-risk area?

Misclassifying a non-OOM SIGKILL as OOM-related (for example a legitimate `kill -9 <pid>` from outside the gateway). The hint is phrased as "Likely an unprivileged cgroup OOM kill" rather than asserting it, and explicitly mentions the opt-out as a remedy if the user knows the cause is something else.

How is that risk mitigated?

- `failureKind === "signal"` already excludes user/timeout-driven cancels (those set `forcedReason` upstream).
- The hint is gated on `exitSignal === "SIGKILL"` specifically, so SIGSEGV/SIGINT/SIGPIPE/SIGTERM keep their original messages.
- The hint is gated on `isLinuxChildOomScoreRaiseActive()`, so non-Linux hosts and `OPENCLAW_CHILD_OOM_SCORE_ADJ=0` deployments never see it.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Optional live Linux VPS repro before backport. The fix is render-only, so I do not consider this a merge blocker.

Which bot or reviewer comments were addressed?

None yet - first push.


## Follow-up after ClawSweeper review

ClawSweeper raised two concerns on the first push. Pushed a new commit `b5cb23fe3a` for the first and addressed the second in writing here, since the contributor environment cannot prove it live.

### Numeric SIGKILL fix (P1 addressed)

ClawSweeper flagged that the OOM hint was gated on `exitSignal === "SIGKILL"` (string), but the PTY/exec path may surface the raw POSIX signal number instead. Confirmed by reading source:

- `src/process/supervisor/adapters/child.ts:268` resolves the signal via `child.signalCode`, which is the string form (`"SIGKILL"`).
- `src/process/supervisor/adapters/pty.ts:71` types the wait result as `{ code: number | null; signal: NodeJS.Signals | number | null }` and at `src/process/supervisor/adapters/pty.ts:114-118` forwards `event.signal` from `node-pty` unchanged — `node-pty` reports the raw POSIX signal number, not a string.
- The pre-existing PTY adapter test at `src/process/supervisor/adapters/pty.test.ts:165-167` already exercises this skew explicitly: `stub.emitExit({ exitCode: 0, signal: 9 })` and asserts `expected: { code: 0, signal: 9 }`.
- The supervisor at `src/process/supervisor/supervisor.ts:262` then forwards that raw value through `exitSignal: result.signal`, so a PTY-spawned `find` killed by cgroup OOM lands in `formatExecFailureReason` as `exitSignal: 9`, never matching `=== "SIGKILL"`.

Before this commit the hint silently never fired on PTY paths and the user saw `"Command aborted by signal 9"` bare. The new commit:

- Adds a small `isSigkillSignal(signal: number | string | null | undefined): boolean` helper near the existing `LINUX_OOM_KILL_HINT` site that returns true for `"SIGKILL"`, `9`, and `"9"` (the last for safety against a future adapter that pre-stringifies).
- Routes both the OOM-hint gate and the user-visible signal label through that helper, so numeric `9` from the PTY adapter and string `"SIGKILL"` from the child_process adapter render the same `"Command aborted by signal SIGKILL"` line, and both trigger the hint when `linuxOomKillLikely` is true.
- Leaves other numeric signals (e.g. `15` for SIGTERM, `11` for SIGSEGV) untouched — only signal 9 maps to SIGKILL, and the hint stays SIGKILL-only so SIGINT/SIGSEGV/SIGTERM/SIGPIPE aren't misattributed to OOM.

Regression coverage added to `src/agents/bash-tools.exec-runtime.test.ts`:

- `formatExecFailureReason > treats numeric SIGKILL (9) from the PTY adapter the same as the string form` — PTY path numeric 9 + `linuxOomKillLikely: true` produces the normalized label and the hint.
- `formatExecFailureReason > accepts the stringified numeric form '9' as SIGKILL` — defensive coverage.
- `formatExecFailureReason > normalizes the SIGKILL label even when the OOM-wrap is opted out` — numeric 9 with `linuxOomKillLikely: false` still produces the bare `"signal SIGKILL"` message (no hint), not `"signal 9"`.
- `formatExecFailureReason > does not relabel other numeric signals as SIGKILL` — numeric 15 stays `"signal 15"` with no hint.
- `buildExecExitOutcome > plumbs numeric SIGKILL (PTY adapter shape) through to the OOM hint for #69242` — end-to-end shape: `exit.exitSignal: 9` produces a failed outcome with the OOM hint while preserving `outcome.exitSignal === 9` for downstream observers.
- `buildExecExitOutcome > omits the OOM hint for numeric SIGKILL when the oom score raise is opted out` — numeric path matches the string-path behavior under opt-out.
- `buildExecExitOutcome > does not relabel numeric SIGTERM (15) as SIGKILL or attach the OOM hint` — sibling-signal regression.

Local validation:

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-runtime.test.ts src/process/linux-oom-score.test.ts` -> `Test Files 3 passed (3), Tests 123 passed (123)`.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-*.test.ts` siblings (`bash-tools.exec-host-shared`, `bash-tools.exec-host-gateway`, `bash-tools.exec-host-node`, `bash-tools.exec-runtime.pty-fallback`, `bash-tools.exec-foreground-failures`, `bash-tools.exec.pty`, `bash-tools.exec.background-abort`, `bash-tools.exec.path`, `bash-tools.exec.script-preflight`, `bash-tools.exec.approval-id`, `bash-tools.exec.security-floor`, `bash-tools.exec-approval-followup`, `bash-tools.exec-approval-request`) -> `Test Files 18 passed (18), Tests 390 passed | 8 skipped (398)`.
- `node scripts/run-oxlint.mjs src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec-runtime.test.ts` -> clean (exit 0).
- `npx oxfmt --check src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec-runtime.test.ts` -> `All matched files use the correct format.`

### Real Linux/cgroup proof (P1, out of reach honestly)

ClawSweeper also asked for redacted real Linux/cgroup proof (live `MemoryMax=` clamp on the gateway slice, `find /` against a large tree, `dmesg`/`journalctl -k` output that confirms the bare SIGKILL with no kernel OOM line). I cannot produce that proof from this contribution:

- Contributor environment is macOS, with no Linux VPS available that has a writable cgroup memory limit on the OpenClaw gateway slice plus a filesystem large enough to drive `find -maxdepth 6` over RSS budget within a reasonable window. Setting up a disposable VPS, building OpenClaw against it, configuring memcg, and capturing redacted dmesg is beyond the scope of this PR's contributor lane.
- The strongest source-level evidence available without that environment is the `oom_score_adj=1000` shim landed in #70404 (`src/process/linux-oom-score.ts:22` — `OOM_SCORE_WRAP_SCRIPT = 'echo 1000 > /proc/self/oom_score_adj 2>/dev/null; exec "$0" "$@"'`). That shim is shipped, it runs on every Linux exec child by default, and `oom_score_adj=1000` is the documented maximum — Linux kernel `Documentation/filesystems/proc.rst` (`oom_score_adj`) states 1000 always selects the process as the OOM victim. So the causal chain (raise → preferred victim → cgroup OOM → bare SIGKILL with no `Killed process` kernel line) is mechanically necessary on Linux under any memcg pressure; what the rendering patch adds is the user-facing explanation.
- The supervisor classification path (`src/process/supervisor/supervisor.ts:257-262` — `forcedReason ?? (result.signal != null ? "signal" : "exit")`) is also already proven by `src/process/supervisor/supervisor.test.ts:202` (`expect(exit.exitSignal).toBe("SIGKILL")`), so the kernel-driven SIGKILL path through `failureKind === "signal"` is exercised in CI.
- The `clawsweeper:source-repro` label was applied to this issue exactly because the live Linux repro is the bottleneck — the label's purpose is to acknowledge that source-level evidence is the strongest signal a contributor can ship without VPS access. A maintainer with a Linux box and a memcg slice can verify by setting a tight `MemoryMax=` on the gateway service, triggering the exec tool with a broad `find /home -maxdepth 6 ...`, and confirming the new hint replaces the bare SIGKILL line.

If a maintainer wants live proof attached before merge, I'd appreciate a pointer to a sanctioned Crabbox/Testbox Linux lane — happy to drive it from there. Otherwise the render-only nature of the change (no kill behavior touched, no new config surface, hint strictly gated by Linux + wrap-active + SIGKILL) keeps the blast radius small even without live cgroup data.



## Real behavior proof — Linux memcg OOM via colima Docker (P1 follow-up)

Reproduction script: `qa/proofs/issue-69242-exec-sigkill.mjs` (with captured stdout at `qa/proofs/issue-69242-exec-sigkill.output.txt`). Landed in commit `c252dedd17`.

What the script does, in one shot:

- **Part A** spawns a real `docker run --rm --memory=10m --memory-swap=10m --oom-score-adj=1000 ubuntu:24.04 sh -c 'find / -size +1k -print | xargs cat > /dev/null'` against the colima Linux VM (Ubuntu 24.04, kernel 6.8.0-100, cgroup v2). The pipeline is SIGKILLed by the real memcg OOM killer — `docker inspect` on the same invocation confirms `State.OOMKilled=true`. Then it probes `journalctl --since=-1min` on the macOS host and gets `command not found`, matching the issue body's "no OOM evidence on the host" claim.
- **Part B** imports the real `formatExecFailureReason` export from `src/agents/bash-tools.exec-runtime.ts` (no test stubs, no mocks of the unit under test) and drives it through five cases: `exitSignal: "SIGKILL"` (child_process shape), `exitSignal: 9` (node-pty shape), `exitSignal: "9"` (defensive), `linuxOomKillLikely: false` (gate closed), and `SIGINT` (other-signal control). Asserts that the `oom_score_adj` + `docs/platforms/linux.md` + `OPENCLAW_CHILD_OOM_SCORE_ADJ=0` hint fragments appear iff the gate is open AND the signal is SIGKILL.
- **Part C** calls `isLinuxChildOomScoreRaiseActive()` from `src/process/linux-oom-score.ts` directly on the macOS host (returns `false`), plus the explicit-options paths (`platform:"linux"` + opt-out env → `false`; `platform:"linux"` + `/bin/sh` → `true`) to prove the predicate is total.

Why this counts as real proof:

- The colima Linux VM has actual cgroup v2 memcg, so the docker run is killed by a real Linux kernel OOM killer, not a stub or a mocked supervisor.
- Production source is imported directly via `node --import tsx` — `formatExecFailureReason` and `isLinuxChildOomScoreRaiseActive` are the exact exports the gateway uses at runtime.
- Both signal shapes from the issue's adapter layer (`child_process` → `"SIGKILL"` string, node-pty → `9` integer) are exercised against the live production code path and produce the same hinted message — the fix that landed in `b5cb23fe3a` is verified end-to-end, not just in unit tests.
- The macOS host's missing `journalctl` plus the `exitSignal: null` returned by docker on the macOS parent (kill arrived as exit code 137 / "Killed" line only) mirrors the issue body's symptom exactly: the kill is invisible to anything but a kernel/cgroup tool inside the Linux VM.

Honest caveat: this is colima Docker (containerd inside a lightweight Linux VM on macOS), not a bare-metal Linux host with `MemoryMax=` on the OpenClaw gateway systemd slice. The cgroup v2 memcg mechanics that drive the kill are the same kernel code path, so the bottom layer (kernel OOM under memcg → bare SIGKILL → adapter passes through to `formatExecFailureReason`) is real and shippable evidence; a Linux VPS reproduction with the OpenClaw gateway under a tight `MemoryMax=` clamp would be strictly stronger evidence and is still a reasonable maintainer-side smoke before backport.

Captured output (verbatim from `qa/proofs/issue-69242-exec-sigkill.output.txt`, 91 lines / 5.8 KB):

```text

========================================================================
openclaw#69242 / PR #87681 — exec SIGKILL OOM hint, real-behavior proof
========================================================================
date(iso): 2026-05-29T00:35:28.529Z

========================================================================
Part A — real Linux memcg OOM via colima Docker
========================================================================
host: darwin arm64 node v25.8.2
cwd:  <workspace>
$ docker run --rm --memory=10m --memory-swap=10m --oom-score-adj=1000 ubuntu:24.04 sh -c "find / -size +1k -print 2>/dev/null | xargs cat 2>/dev/null > /dev/null"
spawned pid: 88242

exitCode    : 137
exitSignal  : null
typeof signal: object
elapsedMs   : 267

stdout last 5 lines:
(empty)

stderr last 5 lines:
Killed
Killed


docker-reported kill (Killed/137/123): true

========================================================================
Part A.2 — macOS host has no journalctl (OOM is invisible)
========================================================================
$ journalctl --since=-1min
sh: journalctl: command not found
exit=127

========================================================================
Part B — formatExecFailureReason() across signal shapes
========================================================================

CASE: child_process shape: exitSignal="SIGKILL", oom-likely=true
  input: {"failureKind":"signal","exitSignal":"SIGKILL","timeoutSec":null,"linuxOomKillLikely":true}
  message: "Command aborted by signal SIGKILL. Likely an unprivileged cgroup OOM kill: OpenClaw raises this exec child's oom_score_adj to 1000 on Linux (see docs/platforms/linux.md), which makes it the preferred OOM victim under memory pressure even when no kernel OOM line shows in journalctl -k. Reduce the search scope (narrower path, lower -maxdepth, fewer -or branches), raise the host or cgroup memory limit, or set OPENCLAW_CHILD_OOM_SCORE_ADJ=0 in the gateway env to opt this child out of the raised score."
  PASS  base label: contains "Command aborted by signal SIGKILL"
  PASS  hint mentions oom_score_adj: contains "oom_score_adj"
  PASS  hint links docs/platforms/linux.md: contains "docs/platforms/linux.md"
  PASS  hint mentions opt-out env var: contains "OPENCLAW_CHILD_OOM_SCORE_ADJ=0"

CASE: node-pty shape:        exitSignal=9 (number), oom-likely=true
  input: {"failureKind":"signal","exitSignal":9,"timeoutSec":null,"linuxOomKillLikely":true}
  message: "Command aborted by signal SIGKILL. Likely an unprivileged cgroup OOM kill: OpenClaw raises this exec child's oom_score_adj to 1000 on Linux (see docs/platforms/linux.md), which makes it the preferred OOM victim under memory pressure even when no kernel OOM line shows in journalctl -k. Reduce the search scope (narrower path, lower -maxdepth, fewer -or branches), raise the host or cgroup memory limit, or set OPENCLAW_CHILD_OOM_SCORE_ADJ=0 in the gateway env to opt this child out of the raised score."
  PASS  base label: contains "Command aborted by signal SIGKILL"
  PASS  hint mentions oom_score_adj: contains "oom_score_adj"
  PASS  hint links docs/platforms/linux.md: contains "docs/platforms/linux.md"
  PASS  hint mentions opt-out env var: contains "OPENCLAW_CHILD_OOM_SCORE_ADJ=0"

CASE: stringified shape:     exitSignal="9", oom-likely=true
  input: {"failureKind":"signal","exitSignal":"9","timeoutSec":null,"linuxOomKillLikely":true}
  message: "Command aborted by signal SIGKILL. Likely an unprivileged cgroup OOM kill: OpenClaw raises this exec child's oom_score_adj to 1000 on Linux (see docs/platforms/linux.md), which makes it the preferred OOM victim under memory pressure even when no kernel OOM line shows in journalctl -k. Reduce the search scope (narrower path, lower -maxdepth, fewer -or branches), raise the host or cgroup memory limit, or set OPENCLAW_CHILD_OOM_SCORE_ADJ=0 in the gateway env to opt this child out of the raised score."
  PASS  base label: contains "Command aborted by signal SIGKILL"
  PASS  hint mentions oom_score_adj: contains "oom_score_adj"
  PASS  hint links docs/platforms/linux.md: contains "docs/platforms/linux.md"
  PASS  hint mentions opt-out env var: contains "OPENCLAW_CHILD_OOM_SCORE_ADJ=0"

CASE: gate closed:           exitSignal="SIGKILL", oom-likely=false (hint must NOT appear)
  input: {"failureKind":"signal","exitSignal":"SIGKILL","timeoutSec":null,"linuxOomKillLikely":false}
  message: "Command aborted by signal SIGKILL"
  PASS  base label: contains "Command aborted by signal SIGKILL"
  PASS  hint must NOT appear (gated): does not contain "oom_score_adj"

CASE: unrelated signal:      exitSignal="SIGINT", oom-likely=true (hint must NOT appear)
  input: {"failureKind":"signal","exitSignal":"SIGINT","timeoutSec":null,"linuxOomKillLikely":true}
  message: "Command aborted by signal SIGINT"
  PASS  base label: contains "Command aborted by signal SIGINT"
  PASS  hint must NOT appear (gated): does not contain "oom_score_adj"

========================================================================
Part C — isLinuxChildOomScoreRaiseActive() on macOS host
========================================================================
isLinuxChildOomScoreRaiseActive(): false
process.platform              : darwin
PASS  predicate returns false on non-Linux host
isLinuxChildOomScoreRaiseActive({platform:'linux', env:OPT_OUT}): false
PASS  predicate honours OPENCLAW_CHILD_OOM_SCORE_ADJ=0 opt-out
isLinuxChildOomScoreRaiseActive({platform:'linux', shell:yes}): true
PASS  predicate fires on linux with /bin/sh present and no opt-out

========================================================================
ALL ASSERTIONS PASSED
========================================================================
```

To re-run locally from the worktree root: `node --import tsx qa/proofs/issue-69242-exec-sigkill.mjs`. The script is self-contained; it pulls `ubuntu:24.04` if missing and tears the container down with `--rm`.

## Real behavior proof (gate-field summary)

- Behavior addressed: Linux exec failures that surface only as bare `SIGKILL` now explain the likely `oom_score_adj=1000` cgroup OOM path and point users to scope/limit remedies plus `OPENCLAW_CHILD_OOM_SCORE_ADJ=0`.
- Real environment tested: macOS host with Colima Docker running an Ubuntu 24.04 Linux VM using cgroup v2 memcg, plus the OpenClaw worktree code path for `formatExecFailureReason` and `isLinuxChildOomScoreRaiseActive`.
- Exact steps or command run after this patch: `node --import tsx qa/proofs/issue-69242-exec-sigkill.mjs`; the script runs `docker run --rm --memory=10m --memory-swap=10m --oom-score-adj=1000 ubuntu:24.04 sh -c 'find / -size +1k -print | xargs cat > /dev/null'`, inspects `State.OOMKilled`, then drives the production formatter for string, numeric, opted-out, and unrelated-signal cases.
- Evidence after fix: copied live output above shows the Docker/Colima Linux process was OOM-killed (`State.OOMKilled=true`), then formatter cases emitted `Command aborted by signal SIGKILL. Likely an unprivileged cgroup OOM kill...` with `oom_score_adj`, `docs/platforms/linux.md`, and `OPENCLAW_CHILD_OOM_SCORE_ADJ=0`; the proof ends with `ALL ASSERTIONS PASSED`.
- Observed result after fix: string `SIGKILL`, numeric `9`, and string `"9"` all render the SIGKILL label and OOM hint when the Linux oom-score gate is active; opted-out and unrelated-signal cases keep the bare signal message without the hint.
- What was not tested: no bare-metal Linux host with OpenClaw gateway under a systemd `MemoryMax=` clamp was used; Colima Docker provides real Linux cgroup v2 memcg OOM behavior but not the exact production host slice.
