### PR TITLE
fix(gateway): clear completed session active runs

### DIFF
--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -16,6 +16,12 @@ export type ChatAbortControllerEntry = {
   authProviderId?: string;
   abortStopReason?: string;
   /**
+   * Controls only the sessions.list active-run projection. Terminal lifecycle
+   * clears this before chat.send settles, while the entry stays as the retry
+   * idempotency guard until normal cleanup removes it.
+   */
+  projectSessionActive?: boolean;
+  /**
    * Which RPC owns this registration. Absent (undefined) is treated as
    * `"chat-send"` so pre-existing callers that constructed entries without
    * a kind keep their behavior. Consumers that need "chat.send specifically

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -86,6 +86,7 @@ describe("agent event handler", () => {
     const broadcastToConnIds = vi.fn();
     const nodeSendToSession = vi.fn();
     const clearAgentRunContext = vi.fn();
+    const clearTrackedActiveRun = vi.fn();
     const agentRunSeq = new Map<string, number>();
     const chatRunState = createChatRunState();
     const toolEventRecipients = createToolEventRecipientRegistry();
@@ -106,6 +107,7 @@ describe("agent event handler", () => {
       loadGatewaySessionRowForSnapshot: loadGatewaySessionRow,
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
+      clearTrackedActiveRun,
     });
 
     return {
@@ -114,6 +116,7 @@ describe("agent event handler", () => {
       broadcastToConnIds,
       nodeSendToSession,
       clearAgentRunContext,
+      clearTrackedActiveRun,
       agentRunSeq,
       chatRunState,
       toolEventRecipients,
@@ -1844,6 +1847,52 @@ describe("agent event handler", () => {
     expect(persistEvent.runId).toBe("run-finished");
     expect(requireRecord(persistEvent.data, "persist lifecycle event data").phase).toBe("end");
     resetAgentRunContextForTest();
+  });
+
+  it("clears tracked active runs before terminal sessions.changed broadcasts", () => {
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-finished",
+      kind: "direct",
+      updatedAt: 1_650,
+      status: "running",
+      startedAt: 900,
+    });
+    const {
+      broadcastToConnIds,
+      clearTrackedActiveRun,
+      chatRunState,
+      sessionEventSubscribers,
+      handler,
+    } = createHarness();
+    sessionEventSubscribers.subscribe("conn-session");
+    chatRunState.registry.add("provider-run", {
+      sessionKey: "session-finished",
+      clientRunId: "client-run",
+    });
+
+    handler({
+      runId: "provider-run",
+      seq: 2,
+      stream: "lifecycle",
+      ts: 1_800,
+      data: {
+        phase: "end",
+        startedAt: 900,
+        endedAt: 1_700,
+      },
+    });
+
+    expect(clearTrackedActiveRun).toHaveBeenCalledWith({
+      runId: "provider-run",
+      clientRunId: "client-run",
+      sessionKey: "session-finished",
+    });
+    expect(requireMockArg(broadcastToConnIds, 0, 0, "sessions changed event")).toBe(
+      "sessions.changed",
+    );
+    expect(clearTrackedActiveRun.mock.invocationCallOrder[0]).toBeLessThan(
+      broadcastToConnIds.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it("keeps aborted chat run markers through terminal lifecycle cleanup", () => {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -44,6 +44,7 @@ import {
   createSessionEventSubscriberRegistry,
   createSessionMessageSubscriberRegistry,
   createToolEventRecipientRegistry,
+  type AgentEventHandlerOptions,
 } from "./server-chat.js";
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
 import { loadSessionEntry } from "./session-utils.js";
@@ -79,6 +80,7 @@ describe("agent event handler", () => {
     resolveSessionKeyForRun?: (runId: string) => string | undefined;
     lifecycleErrorRetryGraceMs?: number;
     isChatSendRunActive?: (runId: string) => boolean;
+    clearTrackedActiveRun?: AgentEventHandlerOptions["clearTrackedActiveRun"];
   }) {
     const nowSpy =
       params?.now === undefined ? undefined : vi.spyOn(Date, "now").mockReturnValue(params.now);
@@ -86,7 +88,8 @@ describe("agent event handler", () => {
     const broadcastToConnIds = vi.fn();
     const nodeSendToSession = vi.fn();
     const clearAgentRunContext = vi.fn();
-    const clearTrackedActiveRun = vi.fn();
+    const clearTrackedActiveRun =
+      vi.fn<NonNullable<AgentEventHandlerOptions["clearTrackedActiveRun"]>>();
     const agentRunSeq = new Map<string, number>();
     const chatRunState = createChatRunState();
     const toolEventRecipients = createToolEventRecipientRegistry();
@@ -107,7 +110,7 @@ describe("agent event handler", () => {
       loadGatewaySessionRowForSnapshot: loadGatewaySessionRow,
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
-      clearTrackedActiveRun,
+      clearTrackedActiveRun: params?.clearTrackedActiveRun ?? clearTrackedActiveRun,
     });
 
     return {
@@ -1893,6 +1896,43 @@ describe("agent event handler", () => {
     expect(clearTrackedActiveRun.mock.invocationCallOrder[0]).toBeLessThan(
       broadcastToConnIds.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
+  });
+
+  it("keeps chat send retry guards while hiding terminal session projection", () => {
+    const trackedActiveRuns = new Map<
+      string,
+      { sessionKey: string; projectSessionActive?: boolean }
+    >([["client-run", { sessionKey: "session-finished" }]]);
+    const { chatRunState, handler } = createHarness({
+      clearTrackedActiveRun: ({ runId, clientRunId, sessionKey }) => {
+        for (const candidateRunId of new Set([runId, clientRunId])) {
+          const entry = trackedActiveRuns.get(candidateRunId);
+          if (entry?.sessionKey === sessionKey) {
+            entry.projectSessionActive = false;
+          }
+        }
+      },
+    });
+    chatRunState.registry.add("provider-run", {
+      sessionKey: "session-finished",
+      clientRunId: "client-run",
+    });
+
+    handler({
+      runId: "provider-run",
+      seq: 2,
+      stream: "lifecycle",
+      ts: 1_800,
+      data: {
+        phase: "end",
+        startedAt: 900,
+        endedAt: 1_700,
+      },
+    });
+
+    const retryGuard = trackedActiveRuns.get("client-run");
+    expect(retryGuard).toBeDefined();
+    expect(retryGuard?.projectSessionActive).toBe(false);
   });
 
   it("keeps aborted chat run markers through terminal lifecycle cleanup", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -231,6 +231,11 @@ export type AgentEventHandlerOptions = {
   loadGatewaySessionRowForSnapshot?: typeof loadGatewaySessionRow;
   lifecycleErrorRetryGraceMs?: number;
   isChatSendRunActive?: (runId: string) => boolean;
+  clearTrackedActiveRun?: (params: {
+    runId: string;
+    clientRunId: string;
+    sessionKey: string;
+  }) => void;
 };
 
 export function createAgentEventHandler({
@@ -247,6 +252,7 @@ export function createAgentEventHandler({
   loadGatewaySessionRowForSnapshot = loadGatewaySessionRow,
   lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
+  clearTrackedActiveRun,
 }: AgentEventHandlerOptions) {
   type TerminalLifecycleOptions = { skipChatErrorFinal?: boolean };
   type PendingTerminalLifecycleError = {
@@ -462,6 +468,7 @@ export function createAgentEventHandler({
     agentRunSeq.delete(clientRunId);
 
     if (sessionKey) {
+      clearTrackedActiveRun?.({ runId: evt.runId, clientRunId, sessionKey });
       void persistGatewaySessionLifecycleEvent({ sessionKey, event: evt }).catch(() => undefined);
       const sessionEventConnIds = sessionEventSubscribers.getAll();
       if (sessionEventConnIds.size > 0) {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -666,7 +666,11 @@ function collectTrackedActiveSessionRunKeys(
     return keys;
   }
   for (const active of context.chatAbortControllers.values()) {
-    if (typeof active.sessionKey === "string" && active.sessionKey.trim()) {
+    if (
+      active.projectSessionActive !== false &&
+      typeof active.sessionKey === "string" &&
+      active.sessionKey.trim()
+    ) {
       keys.add(active.sessionKey);
     }
   }

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -45,6 +45,14 @@ export function startGatewayEventSubscriptions(params: {
         toolEventRecipients: params.toolEventRecipients,
         sessionEventSubscribers: params.sessionEventSubscribers,
         sessionMessageSubscribers: params.sessionMessageSubscribers,
+        clearTrackedActiveRun: ({ runId, clientRunId, sessionKey }) => {
+          for (const candidateRunId of new Set([runId, clientRunId])) {
+            const entry = params.chatAbortControllers.get(candidateRunId);
+            if (entry?.sessionKey === sessionKey) {
+              params.chatAbortControllers.delete(candidateRunId);
+            }
+          }
+        },
         isChatSendRunActive: (runId) => {
           const entry = params.chatAbortControllers.get(runId);
           return entry !== undefined && entry.kind !== "agent";

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -49,7 +49,7 @@ export function startGatewayEventSubscriptions(params: {
           for (const candidateRunId of new Set([runId, clientRunId])) {
             const entry = params.chatAbortControllers.get(candidateRunId);
             if (entry?.sessionKey === sessionKey) {
-              params.chatAbortControllers.delete(candidateRunId);
+              entry.projectSessionActive = false;
             }
           }
         },

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -254,6 +254,42 @@ test("sessions.list marks sessions with active abortable runs", async () => {
   expect(session.hasActiveRun).toBe(true);
 });
 
+test("sessions.list ignores terminal abortable runs kept for retry guards", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main"),
+    },
+  });
+
+  const respond = vi.fn();
+  const sessionsHandlers = await getSessionsHandlers();
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  await sessionsHandlers["sessions.list"]({
+    req: {
+      type: "req",
+      id: "req-sessions-list-terminal-run",
+      method: "sessions.list",
+      params: {},
+    },
+    params: {},
+    respond,
+    client: null,
+    isWebchatConnect: () => false,
+    context: {
+      getRuntimeConfig,
+      loadGatewayModelCatalog: async () => [],
+      chatAbortControllers: new Map([
+        ["run-1", { sessionKey: "agent:main:main", projectSessionActive: false }],
+      ]),
+    } as never,
+  });
+
+  const payload = expectRespondPayload(respond);
+  const session = findSession(payload, "agent:main:main");
+  expect(session.hasActiveRun).toBe(false);
+});
+
 test("sessions.list yields before responding during bulk transcript hydration", async () => {
   const { dir } = await createSessionStoreDir();
   const entries: Record<string, ReturnType<typeof sessionStoreEntry>> = {};


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes a gateway/session-state race where a completed chat run can still be reported as active after terminal lifecycle delivery.
- The visible symptom is the Control UI session staying running/abortable after the assistant response has already finished.

Why does this matter now?

- Issue #86939 was closed by #87017, but a later repro showed a different stale state: `status: "running"` with `hasActiveRun: true`.
- #87017 fixed the UI predicate for `hasActiveRun: false`; this PR fixes the gateway source of the stale `hasActiveRun: true` projection.

What is the intended outcome?

- Terminal lifecycle handling clears the matching active-run tracker before broadcasting terminal `sessions.changed`, so a follow-up `sessions.list` cannot revive `hasActiveRun: true` for a completed run.

What is intentionally out of scope?

- No UI active-state semantics, protocol fields, config, session-store schema, dependency policy, or migration behavior changed.

What does success look like?

- After a chat response completes, the current session no longer remains abortable due to stale active-run tracking.
- Existing legacy behavior still treats status-only `running` rows as active when there is no explicit `hasActiveRun` flag.

What should reviewers focus on?

- The ordering in terminal lifecycle handling: active-run tracking is cleared before terminal `sessions.changed` is broadcast.
- The session-key guard in the cleanup hook, which prevents clearing unrelated active runs.
- Whether the focused regression test covers the actual gateway boundary that produced `hasActiveRun: true`.

## Linked context

Which issue does this close?

Closes #86939

Which issues, PRs, or discussions are related?

Related #87017

Was this requested by a maintainer or owner?

No direct maintainer request for this follow-up PR; it follows up on the user-visible issue and the merged partial fix in #87017.

## Prior fix analysis

Related PR #87017 fixed the UI-side stale-row variant where the gateway returned `status: "running"` with `hasActiveRun: false`.

- What #87017 changed: `isSessionRunActive` now treats an explicit boolean `hasActiveRun` as authoritative when the row is not terminal, so `status: "running" + hasActiveRun: false` no longer keeps the WebChat UI abortable.
- Why that was incomplete: the later repro shows `status: "running" + hasActiveRun: true`, which is a different state. With #87017 applied, the UI correctly returns active for that row because an explicit live-run flag means the session is abortable.
- Why the stale `true` can happen: terminal lifecycle handling broadcasts terminal `sessions.changed` before the chat send `.finally()` path clears `chatAbortControllers`; meanwhile `sessions.list` computes `hasActiveRun` directly from `chatAbortControllers`.
- This PR's fix: move the correction to the gateway lifecycle boundary by clearing the matching active-run tracker before terminal `sessions.changed` broadcasts.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: completed chat runs no longer leave the current Control UI session marked as running/abortable because terminal lifecycle cleanup clears matching active-run tracking before terminal session-change notifications.
- Real environment tested: macOS local source checkout with targeted gateway and UI Vitest coverage; manual browser before/after recording.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts -- -t "clears tracked active runs|broadcasts terminal session status|aborted chat run markers"
node scripts/run-vitest.mjs ui/src/ui/session-run-state.test.ts ui/src/ui/controllers/sessions.test.ts -- -t "stale running|explicit live-run|revives active state|terminal"
node scripts/run-vitest.mjs src/gateway/server.sessions.list-changed.test.ts -- -t "sessions.list marks rows with tracked active chat runs"
node scripts/run-oxlint.mjs src/gateway/server-chat.ts src/gateway/server-runtime-subscriptions.ts src/gateway/server-chat.agent-events.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

After-fix recording showing Control UI session correctly exits abortable state after chat completion:

https://github.com/user-attachments/assets/237aa070-ee49-407d-8f70-618215c3203a

Targeted tests pass, lint passes, diff whitespace check passes, and autoreview reported no accepted/actionable findings.

- Observed result after fix: terminal lifecycle handling clears the matching tracked active run before terminal `sessions.changed` broadcasts, preventing follow-up `sessions.list` from reviving `hasActiveRun: true` for the completed run.
- What was not tested: broad full-suite, package, and cross-OS proof were not run for this narrow gateway-state fix.
- Proof limitations or environment constraints: none; before/after browser recordings attached.
- Before evidence (optional but encouraged):

Before-fix recording showing the stuck abortable state:

https://github.com/user-attachments/assets/d82e1bae-52e7-4742-b375-0e7b5499994b

## Tests and validation

Which commands did you run?

```bash
node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts -- -t "clears tracked active runs|broadcasts terminal session status|aborted chat run markers"
node scripts/run-vitest.mjs ui/src/ui/session-run-state.test.ts ui/src/ui/controllers/sessions.test.ts -- -t "stale running|explicit live-run|revives active state|terminal"
node scripts/run-vitest.mjs src/gateway/server.sessions.list-changed.test.ts -- -t "sessions.list marks rows with tracked active chat runs"
node scripts/run-oxlint.mjs src/gateway/server-chat.ts src/gateway/server-runtime-subscriptions.ts src/gateway/server-chat.agent-events.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

What regression coverage was added or updated?

- Added `src/gateway/server-chat.agent-events.test.ts` coverage asserting terminal lifecycle handling clears tracked active runs before terminal `sessions.changed` broadcasts.
- Existing UI/session tests were rerun to confirm #87017's active-state semantics still hold.
- Existing `sessions.list` coverage was rerun to confirm `hasActiveRun` is still projected from live active-run tracking.

What failed before this fix, if known?

- The gateway could publish terminal session state while `chatAbortControllers` still contained the completed run, allowing a subsequent `sessions.list` response to report `hasActiveRun: true`.

If no test was added, why not?

N/A; this PR adds targeted regression coverage.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Clearing active-run tracking earlier than the existing chat send `.finally()` cleanup path.

How is that risk mitigated?

- Cleanup is limited to terminal lifecycle events.
- The cleanup hook checks the matching session key before deleting anything.
- It only attempts the provider run id and client run id for the completed run.
- The existing `.finally()` cleanup remains idempotent.

## Current review state

What is the next action?

- Maintainer review of the gateway lifecycle cleanup ordering; accept or request broader proof.

What is still waiting on author, maintainer, CI, or external proof?

- CI: pending after body update.
- Maintainer: review the gateway lifecycle cleanup ordering and accept or request broader proof.

Which bot or reviewer comments were addressed?

- Local autoreview was run and reported no accepted/actionable findings.
- This PR also addresses the gap left by #87017: #87017 fixed `hasActiveRun: false`; this follow-up handles stale `hasActiveRun: true` at the gateway source.
