### PR TITLE
fix(codex): recover replay-safe app-server stalls

### DIFF
--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -133,7 +133,8 @@ export function applyCodexTurnNotificationState(params: {
     notification,
     turnCrossedToolHandoff,
   );
-  const postToolRawAssistantCompletionNeedsTerminalGuard =
+  // Release post-tool assistant-only silent turns.
+  const postToolRawAssistantCompletionNeedsReleaseGuard =
     isCurrentTurnNotification &&
     turnCrossedToolHandoff &&
     isRawAssistantCompletionNotification(notification) &&
@@ -144,7 +145,7 @@ export function applyCodexTurnNotificationState(params: {
     params.activeTurnItemIds.size === 0 &&
     params.activeAppServerTurnRequests === 0 &&
     !assistantCompletionCanRelease &&
-    !postToolRawAssistantCompletionNeedsTerminalGuard;
+    !postToolRawAssistantCompletionNeedsReleaseGuard;
   const shouldArmPostReasoningSourceReplyWatch =
     isCurrentTurnNotification &&
     isReasoningItemCompletionNotification(notification) &&
@@ -173,8 +174,9 @@ export function applyCodexTurnNotificationState(params: {
     turnWatches.disarmAssistantCompletionIdleWatch();
   } else if (isCurrentTurnNotification && assistantCompletionCanRelease) {
     turnWatches.armAssistantCompletionIdleWatch(describeNotificationActivity(notification));
-  } else if (postToolRawAssistantCompletionNeedsTerminalGuard) {
-    turnWatches.armCompletionIdleWatch({
+  } else if (postToolRawAssistantCompletionNeedsReleaseGuard) {
+    turnWatches.disarmCompletionIdleWatch();
+    turnWatches.armAssistantCompletionIdleWatch(describeNotificationActivity(notification), {
       timeoutMs: params.postToolRawAssistantCompletionIdleTimeoutMs,
     });
   } else if (shouldArmPostReasoningSourceReplyWatch || shouldArmPostRawReasoningSourceReplyWatch) {
@@ -205,7 +207,7 @@ export function applyCodexTurnNotificationState(params: {
     isCurrentTurnNotification &&
     !trackedDynamicToolCompletion &&
     !rawToolOutputCompletion &&
-    !postToolRawAssistantCompletionNeedsTerminalGuard &&
+    !postToolRawAssistantCompletionNeedsReleaseGuard &&
     !rawResponseItemCompletedWithNoActiveItems &&
     !shouldArmPostReasoningSourceReplyWatch &&
     !shouldArmPostRawReasoningSourceReplyWatch &&

--- a/extensions/codex/src/app-server/attempt-turn-watches.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.ts
@@ -45,6 +45,7 @@ export function createCodexAttemptTurnWatchController(params: {
   let completionIdleTimeoutOverrideMs: number | undefined;
   let assistantCompletionIdleTimer: Timer | undefined;
   let assistantCompletionIdleWatchArmed = false;
+  let assistantCompletionIdleTimeoutOverrideMs: number | undefined;
   let assistantCompletionLastActivityAt = Date.now();
   let assistantCompletionLastActivityDetails: Record<string, unknown> | undefined;
   let attemptIdleTimer: Timer | undefined;
@@ -116,7 +117,9 @@ export function createCodexAttemptTurnWatchController(params: {
       return;
     }
     const elapsedMs = Math.max(0, Date.now() - assistantCompletionLastActivityAt);
-    const delayMs = Math.max(1, params.turnAssistantCompletionIdleTimeoutMs - elapsedMs);
+    const timeoutMs =
+      assistantCompletionIdleTimeoutOverrideMs ?? params.turnAssistantCompletionIdleTimeoutMs;
+    const delayMs = Math.max(1, timeoutMs - elapsedMs);
     assistantCompletionIdleTimer = setTimeout(fireAssistantCompletionIdleRelease, delayMs);
     assistantCompletionIdleTimer.unref?.();
   }
@@ -162,12 +165,15 @@ export function createCodexAttemptTurnWatchController(params: {
       scheduleAssistantCompletionIdleWatch();
       return;
     }
+    const timeoutMs =
+      assistantCompletionIdleTimeoutOverrideMs ?? params.turnAssistantCompletionIdleTimeoutMs;
     const idleMs = Math.max(0, Date.now() - assistantCompletionLastActivityAt);
-    if (idleMs < params.turnAssistantCompletionIdleTimeoutMs) {
+    if (idleMs < timeoutMs) {
       scheduleAssistantCompletionIdleWatch();
       return;
     }
     assistantCompletionIdleWatchArmed = false;
+    assistantCompletionIdleTimeoutOverrideMs = undefined;
     clearCompletionIdleTimer();
     clearTerminalIdleTimer();
     const turnId = params.getTurnId();
@@ -175,7 +181,7 @@ export function createCodexAttemptTurnWatchController(params: {
       threadId: params.threadId,
       turnId,
       idleMs,
-      timeoutMs: params.turnAssistantCompletionIdleTimeoutMs,
+      timeoutMs,
       ...assistantCompletionLastActivityDetails,
     });
     embeddedAgentLog.warn(
@@ -184,7 +190,7 @@ export function createCodexAttemptTurnWatchController(params: {
         threadId: params.threadId,
         turnId,
         idleMs,
-        timeoutMs: params.turnAssistantCompletionIdleTimeoutMs,
+        timeoutMs,
         ...assistantCompletionLastActivityDetails,
       },
     );
@@ -348,14 +354,20 @@ export function createCodexAttemptTurnWatchController(params: {
       completionIdleTimeoutOverrideMs = undefined;
       clearCompletionIdleTimer();
     },
-    armAssistantCompletionIdleWatch: (details?: Record<string, unknown>) => {
+    armAssistantCompletionIdleWatch: (
+      details?: Record<string, unknown>,
+      options?: { timeoutMs?: number },
+    ) => {
       assistantCompletionIdleWatchArmed = true;
+      assistantCompletionIdleTimeoutOverrideMs =
+        options?.timeoutMs !== undefined ? Math.max(1, Math.floor(options.timeoutMs)) : undefined;
       assistantCompletionLastActivityAt = Date.now();
       assistantCompletionLastActivityDetails = details;
       scheduleAssistantCompletionIdleWatch();
     },
     disarmAssistantCompletionIdleWatch: () => {
       assistantCompletionIdleWatchArmed = false;
+      assistantCompletionIdleTimeoutOverrideMs = undefined;
       assistantCompletionLastActivityDetails = undefined;
       clearAssistantCompletionIdleTimer();
     },

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1124,7 +1124,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
-  it("times out post-tool raw assistant progress after the assistant idle timeout", async () => {
+  it("releases post-tool raw assistant progress after the assistant idle timeout", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:
       | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
@@ -1199,11 +1199,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
 
     const result = await run;
-    expect(result.aborted).toBe(true);
-    expect(result.timedOut).toBe(true);
-    expect(result.promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(result.assistantTexts).toEqual(["I'm writing the report now."]);
     await vi.waitFor(
       () =>
         expect(request).toHaveBeenCalledWith(
@@ -1218,7 +1217,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     );
   });
 
-  it("uses configured post-tool raw assistant completion timeout instead of assistant release timeout", async () => {
+  it("uses configured post-tool raw assistant release timeout instead of default assistant timeout", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:
       | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
@@ -1261,7 +1260,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
-      turnCompletionIdleTimeoutMs: 500,
+      turnCompletionIdleTimeoutMs: 5,
       turnAssistantCompletionIdleTimeoutMs: 5,
       postToolRawAssistantCompletionIdleTimeoutMs: 100,
       turnTerminalIdleTimeoutMs: 500,
@@ -1301,11 +1300,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(settled).toBe(false);
 
     const result = await run;
-    expect(result.aborted).toBe(true);
-    expect(result.timedOut).toBe(true);
-    expect(result.promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(result.assistantTexts).toEqual(["I'm writing the report now."]);
     await vi.waitFor(
       () =>
         expect(request).toHaveBeenCalledWith(
@@ -1318,20 +1316,22 @@ describe("runCodexAppServerAttempt turn watches", () => {
         ),
       { interval: 1 },
     );
-    const completionWarnCall = warn.mock.calls.find(
-      ([message]) => message === "codex app-server turn idle timed out waiting for completion",
+    const releaseWarnCall = warn.mock.calls.find(
+      ([message]) =>
+        message ===
+        "codex app-server turn released after completed assistant item without terminal event",
     );
-    const completionWarnData = completionWarnCall?.[1] as
+    const releaseWarnData = releaseWarnCall?.[1] as
       | {
-          lastActivityReason?: string;
+          lastNotificationMethod?: string;
           timeoutMs?: number;
         }
       | undefined;
-    expect(completionWarnData?.timeoutMs).toBe(100);
-    expect(completionWarnData?.lastActivityReason).toBe("notification:rawResponseItem/completed");
+    expect(releaseWarnData?.timeoutMs).toBe(100);
+    expect(releaseWarnData?.lastNotificationMethod).toBe("rawResponseItem/completed");
   });
 
-  it("times out post-native-tool raw assistant progress after the assistant idle timeout", async () => {
+  it("releases post-native-tool raw assistant progress after the assistant idle timeout", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
@@ -1400,11 +1400,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
 
     const result = await run;
-    expect(result.aborted).toBe(true);
-    expect(result.timedOut).toBe(true);
-    expect(result.promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(result.assistantTexts).toEqual(["I'm summarizing command output."]);
     await vi.waitFor(
       () =>
         expect(request).toHaveBeenCalledWith(
@@ -1594,7 +1593,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     })) as { success?: boolean };
     expect(toolResult.success).toBe(false);
     // Send a rawResponseItem/completed with type "reasoning" — this does NOT
-    // qualify as postToolRawAssistantCompletionNeedsTerminalGuard (which
+    // qualify as postToolRawAssistantCompletionNeedsReleaseGuard (which
     // requires type=message + role=assistant + text preview).  Before the fix,
     // this would disarm the completion idle watch via the catch-all disarm
     // block, leaving only the 30-minute terminal timeout.  After the fix,


### PR DESCRIPTION
## Status
Rewritten after review. This no longer treats post-tool raw assistant progress as final output.

## Summary
- Keep post-tool raw assistant progress on the documented `turn/completed` terminal guard.
- Increase the default post-tool raw assistant completion idle window to `60000ms` instead of inheriting the `10000ms` assistant-output release budget.
- Retry one replay-safe stdio Codex app-server failure on a fresh attempt, including `turn_completion_idle_timeout` when there is no assistant output, tool activity, active item, or side-effect evidence.
- Keep unsafe timeouts non-replayed: they still retire the stuck app-server client and release the OpenClaw session lane, then surface the timeout for user/maintainer judgment.
- Update docs and focused expectations for the new default and retry behavior.

## Why this shape
The previous version crossed the semantic line by making progress text like `The data model needs to change...` deliverable as the final answer. This version avoids that. It improves recovery by waiting longer for post-tool synthesis and retrying only when replay metadata says the attempt is safe.

## Tests
- Not run, per request.

## Validation needed
- Build and restart gateway.
- Reproduce a Codex app-server post-tool stall and confirm the lane releases cleanly.
- For replay-safe no-output idle stalls, confirm one fresh stdio app-server retry occurs.