### PR TITLE
fix(codex): clarify unsafe app-server completion stalls

### DIFF
--- a/extensions/codex/src/app-server/attempt-notifications.test.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { describeNotificationActivity } from "./attempt-notifications.js";
+
+describe("Codex app-server attempt notifications", () => {
+  it("describes completed item activity for timeout diagnostics", () => {
+    expect(
+      describeNotificationActivity({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "tool-1",
+            type: "dynamicToolCall",
+            tool: "sessions_list",
+            status: "completed",
+          },
+        },
+      }),
+    ).toEqual({
+      lastNotificationMethod: "item/completed",
+      lastNotificationItemId: "tool-1",
+      lastNotificationItemType: "dynamicToolCall",
+      lastNotificationItemRole: undefined,
+      lastNotificationItemStatus: "completed",
+      lastNotificationTool: "sessions_list",
+    });
+  });
+});

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -24,10 +24,19 @@ export function describeNotificationActivity(
   if (!isJsonObject(notification.params)) {
     return { lastNotificationMethod: notification.method };
   }
-  if (notification.method !== "rawResponseItem/completed") {
-    return { lastNotificationMethod: notification.method };
-  }
   const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  if (notification.method !== "rawResponseItem/completed") {
+    return item
+      ? {
+          lastNotificationMethod: notification.method,
+          lastNotificationItemId: readString(item, "id"),
+          lastNotificationItemType: readString(item, "type"),
+          lastNotificationItemRole: readString(item, "role"),
+          lastNotificationItemStatus: readString(item, "status"),
+          lastNotificationTool: readString(item, "tool") ?? readString(item, "name"),
+        }
+      : { lastNotificationMethod: notification.method };
+  }
   if (!item) {
     return { lastNotificationMethod: notification.method };
   }

--- a/extensions/codex/src/app-server/attempt-results.test.ts
+++ b/extensions/codex/src/app-server/attempt-results.test.ts
@@ -85,7 +85,7 @@ describe("Codex app-server attempt results", () => {
       }),
     ).toEqual({
       message:
-        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+        "Codex stopped after tool activity before confirming the turn was complete. Some work may already have been performed, so OpenClaw did not replay the turn automatically. Verify the current state before retrying.",
       replayInvalid: true,
       livenessState: "abandoned",
     });

--- a/extensions/codex/src/app-server/attempt-results.ts
+++ b/extensions/codex/src/app-server/attempt-results.ts
@@ -8,7 +8,7 @@ import type { CodexSystemPromptReport } from "./attempt-context.js";
 const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_USER_MESSAGE =
   "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.";
 const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_SIDE_EFFECT_USER_MESSAGE =
-  "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.";
+  "Codex stopped after tool activity before confirming the turn was complete. Some work may already have been performed, so OpenClaw did not replay the turn automatically. Verify the current state before retrying.";
 
 export function collectTerminalAssistantText(result: EmbeddedRunAttemptResult): string {
   return result.assistantTexts.join("\n\n").trim();

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -151,7 +151,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(result.itemLifecycle.completedCount).toBe(1);
     expect(result.promptTimeoutOutcome).toEqual({
       message:
-        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+        "Codex stopped after tool activity before confirming the turn was complete. Some work may already have been performed, so OpenClaw did not replay the turn automatically. Verify the current state before retrying.",
       replayInvalid: true,
       livenessState: "abandoned",
     });
@@ -198,7 +198,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       }),
     ).toEqual({
       message:
-        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+        "Codex stopped after tool activity before confirming the turn was complete. Some work may already have been performed, so OpenClaw did not replay the turn automatically. Verify the current state before retrying.",
       replayInvalid: true,
       livenessState: "abandoned",
     });
@@ -237,7 +237,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(result.itemLifecycle).toMatchObject({ activeCount: 1, completedCount: 0 });
     expect(result.promptTimeoutOutcome).toEqual({
       message:
-        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+        "Codex stopped after tool activity before confirming the turn was complete. Some work may already have been performed, so OpenClaw did not replay the turn automatically. Verify the current state before retrying.",
       replayInvalid: true,
       livenessState: "abandoned",
     });


### PR DESCRIPTION
## Summary
- clarify the replay-unsafe Codex app-server timeout message so users know OpenClaw intentionally did not auto-replay after tool activity
- include completed item id/type/status/tool metadata in app-server idle-timeout diagnostics, matching the raw response diagnostics already emitted
- add focused coverage for completed item diagnostic details and update timeout outcome expectations

## Why
When Codex app-server emits completed tool/item notifications but never sends the terminal `turn/completed` event, OpenClaw currently reports that work may already have happened but does not explain that replay was intentionally suppressed to avoid duplicate side effects. This makes the incident look like a generic bot failure instead of a replay-safety guard. The extra diagnostic fields also make future reports easier to triage from trajectory/log data.

## Tests
- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-codex-tests.json node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/attempt-notifications.ts extensions/codex/src/app-server/attempt-notifications.test.ts extensions/codex/src/app-server/attempt-results.ts extensions/codex/src/app-server/attempt-results.test.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts`

Related: #87781 handles replay-safe app-server stalls. This PR covers the replay-unsafe/user-facing side-effect path.