### PR TITLE
fix(google-vertex): add Google Vertex AI onboarding wizard, fix ADC auth, add provider docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1530,6 +1530,7 @@
                   "providers/github-copilot",
                   "providers/gmi",
                   "providers/google",
+                  "providers/google-vertex",
                   "providers/gradium",
                   "providers/groq",
                   "providers/huggingface",

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -579,13 +579,19 @@ Supported evidence entries:
 
 | Field              | Required | Type       | What it means                                                                                                  |
 | ------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------------- |
-| `type`             | Yes      | `string`   | Currently `local-file-with-env`.                                                                               |
+| `type`             | Yes      | `string`   | `local-file-with-env` or `env-vars-with-marker`.                                                               |
 | `fileEnvVar`       | No       | `string`   | Env var containing an explicit credential file path.                                                           |
 | `fallbackPaths`    | No       | `string[]` | Local credential file paths checked when `fileEnvVar` is absent or empty. Supports `${HOME}` and `${APPDATA}`. |
 | `requiresAnyEnv`   | No       | `string[]` | At least one listed env var must be non-empty before the evidence is valid.                                    |
 | `requiresAllEnv`   | No       | `string[]` | Every listed env var must be non-empty before the evidence is valid.                                           |
 | `credentialMarker` | Yes      | `string`   | Non-secret marker returned when the evidence is present.                                                       |
 | `source`           | No       | `string`   | User-facing source label for auth/status output.                                                               |
+
+When `type` is `local-file-with-env`, the evidence check requires a credential
+file on disk (via `fileEnvVar` or `fallbackPaths`). When `type` is
+`env-vars-with-marker`, only the env var checks are evaluated without requiring
+a local file. Use `env-vars-with-marker` for ambient credential sources like
+GCE metadata server or workload identity.
 
 ### setup fields
 

--- a/docs/providers/google-vertex.md
+++ b/docs/providers/google-vertex.md
@@ -1,0 +1,237 @@
+---
+summary: "Google Vertex AI / Agent Platform setup (ADC auth for GCE, GKE, gcloud CLI, service accounts)"
+title: "Google Vertex AI"
+read_when:
+  - You want to use Gemini models through Google Cloud Vertex AI (Agent Platform)
+  - You have a GCP project and want to use ADC for authentication
+  - You are running OpenClaw on a GCE VM, GKE, or Cloud Run
+---
+
+The `google-vertex` provider routes Gemini model requests through Google Cloud's
+Vertex AI (now Gemini Enterprise Agent Platform) using Application Default
+Credentials (ADC).
+
+- Provider: `google-vertex`
+- Auth: Application Default Credentials (metadata server, gcloud CLI, service account key)
+- Env vars: `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION` (optional, defaults to `global`)
+- Models: Gemini models accessed via `google-vertex/*` prefix
+
+## Getting started
+
+Choose the setup that matches your environment.
+
+<Tabs>
+  <Tab title="GCE / GKE / Cloud Run">
+    **Best for:** running OpenClaw on Google Cloud infrastructure where the
+    metadata server provides credentials automatically.
+
+    <Steps>
+      <Step title="Run onboarding">
+        ```bash
+        openclaw onboard --auth-choice google-vertex-adc
+        ```
+
+        The wizard auto-detects your GCP project from the metadata server. Confirm
+        or change the detected project and location (defaults to `global`).
+      </Step>
+      <Step title="Enable the Vertex AI API">
+        ```bash
+        gcloud services enable aiplatform.googleapis.com
+        ```
+      </Step>
+      <Step title="Verify">
+        ```bash
+        openclaw models list --provider google-vertex
+        ```
+      </Step>
+    </Steps>
+
+    <Tip>
+      On GCE, make sure your VM has the **Cloud Platform** access scope enabled.
+      You can check with:
+      ```bash
+      curl -s -H "Metadata-Flavor: Google" \
+        http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/scopes
+      ```
+      Look for `https://www.googleapis.com/auth/cloud-platform` in the output.
+    </Tip>
+
+  </Tab>
+
+  <Tab title="gcloud CLI">
+    **Best for:** laptops or workstations with the `gcloud` CLI installed.
+
+    <Steps>
+      <Step title="Log in with ADC">
+        ```bash
+        gcloud auth application-default login
+        ```
+      </Step>
+      <Step title="Run onboarding">
+        ```bash
+        openclaw onboard --auth-choice google-vertex-adc
+        ```
+
+        Enter your GCP project ID when prompted. Location defaults to `global`.
+      </Step>
+      <Step title="Enable the Vertex AI API">
+        ```bash
+        gcloud services enable aiplatform.googleapis.com
+        ```
+      </Step>
+      <Step title="Verify">
+        ```bash
+        openclaw models list --provider google-vertex
+        ```
+      </Step>
+    </Steps>
+
+  </Tab>
+
+  <Tab title="Service account key">
+    **Best for:** CI/CD pipelines, VMs on other cloud providers, or environments
+    without `gcloud`.
+
+    <Steps>
+      <Step title="Create a service account">
+        In the Google Cloud Console, create a service account and grant it the
+        **Vertex AI User** role (`roles/aiplatform.user`). Download the private
+        key as a JSON file.
+      </Step>
+      <Step title="Set the credentials path">
+        ```bash
+        export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account-key.json"
+        ```
+      </Step>
+      <Step title="Run onboarding">
+        ```bash
+        openclaw onboard --auth-choice google-vertex-adc
+        ```
+      </Step>
+      <Step title="Enable the Vertex AI API">
+        ```bash
+        gcloud services enable aiplatform.googleapis.com
+        ```
+      </Step>
+      <Step title="Verify">
+        ```bash
+        openclaw models list --provider google-vertex
+        ```
+      </Step>
+    </Steps>
+
+  </Tab>
+</Tabs>
+
+## Configuration
+
+After onboarding, your `openclaw.json` will include:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "google-vertex/gemini-3.5-flash" },
+    },
+  },
+  models: {
+    providers: {
+      "google-vertex": {
+        models: [{ id: "gemini-3.5-flash", name: "Gemini 3.5 Flash" }],
+      },
+    },
+  },
+  env: {
+    vars: {
+      GOOGLE_CLOUD_PROJECT: "your-project-id",
+      GOOGLE_CLOUD_LOCATION: "global",
+    },
+  },
+}
+```
+
+## Environment variables
+
+| Variable                         | Required                                         | Default  | Description                                    |
+| :------------------------------- | :----------------------------------------------- | :------- | :--------------------------------------------- |
+| `GOOGLE_CLOUD_PROJECT`           | Yes (auto-detected during onboarding on GCE/GKE) | None     | GCP project ID                                 |
+| `GOOGLE_CLOUD_LOCATION`          | No                                               | `global` | Vertex AI endpoint region                      |
+| `GOOGLE_APPLICATION_CREDENTIALS` | No                                               | None     | Path to service account key file               |
+| `GOOGLE_CLOUD_API_KEY`           | No                                               | None     | Vertex AI Express API key (alternative to ADC) |
+
+<Note>
+  Environment variables can be set in your shell, in `openclaw.json` under the
+  `env.vars` key, or in `~/.openclaw/.env`. When running the Gateway as a systemd
+  service, use the `env.vars` key in `openclaw.json` since shell exports do not reach
+  the service process.
+</Note>
+
+## Available models
+
+Use the `google-vertex/` prefix with any Gemini model available on Vertex AI.
+Onboarding sets `gemini-3.5-flash` as the default model.
+
+| Model                 | ID                                    |
+| :-------------------- | :------------------------------------ |
+| Gemini 3.5 Flash      | `google-vertex/gemini-3.5-flash`      |
+| Gemini 3.6 Flash      | `google-vertex/gemini-3.6-flash`      |
+| Gemini 3.5 Flash-Lite | `google-vertex/gemini-3.5-flash-lite` |
+| Gemini 3.1 Pro        | `google-vertex/gemini-3.1-pro`        |
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="No API key found for provider google-vertex">
+    This error should not appear if you completed onboarding with the Google Vertex AI
+    provider. If it does, try running `openclaw onboard --auth-choice google-vertex-adc`
+    again. For manual configurations, check:
+
+    1. `GOOGLE_CLOUD_PROJECT` is set (in env or `openclaw.json` `env.vars` section).
+    2. On GCE/GKE: the metadata server is reachable.
+    3. With gcloud CLI: you have run `gcloud auth application-default login`.
+    4. With a service account: `GOOGLE_APPLICATION_CREDENTIALS` points to a valid JSON key file.
+
+  </Accordion>
+
+  <Accordion title="Vertex AI requires a project ID">
+    Set `GOOGLE_CLOUD_PROJECT` in the `env.vars` section of `openclaw.json`:
+
+    ```json5
+    { env: { vars: { GOOGLE_CLOUD_PROJECT: "your-project-id" } } }
+    ```
+
+    Then restart the gateway: `openclaw gateway restart` or
+    `systemctl --user restart openclaw-gateway`.
+
+  </Accordion>
+
+  <Accordion title="403 / PERMISSION_DENIED">
+    The service account or user does not have the required IAM role. Grant the
+    **Vertex AI User** role (`roles/aiplatform.user`) to the account making
+    requests.
+
+    On GCE, also verify that the VM has the **Cloud Platform** access scope.
+
+  </Accordion>
+
+  <Accordion title="404 / Model not found">
+    Some model aliases are only available on the `global` endpoint. If you set a
+    specific region (e.g. `us-central1`), try switching to `global`:
+
+    ```json5
+    { env: { vars: { GOOGLE_CLOUD_LOCATION: "global" } } }
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Google (Gemini)" href="/providers/google" icon="google">
+    Gemini models via API key in Google AI Studio.
+  </Card>
+  <Card title="Model providers" href="/concepts/model-providers" icon="layer-group">
+    Provider configuration reference.
+  </Card>
+</CardGroup>

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -14,6 +14,12 @@ The Google plugin provides access to Gemini models through Google AI Studio, plu
 - Managed-cloud provider: `google-vertex` with Google Cloud Application Default Credentials
 - Optional runtime: `agentRuntime.id: "google-gemini-cli"` runs an explicitly configured model through the local Gemini CLI
 
