### PR TITLE
fix(reply): deliver plugin binding replies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ Skills own workflows; root owns hard policy and routing.
 - Crabbox/WebVNC human demos: keep remote desktop visible/windowed; no fullscreen remote browser unless video/capture-style output.
 - ClawSweeper ops: `$clawsweeper`. Deployed hook sessions may post one concise `#clawsweeper` note only when surprising/actionable/risky; if using message tool, reply exactly `NO_REPLY`.
 - Generated-media completions wake the requester agent first. Requester visible-reply config decides final text vs message tool; direct media send is fallback/recovery only.
-- `message_tool_only`: visible source reply = current-source `message(action=send)` only. No `NO_REPLY` prompt/contract; no message call = no source reply. Never auto-publish private final.
+- `message_tool_only`: normal agent final visible reply = current-source `message(action=send)` only. No `NO_REPLY` prompt/contract; no message call = no source reply. Plugin-owned bound-thread reply = plugin return value; no message tool needed. Never auto-publish private final.
 - Memory wiki prompt digest stays tiny; prefer `wiki_search` / `wiki_get`; verify contact data before use; source-class provenance for generated people facts.
 - Rebrand/migration/config warnings: run `openclaw doctor`.
 - Never edit `node_modules`.

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -58,6 +58,8 @@ For direct chats and any other source event, use `messages.visibleReplies: "mess
 
 This replaces the old pattern of forcing the model to answer `NO_REPLY` for most lurk-mode turns. In tool-only mode, the prompt does not define a `NO_REPLY` contract. Doing nothing visible simply means not calling the message tool.
 
+Plugin-owned conversation bindings are the exception. Once a plugin binds a thread and claims the inbound turn, the plugin's returned reply is the visible binding response; it does not need `message(action=send)`. That reply is plugin runtime output, not private model final text.
+
 Typing indicators are still sent for direct group requests. Ambient always-on room events, when enabled, stay strict and quiet unless the agent calls the message tool.
 
 Sessions suppress verbose tool/progress summaries by default. Use `/verbose on`

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -794,6 +794,8 @@ Tool-only visible replies require a model/runtime that reliably calls tools, and
 
 If the message tool is unavailable under the active tool policy, OpenClaw falls back to automatic visible replies instead of silently suppressing the response. `openclaw doctor` warns about this mismatch.
 
+This rule applies to normal agent final text. Plugin-owned conversation bindings use the owning plugin's returned reply as the visible response for claimed bound-thread turns; the plugin does not need to call `message(action=send)` for those binding replies.
+
 **Troubleshooting: group @mention triggers typing then silence (no error)**
 
 Symptom: a group/channel @mention shows the typing indicator and the gateway log reports `dispatch complete (queuedFinal=false, replies=0)`, but no message lands in the room. DMs to the same agent reply normally.

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7049,143 +7049,112 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
-  it("routes plugin-owned bindings under message-tool-only source delivery", async () => {
-    setNoAbort();
-    hookMocks.runner.hasHooks.mockImplementation(
-      ((hookName?: string) =>
-        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
-    );
-    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
-    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
-      status: "handled",
-      result: { handled: true },
-    });
-    sessionBindingMocks.resolveByConversation.mockReturnValue({
-      bindingId: "binding-message-tool-only",
-      targetSessionKey: "plugin-binding:codex:abc123",
-      targetKind: "session",
-      conversation: {
-        channel: "telegram",
-        accountId: "default",
-        conversationId: "-1001234567890:topic:11",
-        parentConversationId: "-1001234567890",
-      },
-      status: "active",
-      boundAt: 1710000000000,
-      metadata: {
-        pluginBindingOwner: "plugin",
-        pluginId: "openclaw-codex-app-server",
-        pluginRoot: "/tmp/plugin",
-      },
-    } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
-    const dispatcher = createDispatcher();
-    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
-    const ctx = buildTestCtx({
-      Provider: "telegram",
-      Surface: "telegram",
-      OriginatingChannel: "telegram",
-      OriginatingTo: "telegram:-1001234567890",
-      To: "telegram:-1001234567890",
-      AccountId: "default",
-      MessageThreadId: 11,
-      ChatType: "group",
-      GroupSubject: "Dev",
-      Body: "observed message",
-    });
-
-    const result = await dispatchReplyFromConfig({
-      ctx,
-      cfg: emptyConfig,
-      dispatcher,
-      replyResolver,
-      replyOptions: {
-        sourceReplyDeliveryMode: "message_tool_only",
-      },
-    });
-
-    expect(result).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
-    expect(sessionBindingMocks.touch).toHaveBeenCalledWith("binding-message-tool-only");
-    const claimCall = firstMockCall(
-      hookMocks.runner.runInboundClaimForPluginOutcome,
-      "plugin inbound claim",
-    );
-    expect(claimCall[0]).toBe("openclaw-codex-app-server");
-    expect(claimCall[1]).toMatchObject({
-      channel: "telegram",
-      content: "observed message",
-      threadId: 11,
-    });
-    const claimContext = claimCall[2] as { pluginBinding?: { bindingId?: string } };
-    expect(claimContext.pluginBinding).toMatchObject({ bindingId: "binding-message-tool-only" });
-    expect(replyResolver).not.toHaveBeenCalled();
-    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
-  });
-
-  it("delivers plugin-owned binding replies under message-tool-only source delivery", async () => {
-    setNoAbort();
-    hookMocks.runner.hasHooks.mockImplementation(
-      ((hookName?: string) =>
-        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
-    );
-    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
-    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
-      status: "handled",
-      result: { handled: true, reply: { text: "Codex native reply" } },
-    });
-    sessionBindingMocks.resolveByConversation.mockReturnValue({
-      bindingId: "binding-message-tool-reply",
-      targetSessionKey: "plugin-binding:codex:abc123",
-      targetKind: "session",
-      conversation: {
-        channel: "discord",
-        accountId: "default",
-        conversationId: "channel:reply-test",
-      },
-      status: "active",
-      boundAt: 1710000000000,
-      metadata: {
-        pluginBindingOwner: "plugin",
-        pluginId: "openclaw-codex-app-server",
-        pluginRoot: "/tmp/plugin",
-      },
-    } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
-    const dispatcher = createDispatcher();
-    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      OriginatingChannel: "discord",
-      OriginatingTo: "discord:channel:reply-test",
-      To: "discord:channel:reply-test",
-      AccountId: "default",
-      ChatType: "channel",
-      Body: "observed message",
-      SessionKey: "agent:main:discord:channel:reply-test",
-    });
-
-    const result = await dispatchReplyFromConfig({
-      ctx,
-      cfg: {
-        messages: {
-          groupChat: { visibleReplies: "message_tool" },
+  it.each(
+    [
+      {
+        name: "handled without a plugin reply",
+        bindingId: "binding-message-tool-only",
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "-1001234567890:topic:11",
+          parentConversationId: "-1001234567890",
         },
-      } as OpenClawConfig,
+        ctx: {
+          Provider: "telegram",
+          Surface: "telegram",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "telegram:-1001234567890",
+          To: "telegram:-1001234567890",
+          AccountId: "default",
+          MessageThreadId: 11,
+          ChatType: "group",
+          GroupSubject: "Dev",
+          Body: "observed message",
+        },
+        cfg: emptyConfig,
+        replyOptions: {
+          sourceReplyDeliveryMode: "message_tool_only" as const,
+        },
+        expectedClaim: { channel: "telegram", threadId: 11 },
+      },
+      {
+        name: "handled with a plugin reply",
+        bindingId: "binding-message-tool-reply",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel:reply-test",
+        },
+        ctx: {
+          Provider: "discord",
+          Surface: "discord",
+          OriginatingChannel: "discord",
+          OriginatingTo: "discord:channel:reply-test",
+          To: "discord:channel:reply-test",
+          AccountId: "default",
+          ChatType: "channel",
+          Body: "observed message",
+          SessionKey: "agent:main:discord:channel:reply-test",
+        },
+        cfg: {
+          messages: {
+            groupChat: { visibleReplies: "message_tool" },
+          },
+        } as OpenClawConfig,
+        expectedClaim: { channel: "discord" },
+        pluginReply: { text: "Codex native reply" },
+      },
+    ] satisfies Array<{
+      name: string;
+      bindingId: string;
+      conversation: SessionBindingRecord["conversation"];
+      ctx: Partial<MsgContext>;
+      cfg: OpenClawConfig;
+      replyOptions?: { sourceReplyDeliveryMode: "message_tool_only" };
+      expectedClaim: Record<string, unknown>;
+      pluginReply?: ReplyPayload;
+    }>,
+  )("routes plugin-owned bindings under message-tool-only source delivery: $name", async (params) => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: params.pluginReply
+        ? { handled: true, reply: params.pluginReply }
+        : { handled: true },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: params.bindingId,
+      targetSessionKey: "plugin-binding:codex:abc123",
+      targetKind: "session",
+      conversation: params.conversation,
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/tmp/plugin",
+      },
+    } satisfies SessionBindingRecord);
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx(params.ctx),
+      cfg: params.cfg,
       dispatcher,
       replyResolver,
+      replyOptions: params.replyOptions,
     });
 
     expect(result).toEqual({
@@ -7193,16 +7162,23 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       counts: { tool: 0, block: 0, final: 0 },
       sourceReplyDeliveryMode: "message_tool_only",
     });
-    expect(sessionBindingMocks.touch).toHaveBeenCalledWith("binding-message-tool-reply");
+    expect(sessionBindingMocks.touch).toHaveBeenCalledWith(params.bindingId);
     expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
       "openclaw-codex-app-server",
-      expect.objectContaining({ channel: "discord", content: "observed message" }),
       expect.objectContaining({
-        pluginBinding: expect.objectContaining({ bindingId: "binding-message-tool-reply" }),
+        content: "observed message",
+        ...params.expectedClaim,
+      }),
+      expect.objectContaining({
+        pluginBinding: expect.objectContaining({ bindingId: params.bindingId }),
       }),
     );
     expect(replyResolver).not.toHaveBeenCalled();
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Codex native reply" });
+    if (params.pluginReply) {
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(params.pluginReply);
+    } else {
+      expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    }
   });
 
   it("keeps unmentioned plugin-bound fallback from ordinary group agent dispatch", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5427,7 +5427,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).not.toHaveBeenCalled();
   });
 
-  it("keeps unauthorized plugin-owned binding slash text routed to the bound plugin", async () => {
+  it("keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin", async () => {
     setNoAbort();
     hookMocks.runner.hasHooks.mockImplementation(
       ((hookName?: string) =>
@@ -5436,7 +5436,7 @@ describe("dispatchReplyFromConfig", () => {
     hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
     hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
       status: "handled",
-      result: { handled: true },
+      result: { handled: true, reply: { text: "do not leak slash reply" } },
     });
     sessionBindingMocks.resolveByConversation.mockReturnValue({
       bindingId: "binding-command-escape-denied",
@@ -5467,6 +5467,7 @@ describe("dispatchReplyFromConfig", () => {
       AccountId: "default",
       SenderId: "user-9",
       SenderUsername: "ada",
+      ChatType: "channel",
       CommandSource: "text",
       CommandAuthorized: false,
       WasMentioned: false,
@@ -5480,7 +5481,11 @@ describe("dispatchReplyFromConfig", () => {
 
     const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
     expect(sessionBindingMocks.touch).toHaveBeenCalledWith("binding-command-escape-denied");
     expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
       "openclaw-codex-app-server",
@@ -5491,6 +5496,7 @@ describe("dispatchReplyFromConfig", () => {
     );
     expect(hookMocks.runner.runInboundClaim).not.toHaveBeenCalled();
     expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
   it("delivers plugin-owned binding replies returned by the owning inbound claim hook", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7104,6 +7104,32 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         } as OpenClawConfig,
         expectedClaim: { channel: "discord" },
         pluginReply: { text: "Codex native reply" },
+        expectPluginReplyDelivered: true,
+      },
+      {
+        name: "suppresses ambient room_event plugin reply",
+        bindingId: "binding-message-tool-room-event",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel:room-event-test",
+        },
+        ctx: {
+          Provider: "discord",
+          Surface: "discord",
+          OriginatingChannel: "discord",
+          OriginatingTo: "discord:channel:room-event-test",
+          To: "discord:channel:room-event-test",
+          AccountId: "default",
+          ChatType: "group",
+          InboundEventKind: "room_event",
+          Body: "observed message",
+          SessionKey: "agent:main:discord:channel:room-event-test",
+        },
+        cfg: emptyConfig,
+        expectedClaim: { channel: "discord" },
+        pluginReply: { text: "Codex ambient room event reply" },
+        expectPluginReplyDelivered: false,
       },
     ] satisfies Array<{
       name: string;
@@ -7114,6 +7140,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       replyOptions?: { sourceReplyDeliveryMode: "message_tool_only" };
       expectedClaim: Record<string, unknown>;
       pluginReply?: ReplyPayload;
+      expectPluginReplyDelivered?: boolean;
     }>,
   )("routes plugin-owned bindings under message-tool-only source delivery: $name", async (params) => {
     setNoAbort();
@@ -7174,7 +7201,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       }),
     );
     expect(replyResolver).not.toHaveBeenCalled();
-    if (params.pluginReply) {
+    if (params.expectPluginReplyDelivered) {
       expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(params.pluginReply);
     } else {
       expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7130,6 +7130,81 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("delivers plugin-owned binding replies under message-tool-only source delivery", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: { handled: true, reply: { text: "Codex native reply" } },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-message-tool-reply",
+      targetSessionKey: "plugin-binding:codex:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:reply-test",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/tmp/plugin",
+      },
+    } satisfies SessionBindingRecord);
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "discord:channel:reply-test",
+      To: "discord:channel:reply-test",
+      AccountId: "default",
+      ChatType: "channel",
+      Body: "observed message",
+      SessionKey: "agent:main:discord:channel:reply-test",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        messages: {
+          groupChat: { visibleReplies: "message_tool" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(sessionBindingMocks.touch).toHaveBeenCalledWith("binding-message-tool-reply");
+    expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
+      "openclaw-codex-app-server",
+      expect.objectContaining({ channel: "discord", content: "observed message" }),
+      expect.objectContaining({
+        pluginBinding: expect.objectContaining({ bindingId: "binding-message-tool-reply" }),
+      }),
+    );
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Codex native reply" });
+  });
+
   it("keeps unmentioned plugin-bound fallback from ordinary group agent dispatch", async () => {
     setNoAbort();
     hookMocks.runner.hasHooks.mockImplementation(

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1690,6 +1690,11 @@ export async function dispatchReplyFromConfig(
     sourceReplyDeliveryMode === "message_tool_only"
       ? { ...result, sourceReplyDeliveryMode }
       : result;
+  const explicitCommandTurnCtx = isExplicitSourceReplyCommand(ctx, cfg);
+  const shouldDeliverPluginBindingReply =
+    !suppressAutomaticSourceDelivery ||
+    ctx.InboundEventKind !== "room_event" ||
+    explicitCommandTurnCtx;
 
   const inboundDedupeClaim = claimInboundDedupe(ctx);
   if (inboundDedupeClaim.status === "duplicate" || inboundDedupeClaim.status === "inflight") {
@@ -1774,10 +1779,11 @@ export async function dispatchReplyFromConfig(
 
       switch (targetedClaimOutcome.status) {
         case "handled": {
-          if (targetedClaimOutcome.result.reply) {
+          if (targetedClaimOutcome.result.reply && shouldDeliverPluginBindingReply) {
             // A bound plugin's reply is the explicit output for this claimed turn,
             // not an automatic agent final; message-tool-only suppression must not
-            // turn a successful binding into a silent channel response.
+            // turn normal user-request bindings into silent channel responses.
+            // Ambient room events keep the same privacy guard as final replies.
             await deliverBindingPayload(targetedClaimOutcome.result.reply, "terminal");
           }
           markIdle("plugin_binding_dispatch");
@@ -2780,7 +2786,6 @@ export async function dispatchReplyFromConfig(
     // suppressed in room_event. sendPolicy: deny still suppresses everything.
     // Uses the same helper as the source-reply visibility policy so the bypass
     // and the policy stay aligned.
-    const explicitCommandTurnCtx = isExplicitSourceReplyCommand(ctx, cfg);
     const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) =>
       suppressAutomaticSourceDelivery &&
       !sendPolicyDenied &&

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -138,6 +138,7 @@ import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveReplyRoutingDecision } from "./routing-policy.js";
 import {
   isExplicitSourceReplyCommand,
+  isUnauthorizedTextSlashCommand,
   resolveSourceReplyVisibilityPolicy,
 } from "./source-reply-delivery-mode.js";
 import { resolveStoredModelOverride } from "./stored-model-override.js";
@@ -1691,10 +1692,12 @@ export async function dispatchReplyFromConfig(
       ? { ...result, sourceReplyDeliveryMode }
       : result;
   const explicitCommandTurnCtx = isExplicitSourceReplyCommand(ctx, cfg);
+  const unauthorizedTextSlashSourceReplyCtx =
+    (chatType === "group" || chatType === "channel") && isUnauthorizedTextSlashCommand(ctx);
   const shouldDeliverPluginBindingReply =
     !suppressAutomaticSourceDelivery ||
-    ctx.InboundEventKind !== "room_event" ||
-    explicitCommandTurnCtx;
+    explicitCommandTurnCtx ||
+    (ctx.InboundEventKind !== "room_event" && !unauthorizedTextSlashSourceReplyCtx);
 
   const inboundDedupeClaim = claimInboundDedupe(ctx);
   if (inboundDedupeClaim.status === "duplicate" || inboundDedupeClaim.status === "inflight") {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1506,13 +1506,10 @@ export async function dispatchReplyFromConfig(
     }
   };
 
-  const sendBindingNotice = async (
+  const deliverBindingPayload = async (
     payload: ReplyPayload,
     mode: "additive" | "terminal",
   ): Promise<boolean> => {
-    if (suppressAutomaticSourceDelivery) {
-      return false;
-    }
     const result = await routeReplyToOriginating(payload, {
       kind: mode === "terminal" ? "final" : "tool",
     });
@@ -1528,6 +1525,15 @@ export async function dispatchReplyFromConfig(
     return mode === "additive"
       ? dispatcher.sendToolResult(payload)
       : dispatcher.sendFinalReply(payload);
+  };
+  const sendBindingNotice = async (
+    payload: ReplyPayload,
+    mode: "additive" | "terminal",
+  ): Promise<boolean> => {
+    if (suppressAutomaticSourceDelivery) {
+      return false;
+    }
+    return await deliverBindingPayload(payload, mode);
   };
 
   const pluginOwnedBindingRecord =
@@ -1769,7 +1775,10 @@ export async function dispatchReplyFromConfig(
       switch (targetedClaimOutcome.status) {
         case "handled": {
           if (targetedClaimOutcome.result.reply) {
-            await sendBindingNotice(targetedClaimOutcome.result.reply, "terminal");
+            // A bound plugin's reply is the explicit output for this claimed turn,
+            // not an automatic agent final; message-tool-only suppression must not
+            // turn a successful binding into a silent channel response.
+            await deliverBindingPayload(targetedClaimOutcome.result.reply, "terminal");
           }
           markIdle("plugin_binding_dispatch");
           recordProcessed("completed", { reason: "plugin-bound-handled" });

--- a/src/auto-reply/reply/source-reply-delivery-mode.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.ts
@@ -27,7 +27,7 @@ export function isExplicitSourceReplyCommand(
   return isExplicitCommandTurnContext(ctx, cfg);
 }
 
-function isUnauthorizedTextSlashCommand(ctx: SourceReplyDeliveryModeContext): boolean {
+export function isUnauthorizedTextSlashCommand(ctx: SourceReplyDeliveryModeContext): boolean {
   const commandTurn = resolveCommandTurnContext(ctx);
   return (
     commandTurn.kind === "text-slash" &&


### PR DESCRIPTION
## Summary
- Deliver handled plugin-owned binding replies even when group/channel source delivery is `message_tool_only`.
- Keep automatic binding fallback, decline, error notices, ambient `room_event` plugin-binding replies, and unauthorized text-slash plugin-binding replies suppressed under `message_tool_only`.
- Add parameterized Discord channel regression coverage for Codex-owned bindings under `groupChat.visibleReplies: "message_tool"`, covering handled-without-reply routing, handled reply delivery, ambient room-event suppression, and unauthorized slash reply suppression.

## Root Cause
`message_tool_only` sets `suppressAutomaticSourceDelivery`, and the handled plugin-owned `inbound_claim` reply was sent through `sendBindingNotice()`. That helper returns before delivery when source delivery is suppressed, so a successful Codex binding turn could complete without any channel-visible reply.

## Verification
Supplemental checks:
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "unauthorized plugin-owned binding slash replies|routes plugin-owned bindings under message-tool-only source delivery"`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "source delivery|plugin-owned"`
- `node scripts/run-vitest.mjs src/auto-reply/reply/source-reply-delivery-mode.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts extensions/codex/src/commands.test.ts -t "codex-cli-node-session|bind here|inbound"`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` was not rerun after the latest slash-suppression patch because the approval layer rejected external AI-review data export; the preceding room-event patch had a clean autoreview.

