### PR TITLE
fix(agents): run before_agent_finalize for embedded agents

### DIFF
--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -11,7 +11,10 @@ import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 
-function finalAnswerAttempt(text: string): EmbeddedRunAttemptResult {
+function finalAnswerAttempt(
+  text: string,
+  overrides?: Partial<EmbeddedRunAttemptResult>,
+): EmbeddedRunAttemptResult {
   return makeAttemptResult({
     assistantTexts: [text],
     lastAssistant: {
@@ -26,6 +29,7 @@ function finalAnswerAttempt(text: string): EmbeddedRunAttemptResult {
         content: [{ type: "text", text }],
       } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
     ],
+    ...overrides,
   });
 }
 
@@ -52,7 +56,7 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     );
   });
 
-  it("runs the hook before accepting a normal embedded final answer", async () => {
+  it("passes the finalize revision budget to embedded attempts", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(finalAnswerAttempt("First answer."));
 
     await runEmbeddedAgent({
@@ -62,41 +66,22 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
       runId: "run-before-finalize-continue",
     });
 
-    expect(mockedGlobalHookRunner.runBeforeAgentFinalize).toHaveBeenCalledTimes(1);
-    expect(mockedGlobalHookRunner.runBeforeAgentFinalize).toHaveBeenCalledWith(
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
-        runId: "run-before-finalize-continue",
-        sessionId: "test-session",
-        sessionKey: "test-key",
-        provider: "openai",
-        model: "gpt-5.5",
-        stopHookActive: false,
-        lastAssistantMessage: "First answer.",
-      }),
-      expect.objectContaining({
-        runId: "run-before-finalize-continue",
-        sessionId: "test-session",
-        sessionKey: "test-key",
-        modelProviderId: "openai",
-        modelId: "gpt-5.5",
+        beforeAgentFinalizeRevisionAttempts: 0,
+        maxBeforeAgentFinalizeRevisions: 3,
       }),
     );
   });
 
   it("turns a revise decision into one more hidden continuation", async () => {
-    mockedGlobalHookRunner.runBeforeAgentFinalize
-      .mockResolvedValueOnce({
-        action: "revise",
-        reason: "Tighten the final wording.",
-        retry: {
-          instruction: "Mention the validated behavior.",
-          idempotencyKey: "wording",
-          maxAttempts: 1,
-        },
-      })
-      .mockResolvedValueOnce({ action: "continue" });
     mockedRunEmbeddedAttempt
-      .mockResolvedValueOnce(finalAnswerAttempt("First answer."))
+      .mockResolvedValueOnce(
+        finalAnswerAttempt("First answer.", {
+          beforeAgentFinalizeRevisionReason:
+            "Tighten the final wording.\n\nMention the validated behavior.",
+        }),
+      )
       .mockResolvedValueOnce(finalAnswerAttempt("Revised answer."));
 
     await runEmbeddedAgent({
@@ -113,11 +98,7 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     expect(attemptCall(1).suppressNextUserMessagePersistence).toBe(true);
   });
 
-  it("does not retry a revise decision after potential side effects", async () => {
-    mockedGlobalHookRunner.runBeforeAgentFinalize.mockResolvedValueOnce({
-      action: "revise",
-      reason: "Please revise.",
-    });
+  it("keeps finalizing when the attempt accepted a side-effecting revise decision", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Sent."],
@@ -138,7 +119,31 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
       runId: "run-before-finalize-side-effect",
     });
 
-    expect(mockedGlobalHookRunner.runBeforeAgentFinalize).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry finalize revisions after a timed-out attempt", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      finalAnswerAttempt("Late answer.", {
+        timedOut: true,
+        beforeAgentFinalizeRevisionReason: "Revise the late answer.",
+        promptTimeoutOutcome: {
+          message: "Request timed out.",
+          replayInvalid: true,
+          livenessState: "blocked",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      }),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-before-finalize-timeout",
+    });
+
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -1,0 +1,144 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedGlobalHookRunner,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
+
+function finalAnswerAttempt(text: string): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    assistantTexts: [text],
+    lastAssistant: {
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text }],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    messagesSnapshot: [
+      {
+        role: "assistant",
+        content: [{ type: "text", text }],
+      } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+    ],
+  });
+}
+
+function attemptCall(index: number): {
+  prompt?: string;
+  suppressNextUserMessagePersistence?: boolean;
+} {
+  const call = mockedRunEmbeddedAttempt.mock.calls[index];
+  if (!call) {
+    throw new Error(`Expected embedded attempt call ${index}`);
+  }
+  return call[0] as { prompt?: string; suppressNextUserMessagePersistence?: boolean };
+}
+
+describe("runEmbeddedAgent before_agent_finalize", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+    mockedGlobalHookRunner.hasHooks.mockImplementation(
+      (hookName: string) => hookName === "before_agent_finalize",
+    );
+  });
+
+  it("runs the hook before accepting a normal embedded final answer", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(finalAnswerAttempt("First answer."));
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-before-finalize-continue",
+    });
+
+    expect(mockedGlobalHookRunner.runBeforeAgentFinalize).toHaveBeenCalledTimes(1);
+    expect(mockedGlobalHookRunner.runBeforeAgentFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-before-finalize-continue",
+        sessionId: "test-session",
+        sessionKey: "test-key",
+        provider: "openai",
+        model: "gpt-5.5",
+        stopHookActive: false,
+        lastAssistantMessage: "First answer.",
+      }),
+      expect.objectContaining({
+        runId: "run-before-finalize-continue",
+        sessionId: "test-session",
+        sessionKey: "test-key",
+        modelProviderId: "openai",
+        modelId: "gpt-5.5",
+      }),
+    );
+  });
+
+  it("turns a revise decision into one more hidden continuation", async () => {
+    mockedGlobalHookRunner.runBeforeAgentFinalize
+      .mockResolvedValueOnce({
+        action: "revise",
+        reason: "Tighten the final wording.",
+        retry: {
+          instruction: "Mention the validated behavior.",
+          idempotencyKey: "wording",
+          maxAttempts: 1,
+        },
+      })
+      .mockResolvedValueOnce({ action: "continue" });
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(finalAnswerAttempt("First answer."))
+      .mockResolvedValueOnce(finalAnswerAttempt("Revised answer."));
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-before-finalize-revise",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(attemptCall(1).prompt).toContain("Tighten the final wording.");
+    expect(attemptCall(1).prompt).toContain("Mention the validated behavior.");
+    expect(attemptCall(1).prompt).not.toContain("hello");
+    expect(attemptCall(1).suppressNextUserMessagePersistence).toBe(true);
+  });
+
+  it("does not retry a revise decision after potential side effects", async () => {
+    mockedGlobalHookRunner.runBeforeAgentFinalize.mockResolvedValueOnce({
+      action: "revise",
+      reason: "Please revise.",
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Sent."],
+        didSendViaMessagingTool: true,
+        lastAssistant: {
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "Sent." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-before-finalize-side-effect",
+    });
+
+    expect(mockedGlobalHookRunner.runBeforeAgentFinalize).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -3,6 +3,10 @@ import { type Mock, vi } from "vitest";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
+  PluginHookBeforeAgentFinalizeEvent,
+  PluginHookBeforeAgentFinalizeResult,
+} from "../../plugins/hook-types.js";
+import type {
   PluginHookAgentContext,
   PluginHookBeforeAgentReplyResult,
   PluginHookBeforeAgentStartResult,
@@ -54,6 +58,12 @@ export const mockedGlobalHookRunner = {
       _eventValue: { prompt: string; messages?: unknown[] },
       _ctx: PluginHookAgentContext,
     ): Promise<PluginHookBeforeAgentStartResult | undefined> => undefined,
+  ),
+  runBeforeAgentFinalize: vi.fn(
+    async (
+      _eventValue: PluginHookBeforeAgentFinalizeEvent,
+      _ctx: PluginHookAgentContext,
+    ): Promise<PluginHookBeforeAgentFinalizeResult | undefined> => undefined,
   ),
   runBeforePromptBuild: vi.fn(
     async (
@@ -266,6 +276,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedGlobalHookRunner.runBeforeAgentReply.mockResolvedValue(undefined);
   mockedGlobalHookRunner.runBeforeAgentStart.mockReset();
   mockedGlobalHookRunner.runBeforeAgentStart.mockResolvedValue(undefined);
+  mockedGlobalHookRunner.runBeforeAgentFinalize.mockReset();
+  mockedGlobalHookRunner.runBeforeAgentFinalize.mockResolvedValue(undefined);
   mockedGlobalHookRunner.runBeforePromptBuild.mockReset();
   mockedGlobalHookRunner.runBeforePromptBuild.mockResolvedValue(undefined);
   mockedGlobalHookRunner.runBeforeModelResolve.mockReset();

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -72,6 +72,7 @@ import {
   FailoverError,
   resolveFailoverStatus,
 } from "../failover-error.js";
+import { runAgentHarnessBeforeAgentFinalizeHook } from "../harness/lifecycle-hook-helpers.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import { selectAgentHarness } from "../harness/selection.js";
 import { LiveSessionModelSwitchError } from "../live-model-switch-error.js";
@@ -209,6 +210,9 @@ const MID_TURN_PRECHECK_CONTINUATION_PROMPT =
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 const NO_REAL_CONVERSATION_MESSAGES_REASON = "no real conversation messages";
+const BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX =
+  "Before accepting the previous final answer, apply this revision request and produce the revised final answer. Do not repeat completed work or rerun tools unless the request explicitly requires it.";
+const MAX_BEFORE_AGENT_FINALIZE_REVISIONS = 3;
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
 
 function isNoRealConversationCompactionNoop(params: {
@@ -265,6 +269,10 @@ function resolveAttemptDispatchApiKey(params: {
     return undefined;
   }
   return params.apiKeyInfo?.apiKey;
+}
+
+function buildBeforeAgentFinalizeRetryPrompt(reason: string): string {
+  return `${BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX}\n\n${reason}`;
 }
 
 function resolveEmbeddedRunLaneTimeoutMs(timeoutMs: number): number | undefined {
@@ -1172,6 +1180,7 @@ export async function runEmbeddedAgent(
       let reasoningOnlyRetryAttempts = 0;
       let emptyResponseRetryAttempts = 0;
       let compactionContinuationRetryAttempts = 0;
+      let beforeAgentFinalizeRevisionAttempts = 0;
       let sameModelIdleTimeoutRetries = 0;
       // Cost-runaway breaker for #76293. State lives at the run-loop level
       // on purpose so it survives across attempt boundaries and across
@@ -3479,6 +3488,83 @@ export async function runEmbeddedAgent(
               successfulCronAdds: attempt.successfulCronAdds,
               acceptedSessionSpawns: attempt.acceptedSessionSpawns,
             };
+          }
+
+          const beforeAgentFinalizeLastAssistantMessage =
+            normalizeOptionalString(finalAssistantVisibleText) ??
+            normalizeOptionalString(finalAssistantRawText) ??
+            normalizeOptionalString((attempt.assistantTexts ?? []).join("\n\n"));
+          if (
+            beforeAgentFinalizeLastAssistantMessage &&
+            !aborted &&
+            !promptError &&
+            !timedOut &&
+            !attempt.clientToolCalls &&
+            !attempt.yieldDetected &&
+            !emptyAssistantReplyIsSilent &&
+            hookRunner?.hasHooks("before_agent_finalize")
+          ) {
+            const finalizeOutcome = await runAgentHarnessBeforeAgentFinalizeHook({
+              event: {
+                runId: params.runId,
+                sessionId: sessionIdUsed,
+                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+                provider: reportedModelRef.provider,
+                model: reportedModelRef.model,
+                ...((params.cwd ?? resolvedWorkspace)
+                  ? { cwd: params.cwd ?? resolvedWorkspace }
+                  : {}),
+                ...(activeSessionFile ? { transcriptPath: activeSessionFile } : {}),
+                stopHookActive: false,
+                lastAssistantMessage: beforeAgentFinalizeLastAssistantMessage,
+                messages: attempt.messagesSnapshot,
+              },
+              ctx: {
+                runId: params.runId,
+                agentId: workspaceResolution.agentId,
+                sessionKey: params.sessionKey,
+                sessionId: sessionIdUsed,
+                workspaceDir: resolvedWorkspace,
+                modelProviderId: reportedModelRef.provider,
+                modelId: reportedModelRef.model,
+                trigger: params.trigger,
+                ...buildAgentHookContextChannelFields(params),
+              },
+              hookRunner,
+            });
+            if (finalizeOutcome.action === "revise") {
+              const replayMetadataForFinalize = resolveAttemptReplayMetadata(attempt);
+              if (replayMetadataForFinalize.hadPotentialSideEffects) {
+                log.warn(
+                  `before_agent_finalize requested revision after potential side effects; finalizing ` +
+                    `runId=${params.runId} sessionId=${params.sessionId}`,
+                );
+              } else if (
+                beforeAgentFinalizeRevisionAttempts >= MAX_BEFORE_AGENT_FINALIZE_REVISIONS
+              ) {
+                log.warn(
+                  `before_agent_finalize revision limit reached; finalizing ` +
+                    `runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `attempts=${beforeAgentFinalizeRevisionAttempts}/${MAX_BEFORE_AGENT_FINALIZE_REVISIONS}`,
+                );
+              } else {
+                beforeAgentFinalizeRevisionAttempts += 1;
+                nextAttemptPromptOverride = buildBeforeAgentFinalizeRetryPrompt(
+                  finalizeOutcome.reason,
+                );
+                suppressNextUserMessagePersistence = true;
+                planningOnlyRetryInstruction = null;
+                reasoningOnlyRetryInstruction = null;
+                emptyResponseRetryInstruction = null;
+                compactionContinuationRetryInstruction = null;
+                log.warn(
+                  `before_agent_finalize requested one more pass: ` +
+                    `runId=${params.runId} sessionId=${params.sessionId} ` +
+                    `attempt=${beforeAgentFinalizeRevisionAttempts}/${MAX_BEFORE_AGENT_FINALIZE_REVISIONS}`,
+                );
+                continue;
+              }
+            }
           }
 
           log.debug(

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -72,7 +72,6 @@ import {
   FailoverError,
   resolveFailoverStatus,
 } from "../failover-error.js";
-import { runAgentHarnessBeforeAgentFinalizeHook } from "../harness/lifecycle-hook-helpers.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import { selectAgentHarness } from "../harness/selection.js";
 import { LiveSessionModelSwitchError } from "../live-model-switch-error.js";
@@ -1683,6 +1682,8 @@ export async function runEmbeddedAgent(
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
             suppressNextUserMessagePersistence,
+            beforeAgentFinalizeRevisionAttempts,
+            maxBeforeAgentFinalizeRevisions: MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
             suppressTranscriptOnlyAssistantPersistence:
               params.suppressTranscriptOnlyAssistantPersistence,
             suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
@@ -3490,81 +3491,30 @@ export async function runEmbeddedAgent(
             };
           }
 
-          const beforeAgentFinalizeLastAssistantMessage =
-            normalizeOptionalString(finalAssistantVisibleText) ??
-            normalizeOptionalString(finalAssistantRawText) ??
-            normalizeOptionalString((attempt.assistantTexts ?? []).join("\n\n"));
-          if (
-            beforeAgentFinalizeLastAssistantMessage &&
+          const beforeAgentFinalizeRevisionReason = attempt.beforeAgentFinalizeRevisionReason;
+          const shouldHonorBeforeAgentFinalizeRevision =
             !aborted &&
             !promptError &&
             !timedOut &&
             !attempt.clientToolCalls &&
             !attempt.yieldDetected &&
-            !emptyAssistantReplyIsSilent &&
-            hookRunner?.hasHooks("before_agent_finalize")
-          ) {
-            const finalizeOutcome = await runAgentHarnessBeforeAgentFinalizeHook({
-              event: {
-                runId: params.runId,
-                sessionId: sessionIdUsed,
-                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-                provider: reportedModelRef.provider,
-                model: reportedModelRef.model,
-                ...((params.cwd ?? resolvedWorkspace)
-                  ? { cwd: params.cwd ?? resolvedWorkspace }
-                  : {}),
-                ...(activeSessionFile ? { transcriptPath: activeSessionFile } : {}),
-                stopHookActive: false,
-                lastAssistantMessage: beforeAgentFinalizeLastAssistantMessage,
-                messages: attempt.messagesSnapshot,
-              },
-              ctx: {
-                runId: params.runId,
-                agentId: workspaceResolution.agentId,
-                sessionKey: params.sessionKey,
-                sessionId: sessionIdUsed,
-                workspaceDir: resolvedWorkspace,
-                modelProviderId: reportedModelRef.provider,
-                modelId: reportedModelRef.model,
-                trigger: params.trigger,
-                ...buildAgentHookContextChannelFields(params),
-              },
-              hookRunner,
-            });
-            if (finalizeOutcome.action === "revise") {
-              const replayMetadataForFinalize = resolveAttemptReplayMetadata(attempt);
-              if (replayMetadataForFinalize.hadPotentialSideEffects) {
-                log.warn(
-                  `before_agent_finalize requested revision after potential side effects; finalizing ` +
-                    `runId=${params.runId} sessionId=${params.sessionId}`,
-                );
-              } else if (
-                beforeAgentFinalizeRevisionAttempts >= MAX_BEFORE_AGENT_FINALIZE_REVISIONS
-              ) {
-                log.warn(
-                  `before_agent_finalize revision limit reached; finalizing ` +
-                    `runId=${params.runId} sessionId=${params.sessionId} ` +
-                    `attempts=${beforeAgentFinalizeRevisionAttempts}/${MAX_BEFORE_AGENT_FINALIZE_REVISIONS}`,
-                );
-              } else {
-                beforeAgentFinalizeRevisionAttempts += 1;
-                nextAttemptPromptOverride = buildBeforeAgentFinalizeRetryPrompt(
-                  finalizeOutcome.reason,
-                );
-                suppressNextUserMessagePersistence = true;
-                planningOnlyRetryInstruction = null;
-                reasoningOnlyRetryInstruction = null;
-                emptyResponseRetryInstruction = null;
-                compactionContinuationRetryInstruction = null;
-                log.warn(
-                  `before_agent_finalize requested one more pass: ` +
-                    `runId=${params.runId} sessionId=${params.sessionId} ` +
-                    `attempt=${beforeAgentFinalizeRevisionAttempts}/${MAX_BEFORE_AGENT_FINALIZE_REVISIONS}`,
-                );
-                continue;
-              }
-            }
+            !emptyAssistantReplyIsSilent;
+          if (beforeAgentFinalizeRevisionReason && shouldHonorBeforeAgentFinalizeRevision) {
+            beforeAgentFinalizeRevisionAttempts += 1;
+            nextAttemptPromptOverride = buildBeforeAgentFinalizeRetryPrompt(
+              beforeAgentFinalizeRevisionReason,
+            );
+            suppressNextUserMessagePersistence = true;
+            planningOnlyRetryInstruction = null;
+            reasoningOnlyRetryInstruction = null;
+            emptyResponseRetryInstruction = null;
+            compactionContinuationRetryInstruction = null;
+            log.warn(
+              `before_agent_finalize requested one more pass: ` +
+                `runId=${params.runId} sessionId=${params.sessionId} ` +
+                `attempt=${beforeAgentFinalizeRevisionAttempts}/${MAX_BEFORE_AGENT_FINALIZE_REVISIONS}`,
+            );
+            continue;
           }
 
           log.debug(

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -104,6 +104,7 @@ export function createSubscriptionMock(): SubscriptionMock {
     unsubscribe: () => {},
     setTerminalLifecycleMeta: () => {},
     waitForCompactionRetry: async () => {},
+    waitForPendingEvents: async () => {},
     getAcceptedSessionSpawns: () => [],
     getMessagingToolSentTexts: () => [] as string[],
     getMessagingToolSentMediaUrls: () => [] as string[],

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -6,6 +6,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { isAcpRuntimeSpawnAvailable } from "../../../acp/runtime/availability.js";
 import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
 import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { getRuntimeConfig } from "../../../config/config.js";
 import { resolveStorePath } from "../../../config/sessions/paths.js";
 import {
@@ -148,6 +149,7 @@ import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handle
 import { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { runAgentEndSideEffects } from "../../harness/agent-end-side-effects.js";
+import { runAgentHarnessBeforeAgentFinalizeHook } from "../../harness/lifecycle-hook-helpers.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import {
@@ -417,7 +419,11 @@ import {
   selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
-import { resolveFinalAssistantVisibleText } from "./helpers.js";
+import {
+  resolveFinalAssistantRawText,
+  resolveFinalAssistantVisibleText,
+  resolveReportedModelRef,
+} from "./helpers.js";
 import {
   installHistoryImagePruneContextTransform,
   pruneProcessedHistoryImages,
@@ -3050,11 +3056,119 @@ export async function runEmbeddedAttempt(
         withOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, async () =>
           abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options))),
         );
+      // Hook runner was already obtained earlier before tool creation.
+      const hookAgentId = sessionAgentId;
+      let beforeAgentFinalizeRevisionReason: string | undefined;
       const onBlockReply = params.onBlockReply
         ? bindOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, params.onBlockReply)
         : undefined;
       const onBlockReplyFlush = params.onBlockReplyFlush
         ? bindOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, params.onBlockReplyFlush)
+        : undefined;
+      const onBeforeTerminalDelivery = hookRunner?.hasHooks("before_agent_finalize")
+        ? async (event: {
+            messages: AgentMessage[];
+            willRetry: boolean;
+            lastAssistant?: AgentMessage;
+            assistantTexts: readonly string[];
+            hasAssistantVisibleText: boolean;
+            isError: boolean;
+            incompleteTerminalAssistant: boolean;
+            hadDeterministicSideEffect: boolean;
+          }): Promise<void | { suppressTerminalDelivery: true }> => {
+            if (
+              beforeAgentFinalizeRevisionReason ||
+              event.willRetry ||
+              event.isError ||
+              event.incompleteTerminalAssistant ||
+              !event.hasAssistantVisibleText
+            ) {
+              return;
+            }
+            const lastAssistant = event.lastAssistant as AssistantMessage | undefined;
+            const lastAssistantMessage =
+              normalizeOptionalString(resolveFinalAssistantVisibleText(lastAssistant)) ??
+              normalizeOptionalString(resolveFinalAssistantRawText(lastAssistant)) ??
+              normalizeOptionalString(event.assistantTexts.join("\n\n"));
+            if (!lastAssistantMessage) {
+              return;
+            }
+            const hasCompletedClientToolCall = clientToolCallSlots.some((slot) => slot.completed);
+            const silentFinalReply =
+              params.silentExpected && isSilentReplyText(lastAssistantMessage, SILENT_REPLY_TOKEN);
+            if (
+              aborted ||
+              promptError ||
+              timedOut ||
+              hasCompletedClientToolCall ||
+              yieldDetected ||
+              silentFinalReply
+            ) {
+              return;
+            }
+            const hookMessages = projectToolSearchTargetTranscriptMessages(
+              activeSession.messages.slice(),
+              toolSearchTargetTranscriptProjections,
+            );
+            const reportedModelRef = resolveReportedModelRef({
+              provider: params.provider,
+              model: params.modelId,
+              assistant: lastAssistant,
+            });
+            const maxRevisionAttempts = params.maxBeforeAgentFinalizeRevisions ?? 0;
+            if (
+              maxRevisionAttempts > 0 &&
+              (params.beforeAgentFinalizeRevisionAttempts ?? 0) >= maxRevisionAttempts
+            ) {
+              log.warn(
+                `before_agent_finalize revision limit reached; finalizing ` +
+                  `runId=${params.runId} sessionId=${params.sessionId} ` +
+                  `attempts=${params.beforeAgentFinalizeRevisionAttempts ?? 0}/${maxRevisionAttempts}`,
+              );
+              return;
+            }
+            const outcome = await runAgentHarnessBeforeAgentFinalizeHook({
+              event: {
+                runId: params.runId,
+                sessionId: params.sessionId,
+                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+                provider: reportedModelRef.provider,
+                model: reportedModelRef.model,
+                ...((params.cwd ?? params.workspaceDir)
+                  ? { cwd: params.cwd ?? params.workspaceDir }
+                  : {}),
+                ...(params.sessionFile ? { transcriptPath: params.sessionFile } : {}),
+                stopHookActive: false,
+                lastAssistantMessage,
+                messages: hookMessages,
+              },
+              ctx: {
+                runId: params.runId,
+                trace: freezeDiagnosticTraceContext(diagnosticTrace),
+                agentId: hookAgentId,
+                sessionKey: params.sessionKey,
+                sessionId: params.sessionId,
+                workspaceDir: params.workspaceDir,
+                modelProviderId: reportedModelRef.provider,
+                modelId: reportedModelRef.model,
+                trigger: params.trigger,
+                ...buildAgentHookContextChannelFields(params),
+              },
+              hookRunner,
+            });
+            if (outcome.action !== "revise") {
+              return;
+            }
+            if (event.hadDeterministicSideEffect) {
+              log.warn(
+                `before_agent_finalize requested revision after potential side effects; finalizing ` +
+                  `runId=${params.runId} sessionId=${params.sessionId}`,
+              );
+              return;
+            }
+            beforeAgentFinalizeRevisionReason = outcome.reason;
+            return { suppressTerminalDelivery: true };
+          }
         : undefined;
 
       let toolMetasForTerminal: readonly AsyncStartedToolMeta[] = [];
@@ -3077,6 +3191,7 @@ export async function runEmbeddedAttempt(
           onReasoningEnd: params.onReasoningEnd,
           onBlockReply,
           onBlockReplyFlush,
+          onBeforeTerminalDelivery,
           blockReplyBreak: params.blockReplyBreak,
           blockReplyChunking: params.blockReplyChunking,
           onPartialReply: params.onPartialReply,
@@ -3138,6 +3253,7 @@ export async function runEmbeddedAttempt(
         getUsageTotals,
         getCompactionCount,
         getLastCompactionTokensAfter,
+        waitForPendingEvents,
       } = subscription;
       toolMetasForTerminal = toolMetas;
       isCompactionPendingForExternalSignal = subscription.isCompacting;
@@ -3309,9 +3425,6 @@ export async function runEmbeddedAttempt(
           });
         }
       }
-
-      // Hook runner was already obtained earlier before tool creation
-      const hookAgentId = sessionAgentId;
 
       const activeSessionManager = sessionManager;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
@@ -4283,6 +4396,7 @@ export async function runEmbeddedAttempt(
         }
 
         await sessionLockController.waitForSessionEvents(activeSession);
+        await waitForPendingEvents();
         await sessionLockController.releaseForPrompt();
 
         if (
@@ -4513,7 +4627,7 @@ export async function runEmbeddedAttempt(
         // Let the active context engine run its post-turn lifecycle. These hooks
         // may call runtime LLM capabilities, so only their transcript rewrite
         // helper reacquires the session write lock.
-        if (activeContextEngine) {
+        if (activeContextEngine && !beforeAgentFinalizeRevisionReason) {
           const afterTurnRuntimeContext = buildAfterTurnRuntimeContextFromUsage({
             attempt: params,
             workspaceDir: effectiveWorkspace,
@@ -4556,58 +4670,60 @@ export async function runEmbeddedAttempt(
           });
         }
 
-        await sessionLockController.waitForSessionEvents(activeSession);
-        await sessionLockController.withSessionWriteLock(async () => {
-          if (
-            shouldPersistCompletedBootstrapTurn({
-              shouldRecordCompletedBootstrapTurn,
-              promptError,
-              aborted,
-              timedOutDuringCompaction,
-              compactionOccurredThisAttempt,
-            })
-          ) {
-            try {
-              activeSessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, {
-                timestamp: Date.now(),
-                runId: params.runId,
-                sessionId: params.sessionId,
-              });
-            } catch (entryErr) {
-              log.warn(`failed to persist bootstrap completion entry: ${String(entryErr)}`);
-            }
-          }
-
-          if (
-            compactionOccurredThisAttempt &&
-            !promptError &&
-            !aborted &&
-            !timedOut &&
-            !idleTimedOut &&
-            !timedOutDuringCompaction &&
-            shouldRotateCompactionTranscript(params.config)
-          ) {
-            try {
-              const rotation = await rotateTranscriptAfterCompaction({
-                sessionManager: activeSessionManager,
-                sessionFile: params.sessionFile,
-              });
-              if (rotation.rotated) {
-                sessionIdUsed = rotation.sessionId ?? sessionIdUsed;
-                sessionFileUsed = rotation.sessionFile ?? sessionFileUsed;
-                updateActiveEmbeddedRunSessionFile(params.sessionId, sessionFileUsed);
-                log.info(
-                  `[compaction] rotated active transcript after automatic compaction ` +
-                    `(sessionKey=${params.sessionKey ?? params.sessionId})`,
-                );
+        if (!beforeAgentFinalizeRevisionReason) {
+          await sessionLockController.waitForSessionEvents(activeSession);
+          await sessionLockController.withSessionWriteLock(async () => {
+            if (
+              shouldPersistCompletedBootstrapTurn({
+                shouldRecordCompletedBootstrapTurn,
+                promptError,
+                aborted,
+                timedOutDuringCompaction,
+                compactionOccurredThisAttempt,
+              })
+            ) {
+              try {
+                activeSessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, {
+                  timestamp: Date.now(),
+                  runId: params.runId,
+                  sessionId: params.sessionId,
+                });
+              } catch (entryErr) {
+                log.warn(`failed to persist bootstrap completion entry: ${String(entryErr)}`);
               }
-            } catch (err) {
-              log.warn("[compaction] automatic transcript rotation failed", {
-                errorMessage: formatErrorMessage(err),
-              });
             }
-          }
-        });
+
+            if (
+              compactionOccurredThisAttempt &&
+              !promptError &&
+              !aborted &&
+              !timedOut &&
+              !idleTimedOut &&
+              !timedOutDuringCompaction &&
+              shouldRotateCompactionTranscript(params.config)
+            ) {
+              try {
+                const rotation = await rotateTranscriptAfterCompaction({
+                  sessionManager: activeSessionManager,
+                  sessionFile: params.sessionFile,
+                });
+                if (rotation.rotated) {
+                  sessionIdUsed = rotation.sessionId ?? sessionIdUsed;
+                  sessionFileUsed = rotation.sessionFile ?? sessionFileUsed;
+                  updateActiveEmbeddedRunSessionFile(params.sessionId, sessionFileUsed);
+                  log.info(
+                    `[compaction] rotated active transcript after automatic compaction ` +
+                      `(sessionKey=${params.sessionKey ?? params.sessionId})`,
+                  );
+                }
+              } catch (err) {
+                log.warn("[compaction] automatic transcript rotation failed", {
+                  errorMessage: formatErrorMessage(err),
+                });
+              }
+            }
+          });
+        }
 
         cacheTrace?.recordStage("session:after", {
           messages: messagesSnapshot,
@@ -4619,26 +4735,28 @@ export async function runEmbeddedAttempt(
         });
         anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
 
-        runAgentEndSideEffects({
-          event: {
-            messages: messagesSnapshot,
-            success: !aborted && !promptError,
-            error: promptError ? formatErrorMessage(promptError) : undefined,
-            durationMs: Date.now() - promptStartedAt,
-          },
-          ctx: {
-            runId: params.runId,
-            trace: freezeDiagnosticTraceContext(diagnosticTrace),
-            agentId: hookAgentId,
-            sessionKey: params.sessionKey,
-            sessionId: params.sessionId,
-            workspaceDir: params.workspaceDir,
-            trigger: params.trigger,
-            ...(params.config ? { config: params.config } : {}),
-            ...buildAgentHookContextChannelFields(params),
-          },
-          hookRunner,
-        });
+        if (!beforeAgentFinalizeRevisionReason) {
+          runAgentEndSideEffects({
+            event: {
+              messages: messagesSnapshot,
+              success: !aborted && !promptError,
+              error: promptError ? formatErrorMessage(promptError) : undefined,
+              durationMs: Date.now() - promptStartedAt,
+            },
+            ctx: {
+              runId: params.runId,
+              trace: freezeDiagnosticTraceContext(diagnosticTrace),
+              agentId: hookAgentId,
+              sessionKey: params.sessionKey,
+              sessionId: params.sessionId,
+              workspaceDir: params.workspaceDir,
+              trigger: params.trigger,
+              ...(params.config ? { config: params.config } : {}),
+              ...buildAgentHookContextChannelFields(params),
+            },
+            hookRunner,
+          });
+        }
       } finally {
         clearTimeout(abortTimer);
         if (abortWarnTimer) {
@@ -4987,6 +5105,7 @@ export async function runEmbeddedAttempt(
         systemPromptReport,
         finalPromptText,
         messagesSnapshot,
+        ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),
         assistantTexts,
         toolMetas: toolMetasNormalized,
         acceptedSessionSpawns,

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -74,6 +74,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   modelRegistry: ModelRegistry;
   thinkLevel: ThinkLevel;
   beforeAgentStartResult?: PluginHookBeforeAgentStartResult;
+  beforeAgentFinalizeRevisionAttempts?: number;
+  maxBeforeAgentFinalizeRevisions?: number;
 };
 
 export type EmbeddedRunAttemptResult = {
@@ -141,6 +143,7 @@ export type EmbeddedRunAttemptResult = {
   systemPromptReport?: SessionSystemPromptReport;
   finalPromptText?: string;
   messagesSnapshot: AgentMessage[];
+  beforeAgentFinalizeRevisionReason?: string;
   assistantTexts: string[];
   toolMetas: Array<{
     toolName: string;

--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  emitAssistantTextDeltaAndEnd,
+  createSubscribedSessionHarness,
+  emitMessageStartAndEndForAssistantText,
+} from "./embedded-agent-subscribe.e2e-harness.js";
+
+function hasAssistantEvent(calls: Array<unknown[]>): boolean {
+  return calls.some((call) => {
+    const event = call[0] as { stream?: string } | undefined;
+    return event?.stream === "assistant";
+  });
+}
+
+function hasLifecycleEndEvent(calls: Array<unknown[]>): boolean {
+  return calls.some((call) => {
+    const event = call[0] as { stream?: string; data?: { phase?: string } } | undefined;
+    return event?.stream === "lifecycle" && event.data?.phase === "end";
+  });
+}
+
+describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
+  it("suppresses deferred block replies when the terminal gate requests a revision", async () => {
+    const onBlockReply = vi.fn();
+    const onAgentEvent = vi.fn();
+    const onBeforeTerminalDelivery = vi.fn(async () => ({
+      suppressTerminalDelivery: true,
+    }));
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-before-terminal-revise",
+      onBlockReply,
+      onAgentEvent,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: "message_end",
+    });
+
+    emitMessageStartAndEndForAssistantText({
+      emit,
+      text: "First answer.",
+    });
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+
+    emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "First answer." }],
+          stopReason: "stop",
+        },
+      ],
+      willRetry: false,
+    });
+
+    await vi.waitFor(() => expect(onBeforeTerminalDelivery).toHaveBeenCalledTimes(1));
+    expect(onBeforeTerminalDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasAssistantVisibleText: true,
+        isError: false,
+        incompleteTerminalAssistant: false,
+        willRetry: false,
+      }),
+    );
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+    expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(false);
+  });
+
+  it("waits for async terminal gate decisions before draining", async () => {
+    const onBlockReply = vi.fn();
+    let resolveGate: ((value: { suppressTerminalDelivery: true }) => void) | undefined;
+    const onBeforeTerminalDelivery = vi.fn(
+      () =>
+        new Promise<{ suppressTerminalDelivery: true }>((resolve) => {
+          resolveGate = resolve;
+        }),
+    );
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-before-terminal-wait",
+      onBlockReply,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: "message_end",
+    });
+
+    emitMessageStartAndEndForAssistantText({
+      emit,
+      text: "Slow revise answer.",
+    });
+    emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Slow revise answer." }],
+          stopReason: "stop",
+        },
+      ],
+      willRetry: false,
+    });
+
+    await vi.waitFor(() => expect(onBeforeTerminalDelivery).toHaveBeenCalledTimes(1));
+    let drained = false;
+    const waitPromise = subscription.waitForPendingEvents().then(() => {
+      drained = true;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    resolveGate?.({ suppressTerminalDelivery: true });
+    await waitPromise;
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("defers assistant stream and partial replies until the terminal gate continues", async () => {
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const onBeforeTerminalDelivery = vi.fn(async () => undefined);
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-before-terminal-assistant-stream",
+      onAgentEvent,
+      onPartialReply,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: "message_end",
+    });
+
+    emitAssistantTextDeltaAndEnd({
+      emit,
+      text: "Visible stream.",
+    });
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+    expect(onPartialReply).not.toHaveBeenCalled();
+
+    emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Visible stream." }],
+          stopReason: "stop",
+        },
+      ],
+      willRetry: false,
+    });
+
+    await subscription.waitForPendingEvents();
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
+    expect(onPartialReply).toHaveBeenCalled();
+    expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(true);
+  });
+
+  it("does not send final-only assistant events through partial replies", async () => {
+    const onPartialReply = vi.fn();
+    const onBeforeTerminalDelivery = vi.fn(async () => undefined);
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-before-terminal-final-only",
+      onPartialReply,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: "message_end",
+    });
+
+    emitMessageStartAndEndForAssistantText({
+      emit,
+      text: "Final only.",
+    });
+    emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Final only." }],
+          stopReason: "stop",
+        },
+      ],
+      willRetry: false,
+    });
+
+    await subscription.waitForPendingEvents();
+    expect(onPartialReply).not.toHaveBeenCalled();
+  });
+
+  it("finalizes normally when the terminal gate rejects", async () => {
+    const onBlockReply = vi.fn();
+    const onAgentEvent = vi.fn();
+    const onBeforeTerminalDelivery = vi.fn(async () => {
+      throw new Error("hook failed");
+    });
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-before-terminal-reject",
+      onBlockReply,
+      onAgentEvent,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: "message_end",
+    });
+
+    emitMessageStartAndEndForAssistantText({
+      emit,
+      text: "Fallback answer.",
+    });
+    emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Fallback answer." }],
+          stopReason: "stop",
+        },
+      ],
+      willRetry: false,
+    });
+
+    await subscription.waitForPendingEvents();
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Fallback answer." }),
+    );
+    expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(true);
+  });
+
+  it("flushes deferred block replies when the terminal gate continues", async () => {
+    const onBlockReply = vi.fn();
+    const onBeforeTerminalDelivery = vi.fn(async () => undefined);
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-before-terminal-continue",
+      onBlockReply,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: "message_end",
+    });
+
+    emitMessageStartAndEndForAssistantText({
+      emit,
+      text: "Accepted answer.",
+    });
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Accepted answer." }],
+          stopReason: "stop",
+        },
+      ],
+      willRetry: false,
+    });
+
+    await vi.waitFor(() => expect(onBlockReply).toHaveBeenCalledTimes(1));
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Accepted answer." }),
+    );
+  });
+});

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -51,6 +51,11 @@ function createContext(
     },
     flushBlockReplyBuffer: vi.fn(),
     emitBlockReply,
+    emitAssistantStreamData: vi.fn(),
+    flushDeferredAssistantEvents: vi.fn(),
+    flushDeferredBlockReplies: vi.fn(),
+    clearDeferredAssistantEvents: vi.fn(),
+    clearDeferredBlockReplies: vi.fn(),
     resolveCompactionRetry: vi.fn(),
     maybeResolveCompactionWait: vi.fn(),
   } as unknown as EmbeddedAgentSubscribeContext;

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -55,12 +55,13 @@ export function handleAgentEnd(
   const hasAssistantVisibleText =
     Array.isArray(ctx.state.assistantTexts) &&
     ctx.state.assistantTexts.some((text) => hasAssistantVisibleReply({ text }));
-  const hadDeterministicSideEffect =
+  const hadLivenessPreservingSideEffect =
     ctx.state.hadDeterministicSideEffect === true ||
-    ctx.state.replayState.hadPotentialSideEffects ||
     hasCommittedMessagingToolDeliveryEvidence(ctx.state) ||
     hasAcceptedSessionSpawn(ctx.state.acceptedSessionSpawns) ||
     (ctx.state.successfulCronAdds ?? 0) > 0;
+  const hadBeforeFinalizeSideEffect =
+    hadLivenessPreservingSideEffect || ctx.state.replayState.hadPotentialSideEffects;
   const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
     hasAssistantVisibleText,
     lastAssistant: isAssistantMessage(lastAssistant) ? lastAssistant : null,
@@ -74,7 +75,7 @@ export function handleAgentEnd(
   const derivedWorkingTerminalState = isError
     ? "blocked"
     : replayInvalid &&
-        !hadDeterministicSideEffect &&
+        !hadLivenessPreservingSideEffect &&
         (!hasAssistantVisibleText || incompleteTerminalAssistant)
       ? "abandoned"
       : ctx.state.livenessState;
@@ -234,7 +235,7 @@ export function handleAgentEnd(
       hasAssistantVisibleText,
       isError,
       incompleteTerminalAssistant,
-      hadDeterministicSideEffect,
+      hadDeterministicSideEffect: hadBeforeFinalizeSideEffect,
     });
     if (isPromiseLike<void | { suppressTerminalDelivery?: boolean }>(result)) {
       return result;

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -21,6 +21,7 @@ import {
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import { isAssistantMessage } from "./embedded-agent-utils.js";
+import type { AgentSessionEvent } from "./sessions/index.js";
 
 export {
   handleCompactionEnd,
@@ -43,7 +44,11 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
   });
 }
 
-export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promise<void> {
+export function handleAgentEnd(
+  ctx: EmbeddedAgentSubscribeContext,
+  evt?: Extract<AgentSessionEvent, { type: "agent_end" }>,
+): void | Promise<void> {
+  type BeforeTerminalDeliveryDecision = void | { suppressTerminalDelivery?: boolean };
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
   let lifecycleErrorText: string | undefined;
@@ -52,6 +57,7 @@ export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promi
     ctx.state.assistantTexts.some((text) => hasAssistantVisibleReply({ text }));
   const hadDeterministicSideEffect =
     ctx.state.hadDeterministicSideEffect === true ||
+    ctx.state.replayState.hadPotentialSideEffects ||
     hasCommittedMessagingToolDeliveryEvidence(ctx.state) ||
     hasAcceptedSessionSpawn(ctx.state.acceptedSessionSpawns) ||
     (ctx.state.successfulCronAdds ?? 0) > 0;
@@ -217,6 +223,72 @@ export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promi
     return undefined;
   };
 
+  const runBeforeTerminalDelivery = ():
+    | BeforeTerminalDeliveryDecision
+    | Promise<BeforeTerminalDeliveryDecision> => {
+    const result = ctx.params.onBeforeTerminalDelivery?.({
+      messages: evt?.messages ?? [],
+      willRetry: evt?.willRetry === true,
+      ...(lastAssistant ? { lastAssistant } : {}),
+      assistantTexts: ctx.state.assistantTexts,
+      hasAssistantVisibleText,
+      isError,
+      incompleteTerminalAssistant,
+      hadDeterministicSideEffect,
+    });
+    if (isPromiseLike<void | { suppressTerminalDelivery?: boolean }>(result)) {
+      return result;
+    }
+    return result;
+  };
+
+  const deliverTerminal = () => {
+    ctx.state.deferBlockReplyDelivery = false;
+    ctx.flushDeferredAssistantEvents();
+    ctx.flushDeferredBlockReplies();
+    const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer({ final: true });
+    finalizeAgentEnd();
+    const flushPendingMediaAndChannelResult = isPromiseLike<void>(flushBlockReplyBufferResult)
+      ? Promise.resolve(flushBlockReplyBufferResult).then(() => flushPendingMediaAndChannel())
+      : flushPendingMediaAndChannel();
+
+    if (isPromiseLike<void>(flushPendingMediaAndChannelResult)) {
+      return Promise.resolve(flushPendingMediaAndChannelResult).then(
+        () => emitLifecycleTerminalOnce(),
+        (error: unknown) => {
+          const emitted = emitLifecycleTerminalOnce();
+          if (isPromiseLike<void>(emitted)) {
+            return Promise.resolve(emitted).then(() => {
+              throw error;
+            });
+          }
+          throw error;
+        },
+      );
+    }
+    return emitLifecycleTerminalOnce();
+  };
+
+  const deliverTerminalWithLifecycleErrorFallback = () => {
+    try {
+      return deliverTerminal();
+    } catch (error) {
+      const emitted = emitLifecycleTerminalOnce();
+      if (isPromiseLike<void>(emitted)) {
+        return Promise.resolve(emitted).then(() => {
+          throw error;
+        });
+      }
+      throw error;
+    }
+  };
+
+  const suppressTerminalDelivery = () => {
+    ctx.clearDeferredAssistantEvents();
+    ctx.clearDeferredBlockReplies();
+    finalizeAgentEnd();
+  };
+
   let lifecycleTerminalEmitted = false;
   const emitLifecycleTerminalOnce = (): void | Promise<void> => {
     if (lifecycleTerminalEmitted) {
@@ -241,36 +313,33 @@ export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promi
     emitLifecycleTerminal();
   };
 
+  let beforeTerminalDelivery:
+    | BeforeTerminalDeliveryDecision
+    | Promise<BeforeTerminalDeliveryDecision>;
   try {
-    const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer({ final: true });
-    finalizeAgentEnd();
-    const flushPendingMediaAndChannelResult = isPromiseLike<void>(flushBlockReplyBufferResult)
-      ? Promise.resolve(flushBlockReplyBufferResult).then(() => flushPendingMediaAndChannel())
-      : flushPendingMediaAndChannel();
-
-    if (isPromiseLike<void>(flushPendingMediaAndChannelResult)) {
-      return Promise.resolve(flushPendingMediaAndChannelResult).then(
-        () => emitLifecycleTerminalOnce(),
-        (error: unknown) => {
-          const emitted = emitLifecycleTerminalOnce();
-          if (isPromiseLike<void>(emitted)) {
-            return Promise.resolve(emitted).then(() => {
-              throw error;
-            });
-          }
-          throw error;
-        },
-      );
-    }
+    beforeTerminalDelivery = runBeforeTerminalDelivery();
   } catch (error) {
-    const emitted = emitLifecycleTerminalOnce();
-    if (isPromiseLike<void>(emitted)) {
-      return Promise.resolve(emitted).then(() => {
-        throw error;
-      });
-    }
-    throw error;
+    ctx.log.warn(`before terminal delivery failed: ${String(error)}`);
+    return deliverTerminalWithLifecycleErrorFallback();
   }
 
-  return emitLifecycleTerminalOnce();
+  if (isPromiseLike<void | { suppressTerminalDelivery?: boolean }>(beforeTerminalDelivery)) {
+    return Promise.resolve(beforeTerminalDelivery)
+      .catch((error: unknown) => {
+        ctx.log.warn(`before terminal delivery failed: ${String(error)}`);
+        return undefined;
+      })
+      .then((decision) => {
+        if (decision?.suppressTerminalDelivery === true) {
+          suppressTerminalDelivery();
+          return undefined;
+        }
+        return deliverTerminalWithLifecycleErrorFallback();
+      });
+  }
+  if (beforeTerminalDelivery?.suppressTerminalDelivery === true) {
+    suppressTerminalDelivery();
+    return undefined;
+  }
+  return deliverTerminalWithLifecycleErrorFallback();
 }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -34,6 +34,8 @@ function createMessageUpdateContext(
   } = {},
 ) {
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
+  const onAgentEvent = params.onAgentEvent as ((event: unknown) => void) | undefined;
+  const onPartialReply = params.onPartialReply as ((event: unknown) => void) | undefined;
   return {
     params: {
       runId: "run-1",
@@ -77,6 +79,17 @@ function createMessageUpdateContext(
     resetAssistantMessageState: params.resetAssistantMessageState ?? vi.fn(),
     recordAssistantUsage: vi.fn(),
     commitAssistantUsage: vi.fn(),
+    emitAssistantStreamData: vi.fn(
+      (
+        data: Parameters<EmbeddedAgentSubscribeContext["emitAssistantStreamData"]>[0],
+        options?: { emitPartialReply?: boolean },
+      ) => {
+        onAgentEvent?.({ stream: "assistant", data });
+        if (options?.emitPartialReply === true && (params.shouldEmitPartialReplies ?? true)) {
+          onPartialReply?.(data);
+        }
+      },
+    ),
   } as unknown as EmbeddedAgentSubscribeContext;
 }
 
@@ -95,6 +108,7 @@ function createMessageEndContext(
     state?: Record<string, unknown>;
   } = {},
 ) {
+  const onAgentEvent = params.onAgentEvent as ((event: unknown) => void) | undefined;
   return {
     params: {
       runId: "run-1",
@@ -141,6 +155,11 @@ function createMessageEndContext(
     builtinToolNames: params.builtinToolNames,
     stripBlockTags: (text: string) => text,
     finalizeAssistantTexts: params.finalizeAssistantTexts ?? vi.fn(),
+    emitAssistantStreamData: vi.fn(
+      (data: Parameters<EmbeddedAgentSubscribeContext["emitAssistantStreamData"]>[0]) => {
+        onAgentEvent?.({ stream: "assistant", data });
+      },
+    ),
     emitBlockReply: params.emitBlockReply ?? vi.fn(),
     consumeReplyDirectives: params.consumeReplyDirectives ?? vi.fn(() => ({ text: "Need send." })),
     emitReasoningStream: vi.fn(),

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -8,7 +8,6 @@ import {
 } from "../auto-reply/reply/reply-directives.js";
 import { splitTrailingDirective } from "../auto-reply/reply/streaming-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import { emitAgentEvent } from "../infra/agent-events.js";
 import type { AssistantMessage } from "../llm/types.js";
 import { coerceChatContentText } from "../shared/chat-content.js";
 import {
@@ -784,19 +783,8 @@ export function handleMessageUpdate(
         mediaUrls,
         phase: deliveryPhase ?? assistantPhase,
       });
-      emitAgentEvent({
-        runId: ctx.params.runId,
-        stream: "assistant",
-        data,
-      });
-      void ctx.params.onAgentEvent?.({
-        stream: "assistant",
-        data,
-      });
+      ctx.emitAssistantStreamData(data, { emitPartialReply: true });
       ctx.state.emittedAssistantUpdate = true;
-      if (ctx.params.onPartialReply && ctx.state.shouldEmitPartialReplies) {
-        void ctx.params.onPartialReply(data);
-      }
     }
   }
 
@@ -936,15 +924,7 @@ export function handleMessageEnd(
       mediaUrls,
       phase: assistantPhase,
     });
-    emitAgentEvent({
-      runId: ctx.params.runId,
-      stream: "assistant",
-      data,
-    });
-    void ctx.params.onAgentEvent?.({
-      stream: "assistant",
-      data,
-    });
+    ctx.emitAssistantStreamData(data);
     ctx.state.emittedAssistantUpdate = true;
     ctx.state.lastStreamedAssistantCleaned = cleanedText;
   }

--- a/src/agents/embedded-agent-subscribe.handlers.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.ts
@@ -21,8 +21,6 @@ import type {
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 
 export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscribeContext) {
-  let pendingEventChain: Promise<void> | null = null;
-
   const scheduleEvent = (
     evt: EmbeddedAgentSubscribeEvent,
     handler: () => void | Promise<void>,
@@ -36,7 +34,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
       }
     };
 
-    if (!pendingEventChain) {
+    if (!ctx.state.pendingEventChain) {
       const result = run();
       if (!isPromiseLike<void>(result)) {
         return;
@@ -46,28 +44,28 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
           ctx.log.debug(`${evt.type} handler failed: ${String(err)}`);
         })
         .finally(() => {
-          if (pendingEventChain === task) {
-            pendingEventChain = null;
+          if (ctx.state.pendingEventChain === task) {
+            ctx.state.pendingEventChain = null;
           }
         });
       if (!options?.detach) {
-        pendingEventChain = task;
+        ctx.state.pendingEventChain = task;
       }
       return;
     }
 
-    const task = pendingEventChain
+    const task = ctx.state.pendingEventChain
       .then(() => run())
       .catch((err: unknown) => {
         ctx.log.debug(`${evt.type} handler failed: ${String(err)}`);
       })
       .finally(() => {
-        if (pendingEventChain === task) {
-          pendingEventChain = null;
+        if (ctx.state.pendingEventChain === task) {
+          ctx.state.pendingEventChain = null;
         }
       });
     if (!options?.detach) {
-      pendingEventChain = task;
+      ctx.state.pendingEventChain = task;
     }
   };
 
@@ -133,7 +131,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
         return;
       case "agent_end":
         scheduleEvent(evt, () => {
-          return handleAgentEnd(ctx);
+          return handleAgentEnd(ctx, evt as never);
         });
       default:
     }

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -4,6 +4,7 @@ import type { HeartbeatToolResponse } from "../auto-reply/heartbeat-tool-respons
 import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { HookRunner } from "../plugins/hooks.js";
+import type { AssistantPhase } from "../shared/chat-message-content.js";
 import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import type { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
 import type {
@@ -39,6 +40,19 @@ export type ToolCallSummary = {
   mutatingAction: boolean;
   actionFingerprint?: string;
   fileTarget?: import("./tool-mutation.js").FileTarget;
+};
+
+export type AssistantStreamData = {
+  text: string;
+  delta: string;
+  replace?: true;
+  mediaUrls?: string[];
+  phase?: AssistantPhase;
+};
+
+export type AssistantStreamDelivery = {
+  data: AssistantStreamData;
+  emitPartialReply: boolean;
 };
 
 export type EmbeddedAgentSubscribeState = {
@@ -99,6 +113,9 @@ export type EmbeddedAgentSubscribeState = {
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   lastDeliveredBlockReplyText?: string;
+  deferBlockReplyDelivery: boolean;
+  deferredBlockReplies: BlockReplyPayload[];
+  deferredAssistantEvents: AssistantStreamDelivery[];
   toolExecutionSinceLastBlockReply: boolean;
   reasoningStreamOpen: boolean;
   assistantMessageIndex: number;
@@ -126,6 +143,7 @@ export type EmbeddedAgentSubscribeState = {
   timeoutPhase?: AgentRunTimeoutPhase;
   providerStarted?: boolean;
   hadDeterministicSideEffect?: boolean;
+  pendingEventChain: Promise<void> | null;
 
   messagingToolSentTexts: string[];
   messagingToolSentTextsNormalized: string[];
@@ -218,7 +236,15 @@ export type EmbeddedAgentSubscribeContext = {
   getUsageTotals: () => NormalizedUsage | undefined;
   getCompactionCount: () => number;
   getLastCompactionTokensAfter: () => number | undefined;
+  emitAssistantStreamData: (
+    data: AssistantStreamData,
+    options?: { emitPartialReply?: boolean },
+  ) => void;
   emitBlockReply: (payload: BlockReplyPayload) => void;
+  flushDeferredAssistantEvents: () => void;
+  flushDeferredBlockReplies: () => void;
+  clearDeferredAssistantEvents: () => void;
+  clearDeferredBlockReplies: () => void;
 };
 
 /**

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -188,6 +188,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
     lastDeliveredBlockReplyText: undefined,
+    deferBlockReplyDelivery: typeof params.onBeforeTerminalDelivery === "function",
+    deferredBlockReplies: [],
+    deferredAssistantEvents: [],
     toolExecutionSinceLastBlockReply: false,
     reasoningStreamOpen: false,
     assistantMessageIndex: 0,
@@ -210,6 +213,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     replayState: createEmbeddedRunReplayState(params.initialReplayState),
     livenessState: "working",
     hadDeterministicSideEffect: false,
+    pendingEventChain: null,
     messagingToolSentTexts: [],
     messagingToolSentTextsNormalized: [],
     messagingToolSentTargets: [],
@@ -254,6 +258,46 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   const shouldAllowSilentTurnText = (text: string | undefined) =>
     Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
+  const emitAssistantStreamDataSafely = (
+    delivery: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number],
+  ) => {
+    const { data } = delivery;
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "assistant",
+      data,
+    });
+    void params.onAgentEvent?.({
+      stream: "assistant",
+      data,
+    });
+    if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
+      void params.onPartialReply(data);
+    }
+  };
+  const emitAssistantStreamData = (
+    data: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number]["data"],
+    options?: { emitPartialReply?: boolean },
+  ) => {
+    const delivery = { data, emitPartialReply: options?.emitPartialReply === true };
+    if (state.deferBlockReplyDelivery) {
+      state.deferredAssistantEvents.push(delivery);
+      return;
+    }
+    emitAssistantStreamDataSafely(delivery);
+  };
+  const flushDeferredAssistantEvents = () => {
+    if (state.deferredAssistantEvents.length === 0) {
+      return;
+    }
+    const deferred = state.deferredAssistantEvents.splice(0);
+    for (const delivery of deferred) {
+      emitAssistantStreamDataSafely(delivery);
+    }
+  };
+  const clearDeferredAssistantEvents = () => {
+    state.deferredAssistantEvents.length = 0;
+  };
   const emitBlockReplySafely = (
     payload: Parameters<NonNullable<SubscribeEmbeddedAgentSessionParams["onBlockReply"]>>[0],
     options?: { assistantMessageIndex?: number },
@@ -294,10 +338,35 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       options?.consumePendingToolMedia === false
         ? withAssistantDirectives
         : consumePendingToolMediaIntoReply(state, withAssistantDirectives);
+    if (state.deferBlockReplyDelivery) {
+      const deferredPayload =
+        options?.assistantMessageIndex !== undefined
+          ? setReplyPayloadMetadata(withToolMedia, {
+              assistantMessageIndex: options.assistantMessageIndex,
+            })
+          : withToolMedia;
+      state.deferredBlockReplies.push(deferredPayload);
+      return;
+    }
     const emitted = emitBlockReplySafely(withToolMedia, options);
     if (emitted && !withToolMedia.isReasoning && hasAssistantVisibleReply(withToolMedia)) {
       state.visibleBlockReplyCount += 1;
     }
+  };
+  const flushDeferredBlockReplies = () => {
+    if (state.deferredBlockReplies.length === 0) {
+      return;
+    }
+    const deferred = state.deferredBlockReplies.splice(0);
+    for (const payload of deferred) {
+      const emitted = emitBlockReplySafely(payload);
+      if (emitted && !payload.isReasoning && hasAssistantVisibleReply(payload)) {
+        state.visibleBlockReplyCount += 1;
+      }
+    }
+  };
+  const clearDeferredBlockReplies = () => {
+    state.deferredBlockReplies.length = 0;
   };
 
   const resetAssistantMessageState = (nextAssistantTextBaseline: number) => {
@@ -1132,6 +1201,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.pendingToolAudioAsVoice = false;
     state.pendingToolTrustedLocalMedia = false;
     state.visibleBlockReplyCount = 0;
+    state.deferBlockReplyDelivery = typeof params.onBeforeTerminalDelivery === "function";
+    clearDeferredAssistantEvents();
+    clearDeferredBlockReplies();
     state.pendingAssistantReplyDirectives = undefined;
     state.deterministicApprovalPromptPending = false;
     state.deterministicApprovalPromptSent = false;
@@ -1165,7 +1237,12 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     stripBlockTags,
     emitBlockChunk,
     flushBlockReplyBuffer,
+    emitAssistantStreamData,
     emitBlockReply,
+    flushDeferredAssistantEvents,
+    flushDeferredBlockReplies,
+    clearDeferredAssistantEvents,
+    clearDeferredBlockReplies,
     emitReasoningStream,
     consumeReplyDirectives,
     consumePartialReplyDirectives,
@@ -1312,6 +1389,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     getUsageTotals,
     getCompactionCount: () => compactionCount,
     getLastCompactionTokensAfter: () => state.lastCompactionTokensAfter,
+    waitForPendingEvents: () => state.pendingEventChain ?? Promise.resolve(),
     getItemLifecycle: () => ({
       startedCount: state.itemStartedCount,
       completedCount: state.itemCompletedCount,

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -15,6 +15,7 @@ import type {
   ToolResultFormat,
 } from "./embedded-agent-subscribe.shared-types.js";
 import type { AgentInternalEvent } from "./internal-events.js";
+import type { AgentMessage } from "./runtime/index.js";
 import type { AgentSession } from "./sessions/index.js";
 export type {
   BlockReplyChunking,
@@ -65,6 +66,17 @@ export type SubscribeEmbeddedAgentSessionParams = {
   }) => void | Promise<void>;
   onHeartbeatToolResponse?: (response: HeartbeatToolResponse) => void | Promise<void>;
   terminalLifecyclePhase?: "end" | "finishing";
+  /** Gate final block delivery/lifecycle after the natural answer is known. */
+  onBeforeTerminalDelivery?: (event: {
+    messages: AgentMessage[];
+    willRetry: boolean;
+    lastAssistant?: AgentMessage;
+    assistantTexts: readonly string[];
+    hasAssistantVisibleText: boolean;
+    isError: boolean;
+    incompleteTerminalAssistant: boolean;
+    hadDeterministicSideEffect: boolean;
+  }) => void | Promise<void | { suppressTerminalDelivery?: boolean }>;
   /** Best-effort hook invoked immediately before the terminal lifecycle event is emitted. */
   onBeforeLifecycleTerminal?: () => void | Promise<void>;
   enforceFinalTag?: boolean;


### PR DESCRIPTION
Summary

- Wire the normal embedded OpenClaw run loop through the existing `before_agent_finalize` hook before accepting a natural final assistant answer.
- Honor `revise` decisions by scheduling one hidden continuation with the hook reason, while suppressing duplicate user-turn persistence and preserving the existing finalize/continue behavior.
- Guard revision retries when the completed attempt already recorded potential side effects, and cap repeated finalize revisions.

Fixes #87585

Real behavior proof

- behavior: A normal embedded OpenClaw final answer now invokes `before_agent_finalize`; a `revise` result schedules one more hidden model pass, and side-effecting attempts finalize instead of replaying.
- environment: Local OpenClaw source checkout on Node 22 with pnpm; focused embedded-run harness using the normal run loop and plugin hook runner.
- steps:
  - `pnpm test src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts`
  - `pnpm test src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts src/agents/harness/lifecycle-hook-helpers.test.ts src/plugins/hooks.before-agent-finalize.test.ts`
  - `pnpm format:check src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts`
  - `git diff --check`
- evidence:
  - `run.before-agent-finalize.test.ts`: 3 passed
  - combined hook suite: 2 Vitest shards passed; 24 tests passed
  - formatter check: all matched files use the correct format
  - `git diff --check`: clean
- observedResult: The hook receives the embedded final-answer event before terminal success, `revise` triggers a second attempt with the revision instruction as a hidden continuation, and revision is not replayed after potential side effects.
- notTested: Full live provider E2E was not run locally; this proof focuses the embedded run-loop, hook normalizer, and plugin hook runner paths without requiring a live model endpoint.

Verification

- `pnpm test src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts src/agents/harness/lifecycle-hook-helpers.test.ts src/plugins/hooks.before-agent-finalize.test.ts`
- `pnpm format:check src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts`
- `git diff --check`
