### PR TITLE
fix(anthropic): stop migrating current claude-haiku-4-5 to sonnet

### DIFF
--- a/extensions/anthropic/claude-model-refs.ts
+++ b/extensions/anthropic/claude-model-refs.ts
@@ -4,7 +4,7 @@ import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_MODEL_ALIASES } from "./cli-constants
 const DEFAULT_CLAUDE_MODEL_BY_FAMILY: Record<string, string> = {
   opus: "claude-opus-4-7",
   sonnet: "claude-sonnet-4-6",
-  haiku: "claude-sonnet-4-6",
+  haiku: "claude-haiku-4-5",
 };
 
 export type ClaudeCliAnthropicModelRefs = {
@@ -117,6 +117,10 @@ function upgradeOldClaudeModelId(normalized: string): string | null {
   if (normalized.startsWith("claude-sonnet-4-6") || normalized.startsWith("claude-sonnet-4.6")) {
     return null;
   }
+  // claude-haiku-4-5 is a current production model and must not be migrated.
+  if (normalized.startsWith("claude-haiku-4-5") || normalized.startsWith("claude-haiku-4.5")) {
+    return null;
+  }
   if (
     normalized === "claude-opus-4" ||
     hasAnyRetiredVersionPrefix(normalized, [
@@ -140,8 +144,6 @@ function upgradeOldClaudeModelId(normalized: string): string | null {
       "claude-sonnet-4.1",
       "claude-sonnet-4-0",
       "claude-sonnet-4.0",
-      "claude-haiku-4-5",
-      "claude-haiku-4.5",
     ]) ||
     /^claude-sonnet-4-20\d{6}/.test(normalized)
   ) {
@@ -172,7 +174,6 @@ function upgradeOldClaudeModelId(normalized: string): string | null {
     normalized === "sonnet-3.7" ||
     normalized === "sonnet-3.5" ||
     normalized === "sonnet-3" ||
-    normalized === "haiku-4.5" ||
     normalized === "haiku-3.5" ||
     normalized === "haiku-3"
   ) {

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -55,6 +55,28 @@ describe("anthropic Claude model refs", () => {
     expect(resolveKnownAnthropicModelRef("anthropic/claude-sonnet-4-7")).toBe(
       "anthropic/claude-sonnet-4-7",
     );
+    expect(resolveKnownAnthropicModelRef("anthropic/claude-haiku-4-5")).toBe(
+      "anthropic/claude-haiku-4-5",
+    );
+  });
+
+  it("preserves the current claude-haiku-4-5 model and its bare alias", () => {
+    // claude-haiku-4-5 is a current production model (not retired), so neither
+    // its full ref, its dotted variant, nor the bare "haiku" family alias must
+    // be rewritten to sonnet.
+    expect(resolveKnownAnthropicModelRef("anthropic/claude-haiku-4-5")).toBe(
+      "anthropic/claude-haiku-4-5",
+    );
+    expect(resolveKnownAnthropicModelRef("anthropic/claude-haiku-4.5")).toBe(
+      "anthropic/claude-haiku-4.5",
+    );
+    expect(resolveKnownAnthropicModelRef("anthropic/claude-haiku-4-5@anthropic:work")).toBe(
+      "anthropic/claude-haiku-4-5@anthropic:work",
+    );
+    // Genuinely retired Claude 3 Haiku still upgrades to the current sonnet.
+    expect(resolveKnownAnthropicModelRef("anthropic/claude-3-5-haiku-20241022")).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
   });
 });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1707,7 +1707,7 @@ describe("legacy model compat migrate", () => {
       },
     });
 
-    expect(res.config?.agents?.defaults?.imageModel).toBe("anthropic/claude-sonnet-4-6");
+    expect(res.config?.agents?.defaults?.imageModel).toBe("anthropic/claude-haiku-4-5");
     expect(res.config?.agents?.defaults?.imageGenerationModel).toEqual({
       primary: "github-copilot/claude-sonnet-4.6",
       fallbacks: ["github-copilot/gpt-5.4-mini"],
@@ -1751,6 +1751,7 @@ describe("legacy model compat migrate", () => {
     });
     expect(res.config?.agents?.defaults?.workspace).toBe("/tmp/claude-3-sonnet");
     expect(res.config?.agents?.defaults?.models).toEqual({
+      "anthropic/claude-haiku-4-5": { alias: "haiku" },
       "anthropic/claude-sonnet-4-6": { alias: "current-sonnet" },
       "github-copilot/claude-opus-4.7": { alias: "copilot-opus" },
       "openai/gpt-5.5-pro": { alias: "old-pro" },
@@ -1770,10 +1771,9 @@ describe("legacy model compat migrate", () => {
           subagent?: { allowedModels?: string[] };
         }
       )?.subagent?.allowedModels,
-    ).toEqual(["anthropic/claude-sonnet-4-6", "*"]);
+    ).toEqual(["anthropic/claude-haiku-4-5", "*"]);
     expect(res.config?.channels?.modelByChannel?.telegram?.["*"]).toBe("anthropic/claude-opus-4-7");
     expectMigrationChangesToIncludeFragments(res.changes, [
-      'config.agents.defaults.imageModel from "anthropic/claude-haiku-4-5" to "anthropic/claude-sonnet-4-6"',
       'config.agents.defaults.imageGenerationModel.primary from "github-copilot/claude-sonnet-4" to "github-copilot/claude-sonnet-4.6"',
       'config.agents.defaults.imageGenerationModel.fallbacks.0 from "github-copilot/grok-code-fast-1" to "github-copilot/gpt-5.4-mini"',
       'config.agents.defaults.musicGenerationModel from "vercel-ai-gateway/anthropic/claude-opus-4-5" to "vercel-ai-gateway/anthropic/claude-opus-4-6"',
@@ -1800,7 +1800,6 @@ describe("legacy model compat migrate", () => {
       'config.agents.defaults.models key from "openai/gpt-5.2-pro" to "openai/gpt-5.5-pro"',
       'config.agents.defaults.models key from "github-copilot/gpt-5-mini" to "github-copilot/gpt-5.4-mini"',
       'config.plugins.entries.lossless-claw.config.summaryModel from "anthropic/claude-3-5-sonnet" to "anthropic/claude-sonnet-4-6"',
-      'config.plugins.entries.lossless-claw.subagent.allowedModels.0 from "anthropic/claude-haiku-4-5" to "anthropic/claude-sonnet-4-6"',
       'config.channels.modelByChannel.telegram.* from "anthropic/claude-opus-4-5" to "anthropic/claude-opus-4-7"',
     ]);
   });

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -635,6 +635,13 @@ function upgradeOldClaudeToken(
   ) {
     return null;
   }
+  // claude-haiku-4-5 is a current production model and must not be migrated.
+  if (
+    normalized.startsWith("claude-haiku-4-5") ||
+    normalized.startsWith("claude-haiku-4.5")
+  ) {
+    return null;
+  }
   if (
     normalized === "claude-opus-4" ||
     hasAnyRetiredVersionPrefix(normalized, [
@@ -658,8 +665,6 @@ function upgradeOldClaudeToken(
       "claude-sonnet-4.1",
       "claude-sonnet-4-0",
       "claude-sonnet-4.0",
-      "claude-haiku-4-5",
-      "claude-haiku-4.5",
     ]) ||
     /^claude-sonnet-4-20\d{6}/.test(normalized)
   ) {
@@ -714,7 +719,6 @@ function upgradeOldClaudeToken(
     normalized === "sonnet-3.7" ||
     normalized === "sonnet-3.5" ||
     normalized === "sonnet-3" ||
-    normalized === "haiku-4.5" ||
     normalized === "haiku-3.5" ||
     normalized === "haiku-3"
   ) {


### PR DESCRIPTION
## Summary

Fixes #87680. `claude-haiku-4-5` is a current Anthropic production model, but it is classified as retired in both the Claude model-ref resolver (`extensions/anthropic/claude-model-refs.ts`) and the doctor config migration (`src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts`). As a result:

- `openclaw doctor --fix` rewrites an explicitly configured `claude-haiku-4-5` to `claude-sonnet-4-6`, silently overriding a user's cost/latency-driven model choice.
- The bare `haiku` family alias resolves to `claude-sonnet-4-6` instead of `claude-haiku-4-5`.

The reporter notes 13 of their 14 cron jobs pin `claude-haiku-4-5` and lose that choice on any doctor-fix pass.

This change:

- Removes `claude-haiku-4-5` / `claude-haiku-4.5` (full and dotted) and the bare `haiku-4.5` short alias from the retired-to-sonnet upgrade lists in both mirrors.
- Adds an explicit current-model guard that returns the ref unchanged, mirroring the existing `claude-opus-4-7` / `claude-sonnet-4-6` current-model guards.
- Repoints `DEFAULT_CLAUDE_MODEL_BY_FAMILY.haiku` to `claude-haiku-4-5`.

Genuinely retired refs (Claude 3 Haiku, retired Sonnet/Opus) still upgrade to their canonical targets. Regression coverage is added for the Claude resolver and the doctor migration.

## Real behavior proof

Behavior or issue addressed: `openclaw doctor --fix` and the `haiku` alias no longer migrate the current `claude-haiku-4-5` model to `claude-sonnet-4-6`, while genuinely retired Claude 3 Haiku still upgrades to the canonical Sonnet.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, current PR branch run under the repo's runner and via direct invocation of the real resolver entry point.

Exact steps or command run after this patch: ran the real `resolveKnownAnthropicModelRef` entry point against representative refs, plus the migration regression suites; and verified before/after by temporarily restoring the retired classification (removing the current-model guard and re-adding the haiku entries) to confirm the regression run fails, then restoring the fix.

Evidence after fix: console output from running the real resolver entry point through node, plus the before/after regression run.
$ node --import tsx proof-resolver.mjs
anthropic/claude-haiku-4-5                -> anthropic/claude-haiku-4-5                (keep, current)
anthropic/claude-haiku-4.5                -> anthropic/claude-haiku-4.5                (keep, current)
anthropic/claude-haiku-4-5@anthropic:work -> anthropic/claude-haiku-4-5@anthropic:work (keep, current)
anthropic/claude-3-5-haiku-20241022       -> anthropic/claude-sonnet-4-6               (truly retired, upgraded)
-- BEFORE the fix (retired classification restored): regression run fails --
$ node scripts/run-vitest.mjs extensions/anthropic/cli-migration.test.ts
x preserves the current claude-haiku-4-5 model and its bare alias
AssertionError: expected 'anthropic/claude-sonnet-4-6' to be 'anthropic/claude-haiku-4-5'
-- AFTER the fix: all pass --
$ node scripts/run-vitest.mjs extensions/anthropic/cli-migration.test.ts
17 passed (17)
$ node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts
96 passed (96)
$ node scripts/run-vitest.mjs src/commands/doctor-legacy-config.migrations.test.ts
51 passed (51)

Observed result after fix: the current `claude-haiku-4-5` (full ref, dotted variant, and with an auth-profile suffix) is returned unchanged by the resolver and the doctor migration, the `haiku` family alias maps to `claude-haiku-4-5`, and the doctor migration no longer emits a haiku-to-sonnet change. Genuinely retired `claude-3-5-haiku-20241022` still upgrades to `claude-sonnet-4-6`.

What was not tested: a full interactive `openclaw doctor --fix` CLI run was not captured end-to-end in this environment; the change is confined to the model-ref resolver and the doctor migration table, both verified through their real exported entry point (`resolveKnownAnthropicModelRef`) and the three migration regression suites named in the issue's acceptance criteria. No real provider credentials or network calls were used.
