### PR TITLE
fix: tolerate legacy gateway token env alias

### DIFF
--- a/src/cli/daemon-cli/gateway-token-drift.test.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.test.ts
@@ -45,6 +45,30 @@ describe("resolveGatewayTokenForDriftCheck", () => {
     expect(token).toBe("service-token");
   });
 
+  it("resolves the canonical gateway token ref from the legacy env alias", async () => {
+    const token = await resolveGatewayTokenForDriftCheck({
+      cfg: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" },
+          },
+        },
+      } as OpenClawConfig,
+      env: {
+        OPENCLAW_GATEWAY_AUTH_TOKEN: "legacy-service-token",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(token).toBe("legacy-service-token");
+  });
+
   it("throws when an active local token ref is unresolved", async () => {
     await expect(
       resolveGatewayTokenForDriftCheck({

--- a/src/commands/doctor-gateway-auth-token.test.ts
+++ b/src/commands/doctor-gateway-auth-token.test.ts
@@ -52,6 +52,32 @@ describe("resolveGatewayAuthTokenForService", () => {
     expect(resolved).toEqual({ token: "resolved-token" });
   });
 
+  it("resolves canonical gateway token SecretRef from the legacy env alias", async () => {
+    const resolved = await resolveGatewayAuthTokenForService(
+      {
+        gateway: {
+          auth: {
+            token: {
+              source: "env",
+              provider: "default",
+              id: "OPENCLAW_GATEWAY_TOKEN",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      } as OpenClawConfig,
+      {
+        OPENCLAW_GATEWAY_AUTH_TOKEN: "legacy-token",
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(resolved).toEqual({ token: "legacy-token" });
+  });
+
   it("resolves env-template gateway.auth.token via SecretRef resolution", async () => {
     const resolved = await resolveGatewayAuthTokenForService(
       {

--- a/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
+++ b/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  collectCodexAppServerSplitBrainWarning,
   collectMacLaunchAgentOverrideWarning,
   collectMacLaunchctlGatewayEnvOverrideWarning,
   collectMacStaleOpenClawUpdateLaunchdJobsWarning,
@@ -118,6 +119,32 @@ describe("noteMacLaunchctlGatewayEnvOverrides", () => {
 
     expect(getenv).not.toHaveBeenCalled();
     expect(noteFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("collectCodexAppServerSplitBrainWarning", () => {
+  it("warns when managed and unmanaged Codex app-servers both exist", async () => {
+    const warning = await collectCodexAppServerSplitBrainWarning({
+      listProcesses: async () =>
+        [
+          "123 node /Users/test/.openclaw/npm/node_modules/@openclaw/codex/node_modules/.bin/codex app-server --listen stdio://",
+          "456 node /opt/homebrew/bin/codex app-server --listen unix://",
+          "789 /opt/homebrew/bin/codex app-server proxy",
+        ].join("\n"),
+    });
+
+    expect(warning).toContain("Dual Codex app-server daemons detected");
+    expect(warning).toContain("Managed OpenClaw Codex app-server PID(s): 123");
+    expect(warning).toContain("Unmanaged system Codex app-server PID(s): 456, 789");
+  });
+
+  it("does nothing when only the managed Codex app-server exists", async () => {
+    await expect(
+      collectCodexAppServerSplitBrainWarning({
+        listProcesses: async () =>
+          "123 node /Users/test/.openclaw/npm/node_modules/@openclaw/codex/node_modules/.bin/codex app-server --listen stdio://",
+      }),
+    ).resolves.toBeNull();
   });
 });
 

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -171,6 +171,52 @@ export async function noteMacLaunchctlGatewayEnvOverrides(
   }
 }
 
+function parseCodexAppServerProcessRows(output: string): Array<{ pid: string; command: string }> {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = /^(\d+)\s+(.+)$/.exec(line);
+      return match ? { pid: match[1]!, command: match[2]! } : undefined;
+    })
+    .filter((row): row is { pid: string; command: string } => Boolean(row))
+    .filter((row) => /\bcodex\b.*\bapp-server\b/i.test(row.command));
+}
+
+async function listProcessCommands(): Promise<string> {
+  const result = await execFileAsync("/bin/ps", ["-axo", "pid=,command="], { encoding: "utf8" });
+  return result.stdout ?? "";
+}
+
+export async function collectCodexAppServerSplitBrainWarning(deps?: {
+  listProcesses?: () => Promise<string>;
+}): Promise<string | null> {
+  const processRows = parseCodexAppServerProcessRows(
+    await (deps?.listProcesses ?? listProcessCommands)().catch(() => ""),
+  );
+  if (processRows.length === 0) {
+    return null;
+  }
+
+  const managed = processRows.filter((row) =>
+    row.command.includes(".openclaw/npm/node_modules/@openclaw/codex"),
+  );
+  const unmanaged = processRows.filter(
+    (row) => !row.command.includes(".openclaw/npm/node_modules/@openclaw/codex"),
+  );
+  if (managed.length === 0 || unmanaged.length === 0) {
+    return null;
+  }
+
+  return [
+    "- Dual Codex app-server daemons detected.",
+    `- Managed OpenClaw Codex app-server PID(s): ${managed.map((row) => row.pid).join(", ")}.`,
+    `- Unmanaged system Codex app-server PID(s): ${unmanaged.map((row) => row.pid).join(", ")}.`,
+    "- Stop the unmanaged system Codex app-server before diagnosing agent timeout settings.",
+  ].join("\n");
+}
+
 export async function collectMacGatewayPlatformWarnings(
   cfg: OpenClawConfig,
 ): Promise<readonly string[]> {
@@ -186,6 +232,10 @@ export async function collectMacGatewayPlatformWarnings(
   const launchctlWarning = await collectMacLaunchctlGatewayEnvOverrideWarning(cfg);
   if (launchctlWarning) {
     warnings.push(launchctlWarning);
+  }
+  const codexSplitBrainWarning = await collectCodexAppServerSplitBrainWarning();
+  if (codexSplitBrainWarning) {
+    warnings.push(codexSplitBrainWarning);
   }
   return warnings;
 }

--- a/src/gateway/auth-token-resolution.ts
+++ b/src/gateway/auth-token-resolution.ts
@@ -9,6 +9,18 @@ import {
 type GatewayAuthTokenResolutionSource = "explicit" | "config" | "secretRef" | "env";
 type GatewayAuthTokenEnvFallback = "never" | "no-secret-ref" | "always";
 
+function withGatewayTokenEnvAlias(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const canonical = trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN);
+  const legacy = trimToUndefined(env.OPENCLAW_GATEWAY_AUTH_TOKEN);
+  if (canonical || !legacy) {
+    return env;
+  }
+  return {
+    ...env,
+    OPENCLAW_GATEWAY_TOKEN: legacy,
+  };
+}
+
 export async function resolveGatewayAuthToken(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -36,7 +48,8 @@ export async function resolveGatewayAuthToken(params: {
     defaults: params.cfg.secrets?.defaults,
   }).ref;
   const envFallback = params.envFallback ?? "always";
-  const envToken = trimToUndefined(params.env.OPENCLAW_GATEWAY_TOKEN);
+  const env = withGatewayTokenEnvAlias(params.env);
+  const envToken = trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN);
 
   if (!tokenRef) {
     const configToken = trimToUndefined(tokenInput);
@@ -59,7 +72,7 @@ export async function resolveGatewayAuthToken(params: {
 
   const resolved = await resolveConfiguredSecretInputString({
     config: params.cfg,
-    env: params.env,
+    env,
     value: tokenInput,
     path: "gateway.auth.token",
     unresolvedReasonStyle: params.unresolvedReasonStyle,


### PR DESCRIPTION
Summary
- resolve canonical OPENCLAW_GATEWAY_TOKEN SecretRefs from the legacy OPENCLAW_GATEWAY_AUTH_TOKEN alias when the canonical env var is absent
- add doctor warning for simultaneous managed and unmanaged Codex app-server daemons
- cover service token resolution, drift checks, and doctor process detection with focused tests

Why
- staged installs can have the legacy gateway token env name after config has moved to OPENCLAW_GATEWAY_TOKEN, causing command paths to report GatewaySecretRefUnavailableError
- unmanaged system Codex app-server daemons can coexist with the OpenClaw-managed Codex app-server and confuse timeout diagnosis

Test
- pnpm vitest run src/commands/doctor-gateway-auth-token.test.ts src/cli/daemon-cli/gateway-token-drift.test.ts src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts