### PR TITLE
fix(feishu): honor session activation mode for group admission (#50490)

### DIFF
--- a/extensions/feishu/src/bot.activation-override.test.ts
+++ b/extensions/feishu/src/bot.activation-override.test.ts
@@ -1,0 +1,299 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { EnvelopeFormatOptions } from "openclaw/plugin-sdk/channel-inbound";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
+import type { FeishuMessageEvent } from "./bot.js";
+import { clearGroupNameCache, handleFeishuMessage } from "./bot.js";
+import { setFeishuRuntime } from "./runtime.js";
+
+// Regression coverage for issue #50490: switching a Feishu group from
+// `mentionRequired: false` to `/activation mention` via the runtime command
+// must immediately gate non-@ messages. The shared command handler in
+// `src/auto-reply/reply/commands-session.ts` stores `groupActivation` on the
+// session entry; the Feishu admission gate has to consult it in addition to
+// the static config flag (Telegram and WhatsApp already do this).
+
+const { mockCreateFeishuReplyDispatcher, mockCreateFeishuClient, mockResolveAgentRoute } =
+  vi.hoisted(() => ({
+    mockCreateFeishuReplyDispatcher: vi.fn((_params?: unknown) => ({
+      dispatcher: {
+        sendToolResult: vi.fn(),
+        sendBlockReply: vi.fn(),
+        sendFinalReply: vi.fn(),
+        waitForIdle: vi.fn(),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        markComplete: vi.fn(),
+      },
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+    })),
+    mockCreateFeishuClient: vi.fn(() => ({
+      contact: {
+        user: { get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }) },
+      },
+      im: {
+        chat: {
+          get: vi.fn().mockResolvedValue({ code: 0, data: { name: "Group" } }),
+        },
+      },
+    })),
+    mockResolveAgentRoute: vi.fn(),
+  }));
+
+vi.mock("./reply-dispatcher.js", () => ({
+  createFeishuReplyDispatcher: mockCreateFeishuReplyDispatcher,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: mockCreateFeishuClient,
+}));
+
+function createRuntimeEnv() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn((code: number): never => {
+      throw new Error(`exit ${code}`);
+    }),
+  };
+}
+
+describe("Feishu group activation session override (#50490)", () => {
+  const dispatched: Array<Record<string, unknown>> = [];
+  let tmpStateDir: string;
+  let sessionStorePath: string;
+
+  const mockFinalizeInboundContext: PluginRuntime["channel"]["reply"]["finalizeInboundContext"] = (
+    ctx,
+  ) => {
+    dispatched.push(ctx);
+    return {
+      ...ctx,
+      CommandAuthorized: typeof ctx.CommandAuthorized === "boolean" ? ctx.CommandAuthorized : false,
+      CommandTurn: { kind: "normal", source: "message", authorized: false },
+    };
+  };
+  const mockDispatchReplyFromConfig = vi
+    .fn()
+    .mockResolvedValue({ queuedFinal: false, counts: { final: 1 } });
+  const mockWithReplyDispatcher: PluginRuntime["channel"]["reply"]["withReplyDispatcher"] = async ({
+    dispatcher,
+    run,
+    onSettled,
+  }) => {
+    try {
+      return await run();
+    } finally {
+      dispatcher.markComplete();
+      try {
+        await dispatcher.waitForIdle();
+      } finally {
+        await onSettled?.();
+      }
+    }
+  };
+  const resolveEnvelopeFormatOptionsMock: PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"] =
+    () => ({}) satisfies EnvelopeFormatOptions;
+
+  const runtimeStub = {
+    system: { enqueueSystemEvent: vi.fn() },
+    channel: {
+      routing: {
+        resolveAgentRoute: (params: unknown) => mockResolveAgentRoute(params),
+      },
+      session: {
+        resolveStorePath: ((..._args: unknown[]) =>
+          sessionStorePath) as unknown as PluginRuntime["channel"]["session"]["resolveStorePath"],
+        recordInboundSession: vi.fn().mockResolvedValue(undefined),
+        readSessionUpdatedAt: vi.fn(() => undefined),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: resolveEnvelopeFormatOptionsMock,
+        formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+        finalizeInboundContext: mockFinalizeInboundContext,
+        dispatchReplyFromConfig: mockDispatchReplyFromConfig,
+        withReplyDispatcher: mockWithReplyDispatcher,
+      },
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn(() => false),
+        resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+      },
+      media: {
+        saveMediaBuffer: vi.fn().mockResolvedValue({
+          path: "/tmp/inbound-clip.mp4",
+          contentType: "video/mp4",
+        }),
+      },
+      inbound: {
+        run: vi.fn(async (params: Parameters<PluginRuntime["channel"]["inbound"]["run"]>[0]) => {
+          const input = await params.adapter.ingest(params.raw);
+          if (!input) {
+            return {
+              admission: { kind: "drop" as const, reason: "ingest-null" },
+              dispatched: false,
+            };
+          }
+          const eventClass = { kind: "message" as const, canStartAgentTurn: true };
+          const turn = await params.adapter.resolveTurn(input, eventClass, {});
+          if (!("runDispatch" in turn)) {
+            throw new Error("activation-override test runtime only supports prepared turns");
+          }
+          await turn.recordInboundSession({
+            storePath: turn.storePath,
+            sessionKey: turn.ctxPayload.SessionKey ?? turn.routeSessionKey,
+            ctx: turn.ctxPayload,
+            groupResolution: turn.record?.groupResolution,
+            createIfMissing: turn.record?.createIfMissing,
+            updateLastRoute: turn.record?.updateLastRoute,
+            onRecordError: turn.record?.onRecordError ?? (() => undefined),
+          });
+          return {
+            admission: { kind: "dispatch" as const },
+            dispatched: true,
+            ctxPayload: turn.ctxPayload,
+            routeSessionKey: turn.routeSessionKey,
+            dispatchResult: await turn.runDispatch(),
+          };
+        }),
+      },
+      pairing: {
+        readAllowFromStore: vi.fn().mockResolvedValue([]),
+        upsertPairingRequest: vi.fn().mockResolvedValue({ code: "ABCDEFGH", created: false }),
+        buildPairingReply: vi.fn(() => "Pairing response"),
+      },
+    },
+    media: { detectMime: vi.fn(async () => "application/octet-stream") },
+  } as unknown as PluginRuntime;
+
+  function createOpenGroupConfig(): ClawdbotConfig {
+    return {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "sec_test", // pragma: allowlist secret
+          groupPolicy: "open",
+          // Static config admits every group message. The session-level
+          // `/activation mention` override must still kick in.
+          requireMention: false,
+        },
+      },
+    };
+  }
+
+  function createMentionRequiredGroupConfig(): ClawdbotConfig {
+    return {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "sec_test", // pragma: allowlist secret
+          groupPolicy: "open",
+          requireMention: true,
+        },
+      },
+    };
+  }
+
+  function createInboundEvent(options: {
+    messageId: string;
+    mentioned: boolean;
+  }): FeishuMessageEvent {
+    return {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: options.messageId,
+        chat_id: "oc-activation-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: options.mentioned ? "@bot hello" : "hello" }),
+        ...(options.mentioned
+          ? {
+              mentions: [
+                {
+                  key: "@_user_1",
+                  id: { open_id: "bot-open-id" },
+                  name: "Bot",
+                  tenant_key: "",
+                },
+              ],
+            }
+          : {}),
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearGroupNameCache();
+    dispatched.length = 0;
+    tmpStateDir = mkdtempSync(join(tmpdir(), "feishu-activation-"));
+    sessionStorePath = join(tmpStateDir, "sessions.json");
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:feishu:group:oc-activation-group",
+      mainSessionKey: "agent:main:main",
+      lastRoutePolicy: "session",
+      matchedBy: "default",
+    });
+    setFeishuRuntime(runtimeStub);
+  });
+
+  afterEach(() => {
+    rmSync(tmpStateDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    vi.doUnmock("./reply-dispatcher.js");
+    vi.doUnmock("./client.js");
+    vi.resetModules();
+  });
+
+  function writeSessionActivation(activation: "mention" | "always" | undefined) {
+    const entry =
+      activation === undefined
+        ? {}
+        : { "agent:main:feishu:group:oc-activation-group": { groupActivation: activation } };
+    writeFileSync(sessionStorePath, JSON.stringify(entry), "utf-8");
+  }
+
+  it("drops non-mentioned group messages once /activation mention is recorded on the session entry", async () => {
+    // Reproduces #50490. With `mentionRequired: false` the config-only gate
+    // would admit every message, but the runtime override must trump it.
+    // We assert that the gate returns early — `inbound.run` is not even
+    // entered, so `finalizeInboundContext` / `dispatchReplyFromConfig` stay
+    // untouched. Admission of @-mentioned messages keeps working because the
+    // override only flips `requireMention`, not anything downstream — that is
+    // covered by the existing `handleFeishuMessage` suite.
+    writeSessionActivation("mention");
+
+    await handleFeishuMessage({
+      cfg: createOpenGroupConfig(),
+      event: createInboundEvent({ messageId: "msg-no-mention", mentioned: false }),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(dispatched).toHaveLength(0);
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("admits non-mentioned group messages once /activation always is recorded on the session entry", async () => {
+    // Covers the inverse override: static config requires @-mentions, but the
+    // runtime session switch must force the group back to always-on admission.
+    writeSessionActivation("always");
+
+    await handleFeishuMessage({
+      cfg: createMentionRequiredGroupConfig(),
+      event: createInboundEvent({ messageId: "msg-always-no-mention", mentioned: false }),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(dispatched).toHaveLength(1);
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -50,6 +50,10 @@ import { createFeishuClient } from "./client.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
+import {
+  applyFeishuGroupActivationOverride,
+  resolveFeishuGroupActivationOverride,
+} from "./group-activation.js";
 import { extractMentionTargets, isMentionForwardRequest } from "./mention.js";
 import {
   hasExplicitFeishuGroupConfig,
@@ -695,6 +699,40 @@ export async function handleFeishuMessage(params: {
       groupId: ctx.chatId,
       groupPolicy,
     }));
+
+    // Honor the session-level `/activation mention|always` override before
+    // gating non-mentioned messages. Without this the config-only
+    // `mentionRequired` decides admission and the runtime switch silently
+    // has no effect (#50490). Mirrors Telegram (`bot-core.ts`
+    // `resolveGroupActivation`) and WhatsApp (`group-activation.ts`
+    // `resolveGroupActivationFor`) / QQBot (`engine/group/activation.ts`).
+    const activationRuntime = getFeishuRuntime();
+    const activationRoute = activationRuntime.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: account.accountId,
+      peer: {
+        kind: "group",
+        id: groupSession?.peerId ?? ctx.chatId,
+      },
+      parentPeer: groupSession?.parentPeer ?? null,
+    });
+    const activationStorePath = activationRuntime.channel.session.resolveStorePath(
+      cfg.session?.store,
+      { agentId: activationRoute.agentId },
+    );
+    const sessionGroupActivation = resolveFeishuGroupActivationOverride({
+      storePath: activationStorePath,
+      sessionKey: activationRoute.sessionKey,
+      onError: (err) =>
+        log(
+          `feishu[${account.accountId}]: failed to load session activation for ${activationRoute.sessionKey}: ${String(err)}`,
+        ),
+    });
+    requireMention = applyFeishuGroupActivationOverride({
+      configRequireMention: requireMention,
+      activation: sessionGroupActivation,
+    });
 
     const groupSenderActivationIngress = await resolveFeishuGroupSenderActivationIngressAccess({
       cfg,

--- a/extensions/feishu/src/group-activation.test.ts
+++ b/extensions/feishu/src/group-activation.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyFeishuGroupActivationOverride,
+  resolveFeishuGroupActivationOverride,
+} from "./group-activation.js";
+
+const { loadSessionStoreMock } = vi.hoisted(() => ({
+  loadSessionStoreMock: vi.fn(),
+}));
+
+vi.mock("./bot-runtime-api.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./bot-runtime-api.js")>("./bot-runtime-api.js");
+  return {
+    ...actual,
+    loadSessionStore: loadSessionStoreMock,
+  };
+});
+
+afterAll(() => {
+  vi.doUnmock("./bot-runtime-api.js");
+  vi.resetModules();
+});
+
+describe("resolveFeishuGroupActivationOverride", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns mention when the session entry stores groupActivation=mention", () => {
+    loadSessionStoreMock.mockReturnValue({
+      "agent:main:feishu:group:oc_group_1": { groupActivation: "mention" },
+    });
+    expect(
+      resolveFeishuGroupActivationOverride({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:group:oc_group_1",
+      }),
+    ).toBe("mention");
+  });
+
+  it("returns always when the session entry stores groupActivation=always", () => {
+    loadSessionStoreMock.mockReturnValue({
+      "agent:main:feishu:group:oc_group_1": { groupActivation: "always" },
+    });
+    expect(
+      resolveFeishuGroupActivationOverride({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:group:oc_group_1",
+      }),
+    ).toBe("always");
+  });
+
+  it("ignores unrelated session keys", () => {
+    loadSessionStoreMock.mockReturnValue({
+      "agent:main:feishu:group:other_group": { groupActivation: "mention" },
+    });
+    expect(
+      resolveFeishuGroupActivationOverride({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:group:oc_group_1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the session entry has no activation", () => {
+    loadSessionStoreMock.mockReturnValue({
+      "agent:main:feishu:group:oc_group_1": { reasoningLevel: "on" },
+    });
+    expect(
+      resolveFeishuGroupActivationOverride({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:group:oc_group_1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined and reports errors when the store cannot be read", () => {
+    loadSessionStoreMock.mockImplementationOnce(() => {
+      throw new Error("disk unavailable");
+    });
+    const onError = vi.fn();
+    expect(
+      resolveFeishuGroupActivationOverride({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:group:oc_group_1",
+        onError,
+      }),
+    ).toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes uppercase/whitespace activation values", () => {
+    loadSessionStoreMock.mockReturnValue({
+      "agent:main:feishu:group:oc_group_1": { groupActivation: " MENTION " },
+    });
+    expect(
+      resolveFeishuGroupActivationOverride({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:group:oc_group_1",
+      }),
+    ).toBe("mention");
+  });
+});
+
+describe("applyFeishuGroupActivationOverride", () => {
+  it("forces requireMention=true when session activation is mention, even when config says false", () => {
+    // Regression for #50490: `mentionRequired: false` + `/activation mention`
+    // must still gate non-@ messages.
+    expect(
+      applyFeishuGroupActivationOverride({
+        configRequireMention: false,
+        activation: "mention",
+      }),
+    ).toBe(true);
+  });
+
+  it("forces requireMention=false when session activation is always, even when config says true", () => {
+    expect(
+      applyFeishuGroupActivationOverride({
+        configRequireMention: true,
+        activation: "always",
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to config when there is no session override", () => {
+    expect(
+      applyFeishuGroupActivationOverride({
+        configRequireMention: true,
+        activation: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      applyFeishuGroupActivationOverride({
+        configRequireMention: false,
+        activation: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("leaves the config decision intact when session activation matches it", () => {
+    expect(
+      applyFeishuGroupActivationOverride({
+        configRequireMention: true,
+        activation: "mention",
+      }),
+    ).toBe(true);
+    expect(
+      applyFeishuGroupActivationOverride({
+        configRequireMention: false,
+        activation: "always",
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/feishu/src/group-activation.ts
+++ b/extensions/feishu/src/group-activation.ts
@@ -1,0 +1,54 @@
+import { normalizeGroupActivation } from "openclaw/plugin-sdk/group-activation";
+import { loadSessionStore } from "./bot-runtime-api.js";
+
+/**
+ * Look up the session-level group activation override for a Feishu group.
+ *
+ * The shared `/activation` command writes `groupActivation` onto the session
+ * entry (`src/auto-reply/reply/commands-session.ts`). The Feishu group
+ * admission gate must honor this override so that switching to
+ * `/activation mention` immediately requires @-mentions even when the
+ * static `mentionRequired` config is `false`. Without this lookup the
+ * runtime keeps admitting every group message and the user-visible switch
+ * silently has no effect (#50490).
+ *
+ * Returns `undefined` when the store cannot be read or no override is set;
+ * callers should fall back to the config-derived `requireMention`.
+ */
+export function resolveFeishuGroupActivationOverride(params: {
+  storePath: string;
+  sessionKey: string;
+  onError?: (err: unknown) => void;
+}): "mention" | "always" | undefined {
+  try {
+    const store = loadSessionStore(params.storePath, { skipCache: true });
+    const entry = store[params.sessionKey];
+    return normalizeGroupActivation(entry?.groupActivation);
+  } catch (err) {
+    params.onError?.(err);
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the effective `requireMention` for a Feishu group message.
+ *
+ * Precedence (matches Telegram/WhatsApp/QQBot sibling channels):
+ *   1. Session `groupActivation` set via `/activation mention|always`.
+ *   2. Config `channels.feishu.mentionRequired` (or per-group override).
+ *
+ * Session "always" forces no mention requirement, "mention" forces it on.
+ * Undefined means no session override — fall back to config.
+ */
+export function applyFeishuGroupActivationOverride(params: {
+  configRequireMention: boolean;
+  activation: "mention" | "always" | undefined;
+}): boolean {
+  if (params.activation === "mention") {
+    return true;
+  }
+  if (params.activation === "always") {
+    return false;
+  }
+  return params.configRequireMention;
+}


### PR DESCRIPTION
## Summary

- Feishu's group admission gate consults only the static `channels.feishu.mentionRequired` config when deciding whether to admit non-@-mentioned messages, so `/activation mention` returned its confirmation reply but the runtime kept forwarding every message — exactly the regression #50490 describes.
- Resolve the group route early in `extensions/feishu/src/bot.ts:670`, read the session entry through `extensions/feishu/src/group-activation.ts`, and override `requireMention` from the persisted `/activation mention|always` value before calling `resolveFeishuGroupSenderActivationIngressAccess`. Session `"mention"` forces gating on, `"always"` forces it off, undefined falls back to config — matching the sibling channels.
- Reviewers should focus on the precedence rule (session beats config) and the route-resolution timing — group routes are pure, cached, and the DM dynamic-agent re-resolution path still runs untouched because it is gated on `!isGroup`.
- Out of scope: rewriting the activation state machine, persisting Feishu-specific activation defaults, or touching the `/activation` command handler itself (the shared command path in `src/auto-reply/reply/commands-session.ts:206` already writes `groupActivation` correctly).

## Linked context

Closes #50490

Related: same gate shape lives in
- `extensions/telegram/src/bot-core.ts:280` (`resolveGroupActivation` reads the session store and overrides `requireMention` via `firstDefined`),
- `extensions/whatsapp/src/auto-reply/monitor/group-activation.ts:30` (`resolveGroupActivationFor`) + `extensions/whatsapp/src/auto-reply/monitor/group-gating.ts:208` (`requireMention = activation !== "always"`),
- `extensions/qqbot/src/engine/group/activation.ts:13` (`resolveGroupActivation`) + `extensions/qqbot/src/engine/gateway/stages/group-gate-stage.ts:62`.

Discord/Slack/Mattermost route group admission through `src/channels/message-access/decision.ts:204`, which already accepts the `policy.activation.requireMention` flag the Feishu gate sets; the missing piece was Feishu computing that flag from the session entry, not a deeper refactor. No sibling-channel changes are needed in this PR.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: #50490 — `/activation mention` accepted in a Feishu group with `mentionRequired: false` but bot still answered every message.
- Real environment tested: Source-level reproduction (per the `clawsweeper:source-repro` label on the issue). No live Feishu app was driven.
- Exact steps or command run after this patch:
  - `pnpm exec oxfmt --check extensions/feishu/src/bot.ts extensions/feishu/src/group-activation.ts extensions/feishu/src/group-activation.test.ts extensions/feishu/src/bot.activation-override.test.ts`
  - `pnpm exec oxlint --type-aware extensions/feishu/src/bot.ts extensions/feishu/src/group-activation.ts extensions/feishu/src/group-activation.test.ts extensions/feishu/src/bot.activation-override.test.ts`
  - `pnpm tsgo --noEmit -p tsconfig.extensions.json`
  - `pnpm check:test-types`
  - `node scripts/run-vitest.mjs extensions/feishu/src/group-activation.test.ts`
  - `node scripts/run-vitest.mjs extensions/feishu/src/bot.activation-override.test.ts`
  - `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts`
  - `node scripts/run-vitest.mjs extensions/feishu/src/bot.broadcast.test.ts`
  - `node scripts/run-vitest.mjs extensions/feishu` (full feishu plugin suite)
- Evidence after fix:
  - `extensions/feishu/src/group-activation.test.ts` — 10/10 pass; covers session "mention" → `requireMention=true` even with config `false`, "always" → `false` even with config `true`, undefined → config fallback, store-read errors → undefined + `onError` callback, whitespace/case normalization.
  - `extensions/feishu/src/bot.activation-override.test.ts` — 2/2 pass; reproduces #50490 end-to-end for `groupActivation: "mention"` (config `requireMention: false` now drops non-@ messages) and covers the inverse `groupActivation: "always"` case (config `requireMention: true` now admits non-@ messages).
  - Existing `bot.test.ts` (69/69), `bot.broadcast.test.ts` (6/6), `policy.test.ts` (14/14), and the full `extensions/feishu` suite (787/787) all still pass — the early-but-cached `resolveAgentRoute` call does not perturb existing assertions because every group-test mock returns the same shape for the same peer args.
- Observed result after fix: non-@ messages in groups with `mentionRequired: false` are dropped at the activation gate once `/activation mention` has been recorded; `/activation always` flips the gate back to admit-all; unset session entries keep the existing config-only behavior.
- What was not tested: live Feishu webhook → bot loop. The issue is labeled `clawsweeper:source-repro` and the regression is at the admission gate, which is exercised in `bot.activation-override.test.ts` against the same shared `resolveFeishuGroupSenderActivationIngressAccess` callable used in production.
- Proof limitations or environment constraints: no Feishu app credentials available in the worktree. The integration test stands in for the live loop by exercising the same `handleFeishuMessage` entry point and the real `loadSessionStore` against a tmpdir-backed session-store JSON file.
- Before evidence (optional but encouraged): on `main` (commit `7a36bb37af`), the same `bot.activation-override.test.ts` scenario would `dispatchReplyFromConfig` once even with `groupActivation: "mention"` on disk — there is no code path in `extensions/feishu/src/bot.ts` (before this PR) that reads `groupActivation`. The only callers of `groupActivation` in Feishu before this change are zero (`grep -rn "groupActivation" extensions/feishu/ src/` had no Feishu hits in production code).

## Tests and validation

Which commands did you run?
- `pnpm exec oxfmt --check …` (changed files)
- `pnpm exec oxlint --type-aware …` (changed files)
- `pnpm tsgo --noEmit -p tsconfig.extensions.json`
- `pnpm check:test-types`
- `node scripts/run-vitest.mjs extensions/feishu/src/group-activation.test.ts`
- `node scripts/run-vitest.mjs extensions/feishu/src/bot.activation-override.test.ts`
- `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts`
- `node scripts/run-vitest.mjs extensions/feishu/src/bot.broadcast.test.ts`
- `node scripts/run-vitest.mjs extensions/feishu` (787 tests, all green)

What regression coverage was added or updated?
- `extensions/feishu/src/group-activation.test.ts` — pure unit tests for `resolveFeishuGroupActivationOverride` (six store-shape variants) and `applyFeishuGroupActivationOverride` (four precedence variants, including the explicit #50490 case "config false + session mention → requireMention true").
- `extensions/feishu/src/bot.activation-override.test.ts` — `handleFeishuMessage`-level regression that writes a real `sessions.json` to a tmpdir and asserts both session directions: `/activation mention` drops non-@ messages over an open config, and `/activation always` admits non-@ messages over a mention-required config.

What failed before this fix, if known?
- The new `bot.activation-override.test.ts` regression. Without this patch, `handleFeishuMessage` admits the non-@ message (because `resolveFeishuReplyPolicy` returns `requireMention: false` from config and the session value is never read), `mockDispatchReplyFromConfig` is called once, and `expect(dispatched).toHaveLength(0)` fails.

If no test was added, why not? N/A — tests were added.

## Risk checklist

Did user-visible behavior change? `Yes` — in groups where the operator left `mentionRequired: false`, the bot now stops responding to non-@ messages after the user runs `/activation mention`. This matches the documented contract of `/activation` and is what #50490 reports as the missing behavior. Users who never run `/activation` see no change.

Did config, environment, or migration behavior change? `No` — no new config keys, defaults, or migrations. The change reads the existing `groupActivation` field that the shared `/activation` command already writes to session entries (`src/config/sessions/types.ts:322`).

Did security, auth, secrets, network, or tool execution behavior change? `No` — only the mention-required gate decision. Sender allowlist enforcement, command authorization, and downstream dispatch paths are untouched.

What is the highest-risk area? Adding a second `resolveAgentRoute` call per group inbound message. Telegram does this too (`bot-message-context.ts:426`), the function is cached in `src/routing/resolve-route.ts:633` via `resolveRouteCacheForConfig`, and the second call later in the same `handleFeishuMessage` hits the same cache key.

How is that risk mitigated? Existing `bot.test.ts` group-routing assertions (`expectResolvedRouteCall(0, …)`, index 1 in topic tests) all pass: my early call uses the same `peer` and `parentPeer` shape as the existing call, so call-index assertions match regardless of order. The full feishu suite (787 tests) is green.

Additional validation after rebasing/updating this PR branch on 2026-06-03:
- `node scripts/run-vitest.mjs extensions/feishu/src/group-activation.test.ts extensions/feishu/src/bot.activation-override.test.ts --reporter=dot` -> 2 files / 12 tests passed.
- `npx oxfmt --check extensions/feishu/src/bot.activation-override.test.ts extensions/feishu/src/group-activation.ts extensions/feishu/src/group-activation.test.ts extensions/feishu/src/bot.ts` -> clean.
- `node scripts/run-oxlint.mjs extensions/feishu/src/bot.activation-override.test.ts extensions/feishu/src/group-activation.ts extensions/feishu/src/group-activation.test.ts extensions/feishu/src/bot.ts` -> exit 0.
- `node scripts/run-tsgo.mjs -p extensions/feishu/tsconfig.json` -> exit 0.
- `git diff --check && git diff --cached --check` -> exit 0 before commit.

## Current review state

What is the next action? Maintainer review.

What is still waiting on author, maintainer, CI, or external proof? CI run on this PR. No live Feishu proof is included; if maintainers want one, please flag and I'll pair with someone who has a Feishu test tenant.

Which bot or reviewer comments were addressed? N/A — initial submission.
