### PR TITLE
fix(types): unblock changed gate checks

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -608,10 +608,13 @@ function readCandidatePackageManifest(params: {
     return cached;
   }
   const canUseProcessCache = params.origin === "bundled" || !params.rejectHardlinks;
-  const stat = readPackageManifestStat(params.dir);
-  if (canUseProcessCache && stat) {
+  const manifestStat = readPackageManifestStat(params.dir);
+  if (canUseProcessCache && manifestStat !== null) {
     const processCached = packageManifestProcessCache.get(cacheKey);
-    if (processCached?.mtimeMs === stat.mtimeMs && processCached.size === stat.size) {
+    if (
+      processCached?.mtimeMs === manifestStat.mtimeMs &&
+      processCached.size === manifestStat.size
+    ) {
       params.packageManifestCache?.set(cacheKey, processCached.manifest);
       return processCached.manifest;
     }
@@ -621,8 +624,8 @@ function readCandidatePackageManifest(params: {
       ? readTrustedPackageManifest(params.dir)
       : readPackageManifest(params.dir, params.rejectHardlinks, params.rootRealPath);
   params.packageManifestCache?.set(cacheKey, manifest);
-  if (canUseProcessCache && stat) {
-    packageManifestProcessCache.set(cacheKey, { ...stat, manifest });
+  if (canUseProcessCache && manifestStat !== null) {
+    packageManifestProcessCache.set(cacheKey, { ...manifestStat, manifest });
     prunePackageManifestProcessCache();
   }
   return manifest;


### PR DESCRIPTION
## Summary
- Adds the optional approval-action marker that `approval-reaction-runtime` already reads.
- Narrows package manifest cache stat handling through an explicit non-null local.
- Unblocks `check:changed` type/lint gates that are currently blocking the small-model/local-provider fix stack.

## Verification
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/gate-types-rebase-$USER-$$ node scripts/run-vitest.mjs src/plugin-sdk/approval-reaction-runtime.test.ts src/infra/approval-view-model.test.ts src/plugins/discovery.test.ts` - 3 files / 83 tests passed
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` - passed
- `./node_modules/.bin/oxfmt --check --threads=1 src/infra/approval-view-model.types.ts src/plugins/discovery.ts` - passed
- `./node_modules/.bin/oxlint src/infra/approval-view-model.types.ts src/plugins/discovery.ts` - passed
- `git diff --check` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, overall 0.92
- AWS Crabbox `run_c03dbb32688a`, lease `cbx_efe87fadb37a`, provider `aws`: `corepack pnpm check:changed` passed at base `79e733cc34`; branch was then rebased to `b261e9e6dd`, whose drift did not touch the changed files, and focused local proof/autoreview were rerun after the rebase.

Behavior addressed: changed gates no longer fail on the approval-action view-model marker type or nullable package manifest stat cache reads.
Real environment tested: local focused node-wrapper tests plus AWS Crabbox Linux changed gate.
Exact steps or command run after this patch: see Verification.
Evidence after fix: focused tests, extension tsgo, formatting/lint checks, autoreview, and AWS Crabbox changed gate all passed.
Observed result after fix: `check:changed` reached exit 0 for `core` and `coreTests` lanes on the touched surface.
What was not tested: no full repository test suite; this is a narrow type/refactor unblocker.