+<Note>
+  To use Gemini models through Google Cloud Vertex AI (Agent Platform) with
+  GCP project billing and credits, see the
+  [Google Vertex AI](/providers/google-vertex) provider instead.
+</Note>
+
 ## Getting started
 
 For most installations, use a Google AI Studio API key. Use `google-vertex` when
@@ -502,5 +508,8 @@ roundtrip; pass `--openai-audio-cycles 3` for a short repeated lifecycle soak.
   </Card>
   <Card title="Music generation" href="/tools/music-generation" icon="music">
     Shared music tool parameters and provider selection.
+  </Card>
+  <Card title="Google Vertex AI" href="/providers/google-vertex" icon="cloud">
+    Gemini models via GCP project billing and ADC (Vertex AI / Agent Platform).
   </Card>
 </CardGroup>

--- a/extensions/google/manifest.test.ts
+++ b/extensions/google/manifest.test.ts
@@ -102,12 +102,19 @@ describe("google manifest model catalog", () => {
 
     expect(vertex?.authEvidence).toEqual([
       expect.objectContaining({
+        type: "local-file-with-env",
         fileEnvVar: "GOOGLE_APPLICATION_CREDENTIALS",
         fallbackPaths: [
           "${CLOUDSDK_CONFIG}/application_default_credentials.json",
           "${HOME}/.config/gcloud/application_default_credentials.json",
           "${APPDATA}/gcloud/application_default_credentials.json",
         ],
+        credentialMarker: "gcp-vertex-credentials",
+      }),
+      expect.objectContaining({
+        type: "env-vars-with-marker",
+        requiresAnyEnv: ["GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"],
+        credentialMarker: "gcp-vertex-credentials",
       }),
     ]);
   });
@@ -122,6 +129,11 @@ describe("google manifest model catalog", () => {
         choiceLabel: "Google AI Studio API key",
         choiceHint: "Supported API-key access from aistudio.google.com/apikey",
         groupHint: "Supported API-key setup",
+      }),
+      expect.objectContaining({
+        provider: "google-vertex",
+        method: "adc",
+        choiceLabel: "Google Vertex AI",
       }),
     ]);
     expect(choices.some((choice) => choice.provider === "google-gemini-cli")).toBe(false);

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -5,6 +5,7 @@
     "onStartup": false
   },
   "enabledByDefault": true,
+  "nonSecretAuthMarkers": ["gcp-vertex-credentials"],
   "providers": ["google", "google-gemini-cli", "google-vertex"],
   "providerCatalogEntry": "./provider-discovery.ts",
   "autoEnableWhenConfiguredProviders": ["google-gemini-cli"],
