### PR TITLE
fix(ci): stabilize agentic drift checks

### DIFF
--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Install opengrep
         env:
           # Pin both the install script (by commit SHA) and the binary version.
-          # The script SHA must match the v1.19.0 release tag in opengrep/opengrep
+          # The script SHA must match the v1.22.0 release tag in opengrep/opengrep
           # so a compromised or force-pushed `main` cannot RCE in our CI runner.
           # Bump both together when upgrading.
-          OPENGREP_VERSION: v1.19.0
-          OPENGREP_INSTALL_SHA: 9a4c0a68220618441608cd2bad4ff2eddccf8113
+          OPENGREP_VERSION: v1.22.0
+          OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
         run: |
           curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
             | bash -s -- -v "$OPENGREP_VERSION"

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -58,11 +58,11 @@ jobs:
       - name: Install opengrep
         env:
           # Pin both the install script (by commit SHA) and the binary version.
-          # The script SHA must match the v1.19.0 release tag in opengrep/opengrep
+          # The script SHA must match the v1.22.0 release tag in opengrep/opengrep
           # so a compromised or force-pushed `main` cannot RCE in our CI runner.
           # Bump both together when upgrading.
-          OPENGREP_VERSION: v1.19.0
-          OPENGREP_INSTALL_SHA: 9a4c0a68220618441608cd2bad4ff2eddccf8113
+          OPENGREP_VERSION: v1.22.0
+          OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
         run: |
           curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
             | bash -s -- -v "$OPENGREP_VERSION"

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           persist-credentials: false
           submodules: false

--- a/scripts/e2e/kitchen-sink-rpc-walk.mjs
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mjs
@@ -734,6 +734,9 @@ export async function waitForGatewayReady(child, port, logPath, options = {}) {
     }
     await delay(pollDelayMs);
   }
+  if (hasChildExited(child)) {
+    throw new Error(`gateway exited before ready\n${tailFile(logPath)}`);
+  }
   throw new Error(`gateway did not become ready: ${lastError}\n${tailFile(logPath)}`);
 }
 

--- a/scripts/run-opengrep.sh
+++ b/scripts/run-opengrep.sh
@@ -46,7 +46,7 @@ if ! command -v opengrep >/dev/null 2>&1; then
 error: 'opengrep' not found on PATH.
 
 Install with one of:
-  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/v1.19.0/install.sh | bash -s -- -v v1.19.0
+  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/v1.22.0/install.sh | bash -s -- -v v1.22.0
   brew install opengrep/tap/opengrep
   pipx install opengrep
 

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -62,7 +62,7 @@ function hashFile(filePath: string): string {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
 
-function createCandidate(rootDir: string): PluginCandidate {
+function createCandidate(rootDir: string, pluginId = "demo"): PluginCandidate {
   fs.writeFileSync(
     path.join(rootDir, "index.ts"),
     "throw new Error('runtime entry should not load while reading plugin registry');\n",
@@ -71,46 +71,46 @@ function createCandidate(rootDir: string): PluginCandidate {
   fs.writeFileSync(
     path.join(rootDir, "openclaw.plugin.json"),
     JSON.stringify({
-      id: "demo",
-      name: "Demo",
+      id: pluginId,
+      name: pluginId,
       configSchema: { type: "object" },
-      providers: ["demo"],
-      channels: ["demo-chat"],
-      cliBackends: ["demo-cli"],
+      providers: [pluginId],
+      channels: [`${pluginId}-chat`],
+      cliBackends: [`${pluginId}-cli`],
       setup: {
-        providers: [{ id: "demo-setup", envVars: ["DEMO_API_KEY"] }],
-        cliBackends: ["demo-setup-cli"],
+        providers: [{ id: `${pluginId}-setup`, envVars: ["DEMO_API_KEY"] }],
+        cliBackends: [`${pluginId}-setup-cli`],
       },
       channelConfigs: {
-        "demo-chat": {
+        [`${pluginId}-chat`]: {
           schema: { type: "object" },
         },
       },
       modelCatalog: {
         aliases: {
-          "demo-alias": {
-            provider: "demo",
+          [`${pluginId}-alias`]: {
+            provider: pluginId,
           },
         },
         providers: {
-          demo: {
-            models: [{ id: "demo-model" }],
+          [pluginId]: {
+            models: [{ id: `${pluginId}-model` }],
           },
         },
       },
-      commandAliases: [{ name: "demo-command" }],
+      commandAliases: [{ name: `${pluginId}-command` }],
       contracts: {
-        tools: ["demo-tool"],
-        webSearchProviders: ["demo-search"],
+        tools: [`${pluginId}-tool`],
+        webSearchProviders: [`${pluginId}-search`],
       },
       configContracts: {
-        compatibilityRuntimePaths: ["tools.web.search.demo-search.apiKey"],
+        compatibilityRuntimePaths: [`tools.web.search.${pluginId}-search.apiKey`],
       },
     }),
     "utf8",
   );
   return {
-    idHint: "demo",
+    idHint: pluginId,
     source: path.join(rootDir, "index.ts"),
     rootDir,
     origin: "global",
@@ -746,6 +746,30 @@ describe("plugin registry facade", () => {
     expect(second.source).toBe("derived");
     expect(manifestReadsAfterFirst).toBeGreaterThan(0);
     expect(manifestReadsAfterSecond).toBe(manifestReadsAfterFirst);
+  });
+
+  it("does not reuse the process registry memo after profile extensions change", () => {
+    const stateDir = makeTempDir();
+    const configDir = makeTempDir();
+    const extensionsDir = path.join(configDir, "extensions");
+    const firstRoot = path.join(extensionsDir, "first");
+    fs.mkdirSync(firstRoot, { recursive: true });
+    createCandidate(firstRoot, "first");
+    const env = hermeticEnv({
+      OPENCLAW_CONFIG_PATH: path.join(configDir, "openclaw.json"),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    });
+
+    const first = loadPluginRegistrySnapshotWithMetadata({ stateDir, env });
+    const secondRoot = path.join(extensionsDir, "second");
+    fs.mkdirSync(secondRoot, { recursive: true });
+    createCandidate(secondRoot, "second");
+    const second = loadPluginRegistrySnapshotWithMetadata({ stateDir, env });
+
+    expect(first.source).toBe("derived");
+    expect(second.source).toBe("derived");
+    expectSnapshotPluginIds(first.snapshot, ["first"]);
+    expectSnapshotPluginIds(second.snapshot, ["first", "second"]);
   });
 
   it("keys the process registry memo by resolved host contract version", () => {


### PR DESCRIPTION
## Summary
- invalidate plugin registry snapshot memos when profile or workspace extension roots change
- harden the command setup test against unrelated manifest registry mock call shape
- make kitchen-sink gateway readiness report an exited child after tight timeout races
- fix the current core oxlint `no-map-spread` failure in plugin registry fixtures

## Verification
- `node_modules/.bin/oxfmt --check scripts/e2e/kitchen-sink-rpc-walk.mjs src/commands/channel-setup/plugin-install.test.ts src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-registry.test.ts`
- `git diff --check`
- `node scripts/run-oxlint-shards.mjs --only core --format=json`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/skills.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/plugin-registry.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_INCLUDE_FILE=<json include file> OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=agentic-commands-agent-channel node scripts/test-projects.mjs test/vitest/vitest.commands.config.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/kitchen-sink-rpc-walk.test.ts --reporter=verbose`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Unblocks current-main CI drift seen on https://github.com/openclaw/openclaw/pull/87617 and https://github.com/openclaw/openclaw/pull/87619.
