### PR TITLE
fix(ci): raise plugin sdk strict smoke heap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1172,7 +1172,7 @@ jobs:
               pnpm lint:auth:pairing-account-scope
               pnpm check:import-cycles
               # build-artifacts already runs the tsdown/runtime build for the same Node-relevant changes.
-              pnpm build:plugin-sdk:strict-smoke
+              NODE_OPTIONS=--max-old-space-size=8192 pnpm build:plugin-sdk:strict-smoke
               ;;
             prod-types)
               pnpm tsgo:prod


### PR DESCRIPTION
## Summary

- raises the heap budget only for the `check-guards` plugin SDK strict-smoke command
- keeps the shard on its existing runner while matching the memory budget already used by heavier plugin SDK/build checks

## Verification

- `git diff --check origin/main...HEAD -- .github/workflows/ci.yml`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm build:plugin-sdk:strict-smoke`
- Confirmed the original PR #87503 rerun passed `check-guards` on attempt 2 after the first attempt OOMed in the same strict-smoke command

Behavior addressed: `check-guards` can OOM while generating plugin SDK declarations with the default Node heap.
Real environment tested: local macOS checkout plus GitHub Actions log/rerun inspection.
Exact steps or command run after this patch: `NODE_OPTIONS=--max-old-space-size=8192 pnpm build:plugin-sdk:strict-smoke`.
Evidence after fix: focused command completed successfully with the same heap setting this workflow now applies.
Observed result after fix: plugin SDK strict-smoke finished without a Node heap OOM.
What was not tested: a fresh full CI run for this new branch has not completed yet.
