### PR TITLE
feat: support owner-scoped ClawHub skill refs

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -24,24 +24,24 @@ Related:
 ```bash
 openclaw skills search "calendar"
 openclaw skills search --limit 20 --json
-openclaw skills install <slug>
-openclaw skills install <slug> --version <version>
+openclaw skills install @owner/slug
+openclaw skills install @owner/slug --version <version>
 openclaw skills install git:owner/repo
 openclaw skills install git:owner/repo@main
 openclaw skills install ./path/to/skill --as custom-name
-openclaw skills install <slug> --force
-openclaw skills install <slug> --agent <id>
-openclaw skills install <slug> --global
-openclaw skills update <slug>
-openclaw skills update <slug> --global
+openclaw skills install @owner/slug --force
+openclaw skills install @owner/slug --agent <id>
+openclaw skills install @owner/slug --global
+openclaw skills update @owner/slug
+openclaw skills update @owner/slug --global
 openclaw skills update --all
 openclaw skills update --all --agent <id>
 openclaw skills update --all --global
-openclaw skills verify <slug>
-openclaw skills verify <slug> --version <version>
-openclaw skills verify <slug> --tag <tag>
-openclaw skills verify <slug> --card
-openclaw skills verify <slug> --global
+openclaw skills verify @owner/slug
+openclaw skills verify @owner/slug --version <version>
+openclaw skills verify @owner/slug --tag <tag>
+openclaw skills verify @owner/slug --card
+openclaw skills verify @owner/slug --global
 openclaw skills list
 openclaw skills list --eligible
 openclaw skills list --json
@@ -55,8 +55,8 @@ openclaw skills check --agent <id>
 openclaw skills check --json
 ```
 
-`search`, `update`, and `verify` use ClawHub directly. `install <slug>` installs
-a ClawHub skill, `install git:owner/repo[@ref]` clones a Git skill, and
+`search`, `update`, and `verify` use ClawHub directly. `install @owner/slug`
+installs a ClawHub skill, `install git:owner/repo[@ref]` clones a Git skill, and
 `install ./path` copies a local skill directory. By default, `install`, `update`,
 and `verify` target the active workspace `skills/` directory; with `--global`,
 they target the shared managed skills directory. `list`/`info`/`check` still
@@ -85,6 +85,8 @@ Notes:
   `SKILL.md`.
 - `install --as <slug>` overrides the inferred slug for Git and local directory
   installs.
+- ClawHub skill refs should use `@owner/slug`. Bare slugs still work for
+  legacy installs when ClawHub can resolve them unambiguously.
 - `install --version <version>` applies only to ClawHub skill slugs.
 - `install --force` overwrites an existing workspace skill folder for the same
   slug.
@@ -92,11 +94,12 @@ Notes:
   with `--agent <id>`.
 - `--agent <id>` targets one configured agent workspace and overrides current
   working directory inference.
-- `update <slug>` updates a single tracked skill. Add `--global` to target the
+- `update @owner/slug` updates a single tracked skill. Bare slugs remain
+  supported for existing unambiguous installs. Add `--global` to target the
   shared managed skills directory instead of the workspace.
 - `update --all` updates tracked ClawHub installs in the selected workspace, or
   in the shared managed skills directory when combined with `--global`.
-- `verify <slug>` prints ClawHub's `clawhub.skill.verify.v1` JSON envelope by
+- `verify @owner/slug` prints ClawHub's `clawhub.skill.verify.v1` JSON envelope by
   default. There is no `--json` flag because JSON is already the default.
 - `verify` uses `.clawhub/origin.json` for installed ClawHub skills, so it
   verifies the installed version against the registry it came from. `--version`

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -321,10 +321,10 @@ lives on the [First-run FAQ](/help/faq-first-run).
     ```bash
     openclaw skills search "calendar"
     openclaw skills search --limit 20
-    openclaw skills install <skill-slug>
-    openclaw skills install <skill-slug> --version <version>
-    openclaw skills install <skill-slug> --force
-    openclaw skills install <skill-slug> --global
+    openclaw skills install @owner/skill-slug
+    openclaw skills install @owner/skill-slug --version <version>
+    openclaw skills install @owner/skill-slug --force
+    openclaw skills install @owner/skill-slug --global
     openclaw skills update --all
     openclaw skills update --all --global
     openclaw skills list --eligible
@@ -408,11 +408,11 @@ lives on the [First-run FAQ](/help/faq-first-run).
     Install skills:
 
     ```bash
