### PR TITLE
ci: sparse checkout CodeQL actions security shard

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,9 +85,20 @@ jobs:
             config_file: ./.github/codeql/codeql-actions-critical-security.yml
     steps:
       - name: Checkout
+        if: ${{ matrix.category != 'actions' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: false
+
+      - name: Checkout Actions security sources
+        if: ${{ matrix.category == 'actions' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+          sparse-checkout: |
+            .github/actions
+            .github/workflows
+            .github/codeql
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4


### PR DESCRIPTION
## Summary

- Split the CodeQL security checkout path so only the `actions` shard uses a sparse checkout.
- Limit that shard to `.github/actions`, `.github/workflows`, and `.github/codeql`, which are the files needed by the Actions CodeQL config.
- Keep the 10-minute job timeout unchanged while reducing the fetch payload; `actions/checkout` applies `blob:none` automatically when sparse checkout is enabled.

## Verification

- `git diff --check`
- `ruby -ryaml -rjson -e 'doc=YAML.load_file(".github/workflows/codeql.yml"); steps=doc.fetch("jobs").fetch("security-high").fetch("steps"); puts JSON.pretty_generate(steps.select{|s| s["uses"]&.include?("actions/checkout")}.map{|s| {"name"=>s["name"],"if"=>s["if"],"sparse"=>s.dig("with","sparse-checkout")}})'`

## Real behavior proof

Behavior addressed: CodeQL `Security High (actions)` can spend the full 10-minute job budget in checkout when a PR merge-ref fetch stalls, preventing CodeQL from initializing.
Real environment tested: Local workflow-file validation in the OpenClaw repo checkout.
Exact steps or command run after this patch: `git diff --check`; YAML parse command listed above.
Evidence after fix: The workflow now has a full checkout for non-actions shards and a sparse checkout for the actions shard containing `.github/actions`, `.github/workflows`, and `.github/codeql`.
Observed result after fix: YAML parsed successfully and reported the expected sparse checkout only for the actions shard.
What was not tested: A live GitHub Actions run has not completed yet for this branch.
