### PR TITLE
fix(cli): load plugins for openclaw sandbox so OpenShell backend reports live status (#59528)

### DIFF
--- a/src/agents/sandbox/manage.test.ts
+++ b/src/agents/sandbox/manage.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let listSandboxBrowsers: typeof import("./manage.js").listSandboxBrowsers;
+let listSandboxContainers: typeof import("./manage.js").listSandboxContainers;
 let removeSandboxBrowserContainer: typeof import("./manage.js").removeSandboxBrowserContainer;
 
 const configMocks = vi.hoisted(() => ({
@@ -17,10 +18,15 @@ const registryMocks = vi.hoisted(() => ({
 const backendMocks = vi.hoisted(() => ({
   describeRuntime: vi.fn(),
   removeRuntime: vi.fn(),
+  getSandboxBackendManager: vi.fn(),
 }));
 
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: configMocks.getRuntimeConfig,
+}));
+
+vi.mock("./backend.js", () => ({
+  getSandboxBackendManager: backendMocks.getSandboxBackendManager,
 }));
 
 vi.mock("../../plugin-sdk/browser-bridge.js", () => ({
@@ -47,7 +53,8 @@ vi.mock("./browser-bridges.js", () => ({
 }));
 
 beforeAll(async () => {
-  ({ listSandboxBrowsers, removeSandboxBrowserContainer } = await import("./manage.js"));
+  ({ listSandboxBrowsers, listSandboxContainers, removeSandboxBrowserContainer } =
+    await import("./manage.js"));
 });
 
 function firstDescribeRuntimeInput(): { agentId?: string; entry?: { configLabelKind?: string } } {
@@ -153,5 +160,84 @@ describe("listSandboxBrowsers", () => {
     expect(removeInput?.entry?.runtimeLabel).toBe("browser-1");
     expect(removeInput?.entry?.backendId).toBe("docker");
     expect(registryMocks.removeBrowserRegistryEntry).toHaveBeenCalledWith("browser-1");
+  });
+});
+
+describe("listSandboxContainers", () => {
+  beforeEach(() => {
+    configMocks.getRuntimeConfig.mockReset();
+    registryMocks.readRegistry.mockReset();
+    backendMocks.describeRuntime.mockReset();
+    backendMocks.getSandboxBackendManager.mockReset();
+
+    configMocks.getRuntimeConfig.mockReturnValue({
+      agents: {
+        defaults: { sandbox: { backend: "openshell" } },
+        list: [],
+      },
+    });
+  });
+
+  it("asks the registered backend manager for live status when backendId is plugin-owned", async () => {
+    registryMocks.readRegistry.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-openshell-agent-coder-main",
+          backendId: "openshell",
+          runtimeLabel: "openclaw-openshell-agent-coder-main",
+          sessionKey: "agent:coder:main",
+          image: "openshell:1.0",
+          configLabelKind: "Image",
+          createdAtMs: 1,
+          lastUsedAtMs: 1,
+        },
+      ],
+    });
+    const openshellManager = {
+      describeRuntime: vi.fn(async () => ({
+        running: true,
+        actualConfigLabel: "openshell:1.0",
+        configLabelMatch: true,
+      })),
+      removeRuntime: vi.fn(),
+    };
+    backendMocks.getSandboxBackendManager.mockImplementation((id: string) =>
+      id === "openshell" ? openshellManager : null,
+    );
+
+    const results = await listSandboxContainers();
+
+    expect(backendMocks.getSandboxBackendManager).toHaveBeenCalledWith("openshell");
+    expect(openshellManager.describeRuntime).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.running).toBe(true);
+    expect(results[0]?.imageMatch).toBe(true);
+  });
+
+  it("falls back to stopped when no backend manager is registered for the entry's backendId", async () => {
+    // Regression for openclaw#59528: when the sandbox CLI runs without plugin
+    // registration, OpenShell's manager is missing and registry entries report
+    // running=false even though the OpenShell sandbox would actually run them.
+    registryMocks.readRegistry.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-openshell-agent-coder-main",
+          backendId: "openshell",
+          runtimeLabel: "openclaw-openshell-agent-coder-main",
+          sessionKey: "agent:coder:main",
+          image: "openshell:1.0",
+          configLabelKind: "Image",
+          createdAtMs: 1,
+          lastUsedAtMs: 1,
+        },
+      ],
+    });
+    backendMocks.getSandboxBackendManager.mockReturnValue(null);
+
+    const results = await listSandboxContainers();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.running).toBe(false);
+    expect(results[0]?.imageMatch).toBe(true);
   });
 });

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -287,6 +287,15 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["nodes"], policy: { networkProxy: "bypass" } },
   { commandPath: ["pairing"], policy: { networkProxy: "bypass" } },
   { commandPath: ["proxy"], policy: { networkProxy: "bypass" } },
