### PR TITLE
fix(codex): recover raw missing-thread compaction failures

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -769,6 +769,86 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(updatedEntry?.compactionCount).toBe(1);
   });
 
+  it("falls back to context-engine compaction when Codex native compaction returns a raw missing thread reason", async () => {
+    const sessionKey = "agent:main:codex-raw-stale-binding";
+    const sessionId = "session-codex-raw-stale-binding";
+    const sessionFile = path.join(tmpDir, "session-codex-raw-stale-binding.jsonl");
+    const storePath = path.join(tmpDir, "sessions-codex-raw-stale-binding.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const compactAgentHarnessSession = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "thread not found: thread-raw",
+    }));
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    const recordCliCompactionInStore = vi.fn(async () => ({
+      ...sessionEntry,
+      compactionCount: 1,
+    }));
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
+      recordCliCompactionInStore,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "codex",
+      model: "gpt-5.5",
+    });
+
+    expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(1);
+    expect(maintenance).toHaveBeenCalledTimes(1);
+    expect(recordCliCompactionInStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "codex",
+        sessionKey,
+        tokensAfter: undefined,
+      }),
+    );
+    expect(updatedEntry?.compactionCount).toBe(1);
+  });
+
   it("keeps successful context-engine fallback when post-compaction maintenance fails", async () => {
     const sessionKey = "agent:main:codex-stale-maintenance";
     const sessionId = "session-codex-stale-maintenance";

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -22,6 +22,7 @@ import { runContextEngineMaintenance as runContextEngineMaintenanceImpl } from "
 import { shouldPreemptivelyCompactBeforePrompt as shouldPreemptivelyCompactBeforePromptImpl } from "../embedded-agent-runner/run/preemptive-compaction.js";
 import { resolveLiveToolResultMaxChars as resolveLiveToolResultMaxCharsImpl } from "../embedded-agent-runner/tool-result-truncation.js";
 import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
+import { isRecoverableNativeHarnessBindingFailure } from "../harness/compaction-recovery.js";
 import { ensureSelectedAgentHarnessPlugin as ensureSelectedAgentHarnessPluginImpl } from "../harness/runtime-plugin.js";
 import { maybeCompactAgentHarnessSession as maybeCompactAgentHarnessSessionImpl } from "../harness/selection.js";
 import type { AgentMessage } from "../runtime/index.js";
@@ -172,16 +173,6 @@ function isUnsupportedNativeHarnessCompaction(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
   return result?.ok === false && result.failure?.reason === "unsupported_harness_compaction";
-}
-
-function isRecoverableNativeHarnessCompactionFailure(
-  result: EmbeddedAgentCompactResult | undefined,
-): boolean {
-  return (
-    result?.ok === false &&
-    (result.failure?.reason === "missing_thread_binding" ||
-      result.failure?.reason === "stale_thread_binding")
-  );
 }
 
 function readAgentIdFromSessionKey(sessionKey: string): string | undefined {
@@ -411,7 +402,7 @@ async function compactNativeHarnessCliTranscript(params: {
   if (!result?.compacted) {
     const fallbackToContextEngine =
       isUnsupportedNativeHarnessCompaction(result) ||
-      isRecoverableNativeHarnessCompactionFailure(result);
+      isRecoverableNativeHarnessBindingFailure(result);
     log.warn(
       `CLI native harness compaction did not reduce context for ${params.provider}/${params.model}: ${result?.reason ?? "nothing to compact"}`,
     );

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -20,6 +20,7 @@ import { resolveUserPath } from "../../utils.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
+import { isRecoverableNativeHarnessBindingFailure } from "../harness/compaction-recovery.js";
 import {
   maybeCompactAgentHarnessSession,
   resolveAgentHarnessPolicy,
@@ -53,11 +54,7 @@ import { normalizeContextTokenBudget } from "./utils.js";
 function shouldFallbackAfterHarnessCompaction(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
-  return (
-    result?.ok === false &&
-    (result.failure?.reason === "missing_thread_binding" ||
-      result.failure?.reason === "stale_thread_binding")
-  );
+  return isRecoverableNativeHarnessBindingFailure(result);
 }
 
 const DEFERRED_CONTEXT_ENGINE_COMPACTION_SCHEDULE_FAILURE_REASON =

--- a/src/agents/harness/compaction-recovery.ts
+++ b/src/agents/harness/compaction-recovery.ts
@@ -1,0 +1,24 @@
+import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
+
+export function isRecoverableNativeHarnessBindingReason(reason: unknown): boolean {
+  if (typeof reason !== "string") {
+    return false;
+  }
+  const normalized = reason.trim().toLowerCase();
+  return (
+    normalized === "missing_thread_binding" ||
+    normalized === "stale_thread_binding" ||
+    normalized.includes("thread not found") ||
+    normalized.includes("no thread binding")
+  );
+}
+
+export function isRecoverableNativeHarnessBindingFailure(
+  result: EmbeddedAgentCompactResult | undefined,
+): boolean {
+  return (
+    result?.ok === false &&
+    (isRecoverableNativeHarnessBindingReason(result.failure?.reason) ||
+      isRecoverableNativeHarnessBindingReason(result.reason))
+  );
+}

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -929,6 +929,57 @@ describe("runMemoryFlushIfNeeded", () => {
     },
   );
 
+  it("continues after an unstructured thread-not-found preflight compaction failure", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "thread not found: <codex-thread-id>",
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 120,
+      totalTokensFresh: true,
+    };
+    const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "agent:main:telegram:group:redacted",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:telegram:group:redacted",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+  });
+
   it("still fails preflight compaction for non-binding native harness failures", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -7,6 +7,7 @@ import {
   classifyCompactionReason,
   DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON,
 } from "../../agents/embedded-agent-runner/compact-reasons.js";
+import { isRecoverableNativeHarnessBindingFailure } from "../../agents/harness/compaction-recovery.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -128,14 +129,6 @@ const memoryDeps = {
   randomUUID: () => crypto.randomUUID(),
   now: () => Date.now(),
 };
-
-function isRecoverableNativeHarnessBindingFailure(result: unknown): boolean {
-  if (!result || typeof result !== "object") {
-    return false;
-  }
-  const failure = (result as { failure?: { reason?: unknown } }).failure;
-  return failure?.reason === "missing_thread_binding" || failure?.reason === "stale_thread_binding";
-}
 
 export function setAgentRunnerMemoryTestDeps(overrides?: Partial<typeof memoryDeps>): void {
   Object.assign(memoryDeps, {


### PR DESCRIPTION
## Summary

Fixes #87736.

This is a narrow follow-up to #86211 / #86602. The existing recovery path handles structured Codex native harness binding failures when `failure.reason` is `missing_thread_binding` or `stale_thread_binding`. A live regression on OpenClaw `2026.5.27` still surfaced the raw preflight error:

```text
Preflight compaction required but failed: thread not found: <codex-thread-id>
```

This patch classifies the raw `reason` text for the same missing/stale binding shapes as recoverable too, so preflight compaction continues into the existing recovery path instead of surfacing a generic Telegram failure.

## User-visible problem

A Telegram group inbound was accepted, but dispatch failed before a normal assistant turn. The user saw the generic channel failure message rather than automatic session recovery. The session later rotated/recovered and subsequent dispatches worked, which matches the same operational class as #86211.

All issue/PR evidence is sanitized: no private chat ids, message ids, session ids, bot handles, or raw Codex thread ids.

## Implementation

- Adds a shared native harness recovery classifier in `src/agents/harness/compaction-recovery.ts`.
- Classifies both structured binding reasons and raw missing-thread reason strings as recoverable.
- Uses the shared classifier from auto-reply preflight compaction, CLI compaction, and queued embedded compaction so sibling Codex recovery paths handle the same raw result shape.
- Adds regression coverage for:
  - auto-reply preflight `{ ok:false, compacted:false, reason:"thread not found: <codex-thread-id>" }`
  - CLI native compaction fallback when the harness returns a raw top-level `thread not found` reason with no `failure.reason`.

## Real behavior proof

- **Behavior addressed:** Raw missing-thread preflight compaction results should be treated as recoverable, matching the structured `missing_thread_binding` / `stale_thread_binding` recovery path from #86602.
- **Real environment tested:** Local OpenClaw source checkout for this PR branch on Linux with Node `22.22.2`, using the real `runPreflightCompactionIfNeeded` runtime helper from `src/auto-reply/reply/agent-runner-memory.ts`.
- **Exact steps or command run after this patch:** Ran a local Node/tsx runtime invocation that created a redacted Telegram-group session entry, invoked `runPreflightCompactionIfNeeded`, and returned a raw compaction result shaped as `{ ok:false, compacted:false, reason:"thread not found: <codex-thread-id>" }`.
- **Evidence after fix:**

```json
{
  "proof": "raw thread-not-found preflight compaction is recoverable",
  "returnedSameSessionEntry": true,
  "compactCalls": 1,
  "incrementCalls": 0,
  "threw": false
}
```

- **Observed result after fix:** The runtime helper returned the active session entry and did not throw `Preflight compaction required but failed: thread not found: <codex-thread-id>`.
- **What was not tested:** Live Telegram delivery against a production gateway running this branch was not tested; the proof covers the runtime recovery branch directly with sanitized local session state.

## Validation

Passed on rebased head `24ea4a100b2e0877c4eec97e7e3eca2ebbce4cce`:

```text
node --import tsx --input-type=module -e "await import('./src/agents/harness/compaction-recovery.ts'); console.log('import-ok')"
pnpm exec oxlint src/agents/harness/compaction-recovery.ts src/auto-reply/reply/agent-runner-memory.ts src/auto-reply/reply/agent-runner-memory.test.ts src/agents/command/cli-compaction.ts src/agents/command/cli-compaction.test.ts src/agents/embedded-agent-runner/compact.queued.ts
pnpm exec oxfmt --check src/agents/harness/compaction-recovery.ts src/auto-reply/reply/agent-runner-memory.ts src/auto-reply/reply/agent-runner-memory.test.ts src/agents/command/cli-compaction.ts src/agents/command/cli-compaction.test.ts src/agents/embedded-agent-runner/compact.queued.ts
git diff --check
```


Attempted but not completed locally:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts -t 'unstructured thread-not-found' --run
```

The Vitest process stayed CPU-bound without reporter output in this fresh worktree even with a timeout. I stopped treating the local wrapper as authoritative and pushed the branch for CI to exercise the included regression tests.


