### PR TITLE
fix(webchat): queue outbound and flush on WS reconnect to prevent message loss (#45952)

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -10,6 +10,7 @@ import {
   resetChatAttachmentPayloadStoreForTest,
 } from "./chat/attachment-payload-store.ts";
 import type { executeSlashCommand } from "./chat/slash-command-executor.ts";
+import { GatewayRequestError } from "./gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "./types.ts";
 
 type ExecuteSlashCommand = typeof executeSlashCommand;
@@ -1723,6 +1724,136 @@ describe("handleSendChat", () => {
     expect(queued?.attachments).toHaveLength(1);
     expect(queued?.attachments?.[0]?.id).toBe("att-disc");
     expect(typeof queued?.idempotencyKey).toBe("string");
+  });
+
+  // Regression coverage for ClawSweeper's pre-ACK risk on #45952: a normal
+  // send that passes the host.connected gate but whose chat.send rejects
+  // because the WS dropped mid-call must land in the chat queue with the
+  // same idempotency key, not silently turn into a transcript error toast.
+  it("queues direct send when chat.send rejects with transport error and ws is closed", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        // Mirrors the exact Error message that GatewayBrowserClient
+        // emits from flushPending when the socket closes with pending
+        // requests in flight.
+        throw new Error("gateway closed (1006): abnormal closure");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: true,
+      chatMessage: "survive a mid-call WS drop",
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host);
+
+    // chat.send was attempted exactly once; transport rejection redirected
+    // the message into the queue instead of a transcript error bubble.
+    expect(request).toHaveBeenCalledWith("chat.send", expect.any(Object));
+    expect(host.chatQueue).toHaveLength(1);
+    const queued = host.chatQueue[0];
+    expect(queued?.text).toBe("survive a mid-call WS drop");
+    expect(queued?.failed).toBeFalsy();
+    expect(queued?.retryCount ?? 0).toBe(0);
+    expect(typeof queued?.idempotencyKey).toBe("string");
+    expect(uuidPattern.test(queued?.idempotencyKey as string)).toBe(true);
+    // The optimistic user transcript entry must be rolled back so the queue
+    // UI is the only visible representation of the in-flight message.
+    expect(host.chatMessages).toStrictEqual([]);
+    // No transport-failure toast; the queue carries the retry signal instead.
+    expect(host.lastError).toBeNull();
+    // chatRunId is cleared so the user can submit again without being blocked.
+    expect(host.chatRunId).toBeNull();
+    // Composer is empty; draft recallable via input-history.
+    expect(host.chatMessage).toBe("");
+    expect(navigateChatInputHistory(host, "up")).toBe(true);
+    expect(host.chatMessage).toBe("survive a mid-call WS drop");
+  });
+
+  it("preserves idempotency key across pre-ACK failure replay", async () => {
+    // Phase 1: connected send. Capture the idempotency key the client tries
+    // to use, then reject with a transport error mid-call.
+    let firstAttemptKey: string | undefined;
+    const request = vi.fn();
+    request.mockImplementation(async (method: string, params: unknown) => {
+      if (method === "chat.send") {
+        firstAttemptKey = (params as { idempotencyKey?: string }).idempotencyKey;
+        throw new Error("gateway not connected");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: true,
+      chatMessage: "same key after replay",
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host);
+
+    expect(typeof firstAttemptKey).toBe("string");
+    expect(uuidPattern.test(firstAttemptKey as string)).toBe(true);
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]?.idempotencyKey).toBe(firstAttemptKey);
+
+    // Phase 2: gateway reconnects, queue flushes, and chat.send is replayed
+    // with the EXACT same idempotency key. This is what lets the server-side
+    // `chat:${idempotencyKey}` dedupe collapse the retry into the original
+    // run instead of starting a duplicate agent turn.
+    request.mockImplementation(async (method: string, params: unknown) => {
+      if (method === "chat.send") {
+        return {
+          runId: (params as { idempotencyKey?: string }).idempotencyKey,
+          status: "started",
+        };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    await flushChatQueueForEvent(host);
+
+    expect(host.chatQueue).toStrictEqual([]);
+    const chatSendCalls = request.mock.calls.filter((call) => call[0] === "chat.send");
+    expect(chatSendCalls).toHaveLength(2);
+    const firstCallKey = requireRecord(chatSendCalls[0]?.[1], "first attempt").idempotencyKey;
+    const replayKey = requireRecord(chatSendCalls[1]?.[1], "replay attempt").idempotencyKey;
+    expect(replayKey).toBe(firstCallKey);
+    expect(host.chatRunId).toBe(firstAttemptKey);
+  });
+
+  it("does NOT queue when chat.send rejects with a non-transport error (e.g., auth)", async () => {
+    // Auth/validation/business errors come back as GatewayRequestError with
+    // a server-assigned code. Requeueing those would loop forever on the
+    // same rejection — they must keep the existing transcript error path.
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        throw new GatewayRequestError({
+          code: "PERMISSION_DENIED",
+          message: "not authorized",
+          details: { code: "AUTH_UNAUTHORIZED" },
+        });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: true,
+      chatMessage: "rejected by gateway",
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host);
+
+    // No queue entry — auth failures are not retryable.
+    expect(host.chatQueue).toStrictEqual([]);
+    // The existing business-error path runs: assistant Error transcript
+    // entry + state.lastError populated for the UI to show.
+    expect(host.lastError).toBe("gateway auth failed");
+    const lastMessage = requireRecord(host.chatMessages.at(-1), "assistant Error entry");
+    expect(lastMessage.role).toBe("assistant");
+    const content = lastMessage.content as Array<Record<string, unknown>>;
+    expect(content[0]?.text).toBe("Error: gateway auth failed");
   });
 });
 

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -49,6 +49,9 @@ let refreshChat: typeof import("./app-chat.ts").refreshChat;
 let refreshChatAvatar: typeof import("./app-chat.ts").refreshChatAvatar;
 let clearPendingQueueItemsForRun: typeof import("./app-chat.ts").clearPendingQueueItemsForRun;
 let removeQueuedMessage: typeof import("./app-chat.ts").removeQueuedMessage;
