### PR TITLE
Telegram: keep long DM turns alive through progress previews

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -8,6 +8,7 @@ import {
   createTestDraftStream,
 } from "./draft-stream.test-helpers.js";
 import { notifyTelegramInboundEventOutboundSuccess } from "./inbound-event-delivery.js";
+import { createTelegramLongTurnProgressState } from "./long-turn-progress.js";
 import {
   buildTelegramConversationContext,
   createTelegramMessageCache,
@@ -18,6 +19,17 @@ import { recordOutboundMessageForPromptContext as recordOutboundMessageForPrompt
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
 >[0];
+type ForegroundFreshnessPolicyForTest = {
+  allowSupersededDelivery?: (delivery: {
+    payload: { text?: string; isError?: boolean; mediaUrl?: string };
+    info: { kind: "block" | "final" | "tool" };
+  }) => boolean;
+  registerVisibleDeliveryMarker?: (markVisibleDelivery: (() => void) | undefined) => void;
+};
+
+const foregroundReplyFreshnessPolicyKey = Symbol.for(
+  "openclaw.internal.foregroundReplyFreshnessPolicy",
+);
 
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const createNativeTelegramToolProgressDraft = vi.hoisted(() => vi.fn());
@@ -364,6 +376,14 @@ describe("dispatchTelegramMessage draft streaming", () => {
     return expectRecordFields(mockCallArg(dispatchReplyWithBufferedBlockDispatcher), expected);
   }
 
+  function readForegroundFreshnessPolicy(
+    replyOptions: DispatchReplyWithBufferedBlockDispatcherArgs["replyOptions"],
+  ): ForegroundFreshnessPolicyForTest | undefined {
+    return (
+      replyOptions as Record<symbol, ForegroundFreshnessPolicyForTest | undefined> | undefined
+    )?.[foregroundReplyFreshnessPolicyKey];
+  }
+
   function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
     const base = {
       ctxPayload: {},
@@ -482,6 +502,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     bot?: Bot;
     replyToMode?: Parameters<typeof dispatchTelegramMessage>[0]["replyToMode"];
     textLimit?: number;
+    longTurnProgressState?: Parameters<typeof dispatchTelegramMessage>[0]["longTurnProgressState"];
   }) {
     const bot = params.bot ?? createBot();
     await dispatchTelegramMessage({
@@ -495,6 +516,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: params.telegramCfg ?? {},
       telegramDeps: params.telegramDeps ?? telegramDepsForTest,
       opts: { token: "token" },
+      ...(params.longTurnProgressState
+        ? { longTurnProgressState: params.longTurnProgressState }
+        : {}),
     });
   }
 
@@ -554,6 +578,492 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectRecordFields(dispatchParams.replyOptions, { disableBlockStreaming: true });
     expect(editMessageTelegram).not.toHaveBeenCalled();
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("materializes a long-turn progress preview and finalizes the same draft", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createSequencedDraftStream(2001);
+    const markVisiblePreview = vi.fn();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(
+          markVisiblePreview,
+        );
+        longTurnProgressState.requestProgressPreview();
+        await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("ready");
+        const freshnessPolicy = readForegroundFreshnessPolicy(replyOptions);
+        expect(
+          freshnessPolicy?.allowSupersededDelivery?.({
+            payload: { text: "final answer" },
+            info: { kind: "final" },
+          }),
+        ).toBe(true);
+        expect(
+          freshnessPolicy?.allowSupersededDelivery?.({
+            payload: { text: "final answer" },
+            info: { kind: "tool" },
+          }),
+        ).toBe(false);
+        expect(
+          freshnessPolicy?.allowSupersededDelivery?.({
+            payload: { text: "final answer", mediaUrl: "file:///tmp/final.png" },
+            info: { kind: "final" },
+          }),
+        ).toBe(false);
+        expect(
+          freshnessPolicy?.allowSupersededDelivery?.({
+            payload: { text: "x".repeat(5000) },
+            info: { kind: "final" },
+          }),
+        ).toBe(false);
+        expect(
+          freshnessPolicy?.allowSupersededDelivery?.({
+            payload: { text: `${"x".repeat(60)}...` },
+            info: { kind: "final" },
+          }),
+        ).toBe(false);
+        await dispatcherOptions.deliver({ text: "final answer" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(true);
+    expect(markVisiblePreview).toHaveBeenCalledTimes(1);
+    expect(draftStream.update.mock.calls[0]?.[0]).toBe("Working");
+    expect(draftStream.update).toHaveBeenLastCalledWith("final answer");
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("waits for the foreground freshness marker before reporting long-turn preview readiness", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createSequencedDraftStream(2001);
+    const markVisiblePreview = vi.fn();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      longTurnProgressState.requestProgressPreview();
+      const previewWait = longTurnProgressState.waitForProgressPreview();
+      let previewResolved = false;
+      void previewWait.then(() => {
+        previewResolved = true;
+      });
+      await vi.waitFor(() => expect(draftStream.update).toHaveBeenCalledWith("Working"));
+      await Promise.resolve();
+      expect(previewResolved).toBe(false);
+      readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(
+        markVisiblePreview,
+      );
+      await expect(previewWait).resolves.toBe("ready");
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(true);
+    expect(markVisiblePreview).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send a stale fallback final when superseded progress preview finalization misses", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(vi.fn());
+        longTurnProgressState.requestProgressPreview();
+        await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("ready");
+        const freshnessPolicy = readForegroundFreshnessPolicy(replyOptions);
+        expect(
+          freshnessPolicy?.allowSupersededDelivery?.({
+            payload: { text: "final answer" },
+            info: { kind: "final" },
+          }),
+        ).toBe(true);
+        draftStream.lastDeliveredText.mockReturnValue("Working");
+        await dispatcherOptions.deliver({ text: "final answer" }, { kind: "final" });
+        return {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(true);
+    expect(draftStream.update.mock.calls[0]?.[0]).toBe("Working");
+    expect(draftStream.update).toHaveBeenLastCalledWith("final answer");
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("finalizes a long-turn progress preview with an error instead of sending a separate fallback", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    const context = createContext({
+      ctxPayload: createDirectSessionPayload(),
+    });
+    loadSessionStore.mockReturnValue({
+      "agent:test:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(vi.fn());
+      longTurnProgressState.requestProgressPreview();
+      await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("ready");
+      throw new Error("provider down");
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context,
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(draftStream.update.mock.calls[0]?.[0]).toBe("Working");
+    expect(draftStream.update).toHaveBeenLastCalledWith(
+      "Something went wrong while processing your request. Please try again.",
+    );
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+      content: "Something went wrong while processing your request. Please try again.",
+      messageId: 2001,
+    });
+    expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext), {
+      chatId: "123",
+      messageId: 2001,
+      text: "Something went wrong while processing your request. Please try again.",
+      messageThreadId: 777,
+    });
+    await vi.waitFor(() => expect(appendSessionTranscriptMessage).toHaveBeenCalledTimes(1));
+    const transcriptCall = expectRecordFields(mockCallArg(appendSessionTranscriptMessage), {
+      transcriptPath: "/tmp/session.jsonl",
+    });
+    expectRecordFields(transcriptCall.message, {
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [
+        {
+          type: "text",
+          text: "Something went wrong while processing your request. Please try again.",
+        },
+      ],
+    });
+  });
+
+  it("uses normal failure fallback when long-turn error preview edit is not delivered", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createSequencedDraftStream(2001);
+    draftStream.lastDeliveredText.mockReturnValue("Working");
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(vi.fn());
+      longTurnProgressState.requestProgressPreview();
+      await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("ready");
+      throw new Error("provider down");
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(draftStream.update).toHaveBeenLastCalledWith(
+      "Something went wrong while processing your request. Please try again.",
+    );
+    expectDeliveredReply(0, {
+      text: "Something went wrong while processing your request. Please try again.",
+    });
+  });
+
+  it("uses normal failure fallback when long-turn progress has no confirmed preview message", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createTestDraftStream();
+    draftStream.sendMayHaveLanded.mockReturnValue(true);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async () => {
+      longTurnProgressState.requestProgressPreview();
+      await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("unavailable");
+      throw new Error("provider down");
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(false);
+    expect(draftStream.update).not.toHaveBeenCalled();
+    expectDeliveredReply(0, {
+      text: "Something went wrong while processing your request. Please try again.",
+    });
+  });
+
+  it("waits for in-flight long-turn preview sends before reporting progress readiness", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    let releaseFlush!: () => void;
+    let flushStarted!: () => void;
+    const flushStartedPromise = new Promise<void>((resolve) => {
+      flushStarted = resolve;
+    });
+    const flushReleasePromise = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+    const draftStream = createTestDraftStream();
+    draftStream.sendMayHaveLanded.mockReturnValue(true);
+    draftStream.flush.mockImplementation(async () => {
+      flushStarted();
+      await flushReleasePromise;
+      draftStream.setMessageId(2001);
+      draftStream.sendMayHaveLanded.mockReturnValue(false);
+    });
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(vi.fn());
+      longTurnProgressState.requestProgressPreview();
+      const waitForPreview = longTurnProgressState.waitForProgressPreview();
+      await flushStartedPromise;
+      let resolved = false;
+      void waitForPreview.then(() => {
+        resolved = true;
+      });
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+      releaseFlush();
+      await expect(waitForPreview).resolves.toBe("ready");
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(true);
+    expect(draftStream.flush).toHaveBeenCalledTimes(1);
+    expect(draftStream.update).not.toHaveBeenCalledWith("Working");
+  });
+
+  it("preserves already-visible tool progress previews before detaching", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        expect(draftStream.messageId()).toBe(2001);
+        readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(vi.fn());
+        longTurnProgressState.requestProgressPreview();
+        await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("ready");
+        const freshnessPolicy = readForegroundFreshnessPolicy(replyOptions);
+        expect(
+          freshnessPolicy?.allowSupersededDelivery?.({
+            payload: { text: "final answer" },
+            info: { kind: "final" },
+          }),
+        ).toBe(true);
+        await dispatcherOptions.deliver({ text: "final answer" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(true);
+    expect(draftStream.update.mock.calls[0]?.[0]).toContain("Exec");
+    expect(draftStream.update).toHaveBeenLastCalledWith("final answer");
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("does not bypass freshness for ambiguous long-turn previews without a message id", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createTestDraftStream();
+    draftStream.sendMayHaveLanded.mockReturnValue(true);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      longTurnProgressState.requestProgressPreview();
+      await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("unavailable");
+      const freshnessPolicy = readForegroundFreshnessPolicy(replyOptions);
+      expect(
+        freshnessPolicy?.allowSupersededDelivery?.({
+          payload: { text: "final answer" },
+          info: { kind: "final" },
+        }),
+      ).toBe(false);
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(false);
+    expect(draftStream.messageId()).toBeUndefined();
+    expect(draftStream.update).not.toHaveBeenCalled();
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+  });
+
+  it("replaces unsent partial answer drafts when materializing a long-turn progress preview", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftUpdates: string[] = [];
+    const draftEvents: string[] = [];
+    let draftStream!: ReturnType<typeof createTestDraftStream>;
+    draftStream = createTestDraftStream({
+      onUpdate: (text) => {
+        draftUpdates.push(text);
+        draftEvents.push(`update:${text}`);
+        if (text === "Working") {
+          draftStream.setMessageId(2001);
+        }
+      },
+    });
+    const forceNewMessage = draftStream.forceNewMessage.getMockImplementation();
+    draftStream.forceNewMessage.mockImplementation(() => {
+      draftEvents.push("force-new");
+      forceNewMessage?.();
+    });
+    const stop = draftStream.stop.getMockImplementation();
+    draftStream.stop.mockImplementation(async () => {
+      draftEvents.push("stop");
+      await stop?.();
+    });
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Hi" });
+        expect(draftStream.messageId()).toBeUndefined();
+        readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(vi.fn());
+        longTurnProgressState.requestProgressPreview();
+        await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("ready");
+        await replyOptions?.onPartialReply?.({ text: "Hi there" });
+        await dispatcherOptions.deliver({ text: "Hi there final" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(true);
+    expect(draftStream.forceInitialSend).toHaveBeenCalledTimes(1);
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(draftEvents.slice(0, 3)).toEqual(["update:Hi", "force-new", "update:Working"]);
+    const progressPreviewIndex = draftEvents.indexOf("update:Working");
+    const firstStopIndex = draftEvents.indexOf("stop");
+    expect(firstStopIndex === -1 || firstStopIndex > progressPreviewIndex).toBe(true);
+    expect(draftUpdates).toEqual(["Hi", "Working", "Hi there", "Hi there final"]);
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("clears long-turn progress previews before separate progress-mode final delivery", async () => {
+    const longTurnProgressState = createTelegramLongTurnProgressState();
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        readForegroundFreshnessPolicy(replyOptions)?.registerVisibleDeliveryMarker?.(vi.fn());
+        longTurnProgressState.requestProgressPreview();
+        await expect(longTurnProgressState.waitForProgressPreview()).resolves.toBe("ready");
+        const freshnessPolicy = readForegroundFreshnessPolicy(replyOptions);
+        expect(
+          freshnessPolicy?.allowSupersededDelivery?.({
+            payload: { text: "final answer" },
+            info: { kind: "final" },
+          }),
+        ).toBe(false);
+        await dispatcherOptions.deliver({ text: "final answer" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "progress",
+      telegramCfg: { streaming: { progress: { label: "Working" } } },
+      longTurnProgressState,
+    });
+
+    expect(longTurnProgressState.hasProgressPreview()).toBe(true);
+    expect(draftStream.update.mock.calls[0]?.[0]).toBe("Working");
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(draftStream.update).not.toHaveBeenLastCalledWith("final answer");
+    expectDeliveredReply(0, { text: "final answer" });
   });
 
   it("recovers forum thread context from a topic-scoped session key", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -30,6 +30,7 @@ import {
   formatChannelProgressDraftLineForEntry,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
+  isPotentialTruncatedFinal,
   mergeChannelProgressDraftLine,
   resolveChannelProgressDraftMaxLines,
   resolveChannelStreamingBlockEnabled,
@@ -117,6 +118,7 @@ import {
   type LaneDeliveryResult,
   type LaneName,
 } from "./lane-delivery.js";
+import type { TelegramLongTurnProgressState } from "./long-turn-progress.js";
 import { createNativeTelegramToolProgressDraft } from "./native-tool-progress-draft.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import {
@@ -143,8 +145,28 @@ import {
 export { pruneStickerMediaFromContext } from "./bot-message-dispatch.media.js";
 export { getTelegramReplyFenceSizeForTests, resetTelegramReplyFenceForTests };
 
+const ERROR_RESPONSE_FALLBACK =
+  "Something went wrong while processing your request. Please try again.";
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
+// Mirrors the private auto-reply hook without making this a public channel API.
+const INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY = Symbol.for(
+  "openclaw.internal.foregroundReplyFreshnessPolicy",
+);
+
+type TelegramForegroundReplyFreshnessPolicy = {
+  allowSupersededDelivery?: (delivery: {
+    payload: ReplyPayload;
+    info: { kind: "tool" | "block" | "final" };
+  }) => boolean;
+  registerVisibleDeliveryMarker?: (markVisibleDelivery: (() => void) | undefined) => void;
+};
+
+type TelegramReplyOptionsWithInternalFreshness = NonNullable<
+  Parameters<TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]>[0]["replyOptions"]
+> & {
+  [INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY]?: TelegramForegroundReplyFreshnessPolicy;
+};
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
@@ -246,6 +268,7 @@ type DispatchTelegramMessageParams = {
   telegramCfg: TelegramAccountConfig;
   telegramDeps?: TelegramBotDeps;
   opts: Pick<TelegramBotOptions, "token" | "mediaMaxMb">;
+  longTurnProgressState?: TelegramLongTurnProgressState;
 };
 
 type TelegramReasoningLevel = "off" | "on" | "stream";
@@ -677,6 +700,7 @@ export const dispatchTelegramMessage = async ({
   telegramCfg,
   telegramDeps: injectedTelegramDeps,
   opts,
+  longTurnProgressState,
 }: DispatchTelegramMessageParams) => {
   const dispatchStartedAt = Date.now();
   const dispatchContext = resolveDispatchTelegramContext({ cfg, context });
@@ -922,8 +946,10 @@ export const dispatchTelegramMessage = async ({
   let streamToolProgressLines: Array<string | ChannelProgressDraftLine> = [];
   let lastAnswerPartialText = "";
   let activeAnswerDraftIsToolProgressOnly = false;
+  let preserveProgressDraftForFinal = false;
   function resetAnswerToolProgressDraft() {
     activeAnswerDraftIsToolProgressOnly = false;
+    preserveProgressDraftForFinal = false;
   }
   async function prepareAnswerLaneForToolProgress() {
     if (activeAnswerDraftIsToolProgressOnly) {
@@ -951,6 +977,7 @@ export const dispatchTelegramMessage = async ({
     answerLane.lastPartialText = streamText;
     answerLane.hasStreamedMessage = true;
     answerLane.finalized = false;
+    answerLane.stream.forceInitialSend?.();
     answerLane.stream.update(streamText);
     if (options?.flush) {
       await answerLane.stream.flush();
@@ -1044,6 +1071,83 @@ export const dispatchTelegramMessage = async ({
     }
     return false;
   };
+  let markLongTurnProgressPreviewVisible: (() => void) | undefined;
+  let pendingLongTurnProgressPreviewReady = false;
+  const markLongTurnProgressPreviewReadyWhenFenced = (): boolean => {
+    if (!longTurnProgressState || !pendingLongTurnProgressPreviewReady) {
+      return false;
+    }
+    if (longTurnProgressState.progressPreviewStatus() !== "requested") {
+      pendingLongTurnProgressPreviewReady = false;
+      return false;
+    }
+    if (!markLongTurnProgressPreviewVisible) {
+      return false;
+    }
+    markLongTurnProgressPreviewVisible();
+    pendingLongTurnProgressPreviewReady = false;
+    longTurnProgressState.markProgressPreviewReady();
+    return true;
+  };
+  const hasConfirmedAnswerPreviewMessage = (): boolean =>
+    typeof answerLane.stream?.messageId() === "number";
+  const waitForSettledLongTurnPreview = async (): Promise<boolean> => {
+    if (!answerLane.stream) {
+      return false;
+    }
+    if (hasConfirmedAnswerPreviewMessage()) {
+      return true;
+    }
+    if (answerLane.stream.sendMayHaveLanded?.() !== true) {
+      return false;
+    }
+    await answerLane.stream.flush();
+    return hasConfirmedAnswerPreviewMessage();
+  };
+  const materializeLongTurnProgressPreview = async (): Promise<boolean> => {
+    if (
+      !answerLane.stream ||
+      answerLane.finalized ||
+      finalAnswerDeliveryStarted ||
+      finalAnswerDelivered ||
+      isDispatchSuperseded()
+    ) {
+      return false;
+    }
+    if (await waitForSettledLongTurnPreview()) {
+      preserveProgressDraftForFinal = streamMode !== "progress";
+      return true;
+    }
+    if (answerLane.stream?.sendMayHaveLanded?.() === true) {
+      return false;
+    }
+    if (answerLane.hasStreamedMessage) {
+      answerLane.stream.forceNewMessage();
+      answerLane.lastPartialText = "";
+      answerLane.hasStreamedMessage = false;
+      answerLane.finalized = false;
+    }
+    await prepareAnswerLaneForToolProgress();
+    // Non-progress stream mode can finalize this same draft; progress mode keeps
+    // its existing separate-progress-then-final contract.
+    preserveProgressDraftForFinal = streamMode !== "progress";
+    const streamText = formatChannelProgressDraftText({
+      entry: telegramCfg,
+      lines: streamToolProgressLines,
+      seed: progressSeed,
+      formatLine: formatProgressAsMarkdownCode,
+    });
+    if (!streamText) {
+      return false;
+    }
+    answerLane.lastPartialText = streamText;
+    answerLane.hasStreamedMessage = true;
+    answerLane.finalized = false;
+    answerLane.stream.forceInitialSend?.();
+    answerLane.stream.update(streamText);
+    await answerLane.stream.flush();
+    return hasConfirmedAnswerPreviewMessage();
+  };
   let splitReasoningOnNextStream = false;
   let draftLaneEventQueue = Promise.resolve();
   const reasoningStepState = createTelegramReasoningStepState();
@@ -1059,6 +1163,32 @@ export const dispatchTelegramMessage = async ({
     });
     return draftLaneEventQueue;
   };
+  longTurnProgressState?.setCanCreateProgressPreview(
+    () =>
+      Boolean(answerLane.stream) &&
+      !answerLane.finalized &&
+      !finalAnswerDeliveryStarted &&
+      !finalAnswerDelivered &&
+      !isDispatchSuperseded(),
+  );
+  longTurnProgressState?.onProgressPreviewRequested(() => {
+    void enqueueDraftLaneEvent(async () => {
+      try {
+        const previewReady = await materializeLongTurnProgressPreview();
+        if (previewReady) {
+          pendingLongTurnProgressPreviewReady = true;
+          markLongTurnProgressPreviewReadyWhenFenced();
+        } else {
+          pendingLongTurnProgressPreviewReady = false;
+          longTurnProgressState.markProgressPreviewUnavailable();
+        }
+      } catch (err) {
+        logVerbose(`telegram: long-turn progress preview failed: ${String(err)}`);
+        pendingLongTurnProgressPreviewReady = false;
+        longTurnProgressState.markProgressPreviewUnavailable();
+      }
+    });
+  });
   type SplitLaneSegment = { lane: LaneName; update: DraftPartialTextUpdate };
   type SplitLaneSegmentsResult = {
     segments: SplitLaneSegment[];
@@ -1121,6 +1251,11 @@ export const dispatchTelegramMessage = async ({
   const rotateAnswerLaneAfterToolProgress = async () => {
     nativeToolProgressDraft?.stop();
     if (!activeAnswerDraftIsToolProgressOnly) {
+      return false;
+    }
+    if (preserveProgressDraftForFinal) {
+      resetAnswerToolProgressDraft();
+      streamToolProgressLines = [];
       return false;
     }
     await answerLane.stream?.clear();
@@ -1322,6 +1457,56 @@ export const dispatchTelegramMessage = async ({
         }
       : undefined,
   };
+  type PreviewFinalizedDeliveryRecord = {
+    content: string;
+    promptContextContent?: string;
+    messageId: number;
+  };
+  const recordPreviewFinalizedDelivery = async (
+    delivery: PreviewFinalizedDeliveryRecord,
+  ): Promise<void> => {
+    if (isDispatchSuperseded()) {
+      return;
+    }
+    (telegramDeps.emitInternalMessageSentHook ?? emitInternalMessageSentHook)({
+      sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
+      chatId: deliveryBaseOptions.chatId,
+      accountId: deliveryBaseOptions.accountId,
+      content: delivery.content,
+      success: true,
+      messageId: delivery.messageId,
+      isGroup: deliveryBaseOptions.mirrorIsGroup,
+      groupId: deliveryBaseOptions.mirrorGroupId,
+    });
+    try {
+      await (
+        telegramDeps.recordOutboundMessageForPromptContext ?? recordOutboundMessageForPromptContext
+      )({
+        cfg,
+        account: { accountId: route.accountId },
+        chatId: deliveryBaseOptions.chatId,
+        message: { message_id: delivery.messageId },
+        messageId: delivery.messageId,
+        text: delivery.promptContextContent ?? delivery.content,
+        ...(threadSpec.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
+      });
+    } catch (error) {
+      logVerbose(
+        `telegram: failed to record streamed reply for prompt context: ${formatErrorMessage(
+          error,
+        )}`,
+      );
+    }
+    if (deliveryBaseOptions.transcriptMirror && delivery.content) {
+      void deliveryBaseOptions
+        .transcriptMirror({ text: delivery.content })
+        .catch((err: unknown) => {
+          logVerbose(
+            `telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`,
+          );
+        });
+    }
+  };
   const silentErrorReplies = telegramCfg.silentErrorReplies === true;
   const isDmTopic = !isGroup && threadSpec.scope === "dm" && threadSpec.id != null;
   let queuedFinal = false;
@@ -1329,6 +1514,48 @@ export const dispatchTelegramMessage = async ({
   let hadErrorReplyFailureOrSkip = false;
   let isFirstTurnInSession = false;
   let dispatchError: unknown;
+  let longTurnFailureFallbackHandled = false;
+  let requireLongTurnPreviewOnlyFinal = false;
+  const finalizeLongTurnFailureProgressPreview = async (): Promise<boolean> => {
+    if (
+      !longTurnProgressState?.hasProgressPreview() ||
+      !answerLane.stream ||
+      isDispatchSuperseded()
+    ) {
+      return false;
+    }
+    const stream = answerLane.stream;
+    if (!hasConfirmedAnswerPreviewMessage()) {
+      return false;
+    }
+    try {
+      const messageId = stream.messageId();
+      if (typeof messageId !== "number") {
+        return false;
+      }
+      longTurnProgressState.markFinalDeliveryStarted();
+      finalAnswerDeliveryStarted = true;
+      answerLane.lastPartialText = ERROR_RESPONSE_FALLBACK;
+      answerLane.hasStreamedMessage = true;
+      stream.update(ERROR_RESPONSE_FALLBACK);
+      await stream.stop();
+      if (stream.lastDeliveredText?.().trimEnd() !== ERROR_RESPONSE_FALLBACK) {
+        return false;
+      }
+      answerLane.finalized = true;
+      finalAnswerDelivered = true;
+      deliveryState.markDelivered();
+      await recordPreviewFinalizedDelivery({
+        content: ERROR_RESPONSE_FALLBACK,
+        promptContextContent: ERROR_RESPONSE_FALLBACK,
+        messageId,
+      });
+      return true;
+    } catch (err) {
+      logVerbose(`telegram: long-turn failure preview finalization failed: ${String(err)}`);
+      return false;
+    }
+  };
 
   try {
     const sticker = ctxPayload.Sticker;
@@ -1423,6 +1650,9 @@ export const dispatchTelegramMessage = async ({
       if (isDispatchSuperseded()) {
         return false;
       }
+      if (options?.durable) {
+        longTurnProgressState?.markFinalDeliveryStarted();
+      }
       const deliverablePayload = applyQuoteReplyTarget(payload);
       const silent = options?.silent ?? (silentErrorReplies && payload.isError === true);
       const durableDelivery = telegramDeps.deliverInboundReplyWithMessageSendContext;
@@ -1483,45 +1713,7 @@ export const dispatchTelegramMessage = async ({
       if (isDispatchSuperseded() || result.kind !== "preview-finalized") {
         return;
       }
-      (telegramDeps.emitInternalMessageSentHook ?? emitInternalMessageSentHook)({
-        sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
-        chatId: deliveryBaseOptions.chatId,
-        accountId: deliveryBaseOptions.accountId,
-        content: result.delivery.content,
-        success: true,
-        messageId: result.delivery.messageId,
-        isGroup: deliveryBaseOptions.mirrorIsGroup,
-        groupId: deliveryBaseOptions.mirrorGroupId,
-      });
-      try {
-        await (
-          telegramDeps.recordOutboundMessageForPromptContext ??
-          recordOutboundMessageForPromptContext
-        )({
-          cfg,
-          account: { accountId: route.accountId },
-          chatId: deliveryBaseOptions.chatId,
-          message: { message_id: result.delivery.messageId },
-          messageId: result.delivery.messageId,
-          text: result.delivery.promptContextContent ?? result.delivery.content,
-          ...(threadSpec.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
-        });
-      } catch (error) {
-        logVerbose(
-          `telegram: failed to record streamed reply for prompt context: ${formatErrorMessage(
-            error,
-          )}`,
-        );
-      }
-      if (deliveryBaseOptions.transcriptMirror && result.delivery.content) {
-        void deliveryBaseOptions
-          .transcriptMirror({ text: result.delivery.content })
-          .catch((err: unknown) => {
-            logVerbose(
-              `telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`,
-            );
-          });
-      }
+      await recordPreviewFinalizedDelivery(result.delivery);
     };
     const deliverLaneText = createLaneTextDeliverer({
       lanes,
@@ -1578,6 +1770,52 @@ export const dispatchTelegramMessage = async ({
         finalText: text,
         resolveCandidateText: resolveCurrentTurnTranscriptFinalText,
       });
+    const canFinalizeLongTurnProgressPreviewWithoutNewMessages = (
+      payload: ReplyPayload,
+    ): boolean => {
+      if (
+        streamMode === "progress" ||
+        payload.isError === true ||
+        !longTurnProgressState?.hasProgressPreview()
+      ) {
+        return false;
+      }
+      if (!answerLane.stream) {
+        return false;
+      }
+      if (activeAnswerDraftIsToolProgressOnly && !preserveProgressDraftForFinal) {
+        return false;
+      }
+      if (typeof answerLane.stream.messageId() !== "number") {
+        return false;
+      }
+      const text = typeof payload.text === "string" ? payload.text.trimEnd() : "";
+      if (!text.trim()) {
+        return false;
+      }
+      if (isPotentialTruncatedFinal(text)) {
+        return false;
+      }
+      const reply = resolveSendableOutboundReplyParts(payload, { text });
+      if (reply.hasMedia) {
+        return false;
+      }
+      const chunks = splitFinalTextForStream(text);
+      return chunks.length === 1 && (chunks[0]?.length ?? 0) <= draftMaxChars;
+    };
+    const allowLongTurnSupersededFinalDelivery = (params: {
+      payload: ReplyPayload;
+      info: { kind: "block" | "final" | "tool" };
+    }): boolean => {
+      const allowed =
+        params.info.kind === "final" &&
+        canFinalizeLongTurnProgressPreviewWithoutNewMessages(params.payload) &&
+        !replyAbortController.signal.aborted;
+      if (allowed) {
+        requireLongTurnPreviewOnlyFinal = true;
+      }
+      return allowed;
+    };
 
     if (isDmTopic) {
       try {
@@ -1704,9 +1942,19 @@ export const dispatchTelegramMessage = async ({
                       text: string,
                       buttons?: TelegramInlineButtons,
                     ) => {
+                      longTurnProgressState?.markFinalDeliveryStarted();
                       const finalText = await resolveTranscriptBackedFinalText(text);
                       if (streamMode === "progress") {
                         return deliverProgressModeFinalAnswer(answerPayload, finalText);
+                      }
+                      const requireExistingPreviewFinalization = requireLongTurnPreviewOnlyFinal;
+                      requireLongTurnPreviewOnlyFinal = false;
+                      const finalPayload = applyTextToPayload(answerPayload, finalText);
+                      if (
+                        requireExistingPreviewFinalization &&
+                        !canFinalizeLongTurnProgressPreviewWithoutNewMessages(finalPayload)
+                      ) {
+                        return { kind: "skipped" } satisfies LaneDeliveryResult;
                       }
                       await rotateAnswerLaneAfterToolProgress();
                       const result = await deliverLaneText({
@@ -1715,6 +1963,7 @@ export const dispatchTelegramMessage = async ({
                         payload: answerPayload,
                         infoKind: "final",
                         buttons,
+                        requireExistingPreviewFinalization,
                       });
                       if (result.kind !== "skipped") {
                         finalAnswerDelivered = true;
@@ -1901,6 +2150,17 @@ export const dispatchTelegramMessage = async ({
                   },
                 },
                 replyOptions: {
+                  ...(longTurnProgressState
+                    ? {
+                        [INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY]: {
+                          registerVisibleDeliveryMarker: (markVisibleDelivery) => {
+                            markLongTurnProgressPreviewVisible = markVisibleDelivery;
+                            markLongTurnProgressPreviewReadyWhenFenced();
+                          },
+                          allowSupersededDelivery: allowLongTurnSupersededFinalDelivery,
+                        },
+                      }
+                    : {}),
                   skillFilter,
                   disableBlockStreaming,
                   abortSignal: replyAbortController.signal,
@@ -2073,7 +2333,7 @@ export const dispatchTelegramMessage = async ({
                       }
                     : undefined,
                   onModelSelected,
-                },
+                } satisfies TelegramReplyOptionsWithInternalFreshness,
               });
             },
           }),
@@ -2088,6 +2348,7 @@ export const dispatchTelegramMessage = async ({
     } catch (err) {
       dispatchError = err;
       runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
+      longTurnFailureFallbackHandled = await finalizeLongTurnFailureProgressPreview();
     } finally {
       progressDraftGate.cancel();
       await draftLaneEventQueue;
@@ -2153,13 +2414,12 @@ export const dispatchTelegramMessage = async ({
   const deliverySummary = deliveryState.snapshot();
   const shouldSendFailureFallback =
     !isRoomEvent &&
+    !longTurnFailureFallbackHandled &&
     (dispatchError ||
       (!deliverySummary.delivered &&
         (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0)));
   if (shouldSendFailureFallback) {
-    const fallbackText = dispatchError
-      ? "Something went wrong while processing your request. Please try again."
-      : EMPTY_RESPONSE_FALLBACK;
+    const fallbackText = dispatchError ? ERROR_RESPONSE_FALLBACK : EMPTY_RESPONSE_FALLBACK;
     const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
       replies: [{ text: fallbackText }],
       ...deliveryBaseOptions,

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
+import { TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS } from "./long-turn-progress.js";
 
 const buildTelegramMessageContext = vi.hoisted(() => vi.fn());
 const dispatchTelegramMessage = vi.hoisted(() => vi.fn());
@@ -38,7 +39,7 @@ describe("telegram bot message processor", () => {
 
   beforeEach(() => {
     buildTelegramMessageContext.mockClear();
-    dispatchTelegramMessage.mockClear();
+    dispatchTelegramMessage.mockReset();
     telegramInboundInfo.mockClear();
     upsertChannelPairingRequest.mockClear();
   });
@@ -164,6 +165,210 @@ describe("telegram bot message processor", () => {
     expect(onDispatchStart.mock.invocationCallOrder[0]).toBeLessThan(
       dispatchTelegramMessage.mock.invocationCallOrder[0],
     );
+  });
+
+  it("detaches long-running direct turns after the normal progress preview is visible", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    let resolveDispatch: (() => void) | undefined;
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        threadSpec: { id: 456, scope: "dm" },
+      }),
+    );
+    dispatchTelegramMessage.mockImplementation((params) => {
+      (
+        params as {
+          longTurnProgressState?: {
+            onProgressPreviewRequested: (listener: () => void) => void;
+            markProgressPreviewReady: () => void;
+          };
+        }
+      ).longTurnProgressState?.onProgressPreviewRequested(() => {
+        (
+          params as {
+            longTurnProgressState?: { markProgressPreviewReady: () => void };
+          }
+        ).longTurnProgressState?.markProgressPreviewReady();
+      });
+      return new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      });
+    });
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS);
+      await expect(processPromise).resolves.toBe(true);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+
+      resolveDispatch?.();
+      await Promise.resolve();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps waiting when the progress preview surface is unavailable", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    let resolveDispatch: (() => void) | undefined;
+    let processResolved = false;
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        threadSpec: { id: 456, scope: "dm" },
+      }),
+    );
+    dispatchTelegramMessage.mockImplementation((params) => {
+      (
+        params as {
+          longTurnProgressState?: {
+            onProgressPreviewRequested: (listener: () => void) => void;
+            markProgressPreviewUnavailable: () => void;
+          };
+        }
+      ).longTurnProgressState?.onProgressPreviewRequested(() => {
+        (
+          params as {
+            longTurnProgressState?: { markProgressPreviewUnavailable: () => void };
+          }
+        ).longTurnProgressState?.markProgressPreviewUnavailable();
+      });
+      return new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      });
+    });
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage).then((result) => {
+        processResolved = true;
+        return result;
+      });
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS);
+
+      expect(processResolved).toBe(false);
+      expect(sendMessage).not.toHaveBeenCalled();
+
+      resolveDispatch?.();
+      await expect(processPromise).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not detach group turns before visible reply eligibility is known", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    let resolveDispatch: (() => void) | undefined;
+    let processResolved = false;
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        isGroup: true,
+        threadSpec: { id: undefined, scope: "none" },
+        ctxPayload: {
+          From: "telegram:group:-100",
+          To: "@openclaw_bot",
+          ChatType: "group",
+          RawBody: "@bot think for a while",
+        },
+      }),
+    );
+    dispatchTelegramMessage.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      }),
+    );
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage).then((result) => {
+        processResolved = true;
+        return result;
+      });
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS);
+
+      expect(processResolved).toBe(false);
+      expect(sendMessage).not.toHaveBeenCalled();
+
+      resolveDispatch?.();
+      await expect(processPromise).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("logs detached dispatch failures without posting unfenced fallback messages", async () => {
+    vi.useFakeTimers();
+    let rejectDispatch: ((error: unknown) => void) | undefined;
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    let resolveFailureLogged: (() => void) | undefined;
+    const failureLogged = new Promise<void>((resolve) => {
+      resolveFailureLogged = resolve;
+    });
+    const runtimeError = vi.fn(() => {
+      resolveFailureLogged?.();
+    });
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        threadSpec: { id: 456, scope: "dm" },
+      }),
+    );
+    dispatchTelegramMessage.mockImplementation((params) => {
+      (
+        params as {
+          longTurnProgressState?: {
+            onProgressPreviewRequested: (listener: () => void) => void;
+            markProgressPreviewReady: () => void;
+          };
+        }
+      ).longTurnProgressState?.onProgressPreviewRequested(() => {
+        (
+          params as {
+            longTurnProgressState?: { markProgressPreviewReady: () => void };
+          }
+        ).longTurnProgressState?.markProgressPreviewReady();
+      });
+      return new Promise<void>((_resolve, reject) => {
+        rejectDispatch = reject;
+      });
+    });
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+      runtime: { error: runtimeError },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS);
+      await expect(processPromise).resolves.toBe(true);
+
+      rejectDispatch?.(new Error("provider down"));
+      await failureLogged;
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(runtimeError).toHaveBeenCalledWith(
+        "telegram detached dispatch failed: Error: provider down",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not run the dispatch-start lifecycle when no context is produced", async () => {

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -19,6 +19,10 @@ import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
+import {
+  createTelegramLongTurnProgressState,
+  TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS,
+} from "./long-turn-progress.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
 
 const telegramInboundLog = createSubsystemLogger("gateway/channels/telegram").child("inbound");
@@ -50,6 +54,8 @@ type TelegramMessageProcessorDeps = Omit<
 export type TelegramMessageProcessorLifecycle = {
   onDispatchStart?: () => Promise<void> | void;
 };
+
+type TelegramDispatchOutcome = { status: "completed" } | { status: "failed"; error: unknown };
 
 export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
   const {
@@ -180,19 +186,85 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       }),
     );
     await lifecycle?.onDispatchStart?.();
+    const dispatchParams = {
+      context,
+      bot,
+      cfg,
+      runtime,
+      replyToMode,
+      streamMode,
+      textLimit,
+      telegramCfg,
+      telegramDeps,
+      opts,
+    };
     try {
-      await dispatchTelegramMessage({
-        context,
-        bot,
-        cfg,
-        runtime,
-        replyToMode,
-        streamMode,
-        textLimit,
-        telegramCfg,
-        telegramDeps,
-        opts,
-      });
+      const longTurnProgressState = createTelegramLongTurnProgressState();
+      const dispatchPromise = Promise.resolve().then(() =>
+        dispatchTelegramMessage({
+          ...dispatchParams,
+          longTurnProgressState,
+        }),
+      );
+      const dispatchOutcome: Promise<TelegramDispatchOutcome> = dispatchPromise.then(
+        () => ({ status: "completed" }),
+        (error: unknown) => ({ status: "failed", error }),
+      );
+      const canDetachForLongTurn =
+        context.ctxPayload.InboundEventKind !== "room_event" && !context.isGroup;
+      let softDeadlineTimer: ReturnType<typeof setTimeout> | undefined;
+      const softDeadline = canDetachForLongTurn
+        ? new Promise<"soft-deadline">((resolve) => {
+            softDeadlineTimer = setTimeout(
+              () => resolve("soft-deadline"),
+              TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS,
+            );
+          })
+        : undefined;
+      const firstOutcome = softDeadline
+        ? await Promise.race([dispatchOutcome, softDeadline])
+        : await dispatchOutcome;
+      if (softDeadlineTimer) {
+        clearTimeout(softDeadlineTimer);
+      }
+      if (firstOutcome === "soft-deadline") {
+        if (
+          longTurnProgressState.hasFinalDeliveryStarted() ||
+          !longTurnProgressState.canCreateProgressPreview()
+        ) {
+          const finalOutcome = await dispatchOutcome;
+          if (finalOutcome.status === "failed") {
+            throw finalOutcome.error;
+          }
+        } else {
+          longTurnProgressState.requestProgressPreview();
+          const progressOutcome = await Promise.race([
+            longTurnProgressState.waitForProgressPreview(),
+            dispatchOutcome,
+          ]);
+          if (progressOutcome === "ready") {
+            void dispatchOutcome.then(async (outcome) => {
+              if (outcome.status === "completed") {
+                return;
+              }
+              runtime.error?.(
+                danger(`telegram detached dispatch failed: ${String(outcome.error)}`),
+              );
+            });
+            return true;
+          }
+          if (progressOutcome === "unavailable") {
+            const finalOutcome = await dispatchOutcome;
+            if (finalOutcome.status === "failed") {
+              throw finalOutcome.error;
+            }
+          } else if (progressOutcome.status === "failed") {
+            throw progressOutcome.error;
+          }
+        }
+      } else if (firstOutcome.status === "failed") {
+        throw firstOutcome.error;
+      }
       if (ingressDebugEnabled && ingressReceivedAtMs) {
         logVerbose(
           `telegram ingress: chatId=${context.chatId} dispatchCompleteMs=${Date.now() - ingressReceivedAtMs}` +

--- a/extensions/telegram/src/draft-stream.test-helpers.ts
+++ b/extensions/telegram/src/draft-stream.test-helpers.ts
@@ -9,6 +9,7 @@ type TestDraftStream = {
   lastDeliveredText: ReturnType<typeof vi.fn<() => string>>;
   clear: ReturnType<typeof vi.fn<() => Promise<void>>>;
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  forceInitialSend: ReturnType<typeof vi.fn<() => void>>;
   discard: ReturnType<typeof vi.fn<() => Promise<void>>>;
   materialize: ReturnType<typeof vi.fn<() => Promise<number | undefined>>>;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
@@ -43,6 +44,7 @@ export function createTestDraftStream(params?: {
     stop: vi.fn().mockImplementation(async () => {
       await params?.onStop?.();
     }),
+    forceInitialSend: vi.fn(),
     discard: vi.fn().mockImplementation(async () => {
       await params?.onDiscard?.();
     }),
@@ -83,6 +85,7 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
     lastDeliveredText: vi.fn().mockImplementation(() => lastDeliveredText),
     clear: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
+    forceInitialSend: vi.fn(),
     discard: vi.fn().mockResolvedValue(undefined),
     materialize: vi.fn().mockImplementation(async () => activeMessageId),
     forceNewMessage: vi.fn().mockImplementation(() => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -631,6 +631,23 @@ describe("draft stream initial message debounce", () => {
       expect(api.sendMessage).not.toHaveBeenCalled();
     });
 
+    it("can force a short first message through the threshold once", async () => {
+      const api = createMockApi();
+      const stream = createDebouncedStream(api);
+
+      stream.forceInitialSend?.();
+      stream.update("Working");
+      await stream.flush();
+
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Working", undefined);
+
+      stream.forceNewMessage();
+      stream.update("Short");
+      await stream.flush();
+
+      expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
     it("does not send a first message when discard() supersedes a short partial", async () => {
       const api = createMockApi();
       const stream = createDebouncedStream(api);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -20,6 +20,8 @@ export type TelegramDraftStream = {
   lastDeliveredText?: () => string;
   clear: () => Promise<void>;
   stop: () => Promise<void>;
+  /** Force the next initial flush through minInitialChars. */
+  forceInitialSend?: () => void;
   /** Stop without a final flush or delete. */
   discard?: () => Promise<void>;
   /** Return the current preview message id after pending updates settle. */
@@ -117,6 +119,7 @@ export function createTelegramDraftStream(params: {
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
+  let forceInitialSend = false;
   let resetStreamToNewMessage: (options?: {
     keepFinal?: boolean;
     keepPending?: boolean;
@@ -259,7 +262,14 @@ export function createTelegramDraftStream(params: {
     }
     const sendGeneration = generation;
 
-    if (typeof streamMessageId !== "number" && minInitialChars != null && !streamState.final) {
+    const bypassMinInitialChars = forceInitialSend;
+    forceInitialSend = false;
+    if (
+      typeof streamMessageId !== "number" &&
+      minInitialChars != null &&
+      !streamState.final &&
+      !bypassMinInitialChars
+    ) {
       if (renderedText.length < minInitialChars) {
         return false;
       }
@@ -378,6 +388,9 @@ export function createTelegramDraftStream(params: {
     lastDeliveredText: () => lastDeliveredText,
     clear,
     stop,
+    forceInitialSend: () => {
+      forceInitialSend = true;
+    },
     discard,
     materialize,
     forceNewMessage,

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -76,6 +76,7 @@ type DeliverLaneTextParams = {
   payload: ReplyPayload;
   infoKind: string;
   buttons?: TelegramInlineButtons;
+  requireExistingPreviewFinalization?: boolean;
 };
 
 function result(
@@ -265,18 +266,25 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     payload: ReplyPayload,
     isFinal: boolean,
     buttons?: TelegramInlineButtons,
+    options?: { requireExistingPreviewFinalization?: boolean },
   ): Promise<LaneDeliveryResult | undefined> => {
     const stream = lane.stream;
     if (!stream || text.length === 0 || payload.isError) {
       return undefined;
     }
+    const requireExistingPreviewFinalization =
+      isFinal && options?.requireExistingPreviewFinalization === true;
 
     const chunks =
       text.length > params.draftMaxChars
         ? compactChunks(params.splitFinalTextForStream?.(text) ?? [])
         : [text];
     const [firstChunk, ...remainingChunks] = chunks;
-    if (!firstChunk || firstChunk.length > params.draftMaxChars) {
+    if (
+      !firstChunk ||
+      firstChunk.length > params.draftMaxChars ||
+      (requireExistingPreviewFinalization && remainingChunks.length > 0)
+    ) {
       return undefined;
     }
     const finalText = text.trimEnd();
@@ -292,7 +300,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     const finalizeDeliveredPrefix = async (
       deliveredStreamText: string,
       messageId: number,
-    ): Promise<LaneDeliveryResult> => {
+    ): Promise<LaneDeliveryResult | undefined> => {
+      const suffix = finalText.slice(deliveredStreamText.length);
+      if (suffix.trim().length > 0 && requireExistingPreviewFinalization) {
+        return undefined;
+      }
       lane.finalized = true;
       params.markDelivered();
       let buttonsAttached = false;
@@ -310,7 +322,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           }
         }
       }
-      const suffix = finalText.slice(deliveredStreamText.length);
       if (suffix.trim().length > 0) {
         for (const chunk of compactChunks(params.splitFinalTextForStream?.(suffix) ?? [])) {
           if (chunk.trim().length === 0) {
@@ -456,15 +467,21 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     payload,
     infoKind,
     buttons,
+    requireExistingPreviewFinalization,
   }: DeliverLaneTextParams): Promise<LaneDeliveryResult> => {
     const lane = params.lanes[laneName];
     const reply = resolveSendableOutboundReplyParts(payload, { text });
     const isFinal = infoKind === "final";
     const streamed = !reply.hasMedia
-      ? await streamText(laneName, lane, text, payload, isFinal, buttons)
+      ? await streamText(laneName, lane, text, payload, isFinal, buttons, {
+          requireExistingPreviewFinalization,
+        })
       : undefined;
     if (streamed) {
       return streamed;
+    }
+    if (isFinal && requireExistingPreviewFinalization) {
+      return result("skipped");
     }
 
     if (
@@ -482,6 +499,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         textOnlyPayload(payload),
         true,
         buttons,
+        { requireExistingPreviewFinalization: false },
       );
       if (finalizedPreview) {
         const stripButtons =

--- a/extensions/telegram/src/long-turn-progress.ts
+++ b/extensions/telegram/src/long-turn-progress.ts
@@ -1,0 +1,90 @@
+export const TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS = 30_000;
+
+type ProgressPreviewStatus = "idle" | "requested" | "ready" | "unavailable";
+
+export type TelegramLongTurnProgressState = {
+  requestProgressPreview: () => void;
+  onProgressPreviewRequested: (listener: () => void) => () => void;
+  waitForProgressPreview: () => Promise<"ready" | "unavailable">;
+  progressPreviewStatus: () => ProgressPreviewStatus;
+  hasProgressPreview: () => boolean;
+  markProgressPreviewReady: () => void;
+  markProgressPreviewUnavailable: () => void;
+  markFinalDeliveryStarted: () => void;
+  hasFinalDeliveryStarted: () => boolean;
+  setCanCreateProgressPreview: (check: () => boolean) => void;
+  canCreateProgressPreview: () => boolean;
+};
+
+export function createTelegramLongTurnProgressState(): TelegramLongTurnProgressState {
+  let status: ProgressPreviewStatus = "idle";
+  let finalDeliveryStarted = false;
+  let canCreateProgressPreview = () => true;
+  let resolveProgressPreview: ((status: "ready" | "unavailable") => void) | undefined;
+  const progressPreviewSettled = new Promise<"ready" | "unavailable">((resolve) => {
+    resolveProgressPreview = resolve;
+  });
+  const requestListeners = new Set<() => void>();
+
+  const settleProgressPreview = (nextStatus: "ready" | "unavailable") => {
+    if (status === "ready" || status === "unavailable") {
+      return;
+    }
+    status = nextStatus;
+    resolveProgressPreview?.(nextStatus);
+  };
+
+  const notifyRequestListeners = () => {
+    for (const listener of requestListeners) {
+      listener();
+    }
+  };
+
+  return {
+    requestProgressPreview: () => {
+      if (status !== "idle") {
+        return;
+      }
+      status = "requested";
+      notifyRequestListeners();
+    },
+    onProgressPreviewRequested: (listener) => {
+      if (status === "requested") {
+        listener();
+        return () => {};
+      }
+      if (status !== "idle") {
+        return () => {};
+      }
+      requestListeners.add(listener);
+      return () => {
+        requestListeners.delete(listener);
+      };
+    },
+    waitForProgressPreview: async () => {
+      if (status === "ready" || status === "unavailable") {
+        return status;
+      }
+      return await progressPreviewSettled;
+    },
+    progressPreviewStatus: () => status,
+    hasProgressPreview: () => status === "ready",
+    markProgressPreviewReady: () => {
+      settleProgressPreview("ready");
+    },
+    markProgressPreviewUnavailable: () => {
+      settleProgressPreview("unavailable");
+    },
+    markFinalDeliveryStarted: () => {
+      finalDeliveryStarted = true;
+      if (status === "requested") {
+        settleProgressPreview("unavailable");
+      }
+    },
+    hasFinalDeliveryStarted: () => finalDeliveryStarted,
+    setCanCreateProgressPreview: (check) => {
+      canCreateProgressPreview = check;
+    },
+    canCreateProgressPreview: () => canCreateProgressPreview(),
+  };
+}

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -5,7 +5,7 @@ import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { ReplyDispatchBeforeDeliver } from "./reply/reply-dispatcher.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
-import type { ReplyPayload } from "./types.js";
+import type { GetReplyOptions, ReplyPayload } from "./types.js";
 
 type DispatchReplyFromConfigFn =
   typeof import("./reply/dispatch-from-config.js").dispatchReplyFromConfig;
@@ -65,6 +65,7 @@ function dispatchWithDeliveries(
     deliver?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => Promise<object | void>;
     onSettled?: () => object | void | Promise<object | void>;
     onFreshSettledDelivery?: () => object | void | Promise<object | void>;
+    replyOptions?: Omit<GetReplyOptions, "onBlockReply"> & Record<PropertyKey, unknown>;
   } = {},
 ) {
   return dispatchInboundMessageWithBufferedDispatcher({
@@ -78,6 +79,7 @@ function dispatchWithDeliveries(
           deliveries.push({ kind: info.kind, text: payload.text });
         }),
     },
+    replyOptions: dispatcherOptions.replyOptions,
   });
 }
 
@@ -130,6 +132,259 @@ describe("foreground reply freshness", () => {
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
+    expect(olderResult).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+  });
+
+  it("allows channel-owned preview finalization after a newer visible delivery", async () => {
+    const deliveries: Delivery[] = [];
+    const olderStarted = createDeferred<void>();
+    const releaseOlderFinal = createDeferred<void>();
+    const foregroundFreshnessPolicyKey = Symbol.for(
+      "openclaw.internal.foregroundReplyFreshnessPolicy",
+    );
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          olderStarted.resolve();
+          await releaseOlderFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      {
+        replyOptions: {
+          [foregroundFreshnessPolicyKey]: {
+            allowSupersededDelivery: () => true,
+          },
+        },
+      },
+    );
+    await olderStarted.promise;
+
+    await dispatchWithDeliveries(buildForegroundCtx({ MessageSid: "new-message" }), deliveries);
+
+    releaseOlderFinal.resolve();
+    const olderResult = await olderDispatch;
+
+    expect(olderResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old final" },
+    ]);
+  });
+
+  it("waits for newer active foreground replies before allowing channel-owned preview finalization", async () => {
+    const deliveries: Delivery[] = [];
+    const olderStarted = createDeferred<void>();
+    const releaseOlderFinal = createDeferred<void>();
+    const newerStarted = createDeferred<void>();
+    const releaseNewerFinal = createDeferred<void>();
+    const foregroundFreshnessPolicyKey = Symbol.for(
+      "openclaw.internal.foregroundReplyFreshnessPolicy",
+    );
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          olderStarted.resolve();
+          await releaseOlderFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          newerStarted.resolve();
+          await releaseNewerFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      {
+        replyOptions: {
+          [foregroundFreshnessPolicyKey]: {
+            allowSupersededDelivery: () => true,
+          },
+        },
+      },
+    );
+    await olderStarted.promise;
+
+    const newerDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+    );
+    await newerStarted.promise;
+
+    let olderSettled = false;
+    const watchedOlderDispatch = olderDispatch.then((result) => {
+      olderSettled = true;
+      return result;
+    });
+    releaseOlderFinal.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(olderSettled).toBe(false);
+    expect(deliveries).toEqual([]);
+
+    releaseNewerFinal.resolve();
+    await newerDispatch;
+    const olderResult = await watchedOlderDispatch;
+
+    expect(olderResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old final" },
+    ]);
+  });
+
+  it("lets a channel-owned visible preview marker release older preview finalization while newer turns remain active", async () => {
+    const deliveries: Delivery[] = [];
+    const olderStarted = createDeferred<void>();
+    const releaseOlderFinal = createDeferred<void>();
+    const newerStarted = createDeferred<void>();
+    const releaseNewerFinal = createDeferred<void>();
+    const foregroundFreshnessPolicyKey = Symbol.for(
+      "openclaw.internal.foregroundReplyFreshnessPolicy",
+    );
+    let markNewerPreviewVisible: (() => void) | undefined;
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          olderStarted.resolve();
+          await releaseOlderFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          newerStarted.resolve();
+          await releaseNewerFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      {
+        replyOptions: {
+          [foregroundFreshnessPolicyKey]: {
+            allowSupersededDelivery: () => true,
+          },
+        },
+      },
+    );
+    await olderStarted.promise;
+
+    const newerDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+      {
+        replyOptions: {
+          [foregroundFreshnessPolicyKey]: {
+            registerVisibleDeliveryMarker: (markVisibleDelivery: (() => void) | undefined) => {
+              markNewerPreviewVisible = markVisibleDelivery;
+            },
+          },
+        },
+      },
+    );
+    await newerStarted.promise;
+    expect(markNewerPreviewVisible).toBeTypeOf("function");
+
+    markNewerPreviewVisible?.();
+    releaseOlderFinal.resolve();
+    const olderResult = await olderDispatch;
+
+    expect(olderResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([{ kind: "final", text: "old final" }]);
+
+    releaseNewerFinal.resolve();
+    await newerDispatch;
+    expect(deliveries).toEqual([
+      { kind: "final", text: "old final" },
+      { kind: "final", text: "new final" },
+    ]);
+  });
+
+  it("does not apply channel-owned preview freshness to stale block deliveries", async () => {
+    const deliveries: Delivery[] = [];
+    const olderStarted = createDeferred<void>();
+    const releaseOlderBlock = createDeferred<void>();
+    const foregroundFreshnessPolicyKey = Symbol.for(
+      "openclaw.internal.foregroundReplyFreshnessPolicy",
+    );
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          olderStarted.resolve();
+          await releaseOlderBlock.promise;
+          params.dispatcher.sendBlockReply({ text: "old block" });
+          return {
+            queuedFinal: false,
+            counts: { tool: 0, block: 1, final: 0 },
+          };
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      {
+        replyOptions: {
+          [foregroundFreshnessPolicyKey]: {
+            allowSupersededDelivery: () => true,
+          },
+        },
+      },
+    );
+    await olderStarted.promise;
+
+    await dispatchWithDeliveries(buildForegroundCtx({ MessageSid: "new-message" }), deliveries);
+
+    releaseOlderBlock.resolve();
+    const olderResult = await olderDispatch;
+
     expect(olderResult).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -27,6 +27,7 @@ import {
   createReplyDispatcher,
   createReplyDispatcherWithTyping,
   type ReplyDispatchBeforeDeliver,
+  type ReplyDispatchKind,
   type ReplyDispatcherOptions,
   type ReplyDispatcherWithTypingOptions,
 } from "./reply/reply-dispatcher.js";
@@ -48,6 +49,23 @@ type ForegroundReplyFenceSnapshot = {
 };
 
 const foregroundReplyFenceByKey = new Map<string, ForegroundReplyFenceState>();
+// Private channel hook: a channel may finalize an already-visible preview even
+// after a newer visible foreground reply would normally supersede it.
+const INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY = Symbol.for(
+  "openclaw.internal.foregroundReplyFreshnessPolicy",
+);
+
+type ForegroundReplyFreshnessPolicy = {
+  allowSupersededDelivery?: (delivery: {
+    payload: ReplyPayload;
+    info: { kind: ReplyDispatchKind };
+  }) => boolean;
+  registerVisibleDeliveryMarker?: (markVisibleDelivery: (() => void) | undefined) => void;
+};
+
+type ReplyOptionsWithInternalForegroundFreshness = Omit<GetReplyOptions, "onBlockReply"> & {
+  [INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY]?: ForegroundReplyFreshnessPolicy;
+};
 
 function normalizeForegroundReplyFencePart(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -151,6 +169,57 @@ async function shouldCancelForegroundReplyDelivery(
       state.waiters.add(resolve);
     });
   }
+}
+
+function allowsSupersededForegroundDelivery(
+  policy: ForegroundReplyFreshnessPolicy | undefined,
+  delivery: {
+    payload: ReplyPayload;
+    info: { kind: ReplyDispatchKind };
+  },
+): boolean {
+  if (delivery.info.kind !== "final") {
+    return false;
+  }
+  try {
+    return policy?.allowSupersededDelivery?.(delivery) === true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveForegroundReplyFreshnessPolicy(
+  replyOptions: Omit<GetReplyOptions, "onBlockReply"> | undefined,
+): ForegroundReplyFreshnessPolicy | undefined {
+  return (replyOptions as ReplyOptionsWithInternalForegroundFreshness | undefined)?.[
+    INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY
+  ];
+}
+
+function registerForegroundReplyVisibleDeliveryMarker(
+  policy: ForegroundReplyFreshnessPolicy | undefined,
+  snapshot: ForegroundReplyFenceSnapshot | undefined,
+): void {
+  try {
+    policy?.registerVisibleDeliveryMarker?.(
+      snapshot ? () => markForegroundReplyFenceVisibleDeliveryGeneration(snapshot) : undefined,
+    );
+  } catch {}
+}
+
+async function shouldCancelForegroundDelivery(params: {
+  snapshot: ForegroundReplyFenceSnapshot | undefined;
+  policy: ForegroundReplyFreshnessPolicy | undefined;
+  payload: ReplyPayload;
+  info: { kind: ReplyDispatchKind };
+}): Promise<boolean> {
+  if (!(await shouldCancelForegroundReplyDelivery(params.snapshot))) {
+    return false;
+  }
+  return !allowsSupersededForegroundDelivery(params.policy, {
+    payload: params.payload,
+    info: params.info,
+  });
 }
 
 function markForegroundReplyFenceVisibleDelivery(
@@ -439,10 +508,22 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
   const configuredBeforeDeliver =
     params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized);
+  const foregroundReplyFreshnessPolicy = resolveForegroundReplyFreshnessPolicy(params.replyOptions);
+  registerForegroundReplyVisibleDeliveryMarker(
+    foregroundReplyFreshnessPolicy,
+    foregroundReplyFence,
+  );
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
       ? async (payload, info) => {
-          if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
+          if (
+            await shouldCancelForegroundDelivery({
+              snapshot: foregroundReplyFence,
+              policy: foregroundReplyFreshnessPolicy,
+              payload,
+              info,
+            })
+          ) {
             return null;
           }
           const deliverPayload = configuredBeforeDeliver
@@ -450,7 +531,12 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
             : payload;
           if (
             !deliverPayload ||
-            (await shouldCancelForegroundReplyDelivery(foregroundReplyFence))
+            (await shouldCancelForegroundDelivery({
+              snapshot: foregroundReplyFence,
+              policy: foregroundReplyFreshnessPolicy,
+              payload: deliverPayload,
+              info,
+            }))
           ) {
             return null;
           }
@@ -503,6 +589,7 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
       if (foregroundReplyFence) {
         endForegroundReplyFence(foregroundReplyFence);
       }
+      registerForegroundReplyVisibleDeliveryMarker(foregroundReplyFreshnessPolicy, undefined);
       markRunComplete();
       markDispatchIdle();
     }


### PR DESCRIPTION
## Maintainer Design Check Requested

@steipete @obviyus I’m opening this as the follow-up to #85749, but I want to align the UX contract before spending another full Telegram proof cycle.

This PR intentionally follows the direction from #85749’s close comment:

- no user-facing `Run: <id>` or delivery-state receipt
- no new public config surface
- no new competing progress lane
- keep durable continuation internal
- use the existing Telegram progress/preview surface for long-turn liveness

Specific decisions I’d like confirmed:

1. Should the long-turn soft-deadline surface reuse the existing `Working` progress label machinery, rather than a literal `Still working on this...` message?
2. Is direct DM the right first scope, leaving groups/native quote progress to #82089 and adjacent progress-lane work?
3. Is this final-delivery split correct?
   - preview/block-style modes: finalize/edit the same visible preview when possible
   - progress mode: clear the progress draft, then send the normal final reply
4. If the user sends a newer DM while the old long turn is still running, should the old final remain deliverable only when it already has a visible progress preview, or should it be aborted/marked stale?

I’m also trying to avoid the current cross-PR conflict zone around `src/auto-reply/reply/agent-runner.ts` and `src/auto-reply/reply/agent-runner-execution.ts`; several open PRs already share those functions. This follow-up is intended to stay Telegram-owned unless maintainers want the design moved into shared auto-reply runner internals.

## Summary

- Add a Telegram long-turn progress state and DM-only 30s soft-deadline path that detaches only after the existing draft/progress preview is visible with a confirmed Telegram message id and the foreground freshness marker is registered.
- Reuse existing Telegram progress label/draft machinery and add a one-shot draft-stream initial-send bypass so short labels can materialize at the deadline.
- Keep progress-mode final delivery on the existing clear-progress-then-send-final path, while preview/block-style modes can finalize the same visible preview when safe.
- Add a narrow internal freshness exemption so older detached finals can only survive newer visible replies when they can edit an already-confirmed preview without appending stale messages.
- Preserve normal sent-message hooks, prompt-context recording, and transcript mirroring for preview-finalized success and error paths.

## Related context

- Follow-up to #85749.
- Related progress/draft direction: #76917, #83847, #86968.
- Related Telegram/native-quote/progress areas: #82089, #87072, #41588.
- Cross-PR conflict warning: this intentionally avoids `src/auto-reply/reply/agent-runner.ts` and `src/auto-reply/reply/agent-runner-execution.ts`, which are shared with #85235, #85767, #85904, #86089, #86463, #87171, #87463.

## Verification

- `CI=1 pnpm install --frozen-lockfile` to refresh local deps after rebasing onto current `origin/main`; no git-tracked changes.
- `PATH="/Users/dr/.nvm/versions/node/v24.12.0/bin:$PATH" node scripts/run-vitest.mjs run --reporter=verbose --testTimeout=10000 extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-message.test.ts src/auto-reply/dispatch.freshness.test.ts`: 5 files, 200 tests passed.
- `PATH="/Users/dr/.nvm/versions/node/v24.12.0/bin:$PATH" node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `PATH="/Users/dr/.nvm/versions/node/v24.12.0/bin:$PATH" node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `PATH="/Users/dr/.nvm/versions/node/v24.12.0/bin:$PATH" node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `PATH="/Users/dr/.nvm/versions/node/v24.12.0/bin:$PATH" node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `PATH="/Users/dr/.nvm/versions/node/v24.12.0/bin:$PATH" node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message.test.ts extensions/telegram/src/bot-message.ts extensions/telegram/src/draft-stream.test-helpers.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/draft-stream.ts extensions/telegram/src/lane-delivery-text-deliverer.ts extensions/telegram/src/long-turn-progress.ts src/auto-reply/dispatch.freshness.test.ts src/auto-reply/dispatch.ts`
- `PATH="/Users/dr/.nvm/versions/node/v24.12.0/bin:$PATH" node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message.test.ts extensions/telegram/src/bot-message.ts extensions/telegram/src/draft-stream.test-helpers.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/draft-stream.ts extensions/telegram/src/lane-delivery-text-deliverer.ts extensions/telegram/src/long-turn-progress.ts src/auto-reply/dispatch.freshness.test.ts src/auto-reply/dispatch.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.
- `git merge-tree --write-tree origin/main HEAD`: no conflicts against current `origin/main` at publication time.

## Real behavior proof

Behavior addressed: Telegram direct-message long turns can outlive the 30s soft deadline without a separate run-id receipt, as long as the existing Telegram progress/preview surface has produced a confirmed visible preview that can later be finalized safely.

Real environment tested: Local mocked Telegram dispatch/draft-stream coverage on latest rebased branch; no live Telegram Desktop/Mantis run yet.

Exact steps or command run after this patch: Focused Vitest coverage for Telegram draft streams, Telegram lane delivery, Telegram message dispatch, Telegram message processing, and foreground reply freshness; targeted tsgo configs; touched-file oxfmt/oxlint; diff whitespace check; branch autoreview.

Evidence after fix: Focused tests cover direct-DM detach after confirmed visible progress preview, freshness marker registration before readiness, unavailable/ambiguous preview fallback, group non-detach behavior, detached error fallback suppression with bookkeeping, progress-mode separate final delivery, same-preview finalization, failed preview-edit no-send behavior, confirmed-message-id freshness gating, no stale block/tool bypass, and active-newer-turn ordering.

Observed result after fix: The long-turn processor detaches only after progress preview readiness with a confirmed Telegram message id and registered foreground freshness marker; preview/block-style finals can edit the existing preview only when safe; progress mode keeps the existing clear-progress-then-final contract; stale old finals do not append new messages after newer visible replies.

What was not tested: Live Telegram Desktop/Mantis proof was not rerun yet. This PR is intentionally asking for maintainer design alignment before spending another live proof cycle.
