### PR TITLE
[codex] Add Speakeasy Telegram voice button

### DIFF
--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -28,6 +28,7 @@ import { createNativeTelegramToolProgressDraft } from "./native-tool-progress-dr
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { editMessageTelegram } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
+import { generateSpeakeasyVoiceNote } from "./speakeasy-voice.js";
 
 export type TelegramBotDeps = {
   getRuntimeConfig: typeof getRuntimeConfig;
@@ -57,6 +58,7 @@ export type TelegramBotDeps = {
   editMessageTelegram?: typeof editMessageTelegram;
   recordOutboundMessageForPromptContext?: typeof recordOutboundMessageForPromptContext;
   createChannelMessageReplyPipeline?: typeof createChannelMessageReplyPipeline;
+  generateSpeakeasyVoiceNote?: typeof generateSpeakeasyVoiceNote;
 };
 
 export const defaultTelegramBotDeps: TelegramBotDeps = {
@@ -140,5 +142,8 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get createChannelMessageReplyPipeline() {
     return createChannelMessageReplyPipeline;
+  },
+  get generateSpeakeasyVoiceNote() {
+    return generateSpeakeasyVoiceNote;
   },
 };

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2186,7 +2186,7 @@ export const registerTelegramHandlers = ({
             chatId: String(chatId),
           });
         } catch (err) {
-          logVerbose(`Speakeasy voice reservation failed: ${err}`);
+          logVerbose(`Speakeasy voice reservation failed: ${String(err)}`);
           await answerSpeakeasyCallback("Voice note is temporarily unavailable. Please try again.");
           return;
         }

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2178,11 +2178,18 @@ export const registerTelegramHandlers = ({
         callbackThreadId != null ? `${chatId}:topic:${callbackThreadId}` : String(chatId);
       const runtimeCfg = telegramDeps.getRuntimeConfig();
       if (isSpeakeasyVoiceCallback) {
-        const reserved = reserveSpeakeasyVoiceGeneration({
-          cfg: runtimeCfg,
-          data,
-          chatId: String(chatId),
-        });
+        let reserved: ReturnType<typeof reserveSpeakeasyVoiceGeneration>;
+        try {
+          reserved = reserveSpeakeasyVoiceGeneration({
+            cfg: runtimeCfg,
+            data,
+            chatId: String(chatId),
+          });
+        } catch (err) {
+          logVerbose(`Speakeasy voice reservation failed: ${err}`);
+          await answerSpeakeasyCallback("Voice note is temporarily unavailable. Please try again.");
+          return;
+        }
         if (!reserved.ok) {
           await answerSpeakeasyCallback(
             reserved.reason === "disabled"

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,5 +1,5 @@
 // Telegram plugin module implements bot handlers behavior.
-import { rm } from "node:fs/promises";
+import { unlink } from "node:fs/promises";
 import { InputFile } from "grammy";
 import type { Message, ReactionTypeEmoji } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -165,11 +165,13 @@ function isTelegramVoiceMessagesForbidden(err: unknown): boolean {
   return formatErrorMessage(err).includes(VOICE_MESSAGES_FORBIDDEN_MARKER);
 }
 
-async function cleanupSpeakeasyGeneratedAudio(audioPath: string): Promise<void> {
+async function cleanupSpeakeasyAudioPath(audioPath: string): Promise<void> {
   try {
-    await rm(audioPath, { force: true });
+    await unlink(audioPath);
   } catch (err) {
-    logVerbose(`telegram speakeasy audio cleanup failed: ${String(err)}`);
+    if (!err || typeof err !== "object" || !("code" in err) || err.code !== "ENOENT") {
+      logVerbose(`telegram speakeasy audio cleanup failed: ${String(err)}`);
+    }
   }
 }
 
@@ -2249,7 +2251,6 @@ export const registerTelegramHandlers = ({
                 ...effectiveParams,
               }),
           });
-          await cleanupSpeakeasyGeneratedAudio(audioPath);
         } catch (err) {
           if (isTelegramVoiceMessagesForbidden(err)) {
             logVerbose(
@@ -2273,6 +2274,8 @@ export const registerTelegramHandlers = ({
             return;
           }
           throw new TelegramRetryableCallbackError(err);
+        } finally {
+          await cleanupSpeakeasyAudioPath(audioPath);
         }
         return;
       }

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,4 +1,5 @@
 // Telegram plugin module implements bot handlers behavior.
+import { rm } from "node:fs/promises";
 import { InputFile } from "grammy";
 import type { Message, ReactionTypeEmoji } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -162,6 +163,14 @@ const SPEAKEASY_VOICE_FALLBACK_TEXT =
 
 function isTelegramVoiceMessagesForbidden(err: unknown): boolean {
   return formatErrorMessage(err).includes(VOICE_MESSAGES_FORBIDDEN_MARKER);
+}
+
+async function cleanupSpeakeasyGeneratedAudio(audioPath: string): Promise<void> {
+  try {
+    await rm(audioPath, { force: true });
+  } catch (err) {
+    logVerbose(`telegram speakeasy audio cleanup failed: ${String(err)}`);
+  }
 }
 
 export const registerTelegramHandlers = ({
@@ -2240,6 +2249,7 @@ export const registerTelegramHandlers = ({
                 ...effectiveParams,
               }),
           });
+          await cleanupSpeakeasyGeneratedAudio(audioPath);
         } catch (err) {
           if (isTelegramVoiceMessagesForbidden(err)) {
             logVerbose(

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,4 +1,5 @@
 // Telegram plugin module implements bot handlers behavior.
+import { InputFile } from "grammy";
 import type { Message, ReactionTypeEmoji } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
@@ -145,6 +146,15 @@ import {
 } from "./model-buttons.js";
 import { parseTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
 import { buildInlineKeyboard } from "./send.js";
+import {
+  generateSpeakeasyVoiceNote,
+  isSpeakeasyVoiceCallbackData,
+  loadSpeakeasyCache,
+  markSpeakeasyVoiceGenerated,
+  resolveSpeakeasyCachedText,
+  shouldAllowSpeakeasyVoiceGeneration,
+  writeSpeakeasyCache,
+} from "./speakeasy-voice.js";
 
 export const registerTelegramHandlers = ({
   cfg,
@@ -2200,6 +2210,75 @@ export const registerTelegramHandlers = ({
         },
       });
       if (pluginCallback.handled) {
+        return;
+      }
+
+      if (isSpeakeasyVoiceCallbackData(data)) {
+        const cache = loadSpeakeasyCache(runtimeCfg);
+        const resolved = resolveSpeakeasyCachedText({
+          cfg: runtimeCfg,
+          cache,
+          data,
+          chatId: String(chatId),
+        });
+        writeSpeakeasyCache(runtimeCfg, cache);
+        if (!resolved.ok) {
+          await bot.api
+            .answerCallbackQuery(callback.id, {
+              text:
+                resolved.reason === "disabled"
+                  ? "Voice note is not enabled here."
+                  : "Voice note expired. Ask Nox to resend it.",
+              show_alert: false,
+            })
+            .catch(() => {});
+          return;
+        }
+        if (!shouldAllowSpeakeasyVoiceGeneration({ cache, chatId: String(chatId) })) {
+          await bot.api
+            .answerCallbackQuery(callback.id, {
+              text: "Daily voice-note tap limit reached.",
+              show_alert: false,
+            })
+            .catch(() => {});
+          return;
+        }
+        let audioPath: string;
+        try {
+          await bot.api
+            .answerCallbackQuery(callback.id, {
+              text: "Generating voice note…",
+              show_alert: false,
+            })
+            .catch(() => {});
+          audioPath = await (telegramDeps.generateSpeakeasyVoiceNote ?? generateSpeakeasyVoiceNote)(
+            {
+              cfg: runtimeCfg,
+              text: resolved.text,
+            },
+          );
+        } catch (err) {
+          logVerbose(`telegram speakeasy TTS failed: ${String(err)}`);
+          throw new TelegramRetryableCallbackError(err);
+        }
+        try {
+          await withTelegramApiErrorLogging({
+            operation: "sendVoice",
+            runtime,
+            fn: () =>
+              bot.api.sendVoice(callbackMessage.chat.id, new InputFile(audioPath), {
+                ...(messageThreadId != null ? { message_thread_id: messageThreadId } : {}),
+                reply_parameters: {
+                  message_id: callbackMessage.message_id,
+                  allow_sending_without_reply: true,
+                },
+              }),
+          });
+        } catch (err) {
+          throw new TelegramRetryableCallbackError(err);
+        }
+        markSpeakeasyVoiceGenerated({ cache, chatId: String(chatId) });
+        writeSpeakeasyCache(runtimeCfg, cache);
         return;
       }
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -41,6 +41,7 @@ import {
   resolveSessionStoreEntry,
   updateSessionStore,
 } from "openclaw/plugin-sdk/session-store-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
 import { resolveTelegramMediaRuntimeOptions } from "./accounts.js";
@@ -80,6 +81,7 @@ import {
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.resolve-media.js";
+import { sendTelegramWithThreadFallback } from "./bot/delivery.send.js";
 import {
   getTelegramTextParts,
   hasBotMention,
@@ -147,14 +149,20 @@ import {
 import { parseTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
 import { buildInlineKeyboard } from "./send.js";
 import {
+  assertSpeakeasyVoiceNoteOutputPath,
   generateSpeakeasyVoiceNote,
   isSpeakeasyVoiceCallbackData,
-  loadSpeakeasyCache,
-  markSpeakeasyVoiceGenerated,
-  resolveSpeakeasyCachedText,
-  shouldAllowSpeakeasyVoiceGeneration,
-  writeSpeakeasyCache,
+  releaseSpeakeasyVoiceGenerationReservation,
+  reserveSpeakeasyVoiceGeneration,
 } from "./speakeasy-voice.js";
+
+const VOICE_MESSAGES_FORBIDDEN_MARKER = "VOICE_MESSAGES_FORBIDDEN";
+const SPEAKEASY_VOICE_FALLBACK_TEXT =
+  "Telegram could not deliver that voice note. The original text is still available above.";
+
+function isTelegramVoiceMessagesForbidden(err: unknown): boolean {
+  return formatErrorMessage(err).includes(VOICE_MESSAGES_FORBIDDEN_MARKER);
+}
 
 export const registerTelegramHandlers = ({
   cfg,
@@ -1968,20 +1976,34 @@ export const registerTelegramHandlers = ({
     if (shouldSkipUpdate(ctx)) {
       return;
     }
+    const data = (callback.data ?? "").trim();
+    const callbackMessage = callback.message;
+    const isSpeakeasyVoiceCallback = isSpeakeasyVoiceCallbackData(data);
     const answerCallbackQuery =
       typeof (ctx as { answerCallbackQuery?: unknown }).answerCallbackQuery === "function"
         ? () => ctx.answerCallbackQuery()
         : () => bot.api.answerCallbackQuery(callback.id);
-    // Answer immediately to prevent Telegram from retrying while we process
-    await withTelegramApiErrorLogging({
-      operation: "answerCallbackQuery",
-      runtime,
-      fn: answerCallbackQuery,
-    }).catch(() => {});
+    const answerSpeakeasyCallback = async (text: string) => {
+      await bot.api
+        .answerCallbackQuery(callback.id, {
+          text,
+          show_alert: false,
+        })
+        .catch(() => {});
+    };
+    if (!isSpeakeasyVoiceCallback) {
+      // Answer immediately to prevent Telegram from retrying while we process.
+      await withTelegramApiErrorLogging({
+        operation: "answerCallbackQuery",
+        runtime,
+        fn: answerCallbackQuery,
+      }).catch(() => {});
+    }
     try {
-      const data = (callback.data ?? "").trim();
-      const callbackMessage = callback.message;
       if (!data || !callbackMessage) {
+        if (isSpeakeasyVoiceCallback) {
+          await answerSpeakeasyCallback("Voice note expired. Ask the assistant to resend it.");
+        }
         return;
       }
       const editCallbackMessage = async (
@@ -2083,12 +2105,21 @@ export const registerTelegramHandlers = ({
         });
       if (!execApprovalButtonsEnabled) {
         if (inlineButtonsScope === "off") {
+          if (isSpeakeasyVoiceCallback) {
+            await answerSpeakeasyCallback("Voice note is not enabled here.");
+          }
           return;
         }
         if (inlineButtonsScope === "dm" && isGroup) {
+          if (isSpeakeasyVoiceCallback) {
+            await answerSpeakeasyCallback("Voice note is not enabled here.");
+          }
           return;
         }
         if (inlineButtonsScope === "group" && !isGroup) {
+          if (isSpeakeasyVoiceCallback) {
+            await answerSpeakeasyCallback("Voice note is not enabled here.");
+          }
           return;
         }
       }
@@ -2117,6 +2148,9 @@ export const registerTelegramHandlers = ({
         logVerbose(
           `Blocked telegram callback in DM ${chatId}: requireTopic=true but no topic present`,
         );
+        if (isSpeakeasyVoiceCallback) {
+          await answerSpeakeasyCallback("Voice note is not enabled here.");
+        }
         return;
       }
       const authorizationMode: TelegramEventAuthorizationMode =
@@ -2133,12 +2167,98 @@ export const registerTelegramHandlers = ({
         context: eventAuthContext,
       });
       if (!senderAuthorization) {
+        if (isSpeakeasyVoiceCallback) {
+          await answerSpeakeasyCallback("Voice note is not enabled for this sender.");
+        }
         return;
       }
 
       const callbackThreadId = resolvedThreadId ?? dmThreadId;
       const callbackConversationId =
         callbackThreadId != null ? `${chatId}:topic:${callbackThreadId}` : String(chatId);
+      const runtimeCfg = telegramDeps.getRuntimeConfig();
+      if (isSpeakeasyVoiceCallback) {
+        const reserved = reserveSpeakeasyVoiceGeneration({
+          cfg: runtimeCfg,
+          data,
+          chatId: String(chatId),
+        });
+        if (!reserved.ok) {
+          await answerSpeakeasyCallback(
+            reserved.reason === "disabled"
+              ? "Voice note is not enabled here."
+              : reserved.reason === "limit"
+                ? "Daily voice-note tap limit reached."
+                : "Voice note expired. Ask the assistant to resend it.",
+          );
+          return;
+        }
+        let audioPath: string;
+        try {
+          await answerSpeakeasyCallback("Generating voice note…");
+          audioPath = await (telegramDeps.generateSpeakeasyVoiceNote ?? generateSpeakeasyVoiceNote)(
+            {
+              cfg: runtimeCfg,
+              text: reserved.text,
+            },
+          );
+          assertSpeakeasyVoiceNoteOutputPath(audioPath);
+        } catch (err) {
+          try {
+            releaseSpeakeasyVoiceGenerationReservation({
+              cfg: runtimeCfg,
+              chatId: String(chatId),
+            });
+          } catch (rollbackErr) {
+            logVerbose(`telegram speakeasy quota rollback failed: ${String(rollbackErr)}`);
+          }
+          logVerbose(`telegram speakeasy TTS failed: ${String(err)}`);
+          throw new TelegramRetryableCallbackError(err);
+        }
+        try {
+          const requestParams = {
+            ...(messageThreadId != null ? { message_thread_id: messageThreadId } : {}),
+            reply_parameters: {
+              message_id: callbackMessage.message_id,
+              allow_sending_without_reply: true,
+            },
+          };
+          await sendTelegramWithThreadFallback({
+            operation: "sendVoice",
+            runtime,
+            requestParams,
+            shouldLog: (err) => !isTelegramVoiceMessagesForbidden(err),
+            send: (effectiveParams) =>
+              bot.api.sendVoice(callbackMessage.chat.id, new InputFile(audioPath), {
+                ...effectiveParams,
+              }),
+          });
+        } catch (err) {
+          if (isTelegramVoiceMessagesForbidden(err)) {
+            logVerbose(
+              "telegram speakeasy sendVoice forbidden (recipient has voice messages blocked); falling back to text",
+            );
+            await sendTelegramWithThreadFallback({
+              operation: "sendMessage",
+              runtime,
+              requestParams: {
+                ...(messageThreadId != null ? { message_thread_id: messageThreadId } : {}),
+                reply_parameters: {
+                  message_id: callbackMessage.message_id,
+                  allow_sending_without_reply: true,
+                },
+              },
+              send: (effectiveParams) =>
+                bot.api.sendMessage(callbackMessage.chat.id, SPEAKEASY_VOICE_FALLBACK_TEXT, {
+                  ...effectiveParams,
+                }),
+            });
+            return;
+          }
+          throw new TelegramRetryableCallbackError(err);
+        }
+        return;
+      }
       const pluginBindingApproval = parsePluginBindingApprovalCustomId(data);
       if (pluginBindingApproval) {
         let resolved: Awaited<ReturnType<typeof resolvePluginConversationBindingApproval>>;
@@ -2155,7 +2275,6 @@ export const registerTelegramHandlers = ({
         await replyToCallbackChat(buildPluginBindingResolvedText(resolved));
         return;
       }
-      const runtimeCfg = telegramDeps.getRuntimeConfig();
       const pluginCallback = await dispatchTelegramPluginInteractiveHandler({
         data: pluginCallbackData,
         callbackId: callback.id,
@@ -2210,75 +2329,6 @@ export const registerTelegramHandlers = ({
         },
       });
       if (pluginCallback.handled) {
-        return;
-      }
-
-      if (isSpeakeasyVoiceCallbackData(data)) {
-        const cache = loadSpeakeasyCache(runtimeCfg);
-        const resolved = resolveSpeakeasyCachedText({
-          cfg: runtimeCfg,
-          cache,
-          data,
-          chatId: String(chatId),
-        });
-        writeSpeakeasyCache(runtimeCfg, cache);
-        if (!resolved.ok) {
-          await bot.api
-            .answerCallbackQuery(callback.id, {
-              text:
-                resolved.reason === "disabled"
-                  ? "Voice note is not enabled here."
-                  : "Voice note expired. Ask Nox to resend it.",
-              show_alert: false,
-            })
-            .catch(() => {});
-          return;
-        }
-        if (!shouldAllowSpeakeasyVoiceGeneration({ cache, chatId: String(chatId) })) {
-          await bot.api
-            .answerCallbackQuery(callback.id, {
-              text: "Daily voice-note tap limit reached.",
-              show_alert: false,
-            })
-            .catch(() => {});
-          return;
-        }
-        let audioPath: string;
-        try {
-          await bot.api
-            .answerCallbackQuery(callback.id, {
-              text: "Generating voice note…",
-              show_alert: false,
-            })
-            .catch(() => {});
-          audioPath = await (telegramDeps.generateSpeakeasyVoiceNote ?? generateSpeakeasyVoiceNote)(
-            {
-              cfg: runtimeCfg,
-              text: resolved.text,
-            },
-          );
-        } catch (err) {
-          logVerbose(`telegram speakeasy TTS failed: ${String(err)}`);
-          throw new TelegramRetryableCallbackError(err);
-        }
-        try {
-          await withTelegramApiErrorLogging({
-            operation: "sendVoice",
-            runtime,
-            fn: () =>
-              bot.api.sendVoice(callbackMessage.chat.id, new InputFile(audioPath), {
-                ...(messageThreadId != null ? { message_thread_id: messageThreadId } : {}),
-                reply_parameters: {
-                  message_id: callbackMessage.message_id,
-                  allow_sending_without_reply: true,
-                },
-              }),
-          });
-        } catch (err) {
-          throw new TelegramRetryableCallbackError(err);
-        }
-        markSpeakeasyVoiceGenerated({ cache, chatId: String(chatId) });
-        writeSpeakeasyCache(runtimeCfg, cache);
         return;
       }
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -150,9 +150,9 @@ import {
 import { parseTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
 import { buildInlineKeyboard } from "./send.js";
 import {
-  assertSpeakeasyVoiceNoteOutputPath,
   generateSpeakeasyVoiceNote,
   isSpeakeasyVoiceCallbackData,
+  prepareSpeakeasyGeneratedVoiceNoteOutput,
   releaseSpeakeasyVoiceGenerationReservation,
   reserveSpeakeasyVoiceGeneration,
 } from "./speakeasy-voice.js";
@@ -2220,7 +2220,10 @@ export const registerTelegramHandlers = ({
               text: reserved.text,
             },
           );
-          assertSpeakeasyVoiceNoteOutputPath(audioPath);
+          audioPath = prepareSpeakeasyGeneratedVoiceNoteOutput({
+            cfg: runtimeCfg,
+            outputPath: audioPath,
+          });
         } catch (err) {
           try {
             releaseSpeakeasyVoiceGenerationReservation({
@@ -2256,21 +2259,33 @@ export const registerTelegramHandlers = ({
             logVerbose(
               "telegram speakeasy sendVoice forbidden (recipient has voice messages blocked); falling back to text",
             );
-            await sendTelegramWithThreadFallback({
-              operation: "sendMessage",
-              runtime,
-              requestParams: {
-                ...(messageThreadId != null ? { message_thread_id: messageThreadId } : {}),
-                reply_parameters: {
-                  message_id: callbackMessage.message_id,
-                  allow_sending_without_reply: true,
+            try {
+              await sendTelegramWithThreadFallback({
+                operation: "sendMessage",
+                runtime,
+                requestParams: {
+                  ...(messageThreadId != null ? { message_thread_id: messageThreadId } : {}),
+                  reply_parameters: {
+                    message_id: callbackMessage.message_id,
+                    allow_sending_without_reply: true,
+                  },
                 },
-              },
-              send: (effectiveParams) =>
-                bot.api.sendMessage(callbackMessage.chat.id, SPEAKEASY_VOICE_FALLBACK_TEXT, {
-                  ...effectiveParams,
-                }),
-            });
+                send: (effectiveParams) =>
+                  bot.api.sendMessage(callbackMessage.chat.id, SPEAKEASY_VOICE_FALLBACK_TEXT, {
+                    ...effectiveParams,
+                  }),
+              });
+            } catch (fallbackErr) {
+              try {
+                releaseSpeakeasyVoiceGenerationReservation({
+                  cfg: runtimeCfg,
+                  chatId: String(chatId),
+                });
+              } catch (rollbackErr) {
+                logVerbose(`telegram speakeasy quota rollback failed: ${String(rollbackErr)}`);
+              }
+              throw new TelegramRetryableCallbackError(fallbackErr);
+            }
             return;
           }
           throw new TelegramRetryableCallbackError(err);

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -276,6 +276,10 @@ const execApprovalHoisted = vi.hoisted(() => ({
   resolveExecApprovalSpy: vi.fn(async () => undefined),
 }));
 export const resolveExecApprovalSpy = execApprovalHoisted.resolveExecApprovalSpy;
+const speakeasyVoiceHoisted = vi.hoisted(() => ({
+  generateSpeakeasyVoiceNoteSpy: vi.fn(async () => "/tmp/speakeasy.mp3"),
+}));
+export const generateSpeakeasyVoiceNoteSpy = speakeasyVoiceHoisted.generateSpeakeasyVoiceNoteSpy;
 
 const sentMessageCacheHoisted = vi.hoisted(() => ({
   wasSentByBot: vi.fn(() => false),
@@ -312,6 +316,7 @@ const grammySpies = vi.hoisted(() => ({
   })) as AnyAsyncMock,
   getChatSpy: vi.fn(async () => undefined) as AnyAsyncMock,
   sendMessageSpy: vi.fn(async () => ({ message_id: 77 })) as AnyAsyncMock,
+  sendVoiceSpy: vi.fn(async () => ({ message_id: 80 })) as AnyAsyncMock,
   sendAnimationSpy: vi.fn(async () => ({ message_id: 78 })) as AnyAsyncMock,
   sendPhotoSpy: vi.fn(async () => ({ message_id: 79 })) as AnyAsyncMock,
   getFileSpy: vi.fn(async () => ({ file_path: "media/file.jpg" })) as AnyAsyncMock,
@@ -334,6 +339,7 @@ export const setMyCommandsSpy: AnyAsyncMock = grammySpies.setMyCommandsSpy;
 export const getMeSpy: AnyAsyncMock = grammySpies.getMeSpy;
 export const getChatSpy: AnyAsyncMock = grammySpies.getChatSpy;
 export const sendMessageSpy: AnyAsyncMock = grammySpies.sendMessageSpy;
+export const sendVoiceSpy: AnyAsyncMock = grammySpies.sendVoiceSpy;
 export const sendAnimationSpy: AnyAsyncMock = grammySpies.sendAnimationSpy;
 export const sendPhotoSpy: AnyAsyncMock = grammySpies.sendPhotoSpy;
 export const getFileSpy: AnyAsyncMock = grammySpies.getFileSpy;
@@ -363,6 +369,7 @@ export const telegramBotRuntimeForTest: TelegramBotRuntimeForTest = {
       getMe: grammySpies.getMeSpy,
       getChat: grammySpies.getChatSpy,
       sendMessage: grammySpies.sendMessageSpy,
+      sendVoice: grammySpies.sendVoiceSpy,
       sendAnimation: grammySpies.sendAnimationSpy,
       sendPhoto: grammySpies.sendPhotoSpy,
       getFile: grammySpies.getFileSpy,
@@ -420,6 +427,9 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
   wasSentByBot: wasSentByBot as TelegramBotDeps["wasSentByBot"],
   resolveExecApproval: resolveExecApprovalSpy as NonNullable<
     TelegramBotDeps["resolveExecApproval"]
+  >,
+  generateSpeakeasyVoiceNote: generateSpeakeasyVoiceNoteSpy as NonNullable<
+    TelegramBotDeps["generateSpeakeasyVoiceNote"]
   >,
 };
 
@@ -537,6 +547,8 @@ beforeEach(() => {
   });
   resolveExecApprovalSpy.mockReset();
   resolveExecApprovalSpy.mockResolvedValue(undefined);
+  generateSpeakeasyVoiceNoteSpy.mockReset();
+  generateSpeakeasyVoiceNoteSpy.mockResolvedValue("/tmp/speakeasy.mp3");
   dispatchReplyWithBufferedBlockDispatcher.mockReset();
   dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
     async (params: DispatchReplyHarnessParams) =>
@@ -555,6 +567,8 @@ beforeEach(() => {
   sendPhotoSpy.mockResolvedValue({ message_id: 79 });
   sendMessageSpy.mockReset();
   sendMessageSpy.mockResolvedValue({ message_id: 77 });
+  sendVoiceSpy.mockReset();
+  sendVoiceSpy.mockResolvedValue({ message_id: 80 });
   getFileSpy.mockReset();
   getFileSpy.mockResolvedValue({ file_path: "media/file.jpg" });
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -277,7 +277,7 @@ const execApprovalHoisted = vi.hoisted(() => ({
 }));
 export const resolveExecApprovalSpy = execApprovalHoisted.resolveExecApprovalSpy;
 const speakeasyVoiceHoisted = vi.hoisted(() => ({
-  generateSpeakeasyVoiceNoteSpy: vi.fn(async () => "/tmp/speakeasy.mp3"),
+  generateSpeakeasyVoiceNoteSpy: vi.fn(async () => "/tmp/speakeasy.ogg"),
 }));
 export const generateSpeakeasyVoiceNoteSpy = speakeasyVoiceHoisted.generateSpeakeasyVoiceNoteSpy;
 
@@ -548,7 +548,7 @@ beforeEach(() => {
   resolveExecApprovalSpy.mockReset();
   resolveExecApprovalSpy.mockResolvedValue(undefined);
   generateSpeakeasyVoiceNoteSpy.mockReset();
-  generateSpeakeasyVoiceNoteSpy.mockResolvedValue("/tmp/speakeasy.mp3");
+  generateSpeakeasyVoiceNoteSpy.mockResolvedValue("/tmp/speakeasy.ogg");
   dispatchReplyWithBufferedBlockDispatcher.mockReset();
   dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
     async (params: DispatchReplyHarnessParams) =>

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -2,11 +2,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import {
-  escapeRegExp,
-  formatEnvelopeTimestamp,
-  stripAnsi,
-} from "openclaw/plugin-sdk/channel-test-helpers";
+import { escapeRegExp, formatEnvelopeTimestamp } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { TelegramGroupConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1366,6 +1366,51 @@ describe("createTelegramBot", () => {
       await rm(workspaceDir, { recursive: true, force: true });
     }
   });
+  it("answers Speakeasy reservation failures before leaving the callback", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    await writeFile(path.join(workspaceDir, "state"), "not a directory");
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    try {
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-speakeasy-reservation-fail",
+          data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}voiceid`,
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 10,
+            text: "This is the exact source bubble text to render as a voice note.",
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-speakeasy-reservation-fail", {
+        text: "Voice note is temporarily unavailable. Please try again.",
+        show_alert: false,
+      });
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(generateSpeakeasyVoiceNoteSpy).not.toHaveBeenCalled();
+      expect(sendVoiceSpy).not.toHaveBeenCalled();
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
   it("rejects non-voice-note Speakeasy output before sendVoice", async () => {
     const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
     const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1,5 +1,5 @@
 // Telegram tests cover bot.create telegram bot plugin behavior.
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { escapeRegExp, formatEnvelopeTimestamp } from "openclaw/plugin-sdk/channel-test-helpers";
@@ -56,7 +56,12 @@ const {
 type BuildModelsProviderDataMock = ReturnType<
   typeof vi.fn<NonNullable<typeof telegramBotDepsForTest.buildModelsProviderData>>
 >;
-const { SPEAKEASY_VOICE_CALLBACK_PREFIX } = await import("./speakeasy-voice.js");
+const {
+  SPEAKEASY_VOICE_CALLBACK_PREFIX,
+  loadSpeakeasyCache,
+  setSpeakeasyVoiceStateStoreForTest,
+  writeSpeakeasyCache,
+} = await import("./speakeasy-voice.js");
 const { resolveTelegramFetch } = await import("./fetch.js");
 const {
   createTelegramBotCore: createTelegramBotBase,
@@ -208,6 +213,32 @@ function expectBotClientFields(expected: Record<string, unknown>, callIndex = 0)
   expectRecordFields(options.client, expected, `bot constructor client ${callIndex}`);
 }
 
+function seedSpeakeasyCache(params: {
+  workspaceDir: string;
+  entries?: Record<string, { chatId: string; text: string; createdAt: number }>;
+  generations?: Record<string, { date: string; count: number }>;
+}): void {
+  writeSpeakeasyCache(
+    { agents: { defaults: { workspace: params.workspaceDir } } },
+    {
+      version: 1,
+      entries: params.entries ?? {},
+      generations: params.generations ?? {},
+    },
+  );
+}
+
+function readSpeakeasyCacheForWorkspace(workspaceDir: string) {
+  return loadSpeakeasyCache({ agents: { defaults: { workspace: workspaceDir } } });
+}
+
+async function writeGeneratedSpeakeasyAudio(workspaceDir: string, name = "speakeasy.ogg") {
+  const audioPath = path.join(workspaceDir, "state", "speakeasy", "generated", name);
+  await mkdir(path.dirname(audioPath), { recursive: true });
+  await writeFile(audioPath, "voice bytes");
+  return audioPath;
+}
+
 describe("createTelegramBot", () => {
   beforeAll(() => {
     process.env.TZ = "UTC";
@@ -221,6 +252,7 @@ describe("createTelegramBot", () => {
   });
   afterEach(() => {
     messageDispatchDedupe.setTelegramMessageDispatchDedupeStoreForTest(undefined);
+    setSpeakeasyVoiceStateStoreForTest(undefined);
     pluginStateTestRuntime.resetPluginStateStoreForTests();
   });
   beforeEach(async () => {
@@ -244,6 +276,12 @@ describe("createTelegramBot", () => {
     >;
     await store.clear();
     messageDispatchDedupe.setTelegramMessageDispatchDedupeStoreForTest(store);
+    setSpeakeasyVoiceStateStoreForTest(
+      pluginStateTestRuntime.createPluginStateSyncKeyedStoreForTests("telegram", {
+        namespace: "telegram.speakeasy-voice",
+        maxEntries: 8_192,
+      }),
+    );
   });
 
   // groupPolicy tests
@@ -1235,27 +1273,22 @@ describe("createTelegramBot", () => {
       path.join(workspaceDir, "config", "speakeasy-chats.json"),
       JSON.stringify({ enabled: ["telegram:1234"] }),
     );
-    await writeFile(
-      path.join(workspaceDir, "state", "speakeasy-cache.json"),
-      JSON.stringify({
-        version: 1,
-        entries: {
-          voiceid: {
-            chatId: "1234",
-            text: "This is the exact source bubble text to render as a voice note.",
-            createdAt: Date.now(),
-          },
+    seedSpeakeasyCache({
+      workspaceDir,
+      entries: {
+        voiceid: {
+          chatId: "1234",
+          text: "This is the exact source bubble text to render as a voice note.",
+          createdAt: Date.now(),
         },
-        generations: {},
-      }),
-    );
+      },
+    });
 
     createTelegramBot({ token: "tok" });
     const callbackHandler = getOnHandler("callback_query") as (
       ctx: Record<string, unknown>,
     ) => Promise<void>;
-    const audioPath = path.join(workspaceDir, "state", "speakeasy-generated.ogg");
-    await writeFile(audioPath, "voice bytes");
+    const audioPath = await writeGeneratedSpeakeasyAudio(workspaceDir);
     generateSpeakeasyVoiceNoteSpy.mockResolvedValueOnce(audioPath);
 
     try {
@@ -1311,20 +1344,16 @@ describe("createTelegramBot", () => {
       path.join(workspaceDir, "config", "speakeasy-chats.json"),
       JSON.stringify({ enabled: ["telegram:1234"] }),
     );
-    await writeFile(
-      path.join(workspaceDir, "state", "speakeasy-cache.json"),
-      JSON.stringify({
-        version: 1,
-        entries: {
-          voiceid: {
-            chatId: "1234",
-            text: "This is the exact source bubble text to render as a voice note.",
-            createdAt: Date.now(),
-          },
+    seedSpeakeasyCache({
+      workspaceDir,
+      entries: {
+        voiceid: {
+          chatId: "1234",
+          text: "This is the exact source bubble text to render as a voice note.",
+          createdAt: Date.now(),
         },
-        generations: {},
-      }),
-    );
+      },
+    });
     loadConfig.mockReturnValue({
       agents: { defaults: { workspace: workspaceDir } },
       channels: {
@@ -1375,7 +1404,32 @@ describe("createTelegramBot", () => {
       path.join(workspaceDir, "config", "speakeasy-chats.json"),
       JSON.stringify({ enabled: ["telegram:1234"] }),
     );
-    await writeFile(path.join(workspaceDir, "state"), "not a directory");
+    setSpeakeasyVoiceStateStoreForTest({
+      register: () => {
+        throw new Error("state store unavailable");
+      },
+      registerIfAbsent: () => {
+        throw new Error("state store unavailable");
+      },
+      update: () => {
+        throw new Error("state store unavailable");
+      },
+      lookup: () => {
+        throw new Error("state store unavailable");
+      },
+      consume: () => {
+        throw new Error("state store unavailable");
+      },
+      delete: () => {
+        throw new Error("state store unavailable");
+      },
+      entries: () => {
+        throw new Error("state store unavailable");
+      },
+      clear: () => {
+        throw new Error("state store unavailable");
+      },
+    });
 
     createTelegramBot({ token: "tok" });
     const callbackHandler = getOnHandler("callback_query") as (
@@ -1421,20 +1475,16 @@ describe("createTelegramBot", () => {
       path.join(workspaceDir, "config", "speakeasy-chats.json"),
       JSON.stringify({ enabled: ["telegram:1234"] }),
     );
-    await writeFile(
-      path.join(workspaceDir, "state", "speakeasy-cache.json"),
-      JSON.stringify({
-        version: 1,
-        entries: {
-          voiceid: {
-            chatId: "1234",
-            text: "This is the exact source bubble text to render as a voice note.",
-            createdAt: Date.now(),
-          },
+    seedSpeakeasyCache({
+      workspaceDir,
+      entries: {
+        voiceid: {
+          chatId: "1234",
+          text: "This is the exact source bubble text to render as a voice note.",
+          createdAt: Date.now(),
         },
-        generations: {},
-      }),
-    );
+      },
+    });
 
     createTelegramBot({ token: "tok" });
     const callbackHandler = getOnHandler("callback_query") as (
@@ -1477,25 +1527,23 @@ describe("createTelegramBot", () => {
       path.join(workspaceDir, "config", "speakeasy-chats.json"),
       JSON.stringify({ enabled: ["telegram:1234"] }),
     );
-    await writeFile(
-      path.join(workspaceDir, "state", "speakeasy-cache.json"),
-      JSON.stringify({
-        version: 1,
-        entries: {
-          voiceid: {
-            chatId: "1234",
-            text: "This is the exact source bubble text to render as a voice note.",
-            createdAt: Date.now(),
-          },
+    seedSpeakeasyCache({
+      workspaceDir,
+      entries: {
+        voiceid: {
+          chatId: "1234",
+          text: "This is the exact source bubble text to render as a voice note.",
+          createdAt: Date.now(),
         },
-        generations: {},
-      }),
-    );
+      },
+    });
 
     createTelegramBot({ token: "tok" });
     const callbackHandler = getOnHandler("callback_query") as (
       ctx: Record<string, unknown>,
     ) => Promise<void>;
+    const audioPath = await writeGeneratedSpeakeasyAudio(workspaceDir, "send-fail.ogg");
+    generateSpeakeasyVoiceNoteSpy.mockResolvedValueOnce(audioPath);
     sendVoiceSpy.mockRejectedValueOnce(new Error("telegram rejected voice"));
 
     try {
@@ -1517,9 +1565,7 @@ describe("createTelegramBot", () => {
         }),
       ).rejects.toThrow();
 
-      const cache = JSON.parse(
-        await readFile(path.join(workspaceDir, "state", "speakeasy-cache.json"), "utf8"),
-      ) as { generations?: Record<string, { count: number }> };
+      const cache = readSpeakeasyCacheForWorkspace(workspaceDir);
       const today = new Date().toISOString().slice(0, 10);
       expect(cache.generations?.[`1234:${today}`]?.count ?? 0).toBeGreaterThanOrEqual(1);
     } finally {
@@ -1537,20 +1583,16 @@ describe("createTelegramBot", () => {
       path.join(workspaceDir, "config", "speakeasy-chats.json"),
       JSON.stringify({ enabled: ["telegram:1234"] }),
     );
-    await writeFile(
-      path.join(workspaceDir, "state", "speakeasy-cache.json"),
-      JSON.stringify({
-        version: 1,
-        entries: {
-          voiceid: {
-            chatId: "1234",
-            text: "This is the exact source bubble text to render as a voice note.",
-            createdAt: Date.now(),
-          },
+    seedSpeakeasyCache({
+      workspaceDir,
+      entries: {
+        voiceid: {
+          chatId: "1234",
+          text: "This is the exact source bubble text to render as a voice note.",
+          createdAt: Date.now(),
         },
-        generations: {},
-      }),
-    );
+      },
+    });
 
     createTelegramBot({ token: "tok" });
     const callbackHandler = getOnHandler("callback_query") as (
@@ -1561,6 +1603,8 @@ describe("createTelegramBot", () => {
         "GrammyError: Call to 'sendVoice' failed! (400: Bad Request: VOICE_MESSAGES_FORBIDDEN)",
       ),
     );
+    const audioPath = await writeGeneratedSpeakeasyAudio(workspaceDir, "voice-forbidden.ogg");
+    generateSpeakeasyVoiceNoteSpy.mockResolvedValueOnce(audioPath);
 
     try {
       await callbackHandler({
@@ -1597,6 +1641,66 @@ describe("createTelegramBot", () => {
       await rm(workspaceDir, { recursive: true, force: true });
     }
   });
+  it("keeps voice-forbidden fallback send failures retryable", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    seedSpeakeasyCache({
+      workspaceDir,
+      entries: {
+        voiceid: {
+          chatId: "1234",
+          text: "This is the exact source bubble text to render as a voice note.",
+          createdAt: Date.now(),
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    const audioPath = await writeGeneratedSpeakeasyAudio(workspaceDir, "fallback-fail.ogg");
+    generateSpeakeasyVoiceNoteSpy.mockResolvedValueOnce(audioPath);
+    sendVoiceSpy.mockRejectedValueOnce(
+      new Error(
+        "GrammyError: Call to 'sendVoice' failed! (400: Bad Request: VOICE_MESSAGES_FORBIDDEN)",
+      ),
+    );
+    sendMessageSpy.mockRejectedValueOnce(new Error("fallback send failed"));
+
+    try {
+      await expect(
+        callbackHandler({
+          callbackQuery: {
+            id: "cbq-speakeasy-voice-forbidden-fallback-fail",
+            data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}voiceid`,
+            from: { id: 9, first_name: "Ada", username: "ada_bot" },
+            message: {
+              chat: { id: 1234, type: "private" },
+              date: 1736380800,
+              message_id: 10,
+              text: "This is the exact source bubble text to render as a voice note.",
+            },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({ download: async () => new Uint8Array() }),
+        }),
+      ).rejects.toThrow("fallback send failed");
+      const cache = readSpeakeasyCacheForWorkspace(workspaceDir);
+      const today = new Date().toISOString().slice(0, 10);
+      expect(cache.generations?.[`1234:${today}`]?.count ?? 0).toBe(0);
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
   it("rolls back Speakeasy quota when voice generation fails", async () => {
     const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
     const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
@@ -1607,20 +1711,16 @@ describe("createTelegramBot", () => {
       path.join(workspaceDir, "config", "speakeasy-chats.json"),
       JSON.stringify({ enabled: ["telegram:1234"] }),
     );
-    await writeFile(
-      path.join(workspaceDir, "state", "speakeasy-cache.json"),
-      JSON.stringify({
-        version: 1,
-        entries: {
-          voiceid: {
-            chatId: "1234",
-            text: "This is the exact source bubble text to render as a voice note.",
-            createdAt: Date.now(),
-          },
+    seedSpeakeasyCache({
+      workspaceDir,
+      entries: {
+        voiceid: {
+          chatId: "1234",
+          text: "This is the exact source bubble text to render as a voice note.",
+          createdAt: Date.now(),
         },
-        generations: {},
-      }),
-    );
+      },
+    });
 
     createTelegramBot({ token: "tok" });
     const callbackHandler = getOnHandler("callback_query") as (
@@ -1647,9 +1747,7 @@ describe("createTelegramBot", () => {
         }),
       ).rejects.toThrow();
 
-      const cache = JSON.parse(
-        await readFile(path.join(workspaceDir, "state", "speakeasy-cache.json"), "utf8"),
-      ) as { generations?: Record<string, { count: number }> };
+      const cache = readSpeakeasyCacheForWorkspace(workspaceDir);
       const today = new Date().toISOString().slice(0, 10);
       expect(cache.generations?.[`1234:${today}`]?.count ?? 0).toBe(0);
     } finally {
@@ -1666,14 +1764,6 @@ describe("createTelegramBot", () => {
     await writeFile(
       path.join(workspaceDir, "config", "speakeasy-chats.json"),
       JSON.stringify({ enabled: ["telegram:1234"] }),
-    );
-    await writeFile(
-      path.join(workspaceDir, "state", "speakeasy-cache.json"),
-      JSON.stringify({
-        version: 1,
-        entries: {},
-        generations: {},
-      }),
     );
 
     createTelegramBot({ token: "tok" });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1,5 +1,12 @@
 // Telegram tests cover bot.create telegram bot plugin behavior.
-import { escapeRegExp, formatEnvelopeTimestamp } from "openclaw/plugin-sdk/channel-test-helpers";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  escapeRegExp,
+  formatEnvelopeTimestamp,
+  stripAnsi,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import type { TelegramGroupConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
@@ -22,6 +29,7 @@ const {
   editMessageReplyMarkupSpy,
   editMessageTextSpy,
   enqueueSystemEventSpy,
+  generateSpeakeasyVoiceNoteSpy,
   getLoadWebMediaMock,
   getChatSpy,
   getLoadConfigMock,
@@ -38,6 +46,7 @@ const {
   sendAnimationSpy,
   sendChatActionSpy,
   sendMessageSpy,
+  sendVoiceSpy,
   sendPhotoSpy,
   sequentializeSpy,
   setSessionStoreEntriesForTest,
@@ -51,6 +60,7 @@ const {
 type BuildModelsProviderDataMock = ReturnType<
   typeof vi.fn<NonNullable<typeof telegramBotDepsForTest.buildModelsProviderData>>
 >;
+const { SPEAKEASY_VOICE_CALLBACK_PREFIX } = await import("./speakeasy-voice.js");
 const { resolveTelegramFetch } = await import("./fetch.js");
 const {
   createTelegramBotCore: createTelegramBotBase,
@@ -1218,6 +1228,78 @@ describe("createTelegramBot", () => {
     expect(payload.CommandBody).toBe("/fast status");
     expect(payload.CommandSource).toBe("native");
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-native-1");
+  });
+  it("handles Speakeasy voice callbacks without routing synthetic messages", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    await writeFile(
+      path.join(workspaceDir, "state", "speakeasy-cache.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          voiceid: {
+            chatId: "1234",
+            text: "This is the exact source bubble text to render as a voice note.",
+            createdAt: Date.now(),
+          },
+        },
+        generations: {},
+      }),
+    );
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    try {
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-speakeasy-1",
+          data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}voiceid`,
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 10,
+            message_thread_id: 42,
+            text: "This is the exact source bubble text to render as a voice note.",
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(generateSpeakeasyVoiceNoteSpy).toHaveBeenCalledWith({
+        cfg: expect.any(Object),
+        text: "This is the exact source bubble text to render as a voice note.",
+      });
+      expect(sendVoiceSpy).toHaveBeenCalledTimes(1);
+      expect(sendVoiceSpy.mock.calls[0]?.[0]).toBe(1234);
+      expect(sendVoiceSpy.mock.calls[0]?.[2]).toMatchObject({
+        message_thread_id: 42,
+        reply_parameters: {
+          message_id: 10,
+          allow_sending_without_reply: true,
+        },
+      });
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-speakeasy-1");
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-speakeasy-1", {
+        text: "Generating voice note…",
+        show_alert: false,
+      });
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
   });
   it("reloads callback model routing bindings without recreating the bot", async () => {
     const buildModelsProviderDataMock =

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1,5 +1,5 @@
 // Telegram tests cover bot.create telegram bot plugin behavior.
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -1291,11 +1291,373 @@ describe("createTelegramBot", () => {
           allow_sending_without_reply: true,
         },
       });
-      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-speakeasy-1");
       expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-speakeasy-1", {
         text: "Generating voice note…",
         show_alert: false,
       });
+      expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+  it("acknowledges blocked Speakeasy callbacks before generic callback routing", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    await writeFile(
+      path.join(workspaceDir, "state", "speakeasy-cache.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          voiceid: {
+            chatId: "1234",
+            text: "This is the exact source bubble text to render as a voice note.",
+            createdAt: Date.now(),
+          },
+        },
+        generations: {},
+      }),
+    );
+    loadConfig.mockReturnValue({
+      agents: { defaults: { workspace: workspaceDir } },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"], capabilities: { inlineButtons: "off" } },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    try {
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-speakeasy-blocked",
+          data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}voiceid`,
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 10,
+            text: "This is the exact source bubble text to render as a voice note.",
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-speakeasy-blocked", {
+        text: "Voice note is not enabled here.",
+        show_alert: false,
+      });
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(generateSpeakeasyVoiceNoteSpy).not.toHaveBeenCalled();
+      expect(sendVoiceSpy).not.toHaveBeenCalled();
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+  it("rejects non-voice-note Speakeasy output before sendVoice", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    await writeFile(
+      path.join(workspaceDir, "state", "speakeasy-cache.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          voiceid: {
+            chatId: "1234",
+            text: "This is the exact source bubble text to render as a voice note.",
+            createdAt: Date.now(),
+          },
+        },
+        generations: {},
+      }),
+    );
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    generateSpeakeasyVoiceNoteSpy.mockResolvedValueOnce("/tmp/speakeasy.mp3");
+
+    try {
+      await expect(
+        callbackHandler({
+          callbackQuery: {
+            id: "cbq-speakeasy-invalid-output",
+            data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}voiceid`,
+            from: { id: 9, first_name: "Ada", username: "ada_bot" },
+            message: {
+              chat: { id: 1234, type: "private" },
+              date: 1736380800,
+              message_id: 10,
+              text: "This is the exact source bubble text to render as a voice note.",
+            },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({ download: async () => new Uint8Array() }),
+        }),
+      ).rejects.toThrow();
+
+      expect(sendVoiceSpy).not.toHaveBeenCalled();
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+  it("counts Speakeasy generations when Telegram voice delivery fails", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    await writeFile(
+      path.join(workspaceDir, "state", "speakeasy-cache.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          voiceid: {
+            chatId: "1234",
+            text: "This is the exact source bubble text to render as a voice note.",
+            createdAt: Date.now(),
+          },
+        },
+        generations: {},
+      }),
+    );
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    sendVoiceSpy.mockRejectedValueOnce(new Error("telegram rejected voice"));
+
+    try {
+      await expect(
+        callbackHandler({
+          callbackQuery: {
+            id: "cbq-speakeasy-send-fail",
+            data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}voiceid`,
+            from: { id: 9, first_name: "Ada", username: "ada_bot" },
+            message: {
+              chat: { id: 1234, type: "private" },
+              date: 1736380800,
+              message_id: 10,
+              text: "This is the exact source bubble text to render as a voice note.",
+            },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({ download: async () => new Uint8Array() }),
+        }),
+      ).rejects.toThrow();
+
+      const cache = JSON.parse(
+        await readFile(path.join(workspaceDir, "state", "speakeasy-cache.json"), "utf8"),
+      ) as { generations?: Record<string, { count: number }> };
+      const today = new Date().toISOString().slice(0, 10);
+      expect(cache.generations?.[`1234:${today}`]?.count ?? 0).toBeGreaterThanOrEqual(1);
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+  it("falls back to callback text when Speakeasy voice delivery is forbidden", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    await writeFile(
+      path.join(workspaceDir, "state", "speakeasy-cache.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          voiceid: {
+            chatId: "1234",
+            text: "This is the exact source bubble text to render as a voice note.",
+            createdAt: Date.now(),
+          },
+        },
+        generations: {},
+      }),
+    );
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    sendVoiceSpy.mockRejectedValueOnce(
+      new Error(
+        "GrammyError: Call to 'sendVoice' failed! (400: Bad Request: VOICE_MESSAGES_FORBIDDEN)",
+      ),
+    );
+
+    try {
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-speakeasy-voice-forbidden",
+          data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}voiceid`,
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 10,
+            message_thread_id: 42,
+            text: "This is the exact source bubble text to render as a voice note.",
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      expect(sendVoiceSpy).toHaveBeenCalledTimes(1);
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        1234,
+        "Telegram could not deliver that voice note. The original text is still available above.",
+        expect.objectContaining({
+          message_thread_id: 42,
+          reply_parameters: {
+            message_id: 10,
+            allow_sending_without_reply: true,
+          },
+        }),
+      );
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+  it("rolls back Speakeasy quota when voice generation fails", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    await writeFile(
+      path.join(workspaceDir, "state", "speakeasy-cache.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          voiceid: {
+            chatId: "1234",
+            text: "This is the exact source bubble text to render as a voice note.",
+            createdAt: Date.now(),
+          },
+        },
+        generations: {},
+      }),
+    );
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    generateSpeakeasyVoiceNoteSpy.mockRejectedValueOnce(new Error("tts unavailable"));
+
+    try {
+      await expect(
+        callbackHandler({
+          callbackQuery: {
+            id: "cbq-speakeasy-tts-fail",
+            data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}voiceid`,
+            from: { id: 9, first_name: "Ada", username: "ada_bot" },
+            message: {
+              chat: { id: 1234, type: "private" },
+              date: 1736380800,
+              message_id: 10,
+              text: "This is the exact source bubble text to render as a voice note.",
+            },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({ download: async () => new Uint8Array() }),
+        }),
+      ).rejects.toThrow();
+
+      const cache = JSON.parse(
+        await readFile(path.join(workspaceDir, "state", "speakeasy-cache.json"), "utf8"),
+      ) as { generations?: Record<string, { count: number }> };
+      const today = new Date().toISOString().slice(0, 10);
+      expect(cache.generations?.[`1234:${today}`]?.count ?? 0).toBe(0);
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+  it("uses generic wording for expired Speakeasy callbacks", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:1234"] }),
+    );
+    await writeFile(
+      path.join(workspaceDir, "state", "speakeasy-cache.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {},
+        generations: {},
+      }),
+    );
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    try {
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-speakeasy-expired",
+          data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}missing`,
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 10,
+            text: "This is the exact source bubble text to render as a voice note.",
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-speakeasy-expired", {
+        text: "Voice note expired. Ask the assistant to resend it.",
+        show_alert: false,
+      });
+      expect(generateSpeakeasyVoiceNoteSpy).not.toHaveBeenCalled();
     } finally {
       process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
       await rm(workspaceDir, { recursive: true, force: true });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1254,6 +1254,9 @@ describe("createTelegramBot", () => {
     const callbackHandler = getOnHandler("callback_query") as (
       ctx: Record<string, unknown>,
     ) => Promise<void>;
+    const audioPath = path.join(workspaceDir, "state", "speakeasy-generated.ogg");
+    await writeFile(audioPath, "voice bytes");
+    generateSpeakeasyVoiceNoteSpy.mockResolvedValueOnce(audioPath);
 
     try {
       await callbackHandler({
@@ -1292,6 +1295,7 @@ describe("createTelegramBot", () => {
         show_alert: false,
       });
       expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
+      await expect(readFile(audioPath, "utf8")).rejects.toThrow();
     } finally {
       process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
       await rm(workspaceDir, { recursive: true, force: true });
@@ -1407,7 +1411,7 @@ describe("createTelegramBot", () => {
       await rm(workspaceDir, { recursive: true, force: true });
     }
   });
-  it("rejects non-voice-note Speakeasy output before sendVoice", async () => {
+  it("rejects unsupported Speakeasy output before sendVoice", async () => {
     const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
     const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
     process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
@@ -1436,7 +1440,7 @@ describe("createTelegramBot", () => {
     const callbackHandler = getOnHandler("callback_query") as (
       ctx: Record<string, unknown>,
     ) => Promise<void>;
-    generateSpeakeasyVoiceNoteSpy.mockResolvedValueOnce("/tmp/speakeasy.mp3");
+    generateSpeakeasyVoiceNoteSpy.mockResolvedValueOnce("/tmp/speakeasy.wav");
 
     try {
       await expect(

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1,5 +1,5 @@
 // Telegram tests cover bot.create telegram bot plugin behavior.
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { escapeRegExp, formatEnvelopeTimestamp } from "openclaw/plugin-sdk/channel-test-helpers";
@@ -1295,7 +1295,7 @@ describe("createTelegramBot", () => {
         show_alert: false,
       });
       expect(answerCallbackQuerySpy).toHaveBeenCalledTimes(1);
-      await expect(readFile(audioPath, "utf8")).rejects.toThrow();
+      await expect(stat(audioPath)).rejects.toThrow();
     } finally {
       process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
       await rm(workspaceDir, { recursive: true, force: true });

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -38,6 +38,7 @@ import {
   renderTelegramHtmlText,
   wrapFileReferencesInHtml,
 } from "../format.js";
+import { resolveTelegramInlineButtonsScope } from "../inline-buttons.js";
 import { resolveTelegramInteractiveTextFallback } from "../interactive-fallback.js";
 import { buildInlineKeyboard } from "../send.js";
 import { withSpeakeasyVoiceButton } from "../speakeasy-voice.js";
@@ -847,21 +848,38 @@ export async function deliverReplies(params: {
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
+      const telegramDataBeforeSpeakeasy = reply.channelData?.telegram as
+        | TelegramReplyChannelData
+        | undefined;
+      const existingButtons = resolveTelegramInlineButtons({
+        buttons: telegramDataBeforeSpeakeasy?.buttons,
+        presentation,
+        interactive,
+      });
+      if (existingButtons) {
+        reply = {
+          ...reply,
+          channelData: {
+            ...reply.channelData,
+            telegram: {
+              ...telegramDataBeforeSpeakeasy,
+              buttons: existingButtons,
+            },
+          },
+        };
+      }
       reply = withSpeakeasyVoiceButton({
         reply,
         cfg: params.cfg,
         chatId: params.chatId,
         isGroup: params.mirrorIsGroup,
         hasMedia,
+        inlineButtonsScope: params.cfg
+          ? resolveTelegramInlineButtonsScope({ cfg: params.cfg, accountId: params.accountId })
+          : undefined,
       });
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
-      const replyMarkup = buildInlineKeyboard(
-        resolveTelegramInlineButtons({
-          buttons: telegramData?.buttons,
-          presentation,
-          interactive,
-        }),
-      );
+      const replyMarkup = buildInlineKeyboard(telegramData?.buttons);
       let firstDeliveredMessageId: number | undefined;
       if (mediaList.length === 0) {
         firstDeliveredMessageId = await deliverTextReply({

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -40,6 +40,7 @@ import {
 } from "../format.js";
 import { resolveTelegramInteractiveTextFallback } from "../interactive-fallback.js";
 import { buildInlineKeyboard } from "../send.js";
+import { withSpeakeasyVoiceButton } from "../speakeasy-voice.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
 import {
   buildTelegramSendParams,
@@ -846,6 +847,13 @@ export async function deliverReplies(params: {
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
+      reply = withSpeakeasyVoiceButton({
+        reply,
+        cfg: params.cfg,
+        chatId: params.chatId,
+        isGroup: params.mirrorIsGroup,
+        hasMedia,
+      });
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const replyMarkup = buildInlineKeyboard(
         resolveTelegramInlineButtons({

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1,4 +1,7 @@
 // Telegram tests cover delivery plugin behavior.
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { Bot } from "grammy";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -213,6 +216,79 @@ describe("deliverReplies", () => {
     messageHookRunner.hasHooks.mockReturnValue(false);
     messageHookRunner.runMessageSending.mockReset();
     messageHookRunner.runMessageSent.mockReset();
+  });
+
+  it("adds one Speakeasy voice-note button to eligible enabled Telegram DM text", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:123"] }),
+    );
+
+    try {
+      const runtime = createRuntime(false);
+      const sendMessage = vi.fn().mockResolvedValue({ message_id: 9, chat: { id: "123" } });
+      const bot = createBot({ sendMessage });
+
+      await deliverWith({
+        cfg: { agents: { defaults: { workspace: workspaceDir } } },
+        replies: [{ text: "This is a long enough reply to offer a voice note." }],
+        runtime,
+        bot,
+      });
+
+      const replyMarkup = sendMessage.mock.calls[0]?.[2]?.reply_markup;
+      expect(replyMarkup).toEqual({
+        inline_keyboard: [
+          [
+            {
+              text: "🔊 Voice note",
+              callback_data: expect.stringMatching(/^tts:speakeasy:/),
+            },
+          ],
+        ],
+      });
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not add Speakeasy buttons to groups, short text, or disabled chats", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:123"] }),
+    );
+
+    try {
+      const runtime = createRuntime(false);
+      const sendMessage = vi.fn().mockResolvedValue({ message_id: 9, chat: { id: "123" } });
+      const bot = createBot({ sendMessage });
+
+      await deliverWith({
+        cfg: { agents: { defaults: { workspace: workspaceDir } } },
+        replies: [
+          { text: "group messages should not get a voice button" },
+          { text: "short" },
+          { text: "disabled chats should not get a voice button" },
+        ],
+        runtime,
+        bot,
+        mirrorIsGroup: true,
+      });
+
+      expect(sendMessage.mock.calls.every((call) => !call[2]?.reply_markup)).toBe(true);
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("skips audioAsVoice-only payloads without logging an error", async () => {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -257,6 +257,53 @@ describe("deliverReplies", () => {
     }
   });
 
+  it("preserves presentation buttons when adding Speakeasy voice-note buttons", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:123"] }),
+    );
+
+    try {
+      const runtime = createRuntime(false);
+      const sendMessage = vi.fn().mockResolvedValue({ message_id: 9, chat: { id: "123" } });
+      const bot = createBot({ sendMessage });
+
+      await deliverWith({
+        cfg: { agents: { defaults: { workspace: workspaceDir } } },
+        replies: [
+          {
+            text: "This is a long enough reply to offer a voice note and keep actions.",
+            presentation: {
+              blocks: [{ type: "buttons", buttons: [{ label: "Approve", value: "cmd:approve" }] }],
+            },
+          },
+        ],
+        runtime,
+        bot,
+      });
+
+      const replyMarkup = sendMessage.mock.calls[0]?.[2]?.reply_markup;
+      expect(replyMarkup).toEqual({
+        inline_keyboard: [
+          [{ text: "Approve", callback_data: "cmd:approve" }],
+          [
+            {
+              text: "🔊 Voice note",
+              callback_data: expect.stringMatching(/^tts:speakeasy:/),
+            },
+          ],
+        ],
+      });
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not add Speakeasy buttons to groups, short text, or disabled chats", async () => {
     const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
     const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
@@ -285,6 +332,38 @@ describe("deliverReplies", () => {
       });
 
       expect(sendMessage.mock.calls.every((call) => !call[2]?.reply_markup)).toBe(true);
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("honors Telegram inline-button scope before adding Speakeasy buttons", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:123"] }),
+    );
+
+    try {
+      const runtime = createRuntime(false);
+      const sendMessage = vi.fn().mockResolvedValue({ message_id: 9, chat: { id: "123" } });
+      const bot = createBot({ sendMessage });
+
+      await deliverWith({
+        cfg: {
+          agents: { defaults: { workspace: workspaceDir } },
+          channels: { telegram: { capabilities: { inlineButtons: "off" } } },
+        },
+        replies: [{ text: "This reply is long enough but inline buttons are disabled." }],
+        runtime,
+        bot,
+      });
+
+      expect(sendMessage.mock.calls[0]?.[2]?.reply_markup).toBeUndefined();
     } finally {
       process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
       await rm(workspaceDir, { recursive: true, force: true });

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -1,4 +1,7 @@
 // Telegram tests cover outbound adapter plugin behavior.
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { verifyDurableFinalCapabilityProofs } from "openclaw/plugin-sdk/channel-outbound";
 import { adaptMessagePresentationForChannel } from "openclaw/plugin-sdk/interactive-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -155,6 +158,82 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-buttons", chatId: "12345" });
   });
 
+  it("does not add Speakeasy buttons to group topic payload targets", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-outbound-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:-100123"] }),
+    );
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-group-topic",
+      chatId: "-100123",
+    });
+
+    try {
+      await telegramOutbound.sendPayload!({
+        cfg: { agents: { defaults: { workspace: workspaceDir } } } as never,
+        to: "-100123:topic:7",
+        text: "",
+        payload: {
+          text: "This group topic payload is long enough but must not get a voice button.",
+        },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      });
+
+      const options = callOptionsAt(
+        sendMessageTelegramMock,
+        0,
+        "-100123:topic:7",
+        "This group topic payload is long enough but must not get a voice button.",
+      );
+      expect(options.buttons).toBeUndefined();
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not add Speakeasy buttons to unresolved handle targets", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-outbound-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:@cameron_handle"] }),
+    );
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-handle",
+      chatId: "437286129",
+    });
+
+    try {
+      await telegramOutbound.sendPayload!({
+        cfg: { agents: { defaults: { workspace: workspaceDir } } } as never,
+        to: "@cameron_handle",
+        text: "",
+        payload: {
+          text: "This handle target payload is long enough but must not get a voice button.",
+        },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      });
+
+      const options = callOptionsAt(
+        sendMessageTelegramMock,
+        0,
+        "@cameron_handle",
+        "This handle target payload is long enough but must not get a voice button.",
+      );
+      expect(options.buttons).toBeUndefined();
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses presentation button labels as fallback text for presentation-only payloads", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({
       messageId: "tg-presentation-buttons",
@@ -180,6 +259,59 @@ describe("telegramOutbound", () => {
       messageId: "tg-presentation-buttons",
       chatId: "12345",
     });
+  });
+
+  it("adds Speakeasy to eligible presentation fallback text without dropping presentation buttons", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-outbound-"));
+    const previousWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:12345"] }),
+    );
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-presentation-speakeasy",
+      chatId: "12345",
+    });
+
+    try {
+      const result = await telegramOutbound.sendPayload!({
+        cfg: { agents: { defaults: { workspace: workspaceDir } } } as never,
+        to: "12345",
+        text: "",
+        payload: {
+          presentation: {
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [{ label: "Read the detailed update", value: "cmd:details" }],
+              },
+            ],
+          },
+        },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      });
+
+      const options = callOptionsAt(
+        sendMessageTelegramMock,
+        0,
+        "12345",
+        "- Read the detailed update",
+      );
+      expect(options.buttons).toEqual([
+        [{ text: "Read the detailed update", callback_data: "cmd:details" }],
+        [{ text: "🔊 Voice note", callback_data: expect.stringMatching(/^tts:speakeasy:/) }],
+      ]);
+      expect(result).toEqual({
+        channel: "telegram",
+        messageId: "tg-presentation-speakeasy",
+        chatId: "12345",
+      });
+    } finally {
+      process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("renders presentation web app buttons for payload sends", async () => {

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -21,10 +21,15 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import { markdownToTelegramHtmlChunks, splitTelegramHtmlChunks } from "./format.js";
+import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
 import { withSpeakeasyVoiceButton } from "./speakeasy-voice.js";
-import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
+import {
+  isNumericTelegramChatId,
+  normalizeTelegramOutboundTarget,
+  parseTelegramTarget,
+} from "./targets.js";
 
 export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
 export const TELEGRAM_POLL_OPTION_LIMIT = 10;
@@ -135,11 +140,37 @@ export async function sendTelegramPayloadMessages(params: {
       presentation,
     }) ?? "";
   const mediaUrls = resolvePayloadMediaUrls(params.payload);
+  const target = parseTelegramTarget(params.to);
+  const baseButtons = resolveTelegramInlineButtons({
+    buttons: telegramData?.buttons,
+    presentation,
+    interactive: params.payload.interactive,
+  });
   const enrichedPayload = withSpeakeasyVoiceButton({
-    reply: params.payload,
+    reply: {
+      ...params.payload,
+      text,
+      channelData: {
+        ...params.payload.channelData,
+        telegram: {
+          ...telegramData,
+          buttons: baseButtons,
+        },
+      },
+    },
     cfg: params.baseOpts.cfg,
-    chatId: params.to,
+    chatId:
+      target.chatType === "direct" && isNumericTelegramChatId(target.chatId)
+        ? target.chatId
+        : undefined,
+    isGroup: target.chatType === "group",
     hasMedia: mediaUrls.length > 0,
+    inlineButtonsScope: params.baseOpts.cfg
+      ? resolveTelegramInlineButtonsScope({
+          cfg: params.baseOpts.cfg,
+          accountId: params.baseOpts.accountId,
+        })
+      : undefined,
   });
   const enrichedTelegramData = enrichedPayload.channelData?.telegram as
     | { buttons?: TelegramInlineButtons; quoteText?: string }

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -23,6 +23,7 @@ import { resolveTelegramInlineButtons } from "./button-types.js";
 import { markdownToTelegramHtmlChunks, splitTelegramHtmlChunks } from "./format.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
+import { withSpeakeasyVoiceButton } from "./speakeasy-voice.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 
 export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
@@ -134,8 +135,17 @@ export async function sendTelegramPayloadMessages(params: {
       presentation,
     }) ?? "";
   const mediaUrls = resolvePayloadMediaUrls(params.payload);
+  const enrichedPayload = withSpeakeasyVoiceButton({
+    reply: params.payload,
+    cfg: params.baseOpts.cfg,
+    chatId: params.to,
+    hasMedia: mediaUrls.length > 0,
+  });
+  const enrichedTelegramData = enrichedPayload.channelData?.telegram as
+    | { buttons?: TelegramInlineButtons; quoteText?: string }
+    | undefined;
   const buttons = resolveTelegramInlineButtons({
-    buttons: telegramData?.buttons,
+    buttons: enrichedTelegramData?.buttons,
     presentation,
     interactive: params.payload.interactive,
   });

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -255,8 +255,8 @@ describe("speakeasy voice button", () => {
         failure = err;
       }
       expect(failure).toBeInstanceOf(Error);
-      expect(String((failure as Error).message)).toMatch(/Speakeasy TTS failed/);
-      expect(String((failure as Error).message).length).toBeLessThan(1024 * 1024 + 1024);
+      expect((failure as Error).message).toMatch(/Speakeasy TTS failed/);
+      expect((failure as Error).message.length).toBeLessThan(1024 * 1024 + 1024);
     });
   });
 

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -107,6 +107,23 @@ describe("speakeasy voice button", () => {
     });
   });
 
+  it("fixes existing cache file permissions before writing reply text", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      const cachePath = path.join(workspaceDir, "state", "speakeasy-cache.json");
+      await writeFile(cachePath, JSON.stringify({ version: 1, entries: {}, generations: {} }), {
+        mode: 0o644,
+      });
+
+      withSpeakeasyVoiceButton({
+        reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
+        cfg,
+        chatId: "123",
+      });
+
+      expect((await stat(cachePath)).mode & 0o777).toBe(0o600);
+    });
+  });
+
   it("rejects non-voice-note Speakeasy output paths", () => {
     expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.mp3")).toThrow(
       "not a Telegram voice-note file",

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -232,6 +232,34 @@ describe("speakeasy voice button", () => {
     });
   });
 
+  it("caps noisy TTS helper stderr before reporting failures", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      await mkdir(path.join(workspaceDir, "scripts"), { recursive: true });
+      const scriptPath = path.join(workspaceDir, "scripts", "tts_elevenlabs_v2.py");
+      await writeFile(
+        scriptPath,
+        [
+          "#!/usr/bin/env python3",
+          "import sys",
+          "sys.stderr.write('x' * (1024 * 1024 + 4096))",
+          "raise SystemExit(1)",
+          "",
+        ].join("\n"),
+      );
+      await chmod(scriptPath, 0o755);
+
+      let failure: unknown;
+      try {
+        await generateSpeakeasyVoiceNote({ cfg, text: "Hello from Speakeasy" });
+      } catch (err) {
+        failure = err;
+      }
+      expect(failure).toBeInstanceOf(Error);
+      expect(String((failure as Error).message)).toMatch(/Speakeasy TTS failed/);
+      expect(String((failure as Error).message).length).toBeLessThan(1024 * 1024 + 1024);
+    });
+  });
+
   it("skips the optional voice button when the callback cache cannot be written", async () => {
     const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-cache-fail-"));
     await mkdir(path.join(workspaceDir, "config"), { recursive: true });
@@ -252,6 +280,17 @@ describe("speakeasy voice button", () => {
     } finally {
       await rm(workspaceDir, { recursive: true, force: true });
     }
+  });
+
+  it("skips the optional voice button when a fresh cache lock exists", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      const cachePath = path.join(workspaceDir, "state", "speakeasy-cache.json");
+      const lockPath = `${cachePath}.lock`;
+      await writeFile(lockPath, "active lock");
+      const reply = { text: "This reply is long enough to qualify for on-demand voice playback." };
+
+      expect(withSpeakeasyVoiceButton({ reply, cfg, chatId: "123" })).toBe(reply);
+    });
   });
 
   it("does not alter disabled, group, short, media, voice, or already-Speakeasy replies", async () => {
@@ -375,6 +414,29 @@ describe("speakeasy voice button", () => {
       releaseSpeakeasyVoiceGenerationReservation({ cfg, chatId: "123" });
       cache = loadSpeakeasyCache(cfg);
       expect(cache.generations[`123:${today}`]).toBeUndefined();
+    });
+  });
+
+  it("prunes generation records from prior days", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      await writeFile(
+        path.join(workspaceDir, "state", "speakeasy-cache.json"),
+        JSON.stringify({
+          version: 1,
+          entries: {},
+          generations: {
+            "123:2026-01-01": { date: "2026-01-01", count: 50 },
+            [`123:${new Date().toISOString().slice(0, 10)}`]: {
+              date: new Date().toISOString().slice(0, 10),
+              count: 1,
+            },
+          },
+        }),
+      );
+
+      const cache = loadSpeakeasyCache(cfg);
+      expect(cache.generations["123:2026-01-01"]).toBeUndefined();
+      expect(cache.generations[`123:${new Date().toISOString().slice(0, 10)}`]?.count).toBe(1);
     });
   });
 

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -1,0 +1,142 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  SPEAKEASY_VOICE_BUTTON_LABEL,
+  SPEAKEASY_VOICE_CALLBACK_PREFIX,
+  loadSpeakeasyCache,
+  markSpeakeasyVoiceGenerated,
+  resolveSpeakeasyCachedText,
+  shouldAllowSpeakeasyVoiceGeneration,
+  withSpeakeasyVoiceButton,
+} from "./speakeasy-voice.js";
+
+async function withSpeakeasyWorkspace<T>(
+  fn: (params: {
+    workspaceDir: string;
+    cfg: { agents: { defaults: { workspace: string } } };
+  }) => Promise<T>,
+) {
+  const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+  await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+  await mkdir(path.join(workspaceDir, "state"), { recursive: true });
+  await writeFile(
+    path.join(workspaceDir, "config", "speakeasy-chats.json"),
+    JSON.stringify({ enabled: ["telegram:123"] }),
+  );
+  try {
+    return await fn({
+      workspaceDir,
+      cfg: { agents: { defaults: { workspace: workspaceDir } } },
+    });
+  } finally {
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+}
+
+describe("speakeasy voice button", () => {
+  it("adds one cached callback button to eligible enabled DM text replies", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg }) => {
+      const reply = withSpeakeasyVoiceButton({
+        reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
+        cfg,
+        chatId: "123",
+        isGroup: false,
+      }) as {
+        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      };
+
+      expect(reply.channelData?.telegram?.buttons).toEqual([
+        [
+          {
+            text: SPEAKEASY_VOICE_BUTTON_LABEL,
+            callback_data: expect.stringMatching(/^tts:speakeasy:/),
+          },
+        ],
+      ]);
+
+      const callbackData = reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
+      const cache = loadSpeakeasyCache(cfg);
+      expect(resolveSpeakeasyCachedText({ cfg, cache, data: callbackData, chatId: "123" })).toEqual(
+        {
+          ok: true,
+          text: "This reply is long enough to qualify for on-demand voice playback.",
+        },
+      );
+    });
+  });
+
+  it("does not alter disabled, group, short, media, voice, or already-Speakeasy replies", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg }) => {
+      const text = "This reply is long enough to qualify for on-demand voice playback.";
+      expect(withSpeakeasyVoiceButton({ reply: { text }, cfg, chatId: "999" })).toEqual({
+        text,
+      });
+      expect(
+        withSpeakeasyVoiceButton({ reply: { text }, cfg, chatId: "123", isGroup: true }),
+      ).toEqual({ text });
+      expect(withSpeakeasyVoiceButton({ reply: { text: "short" }, cfg, chatId: "123" })).toEqual({
+        text: "short",
+      });
+      expect(
+        withSpeakeasyVoiceButton({
+          reply: { text, mediaUrl: "/tmp/audio.mp3" },
+          cfg,
+          chatId: "123",
+        }),
+      ).toEqual({ text, mediaUrl: "/tmp/audio.mp3" });
+      expect(
+        withSpeakeasyVoiceButton({
+          reply: { text, audioAsVoice: true },
+          cfg,
+          chatId: "123",
+        }),
+      ).toEqual({ text, audioAsVoice: true });
+      const existingReply = {
+        text,
+        channelData: {
+          telegram: {
+            buttons: [
+              [
+                {
+                  text: SPEAKEASY_VOICE_BUTTON_LABEL,
+                  callback_data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}abc`,
+                },
+              ],
+            ],
+          },
+        },
+      };
+      expect(withSpeakeasyVoiceButton({ reply: existingReply, cfg, chatId: "123" })).toBe(
+        existingReply,
+      );
+    });
+  });
+
+  it("expires stale cached callbacks and enforces the daily generation cap", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg }) => {
+      const cache = loadSpeakeasyCache(cfg);
+      cache.entries.old = {
+        chatId: "123",
+        text: "Expired text",
+        createdAt: Date.now() - 25 * 60 * 60 * 1000,
+      };
+
+      expect(
+        resolveSpeakeasyCachedText({
+          cfg,
+          cache,
+          data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}old`,
+          chatId: "123",
+        }),
+      ).toEqual({ ok: false, reason: "expired" });
+
+      for (let index = 0; index < 50; index += 1) {
+        markSpeakeasyVoiceGenerated({ cache, chatId: "123" });
+      }
+      expect(shouldAllowSpeakeasyVoiceGeneration({ cache, chatId: "123" })).toBe(false);
+      expect(shouldAllowSpeakeasyVoiceGeneration({ cache, chatId: "999" })).toBe(true);
+    });
+  });
+});

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -423,6 +423,52 @@ describe("speakeasy voice button", () => {
     });
   });
 
+  it("requires atomic plugin-state updates before reserving generation quota", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg }) => {
+      const entries = new Map<string, SpeakeasyVoiceStateRecord>();
+      setSpeakeasyVoiceStateStoreForTest({
+        register: (key, value) => {
+          entries.set(key, value);
+        },
+        registerIfAbsent: (key, value) => {
+          if (entries.has(key)) {
+            return false;
+          }
+          entries.set(key, value);
+          return true;
+        },
+        lookup: (key) => entries.get(key),
+        consume: (key) => {
+          const value = entries.get(key);
+          entries.delete(key);
+          return value;
+        },
+        delete: (key) => entries.delete(key),
+        entries: () =>
+          Array.from(entries, ([key, value]) => ({
+            key,
+            value,
+            createdAt: Date.now(),
+          })),
+        clear: () => {
+          entries.clear();
+        },
+      });
+      const reply = withSpeakeasyVoiceButton({
+        reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
+        cfg,
+        chatId: "123",
+      }) as {
+        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      };
+      const callbackData = reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
+
+      expect(() =>
+        reserveSpeakeasyVoiceGeneration({ cfg, data: callbackData, chatId: "123" }),
+      ).toThrow("does not support atomic updates");
+    });
+  });
+
   it("prunes generation records from prior days", async () => {
     await withSpeakeasyWorkspace(async ({ cfg }) => {
       const cache = loadSpeakeasyCache(cfg);

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -1,7 +1,12 @@
-import { chmod, mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   SPEAKEASY_VOICE_BUTTON_LABEL,
   SPEAKEASY_VOICE_CALLBACK_PREFIX,
@@ -14,9 +19,27 @@ import {
   reserveSpeakeasyVoiceGeneration,
   resolveSpeakeasyCachedText,
   resolveSpeakeasyWorkspaceDir,
+  setSpeakeasyVoiceStateStoreForTest,
   shouldAllowSpeakeasyVoiceGeneration,
   withSpeakeasyVoiceButton,
+  writeSpeakeasyCache,
+  type SpeakeasyVoiceStateRecord,
 } from "./speakeasy-voice.js";
+
+beforeEach(() => {
+  resetPluginStateStoreForTests();
+  setSpeakeasyVoiceStateStoreForTest(
+    createPluginStateSyncKeyedStoreForTests<SpeakeasyVoiceStateRecord>("telegram", {
+      namespace: "telegram.speakeasy-voice",
+      maxEntries: 8_192,
+    }),
+  );
+});
+
+afterEach(() => {
+  setSpeakeasyVoiceStateStoreForTest(undefined);
+  resetPluginStateStoreForTests();
+});
 
 async function withSpeakeasyWorkspace<T>(
   fn: (params: {
@@ -25,6 +48,7 @@ async function withSpeakeasyWorkspace<T>(
   }) => Promise<T>,
 ) {
   const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-test-"));
+  const previousSpeakeasyWorkspace = process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR;
   await mkdir(path.join(workspaceDir, "config"), { recursive: true });
   await mkdir(path.join(workspaceDir, "state"), { recursive: true });
   await writeFile(
@@ -32,11 +56,13 @@ async function withSpeakeasyWorkspace<T>(
     JSON.stringify({ enabled: ["telegram:123"] }),
   );
   try {
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = workspaceDir;
     return await fn({
       workspaceDir,
       cfg: { agents: { defaults: { workspace: workspaceDir } } },
     });
   } finally {
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR = previousSpeakeasyWorkspace;
     await rm(workspaceDir, { recursive: true, force: true });
   }
 }
@@ -71,9 +97,7 @@ describe("speakeasy voice button", () => {
           text: "This reply is long enough to qualify for on-demand voice playback.",
         },
       );
-      expect(
-        (await stat(path.join(workspaceDir, "state", "speakeasy-cache.json"))).mode & 0o777,
-      ).toBe(0o600);
+      expect(existsSync(path.join(workspaceDir, "state", "speakeasy-cache.json"))).toBe(false);
     });
   });
 
@@ -107,24 +131,6 @@ describe("speakeasy voice button", () => {
       expect(
         resolveSpeakeasyCachedText({ cfg, cache, data: secondCallbackData, chatId: "123" }),
       ).toMatchObject({ ok: true, text: expect.stringContaining("second reply") });
-    });
-  });
-
-  it("fixes existing cache file permissions before writing reply text", async () => {
-    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
-      const cachePath = path.join(workspaceDir, "state", "speakeasy-cache.json");
-      await writeFile(cachePath, JSON.stringify({ version: 1, entries: {}, generations: {} }), {
-        mode: 0o644,
-      });
-
-      withSpeakeasyVoiceButton({
-        reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
-        cfg,
-        chatId: "123",
-      });
-      await flushSpeakeasyCacheWritesForTest();
-
-      expect((await stat(cachePath)).mode & 0o777).toBe(0o600);
     });
   });
 
@@ -185,14 +191,14 @@ describe("speakeasy voice button", () => {
           "import sys",
           "if sys.argv[1] != 'Hello from Speakeasy':",
           "    raise SystemExit('missing text argument')",
-          "print('state/speakeasy/out.ogg')",
+          "print('state/speakeasy/generated/out.ogg')",
           "",
         ].join("\n"),
       );
       await chmod(scriptPath, 0o755);
 
       await expect(generateSpeakeasyVoiceNote({ cfg, text: "Hello from Speakeasy" })).resolves.toBe(
-        path.join(workspaceDir, "state", "speakeasy", "out.ogg"),
+        path.join(workspaceDir, "state", "speakeasy", "generated", "out.ogg"),
       );
     });
   });
@@ -202,7 +208,7 @@ describe("speakeasy voice button", () => {
       await mkdir(path.join(workspaceDir, "scripts"), { recursive: true });
       await writeFile(
         path.join(workspaceDir, "scripts", "speakeasy_helper.py"),
-        "def output_path():\n    return 'state/speakeasy/helper.ogg'\n",
+        "def output_path():\n    return 'state/speakeasy/generated/helper.ogg'\n",
       );
       const scriptPath = path.join(workspaceDir, "scripts", "tts_elevenlabs_v2.py");
       await writeFile(
@@ -217,8 +223,34 @@ describe("speakeasy voice button", () => {
       await chmod(scriptPath, 0o755);
 
       await expect(generateSpeakeasyVoiceNote({ cfg, text: "Hello from Speakeasy" })).resolves.toBe(
-        path.join(workspaceDir, "state", "speakeasy", "helper.ogg"),
+        path.join(workspaceDir, "state", "speakeasy", "generated", "helper.ogg"),
       );
+    });
+  });
+
+  it("copies legacy TTS output paths into the generated audio directory", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      await mkdir(path.join(workspaceDir, "scripts"), { recursive: true });
+      const scriptPath = path.join(workspaceDir, "scripts", "tts_elevenlabs_v2.py");
+      const legacyOutputPath = path.join(workspaceDir, "state", "speakeasy", "reusable.ogg");
+      await mkdir(path.dirname(legacyOutputPath), { recursive: true });
+      await writeFile(legacyOutputPath, "voice bytes");
+      await writeFile(
+        scriptPath,
+        ["#!/usr/bin/env python3", "print('state/speakeasy/reusable.ogg')", ""].join("\n"),
+      );
+      await chmod(scriptPath, 0o755);
+
+      const generatedPath = await generateSpeakeasyVoiceNote({
+        cfg,
+        text: "Hello from Speakeasy",
+      });
+      const generatedRelativePath = path.relative(
+        path.join(workspaceDir, "state", "speakeasy", "generated"),
+        generatedPath,
+      );
+      expect(generatedRelativePath).toMatch(/^[^.].+\.ogg$/);
+      expect(existsSync(legacyOutputPath)).toBe(true);
     });
   });
 
@@ -263,49 +295,6 @@ describe("speakeasy voice button", () => {
       expect(failure).toBeInstanceOf(Error);
       expect((failure as Error).message).toMatch(/Speakeasy TTS failed/);
       expect((failure as Error).message.length).toBeLessThan(1024 * 1024 + 1024);
-    });
-  });
-
-  it("keeps optional voice-button delivery off the synchronous cache-write path", async () => {
-    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-cache-fail-"));
-    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
-    await writeFile(
-      path.join(workspaceDir, "config", "speakeasy-chats.json"),
-      JSON.stringify({ enabled: ["telegram:123"] }),
-    );
-    await writeFile(path.join(workspaceDir, "state"), "not a directory");
-    try {
-      const reply = { text: "This reply is long enough to qualify for on-demand voice playback." };
-      const enriched = withSpeakeasyVoiceButton({
-        reply,
-        cfg: { agents: { defaults: { workspace: workspaceDir } } },
-        chatId: "123",
-      }) as {
-        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
-      };
-
-      expect(enriched.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
-        /^tts:speakeasy:/,
-      );
-      await flushSpeakeasyCacheWritesForTest();
-    } finally {
-      await rm(workspaceDir, { recursive: true, force: true });
-    }
-  });
-
-  it("does not wait on a fresh cache lock before adding the optional voice button", async () => {
-    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
-      const cachePath = path.join(workspaceDir, "state", "speakeasy-cache.json");
-      const lockPath = `${cachePath}.lock`;
-      await writeFile(lockPath, "active lock");
-      const reply = { text: "This reply is long enough to qualify for on-demand voice playback." };
-
-      const enriched = withSpeakeasyVoiceButton({ reply, cfg, chatId: "123" }) as {
-        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
-      };
-      expect(enriched.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
-        /^tts:speakeasy:/,
-      );
     });
   });
 
@@ -408,7 +397,7 @@ describe("speakeasy voice button", () => {
     });
   });
 
-  it("reserves and releases generation quota under the cache lock", async () => {
+  it("reserves and releases generation quota in plugin state", async () => {
     await withSpeakeasyWorkspace(async ({ cfg }) => {
       const reply = withSpeakeasyVoiceButton({
         reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
@@ -435,48 +424,20 @@ describe("speakeasy voice button", () => {
   });
 
   it("prunes generation records from prior days", async () => {
-    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
-      await writeFile(
-        path.join(workspaceDir, "state", "speakeasy-cache.json"),
-        JSON.stringify({
-          version: 1,
-          entries: {},
-          generations: {
-            "123:2026-01-01": { date: "2026-01-01", count: 50 },
-            [`123:${new Date().toISOString().slice(0, 10)}`]: {
-              date: new Date().toISOString().slice(0, 10),
-              count: 1,
-            },
-          },
-        }),
-      );
-
+    await withSpeakeasyWorkspace(async ({ cfg }) => {
       const cache = loadSpeakeasyCache(cfg);
-      expect(cache.generations["123:2026-01-01"]).toBeUndefined();
-      expect(cache.generations[`123:${new Date().toISOString().slice(0, 10)}`]?.count).toBe(1);
-    });
-  });
-
-  it("recovers stale cache locks", async () => {
-    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
-      const cachePath = path.join(workspaceDir, "state", "speakeasy-cache.json");
-      const lockPath = `${cachePath}.lock`;
-      await writeFile(lockPath, "");
-      const stale = new Date(Date.now() - 60_000);
-      await utimes(lockPath, stale, stale);
-
-      const reply = withSpeakeasyVoiceButton({
-        reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
-        cfg,
-        chatId: "123",
-      }) as {
-        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      cache.generations = {
+        "123:2026-01-01": { date: "2026-01-01", count: 50 },
+        [`123:${new Date().toISOString().slice(0, 10)}`]: {
+          date: new Date().toISOString().slice(0, 10),
+          count: 1,
+        },
       };
-      await flushSpeakeasyCacheWritesForTest();
+      writeSpeakeasyCache(cfg, cache);
 
-      expect(reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
-        /^tts:speakeasy:/,
-      );
+      const reloaded = loadSpeakeasyCache(cfg);
+      expect(reloaded.generations["123:2026-01-01"]).toBeUndefined();
+      expect(reloaded.generations[`123:${new Date().toISOString().slice(0, 10)}`]?.count).toBe(1);
     });
   });
 });

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -42,7 +42,7 @@ async function withSpeakeasyWorkspace<T>(
 
 describe("speakeasy voice button", () => {
   it("adds one cached callback button to eligible enabled DM text replies", async () => {
-    await withSpeakeasyWorkspace(async ({ cfg }) => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
       const reply = withSpeakeasyVoiceButton({
         reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
         cfg,
@@ -69,6 +69,9 @@ describe("speakeasy voice button", () => {
           text: "This reply is long enough to qualify for on-demand voice playback.",
         },
       );
+      expect(
+        (await stat(path.join(workspaceDir, "state", "speakeasy-cache.json"))).mode & 0o777,
+      ).toBe(0o600);
     });
   });
 
@@ -168,6 +171,47 @@ describe("speakeasy voice button", () => {
       await expect(generateSpeakeasyVoiceNote({ cfg, text: "Hello from Speakeasy" })).resolves.toBe(
         path.join(workspaceDir, "state", "speakeasy", "out.ogg"),
       );
+    });
+  });
+
+  it("preserves script-directory imports for the TTS helper wrapper", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      await mkdir(path.join(workspaceDir, "scripts"), { recursive: true });
+      await writeFile(
+        path.join(workspaceDir, "scripts", "speakeasy_helper.py"),
+        "def output_path():\n    return 'state/speakeasy/helper.ogg'\n",
+      );
+      const scriptPath = path.join(workspaceDir, "scripts", "tts_elevenlabs_v2.py");
+      await writeFile(
+        scriptPath,
+        [
+          "#!/usr/bin/env python3",
+          "from speakeasy_helper import output_path",
+          "print(output_path())",
+          "",
+        ].join("\n"),
+      );
+      await chmod(scriptPath, 0o755);
+
+      await expect(generateSpeakeasyVoiceNote({ cfg, text: "Hello from Speakeasy" })).resolves.toBe(
+        path.join(workspaceDir, "state", "speakeasy", "helper.ogg"),
+      );
+    });
+  });
+
+  it("rejects instead of crashing when a fast-failing TTS helper closes stdin early", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      await mkdir(path.join(workspaceDir, "scripts"), { recursive: true });
+      const scriptPath = path.join(workspaceDir, "scripts", "tts_elevenlabs_v2.py");
+      await writeFile(
+        scriptPath,
+        ["#!/usr/bin/env python3", "raise SystemExit('fast fail')", ""].join("\n"),
+      );
+      await chmod(scriptPath, 0o755);
+
+      await expect(
+        generateSpeakeasyVoiceNote({ cfg, text: "x".repeat(1024 * 1024) }),
+      ).rejects.toThrow();
     });
   });
 
@@ -314,6 +358,28 @@ describe("speakeasy voice button", () => {
       releaseSpeakeasyVoiceGenerationReservation({ cfg, chatId: "123" });
       cache = loadSpeakeasyCache(cfg);
       expect(cache.generations[`123:${today}`]).toBeUndefined();
+    });
+  });
+
+  it("recovers stale cache locks", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      const cachePath = path.join(workspaceDir, "state", "speakeasy-cache.json");
+      const lockPath = `${cachePath}.lock`;
+      await writeFile(lockPath, "");
+      const stale = new Date(Date.now() - 60_000);
+      await utimes(lockPath, stale, stale);
+
+      const reply = withSpeakeasyVoiceButton({
+        reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
+        cfg,
+        chatId: "123",
+      }) as {
+        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      };
+
+      expect(reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
+        /^tts:speakeasy:/,
+      );
     });
   });
 });

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -6,6 +6,7 @@ import {
   SPEAKEASY_VOICE_BUTTON_LABEL,
   SPEAKEASY_VOICE_CALLBACK_PREFIX,
   assertSpeakeasyVoiceNoteOutputPath,
+  flushSpeakeasyCacheWritesForTest,
   generateSpeakeasyVoiceNote,
   loadSpeakeasyCache,
   markSpeakeasyVoiceGenerated,
@@ -40,12 +41,6 @@ async function withSpeakeasyWorkspace<T>(
   }
 }
 
-async function flushSpeakeasyCacheWrites(): Promise<void> {
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, 10);
-  });
-}
-
 describe("speakeasy voice button", () => {
   it("adds one cached callback button to eligible enabled DM text replies", async () => {
     await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
@@ -68,7 +63,7 @@ describe("speakeasy voice button", () => {
       ]);
 
       const callbackData = reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
-      await flushSpeakeasyCacheWrites();
+      await flushSpeakeasyCacheWritesForTest();
       const cache = loadSpeakeasyCache(cfg);
       expect(resolveSpeakeasyCachedText({ cfg, cache, data: callbackData, chatId: "123" })).toEqual(
         {
@@ -104,7 +99,7 @@ describe("speakeasy voice button", () => {
       const firstCallbackData = first.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
       const secondCallbackData =
         second.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
-      await flushSpeakeasyCacheWrites();
+      await flushSpeakeasyCacheWritesForTest();
       const cache = loadSpeakeasyCache(cfg);
       expect(
         resolveSpeakeasyCachedText({ cfg, cache, data: firstCallbackData, chatId: "123" }),
@@ -127,20 +122,20 @@ describe("speakeasy voice button", () => {
         cfg,
         chatId: "123",
       });
-      await flushSpeakeasyCacheWrites();
+      await flushSpeakeasyCacheWritesForTest();
 
       expect((await stat(cachePath)).mode & 0o777).toBe(0o600);
     });
   });
 
-  it("accepts Telegram-supported Speakeasy voice-note output paths", () => {
-    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.mp3")).not.toThrow();
-    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.m4a")).not.toThrow();
-    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.ogg")).not.toThrow();
-    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.opus")).not.toThrow();
+  it("accepts Telegram-supported Speakeasy voice output paths", () => {
     expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.wav")).toThrow(
       "not a Telegram voice-note file",
     );
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.ogg")).not.toThrow();
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.opus")).not.toThrow();
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.mp3")).not.toThrow();
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.m4a")).not.toThrow();
   });
 
   it("expands configured tilde workspace paths", async () => {
@@ -271,7 +266,7 @@ describe("speakeasy voice button", () => {
     });
   });
 
-  it("keeps the optional voice button off the send path when the callback cache cannot be written", async () => {
+  it("keeps optional voice-button delivery off the synchronous cache-write path", async () => {
     const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-cache-fail-"));
     await mkdir(path.join(workspaceDir, "config"), { recursive: true });
     await writeFile(
@@ -285,29 +280,29 @@ describe("speakeasy voice button", () => {
         reply,
         cfg: { agents: { defaults: { workspace: workspaceDir } } },
         chatId: "123",
-      }) as typeof reply & {
+      }) as {
         channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
       };
-      expect(enriched).not.toBe(reply);
+
       expect(enriched.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
         /^tts:speakeasy:/,
       );
+      await flushSpeakeasyCacheWritesForTest();
     } finally {
       await rm(workspaceDir, { recursive: true, force: true });
     }
   });
 
-  it("does not block button attachment when a fresh cache lock exists", async () => {
+  it("does not wait on a fresh cache lock before adding the optional voice button", async () => {
     await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
       const cachePath = path.join(workspaceDir, "state", "speakeasy-cache.json");
       const lockPath = `${cachePath}.lock`;
       await writeFile(lockPath, "active lock");
       const reply = { text: "This reply is long enough to qualify for on-demand voice playback." };
 
-      const enriched = withSpeakeasyVoiceButton({ reply, cfg, chatId: "123" }) as typeof reply & {
+      const enriched = withSpeakeasyVoiceButton({ reply, cfg, chatId: "123" }) as {
         channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
       };
-      expect(enriched).not.toBe(reply);
       expect(enriched.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
         /^tts:speakeasy:/,
       );
@@ -423,7 +418,7 @@ describe("speakeasy voice button", () => {
         channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
       };
       const callbackData = reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
-      await flushSpeakeasyCacheWrites();
+      await flushSpeakeasyCacheWritesForTest();
 
       expect(reserveSpeakeasyVoiceGeneration({ cfg, data: callbackData, chatId: "123" })).toEqual({
         ok: true,
@@ -477,6 +472,7 @@ describe("speakeasy voice button", () => {
       }) as {
         channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
       };
+      await flushSpeakeasyCacheWritesForTest();
 
       expect(reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
         /^tts:speakeasy:/,

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -40,6 +40,12 @@ async function withSpeakeasyWorkspace<T>(
   }
 }
 
+async function flushSpeakeasyCacheWrites(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 10);
+  });
+}
+
 describe("speakeasy voice button", () => {
   it("adds one cached callback button to eligible enabled DM text replies", async () => {
     await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
@@ -62,6 +68,7 @@ describe("speakeasy voice button", () => {
       ]);
 
       const callbackData = reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
+      await flushSpeakeasyCacheWrites();
       const cache = loadSpeakeasyCache(cfg);
       expect(resolveSpeakeasyCachedText({ cfg, cache, data: callbackData, chatId: "123" })).toEqual(
         {
@@ -97,6 +104,7 @@ describe("speakeasy voice button", () => {
       const firstCallbackData = first.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
       const secondCallbackData =
         second.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
+      await flushSpeakeasyCacheWrites();
       const cache = loadSpeakeasyCache(cfg);
       expect(
         resolveSpeakeasyCachedText({ cfg, cache, data: firstCallbackData, chatId: "123" }),
@@ -119,17 +127,20 @@ describe("speakeasy voice button", () => {
         cfg,
         chatId: "123",
       });
+      await flushSpeakeasyCacheWrites();
 
       expect((await stat(cachePath)).mode & 0o777).toBe(0o600);
     });
   });
 
-  it("rejects non-voice-note Speakeasy output paths", () => {
-    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.mp3")).toThrow(
-      "not a Telegram voice-note file",
-    );
+  it("accepts Telegram-supported Speakeasy voice-note output paths", () => {
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.mp3")).not.toThrow();
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.m4a")).not.toThrow();
     expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.ogg")).not.toThrow();
     expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.opus")).not.toThrow();
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.wav")).toThrow(
+      "not a Telegram voice-note file",
+    );
   });
 
   it("expands configured tilde workspace paths", async () => {
@@ -260,7 +271,7 @@ describe("speakeasy voice button", () => {
     });
   });
 
-  it("skips the optional voice button when the callback cache cannot be written", async () => {
+  it("keeps the optional voice button off the send path when the callback cache cannot be written", async () => {
     const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-cache-fail-"));
     await mkdir(path.join(workspaceDir, "config"), { recursive: true });
     await writeFile(
@@ -270,26 +281,36 @@ describe("speakeasy voice button", () => {
     await writeFile(path.join(workspaceDir, "state"), "not a directory");
     try {
       const reply = { text: "This reply is long enough to qualify for on-demand voice playback." };
-      expect(
-        withSpeakeasyVoiceButton({
-          reply,
-          cfg: { agents: { defaults: { workspace: workspaceDir } } },
-          chatId: "123",
-        }),
-      ).toBe(reply);
+      const enriched = withSpeakeasyVoiceButton({
+        reply,
+        cfg: { agents: { defaults: { workspace: workspaceDir } } },
+        chatId: "123",
+      }) as typeof reply & {
+        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      };
+      expect(enriched).not.toBe(reply);
+      expect(enriched.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
+        /^tts:speakeasy:/,
+      );
     } finally {
       await rm(workspaceDir, { recursive: true, force: true });
     }
   });
 
-  it("skips the optional voice button when a fresh cache lock exists", async () => {
+  it("does not block button attachment when a fresh cache lock exists", async () => {
     await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
       const cachePath = path.join(workspaceDir, "state", "speakeasy-cache.json");
       const lockPath = `${cachePath}.lock`;
       await writeFile(lockPath, "active lock");
       const reply = { text: "This reply is long enough to qualify for on-demand voice playback." };
 
-      expect(withSpeakeasyVoiceButton({ reply, cfg, chatId: "123" })).toBe(reply);
+      const enriched = withSpeakeasyVoiceButton({ reply, cfg, chatId: "123" }) as typeof reply & {
+        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      };
+      expect(enriched).not.toBe(reply);
+      expect(enriched.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data).toMatch(
+        /^tts:speakeasy:/,
+      );
     });
   });
 
@@ -402,6 +423,7 @@ describe("speakeasy voice button", () => {
         channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
       };
       const callbackData = reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
+      await flushSpeakeasyCacheWrites();
 
       expect(reserveSpeakeasyVoiceGeneration({ cfg, data: callbackData, chatId: "123" })).toEqual({
         ok: true,

--- a/extensions/telegram/src/speakeasy-voice.test.ts
+++ b/extensions/telegram/src/speakeasy-voice.test.ts
@@ -1,13 +1,18 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   SPEAKEASY_VOICE_BUTTON_LABEL,
   SPEAKEASY_VOICE_CALLBACK_PREFIX,
+  assertSpeakeasyVoiceNoteOutputPath,
+  generateSpeakeasyVoiceNote,
   loadSpeakeasyCache,
   markSpeakeasyVoiceGenerated,
+  releaseSpeakeasyVoiceGenerationReservation,
+  reserveSpeakeasyVoiceGeneration,
   resolveSpeakeasyCachedText,
+  resolveSpeakeasyWorkspaceDir,
   shouldAllowSpeakeasyVoiceGeneration,
   withSpeakeasyVoiceButton,
 } from "./speakeasy-voice.js";
@@ -67,6 +72,127 @@ describe("speakeasy voice button", () => {
     });
   });
 
+  it("keeps separate cache entries for back-to-back eligible replies", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg }) => {
+      const first = withSpeakeasyVoiceButton({
+        reply: { text: "This first reply is long enough to qualify for on-demand voice playback." },
+        cfg,
+        chatId: "123",
+      }) as {
+        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      };
+      const second = withSpeakeasyVoiceButton({
+        reply: {
+          text: "This second reply is also long enough to qualify for on-demand voice playback.",
+        },
+        cfg,
+        chatId: "123",
+      }) as {
+        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      };
+
+      const firstCallbackData = first.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
+      const secondCallbackData =
+        second.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
+      const cache = loadSpeakeasyCache(cfg);
+      expect(
+        resolveSpeakeasyCachedText({ cfg, cache, data: firstCallbackData, chatId: "123" }),
+      ).toMatchObject({ ok: true, text: expect.stringContaining("first reply") });
+      expect(
+        resolveSpeakeasyCachedText({ cfg, cache, data: secondCallbackData, chatId: "123" }),
+      ).toMatchObject({ ok: true, text: expect.stringContaining("second reply") });
+    });
+  });
+
+  it("rejects non-voice-note Speakeasy output paths", () => {
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.mp3")).toThrow(
+      "not a Telegram voice-note file",
+    );
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.ogg")).not.toThrow();
+    expect(() => assertSpeakeasyVoiceNoteOutputPath("/tmp/speakeasy.opus")).not.toThrow();
+  });
+
+  it("expands configured tilde workspace paths", async () => {
+    const workspaceDir = await mkdtemp(path.join(homedir(), "openclaw-speakeasy-tilde-test-"));
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:123"] }),
+    );
+    try {
+      const workspaceName = path.basename(workspaceDir);
+      expect(
+        resolveSpeakeasyWorkspaceDir({
+          agents: { defaults: { workspace: `~/${workspaceName}` } },
+        }),
+      ).toBe(workspaceDir);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("honors the canonical workspace env override", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-env-test-"));
+    const previousWorkspace = process.env.OPENCLAW_WORKSPACE_DIR;
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:123"] }),
+    );
+    try {
+      process.env.OPENCLAW_WORKSPACE_DIR = workspaceDir;
+      expect(resolveSpeakeasyWorkspaceDir({})).toBe(workspaceDir);
+    } finally {
+      process.env.OPENCLAW_WORKSPACE_DIR = previousWorkspace;
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves relative TTS output paths against the workspace", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg, workspaceDir }) => {
+      await mkdir(path.join(workspaceDir, "scripts"), { recursive: true });
+      const scriptPath = path.join(workspaceDir, "scripts", "tts_elevenlabs_v2.py");
+      await writeFile(
+        scriptPath,
+        [
+          "#!/usr/bin/env python3",
+          "import sys",
+          "if sys.argv[1] != 'Hello from Speakeasy':",
+          "    raise SystemExit('missing text argument')",
+          "print('state/speakeasy/out.ogg')",
+          "",
+        ].join("\n"),
+      );
+      await chmod(scriptPath, 0o755);
+
+      await expect(generateSpeakeasyVoiceNote({ cfg, text: "Hello from Speakeasy" })).resolves.toBe(
+        path.join(workspaceDir, "state", "speakeasy", "out.ogg"),
+      );
+    });
+  });
+
+  it("skips the optional voice button when the callback cache cannot be written", async () => {
+    const workspaceDir = await mkdtemp(path.join(tmpdir(), "openclaw-speakeasy-cache-fail-"));
+    await mkdir(path.join(workspaceDir, "config"), { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "config", "speakeasy-chats.json"),
+      JSON.stringify({ enabled: ["telegram:123"] }),
+    );
+    await writeFile(path.join(workspaceDir, "state"), "not a directory");
+    try {
+      const reply = { text: "This reply is long enough to qualify for on-demand voice playback." };
+      expect(
+        withSpeakeasyVoiceButton({
+          reply,
+          cfg: { agents: { defaults: { workspace: workspaceDir } } },
+          chatId: "123",
+        }),
+      ).toBe(reply);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not alter disabled, group, short, media, voice, or already-Speakeasy replies", async () => {
     await withSpeakeasyWorkspace(async ({ cfg }) => {
       const text = "This reply is long enough to qualify for on-demand voice playback.";
@@ -75,6 +201,22 @@ describe("speakeasy voice button", () => {
       });
       expect(
         withSpeakeasyVoiceButton({ reply: { text }, cfg, chatId: "123", isGroup: true }),
+      ).toEqual({ text });
+      expect(
+        withSpeakeasyVoiceButton({
+          reply: { text },
+          cfg,
+          chatId: "123",
+          inlineButtonsScope: "off",
+        }),
+      ).toEqual({ text });
+      expect(
+        withSpeakeasyVoiceButton({
+          reply: { text },
+          cfg,
+          chatId: "123",
+          inlineButtonsScope: "group",
+        }),
       ).toEqual({ text });
       expect(withSpeakeasyVoiceButton({ reply: { text: "short" }, cfg, chatId: "123" })).toEqual({
         text: "short",
@@ -111,6 +253,16 @@ describe("speakeasy voice button", () => {
       expect(withSpeakeasyVoiceButton({ reply: existingReply, cfg, chatId: "123" })).toBe(
         existingReply,
       );
+      const fullKeyboard = Array.from({ length: 100 }, (_, index) => [
+        { text: `Button ${index}`, callback_data: `cmd:${index}` },
+      ]);
+      const fullKeyboardReply = {
+        text,
+        channelData: { telegram: { buttons: fullKeyboard } },
+      };
+      expect(withSpeakeasyVoiceButton({ reply: fullKeyboardReply, cfg, chatId: "123" })).toBe(
+        fullKeyboardReply,
+      );
     });
   });
 
@@ -137,6 +289,31 @@ describe("speakeasy voice button", () => {
       }
       expect(shouldAllowSpeakeasyVoiceGeneration({ cache, chatId: "123" })).toBe(false);
       expect(shouldAllowSpeakeasyVoiceGeneration({ cache, chatId: "999" })).toBe(true);
+    });
+  });
+
+  it("reserves and releases generation quota under the cache lock", async () => {
+    await withSpeakeasyWorkspace(async ({ cfg }) => {
+      const reply = withSpeakeasyVoiceButton({
+        reply: { text: "This reply is long enough to qualify for on-demand voice playback." },
+        cfg,
+        chatId: "123",
+      }) as {
+        channelData?: { telegram?: { buttons?: Array<Array<{ callback_data: string }>> } };
+      };
+      const callbackData = reply.channelData?.telegram?.buttons?.[0]?.[0]?.callback_data ?? "";
+
+      expect(reserveSpeakeasyVoiceGeneration({ cfg, data: callbackData, chatId: "123" })).toEqual({
+        ok: true,
+        text: "This reply is long enough to qualify for on-demand voice playback.",
+      });
+      let cache = loadSpeakeasyCache(cfg);
+      const today = new Date().toISOString().slice(0, 10);
+      expect(cache.generations[`123:${today}`]?.count).toBe(1);
+
+      releaseSpeakeasyVoiceGenerationReservation({ cfg, chatId: "123" });
+      cache = loadSpeakeasyCache(cfg);
+      expect(cache.generations[`123:${today}`]).toBeUndefined();
     });
   });
 });

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -4,6 +4,7 @@ import {
   chmodSync,
   closeSync,
   existsSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -154,6 +155,7 @@ export function loadSpeakeasyCache(cfg: OpenClawConfig): SpeakeasyVoiceCache {
 export function writeSpeakeasyCache(cfg: OpenClawConfig, cache: SpeakeasyVoiceCache): void {
   const cachePath = resolveSpeakeasyCachePath(cfg);
   mkdirSync(path.dirname(cachePath), { recursive: true });
+  chmodExistingSpeakeasyCache(cachePath);
   writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, {
     encoding: "utf8",
     mode: 0o600,
@@ -165,20 +167,34 @@ function waitForSpeakeasyCacheLock(): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
 }
 
+function chmodExistingSpeakeasyCache(cachePath: string): void {
+  try {
+    chmodSync(cachePath, 0o600);
+  } catch (err) {
+    if (!isFileNotFoundError(err)) {
+      throw err;
+    }
+  }
+}
+
 function acquireSpeakeasyCacheLock(cachePath: string): () => void {
   const lockPath = `${cachePath}.lock`;
   const deadline = Date.now() + SPEAKEASY_CACHE_LOCK_TIMEOUT_MS;
   mkdirSync(path.dirname(cachePath), { recursive: true });
   while (true) {
     let fd: number | undefined;
+    const lockToken = randomUUID();
     try {
       fd = openSync(lockPath, "wx", 0o600);
+      writeFileSync(fd, lockToken, "utf8");
       return () => {
         if (fd !== undefined) {
           closeSync(fd);
         }
         try {
-          unlinkSync(lockPath);
+          if (readFileSync(lockPath, "utf8") === lockToken) {
+            unlinkSync(lockPath);
+          }
         } catch {
           // Best effort: another recovery path may have already removed a stale lock.
         }
@@ -199,16 +215,37 @@ function isFileAlreadyExistsError(err: unknown): boolean {
   return Boolean(err && typeof err === "object" && "code" in err && err.code === "EEXIST");
 }
 
+function isFileNotFoundError(err: unknown): boolean {
+  return Boolean(err && typeof err === "object" && "code" in err && err.code === "ENOENT");
+}
+
 function recoverStaleSpeakeasyCacheLock(lockPath: string): boolean {
+  const claimPath = `${lockPath}.${process.pid}.${randomUUID()}.stale`;
   try {
-    const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+    linkSync(lockPath, claimPath);
+    const claimStats = statSync(claimPath);
+    const lockStats = statSync(lockPath);
+    if (claimStats.dev !== lockStats.dev || claimStats.ino !== lockStats.ino) {
+      return false;
+    }
+    const ageMs = Date.now() - claimStats.mtimeMs;
     if (ageMs < SPEAKEASY_CACHE_LOCK_STALE_MS) {
+      return false;
+    }
+    const currentStats = statSync(lockPath);
+    if (claimStats.dev !== currentStats.dev || claimStats.ino !== currentStats.ino) {
       return false;
     }
     unlinkSync(lockPath);
     return true;
   } catch {
     return false;
+  } finally {
+    try {
+      unlinkSync(claimPath);
+    } catch {
+      // Best effort: the claim path may not exist if linking failed.
+    }
   }
 }
 

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -1,19 +1,38 @@
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type {
+  OpenClawConfig,
+  TelegramInlineButtonsScope,
+} from "openclaw/plugin-sdk/config-contracts";
 import type { TelegramInlineButtons } from "./button-types.js";
-
-const execFileAsync = promisify(execFile);
 
 export const SPEAKEASY_VOICE_CALLBACK_PREFIX = "tts:speakeasy:";
 export const SPEAKEASY_VOICE_BUTTON_LABEL = "🔊 Voice note";
 const MIN_SPEAKEASY_TEXT_CHARS = 20;
 const SPEAKEASY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const SPEAKEASY_DAILY_GENERATION_CAP = 50;
+const SPEAKEASY_CACHE_LOCK_TIMEOUT_MS = 1000;
+const SPEAKEASY_TTS_TIMEOUT_MS = 120_000;
+const SPEAKEASY_VOICE_NOTE_EXTENSIONS = new Set([".oga", ".ogg", ".opus"]);
+const TELEGRAM_MAX_INLINE_BUTTON_ACTIONS = 100;
+const SPEAKEASY_STDIN_ARGV_WRAPPER = [
+  "import runpy, sys",
+  "script = sys.argv[1]",
+  "text = sys.stdin.read()",
+  "sys.argv = [script, text]",
+  "runpy.run_path(script, run_name='__main__')",
+].join("\n");
 
 type ReplyLike = {
   text?: string;
@@ -33,23 +52,54 @@ type SpeakeasyChatsConfig = {
   enabled?: string[];
 };
 
+function isSpeakeasyInlineButtonScopeAllowed(params: {
+  inlineButtonsScope?: TelegramInlineButtonsScope;
+  isGroup?: boolean;
+}): boolean {
+  const scope = params.inlineButtonsScope ?? "allowlist";
+  if (scope === "off") {
+    return false;
+  }
+  if (scope === "dm" && params.isGroup) {
+    return false;
+  }
+  if (scope === "group" && !params.isGroup) {
+    return false;
+  }
+  return true;
+}
+
 function resolveConfiguredWorkspace(cfg: OpenClawConfig): string | undefined {
   const workspace = cfg.agents?.defaults?.workspace;
   return typeof workspace === "string" && workspace.trim() ? workspace.trim() : undefined;
 }
 
+function expandHomePath(value: string): string {
+  if (value === "~") {
+    return homedir();
+  }
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(homedir(), value.slice(2));
+  }
+  return value;
+}
+
 export function resolveSpeakeasyWorkspaceDir(cfg: OpenClawConfig): string {
   const candidates = [
     process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR,
-    process.env.OPENCLAW_WORKSPACE,
+    process.env.OPENCLAW_WORKSPACE_DIR,
     resolveConfiguredWorkspace(cfg),
     process.cwd(),
     path.join(homedir(), ".openclaw", "workspace"),
   ];
   for (const candidate of candidates) {
-    if (!candidate?.trim()) continue;
-    const resolved = path.resolve(candidate);
-    if (existsSync(path.join(resolved, "config", "speakeasy-chats.json"))) return resolved;
+    if (!candidate?.trim()) {
+      continue;
+    }
+    const resolved = path.resolve(expandHomePath(candidate));
+    if (existsSync(path.join(resolved, "config", "speakeasy-chats.json"))) {
+      return resolved;
+    }
   }
   return path.join(homedir(), ".openclaw", "workspace");
 }
@@ -76,7 +126,9 @@ function emptySpeakeasyCache(): SpeakeasyVoiceCache {
 
 function pruneSpeakeasyCache(cache: SpeakeasyVoiceCache, now = Date.now()): void {
   for (const [id, entry] of Object.entries(cache.entries)) {
-    if (now - entry.createdAt > SPEAKEASY_CACHE_TTL_MS) delete cache.entries[id];
+    if (now - entry.createdAt > SPEAKEASY_CACHE_TTL_MS) {
+      delete cache.entries[id];
+    }
   }
 }
 
@@ -101,6 +153,39 @@ export function writeSpeakeasyCache(cfg: OpenClawConfig, cache: SpeakeasyVoiceCa
   writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
 }
 
+function waitForSpeakeasyCacheLock(): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+}
+
+function acquireSpeakeasyCacheLock(cachePath: string): () => void {
+  const lockPath = `${cachePath}.lock`;
+  const deadline = Date.now() + SPEAKEASY_CACHE_LOCK_TIMEOUT_MS;
+  mkdirSync(path.dirname(cachePath), { recursive: true });
+  while (true) {
+    let fd: number | undefined;
+    try {
+      fd = openSync(lockPath, "wx");
+      return () => {
+        if (fd !== undefined) {
+          closeSync(fd);
+        }
+        unlinkSync(lockPath);
+      };
+    } catch (err) {
+      if (
+        !err ||
+        typeof err !== "object" ||
+        !("code" in err) ||
+        err.code !== "EEXIST" ||
+        Date.now() >= deadline
+      ) {
+        throw err;
+      }
+      waitForSpeakeasyCacheLock();
+    }
+  }
+}
+
 function loadSpeakeasyChatsConfig(cfg: OpenClawConfig): SpeakeasyChatsConfig {
   return readJsonFile<SpeakeasyChatsConfig>(resolveSpeakeasyConfigPath(cfg), {});
 }
@@ -114,7 +199,9 @@ export function isSpeakeasyVoiceCallbackData(data: string): boolean {
 }
 
 function parseSpeakeasyVoiceCallbackId(data: string): string | null {
-  if (!isSpeakeasyVoiceCallbackData(data)) return null;
+  if (!isSpeakeasyVoiceCallbackData(data)) {
+    return null;
+  }
   const id = data.slice(SPEAKEASY_VOICE_CALLBACK_PREFIX.length).trim();
   return id.length > 0 ? id : null;
 }
@@ -151,6 +238,27 @@ export function markSpeakeasyVoiceGenerated(params: {
   };
 }
 
+function unmarkSpeakeasyVoiceGenerated(params: {
+  cache: SpeakeasyVoiceCache;
+  chatId: string;
+  now?: Date;
+}): void {
+  const now = params.now ?? new Date();
+  const key = generationKey(params.chatId, now);
+  const current = params.cache.generations[key];
+  if (!current || current.date !== todayKey(now)) {
+    return;
+  }
+  if (current.count <= 1) {
+    delete params.cache.generations[key];
+    return;
+  }
+  params.cache.generations[key] = {
+    date: current.date,
+    count: current.count - 1,
+  };
+}
+
 export function resolveSpeakeasyCachedText(params: {
   cfg: OpenClawConfig;
   cache: SpeakeasyVoiceCache;
@@ -163,7 +271,9 @@ export function resolveSpeakeasyCachedText(params: {
   }
   const id = parseSpeakeasyVoiceCallbackId(params.data);
   const entry = id ? params.cache.entries[id] : undefined;
-  if (!id || !entry || entry.chatId !== params.chatId) return { ok: false, reason: "miss" };
+  if (!id || !entry || entry.chatId !== params.chatId) {
+    return { ok: false, reason: "miss" };
+  }
   if ((params.now ?? Date.now()) - entry.createdAt > SPEAKEASY_CACHE_TTL_MS) {
     delete params.cache.entries[id];
     return { ok: false, reason: "expired" };
@@ -171,20 +281,80 @@ export function resolveSpeakeasyCachedText(params: {
   return { ok: true, text: entry.text };
 }
 
+function updateSpeakeasyCacheWithLock<T>(
+  cfg: OpenClawConfig,
+  updater: (cache: SpeakeasyVoiceCache) => T,
+): T {
+  const cachePath = resolveSpeakeasyCachePath(cfg);
+  const releaseLock = acquireSpeakeasyCacheLock(cachePath);
+  try {
+    const latest = loadSpeakeasyCache(cfg);
+    const result = updater(latest);
+    writeSpeakeasyCache(cfg, latest);
+    return result;
+  } finally {
+    releaseLock();
+  }
+}
+
 function createSpeakeasyCacheEntry(params: {
   cfg: OpenClawConfig;
   chatId: string;
   text: string;
 }): string {
-  const cache = loadSpeakeasyCache(params.cfg);
   const id = randomUUID().replace(/-/g, "").slice(0, 24);
-  cache.entries[id] = {
+  const entry = {
     chatId: params.chatId,
     text: params.text,
     createdAt: Date.now(),
   };
-  writeSpeakeasyCache(params.cfg, cache);
+  updateSpeakeasyCacheWithLock(params.cfg, (latest) => {
+    latest.entries[id] = entry;
+  });
   return id;
+}
+
+export function reserveSpeakeasyVoiceGeneration(params: {
+  cfg: OpenClawConfig;
+  data: string;
+  chatId: string;
+}): { ok: true; text: string } | { ok: false; reason: "miss" | "expired" | "disabled" | "limit" } {
+  return updateSpeakeasyCacheWithLock(params.cfg, (cache) => {
+    const resolved = resolveSpeakeasyCachedText({
+      cfg: params.cfg,
+      cache,
+      data: params.data,
+      chatId: params.chatId,
+    });
+    if (!resolved.ok) {
+      return resolved;
+    }
+    if (!shouldAllowSpeakeasyVoiceGeneration({ cache, chatId: params.chatId })) {
+      return { ok: false, reason: "limit" };
+    }
+    markSpeakeasyVoiceGenerated({ cache, chatId: params.chatId });
+    return resolved;
+  });
+}
+
+export function releaseSpeakeasyVoiceGenerationReservation(params: {
+  cfg: OpenClawConfig;
+  chatId: string;
+}): void {
+  updateSpeakeasyCacheWithLock(params.cfg, (cache) => {
+    unmarkSpeakeasyVoiceGenerated({ cache, chatId: params.chatId });
+  });
+}
+
+function countTelegramInlineButtonActions(buttons: TelegramInlineButtons | undefined): number {
+  return buttons?.reduce((sum, row) => sum + row.length, 0) ?? 0;
+}
+
+export function assertSpeakeasyVoiceNoteOutputPath(outputPath: string): void {
+  const extension = path.extname(outputPath).toLowerCase();
+  if (!SPEAKEASY_VOICE_NOTE_EXTENSIONS.has(extension)) {
+    throw new Error(`Speakeasy TTS output is not a Telegram voice-note file: ${outputPath}`);
+  }
 }
 
 export function shouldAttachSpeakeasyVoiceButton(params: {
@@ -193,25 +363,46 @@ export function shouldAttachSpeakeasyVoiceButton(params: {
   chatId?: string;
   isGroup?: boolean;
   hasMedia?: boolean;
+  inlineButtonsScope?: TelegramInlineButtonsScope;
 }): boolean {
-  if (params.isGroup) return false;
+  if (params.isGroup) {
+    return false;
+  }
   if (
-    !params.chatId ||
-    !params.cfg ||
-    !isSpeakeasyChatEnabled({ cfg: params.cfg, chatId: params.chatId })
+    !isSpeakeasyInlineButtonScopeAllowed({
+      inlineButtonsScope: params.inlineButtonsScope,
+      isGroup: params.isGroup,
+    })
   ) {
     return false;
   }
   const text = params.reply.text?.trim() ?? "";
-  if (text.length <= MIN_SPEAKEASY_TEXT_CHARS) return false;
+  if (text.length <= MIN_SPEAKEASY_TEXT_CHARS) {
+    return false;
+  }
   if (params.hasMedia || params.reply.mediaUrl || (params.reply.mediaUrls?.length ?? 0) > 0) {
     return false;
   }
-  if (params.reply.audioAsVoice) return false;
+  if (params.reply.audioAsVoice) {
+    return false;
+  }
   if (
     params.reply.channelData?.telegram?.buttons?.some((row) =>
       row.some((button) => button.callback_data?.startsWith(SPEAKEASY_VOICE_CALLBACK_PREFIX)),
     )
+  ) {
+    return false;
+  }
+  if (
+    countTelegramInlineButtonActions(params.reply.channelData?.telegram?.buttons) >=
+    TELEGRAM_MAX_INLINE_BUTTON_ACTIONS
+  ) {
+    return false;
+  }
+  if (
+    !params.chatId ||
+    !params.cfg ||
+    !isSpeakeasyChatEnabled({ cfg: params.cfg, chatId: params.chatId })
   ) {
     return false;
   }
@@ -224,13 +415,21 @@ export function withSpeakeasyVoiceButton<T extends ReplyLike>(params: {
   chatId?: string;
   isGroup?: boolean;
   hasMedia?: boolean;
+  inlineButtonsScope?: TelegramInlineButtonsScope;
 }): T {
-  if (!shouldAttachSpeakeasyVoiceButton(params)) return params.reply;
-  const id = createSpeakeasyCacheEntry({
-    cfg: params.cfg!,
-    chatId: params.chatId!,
-    text: params.reply.text!.trim(),
-  });
+  if (!shouldAttachSpeakeasyVoiceButton(params)) {
+    return params.reply;
+  }
+  let id: string;
+  try {
+    id = createSpeakeasyCacheEntry({
+      cfg: params.cfg!,
+      chatId: params.chatId!,
+      text: params.reply.text!.trim(),
+    });
+  } catch {
+    return params.reply;
+  }
   return {
     ...params.reply,
     channelData: {
@@ -257,13 +456,83 @@ export async function generateSpeakeasyVoiceNote(params: {
 }): Promise<string> {
   const workspaceDir = resolveSpeakeasyWorkspaceDir(params.cfg);
   const scriptPath = path.join(workspaceDir, "scripts", "tts_elevenlabs_v2.py");
-  const { stdout } = await execFileAsync(scriptPath, [params.text], {
+  const stdout = await runSpeakeasyTtsScript({
     cwd: workspaceDir,
-    maxBuffer: 1024 * 1024,
+    scriptPath,
+    text: params.text,
   });
-  const outputPath = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1)?.trim();
-  if (!outputPath) {
+  const rawOutputPath = stdout
+    .trim()
+    .split(/\r?\n/)
+    .findLast((line) => line.trim().length > 0)
+    ?.trim();
+  if (!rawOutputPath) {
     throw new Error("Speakeasy TTS did not print an output path");
   }
+  const outputPath = path.isAbsolute(rawOutputPath)
+    ? rawOutputPath
+    : path.resolve(workspaceDir, rawOutputPath);
+  assertSpeakeasyVoiceNoteOutputPath(outputPath);
   return outputPath;
+}
+
+function runSpeakeasyTtsScript(params: {
+  cwd: string;
+  scriptPath: string;
+  text: string;
+}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const child = spawn("python3", ["-c", SPEAKEASY_STDIN_ARGV_WRAPPER, params.scriptPath], {
+      cwd: params.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const timeout = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.kill("SIGTERM");
+      reject(new Error(`Speakeasy TTS timed out after ${SPEAKEASY_TTS_TIMEOUT_MS}ms`));
+    }, SPEAKEASY_TTS_TIMEOUT_MS);
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      if (stdout.length > 1024 * 1024) {
+        child.kill("SIGTERM");
+      }
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.on("close", (code, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(
+        new Error(
+          `Speakeasy TTS failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}: ${stderr.trim()}`,
+        ),
+      );
+    });
+    child.stdin.end(params.text);
+  });
 }

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -25,9 +25,9 @@ export const SPEAKEASY_VOICE_BUTTON_LABEL = "🔊 Voice note";
 const MIN_SPEAKEASY_TEXT_CHARS = 20;
 const SPEAKEASY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const SPEAKEASY_DAILY_GENERATION_CAP = 50;
-const SPEAKEASY_CACHE_LOCK_TIMEOUT_MS = 1000;
 const SPEAKEASY_CACHE_LOCK_STALE_MS = 30_000;
 const SPEAKEASY_TTS_TIMEOUT_MS = 120_000;
+const SPEAKEASY_TTS_MAX_OUTPUT_CHARS = 1024 * 1024;
 const SPEAKEASY_VOICE_NOTE_EXTENSIONS = new Set([".oga", ".ogg", ".opus"]);
 const TELEGRAM_MAX_INLINE_BUTTON_ACTIONS = 100;
 const SPEAKEASY_STDIN_ARGV_WRAPPER = [
@@ -135,6 +135,12 @@ function pruneSpeakeasyCache(cache: SpeakeasyVoiceCache, now = Date.now()): void
       delete cache.entries[id];
     }
   }
+  const currentDay = todayKey(new Date(now));
+  for (const [id, generation] of Object.entries(cache.generations)) {
+    if (generation.date !== currentDay) {
+      delete cache.generations[id];
+    }
+  }
 }
 
 export function loadSpeakeasyCache(cfg: OpenClawConfig): SpeakeasyVoiceCache {
@@ -163,10 +169,6 @@ export function writeSpeakeasyCache(cfg: OpenClawConfig, cache: SpeakeasyVoiceCa
   chmodSync(cachePath, 0o600);
 }
 
-function waitForSpeakeasyCacheLock(): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
-}
-
 function chmodExistingSpeakeasyCache(cachePath: string): void {
   try {
     chmodSync(cachePath, 0o600);
@@ -179,7 +181,6 @@ function chmodExistingSpeakeasyCache(cachePath: string): void {
 
 function acquireSpeakeasyCacheLock(cachePath: string): () => void {
   const lockPath = `${cachePath}.lock`;
-  const deadline = Date.now() + SPEAKEASY_CACHE_LOCK_TIMEOUT_MS;
   mkdirSync(path.dirname(cachePath), { recursive: true });
   while (true) {
     let fd: number | undefined;
@@ -203,10 +204,7 @@ function acquireSpeakeasyCacheLock(cachePath: string): () => void {
       if (isFileAlreadyExistsError(err) && recoverStaleSpeakeasyCacheLock(lockPath)) {
         continue;
       }
-      if (!isFileAlreadyExistsError(err) || Date.now() >= deadline) {
-        throw err;
-      }
-      waitForSpeakeasyCacheLock();
+      throw err;
     }
   }
 }
@@ -570,13 +568,17 @@ function runSpeakeasyTtsScript(params: {
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk) => {
       stdout += chunk;
-      if (stdout.length > 1024 * 1024) {
+      if (stdout.length > SPEAKEASY_TTS_MAX_OUTPUT_CHARS) {
         child.kill("SIGTERM");
       }
     });
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk) => {
       stderr += chunk;
+      if (stderr.length > SPEAKEASY_TTS_MAX_OUTPUT_CHARS) {
+        stderr = stderr.slice(0, SPEAKEASY_TTS_MAX_OUTPUT_CHARS);
+        child.kill("SIGTERM");
+      }
     });
     child.on("error", (err) => {
       settle(() => reject(err));

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -1,11 +1,13 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
+  chmodSync,
   closeSync,
   existsSync,
   mkdirSync,
   openSync,
   readFileSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -23,13 +25,15 @@ const MIN_SPEAKEASY_TEXT_CHARS = 20;
 const SPEAKEASY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const SPEAKEASY_DAILY_GENERATION_CAP = 50;
 const SPEAKEASY_CACHE_LOCK_TIMEOUT_MS = 1000;
+const SPEAKEASY_CACHE_LOCK_STALE_MS = 30_000;
 const SPEAKEASY_TTS_TIMEOUT_MS = 120_000;
 const SPEAKEASY_VOICE_NOTE_EXTENSIONS = new Set([".oga", ".ogg", ".opus"]);
 const TELEGRAM_MAX_INLINE_BUTTON_ACTIONS = 100;
 const SPEAKEASY_STDIN_ARGV_WRAPPER = [
-  "import runpy, sys",
+  "import os, runpy, sys",
   "script = sys.argv[1]",
   "text = sys.stdin.read()",
+  "sys.path.insert(0, os.path.dirname(script))",
   "sys.argv = [script, text]",
   "runpy.run_path(script, run_name='__main__')",
 ].join("\n");
@@ -150,7 +154,11 @@ export function loadSpeakeasyCache(cfg: OpenClawConfig): SpeakeasyVoiceCache {
 export function writeSpeakeasyCache(cfg: OpenClawConfig, cache: SpeakeasyVoiceCache): void {
   const cachePath = resolveSpeakeasyCachePath(cfg);
   mkdirSync(path.dirname(cachePath), { recursive: true });
-  writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
+  writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  chmodSync(cachePath, 0o600);
 }
 
 function waitForSpeakeasyCacheLock(): void {
@@ -164,25 +172,43 @@ function acquireSpeakeasyCacheLock(cachePath: string): () => void {
   while (true) {
     let fd: number | undefined;
     try {
-      fd = openSync(lockPath, "wx");
+      fd = openSync(lockPath, "wx", 0o600);
       return () => {
         if (fd !== undefined) {
           closeSync(fd);
         }
-        unlinkSync(lockPath);
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Best effort: another recovery path may have already removed a stale lock.
+        }
       };
     } catch (err) {
-      if (
-        !err ||
-        typeof err !== "object" ||
-        !("code" in err) ||
-        err.code !== "EEXIST" ||
-        Date.now() >= deadline
-      ) {
+      if (isFileAlreadyExistsError(err) && recoverStaleSpeakeasyCacheLock(lockPath)) {
+        continue;
+      }
+      if (!isFileAlreadyExistsError(err) || Date.now() >= deadline) {
         throw err;
       }
       waitForSpeakeasyCacheLock();
     }
+  }
+}
+
+function isFileAlreadyExistsError(err: unknown): boolean {
+  return Boolean(err && typeof err === "object" && "code" in err && err.code === "EEXIST");
+}
+
+function recoverStaleSpeakeasyCacheLock(lockPath: string): boolean {
+  try {
+    const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+    if (ageMs < SPEAKEASY_CACHE_LOCK_STALE_MS) {
+      return false;
+    }
+    unlinkSync(lockPath);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -485,17 +511,23 @@ function runSpeakeasyTtsScript(params: {
     let stdout = "";
     let stderr = "";
     let settled = false;
+    const settle = (fn: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      fn();
+    };
     const child = spawn("python3", ["-c", SPEAKEASY_STDIN_ARGV_WRAPPER, params.scriptPath], {
       cwd: params.cwd,
       stdio: ["pipe", "pipe", "pipe"],
     });
     const timeout = setTimeout(() => {
-      if (settled) {
-        return;
-      }
-      settled = true;
       child.kill("SIGTERM");
-      reject(new Error(`Speakeasy TTS timed out after ${SPEAKEASY_TTS_TIMEOUT_MS}ms`));
+      settle(() =>
+        reject(new Error(`Speakeasy TTS timed out after ${SPEAKEASY_TTS_TIMEOUT_MS}ms`)),
+      );
     }, SPEAKEASY_TTS_TIMEOUT_MS);
 
     child.stdout.setEncoding("utf8");
@@ -510,29 +542,30 @@ function runSpeakeasyTtsScript(params: {
       stderr += chunk;
     });
     child.on("error", (err) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      reject(err);
+      settle(() => reject(err));
     });
     child.on("close", (code, signal) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      reject(
-        new Error(
-          `Speakeasy TTS failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}: ${stderr.trim()}`,
-        ),
-      );
+      settle(() => {
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+        reject(
+          new Error(
+            `Speakeasy TTS failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}: ${stderr.trim()}`,
+          ),
+        );
+      });
     });
-    child.stdin.end(params.text);
+    child.stdin.on("error", (err) => {
+      child.kill("SIGTERM");
+      settle(() => reject(err));
+    });
+    try {
+      child.stdin.end(params.text);
+    } catch (err) {
+      child.kill("SIGTERM");
+      settle(() => reject(err instanceof Error ? err : new Error(String(err))));
+    }
   });
 }

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -291,6 +291,15 @@ function openSpeakeasyStateStore(): SpeakeasyVoiceStateStore {
   return store;
 }
 
+function requireSpeakeasyStateUpdate(
+  store: SpeakeasyVoiceStateStore,
+): NonNullable<SpeakeasyVoiceStateStore["update"]> {
+  if (typeof store.update !== "function") {
+    throw new Error("Telegram Speakeasy state store does not support atomic updates");
+  }
+  return store.update.bind(store);
+}
+
 export function shouldAllowSpeakeasyVoiceGeneration(params: {
   cache: SpeakeasyVoiceCache;
   chatId: string;
@@ -399,7 +408,7 @@ export function reserveSpeakeasyVoiceGeneration(params: {
     date: today,
   });
   let limited = false;
-  store.update?.(
+  const updated = requireSpeakeasyStateUpdate(store)(
     generationStoreKey,
     (current) => {
       if (
@@ -418,6 +427,9 @@ export function reserveSpeakeasyVoiceGeneration(params: {
     },
     { ttlMs: SPEAKEASY_GENERATION_COUNTER_TTL_MS },
   );
+  if (!updated) {
+    throw new Error("Telegram Speakeasy state store did not reserve generation quota");
+  }
   if (limited) {
     return { ok: false, reason: "limit" };
   }
@@ -449,7 +461,7 @@ export function releaseSpeakeasyVoiceGenerationReservation(params: {
     store.delete(generationStoreKey);
     return;
   }
-  store.update?.(
+  requireSpeakeasyStateUpdate(store)(
     generationStoreKey,
     (latest) => {
       if (

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -28,7 +28,7 @@ const SPEAKEASY_DAILY_GENERATION_CAP = 50;
 const SPEAKEASY_CACHE_LOCK_STALE_MS = 30_000;
 const SPEAKEASY_TTS_TIMEOUT_MS = 120_000;
 const SPEAKEASY_TTS_MAX_OUTPUT_CHARS = 1024 * 1024;
-const SPEAKEASY_VOICE_NOTE_EXTENSIONS = new Set([".m4a", ".mp3", ".oga", ".ogg", ".opus"]);
+const SPEAKEASY_VOICE_NOTE_EXTENSIONS = new Set([".oga", ".ogg", ".opus", ".mp3", ".m4a"]);
 const TELEGRAM_MAX_INLINE_BUTTON_ACTIONS = 100;
 const SPEAKEASY_STDIN_ARGV_WRAPPER = [
   "import os, runpy, sys",
@@ -358,6 +358,14 @@ function updateSpeakeasyCacheWithLock<T>(
   }
 }
 
+let queuedSpeakeasyCacheWrite: Promise<void> = Promise.resolve();
+
+function nextSpeakeasyCacheWriteTick(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
 function queueSpeakeasyCacheEntry(params: {
   cfg: OpenClawConfig;
   chatId: string;
@@ -369,18 +377,20 @@ function queueSpeakeasyCacheEntry(params: {
     text: params.text,
     createdAt: Date.now(),
   };
-  const timer = setTimeout(() => {
-    try {
+  queuedSpeakeasyCacheWrite = queuedSpeakeasyCacheWrite
+    .catch(() => undefined)
+    .then(nextSpeakeasyCacheWriteTick)
+    .then(() => {
       updateSpeakeasyCacheWithLock(params.cfg, (latest) => {
         latest.entries[id] = entry;
       });
-    } catch {
-      // The Speakeasy button is optional; do not let background cache failures
-      // affect reply delivery on the Telegram send path.
-    }
-  }, 0);
-  timer.unref?.();
+    });
+  void queuedSpeakeasyCacheWrite.catch(() => undefined);
   return id;
+}
+
+export async function flushSpeakeasyCacheWritesForTest(): Promise<void> {
+  await queuedSpeakeasyCacheWrite.catch(() => undefined);
 }
 
 export function reserveSpeakeasyVoiceGeneration(params: {

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -1,0 +1,269 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { TelegramInlineButtons } from "./button-types.js";
+
+const execFileAsync = promisify(execFile);
+
+export const SPEAKEASY_VOICE_CALLBACK_PREFIX = "tts:speakeasy:";
+export const SPEAKEASY_VOICE_BUTTON_LABEL = "🔊 Voice note";
+const MIN_SPEAKEASY_TEXT_CHARS = 20;
+const SPEAKEASY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const SPEAKEASY_DAILY_GENERATION_CAP = 50;
+
+type ReplyLike = {
+  text?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  audioAsVoice?: boolean;
+  channelData?: { telegram?: { buttons?: TelegramInlineButtons } };
+};
+
+export type SpeakeasyVoiceCache = {
+  version: 1;
+  entries: Record<string, { chatId: string; text: string; createdAt: number }>;
+  generations: Record<string, { date: string; count: number }>;
+};
+
+type SpeakeasyChatsConfig = {
+  enabled?: string[];
+};
+
+function resolveConfiguredWorkspace(cfg: OpenClawConfig): string | undefined {
+  const workspace = cfg.agents?.defaults?.workspace;
+  return typeof workspace === "string" && workspace.trim() ? workspace.trim() : undefined;
+}
+
+export function resolveSpeakeasyWorkspaceDir(cfg: OpenClawConfig): string {
+  const candidates = [
+    process.env.OPENCLAW_SPEAKEASY_WORKSPACE_DIR,
+    process.env.OPENCLAW_WORKSPACE,
+    resolveConfiguredWorkspace(cfg),
+    process.cwd(),
+    path.join(homedir(), ".openclaw", "workspace"),
+  ];
+  for (const candidate of candidates) {
+    if (!candidate?.trim()) continue;
+    const resolved = path.resolve(candidate);
+    if (existsSync(path.join(resolved, "config", "speakeasy-chats.json"))) return resolved;
+  }
+  return path.join(homedir(), ".openclaw", "workspace");
+}
+
+function resolveSpeakeasyConfigPath(cfg: OpenClawConfig): string {
+  return path.join(resolveSpeakeasyWorkspaceDir(cfg), "config", "speakeasy-chats.json");
+}
+
+function resolveSpeakeasyCachePath(cfg: OpenClawConfig): string {
+  return path.join(resolveSpeakeasyWorkspaceDir(cfg), "state", "speakeasy-cache.json");
+}
+
+function readJsonFile<T>(filePath: string, fallback: T): T {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8")) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function emptySpeakeasyCache(): SpeakeasyVoiceCache {
+  return { version: 1, entries: {}, generations: {} };
+}
+
+function pruneSpeakeasyCache(cache: SpeakeasyVoiceCache, now = Date.now()): void {
+  for (const [id, entry] of Object.entries(cache.entries)) {
+    if (now - entry.createdAt > SPEAKEASY_CACHE_TTL_MS) delete cache.entries[id];
+  }
+}
+
+export function loadSpeakeasyCache(cfg: OpenClawConfig): SpeakeasyVoiceCache {
+  const cache = readJsonFile<SpeakeasyVoiceCache>(
+    resolveSpeakeasyCachePath(cfg),
+    emptySpeakeasyCache(),
+  );
+  const normalized: SpeakeasyVoiceCache = {
+    version: 1,
+    entries: cache.entries && typeof cache.entries === "object" ? cache.entries : {},
+    generations:
+      cache.generations && typeof cache.generations === "object" ? cache.generations : {},
+  };
+  pruneSpeakeasyCache(normalized);
+  return normalized;
+}
+
+export function writeSpeakeasyCache(cfg: OpenClawConfig, cache: SpeakeasyVoiceCache): void {
+  const cachePath = resolveSpeakeasyCachePath(cfg);
+  mkdirSync(path.dirname(cachePath), { recursive: true });
+  writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
+}
+
+function loadSpeakeasyChatsConfig(cfg: OpenClawConfig): SpeakeasyChatsConfig {
+  return readJsonFile<SpeakeasyChatsConfig>(resolveSpeakeasyConfigPath(cfg), {});
+}
+
+export function isSpeakeasyChatEnabled(params: { cfg: OpenClawConfig; chatId: string }): boolean {
+  return (loadSpeakeasyChatsConfig(params.cfg).enabled ?? []).includes(`telegram:${params.chatId}`);
+}
+
+export function isSpeakeasyVoiceCallbackData(data: string): boolean {
+  return data.startsWith(SPEAKEASY_VOICE_CALLBACK_PREFIX);
+}
+
+function parseSpeakeasyVoiceCallbackId(data: string): string | null {
+  if (!isSpeakeasyVoiceCallbackData(data)) return null;
+  const id = data.slice(SPEAKEASY_VOICE_CALLBACK_PREFIX.length).trim();
+  return id.length > 0 ? id : null;
+}
+
+function todayKey(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+function generationKey(chatId: string, now = new Date()): string {
+  return `${chatId}:${todayKey(now)}`;
+}
+
+export function shouldAllowSpeakeasyVoiceGeneration(params: {
+  cache: SpeakeasyVoiceCache;
+  chatId: string;
+  now?: Date;
+}): boolean {
+  const now = params.now ?? new Date();
+  const record = params.cache.generations[generationKey(params.chatId, now)];
+  return record?.date !== todayKey(now) || record.count < SPEAKEASY_DAILY_GENERATION_CAP;
+}
+
+export function markSpeakeasyVoiceGenerated(params: {
+  cache: SpeakeasyVoiceCache;
+  chatId: string;
+  now?: Date;
+}): void {
+  const now = params.now ?? new Date();
+  const key = generationKey(params.chatId, now);
+  const current = params.cache.generations[key];
+  params.cache.generations[key] = {
+    date: todayKey(now),
+    count: current?.date === todayKey(now) ? current.count + 1 : 1,
+  };
+}
+
+export function resolveSpeakeasyCachedText(params: {
+  cfg: OpenClawConfig;
+  cache: SpeakeasyVoiceCache;
+  data: string;
+  chatId: string;
+  now?: number;
+}): { ok: true; text: string } | { ok: false; reason: "miss" | "expired" | "disabled" } {
+  if (!isSpeakeasyChatEnabled({ cfg: params.cfg, chatId: params.chatId })) {
+    return { ok: false, reason: "disabled" };
+  }
+  const id = parseSpeakeasyVoiceCallbackId(params.data);
+  const entry = id ? params.cache.entries[id] : undefined;
+  if (!id || !entry || entry.chatId !== params.chatId) return { ok: false, reason: "miss" };
+  if ((params.now ?? Date.now()) - entry.createdAt > SPEAKEASY_CACHE_TTL_MS) {
+    delete params.cache.entries[id];
+    return { ok: false, reason: "expired" };
+  }
+  return { ok: true, text: entry.text };
+}
+
+function createSpeakeasyCacheEntry(params: {
+  cfg: OpenClawConfig;
+  chatId: string;
+  text: string;
+}): string {
+  const cache = loadSpeakeasyCache(params.cfg);
+  const id = randomUUID().replace(/-/g, "").slice(0, 24);
+  cache.entries[id] = {
+    chatId: params.chatId,
+    text: params.text,
+    createdAt: Date.now(),
+  };
+  writeSpeakeasyCache(params.cfg, cache);
+  return id;
+}
+
+export function shouldAttachSpeakeasyVoiceButton(params: {
+  reply: ReplyLike;
+  cfg?: OpenClawConfig;
+  chatId?: string;
+  isGroup?: boolean;
+  hasMedia?: boolean;
+}): boolean {
+  if (params.isGroup) return false;
+  if (
+    !params.chatId ||
+    !params.cfg ||
+    !isSpeakeasyChatEnabled({ cfg: params.cfg, chatId: params.chatId })
+  ) {
+    return false;
+  }
+  const text = params.reply.text?.trim() ?? "";
+  if (text.length <= MIN_SPEAKEASY_TEXT_CHARS) return false;
+  if (params.hasMedia || params.reply.mediaUrl || (params.reply.mediaUrls?.length ?? 0) > 0) {
+    return false;
+  }
+  if (params.reply.audioAsVoice) return false;
+  if (
+    params.reply.channelData?.telegram?.buttons?.some((row) =>
+      row.some((button) => button.callback_data?.startsWith(SPEAKEASY_VOICE_CALLBACK_PREFIX)),
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function withSpeakeasyVoiceButton<T extends ReplyLike>(params: {
+  reply: T;
+  cfg?: OpenClawConfig;
+  chatId?: string;
+  isGroup?: boolean;
+  hasMedia?: boolean;
+}): T {
+  if (!shouldAttachSpeakeasyVoiceButton(params)) return params.reply;
+  const id = createSpeakeasyCacheEntry({
+    cfg: params.cfg!,
+    chatId: params.chatId!,
+    text: params.reply.text!.trim(),
+  });
+  return {
+    ...params.reply,
+    channelData: {
+      ...params.reply.channelData,
+      telegram: {
+        ...params.reply.channelData?.telegram,
+        buttons: [
+          ...(params.reply.channelData?.telegram?.buttons ?? []),
+          [
+            {
+              text: SPEAKEASY_VOICE_BUTTON_LABEL,
+              callback_data: `${SPEAKEASY_VOICE_CALLBACK_PREFIX}${id}`,
+            },
+          ],
+        ],
+      },
+    },
+  };
+}
+
+export async function generateSpeakeasyVoiceNote(params: {
+  cfg: OpenClawConfig;
+  text: string;
+}): Promise<string> {
+  const workspaceDir = resolveSpeakeasyWorkspaceDir(params.cfg);
+  const scriptPath = path.join(workspaceDir, "scripts", "tts_elevenlabs_v2.py");
+  const { stdout } = await execFileAsync(scriptPath, [params.text], {
+    cwd: workspaceDir,
+    maxBuffer: 1024 * 1024,
+  });
+  const outputPath = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1)?.trim();
+  if (!outputPath) {
+    throw new Error("Speakeasy TTS did not print an output path");
+  }
+  return outputPath;
+}

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -1,35 +1,28 @@
 import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import {
-  chmodSync,
-  closeSync,
-  existsSync,
-  linkSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import type {
   OpenClawConfig,
   TelegramInlineButtonsScope,
 } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { TelegramInlineButtons } from "./button-types.js";
+import { getOptionalTelegramRuntime } from "./runtime.js";
 
 export const SPEAKEASY_VOICE_CALLBACK_PREFIX = "tts:speakeasy:";
 export const SPEAKEASY_VOICE_BUTTON_LABEL = "🔊 Voice note";
 const MIN_SPEAKEASY_TEXT_CHARS = 20;
 const SPEAKEASY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const SPEAKEASY_GENERATION_COUNTER_TTL_MS = 48 * 60 * 60 * 1000;
 const SPEAKEASY_DAILY_GENERATION_CAP = 50;
-const SPEAKEASY_CACHE_LOCK_STALE_MS = 30_000;
 const SPEAKEASY_TTS_TIMEOUT_MS = 120_000;
 const SPEAKEASY_TTS_MAX_OUTPUT_CHARS = 1024 * 1024;
 const SPEAKEASY_VOICE_NOTE_EXTENSIONS = new Set([".oga", ".ogg", ".opus", ".mp3", ".m4a"]);
 const TELEGRAM_MAX_INLINE_BUTTON_ACTIONS = 100;
+const SPEAKEASY_STATE_NAMESPACE = "telegram.speakeasy-voice";
+const SPEAKEASY_STATE_MAX_ENTRIES = 8_192;
 const SPEAKEASY_STDIN_ARGV_WRAPPER = [
   "import os, runpy, sys",
   "script = sys.argv[1]",
@@ -52,6 +45,12 @@ export type SpeakeasyVoiceCache = {
   entries: Record<string, { chatId: string; text: string; createdAt: number }>;
   generations: Record<string, { date: string; count: number }>;
 };
+
+export type SpeakeasyVoiceStateRecord =
+  | { kind: "entry"; scopeKey: string; chatId: string; text: string; createdAt: number }
+  | { kind: "generation"; scopeKey: string; chatId: string; date: string; count: number };
+
+type SpeakeasyVoiceStateStore = PluginStateSyncKeyedStore<SpeakeasyVoiceStateRecord>;
 
 type SpeakeasyChatsConfig = {
   enabled?: string[];
@@ -113,8 +112,8 @@ function resolveSpeakeasyConfigPath(cfg: OpenClawConfig): string {
   return path.join(resolveSpeakeasyWorkspaceDir(cfg), "config", "speakeasy-chats.json");
 }
 
-function resolveSpeakeasyCachePath(cfg: OpenClawConfig): string {
-  return path.join(resolveSpeakeasyWorkspaceDir(cfg), "state", "speakeasy-cache.json");
+function resolveSpeakeasyGeneratedAudioDir(cfg: OpenClawConfig): string {
+  return path.join(resolveSpeakeasyWorkspaceDir(cfg), "state", "speakeasy", "generated");
 }
 
 function readJsonFile<T>(filePath: string, fallback: T): T {
@@ -143,107 +142,103 @@ function pruneSpeakeasyCache(cache: SpeakeasyVoiceCache, now = Date.now()): void
   }
 }
 
+function resolveSpeakeasyStateScopeKey(cfg: OpenClawConfig): string {
+  return createHash("sha256")
+    .update(resolveSpeakeasyWorkspaceDir(cfg), "utf8")
+    .digest("hex")
+    .slice(0, 24);
+}
+
+function speakeasyStateKeyPrefix(scopeKey: string): string {
+  return `${scopeKey}:`;
+}
+
+function speakeasyEntryStateKey(scopeKey: string, id: string): string {
+  return `${speakeasyStateKeyPrefix(scopeKey)}entry:${id}`;
+}
+
+function speakeasyGenerationStateKey(params: {
+  scopeKey: string;
+  chatId: string;
+  date: string;
+}): string {
+  return `${speakeasyStateKeyPrefix(params.scopeKey)}generation:${params.chatId}:${params.date}`;
+}
+
 export function loadSpeakeasyCache(cfg: OpenClawConfig): SpeakeasyVoiceCache {
-  const cache = readJsonFile<SpeakeasyVoiceCache>(
-    resolveSpeakeasyCachePath(cfg),
-    emptySpeakeasyCache(),
-  );
-  const normalized: SpeakeasyVoiceCache = {
-    version: 1,
-    entries: cache.entries && typeof cache.entries === "object" ? cache.entries : {},
-    generations:
-      cache.generations && typeof cache.generations === "object" ? cache.generations : {},
-  };
+  const scopeKey = resolveSpeakeasyStateScopeKey(cfg);
+  const keyPrefix = speakeasyStateKeyPrefix(scopeKey);
+  const store = openSpeakeasyStateStore();
+  const normalized = emptySpeakeasyCache();
+  for (const { key, value } of store.entries()) {
+    if (!key.startsWith(keyPrefix) || value.scopeKey !== scopeKey) {
+      continue;
+    }
+    if (value.kind === "entry" && key.startsWith(`${keyPrefix}entry:`)) {
+      normalized.entries[key.slice(`${keyPrefix}entry:`.length)] = {
+        chatId: value.chatId,
+        text: value.text,
+        createdAt: value.createdAt,
+      };
+      continue;
+    }
+    if (value.kind === "generation" && key.startsWith(`${keyPrefix}generation:`)) {
+      normalized.generations[key.slice(`${keyPrefix}generation:`.length)] = {
+        date: value.date,
+        count: value.count,
+      };
+    }
+  }
   pruneSpeakeasyCache(normalized);
+  for (const { key, value } of store.entries()) {
+    if (!key.startsWith(keyPrefix) || value.scopeKey !== scopeKey) {
+      continue;
+    }
+    if (value.kind === "entry" && normalized.entries[key.slice(`${keyPrefix}entry:`.length)]) {
+      continue;
+    }
+    if (
+      value.kind === "generation" &&
+      normalized.generations[key.slice(`${keyPrefix}generation:`.length)]
+    ) {
+      continue;
+    }
+    store.delete(key);
+  }
   return normalized;
 }
 
 export function writeSpeakeasyCache(cfg: OpenClawConfig, cache: SpeakeasyVoiceCache): void {
-  const cachePath = resolveSpeakeasyCachePath(cfg);
-  mkdirSync(path.dirname(cachePath), { recursive: true });
-  chmodExistingSpeakeasyCache(cachePath);
-  writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  chmodSync(cachePath, 0o600);
-}
-
-function chmodExistingSpeakeasyCache(cachePath: string): void {
-  try {
-    chmodSync(cachePath, 0o600);
-  } catch (err) {
-    if (!isFileNotFoundError(err)) {
-      throw err;
+  const scopeKey = resolveSpeakeasyStateScopeKey(cfg);
+  const keyPrefix = speakeasyStateKeyPrefix(scopeKey);
+  const store = openSpeakeasyStateStore();
+  for (const { key } of store.entries()) {
+    if (key.startsWith(keyPrefix)) {
+      store.delete(key);
     }
   }
-}
-
-function acquireSpeakeasyCacheLock(cachePath: string): () => void {
-  const lockPath = `${cachePath}.lock`;
-  mkdirSync(path.dirname(cachePath), { recursive: true });
-  while (true) {
-    let fd: number | undefined;
-    const lockToken = randomUUID();
-    try {
-      fd = openSync(lockPath, "wx", 0o600);
-      writeFileSync(fd, lockToken, "utf8");
-      return () => {
-        if (fd !== undefined) {
-          closeSync(fd);
-        }
-        try {
-          if (readFileSync(lockPath, "utf8") === lockToken) {
-            unlinkSync(lockPath);
-          }
-        } catch {
-          // Best effort: another recovery path may have already removed a stale lock.
-        }
-      };
-    } catch (err) {
-      if (isFileAlreadyExistsError(err) && recoverStaleSpeakeasyCacheLock(lockPath)) {
-        continue;
-      }
-      throw err;
-    }
+  for (const [id, entry] of Object.entries(cache.entries)) {
+    store.register(
+      speakeasyEntryStateKey(scopeKey, id),
+      { kind: "entry", scopeKey, ...entry },
+      { ttlMs: Math.max(1, SPEAKEASY_CACHE_TTL_MS - (Date.now() - entry.createdAt)) },
+    );
   }
-}
-
-function isFileAlreadyExistsError(err: unknown): boolean {
-  return Boolean(err && typeof err === "object" && "code" in err && err.code === "EEXIST");
-}
-
-function isFileNotFoundError(err: unknown): boolean {
-  return Boolean(err && typeof err === "object" && "code" in err && err.code === "ENOENT");
-}
-
-function recoverStaleSpeakeasyCacheLock(lockPath: string): boolean {
-  const claimPath = `${lockPath}.${process.pid}.${randomUUID()}.stale`;
-  try {
-    linkSync(lockPath, claimPath);
-    const claimStats = statSync(claimPath);
-    const lockStats = statSync(lockPath);
-    if (claimStats.dev !== lockStats.dev || claimStats.ino !== lockStats.ino) {
-      return false;
+  for (const [key, generation] of Object.entries(cache.generations)) {
+    const [chatId, date] = key.split(":", 2);
+    if (!chatId || !date) {
+      continue;
     }
-    const ageMs = Date.now() - claimStats.mtimeMs;
-    if (ageMs < SPEAKEASY_CACHE_LOCK_STALE_MS) {
-      return false;
-    }
-    const currentStats = statSync(lockPath);
-    if (claimStats.dev !== currentStats.dev || claimStats.ino !== currentStats.ino) {
-      return false;
-    }
-    unlinkSync(lockPath);
-    return true;
-  } catch {
-    return false;
-  } finally {
-    try {
-      unlinkSync(claimPath);
-    } catch {
-      // Best effort: the claim path may not exist if linking failed.
-    }
+    store.register(
+      speakeasyGenerationStateKey({ scopeKey, chatId, date }),
+      {
+        kind: "generation",
+        scopeKey,
+        chatId,
+        ...generation,
+      },
+      { ttlMs: SPEAKEASY_GENERATION_COUNTER_TTL_MS },
+    );
   }
 }
 
@@ -275,6 +270,27 @@ function generationKey(chatId: string, now = new Date()): string {
   return `${chatId}:${todayKey(now)}`;
 }
 
+let speakeasyStateStoreForTest: SpeakeasyVoiceStateStore | undefined;
+
+export function setSpeakeasyVoiceStateStoreForTest(
+  store: SpeakeasyVoiceStateStore | undefined,
+): void {
+  speakeasyStateStoreForTest = store;
+}
+
+function openSpeakeasyStateStore(): SpeakeasyVoiceStateStore {
+  const store =
+    speakeasyStateStoreForTest ??
+    getOptionalTelegramRuntime()?.state.openSyncKeyedStore<SpeakeasyVoiceStateRecord>({
+      namespace: SPEAKEASY_STATE_NAMESPACE,
+      maxEntries: SPEAKEASY_STATE_MAX_ENTRIES,
+    });
+  if (!store) {
+    throw new Error("Telegram Speakeasy state store is unavailable");
+  }
+  return store;
+}
+
 export function shouldAllowSpeakeasyVoiceGeneration(params: {
   cache: SpeakeasyVoiceCache;
   chatId: string;
@@ -296,27 +312,6 @@ export function markSpeakeasyVoiceGenerated(params: {
   params.cache.generations[key] = {
     date: todayKey(now),
     count: current?.date === todayKey(now) ? current.count + 1 : 1,
-  };
-}
-
-function unmarkSpeakeasyVoiceGenerated(params: {
-  cache: SpeakeasyVoiceCache;
-  chatId: string;
-  now?: Date;
-}): void {
-  const now = params.now ?? new Date();
-  const key = generationKey(params.chatId, now);
-  const current = params.cache.generations[key];
-  if (!current || current.date !== todayKey(now)) {
-    return;
-  }
-  if (current.count <= 1) {
-    delete params.cache.generations[key];
-    return;
-  }
-  params.cache.generations[key] = {
-    date: current.date,
-    count: current.count - 1,
   };
 }
 
@@ -342,55 +337,36 @@ export function resolveSpeakeasyCachedText(params: {
   return { ok: true, text: entry.text };
 }
 
-function updateSpeakeasyCacheWithLock<T>(
-  cfg: OpenClawConfig,
-  updater: (cache: SpeakeasyVoiceCache) => T,
-): T {
-  const cachePath = resolveSpeakeasyCachePath(cfg);
-  const releaseLock = acquireSpeakeasyCacheLock(cachePath);
-  try {
-    const latest = loadSpeakeasyCache(cfg);
-    const result = updater(latest);
-    writeSpeakeasyCache(cfg, latest);
-    return result;
-  } finally {
-    releaseLock();
-  }
-}
-
-let queuedSpeakeasyCacheWrite: Promise<void> = Promise.resolve();
-
-function nextSpeakeasyCacheWriteTick(): Promise<void> {
-  return new Promise((resolve) => {
-    setImmediate(resolve);
-  });
-}
-
 function queueSpeakeasyCacheEntry(params: {
   cfg: OpenClawConfig;
   chatId: string;
   text: string;
-}): string {
+}): string | null {
   const id = randomUUID().replace(/-/g, "").slice(0, 24);
+  const scopeKey = resolveSpeakeasyStateScopeKey(params.cfg);
   const entry = {
+    scopeKey,
     chatId: params.chatId,
     text: params.text,
     createdAt: Date.now(),
   };
-  queuedSpeakeasyCacheWrite = queuedSpeakeasyCacheWrite
-    .catch(() => undefined)
-    .then(nextSpeakeasyCacheWriteTick)
-    .then(() => {
-      updateSpeakeasyCacheWithLock(params.cfg, (latest) => {
-        latest.entries[id] = entry;
-      });
-    });
-  void queuedSpeakeasyCacheWrite.catch(() => undefined);
+  try {
+    openSpeakeasyStateStore().register(
+      speakeasyEntryStateKey(scopeKey, id),
+      {
+        kind: "entry",
+        ...entry,
+      },
+      { ttlMs: SPEAKEASY_CACHE_TTL_MS },
+    );
+  } catch {
+    return null;
+  }
   return id;
 }
 
 export async function flushSpeakeasyCacheWritesForTest(): Promise<void> {
-  await queuedSpeakeasyCacheWrite.catch(() => undefined);
+  await Promise.resolve();
 }
 
 export function reserveSpeakeasyVoiceGeneration(params: {
@@ -398,31 +374,96 @@ export function reserveSpeakeasyVoiceGeneration(params: {
   data: string;
   chatId: string;
 }): { ok: true; text: string } | { ok: false; reason: "miss" | "expired" | "disabled" | "limit" } {
-  return updateSpeakeasyCacheWithLock(params.cfg, (cache) => {
-    const resolved = resolveSpeakeasyCachedText({
-      cfg: params.cfg,
-      cache,
-      data: params.data,
-      chatId: params.chatId,
-    });
-    if (!resolved.ok) {
-      return resolved;
-    }
-    if (!shouldAllowSpeakeasyVoiceGeneration({ cache, chatId: params.chatId })) {
-      return { ok: false, reason: "limit" };
-    }
-    markSpeakeasyVoiceGenerated({ cache, chatId: params.chatId });
-    return resolved;
+  if (!isSpeakeasyChatEnabled({ cfg: params.cfg, chatId: params.chatId })) {
+    return { ok: false, reason: "disabled" };
+  }
+  const id = parseSpeakeasyVoiceCallbackId(params.data);
+  if (!id) {
+    return { ok: false, reason: "miss" };
+  }
+  const scopeKey = resolveSpeakeasyStateScopeKey(params.cfg);
+  const store = openSpeakeasyStateStore();
+  const entry = store.lookup(speakeasyEntryStateKey(scopeKey, id));
+  if (entry?.kind !== "entry" || entry.scopeKey !== scopeKey || entry.chatId !== params.chatId) {
+    return { ok: false, reason: "miss" };
+  }
+  if (Date.now() - entry.createdAt > SPEAKEASY_CACHE_TTL_MS) {
+    store.delete(speakeasyEntryStateKey(scopeKey, id));
+    return { ok: false, reason: "expired" };
+  }
+
+  const today = todayKey();
+  const generationStoreKey = speakeasyGenerationStateKey({
+    scopeKey,
+    chatId: params.chatId,
+    date: today,
   });
+  let limited = false;
+  store.update?.(
+    generationStoreKey,
+    (current) => {
+      if (
+        current?.kind === "generation" &&
+        current.scopeKey === scopeKey &&
+        current.chatId === params.chatId &&
+        current.date === today
+      ) {
+        if (current.count >= SPEAKEASY_DAILY_GENERATION_CAP) {
+          limited = true;
+          return current;
+        }
+        return { ...current, count: current.count + 1 };
+      }
+      return { kind: "generation", scopeKey, chatId: params.chatId, date: today, count: 1 };
+    },
+    { ttlMs: SPEAKEASY_GENERATION_COUNTER_TTL_MS },
+  );
+  if (limited) {
+    return { ok: false, reason: "limit" };
+  }
+  return { ok: true, text: entry.text };
 }
 
 export function releaseSpeakeasyVoiceGenerationReservation(params: {
   cfg: OpenClawConfig;
   chatId: string;
 }): void {
-  updateSpeakeasyCacheWithLock(params.cfg, (cache) => {
-    unmarkSpeakeasyVoiceGenerated({ cache, chatId: params.chatId });
+  const scopeKey = resolveSpeakeasyStateScopeKey(params.cfg);
+  const today = todayKey();
+  const generationStoreKey = speakeasyGenerationStateKey({
+    scopeKey,
+    chatId: params.chatId,
+    date: today,
   });
+  const store = openSpeakeasyStateStore();
+  const current = store.lookup(generationStoreKey);
+  if (
+    current?.kind !== "generation" ||
+    current.scopeKey !== scopeKey ||
+    current.chatId !== params.chatId ||
+    current.date !== today
+  ) {
+    return;
+  }
+  if (current.count <= 1) {
+    store.delete(generationStoreKey);
+    return;
+  }
+  store.update?.(
+    generationStoreKey,
+    (latest) => {
+      if (
+        latest?.kind !== "generation" ||
+        latest.scopeKey !== scopeKey ||
+        latest.chatId !== params.chatId ||
+        latest.date !== today
+      ) {
+        return latest;
+      }
+      return { ...latest, count: Math.max(0, latest.count - 1) };
+    },
+    { ttlMs: SPEAKEASY_GENERATION_COUNTER_TTL_MS },
+  );
 }
 
 function countTelegramInlineButtonActions(buttons: TelegramInlineButtons | undefined): number {
@@ -434,6 +475,25 @@ export function assertSpeakeasyVoiceNoteOutputPath(outputPath: string): void {
   if (!SPEAKEASY_VOICE_NOTE_EXTENSIONS.has(extension)) {
     throw new Error(`Speakeasy TTS output is not a Telegram voice-note file: ${outputPath}`);
   }
+}
+
+export function prepareSpeakeasyGeneratedVoiceNoteOutput(params: {
+  cfg: OpenClawConfig;
+  outputPath: string;
+}): string {
+  assertSpeakeasyVoiceNoteOutputPath(params.outputPath);
+  const generatedDir = resolveSpeakeasyGeneratedAudioDir(params.cfg);
+  const relativeToGeneratedDir = path.relative(generatedDir, params.outputPath);
+  if (!relativeToGeneratedDir.startsWith("..") && !path.isAbsolute(relativeToGeneratedDir)) {
+    return params.outputPath;
+  }
+  mkdirSync(generatedDir, { recursive: true });
+  const copiedPath = path.join(
+    generatedDir,
+    `${randomUUID().replace(/-/g, "")}${path.extname(params.outputPath).toLowerCase()}`,
+  );
+  copyFileSync(params.outputPath, copiedPath);
+  return copiedPath;
 }
 
 export function shouldAttachSpeakeasyVoiceButton(params: {
@@ -504,6 +564,9 @@ export function withSpeakeasyVoiceButton<T extends ReplyLike>(params: {
     chatId: params.chatId!,
     text: params.reply.text!.trim(),
   });
+  if (!id) {
+    return params.reply;
+  }
   return {
     ...params.reply,
     channelData: {
@@ -546,8 +609,7 @@ export async function generateSpeakeasyVoiceNote(params: {
   const outputPath = path.isAbsolute(rawOutputPath)
     ? rawOutputPath
     : path.resolve(workspaceDir, rawOutputPath);
-  assertSpeakeasyVoiceNoteOutputPath(outputPath);
-  return outputPath;
+  return prepareSpeakeasyGeneratedVoiceNoteOutput({ cfg: params.cfg, outputPath });
 }
 
 function runSpeakeasyTtsScript(params: {

--- a/extensions/telegram/src/speakeasy-voice.ts
+++ b/extensions/telegram/src/speakeasy-voice.ts
@@ -28,7 +28,7 @@ const SPEAKEASY_DAILY_GENERATION_CAP = 50;
 const SPEAKEASY_CACHE_LOCK_STALE_MS = 30_000;
 const SPEAKEASY_TTS_TIMEOUT_MS = 120_000;
 const SPEAKEASY_TTS_MAX_OUTPUT_CHARS = 1024 * 1024;
-const SPEAKEASY_VOICE_NOTE_EXTENSIONS = new Set([".oga", ".ogg", ".opus"]);
+const SPEAKEASY_VOICE_NOTE_EXTENSIONS = new Set([".m4a", ".mp3", ".oga", ".ogg", ".opus"]);
 const TELEGRAM_MAX_INLINE_BUTTON_ACTIONS = 100;
 const SPEAKEASY_STDIN_ARGV_WRAPPER = [
   "import os, runpy, sys",
@@ -358,7 +358,7 @@ function updateSpeakeasyCacheWithLock<T>(
   }
 }
 
-function createSpeakeasyCacheEntry(params: {
+function queueSpeakeasyCacheEntry(params: {
   cfg: OpenClawConfig;
   chatId: string;
   text: string;
@@ -369,9 +369,17 @@ function createSpeakeasyCacheEntry(params: {
     text: params.text,
     createdAt: Date.now(),
   };
-  updateSpeakeasyCacheWithLock(params.cfg, (latest) => {
-    latest.entries[id] = entry;
-  });
+  const timer = setTimeout(() => {
+    try {
+      updateSpeakeasyCacheWithLock(params.cfg, (latest) => {
+        latest.entries[id] = entry;
+      });
+    } catch {
+      // The Speakeasy button is optional; do not let background cache failures
+      // affect reply delivery on the Telegram send path.
+    }
+  }, 0);
+  timer.unref?.();
   return id;
 }
 
@@ -481,16 +489,11 @@ export function withSpeakeasyVoiceButton<T extends ReplyLike>(params: {
   if (!shouldAttachSpeakeasyVoiceButton(params)) {
     return params.reply;
   }
-  let id: string;
-  try {
-    id = createSpeakeasyCacheEntry({
-      cfg: params.cfg!,
-      chatId: params.chatId!,
-      text: params.reply.text!.trim(),
-    });
-  } catch {
-    return params.reply;
-  }
+  const id = queueSpeakeasyCacheEntry({
+    cfg: params.cfg!,
+    chatId: params.chatId!,
+    text: params.reply.text!.trim(),
+  });
   return {
     ...params.reply,
     channelData: {

--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -301,7 +301,7 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     await fs.mkdir(path.join(pluginRoot, "commands"), { recursive: true });
     await fs.writeFile(
       path.join(pluginRoot, ".claude-plugin", "plugin.json"),
-      `${JSON.stringify({ name: "compound-bundle" }, null, 2)}\n`,
+      `${JSON.stringify({ name: "compound-bundle", commands: "commands" }, null, 2)}\n`,
       "utf-8",
     );
     await fs.writeFile(


### PR DESCRIPTION
## Summary
- add Speakeasy Telegram voice-button eligibility and callback handling
- generate Airy V2 voice replies from cached eligible text via workspace TTS script
- enforce 24h cache expiry and 50 tap generations/chat/day cap
- add Telegram delivery and callback tests

## Validation
- pnpm test extensions/telegram/src/speakeasy-voice.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts
- pnpm tsgo:extensions:test
- git diff --check --cached

## Real behavior proof
- Behavior or issue addressed: Speakeasy now adds a Telegram voice-note button for enabled DM text replies, suppresses ineligible cases, persists cache entries, and resolves callback text from that cache.
- Real environment tested: Local OpenClaw checkout on current origin/main in /tmp/openclaw-nox-5227-clean with a real temp workspace containing config/speakeasy-chats.json and state/speakeasy-cache.json.
- Exact steps or command run after this patch: pnpm exec tsx executed the actual extensions/telegram/src/speakeasy-voice.ts helper against a temporary workspace configured with enabled chat telegram:437286129.
- Evidence after fix: terminal output from the local runtime transcript:

```text
eligible dm true
group suppressed true
short suppressed true
button text 🔊 Voice note
callback prefix true
cache resolved true This after-fix proof text is long enough to expose the Telegram voice-note button.
cache entries 1
```

- Observed result after fix: The eligible DM path returns true, group and short-text cases are suppressed, the rendered inline button is 🔊 Voice note with the tts:speakeasy callback prefix, and the cached text resolves from the generated cache entry.
- What was not tested: Live Telegram delivery and ElevenLabs audio generation were not triggered from the PR branch; NOX-5229 owns deployment/restart and NOX-5230 owns live QA.