### PR TITLE
feat(config): add $includeText raw-text include directive

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1429,6 +1429,35 @@ Split config into multiple files:
 - Root includes, include arrays, and includes with sibling overrides are read-only for OpenClaw-owned writes; those writes fail closed instead of flattening the config.
 - Errors: clear messages for missing files, parse errors, circular includes, invalid path format, and excessive length.
 
+## Raw-text includes (`$includeText`)
+
+Where `$include` merges a parsed JSON5 file into the surrounding object, `$includeText` injects a file's **raw text** as a plain string value. This lets any string field be maintained as a separate file — for example a per-channel system prompt kept as Markdown:
+
+```json5
+// ~/.openclaw/openclaw.json
+{
+  channels: {
+    slack: {
+      channels: {
+        C0AHNL55CQK: {
+          systemPrompt: { $includeText: "./prompts/slack-support.md" },
+        },
+      },
+    },
+  },
+}
+```
+
+**Behavior:**
+
+- The file's contents are inserted verbatim as a string — **not** JSON-parsed. A file containing `{"a":1}` resolves to that literal string, not an object.
+- Takes a **single string path only**. Arrays are not supported (no unambiguous concatenation semantics), and the value must be a string.
+- **No sibling keys**, and it cannot be combined with `$include` in the same object — a raw string cannot deep-merge into surrounding keys.
+- Trailing whitespace and newlines are **preserved** exactly.
+- Same path and security rules as `$include`: resolved relative to the including file, must stay inside the config directory, no null bytes, length-bounded, 2 MB size cap, and symlink/hardlink-guarded.
+- Resolves **before** schema validation and `${ENV}` expansion, so the injected string flows through the normal config pipeline.
+- Treated as include-owned for write-back: OpenClaw-owned (and channel-initiated) config writes that would touch a `$includeText` node fail closed rather than flattening it into a resolved string. Editing the prompt file triggers a config hot-reload.
+
 ---
 
 _Related: [Configuration](/gateway/configuration) · [Configuration Examples](/gateway/configuration-examples) · [Doctor](/gateway/doctor)_

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1457,6 +1457,7 @@ Where `$include` merges a parsed JSON5 file into the surrounding object, `$inclu
 - Same path and security rules as `$include`: resolved relative to the including file, must stay inside the config directory, no null bytes, length-bounded, 2 MB size cap, and symlink/hardlink-guarded.
 - Resolves **before** schema validation and `${ENV}` expansion, so the injected string flows through the normal config pipeline.
 - Treated as include-owned for write-back: OpenClaw-owned (and channel-initiated) config writes that would touch a `$includeText` node fail closed rather than flattening it into a resolved string. Editing the prompt file triggers a config hot-reload.
+- Writes to **other** fields are unaffected: the directive is preserved verbatim, and write-back validation runs against the include-resolved shape, so an unrelated change (e.g. `openclaw config set models.providers.<id>.timeoutSeconds 90`) succeeds even while a `$includeText` system prompt is present elsewhere.
 
 ---
 

--- a/src/config/includes-scan.test.ts
+++ b/src/config/includes-scan.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { collectIncludePathsRecursive } from "./includes-scan.js";
+
+describe("collectIncludePathsRecursive", () => {
+  const configPath = path.join(path.parse(process.cwd()).root, "cfg", "openclaw.json");
+  const resolved = (rel: string) => path.normalize(path.join(path.dirname(configPath), rel));
+
+  it("registers $include paths as watched dependencies", async () => {
+    const result = await collectIncludePathsRecursive({
+      configPath,
+      parsed: { agents: { $include: "./agents.json" } },
+    });
+    expect(result).toContain(resolved("agents.json"));
+  });
+
+  it("registers $includeText paths as watched dependencies", async () => {
+    const result = await collectIncludePathsRecursive({
+      configPath,
+      parsed: {
+        channels: {
+          discord: {
+            guilds: {
+              g1: {
+                channels: { c1: { systemPrompt: { $includeText: "./prompts/c1.md" } } },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(result).toContain(resolved("prompts/c1.md"));
+  });
+
+  it("does not recurse into $includeText leaves even when they contain include directives", async () => {
+    await withTempDir({ prefix: "openclaw-scan-text-" }, async (tempRoot) => {
+      const cfg = path.join(tempRoot, "openclaw.json");
+      // Raw text that *would* parse as a nested $include if (wrongly) descended into.
+      await fs.writeFile(
+        path.join(tempRoot, "prompt.md"),
+        '{"$include":"./nested.json"}\n',
+        "utf-8",
+      );
+      const result = await collectIncludePathsRecursive({
+        configPath: cfg,
+        parsed: { systemPrompt: { $includeText: "./prompt.md" } },
+      });
+      expect(result).toContain(path.normalize(path.join(tempRoot, "prompt.md")));
+      expect(result).not.toContain(path.normalize(path.join(tempRoot, "nested.json")));
+    });
+  });
+});

--- a/src/config/includes-scan.ts
+++ b/src/config/includes-scan.ts
@@ -2,11 +2,17 @@
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
-import { INCLUDE_KEY, MAX_INCLUDE_DEPTH } from "./includes.js";
+import { INCLUDE_KEY, INCLUDE_TEXT_KEY, MAX_INCLUDE_DEPTH } from "./includes.js";
 
 // Include discovery walks nested config objects because include blocks may be embedded.
-function listDirectIncludes(parsed: unknown): string[] {
-  const out: string[] = [];
+type DirectInclude = {
+  path: string;
+  /** Whether the include target may itself contain further includes. */
+  recurse: boolean;
+};
+
+function listDirectIncludes(parsed: unknown): DirectInclude[] {
+  const out: DirectInclude[] = [];
   const visit = (value: unknown) => {
     if (!value) {
       return;
@@ -23,13 +29,19 @@ function listDirectIncludes(parsed: unknown): string[] {
     const rec = value as Record<string, unknown>;
     const includeVal = rec[INCLUDE_KEY];
     if (typeof includeVal === "string") {
-      out.push(includeVal);
+      out.push({ path: includeVal, recurse: true });
     } else if (Array.isArray(includeVal)) {
       for (const item of includeVal) {
         if (typeof item === "string") {
-          out.push(item);
+          out.push({ path: item, recurse: true });
         }
       }
+    }
+    // $includeText injects raw text and cannot contain further includes, so it
+    // is watched as a dependency but never recursed into.
+    const includeTextVal = rec[INCLUDE_TEXT_KEY];
+    if (typeof includeTextVal === "string") {
+      out.push({ path: includeTextVal, recurse: false });
     }
     for (const v of Object.values(rec)) {
       visit(v);
@@ -59,13 +71,19 @@ export async function collectIncludePathsRecursive(params: {
     if (depth > MAX_INCLUDE_DEPTH) {
       return;
     }
-    for (const raw of listDirectIncludes(parsed)) {
+    for (const { path: raw, recurse } of listDirectIncludes(parsed)) {
       const resolved = resolveIncludePath(basePath, raw);
       if (visited.has(resolved)) {
         continue;
       }
       visited.add(resolved);
       result.push(resolved);
+
+      if (!recurse) {
+        // Raw-text leaf: register as a watched dependency but do not parse or
+        // descend into it.
+        continue;
+      }
 
       const rawText = await fs.readFile(resolved, "utf-8").catch(() => null);
       if (!rawText) {

--- a/src/config/includes.test.ts
+++ b/src/config/includes.test.ts
@@ -49,6 +49,27 @@ function resolve(obj: unknown, files: Record<string, unknown> = {}, basePath = D
   return resolveConfigIncludes(obj, basePath, createMockResolver(files));
 }
 
+/** Resolver that returns file contents verbatim (no JSON.stringify), for $includeText. */
+function createTextMockResolver(files: Record<string, string>): IncludeResolver {
+  return {
+    readFile: (filePath: string) => {
+      if (filePath in files) {
+        return files[filePath];
+      }
+      throw new Error(`ENOENT: no such file: ${filePath}`);
+    },
+    parseJson: JSON.parse,
+  };
+}
+
+function resolveText(
+  obj: unknown,
+  files: Record<string, string> = {},
+  basePath = DEFAULT_BASE_PATH,
+) {
+  return resolveConfigIncludes(obj, basePath, createTextMockResolver(files));
+}
+
 function expectResolveIncludeError(
   run: () => unknown,
   expectedPattern?: RegExp,
@@ -811,6 +832,143 @@ describe("OPENCLAW_INCLUDE_ROOTS allowlist", () => {
           { allowedRoots: [allowedDir] },
         ),
       ).toThrow(/resolves outside config directory/);
+    });
+  });
+});
+
+describe("$includeText raw-text includes", () => {
+  it("injects raw file text at a nested string position", () => {
+    expect(
+      resolveText(
+        { agents: { defaults: { systemPrompt: { $includeText: "./prompt.md" } } } },
+        { [configPath("prompt.md")]: "You are a helpful assistant." },
+      ),
+    ).toEqual({ agents: { defaults: { systemPrompt: "You are a helpful assistant." } } });
+  });
+
+  it("does not JSON-parse the included text (literal string is preserved)", () => {
+    expect(
+      resolveText(
+        { systemPrompt: { $includeText: "./prompt.md" } },
+        { [configPath("prompt.md")]: '{"a":1}' },
+      ),
+    ).toEqual({ systemPrompt: '{"a":1}' });
+  });
+
+  it("preserves trailing newlines (real FS)", async () => {
+    await withTempDir({ prefix: "openclaw-include-text-" }, async (tempRoot) => {
+      const configDir = path.join(tempRoot, "config");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(path.join(configDir, "prompt.md"), "line one\nline two\n", "utf-8");
+      const result = resolveConfigIncludes(
+        { systemPrompt: { $includeText: "./prompt.md" } },
+        path.join(configDir, "openclaw.json"),
+      );
+      expect(result).toEqual({ systemPrompt: "line one\nline two\n" });
+    });
+  });
+
+  it("rejects sibling keys", () => {
+    expectResolveIncludeError(
+      () =>
+        resolveText(
+          { systemPrompt: { $includeText: "./p.md", extra: true } },
+          { [configPath("p.md")]: "x" },
+        ),
+      /\$includeText cannot be combined with sibling keys/,
+    );
+  });
+
+  it.each([
+    { name: "array", value: ["./a.md", "./b.md"], expectedType: "array" },
+    { name: "number", value: 42, expectedType: "number" },
+    { name: "boolean", value: true, expectedType: "boolean" },
+    { name: "null", value: null, expectedType: "object" },
+    { name: "object", value: { path: "./a.md" }, expectedType: "object" },
+  ] as const)("rejects non-string $includeText value: $name", ({ value, expectedType }) => {
+    expectResolveIncludeError(
+      () => resolveText({ systemPrompt: { $includeText: value } }),
+      new RegExp(`Invalid \\$includeText value: expected string path, got ${expectedType}`),
+    );
+  });
+
+  it("rejects combining $include and $includeText in the same object", () => {
+    expectResolveIncludeError(
+      () => resolveText({ x: { $include: "./a.json", $includeText: "./b.md" } }),
+      /Cannot combine \$include and \$includeText/,
+    );
+  });
+
+  it.each([
+    { name: "absolute path outside config dir", includePath: "/etc/passwd" },
+    { name: "relative traversal", includePath: "../../x.md" },
+  ] as const)("rejects $includeText path that escapes config dir: $name", ({ includePath }) => {
+    expectResolveIncludeError(
+      () => resolveText({ systemPrompt: { $includeText: includePath } }),
+      /escapes config directory/,
+    );
+  });
+
+  it("rejects $includeText path with null bytes", () => {
+    expectResolveIncludeError(
+      () => resolveText({ systemPrompt: { $includeText: "./p\x00.md" } }),
+      /null bytes?/i,
+    );
+  });
+
+  it("rejects over-length $includeText path", () => {
+    expectResolveIncludeError(
+      () =>
+        resolveText({ systemPrompt: { $includeText: "a".repeat(MAX_INCLUDE_PATH_LENGTH + 1) } }),
+      /maximum length/,
+    );
+  });
+
+  it("enforces the size cap on $includeText files (real FS)", async () => {
+    await withTempDir({ prefix: "openclaw-include-text-big-" }, async (tempRoot) => {
+      const configDir = path.join(tempRoot, "config");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "big.md"),
+        "a".repeat(MAX_INCLUDE_FILE_BYTES + 1),
+        "utf-8",
+      );
+      expect(() =>
+        resolveConfigIncludes(
+          { systemPrompt: { $includeText: "./big.md" } },
+          path.join(configDir, "openclaw.json"),
+        ),
+      ).toThrow(/security checks|max/i);
+    });
+  });
+
+  it("rejects hardlinked $includeText files (real FS)", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withTempDir({ prefix: "openclaw-include-text-hardlink-" }, async (tempRoot) => {
+      const configDir = path.join(tempRoot, "config");
+      const outsideDir = path.join(tempRoot, "outside");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const includePath = path.join(configDir, "prompt.md");
+      const outsidePath = path.join(outsideDir, "secret.md");
+      await fs.writeFile(outsidePath, "secret text\n", "utf-8");
+      try {
+        await fs.link(outsidePath, includePath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+
+      expect(() =>
+        resolveConfigIncludes(
+          { systemPrompt: { $includeText: "./prompt.md" } },
+          path.join(configDir, "openclaw.json"),
+        ),
+      ).toThrow(/security checks|hardlink/i);
     });
   });
 });

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -19,6 +19,7 @@ import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
 
 export const INCLUDE_KEY = "$include";
+export const INCLUDE_TEXT_KEY = "$includeText";
 export const MAX_INCLUDE_DEPTH = 10;
 export const MAX_INCLUDE_FILE_BYTES = 2 * 1024 * 1024;
 
@@ -140,11 +141,59 @@ class IncludeProcessor {
       return obj;
     }
 
-    if (!(INCLUDE_KEY in obj)) {
-      return this.processObject(obj);
+    if (INCLUDE_KEY in obj) {
+      // A string leaf and an object-merge can't coexist; reject the ambiguity
+      // rather than silently preferring one directive over the other.
+      if (INCLUDE_TEXT_KEY in obj) {
+        throw new ConfigIncludeError(
+          "Cannot combine $include and $includeText in the same object",
+          INCLUDE_TEXT_KEY,
+        );
+      }
+      return this.processInclude(obj);
     }
 
-    return this.processInclude(obj);
+    if (INCLUDE_TEXT_KEY in obj) {
+      return this.processTextInclude(obj);
+    }
+
+    return this.processObject(obj);
+  }
+
+  private processTextInclude(obj: Record<string, unknown>): string {
+    const otherKeys = Object.keys(obj).filter((k) => k !== INCLUDE_TEXT_KEY);
+    if (otherKeys.length > 0) {
+      // A raw string can't deep-merge into surrounding keys, unlike $include.
+      throw new ConfigIncludeError(
+        `$includeText cannot be combined with sibling keys: ${otherKeys.join(", ")}`,
+        INCLUDE_TEXT_KEY,
+      );
+    }
+
+    const value = obj[INCLUDE_TEXT_KEY];
+    if (typeof value !== "string") {
+      // Arrays are intentionally unsupported: there is no unambiguous concat
+      // semantics for raw text. This can be added later without breaking the
+      // string contract.
+      const valueType = Array.isArray(value) ? "array" : typeof value;
+      throw new ConfigIncludeError(
+        `Invalid $includeText value: expected string path, got ${valueType}`,
+        INCLUDE_TEXT_KEY,
+      );
+    }
+
+    return this.loadTextFile(value);
+  }
+
+  private loadTextFile(includePath: string): string {
+    // Reuse the same security checks and guarded reader as loadFile, but skip
+    // parseFile/processNested/checkCircular: a text leaf cannot include further,
+    // so there is no recursion or cycle risk. checkDepth is kept to preserve the
+    // uniform depth bound. The raw string is returned verbatim (trailing
+    // newlines preserved).
+    const { resolvedPath, root } = this.resolvePath(includePath);
+    this.checkDepth(includePath);
+    return this.readFile(includePath, resolvedPath, root);
   }
 
   private processObject(obj: Record<string, unknown>): Record<string, unknown> {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -2252,7 +2252,38 @@ export function createConfigIO(
 
     persistCandidate = applyUnsetPathsForWrite(persistCandidate as OpenClawConfig, unsetPaths);
 
-    const validated = validateConfigObjectRawWithPlugins(persistCandidate, {
+    // $include / $includeText directives are preserved verbatim in persistCandidate so
+    // authored include files are never flattened on write (see preserveUntouchedIncludes).
+    // Validate against the include-RESOLVED shape, otherwise an untouched include sitting
+    // in a typed field (e.g. a $includeText systemPrompt, which resolves to a string) reads
+    // as an object and fails validation — which would block writes to entirely unrelated
+    // paths. persistCandidate (directives intact) is still what gets written below.
+    let candidateForValidation: unknown = persistCandidate;
+    try {
+      candidateForValidation = resolveConfigIncludes(
+        persistCandidate,
+        configPath,
+        {
+          readFile: (candidate) => deps.fs.readFileSync(candidate, "utf-8"),
+          readFileWithGuards: ({ includePath, resolvedPath, rootRealDir }) =>
+            readConfigIncludeFileWithGuards({
+              includePath,
+              resolvedPath,
+              rootRealDir,
+              ioFs: deps.fs,
+            }),
+          parseJson: (raw) => deps.json5.parse(raw),
+        },
+        { allowedRoots: resolveIncludeRoots(deps.env, deps.homedir) },
+      );
+    } catch {
+      // If includes can't be resolved (e.g. a missing or guard-rejected file), fall back
+      // to validating the raw candidate so the underlying error still surfaces to the
+      // caller rather than being masked.
+      candidateForValidation = persistCandidate;
+    }
+
+    const validated = validateConfigObjectRawWithPlugins(candidateForValidation, {
       env: deps.env,
       pluginValidation: options.skipPluginValidation ? "skip" : "full",
       preservedLegacyRootKeys: options.preservedLegacyRootKeys,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -233,6 +233,66 @@ describe("config io write", () => {
     });
   });
 
+  it("allows writes to unrelated paths while a $includeText string field is present", async () => {
+    await withSuiteHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      const configPath = path.join(configDir, "openclaw.json");
+      await fs.mkdir(path.join(configDir, "prompts"), { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "prompts", "slack.md"),
+        "resolved prompt text\n",
+        "utf-8",
+      );
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            channels: {
+              slack: { channels: { C0: { systemPrompt: { $includeText: "./prompts/slack.md" } } } },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        configPath,
+        env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      await io.readConfigFileSnapshot();
+      // The runtime config sees systemPrompt resolved to the file's text. Pass that
+      // exact value back so the write does not touch (and thus does not flatten) the
+      // $includeText-owned path — it only changes an unrelated field, gateway.port.
+      const current = io.loadConfig() as {
+        channels?: { slack?: { channels?: Record<string, { systemPrompt?: unknown }> } };
+      };
+      const resolvedPrompt = current.channels?.slack?.channels?.C0?.systemPrompt;
+
+      await io.writeConfigFile({
+        gateway: { mode: "local", port: 19001 },
+        channels: {
+          slack: { channels: { C0: { systemPrompt: resolvedPrompt } } },
+        },
+      } as OpenClawConfig);
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        gateway?: { port?: number };
+        channels?: { slack?: { channels?: Record<string, { systemPrompt?: unknown }> } };
+      };
+      // The unrelated change landed...
+      expect(persisted.gateway?.port).toBe(19001);
+      // ...and the $includeText directive is preserved, not flattened to its text.
+      expect(persisted.channels?.slack?.channels?.C0?.systemPrompt).toEqual({
+        $includeText: "./prompts/slack.md",
+      });
+    });
+  });
+
   it("loads shipped plugin install config records without mutating config or plugin index", async () => {
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -469,6 +469,73 @@ describe("config io write prepare", () => {
     expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
   });
 
+  it("preserves $includeText-owned values during unrelated writes", () => {
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig: {
+        channels: {
+          slack: { channels: { C0: { systemPrompt: "resolved prompt text" } } },
+        },
+        gateway: { mode: "local" },
+      },
+      sourceConfig: {
+        channels: {
+          slack: { channels: { C0: { systemPrompt: "resolved prompt text" } } },
+        },
+        gateway: { mode: "local" },
+      },
+      rootAuthoredConfig: {
+        channels: {
+          slack: {
+            channels: { C0: { systemPrompt: { $includeText: "./prompts/slack.md" } } },
+          },
+        },
+        gateway: { mode: "local" },
+      },
+      nextConfig: {
+        channels: {
+          slack: { channels: { C0: { systemPrompt: "resolved prompt text" } } },
+        },
+        gateway: { mode: "local", port: 18789 },
+      },
+    }) as Record<string, unknown>;
+
+    expect(persisted.channels).toEqual({
+      slack: { channels: { C0: { systemPrompt: { $includeText: "./prompts/slack.md" } } } },
+    });
+    expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
+  });
+
+  it("rejects writes that would flatten $includeText-owned values", () => {
+    expect(() =>
+      resolvePersistCandidateForWrite({
+        runtimeConfig: {
+          channels: {
+            slack: { channels: { C0: { systemPrompt: "resolved prompt text" } } },
+          },
+        },
+        sourceConfig: {
+          channels: {
+            slack: { channels: { C0: { systemPrompt: "resolved prompt text" } } },
+          },
+        },
+        rootAuthoredConfig: {
+          channels: {
+            slack: {
+              channels: { C0: { systemPrompt: { $includeText: "./prompts/slack.md" } } },
+            },
+          },
+        },
+        nextConfig: {
+          channels: {
+            slack: { channels: { C0: { systemPrompt: "different prompt" } } },
+          },
+        },
+      }),
+    ).toThrow(
+      "Config write would flatten $include-owned config at channels.slack.channels.C0.systemPrompt",
+    );
+  });
+
   it("rejects writes that would flatten include-owned subtrees", () => {
     expect(() =>
       resolvePersistCandidateForWrite({

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -81,7 +81,7 @@ export function projectSourceOntoRuntimeShape(source: unknown, runtime: unknown)
 }
 
 function hasOwnIncludeKey(value: unknown): value is Record<string, unknown> {
-  return isRecord(value) && Object.hasOwn(value, "$include");
+  return isRecord(value) && (Object.hasOwn(value, "$include") || Object.hasOwn(value, "$includeText"));
 }
 
 function collectIncludeOwnedPaths(value: unknown, path: string[] = []): string[][] {


### PR DESCRIPTION
## Summary

Adds a `$includeText` config directive — a sibling to `$include` — that injects a file's **raw text** as a plain string value, instead of merging parsed JSON5 into the surrounding object.

- **Problem:** people want to maintain long string config values (notably per-channel `systemPrompt`s) as standalone files rather than inlining them into `openclaw.json`, but `$include` only does JSON object-merge and there was no file-backed path for a plain string field.
- **Outcome:** `systemPrompt: { "$includeText": "./prompts/foo.md" }` resolves to the file's raw text, flowing through the **existing** `systemPrompt` field. No new per-channel config surface, and the read is bounded and rooted by the same guards `$include` already uses.
- **Out of scope:** array values for `$includeText` (no unambiguous concat semantics — can be added later without breaking the string contract); any new channel-level config keys.
- **Success:** any string config value can be file-sourced; the file read is constrained to the config directory with a size cap and symlink/hardlink guards; editing the file hot-reloads config.
- **Reviewers should focus on:** the resolution dispatch in `includes.ts` (it must leave the `$include` path unchanged) and that `$includeText` is correctly treated as include-owned for write-back (fails closed instead of flattening).

This **supersedes #87655**, which added a parallel `systemPromptByChannel` map. ClawSweeper correctly blocked that on two grounds: (1) it duplicated the existing inline `systemPrompt` surface with different precedence, and (2) it read arbitrary absolute/`~` paths with no trusted-root, size cap, or symlink guard. This redesign keeps the genuine value (prompts maintained as files) while removing both objections — it reuses the existing `systemPrompt` field and the existing `readConfigIncludeFileWithGuards` reader.

## Linked context

Closes #87655 (superseded by this redesign).

Related #87655

## Real behavior proof (required for external PRs)

- **Behavior addressed:** a file-backed plain-string config value resolved by the real config loader.
- **Real environment tested:** local OpenClaw gateway (`openclaw config validate` / `get`, which run the production config pipeline).
- **Exact steps or command run after this patch:** a clean temp config with a temp prompt file, no private data:

```jsonc
// /tmp/.../openclaw.json
{
  "channels": {
    "slack": {
      "channels": {
        "C123": { "systemPrompt": { "$includeText": "./prompt.md" } }
      }
    }
  }
}
// /tmp/.../prompt.md
You are the demo channel assistant.
Be concise.
```

```
$ OPENCLAW_CONFIG_PATH=.../openclaw.json openclaw config validate
Config valid: /tmp/.../openclaw.json

