### PR TITLE
fix(agents): don't fail CLI turn when the native harness owns compaction

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -502,6 +502,83 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(compactCalls).toHaveLength(0);
   });
 
+  it("does not throw when the native harness owns automatic compaction (ok:true no-op)", async () => {
+    // Regression: Codex app-server returns a successful no-op (ok:true,
+    // compacted:false) for budget-triggered compaction because it owns
+    // automatic compaction. The lifecycle must treat that as benign and let the
+    // turn proceed, not throw "CLI native harness compaction failed" — throwing
+    // fails the agent run and jams the session lane (endless Discord "typing").
+    const sessionKey = "agent:main:codex-owned-skip";
+    const sessionId = "session-codex-owned-skip";
+    const sessionFile = path.join(tmpDir, "session-codex-owned-skip.jsonl");
+    const storePath = path.join(tmpDir, "sessions-codex-owned-skip.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const compactAgentHarnessSession = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "codex app-server owns automatic compaction",
+    }));
+    const recordCliCompactionInStore = vi.fn(async () => ({
+      ...sessionEntry,
+      compactionCount: 1,
+    }));
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      recordCliCompactionInStore,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "codex",
+      model: "gpt-5.5",
+    });
+
+    expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
+    // No context-engine fallback, no store rotation: the harness self-compacts.
+    expect(compactCalls).toHaveLength(0);
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(updatedEntry).toBe(sessionEntry);
+  });
+
   it("passes owning context engines into native harness CLI compaction", async () => {
     const sessionKey = "agent:main:codex-owned-engine";
     const sessionId = "session-codex-owned-engine";

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -69,6 +69,11 @@ type NativeHarnessCliCompactionOutcome = {
   compacted: boolean;
   result?: EmbeddedAgentCompactResult;
   fallbackToContextEngine?: boolean;
+  // Native harness reported a successful no-op because it owns automatic
+  // compaction itself (e.g. the Codex app-server on non-manual/budget triggers).
+  // Not a failure: the caller must skip the throw and let the harness compact
+  // during the turn, otherwise the agent run errors and the session lane jams.
+  ownedByNativeHarness?: boolean;
   failureReason?: string;
 };
 type CliTranscriptCompactionOutcome = {
@@ -403,12 +408,16 @@ async function compactNativeHarnessCliTranscript(params: {
     const fallbackToContextEngine =
       isUnsupportedNativeHarnessCompaction(result) ||
       isRecoverableNativeHarnessBindingFailure(result);
+    // ok:true with no compaction is a successful no-op (the harness owns
+    // automatic compaction), not a failure — do not throw on it downstream.
+    const ownedByNativeHarness = result?.ok === true;
     log.warn(
       `CLI native harness compaction did not reduce context for ${params.provider}/${params.model}: ${result?.reason ?? "nothing to compact"}`,
     );
     return {
       compacted: false,
       fallbackToContextEngine,
+      ownedByNativeHarness,
       failureReason: result?.reason ?? "native harness compaction did not reduce context",
     };
   }
@@ -519,6 +528,11 @@ export async function runCliTurnCompactionLifecycle(params: {
     if (nativeOutcome.compacted) {
       compacted = true;
       nativeCompactionResult = nativeOutcome.result;
+      useContextEngineCompaction = false;
+    } else if (nativeOutcome.ownedByNativeHarness) {
+      // Harness owns automatic compaction and returned a successful no-op. Skip
+      // both the throw and the context-engine fallback so the turn proceeds and
+      // the harness compacts itself; throwing here jams the session lane.
       useContextEngineCompaction = false;
     } else if (!nativeOutcome.fallbackToContextEngine) {
       throw new Error(


### PR DESCRIPTION
> **AI-assisted:** built with Codex (GPT-5.5) and Claude (Opus 4.8). Human-run real behavior proof from a self-hosted gateway is included below.

## Summary

Budget/auto-triggered compaction on a Codex-backed session calls the Codex app-server, which **owns automatic compaction** and returns a successful no-op (`{ ok: true, compacted: false, reason: "codex app-server owns automatic compaction" }`, the behavior added in #86772). The host lifecycle `runCliTurnCompactionLifecycle` in `src/agents/command/cli-compaction.ts` treated any non-compacted native outcome without `fallbackToContextEngine` as a hard failure and threw `CLI native harness compaction failed …`. That fails the agent run (`UNAVAILABLE`) and the session lane never releases — on a large thread the bot shows a "typing" indicator indefinitely and never replies.

This honors a contract the codebase **already** establishes elsewhere: the auto-reply preflight path skips compaction for Codex runtimes outright (`src/auto-reply/reply/agent-runner-memory.ts`: "Its harness owns automatic compaction; OpenClaw preflight compaction is only for non-Codex embedded runtimes"). `runCliTurnCompactionLifecycle` was the one host path that did not honor it and threw instead.

## Fix

Surface an `ownedByNativeHarness` flag on the native outcome when the harness reports a successful no-op (`result.ok === true`), and add a caller branch **before** the throw that skips both the error and the context-engine fallback, letting the turn proceed so the harness compacts itself. Minimal and additive; no refactor. Genuine failures (`ok:false`, thrown, or `undefined` result) and the unsupported / recoverable-binding cases are unchanged.

Note on shape: I extended the existing `NativeHarnessCliCompactionOutcome` (which already uses parallel optional fields) rather than refactoring it into a discriminated union, to keep the fix small. Happy to take the union refactor in a follow-up if maintainers prefer.

## Sibling surfaces (not one-sided)

The other native-harness compaction entry points already tolerate the `ok:true` no-op, so this is the only path that needed fixing:
- `src/agents/embedded-agent-runner/compact.queued.ts` — `shouldFallbackAfterHarnessCompaction` only fires on `ok:false`; the `ok:true` no-op is returned directly.
- `src/auto-reply/reply/agent-runner-memory.ts` — Codex runtimes skip preflight compaction entirely; otherwise only `isDeferredPreflightCompactionReason` throws, which the owned-skip reason is not.

## Real behavior proof

- **Behavior addressed:** A successful native-harness compaction no-op (`ok:true, compacted:false`, "codex app-server owns automatic compaction") must let the turn proceed instead of throwing and jamming the session lane.
- **Real environment tested:** A self-hosted OpenClaw `2026.5.28` gateway on Linux (Node 22.22.2) where this failure occurred in production, with the equivalent fix applied to the running build and the gateway restarted.
- **Exact steps or command run after this patch:** Drove one real agent turn through the live gateway against the same over-budget Codex session that had been failing (no channel delivery):
  `openclaw agent --session-id <redacted> --message "Reply with exactly: COMPACTION_FIX_OK" --json`
- **Evidence after fix:** Console output / redacted runtime logs copied from the live gateway (same session), captured via `openclaw agent --session-id <redacted> --message "Reply with exactly: COMPACTION_FIX_OK" --json`, before vs. after the fix.

  Before (pre-fix) — the throw and resulting lane jam:
  ```
  [diagnostic] lane wait exceeded: lane=session:agent:main:discord:channel:<redacted> waitedMs=176928 queueAhead=0 activeAhead=1 activeNow=0
  [ws] ⇄ res ✗ agent errorCode=UNAVAILABLE errorMessage=Error: CLI native harness compaction failed for openai-codex/gpt-5.5: codex app-server owns automatic compaction
  ```

  After (post-fix) — same compaction outcome, now skipped instead of thrown; turn completes:
  ```
  [agent/embedded] skipping codex app-server compaction for non-manual trigger
  [agents/cli-compaction] CLI native harness compaction did not reduce context for openai-codex/gpt-5.5: codex app-server owns automatic compaction
  COMPACTION_FIX_OK
  ```
  Agent result JSON: `stopReason: "stop"`, `executionTrace.winnerProvider: "openai-codex"`, `winnerModel: "gpt-5.5"`, `attempts[0].result: "success"`, `fallbackUsed: false`.

- **Observed result after fix:** Copied live output — the previously-jammed over-budget Codex session completed a turn and the agent returned `COMPACTION_FIX_OK` (gateway console output above). Zero `CLI native harness compaction failed` occurrences in gateway logs since the fix was deployed.
- **What was not tested:** Not re-driven through the Discord channel UI specifically — the turn was driven via the gateway `agent` command without `--deliver`; behavior is proven at the live gateway turn boundary.

## Supplemental validation

- New regression test in `cli-compaction.test.ts`: `node scripts/run-vitest.mjs src/agents/command/cli-compaction.test.ts` → 24 passed. Reverting only the source change makes the new test fail with `CLI native harness compaction failed for codex/gpt-5.5: codex app-server owns automatic compaction` (the exact production error).
- `oxfmt --check` clean · `oxlint` clean · `tsgo:test` (core + extensions) exit 0.
- `codex review --base origin/main` run locally: no actionable correctness issues.
- Diff: +14 src / +77 test, 0 deletions.

Complements #87158 (Codex plugin side); coordinates with #87738 (same file, missing-thread `ok:false` case). Related: #85160, #86772, #66263.
