### PR TITLE
perf: defer configured Slack full startup

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1199,7 +1199,7 @@ Important examples:
 | `openclaw.install.minHostVersion`                                                          | Minimum supported OpenClaw host version, using a semver floor like `>=2026.3.22` or `>=2026.5.1-beta.1`.                                                                             |
 | `openclaw.install.expectedIntegrity`                                                       | Expected npm dist integrity string such as `sha512-...`; install and update flows verify the fetched artifact against it.                                                            |
 | `openclaw.install.allowInvalidConfigRecovery`                                              | Allows a narrow bundled-plugin reinstall recovery path when config is invalid.                                                                                                       |
-| `openclaw.startup.deferConfiguredChannelFullLoadUntilAfterListen`                          | Lets setup-only channel surfaces load before the full channel plugin during startup.                                                                                                 |
+| `openclaw.startup.deferConfiguredChannelFullLoadUntilAfterListen`                          | Lets setup-runtime channel surfaces load before listen, then defers the full configured channel plugin until post-listen activation.                                                 |
 
 Manifest metadata decides which provider/channel/setup choices appear in
 onboarding before runtime loads. `package.json#openclaw.install` tells

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -246,11 +246,22 @@ export default defineBundledChannelSetupEntry({
     specifier: "./runtime-api.js",
     exportName: "setMyChannelRuntime",
   },
+  registerSetupRuntime(api) {
+    api.registerHttpRoute({
+      path: "/my-channel/events",
+      auth: "plugin",
+      handler: async (req, res) => {
+        /* setup-safe route */
+      },
+    });
+  },
 });
 ```
 
 Use that bundled contract only when setup flows truly need a lightweight runtime
-setter before the full channel entry loads.
+setter or setup-safe gateway surface before the full channel entry loads.
+`registerSetupRuntime` runs only for `"setup-runtime"` loads; keep it limited to
+config-only routes or methods that must exist before deferred full activation.
 
 ## Registration mode
 

--- a/extensions/slack/index.test.ts
+++ b/extensions/slack/index.test.ts
@@ -19,7 +19,7 @@ describe("slack bundled entries", () => {
     setupEntry,
   });
 
-  it("registers webhook routes without loading the Slack HTTP route sidecar", async () => {
+  it("registers webhook routes through the full channel entry", async () => {
     const registerHttpRoute = vi.fn();
     entry.register({
       registrationMode: "tool-discovery",
@@ -68,6 +68,30 @@ describe("slack bundled entries", () => {
     expect(registerHttpRoute.mock.calls.map((call) => call[0].path)).toEqual([
       "/hooks/ops",
       "/slack/root",
+    ]);
+  });
+
+  it("registers webhook routes through the setup-runtime entry", () => {
+    const registerHttpRoute = vi.fn();
+    setupEntry.registerSetupRuntime?.({
+      registrationMode: "setup-runtime",
+      config: {
+        channels: {
+          slack: {
+            webhookPath: "/slack/root",
+            accounts: {
+              default: { webhookPath: "/slack/default" },
+              ops: { webhookPath: "hooks/ops" },
+            },
+          },
+        },
+      },
+      registerHttpRoute,
+    } as never);
+
+    expect(registerHttpRoute.mock.calls.map((call) => call[0].path)).toEqual([
+      "/hooks/ops",
+      "/slack/default",
     ]);
   });
 });

--- a/extensions/slack/index.ts
+++ b/extensions/slack/index.ts
@@ -1,45 +1,5 @@
 import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
-
-const DEFAULT_SLACK_ACCOUNT_ID = "default";
-
-function normalizeSlackWebhookPath(path?: unknown): string {
-  const trimmed = typeof path === "string" ? path.trim() : "";
-  if (!trimmed) {
-    return "/slack/events";
-  }
-  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-}
-
-function resolveSlackWebhookPaths(config: OpenClawPluginApi["config"]): string[] {
-  const slack = config.channels?.slack as
-    | {
-        webhookPath?: unknown;
-        accounts?: Record<string, { webhookPath?: unknown } | undefined>;
-      }
-    | undefined;
-  const accountConfigs = slack?.accounts ?? {};
-  const paths = new Set<string>();
-  for (const accountId of new Set([DEFAULT_SLACK_ACCOUNT_ID, ...Object.keys(accountConfigs)])) {
-    paths.add(
-      normalizeSlackWebhookPath(accountConfigs[accountId]?.webhookPath ?? slack?.webhookPath),
-    );
-  }
-  return [...paths].toSorted((left, right) => left.localeCompare(right));
-}
-
-function registerSlackPluginHttpRoutes(api: OpenClawPluginApi): void {
-  for (const path of resolveSlackWebhookPaths(api.config)) {
-    api.registerHttpRoute({
-      path,
-      auth: "plugin",
-      handler: async (req, res) => {
-        const { handleSlackHttpRequest } = await import("./src/http/registry.js");
-        return await handleSlackHttpRequest(req, res);
-      },
-    });
-  }
-}
+import { registerSlackPluginHttpRoutes } from "./http-routes-api.js";
 
 export default defineBundledChannelEntry({
   id: "slack",

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -60,11 +60,14 @@
     "install": {
       "npmSpec": "@openclaw/slack",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.5.12-beta.1",
+      "minHostVersion": ">=2026.5.28",
       "allowInvalidConfigRecovery": true
     },
     "compat": {
       "pluginApi": ">=2026.5.28"
+    },
+    "startup": {
+      "deferConfiguredChannelFullLoadUntilAfterListen": true
     },
     "build": {
       "openclawVersion": "2026.5.28",

--- a/extensions/slack/setup-entry.ts
+++ b/extensions/slack/setup-entry.ts
@@ -1,4 +1,5 @@
 import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+import { registerSlackPluginHttpRoutes } from "./http-routes-api.js";
 
 export default defineBundledChannelSetupEntry({
   importMetaUrl: import.meta.url,
@@ -10,4 +11,9 @@ export default defineBundledChannelSetupEntry({
     specifier: "./secret-contract-api.js",
     exportName: "channelSecrets",
   },
+  runtime: {
+    specifier: "./runtime-setter-api.js",
+    exportName: "setSlackRuntime",
+  },
+  registerSetupRuntime: registerSlackPluginHttpRoutes,
 });

--- a/extensions/slack/src/http/plugin-routes.ts
+++ b/extensions/slack/src/http/plugin-routes.ts
@@ -1,21 +1,26 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-plugin-common";
-import { listSlackAccountIds, mergeSlackAccountConfig } from "../accounts.js";
 import { normalizeSlackWebhookPath } from "./paths.js";
 import { handleSlackHttpRequest } from "./registry.js";
 
+type SlackWebhookConfig = {
+  webhookPath?: unknown;
+  accounts?: Record<string, { webhookPath?: unknown } | undefined>;
+};
+
+function resolveSlackWebhookPaths(config: OpenClawPluginApi["config"]): string[] {
+  const slack = config.channels?.slack as SlackWebhookConfig | undefined;
+  const accountConfigs = slack?.accounts ?? {};
+  const paths = new Set<string>();
+  for (const accountId of new Set([DEFAULT_ACCOUNT_ID, ...Object.keys(accountConfigs)])) {
+    const path = accountConfigs[accountId]?.webhookPath ?? slack?.webhookPath;
+    paths.add(normalizeSlackWebhookPath(typeof path === "string" ? path : undefined));
+  }
+  return [...paths].toSorted((left, right) => left.localeCompare(right));
+}
+
 export function registerSlackPluginHttpRoutes(api: OpenClawPluginApi): void {
-  const accountIds = new Set<string>([DEFAULT_ACCOUNT_ID, ...listSlackAccountIds(api.config)]);
-  const registeredPaths = new Set<string>();
-  for (const accountId of accountIds) {
-    // Route registration must remain config-only and should not resolve tokens.
-    const accountConfig = mergeSlackAccountConfig(api.config, accountId);
-    registeredPaths.add(normalizeSlackWebhookPath(accountConfig.webhookPath));
-  }
-  if (registeredPaths.size === 0) {
-    registeredPaths.add(normalizeSlackWebhookPath());
-  }
-  for (const path of registeredPaths) {
+  for (const path of resolveSlackWebhookPaths(api.config)) {
     api.registerHttpRoute({
       path,
       auth: "plugin",

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -91,8 +91,8 @@ const loadPluginLookUpTable = vi.hoisted(() =>
   vi.fn((_params: unknown) => ({
     manifestRegistry: pluginManifestRegistry,
     startup: {
-      configuredDeferredChannelPluginIds: [],
-      pluginIds: ["telegram"],
+      configuredDeferredChannelPluginIds: [] as string[],
+      pluginIds: ["telegram"] as string[],
     },
     metrics: pluginLookUpTableMetrics,
   })),
@@ -182,8 +182,8 @@ describe("prepareGatewayPluginBootstrap startup plugins", () => {
     loadPluginLookUpTable.mockClear().mockReturnValue({
       manifestRegistry: pluginManifestRegistry,
       startup: {
-        configuredDeferredChannelPluginIds: [],
-        pluginIds: ["telegram"],
+        configuredDeferredChannelPluginIds: [] as string[],
+        pluginIds: ["telegram"] as string[],
       },
       metrics: pluginLookUpTableMetrics,
     });
@@ -306,6 +306,87 @@ describe("prepareGatewayPluginBootstrap startup plugins", () => {
       dreaming: { enabled: false },
     });
   });
+
+  it("loads only deferred setup-runtime plugins during pre-bind bootstrap", async () => {
+    loadPluginLookUpTable.mockReturnValueOnce({
+      manifestRegistry: pluginManifestRegistry,
+      startup: {
+        configuredDeferredChannelPluginIds: ["slack"] as string[],
+        pluginIds: ["slack", "memory-core"] as string[],
+      },
+      metrics: {
+        ...pluginLookUpTableMetrics,
+        startupPluginCount: 2,
+        deferredChannelPluginCount: 1,
+      },
+    });
+    const cfg = {
+      channels: {
+        slack: { enabled: true, token: "token" },
+      },
+    } as OpenClawConfig;
+    const log = createLog();
+    const { prepareGatewayPluginBootstrap } = await import("./server-startup-plugins.js");
+
+    const result = await prepareGatewayPluginBootstrap({
+      cfgAtStart: cfg,
+      startupRuntimeConfig: cfg,
+      minimalTestGateway: false,
+      log,
+      loadRuntimePlugins: false,
+      loadSetupRuntimePlugins: true,
+    });
+
+    expect(result.runtimePluginsLoaded).toBe(false);
+    const startupInput = firstCallArg<{
+      pluginIds?: string[];
+      preferSetupRuntimeForChannelPlugins?: boolean;
+      suppressPluginInfoLogs?: boolean;
+    }>(loadGatewayStartupPlugins);
+    expect(startupInput.pluginIds).toEqual(["slack"]);
+    expect(startupInput.preferSetupRuntimeForChannelPlugins).toBe(true);
+    expect(startupInput.suppressPluginInfoLogs).toBe(true);
+  });
+
+  it("does not use setup-runtime preference for full bootstrap loads", async () => {
+    loadPluginLookUpTable.mockReturnValueOnce({
+      manifestRegistry: pluginManifestRegistry,
+      startup: {
+        configuredDeferredChannelPluginIds: ["slack"] as string[],
+        pluginIds: ["slack", "memory-core"] as string[],
+      },
+      metrics: {
+        ...pluginLookUpTableMetrics,
+        startupPluginCount: 2,
+        deferredChannelPluginCount: 1,
+      },
+    });
+    const cfg = {
+      channels: {
+        slack: { enabled: true, token: "token" },
+      },
+    } as OpenClawConfig;
+    const log = createLog();
+    const { prepareGatewayPluginBootstrap } = await import("./server-startup-plugins.js");
+
+    const result = await prepareGatewayPluginBootstrap({
+      cfgAtStart: cfg,
+      startupRuntimeConfig: cfg,
+      minimalTestGateway: false,
+      log,
+    });
+
+    expect(result.runtimePluginsLoaded).toBe(true);
+    const startupInput = firstCallArg<{
+      pluginIds?: string[];
+      preferSetupRuntimeForChannelPlugins?: boolean;
+      suppressPluginInfoLogs?: boolean;
+    }>(loadGatewayStartupPlugins);
+    expect(startupInput.pluginIds).toEqual(["slack", "memory-core"]);
+    expect(startupInput.preferSetupRuntimeForChannelPlugins).toBe(false);
+    expect(startupInput.suppressPluginInfoLogs).toBe(false);
+  });
+
   it("bypasses plugin lookup when plugins are globally disabled", async () => {
     const cfg = {
       channels: {

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -43,6 +43,7 @@ export async function prepareGatewayPluginBootstrap(params: {
   minimalTestGateway: boolean;
   log: GatewayPluginBootstrapLog;
   loadRuntimePlugins?: boolean;
+  loadSetupRuntimePlugins?: boolean;
 }) {
   const activationSourceConfig = params.activationSourceConfig ?? params.cfgAtStart;
   const startupMaintenanceConfig = resolveGatewayStartupMaintenanceConfig({
@@ -114,8 +115,25 @@ export async function prepareGatewayPluginBootstrap(params: {
   let pluginRegistry = emptyPluginRegistry;
   let baseGatewayMethods = baseMethods;
   const shouldLoadRuntimePlugins = params.loadRuntimePlugins !== false;
+  const shouldLoadSetupRuntimePlugins =
+    params.loadSetupRuntimePlugins === true && deferredConfiguredChannelPluginIds.length > 0;
 
-  if (!params.minimalTestGateway && shouldLoadRuntimePlugins) {
+  if (!params.minimalTestGateway && shouldLoadSetupRuntimePlugins) {
+    ({ pluginRegistry, gatewayMethods: baseGatewayMethods } = await loadGatewayStartupPluginRuntime(
+      {
+        cfg: gatewayPluginConfig,
+        activationSourceConfig,
+        workspaceDir: defaultWorkspaceDir,
+        log: params.log,
+        baseMethods,
+        coreGatewayMethodNames,
+        startupPluginIds: deferredConfiguredChannelPluginIds,
+        pluginLookUpTable,
+        preferSetupRuntimeForChannelPlugins: true,
+        suppressPluginInfoLogs: true,
+      },
+    ));
+  } else if (!params.minimalTestGateway && shouldLoadRuntimePlugins) {
     ({ pluginRegistry, gatewayMethods: baseGatewayMethods } = await loadGatewayStartupPluginRuntime(
       {
         cfg: gatewayPluginConfig,
@@ -126,8 +144,8 @@ export async function prepareGatewayPluginBootstrap(params: {
         coreGatewayMethodNames,
         startupPluginIds,
         pluginLookUpTable,
-        preferSetupRuntimeForChannelPlugins: deferredConfiguredChannelPluginIds.length > 0,
-        suppressPluginInfoLogs: deferredConfiguredChannelPluginIds.length > 0,
+        preferSetupRuntimeForChannelPlugins: false,
+        suppressPluginInfoLogs: false,
       },
     ));
   } else {
@@ -146,7 +164,8 @@ export async function prepareGatewayPluginBootstrap(params: {
     baseMethods,
     pluginRegistry,
     baseGatewayMethods,
-    runtimePluginsLoaded: !params.minimalTestGateway && shouldLoadRuntimePlugins,
+    runtimePluginsLoaded:
+      !params.minimalTestGateway && shouldLoadRuntimePlugins && !shouldLoadSetupRuntimePlugins,
   };
 }
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -676,6 +676,7 @@ export async function startGatewayServer(
       minimalTestGateway,
       log,
       loadRuntimePlugins: false,
+      loadSetupRuntimePlugins: true,
     }),
   );
   const {

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -8,7 +8,11 @@ import type { PluginModuleLoaderFactory } from "../plugins/plugin-module-loader-
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import type { OpenClawPluginApi, PluginRegistrationMode } from "../plugins/types.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
-import { defineBundledChannelEntry, loadBundledEntryExportSync } from "./channel-entry-contract.js";
+import {
+  defineBundledChannelEntry,
+  defineBundledChannelSetupEntry,
+  loadBundledEntryExportSync,
+} from "./channel-entry-contract.js";
 
 const tempDirs: string[] = [];
 const pluginModuleLoaderJitiFactoryOverrideKey = Symbol.for(
@@ -207,6 +211,35 @@ describe("defineBundledChannelEntry", () => {
     expect(fs.existsSync(runtimeMarker)).toBe(true);
     expect(registerCliMetadata).toHaveBeenCalledWith(fullApi);
     expect(registerFull).toHaveBeenCalledWith(fullApi);
+  });
+});
+
+describe("defineBundledChannelSetupEntry", () => {
+  it("exposes setup-runtime registrations without loading the full channel entry", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-setup-entry-"));
+    tempDirs.push(tempRoot);
+    const runtimeMarker = path.join(tempRoot, "runtime-loaded");
+    const setupRuntimeRegister = vi.fn<(api: OpenClawPluginApi) => void>();
+    const pluginId = "bundled-setup-runtime";
+    const { importerPath } = writeBundledChannelFixture({
+      pluginRoot: path.join(tempRoot, "dist", "extensions", pluginId),
+      pluginId,
+      runtimeMarker,
+    });
+    const entry = defineBundledChannelSetupEntry({
+      importMetaUrl: pathToFileURL(importerPath).href,
+      plugin: { specifier: "./plugin.cjs", exportName: "channelPlugin" },
+      runtime: { specifier: "./runtime.cjs", exportName: "setRuntime" },
+      registerSetupRuntime: setupRuntimeRegister,
+    });
+
+    const api = createApi("setup-runtime");
+    expect(entry.loadSetupPlugin().id).toBe(pluginId);
+    entry.setChannelRuntime?.(api.runtime);
+    entry.registerSetupRuntime?.(api);
+
+    expect(fs.existsSync(runtimeMarker)).toBe(true);
+    expect(setupRuntimeRegister).toHaveBeenCalledWith(api);
   });
 });
 

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -70,6 +70,7 @@ type DefineBundledChannelSetupEntryOptions = {
   runtime?: BundledEntryModuleRef;
   legacyStateMigrations?: BundledEntryModuleRef;
   legacySessionSurface?: BundledEntryModuleRef;
+  registerSetupRuntime?: (api: OpenClawPluginApi) => void;
   features?: BundledChannelSetupEntryFeatures;
 };
 
@@ -135,6 +136,7 @@ export type BundledChannelSetupEntryContract<TPlugin = ChannelPlugin> = {
     options?: BundledEntryModuleLoadOptions,
   ) => BundledChannelLegacySessionSurface;
   setChannelRuntime?: (runtime: PluginRuntime) => void;
+  registerSetupRuntime?: (api: OpenClawPluginApi) => void;
   features?: BundledChannelSetupEntryFeatures;
 };
 
@@ -577,6 +579,7 @@ export function defineBundledChannelSetupEntry<TPlugin = ChannelPlugin>({
   runtime,
   legacyStateMigrations,
   legacySessionSurface,
+  registerSetupRuntime,
   features,
 }: DefineBundledChannelSetupEntryOptions): BundledChannelSetupEntryContract<TPlugin> {
   // Bundled setup entries stay on a light path during setup-only/setup-runtime loads.
@@ -624,6 +627,7 @@ export function defineBundledChannelSetupEntry<TPlugin = ChannelPlugin>({
     ...(loadLegacyStateMigrationDetector ? { loadLegacyStateMigrationDetector } : {}),
     ...(loadLegacySessionSurface ? { loadLegacySessionSurface } : {}),
     ...(setChannelRuntime ? { setChannelRuntime } : {}),
+    ...(registerSetupRuntime ? { registerSetupRuntime } : {}),
     ...(features ? { features } : {}),
   };
 }

--- a/src/plugins/loader-channel-setup.ts
+++ b/src/plugins/loader-channel-setup.ts
@@ -3,6 +3,7 @@ import { isChannelConfigured } from "../config/channel-configured.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
 import type { PluginRuntime } from "./runtime/types.js";
+import type { OpenClawPluginApi } from "./types.js";
 
 function mergeChannelPluginSection<T>(
   baseValue: T | undefined,
@@ -125,6 +126,7 @@ export function loadBundledRuntimeChannelPlugin(params: {
 export function resolveSetupChannelRegistration(moduleExport: unknown): {
   plugin?: ChannelPlugin;
   setChannelRuntime?: (runtime: PluginRuntime) => void;
+  registerSetupRuntime?: (api: OpenClawPluginApi) => void;
   usesBundledSetupContract?: boolean;
   loadError?: unknown;
 } {
@@ -137,6 +139,7 @@ export function resolveSetupChannelRegistration(moduleExport: unknown): {
     loadSetupPlugin?: unknown;
     loadSetupSecrets?: unknown;
     setChannelRuntime?: unknown;
+    registerSetupRuntime?: unknown;
   };
   if (
     setupEntryRecord.kind === "bundled-channel-setup-entry" &&
@@ -163,6 +166,13 @@ export function resolveSetupChannelRegistration(moduleExport: unknown): {
             ? {
                 setChannelRuntime: setupEntryRecord.setChannelRuntime as (
                   runtime: PluginRuntime,
+                ) => void,
+              }
+            : {}),
+          ...(typeof setupEntryRecord.registerSetupRuntime === "function"
+            ? {
+                registerSetupRuntime: setupEntryRecord.registerSetupRuntime as (
+                  api: OpenClawPluginApi,
                 ) => void,
               }
             : {}),
@@ -208,6 +218,22 @@ export function shouldLoadChannelPluginInSetupRuntime(params: {
   }
   return !params.manifestChannels.some((channelId) =>
     isChannelConfigured(params.cfg, channelId, params.env),
+  );
+}
+
+export function shouldDeferConfiguredChannelFullRuntimeMerge(params: {
+  manifestChannels: string[];
+  startupDeferConfiguredChannelFullLoadUntilAfterListen?: boolean;
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  preferSetupRuntimeForChannelPlugins?: boolean;
+}): boolean {
+  return (
+    params.preferSetupRuntimeForChannelPlugins === true &&
+    params.startupDeferConfiguredChannelFullLoadUntilAfterListen === true &&
+    params.manifestChannels.some((channelId) =>
+      isChannelConfigured(params.cfg, channelId, params.env),
+    )
   );
 }
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -663,6 +663,9 @@ function createSetupEntryChannelPluginFixture(params: {
   bundledSetupEntryId?: string;
   splitBundledSetupSecrets?: boolean;
   bundledSetupRuntimeMarker?: string;
+  bundledSetupRuntimeRoutePath?: string;
+  bundledSetupRuntimeRegisterError?: string;
+  bundledSetupRuntimeLateRoutePath?: string;
   bundledSetupRuntimeError?: string;
   bundledFullRuntimeMarker?: string;
   requireBundledFullRuntimeBeforeLoad?: boolean;
@@ -825,7 +828,34 @@ module.exports = {
   },`
         : ""
   }
