### PR TITLE
fix(auth): clear stale provider cooldowns after reauth

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -86,6 +86,7 @@ export type {
 export {
   calculateAuthProfileCooldownMs,
   clearAuthProfileCooldown,
+  clearProviderAuthProfileCooldowns,
   clearExpiredCooldowns,
   getSoonestCooldownExpiry,
   isProfileInCooldown,

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -10,6 +10,7 @@ import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import {
   testing as authProfileUsageTesting,
   clearAuthProfileCooldown,
+  clearProviderAuthProfileCooldowns,
   clearExpiredCooldowns,
   isProfileInCooldown,
   markAuthProfileBlockedUntil,
@@ -701,6 +702,126 @@ describe("clearAuthProfileCooldown", () => {
     const store = makeStore(undefined);
     await clearAuthProfileCooldown({ store, profileId: "nonexistent" });
     expect(store.usageStats).toBeUndefined();
+  });
+});
+
+describe("clearProviderAuthProfileCooldowns", () => {
+  it("clears matching provider profiles in one locked update", async () => {
+    const freshStore = makeStore({
+      "anthropic:default": {
+        disabledUntil: Date.now() + 3_600_000,
+        disabledReason: "billing",
+        errorCount: 3,
+        failureCounts: { billing: 3 },
+      },
+      "openai:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "rate_limit",
+        errorCount: 2,
+        failureCounts: { rate_limit: 2 },
+      },
+    });
+    const localStore = makeStore({});
+    storeMocks.updateAuthProfileStoreWithLock.mockImplementation(async ({ updater }) => {
+      expect(updater(freshStore)).toBe(true);
+      return freshStore;
+    });
+
+    await clearProviderAuthProfileCooldowns({
+      store: localStore,
+      provider: "anthropic",
+      agentDir: "/tmp/openclaw-agent",
+    });
+
+    expect(storeMocks.updateAuthProfileStoreWithLock).toHaveBeenCalledTimes(1);
+    expectProfileErrorStateCleared(localStore.usageStats?.["anthropic:default"]);
+    expect(localStore.usageStats?.["openai:default"]?.cooldownReason).toBe("rate_limit");
+    expect(storeMocks.saveAuthProfileStore).not.toHaveBeenCalled();
+  });
+
+  it("clears usage for runtime-overlay profiles that are absent from the locked profile map", async () => {
+    const localStore = makeStore({
+      "anthropic:claude-cli": {
+        disabledUntil: Date.now() + 3_600_000,
+        disabledReason: "billing",
+        errorCount: 2,
+        failureCounts: { billing: 2 },
+      },
+    });
+    localStore.profiles["anthropic:claude-cli"] = {
+      type: "oauth",
+      provider: "anthropic",
+      access: "claude-access-token",
+      refresh: "claude-refresh-token",
+      expires: 4_102_444_800_000,
+    };
+    const freshStore: AuthProfileStore = {
+      version: 1,
+      profiles: {},
+      usageStats: {
+        "anthropic:claude-cli": {
+          disabledUntil: Date.now() + 3_600_000,
+          disabledReason: "billing",
+          errorCount: 2,
+          failureCounts: { billing: 2 },
+        },
+      },
+    };
+    storeMocks.updateAuthProfileStoreWithLock.mockImplementation(async ({ updater }) => {
+      expect(updater(freshStore)).toBe(true);
+      return freshStore;
+    });
+
+    await clearProviderAuthProfileCooldowns({ store: localStore, provider: "anthropic" });
+
+    expectProfileErrorStateCleared(localStore.usageStats?.["anthropic:claude-cli"]);
+  });
+
+  it("clears explicit refreshed profile ids even before they appear in the profile map", async () => {
+    const localStore = makeStore({});
+    const freshStore = makeStore({
+      "anthropic:plugin-refresh": {
+        disabledUntil: Date.now() + 3_600_000,
+        disabledReason: "format",
+        errorCount: 1,
+        failureCounts: { format: 1 },
+      },
+    });
+    storeMocks.updateAuthProfileStoreWithLock.mockImplementation(async ({ updater }) => {
+      expect(updater(freshStore)).toBe(true);
+      return freshStore;
+    });
+
+    await clearProviderAuthProfileCooldowns({
+      store: localStore,
+      provider: "anthropic",
+      profileIds: ["anthropic:plugin-refresh"],
+    });
+
+    expectProfileErrorStateCleared(localStore.usageStats?.["anthropic:plugin-refresh"]);
+  });
+
+  it("falls back to the provided store when the lock update is unavailable", async () => {
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: Date.now() + 60_000,
+        disabledUntil: Date.now() + 3_600_000,
+        disabledReason: "billing",
+        errorCount: 5,
+        failureCounts: { billing: 3 },
+      },
+      "openai:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "rate_limit",
+        errorCount: 2,
+      },
+    });
+
+    await clearProviderAuthProfileCooldowns({ store, provider: "anthropic" });
+
+    expectProfileErrorStateCleared(store.usageStats?.["anthropic:default"]);
+    expect(store.usageStats?.["openai:default"]?.cooldownReason).toBe("rate_limit");
+    expect(storeMocks.saveAuthProfileStore).toHaveBeenCalledWith(store, undefined);
   });
 });
 

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -13,9 +13,11 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
 import { readProviderJsonResponse } from "../provider-http-errors.js";
 import { notifyAuthProfileFailureHook, setAuthProfileFailureHook } from "./failure-hook.js";
