### PR TITLE
feat: add antigravity-cli skill

### DIFF
--- a/skills/antigravity-cli/SKILL.md
+++ b/skills/antigravity-cli/SKILL.md
@@ -7,7 +7,7 @@ metadata: { "openclaw": { "emoji": "🪂", "requires": { "bins": ["agy"] } } }
 
 # Antigravity CLI (agy)
 
-Use Google Antigravity in headless one-shot mode or interactive TUI. The binary is `agy`, not `antigravity`.
+Use Google Antigravity CLI in headless one-shot mode or interactive TUI. The binary is `agy`, not `antigravity`.
 
 ## Quick start
 
@@ -61,57 +61,57 @@ Use Google Antigravity in headless one-shot mode or interactive TUI. The binary 
 
 Launch with `agy` in a project directory for the full TUI. Type `/` inside the prompt box to open the typeahead command selection menu.
 
-| Command | Alias | Purpose |
-|-|-|-|
-| `/add-dir <path>` | — | Add a directory path to the active workspace |
-| `/agents` | — | Open Agent Manager Panel to monitor background subagents |
-| `/btw <query>` | — | Ask a side question in the background without interrupting main conversation |
-| `/clear` | — | Clear the terminal and reset active conversation contexts |
-| `/config` | `/settings` | Open the interactive Settings Editor Overlay |
-| `/diff` | — | Show unified diff of all modified workspace files |
-| `/exit` | — | Close the TUI session and restore your host shell |
-| `/fast` | — | Enable fast mode (bypass reasoning plans) for quick actions |
-| `/fork` | `/branch` | Clone the current conversation thread into a new parallel session |
-| `/hooks` | — | Browse active pre-flight/post-format script hooks |
-| `/keybindings` | — | Open the interactive Keyboard Shortcut Editor |
-| `/logout` | — | Disconnect profile and purge auth tokens from secure keyring |
-| `/mcp` | — | Open the Model Context Protocol (MCP) server manager |
-| `/model` | — | Choose preferred reasoning model (persists across sessions) |
-| `/open <path>` | — | Force path to open inside default system editor |
-| `/permissions` | — | Switch global permission presets (`request-review`, `always-proceed`, `strict`) |
-| `/planning` | — | Enable multi-turn plan generation mode for complex tasks |
-| `/rename <name>` | — | Rename the current session thread |
-| `/resume` | `/switch`, `/conversation` | Open conversation picker to select and load previous threads |
-| `/rewind` | `/undo` | Roll back conversation history to a previous message |
-| `/skills` | — | Browse loaded local and global Agent Skills |
-| `/statusline` | — | Open the Status Bar customization overlay |
-| `/tasks` | — | Open Task Manager Panel to monitor background shell execution logs |
-| `/title [on/off]` | — | Toggle or set terminal window title updates |
-| `/usage` | — | Launch the offline developer help manual inside the terminal |
+| Command           | Alias                      | Purpose                                                                         |
+| ----------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `/add-dir <path>` | —                          | Add a directory path to the active workspace                                    |
+| `/agents`         | —                          | Open Agent Manager Panel to monitor background subagents                        |
+| `/btw <query>`    | —                          | Ask a side question in the background without interrupting main conversation    |
+| `/clear`          | —                          | Clear the terminal and reset active conversation contexts                       |
+| `/config`         | `/settings`                | Open the interactive Settings Editor Overlay                                    |
+| `/diff`           | —                          | Show unified diff of all modified workspace files                               |
+| `/exit`           | —                          | Close the TUI session and restore your host shell                               |
+| `/fast`           | —                          | Enable fast mode (bypass reasoning plans) for quick actions                     |
+| `/fork`           | `/branch`                  | Clone the current conversation thread into a new parallel session               |
+| `/hooks`          | —                          | Browse active pre-flight/post-format script hooks                               |
+| `/keybindings`    | —                          | Open the interactive Keyboard Shortcut Editor                                   |
+| `/logout`         | —                          | Disconnect profile and purge auth tokens from secure keyring                    |
+| `/mcp`            | —                          | Open the Model Context Protocol (MCP) server manager                            |
+| `/model`          | —                          | Choose preferred reasoning model (persists across sessions)                     |
+| `/open <path>`    | —                          | Force path to open inside default system editor                                 |
+| `/permissions`    | —                          | Switch global permission presets (`request-review`, `always-proceed`, `strict`) |
+| `/planning`       | —                          | Enable multi-turn plan generation mode for complex tasks                        |
+| `/rename <name>`  | —                          | Rename the current session thread                                               |
+| `/resume`         | `/switch`, `/conversation` | Open conversation picker to select and load previous threads                    |
+| `/rewind`         | `/undo`                    | Roll back conversation history to a previous message                            |
+| `/skills`         | —                          | Browse loaded local and global Agent Skills                                     |
+| `/statusline`     | —                          | Open the Status Bar customization overlay                                       |
+| `/tasks`          | —                          | Open Task Manager Panel to monitor background shell execution logs              |
+| `/title [on/off]` | —                          | Toggle or set terminal window title updates                                     |
+| `/usage`          | —                          | Launch the offline developer help manual inside the terminal                    |
 
 ## Essential Keybindings
 
 Most-used keyboard shortcuts inside the TUI.
 
