### PR TITLE
fix(update): detect npm shrinkwrap package installs

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -10,6 +10,7 @@ async function withPackageManagerRoot<T>(
 ): Promise<T> {
   return await withTempDir({ prefix: "openclaw-detect-pm-" }, async (root) => {
     for (const file of files) {
+      await fs.mkdir(path.dirname(path.join(root, file.path)), { recursive: true });
       await fs.writeFile(path.join(root, file.path), file.content, "utf8");
     }
     return await run(root);
@@ -41,6 +42,75 @@ describe("detectPackageManager", () => {
     );
   });
 
+  it("preserves pnpm-owned package roots that also carry shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-pnpm-" }, async (base) => {
+      const root = path.join(base, "5", "node_modules", "openclaw");
+      await fs.mkdir(root, { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@10.8.1" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
+      await fs.writeFile(path.join(base, "5", "node_modules", ".modules.yaml"), "", "utf8");
+      await fs.writeFile(path.join(base, "5", "pnpm-lock.yaml"), "", "utf8");
+
+      await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+    });
+  });
+
+  it("preserves pnpm virtual-store package roots that also carry shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-pnpm-store-" }, async (base) => {
+      const root = path.join(
+        base,
+        "5",
+        "node_modules",
+        ".pnpm",
+        "openclaw@1.0.0",
+        "node_modules",
+        "openclaw",
+      );
+      await fs.mkdir(root, { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@10.8.1" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
+      await fs.writeFile(path.join(base, "5", "node_modules", ".modules.yaml"), "", "utf8");
+      await fs.writeFile(path.join(base, "5", "pnpm-lock.yaml"), "", "utf8");
+
+      await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+    });
+  });
+
+  it("preserves bun-owned package roots that also carry shrinkwrap", async () => {
+    const previousBunInstall = process.env.BUN_INSTALL;
+    await withTempDir({ prefix: "openclaw-detect-pm-bun-" }, async (base) => {
+      process.env.BUN_INSTALL = path.join(base, ".bun");
+      const root = path.join(
+        process.env.BUN_INSTALL,
+        "install",
+        "global",
+        "node_modules",
+        "openclaw",
+      );
+      await fs.mkdir(root, { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "bun@1.2.0" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
+
+      await expect(detectPackageManager(root)).resolves.toBe("bun");
+    });
+    if (previousBunInstall === undefined) {
+      delete process.env.BUN_INSTALL;
+    } else {
+      process.env.BUN_INSTALL = previousBunInstall;
+    }
+  });
   it("keeps packageManager precedence for git roots that also carry shrinkwrap", async () => {
     await withPackageManagerRoot(
       [

--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -29,6 +29,31 @@ describe("detectPackageManager", () => {
     );
   });
 
+  it("treats published npm package shrinkwrap as npm install evidence", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@10.8.1" }) },
+        { path: "npm-shrinkwrap.json", content: "" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("npm");
+      },
+    );
+  });
+
+  it("keeps packageManager precedence for git roots that also carry shrinkwrap", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: ".git", content: "" },
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@10.8.1" }) },
+        { path: "npm-shrinkwrap.json", content: "" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+      },
+    );
+  });
+
   it.each([
     {
       name: "uses bun.lock",
@@ -46,6 +71,11 @@ describe("detectPackageManager", () => {
         { path: "package.json", content: JSON.stringify({ packageManager: "yarn@4.0.0" }) },
         { path: "package-lock.json", content: "" },
       ],
+      expected: "npm",
+    },
+    {
+      name: "uses npm-shrinkwrap.json",
+      files: [{ path: "npm-shrinkwrap.json", content: "" }],
       expected: "npm",
     },
   ])("falls back to lockfiles when $name", async ({ files, expected }) => {

--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -84,6 +84,60 @@ describe("detectPackageManager", () => {
     });
   });
 
+  it("preserves project-local pnpm package roots that also carry shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-local-pnpm-" }, async (base) => {
+      const root = path.join(base, "node_modules", "openclaw");
+      await fs.mkdir(root, { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@10.8.1" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
+      await fs.writeFile(path.join(base, "node_modules", ".modules.yaml"), "", "utf8");
+      await fs.writeFile(path.join(base, "pnpm-lock.yaml"), "", "utf8");
+
+      await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+    });
+  });
+
+  it("preserves project-local pnpm virtual-store roots that also carry shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-local-pnpm-store-" }, async (base) => {
+      const root = path.join(
+        base,
+        "node_modules",
+        ".pnpm",
+        "openclaw@1.0.0",
+        "node_modules",
+        "openclaw",
+      );
+      await fs.mkdir(root, { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@10.8.1" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
+      await fs.writeFile(path.join(base, "node_modules", ".modules.yaml"), "", "utf8");
+      await fs.writeFile(path.join(base, "pnpm-lock.yaml"), "", "utf8");
+
+      await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+    });
+  });
+
+  it("keeps packageManager precedence for pnpm source roots without git metadata", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@10.8.1" }) },
+        { path: "pnpm-lock.yaml", content: "" },
+        { path: "npm-shrinkwrap.json", content: "" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+      },
+    );
+  });
+
   it("preserves bun-owned package roots that also carry shrinkwrap", async () => {
     const previousBunInstall = process.env.BUN_INSTALL;
     await withTempDir({ prefix: "openclaw-detect-pm-bun-" }, async (base) => {

--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -140,31 +140,66 @@ describe("detectPackageManager", () => {
 
   it("preserves bun-owned package roots that also carry shrinkwrap", async () => {
     const previousBunInstall = process.env.BUN_INSTALL;
-    await withTempDir({ prefix: "openclaw-detect-pm-bun-" }, async (base) => {
-      process.env.BUN_INSTALL = path.join(base, ".bun");
-      const root = path.join(
-        process.env.BUN_INSTALL,
-        "install",
-        "global",
-        "node_modules",
-        "openclaw",
-      );
-      await fs.mkdir(root, { recursive: true });
-      await fs.writeFile(
-        path.join(root, "package.json"),
-        JSON.stringify({ packageManager: "bun@1.2.0" }),
-        "utf8",
-      );
-      await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
+    try {
+      await withTempDir({ prefix: "openclaw-detect-pm-bun-" }, async (base) => {
+        process.env.BUN_INSTALL = path.join(base, ".bun");
+        const root = path.join(
+          process.env.BUN_INSTALL,
+          "install",
+          "global",
+          "node_modules",
+          "openclaw",
+        );
+        await fs.mkdir(root, { recursive: true });
+        await fs.writeFile(
+          path.join(root, "package.json"),
+          JSON.stringify({ packageManager: "bun@1.2.0" }),
+          "utf8",
+        );
+        await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
 
-      await expect(detectPackageManager(root)).resolves.toBe("bun");
-    });
-    if (previousBunInstall === undefined) {
-      delete process.env.BUN_INSTALL;
-    } else {
-      process.env.BUN_INSTALL = previousBunInstall;
+        await expect(detectPackageManager(root)).resolves.toBe("bun");
+      });
+    } finally {
+      if (previousBunInstall === undefined) {
+        delete process.env.BUN_INSTALL;
+      } else {
+        process.env.BUN_INSTALL = previousBunInstall;
+      }
     }
   });
+
+  it("preserves bun-owned package roots with published pnpm metadata", async () => {
+    const previousBunInstall = process.env.BUN_INSTALL;
+    try {
+      await withTempDir({ prefix: "openclaw-detect-pm-bun-published-" }, async (base) => {
+        process.env.BUN_INSTALL = path.join(base, ".bun");
+        const root = path.join(
+          process.env.BUN_INSTALL,
+          "install",
+          "global",
+          "node_modules",
+          "openclaw",
+        );
+        await fs.mkdir(root, { recursive: true });
+        await fs.writeFile(
+          path.join(root, "package.json"),
+          JSON.stringify({ packageManager: "pnpm@10.8.1" }),
+          "utf8",
+        );
+        await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
+
+        await expect(detectPackageManager(root)).resolves.toBe("bun");
+      });
+    } finally {
+      if (previousBunInstall === undefined) {
+        delete process.env.BUN_INSTALL;
+      } else {
+        process.env.BUN_INSTALL = previousBunInstall;
+      }
+    }
+  });
+
   it("keeps packageManager precedence for git roots that also carry shrinkwrap", async () => {
     await withPackageManagerRoot(
       [

--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -84,6 +84,24 @@ describe("detectPackageManager", () => {
     });
   });
 
+  it("preserves pnpm sibling virtual-store package roots that also carry shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-pnpm-sibling-store-" }, async (base) => {
+      const root = path.join(base, "5", ".pnpm", "openclaw@1.0.0", "node_modules", "openclaw");
+      await fs.mkdir(root, { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@10.8.1" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "", "utf8");
+      await fs.mkdir(path.join(base, "5", "node_modules"), { recursive: true });
+      await fs.writeFile(path.join(base, "5", "node_modules", ".modules.yaml"), "", "utf8");
+      await fs.writeFile(path.join(base, "5", "pnpm-lock.yaml"), "", "utf8");
+
+      await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+    });
+  });
+
   it("preserves project-local pnpm package roots that also carry shrinkwrap", async () => {
     await withTempDir({ prefix: "openclaw-detect-pm-local-pnpm-" }, async (base) => {
       const root = path.join(base, "node_modules", "openclaw");

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -4,19 +4,23 @@ import { readPackageManagerSpec } from "./package-json.js";
 type DetectedPackageManager = "pnpm" | "bun" | "npm";
 
 export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
+  const files = await fs.readdir(root).catch((): string[] => []);
+  if (files.includes("npm-shrinkwrap.json") && !files.includes(".git")) {
+    return "npm";
+  }
+
   const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (pm === "pnpm" || pm === "bun" || pm === "npm") {
     return pm;
   }
 
-  const files = await fs.readdir(root).catch((): string[] => []);
   if (files.includes("pnpm-lock.yaml")) {
     return "pnpm";
   }
   if (files.includes("bun.lock") || files.includes("bun.lockb")) {
     return "bun";
   }
-  if (files.includes("package-lock.json")) {
+  if (files.includes("package-lock.json") || files.includes("npm-shrinkwrap.json")) {
     return "npm";
   }
   return null;

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -1,15 +1,84 @@
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { readPackageManagerSpec } from "./package-json.js";
 
 type DetectedPackageManager = "pnpm" | "bun" | "npm";
 
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePnpmGlobalDirFromGlobalRoot(globalRoot?: string | null): string | null {
+  const trimmed = globalRoot?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const normalized = path.resolve(trimmed);
+  if (path.basename(normalized) !== "node_modules") {
+    return null;
+  }
+  const layoutDir = path.dirname(normalized);
+  return /^\d+$/u.test(path.basename(layoutDir)) ? path.dirname(layoutDir) : null;
+}
+
+function inferPnpmGlobalRootFromPackageRoot(pkgRoot: string): string | null {
+  const normalized = path.resolve(pkgRoot);
+  const parts = normalized.split(path.sep);
+  const pnpmIndex = parts.lastIndexOf(".pnpm");
+  if (pnpmIndex > 0 && parts[pnpmIndex + 2] === "node_modules") {
+    const layoutDir = parts.slice(0, pnpmIndex).join(path.sep) || path.sep;
+    const globalRoot =
+      path.basename(layoutDir) === "node_modules"
+        ? layoutDir
+        : path.join(layoutDir, "node_modules");
+    return resolvePnpmGlobalDirFromGlobalRoot(globalRoot) ? globalRoot : null;
+  }
+
+  const directGlobalRoot = path.dirname(normalized);
+  return resolvePnpmGlobalDirFromGlobalRoot(directGlobalRoot) ? directGlobalRoot : null;
+}
+
+async function isPnpmOwnedPackageRoot(root: string): Promise<boolean> {
+  const globalRoot = inferPnpmGlobalRootFromPackageRoot(root);
+  if (!globalRoot) {
+    return false;
+  }
+  const layoutDir = path.dirname(globalRoot);
+  return (
+    (await exists(path.join(globalRoot, ".modules.yaml"))) &&
+    ((await exists(path.join(layoutDir, "pnpm-lock.yaml"))) ||
+      (await exists(path.join(layoutDir, "package.json"))))
+  );
+}
+
+function resolveBunGlobalRoot(): string {
+  const bunInstall = process.env.BUN_INSTALL?.trim() || path.join(os.homedir(), ".bun");
+  return path.join(bunInstall, "install", "global", "node_modules");
+}
+
+function isBunOwnedPackageRoot(root: string): boolean {
+  return path.resolve(path.dirname(root)) === path.resolve(resolveBunGlobalRoot());
+}
+
 export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
   const files = await fs.readdir(root).catch((): string[] => []);
+  const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (files.includes("npm-shrinkwrap.json") && !files.includes(".git")) {
+    if (pm === "pnpm" && (await isPnpmOwnedPackageRoot(root))) {
+      return "pnpm";
+    }
+    if (pm === "bun" && isBunOwnedPackageRoot(root)) {
+      return "bun";
+    }
     return "npm";
   }
 
-  const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (pm === "pnpm" || pm === "bun" || pm === "npm") {
     return pm;
   }

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -19,8 +19,10 @@ function inferPnpmOwningNodeModulesFromPackageRoot(pkgRoot: string): string | nu
   const parts = normalized.split(path.sep);
   const pnpmIndex = parts.lastIndexOf(".pnpm");
   if (pnpmIndex > 0 && parts[pnpmIndex + 2] === "node_modules") {
-    const owningNodeModules = parts.slice(0, pnpmIndex).join(path.sep) || path.sep;
-    return path.basename(owningNodeModules) === "node_modules" ? owningNodeModules : null;
+    const layoutDir = parts.slice(0, pnpmIndex).join(path.sep) || path.sep;
+    return path.basename(layoutDir) === "node_modules"
+      ? layoutDir
+      : path.join(layoutDir, "node_modules");
   }
 
   const directNodeModules = path.dirname(normalized);

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -14,46 +14,34 @@ async function exists(p: string): Promise<boolean> {
   }
 }
 
-function resolvePnpmGlobalDirFromGlobalRoot(globalRoot?: string | null): string | null {
-  const trimmed = globalRoot?.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const normalized = path.resolve(trimmed);
-  if (path.basename(normalized) !== "node_modules") {
-    return null;
-  }
-  const layoutDir = path.dirname(normalized);
-  return /^\d+$/u.test(path.basename(layoutDir)) ? path.dirname(layoutDir) : null;
-}
-
-function inferPnpmGlobalRootFromPackageRoot(pkgRoot: string): string | null {
+function inferPnpmOwningNodeModulesFromPackageRoot(pkgRoot: string): string | null {
   const normalized = path.resolve(pkgRoot);
   const parts = normalized.split(path.sep);
   const pnpmIndex = parts.lastIndexOf(".pnpm");
   if (pnpmIndex > 0 && parts[pnpmIndex + 2] === "node_modules") {
-    const layoutDir = parts.slice(0, pnpmIndex).join(path.sep) || path.sep;
-    const globalRoot =
-      path.basename(layoutDir) === "node_modules"
-        ? layoutDir
-        : path.join(layoutDir, "node_modules");
-    return resolvePnpmGlobalDirFromGlobalRoot(globalRoot) ? globalRoot : null;
+    const owningNodeModules = parts.slice(0, pnpmIndex).join(path.sep) || path.sep;
+    return path.basename(owningNodeModules) === "node_modules" ? owningNodeModules : null;
   }
 
-  const directGlobalRoot = path.dirname(normalized);
-  return resolvePnpmGlobalDirFromGlobalRoot(directGlobalRoot) ? directGlobalRoot : null;
+  const directNodeModules = path.dirname(normalized);
+  return path.basename(directNodeModules) === "node_modules" ? directNodeModules : null;
 }
 
 async function isPnpmOwnedPackageRoot(root: string): Promise<boolean> {
-  const globalRoot = inferPnpmGlobalRootFromPackageRoot(root);
-  if (!globalRoot) {
+  const nodeModulesRoot = inferPnpmOwningNodeModulesFromPackageRoot(root);
+  if (!nodeModulesRoot) {
     return false;
   }
-  const layoutDir = path.dirname(globalRoot);
+  const projectOrLayoutRoot = path.dirname(nodeModulesRoot);
+  const globalStoreRoot = /^\d+$/u.test(path.basename(projectOrLayoutRoot))
+    ? path.dirname(projectOrLayoutRoot)
+    : projectOrLayoutRoot;
   return (
-    (await exists(path.join(globalRoot, ".modules.yaml"))) &&
-    ((await exists(path.join(layoutDir, "pnpm-lock.yaml"))) ||
-      (await exists(path.join(layoutDir, "package.json"))))
+    (await exists(path.join(nodeModulesRoot, ".modules.yaml"))) &&
+    ((await exists(path.join(projectOrLayoutRoot, "pnpm-lock.yaml"))) ||
+      (await exists(path.join(projectOrLayoutRoot, "package.json"))) ||
+      (await exists(path.join(globalStoreRoot, "pnpm-lock.yaml"))) ||
+      (await exists(path.join(globalStoreRoot, "package.json"))))
   );
 }
 
@@ -70,10 +58,16 @@ export async function detectPackageManager(root: string): Promise<DetectedPackag
   const files = await fs.readdir(root).catch((): string[] => []);
   const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (files.includes("npm-shrinkwrap.json") && !files.includes(".git")) {
-    if (pm === "pnpm" && (await isPnpmOwnedPackageRoot(root))) {
+    if (
+      pm === "pnpm" &&
+      (files.includes("pnpm-lock.yaml") || (await isPnpmOwnedPackageRoot(root)))
+    ) {
       return "pnpm";
     }
-    if (pm === "bun" && isBunOwnedPackageRoot(root)) {
+    if (
+      pm === "bun" &&
+      (files.includes("bun.lock") || files.includes("bun.lockb") || isBunOwnedPackageRoot(root))
+    ) {
       return "bun";
     }
     return "npm";

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -58,6 +58,9 @@ export async function detectPackageManager(root: string): Promise<DetectedPackag
   const files = await fs.readdir(root).catch((): string[] => []);
   const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (files.includes("npm-shrinkwrap.json") && !files.includes(".git")) {
+    if (isBunOwnedPackageRoot(root)) {
+      return "bun";
+    }
     if (
       pm === "pnpm" &&
       (files.includes("pnpm-lock.yaml") || (await isPnpmOwnedPackageRoot(root)))

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -230,6 +230,22 @@ describe("checkDepsStatus", () => {
       expect(okDeps.status).toBe("ok");
     });
   });
+
+  it("uses npm-shrinkwrap as the npm dependency lock marker when present", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-" }, async (root) => {
+      const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
+      const markerPath = path.join(root, "node_modules");
+      await fs.writeFile(shrinkwrapPath, "lock", "utf8");
+      await fs.mkdir(markerPath, { recursive: true });
+
+      await expect(checkDepsStatus({ root, manager: "npm" })).resolves.toMatchObject({
+        manager: "npm",
+        status: "ok",
+        lockfilePath: shrinkwrapPath,
+        markerPath,
+      });
+    });
+  });
 });
 
 describe("checkUpdateStatus", () => {
@@ -266,6 +282,31 @@ describe("checkUpdateStatus", () => {
       expect(status.git).toBeUndefined();
       expect(status.registry).toBeUndefined();
       expect(status.deps?.manager).toBe("npm");
+    });
+  });
+
+  it("reports npm for published npm roots with pnpm build metadata and shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-" }, async (root) => {
+      const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@10.8.1" }),
+        "utf8",
+      );
+      await fs.writeFile(shrinkwrapPath, "lock", "utf8");
+      await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+
+      const status = await checkUpdateStatus({
+        root,
+        includeRegistry: false,
+        fetchGit: false,
+        timeoutMs: 1000,
+      });
+      expect(status.installKind).toBe("package");
+      expect(status.packageManager).toBe("npm");
+      expect(status.deps?.manager).toBe("npm");
+      expect(status.deps?.status).toBe("ok");
+      expect(status.deps?.lockfilePath).toBe(shrinkwrapPath);
     });
   });
 

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -200,10 +200,10 @@ async function statMtimeMs(p: string): Promise<number | null> {
   }
 }
 
-function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
+async function resolveDepsMarker(params: { root: string; manager: PackageManager }): Promise<{
   lockfilePath: string | null;
   markerPath: string | null;
-} {
+}> {
   const root = params.root;
   if (params.manager === "pnpm") {
     return {
@@ -218,8 +218,11 @@ function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
     };
   }
   if (params.manager === "npm") {
+    const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
     return {
-      lockfilePath: path.join(root, "package-lock.json"),
+      lockfilePath: (await exists(shrinkwrapPath))
+        ? shrinkwrapPath
+        : path.join(root, "package-lock.json"),
       markerPath: path.join(root, "node_modules"),
     };
   }
@@ -231,7 +234,7 @@ export async function checkDepsStatus(params: {
   manager: PackageManager;
 }): Promise<DepsStatus> {
   const root = path.resolve(params.root);
-  const { lockfilePath, markerPath } = resolveDepsMarker({
+  const { lockfilePath, markerPath } = await resolveDepsMarker({
     root,
     manager: params.manager,
   });


### PR DESCRIPTION
## Summary
- treat `npm-shrinkwrap.json` as npm install evidence for published npm package roots, even when package.json carries build-time `packageManager: pnpm`
- preserve pnpm package-root ownership when pnpm global/project layout proves it owns a package root that also carries `npm-shrinkwrap.json`
- preserve pnpm sibling virtual-store roots shaped like `.../5/.pnpm/.../node_modules/openclaw` by mapping them back to the owning `.../5/node_modules` layout
- preserve Bun global package-root ownership even when the published package metadata still says `pnpm`
- use `npm-shrinkwrap.json` as the npm dependency lock marker when present so update/status reports do not look for the wrong lockfile marker

Fixes #87732.

## Surface area
- No public config changes.
- No plugin API or plugin contract changes.
- No new CLI flags, env vars, migrations, or public update/config surface.
- No update command behavior rewrite; this only changes status/install detection and dependency marker reporting.

## Real npm-installed proof

ClawSweeper asked for proof from a real package-style npm install, not only synthetic temp roots. I built the PR head, packed the package, installed that tarball with npm into an isolated global prefix, then ran the installed `openclaw` binary from the installed package root.

Environment:
- WSL2 Ubuntu checkout: `/tmp/openclaw-pr-87778-refresh`
- Signed PR head tested: `090c9a955061ba844a1b55b1834634c63c2db344`
- Local validation base contained: `origin/main` `2d0c7550131d25f5c5f61a802c510d4d640f1260`
- Packed tarball: `/tmp/openclaw-pr-87778-npm-proof/pack/openclaw-2026.5.31.tgz`
- npm global prefix: `/tmp/openclaw-pr-87778-npm-proof/npm-prefix`
- Installed package root: `/tmp/openclaw-pr-87778-npm-proof/npm-prefix/lib/node_modules/openclaw`
- Installed shrinkwrap marker present: `/tmp/openclaw-pr-87778-npm-proof/npm-prefix/lib/node_modules/openclaw/npm-shrinkwrap.json` (`126321` bytes)

Exact proof commands:
```bash
CI=true pnpm run build
npm pack --pack-destination /tmp/openclaw-pr-87778-npm-proof/pack
npm install --global --prefix /tmp/openclaw-pr-87778-npm-proof/npm-prefix /tmp/openclaw-pr-87778-npm-proof/pack/openclaw-2026.5.31.tgz
cd /tmp/openclaw-pr-87778-npm-proof/npm-prefix/lib/node_modules/openclaw
OPENCLAW_DISABLE_AUTO_UPDATE=1 HOME=/tmp/openclaw-pr-87778-npm-proof/home OPENCLAW_HOME=/tmp/openclaw-pr-87778-npm-proof/openclaw-home /tmp/openclaw-pr-87778-npm-proof/npm-prefix/bin/openclaw update status --json > /tmp/openclaw-pr-87778-npm-proof/update-status-package-root.json
OPENCLAW_DISABLE_AUTO_UPDATE=1 HOME=/tmp/openclaw-pr-87778-npm-proof/home OPENCLAW_HOME=/tmp/openclaw-pr-87778-npm-proof/openclaw-home /tmp/openclaw-pr-87778-npm-proof/npm-prefix/bin/openclaw status --all --json > /tmp/openclaw-pr-87778-npm-proof/status-all-package-root.json
```

Observed proof output in both `update status --json` and `status --all --json`:
- `update.installKind = "package"`
- `update.packageManager = "npm"`
- `update.deps.manager = "npm"`
- `update.deps.status = "ok"`
- `update.deps.lockfilePath = "/tmp/openclaw-pr-87778-npm-proof/npm-prefix/lib/node_modules/openclaw/npm-shrinkwrap.json"`
- `update.deps.markerPath = "/tmp/openclaw-pr-87778-npm-proof/npm-prefix/lib/node_modules/openclaw/node_modules"`

Note: plain `openclaw status --json` uses the fast status payload and does not include the full update details. The real proof therefore uses `openclaw update status --json` and `openclaw status --all --json`, which are the status/update surfaces that expose the package manager and dependency marker fields.

## Regression coverage
- npm shrinkwrap package roots detect npm and use `npm-shrinkwrap.json` as the npm lockfile marker.
- pnpm package roots still detect pnpm when pnpm owns the root.
- pnpm virtual-store and sibling virtual-store package roots still detect pnpm from the owning `node_modules` layout.
- local pnpm package roots stay pnpm.
- Bun-owned package roots stay Bun even when the published package metadata says `pnpm` and the root includes shrinkwrap.
- update/status JSON reports the dependency marker selected by the detected package manager.

## Validation
- `CI=true pnpm run build` -> passed
- real npm global install proof commands above -> passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts src/infra/update-global.test.ts src/commands/status.update.test.ts src/commands/status-json-payload.test.ts --reporter=dot` -> 5 files, 74 tests passed
- `CI=true pnpm exec oxfmt --check src/infra/detect-package-manager.ts src/infra/detect-package-manager.test.ts` -> passed
- `CI=true pnpm exec oxlint --tsconfig ./tsconfig.json src/infra/detect-package-manager.ts src/infra/detect-package-manager.test.ts` -> 0 warnings, 0 errors
- `git diff --check origin/main...HEAD` -> passed
- `git diff --check` -> passed
- `/home/giodl/.local/toolchains/node-v22.22.3-linux-x64/bin/codex review --base origin/main` -> no actionable correctness issues found
- `git log --show-signature --format="%H %G? %s" origin/main..HEAD` -> all 5 commits have good signatures

Signed head: `090c9a955061ba844a1b55b1834634c63c2db344`. GitHub currently reports the PR as mergeable against `main`.