+import { listProfilesForProvider } from "./profile-list.js";
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
 
 const authProfileUsageLog = createSubsystemLogger("agent/embedded");
@@ -578,6 +580,39 @@ function updateUsageStatsEntry(
   store.usageStats[profileId] = updater(store.usageStats[profileId]);
 }
 
+function resolveProviderCooldownEntryIds(
+  store: AuthProfileStore,
+  provider: string,
+  profileIds?: string[],
+): string[] {
+  return profileIds === undefined
+    ? listProfilesForProvider(store, provider)
+    : profileIds.filter((profileId) => {
+        const profileProvider = store.profiles[profileId]?.provider;
+        return (
+          profileProvider === undefined ||
+          resolveProviderIdForAuth(profileProvider) === resolveProviderIdForAuth(provider)
+        );
+      });
+}
+
+function clearProviderCooldownEntries(
+  store: AuthProfileStore,
+  provider: string,
+  profileIds?: string[],
+): boolean {
+  const idsToClear = resolveProviderCooldownEntryIds(store, provider, profileIds);
+  let changed = false;
+  for (const profileId of new Set(idsToClear)) {
+    if (!store.usageStats?.[profileId]) {
+      continue;
+    }
+    updateUsageStatsEntry(store, profileId, (existing) => resetUsageStats(existing));
+    changed = true;
+  }
+  return changed;
+}
+
 function keepActiveWindowOrRecompute(params: {
   existingUntil: number | undefined;
   now: number;
@@ -1004,6 +1039,53 @@ export async function clearAuthProfileCooldown(params: {
   }
 
   updateUsageStatsEntry(store, profileId, (existing) => resetUsageStats(existing));
+  authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
+}
+
+/**
+ * Clear cooldown/disabled state for provider profiles. Omitting profileIds
+ * clears every profile owned by the provider; passing profileIds limits cleanup
+ * to those refreshed profiles.
+ */
+export async function clearProviderAuthProfileCooldowns(params: {
+  store: AuthProfileStore;
+  provider: string;
+  profileIds?: string[];
+  agentDir?: string;
+}): Promise<void> {
+  const { store, provider, profileIds, agentDir } = params;
+  const providerWideProfileIds =
+    profileIds === undefined ? listProfilesForProvider(store, provider) : undefined;
+  let lockedStoreChanged = false;
+  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+    agentDir,
+    updater: (freshStore) => {
+      const lockedProfileIds =
+        profileIds === undefined
+          ? [...(providerWideProfileIds ?? []), ...listProfilesForProvider(freshStore, provider)]
+          : profileIds;
+      lockedStoreChanged = clearProviderCooldownEntries(freshStore, provider, lockedProfileIds);
+      return lockedStoreChanged;
+    },
+  });
+  if (updated) {
+    // Keep the caller's runtime-only overlay entries in sync with the fresh
+    // locked store without re-saving a stale pre-lock snapshot to disk.
+    const callerProfileIds = resolveProviderCooldownEntryIds(store, provider, profileIds);
+    const callerUsageStats = store.usageStats;
+    store.usageStats = updated.usageStats;
+    for (const profileId of new Set(callerProfileIds)) {
+      if (updated.usageStats?.[profileId] || !callerUsageStats?.[profileId]) {
+        continue;
+      }
+      updateUsageStatsEntry(store, profileId, () => resetUsageStats(callerUsageStats[profileId]));
+    }
+    return;
+  }
+
+  if (!clearProviderCooldownEntries(store, provider, profileIds)) {
+    return;
+  }
   authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
 }
 export { testing as __testing };

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -501,6 +501,7 @@ describe("runWithModelFallback – probe logic", () => {
     expect(run).toHaveBeenCalledTimes(1);
     expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
       allowTransientCooldownProbe: true,
+      isFinalFallbackAttempt: false,
     });
   });
 