@@ -46,8 +47,26 @@
     }
   },
   "modelCatalog": {
+    "providers": {
+      "google-vertex": {
+        "api": "google-vertex",
+        "baseUrl": "https://{location}-aiplatform.googleapis.com",
+        "models": [
+          { "id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536 },
+          { "id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536 },
+          { "id": "gemini-2.5-flash-lite", "name": "Gemini 2.5 Flash-Lite", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536 },
+          { "id": "gemini-3.5-flash", "name": "Gemini 3.5 Flash", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536, "tags": ["default"] },
+          { "id": "gemini-3.6-flash", "name": "Gemini 3.6 Flash", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536 },
+          { "id": "gemini-3.5-flash-lite", "name": "Gemini 3.5 Flash-Lite", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536 },
+          { "id": "gemini-3.1-pro-preview", "name": "Gemini 3.1 Pro Preview", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536 },
+          { "id": "gemini-3.1-flash-lite", "name": "Gemini 3.1 Flash Lite", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536 },
+          { "id": "gemini-3-flash-preview", "name": "Gemini 3 Flash Preview", "reasoning": true, "input": ["text", "image"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 1048576, "maxTokens": 65536 }
+        ]
+      }
+    },
     "discovery": {
-      "google": "runtime"
+      "google": "runtime",
+      "google-vertex": "static"
     },
     "suppressions": [
       {
@@ -662,7 +681,7 @@
     "providers": [
       {
         "id": "google-vertex",
-        "authMethods": ["api-key"],
+        "authMethods": ["adc"],
         "envVars": ["GOOGLE_CLOUD_API_KEY"],
         "authEvidence": [
           {
@@ -674,9 +693,14 @@
               "${APPDATA}/gcloud/application_default_credentials.json"
             ],
             "requiresAnyEnv": ["GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"],
-            "requiresAllEnv": ["GOOGLE_CLOUD_LOCATION"],
             "credentialMarker": "gcp-vertex-credentials",
             "source": "gcloud adc"
+          },
+          {
+            "type": "env-vars-with-marker",
+            "requiresAnyEnv": ["GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"],
+            "credentialMarker": "gcp-vertex-credentials",
+            "source": "gcp adc (metadata server / workload identity)"
           }
         ]
       },
@@ -703,6 +727,14 @@
       "cliFlag": "--gemini-api-key",
       "cliOption": "--gemini-api-key <key>",
       "cliDescription": "Gemini API key"
+    },
+    {
+      "provider": "google-vertex",
+      "method": "adc",
+      "choiceId": "google-vertex-adc",
+      "choiceLabel": "Google Vertex AI",
+      "groupId": "google-vertex",
+      "groupLabel": "Google Vertex AI"
     }
   ],
   "uiHints": {

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -3,15 +3,16 @@ import {
   getCachedLiveProviderModelRows,
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { isGoogleTextGenerationModelId, resolveGoogleStaticModelId } from "./provider-models.js";
 
 const GOOGLE_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 const GOOGLE_GEMINI_MODELS_ENDPOINT = `${GOOGLE_GEMINI_BASE_URL}/models?pageSize=1000`;
-const GOOGLE_VERTEX_BASE_URL = "https://{location}-aiplatform.googleapis.com";
 const GOOGLE_GEMINI_MODELS_CACHE_TTL_MS = 60_000;
 const GOOGLE_GEMINI_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
 const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
@@ -237,10 +238,25 @@ export async function buildGoogleLiveCatalogProvider(params: {
   }
 }
 
+const VERTEX_MANIFEST_CATALOG = manifest.modelCatalog.providers["google-vertex"];
+// codeMode tiers stay in source (google is a source-catalog plugin per
+// shared-upstream-model.contract); the manifest catalog is codeMode-free so it
+// never conflicts with sibling plugins shipping the same gemini ids.
+const GEMINI_CODE_MODE_PREFERRED = new Set(
+  GOOGLE_GEMINI_TEXT_MODELS.filter((model) => model.compat?.codeMode === "preferred").map(
+    (model) => model.id,
+  ),
+);
+
 export function buildGoogleVertexStaticCatalogProvider(): ModelProviderConfig {
-  return {
-    baseUrl: GOOGLE_VERTEX_BASE_URL,
-    api: "google-vertex",
-    models: GOOGLE_GEMINI_TEXT_MODELS,
-  };
+  const provider = buildManifestModelProviderConfig({
+    providerId: "google-vertex",
+    catalog: VERTEX_MANIFEST_CATALOG,
+  });
+  for (const model of provider.models) {
+    if (GEMINI_CODE_MODE_PREFERRED.has(model.id)) {
+      model.compat = { codeMode: "preferred" };
+    }
+  }
+  return provider;
 }

--- a/extensions/google/provider-contract-api.test.ts
+++ b/extensions/google/provider-contract-api.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { createGoogleGeminiCliProvider, createGoogleProvider } from "./provider-contract-api.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGoogleGeminiCliProvider,
+  createGoogleProvider,
+  createGoogleVertexProvider,
+} from "./provider-contract-api.js";
+
+vi.mock("google-auth-library", () => ({
+  GoogleAuth: class {
+    async getProjectId() {
+      return "auto-detected-project";
+    }
+  },
+}));
 
 describe("google provider contract", () => {
   it("exposes Google AI Studio API-key setup", () => {
@@ -25,5 +37,20 @@ describe("google provider contract", () => {
     expect(provider.auth).toEqual([]);
     expect(provider.envVars).toEqual([]);
     expect(provider.wizard).toBeUndefined();
+  });
+
+  it("preserves existing Vertex project/location on onboarding rerun", async () => {
+    const adc = createGoogleVertexProvider().auth?.find((method) => method.id === "adc");
+    const result = await adc?.run?.({
+      config: {
+        env: {
+          vars: { GOOGLE_CLOUD_PROJECT: "existing-project", GOOGLE_CLOUD_LOCATION: "us-central1" },
+        },
+      },
+      prompter: { text: vi.fn(async () => ""), note: vi.fn(async () => {}) },
+    } as never);
+    const patch = result?.configPatch as { env?: { vars?: Record<string, string> } } | undefined;
+    expect(patch?.env?.vars?.GOOGLE_CLOUD_PROJECT).toBe("existing-project");
+    expect(patch?.env?.vars?.GOOGLE_CLOUD_LOCATION).toBe("us-central1");
   });
 });

--- a/extensions/google/provider-contract-api.ts
+++ b/extensions/google/provider-contract-api.ts
@@ -1,7 +1,11 @@
 // Google API module exposes the plugin public contract.
+import type { OpenClawConfig, ProviderAuthContext } from "openclaw/plugin-sdk/plugin-entry";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 
 const noopAuth = async () => ({ profiles: [] });
+
+const VERTEX_DEFAULT_MODEL = "google-vertex/gemini-3.5-flash";
+const VERTEX_DEFAULT_LOCATION = "global";
 
 export function createGoogleProvider(): ProviderPlugin {
   return {
@@ -33,7 +37,7 @@ export function createGoogleVertexProvider(): ProviderPlugin {
   return {
     id: "google-vertex",
     label: "Google Vertex AI",
-    docsPath: "/providers/models",
+    docsPath: "/providers/google-vertex",
     envVars: [
       "GOOGLE_CLOUD_API_KEY",
       "GOOGLE_CLOUD_PROJECT",
@@ -41,7 +45,131 @@ export function createGoogleVertexProvider(): ProviderPlugin {
       "GOOGLE_CLOUD_LOCATION",
       "GOOGLE_APPLICATION_CREDENTIALS",
     ],
-    auth: [],
+    auth: [
+      {
+        id: "adc",
+        kind: "api_key" as const,
+        label: "Google Cloud ADC",
+        hint: "Application Default Credentials (GCE, GKE, gcloud, service account)",
+        run: async (ctx: ProviderAuthContext) => {
+          // Try to auto-detect project via google-auth-library
+          let detectedProject: string | undefined;
+          try {
+            const { GoogleAuth } = await import("google-auth-library");
+            const auth = new GoogleAuth({
+              scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+            });
+            detectedProject = (await auth.getProjectId()) ?? undefined;
+          } catch {
+            // Auto-detection not available (not on GCE, no gcloud, etc.)
+          }
+
+          // Rerun-safe: prefer values already in config so re-running onboarding
+          // over a working setup keeps its project/location instead of silently
+          // redirecting later requests to the auto-detected/default region.
+          const existingVars = ctx.config.env?.vars as Record<string, string> | undefined;
+          const pickVar = (value: unknown) =>
+            typeof value === "string" && value.trim() ? value.trim() : undefined;
+          const existingProject =
+            pickVar(existingVars?.GOOGLE_CLOUD_PROJECT) ?? pickVar(existingVars?.GCLOUD_PROJECT);
+          const existingLocation = pickVar(existingVars?.GOOGLE_CLOUD_LOCATION);
+
+          const projectDefault = existingProject ?? detectedProject;
+          const projectPrompt = await ctx.prompter.text({
+            message: "GCP project ID",
+            ...(projectDefault
+              ? {
+                  placeholder: projectDefault,
+                  initialValue: projectDefault,
+                }
+              : {
+                  placeholder: "my-gcp-project",
+                }),
+          });
+          const project =
+            typeof projectPrompt === "string" && projectPrompt.trim()
+              ? projectPrompt.trim()
+              : projectDefault;
+          if (!project) {
+            await ctx.prompter.note(
+              "A GCP project ID is required for Vertex AI. Set GOOGLE_CLOUD_PROJECT in your environment.",
+              "Setup skipped",
+            );
+            return { profiles: [] };
+          }
+
+          const locationDefault = existingLocation ?? VERTEX_DEFAULT_LOCATION;
+          const locationPrompt = await ctx.prompter.text({
+            message: "GCP location",
+            initialValue: locationDefault,
+            placeholder: locationDefault,
+          });
+          const location =
+            typeof locationPrompt === "string" && locationPrompt.trim()
+              ? locationPrompt.trim()
+              : locationDefault;
+
+          // Onboarding writes are additive: env vars, marker profile, and
+          // default model. Reruns preserve existing google-vertex models via the
+          // configPatch merge below, and the project/location prompts default to
+          // existing config so accepting them leaves a working setup unchanged.
+          return {
+            profiles: [
+              {
+                profileId: "google-vertex:default",
+                credential: {
+                  type: "api_key" as const,
+                  provider: "google-vertex",
+                  key: "gcp-vertex-credentials",
+                },
+              },
+            ],
+            defaultModel: VERTEX_DEFAULT_MODEL,
+            configPatch: (() => {
+              const existingVertexConfig = (
+                ctx.config.models as Record<string, unknown> | undefined
+              )?.providers as Record<string, Record<string, unknown>> | undefined;
+              const existingModels = Array.isArray(existingVertexConfig?.["google-vertex"]?.models)
+                ? (existingVertexConfig["google-vertex"].models as Array<{ id?: string }>)
+                : [];
+              const defaultModelId = "gemini-3.5-flash";
+              const hasDefault = existingModels.some((m) => m.id === defaultModelId);
+              const mergedModels = hasDefault
+                ? existingModels
+                : [...existingModels, { id: defaultModelId, name: "Gemini 3.5 Flash" }];
+              return {
+                env: {
+                  vars: {
+                    GOOGLE_CLOUD_PROJECT: project,
+                    GOOGLE_CLOUD_LOCATION: location,
+                  },
+                },
+                models: {
+                  providers: {
+                    "google-vertex": {
+                      models: mergedModels,
+                    },
+                  },
+                },
+              } as unknown as Partial<OpenClawConfig>;
+            })(),
+            notes: [
+              `Project: ${project}, Location: ${location}`,
+              "Credentials will be resolved via Application Default Credentials (ADC).",
+              "On GCE/GKE/Cloud Run, the metadata server provides credentials automatically.",
+              "With gcloud CLI, run: gcloud auth application-default login",
+            ],
+          };
+        },
+        wizard: {
+          choiceId: "google-vertex-adc",
+          choiceLabel: "Google Vertex AI (ADC)",
+          groupId: "google",
+          groupLabel: "Google",
+          groupHint: "Gemini API key + OAuth + Vertex AI",
+        },
+      },
+    ],
   };
 }
 

--- a/extensions/google/provider-registration.test.ts
+++ b/extensions/google/provider-registration.test.ts
@@ -66,3 +66,38 @@ describe("buildGoogleProvider createStreamFn", () => {
     expect(streamFns.createGenerativeAi).not.toHaveBeenCalled();
   });
 });
+
+describe("buildGoogleProvider normalizeTransport", () => {
+  it("defaults bare google-vertex config to the native transport", () => {
+    expect(
+      buildGoogleProvider().normalizeTransport?.({
+        provider: "google-vertex",
+        api: undefined,
+        baseUrl: undefined,
+      } as never),
+    ).toEqual({ api: "google-vertex", baseUrl: undefined });
+  });
+
+  it("routes native Vertex hosts to the native transport", () => {
+    expect(
+      buildGoogleProvider().normalizeTransport?.({
+        provider: "google-vertex",
+        api: undefined,
+        baseUrl: "https://us-central1-aiplatform.googleapis.com",
+      } as never),
+    ).toEqual({
+      api: "google-vertex",
+      baseUrl: "https://us-central1-aiplatform.googleapis.com",
+    });
+  });
+
+  it("preserves a custom proxy baseUrl instead of forcing native Vertex", () => {
+    const result = buildGoogleProvider().normalizeTransport?.({
+      provider: "google-vertex",
+      api: undefined,
+      baseUrl: "https://proxy.example.com/vertex",
+    } as never);
+    expect(result?.api).not.toBe("google-vertex");
+    expect(result?.baseUrl).toBe("https://proxy.example.com/vertex");
+  });
+});

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -66,8 +66,16 @@ export function buildGoogleProvider(): ProviderPlugin {
         },
       }),
     ],
-    normalizeTransport: ({ provider, api, baseUrl }) =>
-      resolveGoogleGenerativeAiTransport({ provider, api, baseUrl }),
+    normalizeTransport: ({ provider, api, baseUrl }) => {
+      // Bare google-vertex (no api, no baseUrl) has no URL to normalize, so the
+      // provider name implies the native transport. With a baseUrl, defer to the
+      // shared resolver so vertex hosts map to native and proxy endpoints keep
+      // their generic routing.
+      if (provider === "google-vertex" && !api && !baseUrl) {
+        return { api: "google-vertex" as const, baseUrl };
+      }
+      return resolveGoogleGenerativeAiTransport({ provider, api, baseUrl });
+    },
     normalizeConfig: ({ provider, providerConfig }) =>
       normalizeGoogleProviderConfig(provider, providerConfig),
     resolveConfigApiKey: ({ provider, env }) =>
@@ -105,13 +113,13 @@ export function buildGoogleProvider(): ProviderPlugin {
         providerId: ctx.provider,
         ctx,
       }),
-    createStreamFn: ({ model }) => {
+    createStreamFn: ({ model, config }) => {
       if (
         model.api === "google-vertex" ||
         (model.api === "google-generative-ai" &&
           (model.provider === "google-vertex" || isGoogleVertexBaseUrl(model.baseUrl)))
       ) {
-        return createGoogleVertexTransportStreamFn();
+        return createGoogleVertexTransportStreamFn(config);
       }
       if (model.api === "google-generative-ai") {
         return createGoogleGenerativeAiTransportStreamFn();

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1454,6 +1454,43 @@ describe("google transport stream", () => {
     },
   );
 
+  it("resolves Vertex project/location from candidate config without process.env", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-config-"));
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    // Deliberately leave the Vertex env vars unset: project/location must come from
+    // the candidate config passed into the stream fn, not the global process.env.
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "");
+    vi.stubEnv("GCLOUD_PROJECT", "");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("oauth-token");
+    guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+    const streamFn = createGoogleVertexTransportStreamFn({
+      env: {
+        vars: { GOOGLE_CLOUD_PROJECT: "config-project", GOOGLE_CLOUD_LOCATION: "us-central1" },
+      },
+    } as Parameters<typeof createGoogleVertexTransportStreamFn>[0]);
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as Parameters<
+          typeof streamFn
+        >[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+          fetch: vi.fn(),
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    const [url] = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    expect(String(url)).toBe(
+      "https://us-central1-aiplatform.googleapis.com/v1/projects/config-project/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
+    );
+  });
+
   it("resolves non-file Vertex ADC through google-auth-library without OAuth refresh fetch", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-authlib-"));
     vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -18,6 +18,7 @@ import {
   providerOperationRetryConfig,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import {
   buildGuardedModelFetch,
   coerceTransportToolCallArguments,
@@ -351,29 +352,35 @@ function buildGoogleGenerativeAiRequestUrl(model: GoogleTransportModel): string 
   return `${baseUrl}/${resolveGoogleModelPath(model.id)}:streamGenerateContent?alt=sse`;
 }
 
-function resolveGoogleVertexProject(options: GoogleTransportOptions | undefined): string {
+function resolveGoogleVertexProject(
+  options: GoogleTransportOptions | undefined,
+  config?: OpenClawConfig,
+): string {
   const project =
     normalizeOptionalString((options as { project?: unknown } | undefined)?.project) ||
+    normalizeOptionalString(config?.env?.vars?.GOOGLE_CLOUD_PROJECT) ||
     normalizeOptionalString(process.env.GOOGLE_CLOUD_PROJECT) ||
     normalizeOptionalString(process.env.GCLOUD_PROJECT);
   if (!project) {
     throw new Error(
-      "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT or pass project in options.",
+      "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT in your environment " +
+        'or add "GOOGLE_CLOUD_PROJECT" to the "env" section of openclaw.json. ' +
+        "On GCE/GKE, the project can be detected during onboarding with `openclaw onboard`.",
     );
   }
   return project;
 }
 
-function resolveGoogleVertexLocation(options: GoogleTransportOptions | undefined): string {
-  const location =
+function resolveGoogleVertexLocation(
+  options: GoogleTransportOptions | undefined,
+  config?: OpenClawConfig,
+): string {
+  return (
     normalizeOptionalString((options as { location?: unknown } | undefined)?.location) ||
-    normalizeOptionalString(process.env.GOOGLE_CLOUD_LOCATION);
-  if (!location) {
-    throw new Error(
-      "Vertex AI requires a location. Set GOOGLE_CLOUD_LOCATION or pass location in options.",
-    );
-  }
-  return location;
+    normalizeOptionalString(config?.env?.vars?.GOOGLE_CLOUD_LOCATION) ||
+    normalizeOptionalString(process.env.GOOGLE_CLOUD_LOCATION) ||
+    "global"
+  );
 }
 
 function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: string): string {
@@ -404,9 +411,10 @@ function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: st
 function buildGoogleVertexRequestUrl(
   model: GoogleTransportModel,
   options: GoogleTransportOptions | undefined,
+  config?: OpenClawConfig,
 ): string {
-  const project = encodeURIComponent(resolveGoogleVertexProject(options));
-  const location = encodeURIComponent(resolveGoogleVertexLocation(options));
+  const project = encodeURIComponent(resolveGoogleVertexProject(options, config));
+  const location = encodeURIComponent(resolveGoogleVertexLocation(options, config));
   // Mirror resolveGoogleModelPath: strip the google/ provider prefix so a
   // provider-qualified id does not become an invalid models/google%2F... path.
   const modelId = encodeURIComponent(stripGoogleProviderPrefix(model.id));
@@ -872,9 +880,10 @@ function buildGoogleTransportRequestUrl(
   kind: CanonicalGoogleTransportApi,
   model: GoogleTransportModel,
   options: GoogleTransportOptions | undefined,
+  config?: OpenClawConfig,
 ): string {
   return kind === "google-vertex"
-    ? buildGoogleVertexRequestUrl(model, options)
+    ? buildGoogleVertexRequestUrl(model, options, config)
     : buildGoogleGenerativeAiRequestUrl(model);
 }
 
@@ -1306,7 +1315,10 @@ function pushTextBlockEnd(
   }
 }
 
-function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): StreamFn {
+function createGoogleTransportStreamFn(
+  kind: CanonicalGoogleTransportApi,
+  config?: OpenClawConfig,
+): StreamFn {
   return (rawModel, context, rawOptions) => {
     const model = rawModel as GoogleTransportModel;
     const options = rawOptions as GoogleTransportOptions | undefined;
@@ -1330,7 +1342,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
         if (nextParams !== undefined) {
           params = nextParams as GoogleGenerateContentRequest;
         }
-        const requestUrl = buildGoogleTransportRequestUrl(kind, model, options);
+        const requestUrl = buildGoogleTransportRequestUrl(kind, model, options, config);
         const fetchImpl = (options as { fetch?: typeof fetch } | undefined)?.fetch;
         const openSse = async (apiKeyForRequest: string | undefined) => {
           const requestHeaders = await buildGoogleTransportHeaders({
@@ -1567,7 +1579,7 @@ export function createGoogleGenerativeAiTransportStreamFn(): StreamFn {
   return createGoogleTransportStreamFn("google-generative-ai");
 }
 
-export function createGoogleVertexTransportStreamFn(): StreamFn {
-  return createGoogleTransportStreamFn("google-vertex");
+export function createGoogleVertexTransportStreamFn(config?: OpenClawConfig): StreamFn {
+  return createGoogleTransportStreamFn("google-vertex", config);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -1,18 +1,10 @@
 // NEVER convert to top-level imports - breaks browser/Vite builds
-let existsSync: typeof import("node:fs").existsSync | null = null;
-let homedir: typeof import("node:os").homedir | null = null;
-let join: typeof import("node:path").join | null = null;
-
-type DynamicImport = (specifier: string) => Promise<unknown>;
 type NodeBuiltinModule =
   | typeof import("node:fs")
   | typeof import("node:os")
   | typeof import("node:path");
 
-const dynamicImport: DynamicImport = (specifier) => import(specifier);
 const NODE_FS_SPECIFIER = "node:fs";
-const NODE_OS_SPECIFIER = "node:os";
-const NODE_PATH_SPECIFIER = "node:path";
 
 function loadNodeBuiltinModule(specifier: string): NodeBuiltinModule | null {
   const getBuiltinModule = (typeof process !== "undefined" ? process : undefined) as
@@ -25,40 +17,6 @@ function loadNodeBuiltinModule(specifier: string): NodeBuiltinModule | null {
     return require(specifier) as NodeBuiltinModule;
   }
   return null;
-}
-
-function loadNodeHelpersSync(): boolean {
-  try {
-    const fsModule = loadNodeBuiltinModule(NODE_FS_SPECIFIER) as typeof import("node:fs") | null;
-    const osModule = loadNodeBuiltinModule(NODE_OS_SPECIFIER) as typeof import("node:os") | null;
-    const pathModule = loadNodeBuiltinModule(NODE_PATH_SPECIFIER) as
-      | typeof import("node:path")
-      | null;
-    existsSync ??= fsModule?.existsSync ?? null;
-    homedir ??= osModule?.homedir ?? null;
-    join ??= pathModule?.join ?? null;
-    if (!existsSync || !homedir || !join) {
-      return false;
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-// Eagerly load in Node.js/Bun environment only
-if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
-  if (!loadNodeHelpersSync()) {
-    void dynamicImport(NODE_FS_SPECIFIER).then((m) => {
-      existsSync = (m as typeof import("node:fs")).existsSync;
-    });
-    void dynamicImport(NODE_OS_SPECIFIER).then((m) => {
-      homedir = (m as typeof import("node:os")).homedir;
-    });
-    void dynamicImport(NODE_PATH_SPECIFIER).then((m) => {
-      join = (m as typeof import("node:path")).join;
-    });
-  }
 }
 
 let procEnvCache: Map<string, string> | null = null;
@@ -110,40 +68,6 @@ function getProcEnv(key: string): string | undefined {
 
 function getEnvValue(key: string): string | undefined {
   return (getProcessEnv()?.[key] || getProcEnv(key))?.trim() || undefined;
-}
-
-let cachedVertexAdcCredentialsExists: true | null = null;
-
-function hasVertexAdcCredentials(): boolean {
-  if (cachedVertexAdcCredentialsExists === null) {
-    if (!existsSync || !homedir || !join) {
-      const isNode =
-        typeof process !== "undefined" && (process.versions?.node || process.versions?.bun);
-      if (!isNode || !loadNodeHelpersSync()) {
-        return false;
-      }
-    }
-    const nodeExistsSync = existsSync;
-    const nodeHomedir = homedir;
-    const nodeJoin = join;
-    if (!nodeExistsSync || !nodeHomedir || !nodeJoin) {
-      return false;
-    }
-
-    // Check GOOGLE_APPLICATION_CREDENTIALS env var first (standard way)
-    const gacPath = getEnvValue("GOOGLE_APPLICATION_CREDENTIALS");
-    if (gacPath) {
-      cachedVertexAdcCredentialsExists = nodeExistsSync(gacPath) ? true : null;
-    } else {
-      // Fall back to default ADC path (lazy evaluation)
-      cachedVertexAdcCredentialsExists = nodeExistsSync(
-        nodeJoin(nodeHomedir(), ".config", "gcloud", "application_default_credentials.json"),
-      )
-        ? true
-        : null;
-    }
-  }
-  return cachedVertexAdcCredentialsExists === true;
 }
 
 function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
@@ -227,16 +151,17 @@ export function getEnvApiKey(provider: string): string | undefined {
     return getEnvValue(envKeys[0]);
   }
 
-  // Vertex AI supports either an explicit API key or Application Default Credentials.
-  // Auth is configured via `gcloud auth application-default login`.
+  // Vertex AI requires a GCP project. A non-blank project is the gate signal;
+  // actual credentials (GCE/GKE/Cloud Run metadata server, gcloud application
+  // default login, service account key files, or Workload Identity Federation)
+  // are resolved at request time by the downstream transport. Blank markers are
+  // treated as absent (getEnvValue trims), and a credentials file alone without
+  // a configured project does not authenticate.
   if (provider === "google-vertex") {
-    const hasCredentials = hasVertexAdcCredentials();
     const hasProject = Boolean(
       getEnvValue("GOOGLE_CLOUD_PROJECT") || getEnvValue("GCLOUD_PROJECT"),
     );
-    const hasLocation = Boolean(getEnvValue("GOOGLE_CLOUD_LOCATION"));
-
-    if (hasCredentials && hasProject && hasLocation) {
+    if (hasProject) {
       return "<authenticated>";
     }
   }

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -78,6 +78,20 @@ export function shouldSuppressConfiguredModel(params: {
   });
 }
 
+/**
+ * Map well-known provider names to their native API transport. Providers like
+ * google-vertex build request URLs dynamically and carry no configured baseUrl,
+ * so the provider name implies the transport even without an explicit api.
+ */
+function resolveProviderNameDefaultApi(provider: string): Api | undefined {
+  switch (provider) {
+    case "google-vertex":
+      return "google-vertex";
+    default:
+      return undefined;
+  }
+}
+
 export function resolveConfiguredProviderDefaultApi(params: {
   provider: string;
   providerConfig: InlineProviderConfig | undefined;
@@ -92,7 +106,10 @@ export function resolveConfiguredProviderDefaultApi(params: {
   }
   const providerConfiguredBaseUrl = normalizeTransportBaseUrl(providerConfig?.baseUrl);
   if (!providerConfiguredBaseUrl) {
-    return undefined;
+    // No configured baseUrl: the provider name implies the native transport
+    // (google-vertex builds request URLs dynamically). With a baseUrl present,
+    // transport resolution owns it so custom/proxy endpoints are preserved.
+    return resolveProviderNameDefaultApi(params.provider);
   }
   const normalized = resolveProviderTransport({
     provider: params.provider,

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -1807,6 +1807,10 @@ describe("getApiKeyForModel", () => {
     }
   });
 
+  // The env-vars-with-marker evidence entry added for metadata-server ADC does
+  // not affect this test: resolveEnvApiKey uses precomputed authEvidenceMap from
+  // plugin manifests, and the test harness does not load the google plugin
+  // manifest, so only the local-file-with-env entry is evaluated.
   it("resolveEnvApiKey('google-vertex') rejects missing explicit ADC path before fallback paths", async () => {
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-google-adc-home-"));
     const fallbackDir = path.join(homeDir, ".config", "gcloud");

--- a/src/llm/env-api-keys.test.ts
+++ b/src/llm/env-api-keys.test.ts
@@ -177,7 +177,11 @@ describe("getEnvApiKey", () => {
         vi.resetModules();
         const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
 
-        expect(getEnvApiKey("google-vertex")).toBeUndefined();
+        // With the relaxed auth gate, GOOGLE_CLOUD_PROJECT alone is sufficient
+        // to return "<authenticated>" even without a credentials file on disk.
+        // The downstream transport (vertex-adc.ts) handles actual credential
+        // resolution at request time via google-auth-library.
+        expect(getEnvApiKey("google-vertex")).toBe("<authenticated>");
         await writeFile(credentialsPath, "{}", "utf-8");
         expect(getEnvApiKey("google-vertex")).toBe("<authenticated>");
       },

--- a/src/plugins/manifest-setup-normalizers.ts
+++ b/src/plugins/manifest-setup-normalizers.ts
@@ -113,30 +113,49 @@ function normalizeManifestSetupProviderAuthEvidence(
   }
   const normalized: PluginManifestSetupProviderAuthEvidence[] = [];
   for (const entry of value) {
-    if (!isRecord(entry) || entry.type !== "local-file-with-env") {
+    if (!isRecord(entry)) {
       continue;
     }
     const credentialMarker = normalizeOptionalString(entry.credentialMarker);
     if (!credentialMarker) {
       continue;
     }
-    const fileEnvVar = normalizeOptionalString(entry.fileEnvVar);
-    const fallbackPaths = normalizeTrimmedStringList(entry.fallbackPaths);
-    if (!fileEnvVar && fallbackPaths.length === 0) {
-      continue;
+    if (entry.type === "local-file-with-env") {
+      const fileEnvVar = normalizeOptionalString(entry.fileEnvVar);
+      const fallbackPaths = normalizeTrimmedStringList(entry.fallbackPaths);
+      if (!fileEnvVar && fallbackPaths.length === 0) {
+        continue;
+      }
+      const requiresAnyEnv = normalizeTrimmedStringList(entry.requiresAnyEnv);
+      const requiresAllEnv = normalizeTrimmedStringList(entry.requiresAllEnv);
+      const source = normalizeOptionalString(entry.source);
+      normalized.push({
+        type: "local-file-with-env",
+        ...(fileEnvVar ? { fileEnvVar } : {}),
+        ...(fallbackPaths.length > 0 ? { fallbackPaths } : {}),
+        ...(requiresAnyEnv.length > 0 ? { requiresAnyEnv } : {}),
+        ...(requiresAllEnv.length > 0 ? { requiresAllEnv } : {}),
+        credentialMarker,
+        ...(source ? { source } : {}),
+      });
+    } else if (entry.type === "env-vars-with-marker") {
+      const requiresAnyEnv = normalizeTrimmedStringList(entry.requiresAnyEnv);
+      const requiresAllEnv = normalizeTrimmedStringList(entry.requiresAllEnv);
+      // Ambient evidence must gate on at least one env var; without any
+      // requirement it would report the provider authenticated for an empty
+      // environment.
+      if (requiresAnyEnv.length === 0 && requiresAllEnv.length === 0) {
+        continue;
+      }
+      const source = normalizeOptionalString(entry.source);
+      normalized.push({
+        type: "env-vars-with-marker",
+        ...(requiresAnyEnv.length > 0 ? { requiresAnyEnv } : {}),
+        ...(requiresAllEnv.length > 0 ? { requiresAllEnv } : {}),
+        credentialMarker,
+        ...(source ? { source } : {}),
+      });
     }
-    const requiresAnyEnv = normalizeTrimmedStringList(entry.requiresAnyEnv);
-    const requiresAllEnv = normalizeTrimmedStringList(entry.requiresAllEnv);
-    const source = normalizeOptionalString(entry.source);
-    normalized.push({
-      type: "local-file-with-env",
-      ...(fileEnvVar ? { fileEnvVar } : {}),
-      ...(fallbackPaths.length > 0 ? { fallbackPaths } : {}),
-      ...(requiresAnyEnv.length > 0 ? { requiresAnyEnv } : {}),
-      ...(requiresAllEnv.length > 0 ? { requiresAllEnv } : {}),
-      credentialMarker,
-      ...(source ? { source } : {}),
-    });
   }
   return normalized.length > 0 ? normalized : undefined;
 }

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -194,22 +194,35 @@ export type PluginManifestSetupProvider = {
   authEvidence?: PluginManifestSetupProviderAuthEvidence[];
 };
 
-export type PluginManifestSetupProviderAuthEvidence = {
-  /** Generic local file evidence gated by required environment metadata. */
-  type: "local-file-with-env";
-  /** Optional env var containing an explicit credential file path. */
-  fileEnvVar?: string;
-  /** Optional fallback credential file paths. Supports `${HOME}` and `${APPDATA}`. */
-  fallbackPaths?: string[];
-  /** At least one of these env vars must be non-empty when provided. */
-  requiresAnyEnv?: string[];
-  /** Every env var listed here must be non-empty when provided. */
-  requiresAllEnv?: string[];
-  /** Non-secret marker returned when this evidence is present. */
-  credentialMarker: string;
-  /** Human-readable auth source label. */
-  source?: string;
-};
+export type PluginManifestSetupProviderAuthEvidence =
+  | {
+      /** Generic local file evidence gated by required environment metadata. */
+      type: "local-file-with-env";
+      /** Optional env var containing an explicit credential file path. */
+      fileEnvVar?: string;
+      /** Optional fallback credential file paths. Supports `${HOME}` and `${APPDATA}`. */
+      fallbackPaths?: string[];
+      /** At least one of these env vars must be non-empty when provided. */
+      requiresAnyEnv?: string[];
+      /** Every env var listed here must be non-empty when provided. */
+      requiresAllEnv?: string[];
+      /** Non-secret marker returned when this evidence is present. */
+      credentialMarker: string;
+      /** Human-readable auth source label. */
+      source?: string;
+    }
+  | {
+      /** Env-var-only evidence for ambient credential sources (metadata server, workload identity). */
+      type: "env-vars-with-marker";
+      /** At least one of these env vars must be non-empty when provided. */
+      requiresAnyEnv?: string[];
+      /** Every env var listed here must be non-empty when provided. */
+      requiresAllEnv?: string[];
+      /** Non-secret marker returned when this evidence is present. */
+      credentialMarker: string;
+      /** Human-readable auth source label. */
+      source?: string;
+    };
 
 export type PluginManifestSetup = {
   /** Cheap provider setup metadata exposed before runtime loads. */

--- a/src/plugins/provider-model-primary.ts
+++ b/src/plugins/provider-model-primary.ts
@@ -5,6 +5,22 @@ import {
 } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
+/**
+ * Derive a human-readable model name from a model id.
+ * e.g. "gemini-2.5-flash" -> "Gemini 2.5 Flash"
+ */
+function humanizeModelId(modelId: string): string {
+  return modelId
+    .split("-")
+    .map((word) => {
+      if (/^\d/.test(word)) {
+        return word;
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
+}
+
 /** Applies a primary model to agent defaults while preserving model fallback metadata. */
 export function applyPrimaryModel(cfg: OpenClawConfig, model: string): OpenClawConfig {
   const normalizedModel = normalizeAgentModelRefForConfig(model);
@@ -17,7 +33,7 @@ export function applyPrimaryModel(cfg: OpenClawConfig, model: string): OpenClawC
           normalizeAgentModelRefForConfig(fallback),
         )
       : undefined;
-  return {
+  let result: OpenClawConfig = {
     ...cfg,
     agents: {
       ...cfg.agents,
@@ -34,4 +50,47 @@ export function applyPrimaryModel(cfg: OpenClawConfig, model: string): OpenClawC
       },
     },
   };
+
+  // Also register the model in models.providers so the runtime model
+  // resolver can find it. The wizard writes to agents.defaults.model.primary
+  // but not to models.providers, causing "Unknown model" errors at runtime.
+  const slashIndex = normalizedModel.indexOf("/");
+  if (slashIndex > 0) {
+    const providerName = normalizedModel.slice(0, slashIndex);
+    const modelId = normalizedModel.slice(slashIndex + 1);
+    const modelName = humanizeModelId(modelId);
+    const existingProviders =
+      (result.models as Record<string, unknown> | undefined)?.providers ?? {};
+    const existingProvider = (existingProviders as Record<string, Record<string, unknown>>)[
+      providerName
+    ];
+    if (!existingProvider) {
+      // Only auto-register models for providers that already have config.
+      // Creating a provider entry without baseUrl for an unknown custom
+      // provider would produce invalid config.
+      return result;
+    }
+    const existingProviderModels = Array.isArray(existingProvider.models)
+      ? (existingProvider.models as Array<{ id?: string }>)
+      : [];
+    const alreadyRegistered = existingProviderModels.some((m) => m.id === modelId);
+    if (!alreadyRegistered) {
+      const updatedProviders = {
+        ...(existingProviders as Record<string, unknown>),
+        [providerName]: {
+          ...existingProvider,
+          models: [...existingProviderModels, { id: modelId, name: modelName }],
+        },
+      };
+      result = {
+        ...result,
+        models: {
+          ...result.models,
+          providers: updatedProviders,
+        } as OpenClawConfig["models"],
+      };
+    }
+  }
+
+  return result;
 }

--- a/src/secrets/provider-auth-evidence.ts
+++ b/src/secrets/provider-auth-evidence.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import { normalizeOptionalString as normalizeOptionalPathInput } from "@openclaw/normalization-core/string-coerce";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+import type { ProviderAuthEvidence } from "./provider-env-vars.js";
 
 type LocalProviderAuthEvidence = {
   type: "local-file-with-env";
@@ -49,7 +50,7 @@ function expandAuthEvidencePath(
 }
 
 function hasRequiredAuthEvidenceEnv(
-  evidence: LocalProviderAuthEvidence,
+  evidence: ProviderAuthEvidence,
   env: NodeJS.ProcessEnv,
 ): boolean {
   const hasEnv = (key: string) => Boolean(normalizeOptionalSecretInput(env[key]));
@@ -89,21 +90,34 @@ function hasLocalFileAuthEvidence(
 }
 
 export function resolveLocalProviderAuthEvidence(
-  evidenceEntries: readonly LocalProviderAuthEvidence[] | undefined,
+  evidenceEntries: readonly ProviderAuthEvidence[] | undefined,
   env: NodeJS.ProcessEnv,
 ): ResolvedLocalProviderAuthEvidence | null {
   for (const evidence of evidenceEntries ?? []) {
-    if (
-      evidence.type !== "local-file-with-env" ||
-      !hasRequiredAuthEvidenceEnv(evidence, env) ||
-      !hasLocalFileAuthEvidence(evidence, env)
-    ) {
+    if (!hasRequiredAuthEvidenceEnv(evidence, env)) {
       continue;
     }
-    return {
-      credentialMarker: evidence.credentialMarker,
-      source: evidence.source ?? "local auth evidence",
-    };
+    // Ambient credential sources (metadata server, workload identity) expose no
+    // credentials file; the required env vars alone are sufficient evidence.
+    if (evidence.type === "env-vars-with-marker") {
+      // Never treat a marker with no env conditions as authenticated; that would
+      // pass for an empty environment (hasRequiredAuthEvidenceEnv returns true
+      // when there are no requirements).
+      if (!evidence.requiresAnyEnv?.length && !evidence.requiresAllEnv?.length) {
+        continue;
+      }
+      return {
+        credentialMarker: evidence.credentialMarker,
+        source: evidence.source ?? "env auth evidence",
+      };
+    }
+    // local-file-with-env additionally requires the credential file to exist.
+    if (evidence.type === "local-file-with-env" && hasLocalFileAuthEvidence(evidence, env)) {
+      return {
+        credentialMarker: evidence.credentialMarker,
+        source: evidence.source ?? "local auth evidence",
+      };
+    }
   }
   return null;
 }

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -25,15 +25,24 @@ type MockManifestPlugin = {
     providers?: Array<{
       id: string;
       envVars?: string[];
-      authEvidence?: Array<{
-        type: "local-file-with-env";
-        fileEnvVar?: string;
-        fallbackPaths?: string[];
-        requiresAnyEnv?: string[];
-        requiresAllEnv?: string[];
-        credentialMarker: string;
-        source?: string;
-      }>;
+      authEvidence?: Array<
+        | {
+            type: "local-file-with-env";
+            fileEnvVar?: string;
+            fallbackPaths?: string[];
+            requiresAnyEnv?: string[];
+            requiresAllEnv?: string[];
+            credentialMarker: string;
+            source?: string;
+          }
+        | {
+            type: "env-vars-with-marker";
+            requiresAnyEnv?: string[];
+            requiresAllEnv?: string[];
+            credentialMarker: string;
+            source?: string;
+          }
+      >;
     }>;
   };
 };
@@ -287,6 +296,34 @@ describe("provider env vars dynamic manifest metadata", () => {
     ]);
     const [snapshotOptions] = requireLastMetadataSnapshotCall() as [{ preferPersisted?: boolean }];
     expect(snapshotOptions.preferPersisted).toBe(false);
+  });
+
+  it("drops ambient auth evidence that declares no environment requirements", () => {
+    useRegistrySetupPlugin("external-cloud", "global", {
+      id: "external-cloud",
+      authEvidence: [
+        {
+          type: "env-vars-with-marker",
+          credentialMarker: "external-cloud-ambient-credentials",
+          source: "external cloud ambient",
+        },
+      ],
+    });
+
+    // The normalizer must reject an ambient marker with no env conditions,
+    // otherwise it would report the provider authenticated for an empty env.
+    expect(resolveProviderAuthLookupMaps().authEvidenceMap["external-cloud"]).toBeUndefined();
+  });
+
+  it("never authenticates an ambient marker that has no environment requirements", () => {
+    // Defensive boundary guard: even if such an entry reached the resolver, it
+    // must not return the marker for an empty environment.
+    expect(
+      resolveLocalProviderAuthEvidence(
+        [{ type: "env-vars-with-marker", credentialMarker: "external-cloud-ambient-credentials" }],
+        {},
+      ),
+    ).toBeNull();
   });
 
   it("expands provider-owned directory variables in manifest credential evidence", () => {

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -42,15 +42,23 @@ export type ProviderEnvVarLookupParams = {
 };
 
 /** Manifest-provided evidence that a provider auth credential exists outside config. */
-export type ProviderAuthEvidence = {
-  type: "local-file-with-env";
-  fileEnvVar?: string;
-  fallbackPaths?: readonly string[];
-  requiresAnyEnv?: readonly string[];
-  requiresAllEnv?: readonly string[];
-  credentialMarker: string;
-  source?: string;
-};
+export type ProviderAuthEvidence =
+  | {
+      type: "local-file-with-env";
+      fileEnvVar?: string;
+      fallbackPaths?: readonly string[];
+      requiresAnyEnv?: readonly string[];
+      requiresAllEnv?: readonly string[];
+      credentialMarker: string;
+      source?: string;
+    }
+  | {
+      type: "env-vars-with-marker";
+      requiresAnyEnv?: readonly string[];
+      requiresAllEnv?: readonly string[];
+      credentialMarker: string;
+      source?: string;
+    };
 
 /** Provider auth lookup maps resolved from plugin metadata and core fallback rules. */
 export type ProviderAuthLookupMaps = {
@@ -103,12 +111,21 @@ function appendUniqueAuthEvidence(
   evidence: readonly ProviderAuthEvidence[],
 ) {
   const normalizedProviderId = providerId.trim();
-  if (!normalizedProviderId || evidence.length === 0) {
+  // Ambient (env-vars-with-marker) evidence must gate on at least one env var;
+  // without any requirement it would report the provider authenticated for an
+  // empty environment. Drop such entries before they enter the lookup map.
+  const usable = evidence.filter(
+    (entry) =>
+      entry.type !== "env-vars-with-marker" ||
+      Boolean(entry.requiresAnyEnv?.length) ||
+      Boolean(entry.requiresAllEnv?.length),
+  );
+  if (!normalizedProviderId || usable.length === 0) {
     return;
   }
   const bucket = (target[normalizedProviderId] ??= []);
   const seen = new Set(bucket.map((entry) => JSON.stringify(entry)));
-  for (const entry of evidence) {
+  for (const entry of usable) {
     const key = JSON.stringify(entry);
     if (seen.has(key)) {
       continue;

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5690,6 +5690,108 @@ describe("verifySetupInference", () => {
     expect(runEmbeddedAgent).toHaveBeenCalledOnce();
   });
 
+  it("passes candidate config env to the probe without mutating global process.env", async () => {
+    // google-vertex reads its project/location from the candidate config passed into
+    // the probe transport, not from process.env. The probe must never mutate the
+    // gateway's global process.env, or a concurrent gateway request could observe the
+    // candidate's provider settings during the awaited probe.
+    const priorProject = process.env.GOOGLE_CLOUD_PROJECT;
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    const profiles = {
+      "openai:default": { type: "api_key" as const, provider: "openai", key: "key-1" },
+    };
+    let configDuringProbe: OpenClawConfig | undefined;
+    let envDuringProbe: string | undefined;
+    const runEmbeddedAgent = vi.fn(async (params: { config?: OpenClawConfig }) => {
+      configDuringProbe = params.config;
+      envDuringProbe = process.env.GOOGLE_CLOUD_PROJECT;
+      return successfulRun("openai", "gpt-5.5");
+    });
+
+    try {
+      const result = await verifySetupInferenceConfig({
+        config: {
+          agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+          auth: { profiles: { "openai:default": { provider: "openai", mode: "api_key" } } },
+          env: { vars: { GOOGLE_CLOUD_PROJECT: "probe-project" } },
+        } satisfies OpenClawConfig,
+        runtime,
+        deps: {
+          loadAuthProfileStoreForRuntime: vi.fn(() => ({ version: 1, profiles })) as never,
+          runEmbeddedAgent: runEmbeddedAgent as never,
+          createTempDir: makeTempDir,
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true });
+      // Candidate project reaches the probe via the config, not global env.
+      expect(configDuringProbe?.env?.vars?.GOOGLE_CLOUD_PROJECT).toBe("probe-project");
+      // process.env is never mutated, during or after the probe.
+      expect(envDuringProbe).toBeUndefined();
+      expect(process.env.GOOGLE_CLOUD_PROJECT).toBeUndefined();
+    } finally {
+      if (priorProject === undefined) {
+        delete process.env.GOOGLE_CLOUD_PROJECT;
+      } else {
+        process.env.GOOGLE_CLOUD_PROJECT = priorProject;
+      }
+    }
+  });
+
+  it("keeps overlapping probes isolated and never mutates global process.env", async () => {
+    // Two setup probes running concurrently must each see only their own candidate
+    // project and must never leak candidate values into the shared process.env.
+    const priorProject = process.env.GOOGLE_CLOUD_PROJECT;
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    const profiles = {
+      "openai:default": { type: "api_key" as const, provider: "openai", key: "key-1" },
+    };
+    const seenProjects: Array<string | undefined> = [];
+    let observedGlobalDuringProbe: string | undefined;
+    const makeRunner = () =>
+      vi.fn(async (params: { config?: OpenClawConfig }) => {
+        // Yield so the two probes interleave on the event loop.
+        await new Promise((resolve) => {
+          setTimeout(resolve, 5);
+        });
+        seenProjects.push(params.config?.env?.vars?.GOOGLE_CLOUD_PROJECT);
+        observedGlobalDuringProbe ??= process.env.GOOGLE_CLOUD_PROJECT;
+        return successfulRun("openai", "gpt-5.5");
+      });
+    const runProbe = (project: string) =>
+      verifySetupInferenceConfig({
+        config: {
+          agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+          auth: { profiles: { "openai:default": { provider: "openai", mode: "api_key" } } },
+          env: { vars: { GOOGLE_CLOUD_PROJECT: project } },
+        } satisfies OpenClawConfig,
+        runtime,
+        deps: {
+          loadAuthProfileStoreForRuntime: vi.fn(() => ({ version: 1, profiles })) as never,
+          runEmbeddedAgent: makeRunner() as never,
+          createTempDir: makeTempDir,
+        },
+      });
+
+    try {
+      const [a, b] = await Promise.all([runProbe("project-a"), runProbe("project-b")]);
+      expect(a).toMatchObject({ ok: true });
+      expect(b).toMatchObject({ ok: true });
+      // Each probe saw only its own candidate project; global env untouched throughout.
+      expect(
+        seenProjects.toSorted((left, right) => String(left).localeCompare(String(right))),
+      ).toEqual(["project-a", "project-b"]);
+      expect(observedGlobalDuringProbe).toBeUndefined();
+      expect(process.env.GOOGLE_CLOUD_PROJECT).toBeUndefined();
+    } finally {
+      if (priorProject === undefined) {
+        delete process.env.GOOGLE_CLOUD_PROJECT;
+      } else {
+        process.env.GOOGLE_CLOUD_PROJECT = priorProject;
+      }
+    }
+  });
+
   it("returns a refreshed staged profile without changing the configured agent store", async () => {
     const stateDir = await makeTempDir();
     const agentDir = path.join(stateDir, "configured-agent");

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -123,7 +123,7 @@ describe("publish model catalog", () => {
       { cwd: root, encoding: "utf8" },
     );
     expect(result.status, result.stderr).toBe(0);
-    const stats = /dry-run schemaVersion=1 providers=40 models=(\d+)/u.exec(result.stdout);
+    const stats = /dry-run schemaVersion=1 providers=41 models=(\d+)/u.exec(result.stdout);
     expect(stats).not.toBeNull();
     expect(Number(stats?.[1])).toBeGreaterThanOrEqual(MODEL_CATALOG_MIN_MODELS);
     expect(fs.existsSync(out)).toBe(false);


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**

The `google-vertex` provider does not work end-to-end for developers using Application Default Credentials (ADC). The auth gate requires a credentials file on disk, rejecting metadata server ADC (GCE/GKE/Cloud Run) before the transport layer can run. The onboarding wizard has no auth flow for google-vertex, doesn't register models in the provider config, doesn't prompt for GCP project/location, has no model catalog, and has no dedicated documentation.

**Why does this matter now?**

Multiple open issues document this problem (#56253, #79595, #85864, #79837, #11413). We reproduced the issue on a fresh install: a new OpenClaw install requires numerous manual undocumented steps and manual edits to JSON config to get a working `google-vertex` setup. Users on GCE/GKE with valid GCP credentials consistently hit "No API key found" because the auth gate only accepts file-based ADC.

**What is the intended outcome?**

A developer picks "Google Vertex AI" in the onboarding wizard, confirms their auto-detected GCP project, and sends a message. Three steps without manual config editing.

**What is intentionally out of scope?**

- Changes to the `google` (AI Studio) or `google-gemini-cli` providers

**What does success look like?**

`openclaw onboard --auth-choice google-vertex-adc` on a GCE VM (or any machine with ADC configured) produces a working setup with zero manual config editing.

**What should reviewers focus on?**

- The new `"env-vars-with-marker"` auth evidence type (type in `src/plugins/manifest-types.ts` + `src/secrets/provider-env-vars.ts`, parsing in `src/plugins/manifest-setup-normalizers.ts`, resolution in `src/secrets/provider-auth-evidence.ts`)
- The relaxed auth gate in `src/llm/env-api-keys.ts` (accepts project OR credentials file OR credentials env var, no longer requires all three)
- The `configPatch` model registration approach in `extensions/google/provider-contract-api.ts` (workaround for `applyPrimaryModel` not persisting `models.providers` through the wizard config serialization)
- The `gcp-vertex-credentials` marker profile stored during onboarding for auth detection

All changes were reviewed and tested by the author on a fresh VM.

## Linked context

**Which issue does this close?**

Related #56253, #85864, #79595, #79837, #11413

**Which issues, PRs, or discussions are related?**

Related #49191, #50053, #52476, #48910, #77643, #55572, #53566, #9729

See also #83971 (merged, fixed transport-layer ADC but not the upstream auth gate)

**Was this requested by a maintainer or owner?**

No. Reproduced independently on a GCE VM based on multiple open issues reporting the same auth failure.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** google-vertex provider fails with "No API key found" on GCE VMs using metadata server ADC. Onboarding wizard provides no auth flow, no model catalog, and no documentation path for google-vertex users.
- **Real environment tested:** Fresh VM (e2-standard-4, Debian 12, Cloud Platform access scope), OpenClaw built from this branch.
- **Exact steps or command run after this patch:**
  ```bash
  pnpm openclaw uninstall --all --yes
  pnpm openclaw onboard --auth-choice google-vertex-adc
  # Confirmed auto-detected project
  # Accepted "global" location
  # Kept default model (google-vertex/gemini-3.5-flash)
  # Hatched in Terminal, sent "Wake up, my friend!"
  ```
- **Evidence after fix:**

  <img width="1381" height="880" alt="Vertex AI Onboarding 1" src="https://github.com/user-attachments/assets/96f5bf4c-0128-428f-9864-66b52bb07bac" />

  <img width="1380" height="787" alt="Vertex AI Onboarding 2" src="https://github.com/user-attachments/assets/7c84f620-ce6d-489e-bd90-fa11a70fc463" />

  <img width="1377" height="372" alt="Vertex AI Onboarding 3" src="https://github.com/user-attachments/assets/f1eeb9e5-d8b2-4b20-9948-296d98da2b8b" />

- **Observed result after fix:** Gemini responded successfully via Vertex AI with ADC from the GCE metadata server. No auth warnings during onboarding. Model catalog populated in "Browse all models." Project auto-detected. Default model `gemini-3.5-flash` set and registered in provider config.
- **Proof limitations or environment constraints:** The gcloud CLI and service account key auth paths follow the same downstream transport code (`vertex-adc.ts`) which is unchanged; only the upstream auth gate and wizard flow are new.
- **Before evidence:** Same VM, same credentials, without this patch a fresh install produced "No API key found for provider google-vertex". A direct request to the Vertex AI endpoint with the same metadata server credentials succeeded, confirming the issue is in OpenClaw's auth gate.
- Onboarding writes GCP project and location under the `env.vars` config shape and passes config validation with no "Unrecognized keys" error.
- The setup access probe resolves ADC and completes a live Vertex completion, and the TUI agent then responds on `google-vertex/gemini-3.5-flash` through the Vertex transport using metadata-server ADC (the exact path the relaxed auth gate enables).

## Tests and validation

**Which commands did you run?**

```bash
pnpm build                    # clean, no errors
pnpm check                    # typecheck + lint passed
pnpm test:extension google    # 293 tests, all passed
```

End-to-end onboarding and API call on GCE VM validated across multiple iterations.

**What regression coverage was added or updated?**

No new unit tests. Existing tests for `hasVertexAdcCredentials`, `resolveAuthEvidence`, `normalizeManifestSetupProviderAuthEvidence`, and the google extension transport/auth tests (293 tests) cover the touched code paths and all passed.

**What failed before this fix, if known?**

"No API key found for provider google-vertex" on any environment using metadata server ADC (GCE, GKE, Cloud Run). Also: "Unknown model" after onboarding (wizard didn't register models in provider config), requests routed to OpenAI endpoints (wrong default transport type), empty model catalog in "Browse all models," no auth flow during onboarding.

**If no test was added, why not?**

The changes span auth gating, manifest parsing, wizard flow, model resolution, and transport defaults across multiple subsystems. Real behavior proof from a GCE VM is more representative than unit tests for this class of end-to-end configuration issue.

## Risk checklist

**Did user-visible behavior change?** Yes. New wizard auth flow for google-vertex (project auto-detection, location default, model catalog). New default model `gemini-3.5-flash`. "Google Vertex AI" label in wizard (was "Google Vertex"). New dedicated docs page.

**Did config, environment, or migration behavior change?** Yes. New `"env-vars-with-marker"` auth evidence type in the plugin manifest system. `GOOGLE_CLOUD_LOCATION` no longer required (defaults to `"global"`). Auth gate accepts `GOOGLE_CLOUD_PROJECT` alone without requiring a credentials file on disk.

**Did security, auth, secrets, network, or tool execution behavior change?** Yes. The auth gate is more permissive: accepts project env var OR credentials file OR credentials env var (previously required all three of: file + project + location). The `gcp-vertex-credentials` marker is stored as an auth profile credential during onboarding. `nonSecretAuthMarkers` added to the google plugin manifest.

**What is the highest-risk area?**

The relaxed auth gate in `src/llm/env-api-keys.ts`. Previously required `hasCredentials && hasProject && hasLocation`. Now accepts `hasProject || hasCredentials || hasCredentialsEnv`.

**How is that risk mitigated?**

The downstream transport (`extensions/google/vertex-adc.ts`) validates credentials at request time via `google-auth-library`'s `GoogleAuth`. If ADC is not actually available, the request fails with a clear error ("Google Vertex ADC fallback did not return an access token") rather than the opaque "No API key found" gate error. The gate change only affects whether the request reaches the transport layer, not whether it succeeds.

**Operator diagnostics when ambient ADC is missing or invalid:**

The relaxed gate lets a project-only configuration pass onboarding; credential validation is deferred to request time (matching how `google-auth-library` resolves ADC). If ambient ADC is absent or invalid, the request fails with an explicit, actionable error rather than a silent success or the opaque "No API key found" gate error — `extensions/google/vertex-adc.ts` surfaces `"Google Vertex ADC fallback did not return an access token"`. Failed ambient ADC is a visible request-time failure, not a silent misconfiguration.

**Setup-probe environment isolation (no global `process.env` mutation):**

The onboarding setup/inference probe does not mutate the gateway's global `process.env`. The Google Vertex transport reads the candidate project/location directly from the config passed into the probe (`config.env.vars.GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION`, in `extensions/google/transport-stream.ts`), with `process.env` retained only as a fallback for shell-set values. Because the probe never writes to shared process state, a concurrent gateway request cannot observe the onboarding candidate's provider settings, and there is no snapshot/restore that could clobber concurrent environment changes. Regression coverage: `src/system-agent/setup-inference.test.ts` asserts the probe leaves `process.env` untouched and that two overlapping probes each see only their own candidate project; `extensions/google/transport-stream.test.ts` asserts Vertex project/location resolve from config with no `process.env` set.

## Maintainer decision requested: `env-vars-with-marker` auth-evidence variant

This PR extends the existing plugin-manifest auth-evidence type `PluginManifestSetupProviderAuthEvidence` (`src/plugins/manifest-types.ts`) with a second variant, `env-vars-with-marker`, alongside the existing `local-file-with-env`. It lets a provider assert readiness from required env vars plus a non-secret marker, for ambient credential sources that expose no on-disk file (GCE/GKE/Cloud Run metadata server, Workload Identity Federation).

- **Additive:** `local-file-with-env` behavior is unchanged; the new variant is only consumed when a manifest declares it (parsed in `manifest-setup-normalizers.ts`, resolved in `src/secrets/provider-auth-evidence.ts`).
- **Precedent:** `anthropic-vertex` already uses the same `gcp-vertex-credentials` marker pattern for ADC-based auth with no real API key. This generalizes that idea into a documented manifest variant.
- **Decision requested:** please confirm whether `env-vars-with-marker` is acceptable as a supported, reusable manifest auth-evidence contract. If you would prefer it scoped to google-vertex only for now, I can keep the recognition inside the Google plugin instead of the shared manifest type.

Two related items depend on the same design direction and are stated here so they can be settled with the contract decision above:

- **Transport ownership:** the small core provider-name default is retained because both the configured and fallback model paths resolve `api` before the Google plugin's `normalizeTransport` hook runs; removing it reintroduces `openai-responses` routing for google-vertex. It can instead move fully into plugin-owned config (persisting `api: "google-vertex"` during onboarding) with the core branch removed, if that ownership is preferred.
- **Service-account scope:** the onboarding wizard configures ambient ADC (metadata server / gcloud ADC / Workload Identity) and persists project + location. Service-account key-file auth persists in the operator's own environment (`GOOGLE_APPLICATION_CREDENTIALS`) and needs nothing stored by the wizard; it stays a documented manual path.

## Responses to automated review findings

- **`applyPrimaryModel` does not "append models to every provider."** `src/plugins/provider-model-primary.ts` registers the model only under the single provider named in the model ref, and only when that provider already has a config entry, otherwise it returns the config unchanged (`if (!existingProvider) return result`). It never iterates other providers and never creates a provider entry, so it cannot alter unrelated provider allowlists.

- **Existing-config preservation (re: upgrade coverage).** Onboarding writes are additive: the `configPatch` merges into existing `models.providers["google-vertex"].models` rather than replacing it, and `env.vars` writes are keyed. Re-running onboarding over an existing config preserves user-registered models and env values. Fresh-install behavior is shown in the GCE screenshots above.

- **`extensions/google/manifest.test.ts` assertions.** The test now asserts both auth-evidence entries (`local-file-with-env` and the ambient `env-vars-with-marker`) and both auth choices (Google AI Studio api-key and the explicit "Google Vertex AI" adc choice).

- **Core Vertex transport default (`resolveConfiguredProviderDefaultApi`).** The core provider-name default is deliberate: both the configured and fallback model paths resolve `api` before the Google plugin's `normalizeTransport` hook runs, so removing it reintroduced `openai-responses` routing for google-vertex.

- **Service-account credential path persistence.** The ADC wizard (`extensions/google/provider-contract-api.ts`) only prompts for project and location; it never collects or exports a `GOOGLE_APPLICATION_CREDENTIALS` path, so a restart has nothing to lose. ADC is resolved at request time by `google-auth-library` in `extensions/google/vertex-adc.ts` from the metadata server, the default ADC file, or a user-set `GOOGLE_APPLICATION_CREDENTIALS`, all of which live in the environment/filesystem and survive restart without wizard-written state. The config patch persists only the two values ADC cannot infer (project + location). Service-account keys stay a documented manual path (`docs/providers/google-vertex.md`, "Service account key").

- **Vertex static catalog duplication.** Removed the `modelCatalog.providers.google-vertex` block. The Google source catalog (`extensions/google/provider-catalog.ts`, `buildGoogleVertexStaticCatalogProvider`) is now the sole owner of google-vertex model rows and their `compat: { codeMode: "preferred" }` metadata, matching how sibling `google` is handled (source/runtime catalog, not a manifest catalog). This resolves the duplicate-catalog finding and keeps code-mode tiers consistent with `src/plugins/contracts/shared-upstream-model.contract.test.ts`, which designates `google` as a source-catalog plugin. The onboarding default is unaffected: it comes from the auth choice's `defaultModel` via `applyDefaultModel`, not the manifest catalog.

## Current review state

**What is the next action?**

Ready for maintainer review.

**What is still waiting on author, maintainer, CI, or external proof?**

Nothing blocking. `pnpm test:extension google` (293 tests) and `pnpm check` (typecheck + lint) passed cleanly.

**Which bot or reviewer comments were addressed?**

Addressed across ClawSweeper iterations: setup-probe `process.env` isolation + concurrency test (P1, resolved); ambient auth-evidence now requires at least one env condition at the normalizer, map-builder, and resolver, with test coverage (resolved); redacted current-head GCE ADC proof supplied (proof: sufficient). The "appends to every provider" finding is rebutted under "Responses to automated review findings" above. The remaining items (`manifest.test.ts` assertions, core-vs-plugin transport ownership, service-account persistence) are pending the maintainer decisions requested above, since each depends on which design direction is intended.