### PR TITLE
fix(auth): tighten billing cooldown defaults to recover from multi-hour lockouts (#70903)

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -268,7 +268,12 @@ State is stored in `auth-state.json`:
 
 Defaults:
 
-- Billing backoff starts at **5 hours**, doubles per billing failure, and caps at **24 hours**.
+- Billing backoff starts at **~5 minutes**, doubles per billing failure, and
+  caps at **~15 minutes**. The defaults are intentionally tight because a
+  persisted `disabledUntil` window blocks new requests for its full duration
+  even after billing recovers — the call layer skips disabled profiles before
+  any probe can run. Raise `auth.cooldowns.billingBackoffHours` and
+  `auth.cooldowns.billingMaxHours` if you need a longer pause.
 - Backoff counters reset if the profile hasn't failed for **24 hours** (configurable).
 - Overloaded retries allow **1 same-provider profile rotation** before model fallback.
 - Overloaded retries use **0 ms backoff** by default.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1008,9 +1008,12 @@ Notes:
 {
   auth: {
     cooldowns: {
-      billingBackoffHours: 5,
-      billingBackoffHoursByProvider: { anthropic: 3, openai: 8 },
-      billingMaxHours: 24,
+      // Default: ~5 minutes (field unit is hours).
+      billingBackoffHours: 0.0833,
+      // Optional per-provider overrides, in hours.
+      billingBackoffHoursByProvider: { anthropic: 0.0833, openai: 0.25 },
+      // Default: 15 minutes.
+      billingMaxHours: 0.25,
       authPermanentBackoffMinutes: 10,
       authPermanentMaxMinutes: 60,
       failureWindowHours: 24,
@@ -1023,14 +1026,19 @@ Notes:
 ```
 
 - `billingBackoffHours`: base backoff in hours when a profile fails due to true
-  billing/insufficient-credit errors (default: `5`). Explicit billing text can
+  billing/insufficient-credit errors (default: `0.0833`, i.e. ~5 minutes). The
+  field unit is hours, but the default is intentionally sub-hour so a provider
+  whose billing is fixed is retried within minutes instead of being locked out
+  for hours (see #70903). Explicit billing text can
   still land here even on `401`/`403` responses, but provider-specific text
   matchers stay scoped to the provider that owns them (for example OpenRouter
   `Key limit exceeded`). Retryable HTTP `402` usage-window or
   organization/workspace spend-limit messages stay in the `rate_limit` path
   instead.
-- `billingBackoffHoursByProvider`: optional per-provider overrides for billing backoff hours.
-- `billingMaxHours`: cap in hours for billing backoff exponential growth (default: `24`).
+- `billingBackoffHoursByProvider`: optional per-provider overrides for billing
+  backoff hours.
+- `billingMaxHours`: cap in hours for billing backoff exponential growth
+  (default: `0.25`, i.e. 15 minutes).
 - `authPermanentBackoffMinutes`: base backoff in minutes for high-confidence `auth_permanent` failures (default: `10`).
 - `authPermanentMaxMinutes`: cap in minutes for `auth_permanent` backoff growth (default: `60`).
 - `failureWindowHours`: rolling window in hours used for backoff counters (default: `24`).

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -395,6 +395,13 @@ vi.mock("./auth-profiles.js", () => ({
 
 vi.mock("./auth-profiles/store.js", () => ({
   ensureAuthProfileStore: () => state.authProfileStoreMock,
+  saveAuthProfileStore: vi.fn(),
+  updateAuthProfileStoreWithLock: vi.fn(
+    async ({ updater }: { updater: (store: typeof state.authProfileStoreMock) => boolean }) => {
+      updater(state.authProfileStoreMock);
+      return state.authProfileStoreMock;
+    },
+  ),
 }));
 
 vi.mock("./auth-profiles/session-override.js", () => ({

--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -143,7 +143,10 @@ describe("markAuthProfileFailure", () => {
     expect(typeof reloaded.usageStats?.["openai:default"]?.cooldownUntil).toBe("number");
   });
 
-  it("disables billing failures for ~5 hours by default", async () => {
+  it("disables billing failures for ~5 minutes by default (#70903)", async () => {
+    // Persisted disabledUntil locks users out for the full window even after
+    // billing recovers, because the call layer skips disabled profiles before
+    // any probe runs. Keep the default tight; operators raise via config.
     await withAuthProfileStore(async ({ agentDir, store }) => {
       const startedAt = Date.now();
       await markAuthProfileFailure({
@@ -156,8 +159,54 @@ describe("markAuthProfileFailure", () => {
       const disabledUntil = store.usageStats?.["anthropic:default"]?.disabledUntil;
       expect(typeof disabledUntil).toBe("number");
       const remainingMs = (disabledUntil as number) - startedAt;
-      expectCooldownInRange(remainingMs, 4.5 * 60 * 60 * 1000, 5.5 * 60 * 60 * 1000);
+      expectCooldownInRange(remainingMs, 4.5 * 60 * 1000, 5.5 * 60 * 1000);
     });
+  });
+
+  it("caps repeated billing failures at the default ~15-minute ceiling (#70903)", async () => {
+    const agentDir = makeAgentDir("billing-cap");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+    const now = Date.now();
+    // Seed the on-disk state with a high accumulated billing failure count
+    // inside the active failure window but with no active disable window. The
+    // next failure should escalate via the disable-lane exponential backoff,
+    // which the new 15-minute default cap clamps tightly.
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "anthropic:default": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "sk-default",
+          },
+        },
+        usageStats: {
+          "anthropic:default": {
+            errorCount: 5,
+            failureCounts: { billing: 5 },
+            lastFailureAt: now - 60_000,
+          },
+        },
+      }),
+    );
+
+    const store = ensureAuthProfileStore(agentDir);
+    const startedAt = Date.now();
+    await markAuthProfileFailure({
+      store,
+      profileId: "anthropic:default",
+      reason: "billing",
+      agentDir,
+    });
+
+    const disabledUntil = store.usageStats?.["anthropic:default"]?.disabledUntil;
+    expect(typeof disabledUntil).toBe("number");
+    const remainingMs = (disabledUntil as number) - startedAt;
+    // failureCounts.billing now 6 → exponent 5 → 5min*32 = 160min raw → capped
+    // to ~15 minutes by the new default.
+    expectCooldownInRange(remainingMs, 14 * 60 * 1000, 16 * 60 * 1000);
   });
   it("honors per-provider billing backoff overrides", async () => {
     await withAuthProfileStore(async ({ agentDir, store }) => {

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -544,6 +544,101 @@ describe("resolveAuthProfileOrder", () => {
     }
   });
 
+  it("clamps a stale persisted billing disable so the profile is reachable again (#70903)", () => {
+    // Simulates a user upgrading from an older OpenClaw default that wrote
+    // `disabledUntil` ~5 hours into the future for a billing failure. Without
+    // the clamp the profile would be filtered from the resolved order for the
+    // full window and the user would stay locked out even after topping up.
+    const fiveHours = 5 * 60 * 60 * 1000;
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "fixture-provider:default": {
+          type: "api_key",
+          provider: "fixture-provider",
+          key: "sk-test",
+        },
+      },
+      usageStats: {
+        "fixture-provider:default": {
+          disabledUntil: Date.now() + fiveHours,
+          disabledReason: "billing",
+          errorCount: 2,
+          failureCounts: { billing: 2 },
+          lastFailureAt: Date.now() - 1_000,
+        },
+      },
+    };
+
+    const order = resolveAuthProfileOrder({
+      store,
+      provider: "fixture-provider",
+    });
+
+    // Profile is still in the order (last, behind any available ones — here
+    // it's alone, so it shows up): the clamp pulls disabledUntil down to the
+    // ~15-minute default ceiling, so the existing cooldown sort still keeps
+    // it considered.
+    expect(order).toEqual(["fixture-provider:default"]);
+    const clamped = store.usageStats?.["fixture-provider:default"]?.disabledUntil;
+    expect(typeof clamped).toBe("number");
+    expect((clamped as number) - Date.now()).toBeLessThanOrEqual(16 * 60 * 1000);
+  });
+
+  it("recovers a stale on-disk billing disable across repeated reloads without sliding the window (#70903)", () => {
+    // Reproduce the restart/reload path: the same stale auth-state.json bytes
+    // are reconstructed into a fresh store on each call, and `Date.now()`
+    // advances between calls (as it would across gateway restarts).
+    const failureAt = 1_700_000_000_000;
+    const fiveHours = 5 * 60 * 60 * 1000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    const profileId = "fixture-provider:default";
+
+    // Fresh store from the persisted bytes — stale 5h disable + the original
+    // failure timestamp the disable was written against.
+    const reloadStore = (): AuthProfileStore => ({
+      version: 1,
+      profiles: {
+        [profileId]: { type: "api_key", provider: "fixture-provider", key: "sk-test" },
+      },
+      usageStats: {
+        [profileId]: {
+          disabledUntil: failureAt + fiveHours,
+          disabledReason: "billing",
+          errorCount: 2,
+          failureCounts: { billing: 2 },
+          lastFailureAt: failureAt,
+        },
+      },
+    });
+
+    vi.useFakeTimers();
+    try {
+      // Reload BEFORE the cap elapses: the clamp pins disabledUntil to the
+      // failure-anchored ceiling and the profile is still cooling down.
+      vi.setSystemTime(failureAt + 10 * 60 * 1000);
+      const earlyStore = reloadStore();
+      resolveAuthProfileOrder({ store: earlyStore, provider: "fixture-provider" });
+      expect(earlyStore.usageStats?.[profileId]?.disabledUntil).toBe(failureAt + fifteenMinutes);
+
+      // Reload repeatedly AFTER the cap elapses: each fresh load pins to the
+      // same past ceiling (no sliding) and the expiry sweep clears it, so the
+      // profile becomes usable again instead of staying disabled forever.
+      for (const offset of [16 * 60 * 1000, 2 * 60 * 60 * 1000, fiveHours]) {
+        vi.setSystemTime(failureAt + offset);
+        const store = reloadStore();
+        const order = resolveAuthProfileOrder({ store, provider: "fixture-provider" });
+        expect(order).toEqual([profileId]);
+        // Cleared by clearExpiredCooldowns after the anchored clamp — NOT
+        // reclamped to now + 15m.
+        expect(store.usageStats?.[profileId]?.disabledUntil).toBeUndefined();
+        expect(store.usageStats?.[profileId]?.disabledReason).toBeUndefined();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses caller-provided auth alias metadata for stored credential compatibility", () => {
     expect(
       isStoredCredentialCompatibleWithAuthProvider({

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -14,10 +14,12 @@ import {
 import { dedupeProfileIds, listProfilesForProvider } from "./profile-list.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 import {
+  clampStaleBillingDisable,
   clearExpiredCooldowns,
   isProfileInCooldown,
   resolveProfileUnusableUntil,
 } from "./usage-state.js";
+import { resolveBillingDisableCeilingMs } from "./usage.js";
 
 export type AuthProfileEligibilityReasonCode =
   | AuthCredentialReasonCode
@@ -238,6 +240,15 @@ export function resolveAuthProfileOrder(params: {
   const providerAuthKey = resolveProviderIdForAuth(provider, { config: cfg });
   const now = Date.now();
 
+  // Clamp stale persisted billing disables to the active cap before the expiry
+  // sweep. Users who upgraded from an older default (24h cap) carry timestamps
+  // that the call layer would otherwise honour for hours after billing
+  // recovery. See #70903.
+  clampStaleBillingDisable(
+    store,
+    resolveBillingDisableCeilingMs({ cfg, providerId: providerAuthKey }),
+    now,
+  );
   // Clear any cooldowns that have expired since the last check so profiles
   // get a fresh error count and are not immediately re-penalized on the
   // next transient failure. See #3604.

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -127,6 +127,77 @@ export function getSoonestCooldownExpiry(
 }
 
 /**
+ * Clamp persisted billing-disable windows so they cannot extend past the active
+ * `auth.cooldowns.billingMax*` ceiling (see #70903).
+ *
+ * Why: `disabledUntil` is persisted to `auth-state.json`. Users who upgraded
+ * from an older OpenClaw default (`billingMaxHours: 24`) carry stale multi-hour
+ * timestamps even after they've topped up credit. The call layer filters
+ * disabled profiles before any probe can run, so `markAuthProfileSuccess` (the
+ * normal clear path) never fires for stuck users. Re-clamping on read drains
+ * those stale values to the current configured ceiling.
+ *
+ * Only billing-reason disables are touched. `auth_permanent` and
+ * `cooldownUntil`/`blockedUntil` already cap at short windows in code paths
+ * that own them.
+ *
+ * The ceiling is anchored to each profile's `lastFailureAt` (`disabledUntil`
+ * was originally written as `lastFailureAt + backoff` by
+ * `computeNextProfileUsageStats`), NOT to `now`. Anchoring to `now` made the
+ * clamp non-idempotent: every fresh store load (gateway restart, repeated
+ * `resolveAuthProfileOrder`) reclamped `disabledUntil` to `now + billingMaxMs`,
+ * so the window slid forward on each read and the profile never became eligible
+ * (#70903). Anchoring to the failure time makes the clamp idempotent — the same
+ * store re-clamped at any later `now` lands on the same ceiling, and the window
+ * actually elapses once `lastFailureAt + billingMaxMs < now`. The subsequent
+ * `clearExpiredCooldowns` sweep then drops the past-due disable.
+ *
+ * If `lastFailureAt` is missing or non-finite (malformed/legacy record), we
+ * cannot reconstruct the original failure time, so we fall back to clamping
+ * against `now + billingMaxMs` once. That still bounds a stale value to the
+ * current cap rather than honouring a multi-hour timestamp, and a malformed
+ * record without a failure anchor is treated as freshly failing at `now`.
+ *
+ * @returns `true` if any profile was modified.
+ */
+export function clampStaleBillingDisable(
+  store: AuthProfileStore,
+  billingMaxMs: number,
+  now?: number,
+): boolean {
+  const usageStats = store.usageStats;
+  if (!usageStats || !Number.isFinite(billingMaxMs) || billingMaxMs <= 0) {
+    return false;
+  }
+  const ts = now ?? Date.now();
+  let mutated = false;
+  for (const stats of Object.values(usageStats)) {
+    if (
+      !stats ||
+      stats.disabledReason !== "billing" ||
+      typeof stats.disabledUntil !== "number" ||
+      !Number.isFinite(stats.disabledUntil)
+    ) {
+      continue;
+    }
+    // Anchor to the original failure time so the clamp is idempotent across
+    // fresh store loads. Fall back to `now` only when the failure anchor is
+    // missing/non-finite (legacy/malformed record).
+    const anchor =
+      typeof stats.lastFailureAt === "number" && Number.isFinite(stats.lastFailureAt)
+        ? stats.lastFailureAt
+        : ts;
+    const ceiling = anchor + billingMaxMs;
+    if (stats.disabledUntil <= ceiling) {
+      continue;
+    }
+    stats.disabledUntil = ceiling;
+    mutated = true;
+  }
+  return mutated;
+}
+
+/**
  * Clear expired cooldowns from all profiles in the store.
  *
  * When `cooldownUntil` or `disabledUntil` has passed, the corresponding fields

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -4,11 +4,13 @@ import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import {
   testing as authProfileUsageTesting,
+  clampStaleBillingDisable,
   clearAuthProfileCooldown,
   clearExpiredCooldowns,
   isProfileInCooldown,
   markAuthProfileBlockedUntil,
   markAuthProfileFailure,
+  resolveBillingDisableCeilingMs,
   resolveProfilesUnavailableReason,
   resolveProfileUnusableUntil,
   resolveProfileUnusableUntilForDisplay,
@@ -652,6 +654,230 @@ describe("clearExpiredCooldowns", () => {
 });
 
 // ---------------------------------------------------------------------------
+// clampStaleBillingDisable (#70903)
+// ---------------------------------------------------------------------------
+
+describe("clampStaleBillingDisable", () => {
+  it("clamps a multi-hour persisted billing disable to the active cap anchored to lastFailureAt", () => {
+    const now = 1_700_000_000_000;
+    const fiveHours = 5 * 60 * 60 * 1000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    const lastFailureAt = now - 1_000;
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: now + fiveHours,
+        disabledReason: "billing",
+        errorCount: 2,
+        failureCounts: { billing: 2 },
+        lastFailureAt,
+      },
+    });
+
+    expect(clampStaleBillingDisable(store, fifteenMinutes, now)).toBe(true);
+    // Ceiling is anchored to the original failure time, not `now`.
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(
+      lastFailureAt + fifteenMinutes,
+    );
+    // Reason and counters stay intact so the next failure still escalates
+    // correctly within the failure window.
+    expect(store.usageStats?.["anthropic:default"]?.disabledReason).toBe("billing");
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(2);
+  });
+
+  it("leaves values inside the cap untouched", () => {
+    const now = 1_700_000_000_000;
+    const fiveMinutes = 5 * 60 * 1000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: now + fiveMinutes,
+        disabledReason: "billing",
+      },
+    });
+
+    expect(clampStaleBillingDisable(store, fifteenMinutes, now)).toBe(false);
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(now + fiveMinutes);
+  });
+
+  it("is idempotent: re-clamping the same store at the same now does not move disabledUntil", () => {
+    const now = 1_700_000_000_000;
+    const fiveHours = 5 * 60 * 60 * 1000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    const lastFailureAt = now - 1_000;
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: now + fiveHours,
+        disabledReason: "billing",
+        lastFailureAt,
+      },
+    });
+
+    // First clamp lands on the failure-anchored ceiling and mutates.
+    expect(clampStaleBillingDisable(store, fifteenMinutes, now)).toBe(true);
+    const afterFirst = store.usageStats?.["anthropic:default"]?.disabledUntil;
+    expect(afterFirst).toBe(lastFailureAt + fifteenMinutes);
+
+    // Second clamp with the same `now` is a no-op: the window does not slide.
+    expect(clampStaleBillingDisable(store, fifteenMinutes, now)).toBe(false);
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(afterFirst);
+  });
+
+  it("expires a stale persisted disable instead of reclamping it forward across reloads", () => {
+    const now = 1_700_000_000_000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    // Simulate an old auth-state.json: failure happened long ago, but the
+    // persisted disabledUntil still carries an old multi-hour timestamp.
+    const lastFailureAt = now - 2 * 60 * 60 * 1000; // 2h ago, > 15m cap
+    const stalePersisted = lastFailureAt + 24 * 60 * 60 * 1000; // old 24h default
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: stalePersisted,
+        disabledReason: "billing",
+        lastFailureAt,
+      },
+    });
+
+    // First fresh load clamps to the failure-anchored ceiling, which is already
+    // in the past (lastFailureAt + 15m < now).
+    expect(clampStaleBillingDisable(store, fifteenMinutes, now)).toBe(true);
+    const ceiling = lastFailureAt + fifteenMinutes;
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(ceiling);
+    expect(ceiling).toBeLessThan(now);
+
+    // The profile is now eligible (no active unusable window), and the expiry
+    // sweep clears the past-due disable.
+    const stats = store.usageStats?.["anthropic:default"];
+    expect(resolveProfileUnusableUntil(stats ?? {})).toBeLessThan(now);
+    expect(clearExpiredCooldowns(store, now)).toBe(true);
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBeUndefined();
+    expect(store.usageStats?.["anthropic:default"]?.disabledReason).toBeUndefined();
+  });
+
+  it("moving-window regression: repeated reloads past the cap make the profile usable, not stuck", () => {
+    const failureAt = 1_700_000_000_000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    const profileId = "anthropic:default";
+
+    // Reconstruct a fresh store on each simulated reload from the same on-disk
+    // bytes (stale 5h disable + the original failure timestamp).
+    const reload = () =>
+      makeStore({
+        [profileId]: {
+          disabledUntil: failureAt + 5 * 60 * 60 * 1000,
+          disabledReason: "billing",
+          lastFailureAt: failureAt,
+        },
+      });
+
+    // Reads BEFORE the cap elapses keep the profile disabled.
+    for (const offset of [0, 5 * 60 * 1000, 10 * 60 * 1000]) {
+      const store = reload();
+      const now = failureAt + offset;
+      clampStaleBillingDisable(store, fifteenMinutes, now);
+      expect(isProfileInCooldown(store, profileId, now)).toBe(true);
+      // Ceiling stays pinned to the failure anchor regardless of `now`.
+      expect(store.usageStats?.[profileId]?.disabledUntil).toBe(failureAt + fifteenMinutes);
+    }
+
+    // Reads AFTER the cap elapses make the profile usable instead of sliding the
+    // window forward — the exact bug the anchor fixes.
+    for (const offset of [16 * 60 * 1000, 60 * 60 * 1000, 5 * 60 * 60 * 1000]) {
+      const store = reload();
+      const now = failureAt + offset;
+      clampStaleBillingDisable(store, fifteenMinutes, now);
+      // disabledUntil stays anchored in the past; it is NOT pushed to now + cap.
+      expect(store.usageStats?.[profileId]?.disabledUntil).toBe(failureAt + fifteenMinutes);
+      expect(isProfileInCooldown(store, profileId, now)).toBe(false);
+      clearExpiredCooldowns(store, now);
+      expect(store.usageStats?.[profileId]?.disabledUntil).toBeUndefined();
+    }
+  });
+
+  it("falls back to now + cap when lastFailureAt is missing (legacy/malformed record)", () => {
+    const now = 1_700_000_000_000;
+    const fiveHours = 5 * 60 * 60 * 1000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: now + fiveHours,
+        disabledReason: "billing",
+        // no lastFailureAt anchor
+      },
+    });
+
+    expect(clampStaleBillingDisable(store, fifteenMinutes, now)).toBe(true);
+    // Without an anchor we clamp once against now + cap so the stale value
+    // cannot keep the profile disabled for hours.
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(now + fifteenMinutes);
+  });
+
+  it("does not touch non-billing disables (auth_permanent)", () => {
+    const now = 1_700_000_000_000;
+    const twoHours = 2 * 60 * 60 * 1000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: now + twoHours,
+        disabledReason: "auth_permanent",
+      },
+    });
+
+    expect(clampStaleBillingDisable(store, fifteenMinutes, now)).toBe(false);
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(now + twoHours);
+  });
+
+  it("does not touch cooldownUntil or blockedUntil", () => {
+    const now = 1_700_000_000_000;
+    const twoHours = 2 * 60 * 60 * 1000;
+    const fifteenMinutes = 15 * 60 * 1000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: now + twoHours,
+        blockedUntil: now + twoHours,
+      },
+    });
+
+    expect(clampStaleBillingDisable(store, fifteenMinutes, now)).toBe(false);
+    expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBe(now + twoHours);
+    expect(store.usageStats?.["anthropic:default"]?.blockedUntil).toBe(now + twoHours);
+  });
+
+  it("no-ops on empty stats and invalid caps", () => {
+    const now = 1_700_000_000_000;
+    expect(clampStaleBillingDisable(makeStore(undefined), 60_000, now)).toBe(false);
+    const store = makeStore({
+      "anthropic:default": {
+        disabledUntil: now + 60 * 60 * 1000,
+        disabledReason: "billing",
+      },
+    });
+    expect(clampStaleBillingDisable(store, 0, now)).toBe(false);
+    expect(clampStaleBillingDisable(store, Number.NaN, now)).toBe(false);
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(now + 60 * 60 * 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBillingDisableCeilingMs (#70903)
+// ---------------------------------------------------------------------------
+
+describe("resolveBillingDisableCeilingMs", () => {
+  it("returns the ~15-minute default when no config is provided", () => {
+    const ms = resolveBillingDisableCeilingMs({ providerId: "anthropic" });
+    expect(ms).toBeGreaterThanOrEqual(14 * 60 * 1000);
+    expect(ms).toBeLessThanOrEqual(16 * 60 * 1000);
+  });
+
+  it("honors operator-configured billingMaxHours", () => {
+    const ms = resolveBillingDisableCeilingMs({
+      providerId: "anthropic",
+      cfg: { auth: { cooldowns: { billingMaxHours: 2 } } } as never,
+    });
+    expect(ms).toBe(2 * 60 * 60 * 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // clearAuthProfileCooldown
 // ---------------------------------------------------------------------------
 
@@ -807,8 +1033,10 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
         lastFailureAt: now - 60_000,
       }),
       // errorCount resets, billing count resets to 1 →
-      // calculateDisabledLaneBackoffMs(1, 5h, 24h) = 5h
-      expectedUntil: (now: number) => now + 5 * 60 * 60 * 1000,
+      // calculateDisabledLaneBackoffMs(1, base, max) — base is clamped to
+      // the 60s floor in calculateDisabledLaneBackoffMs, and the new default
+      // base is ~5 minutes after the #70903 tightening, so 5min wins.
+      expectedUntil: (now: number) => now + 5 * 60 * 1000,
       readUntil: (stats: WindowStats | undefined) => stats?.disabledUntil,
     },
     {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -26,6 +26,7 @@ import {
   resolveProfileUnusableUntil,
 } from "./usage-state.js";
 export {
+  clampStaleBillingDisable,
   clearExpiredCooldowns,
   getSoonestCooldownExpiry,
   isProfileInCooldown,
@@ -443,9 +444,14 @@ function resolveAuthCooldownConfig(params: {
   cfg?: OpenClawConfig;
   providerId: string;
 }): ResolvedAuthCooldownConfig {
+  // Billing defaults stay short on purpose: a multi-hour persisted lockout (see
+  // #70903) blocks users for the full window even after they top up credit,
+  // because the call layer filters disabled profiles before any probe can run
+  // and `markAuthProfileSuccess` is what clears `disabledUntil`. Operators can
+  // still raise these via `auth.cooldowns.*` config; the cap stays bounded.
   const defaults = {
-    billingBackoffHours: 5,
-    billingMaxHours: 24,
+    billingBackoffHours: 5 / 60, // 5 minutes
+    billingMaxHours: 15 / 60, // 15 minutes
     authPermanentBackoffMinutes: 10,
     authPermanentMaxMinutes: 60,
     failureWindowHours: 24,
@@ -496,6 +502,18 @@ function resolveAuthCooldownConfig(params: {
     authPermanentMaxMs: authPermanentMaxMinutes * 60 * 1000,
     failureWindowMs: failureWindowHours * 60 * 60 * 1000,
   };
+}
+
+/**
+ * Resolve the effective billing-disable ceiling (ms) for a provider, given the
+ * active config. Used at read time to clamp stale persisted `disabledUntil`
+ * windows that were written by an older OpenClaw default (see #70903).
+ */
+export function resolveBillingDisableCeilingMs(params: {
+  cfg?: OpenClawConfig;
+  providerId: string;
+}): number {
+  return resolveAuthCooldownConfig(params).billingMaxMs;
 }
 
 function calculateDisabledLaneBackoffMs(params: {

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -54,6 +54,7 @@ const mocks = vi.hoisted(() => {
     resolveAuthStorePathForDisplay: vi.fn(
       (agentDir?: string) => `${agentDir ?? "/tmp/openclaw-agent"}/auth-profiles.json`,
     ),
+    resolveBillingDisableCeilingMs: vi.fn().mockReturnValue(900_000),
     resolveProfileUnusableUntilForDisplay: vi.fn().mockReturnValue(undefined),
     resolveEnvApiKey: vi.fn((provider: string) => {
       if (provider === "openai") {
@@ -179,6 +180,7 @@ vi.mock("../../agents/auth-profiles/store.js", () => ({
   ensureAuthProfileStoreWithoutExternalProfiles: mocks.ensureAuthProfileStore,
 }));
 vi.mock("../../agents/auth-profiles/usage.js", () => ({
+  resolveBillingDisableCeilingMs: mocks.resolveBillingDisableCeilingMs,
   resolveProfileUnusableUntilForDisplay: mocks.resolveProfileUnusableUntilForDisplay,
 }));
 vi.mock("../../agents/auth-health.js", () => ({

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1099,10 +1099,11 @@ export const FIELD_HELP: Record<string, string> = {
   "auth.cooldowns":
     "Cooldown/backoff controls for temporary profile suppression after billing-related failures and retry windows. Use these to prevent rapid re-selection of profiles that are still blocked.",
   "auth.cooldowns.billingBackoffHours":
-    "Base backoff (hours) when a profile fails due to billing/insufficient credits (default: 5).",
+    "Base backoff (hours) when a profile fails due to billing/insufficient credits. Default: ~5 minutes (0.083 hours). The default stays tight because disabled profiles are skipped before any probe runs, so a multi-hour persisted lockout blocks users for the full window even after billing is fixed.",
   "auth.cooldowns.billingBackoffHoursByProvider":
     "Optional per-provider overrides for billing backoff (hours).",
-  "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
+  "auth.cooldowns.billingMaxHours":
+    "Cap (hours) for billing backoff. Default: ~15 minutes (0.25 hours). See billingBackoffHours for why this stays bounded.",
   "auth.cooldowns.authPermanentBackoffMinutes":
     "Base backoff (minutes) for high-confidence auth_permanent failures (default: 10). Keep this shorter than billing so providers recover automatically after transient upstream auth incidents.",
   "auth.cooldowns.authPermanentMaxMinutes":

--- a/src/config/types.auth.ts
+++ b/src/config/types.auth.ts
@@ -16,11 +16,11 @@ export type AuthConfig = {
   profiles?: Record<string, AuthProfileConfig>;
   order?: Record<string, string[]>;
   cooldowns?: {
-    /** Default billing backoff (hours). Default: 5. */
+    /** Default billing backoff (hours). Default: ~5 minutes (0.083 hours). */
     billingBackoffHours?: number;
     /** Optional per-provider billing backoff (hours). */
     billingBackoffHoursByProvider?: Record<string, number>;
-    /** Billing backoff cap (hours). Default: 24. */
+    /** Billing backoff cap (hours). Default: 15 minutes (0.25 hours). */
     billingMaxHours?: number;
     /**
      * Base backoff for high-confidence permanent-auth failures (minutes).


### PR DESCRIPTION
## Summary

- Multi-hour persisted `disabledUntil` (old 5h base / 24h cap billing defaults) keeps users locked out of a provider for the full window even after billing is fixed. The call layer skips disabled profiles before any probe runs, so `markAuthProfileSuccess` never gets a chance to clear the field. See #70903.
- Lower the billing-disable defaults to ~5 minutes base / ~15 minutes cap so new billing failures recover quickly. Operators who want a longer pause can still set `auth.cooldowns.billingBackoffHours` / `auth.cooldowns.billingMaxHours`.
- Clamp stale persisted billing `disabledUntil` values inside `resolveAuthProfileOrder`, anchored to the original `lastFailureAt`, so upgraded users are not stuck for hours and repeated reloads do not slide the clamp window forward.
- Align the config contract surfaces: runtime defaults, docs, schema help, and exported `AuthConfig` comments now describe the same 5-minute / 15-minute billing cooldown defaults.

## Linked context

Closes #70903

## Real behavior proof (required for external PRs)

Behavior addressed: Persisted `disabledUntil` in `~/.openclaw/agents/<id>/agent/auth-state.json` can block users from a provider for hours after billing recovery. This patch lowers new billing-disable defaults and retroactively clamps stale on-disk billing disables during auth-profile ordering.

Real environment tested: Local macOS arm64 checkout rebuilt on current `openclaw/openclaw` `main` at `6c7644268f59770361d2760a27cb49823ec76717`. Runtime fixture executed with Node + `tsx`, importing the production `resolveAuthProfileOrder`, `resolveBillingDisableCeilingMs`, and `isProfileInCooldown` functions from this branch. This does not use a live paid-provider billing drain/re-credit path.

Exact steps or command run after this patch:
- Runtime fixture: `NO_COLOR=1 node --import tsx --input-type=module -`, with an inline fixture that reconstructs the same stale persisted store on repeated reloads (`disabledUntil = lastFailureAt + 5h`, `disabledReason = "billing"`, `lastFailureAt` preserved), then calls the production auth-profile ordering path at `lastFailureAt + 10m` and `lastFailureAt + 16m`.
- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/agents/auth-profiles/usage.test.ts src/agents/auth-profiles/order.test.ts src/agents/auth-profiles.markauthprofilefailure.test.ts`
- `node scripts/run-oxlint.mjs src/agents/auth-profiles/usage.ts src/agents/auth-profiles/usage.test.ts src/agents/auth-profiles/order.ts src/agents/auth-profiles/order.test.ts src/agents/auth-profiles/usage-state.ts src/agents/auth-profiles.markauthprofilefailure.test.ts src/config/schema.help.ts src/config/types.auth.ts`
- `npx oxfmt --check docs/concepts/model-failover.md docs/gateway/configuration-reference.md src/agents/auth-profiles/usage.ts src/agents/auth-profiles/usage.test.ts src/agents/auth-profiles/order.ts src/agents/auth-profiles/order.test.ts src/agents/auth-profiles/usage-state.ts src/agents/auth-profiles.markauthprofilefailure.test.ts src/config/schema.help.ts src/config/types.auth.ts`
- `pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config config/markdownlint-cli2.jsonc docs/concepts/model-failover.md docs/gateway/configuration-reference.md`
- `git diff --check`

Evidence after fix:

Copied live output from the runtime fixture:

```json
{
  "behavior": "billing disable reload recovery (#70903)",
  "defaultBillingCeilingMs": 900000,
  "stalePersistedDisableMs": 18000000,
  "beforeCapReload": {
    "nowOffsetMs": 600000,
    "order": [
      "fixture-provider:default"
    ],
    "clampedDisabledUntilOffsetMs": 900000,
    "remainingMs": 300000,
    "inCooldown": true
  },
  "afterCapReload": {
    "nowOffsetMs": 960000,
    "order": [
      "fixture-provider:default"
    ],
    "disabledUntil": "CLEARED",
    "disabledReason": "CLEARED",
    "inCooldown": false
  },
  "result": "ALL ASSERTIONS PASSED"
}
```

Supplemental checks:
- Vitest: 3 files passed, 119 tests passed.
- Oxlint: clean on touched TypeScript files.
- Oxfmt: all 10 matched files use the correct format.
- Markdownlint with repo config: 660 docs files linted, 0 errors.
- `git diff --check`: clean.
- New and refreshed coverage exercises `clampStaleBillingDisable`, the default billing-disable ceiling, the full `resolveAuthProfileOrder` read path, repeated fresh-store reloads after the cap, missing-anchor fallback, and sibling non-billing/cooldown/block windows.

Observed result after fix:
- Default billing disable after the first billing failure is ~5 minutes instead of ~5 hours.
- Default repeated billing-disable cap is ~15 minutes instead of 24 hours.
- A stale persisted multi-hour billing disable is clamped to the active cap before expiry cleanup.
- A stale persisted billing disable anchored to an old `lastFailureAt` becomes eligible after the cap instead of sliding to `now + 15m` on every reload.
- Non-billing disables, `cooldownUntil`, and `blockedUntil` are not clamped.

What was not tested: A live paid-provider billing drain/re-credit scenario was not run because it would require intentionally exhausting and restoring real provider credit. The compatibility policy decision around shorter defaults remains maintainer-owned.
