### PR TITLE
Add WhatsApp approval QA scenarios

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -665,6 +665,48 @@ pnpm openclaw qa slack \
 
 A green run completes in well under 30 seconds and `slack-qa-report.md` shows both `slack-canary` and `slack-mention-gating` at status `pass`. If the lane hangs for ~90 seconds and exits with `Convex credential pool exhausted for kind "slack"`, either the pool is empty or every row is leased - `qa credentials list --kind slack --status all --json` will tell you which.
 
+### WhatsApp QA
+
+```bash
+pnpm openclaw qa whatsapp
+```
+
+Targets two dedicated WhatsApp Web accounts: a driver account controlled by
+the harness and a SUT account started by the child OpenClaw gateway through the
+bundled WhatsApp plugin.
+
+Required env when `--credential-source env`:
+
+- `OPENCLAW_QA_WHATSAPP_DRIVER_PHONE_E164`
+- `OPENCLAW_QA_WHATSAPP_SUT_PHONE_E164`
+- `OPENCLAW_QA_WHATSAPP_DRIVER_AUTH_ARCHIVE_BASE64`
+- `OPENCLAW_QA_WHATSAPP_SUT_AUTH_ARCHIVE_BASE64`
+
+Optional:
+
+- `OPENCLAW_QA_WHATSAPP_GROUP_JID` enables `whatsapp-mention-gating`.
+- `OPENCLAW_QA_WHATSAPP_CAPTURE_CONTENT=1` keeps message bodies in
+  observed-message artifacts.
+
+Scenarios (`extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts`):
+
+- `whatsapp-canary`
+- `whatsapp-pairing-block`
+- `whatsapp-mention-gating`
+- `whatsapp-approval-exec-native` - opt-in native WhatsApp exec approval
+  scenario. Requests an exec approval through the gateway, verifies the
+  WhatsApp message has native reaction approval affordances, resolves it, and
+  verifies the resolved WhatsApp follow-up.
+- `whatsapp-approval-plugin-native` - opt-in native WhatsApp plugin approval
+  scenario. Enables exec and plugin approval forwarding together, then verifies
+  the same pending/resolved native WhatsApp path.
+
+Output artifacts:
+
+- `whatsapp-qa-report.md`
+- `whatsapp-qa-summary.json`
+- `whatsapp-qa-observed-messages.json` - bodies redacted unless `OPENCLAW_QA_WHATSAPP_CAPTURE_CONTENT=1`.
+
 ### Convex credential pool
 
 Telegram, Discord, Slack, and WhatsApp lanes can lease credentials from a shared Convex pool instead of reading the env vars above. Pass `--credential-source convex` (or set `OPENCLAW_QA_CREDENTIAL_SOURCE=convex`); QA Lab acquires an exclusive lease, heartbeats it for the duration of the run, and releases it on shutdown. Pool kinds are `"telegram"`, `"discord"`, `"slack"`, and `"whatsapp"`.

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -164,6 +164,17 @@ describe("WhatsApp QA live runtime", () => {
     ]);
   });
 