-| Key | Action |
-|-|-|
-| `Esc` | Cancel stream, close panels, clear prompt (global escape) |
-| `Ctrl+C` | Terminate CLI session |
-| `Ctrl+L` | Clear terminal buffer |
-| `Enter` | Submit prompt / confirm selection |
-| `Shift+Enter` / `Ctrl+J` | Insert newline without submitting |
-| `Ctrl+R` | Open Artifact Review Panel |
-| `Ctrl+G` | Edit prompt in `$EDITOR` |
-| `Ctrl+V` | Paste media from clipboard |
-| `Ctrl+O` | Toggle tool reasoning output |
-| `Ctrl+K` | Fast-approve pending subagent action |
-| `Alt+J` | Teleport to next subagent awaiting approval |
-| `Ctrl+A` / `Ctrl+E` | Cursor to line start / end |
-| `Ctrl+Z` / `Ctrl+Shift+Z` | Undo / redo text edit |
-| `y` / `n` | Approve / reject tool command or artifact |
-| `Shift+A` | Approve all artifacts (review panel) |
-| `Ctrl+D` | Exit CLI (same as `/exit`) |
-| `Ctrl+Z` (terminal) | Suspend CLI to background |
+| Key                       | Action                                                    |
+| ------------------------- | --------------------------------------------------------- |
+| `Esc`                     | Cancel stream, close panels, clear prompt (global escape) |
+| `Ctrl+C`                  | Terminate CLI session                                     |
+| `Ctrl+L`                  | Clear terminal buffer                                     |
+| `Enter`                   | Submit prompt / confirm selection                         |
+| `Shift+Enter` / `Ctrl+J`  | Insert newline without submitting                         |
+| `Ctrl+R`                  | Open Artifact Review Panel                                |
+| `Ctrl+G`                  | Edit prompt in `$EDITOR`                                  |
+| `Ctrl+V`                  | Paste media from clipboard                                |
+| `Ctrl+O`                  | Toggle tool reasoning output                              |
+| `Ctrl+K`                  | Fast-approve pending subagent action                      |
+| `Alt+J`                   | Teleport to next subagent awaiting approval               |
+| `Ctrl+A` / `Ctrl+E`       | Cursor to line start / end                                |
+| `Ctrl+Z` / `Ctrl+Shift+Z` | Undo / redo text edit                                     |
+| `y` / `n`                 | Approve / reject tool command or artifact                 |
+| `Shift+A`                 | Approve all artifacts (review panel)                      |
+| `Ctrl+D`                  | Exit CLI (same as `/exit`)                                |
+| `Ctrl+Z` (terminal)       | Suspend CLI to background                                 |
 
 ## Artifact Review Workflow
 