-};`
+	  ${
+      params.bundledSetupRuntimeRoutePath
+        ? `registerSetupRuntime: (api) => {
+	    api.registerHttpRoute({
+	      path: ${JSON.stringify(params.bundledSetupRuntimeRoutePath)},
+	      auth: "plugin",
+	      handler: async () => true,
+	    });
+	    ${
+        params.bundledSetupRuntimeRegisterError
+          ? `throw new Error(${JSON.stringify(params.bundledSetupRuntimeRegisterError)});`
+          : ""
+      }
+	    ${
+        params.bundledSetupRuntimeLateRoutePath
+          ? `queueMicrotask(() => {
+	      api.registerHttpRoute({
+	        path: ${JSON.stringify(params.bundledSetupRuntimeLateRoutePath)},
+	        auth: "plugin",
+	        handler: async () => true,
+	      });
+	    });`
+          : ""
+      }
+	  },`
+        : ""
+    }
+	};`
       : `require("node:fs").writeFileSync(${JSON.stringify(setupMarker)}, "loaded", "utf-8");
 module.exports = {
   plugin: {
@@ -5481,6 +5511,41 @@ module.exports = {
       expectSetupRuntimeLoaded: true,
     },
     {
+      name: "runs bundled setupEntry setup-runtime registrations before deferred full loads",
+      fixture: {
+        id: "setup-runtime-bundled-route-test",
+        label: "Setup Runtime Bundled Route Test",
+        packageName: "@openclaw/setup-runtime-bundled-route-test",
+        fullBlurb: "full entry should defer while configured",
+        setupBlurb: "setup runtime route",
+        configured: true,
+        startupDeferConfiguredChannelFullLoadUntilAfterListen: true,
+        useBundledSetupEntryContract: true,
+        bundledSetupRuntimeRoutePath: "/setup-runtime-route",
+      },
+      load: ({ pluginDir }: { pluginDir: string }) =>
+        loadOpenClawPlugins({
+          cache: false,
+          preferSetupRuntimeForChannelPlugins: true,
+          config: {
+            channels: {
+              "setup-runtime-bundled-route-test": {
+                enabled: true,
+                token: "configured",
+              },
+            },
+            plugins: {
+              load: { paths: [pluginDir] },
+              allow: ["setup-runtime-bundled-route-test"],
+            },
+          },
+        }),
+      expectFullLoaded: false,
+      expectSetupLoaded: true,
+      expectedChannels: 1,
+      expectedSetupRuntimeRoutePath: "/setup-runtime-route",
+    },
+    {
       name: "merges bundled runtime plugin into setup-runtime channel loads",
       fixture: {
         id: "setup-runtime-bundled-runtime-merge-test",
@@ -5584,6 +5649,7 @@ module.exports = {
       expectedSetupSecretId,
       expectSetupRuntimeLoaded,
       expectBundledFullRuntimeLoaded,
+      expectedSetupRuntimeRoutePath,
     }) => {
       const built = createSetupEntryChannelPluginFixture(fixture);
       const registry = load({ pluginDir: built.pluginDir });
@@ -5611,6 +5677,14 @@ module.exports = {
         expect(
           registry.channels[0]?.plugin.secrets?.secretTargetRegistryEntries?.some(
             (entry) => entry.id === expectedSetupSecretId,
+          ),
+        ).toBe(true);
+      }
+      if (expectedSetupRuntimeRoutePath) {
+        expect(
+          registry.httpRoutes.some(
+            (route) =>
+              route.pluginId === fixture.id && route.path === expectedSetupRuntimeRoutePath,
           ),
         ).toBe(true);
       }
@@ -5683,6 +5757,97 @@ module.exports = {
     ).toContain("broken setup runtime setter");
     expect(registry.plugins.find((entry) => entry.id === "setup-runtime-helper-test")?.status).toBe(
       "loaded",
+    );
+  });
+
+  it("rolls back setup-runtime registrations when setup side effects fail", () => {
+    const built = createSetupEntryChannelPluginFixture({
+      id: "setup-runtime-route-error-test",
+      label: "Setup Runtime Route Error Test",
+      packageName: "@openclaw/setup-runtime-route-error-test",
+      fullBlurb: "full runtime plugin",
+      setupBlurb: "setup runtime route",
+      configured: true,
+      startupDeferConfiguredChannelFullLoadUntilAfterListen: true,
+      useBundledSetupEntryContract: true,
+      bundledSetupRuntimeRoutePath: "/setup-runtime-route-error",
+      bundledSetupRuntimeRegisterError: "broken setup-runtime registrar",
+    });
+    const helperPlugin = writePlugin({
+      id: "setup-runtime-route-helper-test",
+      filename: "setup-runtime-route-helper-test.cjs",
+      body: `module.exports = { id: "setup-runtime-route-helper-test", register() {} };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      preferSetupRuntimeForChannelPlugins: true,
+      config: {
+        channels: {
+          "setup-runtime-route-error-test": {
+            enabled: true,
+            token: "configured",
+          },
+        },
+        plugins: {
+          load: { paths: [built.pluginDir, helperPlugin.file] },
+          allow: ["setup-runtime-route-error-test", "setup-runtime-route-helper-test"],
+        },
+      },
+    });
+
+    expect(
+      registry.plugins.find((entry) => entry.id === "setup-runtime-route-error-test")?.status,
+    ).toBe("error");
+    expect(
+      registry.plugins.find((entry) => entry.id === "setup-runtime-route-error-test")?.error,
+    ).toContain("broken setup-runtime registrar");
+    expect(registry.httpRoutes.some((route) => route.path === "/setup-runtime-route-error")).toBe(
+      false,
+    );
+    expect(
+      registry.plugins.find((entry) => entry.id === "setup-runtime-route-helper-test")?.status,
+    ).toBe("loaded");
+  });
+
+  it("closes setup-runtime registration APIs after synchronous registration", async () => {
+    const built = createSetupEntryChannelPluginFixture({
+      id: "setup-runtime-late-route-test",
+      label: "Setup Runtime Late Route Test",
+      packageName: "@openclaw/setup-runtime-late-route-test",
+      fullBlurb: "full runtime plugin",
+      setupBlurb: "setup runtime route",
+      configured: true,
+      startupDeferConfiguredChannelFullLoadUntilAfterListen: true,
+      useBundledSetupEntryContract: true,
+      bundledSetupRuntimeRoutePath: "/setup-runtime-sync-route",
+      bundledSetupRuntimeLateRoutePath: "/setup-runtime-late-route",
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      preferSetupRuntimeForChannelPlugins: true,
+      config: {
+        channels: {
+          "setup-runtime-late-route-test": {
+            enabled: true,
+            token: "configured",
+          },
+        },
+        plugins: {
+          load: { paths: [built.pluginDir] },
+          allow: ["setup-runtime-late-route-test"],
+        },
+      },
+    });
+
+    await Promise.resolve();
+
+    expect(registry.httpRoutes.some((route) => route.path === "/setup-runtime-sync-route")).toBe(
+      true,
+    );
+    expect(registry.httpRoutes.some((route) => route.path === "/setup-runtime-late-route")).toBe(
+      false,
     );
   });
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -77,6 +77,7 @@ import {
   mergeSetupRuntimeChannelPlugin,
   resolveBundledRuntimeChannelRegistration,
   resolveSetupChannelRegistration,
+  shouldDeferConfiguredChannelFullRuntimeMerge,
   shouldLoadChannelPluginInSetupRuntime,
 } from "./loader-channel-setup.js";
 import {
@@ -2221,6 +2222,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           if (
             registrationPlan.loadSetupRuntimeEntry &&
             setupRegistration.usesBundledSetupContract &&
+            !shouldDeferConfiguredChannelFullRuntimeMerge({
+              manifestChannels: manifestRecord.channels,
+              startupDeferConfiguredChannelFullLoadUntilAfterListen:
+                manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
+              cfg,
+              env,
+              preferSetupRuntimeForChannelPlugins,
+            }) &&
             resolveCanonicalDistRuntimeSource(runtimeCandidateEntry.source) !== safeSource
           ) {
             const runtimeModuleSource = resolveCanonicalDistRuntimeSource(
@@ -2363,6 +2372,34 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                 diagnosticMessagePrefix: "failed to apply setup channel runtime: ",
               });
               continue;
+            }
+          }
+          if (registrationMode === "setup-runtime") {
+            const registerSetupRuntime = mergedSetupRegistration.registerSetupRuntime;
+            if (registerSetupRuntime) {
+              const registrySnapshot = snapshotPluginRegistry(registry);
+              try {
+                runPluginRegisterSync(
+                  (registrationApi) => registerSetupRuntime(registrationApi),
+                  api,
+                );
+              } catch (err) {
+                restorePluginRegistry(registry, registrySnapshot);
+                recordPluginError({
+                  logger,
+                  registry,
+                  record,
+                  seenIds,
+                  pluginId,
+                  origin: candidate.origin,
+                  phase: "register",
+                  error: err,
+                  logPrefix: `[plugins] ${record.id} failed to register setup-runtime channel side effects from ${record.source}: `,
+                  diagnosticMessagePrefix:
+                    "failed to register setup-runtime channel side effects: ",
+                });
+                continue;
+              }
             }
           }
           api.registerChannel(mergedSetupPlugin);

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -339,6 +339,8 @@ type PluginSideEffectGuard = {
 type PluginRegistrationCapabilities = {
   /** Broad registry writes that discovery and live activation both need. */
   capabilityHandlers: boolean;
+  /** Setup-runtime may publish pre-listen gateway surfaces without full activation. */
+  setupRuntimeHandlers: boolean;
   /** Runtime channel registration is suppressed for setup-only and tool discovery loads. */
   runtimeChannel: boolean;
 };
@@ -354,6 +356,7 @@ function resolvePluginRegistrationCapabilities(
   const capabilityHandlers = mode === "full" || mode === "discovery" || mode === "tool-discovery";
   return {
     capabilityHandlers,
+    setupRuntimeHandlers: mode === "setup-runtime",
     runtimeChannel: mode !== "setup-only" && mode !== "tool-discovery",
   };
 }
@@ -3080,6 +3083,13 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               },
               on: (hookName, handler, opts) =>
                 registerTypedHook(record, hookName, handler, opts, params.hookPolicy),
