### PR TITLE
fix: stabilize code mode timeout and prompt snapshots

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -889,6 +889,32 @@ describe("Code Mode", () => {
     expect(details.code).toBe("timeout");
   });
 
+  it("normalizes QuickJS interrupt timeout errors", () => {
+    expect(
+      testing.normalizeCodeModeWorkerResult({
+        status: "failed",
+        code: "timeout",
+        error: "interrupted",
+        output: [],
+      }),
+    ).toMatchObject({
+      code: "timeout",
+      error: "code mode timeout exceeded",
+    });
+
+    expect(
+      testing.normalizeCodeModeWorkerResult({
+        status: "failed",
+        code: "internal_error",
+        error: "interrupted",
+        output: [],
+      }),
+    ).toMatchObject({
+      code: "internal_error",
+      error: "interrupted",
+    });
+  });
+
   it("classifies missing worker runtime as unavailable", async () => {
     const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
     const missingWorkerUrl = new URL("./missing-code-mode.worker.js", import.meta.url);

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -546,6 +546,16 @@ function failedCodeModeWorkerResult(
   };
 }
 
+function normalizeCodeModeWorkerResult(result: CodeModeWorkerResult): CodeModeWorkerResult {
+  if (result.status === "failed" && result.code === "timeout" && result.error === "interrupted") {
+    return {
+      ...result,
+      error: "code mode timeout exceeded",
+    };
+  }
+  return result;
+}
+
 async function runCodeModeWorker(
   workerData: unknown,
   timeoutMs: number,
@@ -581,16 +591,15 @@ async function runCodeModeWorker(
       }, timeoutMs);
       worker.once("message", (message: unknown) => {
         void worker.terminate();
-        finish(
-          isRecord(message)
-            ? (message as CodeModeWorkerResult)
-            : {
-                status: "failed",
-                error: "invalid code mode worker response",
-                code: "internal_error",
-                output: [],
-              },
-        );
+        const result = isRecord(message)
+          ? (message as CodeModeWorkerResult)
+          : ({
+              status: "failed",
+              error: "invalid code mode worker response",
+              code: "internal_error",
+              output: [],
+            } satisfies CodeModeWorkerResult);
+        finish(normalizeCodeModeWorkerResult(result));
       });
       worker.once("error", (error) => {
         finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
@@ -992,6 +1001,7 @@ export const testing = {
   activeRuns,
   resumingRunIds,
   codeModeWorkerUrl,
+  normalizeCodeModeWorkerResult,
   runCodeModeWorker,
   resolveCodeModeWorkerUrl,
   resolveCodeModeConfig,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1185,7 +1185,7 @@
         "maxChars": {
           "description": "Max chars returned; truncates.",
           "minimum": 100,
-          "type": "number"
+          "type": "integer"
         },
         "url": {
           "description": "HTTP(S) URL.",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1217,7 +1217,7 @@
         "maxChars": {
           "description": "Max chars returned; truncates.",
           "minimum": 100,
-          "type": "number"
+          "type": "integer"
         },
         "url": {
           "description": "HTTP(S) URL.",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1181,7 +1181,7 @@
         "maxChars": {
           "description": "Max chars returned; truncates.",
           "minimum": 100,
-          "type": "number"
+          "type": "integer"
         },
         "url": {
           "description": "HTTP(S) URL.",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,7 +221,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40278,
+    "chars": 40279,
     "roughTokens": 10070
   },
   "openClawDeveloperInstructions": {
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67980,
-    "roughTokens": 16995
+    "chars": 67981,
+    "roughTokens": 16996
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,7 +221,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 39999,
+    "chars": 40000,
     "roughTokens": 10000
   },
   "openClawDeveloperInstructions": {
@@ -233,7 +233,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66177,
+    "chars": 66178,
     "roughTokens": 16545
   },
   "userInputText": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,7 +222,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41094,
+    "chars": 41095,
     "roughTokens": 10274
   },
   "openClawDeveloperInstructions": {
@@ -234,7 +234,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68215,
+    "chars": 68216,
     "roughTokens": 17054
   },
   "userInputText": {


### PR DESCRIPTION
## Summary
- Normalize code-mode worker timeout results that surface QuickJS's raw `interrupted` message after the result is already classified as `timeout`.
- Add regression coverage that preserves guest-thrown `interrupted` errors as non-timeout failures.
- Refresh Codex prompt snapshots for the existing Firecrawl `maxChars` integer schema drift that was also broken on current main, so both independent CI failures can be fixed in parallel.

## Verification
- `node scripts/run-vitest.mjs src/agents/code-mode.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts --reporter=verbose`
- `node --import tsx scripts/generate-prompt-snapshots.ts --check`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof
Behavior addressed: Code mode hostile infinite loops still time out, but dependency raw QuickJS `interrupted` timeout messages are normalized to OpenClaw's timeout message. Separately, committed Codex prompt snapshot fixtures now match the generator output for the Firecrawl `maxChars` integer schema that was already present on main.
Real environment tested: Local macOS checkout, Node via repo Vitest wrapper and prompt snapshot generator; GitHub Actions PR CI reproduced the prompt snapshot drift before the fixture refresh.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/code-mode.test.ts --reporter=verbose`; `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts --reporter=verbose`; `node --import tsx scripts/generate-prompt-snapshots.ts --check`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`.
Evidence after fix: Focused code-mode tests passed after rebase with 2 files and 66 tests passing; full `agents-core` shard passed before rebase with 301 files and 4378 tests passing, 4 skipped; prompt snapshot check reports 7 files current; diff check clean; autoreview reported no accepted/actionable findings before the snapshot-only follow-up.
Observed result after fix: The timeout result keeps `code: "timeout"` and normalizes `error` to `code mode timeout exceeded`; guest `Error("interrupted")` remains `internal_error`. Prompt snapshots now record `fetch_url.maxChars` as JSON schema `integer` and update the derived prompt size counts.
What was not tested: CI rerun was not manually dispatched; no live provider or end-to-end packaged lane was run because these are local worker/test fixture fixes.
