### PR TITLE
fix(telegram): allow inline button sends in group prompts

### DIFF
--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -51,7 +51,7 @@ export function registerGroupIntroPromptCases(): void {
           Provider: "whatsapp",
         },
         expected: [
-          "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
+          "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send plain text to this same group — reply normally. Exception: when a live decision needs channel-native interactive controls such as inline buttons, use the message tool with action=send and presentation.blocks buttons, then make the final assistant turn silent to avoid a duplicate.",
           groupParticipationNote,
           groupSilentNote,
           groupSilentProseGuard,

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -29,7 +29,7 @@ describe("group runtime loading", () => {
       silentToken: "NO_REPLY",
     });
     expect(groupChatContext).toContain(
-      "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
+      "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send plain text to this same group — reply normally. Exception: when a live decision needs channel-native interactive controls such as inline buttons, use the message tool with action=send and presentation.blocks buttons, then make the final assistant turn silent to avoid a duplicate.",
     );
     expect(groupChatContext).toContain("Minimize empty lines and use normal chat conventions");
     expect(groupChatContext).not.toContain("wrap bare URLs");

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -235,7 +235,7 @@ export function buildGroupChatContext(params: {
     );
   } else {
     lines.push(
-      "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
+      "Your replies are automatically sent to this group chat. Do not use the message tool to send plain text to this same group — reply normally. Exception: when a live decision needs channel-native interactive controls such as inline buttons, use the message tool with action=send and presentation.blocks buttons, then make the final assistant turn silent to avoid a duplicate.",
     );
   }
   lines.push(


### PR DESCRIPTION
## Summary
- Updates the group-chat auto-reply guidance to permit using the message tool with `action=send` and `presentation.blocks` inline buttons when a live decision needs channel-native interactive controls.
- Adds explicit instruction that the final assistant turn must be silent after such a send to avoid a duplicate.
- Updates the corresponding unit test (`src/auto-reply/reply/groups.test.ts`) and the WhatsApp expected-output case in `src/auto-reply/reply.triggers.group-intro-prompts.cases.ts` to match the new prompt wording.

## Why
The previous prompt forbade all message-tool sends to the same group, which also blocked legitimate interactive button sends. Group flows that need buttons (e.g., confirmation, model picker) had no way to render them without violating the guidance.

## Test plan
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/groups.test.ts` — 5/5 passed
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts` — 20/20 passed (consumes `registerGroupIntroPromptCases`)