@@ -540,7 +541,9 @@ describe("runWithModelFallback – probe logic", () => {
 
     expect(result.result).toBe("fallback-ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5");
+    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5", {
+      isFinalFallbackAttempt: true,
+    });
   });
 
   it("re-probes a single-provider primary blocked by a far-future subscription_limit (#90702)", () => {

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -6,6 +6,12 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { OpenClawConfig } from "../config/config.js";
 import { createDiagnosticLogRecordCapture } from "../logging/test-helpers/diagnostic-log-capture.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
+import {
+  markFallbackCandidateSkipped,
+  resetFallbackSkipCacheForTest,
+} from "./fallback-skip-cache.js";
+import { clearAgentHarnesses, registerAgentHarness } from "./harness/registry.js";
+import type { AgentHarness } from "./harness/types.js";
 import type { SessionSuspensionParams } from "./session-suspension.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
@@ -282,6 +288,7 @@ describe("runWithModelFallback – probe logic", () => {
     soonest: number | null;
     isPrimary?: boolean;
     hasFallbackCandidates?: boolean;
+    hasAvailableAuthFallbackCandidate?: boolean;
     requestedModel?: boolean;
     throttleKey?: string;
     usageStats?: AuthProfileStore["usageStats"];
@@ -297,6 +304,8 @@ describe("runWithModelFallback – probe logic", () => {
       isPrimary: params.isPrimary ?? true,
       requestedModel: params.requestedModel ?? true,
       hasFallbackCandidates: params.hasFallbackCandidates ?? true,
+      hasAvailableAuthFallbackCandidate:
+        params.hasAvailableAuthFallbackCandidate ?? params.hasFallbackCandidates ?? true,
       now: NOW,
       probeThrottleKey: params.throttleKey ?? "openai",
       authRuntime: {
@@ -377,6 +386,8 @@ describe("runWithModelFallback – probe logic", () => {
     resetLogger();
     sessionSuspensionMocks.suspendSession.mockClear();
     sessionSuspensionMocks.runWithDeferredSessionSuspension.mockClear();
+    clearAgentHarnesses();
+    resetFallbackSkipCacheForTest();
     vi.restoreAllMocks();
   });
 
@@ -394,6 +405,142 @@ describe("runWithModelFallback – probe logic", () => {
 
   it("uses inferred unavailable reason when skipping a cooldowned primary model", async () => {
     await expectPrimarySkippedAfterLongCooldown("billing");
+  });
+
+  it("probes billing cooldowns when configured fallbacks share the unavailable auth path", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["openai/gpt-4.1"],
+          },
+        },
+      },
+    } as Partial<OpenClawConfig>);
+    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 30 * 60 * 1000);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
+
+    const run = vi.fn().mockResolvedValue("recovered");
+
+    const result = await runPrimaryCandidate(cfg, run);
+
+    expectPrimaryProbeSuccess(result, run, "recovered");
+  });
+
+  it("uses config-aware auth order when deciding whether a fallback is available", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5"],
+          },
+        },
+      },
+    } as Partial<OpenClawConfig>);
+    mockedResolveAuthProfileOrder.mockImplementation(
+      ({ provider, cfg: activeCfg }: { provider: string; cfg?: OpenClawConfig }) => {
+        if (provider === "openai") {
+          return ["openai-profile-1"];
+        }
+        if (provider === "anthropic") {
+          return activeCfg
+            ? ["anthropic-cooldown-profile"]
+            : ["anthropic-cooldown-profile", "anthropic-healthy-profile"];
+        }
+        return [];
+      },
+    );
+    mockedIsProfileInCooldown.mockImplementation(
+      (_store: AuthProfileStore, profileId: string) => profileId !== "anthropic-healthy-profile",
+    );
+    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 30 * 60 * 1000);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
+
+    const run = vi.fn().mockResolvedValue("recovered");
+
+    const result = await runPrimaryCandidate(cfg, run);
+
+    expectPrimaryProbeSuccess(result, run, "recovered");
+  });
+
+  it("does not count a session-skip-cached fallback as available for billing probe gating", async () => {
+    const sessionId = "session:billing-probe-skip-cache";
+    markFallbackCandidateSkipped({
+      sessionId,
+      provider: "anthropic",
+      model: "claude-haiku-3-5",
+      reason: "auth",
+      ttlMs: 60_000,
+    });
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5"],
+          },
+        },
+      },
+    } as Partial<OpenClawConfig>);
+    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 30 * 60 * 1000);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
+
+    const run = vi.fn().mockResolvedValue("recovered");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionId,
+      run,
+    });
+
+    expectPrimaryProbeSuccess(result, run, "recovered");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
+      allowTransientCooldownProbe: true,
+    });
+  });
+
+  it("treats harness-backed fallbacks as available despite provider cooldown state", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5"],
+          },
+          models: {
+            "anthropic/*": { agentRuntime: { id: "claude-tmux" } },
+          },
+        },
+      },
+    } as Partial<OpenClawConfig>);
+    registerAgentHarness(
+      {
+        id: "claude-tmux",
+        label: "Claude tmux",
+        supports: ({ provider }) =>
+          provider === "anthropic" ? { supported: true } : { supported: false },
+        runAttempt: vi.fn<AgentHarness["runAttempt"]>(async () => {
+          throw new Error("probe test should not invoke the harness runtime");
+        }),
+      },
+      { ownerPluginId: "claude-tmux-test" },
+    );
+    mockedIsProfileInCooldown.mockReturnValue(true);
+    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 30 * 60 * 1000);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
+
+    const run = vi.fn().mockResolvedValue("fallback-ok");
+
+    const result = await runPrimaryCandidate(cfg, run);
+
+    expect(result.result).toBe("fallback-ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5");
   });
 
   it("re-probes a single-provider primary blocked by a far-future subscription_limit (#90702)", () => {
@@ -837,6 +984,13 @@ describe("runWithModelFallback – probe logic", () => {
       }),
       "billing",
     );
+    expect(
+      resolveOpenAiCooldownDecision({
+        reason: "billing",
+        soonest: NOW + 30 * 60 * 1000,
+        hasAvailableAuthFallbackCandidate: false,
+      }),
+    ).toEqual({ type: "attempt", reason: "billing", markProbe: true });
   });
 
   it("does not lock lane when fallback candidates remain after suspend_lanes decision", async () => {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1190,7 +1190,7 @@ describe("runWithModelFallback", () => {
     expect(run.mock.calls[0]).toEqual([
       "anthropic",
       "claude-sonnet-4-6",
-      { isFinalFallbackAttempt: true },
+      { allowTransientCooldownProbe: true, isFinalFallbackAttempt: true },
     ]);
     expect(result.attempts).toStrictEqual([]);
   });
@@ -1239,7 +1239,11 @@ describe("runWithModelFallback", () => {
 
     expect(result.result).toBe("direct cli ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run.mock.calls[0]).toEqual(["claude-cli", "opus", { isFinalFallbackAttempt: true }]);
+    expect(run.mock.calls[0]).toEqual([
+      "claude-cli",
+      "opus",
+      { allowTransientCooldownProbe: true, isFinalFallbackAttempt: true },
+    ]);
     expect(result.attempts).toStrictEqual([]);
   });
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -494,9 +494,13 @@ function isCliAgentRuntime(runtime: string | undefined, cfg: OpenClawConfig | un
   return isCliRuntimeAlias(normalized) || isCliProvider(normalized, cfg);
 }
 
-async function resolveModelFallbackCandidateHarnessAuthPrecheck(
+function resolveModelFallbackCandidateHarnessAuthCooldownPolicy(
   params: ModelFallbackRuntimeContext & ModelCandidate,
-): Promise<{ skipsProviderAuthCooldown: boolean }> {
+): {
+  skipsProviderAuthCooldown: boolean;
+  agentRuntime?: string;
+  agentHarnessRuntimeOverride?: string;
+} {
   if (!params.cfg) {
     return { skipsProviderAuthCooldown: false };
   }
@@ -534,17 +538,31 @@ async function resolveModelFallbackCandidateHarnessAuthPrecheck(
   if (agentRuntime === "auto" || (agentRuntime === "codex" && agentRuntimeSource === "implicit")) {
     return { skipsProviderAuthCooldown: false };
   }
+  return {
+    skipsProviderAuthCooldown: agentRuntime !== "codex",
+    agentRuntime,
+    agentHarnessRuntimeOverride,
+  };
+}
+
+async function resolveModelFallbackCandidateHarnessAuthPrecheck(
+  params: ModelFallbackRuntimeContext & ModelCandidate,
+): Promise<{ skipsProviderAuthCooldown: boolean }> {
+  const policy = resolveModelFallbackCandidateHarnessAuthCooldownPolicy(params);
+  if (!policy.agentRuntime) {
+    return { skipsProviderAuthCooldown: false };
+  }
   await params.prepareAgentHarnessRuntime?.({
     provider: params.provider,
     model: params.model,
-    agentHarnessRuntimeOverride,
+    agentHarnessRuntimeOverride: policy.agentHarnessRuntimeOverride,
   });
-  if (!getRegisteredAgentHarness(agentRuntime)) {
-    throw new MissingAgentHarnessError(agentRuntime);
+  if (!getRegisteredAgentHarness(policy.agentRuntime)) {
+    throw new MissingAgentHarnessError(policy.agentRuntime);
   }
   // Explicit non-Codex plugin harnesses own transport/auth; stale OpenClaw
   // provider cooldowns must not block the harness before it starts.
-  return { skipsProviderAuthCooldown: agentRuntime !== "codex" };
+  return { skipsProviderAuthCooldown: policy.skipsProviderAuthCooldown };
 }
 
 function resolveCandidateAttemptError(
@@ -1160,6 +1178,62 @@ function shouldProbePrimaryDuringCooldown(params: {
   return params.now >= soonest - PROBE_MARGIN_MS;
 }
 
+function hasLaterAvailableAuthFallbackCandidate(params: {
+  candidates: ModelCandidate[];
+  currentIndex: number;
+  cfg: OpenClawConfig | undefined;
+  authRuntime: ModelFallbackAuthRuntime;
+  authStore: AuthProfileStore;
+  sessionId?: string;
+  agentId?: string;
+  sessionKey?: string;
+  resolveAgentHarnessRuntimeOverride?: (provider: string, model: string) => string | undefined;
+}): boolean {
+  for (let i = params.currentIndex + 1; i < params.candidates.length; i += 1) {
+    const candidate = params.candidates[i];
+    if (!candidate) {
+      continue;
+    }
+    if (
+      params.sessionId &&
+      isFallbackCandidateSkipped({
+        sessionId: params.sessionId,
+        provider: candidate.provider,
+        model: candidate.model,
+      })
+    ) {
+      continue;
+    }
+    const harnessAuth = resolveModelFallbackCandidateHarnessAuthCooldownPolicy({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      resolveAgentHarnessRuntimeOverride: params.resolveAgentHarnessRuntimeOverride,
+      ...candidate,
+    });
+    if (harnessAuth.skipsProviderAuthCooldown) {
+      return true;
+    }
+    const profileIds = params.authRuntime.resolveAuthProfileOrder({
+      cfg: params.cfg,
+      store: params.authStore,
+      provider: candidate.provider,
+    });
+    if (profileIds.length === 0) {
+      return true;
+    }
+    if (
+      profileIds.some(
+        (id) =>
+          !params.authRuntime.isProfileInCooldown(params.authStore, id, undefined, candidate.model),
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** @internal – exposed for unit tests only */
 export const probeThrottleInternals = {
   lastProbeAttempt,
@@ -1195,6 +1269,7 @@ function resolveCooldownDecision(params: {
   isPrimary: boolean;
   requestedModel: boolean;
   hasFallbackCandidates: boolean;
+  hasAvailableAuthFallbackCandidate: boolean;
   now: number;
   probeThrottleKey: string;
   authRuntime: ModelFallbackAuthRuntime;
@@ -1233,7 +1308,11 @@ function resolveCooldownDecision(params: {
   // single-provider setups on the throttle (no fallback chain to prefer) and
   // multi-fallback setups near cooldown expiry, so both recover without a restart.
   if (inferredReason === "billing") {
-    if (params.isPrimary && shouldProbe) {
+    const shouldProbeSingleProviderBilling =
+      params.isPrimary &&
+      !params.hasAvailableAuthFallbackCandidate &&
+      isProbeThrottleOpen(params.now, params.probeThrottleKey);
+    if (params.isPrimary && (shouldProbe || shouldProbeSingleProviderBilling)) {
       return { type: "attempt", reason: inferredReason, markProbe: true };
     }
     return {
@@ -1476,6 +1555,17 @@ async function runWithModelFallbackInternal<T>(
           isPrimary,
           requestedModel,
           hasFallbackCandidates,
+          hasAvailableAuthFallbackCandidate: hasLaterAvailableAuthFallbackCandidate({
+            candidates,
+            currentIndex: i,
+            cfg: params.cfg,
+            authRuntime,
+            authStore,
+            sessionId: params.sessionId,
+            agentId: params.agentId,
+            sessionKey: params.sessionKey,
+            resolveAgentHarnessRuntimeOverride: params.resolveAgentHarnessRuntimeOverride,
+          }),
           now,
           probeThrottleKey,
           authRuntime,

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -42,8 +42,13 @@ vi.mock("../plugins/provider-auth-choices.js", () => ({
   resolveManifestProviderAuthChoice,
 }));
 
+const authProfileStore = vi.hoisted(() => ({ version: 1, profiles: {} }));
 const upsertAuthProfile = vi.hoisted(() => vi.fn(() => ({ version: 1, profiles: {} })));
+const ensureAuthProfileStore = vi.hoisted(() => vi.fn(() => authProfileStore));
+const clearProviderAuthProfileCooldowns = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock("../agents/auth-profiles.js", () => ({
+  clearProviderAuthProfileCooldowns,
+  ensureAuthProfileStore,
   upsertAuthProfile,
   upsertAuthProfileWithLock: upsertAuthProfile,
 }));
@@ -222,6 +227,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     applyAuthProfileConfig.mockImplementation((config) => config);
+    ensureAuthProfileStore.mockReturnValue(authProfileStore);
     resolveManifestProviderAuthChoice.mockReturnValue(undefined);
     resolvePluginSetupProvider.mockReturnValue(undefined);
     resolveProviderInstallCatalogEntry.mockReturnValue(undefined);
@@ -588,6 +594,12 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       provider: LOCAL_PROVIDER_ID,
       mode: "api_key",
     });
+    expect(clearProviderAuthProfileCooldowns).toHaveBeenCalledWith({
+      store: authProfileStore,
+      provider: LOCAL_PROVIDER_ID,
+      profileIds: [LOCAL_PROFILE_ID],
+      agentDir: "/tmp/agent",
+    });
     expect(note).toHaveBeenCalledWith(
       "Detected local provider runtime.\nPulled model metadata.",
       "Provider notes",
@@ -615,6 +627,28 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     });
 
     expect(result.defaultModel).toBe("google/gemini-3.1-pro-preview");
+  });
+
+  it("keeps plugin auth successful when stale cooldown cleanup fails", async () => {
+    const provider = buildProvider();
+    resolvePluginProviders.mockReturnValue([provider]);
+    resolveProviderPluginChoice.mockReturnValue({
+      provider,
+      method: provider.auth[0],
+    });
+    clearProviderAuthProfileCooldowns.mockRejectedValueOnce(new Error("lock busy"));
+
+    const result = await applyAuthChoiceLoadedPluginProvider(buildParams());
+
+    expect(result?.config.agents?.defaults?.model).toEqual({
+      primary: LOCAL_DEFAULT_MODEL,
+    });
+    expect(clearProviderAuthProfileCooldowns).toHaveBeenCalledWith({
+      store: authProfileStore,
+      provider: LOCAL_PROVIDER_ID,
+      profileIds: [LOCAL_PROFILE_ID],
+      agentDir: "/tmp/agent",
+    });
   });
 
   it("replaces provider-owned default model maps during auth migrations", async () => {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -61,7 +61,7 @@ const mocks = vi.hoisted(() => ({
   loadAuthProfileStoreForRuntime: vi.fn(),
   listProfilesForProvider: vi.fn(),
   promoteAuthProfileInOrder: vi.fn(),
-  clearAuthProfileCooldown: vi.fn(),
+  clearProviderAuthProfileCooldowns: vi.fn(),
   resolvePluginSetupProvider: vi.fn(),
   resolvePluginSetupRegistry: vi.fn(),
 }));
@@ -79,7 +79,7 @@ vi.mock("../../agents/auth-profiles/store.js", () => ({
 }));
 
 vi.mock("../../agents/auth-profiles/usage.js", () => ({
-  clearAuthProfileCooldown: mocks.clearAuthProfileCooldown,
+  clearProviderAuthProfileCooldowns: mocks.clearProviderAuthProfileCooldowns,
 }));
 
 vi.mock("../../plugins/provider-auth-helpers.js", () => ({
@@ -418,7 +418,7 @@ describe("modelsAuthLoginCommand", () => {
     ]);
     mocks.loadAuthProfileStoreForRuntime.mockReturnValue({ profiles: {}, usageStats: {} });
     mocks.listProfilesForProvider.mockReturnValue([]);
-    mocks.clearAuthProfileCooldown.mockResolvedValue(undefined);
+    mocks.clearProviderAuthProfileCooldowns.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -471,12 +471,12 @@ describe("modelsAuthLoginCommand", () => {
         providerIds: ["openai"],
       },
     });
-    expect(mocks.clearAuthProfileCooldown).toHaveBeenCalledWith({
+    expect(mocks.clearProviderAuthProfileCooldowns).toHaveBeenCalledWith({
       store: fakeStore,
-      profileId: "openai:user@example.com",
+      provider: "openai",
       agentDir: "/tmp/openclaw/agents/main",
     });
-    expect(mocks.clearAuthProfileCooldown.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(mocks.clearProviderAuthProfileCooldowns.mock.invocationCallOrder[0]).toBeLessThan(
       runProviderAuth.mock.invocationCallOrder[0],
     );
     expect(runProviderAuth).toHaveBeenCalledOnce();
@@ -593,13 +593,6 @@ describe("modelsAuthLoginCommand", () => {
       select,
     });
     mocks.loadAuthProfileStoreForRuntime.mockReturnValue(fakeStore);
-    mocks.listProfilesForProvider.mockImplementation((_store: unknown, provider: string) =>
-      provider === "openai"
-        ? ["openai:api-key-backup"]
-        : provider === "openai"
-          ? ["openai:user@example.com"]
-          : [],
-    );
     mocks.resolvePluginProviders.mockReturnValue([
       createProvider({
         id: "openai",
@@ -647,12 +640,12 @@ describe("modelsAuthLoginCommand", () => {
     expect(runOauthAuth).toHaveBeenCalledOnce();
     expect(runApiKeyAuth).not.toHaveBeenCalled();
     expect(select).not.toHaveBeenCalled();
-    expect(mocks.clearAuthProfileCooldown).toHaveBeenCalledWith({
+    expect(mocks.clearProviderAuthProfileCooldowns).toHaveBeenCalledWith({
       store: fakeStore,
-      profileId: "openai:api-key-backup",
+      provider: "openai",
       agentDir: "/tmp/openclaw/agents/main",
     });
-    expect(mocks.clearAuthProfileCooldown).toHaveBeenCalledOnce();
+    expect(mocks.clearProviderAuthProfileCooldowns).toHaveBeenCalledOnce();
   });
 
   it("honors --method api-key for OpenAI login", async () => {
@@ -995,19 +988,14 @@ describe("modelsAuthLoginCommand", () => {
 
     expect(runClaudeCliMigration).toHaveBeenCalledOnce();
     expect(runApiKeyAuth).not.toHaveBeenCalled();
-    expect(mocks.clearAuthProfileCooldown).toHaveBeenCalledTimes(2);
-    expect(mocks.clearAuthProfileCooldown).toHaveBeenNthCalledWith(1, {
+    expect(mocks.clearProviderAuthProfileCooldowns).toHaveBeenCalledTimes(1);
+    expect(mocks.clearProviderAuthProfileCooldowns).toHaveBeenCalledWith({
       store: fakeStore,
-      profileId: "anthropic:claude-cli",
-      agentDir: "/tmp/openclaw/agents/main",
-    });
-    expect(mocks.clearAuthProfileCooldown).toHaveBeenNthCalledWith(2, {
-      store: fakeStore,
-      profileId: "anthropic:legacy",
+      provider: "anthropic",
       agentDir: "/tmp/openclaw/agents/main",
     });
     expect(
-      mocks.clearAuthProfileCooldown.mock.invocationCallOrder.every(
+      mocks.clearProviderAuthProfileCooldowns.mock.invocationCallOrder.every(
         (order) => order < runClaudeCliMigration.mock.invocationCallOrder[0],
       ),
     ).toBe(true);

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -26,13 +26,12 @@ import {
   removeProviderAuthProfilesWithLock,
 } from "../../agents/auth-profiles.js";
 import {
-  listProfilesForProvider,
   promoteAuthProfileInOrder,
   upsertAuthProfileWithLock,
 } from "../../agents/auth-profiles/profiles.js";
 import { loadAuthProfileStoreForRuntime } from "../../agents/auth-profiles/store.js";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
-import { clearAuthProfileCooldown } from "../../agents/auth-profiles/usage.js";
+import { clearProviderAuthProfileCooldowns } from "../../agents/auth-profiles/usage.js";
 import { normalizeProviderId } from "../../agents/model-selection-normalize.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
@@ -904,10 +903,7 @@ async function clearStaleProfileLockouts(provider: string, agentDir: string): Pr
     const store = loadAuthProfileStoreForRuntime(agentDir, {
       externalCli: externalCliDiscoveryForProviderAuth({ provider }),
     });
-    const profileIds = listProfilesForProvider(store, provider);
-    for (const profileId of profileIds) {
-      await clearAuthProfileCooldown({ store, profileId, agentDir });
-    }
+    await clearProviderAuthProfileCooldowns({ store, provider, agentDir });
   } catch {
     // Best-effort housekeeping — never block re-authentication.
   }

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -5,7 +5,11 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
-import { upsertAuthProfileWithLock } from "../agents/auth-profiles.js";
+import {
+  clearProviderAuthProfileCooldowns,
+  ensureAuthProfileStore,
+  upsertAuthProfileWithLock,
+} from "../agents/auth-profiles.js";
 import { formatLiteralProviderPrefixedModelRef } from "../agents/model-ref-shared.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import { normalizeAgentModelRefForConfig } from "../config/model-input.js";
@@ -225,6 +229,31 @@ async function loadPluginProviderRuntime() {
   return await providerAuthChoiceDeps.loadPluginProviderRuntime();
 }
 
+async function clearRefreshedProviderCooldowns(params: {
+  profiles: Array<{ profileId: string; credential: { provider: string } }>;
+  agentDir: string;
+}): Promise<void> {
+  const providers = [...new Set(params.profiles.map((profile) => profile.credential.provider))];
+  if (providers.length === 0) {
+    return;
+  }
+  try {
+    const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
+    for (const provider of providers) {
+      await clearProviderAuthProfileCooldowns({
+        store,
+        provider,
+        profileIds: params.profiles
+          .filter((profile) => profile.credential.provider === provider)
+          .map((profile) => profile.profileId),
+        agentDir: params.agentDir,
+      });
+    }
+  } catch {
+    // Best-effort recovery: a cleanup failure must not block successful auth setup.
+  }
+}
+
 function resolveManifestAuthChoiceScope(params: {
   authChoice: string;
   config: OpenClawConfig;
@@ -321,6 +350,7 @@ export async function runProviderPluginAuthMethod(params: {
         : {}),
     });
   }
+  await clearRefreshedProviderCooldowns({ profiles: result.profiles, agentDir });
 
   if (params.emitNotes !== false && result.notes && result.notes.length > 0) {
     await params.prompter.note(result.notes.join("\n"), "Provider notes");

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -93,6 +93,16 @@ function writeMigratedSessionState(stateDir: string): void {
   }
 }
 
+function cleanUpgradeSurvivorEnv(env: Record<string, string>): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(childEnv)) {
+    if (key.startsWith("OPENCLAW_UPGRADE_SURVIVOR_")) {
+      delete childEnv[key];
+    }
+  }
+  return { ...childEnv, ...env };
+}
+
 function assertConfiguredPluginState(params: { installPath?: string } = {}): void {
   const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-"));
   try {
@@ -131,13 +141,13 @@ function assertConfiguredPluginState(params: { installPath?: string } = {}): voi
     });
 
     execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-state"], {
-      env: {
-        ...process.env,
+      env: cleanUpgradeSurvivorEnv({
         OPENCLAW_STATE_DIR: stateDir,
         OPENCLAW_TEST_WORKSPACE_DIR: workspace,
+        OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE: "survival",
         OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON: coveragePath,
         OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "configured-plugin-installs",
-      },
+      }),
       stdio: "pipe",
     });
   } finally {
@@ -216,6 +226,24 @@ describe("upgrade survivor assertions", () => {
         assertConfiguredPluginState({ installPath: join(root, "outside-matrix") }),
       ).toThrow(/managed extensions root/);
     } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("ignores parent upgrade survivor stage when asserting configured plugin installs", () => {
+    const previousStage = process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE;
+    process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE = "baseline";
+    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-stage-"));
+    try {
+      expect(() =>
+        assertConfiguredPluginState({ installPath: join(root, "outside-matrix") }),
+      ).toThrow(/managed extensions root/);
+    } finally {
+      if (previousStage === undefined) {
+        delete process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE;
+      } else {
+        process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE = previousStage;
+      }
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -93,16 +93,6 @@ function writeMigratedSessionState(stateDir: string): void {
   }
 }
 
-function cleanUpgradeSurvivorEnv(env: Record<string, string>): NodeJS.ProcessEnv {
-  const childEnv: NodeJS.ProcessEnv = { ...process.env };
-  for (const key of Object.keys(childEnv)) {
-    if (key.startsWith("OPENCLAW_UPGRADE_SURVIVOR_")) {
-      delete childEnv[key];
-    }
-  }
-  return { ...childEnv, ...env };
-}
-
 function assertConfiguredPluginState(params: { installPath?: string } = {}): void {
   const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-"));
   try {
@@ -141,13 +131,13 @@ function assertConfiguredPluginState(params: { installPath?: string } = {}): voi
     });
 
     execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-state"], {
-      env: cleanUpgradeSurvivorEnv({
+      env: {
+        ...process.env,
         OPENCLAW_STATE_DIR: stateDir,
         OPENCLAW_TEST_WORKSPACE_DIR: workspace,
-        OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE: "survival",
         OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON: coveragePath,
         OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "configured-plugin-installs",
-      }),
+      },
       stdio: "pipe",
     });
   } finally {
@@ -226,24 +216,6 @@ describe("upgrade survivor assertions", () => {
         assertConfiguredPluginState({ installPath: join(root, "outside-matrix") }),
       ).toThrow(/managed extensions root/);
     } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
-  it("ignores parent upgrade survivor stage when asserting configured plugin installs", () => {
-    const previousStage = process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE;
-    process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE = "baseline";
-    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-stage-"));
-    try {
-      expect(() =>
-        assertConfiguredPluginState({ installPath: join(root, "outside-matrix") }),
-      ).toThrow(/managed extensions root/);
-    } finally {
-      if (previousStage === undefined) {
-        delete process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE;
-      } else {
-        process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE = previousStage;
-      }
       rmSync(root, { force: true, recursive: true });
     }
   });


### PR DESCRIPTION
## Summary

- Allow billing cooldown probes when configured model fallbacks share the same unavailable auth-profile path, instead of treating any configured fallback as a real recovery path.
- Clear stale provider auth-profile cooldown/disabled state after successful plugin/configure re-auth, reusing the same provider-level cleanup path for direct `models auth login`.
- Add focused coverage for same-auth billing fallback, config-aware fallback auth order, provider cooldown cleanup, runtime-overlay profile IDs, and best-effort plugin auth cleanup.

Fixes #70903.

## AI Assistance Disclosure

This PR was implemented with Codex assistance. I reviewed and understand the affected auth-profile fallback/configure path.

## Real behavior proof

Behavior addressed: Persistent file-backed provider lockouts from `auth-state.json` no longer keep a recovered billing/auth/profile path unavailable after a same-auth billing fallback chain or a successful plugin/configure re-auth.

Real environment tested: Local OpenClaw source checkout using production TypeScript modules with an isolated throwaway `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and agent dir. Fake credentials only.

Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` with an inline script that imported production `runWithModelFallback`, `saveAuthProfileStore`, `ensureAuthProfileStore`, and `runProviderPluginAuthMethod`; wrote fake profiles into an isolated agent dir; then exercised `anthropic/claude-opus-4-7` with `anthropic/claude-opus-4-6` sharing a billing-disabled auth profile, plus `github-copilot` plugin/configure auth refresh over stale format cooldown state.

Evidence after fix: terminal output from the isolated production-module proof:

```text
fallback_proof.result: billing-probe-recovered
fallback_proof.calls: [{"provider":"anthropic","model":"claude-opus-4-7","allowTransientCooldownProbe":true}]
fallback_proof.primary_probe_allowed: true
configure_proof.cleanup_cleared: true
configure_proof.profile_provider: github-copilot
```

Observed result after fix: The same-auth billing fallback case attempted the primary once with `allowTransientCooldownProbe: true`, and successful plugin/configure re-auth cleared stale `cooldownUntil`, `cooldownReason`, `disabledUntil`, `disabledReason`, `errorCount`, and `failureCounts` for the refreshed provider profile.

What was not tested: No live Anthropic, GitHub Copilot, or Claude CLI credentials were used. Remote Testbox `pnpm check:changed` was not run because this environment has no usable `crabbox` binary; the repo wrapper failed its sanity check before it could allocate Blacksmith Testbox.

## Root Cause

`runWithModelFallback` used the presence of later configured candidates as a proxy for available auth fallback capacity. For a primary and fallback that resolve to the same disabled auth profile, that proxy was false: the primary billing cooldown was skipped because a fallback existed, then the fallback was also skipped because the shared profile was still disabled.

Separately, direct `models auth login` already cleared stale profile lockouts after re-auth, but plugin/configure auth methods only upserted fresh credentials and applied config. They did not clear stale provider usage state.

## Dependency Contract

No external dependency behavior is changed or assumed. The patch relies on internal auth-profile contracts:

- `resetUsageStats` clears blocked/cooldown/disabled/error fields while preserving unrelated timestamps.
- `updateAuthProfileStoreWithLock` is the canonical locked mutation path for persisted auth-profile state.
- `resolveAuthProfileOrder` must receive the active config when checking configured auth/profile order.

## Regression Test Plan

- `src/agents/model-fallback.probe.test.ts`: same-provider billing fallback now probes the primary when later candidates share the unavailable auth path; helper uses config-aware auth order.
- `src/agents/auth-profiles/usage.test.ts`: provider cleanup clears matching profiles in one locked update, preserves other providers, handles runtime-overlay/external profile IDs, handles explicit refreshed profile IDs, and falls back to saving the provided store when locking is unavailable.
- `src/commands/auth-choice.apply.plugin-provider.test.ts`: plugin auth cleanup runs after successful auth and remains best-effort if cleanup fails.

## Security Impact

This does not change credential formats, storage locations, token material handling, or auth schemas. It clears stale usage/cooldown metadata only after explicit successful re-auth or direct provider login. If refreshed credentials are still invalid, the next provider failure records a fresh cooldown.

## Human Verification

I reviewed the fallback auth-profile decision path, provider auth choice flow, auth-profile usage cleanup, issue 70903 comments, related open/closed PR searches, and the final diff.

## CODEOWNERS / Owner Review

Expected CODEOWNERS review: `@openclaw/openclaw-secops` for `src/agents/*auth*.ts`, `src/agents/**/*auth*.ts`, and `src/agents/auth-profiles/`.

## Changelog

No `CHANGELOG.md` edit. Contributor PR should carry release-note context in the PR body/squash message if maintainers want it.

## Review conversations

No GitHub review conversations yet. Local `codex review --base origin/main` initially found config-aware auth order and TypeScript narrowing issues; both were fixed. Final review reported no actionable regressions.

## Risks

- Provider-level cleanup clears stale cooldown state for all refreshed provider profiles, not just the exact profile that failed previously. This mirrors the direct login recovery intent; a still-bad credential will re-enter cooldown on the next real failure.
- Remote Testbox proof is still desirable before marking ready if a reviewer wants hosted parity.

## Behavior tradeoffs

- Same-auth billing chains can probe the primary sooner, but the existing probe throttle still bounds retries.
- Healthy later fallbacks still suppress the primary billing probe, preserving normal fallback preference.

## Scope boundaries

- No config/default/schema changes.
- No doctor migration.
- No provider catalog, plugin SDK, credential format, or cooldown duration changes.
- No live provider behavior is mocked into production code.

## Validation

```bash
node scripts/run-vitest.mjs src/agents/model-fallback.probe.test.ts src/agents/auth-profiles/usage.test.ts src/commands/auth-choice.apply.plugin-provider.test.ts
# Test Files 5 passed; Tests 173 passed

pnpm tsgo:core
# exit 0

codex review --base origin/main
# No actionable regressions were found in the changed auth cooldown cleanup or model fallback probe logic.

node scripts/changed-lanes.mjs --json
# lanes: core=true, coreTests=true

OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs
# lanes=core, coreTests; exit 0
```
