### PR TITLE
fix: suppress Codex timeout fallback in Discord groups

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4780,6 +4780,86 @@ describe("runAgentTurnWithFallback", () => {
   );
 
   it.each(["group", "channel"] as const)(
+    "keeps Codex prompt-timeout payloads out of Discord %s chats",
+    async (chatType) => {
+      state.runEmbeddedAgentMock.mockResolvedValueOnce({
+        payloads: [
+          {
+            text: "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+            isError: true,
+          },
+        ],
+        meta: { livenessState: "abandoned", replayInvalid: true },
+      });
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          sessionCtx: {
+            Provider: "discord",
+            Surface: "discord",
+            ChatType: chatType,
+            GroupSubject: "agent group",
+            GroupChannel: "#general",
+            MessageSid: "msg",
+          } as unknown as TemplateContext,
+        }),
+      );
+
+      expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.runResult.payloads).toEqual([{ text: SILENT_REPLY_TOKEN, isError: true }]);
+      }
+    },
+  );
+
+  it("uses channel-safe Codex prompt-timeout copy when Discord group failures are explicitly surfaced", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+          isError: true,
+        },
+      ],
+      meta: { livenessState: "abandoned", replayInvalid: true },
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.config = {
+      agents: {
+        defaults: {
+          silentReply: { group: "disallow" },
+        },
+      },
+    };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "group",
+          GroupSubject: "agent group",
+          GroupChannel: "#general",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads?.[0]?.text).toContain(
+        "Codex did not finish the turn cleanly",
+      );
+      expect(result.runResult.payloads?.[0]?.text).not.toContain(
+        "Codex stopped before confirming the turn was complete",
+      );
+    }
+  });
+
+  it.each(["group", "channel"] as const)(
     "surfaces raw runner failure copy in Discord %s chats when silentReply.group is set to disallow",
     async (chatType) => {
       state.runEmbeddedAgentMock.mockRejectedValueOnce(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -676,6 +676,10 @@ const CODEX_APP_SERVER_CLIENT_CLOSED_BEFORE_REPLY_RE =
   /\bcodex app-server client closed before turn completed\b/iu;
 const CODEX_APP_SERVER_TURN_COMPLETION_IDLE_TIMEOUT_RE =
   /\bcodex app-server turn idle timed out waiting for turn\/completed\b/iu;
+const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_REPLY_RE =
+  /\bCodex stopped before confirming the turn was complete\./iu;
+const CODEX_APP_SERVER_CHANNEL_SAFE_TIMEOUT_TEXT =
+  "⚠️ Codex did not finish the turn cleanly. Some work may already have been performed; verify the current state before retrying.";
 
 function buildCodexAppServerFailureText(message: string): string | null {
   const normalizedMessage = collapseRepeatedFailureDetail(message);
@@ -792,6 +796,31 @@ function buildExternalRunFailureReply(
 
 function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload: T): T {
   return markReplyPayloadForSourceSuppressionDelivery(payload);
+}
+
+function buildCodexPromptTimeoutReplyPayloadForConversation(params: {
+  payloads: readonly ReplyPayload[] | undefined;
+  sessionCtx: TemplateContext;
+  cfg?: OpenClawConfig;
+}): ReplyPayload | undefined {
+  const hasCodexPromptTimeoutPayload = params.payloads?.some(
+    (payload) =>
+      payload.isError === true &&
+      hasNonEmptyString(payload.text) &&
+      CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_REPLY_RE.test(payload.text),
+  );
+  if (!hasCodexPromptTimeoutPayload) {
+    return undefined;
+  }
+  return markAgentRunFailureReplyPayload({
+    text: resolveExternalRunFailureTextForConversation({
+      text: CODEX_APP_SERVER_CHANNEL_SAFE_TIMEOUT_TEXT,
+      sessionCtx: params.sessionCtx,
+      isGenericRunnerFailure: true,
+      cfg: params.cfg,
+    }),
+    isError: true,
+  });
 }
 
 export function buildKnownAgentRunFailureReplyPayload(params: {
@@ -2860,6 +2889,14 @@ export async function runAgentTurnWithFallback(params: {
       (p) => !p.isError && !p.isReasoning && hasOutboundReplyContent(p, { trimText: true }),
     );
     if (!hasNonErrorContent) {
+      const codexPromptTimeoutPayload = buildCodexPromptTimeoutReplyPayloadForConversation({
+        payloads: runResult.payloads,
+        sessionCtx: params.sessionCtx,
+        cfg: params.followupRun.run.config,
+      });
+      if (codexPromptTimeoutPayload) {
+        runResult.payloads = [codexPromptTimeoutPayload];
+      }
       const metaErrorMsg = finalEmbeddedError?.message ?? "";
       const rawErrorPayloadText =
         runResult.payloads?.find(
@@ -2869,7 +2906,7 @@ export async function runAgentTurnWithFallback(params: {
       const formattedErrorCandidate = errorCandidate
         ? formatRateLimitOrOverloadedErrorCopy(errorCandidate)
         : undefined;
-      if (formattedErrorCandidate) {
+      if (!codexPromptTimeoutPayload && formattedErrorCandidate) {
         runResult.payloads = [
           markAgentRunFailureReplyPayload({
             text: resolveExternalRunFailureTextForConversation({


### PR DESCRIPTION
## Summary
- add a Codex prompt-timeout payload guard before reply payload delivery
- keep the raw `Codex stopped before confirming...` fallback out of Discord group/channel chats by default
- preserve explicit surfaced failures with channel-safe copy and keep replay/liveness metadata intact

## Real behavior proof
- **Behavior or issue addressed**: Codex missing-terminal/side-effect timeout payloads should not be delivered to Discord group or channel chats as normal assistant text. If an operator explicitly disables silent group failure handling, the message should use channel-safe wording instead of the raw internal `Codex stopped before confirming...` fallback.
- **Real environment tested**: macOS local OpenClaw source checkout on branch `fix/issue-87725-codex-discord-fallback`, Node/pnpm workspace install, running the same auto-reply runner path used by the gateway reply lane.
- **Exact steps or command run after the patch**: In the patched checkout, ran the auto-reply runner proof lane that exercises Discord `group` and `channel` contexts with a Codex prompt-timeout payload carrying `livenessState: "abandoned"` and `replayInvalid: true`.
- **Evidence after fix**: Copied terminal output from the patched checkout:

```text
$ pnpm exec vitest run src/auto-reply/reply/agent-runner-execution.test.ts --testNamePattern "Codex prompt-timeout|raw runner failure boilerplate|silent behavior in Discord"

 RUN  v4.1.7 /private/tmp/openclaw-87725-1779988902

 Test Files  1 passed (1)
      Tests  7 passed | 142 skipped (149)
   Duration  5.19s
```

The exercised Discord group/channel prompt-timeout cases assert the returned payload is `NO_REPLY`, while the explicit `silentReply.group = "disallow"` case asserts the raw internal text is replaced by `Codex did not finish the turn cleanly...`.
- **Observed result after fix**: The raw `Codex stopped before confirming the turn was complete...` string is no longer emitted from the patched runner path for default Discord group/channel chats. The replay-invalid/abandoned side-effect case still produces a guarded failure payload, so unsafe automatic replay remains blocked.
- **What was not tested**: I did not hotpatch or restart a live production gateway with this branch. The proof is from the patched local OpenClaw checkout and focused runner path; full CI is still running on the PR.

## Verification
- `pnpm exec vitest run src/auto-reply/reply/agent-runner-execution.test.ts --testNamePattern "Codex prompt-timeout|raw runner failure boilerplate|silent behavior in Discord"`
- `pnpm exec vitest run src/auto-reply/reply/agent-runner-execution.test.ts`
- `git diff --check`

Fixes #87725
