### PR TITLE
fix(reply): deliver plugin binding replies under message-tool mode

### DIFF
--- a/src/agents/live-model-dynamic-candidates.test.ts
+++ b/src/agents/live-model-dynamic-candidates.test.ts
@@ -3,7 +3,12 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Model } from "../llm/types.js";
 import { appendPrioritizedDynamicLiveModels } from "./live-model-dynamic-candidates.js";
 
+vi.mock("./agent-model-discovery.js", () => ({
+  normalizeDiscoveredAgentModel: <T>(value: T) => value,
+}));
+
 const REGISTRY = { find: () => undefined } as never;
+const DYNAMIC_TEST_PROVIDER = "dynamic-test-provider";
 type DynamicModelResolver = NonNullable<
   Parameters<typeof appendPrioritizedDynamicLiveModels>[0]["resolveDynamicModel"]
 >;
@@ -29,15 +34,15 @@ function model(provider: string, id: string): Model {
 describe("appendPrioritizedDynamicLiveModels", () => {
   it("materializes prioritized refs from provider dynamic model hooks", async () => {
     const resolveDynamicModel: DynamicModelResolver = vi.fn((params) =>
-      params.context.provider === "opencode-go" && params.context.modelId === "glm-5"
-        ? model("opencode-go", "glm-5")
+      params.context.provider === DYNAMIC_TEST_PROVIDER && params.context.modelId === "glm-5"
+        ? model(DYNAMIC_TEST_PROVIDER, "glm-5")
         : undefined,
     );
     const prepareDynamicModel: DynamicModelPreparer = vi.fn(async () => undefined);
     const config = {
       models: {
         providers: {
-          "opencode-go": {
+          [DYNAMIC_TEST_PROVIDER]: {
             api: "openai-completions",
             baseUrl: "https://configured.example/v1",
             models: [],
@@ -55,40 +60,40 @@ describe("appendPrioritizedDynamicLiveModels", () => {
       prepareDynamicModel,
       refs: [
         { provider: "anthropic", id: "claude-sonnet-4-6" },
-        { provider: "opencode-go", id: "glm-5" },
+        { provider: DYNAMIC_TEST_PROVIDER, id: "glm-5" },
       ],
     });
 
     expect(result.added.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
-      "opencode-go/glm-5",
+      `${DYNAMIC_TEST_PROVIDER}/glm-5`,
     ]);
     expect(result.models.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
       "anthropic/claude-sonnet-4-6",
-      "opencode-go/glm-5",
+      `${DYNAMIC_TEST_PROVIDER}/glm-5`,
     ]);
     expect(prepareDynamicModel).toHaveBeenCalledTimes(1);
     expect(prepareDynamicModel).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "opencode-go",
+        provider: DYNAMIC_TEST_PROVIDER,
         context: expect.objectContaining({
           agentDir: "/tmp/openclaw-agent",
           modelId: "glm-5",
           modelRegistry: REGISTRY,
-          provider: "opencode-go",
-          providerConfig: config.models?.providers?.["opencode-go"],
+          provider: DYNAMIC_TEST_PROVIDER,
+          providerConfig: config.models?.providers?.[DYNAMIC_TEST_PROVIDER],
         }),
       }),
     );
     expect(resolveDynamicModel).toHaveBeenCalledTimes(1);
     expect(resolveDynamicModel).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "opencode-go",
+        provider: DYNAMIC_TEST_PROVIDER,
         context: expect.objectContaining({
           agentDir: "/tmp/openclaw-agent",
           modelId: "glm-5",
           modelRegistry: REGISTRY,
-          provider: "opencode-go",
-          providerConfig: config.models?.providers?.["opencode-go"],
+          provider: DYNAMIC_TEST_PROVIDER,
+          providerConfig: config.models?.providers?.[DYNAMIC_TEST_PROVIDER],
         }),
       }),
     );

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -6815,7 +6815,10 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       ChatType: "group",
       GroupSubject: "Dev",
       Body: "observed message",
+      RawBody: "observed message",
+      CommandBody: "observed message",
     });
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockClear();
 
     const result = await dispatchReplyFromConfig({
       ctx,
@@ -6847,6 +6850,85 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(claimContext.pluginBinding).toMatchObject({ bindingId: "binding-message-tool-only" });
     expect(replyResolver).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers plugin-owned binding replies under message-tool-only source delivery", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: { handled: true, reply: { text: "Codex native reply" } },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-message-tool-reply",
+      targetSessionKey: "plugin-binding:codex:reply123",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1481858418548412579",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/tmp/plugin",
+      },
+    } satisfies SessionBindingRecord);
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "discord:channel:1481858418548412579",
+      To: "discord:channel:1481858418548412579",
+      AccountId: "default",
+      ChatType: "group",
+      Body: "continue bound Codex session",
+      RawBody: "continue bound Codex session",
+      CommandBody: "continue bound Codex session",
+      WasMentioned: false,
+      SessionKey: "agent:main:discord:channel:1481858418548412579",
+    });
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockClear();
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        messages: { groupChat: { visibleReplies: "message_tool" } },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
+      "openclaw-codex-app-server",
+      expect.objectContaining({
+        channel: "discord",
+        content: "continue bound Codex session",
+      }),
+      expect.objectContaining({
+        pluginBinding: expect.objectContaining({ bindingId: "binding-message-tool-reply" }),
+      }),
+    );
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Codex native reply" });
   });
 
   it("keeps unmentioned plugin-bound fallback from ordinary group agent dispatch", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1364,8 +1364,9 @@ export async function dispatchReplyFromConfig(
   const sendBindingNotice = async (
     payload: ReplyPayload,
     mode: "additive" | "terminal",
+    options?: { allowSuppressedAutomaticDelivery?: boolean },
   ): Promise<boolean> => {
-    if (suppressAutomaticSourceDelivery) {
+    if (suppressAutomaticSourceDelivery && options?.allowSuppressedAutomaticDelivery !== true) {
       return false;
     }
     const result = await routeReplyToOriginating(payload);
@@ -1622,7 +1623,9 @@ export async function dispatchReplyFromConfig(
       switch (targetedClaimOutcome.status) {
         case "handled": {
           if (targetedClaimOutcome.result.reply) {
-            await sendBindingNotice(targetedClaimOutcome.result.reply, "terminal");
+            await sendBindingNotice(targetedClaimOutcome.result.reply, "terminal", {
+              allowSuppressedAutomaticDelivery: true,
+            });
           }
           markIdle("plugin_binding_dispatch");
           recordProcessed("completed", { reason: "plugin-bound-handled" });

--- a/src/infra/net/node-proxy-agent.ts
+++ b/src/infra/net/node-proxy-agent.ts
@@ -1,5 +1,6 @@
 import type { Agent as HttpAgent } from "node:http";
-import { createAmbientNodeProxyAgent } from "@openclaw/proxyline";
+import { createRequire } from "node:module";
+import type { createAmbientNodeProxyAgent as createAmbientNodeProxyAgentType } from "@openclaw/proxyline";
 import { matchesNoProxy, resolveEnvHttpProxyAgentOptions } from "./proxy-env.js";
 import { resolveActiveManagedProxyTlsOptions } from "./proxy/managed-proxy-undici.js";
 
@@ -7,9 +8,15 @@ export const UNSUPPORTED_PROXY_PROTOCOL_MESSAGE =
   "Unsupported proxy protocol. SOCKS and PAC proxy URLs are not supported; use an HTTP or HTTPS proxy URL.";
 
 type NodeProxyProtocol = "http" | "https";
-type ProxylineAgentOptions = NonNullable<Parameters<typeof createAmbientNodeProxyAgent>[0]>;
+type ProxylineAgentOptions = NonNullable<Parameters<typeof createAmbientNodeProxyAgentType>[0]>;
 type ProxylineEnvSnapshot = NonNullable<ProxylineAgentOptions["env"]>;
 type ProxylineTlsOptions = ProxylineAgentOptions["proxyTls"];
+
+function loadCreateAmbientNodeProxyAgent(): typeof createAmbientNodeProxyAgentType {
+  const require = createRequire(import.meta.url);
+  return (require("@openclaw/proxyline") as typeof import("@openclaw/proxyline"))
+    .createAmbientNodeProxyAgent;
+}
 
 export type CreateNodeProxyAgentOptions =
   | {
@@ -123,6 +130,7 @@ function createFixedNodeProxyAgent(
     proxyUrl instanceof URL
       ? proxyUrl
       : proxyUrlWithDefaultScheme(proxyUrl, options.protocol ?? "https");
+  const createAmbientNodeProxyAgent = loadCreateAmbientNodeProxyAgent();
   const agent = createAmbientNodeProxyAgent({
     env: fixedProxyEnv(parsedProxyUrl),
     protocol: options.protocol ?? "https",


### PR DESCRIPTION
## Summary
- Allow handled plugin-owned `inbound_claim` replies to deliver even when a group/channel uses `message_tool` visible replies.
- Keep message-tool-only suppression for normal automatic agent finals and for plugin fallback/decline/error notices.
- Add regression coverage for a Discord plugin-owned binding reply under `messages.groupChat.visibleReplies: "message_tool"`.
- Stabilize required CI shards by keeping dynamic-model hook tests isolated from plugin runtime normalization and lazy-loading proxyline so plugin SDK fetch imports stay inert.

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "plugin-owned"`
- `node scripts/run-vitest.mjs --config test/vitest/vitest.agents-core.config.ts src/agents/live-model-dynamic-candidates.test.ts --reporter verbose --testTimeout 30000`
- `node scripts/run-vitest.mjs --config test/vitest/vitest.plugin-sdk.config.ts src/plugin-sdk/fetch-runtime.test.ts --reporter verbose`
- `node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts extensions/codex/src/commands.test.ts -t "codex-cli-node-session|bind here|inbound"`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/infra/net/node-proxy-agent.ts src/agents/live-model-dynamic-candidates.test.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: a plugin-owned Codex binding reply is no longer silently dropped when the source room is configured for message-tool-only visible replies.

Real environment tested: local OpenClaw checkout at PR head, real dispatch-from-config implementation, Discord-shaped group/channel context, plugin-owned binding record, and the repo's Vitest dispatch harness.

Exact steps or command run after this patch:
```text
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "plugin-owned"
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts
```

Evidence after fix:
```text
Test Files  1 passed (1)
Tests  10 passed | 162 skipped (172)

Test Files  1 passed (1)
Tests  172 passed (172)
```

Observed result after fix: the new regression builds a Discord group turn with `messages.groupChat.visibleReplies: "message_tool"`, resolves an active plugin-owned Codex binding, receives a handled `inbound_claim` reply, skips the normal agent reply resolver, and calls `dispatcher.sendFinalReply({ text: "Codex native reply" })` while preserving `sourceReplyDeliveryMode: "message_tool_only"`. The neighboring test still proves a plugin-owned binding with no returned reply remains silent under message-tool-only delivery.

What was not tested: no live Discord bot/account was used; this is deterministic source-level proof of the exact dispatch branch that ClawSweeper identified.

Fixes #87721.

If this PR is squash/reworked, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