+  {
+    // Sandbox subcommands need plugin runtime so backend plugins (OpenShell,
+    // future third-party backends) register their managers before
+    // listSandboxContainers asks getSandboxBackendManager(entry.backendId).
+    // Without this, registry entries owned by a plugin backend report
+    // running=false because no manager is registered to describe them.
+    commandPath: ["sandbox"],
+    policy: { loadPlugins: "always", networkProxy: "bypass" },
+  },
   { commandPath: ["qr"], policy: { networkProxy: "bypass" } },
   { commandPath: ["reset"], policy: { networkProxy: "bypass" } },
   {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -245,6 +245,24 @@ describe("command-path-policy", () => {
     });
   });
 
+  it("loads plugins for sandbox subcommands so backend plugins register", () => {
+    // Sandbox-backed plugins (OpenShell today) only register their
+    // SandboxBackendManager during full plugin registration. Without
+    // loadPlugins=always, `sandbox list` falls back to the default
+    // no-plugin policy and reports plugin-owned runtimes as stopped.
+    for (const commandPath of [
+      ["sandbox"],
+      ["sandbox", "list"],
+      ["sandbox", "recreate"],
+      ["sandbox", "explain"],
+    ]) {
+      expectResolvedPolicy(commandPath, {
+        loadPlugins: "always",
+        networkProxy: "bypass",
+      });
+    }
+  });
+
   it("defaults unknown command paths to network proxy routing", () => {
     expect(resolveCliNetworkProxyPolicy(["node", "openclaw", "googlemeet", "login"])).toBe(
       "default",


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- \`openclaw sandbox list\` reports OpenShell-backed sandboxes as \`stopped\` (and \`sandbox recreate\` / \`sandbox explain\` cannot reach the live backend either), regressing the bundled \`openshell\` plugin since the 2026.03.13 release.

Why does this matter now?

- Users who follow the docs (\`agents.defaults.sandbox.backend = \"openshell\"\`) and enable the bundled plugin see a sandbox CLI that disagrees with reality and with the \`openshell\` CLI, which makes the documented \"bundled OpenShell\" path unusable for status / recreate decisions.

What is the intended outcome?

- The sandbox CLI loads plugin runtime before walking the sandbox registry, so OpenShell's \`SandboxBackendManager\` is installed and \`listSandboxContainers\` can describe live status for every backend the registry references (docker / ssh / openshell / future third-party).

What is intentionally out of scope?

- Plugin loader / activation lifecycle refactor.
- Any change to OpenShell's own registration shape (\`api.registrationMode === \"full\"\` gate is preserved; we just give the sandbox CLI a path that reaches it).
- Any change to docker / ssh backends — those register at module import time and were never affected by the regression.

What does success look like?

- \`openclaw sandbox list\` shows \`running\` (instead of \`stopped\`) for OpenShell-backed entries when the OpenShell sandbox is actually running.
- The catalog policy is locked in by a unit test, and the manager-missing fallback shape is locked in by a \`listSandboxContainers\` regression test so a future loader refactor cannot silently re-break this path.

What should reviewers focus on?

- Whether \`loadPlugins: \"always\"\` for the entire \`sandbox\` namespace is the right scope (versus narrower per-subcommand). My read of the code is: every \`sandbox\` subcommand (\`list\`, \`recreate\`, \`explain\`) ends up consulting backend-owned state, so loading plugins is the clean bounded fix.
- The sibling-surface paragraph below: docker / ssh / browser containers are unaffected; OpenShell is the only bundled sandbox backend plugin and is the only bundled sandbox surface that benefits.

## Linked context

Which issue does this close?

Closes #59528

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

ClawSweeper source-repro evidence (\`clawsweeper:source-repro\`, \`clawsweeper:fix-shape-clear\`, \`clawsweeper:queueable-fix\`) on the linked issue.

## Real behavior proof (required for external PRs)

Behavior addressed: \`openclaw sandbox list\` reports OpenShell-backed sandbox entries as \`stopped\` (\"No sandboxes found.\" is what \`openshell sandbox list\` says at the same time) because the bundled OpenShell plugin's \`registerSandboxBackend(\"openshell\", { manager })\` only runs during \`api.registrationMode === \"full\"\`, and the sandbox CLI command path had no \`cliCommandCatalog\` entry — so it fell back to the default \`loadPlugins: \"never\"\` policy and never triggered full plugin registration.

Real environment tested: source-level + unit tests on this worktree (macOS, Node 22.x). No live OpenShell on WSL+Ubuntu run; the reproducer is covered by the \`clawsweeper:source-repro\` evidence on the linked issue (which already traced \`src/agents/sandbox/manage.ts\` → \`getSandboxBackendManager\` → null → \`running: false\` and matched it to the missing CLI plugin-load path).

Exact steps or command run after this patch:

\`\`\`
node scripts/run-vitest.mjs src/cli/command-path-policy.test.ts
node scripts/run-vitest.mjs src/agents/sandbox/manage.test.ts
node scripts/run-vitest.mjs src/commands/sandbox.test.ts src/agents/sandbox/backend.test.ts
node scripts/run-vitest.mjs src/cli/command-bootstrap.test.ts src/cli/command-execution-startup.test.ts src/cli/command-startup-policy.test.ts
node scripts/run-vitest.mjs src/commands/sandbox-explain.test.ts
\`\`\`

Evidence after fix (terminal output, vitest summary lines):

\`\`\`
src/cli/command-path-policy.test.ts        Test Files 1 passed | Tests 13 passed
src/agents/sandbox/manage.test.ts          Test Files 2 passed | Tests  8 passed
src/commands/sandbox.test.ts +
  src/agents/sandbox/backend.test.ts        Test Files 2 passed | Tests 21 passed
src/cli/command-bootstrap.test.ts +
  command-execution-startup.test.ts +
  command-startup-policy.test.ts            Test Files 3 passed | Tests 19 passed
src/commands/sandbox-explain.test.ts       Test Files 1 passed | Tests  2 passed
\`\`\`

Observed result after fix:

- \`resolveCliCommandPathPolicy([\"sandbox\", ...])\` now returns \`loadPlugins: \"always\"\` for \`sandbox\`, \`sandbox list\`, \`sandbox recreate\`, \`sandbox explain\` (asserted by \`command-path-policy.test.ts\`).
- \`ensureCliCommandBootstrap\` reads that policy and calls \`ensureCliPluginRegistryLoaded\`, which goes through \`loadOpenClawPlugins\` with \`shouldActivate: true\`. That sets \`registrationMode = \"full\"\` for bundled plugins, so OpenShell's \`registerSandboxBackend(\"openshell\", { manager })\` runs.
- \`listSandboxContainers\` therefore gets a real manager for \`entry.backendId === \"openshell\"\` and propagates \`runtime.running\` / \`runtime.configLabelMatch\` instead of defaulting to \`running: false\` (asserted by the new \`listSandboxContainers\` describe block in \`manage.test.ts\`).

What was not tested: live WSL+Ubuntu+OpenShell run as described in the issue. That environment is the originally-reported repro, but the failure is fully explained at source by ClawSweeper's analysis (cited above) and the unit test now locks the manager-missing → \`running: false\` shape so the regression cannot recur silently.

Proof limitations or environment constraints: macOS dev workstation, no Linux + OpenShell daemon available; relying on source + unit + ClawSweeper source-repro for end-to-end correctness.

Before evidence (optional but encouraged): n/a — \`openclaw sandbox list\` before this patch returns the registry entry with \`running: false\` because \`getSandboxBackendManager(\"openshell\")\` is \`null\` (the same code path the new regression test pins).

## Tests and validation

Which commands did you run?

- \`node scripts/run-vitest.mjs src/cli/command-path-policy.test.ts\` — 13 passed
- \`node scripts/run-vitest.mjs src/agents/sandbox/manage.test.ts\` — 8 passed (includes 2 new \`listSandboxContainers\` cases)
- \`node scripts/run-vitest.mjs src/commands/sandbox.test.ts src/agents/sandbox/backend.test.ts\` — 21 passed
- \`node scripts/run-vitest.mjs src/cli/command-bootstrap.test.ts src/cli/command-execution-startup.test.ts src/cli/command-startup-policy.test.ts\` — 19 passed (no startup regression from the new catalog entry)
- \`node scripts/run-vitest.mjs src/commands/sandbox-explain.test.ts\` — 2 passed

What regression coverage was added or updated?

- \`src/cli/command-path-policy.test.ts\`: new case \`loads plugins for sandbox subcommands so backend plugins register\` asserts the policy resolves to \`loadPlugins: \"always\"\` and \`networkProxy: \"bypass\"\` for \`sandbox\`, \`sandbox list\`, \`sandbox recreate\`, \`sandbox explain\`.
- \`src/agents/sandbox/manage.test.ts\`: new \`describe(\"listSandboxContainers\")\` block with (a) a happy path that confirms the registered plugin manager (\`openshell\`) gets \`describeRuntime\` called and live status flows into the result, and (b) a regression case that pins the \"no manager registered → \`running: false\`\" fallback shape so a future loader refactor cannot silently re-break this exact path.

What failed before this fix, if known?

Source-level repro is covered by ClawSweeper's analysis on #59528: with the previous catalog, \`resolveCliCommandPathPolicy([\"sandbox\", \"list\"])\` returned \`loadPlugins: \"never\"\`, the plugin registry was never loaded for sandbox commands, and OpenShell's manager never registered — exactly the user-reported state.

If no test was added, why not?

n/a — tests added.

## Risk checklist

Did user-visible behavior change? (\`Yes/No\`)

- Yes — \`openclaw sandbox\` subcommands now load plugin runtime so plugin-owned sandbox backends report accurate live status. The output goes from incorrect \`stopped\` to correct \`running\` for affected entries.

Did config, environment, or migration behavior change? (\`Yes/No\`)

- No — no config keys, defaults, or migration paths touched. The catalog entry is a CLI startup policy, not a config surface. Runtime still reads canonical config only.

Did security, auth, secrets, network, or tool execution behavior change? (\`Yes/No\`)

- No — \`networkProxy: \"bypass\"\` matches sibling local-only CLI namespaces (nodes, proxy, secrets, etc.). No new network calls; sandbox CLI remains local-only.

What is the highest-risk area?

- Startup cost: \`sandbox\` subcommands now go through \`ensureCliPluginRegistryLoaded({ scope: \"all\" })\`. This matches the \`agent\` CLI's scope and is acceptable for an interactive human-facing CLI namespace; it is not on a hot agent loop.

How is that risk mitigated?

- Scope is the existing \`all\` default and reuses the same \`ensurePluginRegistryLoaded\` machinery channels and agent commands already use. No new loader / activation paths introduced.

## Sibling-surface check

- Docker sandbox backend (\`src/agents/sandbox/backend.ts\` → \`registerSandboxBackend(\"docker\", ...)\` at module import time): unaffected — its manager is always registered regardless of CLI plugin policy.
- SSH sandbox backend (same file, \`registerSandboxBackend(\"ssh\", ...)\` at module import time): unaffected for the same reason.
- Browser containers in \`listSandboxBrowsers\` (\`src/agents/sandbox/manage.ts\`): unaffected — they call \`dockerSandboxBackendManager\` directly without going through the dynamic registry lookup.
- OpenShell sandbox backend (\`extensions/openshell/index.ts\`, only registers during \`registrationMode === \"full\"\`): this is the bundled plugin that benefits from the fix.
- Any future third-party sandbox backend plugin that registers via \`openclaw/plugin-sdk/sandbox\`: benefits automatically from this fix without additional code.
- \`crabbox\` / \`local-exec\`: not sandbox backends in the \`registerSandboxBackend\` sense; outside the surface this PR touches.

## Current review state

What is the next action?

Maintainer review of the policy choice (\`loadPlugins: \"always\"\` for the whole \`sandbox\` namespace) and the regression-test shape.

What is still waiting on author, maintainer, CI, or external proof?

- Maintainer review.
- Optional live WSL+Ubuntu+OpenShell verification — happy to run Crabbox/Testbox if the maintainer wants end-to-end proof beyond the source + unit-test evidence.

Which bot or reviewer comments were addressed?

n/a — initial submission.

## Real behavior proof (gate-field summary)

- Behavior addressed: `openclaw sandbox list` must load plugin runtime before reading sandbox registry entries so the bundled OpenShell plugin registers its `SandboxBackendManager`; otherwise `listSandboxContainers()` sees `getSandboxBackendManager("openshell") === null` and reports OpenShell-owned entries as `running: false`.
- Real environment tested: macOS Darwin 25.5.0, Node 22, pnpm 11.2.2, PR head rebased on `origin/main` `0b98aea71a`; local OpenClaw source checkout with a temporary `OPENCLAW_STATE_DIR`, an enabled `plugins.entries.openshell` config, and a controlled executable shim at `/tmp/openclaw-87696-proof/bin/openshell` to capture backend-manager CLI calls.
- Exact steps or command run after this patch:
  ```sh
  OPENCLAW_STATE_DIR=/tmp/openclaw-87696-proof/state \
  OPENCLAW_FAKE_OPENSHELL_LOG=/tmp/openclaw-87696-proof/openshell.log \
  OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY=1 \
  PATH=/tmp/openclaw-87696-proof/bin:$PATH \
  pnpm openclaw sandbox list --json
  cat /tmp/openclaw-87696-proof/openshell.log
  ```
- Evidence after fix:
  ```json
  {
    "containers": [
      {
        "containerName": "openclaw-openshell-proof",
        "backendId": "openshell",
        "runtimeLabel": "openclaw-openshell-proof",
        "sessionKey": "agent:proof:main",
        "createdAtMs": 1,
        "lastUsedAtMs": 1,
        "image": "openclaw",
        "configLabelKind": "Source",
        "running": true,
        "imageMatch": true
      }
    ],
    "browsers": []
  }
  ```
  Captured executable log:
  ```
  sandbox get openclaw-openshell-proof
  ```
- Observed result after fix: The sandbox CLI returned the OpenShell registry entry with `running: true` and the executable log recorded `sandbox get openclaw-openshell-proof`, proving the `sandbox` command path loaded plugin runtime, registered the OpenShell backend manager, and used that manager instead of the missing-manager fallback.
- What was not tested: A real NVIDIA OpenShell CLI/daemon or WSL+Ubuntu gateway roundtrip. This local proof verifies the OpenClaw CLI/plugin-loading/backend-manager path at runtime; it does not claim OpenShell's own daemon behavior.
