### PR TITLE
docs: correct CI timing summary guidance

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,7 +43,7 @@ OpenClaw CI runs on every push to `main` and every pull request. The `preflight`
 
 GitHub may mark superseded jobs as `cancelled` when a newer push lands on the same PR or `main` ref. Treat that as CI noise unless the newest run for the same ref is also failing. Matrix jobs use `fail-fast: false`, and `build-artifacts` reports embedded channel, core-support-boundary, and gateway-watch failures directly instead of queuing tiny verifier jobs. The automatic CI concurrency key is versioned (`CI-v7-*`) so a GitHub-side zombie in an old queue group cannot indefinitely block newer main runs. Manual full-suite runs use `CI-manual-v1-*` and do not cancel in-progress runs.
 
-The `ci-timings-summary` job uploads a compact `ci-timings-summary` artifact for each non-draft CI run. It records wall time, queue time, slowest jobs, and failed jobs for the current run, so CI health checks do not need to scrape the full Actions payload repeatedly. The `build-artifacts` job also runs the blocking startup-memory smoke and uploads a `startup-memory` artifact with per-command RSS values for `--help`, `status --json`, and `gateway status`.
+Use `pnpm ci:timings`, `pnpm ci:timings:recent`, or `node scripts/ci-run-timings.mjs <run-id>` to summarize wall time, queue time, slowest jobs, and failures from GitHub Actions. For build timing, check the `build-artifacts` job's `Build dist` step: `pnpm build:ci-artifacts` prints `[build-all] phase timings:` and includes `ui:build`. The job also uploads the `startup-memory` artifact.
 
 ## Real behavior proof
 


### PR DESCRIPTION
## Summary

- Docs-only: correct `docs/ci.md` after #87514.
- Clarify that CI timing data now comes from `pnpm ci:timings` / `scripts/ci-run-timings.mjs` and `build-all` phase timing log output, not a standalone `ci-timings-summary` artifact.
- Note that `build-artifacts` runs `pnpm build:ci-artifacts`, which already includes `ui:build`; `startup-memory` remains the uploaded artifact.

## Verification

- `pnpm docs:list`
- `git diff --check origin/main...HEAD`
- `pnpm docs:check-mdx`
- Focused `rg` checks for timing commands, workflow steps, phase timing output, and `startup-memory` artifact references.

## Real behavior proof

Behavior addressed: CI docs claimed a standalone timing-summary artifact exists, but current CI exposes timing through scripts and `build-all` phase timing logs.

Real environment tested: Local docs worktree rebased onto current `origin/main`.

Exact steps or command run after this patch: `pnpm docs:list`; `git diff --check origin/main...HEAD`; `pnpm docs:check-mdx`; focused `rg` source checks.

Evidence after fix: Source checks confirm #87514 added `build-all` phase timing output and removed the duplicate `Build Control UI` step; no standalone `ci-timings-summary` artifact is present in current CI.

Observed result after fix: Docs checks passed; branch changes only `docs/ci.md`.

What was not tested: Full GitHub Actions run; docs-only change.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

```text
User asked to continue the docs timing work, rebase the existing docs-only worktree, verify it, commit, push, and open a PR.

Codex inspected the existing `docs/ci.md` diff, confirmed it only corrected the stale standalone `ci-timings-summary` artifact claim, rebased onto current `origin/main`, and verified the docs change with `pnpm docs:list`, `git diff --check origin/main...HEAD`, `pnpm docs:check-mdx`, and focused source `rg` checks.

After the user approved including a transcript, Codex opened #87813 with the docs-only commit `baf0e48ae0`.
```

</details>
<!-- agent-transcript:end -->