-    openclaw skills install <skill-slug>
+    openclaw skills install @owner/skill-slug
     openclaw skills update --all
     ```
 
-    Native installs land in the active workspace `skills/` directory. For shared skills across all local agents, use `openclaw skills install <slug> --global` (or place them manually in `~/.openclaw/skills/<name>/SKILL.md`). If only some agents should see a shared install, configure `agents.defaults.skills` or `agents.list[].skills`. Some skills expect binaries installed via Homebrew; on Linux that means Linuxbrew (see the Homebrew Linux FAQ entry above). See [Skills](/tools/skills), [Skills config](/tools/skills-config), and [ClawHub](/tools/clawhub).
+    Native installs land in the active workspace `skills/` directory. For shared skills across all local agents, use `openclaw skills install @owner/slug --global` (or place them manually in `~/.openclaw/skills/<name>/SKILL.md`). If only some agents should see a shared install, configure `agents.defaults.skills` or `agents.list[].skills`. Some skills expect binaries installed via Homebrew; on Linux that means Linuxbrew (see the Homebrew Linux FAQ entry above). See [Skills](/tools/skills), [Skills config](/tools/skills-config), and [ClawHub](/tools/clawhub).
 
   </Accordion>
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -144,15 +144,15 @@ separate `clawhub` CLI for publish/sync workflows. Full guide:
 
 | Action                                 | Command                                                |
 | -------------------------------------- | ------------------------------------------------------ |
-| Install a ClawHub skill into workspace | `openclaw skills install <skill-slug>`                 |
+| Install a ClawHub skill into workspace | `openclaw skills install @owner/skill-slug`            |
 | Install a Git skill into workspace     | `openclaw skills install git:owner/repo@ref`           |
 | Install a local skill into workspace   | `openclaw skills install ./path/to/skill --as my-tool` |
-| Install a skill for all local agents   | `openclaw skills install <skill-slug> --global`        |
+| Install a skill for all local agents   | `openclaw skills install @owner/skill-slug --global`   |
 | Update all workspace-installed skills  | `openclaw skills update --all`                         |
-| Update a single shared managed skill   | `openclaw skills update <skill-slug> --global`         |
+| Update a single shared managed skill   | `openclaw skills update @owner/skill-slug --global`    |
 | Update all shared managed/local skills | `openclaw skills update --all --global`                |
-| Verify a ClawHub skill                 | `openclaw skills verify <skill-slug>`                  |
-| Print the generated Skill Card         | `openclaw skills verify <skill-slug> --card`           |
+| Verify a ClawHub skill                 | `openclaw skills verify @owner/skill-slug`             |
+| Print the generated Skill Card         | `openclaw skills verify @owner/skill-slug --card`      |
 | Sync (scan + publish updates)          | `clawhub sync --all`                                   |
 
 Native `openclaw skills install` installs into the active workspace
@@ -171,12 +171,13 @@ names when grouping, for example `skills/imported/research/SKILL.md` with
 Git and local directory installs expect a `SKILL.md` at the source root. The
 install slug comes from `SKILL.md` frontmatter `name` when it is a valid slug,
 then falls back to the source directory or repository name. Use `--as <slug>` to
-override the inferred slug. `--version` applies only to ClawHub installs. Skill
-installs do not support npm package specs or zip/archive paths. `openclaw skills
-update` updates ClawHub-tracked installs only; reinstall Git or local sources to
-refresh them.
+override the inferred slug. ClawHub refs should use `@owner/slug`; bare slugs
+still work for legacy unambiguous installs. `--version` applies only to ClawHub
+installs. Skill installs do not support npm package specs or zip/archive paths.
+`openclaw skills update` updates ClawHub-tracked installs only; reinstall Git or
+local sources to refresh them.
 
-Use `openclaw skills verify <slug>` to ask ClawHub for the skill's
+Use `openclaw skills verify @owner/slug` to ask ClawHub for the skill's
 `clawhub.skill.verify.v1` trust envelope. Output is JSON by default; use
 `--card` to print the generated Skill Card Markdown. Installed ClawHub skills
 verify against the version and registry recorded in `.clawhub/origin.json`;
@@ -190,7 +191,7 @@ archive with `skills.upload.begin`, `skills.upload.chunk`, and
 `skills.upload.commit`, then install the committed upload with
 `skills.install({ source: "upload", uploadId, slug, force?, sha256? })`. This is
 an explicit admin upload path for trusted clients, not the normal
-`openclaw skills install <slug>` or ClawHub install flow. It is off by default
+`openclaw skills install @owner/slug` or ClawHub install flow. It is off by default
 and only works when `skills.install.allowUploadedArchives: true` is set in
 `openclaw.json`. Upload mode still installs into the default agent workspace
 `skills/<slug>` directory; the archive's internal folder name is ignored for the
@@ -198,7 +199,7 @@ final install target.
 
 ClawHub skill pages expose the latest security scan state before install,
 with scanner detail pages for VirusTotal, ClawScan, and static analysis.
-`openclaw skills install <slug>` remains only the install path; publishers
+`openclaw skills install @owner/slug` remains only the install path; publishers
 recover false positives through the ClawHub dashboard or
 `clawhub skill rescan <slug>`.
 
@@ -223,7 +224,7 @@ Prefer sandboxed runs for untrusted inputs and risky tools. See
   `skills.install.allowUploadedArchives`; normal ClawHub installs do not require
   that setting.
 - Gateway-backed skill dependency installs (`skills.install`, onboarding, and the Skills settings UI) run the built-in dangerous-code scanner before executing installer metadata. `critical` findings block by default unless the caller explicitly sets the dangerous override; suspicious findings still warn only.
-- `openclaw skills install <slug>` is different — it downloads a ClawHub skill
+- `openclaw skills install @owner/slug` is different — it downloads a ClawHub skill
   folder into the workspace, or into shared managed/local skills with
   `--global`, and does not use the installer-metadata path above. Git and local
   directory installs copy a trusted `SKILL.md` directory into the same skills

--- a/src/agents/skills-clawhub.test.ts
+++ b/src/agents/skills-clawhub.test.ts
@@ -82,6 +82,7 @@ async function writeClawHubOriginFixture(params: {
   registry?: string;
   installedVersion?: string;
   installedAt?: number;
+  ownerHandle?: string;
   writeLock?: boolean;
 }) {
   const skillDir = path.join(params.workspaceDir, "skills", params.slug);
@@ -96,6 +97,7 @@ async function writeClawHubOriginFixture(params: {
         version: 1,
         registry,
         slug: params.originSlug ?? params.slug,
+        ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
         installedVersion,
         installedAt,
       },
@@ -116,6 +118,7 @@ async function writeClawHubOriginFixture(params: {
               version: installedVersion,
               installedAt,
               registry,
+              ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
             },
           },
         },
@@ -155,6 +158,10 @@ describe("skills-clawhub", () => {
         version: "1.0.0",
         createdAt: 3,
       },
+      owner: {
+        handle: "openclaw",
+        displayName: "OpenClaw",
+      },
     });
     downloadClawHubSkillArchiveMock.mockResolvedValue({
       archivePath: "/tmp/agentreceipt.zip",
@@ -181,6 +188,7 @@ describe("skills-clawhub", () => {
 
     expect(downloadClawHubSkillArchiveMock).toHaveBeenCalledWith({
       slug: "agentreceipt",
+      ownerHandle: "openclaw",
       version: "1.0.0",
       baseUrl: undefined,
     });
@@ -191,6 +199,117 @@ describe("skills-clawhub", () => {
       targetDir: "/tmp/workspace/skills/agentreceipt",
     });
     expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("installs owner-scoped ClawHub skill refs and persists resolved owner metadata", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-clawhub-"));
+    installPackageDirMock.mockResolvedValueOnce({
+      ok: true,
+      targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "@openclaw/agentreceipt",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      expect(fetchClawHubSkillDetailMock).toHaveBeenCalledWith({
+        slug: "agentreceipt",
+        ownerHandle: "openclaw",
+        baseUrl: undefined,
+      });
+      expect(downloadClawHubSkillArchiveMock).toHaveBeenCalledWith({
+        slug: "agentreceipt",
+        ownerHandle: "openclaw",
+        version: "1.0.0",
+        baseUrl: undefined,
+      });
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin).toMatchObject({
+        slug: "agentreceipt",
+        ownerHandle: "openclaw",
+        installedVersion: "1.0.0",
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt).toMatchObject({
+        version: "1.0.0",
+        ownerHandle: "openclaw",
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects owner-scoped installs when ClawHub resolves a different owner", async () => {
+    fetchClawHubSkillDetailMock.mockResolvedValueOnce({
+      skill: {
+        slug: "agentreceipt",
+        displayName: "AgentReceipt",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: {
+        version: "1.0.0",
+        createdAt: 3,
+      },
+      owner: {
+        handle: "steipete",
+        displayName: "Peter Steinberger",
+      },
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "@openclaw/agentreceipt",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected owner mismatch failure");
+    }
+    expect(result.error).toContain(
+      "ClawHub returned @steipete/agentreceipt for requested @openclaw/agentreceipt.",
+    );
+    expect(downloadClawHubSkillArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it("persists resolved owner metadata for legacy bare slug installs", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-clawhub-"));
+    installPackageDirMock.mockResolvedValueOnce({
+      ok: true,
+      targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+      });
+
+      expectInstalledSkill(result, { slug: "agentreceipt" });
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin.ownerHandle).toBe("openclaw");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it.each(["skill.md", "skills.md", "SKILL.MD"])(
@@ -278,6 +397,7 @@ describe("skills-clawhub", () => {
         });
         expect(downloadClawHubSkillArchiveMock).toHaveBeenCalledWith({
           slug,
+          ownerHandle: "openclaw",
           version: "1.0.0",
           baseUrl: "https://legacy.clawhub.ai",
         });
@@ -302,6 +422,28 @@ describe("skills-clawhub", () => {
         });
 
         expectLegacyUpdateSuccess(results, workspaceDir, slug);
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects owner-scoped updates that target a different installed owner", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-clawhub-"));
+      try {
+        await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "agentreceipt",
+          ownerHandle: "openclaw",
+        });
+
+        await expect(
+          updateSkillsFromClawHub({
+            workspaceDir,
+            slug: "@steipete/agentreceipt",
+          }),
+        ).rejects.toThrow(
+          "Cannot update @steipete/agentreceipt; local ClawHub metadata is for @openclaw/agentreceipt.",
+        );
       } finally {
         await fs.rm(workspaceDir, { recursive: true, force: true });
       }
@@ -434,6 +576,97 @@ describe("skills-clawhub", () => {
             registry: "https://private.example.com/clawhub",
             skillDir,
             installedVersion: "2.0.0",
+          },
+        });
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("uses installed origin owner metadata for verify targets", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
+      try {
+        const skillDir = await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "agentreceipt",
+          registry: "https://private.example.com/clawhub",
+          installedVersion: "2.0.0",
+        });
+        const originPath = path.join(skillDir, ".clawhub", "origin.json");
+        const origin = JSON.parse(await fs.readFile(originPath, "utf8")) as Record<string, unknown>;
+        origin.ownerHandle = "openclaw";
+        await fs.writeFile(originPath, `${JSON.stringify(origin, null, 2)}\n`, "utf8");
+        const lockPath = path.join(workspaceDir, ".clawhub", "lock.json");
+        const lock = JSON.parse(await fs.readFile(lockPath, "utf8")) as {
+          skills: Record<string, Record<string, unknown>>;
+        };
+        lock.skills.agentreceipt.ownerHandle = "openclaw";
+        await fs.writeFile(lockPath, `${JSON.stringify(lock, null, 2)}\n`, "utf8");
+
+        await expect(
+          resolveClawHubSkillVerificationTarget({
+            workspaceDir,
+            slug: "agentreceipt",
+          }),
+        ).resolves.toMatchObject({
+          ok: true,
+          slug: "agentreceipt",
+          ownerHandle: "openclaw",
+          resolution: {
+            source: "installed",
+            registry: "https://private.example.com/clawhub",
+          },
+        });
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects owner-scoped verify refs that target a different installed owner", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
+      try {
+        await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "agentreceipt",
+          registry: "https://private.example.com/clawhub",
+          installedVersion: "2.0.0",
+          ownerHandle: "openclaw",
+        });
+
+        const result = await resolveClawHubSkillVerificationTarget({
+          workspaceDir,
+          slug: "@steipete/agentreceipt",
+        });
+
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+          throw new Error("expected owner mismatch failure");
+        }
+        expect(result.error).toContain(
+          "Cannot verify @steipete/agentreceipt; local ClawHub metadata is for @openclaw/agentreceipt.",
+        );
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("parses owner-scoped registry verify refs", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
+      try {
+        await expect(
+          resolveClawHubSkillVerificationTarget({
+            workspaceDir,
+            slug: "@openclaw/agentreceipt",
+            tag: "latest",
+          }),
+        ).resolves.toMatchObject({
+          ok: true,
+          slug: "agentreceipt",
+          ownerHandle: "openclaw",
+          tag: "latest",
+          resolution: {
+            source: "registry",
+            selector: "tag",
           },
         });
       } finally {

--- a/src/agents/skills-clawhub.ts
+++ b/src/agents/skills-clawhub.ts
@@ -30,6 +30,7 @@ export type ClawHubSkillOrigin = {
   version: 1;
   registry: string;
   slug: string;
+  ownerHandle?: string;
   installedVersion: string;
   installedAt: number;
 };
@@ -42,6 +43,7 @@ export type ClawHubSkillsLockfile = {
       version: string;
       installedAt: number;
       registry?: string;
+      ownerHandle?: string;
     }
   >;
 };
@@ -57,6 +59,7 @@ export type ClawHubSkillStatusLink =
       valid: true;
       registry: string;
       slug: string;
+      ownerHandle?: string;
       installedVersion: string;
       installedAt: number;
       originPath: string;
@@ -68,6 +71,7 @@ export type ClawHubSkillStatusLink =
       reason: string;
       registry?: string;
       slug?: string;
+      ownerHandle?: string;
       installedVersion?: string;
       installedAt?: number;
       originPath?: string;
@@ -109,23 +113,103 @@ type Logger = {
   info?: (message: string) => void;
 };
 
+type ParsedClawHubSkillRef = {
+  slug: string;
+  ownerHandle?: string;
+};
+
+function normalizeOwnerHandle(raw: string): string {
+  try {
+    return validateRequestedSkillSlug(raw);
+  } catch {
+    throw new Error(`Invalid ClawHub skill owner: ${raw}`);
+  }
+}
+
+function normalizeOptionalOwnerHandle(raw: string | null | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed ? normalizeOwnerHandle(trimmed) : undefined;
+}
+
+function parseRequestedClawHubSkillRef(raw: string): ParsedClawHubSkillRef {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("@")) {
+    return { slug: validateRequestedSkillSlug(raw) };
+  }
+  const match = /^@([^/]+)\/([^/]+)$/.exec(trimmed);
+  if (!match?.[1] || !match[2]) {
+    throw new Error(`Invalid skill slug: ${raw}`);
+  }
+  return {
+    ownerHandle: normalizeOwnerHandle(match[1]),
+    slug: validateRequestedSkillSlug(match[2]),
+  };
+}
+
+function mergeOwnerHandles(
+  primary: string | undefined,
+  fallback: string | null | undefined,
+): string | undefined {
+  return primary ?? normalizeOptionalOwnerHandle(fallback);
+}
+
+function ownerScopedRef(ownerHandle: string, slug: string): string {
+  return `@${ownerHandle}/${slug}`;
+}
+
+function ownerMismatchMessage(params: {
+  action: string;
+  slug: string;
+  requestedOwnerHandle: string;
+  installedOwnerHandle?: string;
+}): string {
+  const requested = ownerScopedRef(params.requestedOwnerHandle, params.slug);
+  const installed = params.installedOwnerHandle
+    ? ownerScopedRef(params.installedOwnerHandle, params.slug)
+    : params.slug;
+  return `Cannot ${params.action} ${requested}; local ClawHub metadata is for ${installed}. Reinstall the requested skill before ${params.action}ing it.`;
+}
+
 async function resolveRequestedUpdateSlug(params: {
   workspaceDir: string;
   requestedSlug: string;
   lock: ClawHubSkillsLockfile;
-}): Promise<string> {
-  const trackedSlug = normalizeTrackedSkillSlug(params.requestedSlug);
+}): Promise<ParsedClawHubSkillRef> {
+  const requested = params.requestedSlug.trim().startsWith("@")
+    ? parseRequestedClawHubSkillRef(params.requestedSlug)
+    : { slug: normalizeTrackedSkillSlug(params.requestedSlug) };
+  const trackedSlug = requested.slug;
   const trackedTargetDir = resolveWorkspaceSkillInstallDir(params.workspaceDir, trackedSlug);
   const trackedOrigin = await readClawHubSkillOrigin(trackedTargetDir);
-  if (trackedOrigin || params.lock.skills[trackedSlug]) {
-    return trackedSlug;
+  const locked = params.lock.skills[trackedSlug];
+  if (trackedOrigin || locked) {
+    const installedOwnerHandle = trackedOrigin?.ownerHandle ?? locked?.ownerHandle;
+    if (
+      requested.ownerHandle &&
+      installedOwnerHandle &&
+      requested.ownerHandle !== installedOwnerHandle
+    ) {
+      throw new Error(
+        ownerMismatchMessage({
+          action: "update",
+          slug: trackedSlug,
+          requestedOwnerHandle: requested.ownerHandle,
+          installedOwnerHandle,
+        }),
+      );
+    }
+    return {
+      slug: trackedSlug,
+      ownerHandle: requested.ownerHandle ?? installedOwnerHandle,
+    };
   }
-  return validateRequestedSkillSlug(params.requestedSlug);
+  return parseRequestedClawHubSkillRef(params.requestedSlug);
 }
 
 type ClawHubInstallParams = {
   workspaceDir: string;
   slug: string;
+  ownerHandle?: string;
   version?: string;
   baseUrl?: string;
   force?: boolean;
@@ -136,6 +220,7 @@ type TrackedUpdateTarget =
   | {
       ok: true;
       slug: string;
+      ownerHandle?: string;
       baseUrl?: string;
       previousVersion: string | null;
     }
@@ -153,6 +238,7 @@ export type ClawHubSkillVerificationTargetResult =
       ok: true;
       slug: string;
       baseUrl: string;
+      ownerHandle: string | undefined;
       version: string | undefined;
       tag: string | undefined;
       resolution: {
@@ -288,6 +374,7 @@ function normalizeClawHubSkillOrigin(
       version: 1,
       registry: normalizeStoredRegistry(raw.registry),
       slug: raw.slug,
+      ownerHandle: normalizeOptionalOwnerHandle(raw.ownerHandle),
       installedVersion: raw.installedVersion,
       installedAt: raw.installedAt,
     };
@@ -634,7 +721,8 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       return { ok: false, error: "Use either --version or --tag." };
     }
 
-    const trackedSlug = normalizeTrackedSkillSlug(params.slug);
+    const requested = parseRequestedClawHubSkillRef(params.slug);
+    const trackedSlug = normalizeTrackedSkillSlug(requested.slug);
     const skillDir = resolveWorkspaceSkillInstallDir(params.workspaceDir, trackedSlug);
     const originRead = await readClawHubSkillOriginStrict(skillDir);
     if (originRead.kind === "malformed") {
@@ -663,6 +751,24 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       const originRegistry = normalizeStoredRegistry(originRead.origin.registry);
       const lockedRegistry =
         locked.registry === undefined ? originRegistry : normalizeStoredRegistry(locked.registry);
+      const ownerHandle =
+        requested.ownerHandle ?? originRead.origin.ownerHandle ?? locked.ownerHandle;
+      const installedOwnerHandle = originRead.origin.ownerHandle ?? locked.ownerHandle;
+      if (
+        requested.ownerHandle &&
+        installedOwnerHandle &&
+        requested.ownerHandle !== installedOwnerHandle
+      ) {
+        return {
+          ok: false,
+          error: ownerMismatchMessage({
+            action: "verify",
+            slug: trackedSlug,
+            requestedOwnerHandle: requested.ownerHandle,
+            installedOwnerHandle,
+          }),
+        };
+      }
       if (
         locked.version !== originRead.origin.installedVersion ||
         locked.installedAt !== originRead.origin.installedAt ||
@@ -681,6 +787,7 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       return {
         ok: true,
         slug: trackedSlug,
+        ownerHandle,
         baseUrl: lockedRegistry,
         version: version ?? (tag ? undefined : locked.version),
         tag,
@@ -708,12 +815,13 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       };
     }
 
-    const slug = validateRequestedSkillSlug(params.slug);
+    const { slug, ownerHandle } = requested;
     const registry = resolveClawHubBaseUrl(params.baseUrl);
     const selector: ClawHubSkillVerificationSelector = version ? "version" : tag ? "tag" : "latest";
     return {
       ok: true,
       slug,
+      ownerHandle,
       baseUrl: registry,
       version,
       tag,
@@ -732,11 +840,13 @@ export async function resolveClawHubSkillVerificationTarget(params: {
 
 async function resolveInstallVersion(params: {
   slug: string;
+  ownerHandle?: string;
   version?: string;
   baseUrl?: string;
 }): Promise<{ detail: ClawHubSkillDetail; version: string }> {
   const detail = await fetchClawHubSkillDetail({
     slug: params.slug,
+    ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
     baseUrl: params.baseUrl,
   });
   if (!detail.skill) {
@@ -758,9 +868,23 @@ async function performClawHubSkillInstall(
   try {
     const { detail, version } = await resolveInstallVersion({
       slug: params.slug,
+      ownerHandle: params.ownerHandle,
       version: params.version,
       baseUrl: params.baseUrl,
     });
+    const resolvedOwnerHandle = normalizeOptionalOwnerHandle(detail.owner?.handle);
+    if (params.ownerHandle && resolvedOwnerHandle !== params.ownerHandle) {
+      const resolved = resolvedOwnerHandle
+        ? ownerScopedRef(resolvedOwnerHandle, params.slug)
+        : "an unknown publisher";
+      throw new Error(
+        `ClawHub returned ${resolved} for requested ${ownerScopedRef(
+          params.ownerHandle,
+          params.slug,
+        )}.`,
+      );
+    }
+    const ownerHandle = mergeOwnerHandles(params.ownerHandle, resolvedOwnerHandle);
     const targetDir = resolveWorkspaceSkillInstallDir(params.workspaceDir, params.slug);
     if (!params.force && (await pathExists(targetDir))) {
       return {
@@ -772,6 +896,7 @@ async function performClawHubSkillInstall(
     params.logger?.info?.(`Downloading ${params.slug}@${version} from ClawHub…`);
     const archive = await downloadClawHubSkillArchive({
       slug: params.slug,
+      ...(ownerHandle ? { ownerHandle } : {}),
       version,
       baseUrl: params.baseUrl,
     });
@@ -801,6 +926,7 @@ async function performClawHubSkillInstall(
         version: 1,
         registry: resolveClawHubBaseUrl(params.baseUrl),
         slug: params.slug,
+        ownerHandle,
         installedVersion: version,
         installedAt,
       });
@@ -809,6 +935,7 @@ async function performClawHubSkillInstall(
         version,
         installedAt,
         registry: resolveClawHubBaseUrl(params.baseUrl),
+        ownerHandle,
       };
       await writeClawHubSkillsLockfile(params.workspaceDir, lock);
 
@@ -834,9 +961,17 @@ async function installRequestedSkillFromClawHub(
   params: ClawHubInstallParams,
 ): Promise<InstallClawHubSkillResult> {
   try {
+    const parsed = parseRequestedClawHubSkillRef(params.slug);
+    const explicitOwnerHandle = normalizeOptionalOwnerHandle(params.ownerHandle);
+    if (parsed.ownerHandle && explicitOwnerHandle && parsed.ownerHandle !== explicitOwnerHandle) {
+      throw new Error(
+        `ClawHub owner mismatch: ${parsed.ownerHandle} in skill ref, ${explicitOwnerHandle} in ownerHandle.`,
+      );
+    }
     return await performClawHubSkillInstall({
       ...params,
-      slug: validateRequestedSkillSlug(params.slug),
+      slug: parsed.slug,
+      ownerHandle: parsed.ownerHandle ?? explicitOwnerHandle,
     });
   } catch (err) {
     return {
@@ -853,6 +988,7 @@ async function installTrackedSkillFromClawHub(
     return await performClawHubSkillInstall({
       ...params,
       slug: normalizeTrackedSkillSlug(params.slug),
+      ownerHandle: normalizeOptionalOwnerHandle(params.ownerHandle),
     });
   } catch (err) {
     return {
@@ -880,6 +1016,7 @@ async function resolveTrackedUpdateTarget(params: {
   return {
     ok: true,
     slug: params.slug,
+    ownerHandle: origin?.ownerHandle ?? params.lock.skills[params.slug]?.ownerHandle,
     baseUrl: origin?.registry ?? params.baseUrl,
     previousVersion: origin?.installedVersion ?? params.lock.skills[params.slug]?.version ?? null,
   };
@@ -888,6 +1025,7 @@ async function resolveTrackedUpdateTarget(params: {
 export async function installSkillFromClawHub(params: {
   workspaceDir: string;
   slug: string;
+  ownerHandle?: string;
   version?: string;
   baseUrl?: string;
   force?: boolean;
@@ -899,11 +1037,12 @@ export async function installSkillFromClawHub(params: {
 export async function updateSkillsFromClawHub(params: {
   workspaceDir: string;
   slug?: string;
+  ownerHandle?: string;
   baseUrl?: string;
   logger?: Logger;
 }): Promise<UpdateClawHubSkillResult[]> {
   const lock = await readClawHubSkillsLockfile(params.workspaceDir);
-  const slugs = params.slug
+  const targets = params.slug
     ? [
         await resolveRequestedUpdateSlug({
           workspaceDir: params.workspaceDir,
@@ -911,12 +1050,15 @@ export async function updateSkillsFromClawHub(params: {
           lock,
         }),
       ]
-    : Object.keys(lock.skills).map((slug) => normalizeTrackedSkillSlug(slug));
+    : Object.keys(lock.skills).map((slug) => ({
+        slug: normalizeTrackedSkillSlug(slug),
+        ownerHandle: lock.skills[slug]?.ownerHandle,
+      }));
   const results: UpdateClawHubSkillResult[] = [];
-  for (const slug of slugs) {
+  for (const target of targets) {
     const tracked = await resolveTrackedUpdateTarget({
       workspaceDir: params.workspaceDir,
-      slug,
+      slug: target.slug,
       lock,
       baseUrl: params.baseUrl,
     });
@@ -927,9 +1069,28 @@ export async function updateSkillsFromClawHub(params: {
       });
       continue;
     }
+    const requestedOwnerHandle = params.ownerHandle ?? target.ownerHandle;
+    if (
+      requestedOwnerHandle &&
+      tracked.ownerHandle &&
+      requestedOwnerHandle !== tracked.ownerHandle
+    ) {
+      results.push({
+        ok: false,
+        slug: tracked.slug,
+        error: ownerMismatchMessage({
+          action: "update",
+          slug: tracked.slug,
+          requestedOwnerHandle,
+          installedOwnerHandle: tracked.ownerHandle,
+        }),
+      });
+      continue;
+    }
     const install = await installTrackedSkillFromClawHub({
       workspaceDir: params.workspaceDir,
       slug: tracked.slug,
+      ownerHandle: requestedOwnerHandle ?? tracked.ownerHandle,
       baseUrl: tracked.baseUrl,
       force: true,
       logger: params.logger,

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -373,6 +373,23 @@ describe("skills cli commands", () => {
     ).toBe(true);
   });
 
+  it("forwards owner-scoped ClawHub install refs", async () => {
+    installSkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "discrawl",
+      version: "1.2.3",
+      targetDir: "/tmp/workspace/skills/discrawl",
+    });
+
+    await runCommand(["skills", "install", "@openclaw/discrawl"]);
+
+    expectObjectFields(mockFirstObjectArg(installSkillFromClawHubMock), {
+      workspaceDir: "/tmp/workspace",
+      slug: "@openclaw/discrawl",
+    });
+    expect(runtimeLogs).toContain("Installed discrawl@1.2.3 -> /tmp/workspace/skills/discrawl");
+  });
+
   it("installs a skill from a git source into the active workspace", async () => {
     installSkillFromSourceMock.mockResolvedValue({
       ok: true,
@@ -593,6 +610,27 @@ describe("skills cli commands", () => {
     expect(runtimeErrors).toStrictEqual([]);
   });
 
+  it("forwards owner-scoped ClawHub update refs", async () => {
+    updateSkillsFromClawHubMock.mockResolvedValue([
+      {
+        ok: true,
+        slug: "discrawl",
+        previousVersion: "1.2.2",
+        version: "1.2.3",
+        changed: true,
+        targetDir: "/tmp/workspace/skills/discrawl",
+      },
+    ]);
+
+    await runCommand(["skills", "update", "@openclaw/discrawl"]);
+
+    expectObjectFields(mockFirstObjectArg(updateSkillsFromClawHubMock), {
+      workspaceDir: "/tmp/workspace",
+      slug: "@openclaw/discrawl",
+    });
+    expect(runtimeLogs).toContain("Updated discrawl: 1.2.2 -> 1.2.3");
+  });
+
   it("updates tracked ClawHub skills in the cwd-inferred agent workspace", async () => {
     routeWorkspaceByAgent();
     resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");
@@ -750,6 +788,40 @@ describe("skills cli commands", () => {
       },
     });
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
+  });
+
+  it("passes resolved owner handles to ClawHub verify requests", async () => {
+    resolveClawHubSkillVerificationTargetMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "discrawl",
+      ownerHandle: "openclaw",
+      baseUrl: "https://clawhub.ai",
+      version: undefined,
+      tag: "latest",
+      resolution: {
+        source: "registry",
+        selector: "tag",
+        registry: "https://clawhub.ai",
+        skillDir: undefined,
+        installedVersion: undefined,
+      },
+    });
+
+    await runCommand(["skills", "verify", "@openclaw/discrawl", "--tag", "latest"]);
+
+    expect(resolveClawHubSkillVerificationTargetMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace",
+      slug: "@openclaw/discrawl",
+      version: undefined,
+      tag: "latest",
+    });
+    expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "discrawl",
+      ownerHandle: "openclaw",
+      version: undefined,
+      tag: "latest",
+      baseUrl: "https://clawhub.ai",
+    });
   });
 
   it("passes explicit verify selectors and shared workspace options to the resolver", async () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -378,6 +378,7 @@ export function registerSkillsCli(program: Command) {
           } else {
             const verification = await fetchClawHubSkillVerification({
               slug: target.slug,
+              ...(target.ownerHandle ? { ownerHandle: target.ownerHandle } : {}),
               version: target.version,
               tag: target.tag,
               baseUrl: target.baseUrl,

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -284,6 +284,7 @@ export const SkillsInstallParamsSchema = Type.Union([
     {
       source: Type.Literal("clawhub"),
       slug: NonEmptyString,
+      ownerHandle: Type.Optional(NonEmptyString),
       version: Type.Optional(NonEmptyString),
       force: Type.Optional(Type.Boolean()),
       timeoutMs: Type.Optional(Type.Integer({ minimum: 1000 })),
@@ -317,6 +318,7 @@ export const SkillsUpdateParamsSchema = Type.Union([
     {
       source: Type.Literal("clawhub"),
       slug: Type.Optional(NonEmptyString),
+      ownerHandle: Type.Optional(NonEmptyString),
       all: Type.Optional(Type.Boolean()),
     },
     { additionalProperties: false },
@@ -353,6 +355,7 @@ export const SkillsSearchResultSchema = Type.Object(
 export const SkillsDetailParamsSchema = Type.Object(
   {
     slug: NonEmptyString,
+    ownerHandle: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -323,6 +323,45 @@ describe("skills gateway handlers (clawhub)", () => {
     expect(result?.version).toBe("1.2.3");
   });
 
+  it("passes ownerHandle through ClawHub skills.install", async () => {
+    installSkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "discrawl",
+      version: "1.2.3",
+      targetDir: "/tmp/workspace/skills/discrawl",
+    });
+
+    const respond = vi.fn();
+    await skillsHandlers["skills.install"]({
+      params: {
+        source: "clawhub",
+        slug: "discrawl",
+        ownerHandle: "openclaw",
+      },
+      respond,
+      context: makeContext() as never,
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(installSkillFromClawHubMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace",
+      slug: "discrawl",
+      ownerHandle: "openclaw",
+      version: undefined,
+      force: false,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        slug: "discrawl",
+        version: "1.2.3",
+      }),
+      undefined,
+    );
+  });
+
   it("forwards dangerous override for local skill installs", async () => {
     installSkillMock.mockResolvedValue({
       ok: true,
@@ -387,6 +426,7 @@ describe("skills gateway handlers (clawhub)", () => {
       params: {
         source: "clawhub",
         slug: "calendar",
+        ownerHandle: "openclaw",
       },
       req: {} as never,
       client: null as never,
@@ -402,6 +442,7 @@ describe("skills gateway handlers (clawhub)", () => {
     expect(updateSkillsFromClawHubMock).toHaveBeenCalledWith({
       workspaceDir: "/tmp/workspace",
       slug: "calendar",
+      ownerHandle: "openclaw",
     });
     expect(ok).toBe(true);
     expect(error).toBeUndefined();

--- a/src/gateway/server-methods/skills.search-detail.test.ts
+++ b/src/gateway/server-methods/skills.search-detail.test.ts
@@ -180,6 +180,33 @@ describe("skills.detail handler", () => {
     expect(response).toEqual(detail);
   });
 
+  it("fetches detail with ownerHandle for scoped ClawHub refs", async () => {
+    const detail = {
+      skill: {
+        slug: "github",
+        displayName: "GitHub",
+        createdAt: 1700000000,
+        updatedAt: 1700000000,
+      },
+      owner: {
+        handle: "openclaw",
+      },
+    };
+    fetchClawHubSkillDetailMock.mockResolvedValue(detail);
+
+    const { ok, response } = await callHandler("skills.detail", {
+      slug: "github",
+      ownerHandle: "openclaw",
+    });
+
+    expect(fetchClawHubSkillDetailMock).toHaveBeenCalledWith({
+      slug: "github",
+      ownerHandle: "openclaw",
+    });
+    expect(ok).toBe(true);
+    expect(response).toEqual(detail);
+  });
+
   it("returns error when slug is not found", async () => {
     fetchClawHubSkillDetailMock.mockRejectedValue(new Error("not found"));
 

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -432,6 +432,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
     try {
       const detail = await fetchClawHubSkillDetail({
         slug: (params as { slug: string }).slug,
+        ...((params as { ownerHandle?: string }).ownerHandle
+          ? { ownerHandle: (params as { ownerHandle?: string }).ownerHandle }
+          : {}),
       });
       respond(true, detail, undefined);
     } catch (err) {
@@ -456,12 +459,14 @@ export const skillsHandlers: GatewayRequestHandlers = {
       const p = params as {
         source: "clawhub";
         slug: string;
+        ownerHandle?: string;
         version?: string;
         force?: boolean;
       };
       const result = await installSkillFromClawHub({
         workspaceDir: workspaceDirRaw,
         slug: p.slug,
+        ...(p.ownerHandle ? { ownerHandle: p.ownerHandle } : {}),
         version: p.version,
         force: Boolean(p.force),
       });
@@ -544,6 +549,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
       const p = params as {
         source: "clawhub";
         slug?: string;
+        ownerHandle?: string;
         all?: boolean;
       };
       if (!p.slug && !p.all) {
@@ -570,6 +576,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
       const results = await updateSkillsFromClawHub({
         workspaceDir,
         slug: p.slug,
+        ...(p.ownerHandle ? { ownerHandle: p.ownerHandle } : {}),
       });
       const errors = results.filter((result) => !result.ok);
       respond(

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -8,6 +8,7 @@ import {
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
   fetchClawHubSkillCard,
+  fetchClawHubSkillDetail,
   fetchClawHubSkillSecurityVerdicts,
   fetchClawHubPackageArtifact,
   fetchClawHubPackageReadiness,
@@ -344,6 +345,116 @@ describe("clawhub helpers", () => {
     expect(url.pathname).toBe("/api/v1/skills/agentreceipt/verify");
     expect(url.searchParams.get("version")).toBe("1.2.3");
     expect(url.searchParams.has("tag")).toBe(false);
+  });
+
+  it("adds ownerHandle to scoped skill detail, verify, card, and download requests", async () => {
+    const requestedUrls: string[] = [];
+    const skillDetail = {
+      skill: { slug: "discrawl", displayName: "Discrawl", createdAt: 1, updatedAt: 2 },
+      latestVersion: { version: "1.2.3", createdAt: 3 },
+      owner: { handle: "openclaw", displayName: "OpenClaw" },
+    };
+    const verification = {
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      skill: { slug: "discrawl" },
+      publisher: { handle: "openclaw" },
+      version: { version: "1.2.3" },
+      card: { available: true },
+      artifact: null,
+      provenance: null,
+      security: null,
+      signature: null,
+    };
+    const zipBytes = new TextEncoder().encode("zip");
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requestedUrls.push(url);
+      if (url.includes("/verify")) {
+        return new Response(JSON.stringify(verification), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/card")) {
+        return new Response("# Discrawl\n", {
+          status: 200,
+          headers: { "content-type": "text/markdown" },
+        });
+      }
+      if (url.includes("/download")) {
+        return new Response(zipBytes, { status: 200 });
+      }
+      return new Response(JSON.stringify(skillDetail), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await fetchClawHubSkillDetail({ slug: "discrawl", ownerHandle: "openclaw", fetchImpl });
+    await fetchClawHubSkillVerification({
+      slug: "discrawl",
+      ownerHandle: "openclaw",
+      version: "1.2.3",
+      fetchImpl,
+    });
+    await fetchClawHubSkillCard({
+      slug: "discrawl",
+      ownerHandle: "openclaw",
+      tag: "latest",
+      fetchImpl,
+    });
+    const archive = await downloadClawHubSkillArchive({
+      slug: "discrawl",
+      ownerHandle: "openclaw",
+      version: "1.2.3",
+      fetchImpl,
+    });
+    await archive.cleanup();
+
+    expect(requestedUrls).toHaveLength(4);
+    for (const requestedUrl of requestedUrls) {
+      expect(new URL(requestedUrl).searchParams.get("ownerHandle")).toBe("openclaw");
+    }
+  });
+
+  it("formats ambiguous legacy skill slug errors with OpenClaw scoped install guidance", async () => {
+    await expect(
+      fetchClawHubSkillDetail({
+        slug: "discrawl",
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              code: "AMBIGUOUS_SKILL_SLUG",
+              message:
+                'Found multiple skills with the slug "discrawl"; specify which one you want to install:',
+              slug: "discrawl",
+              matches: [
+                {
+                  ownerHandle: "openclaw",
+                  slug: "discrawl",
+                  ref: "@openclaw/discrawl",
+                  url: "https://clawhub.ai/openclaw/discrawl",
+                },
+              ],
+            }),
+            {
+              status: 409,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+      }),
+    ).rejects.toThrow(
+      [
+        'Found multiple skills with the slug "discrawl"; specify which one you want to install:',
+        "  1.",
+        "     Skill: openclaw/discrawl",
+        "     Page:  https://clawhub.ai/openclaw/discrawl",
+        "     Run:   openclaw skills install @openclaw/discrawl",
+      ].join("\n"),
+    );
   });
 
   it("posts bulk skill security verdict requests", async () => {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -428,6 +428,20 @@ export class ClawHubRequestError extends Error {
   }
 }
 
+type ClawHubAmbiguousSkillSlugMatch = {
+  ownerHandle?: unknown;
+  slug?: unknown;
+  ref?: unknown;
+  url?: unknown;
+};
+
+type ClawHubAmbiguousSkillSlugBody = {
+  code?: unknown;
+  message?: unknown;
+  matches?: unknown;
+  choices?: unknown;
+};
+
 function normalizeBaseUrl(baseUrl?: string): string {
   const envValue =
     normalizeOptionalString(process.env.OPENCLAW_CLAWHUB_URL) ||
@@ -677,12 +691,61 @@ async function readErrorBody(response: Response): Promise<string> {
   }
 }
 
+function formatAmbiguousSkillSlugBody(rawBody: string): string | null {
+  let parsed: ClawHubAmbiguousSkillSlugBody;
+  try {
+    parsed = JSON.parse(rawBody) as ClawHubAmbiguousSkillSlugBody;
+  } catch {
+    return null;
+  }
+  if (parsed.code !== "AMBIGUOUS_SKILL_SLUG") {
+    return null;
+  }
+  const message =
+    typeof parsed.message === "string" && parsed.message.trim()
+      ? parsed.message.trim()
+      : "Found multiple skills with that slug; specify which one you want to install:";
+  const matches = Array.isArray(parsed.matches)
+    ? parsed.matches
+    : Array.isArray(parsed.choices)
+      ? parsed.choices
+      : [];
+  const lines = [message];
+  matches.forEach((rawMatch, index) => {
+    if (!rawMatch || typeof rawMatch !== "object") {
+      return;
+    }
+    const match = rawMatch as ClawHubAmbiguousSkillSlugMatch;
+    const ref =
+      typeof match.ref === "string" && match.ref.trim()
+        ? match.ref.trim()
+        : typeof match.ownerHandle === "string" &&
+            match.ownerHandle.trim() &&
+            typeof match.slug === "string" &&
+            match.slug.trim()
+          ? `@${match.ownerHandle.trim()}/${match.slug.trim()}`
+          : undefined;
+    if (!ref) {
+      return;
+    }
+    const page = typeof match.url === "string" && match.url.trim() ? match.url.trim() : undefined;
+    lines.push(`  ${index + 1}.`);
+    lines.push(`     Skill: ${ref.startsWith("@") ? ref.slice(1) : ref}`);
+    if (page) {
+      lines.push(`     Page:  ${page}`);
+    }
+    lines.push(`     Run:   openclaw skills install ${ref}`);
+  });
+  return lines.join("\n");
+}
+
 async function buildClawHubError(
   response: Response,
   url: URL,
   hasToken: boolean,
 ): Promise<ClawHubRequestError> {
   let body = await readErrorBody(response);
+  body = formatAmbiguousSkillSlugBody(body) ?? body;
   if (response.status === 429) {
     const suffix = formatRateLimitSuffix(response.headers, hasToken);
     if (suffix) {
@@ -747,13 +810,18 @@ export function resolveClawHubBaseUrl(baseUrl?: string): string {
 function buildVersionOrTagSearch(params: {
   version?: string;
   tag?: string;
-}): { version?: string; tag?: string } | undefined {
+  ownerHandle?: string;
+}): { version?: string; tag?: string; ownerHandle?: string } | undefined {
+  const ownerHandle = normalizeOptionalString(params.ownerHandle);
   const version = normalizeOptionalString(params.version);
   if (version) {
-    return { version };
+    return { version, ownerHandle };
   }
   const tag = normalizeOptionalString(params.tag);
-  return tag ? { tag } : undefined;
+  if (tag) {
+    return { tag, ownerHandle };
+  }
+  return ownerHandle ? { ownerHandle } : undefined;
 }
 
 function formatSha256Integrity(bytes: Uint8Array): string {
@@ -959,6 +1027,7 @@ export async function searchClawHubSkills(params: {
 
 export async function fetchClawHubSkillDetail(params: {
   slug: string;
+  ownerHandle?: string;
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
@@ -970,11 +1039,15 @@ export async function fetchClawHubSkillDetail(params: {
     token: params.token,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
+    search: {
+      ownerHandle: normalizeOptionalString(params.ownerHandle),
+    },
   });
 }
 
 export async function fetchClawHubSkillVerification(params: {
   slug: string;
+  ownerHandle?: string;
   version?: string;
   tag?: string;
   baseUrl?: string;
@@ -1015,6 +1088,7 @@ export async function fetchClawHubSkillSecurityVerdicts(params: {
 export async function fetchClawHubSkillCard(params: {
   slug?: string;
   url?: string;
+  ownerHandle?: string;
   version?: string;
   tag?: string;
   baseUrl?: string;
@@ -1202,6 +1276,7 @@ export async function downloadClawHubPackageArchive(params: {
 
 export async function downloadClawHubSkillArchive(params: {
   slug: string;
+  ownerHandle?: string;
   version?: string;
   tag?: string;
   baseUrl?: string;
@@ -1217,6 +1292,7 @@ export async function downloadClawHubSkillArchive(params: {
     fetchImpl: params.fetchImpl,
     search: {
       slug: params.slug,
+      ownerHandle: normalizeOptionalString(params.ownerHandle),
       version: params.version,
       tag: params.version ? undefined : params.tag,
     },


### PR DESCRIPTION
## Summary

- Support owner-qualified ClawHub skill refs such as `@openclaw/demo` across OpenClaw skill install/update/verify flows.
- Pass `ownerHandle` through ClawHub detail, download, resolve, and install calls when the user or stored origin metadata provides it.
- Persist ClawHub owner metadata in installed skill origin/lock data so future updates stay in the same publisher namespace.
- Render ClawHub ambiguous-slug responses as actionable OpenClaw commands.

## Pairing

Pairs with ClawHub PR openclaw/clawhub#2299, which adds owner-aware skill slug resolution and optional `ownerHandle` support to the ClawHub v1 API.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/clawhub.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/skills-clawhub.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/skills-cli.commands.test.ts`
- `OPENCLAW_GATEWAY_PROJECT_SHARDS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/skills.search-detail.test.ts src/gateway/server-methods/skills.clawhub.test.ts`
- `pnpm exec oxfmt --check --threads=1 docs/cli/skills.md docs/help/faq.md docs/tools/skills.md src/agents/skills-clawhub.test.ts src/agents/skills-clawhub.ts src/cli/skills-cli.commands.test.ts src/cli/skills-cli.ts src/gateway/protocol/schema/agents-models-skills.ts src/gateway/server-methods/skills.clawhub.test.ts src/gateway/server-methods/skills.search-detail.test.ts src/gateway/server-methods/skills.ts src/infra/clawhub.test.ts src/infra/clawhub.ts`