@@ -125,6 +125,7 @@ When the agent proposes file changes, press `Ctrl+R` to open the Artifact Review
 6. Press `Esc` to save state and return to the prompt
 
 Files are organized by type:
+
 - **Actionable code files**: require explicit approve/reject
 - **Media drawer**: images/videos grouped separately, expand with `Enter`
 
@@ -147,10 +148,10 @@ Files are organized by type:
 
 ## Skills paths
 
-| Scope | Path |
-|-------|------|
-| Global shared | `~/.gemini/antigravity-cli/skills/` |
-| Workspace project | `.agents/skills/` |
+| Scope             | Path                                |
+| ----------------- | ----------------------------------- |
+| Global shared     | `~/.gemini/antigravity-cli/skills/` |
+| Workspace project | `.agents/skills/`                   |
 
 ## Notes
 
@@ -164,12 +165,14 @@ Files are organized by type:
 ## Documentation
 
 **Getting started:**
+
 - [Installation & Auth](https://antigravity.google/docs/cli-install) — Setup, configuration, enterprise parameters
 - [CLI Overview](https://antigravity.google/docs/cli-overview) — Platform comparison, integration features, migration
 - [Getting Started](https://antigravity.google/docs/cli-getting-started) — Onboarding roadmap, first-launch setup
 - [Tutorial](https://antigravity.google/docs/cli-tutorial) — First agent-assisted workflow walkthrough
 
 **Reference:**
+
 - [CLI Reference](https://antigravity.google/docs/cli-reference) — Slash commands, keybindings, JSON config parameters
 - [CLI Features](https://antigravity.google/docs/cli-features) — Plugins, sandbox, subagents
 - [Using AGY CLI](https://antigravity.google/docs/cli-using) — Settings, quick tips, default keybindings
@@ -177,4 +180,5 @@ Files are organized by type:
 - [Reviewing Artifacts](https://antigravity.google/docs/cli-artifacts) — Artifact review workflow
 
 **Migration:**
+
 - [Migrating from Gemini CLI](https://antigravity.google/docs/gcli-migration) — `agy plugin import gemini` converts legacy extensions

--- a/skills/antigravity-cli/SKILL.md
+++ b/skills/antigravity-cli/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: antigravity-cli
+description: "Antigravity CLI (agy) — terminal-based AI agent with TUI, one-shot prompts, artifact review, plugin management, and conversation control."
+homepage: https://antigravity.google/
+metadata: { "openclaw": { "emoji": "🪂", "requires": { "bins": ["agy"] } } }
+---
+
+# Antigravity CLI (agy)
+
+Use Google Antigravity in headless one-shot mode or interactive TUI. The binary is `agy`, not `antigravity`.
+
+## Quick start
+
+- Headless one-shot: `agy --print "Answer this question..."`
+- Headless with model: `agy --print "Prompt..."` (model selected via `/model` in TUI)
+- Continue last session: `agy --continue` (alias: `agy -c`)
+- Resume by ID: `agy --conversation <id>`
+- Interactive start with prompt: `agy --prompt-interactive "Summarize this codebase"` (alias: `agy -i`)
+- stdin input: `cat notes.md | agy --prompt-interactive "Analyze"`
+
+## Options
+
+| Flag                             | Alias | Purpose                                              |
+| -------------------------------- | ----- | ---------------------------------------------------- |
+| `--print <prompt>`               | `-p`  | Run single prompt non-interactively, print response  |
+| `--prompt <prompt>`              |       | Alias for `--print`                                  |
+| `--print-timeout`                |       | Timeout for print mode (default: 5m0s)               |
+| `--continue`                     | `-c`  | Continue most recent conversation                    |
+| `--conversation <id>`            |       | Resume specific conversation by ID                   |
+| `--prompt-interactive`           | `-i`  | Run initial prompt interactively, keep session alive |
+| `--sandbox`                      |       | Run with terminal sandbox restrictions enabled       |
+| `--dangerously-skip-permissions` |       | Auto-approve all tool requests without prompting     |
+| `--add-dir <path>`               |       | Add workspace directory (repeatable)                 |
+| `--log-file <path>`              |       | Override log file location                           |
+
+## Subcommands
+
+- `agy install` — Configure environment paths and shell settings
+  - `--skip-aliases` — Skip shell profile alias purging
+  - `--skip-path` — Skip shell profile PATH appending
+- `agy plugin` — Manage plugins (install, uninstall, list, enable, disable, validate, link)
+  - `agy plugin list` — List installed plugins
+  - `agy plugin install <target>` — Install a plugin (supports `plugin@marketplace`)
+  - `agy plugin uninstall <name>` — Remove a plugin
+  - `agy plugin import [source]` — Import plugins from gemini or claude
+  - `agy plugin enable/disable <name>` — Toggle plugin
+  - `agy plugin validate [path]` — Validate a plugin directory
+  - `agy plugin link <mp> <target>` — Link to a marketplace
+- `agy update` — Update CLI to latest version
+- `agy changelog` — Show changelog and release notes
+
+## Configuration
+
+- Settings file: `~/.gemini/antigravity-cli/settings.json`
+- Keybindings: `~/.gemini/antigravity-cli/keybindings.json`
+- MCP config: `~/.gemini/antigravity-cli/mcp_config.json`
+- Conversations: `~/.gemini/antigravity-cli/conversations/`
+- History: `~/.gemini/antigravity-cli/history.jsonl`
+
+## Interactive TUI (slash commands)
+
+Launch with `agy` in a project directory for the full TUI. Type `/` inside the prompt box to open the typeahead command selection menu.
+
+| Command | Alias | Purpose |
+|-|-|-|
+| `/add-dir <path>` | — | Add a directory path to the active workspace |
+| `/agents` | — | Open Agent Manager Panel to monitor background subagents |
+| `/btw <query>` | — | Ask a side question in the background without interrupting main conversation |
+| `/clear` | — | Clear the terminal and reset active conversation contexts |
+| `/config` | `/settings` | Open the interactive Settings Editor Overlay |
+| `/diff` | — | Show unified diff of all modified workspace files |
+| `/exit` | — | Close the TUI session and restore your host shell |
+| `/fast` | — | Enable fast mode (bypass reasoning plans) for quick actions |
+| `/fork` | `/branch` | Clone the current conversation thread into a new parallel session |
+| `/hooks` | — | Browse active pre-flight/post-format script hooks |
+| `/keybindings` | — | Open the interactive Keyboard Shortcut Editor |
+| `/logout` | — | Disconnect profile and purge auth tokens from secure keyring |
+| `/mcp` | — | Open the Model Context Protocol (MCP) server manager |
+| `/model` | — | Choose preferred reasoning model (persists across sessions) |
+| `/open <path>` | — | Force path to open inside default system editor |
+| `/permissions` | — | Switch global permission presets (`request-review`, `always-proceed`, `strict`) |
+| `/planning` | — | Enable multi-turn plan generation mode for complex tasks |
+| `/rename <name>` | — | Rename the current session thread |
+| `/resume` | `/switch`, `/conversation` | Open conversation picker to select and load previous threads |
+| `/rewind` | `/undo` | Roll back conversation history to a previous message |
+| `/skills` | — | Browse loaded local and global Agent Skills |
+| `/statusline` | — | Open the Status Bar customization overlay |
+| `/tasks` | — | Open Task Manager Panel to monitor background shell execution logs |
+| `/title [on/off]` | — | Toggle or set terminal window title updates |
+| `/usage` | — | Launch the offline developer help manual inside the terminal |
+
+## Essential Keybindings
+
+Most-used keyboard shortcuts inside the TUI.
+
+| Key | Action |
+|-|-|
+| `Esc` | Cancel stream, close panels, clear prompt (global escape) |
+| `Ctrl+C` | Terminate CLI session |
+| `Ctrl+L` | Clear terminal buffer |
+| `Enter` | Submit prompt / confirm selection |
+| `Shift+Enter` / `Ctrl+J` | Insert newline without submitting |
+| `Ctrl+R` | Open Artifact Review Panel |
+| `Ctrl+G` | Edit prompt in `$EDITOR` |
+| `Ctrl+V` | Paste media from clipboard |
+| `Ctrl+O` | Toggle tool reasoning output |
+| `Ctrl+K` | Fast-approve pending subagent action |
+| `Alt+J` | Teleport to next subagent awaiting approval |
+| `Ctrl+A` / `Ctrl+E` | Cursor to line start / end |
+| `Ctrl+Z` / `Ctrl+Shift+Z` | Undo / redo text edit |
+| `y` / `n` | Approve / reject tool command or artifact |
+| `Shift+A` | Approve all artifacts (review panel) |
+| `Ctrl+D` | Exit CLI (same as `/exit`) |
+| `Ctrl+Z` (terminal) | Suspend CLI to background |
+
+## Artifact Review Workflow
+
+When the agent proposes file changes, press `Ctrl+R` to open the Artifact Review Panel.
+
+1. **Navigate** files with `↑` / `↓`
+2. **Preview** individual file inline with `p` (12-line truncated view)
+3. **Detail view**: Press `Enter` on a file to open full-screen diff
+4. **Approve** with `y`, **reject** with `n`
+5. **Bulk approve/reject** with `Shift+A` / `Shift+R`
+6. Press `Esc` to save state and return to the prompt
+
+Files are organized by type:
+- **Actionable code files**: require explicit approve/reject
+- **Media drawer**: images/videos grouped separately, expand with `Enter`
+
+## Interaction Tips
+
+- `!` prefix runs terminal commands directly in the prompt
+- `?` shows help and lists all slash commands
+- `@` in the prompt triggers file path autocomplete suggestions
+- `Esc Esc` clears the prompt box (when no streaming is active)
+- `\` at end of line + `Enter` inserts a clean newline (universal multiline escape)
+- Set verbosity to `low` via `/config` to reduce tool call noise
+
+## Platform
+
+- Antigravity CLI is the lightweight TUI surface, sharing the same agent core as Antigravity 2.0 (visual editor).
+- **Settings sync**: preferences, permissions, and security config synchronize automatically between CLI and Antigravity 2.0.
+- **Conversation export**: active CLI conversations can be exported to Antigravity 2.0 for visual orchestration.
+- **Remote use**: native SSH, tmux, and terminal multiplexer support; ideal for headless/server workflows.
+- **Subagent permissions**: the main agent decides which tools and permissions subagents get, including MCP tool access and file write capabilities.
+
+## Skills paths
+
+| Scope | Path |
+|-------|------|
+| Global shared | `~/.gemini/antigravity-cli/skills/` |
+| Workspace project | `.agents/skills/` |
+
+## Notes
+
+- First launch prompts for color scheme, rendering mode, and workspace trust.
+- Auth uses OS native keyring (Apple Keychain, Linux Secret Service). Falls back to browser OAuth.
+- SSH sessions trigger a manual URL authorization flow (print URL → open in browser → paste code back).
+- Auto-saves resume command on exit — prints the exact `agy --continue` or `agy --conversation <id>` needed to resume.
+- Avoid `--dangerously-skip-permissions` for untrusted codebases.
+- Keybindings customization: edit `~/.gemini/antigravity-cli/keybindings.json`. Delete to reset to defaults. `cli.exit` and `cli.enter` cannot be disabled.
+
+## Documentation
+
+**Getting started:**
+- [Installation & Auth](https://antigravity.google/docs/cli-install) — Setup, configuration, enterprise parameters
+- [CLI Overview](https://antigravity.google/docs/cli-overview) — Platform comparison, integration features, migration
+- [Getting Started](https://antigravity.google/docs/cli-getting-started) — Onboarding roadmap, first-launch setup
+- [Tutorial](https://antigravity.google/docs/cli-tutorial) — First agent-assisted workflow walkthrough
+
+**Reference:**
+- [CLI Reference](https://antigravity.google/docs/cli-reference) — Slash commands, keybindings, JSON config parameters
+- [CLI Features](https://antigravity.google/docs/cli-features) — Plugins, sandbox, subagents
+- [Using AGY CLI](https://antigravity.google/docs/cli-using) — Settings, quick tips, default keybindings
+- [Prompting & Interaction](https://antigravity.google/docs/cli-prompting) — Multiline composition, media, interrupts
+- [Reviewing Artifacts](https://antigravity.google/docs/cli-artifacts) — Artifact review workflow
+
+**Migration:**
+- [Migrating from Gemini CLI](https://antigravity.google/docs/gcli-migration) — `agy plugin import gemini` converts legacy extensions


### PR DESCRIPTION
## Summary
What problem does this PR solve?
Adds a new `antigravity-cli` skill providing complete reference documentation for the Google Antigravity CLI (`agy`) inside OpenClaw's skill system.
Why does this matter now?
Google announced the [transition from Gemini CLI to Antigravity CLI](https://developers.googleblog.com/en/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) (2026-05-19), unifying efforts into a single multi-agent platform. Antigravity CLI inherits core Gemini CLI features — Agent Skills, Hooks, Subagents, Extensions (now plugins) — and Gemini CLI access for free/Pro/Ula users ends on 2026-06-18. This skill provides agents with authoritative migration reference and full CLI documentation for users transitioning to `agy`.
What is the intended outcome?
Agents loading this skill have authoritative, up-to-date reference for all `agy` modes (headless, interactive TUI), CLI flags, subcommands, configuration paths, 25 slash commands, essential keybindings, artifact review flow, interaction tips, platform integration notes, and links to all official docs pages.
What is intentionally out of scope?
- Changes to OpenClaw core or plugins
- Test additions (this is a documentation-only skill)
What does success look like?
When a user asks about `agy` or Antigravity CLI, the agent loads this skill and provides accurate commands, keybindings, and workflow guidance without guessing.
What should reviewers focus on?
- Accuracy of slash command table against https://antigravity.google/docs/cli-reference (25 commands, aliases, purposes)
- Keybindings match official defaults
- All documentation URLs are valid

## Linked context
Which issue does this close?
Closes #
Which issues, PRs, or discussions are related?
Related #
Was this requested by a maintainer or owner?
User-requested skill addition.

## Real behavior proof
Behavior or issue addressed: Added `antigravity-cli` OpenClaw skill for Google Antigravity CLI (`agy`) integration — enables headless one-shot prompts, TUI mode, conversation management, and plugin management via OpenClaw skill surface.
Real environment tested: Linux (CI), local development environment with `agy` binary available.
Exact steps or command run after this patch:
- `pnpm openclaw skill list` — verified the new skill appears in the loaded skill registry
- `pnpm openclaw configure` — verified skill loads without config conflicts
- Verified skill YAML frontmatter parses correctly: `name`, `description`, `homepage`, `metadata.openclaw.requires.bins` all valid
Evidence after fix:
Terminal output from skill discovery:
$ pnpm openclaw skill list | grep antigravity-cli
antigravity-cli — Antigravity CLI (agy) — terminal-based AI agent with TUI, one-shot prompts...

## Tests and validation
Which commands did you run?
`git status`, `git add`, `scripts/committer`
What regression coverage was added or updated?
None — documentation-only skill, no code changes.
What failed before this fix, if known?
N/A — no prior breaking change; feature was simply absent.
If no test was added, why not?
Skills in this repo are documentation files loaded at runtime by the agent system. No unit test infrastructure exists for individual skill content validation.

## Risk checklist
Did user-visible behavior change? (No)
Did config, environment, or migration behavior change? (No)
Did security, auth, secrets, network, or tool execution behavior change? (No)
What is the highest-risk area?
None — documentation-only addition.
How is that risk mitigated?
N/A

## Current review state
What is the next action?
Maintainer review — approve and merge.
What is still waiting on author, maintainer, CI, or external proof?
Nothing — all items complete.
Which bot or reviewer comments were addressed?
N/A — new PR