### PR TITLE
fix(feishu): preserve group route for mirrored oc replies

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -180,6 +180,33 @@ describe("feishuPlugin.pairing.notifyApproval", () => {
 });
 
 describe("feishuPlugin messaging", () => {
+  const cfg = {} as OpenClawConfig;
+
+  async function resolveRoute(params: {
+    target: string;
+    currentSessionKey?: string;
+    resolvedTarget?: {
+      kind: "user" | "group" | "channel";
+      to: string;
+      source: "directory" | "normalized";
+      display?: string;
+    };
+  }) {
+    const resolver = feishuPlugin.messaging?.resolveOutboundSessionRoute;
+    if (!resolver) {
+      throw new Error("expected Feishu outbound session route resolver");
+    }
+    return await resolver({
+      cfg,
+      channel: "feishu",
+      agentId: "main",
+      accountId: undefined,
+      target: params.target,
+      currentSessionKey: params.currentSessionKey,
+      resolvedTarget: params.resolvedTarget,
+    });
+  }
+
   it("owns sender/topic session inheritance candidates", () => {
     expect(
       feishuPlugin.messaging?.resolveSessionConversation?.({
@@ -211,6 +238,88 @@ describe("feishuPlugin messaging", () => {
       baseConversationId: "oc_group_chat",
       parentConversationCandidates: ["oc_group_chat:topic:om_topic_root", "oc_group_chat"],
     });
+  });
+
+  it("keeps ambiguous bare oc_ outbound targets direct without group context", async () => {
+    const route = await resolveRoute({ target: "oc_group_chat" });
+
+    expect(route?.chatType).toBe("direct");
+    expect(route?.sessionKey).toBe("agent:main:main");
+    expect(route?.to).toBe("oc_group_chat");
+  });
+
+  it("preserves known Feishu group identity for delivery-mirror replies to bare oc_ targets", async () => {
+    const route = await resolveRoute({
+      target: "oc_group_chat",
+      currentSessionKey: "agent:main:feishu:group:oc_group_chat",
+    });
+
+    expect(route?.chatType).toBe("group");
+    expect(route?.sessionKey).toBe("agent:main:feishu:group:oc_group_chat");
+    expect(route?.from).toBe("feishu:group:oc_group_chat");
+    expect(route?.to).toBe("oc_group_chat");
+  });
+
+  it("preserves known Feishu group identity for topic delivery-mirror replies", async () => {
+    const route = await resolveRoute({
+      target: "oc_group_chat",
+      currentSessionKey: "agent:main:feishu:group:oc_group_chat:topic:om_root:sender:ou_user",
+    });
+
+    expect(route?.chatType).toBe("group");
+    expect(route?.sessionKey).toBe("agent:main:feishu:group:oc_group_chat");
+  });
+
+  it("preserves legacy Feishu group session context for bare oc_ targets", async () => {
+    const route = await resolveRoute({
+      target: "oc_group_chat",
+      currentSessionKey: "feishu:group:oc_group_chat",
+    });
+
+    expect(route?.chatType).toBe("group");
+    expect(route?.sessionKey).toBe("agent:main:feishu:group:oc_group_chat");
+  });
+
+  it("does not borrow group identity from an unrelated Feishu group session", async () => {
+    const route = await resolveRoute({
+      target: "oc_other_chat",
+      currentSessionKey: "agent:main:feishu:group:oc_group_chat",
+    });
+
+    expect(route?.chatType).toBe("direct");
+    expect(route?.sessionKey).toBe("agent:main:main");
+  });
+
+  it("uses resolved directory group identity for bare oc_ outbound targets", async () => {
+    const route = await resolveRoute({
+      target: "oc_group_chat",
+      resolvedTarget: { kind: "group", to: "oc_group_chat", source: "directory" },
+    });
+
+    expect(route?.chatType).toBe("group");
+    expect(route?.sessionKey).toBe("agent:main:feishu:group:oc_group_chat");
+  });
+
+  it("keeps bare Feishu open IDs direct when shared routing supplies a group fallback", async () => {
+    const route = await resolveRoute({
+      target: "ou_user",
+      resolvedTarget: { kind: "group", to: "ou_user", source: "normalized" },
+    });
+
+    expect(route?.chatType).toBe("direct");
+    expect(route?.sessionKey).toBe("agent:main:main");
+    expect(route?.from).toBe("feishu:ou_user");
+  });
+
+  it("keeps bare Feishu user IDs direct when shared routing supplies a group fallback", async () => {
+    const route = await resolveRoute({
+      target: "user_123",
+      resolvedTarget: { kind: "group", to: "user_123", source: "normalized" },
+    });
+
+    expect(route?.chatType).toBe("direct");
+    expect(route?.sessionKey).toBe("agent:main:main");
+    expect(route?.from).toBe("feishu:user_123");
   });
 });
 

--- a/extensions/feishu/src/session-route.ts
+++ b/extensions/feishu/src/session-route.ts
@@ -5,6 +5,24 @@ import {
 } from "openclaw/plugin-sdk/channel-core";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+function currentSessionIsFeishuGroupForTarget(params: {
+  currentSessionKey?: string;
+  target: string;
+}): boolean {
+  const sessionKey = normalizeLowercaseStringOrEmpty(params.currentSessionKey);
+  const target = normalizeLowercaseStringOrEmpty(params.target);
+  if (!sessionKey || !target) {
+    return false;
+  }
+  const marker = `feishu:group:${target}`;
+  const markerIndex = sessionKey.startsWith(marker) ? 0 : sessionKey.indexOf(`:${marker}`) + 1;
+  if (markerIndex < 1 && !sessionKey.startsWith(marker)) {
+    return false;
+  }
+  const suffix = sessionKey.slice(markerIndex + marker.length);
+  return suffix === "" || suffix.startsWith(":");
+}
+
 export function resolveFeishuOutboundSessionRoute(params: ChannelOutboundSessionRouteParams) {
   let trimmed = stripChannelTargetPrefix(params.target, "feishu", "lark");
   if (!trimmed) {
@@ -29,6 +47,14 @@ export function resolveFeishuOutboundSessionRoute(params: ChannelOutboundSession
     const idLower = normalizeLowercaseStringOrEmpty(trimmed);
     if (idLower.startsWith("ou_") || idLower.startsWith("on_")) {
       isGroup = false;
+    } else if (
+      (params.resolvedTarget?.kind === "group" && params.resolvedTarget.source === "directory") ||
+      currentSessionIsFeishuGroupForTarget({
+        currentSessionKey: params.currentSessionKey,
+        target: trimmed,
+      })
+    ) {
+      isGroup = true;
     }
   }
 


### PR DESCRIPTION
Refs #58537. This PR fixes the normal mirrored Feishu group-reply route path, but intentionally does not auto-close the broader issue because proactive bare-target sends and duplicate-session cleanup may remain separate maintainer scope.

## Summary

- preserve Feishu group session identity when a delivery-mirror reply resolves a bare `oc_...` target from the matching current Feishu group session
- trust directory-resolved Feishu group targets when building outbound session routes
- keep ambiguous bare `oc_...` targets direct when there is no group context, preserving the existing compatibility boundary
- keep bare Feishu user/open IDs direct when shared target resolution only supplied a normalized fallback group hint

## Why this shape

`oc_...` IDs are compatibility-sensitive because prior history says they can be ambiguous. This fix does not revive the broad "all bare oc_ is group" rule. It only promotes the route to group when OpenClaw already has group evidence: either the current session key is the same Feishu group conversation, or target resolution came from a directory-backed group match. Normalized fallback hints are not trusted for group promotion, so bare Feishu user/open IDs remain direct.

## Public surface

- No config surface changes.
- No plugin public contract/API changes.
- No migration or startup reconciliation behavior added.

## Real behavior proof

Behavior addressed:
A normal Feishu group reply/delivery-mirror path can recreate a phantom `agent:main:feishu:direct:oc_...` session because the route resolver sees a bare `oc_...` target and loses the existing group identity.

Real environment tested:
WSL Ubuntu 24.04, OpenClaw checkout `/root/src/openclaw-87774-proof`, PR head `245e28e44bc3a8d7bc774690dbd2bf84212b6b12`, production Feishu channel route resolver `extensions/feishu/src/session-route.ts:resolveFeishuOutboundSessionRoute`, and focused Feishu/outbound runtime tests.

Exact steps or command run after this patch:
1. Ran a source harness through the production Feishu resolver for three redacted route/session cases: matching current Feishu group session, directory-resolved group target, and normalized fallback user target.
2. Reran focused Feishu/outbound validation: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.card-action.test.ts src/infra/outbound/outbound-session.test.ts src/config/sessions/delivery-info.test.ts --reporter=dot`.
3. Reran changed-file static checks: `CI=true pnpm exec oxfmt --check extensions/feishu/src/session-route.ts extensions/feishu/src/channel.test.ts`, `CI=true pnpm exec oxlint --tsconfig ./tsconfig.json extensions/feishu/src/session-route.ts extensions/feishu/src/channel.test.ts`, and `git diff --check`.

Evidence after fix:
```json
{
  "head": "245e28e44bc3a8d7bc774690dbd2bf84212b6b12",
  "productionResolver": "extensions/feishu/src/session-route.ts:resolveFeishuOutboundSessionRoute",
  "proof": [
    {
      "label": "matching-current-feishu-group-session",
      "input": {
        "target": "oc_group_chat",
        "currentSessionKey": "agent:main:feishu:group:oc_group_chat:topic:om_root:sender:ou_user"
      },
      "route": {
        "sessionKey": "agent:main:feishu:group:oc_group_chat",
        "baseSessionKey": "agent:main:feishu:group:oc_group_chat",
        "peer": { "kind": "group", "id": "oc_group_chat" },
        "chatType": "group",
        "from": "feishu:group:oc_group_chat",
        "to": "oc_group_chat"
      },
      "noDirectPhantomForOcGroup": true
    },
    {
      "label": "directory-resolved-group-target",
      "input": {
        "target": "oc_directory_chat",
        "resolvedTarget": { "kind": "group", "to": "oc_directory_chat", "source": "directory" }
      },
      "route": {
        "sessionKey": "agent:main:feishu:group:oc_directory_chat",
        "baseSessionKey": "agent:main:feishu:group:oc_directory_chat",
        "peer": { "kind": "group", "id": "oc_directory_chat" },
        "chatType": "group",
        "from": "feishu:group:oc_directory_chat",
        "to": "oc_directory_chat"
      },
      "noDirectPhantomForOcGroup": true
    },
    {
      "label": "normalized-fallback-user-stays-direct",
      "input": {
        "target": "ou_user",
        "resolvedTarget": { "kind": "group", "to": "ou_user", "source": "normalized" }
      },
      "route": {
        "sessionKey": "agent:main:main",
        "baseSessionKey": "agent:main:main",
        "peer": { "kind": "direct", "id": "ou_user" },
        "chatType": "direct",
        "from": "feishu:ou_user",
        "to": "ou_user"
      },
      "noDirectPhantomForOcGroup": true
    }
  ]
}
```

Observed result after fix:
The production Feishu resolver preserves `feishu:group:oc_...` session identity when the current session proves the bare `oc_...` target is the active group, and when a directory-backed target resolution proves a Feishu group. It does not promote normalized fallback user/open IDs to group routes.

Supporting checks:
- Focused Feishu/outbound Vitest passed: 5 files, 218 tests.
- Targeted `oxfmt --check` passed.
- Targeted `oxlint` passed with 0 warnings/errors.
- `git diff --check` passed.

What was not tested:
No live Feishu/Lark OpenChat account was available in this session, so this proof does not include an actual Feishu network send. Proactive context-free sends and duplicate-session cleanup remain out of scope for this PR.