### PR TITLE
fix(auto-reply): direct-send text-only block replies when streaming off (#57225)

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -791,6 +791,103 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("suppresses canonical assistant text payload when block chunks were directly delivered (#57225)", async () => {
+    // When block streaming is disabled and multi-segment text was already
+    // streamed directly between tool calls, the canonical assistant final
+    // payload concatenates those segments. Its content key does not match
+    // any individual chunk key, so the exact-match dedup misses it. The
+    // plain-assistant-text suppression handles this case so users do not see
+    // the same text delivered twice (first as chunks, then as the combined
+    // final reply).
+    const { createBlockReplyContentKey } = await import("./block-reply-pipeline.js");
+    const directlySentBlockKeys = new Set<string>();
+    // Three chunks were already delivered directly via the block-reply path.
+    directlySentBlockKeys.add(createBlockReplyContentKey({ text: "Looking up..." }));
+    directlySentBlockKeys.add(createBlockReplyContentKey({ text: "Found three matches..." }));
+    directlySentBlockKeys.add(createBlockReplyContentKey({ text: "Summary: ..." }));
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+      replyToMode: "off",
+      // The canonical answer reaches the dedup as one combined payload.
+      payloads: [{ text: "Looking up...\n\nFound three matches...\n\nSummary: ..." }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("keeps error payloads when block chunks were directly delivered (#57225)", async () => {
+    // The plain-assistant-text suppression must not swallow user-facing errors,
+    // warnings, or fallback notices, even when block chunks were directly sent.
+    const { createBlockReplyContentKey } = await import("./block-reply-pipeline.js");
+    const directlySentBlockKeys = new Set<string>();
+    directlySentBlockKeys.add(createBlockReplyContentKey({ text: "partial answer" }));
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+      replyToMode: "off",
+      payloads: [
+        { text: "partial answer combined", isError: false },
+        { text: "Tool failed", isError: true },
+      ],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("Tool failed");
+    expect(replyPayloads[0]?.isError).toBe(true);
+  });
+
+  it("keeps media-bearing payloads when block chunks were directly delivered (#57225)", async () => {
+    // Media payloads remain renderable through the final delivery path; only
+    // the plain text duplicate should be suppressed.
+    const { createBlockReplyContentKey } = await import("./block-reply-pipeline.js");
+    const directlySentBlockKeys = new Set<string>();
+    directlySentBlockKeys.add(createBlockReplyContentKey({ text: "Here's the image" }));
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+      replyToMode: "off",
+      payloads: [
+        { text: "Here's the image", mediaUrl: "/tmp/render.png", mediaUrls: ["/tmp/render.png"] },
+      ],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.mediaUrl).toBe("/tmp/render.png");
+  });
+
+  it("keeps plain final text when only media blocks were directly delivered (#57225)", async () => {
+    const { createBlockReplyContentKey } = await import("./block-reply-pipeline.js");
+    const directlySentBlockKeys = new Set<string>();
+    directlySentBlockKeys.add(
+      createBlockReplyContentKey({
+        mediaUrl: "/tmp/render.png",
+        mediaUrls: ["/tmp/render.png"],
+      }),
+    );
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+      replyToMode: "off",
+      payloads: [{ text: "Here is the summary after the image." }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("Here is the summary after the image.");
+  });
+
   it("does not suppress same-target replies when accountId differs", async () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -107,6 +107,51 @@ function shouldKeepPayloadDuringSilentTurn(payload: ReplyPayload): boolean {
   return payload.audioAsVoice === true && resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
+/**
+ * A plain assistant-text payload is a text-only final reply with no error, reasoning,
+ * media, structured presentation, or source-reply mirror metadata. When the streaming-off
+ * pipeline has already directly delivered block-reply chunks (see `directlySentBlockKeys`),
+ * the canonical assistant answer concatenates those chunks and would arrive as a duplicate;
+ * suppressing the plain text variant preserves chunk ordering with interleaved tool results.
+ */
+function isPlainAssistantAnswerPayload(payload: ReplyPayload): boolean {
+  if (payload.isError || payload.isReasoning || payload.isFallbackNotice) {
+    return false;
+  }
+  if (payload.presentation || payload.interactive || payload.channelData) {
+    return false;
+  }
+  const metadata = getReplyPayloadMetadata(payload);
+  if (metadata?.sourceReplyTranscriptMirror || metadata?.deliverDespiteSourceReplySuppression) {
+    return false;
+  }
+  if (resolveSendableOutboundReplyParts(payload).hasMedia) {
+    return false;
+  }
+  return Boolean(payload.text);
+}
+
+function hasDirectlySentTextBlock(keys?: Set<string>): boolean {
+  if (!keys?.size) {
+    return false;
+  }
+  for (const key of keys) {
+    try {
+      const parsed: unknown = JSON.parse(key);
+      if (!parsed || typeof parsed !== "object") {
+        return true;
+      }
+      const text = (parsed as { text?: unknown }).text;
+      if (typeof text === "string" && text.trim()) {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
 function sanitizeFinalReplyText(
   payload: ReplyPayload,
   text: string | undefined,
@@ -382,10 +427,21 @@ export async function buildReplyPayloads(params: {
       : params.directlySentBlockKeys?.size
         ? (() => {
             const unsent: ReplyPayload[] = [];
+            const directlySentTextBlock = hasDirectlySentTextBlock(params.directlySentBlockKeys);
             for (const payload of dedupedPayloads) {
-              if (!params.directlySentBlockKeys.has(createBlockReplyContentKey(payload))) {
-                unsent.push(payload);
+              if (params.directlySentBlockKeys.has(createBlockReplyContentKey(payload))) {
+                continue;
               }
+              // Streaming-off + tool-interleaved runs deliver each block-reply chunk
+              // directly; the final canonical assistant text concatenates those chunks
+              // and so produces a different content key. Drop plain assistant-text
+              // payloads (no media, no errors, no reasoning, no source-reply mirror)
+              // when text blocks were already streamed directly, so users do not see the
+              // same text twice. Errors, warnings, media, and source replies still pass.
+              if (directlySentTextBlock && isPlainAssistantAnswerPayload(payload)) {
+                continue;
+              }
+              unsent.push(payload);
             }
             return unsent;
           })()

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -166,8 +166,13 @@ describe("createBlockReplyDeliveryHandler", () => {
     expect(directlySentBlockKeys).toEqual(new Set([createBlockReplyContentKey(expectedPayload)]));
   });
 
-  it("keeps text-only block replies buffered when block streaming is disabled", async () => {
+  it("sends text-only block replies directly when block streaming is disabled (preserves tool-call interleaving)", async () => {
+    // Regression guard for issue #57225: when an agent emits text segments
+    // between tool calls on a streaming-off channel (Discord default),
+    // each text segment must be delivered directly so it arrives in the
+    // correct order rather than being deferred behind tool-result delivery.
     const onBlockReply = vi.fn(async () => {});
+    const directlySentBlockKeys = new Set<string>();
 
     const handler = createBlockReplyDeliveryHandler({
       onBlockReply,
@@ -178,12 +183,56 @@ describe("createBlockReplyDeliveryHandler", () => {
       } as unknown as TypingSignaler,
       blockStreamingEnabled: false,
       blockReplyPipeline: null,
-      directlySentBlockKeys: new Set(),
+      directlySentBlockKeys,
     });
 
     await handler({ text: "text only" });
 
-    expect(onBlockReply).not.toHaveBeenCalled();
+    const expectedPayload = {
+      text: "text only",
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+      replyToId: undefined,
+      replyToCurrent: undefined,
+      replyToTag: undefined,
+      audioAsVoice: false,
+    };
+    expect(onBlockReply).toHaveBeenCalledWith(expectedPayload);
+    expect(directlySentBlockKeys).toEqual(new Set([createBlockReplyContentKey(expectedPayload)]));
+  });
+
+  it("delivers interleaved text segments and tracks each as a separately-sent block when streaming is disabled", async () => {
+    // The agent emits: text1 -> (tool call) -> text2 -> (tool call) -> text3.
+    // Each text segment hits the block-reply handler when flushBlockReplyBuffer
+    // runs before tool execution. With block streaming disabled, each segment
+    // must be sent directly with its own tracking key so the runner-payloads
+    // dedup can suppress the canonical assistant text from re-delivering them.
+    const calls: string[] = [];
+    const onBlockReply = vi.fn(async (payload: { text?: string }) => {
+      if (payload.text) {
+        calls.push(payload.text);
+      }
+    });
+    const directlySentBlockKeys = new Set<string>();
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply,
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+    });
+
+    await handler({ text: "Looking up..." });
+    await handler({ text: "Found three matches..." });
+    await handler({ text: "Summary: ..." });
+
+    expect(calls).toEqual(["Looking up...", "Found three matches...", "Summary: ..."]);
+    expect(directlySentBlockKeys.size).toBe(3);
   });
 
   it("trims leading whitespace in block-streamed replies", async () => {

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -152,18 +152,16 @@ export function createBlockReplyDeliveryHandler(params: {
     }
 
     // Use pipeline if available (block streaming enabled), otherwise send directly.
+    // Text-only blocks must also be sent directly when streaming is disabled, otherwise
+    // text segments emitted between tool calls get deferred behind tool-result delivery
+    // and arrive out of order at channels like Discord (issue #57225). The matching
+    // dedup in agent-runner-payloads.ts suppresses the canonical assistant text payload
+    // once any block was directly delivered, so this does not duplicate the final reply.
     if (params.blockStreamingEnabled && params.blockReplyPipeline) {
       params.blockReplyPipeline.enqueue(blockPayload);
-    } else if (params.blockStreamingEnabled) {
-      // Send directly when flushing before tool execution (no pipeline but streaming enabled).
-      // Track sent key to avoid duplicate in final payloads.
-      await sendDirectBlockReply({
-        onBlockReply: params.onBlockReply,
-        directlySentBlockKeys: params.directlySentBlockKeys,
-        trackingPayload: blockPayload,
-        payload: blockPayload,
-      });
-    } else if (blockHasNonTextContent) {
+    } else {
+      // Send directly: either streaming-enabled flush before tool execution (no pipeline),
+      // or streaming-disabled mode that needs interleaved delivery with tool results.
       await sendDirectBlockReply({
         onBlockReply: params.onBlockReply,
         directlySentBlockKeys: params.directlySentBlockKeys,
@@ -171,6 +169,5 @@ export function createBlockReplyDeliveryHandler(params: {
         payload: blockPayload,
       });
     }
-    // When streaming is disabled entirely, text-only blocks are accumulated in final text.
   };
 }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

When block streaming is disabled (the Discord, Telegram, msteams, IRC, Mattermost, Synology Chat, NextCloud Talk, Slack Block Kit, etc. default), the shared block-reply delivery handler in `src/auto-reply/reply/reply-delivery.ts` only sent media-bearing payloads directly and silently dropped text-only blocks. `flushBlockReplyBuffer` runs before every tool execution (`src/agents/embedded-agent-subscribe.handlers.tools.ts:1044`) and at message_end, but the text it emitted there reached `createBlockReplyDeliveryHandler` and hit the `else if (blockHasNonTextContent)` guard — text-only never made it out. Tool results, in contrast, deliver immediately through `onToolResult` (serialized via `toolResultChain` at `src/auto-reply/reply/agent-runner-execution.ts:2489-2513`). The net effect for a sequence like `text1 → tool_call → text2 → tool_call → text3 → tool_call → final_summary` was: three tool outputs first, then one combined final reply — losing the live-typed interleaving.

Why does this matter now?

The ClawSweeper triage on #57225 (`clawsweeper:source-repro`) traced this to `src/auto-reply/reply/reply-delivery.ts` and noted the recent "await block-reply flush before tool execution starts" fix (`99d854db82`) only awaited replies that were already sent — it did not start sending the buffered text. Discord users see this most because Discord's bundled config leaves block streaming off; the same regression exists on every channel sharing the streaming-off + tool-interleave path.

What is the intended outcome?

- Text segments emitted between tool calls land in the user's channel in production order, just before each tool's output.
- The final assistant reply no longer re-delivers the same text the user already saw chunk-by-chunk.
- Pure text turns with no tool calls still arrive as one cohesive payload (streaming-off + no chunker = single buffered emit), so the streaming-off UX promise is preserved.

What is intentionally out of scope?

- No changes to channel-specific dispatchers (Discord, Telegram, etc.). The fix is purely in `src/auto-reply/reply`.
- No changes to the `blockStreaming` default or any channel config.
- No rewrite of the block-streaming pipeline; the streaming-enabled path is untouched.

What does success look like?

- New `reply-delivery.test.ts` cases prove text-only blocks are direct-sent and each segment is tracked in `directlySentBlockKeys` when streaming is off.
- New `agent-runner-payloads.test.ts` cases prove the canonical assistant text payload is suppressed once any block was directly delivered, while errors and media payloads still pass.
- Existing tests around block streaming, dedup, and reply-delivery continue to pass.

What should reviewers focus on?

- The two-part fix is coordinated: `reply-delivery.ts` direct-sends text-only blocks; `agent-runner-payloads.ts` suppresses the duplicate canonical text. Either change in isolation would either drop text or duplicate it.
- The new `isPlainAssistantAnswerPayload` predicate is the survivor surface — please sanity-check the metadata fields (`sourceReplyTranscriptMirror`, `deliverDespiteSourceReplySuppression`) and the `isError | isReasoning | isFallbackNotice | presentation | interactive | channelData | hasMedia` exclusions.
- Sibling-surface: this is a shared-layer fix; every channel inheriting the streaming-off default benefits. No channel-specific dispatcher needed code changes. PR-side this is the desired outcome — please confirm that's the maintainer preference rather than gating the fix behind a Discord-only flag.

## Linked context

Which issue does this close?

Closes #57225

Which issues, PRs, or discussions are related?

Related #2451 (Tyler Yust's original "send text between tool calls" fix in `agent-runner-execution.ts`, which had the same intent for the inline-handler path before the `reply-delivery.ts` extraction; the streaming-off direct-send branch was lost in a later refactor — `eefb2f8fb3` extracted `reply-delivery.ts`; `24032dcc0e` and `18c98316f7` reshaped the text/media handling and ended up only delivering blocks with non-text content when streaming is off).

Was this requested by a maintainer or owner?

No — sourced from the ClawSweeper triage on issue #57225 (labels `P1`, `clawsweeper:source-repro`, `clawsweeper:fix-shape-clear`, `clawsweeper:queueable-fix`, `impact:message-loss`).

## Real behavior proof (required for external PRs)

- Behavior addressed: Discord and every shared streaming-off channel can currently deliver tool results before the text segments that were produced before those tools. The fix direct-sends text-only block replies during streaming-off tool-interleaved runs, tracks those text chunks, and suppresses the later canonical plain assistant answer only when text chunks were already sent.
- Additional bug fixed after review: a media-only or presentation-only direct send must not suppress a later plain final assistant text. The current head only suppresses the plain final text when `directlySentBlockKeys` contains a directly sent text block.
- Real environment tested: source-level reproduction and targeted automated coverage in the shared auto-reply layer. This is the production path used by Discord and sibling channels with `blockStreaming=false`.
- Exact commands run at current head:
  - `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts` -> 43 passed.
  - `node scripts/run-vitest.mjs src/auto-reply/reply/reply-delivery.test.ts` -> 15 passed.
  - `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.test.ts src/auto-reply/reply/agent-runner-execution.test.ts` -> 3 files / 240 passed.
  - `node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.ts src/auto-reply/reply/reply-delivery.test.ts` -> exit 0.
  - `npx oxfmt --check src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.ts src/auto-reply/reply/reply-delivery.test.ts` -> exit 0.
  - `git diff --check` -> exit 0.
- Evidence after fix:
  - `reply-delivery.test.ts` proves text-only block replies are direct-sent when block streaming is disabled and multiple text chunks are tracked separately before tool delivery.
  - `agent-runner-payloads.test.ts` proves directly sent text chunks suppress only the duplicate canonical plain assistant text, while errors, media-bearing payloads, and media-only direct sends still allow the correct final payload through.
- Observed result after fix: text segments and tool outputs interleave in production order at the shared auto-reply layer, without duplicating the final joined assistant text.
- What was not tested: I still do not have a successful live Discord or Telegram Desktop before/after proof for this PR. Mantis Telegram Desktop Proof run `26877263822` attempted a native Telegram proof but produced `comparison.pass=false` because the required tool-interleaved answer sequence was unavailable to capture in the current proof harness.
- Proof limitations or environment constraints: the remaining proof gate requires live channel evidence or a maintainer/Mantis proof path that can generate the tool-interleaved model sequence in a native channel. The local tests are regression coverage, not a substitute for that gate.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts` -> 43 passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-delivery.test.ts` -> 15 passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.test.ts src/auto-reply/reply/agent-runner-execution.test.ts` -> 3 files / 240 passed.
- `node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.ts src/auto-reply/reply/reply-delivery.test.ts` -> exit 0.
- `npx oxfmt --check src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.ts src/auto-reply/reply/reply-delivery.test.ts` -> exit 0.
- `git diff --check` -> exit 0.

What regression coverage was added or updated?

- `src/auto-reply/reply/reply-delivery.test.ts`: rewrites the obsolete text-only streaming-off expectation and adds coverage for direct delivery plus per-chunk key tracking.
- `src/auto-reply/reply/agent-runner-payloads.test.ts`: covers duplicate canonical text suppression, error preservation, media preservation, and the media-only direct-send case that must keep later plain final text.

What failed before this fix, if known?

- The previous text-only streaming-off test asserted the buggy behavior by expecting no direct block reply send.
- The added media-only direct-send regression failed before the latest refinement because any direct-send key suppressed later plain final text.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Channels using `blockStreaming=false` (Discord, Telegram, msteams, IRC, Mattermost, Synology Chat, NextCloud Talk, Slack Block Kit, etc.) will now stream block-reply chunks live during tool-interleaved runs instead of batching them into one final reply. Pure-text turns are unchanged because with no chunker the whole buffer flushes as a single block.

Did config, environment, or migration behavior change? (`Yes/No`)

No. No config keys, defaults, env vars, or migration surfaces are touched.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Final-payload dedup. The new `isPlainAssistantAnswerPayload` predicate suppresses plain assistant-text payloads when any block was already streamed directly. If the predicate is too broad it would swallow user-facing replies; if too narrow it would duplicate text.

How is that risk mitigated?

- The predicate only fires when `params.directlySentBlockKeys?.size > 0` and `blockStreamingEnabled === false` — turns that delivered no chunks (no tools, message-tool-only runs, source-reply mirror runs) keep the original behavior.
- Excludes `isError`, `isReasoning`, `isFallbackNotice`, `presentation`, `interactive`, `channelData`, `sourceReplyTranscriptMirror`, `deliverDespiteSourceReplySuppression`, and any payload with media — so errors, warnings, source-reply mirrors, presentations, interactive blocks, and media payloads still pass.
- Exact-key dedup still runs first; the plain-text branch is a fallback for the canonical-final-answer case where the key differs because the final text joins per-chunk text segments.

## Current review state

What is the next action?

Maintainer review plus real behavior proof. The code path is now bounded to the shared auto-reply layer and the source-level regression coverage is current.

What is still waiting on author, maintainer, CI, or external proof?

The only known remaining blocker is external proof: the PR still needs live channel evidence or a Mantis/native proof path that can capture a tool-interleaved answer sequence. The latest Mantis Telegram Desktop attempt failed because the proof harness could not supply that sequence, not because CI found a source/test regression in this patch.

Which bot or reviewer comments were addressed?

The latest patch addresses the local risk found during re-audit: media-only/presentation direct sends no longer suppress a later plain final assistant text. The PR body now reflects the current head and the failed Mantis proof attempt.
