### PR TITLE
test: refresh Codex prompt snapshots

### DIFF
--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -773,7 +773,7 @@
         "timeoutMs": {
           "description": "Provider timeout ms.",
           "minimum": 1,
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": ["text"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -809,7 +809,7 @@
         "timeoutMs": {
           "description": "Provider timeout ms.",
           "minimum": 1,
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": ["text"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -773,7 +773,7 @@
         "timeoutMs": {
           "description": "Provider timeout ms.",
           "minimum": 1,
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": ["text"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,7 +221,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40277,
+    "chars": 40278,
     "roughTokens": 10070
   },
   "openClawDeveloperInstructions": {
@@ -233,7 +233,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67979,
+    "chars": 67980,
     "roughTokens": 16995
   },
   "userInputText": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,7 +221,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 39998,
+    "chars": 39999,
     "roughTokens": 10000
   },
   "openClawDeveloperInstructions": {
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66176,
-    "roughTokens": 16544
+    "chars": 66177,
+    "roughTokens": 16545
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,7 +222,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41093,
+    "chars": 41094,
     "roughTokens": 10274
   },
   "openClawDeveloperInstructions": {
@@ -234,7 +234,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68214,
+    "chars": 68215,
     "roughTokens": 17054
   },
   "userInputText": {


### PR DESCRIPTION
## Summary

- Refresh Codex happy-path prompt snapshots after the dynamic tool schema changed `timeoutMs` from `number` to `integer`.
- Update the derived prompt-size counters in the generated Markdown snapshots.

## Verification

- `pnpm prompt:snapshots:gen`
- `pnpm prompt:snapshots:check`
- `git diff --check`

## Real behavior proof

Behavior addressed: `pnpm prompt:snapshots:check` no longer reports drift for the Codex happy-path prompt fixtures on current `main`.
Real environment tested: local macOS checkout, Node `v24.16.0`, pnpm `11.2.2`.
Exact steps or command run after this patch: `pnpm prompt:snapshots:check`.
Evidence after fix: command completed with `Prompt snapshots are current (7 files).`
Observed result after fix: generated dynamic tool snapshots now encode `timeoutMs` as an integer and the prompt snapshot check passes.
What was not tested: Linux Node 24.13.0 CI environment was not run locally.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":5,"user":2,"assistant":2,"toolCalls":58,"toolOutputsDropped":57,"web":0,"redactions":0,"omittedUnsafe":0,"rawEntries":17}

[user]
look at ../openclaw.pnpm-lock-gating/plan-to-fix.md and open pr with the fix

[assistant]
I’ll read the PR-prep and transcript workflow instructions first, then inspect the sibling plan and current worktree state before touching files.

The sibling plan identifies mainline prompt snapshot drift, not a dependency-gating code bug. I’m checking the scoped test-fixture guidance and PR tooling before regenerating only those snapshots.

I’m using the existing `fix-prompt-boundary-test` branch, which is currently clean and exactly at `origin/main`. The fix should be a generated fixture-only update from `pnpm prompt:snapshots:gen`, followed by the snapshot check.

I’m regenerating now. Since these are generated prompt fixtures, I’m going to inspect the resulting diff before committing so the PR stays limited to the drift described in the plan.

The generator had to hydrate dependencies first, then started the snapshot write. I’m waiting on that process and will check whether it changed only the six files from the plan.

The snapshot writer is still running without new stdout, which is normal for this script once it starts building the fixture context. I’m letting it finish rather than interrupting mid-write.

Generation completed and reported seven snapshot files written. I’m checking the diff now; if an extra generated file moved, I’ll include it only if it is part of the same prompt snapshot surface.

The diff is tight: six generated files, changing the Codex dynamic tool `timeoutMs` schema from `number` to `integer` plus derived size counters. I’m running the snapshot check next.

The check is running the same generator path in read-only mode. No failures have surfaced yet; I’ll wait for its final status before committing.

The generated fixtures now pass `pnpm prompt:snapshots:check`. I’m doing a final whitespace/status check, then I’ll commit only those six files and create the PR.

The fixture refresh is committed on `fix-prompt-boundary-test`. I’m checking for an existing PR for this branch, then I’ll push and create one if needed.

I found a high-confidence local session for an optional redacted agent transcript, but I’m not adding it without your explicit approval. I’ll create the PR without transcript now; it can be updated later if you want the sanitized log included.

[user]
yes add the transcript

[assistant]
Got it. I’m letting the PR creation finish, then I’ll render the sanitized transcript and update the PR body instead of creating a duplicate PR.

The rendered transcript is scoped to this PR work and excludes raw tool output and local absolute paths. I’m appending it to the PR body now.

[tool summary]
20 read, 1 write, 37 execute; raw tool outputs dropped: 57
````

</details>
<!-- agent-transcript:end -->
