### PR TITLE
fix: preserve embedded base system prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents: fall back to local config pruning when the optional `agents delete` Gateway probe cannot authenticate, so offline installs can still delete agents without removing shared workspaces.
+- Agents: keep embedded runs on the OpenClaw system prompt after active tool selection. Thanks @shakkernerd.
 - Tighten phone-control mutation authorization [AI]. (#87150) Thanks @pgondhi987.
 - Clarify directive persistence authorization policy [AI]. (#86369) Thanks @pgondhi987.
 - Agents/Codex: keep spawned agent cwd/workspace state separated, keep hook context prompt-local, release session locks on timeout abort, avoid session event queue self-wait, preserve shared app-server state across startup or helper failures, keep native hook relay alive across restarts, route workspace memory through tools, resolve Codex runtime models first, report quarantined dynamic tools, format `skills` command output, and bound compaction/steering retries. (#87218, #86875, #86123, #87399, #87375, #87383, #87400) Thanks @mbelinky, @Alix-007, @luoyanglang, @yetval, and @sjf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents: fall back to local config pruning when the optional `agents delete` Gateway probe cannot authenticate, so offline installs can still delete agents without removing shared workspaces.
-- Agents: keep embedded runs on the OpenClaw system prompt after active tool selection. Thanks @shakkernerd.
 - Tighten phone-control mutation authorization [AI]. (#87150) Thanks @pgondhi987.
 - Clarify directive persistence authorization policy [AI]. (#86369) Thanks @pgondhi987.
 - Agents/Codex: keep spawned agent cwd/workspace state separated, keep hook context prompt-local, release session locks on timeout abort, avoid session event queue self-wait, preserve shared app-server state across startup or helper failures, keep native hook relay alive across restarts, route workspace memory through tools, resolve Codex runtime models first, report quarantined dynamic tools, format `skills` command output, and bound compaction/steering retries. (#87218, #86875, #86123, #87399, #87375, #87383, #87400) Thanks @mbelinky, @Alix-007, @luoyanglang, @yetval, and @sjf.

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -110,6 +110,7 @@ function createMockCompactionSession() {
         set messages(messages: unknown[]) {
           session.messages = [...messages];
         },
+        systemPrompt: undefined as string | undefined,
       },
     },
     compact: vi.fn(async () => {
@@ -117,6 +118,9 @@ function createMockCompactionSession() {
       return await sessionCompactImpl();
     }),
     setActiveToolsByName: vi.fn(),
+    setBaseSystemPrompt: vi.fn((systemPrompt: string) => {
+      session.agent.state.systemPrompt = systemPrompt;
+    }),
     abortCompaction: sessionAbortCompactionMock,
     dispose: vi.fn(),
   };
@@ -854,7 +858,11 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("./system-prompt.js", () => ({
-    applySystemPromptToSession: vi.fn(),
+    applySystemPromptToSession: vi.fn(
+      (session: { setBaseSystemPrompt: (systemPrompt: string) => void }, systemPrompt: string) => {
+        session.setBaseSystemPrompt(systemPrompt);
+      },
+    ),
     buildEmbeddedSystemPrompt: buildEmbeddedSystemPromptMock,
   }));
 

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -473,7 +473,8 @@ export async function loadCompactHooksHarness(): Promise<{
     resolveProviderSystemPromptContribution: vi.fn(() => undefined),
     resolveProviderTextTransforms: vi.fn(() => undefined),
     transformProviderSystemPrompt: vi.fn(
-      (params: { systemPrompt?: string }) => params.systemPrompt,
+      (params: { systemPrompt?: string; context?: { systemPrompt?: string } }) =>
+        params.context?.systemPrompt ?? params.systemPrompt,
     ),
   }));
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
   applyExtraParamsToAgentMock,
   applyAgentCompactionSettingsFromConfigMock,

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -309,6 +309,30 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
   });
 
+  it("keeps the embedded compaction system prompt after active tool selection", async () => {
+    buildEmbeddedSystemPromptMock.mockReturnValueOnce("compaction system prompt");
+
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    const createdSession = (await createAgentSessionMock.mock.results[0]?.value) as {
+      session: {
+        agent: { state: { systemPrompt?: string } };
+        setActiveToolsByName: Mock;
+        setBaseSystemPrompt: Mock;
+      };
+    };
+
+    expect(createdSession.session.agent.state.systemPrompt).toBe("compaction system prompt");
+    expect(createdSession.session.setActiveToolsByName.mock.invocationCallOrder[0]).toBeLessThan(
+      createdSession.session.setBaseSystemPrompt.mock.invocationCallOrder[0],
+    );
+  });
+
   it("routes compaction through shared stream resolution and extra params", () => {
     const resolvedStreamFn = vi.fn();
     resolveEmbeddedAgentStreamFnMock.mockReturnValue(resolvedStreamFn);

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -327,7 +327,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       };
     };
 
-    expect(createdSession.session.agent.state.systemPrompt).toBe("compaction system prompt");
+    expect(createdSession.session.setBaseSystemPrompt).toHaveBeenCalledWith(
+      "compaction system prompt",
+    );
     expect(createdSession.session.setActiveToolsByName.mock.invocationCallOrder[0]).toBeLessThan(
       createdSession.session.setBaseSystemPrompt.mock.invocationCallOrder[0],
     );

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1124,6 +1124,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
         // Rebuild the compaction session on retry so provider wrappers, payload
         // shaping, and the embedded system prompt all reflect the fallback level.
         attemptedThinking.add(thinkLevel);
+        const systemPromptText = buildSystemPromptText(thinkLevel);
         let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
         try {
           const createdSession = await createAgentSession({
@@ -1140,8 +1141,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
             resourceLoader,
           });
           session = createdSession.session;
-          applySystemPromptToSession(session, buildSystemPromptText(thinkLevel));
           session.setActiveToolsByName(sessionToolAllowlist);
+          applySystemPromptToSession(session, systemPromptText);
           // Compaction builds the same embedded system prompt, so it must flow
           // through the same transport/payload shaping stack as normal turns.
           prepareCompactionSessionAgent({

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -320,6 +320,22 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(activeToolNames).toEqual([["healthy_lookup"]]);
   });
 
+  it("keeps the embedded system prompt after active tool selection", async () => {
+    let seenSystemPrompt: string | undefined;
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      sessionMessages: [seedMessage],
+      sessionPrompt: async (activeSession) => {
+        seenSystemPrompt = activeSession.agent.state.systemPrompt;
+      },
+    });
+
+    expect(seenSystemPrompt).toBe("system prompt");
+  });
+
   it("enforces code-mode payload surface from active-agent config during an embedded attempt", async () => {
     const observedOptions: Array<Record<string, unknown>> = [];
     const payloads: Array<Record<string, unknown>> = [];

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -524,7 +524,7 @@ vi.mock("../system-prompt.js", async () => {
     ...actual,
     applySystemPromptToSession: (session: MutableSession, systemPrompt: string) => {
       hoisted.systemPromptTexts.push(systemPrompt);
-      session.agent.state.systemPrompt = systemPrompt;
+      session.setBaseSystemPrompt(systemPrompt);
     },
     buildEmbeddedSystemPrompt: (params: unknown) => {
       hoisted.embeddedSystemPromptInputs.push(params);
@@ -855,6 +855,7 @@ export type MutableSession = {
     prompt: string,
     options?: { images?: unknown[]; preflightResult?: (submitted: boolean) => void },
   ) => Promise<void>;
+  setBaseSystemPrompt: (systemPrompt: string) => void;
   sendCustomMessage: (
     message: {
       customType: string;
@@ -1063,6 +1064,9 @@ export function createDefaultEmbeddedSession(params?: {
       },
     },
     setActiveToolsByName: () => {},
+    setBaseSystemPrompt: (systemPrompt) => {
+      session.agent.state.systemPrompt = systemPrompt;
+    },
     prompt: async (prompt, options) => {
       await session.agent.prompt?.(prompt, options);
       if (params?.prompt) {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2096,12 +2096,16 @@ export async function runEmbeddedAttempt(
         },
       });
       session = createdSession.session;
-      applySystemPromptToSession(session, systemPromptText);
       if (!session) {
         throw new Error("Embedded agent session missing");
       }
       session.setActiveToolsByName(sessionToolAllowlist);
       const activeSession = session;
+      const setActiveSessionSystemPrompt = (nextSystemPrompt: string) => {
+        systemPromptText = nextSystemPrompt;
+        applySystemPromptToSession(activeSession, nextSystemPrompt);
+      };
+      setActiveSessionSystemPrompt(systemPromptText);
       installMessageToolOnlyTerminalHook({
         agent: activeSession.agent,
         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
@@ -2113,8 +2117,7 @@ export async function runEmbeddedAttempt(
         // and queues; the empty system prompt prevents the runtime from rebuilding the
         // normal OpenClaw agent/tool prompt when `session.prompt()` starts.
         activeSession.agent.reset();
-        applySystemPromptToSession(activeSession, "");
-        systemPromptText = "";
+        setActiveSessionSystemPrompt("");
       }
       if (typeof activeSession.agent.convertToLlm === "function") {
         const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
@@ -2661,8 +2664,7 @@ export async function runEmbeddedAttempt(
       try {
         if (isRawModelRun) {
           activeSession.agent.reset();
-          applySystemPromptToSession(activeSession, "");
-          systemPromptText = "";
+          setActiveSessionSystemPrompt("");
           cacheTrace?.recordStage("session:raw-model-run", {
             messages: activeSession.messages,
             system: systemPromptText,
@@ -2739,11 +2741,12 @@ export async function runEmbeddedAttempt(
               hasSessionsYield: effectiveTools.some((tool) => tool.name === "sessions_yield"),
             });
             if (activeSubagentPromptAddition) {
-              systemPromptText = prependSystemPromptAddition({
-                systemPrompt: systemPromptText,
-                systemPromptAddition: activeSubagentPromptAddition,
-              });
-              applySystemPromptToSession(activeSession, systemPromptText);
+              setActiveSessionSystemPrompt(
+                prependSystemPromptAddition({
+                  systemPrompt: systemPromptText,
+                  systemPromptAddition: activeSubagentPromptAddition,
+                }),
+              );
             }
           }
 
@@ -2805,11 +2808,12 @@ export async function runEmbeddedAttempt(
                 preassemblyContextEngineMessagesForPrecheck;
             }
             if (assembled.systemPromptAddition) {
-              systemPromptText = prependSystemPromptAddition({
-                systemPrompt: systemPromptText,
-                systemPromptAddition: assembled.systemPromptAddition,
-              });
-              applySystemPromptToSession(activeSession, systemPromptText);
+              setActiveSessionSystemPrompt(
+                prependSystemPromptAddition({
+                  systemPrompt: systemPromptText,
+                  systemPromptAddition: assembled.systemPromptAddition,
+                }),
+              );
               log.debug(
                 `context engine: prepended system prompt addition (${assembled.systemPromptAddition.length} chars)`,
               );
@@ -3277,8 +3281,7 @@ export async function runEmbeddedAttempt(
           }
           const legacySystemPrompt = normalizeOptionalString(hookResult?.systemPrompt) ?? "";
           if (legacySystemPrompt) {
-            applySystemPromptToSession(activeSession, legacySystemPrompt);
-            systemPromptText = legacySystemPrompt;
+            setActiveSessionSystemPrompt(legacySystemPrompt);
             log.debug(`hooks: applied systemPrompt (${legacySystemPrompt.length} chars)`);
           }
           const prependedOrAppendedSystemPrompt = composeSystemPromptWithHookContext({
@@ -3293,8 +3296,7 @@ export async function runEmbeddedAttempt(
           if (prependedOrAppendedSystemPrompt) {
             const prependSystemLen = hookResult?.prependSystemContext?.trim().length ?? 0;
             const appendSystemLen = hookResult?.appendSystemContext?.trim().length ?? 0;
-            applySystemPromptToSession(activeSession, prependedOrAppendedSystemPrompt);
-            systemPromptText = prependedOrAppendedSystemPrompt;
+            setActiveSessionSystemPrompt(prependedOrAppendedSystemPrompt);
             log.debug(
               `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
             );
@@ -3305,8 +3307,7 @@ export async function runEmbeddedAttempt(
           model: runtimeInfo.model,
         });
         if (modelAwareSystemPrompt !== systemPromptText) {
-          applySystemPromptToSession(activeSession, modelAwareSystemPrompt);
-          systemPromptText = modelAwareSystemPrompt;
+          setActiveSessionSystemPrompt(modelAwareSystemPrompt);
         }
 
         if (cacheObservabilityEnabled) {
@@ -3481,8 +3482,7 @@ export async function runEmbeddedAttempt(
               appendSystemContext: runtimeSystemContext,
             });
             if (runtimeSystemPrompt) {
-              applySystemPromptToSession(activeSession, runtimeSystemPrompt);
-              systemPromptText = runtimeSystemPrompt;
+              setActiveSessionSystemPrompt(runtimeSystemPrompt);
             }
           }
           const runtimeContextForHook = promptSubmission.runtimeOnly

--- a/src/agents/embedded-agent-runner/system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.test.ts
@@ -1,63 +1,24 @@
-import type { AgentSession } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearMemoryPluginState, registerMemoryPromptSection } from "../../plugins/memory-state.js";
+import type { AgentSession } from "../sessions/index.js";
 import { applySystemPromptToSession, buildEmbeddedSystemPrompt } from "./system-prompt.js";
 
 vi.mock("../../tts/tts.js", () => ({
   buildTtsSystemPromptHint: vi.fn(() => undefined),
 }));
 
-type MutableSession = {
-  _baseSystemPrompt?: string;
-  _rebuildSystemPrompt?: (toolNames: string[]) => string;
-};
-
-type MockSession = MutableSession & {
-  agent: {
-    state: {
-      systemPrompt?: string;
-    };
-  };
-};
-
-function createMockSession(): {
-  session: MockSession;
-} {
-  const session = {
-    agent: { state: {} },
-  } as MockSession;
-  return { session };
-}
-
-function applyAndGetMutableSession(prompt: Parameters<typeof applySystemPromptToSession>[1]) {
-  const { session } = createMockSession();
-  applySystemPromptToSession(session as unknown as AgentSession, prompt);
-  return {
-    mutable: session,
-  };
-}
-
 describe("applySystemPromptToSession", () => {
-  it("applies the string to the session system prompt", () => {
-    const prompt = "You are a helpful assistant with custom context.";
-    const { mutable } = applyAndGetMutableSession(prompt);
+  it("applies the trimmed prompt through the session base prompt setter", () => {
+    const setBaseSystemPrompt = vi.fn();
 
-    expect(mutable.agent.state.systemPrompt).toBe(prompt);
-    expect(mutable["_baseSystemPrompt"]).toBe(prompt);
-  });
+    applySystemPromptToSession(
+      { setBaseSystemPrompt } as unknown as AgentSession,
+      "  embedded prompt  ",
+    );
 
-  it("trims whitespace", () => {
-    const { mutable } = applyAndGetMutableSession("  padded prompt  ");
-
-    expect(mutable.agent.state.systemPrompt).toBe("padded prompt");
-  });
-
-  it("sets _rebuildSystemPrompt that returns the prompt", () => {
-    const { mutable } = applyAndGetMutableSession("rebuild test");
-    expect(mutable["_rebuildSystemPrompt"]?.(["tool1"])).toBe("rebuild test");
+    expect(setBaseSystemPrompt).toHaveBeenCalledWith("embedded prompt");
   });
 });
-
 describe("buildEmbeddedSystemPrompt", () => {
   afterEach(() => {
     clearMemoryPluginState();

--- a/src/agents/embedded-agent-runner/system-prompt.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.ts
@@ -123,12 +123,5 @@ export function buildEmbeddedSystemPrompt(params: {
 }
 
 export function applySystemPromptToSession(session: AgentSession, systemPrompt: string) {
-  const prompt = systemPrompt.trim();
-  session.agent.state.systemPrompt = prompt;
-  const mutableSession = session as unknown as {
-    _baseSystemPrompt?: string;
-    _rebuildSystemPrompt?: (toolNames: string[]) => string;
-  };
-  mutableSession["_baseSystemPrompt"] = prompt;
-  mutableSession["_rebuildSystemPrompt"] = () => prompt;
+  session.setBaseSystemPrompt(systemPrompt.trim());
 }

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -369,6 +369,7 @@ export class AgentSession {
   // Base system prompt (without extension appends) - used to apply fresh appends each turn
   private baseSystemPrompt = "";
   private baseSystemPromptOptions!: BuildSystemPromptOptions;
+  private exactBaseSystemPrompt: string | undefined;
 
   constructor(config: AgentSessionConfig) {
     this.agent = config.agent;
@@ -889,6 +890,20 @@ export class AgentSession {
     this.agent.state.systemPrompt = this.baseSystemPrompt;
   }
 
+  /** Set an exact base prompt owned by the current runtime. */
+  setBaseSystemPrompt(systemPrompt: string): void {
+    this.exactBaseSystemPrompt = systemPrompt;
+    this.baseSystemPrompt = systemPrompt;
+    this.baseSystemPromptOptions = {
+      cwd: this.cwd,
+      selectedTools: this.getActiveToolNames(),
+      toolSnippets: {},
+      promptGuidelines: [],
+      customPrompt: systemPrompt,
+    };
+    this.agent.state.systemPrompt = systemPrompt;
+  }
+
   /** Whether compaction or branch summarization is currently running */
   get isCompacting(): boolean {
     return (
@@ -983,6 +998,18 @@ export class AgentSession {
       if (toolGuidelines) {
         promptGuidelines.push(...toolGuidelines);
       }
+    }
+
+    if (this.exactBaseSystemPrompt !== undefined) {
+      this.baseSystemPromptOptions = {
+        ...this.baseSystemPromptOptions,
+        cwd: this.cwd,
+        customPrompt: this.exactBaseSystemPrompt,
+        selectedTools: validToolNames,
+        toolSnippets,
+        promptGuidelines,
+      };
+      return this.exactBaseSystemPrompt;
     }
 
     const loaderSystemPrompt = this.sessionResourceLoader.getSystemPrompt();

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -283,6 +283,12 @@ interface ToolDefinitionEntry {
   sourceInfo: SourceInfo;
 }
 
+type ActiveToolPromptMetadata = {
+  validToolNames: string[];
+  toolSnippets: Record<string, string>;
+  promptGuidelines: string[];
+};
+
 type CompactionReason = "manual" | "threshold" | "overflow";
 
 type CompactionWorkOutcome =
@@ -892,13 +898,16 @@ export class AgentSession {
 
   /** Set an exact base prompt owned by the current runtime. */
   setBaseSystemPrompt(systemPrompt: string): void {
+    const { validToolNames, toolSnippets, promptGuidelines } = this.collectActiveToolPromptMetadata(
+      this.getActiveToolNames(),
+    );
     this.exactBaseSystemPrompt = systemPrompt;
     this.baseSystemPrompt = systemPrompt;
     this.baseSystemPromptOptions = {
       cwd: this.cwd,
-      selectedTools: this.getActiveToolNames(),
-      toolSnippets: {},
-      promptGuidelines: [],
+      selectedTools: validToolNames,
+      toolSnippets,
+      promptGuidelines,
       customPrompt: systemPrompt,
     };
     this.agent.state.systemPrompt = systemPrompt;
@@ -984,7 +993,7 @@ export class AgentSession {
     return Array.from(unique);
   }
 
-  private rebuildSystemPrompt(toolNames: string[]): string {
+  private collectActiveToolPromptMetadata(toolNames: string[]): ActiveToolPromptMetadata {
     const validToolNames = toolNames.filter((name) => this.toolRegistry.has(name));
     const toolSnippets: Record<string, string> = {};
     const promptGuidelines: string[] = [];
@@ -999,6 +1008,13 @@ export class AgentSession {
         promptGuidelines.push(...toolGuidelines);
       }
     }
+
+    return { validToolNames, toolSnippets, promptGuidelines };
+  }
+
+  private rebuildSystemPrompt(toolNames: string[]): string {
+    const { validToolNames, toolSnippets, promptGuidelines } =
+      this.collectActiveToolPromptMetadata(toolNames);
 
     if (this.exactBaseSystemPrompt !== undefined) {
       this.baseSystemPromptOptions = {

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -95,6 +95,36 @@ describe("createAgentSession tool defaults", () => {
     expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
   });
 
+  it("preserves an exact base system prompt when active tools change", async () => {
+    const customTool: ToolDefinition = {
+      name: "custom_lookup",
+      label: "Custom Lookup",
+      description: "Looks up a test value.",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        details: {},
+      }),
+    };
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [customTool],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+    const systemPrompt = "You are a personal assistant running inside OpenClaw.";
+
+    session.setBaseSystemPrompt(systemPrompt);
+    session.setActiveToolsByName(["bash", "custom_lookup"]);
+
+    expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
+    expect(session.systemPrompt).toBe(systemPrompt);
+  });
+
   it("runs session message persistence under the configured write lock", async () => {
     const events: string[] = [];
     const sessionManager = SessionManager.inMemory();

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -102,6 +102,8 @@ describe("createAgentSession tool defaults", () => {
       name: "custom_lookup",
       label: "Custom Lookup",
       description: "Looks up a test value.",
+      promptSnippet: "Lookup test values",
+      promptGuidelines: ["Use custom_lookup for test values."],
       parameters: Type.Object({}),
       execute: async () => ({
         content: [{ type: "text", text: "ok" }],

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -70,6 +70,8 @@ describe("createAgentSession tool defaults", () => {
       name: "custom_lookup",
       label: "Custom Lookup",
       description: "Looks up a test value.",
+      promptSnippet: "Lookup test values",
+      promptGuidelines: ["Use custom_lookup for test values."],
       parameters: Type.Object({}),
       execute: async () => ({
         content: [{ type: "text", text: "ok" }],
@@ -123,6 +125,21 @@ describe("createAgentSession tool defaults", () => {
 
     expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
     expect(session.systemPrompt).toBe(systemPrompt);
+
+    const exactPromptOptions = (
+      session as unknown as {
+        baseSystemPromptOptions: {
+          selectedTools?: string[];
+          toolSnippets?: Record<string, string>;
+          promptGuidelines?: string[];
+        };
+      }
+    ).baseSystemPromptOptions;
+    expect(exactPromptOptions.selectedTools).toEqual(["custom_lookup"]);
+    expect(exactPromptOptions.toolSnippets).toEqual({
+      custom_lookup: "Lookup test values",
+    });
+    expect(exactPromptOptions.promptGuidelines).toEqual(["Use custom_lookup for test values."]);
   });
 
   it("runs session message persistence under the configured write lock", async () => {


### PR DESCRIPTION
## Summary

Fixes the embedded agent runtime prompt regression where active tool selection could replace the OpenClaw embedded system prompt with the generic coding-harness session prompt.

OpenClaw now owns the internal agent runtime, so the fix does not use private-field shims or a prompt override helper. Instead, `AgentSession` gets a narrow exact base-prompt path. Embedded runs and embedded compaction set their OpenClaw-built prompt as that exact session base prompt, and later prompt updates from context, hooks, runtime-only context, or model identity flow through the same path.

This keeps the model-visible embedded prompt byte-for-byte owned by the embedded runner and prevents `setActiveToolsByName(...)` from regenerating the generic session prompt.

Fixes #87807.

## Changes

- Add `AgentSession.setBaseSystemPrompt(...)` for runtime-owned exact base prompts.
- Preserve exact base prompts across active tool changes.
- Use the exact base-prompt path in embedded agent turns.
- Use the same path for embedded compaction sessions.
- Remove the old `applySystemPromptOverrideToSession(...)` shim and its private-field tests.
- Add regression coverage for:
  - exact base prompts surviving active tool changes;
  - embedded-attempt prompt preservation after tool activation;
  - existing embedded prompt construction behavior.

## Verification

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/resource-loader.test.ts src/agents/embedded-agent-runner/system-prompt.test.ts src/agents/sessions/sdk.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts`
  - 7 files passed
  - 133 tests passed

Note: a Crabbox/Testbox run was started, then intentionally stopped before completion when the branch was pushed immediately. GitHub CI is running on the updated PR head.