+            }
+          : {}),
+        ...(registrationCapabilities.setupRuntimeHandlers
+          ? {
+              registerHttpRoute: (routeParams) => registerHttpRoute(record, routeParams),
+              registerGatewayMethod: (method, handler, opts) =>
+                registerGatewayMethod(record, method, handler, opts),
             }
           : {}),
         // Allow setup-only/setup-runtime paths to surface parse-time CLI metadata


### PR DESCRIPTION
## Summary

- Add a setup-runtime registration hook for bundled channel setup entries, with guarded API lifetime and rollback when registration fails.
- Load deferred configured channel setup runtimes before gateway listen, then load the full runtime after bind so HTTP routes are ready without activating Slack early.
- Move Slack webhook route registration into a shared config-only path and wire the Slack setup entry to register those routes.
- Document the setup-runtime hook and deferred configured-channel startup contract.

## Verification

- `git diff --check`
- `node --check src/plugin-sdk/channel-entry-contract.ts src/plugins/loader-channel-setup.ts src/plugins/loader.ts src/plugins/registry.ts src/gateway/server-startup-plugins.ts src/gateway/server.impl.ts extensions/slack/index.ts extensions/slack/setup-entry.ts extensions/slack/src/http/plugin-routes.ts`
- `node scripts/run-vitest.mjs src/plugin-sdk/channel-entry-contract.test.ts src/plugins/loader.test.ts src/gateway/server-startup-plugins.test.ts extensions/slack/index.test.ts` passed: 4 files, 163 tests.
- `node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts src/plugins/plugin-lookup-table.test.ts src/plugins/manifest-registry-installed.test.ts extensions/slack/src/channel.lazy-seams.test.ts` passed: 4 files, 135 tests.
- `node scripts/generate-npm-shrinkwrap.mjs --check --package-dir extensions/slack`
- `pnpm docs:list`
- `pnpm check:docs`
- `pnpm build`
- `OPENCLAW_TESTBOX=0 pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.

## Real behavior proof

Behavior addressed: Configured Slack HTTP mode no longer has to fully activate Slack before the gateway binds just to register webhook routes.

Real environment tested: Local macOS gateway run with fake Slack HTTP config, Discord and Telegram disabled, startup trace and plugin load profile enabled.

Exact steps or command run after this patch: Started `node scripts/run-node.mjs gateway run --force --bind loopback --port 19442` with `OPENCLAW_GATEWAY_STARTUP_TRACE=1`, `OPENCLAW_PLUGIN_LOAD_PROFILE=1`, isolated `OPENCLAW_CONFIG_PATH`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_RUN_NODE_CPU_PROF_DIR=.artifacts/perf-slack-defer-gateway-final`.

Evidence after fix: Trace showed Slack setup-runtime pre-bind at 229.1ms, `http.bound` at 2025.4ms, then full Slack runtime post-bind at 12.9ms with `plugins.runtime-post-bind` completing at 2926.6ms. CPU profile: `.artifacts/perf-slack-defer-gateway-final/openclaw-gateway-23172-2026-05-28T17-17-54-512Z.cpuprofile`.

Observed result after fix: Slack webhook routes were available before bind through setup-runtime registration, while full Slack provider/channel activation moved after listen and still started normally; fake Slack auth failed later as expected for the isolated config.

What was not tested: Real Slack credentials or a live Slack webhook delivery were not used; this proof isolates startup ordering and route registration behavior.
