### PR TITLE
fix(ci): bound ClawHub docs checkout

### DIFF
--- a/.github/actions/detect-docs-changes/action.yml
+++ b/.github/actions/detect-docs-changes/action.yml
@@ -35,17 +35,29 @@ runs:
           exit 0
         fi
 
-        # Check if any changed file is a doc
-        DOCS=$(echo "$CHANGED" | grep -E '^docs/|\.md$|\.mdx$' || true)
-        if [ -n "$DOCS" ]; then
+        docs_changed=false
+        non_docs=false
+        while IFS= read -r changed_path; do
+          case "$changed_path" in
+            test/fixtures/*)
+              non_docs=true
+              ;;
+            docs/* | *.md | *.mdx)
+              docs_changed=true
+              ;;
+            *)
+              non_docs=true
+              ;;
+          esac
+        done <<< "$CHANGED"
+
+        if [ "$docs_changed" = "true" ]; then
           echo "docs_changed=true" >> "$GITHUB_OUTPUT"
         else
           echo "docs_changed=false" >> "$GITHUB_OUTPUT"
         fi
 
-        # Check if all changed files are docs or markdown
-        NON_DOCS=$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)
-        if [ -z "$NON_DOCS" ]; then
+        if [ "$non_docs" = "false" ]; then
           echo "docs_only=true" >> "$GITHUB_OUTPUT"
           echo "Docs-only change detected — skipping heavy jobs"
         else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1494,11 +1494,44 @@ jobs:
       - name: Checkout ClawHub docs source
         run: |
           set -euo pipefail
-          git init clawhub-source
-          git -C clawhub-source config gc.auto 0
-          git -C clawhub-source remote add origin "https://github.com/openclaw/clawhub.git"
-          git -C clawhub-source fetch --no-tags --depth=1 origin "+HEAD:refs/remotes/origin/checkout"
-          git -C clawhub-source checkout --detach refs/remotes/origin/checkout
+
+          workdir="$GITHUB_WORKSPACE/clawhub-source"
+          started_at="$(date +%s)"
+
+          reset_checkout_dir() {
+            mkdir -p "$workdir"
+            find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          }
+
+          checkout_attempt() {
+            local attempt="$1"
+
+            reset_checkout_dir
+            git init "$workdir" >/dev/null
+            git -C "$workdir" config gc.auto 0
+            git -C "$workdir" remote add origin "https://github.com/openclaw/clawhub.git"
+
+            timeout --signal=TERM --kill-after=10s 30s git -C "$workdir" \
+              -c protocol.version=2 \
+              fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
+              "+refs/heads/main:refs/remotes/origin/checkout" || return 1
+
+            git -C "$workdir" checkout --force --detach refs/remotes/origin/checkout || return 1
+            echo "ClawHub checkout attempt ${attempt}/5 succeeded"
+          }
+
+          for attempt in 1 2 3 4 5; do
+            if checkout_attempt "$attempt"; then
+              elapsed="$(( $(date +%s) - started_at ))"
+              echo "ClawHub checkout completed in ${elapsed}s"
+              exit 0
+            fi
+            echo "ClawHub checkout attempt ${attempt}/5 failed"
+            sleep $((attempt * 5))
+          done
+
+          echo "ClawHub checkout failed after 5 attempts" >&2
+          exit 1
 
       - name: Check docs
         env:


### PR DESCRIPTION
## Summary

- Bound the raw ClawHub docs-source checkout with a 30s fetch timeout, kill-after, five retries, and elapsed-time logging.
- Fetch `openclaw/clawhub` `refs/heads/main` explicitly while keeping unauthenticated Git reads.
- Treat `test/fixtures/**` markdown as fixture content so prompt snapshots do not trigger `check-docs`.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/detect-docs-changes/action.yml"); YAML.load_file(".github/workflows/ci.yml")'`
- `node scripts/check-workflows.mjs`
- Manual classifier probe: `test/fixtures/.../*.md` -> `docs_changed=false docs_only=false`; docs-only files -> `docs_changed=true docs_only=true`; mixed docs/source -> `docs_changed=true docs_only=false`
- Manual unauthenticated ClawHub fetch probe: `git -C <temp>/clawhub-source -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin '+refs/heads/main:refs/remotes/origin/checkout'`

## Real behavior proof

Behavior addressed: `check-docs` could spend minutes in the raw ClawHub checkout step, and prompt snapshot markdown under `test/fixtures/**` could trigger the docs lane.

Real environment tested: Local macOS checkout plus live unauthenticated Git fetch from `https://github.com/openclaw/clawhub.git`; CI target remains Ubuntu where `timeout` is already used by existing CI checkout steps.

Exact steps or command run after this patch: `git diff --check`; YAML parse with Ruby; `node scripts/check-workflows.mjs`; manual shell classifier probe; manual unauthenticated ClawHub `refs/heads/main` shallow fetch.

Evidence after fix: The classifier probe returned `docs_changed=false docs_only=false` for `test/fixtures/agents/prompt-snapshots/foo.md` plus JSON fixture content; the ClawHub fetch resolved `ff48b2c` from `main` successfully.

Observed result after fix: Fixture prompt snapshots no longer route to `check-docs`, and the ClawHub checkout path now has bounded fetch attempts with timing logs.

What was not tested: A full GitHub Actions PR run had not completed at PR creation time; local macOS does not provide GNU `timeout`, so the exact timeout wrapper was syntax-checked locally and relies on the existing Ubuntu CI environment contract.