+  it("keeps native approval scenarios out of default WhatsApp selection", () => {
+    const expectedDefaultIds = [
+      "whatsapp-canary",
+      "whatsapp-pairing-block",
+      "whatsapp-mention-gating",
+    ];
+
+    expect(testing.findScenarios().map(({ id }) => id)).toEqual(expectedDefaultIds);
+    expect(testing.findScenarios([]).map(({ id }) => id)).toEqual(expectedDefaultIds);
+  });
+
   it("selects native approval scenarios by id without changing standard coverage", () => {
     const scenarios = testing.findScenarios([
       "whatsapp-approval-exec-native",
@@ -224,6 +235,9 @@ describe("WhatsApp QA live runtime", () => {
   it("uses automatic visible replies for WhatsApp group mention gating", () => {
     const [scenario] = testing.findScenarios(["whatsapp-mention-gating"]);
     const scenarioRun = scenario.buildRun();
+    if (scenarioRun.kind === "approval") {
+      throw new Error("whatsapp-mention-gating unexpectedly built an approval scenario run");
+    }
     expect(scenarioRun.input).toContain("openclawqa reply with only this exact marker");
     expect(scenarioRun.input).not.toContain("visible reply tool check");
 

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -156,6 +156,71 @@ describe("WhatsApp QA live runtime", () => {
     expect(scenarios.map(({ id }) => id)).toEqual(["whatsapp-canary", "whatsapp-pairing-block"]);
   });
 
+  it("reports standard WhatsApp live transport scenario coverage", () => {
+    expect(testing.WHATSAPP_QA_STANDARD_SCENARIO_IDS).toEqual([
+      "canary",
+      "allowlist-block",
+      "mention-gating",
+    ]);
+  });
+
+  it("selects native approval scenarios by id without changing standard coverage", () => {
+    const scenarios = testing.findScenarios([
+      "whatsapp-approval-exec-native",
+      "whatsapp-approval-plugin-native",
+    ]);
+
+    expect(scenarios.map(({ id }) => id)).toEqual([
+      "whatsapp-approval-exec-native",
+      "whatsapp-approval-plugin-native",
+    ]);
+    expect(testing.WHATSAPP_QA_STANDARD_SCENARIO_IDS).not.toContain(
+      "whatsapp-approval-exec-native",
+    );
+    expect(scenarios.map((scenario) => scenario.buildRun().kind)).toEqual(["approval", "approval"]);
+  });
+
+  it("enables WhatsApp native exec and plugin approval delivery for approval scenarios", () => {
+    const cfg = testing.buildWhatsAppQaConfig(
+      {},
+      {
+        allowFrom: ["+15550000001"],
+        authDir: "/tmp/openclaw-whatsapp-qa-auth",
+        dmPolicy: "allowlist",
+        overrides: {
+          approvals: {
+            exec: true,
+            plugin: true,
+          },
+        },
+        sutAccountId: "sut",
+      },
+    );
+
+    expect(cfg.approvals?.exec).toEqual({ enabled: true, mode: "session" });
+    expect(cfg.approvals?.plugin).toEqual({ enabled: true, mode: "session" });
+    const account = cfg.channels?.whatsapp?.accounts?.sut;
+    expect(account?.allowFrom).toEqual(["+15550000001"]);
+    expect(account).not.toHaveProperty("execApprovals");
+  });
+
+  it("matches native approval resolved text emitted by the WhatsApp approval handler", () => {
+    expect(
+      testing.matchesWhatsAppApprovalResolvedText({
+        approvalId: "whatsapp-qa-exec-123",
+        approvalKind: "exec",
+        text: "✅ Exec approval allow-once. ID: whatsapp-qa-exec-123",
+      }),
+    ).toBe(true);
+    expect(
+      testing.matchesWhatsAppApprovalResolvedText({
+        approvalId: "whatsapp-qa-plugin-123",
+        approvalKind: "plugin",
+        text: "✅ Plugin approval allowed once. ID: whatsapp-qa-plugin-123",
+      }),
+    ).toBe(true);
+  });
+
   it("uses automatic visible replies for WhatsApp group mention gating", () => {
     const [scenario] = testing.findScenarios(["whatsapp-mention-gating"]);
     const scenarioRun = scenario.buildRun();

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -47,12 +47,18 @@ export type WhatsAppQaRuntimeEnv = {
 type WhatsAppQaScenarioId =
   | "whatsapp-canary"
   | "whatsapp-pairing-block"
-  | "whatsapp-mention-gating";
+  | "whatsapp-mention-gating"
+  | "whatsapp-approval-exec-native"
+  | "whatsapp-approval-plugin-native";
 
-type WhatsAppQaScenarioRun = {
+type WhatsAppQaApprovalKind = "exec" | "plugin";
+type WhatsAppQaApprovalDecision = "allow-once";
+
+type WhatsAppQaMessageScenarioRun = {
   configMode: "allowlist" | "pairing";
   expectReply: boolean;
   input: string;
+  kind?: "message";
   matchText: string | RegExp;
   quietInput?: string;
   quietMatchText?: string | RegExp;
@@ -60,8 +66,25 @@ type WhatsAppQaScenarioRun = {
   target: "dm" | "group";
 };
 
+type WhatsAppQaApprovalScenarioRun = {
+  approvalKind: WhatsAppQaApprovalKind;
+  decision: WhatsAppQaApprovalDecision;
+  kind: "approval";
+  token: string;
+};
+
+type WhatsAppQaScenarioRun = WhatsAppQaApprovalScenarioRun | WhatsAppQaMessageScenarioRun;
+
+type WhatsAppQaConfigOverrides = {
+  approvals?: {
+    exec?: boolean;
+    plugin?: boolean;
+  };
+};
+
 type WhatsAppQaScenarioDefinition = LiveTransportScenarioDefinition<WhatsAppQaScenarioId> & {
   buildRun: () => WhatsAppQaScenarioRun;
+  configOverrides?: WhatsAppQaConfigOverrides;
   requiresGroupJid?: boolean;
 };
 
@@ -83,13 +106,17 @@ type WhatsAppQaDriverSession = {
   }) => Promise<WhatsAppQaDriverObservedMessage>;
 };
 
+type WhatsAppQaGateway = Awaited<ReturnType<typeof startQaGatewayChild>>;
+
 type WhatsAppObservedMessage = WhatsAppQaDriverObservedMessage & {
+  approvalState?: "pending" | "resolved";
   matchedScenario?: boolean;
   scenarioId?: string;
   scenarioTitle?: string;
 };
 
 type WhatsAppObservedMessageArtifact = {
+  approvalState?: "pending" | "resolved";
   fromPhoneE164?: string | null;
   matchedScenario?: boolean;
   messageId?: string;
@@ -109,7 +136,7 @@ type WhatsAppQaScenarioResult = {
     finalMatchedReplyRttMs: number;
     requestStartedAt: string;
     responseObservedAt: string;
-    source: "request-to-observed-message";
+    source: "approval-request-to-resolution" | "request-to-observed-message";
   };
   status: "fail" | "pass" | "skip";
   title: string;
@@ -158,6 +185,7 @@ const WHATSAPP_QA_TRANSIENT_DRIVER_ATTEMPTS = 5;
 const WHATSAPP_QA_READY_TIMEOUT_MS = 150_000;
 const WHATSAPP_QA_READY_STABILITY_MS = 20_000;
 const WHATSAPP_QA_DRIVER_RECONNECT_DELAY_MS = 10_000;
+const WHATSAPP_QA_APPROVAL_DECISION_TIMEOUT_MS = 60_000;
 const WHATSAPP_QA_ENV_KEYS = [
   "OPENCLAW_QA_WHATSAPP_DRIVER_PHONE_E164",
   "OPENCLAW_QA_WHATSAPP_SUT_PHONE_E164",
@@ -223,6 +251,39 @@ const WHATSAPP_QA_SCENARIOS: WhatsAppQaScenarioDefinition[] = [
         target: "group",
       };
     },
+  },
+  {
+    id: "whatsapp-approval-exec-native",
+    title: "WhatsApp native exec approval prompt resolves",
+    timeoutMs: 60_000,
+    configOverrides: {
+      approvals: {
+        exec: true,
+      },
+    },
+    buildRun: () => ({
+      approvalKind: "exec",
+      decision: "allow-once",
+      kind: "approval",
+      token: `WHATSAPP_QA_EXEC_APPROVAL_${randomUUID().slice(0, 8).toUpperCase()}`,
+    }),
+  },
+  {
+    id: "whatsapp-approval-plugin-native",
+    title: "WhatsApp native plugin approval prompt resolves with exec approvals enabled",
+    timeoutMs: 60_000,
+    configOverrides: {
+      approvals: {
+        exec: true,
+        plugin: true,
+      },
+    },
+    buildRun: () => ({
+      approvalKind: "plugin",
+      decision: "allow-once",
+      kind: "approval",
+      token: `WHATSAPP_QA_PLUGIN_APPROVAL_${randomUUID().slice(0, 8).toUpperCase()}`,
+    }),
   },
 ];
 
@@ -325,12 +386,41 @@ function buildWhatsAppQaConfig(
     authDir: string;
     dmPolicy: "allowlist" | "pairing";
     groupJid?: string;
+    overrides?: WhatsAppQaConfigOverrides;
     sutAccountId: string;
   },
 ): OpenClawConfig {
   const pluginAllow = uniqueStrings([...(baseCfg.plugins?.allow ?? []), "whatsapp"]);
+  const approvalOverrides = params.overrides?.approvals;
+  const approvalForwardingConfig =
+    approvalOverrides?.exec || approvalOverrides?.plugin
+      ? {
+          approvals: {
+            ...baseCfg.approvals,
+            ...(approvalOverrides.exec
+              ? {
+                  exec: {
+                    ...baseCfg.approvals?.exec,
+                    enabled: true,
+                    mode: "session" as const,
+                  },
+                }
+              : {}),
+            ...(approvalOverrides.plugin
+              ? {
+                  plugin: {
+                    ...baseCfg.approvals?.plugin,
+                    enabled: true,
+                    mode: "session" as const,
+                  },
+                }
+              : {}),
+          },
+        }
+      : {};
   return {
     ...baseCfg,
+    ...approvalForwardingConfig,
     plugins: {
       ...baseCfg.plugins,
       allow: pluginAllow,
@@ -392,7 +482,7 @@ type WhatsAppChannelStatus = {
 };
 
 async function waitForWhatsAppChannelRunning(
-  gateway: Awaited<ReturnType<typeof startQaGatewayChild>>,
+  gateway: WhatsAppQaGateway,
   accountId: string,
 ): Promise<WhatsAppChannelStatus> {
   const startedAt = Date.now();
@@ -448,10 +538,7 @@ async function waitForWhatsAppChannelRunning(
   );
 }
 
-async function waitForWhatsAppChannelStable(
-  gateway: Awaited<ReturnType<typeof startQaGatewayChild>>,
-  accountId: string,
-) {
+async function waitForWhatsAppChannelStable(gateway: WhatsAppQaGateway, accountId: string) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < WHATSAPP_QA_READY_TIMEOUT_MS) {
     const status = await waitForWhatsAppChannelRunning(gateway, accountId);
@@ -548,6 +635,291 @@ async function startWhatsAppQaDriverSessionWithRetry(params: { authDir: string }
   }
 }
 
+function formatApprovalResultValue(value: unknown) {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value == null) {
+    return "<missing>";
+  }
+  return JSON.stringify(value) ?? "<unserializable>";
+}
+
+function readAcceptedApprovalRequest(result: unknown) {
+  const accepted =
+    typeof result === "object" && result !== null
+      ? (result as { id?: unknown; status?: unknown })
+      : null;
+  if (accepted?.status !== "accepted") {
+    throw new Error(
+      `approval request status was ${formatApprovalResultValue(
+        accepted?.status,
+      )} instead of accepted`,
+    );
+  }
+  return accepted;
+}
+
+function readAcceptedApprovalRequestId(result: unknown) {
+  const id = readAcceptedApprovalRequest(result).id;
+  if (typeof id !== "string" || id.trim().length === 0) {
+    throw new Error(`approval request id was ${formatApprovalResultValue(id)}`);
+  }
+  return id;
+}
+
+async function requestWhatsAppApproval(params: {
+  approvalId: string;
+  driverPhoneE164: string;
+  gateway: WhatsAppQaGateway;
+  run: WhatsAppQaApprovalScenarioRun;
+  sutAccountId: string;
+}) {
+  const commonParams = {
+    timeoutMs: WHATSAPP_QA_APPROVAL_DECISION_TIMEOUT_MS,
+    turnSourceAccountId: params.sutAccountId,
+    turnSourceChannel: "whatsapp",
+    turnSourceTo: params.driverPhoneE164,
+    twoPhase: true,
+  };
+  if (params.run.approvalKind === "exec") {
+    const result = await params.gateway.call(
+      "exec.approval.request",
+      {
+        ...commonParams,
+        ask: "always",
+        command: `printf '%s\\n' '${params.run.token}'`,
+        host: "gateway",
+        id: params.approvalId,
+        security: "full",
+      },
+      {
+        expectFinal: false,
+        timeoutMs: WHATSAPP_QA_APPROVAL_DECISION_TIMEOUT_MS + 5_000,
+      },
+    );
+    const acceptedId = readAcceptedApprovalRequestId(result);
+    if (acceptedId !== params.approvalId) {
+      throw new Error(
+        `accepted exec approval id was ${formatApprovalResultValue(
+          acceptedId,
+        )} instead of ${params.approvalId}`,
+      );
+    }
+    return acceptedId;
+  }
+  const result = await params.gateway.call(
+    "plugin.approval.request",
+    {
+      ...commonParams,
+      agentId: "qa",
+      description: `WhatsApp plugin approval QA request ${params.run.token}`,
+      pluginId: "qa-whatsapp-plugin",
+      severity: "warning",
+      title: `WhatsApp plugin approval QA ${params.run.token}`,
+      toolName: "whatsapp_qa_tool",
+    },
+    {
+      expectFinal: false,
+      timeoutMs: WHATSAPP_QA_APPROVAL_DECISION_TIMEOUT_MS + 5_000,
+    },
+  );
+  return readAcceptedApprovalRequestId(result);
+}
+
+async function waitForApprovalDecision(params: {
+  approvalId: string;
+  gateway: WhatsAppQaGateway;
+  kind: WhatsAppQaApprovalKind;
+}) {
+  const method =
+    params.kind === "exec" ? "exec.approval.waitDecision" : "plugin.approval.waitDecision";
+  return await params.gateway.call(
+    method,
+    { id: params.approvalId },
+    {
+      expectFinal: true,
+      timeoutMs: WHATSAPP_QA_APPROVAL_DECISION_TIMEOUT_MS + 5_000,
+    },
+  );
+}
+
+async function resolveApprovalDecision(params: {
+  approvalId: string;
+  decision: WhatsAppQaApprovalDecision;
+  gateway: WhatsAppQaGateway;
+  kind: WhatsAppQaApprovalKind;
+}) {
+  const method = params.kind === "exec" ? "exec.approval.resolve" : "plugin.approval.resolve";
+  return await params.gateway.call(
+    method,
+    { decision: params.decision, id: params.approvalId },
+    {
+      expectFinal: false,
+      timeoutMs: WHATSAPP_QA_APPROVAL_DECISION_TIMEOUT_MS + 5_000,
+    },
+  );
+}
+
+function assertApprovalDecisionResult(params: {
+  decision: WhatsAppQaApprovalDecision;
+  result: unknown;
+}) {
+  const resultDecision =
+    typeof params.result === "object" && params.result !== null
+      ? (params.result as { decision?: unknown }).decision
+      : undefined;
+  if (resultDecision !== params.decision) {
+    throw new Error(
+      `approval decision was ${formatApprovalResultValue(resultDecision)} instead of ${params.decision}`,
+    );
+  }
+}
+
+function matchesWhatsAppApprovalPendingText(params: {
+  approvalId: string;
+  approvalKind: WhatsAppQaApprovalKind;
+  text: string;
+  token: string;
+}) {
+  const heading =
+    params.approvalKind === "exec" ? "Exec approval required" : "Plugin approval required";
+  return (
+    params.text.includes(heading) &&
+    params.text.includes(params.approvalId) &&
+    params.text.includes(params.token) &&
+    params.text.includes("React with:") &&
+    params.text.includes("👍")
+  );
+}
+
+function matchesWhatsAppApprovalResolvedText(params: {
+  approvalId: string;
+  approvalKind: WhatsAppQaApprovalKind;
+  text: string;
+}) {
+  const heading =
+    params.approvalKind === "exec" ? "Exec approval allow-once" : "Plugin approval allowed once";
+  return params.text.includes(params.approvalId) && params.text.includes(heading);
+}
+
+async function waitForWhatsAppApprovalMessage(params: {
+  approvalId: string;
+  approvalKind: WhatsAppQaApprovalKind;
+  driver: WhatsAppQaDriverSession;
+  observedMessages: WhatsAppObservedMessage[];
+  scenario: WhatsAppQaScenarioDefinition;
+  state: "pending" | "resolved";
+  sutPhoneE164: string;
+  timeoutMs: number;
+  token: string;
+}) {
+  const reply = await params.driver.waitForMessage({
+    timeoutMs: params.timeoutMs,
+    match: (message) => {
+      const fromExpectedSender =
+        !message.fromPhoneE164 || message.fromPhoneE164 === params.sutPhoneE164;
+      return (
+        fromExpectedSender &&
+        (params.state === "pending"
+          ? matchesWhatsAppApprovalPendingText({
+              approvalId: params.approvalId,
+              approvalKind: params.approvalKind,
+              text: message.text,
+              token: params.token,
+            })
+          : matchesWhatsAppApprovalResolvedText({
+              approvalId: params.approvalId,
+              approvalKind: params.approvalKind,
+              text: message.text,
+            }))
+      );
+    },
+  });
+  const observed: WhatsAppObservedMessage = {
+    ...reply,
+    approvalState: params.state,
+    matchedScenario: true,
+    scenarioId: params.scenario.id,
+    scenarioTitle: params.scenario.title,
+  };
+  params.observedMessages.push(observed);
+  return observed;
+}
+
+async function runWhatsAppApprovalScenario(params: {
+  driver: WhatsAppQaDriverSession;
+  driverPhoneE164: string;
+  gateway: WhatsAppQaGateway;
+  observedMessages: WhatsAppObservedMessage[];
+  run: WhatsAppQaApprovalScenarioRun;
+  scenario: WhatsAppQaScenarioDefinition;
+  sutAccountId: string;
+  sutPhoneE164: string;
+}) {
+  const requestStartedAt = new Date();
+  const requestedApprovalId =
+    params.run.approvalKind === "exec"
+      ? `whatsapp-qa-exec-${randomUUID()}`
+      : `whatsapp-qa-plugin-${randomUUID()}`;
+  const approvalId = await requestWhatsAppApproval({
+    approvalId: requestedApprovalId,
+    driverPhoneE164: params.driverPhoneE164,
+    gateway: params.gateway,
+    run: params.run,
+    sutAccountId: params.sutAccountId,
+  });
+  await waitForWhatsAppApprovalMessage({
+    approvalId,
+    approvalKind: params.run.approvalKind,
+    driver: params.driver,
+    observedMessages: params.observedMessages,
+    scenario: params.scenario,
+    state: "pending",
+    sutPhoneE164: params.sutPhoneE164,
+    timeoutMs: params.scenario.timeoutMs,
+    token: params.run.token,
+  });
+  const resolvedPromise = waitForWhatsAppApprovalMessage({
+    approvalId,
+    approvalKind: params.run.approvalKind,
+    driver: params.driver,
+    observedMessages: params.observedMessages,
+    scenario: params.scenario,
+    state: "resolved",
+    sutPhoneE164: params.sutPhoneE164,
+    timeoutMs: params.scenario.timeoutMs,
+    token: params.run.token,
+  });
+  try {
+    await resolveApprovalDecision({
+      approvalId,
+      decision: params.run.decision,
+      gateway: params.gateway,
+      kind: params.run.approvalKind,
+    });
+    assertApprovalDecisionResult({
+      decision: params.run.decision,
+      result: await waitForApprovalDecision({
+        approvalId,
+        gateway: params.gateway,
+        kind: params.run.approvalKind,
+      }),
+    });
+  } catch (error) {
+    resolvedPromise.catch(() => {});
+    throw error;
+  }
+  const resolved = await resolvedPromise;
+  const responseObservedAt = new Date(resolved.observedAt);
+  return {
+    approvalId,
+    requestStartedAt,
+    responseObservedAt,
+    rttMs: responseObservedAt.getTime() - requestStartedAt.getTime(),
+  };
+}
+
 async function runWhatsAppScenario(params: {
   driver: WhatsAppQaDriverSession;
   driverPhoneE164: string;
@@ -565,13 +937,21 @@ async function runWhatsAppScenario(params: {
   groupJid?: string;
 }): Promise<WhatsAppQaScenarioResult> {
   const scenarioRun = params.scenario.buildRun();
-  if (scenarioRun.target === "group" && !params.groupJid) {
+  if (scenarioRun.kind !== "approval" && scenarioRun.target === "group" && !params.groupJid) {
     throw new Error(`WhatsApp scenario ${params.scenario.id} requires groupJid.`);
   }
-  const target = scenarioRun.target === "group" ? params.groupJid! : params.sutPhoneE164;
+  const target =
+    scenarioRun.kind !== "approval" && scenarioRun.target === "group"
+      ? params.groupJid!
+      : params.sutPhoneE164;
   const allowFrom =
-    scenarioRun.configMode === "allowlist" ? [params.driverPhoneE164] : ["+15550000000"];
-  const dmPolicy = scenarioRun.configMode === "allowlist" ? "allowlist" : "pairing";
+    scenarioRun.kind === "approval" || scenarioRun.configMode === "allowlist"
+      ? [params.driverPhoneE164]
+      : ["+15550000000"];
+  const dmPolicy =
+    scenarioRun.kind === "approval" || scenarioRun.configMode === "allowlist"
+      ? "allowlist"
+      : "pairing";
   const gatewayHarness = await startQaLiveLaneGateway({
     repoRoot: params.repoRoot,
     transport: {
@@ -594,13 +974,44 @@ async function runWhatsAppScenario(params: {
         allowFrom,
         authDir: params.sutAuthDir,
         dmPolicy,
-        groupJid: scenarioRun.target === "group" ? params.groupJid : undefined,
+        groupJid:
+          scenarioRun.kind !== "approval" && scenarioRun.target === "group"
+            ? params.groupJid
+            : undefined,
+        overrides: params.scenario.configOverrides,
         sutAccountId: params.sutAccountId,
       }),
   });
   let preservedGatewayDebug = false;
   try {
     await waitForWhatsAppChannelStable(gatewayHarness.gateway, params.sutAccountId);
+    if (scenarioRun.kind === "approval") {
+      const approval = await runWhatsAppApprovalScenario({
+        driver: params.driver,
+        driverPhoneE164: params.driverPhoneE164,
+        gateway: gatewayHarness.gateway,
+        observedMessages: params.observedMessages,
+        run: scenarioRun,
+        scenario: params.scenario,
+        sutAccountId: params.sutAccountId,
+        sutPhoneE164: params.sutPhoneE164,
+      });
+      return {
+        id: params.scenario.id,
+        title: params.scenario.title,
+        status: "pass" as const,
+        details: `${scenarioRun.approvalKind} approval ${approval.approvalId} resolved ${scenarioRun.decision} in ${approval.rttMs}ms`,
+        rttMs: approval.rttMs,
+        requestStartedAt: approval.requestStartedAt.toISOString(),
+        responseObservedAt: approval.responseObservedAt.toISOString(),
+        rttMeasurement: {
+          finalMatchedReplyRttMs: approval.rttMs,
+          requestStartedAt: approval.requestStartedAt.toISOString(),
+          responseObservedAt: approval.responseObservedAt.toISOString(),
+          source: "approval-request-to-resolution" as const,
+        },
+      };
+    }
     if (scenarioRun.quietInput) {
       const quietStartedAt = new Date();
       await params.driver.sendText(target, scenarioRun.quietInput);
@@ -682,6 +1093,7 @@ function toObservedWhatsAppArtifacts(params: {
   redactMetadata: boolean;
 }): WhatsAppObservedMessageArtifact[] {
   return params.messages.map((message) => ({
+    approvalState: message.approvalState,
     fromPhoneE164: params.redactMetadata ? undefined : message.fromPhoneE164,
     matchedScenario: message.matchedScenario,
     messageId: params.redactMetadata ? undefined : message.messageId,
@@ -1052,6 +1464,7 @@ export const testing = {
   findScenarios,
   fingerprintWhatsAppCredentialId: fingerprintQaCredentialId,
   isTransientWhatsAppQaDriverError,
+  matchesWhatsAppApprovalResolvedText,
   parseWhatsAppQaCredentialPayload,
   renderWhatsAppQaMarkdown,
   resolveWhatsAppQaRuntimeEnv,

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -371,11 +371,16 @@ function parseWhatsAppQaCredentialPayload(payload: unknown): WhatsAppQaRuntimeEn
   return validateWhatsAppQaRuntimeEnv(parsed, "WhatsApp credential payload");
 }
 
+function defaultWhatsAppQaScenarios() {
+  return WHATSAPP_QA_SCENARIOS.filter((scenario) => scenario.standardId);
+}
+
 function findScenarios(ids?: string[]) {
+  const scenarios = ids && ids.length > 0 ? WHATSAPP_QA_SCENARIOS : defaultWhatsAppQaScenarios();
   return selectLiveTransportScenarios({
     ids,
     laneLabel: "WhatsApp",
-    scenarios: WHATSAPP_QA_SCENARIOS,
+    scenarios,
   });
 }
 


### PR DESCRIPTION
## Summary

- Add WhatsApp QA Lab equivalents for the Slack native approval scenarios: `whatsapp-approval-exec-native` and `whatsapp-approval-plugin-native`.
- Enable the scenarios through top-level session approval forwarding and verify the native pending/resolved WhatsApp approval messages.
- Keep the new native approval scenarios explicit-only so omitted or empty WhatsApp QA selections still run the standard canary/pairing/mention set.
- Document the WhatsApp QA lane, credential env vars, scenarios, and artifacts.

## Verification

- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts extensions/qa-lab/src/live-transports/whatsapp/whatsapp-boundary.test.ts extensions/qa-lab/src/live-transports/shared/live-transport-scenarios.test.ts extensions/whatsapp/src/approval-auth.test.ts extensions/whatsapp/src/approval-handler.runtime.test.ts extensions/whatsapp/src/approval-native.test.ts extensions/whatsapp/src/approval-reactions.test.ts`
  - 7 files passed, 57 tests passed after rebasing onto current `origin/main`.
- `OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD=1 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental false`
  - Passed.
- `OPENCLAW_OXLINT_SKIP_LOCK=1 OPENCLAW_OXLINT_SHARD_HEARTBEAT_MS=0 node scripts/run-oxlint-shards.mjs --only extensions`
  - Passed.
- `CI=true pnpm_config_confirm_modules_purge=false pnpm_config_minimum_release_age=0 OPENCLAW_HOME=/private/tmp/openclaw-whatsapp-approval-qa-home-prebuild node scripts/run-node.mjs qa whatsapp --help`
  - Rebuilt the private QA CLI and printed WhatsApp QA help. Known Baileys optional `jimp` warning was treated as external and the command exited 0.
- `git diff --check`
  - Exited 0.
- WhatsApp QA Lab live run:
  - Output: `.artifacts/qa-e2e/whatsapp-approval-env-20260528-1310/whatsapp-qa-summary.json`
  - Counts: total 2, passed 2, failed 0, skipped 0.

## Real behavior proof

Behavior addressed: WhatsApp now has QA Lab coverage equivalent to `slack-approval-exec-native` and `slack-approval-plugin-native`, proving native WhatsApp exec and plugin approval prompts can be requested, observed, resolved, and matched.

Real environment tested: Local OpenClaw worktree with the WhatsApp QA Lab lane, real pre-linked WhatsApp Web QA credentials sourced from the Convex credential payload in memory, and `mock-openai` provider mode.

Exact steps or command run after this patch: Ran the private QA CLI against `--scenario whatsapp-approval-exec-native --scenario whatsapp-approval-plugin-native` with `--credential-source env`, after mapping the active Convex WhatsApp credential payload into `OPENCLAW_QA_WHATSAPP_*` variables in the child process without printing the payload.

Evidence after fix: `.artifacts/qa-e2e/whatsapp-approval-env-20260528-1310/whatsapp-qa-summary.json` reports `total: 2`, `passed: 2`, `failed: 0`, `skipped: 0`.

Copied live output from the redacted summary artifact:

```json
{
  "counts": {
    "total": 2,
    "passed": 2,
    "failed": 0,
    "skipped": 0
  },
  "scenarios": [
    {
      "id": "whatsapp-approval-exec-native",
      "status": "pass",
      "details": "exec approval whatsapp-qa-exec-a2151c2f-0225-4f13-b5ef-387bde27837b resolved allow-once in 838ms"
    },
    {
      "id": "whatsapp-approval-plugin-native",
      "status": "pass",
      "details": "plugin approval plugin:72620973-7ebb-42cd-97ae-935287bd46ca resolved allow-once in 494ms"
    }
  ]
}
```

Observed result after fix: `whatsapp-approval-exec-native` passed with `allow-once` resolution in 838ms, and `whatsapp-approval-plugin-native` passed with `allow-once` resolution in 494ms. `whatsapp-qa-observed-messages.json` includes pending and resolved matched messages for both scenarios.

What was not tested: The full all-scenario WhatsApp lane was not rerun after this patch; the live run was scoped to the two new approval scenarios.