$ OPENCLAW_CONFIG_PATH=.../openclaw.json openclaw config get channels.slack.channels.C123.systemPrompt
You are the demo channel assistant.
Be concise.
```

- **Evidence after fix:** terminal capture above — `openclaw config validate` / `openclaw config get` output showing the file's raw text resolved through the real loader, plus the path-escape failure.
- **Observed result after fix:** the `$includeText` object resolved to the file's **raw text** (not JSON-parsed), through the real loader, and validated against the `systemPrompt: z.string()` schema (proving the directive resolves *before* validation). Trailing newline preserved.
- **Security behavior (real loader):** an escaping path fails closed:

```
$ openclaw config validate   # systemPrompt: { "$includeText": "../../../../etc/passwd" }
  × <root>: Include path escapes config directory: ../../../../etc/passwd (root: /tmp/...)
```

- **What was not tested:** a live Discord/Slack reply visibly reflecting a file-backed prompt. Locally the migrated gateway restarted cleanly and resolved all configured channels (Slack `C0AHNL55CQK→shrink`; 19 Discord channels under the configured guild) with their `$includeText` prompts; a channel-visible screenshot can be added.
- **Proof limitations:** the channel-visible capture above involves private prompt content, so the reproducible proof here uses a synthetic temp config instead.

## Tests and validation

Commands run:
- `pnpm lint` — clean.
- `pnpm test:unit` — green (one unrelated `memory-search` test is a known parallelism flake in shared plugin-registry global state; passes in isolation).
- `pnpm build` — exit 0.
- Targeted: `vitest run src/config/includes.test.ts src/config/includes-scan.test.ts src/config/io.write-prepare.test.ts` → 110 passed.

Regression coverage added:
- `includes.test.ts`: raw-string injection at a nested position; content is **not** JSON-parsed; trailing newline preserved (real FS); rejects sibling keys / array / non-string values / `$include`+`$includeText` together; security reuse — path escape, null byte, over-length, size cap, hardlink rejection.
- `io.write-prepare.test.ts`: a `$includeText`-owned value is preserved (not flattened) on an unrelated owned write, and a write touching it fails closed.
- `includes-scan.test.ts` (new): `$includeText` paths are registered as watched dependencies but **not** recursed into (a raw-text leaf containing a nested `$include` directive does not pull that nested path into the watch set).

## Risk checklist

- **User-visible behavior changed?** Yes — a new config directive.
- **Config / migration behavior changed?** Yes — new directive; treated as include-owned for write-back so owned/channel-initiated writes fail closed rather than flattening the node.
- **Security / secrets / network / tool-exec changed?** Reads a file into the config. Mitigated by **reusing the existing `$include` guards verbatim** (`readConfigIncludeFileWithGuards` + `resolvePath`): config-directory root containment, 2 MB cap, path length / null-byte checks, and symlink revalidation + hardlink rejection. `loadTextFile` deliberately omits JSON parse / nested resolution / circular-check (a text leaf cannot include further) but keeps the uniform depth bound.
- **Highest-risk area:** path resolution / file read. **Mitigation:** the read path is identical to `$include`; only JSON parsing is skipped. No new schema field (resolves pre-validation), no central directive allowlist change.

## Current review state

- **Next action:** maintainer review; close #87655 as superseded.
- **Waiting on:** optional live channel-visible screenshot.
- **Addressed bot/reviewer comments:** ClawSweeper's two blocks on #87655 (duplicate config surface; unbounded path read) are both resolved by this redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
