### PR TITLE
fix(agents): loosen abort settle env typing

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.ts
@@ -1,6 +1,12 @@
 import { parseStrictPositiveInteger } from "../../../infra/parse-finite-number.js";
 
-export function resolveEmbeddedAbortSettleTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+type AbortSettleTimeoutEnv = Partial<
+  Pick<NodeJS.ProcessEnv, "OPENCLAW_EMBEDDED_ABORT_SETTLE_TIMEOUT_MS" | "OPENCLAW_TEST_FAST">
+>;
+
+export function resolveEmbeddedAbortSettleTimeoutMs(
+  env: AbortSettleTimeoutEnv = process.env,
+): number {
   const override = parseStrictPositiveInteger(env.OPENCLAW_EMBEDDED_ABORT_SETTLE_TIMEOUT_MS);
   if (override !== undefined) {
     return override;

--- a/src/agents/live-model-dynamic-candidates.test.ts
+++ b/src/agents/live-model-dynamic-candidates.test.ts
@@ -3,6 +3,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Model } from "../llm/types.js";
 import { appendPrioritizedDynamicLiveModels } from "./live-model-dynamic-candidates.js";
 
+vi.mock("./agent-model-discovery.js", () => ({
+  normalizeDiscoveredAgentModel: <T>(value: T) => value,
+}));
+
 const REGISTRY = { find: () => undefined } as never;
 type DynamicModelResolver = NonNullable<
   Parameters<typeof appendPrioritizedDynamicLiveModels>[0]["resolveDynamicModel"]


### PR DESCRIPTION
## Summary

- narrow `resolveEmbeddedAbortSettleTimeoutMs` to the two env keys it actually reads
- keep the existing `process.env` default and runtime timeout behavior unchanged
- unblock `check:changed` generated/test type surfaces that reject full `NodeJS.ProcessEnv` as a required-key `Pick`
- keep `live-model-dynamic-candidates.test.ts` focused on injected dynamic-model hooks instead of loading the real provider normalization/plugin runtime path

## Verification

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/abort-settle-env-final-$USER-$$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.test.ts`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/live-dynamic-mocked-$USER-$$ node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/live-model-dynamic-candidates.test.ts --reporter=verbose`
- `./node_modules/oxfmt/bin/oxfmt --check --threads=1 src/agents/live-model-dynamic-candidates.test.ts`
- `node scripts/run-oxlint.mjs src/agents/live-model-dynamic-candidates.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `run_8a485e593c2e`, lease `cbx_ab53fb060315`, slug `quick-crab`, provider `aws`: `corepack pnpm check:changed` passed on amended head `a05e30b1c8`
- clean ancestry rebase to `21e69fdd4f`, followed by focused Vitest, format/lint/diff checks, and autoreview

## Real behavior proof

Behavior addressed: `check:changed` failed in generated/test type surfaces because the helper accepted `NodeJS.ProcessEnv`, making the narrowed keys appear required at the boundary. The agentic-agents CI shard also timed out in `live-model-dynamic-candidates.test.ts` because a hook-focused unit test paid the real provider normalization/plugin-runtime load cost.

Real environment tested: focused local Codex worktree plus AWS Crabbox Linux runner.

Exact steps or command run after this patch: focused Vitest for the abort settle timeout helper, focused Vitest for `live-model-dynamic-candidates.test.ts`, local format/lint/diff checks, autoreview, and remote `corepack pnpm check:changed`.

Evidence after fix: abort-settle focused test passed 1 file / 5 tests in the earlier branch proof; `live-model-dynamic-candidates.test.ts` passed 1 file / 2 tests in 2.01s after the scoped mock; autoreview reported no actionable findings; AWS Crabbox `run_8a485e593c2e` exited 0.

Observed result after fix: the prior `ProcessEnv` assignability failure is gone while the helper still reads the same override and `OPENCLAW_TEST_FAST` fallback; the dynamic live model unit test no longer spends roughly 78s loading provider normalization/runtime plugins.

What was not tested: no live provider or runtime session smoke; this is a static env typing repair plus a test-only CI timeout fix.
