### PR TITLE
Fix directive persistence for relayed channel metadata

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -136,7 +136,7 @@ Current source-of-truth:
   </Accordion>
   <Accordion title="Model and run controls">
     - `/think <level|default>` sets the thinking level or clears the session override. Options come from the active model's provider profile; common levels are `off`, `minimal`, `low`, `medium`, and `high`, with custom levels such as `xhigh`, `adaptive`, `max`, or binary `on` only where supported. Aliases: `/thinking`, `/t`.
-    - `/verbose on|off|full` toggles verbose output. Alias: `/v`.
+    - `/verbose on|off|full` toggles verbose output. Authorized external channel senders may persist the session override; internal gateway/webchat clients need `operator.admin`. Alias: `/v`.
     - `/trace on|off` toggles plugin trace output for the current session.
     - `/fast [status|on|off|default]` shows, sets, or clears fast mode.
     - `/reasoning [on|off|stream]` toggles reasoning visibility. Alias: `/reason`.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -81,6 +81,7 @@ title: "Thinking levels"
 - Levels: `on` (minimal) | `full` | `off` (default).
 - Directive-only message toggles session verbose and replies `Verbose logging enabled.` / `Verbose logging disabled.`; invalid levels return a hint without changing state.
 - `/verbose off` stores an explicit session override; clear it via the Sessions UI by choosing `inherit`.
+- Authorized external channel senders may persist the session verbose override. Internal gateway/webchat clients need `operator.admin` to persist it.
 - Inline directive affects only that message; session/global defaults apply otherwise.
 - Send `/verbose` (or `/verbose:`) with no argument to see the current verbose level.
 - When verbose is on, agents that emit structured tool results send each tool call back as its own metadata-only message, prefixed with `<emoji> <tool-name>: <arg>` when available. These tool summaries are sent as soon as each tool starts (separate bubbles), not as streaming deltas.

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1981,6 +1981,34 @@ describe("persistInlineDirectives session directive persistence policy", () => {
     expect(sessionEntry.verboseLevel).toBe("full");
   });
 
+  it("allows authorized external provider callers when surface carries webchat metadata", async () => {
+    const sessionEntry = await persistInternalOperatorWriteDirective(
+      "/exec host=node security=allowlist ask=always node=worker-1",
+      {
+        messageProvider: "telegram",
+        surface: "webchat",
+        gatewayClientScopes: ["operator.write"],
+        commandAuthorized: true,
+      },
+    );
+
+    expect(sessionEntry.execHost).toBe("node");
+    expect(sessionEntry.execSecurity).toBe("allowlist");
+    expect(sessionEntry.execAsk).toBe("always");
+    expect(sessionEntry.execNode).toBe("worker-1");
+  });
+
+  it("allows authorized external provider verbose callers when surface carries webchat metadata", async () => {
+    const sessionEntry = await persistInternalOperatorWriteDirective("/verbose full", {
+      messageProvider: "telegram",
+      surface: "webchat",
+      gatewayClientScopes: ["operator.write"],
+      commandAuthorized: true,
+    });
+
+    expect(sessionEntry.verboseLevel).toBe("full");
+  });
+
   it("allows exec persistence for local callers without channel context", async () => {
     const sessionEntry = await persistInternalOperatorWriteDirective(
       "/exec host=node security=allowlist ask=always node=worker-1",
@@ -2001,6 +2029,17 @@ describe("persistInlineDirectives session directive persistence policy", () => {
     const sessionEntry = await persistInternalOperatorWriteDirective("/verbose full", {
       messageProvider: "webchat",
       surface: "forum",
+    });
+
+    expect(sessionEntry.verboseLevel).toBeUndefined();
+  });
+
+  it("keeps internal provider authoritative over authorized external surface metadata", async () => {
+    const sessionEntry = await persistInternalOperatorWriteDirective("/verbose full", {
+      messageProvider: "webchat",
+      surface: "telegram",
+      gatewayClientScopes: ["operator.write"],
+      commandAuthorized: true,
     });
 
     expect(sessionEntry.verboseLevel).toBeUndefined();

--- a/src/auto-reply/reply/directive-handling.shared.ts
+++ b/src/auto-reply/reply/directive-handling.shared.ts
@@ -1,6 +1,7 @@
 import { formatCliCommand } from "../../cli/command-format.js";
 import { SYSTEM_MARK, prefixSystemMessage } from "../../infra/system-message.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { ElevatedLevel, ReasoningLevel } from "./directives.js";
 
 export const formatDirectiveAck = (text: string): string => {
@@ -32,18 +33,17 @@ export function canPersistSessionDirectiveDefaults(params: {
 }): boolean {
   const messageProvider = normalizeOptionalString(params.messageProvider);
   const surface = normalizeOptionalString(params.surface);
-  const hasChannelContext = messageProvider !== undefined || surface !== undefined;
-  const isInternalGatewayCaller = messageProvider === "webchat" || surface === "webchat";
+  const authoritativeChannel = messageProvider ?? surface;
 
-  if (isInternalGatewayCaller) {
+  if (!authoritativeChannel) {
+    return true;
+  }
+
+  if (isInternalMessageChannel(authoritativeChannel)) {
     return params.gatewayClientScopes?.includes("operator.admin") === true;
   }
 
-  if (hasChannelContext) {
-    return params.commandAuthorized === true || params.senderIsOwner === true;
-  }
-
-  return true;
+  return params.commandAuthorized === true || params.senderIsOwner === true;
 }
 
 const formatElevatedEvent = (level: ElevatedLevel) => {


### PR DESCRIPTION
## Summary
- Follow up #86369 by treating `messageProvider` as the authoritative caller channel for directive persistence, falling back to `surface` only when no provider is present.
- Keep internal gateway/webchat callers gated on `operator.admin`, while allowing authorized external channel callers whose surface metadata is `webchat` to persist `/exec` and `/verbose` session defaults.
- Document the `/verbose` persistence authorization policy.

cc @pgondhi987

## Verification
- `pnpm test src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply/directive-handling.mixed-inline.test.ts -- --reporter=verbose` (76 tests passed on rebased SHA `87ac61fa078e21ad80c3e8981be7d6be395f0567`)
- `pnpm docs:list`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean, no accepted/actionable findings)
- GitHub PR CI on rebased SHA `87ac61fa078e21ad80c3e8981be7d6be395f0567` (passed; CodeQL neutral)

## Real behavior proof
Behavior addressed: authorized external provider calls with webchat surface metadata can persist `/exec` and `/verbose` session defaults, while authoritative internal webchat provider calls still require `operator.admin`.
Real environment tested: local source checkout plus delegated Blacksmith Testbox changed gate.
Exact steps or command run after this patch: focused auto-reply Vitest command, docs list, diff check, branch autoreview, and `pnpm check:changed` on Testbox.
Evidence after fix: new regression tests cover `messageProvider: "telegram", surface: "webchat"` for `/exec` and `/verbose`, plus `messageProvider: "webchat", surface: "telegram"` remaining blocked without admin.
Observed result after fix: focused tests, changed gate, and final PR CI passed.
What was not tested: live Telegram or gateway channel delivery.
