### PR TITLE
fix(auto-reply): preserve post-compaction failure context in user-facing recovery message (#67750)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4798,6 +4798,149 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("surfaces post-compaction context when the retried turn times out (#67750)", async () => {
+    // Embedded run announces a successful compaction (so autoCompactionCount > 0),
+    // then the retried turn throws. The fallback layer rejects with a structured
+    // FallbackSummaryError carrying timeout + billing-skip attempts. The user
+    // message must preserve that compaction succeeded plus the cause chain,
+    // not collapse to BILLING_ERROR_USER_MESSAGE or the generic /new copy.
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "end", completed: true },
+      });
+      throw new Error("LLM idle timeout (120s): no response from model");
+    });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      try {
+        await params.run("openai-codex", "gpt-5.4");
+      } catch {
+        // Swallow the per-candidate error; the fallback layer reports the
+        // aggregate summary below, mirroring the production failure shape.
+      }
+      throw Object.assign(
+        new Error(
+          "All models failed (3): openai-codex/gpt-5.4: LLM request timed out. (timeout) | " +
+            "anthropic/claude-opus-4-7: Provider anthropic has billing issue (billing) | " +
+            "anthropic/claude-sonnet-4-7: Provider anthropic has billing issue (billing)",
+        ),
+        {
+          name: "FallbackSummaryError",
+          attempts: [
+            {
+              provider: "openai-codex",
+              model: "gpt-5.4",
+              error: "LLM request timed out.",
+              reason: "timeout",
+            },
+            {
+              provider: "anthropic",
+              model: "claude-opus-4-7",
+              error: "Provider anthropic has billing issue",
+              reason: "billing",
+            },
+            {
+              provider: "anthropic",
+              model: "claude-sonnet-4-7",
+              error: "Provider anthropic has billing issue",
+              reason: "billing",
+            },
+          ],
+          soonestCooldownExpiry: null,
+        },
+      );
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      // Compaction context preserved.
+      expect(result.payload.text).toContain("Auto-compaction succeeded");
+      // Retried turn cause preserved (billing was the resolved cause-specific copy).
+      expect(result.payload.text).toContain("billing");
+      // Per-attempt summary preserved (timeout + billing skips).
+      expect(result.payload.text).toContain("openai-codex/gpt-5.4 timed out");
+      expect(result.payload.text).toContain("anthropic/claude-opus-4-7 skipped (billing)");
+      // Not the bare GENERIC_RUN_FAILURE_TEXT.
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+      // Not the unwrapped BILLING_ERROR_USER_MESSAGE on its own.
+      expect(result.payload.text).not.toBe("billing");
+    }
+  });
+
+  it("surfaces post-compaction context for plain failures without a fallback summary", async () => {
+    // Plain (non-FallbackSummaryError) failure after a successful compaction.
+    // The generic fallback copy would normally erase compaction history; with
+    // the post-compaction wrap, the user still learns compaction succeeded and
+    // gets specific next-step guidance instead of just "/new".
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "end", completed: true },
+      });
+      throw new Error("INVALID_ARGUMENT: some opaque post-compaction failure");
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams(),
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toContain("Auto-compaction succeeded");
+      // Generic-runner-failure path → guidance, not bare /new fallback.
+      expect(result.payload.text).toContain(
+        "The context was compacted but no candidate could finish the turn",
+      );
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+    }
+  });
+
+  it("does not add post-compaction context when no compaction succeeded", async () => {
+    // Regression guard: ordinary unknown error without a prior successful
+    // compaction must still produce the generic fallback copy.
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new Error("INVALID_ARGUMENT: some other failure"),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams(),
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
+      expect(result.payload.text).not.toContain("Auto-compaction succeeded");
+    }
+  });
+
   it("surfaces gateway restart text when fallback exhaustion wraps a drain error", async () => {
     const { replyOperation, failMock } = createMockReplyOperation();
     state.runWithModelFallbackMock.mockRejectedValueOnce(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -627,6 +627,95 @@ function collapseRepeatedFailureDetail(message: string): string {
   return message.trim();
 }
 
+const FAILOVER_REASON_VERB: Record<string, string> = {
+  timeout: "timed out",
+  rate_limit: "rate-limited",
+  overloaded: "overloaded",
+  billing: "skipped (billing)",
+  auth: "auth failure",
+  auth_permanent: "auth permanently revoked",
+  server_error: "server error",
+  format: "response format error",
+  model_not_found: "model not found",
+  session_expired: "session expired",
+  empty_response: "empty response",
+  no_error_details: "unspecified error",
+  unclassified: "failed",
+  unknown: "failed",
+};
+
+const POST_COMPACTION_ATTEMPT_SUMMARY_MAX_CHARS = 240;
+const POST_COMPACTION_FAILURE_PREFIX =
+  "⚠️ Auto-compaction succeeded, but the retried turn still failed";
+
+/**
+ * Summarize FallbackSummaryError attempts as a short, user-readable list:
+ * "openai/gpt-5.4 timed out; anthropic/claude skipped (billing)".
+ * Returns undefined when the error is not a structured fallback summary
+ * (e.g. raw embedded error) so callers fall back to the resolved cause text.
+ */
+function summarizeFallbackAttemptsForUser(err: unknown): string | undefined {
+  if (!isFallbackSummaryError(err)) {
+    return undefined;
+  }
+  const parts: string[] = [];
+  for (const attempt of err.attempts) {
+    const ref = `${attempt.provider}/${attempt.model}`;
+    const verb = attempt.reason ? (FAILOVER_REASON_VERB[attempt.reason] ?? "failed") : "failed";
+    parts.push(`${ref} ${verb}`);
+  }
+  if (parts.length === 0) {
+    return undefined;
+  }
+  const summary = parts.join("; ");
+  if (summary.length <= POST_COMPACTION_ATTEMPT_SUMMARY_MAX_CHARS) {
+    return summary;
+  }
+  return `${summary.slice(0, POST_COMPACTION_ATTEMPT_SUMMARY_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+/**
+ * Wrap a resolved fallback failure message with post-compaction context so the
+ * user sees that compaction succeeded before the retried turn failed — instead
+ * of the generic "Something went wrong" or bare cause-specific text that erases
+ * the compaction history. The base text is preserved so existing cause-specific
+ * guidance (billing, rate-limit, timeout) still reaches the user.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/67750
+ */
+function buildPostCompactionFailureRecoveryText(params: {
+  baseText: string;
+  err: unknown;
+  autoCompactionCount: number;
+  isGenericRunnerFailure: boolean;
+}): string {
+  if (params.autoCompactionCount <= 0) {
+    return params.baseText;
+  }
+  const countSuffix =
+    params.autoCompactionCount > 1 ? ` (${params.autoCompactionCount} compactions)` : "";
+  const attemptSummary = summarizeFallbackAttemptsForUser(params.err);
+  const baseTrimmed = params.baseText.replace(/^⚠️\s*/u, "").trim();
+  // Generic catch-all (`isGenericRunnerFailure`) carries no cause signal,
+  // so drop the base text and rely on the attempt summary or the
+  // generic-mode guidance below. Cause-specific copy (billing, rate-limit,
+  // timeout, oauth) is preserved verbatim so the user still gets the actionable
+  // hint that already covers their failure mode.
+  const causeDetail = params.isGenericRunnerFailure
+    ? attemptSummary
+      ? `: ${attemptSummary}.`
+      : "."
+    : baseTrimmed
+      ? ` — ${baseTrimmed}`
+      : ".";
+  const attemptTrailer =
+    !params.isGenericRunnerFailure && attemptSummary ? `\n\nAttempts: ${attemptSummary}.` : "";
+  const guidance = params.isGenericRunnerFailure
+    ? "\n\nThe context was compacted but no candidate could finish the turn. Try again in a moment, or use /new only if the session stays stuck."
+    : "";
+  return `${POST_COMPACTION_FAILURE_PREFIX}${countSuffix}${causeDetail}${attemptTrailer}${guidance}`;
+}
+
 const SAFE_MISSING_API_KEY_PROVIDERS = new Set(["anthropic", "google", "openai"]);
 const EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS = 900;
 const AGENT_FAILED_BEFORE_REPLY_TEXT = "Agent failed before reply:";
@@ -2921,8 +3010,23 @@ export async function runAgentTurnWithFallback(params: {
               : shouldSurfaceToControlUi
                 ? `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`
                 : (externalRunFailureReply?.text ?? genericFallbackText);
+      // When auto-compaction succeeded earlier in this turn (#67750), prepend
+      // the post-compaction context so the user does not see the cause-specific
+      // or generic text without learning that the retried turn was the one
+      // that failed. Skip for heartbeat probes (separate copy contract) and
+      // control-UI surfaces (already includes raw cause + logs link).
+      const shouldSurfacePostCompactionContext =
+        autoCompactionCount > 0 && !params.isHeartbeat && !shouldSurfaceToControlUi;
+      const fallbackTextWithPostCompactionContext = shouldSurfacePostCompactionContext
+        ? buildPostCompactionFailureRecoveryText({
+            baseText: fallbackText,
+            err,
+            autoCompactionCount,
+            isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
+          })
+        : fallbackText;
       const userVisibleFallbackText = resolveExternalRunFailureTextForConversation({
-        text: fallbackText,
+        text: fallbackTextWithPostCompactionContext,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
         suppressInNonDirect: Boolean(isRateLimit || rateLimitOrOverloadedCopy),


### PR DESCRIPTION
## Summary

What problem does this PR solve?

When auto-compaction succeeds inside a turn and the retried run still fails (e.g. `LLM idle timeout (120s)`, fallback exhausted with billing-skipped candidates), `runAgentTurnWithFallback`'s catch path collapses the failure into either the generic `⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.` copy or a bare cause-specific message (e.g. `BILLING_ERROR_USER_MESSAGE`). Either way, the user loses the fact that compaction was attempted, that the timeout was on the retried turn, and which fallback candidates failed for which reason — exactly the chain in the bug report at `src/auto-reply/reply/agent-runner-execution.ts`.

Why does this matter now?

`#67750` was filed against the user-facing chain in `src/auto-reply/reply/agent-runner-execution.ts`. The same catch block is on the hot path for every messaging surface (embedded harness runs and Codex / Pi-style CLI dispatch), so the same erasure happens across channels.

What is the intended outcome?

The user-facing message preserves the post-compaction signal already tracked in `autoCompactionCount` and the per-attempt reason chain already carried on `FallbackSummaryError.attempts`. Cause-specific copy (billing, rate-limit, timeout, oauth) is preserved verbatim so existing actionable hints still surface; the generic catch-all gains a structured `Auto-compaction succeeded, but the retried turn still failed — ...` prefix plus a concrete next step instead of bare `/new`.

What is intentionally out of scope?

- No changes to the model-fallback engine (`src/agents/model-fallback.ts`) or to `FallbackSummaryError`'s shape.
- No changes to the embedded harness compaction lifecycle (`src/agents/embedded-agent-subscribe.ts`) — the `attemptCompactionCount` increment in the outer execution layer (`src/auto-reply/reply/agent-runner-execution.ts:2535,2631`) is already the source of truth.
- Heartbeat (`HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT`) and control-UI surfaces keep their existing copy contracts.

What does success look like?

Three new vitest cases under `runAgentTurnWithFallback` cover: (1) post-compaction `FallbackSummaryError` with timeout + billing-skip attempts surfaces both compaction context and the per-attempt summary; (2) post-compaction plain failure surfaces the structured prefix plus the generic-mode guidance; (3) failure without a successful compaction still produces the plain `GENERIC_EXTERNAL_RUN_FAILURE_TEXT`.

What should reviewers focus on?

- The wrap is gated on `autoCompactionCount > 0 && !params.isHeartbeat && !shouldSurfaceToControlUi`, so existing copy tests (rate-limit, billing-only, gateway-restart, Codex usage-limit, missing-API-key, CLI subprocess timeout) keep their exact strings.
- The attempt summary cap (`POST_COMPACTION_ATTEMPT_SUMMARY_MAX_CHARS = 240`) is sized to keep the prefix concise on transports with text-length caps.

## Linked context

Which issue does this close?

Closes #67750

Which issues, PRs, or discussions are related?

Related #67750

Was this requested by a maintainer or owner?

No — addressing the labelled `P2` / `clawsweeper:fix-shape-clear` / `clawsweeper:queueable-fix` / `clawsweeper:source-repro` triage on #67750.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Post-auto-compaction LLM idle timeout collapses the cause chain into the generic `/new` fallback (or a bare `BILLING_ERROR_USER_MESSAGE`) and erases the compaction-succeeded signal that is already tracked in `autoCompactionCount` and on `FallbackSummaryError.attempts`.
- Real environment tested: Source-level repro via vitest mocks of the inner `runEmbeddedAgent` + `runWithModelFallback` seam that drive the exact failure shape from the bug report (embedded run emits `compaction phase=end completed=true`, then throws an LLM idle timeout; fallback layer rejects with a `FallbackSummaryError` containing `reason: "timeout"` plus `reason: "billing"` skip entries). The `clawsweeper:source-repro` label on the issue already covers the source-of-truth chain at `src/auto-reply/reply/agent-runner-execution.ts:2660-2811`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts` (149 tests, all passing). `pnpm tsgo:core` and `pnpm tsgo:core:test` (clean). `pnpm format:check src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts` (clean). `node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts` (clean).
- Evidence after fix: Test `surfaces post-compaction context when the retried turn times out (#67750)` asserts the rendered text contains `Auto-compaction succeeded`, retains the cause-specific `billing` copy, and includes the per-attempt summary `openai-codex/gpt-5.4 timed out` plus `anthropic/claude-opus-4-7 skipped (billing)`. Test `surfaces post-compaction context for plain failures without a fallback summary` asserts the generic-mode guidance ("The context was compacted but no candidate could finish the turn ...") instead of the bare `/new` copy.
- Observed result after fix: Vitest output: `Test Files  1 passed (1) / Tests  149 passed (149)`.
- What was not tested: No live LLM timeout repro against a real provider. The issue is labelled `clawsweeper:source-repro` precisely because the failure chain is observable in source plus emitted log lines (see the verbatim repro evidence in the issue body), and the diff exercises the exact `autoCompactionCount > 0 && FallbackSummaryError` seam from that chain.
- Proof limitations or environment constraints: Triggering the live 120s LLM idle timeout would require either an actual provider hang or a configured billing-disabled fallback chain, neither of which is reliable to set up without disturbing other users. The source-level mocks reproduce the exact error shape from the repro log.
- Before evidence (optional but encouraged): Before this patch, `src/auto-reply/reply/agent-runner-execution.ts:2795-2805` would resolve `fallbackText` to either `BILLING_ERROR_USER_MESSAGE` (when `hasBillingAttemptSummary` is true) or `GENERIC_EXTERNAL_RUN_FAILURE_TEXT` (when no specific classifier matches) — both of which drop `autoCompactionCount` and the `FallbackSummaryError.attempts` cause chain on the floor.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts` (149 passed)
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner-helpers.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts` (194 passed)
- `node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts` (55 passed — sibling-surface check; followup-runner shares `autoCompactionCount` but uses a different non-user-facing failure path)
- `pnpm tsgo:core` and `pnpm tsgo:core:test` (clean)
- `pnpm format:check` (clean)

What regression coverage was added or updated?

Three new cases in `src/auto-reply/reply/agent-runner-execution.test.ts` under `describe("runAgentTurnWithFallback")`:

1. `surfaces post-compaction context when the retried turn times out (#67750)` — full repro of the bug-report failure chain (compaction succeeds; retried turn timeout; fallback exhausted with timeout + billing-skip attempts). Asserts the rendered text preserves compaction context, the resolved cause-specific copy, and the per-attempt summary.
2. `surfaces post-compaction context for plain failures without a fallback summary` — covers the generic catch-all branch when the error is a plain `Error` (no `FallbackSummaryError`), confirming the structured prefix and the specific next-step guidance replace the bare `/new` fallback.
3. `does not add post-compaction context when no compaction succeeded` — regression guard so the wrap stays scoped to `autoCompactionCount > 0` and ordinary unknown errors still resolve to `GENERIC_EXTERNAL_RUN_FAILURE_TEXT`.

What failed before this fix, if known?

Test #1 above would have produced `result.payload.text === "billing"` (the mocked `BILLING_ERROR_USER_MESSAGE`), with no mention of compaction or the per-attempt timeout. Test #2 would have produced `result.payload.text === GENERIC_RUN_FAILURE_TEXT`, with no mention of compaction succeeding.

If no test was added, why not?

N/A — tests added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — only on the post-auto-compaction failure path. The pre-compaction failure path (`autoCompactionCount === 0`) returns the existing `fallbackText` unchanged, and existing tests for billing, rate-limit, gateway-restart, Codex usage-limit, missing-API-key, CLI subprocess timeout, and the generic copy all still assert their exact strings.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

User-facing copy on the post-compaction failure path. Wrong wording on a hot error path can confuse users about whether the message they sent was processed.

How is that risk mitigated?

- The wrap is gated on three independent predicates (`autoCompactionCount > 0`, `!params.isHeartbeat`, `!shouldSurfaceToControlUi`), so heartbeat probes and the control-UI logs path keep their existing copy.
- Cause-specific resolved text (`BILLING_ERROR_USER_MESSAGE`, rate-limit cooldown, Codex usage-limit, missing-API-key, OAuth re-auth, CLI timeout) is preserved verbatim — the wrap only prepends/appends, never replaces.
- All 149 existing `agent-runner-execution.test.ts` cases still pass (including every `surfaces X` copy contract).

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI run on the new commit.

Which bot or reviewer comments were addressed?

None yet — first revision.