### PR TITLE
Claude/llm token optimization mp g ro

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 
-**OpenClaw** is a _personal AI assistant_ you run on your own devices.
+**OpenClawMac** is a fork of [OpenClaw](https://github.com/openclaw/openclaw) — a _personal AI assistant_ you run on your own devices.
 It answers you on the channels you already use. It can speak and listen on macOS/iOS/Android, and can render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
 
 If you want a personal, single-user assistant that feels local, fast, and always-on, this is it.
@@ -94,18 +94,52 @@ Works with npm, pnpm, or bun.
 
 Model note: while many providers and models are supported, prefer a current flagship model from the provider you trust and already use. See [Onboarding](https://docs.openclaw.ai/start/wizard).
 
-## Install (recommended)
+## Install from this fork
+
+This is a personal fork. You install it by cloning the repo, building it, and then using the built package globally.
 
 Runtime: **Node 24 (recommended) or Node 22.19+**.
 
 ```bash
-npm install -g openclaw@latest
-# or: pnpm add -g openclaw@latest
+# Clone this fork
+git clone https://github.com/jeremyunck/OpenClawMac.git
+cd OpenClawMac
 
+# Install workspace dependencies (requires pnpm)
+pnpm install
+
+# Build the dist output
+pnpm build
+
+# Install the forked package globally from the local checkout
+npm install -g .
+
+# Run onboarding to set up the gateway, workspace, etc.
 openclaw onboard --install-daemon
 ```
 
 OpenClaw Onboard installs the Gateway daemon (launchd/systemd user service) so it stays running.
+
+To update from the upstream source:
+
+```bash
+cd OpenClawMac
+git pull
+pnpm install
+pnpm build
+npm install -g .
+```
+
+To pull upstream OpenClaw changes into your fork:
+
+```bash
+git remote add upstream https://github.com/openclaw/openclaw.git
+git fetch upstream
+git merge upstream/main
+pnpm install
+pnpm build
+npm install -g .
+```
 
 ## Quick start (TL;DR)
 
@@ -231,8 +265,8 @@ root is not a supported source setup.
 For the dev loop:
 
 ```bash
-git clone https://github.com/openclaw/openclaw.git
-cd openclaw
+git clone https://github.com/jeremyunck/OpenClawMac.git
+cd OpenClawMac
 
 pnpm install
 

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -53,6 +53,14 @@ for bounded runtime excerpts and injected runtime-owned blocks. They are
 separate from bootstrap limits, startup-context limits, and skills prompt
 limits.
 
+Tool schemas are a large, recurring part of the prompt for tool-rich setups
+(many plugins or MCP servers). [Tool Search](/tools/tool-search) defaults to
+auto mode: small catalogs stay fully direct, and once the eligible tool count
+reaches `tools.toolSearch.autoEnableMinTools` (default `40`) the catalog is
+compacted behind a compact search/call surface so schemas are loaded on demand
+instead of sent up front. Set `tools.toolSearch` to `true` to always compact or
+`false` to always expose tool schemas directly.
+
 `toolResultMaxChars` is an advanced ceiling. When it is unset, OpenClaw chooses
 the live tool-result cap from the effective model context window: `16000` chars
 below 100K tokens, `32000` chars at 100K+ tokens, and `64000` chars at 200K+

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -7,9 +7,15 @@ read_when:
   - You are implementing or debugging tool discovery for OpenClaw runs
 ---
 
-Tool Search is an experimental OpenClaw agent runtime feature. It gives agents one
+Tool Search is an OpenClaw agent runtime feature. It gives agents one
 compact way to discover and call large tool catalogs. It is useful when the run
 has many available tools but the model is likely to need only a few of them.
+
+By default Tool Search runs in **auto** mode: small catalogs stay fully direct
+(every schema in the prompt, no behavior change), and large catalogs compact
+automatically once the eligible tool count reaches `autoEnableMinTools`
+(default `40`). Set `tools.toolSearch` to `true` to always compact, or `false`
+to always expose tools directly.
 
 This page documents OpenClaw Tool Search. It is not the Codex-native tool
 search or dynamic-tools surface. Codex-native code mode, tool search, deferred
@@ -158,7 +164,21 @@ Normal OpenClaw behavior still applies to final calls:
 
 ## Config
 
-Enable Tool Search for OpenClaw runs with the default code bridge:
+Tool Search defaults to auto mode, so no config is required to benefit from it
+on large catalogs. Tune the auto-compaction threshold (catalog size that
+triggers compaction when `enabled` is unset):
+
+```json5
+{
+  tools: {
+    toolSearch: {
+      autoEnableMinTools: 40,
+    },
+  },
+}
+```
+
+Always compact (legacy always-on behavior) with the default code bridge:
 
 ```bash
 openclaw config set tools.toolSearch true

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -228,6 +228,8 @@ export function resolveCodeModeConfig(config?: OpenClawConfig, agentId?: string)
 function toToolSearchConfig(config: CodeModeConfig): ToolSearchConfig {
   return {
     enabled: true,
+    // Code mode always compacts when enabled; it has its own opt-in gate.
+    minCatalogTools: 0,
     mode: "tools",
     codeTimeoutMs: config.timeoutMs,
     searchDefaultLimit: config.searchDefaultLimit,

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -70,6 +70,67 @@ describe("Tool Search", () => {
     } as never);
     expect(resolved.enabled).toBe(true);
     expect(resolved.mode).toBe("tools");
+    // Pinned on (non-threshold key) keeps historical always-compact behavior.
+    expect(resolved.minCatalogTools).toBe(0);
+  });
+
+  it("defaults to auto mode with a catalog threshold when unconfigured", () => {
+    const resolved = testing.resolveToolSearchConfig(undefined);
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.minCatalogTools).toBeGreaterThan(0);
+  });
+
+  it("treats explicit enabled:true as always-compact, false as off", () => {
+    const on = testing.resolveToolSearchConfig({
+      tools: { toolSearch: { enabled: true } },
+    } as never);
+    expect(on.enabled).toBe(true);
+    expect(on.minCatalogTools).toBe(0);
+
+    const off = testing.resolveToolSearchConfig({
+      tools: { toolSearch: false },
+    } as never);
+    expect(off.enabled).toBe(false);
+  });
+
+  it("honors an explicit autoEnableMinTools threshold", () => {
+    const resolved = testing.resolveToolSearchConfig({
+      tools: { toolSearch: { autoEnableMinTools: 25 } },
+    } as never);
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.minCatalogTools).toBe(25);
+  });
+
+  it("auto mode leaves small catalogs direct and strips control tools", () => {
+    const config = { tools: { toolSearch: { autoEnableMinTools: 3 } } } as never;
+    const compacted = applyToolSearchCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode"),
+        pluginTool("fake_one", "Tool one"),
+        pluginTool("fake_two", "Tool two"),
+      ],
+      config,
+      sessionId: "session-auto-below",
+    });
+    expect(compacted.compacted).toBe(false);
+    expect(compacted.catalogToolCount).toBe(0);
+    expect(compacted.tools.map((tool) => tool.name)).toEqual(["fake_one", "fake_two"]);
+  });
+
+  it("auto mode compacts once the catalog reaches the threshold", () => {
+    const config = { tools: { toolSearch: { autoEnableMinTools: 2 } } } as never;
+    const compacted = applyToolSearchCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode"),
+        pluginTool("fake_one", "Tool one"),
+        pluginTool("fake_two", "Tool two"),
+      ],
+      config,
+      sessionId: "session-auto-above",
+    });
+    expect(compacted.compacted).toBe(true);
+    expect(compacted.catalogToolCount).toBe(2);
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME]);
   });
 
   it("falls back to structured controls when code mode is unsupported", () => {

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -35,6 +35,11 @@ const DEFAULT_CODE_TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 8;
 const DEFAULT_MAX_SEARCH_LIMIT = 20;
 const MAX_REUSABLE_CATALOG_SNAPSHOTS = 256;
+// Default catalog size at which Tool Search auto-compacts when the user has not
+// pinned tools.toolSearch on/off. Kept above the core tool count so typical
+// core-only runs stay fully direct (no behavior change); larger MCP/plugin
+// catalogs auto-compact to keep schema bytes out of the prompt.
+const DEFAULT_AUTO_ENABLE_MIN_TOOLS = 40;
 
 type ToolSearchMode = "code" | "tools";
 type CatalogSource = "openclaw" | "mcp" | "client";
@@ -71,6 +76,12 @@ export type ToolSearchConfig = {
   codeTimeoutMs: number;
   searchDefaultLimit: number;
   maxSearchLimit: number;
+  /**
+   * Minimum catalogable tool count before compaction actually runs. 0 means
+   * always compact when enabled. Used for the default "auto" mode so small
+   * catalogs stay direct while large ones compact without explicit opt-in.
+   */
+  minCatalogTools: number;
 };
 
 export type ToolSearchToolContext = {
@@ -394,10 +405,6 @@ function readToolSearchConfig(config?: OpenClawConfig): Record<string, unknown> 
   return isRecord(toolSearch) ? toolSearch : {};
 }
 
-function readBoolean(value: unknown, fallback: boolean): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
 function readInteger(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
 }
@@ -418,13 +425,29 @@ export function resolveToolSearchConfig(config?: OpenClawConfig): ToolSearchConf
     rawMode === "tools" || rawMode === "code" ? rawMode : "code";
   const mode: ToolSearchMode =
     requestedMode === "code" && !isToolSearchCodeModeSupported() ? "tools" : requestedMode;
-  const configured = Object.keys(raw).some((key) => key !== "enabled");
   const maxSearchLimit = Math.max(
     1,
     Math.min(50, readInteger(raw.maxSearchLimit, DEFAULT_MAX_SEARCH_LIMIT)),
   );
+  // Default-on: controls are available unless explicitly disabled. When the user
+  // actively pinned Tool Search on (enabled:true or any non-threshold key) keep
+  // the historical always-compact behavior (threshold 0) unless they also set an
+  // explicit autoEnableMinTools. With no config, auto-compact only above the
+  // default threshold so small core-only runs stay fully direct.
+  const explicitlyOff = raw.enabled === false;
+  const pinnedOn =
+    raw.enabled === true ||
+    Object.keys(raw).some((key) => key !== "enabled" && key !== "autoEnableMinTools");
+  const thresholdConfigured =
+    typeof raw.autoEnableMinTools === "number" &&
+    Number.isInteger(raw.autoEnableMinTools) &&
+    raw.autoEnableMinTools > 0;
+  const autoEnableMinTools = thresholdConfigured
+    ? (raw.autoEnableMinTools as number)
+    : DEFAULT_AUTO_ENABLE_MIN_TOOLS;
+  const minCatalogTools = pinnedOn && !thresholdConfigured ? 0 : autoEnableMinTools;
   return {
-    enabled: readBoolean(raw.enabled, configured),
+    enabled: !explicitlyOff,
     mode,
     codeTimeoutMs: Math.max(
       1000,
@@ -435,6 +458,7 @@ export function resolveToolSearchConfig(config?: OpenClawConfig): ToolSearchConf
       Math.min(maxSearchLimit, readInteger(raw.searchDefaultLimit, DEFAULT_SEARCH_LIMIT)),
     ),
     maxSearchLimit,
+    minCatalogTools,
   };
 }
 
@@ -831,6 +855,7 @@ export function applyToolSearchCatalog(params: {
   return applyToolCatalogCompaction({
     ...params,
     enabled: config.enabled,
+    minCatalogTools: config.minCatalogTools,
     isVisibleControlTool: (tool) =>
       TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name) &&
       shouldExposeControlTool(tool.name, config.mode),
@@ -1149,6 +1174,8 @@ export class ToolSearchRuntime {
 export function applyToolCatalogCompaction(params: {
   tools: AnyAgentTool[];
   enabled: boolean;
+  /** Minimum catalogable tools before compaction runs. Defaults to 0 (always). */
+  minCatalogTools?: number;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
@@ -1201,6 +1228,19 @@ export function applyToolCatalogCompaction(params: {
       continue;
     }
     visible.push(tool);
+  }
+  // Auto mode: below the threshold, leave the catalog direct so small tool sets
+  // keep full schemas. Strip only the control tools so they never leak as bare
+  // no-op tools when nothing was compacted.
+  const minCatalogTools = params.minCatalogTools ?? 0;
+  if (catalog.length < minCatalogTools) {
+    return {
+      tools: params.tools.filter((tool) => !TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name)),
+      compacted: false,
+      catalogToolCount: 0,
+      catalogRegistered: false,
+      catalogReused: false,
+    };
   }
   const incomingFingerprint = catalogEntriesFingerprint(catalog);
   const existingCatalog =

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -426,9 +426,11 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.experimental.planTool":
     "Enable the experimental structured `update_plan` tool for non-trivial multi-step work tracking. Leave this off unless you explicitly want the tool outside strict-agentic embedded OpenClaw runs.",
   "tools.toolSearch":
-    "Compact large OpenClaw, MCP, and client tool catalogs behind one search/call surface. Set to true for the default code bridge or use the object form to choose the structured fallback.",
+    "Compact large OpenClaw, MCP, and client tool catalogs behind one search/call surface. Defaults to auto: small catalogs stay direct and large ones (>= `autoEnableMinTools`) compact automatically. Set to true to always compact, false to disable.",
   "tools.toolSearch.enabled":
-    "Enables Tool Search. When on, OpenClaw hides large tool catalogs behind `tool_search_code` or structured search/describe/call tools during embedded runtime runs.",
+    "Enables Tool Search. Leave unset for auto mode (compact only once the catalog reaches `autoEnableMinTools`). Set true to always compact, false to always expose tools directly.",
+  "tools.toolSearch.autoEnableMinTools":
+    "In auto mode (when `enabled` is unset), the catalog size at which Tool Search starts compacting tools behind the search surface. Default: 40. Ignored when `enabled` is set true or false.",
   "tools.toolSearch.mode":
     'Choose the model-facing surface: "code" exposes `tool_search_code`; "tools" exposes structured search/describe/call fallback tools.',
   "tools.toolSearch.codeTimeoutMs":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -247,6 +247,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.experimental.planTool": "Enable Structured Plan Tool",
   "tools.toolSearch": "Tool Search",
   "tools.toolSearch.enabled": "Enable Tool Search",
+  "tools.toolSearch.autoEnableMinTools": "Tool Search Auto Threshold",
   "tools.toolSearch.mode": "Tool Search Surface",
   "tools.toolSearch.codeTimeoutMs": "Tool Search Code Timeout",
   "tools.toolSearch.searchDefaultLimit": "Tool Search Default Results",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -193,8 +193,17 @@ export type ToolLoopDetectionConfig = {
 export type ToolSearchConfig =
   | boolean
   | {
-      /** Enable compact search/call cataloging for large tool sets. */
+      /**
+       * Enable compact search/call cataloging for large tool sets. Unset means
+       * auto: compact only when the catalog reaches `autoEnableMinTools`. Set
+       * `true` to always compact, `false` to always expose tools directly.
+       */
       enabled?: boolean;
+      /**
+       * Catalog size that triggers auto-compaction when `enabled` is unset.
+       * Default: 40. Ignored when `enabled` is explicitly true or false.
+       */
+      autoEnableMinTools?: number;
       /** Exposed model surface. "code" exposes tool_search_code; "tools" exposes structured fallback tools. */
       mode?: "code" | "tools";
       /** Timeout in milliseconds for one tool_search_code execution. Runtime clamps to 1s..60s. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -648,6 +648,7 @@ const ToolSearchSchema = z
     z
       .object({
         enabled: z.boolean().optional(),
+        autoEnableMinTools: z.number().int().positive().optional(),
         mode: z.enum(["code", "tools"]).optional(),
         codeTimeoutMs: z.number().int().positive().optional(),
         searchDefaultLimit: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

What problem does this PR solve?


Why does this matter now?


What is the intended outcome?


What is intentionally out of scope?


What does success look like?


What should reviewers focus on?

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
- Real environment tested:
- Exact steps or command run after this patch:
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
- Observed result after fix:
- What was not tested:
- Proof limitations or environment constraints:
- Before evidence (optional but encouraged):

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?


What regression coverage was added or updated?


What failed before this fix, if known?


If no test was added, why not?

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)


Did config, environment, or migration behavior change? (`Yes/No`)


Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)


What is the highest-risk area?


How is that risk mitigated?

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?


What is still waiting on author, maintainer, CI, or external proof?


Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