## Real behavior proof
Behavior addressed: Plugin-owned Codex conversation binding replies are no longer silenced when group/channel visible replies require the message tool. This is the delivery path used by the Discord/Codex binding bug in #87721; the proof below exercises the same OpenClaw gateway reply-dispatch path with qa-channel transport.

Real environment tested: Local OpenClaw setup from this PR build, using a real gateway child process, real qa-channel transport polling the qa-lab bus, and the bundled Codex plugin loaded by the runtime. The configured provider mode was `mock-openai`, but the observed outbound was produced by the Codex plugin-owned binding hook before model dispatch; unit tests/mocks/CI are supplemental only.

Exact steps or command run after this patch: Ran an inline `node --input-type=module` proof harness from the repo root that imported `dist/extensions/qa-lab/api.js`, started `startQaBusServer()`, started `startQaGatewayChild()` with `qa-channel` and `codex` enabled, set `messages.groupChat.visibleReplies=message_tool` and `plugins.entries.codex.hooks.timeoutMs=5000`, wrote a real persisted current-conversation binding for `qa-channel/default/group:qa-bound-room` with Codex `codex-cli-node-session` data, injected a group inbound message through the qa bus, and waited for the visible outbound text `Codex CLI node turn failed: node not connected`.

Evidence after fix: Terminal transcript from that real OpenClaw setup:
```text
REAL BEHAVIOR PROOF: OpenClaw qa-channel + real gateway child + bundled Codex plugin
Gateway ready: http://127.0.0.1:58535
Initial qa-channel status: {"accountId":"default","running":true,"restartPending":false}
Post-binding qa-channel status: {"accountId":"default","running":true,"restartPending":false}
Config: messages.groupChat.visibleReplies=message_tool; plugins.entries.codex.hooks.timeoutMs=5000
Seeded binding: channel=qa-channel account=default conversation=group:qa-bound-room plugin=codex data.kind=codex-cli-node-session
Inbound: group:qa-bound-room:@openclaw prove Codex bound reply delivery under message_tool visible replies
Outbound: group:qa-bound-room:Codex CLI node turn failed: node not connected
Matching outbound count: 1
Gateway logs:
2026-05-28T20:03:52.716-07:00 [gateway] http server listening (4 plugins: acpx, codex, memory-core, qa-channel; 1.0s)
2026-05-28T20:03:56.036-07:00 [gateway] http server listening (4 plugins: acpx, codex, memory-core, qa-channel; 1.1s)
Transcript snapshot:
[
  {
    "direction": "inbound",
    "kind": "group",
    "conversationId": "qa-bound-room",
    "text": "@openclaw prove Codex bound reply delivery under message_tool visible replies"
  },
  {
    "direction": "outbound",
    "kind": "group",
    "conversationId": "qa-bound-room",
    "text": "Codex CLI node turn failed: node not connected"
  }
]
Result: PASS - the Codex-owned binding reply was delivered visibly while message_tool-only source delivery was active.
```

Observed result after fix: The real gateway loaded `acpx`, `codex`, `memory-core`, and `qa-channel`; qa-channel stayed running before and after the binding seed; a group inbound message to the bound conversation produced exactly one visible outbound reply in the same group transcript. That outbound text is the bundled Codex binding hook's real not-connected reply, which proves the fixed `handled` plugin-binding branch delivered a plugin reply under `message_tool_only` instead of silently completing the turn.

What was not tested: No live Discord bot/account or connected Codex CLI node was available in this Codex session. The real-runtime proof uses qa-channel synthetic transport rather than Discord, and the stock `group-visible-reply-tool` QA scenario used `mock-openai` for the generic message-tool group path. The regression suite remains the supplemental proof for normal-final privacy, fallback/error notice suppression, sendPolicy deny behavior, room-event suppression, and unauthorized slash reply suppression.

Fixes #87721