+let flushChatQueueForEvent: typeof import("./app-chat.ts").flushChatQueueForEvent;
+let retryFailedQueuedMessage: typeof import("./app-chat.ts").retryFailedQueuedMessage;
+let CHAT_QUEUE_RETRY_BUDGET: typeof import("./app-chat.ts").CHAT_QUEUE_RETRY_BUDGET;
 
 async function loadChatHelpers(): Promise<void> {
   ({
@@ -61,6 +64,9 @@ async function loadChatHelpers(): Promise<void> {
     refreshChatAvatar,
     clearPendingQueueItemsForRun,
     removeQueuedMessage,
+    flushChatQueueForEvent,
+    retryFailedQueuedMessage,
+    CHAT_QUEUE_RETRY_BUDGET,
   } = await import("./app-chat.ts"));
 }
 
@@ -1484,6 +1490,239 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toStrictEqual([]);
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:queued");
+  });
+
+  // Regression coverage for issue #45952: messages typed during a WebSocket
+  // reconnect window must survive the disconnect and replay on the next
+  // hello using the same idempotency key so the server-side chat.send dedupe
+  // collapses retries into the original run.
+  it("queues a disconnected normal send instead of silently dropping it", async () => {
+    const request = vi.fn(async (method: string) => {
+      throw new Error(`Unexpected request while disconnected: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: false,
+      chatMessage: "queued during reconnect",
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(host.chatQueue).toHaveLength(1);
+    const queued = host.chatQueue[0];
+    expect(queued?.text).toBe("queued during reconnect");
+    expect(queued?.failed).toBeFalsy();
+    expect(queued?.retryCount ?? 0).toBe(0);
+    expect(typeof queued?.idempotencyKey).toBe("string");
+    expect(uuidPattern.test(queued?.idempotencyKey as string)).toBe(true);
+    // Composer cleared so the user does not see a stale draft sitting there.
+    expect(host.chatMessage).toBe("");
+    // Draft text is still recallable via input-history navigation.
+    expect(navigateChatInputHistory(host, "up")).toBe(true);
+    expect(host.chatMessage).toBe("queued during reconnect");
+  });
+
+  it("does not queue stop or abort commands while disconnected", async () => {
+    const request = vi.fn();
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: false,
+      chatMessage: "/stop",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("does not queue local slash commands while disconnected", async () => {
+    const request = vi.fn();
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: false,
+      chatMessage: "/focus",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("replays a queued disconnected send with the preserved idempotency key on flush", async () => {
+    // Phase 1: disconnected submit lands in the queue with a pre-allocated key.
+    const request = vi.fn();
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: false,
+      chatMessage: "save me across reconnect",
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatQueue).toHaveLength(1);
+    const queuedKey = host.chatQueue[0]?.idempotencyKey;
+    expect(typeof queuedKey).toBe("string");
+    expect(uuidPattern.test(queuedKey as string)).toBe(true);
+
+    // Phase 2: gateway reconnects. The post-hello drain invokes
+    // flushChatQueueForEvent, which must send chat.send carrying the
+    // preserved idempotencyKey so the server-side dedupe collapses any
+    // duplicate replay into the same run instead of starting a new turn.
+    request.mockImplementation(async (method: string, params: unknown) => {
+      if (method === "chat.send") {
+        return {
+          runId: (params as { idempotencyKey?: string }).idempotencyKey,
+          status: "started",
+        };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    host.connected = true;
+    await flushChatQueueForEvent(host);
+
+    expect(host.chatQueue).toStrictEqual([]);
+    const payload = findRequestPayload(
+      request as unknown as MockCallSource,
+      "chat.send",
+      "replayed chat send payload",
+    );
+    expect(payload.message).toBe("save me across reconnect");
+    expect(payload.idempotencyKey).toBe(queuedKey);
+    expect(host.chatRunId).toBe(queuedKey);
+  });
+
+  it("marks a queued send failed after the retry budget is exhausted", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        throw new Error("gateway not connected");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: true,
+      chatQueue: [
+        {
+          id: "stuck",
+          text: "please retry me",
+          createdAt: 1,
+          idempotencyKey: "key-stuck",
+        },
+      ],
+    });
+
+    // Each flush attempt bumps retryCount; once it exceeds the budget the
+    // item is marked failed and flush stops draining so the UI can surface it.
+    for (let i = 0; i <= CHAT_QUEUE_RETRY_BUDGET; i++) {
+      await flushChatQueueForEvent(host);
+    }
+
+    expect(host.chatQueue).toHaveLength(1);
+    const stuck = host.chatQueue[0];
+    expect(stuck?.id).toBe("stuck");
+    expect(stuck?.failed).toBe(true);
+    expect(stuck?.retryCount).toBeGreaterThan(CHAT_QUEUE_RETRY_BUDGET);
+    expect(stuck?.idempotencyKey).toBe("key-stuck");
+  });
+
+  it("does not redrive a failed queue item until the user retries it", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("should not be called for failed items");
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: true,
+      chatQueue: [
+        {
+          id: "failed",
+          text: "needs manual retry",
+          createdAt: 1,
+          idempotencyKey: "key-failed",
+          retryCount: CHAT_QUEUE_RETRY_BUDGET + 1,
+          failed: true,
+        },
+      ],
+    });
+
+    await flushChatQueueForEvent(host);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]?.failed).toBe(true);
+  });
+
+  it("retryFailedQueuedMessage clears the failed marker and redrives the send", async () => {
+    const sendDeferred = createDeferred<unknown>();
+    const request = vi.fn(async (method: string, params: unknown) => {
+      if (method === "chat.send") {
+        const ack = {
+          runId: (params as { idempotencyKey?: string }).idempotencyKey,
+          status: "started",
+        };
+        sendDeferred.resolve(ack);
+        return ack;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: true,
+      chatQueue: [
+        {
+          id: "manual-retry",
+          text: "retry me by hand",
+          createdAt: 1,
+          idempotencyKey: "key-manual",
+          retryCount: CHAT_QUEUE_RETRY_BUDGET + 1,
+          failed: true,
+        },
+      ],
+    });
+
+    retryFailedQueuedMessage(host, "manual-retry");
+    await sendDeferred.promise;
+    // flushChatQueue runs as a microtask after the connected/!busy check;
+    // wait one tick so the await chain settles before asserting drained state.
+    await Promise.resolve();
+
+    expect(host.chatQueue).toStrictEqual([]);
+    const payload = findRequestPayload(
+      request as unknown as MockCallSource,
+      "chat.send",
+      "manual-retry chat send",
+    );
+    expect(payload.idempotencyKey).toBe("key-manual");
+    expect(payload.message).toBe("retry me by hand");
+  });
+
+  it("queues a disconnected normal send with attachments preserved", async () => {
+    const request = vi.fn();
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      connected: false,
+      chatMessage: "look at this",
+      chatAttachments: [
+        {
+          id: "att-disc",
+          mimeType: "image/png",
+          fileName: "screenshot.png",
+        },
+      ],
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatQueue).toHaveLength(1);
+    const queued = host.chatQueue[0];
+    expect(queued?.text).toBe("look at this");
+    expect(queued?.attachments).toHaveLength(1);
+    expect(queued?.attachments?.[0]?.id).toBe("att-disc");
+    expect(typeof queued?.idempotencyKey).toBe("string");
   });
 });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -24,6 +24,7 @@ import { parseSlashCommand, refreshSlashCommands } from "./chat/slash-commands.t
 import { resolveControlUiAuthHeader } from "./control-ui-auth.ts";
 import {
   abortChatRun,
+  ChatSendTransportFailedError,
   loadChatHistory,
   sendChatMessage,
   sendDetachedChatMessage,
@@ -295,6 +296,14 @@ async function sendChatMessageNow(
   resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
   // Reset scroll state before sending to ensure auto-scroll works for the response
   resetChatScroll(host as unknown as Parameters<typeof resetChatScroll>[0]);
+  // Pre-ACK transport rejections (socket closed mid-call, or precheck-not-
+  // connected after we passed the host.connected gate) come back as a typed
+  // ChatSendTransportFailedError. We let it propagate so the caller can
+  // preserve the original idempotency key on a queue entry instead of
+  // dropping the user's message — restoring the draft here would leave both
+  // the composer and the queue showing the same text. Business errors
+  // (auth/validation) still resolve to null with an assistant Error
+  // transcript entry; those are not retryable. See issue #45952.
   const runId = await sendChatMessage(host as unknown as ChatState, message, opts?.attachments, {
     idempotencyKey: opts?.idempotencyKey,
   });
@@ -541,7 +550,12 @@ async function flushChatQueue(host: ChatHost) {
       });
     }
   } catch (err) {
-    host.lastError = String(err);
+    // Transport failures during replay are expected during reconnect storms;
+    // surface them through the queue's retry budget instead of a toast so the
+    // user sees the message stay pending rather than a noisy error banner.
+    if (!(err instanceof ChatSendTransportFailedError)) {
+      host.lastError = String(err);
+    }
   }
   if (!ok) {
     // Normal sends that lost ACK are retry-eligible: bump the budget counter
@@ -745,14 +759,44 @@ export async function handleSendChat(
       return;
     }
 
-    await sendChatMessageNow(host, message, {
-      previousDraft: cleared.previousDraft,
-      restoreDraft: Boolean(messageOverride && opts?.restoreDraft),
-      attachments: hasAttachments ? attachmentsToSend : undefined,
-      previousAttachments: cleared.previousAttachments,
-      restoreAttachments: Boolean(messageOverride && opts?.restoreDraft),
-      refreshSessions,
-    });
+    // Allocate the idempotency key up front so a transport failure between
+    // the host.connected check and the chat.send ACK can re-queue this same
+    // send under the original key. Reconnect-flush replays with the same key
+    // and the server-side `chat:${idempotencyKey}` dedupe collapses the retry
+    // into the original run instead of starting a duplicate agent turn. See
+    // issue #45952.
+    const idempotencyKey = generateUUID();
+    try {
+      await sendChatMessageNow(host, message, {
+        previousDraft: cleared.previousDraft,
+        restoreDraft: Boolean(messageOverride && opts?.restoreDraft),
+        attachments: hasAttachments ? attachmentsToSend : undefined,
+        previousAttachments: cleared.previousAttachments,
+        restoreAttachments: Boolean(messageOverride && opts?.restoreDraft),
+        refreshSessions,
+        idempotencyKey,
+      });
+    } catch (err) {
+      if (!(err instanceof ChatSendTransportFailedError)) {
+        throw err;
+      }
+      // chat.send dispatched but never landed an ACK because the WS dropped
+      // mid-call. Capture the message into the chat queue with the same key
+      // so reconnect-flush replays it; the optimistic user transcript entry
+      // was rolled back inside sendChatMessage so the queue UI is the single
+      // visible representation until replay succeeds.
+      if (messageOverride == null) {
+        recordNonTranscriptInputHistory(host, message);
+      }
+      enqueueChatMessage(
+        host,
+        message,
+        hasAttachments ? attachmentsToSend : undefined,
+        refreshSessions,
+        undefined,
+        { idempotencyKey: err.attemptedRunId },
+      );
+    }
   });
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -217,12 +217,19 @@ export async function handleAbortChat(host: ChatHost, opts?: ChatAbortOptions) {
   await abortChatRun(host as unknown as ChatState);
 }
 
+// Bound transport retries per queue item so a wedged socket cannot loop
+// silently. Each failed flush bumps `retryCount`; once it exceeds the budget
+// the item is marked `failed` and the user gets a manual retry control. See
+// issue #45952.
+export const CHAT_QUEUE_RETRY_BUDGET = 5;
+
 function enqueueChatMessage(
   host: ChatHost,
   text: string,
   attachments?: ChatAttachment[],
   refreshSessions?: boolean,
   localCommand?: { args: string; name: string },
+  opts?: { idempotencyKey?: string },
 ) {
   const trimmed = text.trim();
   const hasAttachments = Boolean(attachments && attachments.length > 0);
@@ -239,6 +246,9 @@ function enqueueChatMessage(
       refreshSessions,
       localCommandArgs: localCommand?.args,
       localCommandName: localCommand?.name,
+      // Only normal chat sends carry an idempotencyKey; local slash commands
+      // run client-side and steered entries reuse the live run.
+      idempotencyKey: localCommand ? undefined : opts?.idempotencyKey,
     },
   ];
 }
@@ -277,12 +287,17 @@ async function sendChatMessageNow(
     previousAttachments?: ChatAttachment[];
     restoreAttachments?: boolean;
     refreshSessions?: boolean;
+    // Reuse a queued message's idempotency key so the server collapses replays
+    // into the original run instead of starting a new agent turn (#45952).
+    idempotencyKey?: string;
   },
 ) {
   resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
   // Reset scroll state before sending to ensure auto-scroll works for the response
   resetChatScroll(host as unknown as Parameters<typeof resetChatScroll>[0]);
-  const runId = await sendChatMessage(host as unknown as ChatState, message, opts?.attachments);
+  const runId = await sendChatMessage(host as unknown as ChatState, message, opts?.attachments, {
+    idempotencyKey: opts?.idempotencyKey,
+  });
   const ok = Boolean(runId);
   if (!ok && opts?.previousDraft != null) {
     host.chatMessage = opts.previousDraft;
@@ -504,7 +519,10 @@ async function flushChatQueue(host: ChatHost) {
   if (!host.connected || isChatBusy(host)) {
     return;
   }
-  const nextIndex = host.chatQueue.findIndex((item) => !item.pendingRunId);
+  // Skip failed items so the user can manually retry; eligible items are
+  // pending normal sends or local commands that have not exhausted their
+  // transport retry budget.
+  const nextIndex = host.chatQueue.findIndex((item) => !item.pendingRunId && !item.failed);
   if (nextIndex < 0) {
     return;
   }
@@ -519,15 +537,45 @@ async function flushChatQueue(host: ChatHost) {
       ok = await sendChatMessageNow(host, next.text, {
         attachments: next.attachments,
         refreshSessions: next.refreshSessions,
+        idempotencyKey: next.idempotencyKey,
       });
     }
   } catch (err) {
     host.lastError = String(err);
   }
   if (!ok) {
-    host.chatQueue = [next, ...host.chatQueue];
+    // Normal sends that lost ACK are retry-eligible: bump the budget counter
+    // and re-prepend so the next reconnect or run-finish picks them back up.
+    // Local commands are not deduped server-side; treat them the same way for
+    // transport errors but the budget still applies so a wedged socket cannot
+    // loop silently. See issue #45952.
+    const retryCount = (next.retryCount ?? 0) + 1;
+    const failed = retryCount > CHAT_QUEUE_RETRY_BUDGET;
+    const requeued: ChatQueueItem = { ...next, retryCount, failed };
+    host.chatQueue = [requeued, ...host.chatQueue];
+    if (failed) {
+      // Stop draining this round so the failed item stays visible at the head
+      // of the queue and the user can dismiss or retry it explicitly.
+      return;
+    }
   } else if (host.chatQueue.length > 0) {
     // Continue draining — local commands don't block on server response
+    void flushChatQueue(host);
+  }
+}
+
+export function retryFailedQueuedMessage(host: ChatHost, id: string) {
+  const target = host.chatQueue.find((item) => item.id === id);
+  if (!target || !target.failed) {
+    return;
+  }
+  // Reset budget and clear the failure marker. flushChatQueue picks it up
+  // on the next reconnect or run-finish; if we are already connected and
+  // idle, drain now.
+  host.chatQueue = host.chatQueue.map((item) =>
+    item.id === id ? { ...item, retryCount: 0, failed: false } : item,
+  );
+  if (host.connected && !isChatBusy(host)) {
     void flushChatQueue(host);
   }
 }
@@ -556,9 +604,6 @@ export async function handleSendChat(
   messageOverride?: string,
   opts?: ChatSendOptions,
 ) {
-  if (!host.connected) {
-    return;
-  }
   const previousDraft = host.chatMessage;
   const message = (messageOverride ?? host.chatMessage).trim();
   const submittedSessionKey = host.sessionKey;
@@ -571,6 +616,41 @@ export async function handleSendChat(
   }
 
   if (messageOverride != null && opts?.confirmReset && !confirmChatResetCommand(message)) {
+    return;
+  }
+
+  // Disconnected normal sends used to silently drop here, losing the user's
+  // message during a WS reconnect window. Capture the text into the chat
+  // queue with a pre-allocated idempotency key so flushChatQueue can replay
+  // it after the next hello — the gateway dedupes by `chat:${idempotencyKey}`
+  // so a retry whose original ACK was lost collapses into the same run
+  // instead of starting a duplicate agent turn. See issue #45952.
+  //
+  // Stop/abort, slash commands, and /btw still need a live transport, so they
+  // short-circuit below. We also keep the early-return for those code paths
+  // to avoid changing their disconnected behavior.
+  if (!host.connected) {
+    if (isChatStopCommand(message) || isBtwCommand(message)) {
+      return;
+    }
+    const parsedDisconnected = parseSlashCommand(message);
+    if (parsedDisconnected?.command.executeLocal) {
+      return;
+    }
+    if (messageOverride == null) {
+      recordNonTranscriptInputHistory(host, message);
+    }
+    enqueueChatMessage(
+      host,
+      message,
+      hasAttachments ? attachmentsToSend : undefined,
+      isChatResetCommand(message),
+      undefined,
+      { idempotencyKey: generateUUID() },
+    );
+    if (messageOverride == null) {
+      clearSubmittedComposerState(host, previousDraft, attachmentsToSend);
+    }
     return;
   }
 
@@ -657,7 +737,11 @@ export async function handleSendChat(
       if (messageOverride == null) {
         recordNonTranscriptInputHistory(host, message);
       }
-      enqueueChatMessage(host, message, attachmentsToSend, refreshSessions);
+      // Allocate the idempotency key up front so a disconnect between enqueue
+      // and drain still replays as the same run on the server (#45952).
+      enqueueChatMessage(host, message, attachmentsToSend, refreshSessions, undefined, {
+        idempotencyKey: generateUUID(),
+      });
       return;
     }
 

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -125,6 +125,14 @@ type TestGatewayHost = Parameters<typeof connectGateway>[0] & {
   activityEntries: ActivityEntry[];
   toolStreamById: Map<string, unknown>;
   toolStreamOrder: string[];
+  chatQueue: Array<{
+    id: string;
+    text: string;
+    createdAt: number;
+    idempotencyKey?: string;
+    retryCount?: number;
+    failed?: boolean;
+  }>;
 };
 
 function createHost(): TestGatewayHost {
@@ -648,6 +656,56 @@ describe("connectGateway", () => {
     connectGateway(host);
     expect(host.execApprovalQueue).toHaveLength(1);
     expect(host.execApprovalQueue[0]?.id).toBe("approval-1");
+  });
+
+  // Regression coverage for #45952: an ordinary reconnect (no seq-gap) must
+  // still flush the chat queue on hello so messages typed during the
+  // disconnect window get replayed. Prior behavior only flushed for
+  // reason === "seq-gap".
+  it("flushes the chat queue after hello on an ordinary reconnect", async () => {
+    const host = createHost();
+    host.chatQueue = [
+      {
+        id: "queued-discon",
+        text: "queued during disconnect",
+        createdAt: 1,
+        idempotencyKey: "key-discon",
+      },
+    ];
+
+    connectGateway(host);
+    const client = requireGatewayClient();
+
+    const chatSendResponses: Array<{ method: string; params: unknown }> = [];
+    client.request.mockImplementation(async (method: string, params: unknown) => {
+      if (method === "chat.send") {
+        chatSendResponses.push({ method, params });
+        return {
+          runId: (params as { idempotencyKey?: string }).idempotencyKey,
+          status: "started",
+        };
+      }
+      if (method === "update.status") {
+        return { sentinel: null };
+      }
+      if (method === "models.authStatus") {
+        return { ts: 0, providers: [] };
+      }
+      if (method === "sessions.list") {
+        return { count: 0, sessions: [] };
+      }
+      return {};
+    });
+
+    client.emitHello();
+
+    await vi.waitFor(() => {
+      expect(chatSendResponses).toHaveLength(1);
+    });
+    expect(host.chatQueue).toStrictEqual([]);
+    const sent = chatSendResponses[0]?.params as { idempotencyKey?: string; message?: string };
+    expect(sent.idempotencyKey).toBe("key-discon");
+    expect(sent.message).toBe("queued during disconnect");
   });
 
   it("maps generic fetch-failed auth errors to actionable token mismatch message", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -499,22 +499,27 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
   const shutdownHost = host as GatewayHostWithShutdownMessage;
   const reconnectReason = options?.reason ?? "initial";
   shutdownHost.pendingShutdownMessage = null;
-  shutdownHost.resumeChatQueueAfterReconnect = false;
+  // Always plan to drain the chat queue after the next hello so disconnected
+  // sends queued by handleSendChat (and busy-run enqueues whose original run
+  // got reset by the disconnect) get replayed. Server-side idempotency on
+  // `chat:${idempotencyKey}` keeps replays from creating duplicate runs.
+  // See issue #45952. Prior to this change only `seq-gap` reconnects drained.
+  shutdownHost.resumeChatQueueAfterReconnect = true;
   clearSessionsChangedReloadTimer(host);
   host.lastError = null;
   host.lastErrorCode = null;
   host.hello = null;
   host.connected = false;
   if (reconnectReason === "seq-gap") {
-    host.execApprovalQueue = pruneExecApprovalQueue(host.execApprovalQueue);
+    // Seq-gap recovery throws away the in-flight run's pending queue tags
+    // (we lost events for it); other reconnects keep them since the run may
+    // still be live on the gateway and continue emitting terminal events.
     clearPendingQueueItemsForRun(
       host as unknown as Parameters<typeof clearPendingQueueItemsForRun>[0],
       host.chatRunId ?? undefined,
     );
-    shutdownHost.resumeChatQueueAfterReconnect = true;
-  } else {
-    host.execApprovalQueue = pruneExecApprovalQueue(host.execApprovalQueue);
   }
+  host.execApprovalQueue = pruneExecApprovalQueue(host.execApprovalQueue);
   host.execApprovalError = null;
 
   const previousClient = host.client;
@@ -582,8 +587,11 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
         },
       );
       if (shutdownHost.resumeChatQueueAfterReconnect) {
-        // The interrupted run will never emit its terminal event now that the
-        // old client is gone, so resume any deferred commands after hello.
+        // Drain after every hello so disconnected normal sends queued during
+        // the reconnect window get flushed, and so deferred commands behind a
+        // run that was killed by the disconnect are resumed. The original-run
+        // idempotency key is preserved on queued items, so the server-side
+        // dedupe collapses replays into the same run. See issue #45952.
         shutdownHost.resumeChatQueueAfterReconnect = false;
         void flushChatQueueForEvent(
           host as unknown as Parameters<typeof flushChatQueueForEvent>[0],

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2838,6 +2838,7 @@ export function renderApp(state: AppViewState) {
                   onAbort: () => void state.handleAbortChat({ preserveDraft: true }),
                   onQueueRemove: (id) => state.removeQueuedMessage(id),
                   onQueueSteer: (id) => void state.steerQueuedChatMessage(id),
+                  onQueueRetry: (id) => state.retryFailedQueuedMessage(id),
                   onDismissSideResult: () => {
                     state.chatSideResult = null;
                   },

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -527,6 +527,7 @@ export type AppViewState = {
     steerQueuedChatMessage: (id: string) => Promise<void>;
     handleAbortChat: (opts?: ChatAbortOptions) => Promise<void>;
     removeQueuedMessage: (id: string) => void;
+    retryFailedQueuedMessage: (id: string) => void;
     handleChatScroll: (event: Event) => void;
     resetToolStream: () => void;
     resetChatScroll: () => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -22,6 +22,7 @@ import {
   handleSendChat as handleSendChatInternal,
   removeQueuedMessage as removeQueuedMessageInternal,
   resetChatInputHistoryNavigation as resetChatInputHistoryNavigationInternal,
+  retryFailedQueuedMessage as retryFailedQueuedMessageInternal,
   steerQueuedChatMessage as steerQueuedChatMessageInternal,
   type ChatInputHistoryKeyInput,
   type ChatInputHistoryKeyResult,
@@ -1057,6 +1058,13 @@ export class OpenClawApp extends LitElement {
   removeQueuedMessage(id: string) {
     removeQueuedMessageInternal(
       this as unknown as Parameters<typeof removeQueuedMessageInternal>[0],
+      id,
+    );
+  }
+
+  retryFailedQueuedMessage(id: string) {
+    retryFailedQueuedMessageInternal(
+      this as unknown as Parameters<typeof retryFailedQueuedMessageInternal>[0],
       id,
     );
   }

--- a/ui/src/ui/chat/chat-queue.ts
+++ b/ui/src/ui/chat/chat-queue.ts
@@ -7,6 +7,11 @@ export type ChatQueueProps = {
   canAbort?: boolean;
   onQueueSteer?: (id: string) => void;
   onQueueRemove: (id: string) => void;
+  // Retry handler for items whose transport retries hit
+  // CHAT_QUEUE_RETRY_BUDGET — used by the failed-delivery indicator added for
+  // the WebChat reconnect message-loss fix (#45952). Optional so embedders
+  // that do not surface failed sends still type-check.
+  onQueueRetry?: (id: string) => void;
 };
 
 export function renderChatQueue(props: ChatQueueProps) {
@@ -20,11 +25,21 @@ export function renderChatQueue(props: ChatQueueProps) {
         ${props.queue.map(
           (item) => html`
             <div
-              class="chat-queue__item ${item.kind === "steered" ? "chat-queue__item--steered" : ""}"
+              class="chat-queue__item ${item.kind === "steered"
+                ? "chat-queue__item--steered"
+                : ""} ${item.failed ? "chat-queue__item--failed" : ""}"
             >
               <div class="chat-queue__main">
                 ${item.kind === "steered"
                   ? html`<span class="chat-queue__badge">Steered</span>`
+                  : nothing}
+                ${item.failed
+                  ? html`<span
+                      class="chat-queue__badge chat-queue__badge--failed"
+                      role="alert"
+                      title="Could not deliver this message after multiple attempts"
+                      >Failed to send</span
+                    >`
                   : nothing}
                 <div class="chat-queue__text">
                   ${item.text ||
@@ -32,10 +47,24 @@ export function renderChatQueue(props: ChatQueueProps) {
                 </div>
               </div>
               <div class="chat-queue__actions">
+                ${item.failed && props.onQueueRetry
+                  ? html`
+                      <button
+                        class="btn chat-queue__retry"
+                        type="button"
+                        title="Retry sending"
+                        aria-label="Retry sending queued message"
+                        @click=${() => props.onQueueRetry?.(item.id)}
+                      >
+                        <span>Retry</span>
+                      </button>
+                    `
+                  : nothing}
                 ${props.canAbort &&
                 props.onQueueSteer &&
                 item.kind !== "steered" &&
-                !item.localCommandName
+                !item.localCommandName &&
+                !item.failed
                   ? html`
                       <button
                         class="btn chat-queue__steer"

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1045,6 +1045,42 @@ describe("sendChatMessage", () => {
     expect(sendParams.message).toBe("continue");
   });
 
+  // Regression coverage for #45952: a caller-supplied idempotencyKey must be
+  // threaded through to chat.send so a reconnect-replay collapses on the
+  // server-side `chat:${idempotencyKey}` dedupe entry instead of creating a
+  // duplicate agent turn under a fresh runId.
+  it("reuses a caller-supplied idempotency key for chat.send", async () => {
+    const request = vi.fn().mockResolvedValue({ runId: "key-fixed", status: "started" });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await sendChatMessage(state, "preserved across retries", undefined, {
+      idempotencyKey: "key-fixed",
+    });
+
+    expect(result).toBe("key-fixed");
+    expect(state.chatRunId).toBe("key-fixed");
+    const sendParams = requireRecord(request.mock.calls[0]?.[1]);
+    expect(sendParams.idempotencyKey).toBe("key-fixed");
+    expect(sendParams.message).toBe("preserved across retries");
+  });
+
+  it("generates a fresh idempotency key when none is provided", async () => {
+    const request = vi.fn().mockResolvedValue({ runId: "x", status: "started" });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await sendChatMessage(state, "ad-hoc send");
+
+    expect(result).toMatch(UUID_V4_RE);
+    const sendParams = requireRecord(request.mock.calls[0]?.[1]);
+    expect(sendParams.idempotencyKey).toBe(result);
+  });
+
   it("serializes non-image chat attachments as files", async () => {
     const request = vi.fn().mockResolvedValue({ runId: "run-1", status: "started" });
     const state = createState({

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -6,6 +6,7 @@ import {
 import { GatewayRequestError } from "../gateway.ts";
 import {
   abortChatRun,
+  ChatSendTransportFailedError,
   handleChatEvent,
   loadChatHistory,
   sendChatMessage,
@@ -1248,6 +1249,61 @@ describe("sendChatMessage", () => {
       },
     ]);
     expect(JSON.stringify(captionedState.chatMessages)).not.toContain("data:image/png;base64");
+  });
+
+  // Pre-ACK transport failures (#45952): a raw Error from
+  // GatewayBrowserClient.flushPending (socket closed mid-call) must surface
+  // as a typed ChatSendTransportFailedError carrying the attempted runId,
+  // and the optimistic user message must be rolled back so the queue UI can
+  // be the single source of truth for the in-flight send.
+  it("throws ChatSendTransportFailedError when chat.send rejects with a mid-call socket close", async () => {
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      // Mirrors the exact Error message GatewayBrowserClient emits from
+      // flushPending when the WebSocket closes with pending requests.
+      void params;
+      throw new Error("gateway closed (1006): abnormal closure");
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    await expect(
+      sendChatMessage(state, "in-flight when socket dies", undefined, {
+        idempotencyKey: "key-transport",
+      }),
+    ).rejects.toBeInstanceOf(ChatSendTransportFailedError);
+
+    // Optimistic user message rolled back.
+    expect(state.chatMessages).toStrictEqual([]);
+    // No transcript noise.
+    expect(state.lastError).toBeNull();
+    // Local run cleared so the next attempt is not blocked by chatSending.
+    expect(state.chatSending).toBe(false);
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+  });
+
+  it("preserves the attempted runId on ChatSendTransportFailedError so retries replay with the same dedupe key", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("gateway not connected");
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const failure = await sendChatMessage(state, "retry under same key", undefined, {
+      idempotencyKey: "key-preserved",
+    }).catch((err: unknown) => err);
+
+    expect(failure).toBeInstanceOf(ChatSendTransportFailedError);
+    const typed = failure as ChatSendTransportFailedError;
+    expect(typed.attemptedRunId).toBe("key-preserved");
+    // The original raw Error is preserved as `cause` for debugging without
+    // leaking it into chat state.
+    expect(typed.cause).toBeInstanceOf(Error);
+    expect((typed.cause as Error).message).toBe("gateway not connected");
   });
 
   it("formats structured non-auth connect failures for chat send", async () => {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -489,6 +489,41 @@ export type SendChatMessageOptions = {
   idempotencyKey?: string;
 };
 
+// Pre-ACK transport rejections from the gateway client are conservatively
+// detected: the raw `Error` shape comes from `GatewayBrowserClient.flushPending`
+// or its precheck, never from a server-side `res.error` payload (those become
+// `GatewayRequestError` with a `gatewayCode`). Auth/validation/business errors
+// are always `GatewayRequestError`, so this check keeps them out of the retry
+// queue while still catching socket-closed-mid-call and not-connected-at-call.
+// See issue #45952.
+const TRANSPORT_ERROR_MESSAGE_PATTERN = /^gateway (not connected|closed|client stopped)\b/iu;
+
+function isChatSendTransportFailure(err: unknown): boolean {
+  if (err instanceof GatewayRequestError) {
+    return false;
+  }
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  return TRANSPORT_ERROR_MESSAGE_PATTERN.test(err.message);
+}
+
+// Thrown by `sendChatMessage` when the chat.send round trip never reached the
+// server because the WS transport dropped mid-call. Callers (currently
+// `app-chat.ts`'s `sendChatMessageNow`) catch this to re-queue the original
+// message with the same idempotency key so the next reconnect-flush replays
+// it. The optimistic user transcript entry is rolled back before the throw so
+// the queue UI is the single source of truth for the in-flight message.
+export class ChatSendTransportFailedError extends Error {
+  readonly attemptedRunId: string;
+
+  constructor(attemptedRunId: string, cause: unknown) {
+    super("chat.send transport failure", { cause });
+    this.name = "ChatSendTransportFailedError";
+    this.attemptedRunId = attemptedRunId;
+  }
+}
+
 export async function sendChatMessage(
   state: ChatState,
   message: string,
@@ -579,6 +614,27 @@ export async function sendChatMessage(
     await requestChatSend(state, { message: msg, attachments, runId });
     return runId;
   } catch (err) {
+    if (isChatSendTransportFailure(err)) {
+      // Roll back the optimistic user message so the caller can re-queue this
+      // send under its original idempotency key without leaving a dangling
+      // user bubble in the transcript. The queue UI surfaces the in-flight
+      // message until the next reconnect-flush replays it.
+      state.chatMessages = state.chatMessages.slice(0, -1);
+      // Quietly tear down local run state without an "interrupted" toast —
+      // the queue UI already shows the message as pending and the user does
+      // not need a transport-failure popup that will resolve itself on the
+      // next hello.
+      reconcileChatRunLifecycle(
+        state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
+        {
+          runId,
+          sessionKey: state.sessionKey,
+          clearLocalRun: true,
+          clearChatStream: true,
+        },
+      );
+      throw new ChatSendTransportFailedError(runId, err);
+    }
     const error = formatConnectError(err);
     reconcileChatRunLifecycle(state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
       outcome: "interrupted",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -481,10 +481,19 @@ function normalizeFinalAssistantMessage(message: unknown): Record<string, unknow
   });
 }
 
+export type SendChatMessageOptions = {
+  // Reuse the original idempotency key when retrying a queued send after a
+  // WS reconnect — server dedupes by `chat:${idempotencyKey}` so the gateway
+  // collapses a retry whose original ACK was lost into the same run rather
+  // than starting a duplicate agent turn. See issue #45952.
+  idempotencyKey?: string;
+};
+
 export async function sendChatMessage(
   state: ChatState,
   message: string,
   attachments?: ChatAttachment[],
+  options?: SendChatMessageOptions,
 ): Promise<string | null> {
   if (!state.client || !state.connected) {
     return null;
@@ -561,7 +570,7 @@ export async function sendChatMessage(
   reconcileChatRunLifecycle(state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
     clearRunStatus: true,
   });
-  const runId = generateUUID();
+  const runId = options?.idempotencyKey?.trim() || generateUUID();
   state.chatRunId = runId;
   state.chatStream = "";
   state.chatStreamStartedAt = now;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -17,6 +17,17 @@ export type ChatQueueItem = {
   localCommandArgs?: string;
   localCommandName?: string;
   pendingRunId?: string;
+  // Carried through chat.send so server-side dedupe (`chat:${idempotencyKey}`)
+  // keeps reconnect-replay safe. Set only for normal-send items that are
+  // eligible for transport retry; local commands and steered entries omit it.
+  idempotencyKey?: string;
+  // Transport retries spent since the item was first dispatched. Bumped by
+  // flushChatQueue when chat.send fails before the server ACK lands; capped at
+  // CHAT_QUEUE_RETRY_BUDGET to bound silent loops on a wedged connection.
+  retryCount?: number;
+  // Set true once retryCount exceeds the budget so the queue surfaces a
+  // failed-delivery indicator + manual retry instead of silently dropping.
+  failed?: boolean;
 };
 
 export const CRON_CHANNEL_LAST = "last";

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -155,6 +155,9 @@ export type ChatProps = {
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
   onQueueSteer?: (id: string) => void;
+  // Manual retry for queue items whose transport retries exhausted the
+  // bounded budget; surfaced by chat-queue as a Retry button (#45952).
+  onQueueRetry?: (id: string) => void;
   onDismissSideResult?: () => void;
   onNewSession: () => void;
   onClearHistory?: () => void;
@@ -1495,6 +1498,7 @@ export function renderChat(props: ChatProps) {
         canAbort: showAbortableUi,
         onQueueSteer: props.onQueueSteer,
         onQueueRemove: props.onQueueRemove,
+        onQueueRetry: props.onQueueRetry,
       })}
       ${renderSideResult(props.sideResult, props.onDismissSideResult)}
       ${renderFallbackIndicator(props.fallbackStatus)}


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- WebChat messages typed during a `1001 / Going Away` reconnect window are silently dropped: `handleSendChat` returns immediately when `host.connected` is false, in-flight RPCs reject on socket close, and the post-hello drain only fires for `seq-gap` reconnects. The gateway never receives the prompt and no error surfaces. Two reporters confirmed the symptom on `v2026.5.22`.

Why does this matter now?

- It's a P1, `impact:message-loss` user-data-loss bug for the headline Control UI surface, with no client-side mitigation today. The Gateway already documents a `chat.send` ACK/idempotency contract that a focused UI fix can use without protocol change.

What is the intended outcome?

- Disconnected normal sends queue into the existing `chatQueue` with a pre-allocated idempotency key, every successful hello drains the queue, and replay reuses the original key so server-side `chat:${idempotencyKey}` dedupe collapses retries into the original run instead of creating duplicate agent turns.
- A bounded `CHAT_QUEUE_RETRY_BUDGET=5` caps silent loops on a wedged socket. Items past budget surface a `Failed to send` badge with a manual `Retry` button.

What is intentionally out of scope?

- No gateway protocol change. The existing `chat.send` ACK (`{ runId, status: "started" }`) and same-key duplicate handling (`{ status: "in_flight" }`) per `docs/web/control-ui.md` are reused unchanged.
- No change to `/btw`, `/side`, `/stop`, or local slash commands while disconnected — they keep their pre-existing behavior since they're not the lost-prompt path.
- Broader refresh/history/draft persistence remains separate (called out by clawsweeper review).

What does success look like?

- A message typed before a `1001` close and replayed after the next hello either reaches the gateway under the original `runId` or, after `CHAT_QUEUE_RETRY_BUDGET` retries, stays visible in the queue with a Failed indicator and a Retry control.

What should reviewers focus on?

- The `idempotencyKey` flow: pre-allocated in `handleSendChat` / busy-run enqueue, threaded through `sendChatMessage(state, msg, attachments, { idempotencyKey })`, preserved across `flushChatQueue` requeues.
- The `connectGateway` change widens the seq-gap-only drain to fire on every hello. The seq-gap-only branch is retained only for `clearPendingQueueItemsForRun`, since other reconnects can keep them.

## Linked context

Which issue does this close?

Closes #45952

Which issues, PRs, or discussions are related?

Related: clawsweeper review of #45952 (2026-04-29 / 2026-05-24) — both passes pinned the same shape: client-side outbound queue + reuse of the existing ACK/idempotency contract, no protocol change.

Was this requested by a maintainer or owner?

Issue is labeled `clawsweeper:fix-shape-clear`, `clawsweeper:queueable-fix`, `clawsweeper:source-repro`, `P1`, `impact:session-state`, `impact:message-loss`, `issue-rating: diamond lobster`.

## Real behavior proof (required for external PRs)

- Behavior addressed: WebChat normal-send messages silently lost across a Gateway WebSocket reconnect window (1001 Going Away).
- Real environment tested: macOS source checkout, isolated worktree at branch `fix/45952-webchat-ws-reconnect-msg-loss`, unit-test simulation of the disconnect → enqueue → hello → flush sequence against the same `chat.send` ACK shape the gateway emits today.
- Exact steps or command run after this patch:

  ```bash
  node scripts/run-vitest.mjs \
    ui/src/ui/app-chat.test.ts \
    ui/src/ui/controllers/chat.test.ts \
    ui/src/ui/app-gateway.node.test.ts \
    ui/src/ui/gateway.node.test.ts \
    ui/src/ui/views/chat.test.ts
  node scripts/run-vitest.mjs ui/src/ui
  node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json \
    --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo
  node scripts/run-tsgo.mjs -p tsconfig.core.json \
    --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
  pnpm exec oxfmt --check --threads=1 \
    ui/src/ui/app-chat.ts ui/src/ui/controllers/chat.ts \
    ui/src/ui/app-gateway.ts ui/src/ui/gateway.ts \
    ui/src/ui/ui-types.ts ui/src/ui/chat/chat-queue.ts \
    ui/src/ui/views/chat.ts ui/src/ui/app-render.ts ui/src/ui/app.ts
  pnpm exec oxlint <touched files>
  git diff --check
  ```

- Evidence after fix:
  - Targeted tests: `Test Files 5 passed (5)` / `Tests 257 passed (257)`.
  - Full ui surface: `Test Files 215 passed (215)` / `Tests 2716 passed (2716)`.
  - Format: `All matched files use the correct format.` (12 files).
  - oxlint: exit 0 across all touched files.
  - `git diff --check`: exit 0.
  - Typecheck `tsgo:test:ui` and `tsgo:core`: only `src/plugins/discovery.ts` and `src/plugin-sdk/approval-reaction-runtime.ts` errors remain — verified pre-existing on `origin/main` (`81c90aab6b`) by stashing this patch and re-running the same lane; identical errors reproduce, so they are unrelated baseline noise, not introduced by this PR.
- Observed result after fix: Disconnected sends survive the close and replay on the next hello with their original `idempotencyKey`. After 5 transient failures the item is marked `failed` in the queue and the user gets an explicit Retry button instead of silently looping.
- What was not tested: A live browser-driven 1001 close + reconnect roundtrip against a real running Gateway was not performed in this checkout. The simulation matches the source paths cited by clawsweeper (`handleSendChat` early-return at `app-chat.ts:559`, `connectGateway` seq-gap gate at `app-gateway.ts:500`, server ACK at `chat.ts:2648-2652`) and the existing `chat.send` ACK / dedupe tests in `src/gateway/server-methods/chat.directive-tags.test.ts` plus `chat.abort-persistence.test.ts` (212 passes) continue to hold.
- Proof limitations or environment constraints: No Crabbox/Testbox lane was used for the live browser roundtrip; the read-only source review and unit-level reconstruction match clawsweeper's source-repro conclusion.

## Tests and validation

Which commands did you run?

- See `Exact steps or command run after this patch` above.

What regression coverage was added or updated?

- `ui/src/ui/app-chat.test.ts`: queueing a disconnected normal send preserves draft history, captures attachments, allocates an idempotency key, and is not invoked for `/stop` or local slash commands. Replay through `flushChatQueueForEvent` reuses the queued idempotency key. Retry budget exhaustion marks the item `failed` and stops auto-draining. `retryFailedQueuedMessage` clears the marker and redrives.
- `ui/src/ui/app-gateway.node.test.ts`: an ordinary reconnect (not seq-gap) drains the queue after hello with the preserved `idempotencyKey`. Previously the queue would sit there until a `seq-gap` reconnect happened.
- `ui/src/ui/controllers/chat.test.ts`: `sendChatMessage` accepts and threads a caller-supplied `idempotencyKey` into `chat.send`; falls back to a fresh UUID when none provided (regression guard for existing fresh-send callers).

What failed before this fix, if known?

- Pre-fix `handleSendChat` short-circuited disconnected sends with no enqueue, so the new `queues a disconnected normal send instead of silently dropping it` test would assert `chatQueue.length === 1` against the old code's `0`.
- Pre-fix `connectGateway` only set `resumeChatQueueAfterReconnect = true` for `seq-gap`, so the new `flushes the chat queue after hello on an ordinary reconnect` test would never see the queued `chat.send` call.

If no test was added, why not?

- All four scenarios from the issue's suggested fix have direct unit coverage; no scenario was left untested.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — previously dropped disconnected messages now survive the close and replay with their original `idempotencyKey`, and items past `CHAT_QUEUE_RETRY_BUDGET=5` failures surface a visible Failed badge plus Retry button in the existing chat-queue panel.

Did config, environment, or migration behavior change? (`Yes/No`)

No — no new config keys, env vars, or migrations. No gateway protocol additions: the server-side `chat.send` ACK and `chat:${idempotencyKey}` dedupe entries are reused as-is per `docs/web/control-ui.md`.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No — same `chat.send` payload shape, same auth scopes, same transport. Idempotency keys are client-generated UUIDs (same generator as today's fresh-send path) and are sent only to the gateway.

What is the highest-risk area?

`flushChatQueue`'s requeue-on-failure path: a wedged transport could loop the same item; the explicit `CHAT_QUEUE_RETRY_BUDGET` bound and `failed` short-circuit are the bound. Sibling-surface check: cron/auto-reply paths use `sendDetachedChatMessage` and keep their early-disconnect return, so they're unaffected. The new `idempotencyKey` option on `sendChatMessage` is opt-in and falls back to the existing UUID generator when omitted, preserving every current caller.

How is that risk mitigated?

- Bounded retry counter + `failed` marker prevent silent loops.
- Manual Retry button gives the user an explicit out without auto-resending.
- Server-side dedupe on `chat:${idempotencyKey}` already handles the case where the ACK was lost but the run started — replay is collapsed into the original run, not a duplicate turn (`src/gateway/server-methods/chat.ts:2492-2536`).

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- CI typecheck/build/test results.
- Optional: live browser reconnect-window roundtrip in a maintainer environment for the `Real behavior proof` section — happy to provide if asked.

Which bot or reviewer comments were addressed?

- clawsweeper #45952 (2026-04-29 + 2026-05-24): adopted the recommended shape verbatim — outbound queue in the Control UI send path that captures before transport, preserves one idempotency key through ACK, retries transient closed/not-connected failures after reconnect hello, and surfaces bounded failed-delivery feedback. No new gateway protocol surface added.




## Follow-up — addressing ClawSweeper risks (commit 64b912392c)

### Pre-ACK transport loss closed

ClawSweeper's first-pass review flagged that the original commit covered the "send while already disconnected → enqueue" path but left the "send while connected → chat.send rejects because the socket dropped mid-call" path silently dropping into a transcript `Error: ...` message. The follow-up commit closes that gap:

- `ui/src/ui/controllers/chat.ts:492-560` — `sendChatMessage` now conservatively detects pre-ACK transport rejections (plain `Error` from `GatewayBrowserClient.flushPending` or its `gateway not connected` precheck, message-prefix-matched against `gateway not connected | closed | client stopped`). It rolls back the optimistic user transcript entry and throws the new typed `ChatSendTransportFailedError` carrying the attempted `runId`. `GatewayRequestError` — the shape used for auth, validation, and any other server-acknowledged business error — is explicitly excluded from the detector, so those keep the existing transcript-Error path and do not infinite-loop in the queue.
- `ui/src/ui/app-chat.ts:756-799` — `handleSendChat`'s connected normal-send path now pre-allocates the idempotency key before the `chat.send` attempt and catches `ChatSendTransportFailedError`. On catch it enqueues the same text + attachments under the original `attemptedRunId` as the queue item's `idempotencyKey`, so reconnect-flush replays with the same key. The composer is left empty (the queue UI is the single source of truth for the in-flight message) and the draft remains recallable via input-history. Pre-existing behavior for `/btw`, `/side`, `/stop`, local slash commands, and detached cron/auto-reply sends (`sendDetachedChatMessage`) is unchanged.
- `ui/src/ui/app-chat.ts:548-560` — `flushChatQueue`'s catch suppresses `lastError` noise for `ChatSendTransportFailedError` during replay so a reconnect storm surfaces through the queue's retry budget instead of a toast banner.

### Why the replay does not duplicate

The queue piggybacks on the server-side idempotency contract that already exists for `chat.send`. The gateway dedupes by `chat:${idempotencyKey}` (see `src/gateway/server-methods/chat.ts:2492-2536` referenced in the original PR body): a retry whose original ACK was lost lands on the same dedupe entry and collapses into the original run, not a fresh agent turn. The new code preserves the **exact** same idempotency key across both the pre-ACK rejection and the reconnect-flush replay:

1. `handleSendChat` allocates `idempotencyKey = generateUUID()` up front.
2. `sendChatMessage` calls `chat.send` with that key as `runId`.
3. On pre-ACK transport failure, `ChatSendTransportFailedError.attemptedRunId` carries the same key out.
4. `handleSendChat` enqueues with `idempotencyKey: err.attemptedRunId`.
5. `flushChatQueue` calls `sendChatMessageNow(..., { idempotencyKey: next.idempotencyKey })` on the next hello drain.
6. `sendChatMessage`'s `const runId = options?.idempotencyKey?.trim() || generateUUID()` reuses it as the runId on the wire.

Regression coverage in `ui/src/ui/app-chat.test.ts` (`preserves idempotency key across pre-ACK failure replay`) asserts the chain end-to-end: the same key flows through `request.mock.calls[0]` (failed attempt) and `request.mock.calls[1]` (post-hello replay). If a future change breaks the key handoff anywhere along the chain, this test fails.

The pre-existing `flushes the chat queue after hello on an ordinary reconnect` test in `ui/src/ui/app-gateway.node.test.ts:665-709` plus the new `preserves idempotency key across pre-ACK failure replay` test together cover ClawSweeper's "duplicate replay timing not fully de-risked" risk.

### Regression coverage added in this commit

- `ui/src/ui/app-chat.test.ts`:
  - `queues direct send when chat.send rejects with transport error and ws is closed` — asserts the user message is rolled back from the transcript, the queue gets exactly one entry with `failed === false / retryCount === 0`, `lastError` stays `null`, and the message is recallable via input-history.
  - `preserves idempotency key across pre-ACK failure replay` — verifies both the failed first attempt and the post-hello replay carry the **same** `idempotencyKey`.
  - `does NOT queue when chat.send rejects with a non-transport error (e.g., auth)` — guards the auth-failure path: `GatewayRequestError` with `AUTH_UNAUTHORIZED` keeps the transcript `Error: gateway auth failed` entry and never lands in the queue, so auth-style rejections cannot loop.
- `ui/src/ui/controllers/chat.test.ts`:
  - `throws ChatSendTransportFailedError when chat.send rejects with a mid-call socket close` — proves rollback of the optimistic user entry, clean `chatRunId`, clean `chatStream`, and no transcript noise.
  - `preserves the attempted runId on ChatSendTransportFailedError so retries replay with the same dedupe key` — proves the `attemptedRunId` shape and `cause` chain.

### Honest proof gap

The contributor environment still does not have a live Mantis/Control-UI + Gateway pair to drive a real browser reconnect against. The strongest contributor-level evidence remains the integration test scenarios — both the pre-existing reconnect drain test and the new pre-ACK transport-failure tests reconstruct the exact `chat.send` reject shape that `GatewayBrowserClient.flushPending` emits in production (`new Error("gateway closed (<code>): <reason>")` and `new Error("gateway not connected")` — see `ui/src/ui/gateway.ts:519-563`, `:870-871`). A maintainer-side live reconnect roundtrip is still welcome as a final confirmation; the unit reconstruction matches the wire-level transport-error shape and the server-side dedupe contract that the queue depends on.

### Validation commands run after the follow-up commit

```bash
node scripts/run-vitest.mjs \
  ui/src/ui/app-chat.test.ts \
  ui/src/ui/controllers/chat.test.ts \
  ui/src/ui/app-gateway.node.test.ts
# Test Files  3 passed (3) / Tests  176 passed (176)

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --noEmit
# exit 0

pnpm format:check ui/src/ui/app-chat.ts ui/src/ui/app-chat.test.ts \
  ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts
# All matched files use the correct format.

node scripts/run-oxlint.mjs ui/src/ui/app-chat.ts ui/src/ui/app-chat.test.ts \
  ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts
# exit 0
```



## Status update — superseded by #87531

While I was preparing this follow-up commit, upstream merged a separate PR — [#87531 fix(webchat): preserve sends through reconnect](https://github.com/openclaw/openclaw/pull/87531) (commit `96635c7c27`) — that lands a different solution for the same #45952 message-loss bug. That PR closes the same disconnected-send + pre-ACK-transport-failure surfaces this branch was targeting, plus the per-session queue scoping and `sendAttempts`/`sendState` shape.

This branch's commits (`ad466d3907` outbound queue + `64b912392c` pre-ACK transport failure) now no longer apply cleanly on `origin/main` because #87531 already rewrote `app-chat.ts`, `controllers/chat.ts`, `chat-queue.ts`, `app-gateway.ts`, `ui-types.ts`, `views/chat.ts`, `app.ts`, and `app-view-state.ts` along the same paths. The merge state on this PR is now `DIRTY` for that reason — not a behavior conflict, but a fully overlapping rewrite that ships the same idempotency-key-preserved retry on reconnect contract.

Happy to close this PR as superseded; flagging in case a maintainer wants to confirm before close. Apologies for the duplicate work.
