### PR TITLE
Fix config set slash args

### DIFF
--- a/extensions/discord/src/monitor/native-command.args.ts
+++ b/extensions/discord/src/monitor/native-command.args.ts
@@ -1,4 +1,5 @@
 import {
+  findCommandByNativeName,
   type ChatCommandDefinition,
   type CommandArgDefinition,
   type CommandArgValues,
@@ -32,14 +33,18 @@ export function readDiscordCommandArgs(
 }
 
 export function createNativeCommandDefinition(command: NativeCommandSpec): ChatCommandDefinition {
+  const sharedCommand = findCommandByNativeName(command.name);
   return {
-    key: command.name,
-    nativeName: command.name,
-    description: command.description,
+    key: sharedCommand?.key ?? command.name,
+    nativeName: sharedCommand?.nativeName ?? command.name,
+    description: sharedCommand?.description ?? command.description,
+    descriptionLocalizations:
+      sharedCommand?.descriptionLocalizations ?? command.descriptionLocalizations,
     textAliases: [],
     acceptsArgs: command.acceptsArgs,
-    args: command.args,
-    argsParsing: "none",
+    args: sharedCommand?.args ?? command.args,
+    argsParsing: sharedCommand?.argsParsing ?? "none",
+    formatArgs: sharedCommand?.formatArgs,
     scope: "native",
   };
 }

--- a/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
@@ -63,6 +63,7 @@ export function createNativeCommandTestParams(
 
 export function createTelegramPrivateCommandContext(params?: {
   match?: string;
+  text?: string;
   messageId?: number;
   date?: number;
   chatId?: number;
@@ -76,6 +77,7 @@ export function createTelegramPrivateCommandContext(params?: {
       message_id: params?.messageId ?? 1,
       date: params?.date ?? Math.floor(Date.now() / 1000),
       chat: { id: params?.chatId ?? 100, type: "private" as const },
+      ...(params?.text != null ? { text: params.text } : {}),
       ...(params?.threadId != null ? { message_thread_id: params.threadId } : {}),
       from: { id: params?.userId ?? 200, username: params?.username ?? "bob" },
     },

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -411,6 +411,69 @@ describe("registerTelegramNativeCommands", () => {
     expect(parseTelegramNativeCommandCallbackData("tgcmd:fast status")).toBeNull();
   });
 
+  it("preserves raw /config values when routing Telegram native commands", async () => {
+    const { bot, commandHandlers } = createCommandBot();
+    const params = createNativeCommandTestParams(
+      { commands: { config: true } },
+      { bot, allowFrom: [200] },
+    );
+
+    registerTelegramNativeCommands(params);
+
+    const handler = commandHandlers.get("config");
+    if (!handler) {
+      throw new Error("expected config command handler to be registered");
+    }
+    await handler(
+      createPrivateCommandContext({
+        match: 'set messages.responsePrefix="[cu-bracket]"',
+      }),
+    );
+
+    const dispatchParams = firstCallArg(
+      params.telegramDeps?.dispatchReplyWithBufferedBlockDispatcher as unknown as {
+        mock: { calls: Array<Array<unknown>> };
+      },
+    );
+    const ctxPayload = dispatchParams.ctx as Record<string, unknown>;
+    expect(ctxPayload.CommandBody).toBe('/config set messages.responsePrefix="[cu-bracket]"');
+    expect(ctxPayload.CommandArgs).toEqual({
+      raw: 'set messages.responsePrefix="[cu-bracket]"',
+    });
+  });
+
+  it("prefers Telegram message text when framework command payload drops bracketed spans", async () => {
+    const { bot, commandHandlers } = createCommandBot();
+    const params = createNativeCommandTestParams(
+      { commands: { config: true } },
+      { bot, allowFrom: [200] },
+    );
+
+    registerTelegramNativeCommands(params);
+
+    const handler = commandHandlers.get("config");
+    if (!handler) {
+      throw new Error("expected config command handler to be registered");
+    }
+    await handler(
+      createPrivateCommandContext({
+        match: 'set messages.responsePrefix="prepost"',
+        text: '/config set messages.responsePrefix="pre[cu]post"',
+      }),
+    );
+
+    const dispatchParams = firstCallArg(
+      params.telegramDeps?.dispatchReplyWithBufferedBlockDispatcher as unknown as {
+        mock: { calls: Array<Array<unknown>> };
+      },
+    );
+    const ctxPayload = dispatchParams.ctx as Record<string, unknown>;
+    expect(ctxPayload.CommandBody).toBe('/config set messages.responsePrefix="pre[cu]post"');
+    expect(ctxPayload.CommandArgs).toEqual({
+      raw: 'set messages.responsePrefix="pre[cu]post"',
+    });
+  });
+
   it("passes agent-scoped media roots for plugin command replies with media", async () => {
     const mediaMaxBytes = 50 * 1024 * 1024;
     const cfg: OpenClawConfig = {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -142,6 +142,49 @@ type TelegramNativeCommandThreadContext = {
   threadParams: ReturnType<typeof buildTelegramThreadParams>;
 };
 
+function resolveTelegramNativeCommandPayloadFromText(params: {
+  text?: unknown;
+  commandName: string;
+  botUsername?: string;
+}): string | undefined {
+  if (typeof params.text !== "string") {
+    return undefined;
+  }
+  const text = params.text.trimStart();
+  if (!text.startsWith("/")) {
+    return undefined;
+  }
+
+  let index = 1;
+  while (index < text.length && /[A-Za-z0-9_]/.test(text[index] ?? "")) {
+    index += 1;
+  }
+  const incomingName = text.slice(1, index);
+  if (
+    normalizeTelegramCommandName(incomingName) !== normalizeTelegramCommandName(params.commandName)
+  ) {
+    return undefined;
+  }
+
+  if (text[index] === "@") {
+    let mentionEnd = index + 1;
+    while (mentionEnd < text.length && /[A-Za-z0-9_]/.test(text[mentionEnd] ?? "")) {
+      mentionEnd += 1;
+    }
+    const mention = text.slice(index + 1, mentionEnd);
+    const botUsername = normalizeOptionalLowercaseString(params.botUsername);
+    if (botUsername && normalizeOptionalLowercaseString(mention) !== botUsername) {
+      return undefined;
+    }
+    index = mentionEnd;
+  }
+
+  if (index < text.length && !/\s/.test(text[index] ?? "")) {
+    return undefined;
+  }
+  return text.slice(index).trim();
+}
+
 let telegramNativeCommandDeliveryRuntimePromise:
   | Promise<typeof import("./bot-native-commands.delivery.runtime.js")>
   | undefined;
@@ -1092,7 +1135,14 @@ export const registerTelegramNativeCommands = ({
         const executionCfg = getRuntimeConfigSnapshot() ?? cfg;
 
         const commandDefinition = findCommandByNativeName(command.name, "telegram");
-        const rawText = ctx.match?.trim() ?? "";
+        const rawText =
+          resolveTelegramNativeCommandPayloadFromText({
+            text: "text" in msg ? msg.text : undefined,
+            commandName: command.name,
+            botUsername: ctx.me?.username,
+          }) ??
+          ctx.match?.trim() ??
+          "";
         const commandArgs = commandDefinition
           ? parseCommandArgs(commandDefinition, rawText)
           : rawText
@@ -1369,7 +1419,14 @@ export const registerTelegramNativeCommands = ({
         const runtimeCfg = loadFreshRuntimeConfig();
         const runtimeTelegramCfg = resolveFreshTelegramConfig(runtimeCfg);
         const { threadParams } = await resolveTelegramNativeCommandThreadContext({ msg, bot });
-        const rawText = ctx.match?.trim() ?? "";
+        const rawText =
+          resolveTelegramNativeCommandPayloadFromText({
+            text: "text" in msg ? msg.text : undefined,
+            commandName: pluginCommand.command,
+            botUsername: ctx.me?.username,
+          }) ??
+          ctx.match?.trim() ??
+          "";
         const commandBody = `/${pluginCommand.command}${rawText ? ` ${rawText}` : ""}`;
         const nativeCommandRuntime = await loadTelegramNativeCommandRuntime();
         const match = nativeCommandRuntime.matchPluginCommand(commandBody);

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -27,6 +27,11 @@ describe("markdownToTelegramHtml", () => {
         "&lt;script&gt;nope&lt;/script&gt;",
       ],
       ["escapes unsafe characters", "a & b < c", "a &amp; b &lt; c"],
+      [
+        "keeps bracketed config values visible",
+        '⚙️ Config updated: messages.responsePrefix="[cu-bracket]"',
+        '⚙️ Config updated: messages.responsePrefix="[cu-bracket]"',
+      ],
       ["renders paragraphs with blank lines", "first\n\nsecond", "first\n\nsecond"],
       ["renders lists without block HTML", "- one\n- two", "• one\n• two"],
       ["renders ordered lists with numbering", "2. two\n3. three", "2. two\n3. three"],
@@ -57,6 +62,9 @@ describe("markdownToTelegramHtml", () => {
   it("does not promote Telegram HTML tags inside code", () => {
     expect(markdownToTelegramHtml("`<b>literal</b>`")).toBe(
       "<code>&lt;b&gt;literal&lt;/b&gt;</code>",
+    );
+    expect(markdownToTelegramHtml('```json\n"[cu-bracket]"\n```')).toBe(
+      '<pre><code class="language-json">"[cu-bracket]"\n</code></pre>',
     );
     expect(markdownToTelegramHtml("```\n<blockquote>literal</blockquote>\n```")).toBe(
       "<pre><code>&lt;blockquote&gt;literal&lt;/blockquote&gt;\n</code></pre>",

--- a/src/auto-reply/commands-args.test.ts
+++ b/src/auto-reply/commands-args.test.ts
@@ -18,6 +18,11 @@ describe("COMMAND_ARG_FORMATTERS", () => {
     expect(formatArgs("config", { action: "set" })).toBe("set");
     expect(formatArgs("config", { action: "set", path: "x" })).toBe("set x");
     expect(formatArgs("config", { action: "set", path: "x", value: 1 })).toBe("set x=1");
+    expect(formatArgs("config", { action: "set", path: "x", value: "1" })).toBe('set x="1"');
+    expect(formatArgs("config", { action: "set", path: "x", value: "[tag]" })).toBe(
+      'set x="[tag]"',
+    );
+    expect(formatArgs("config", { action: "set", path: "x", value: "" })).toBe('set x=""');
     expect(formatArgs("config", { action: "set", path: "x", value: { ok: true } })).toBe(
       'set x={"ok":true}',
     );

--- a/src/auto-reply/commands-args.ts
+++ b/src/auto-reply/commands-args.ts
@@ -26,6 +26,17 @@ function normalizeArgValue(value: unknown): string | undefined {
   return text ? text : undefined;
 }
 
+function formatAssignmentArgValue(value: unknown): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    const text = normalizeOptionalString(value) ?? "";
+    return JSON.stringify(text);
+  }
+  return normalizeArgValue(value);
+}
+
 function formatActionArgs(
   values: CommandArgValues,
   params: {
@@ -34,7 +45,7 @@ function formatActionArgs(
 ): string | undefined {
   const action = normalizeOptionalLowercaseString(normalizeArgValue(values.action));
   const path = normalizeArgValue(values.path);
-  const value = normalizeArgValue(values.value);
+  const value = formatAssignmentArgValue(values.value);
   if (!action) {
     return undefined;
   }

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -614,6 +614,26 @@ describe("commands registry args", () => {
     );
   });
 
+  it("serializes native config string values without changing their type", () => {
+    const command = requireNativeCommand("config");
+
+    expect(
+      buildCommandTextFromArgs(command, {
+        values: { action: "set", path: "messages.responsePrefix", value: "[tag]" },
+      }),
+    ).toBe('/config set messages.responsePrefix="[tag]"');
+    expect(
+      buildCommandTextFromArgs(command, {
+        values: { action: "set", path: "messages.responsePrefix", value: "true" },
+      }),
+    ).toBe('/config set messages.responsePrefix="true"');
+    expect(
+      buildCommandTextFromArgs(command, {
+        values: { action: "set", path: "messages.responsePrefix", value: "" },
+      }),
+    ).toBe('/config set messages.responsePrefix=""');
+  });
+
   it("resolves auto arg menus when missing a choice arg", () => {
     const command = createUsageModeCommand();
 

--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -171,10 +171,7 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
       }
       throw error;
     }
-    const valueLabel =
-      typeof configCommand.value === "string"
-        ? `"${configCommand.value}"`
-        : JSON.stringify(configCommand.value);
+    const valueLabel = JSON.stringify(configCommand.value);
     return {
       shouldContinue: false,
       reply: {

--- a/src/auto-reply/reply/commands-parse.test.ts
+++ b/src/auto-reply/reply/commands-parse.test.ts
@@ -35,6 +35,31 @@ describe("config/debug command parsing", () => {
         input: '/config set foo={"a":1}',
         expected: { action: "set", path: "foo", value: { a: 1 } },
       },
+      {
+        parse: parseConfigCommand,
+        input: '/config set messages.responsePrefix="cu-quoted"',
+        expected: { action: "set", path: "messages.responsePrefix", value: "cu-quoted" },
+      },
+      {
+        parse: parseConfigCommand,
+        input: '/config set messages.responsePrefix="[cu-bracket]"',
+        expected: { action: "set", path: "messages.responsePrefix", value: "[cu-bracket]" },
+      },
+      {
+        parse: parseConfigCommand,
+        input: "/config set messages.responsePrefix=[cu-unquoted]",
+        expected: { action: "set", path: "messages.responsePrefix", value: "[cu-unquoted]" },
+      },
+      {
+        parse: parseConfigCommand,
+        input: "/config set messages.responsePrefix={cu-objectish}",
+        expected: { action: "set", path: "messages.responsePrefix", value: "{cu-objectish}" },
+      },
+      {
+        parse: parseConfigCommand,
+        input: '/config set messages.responsePrefix="pre[cu]post"',
+        expected: { action: "set", path: "messages.responsePrefix", value: "pre[cu]post" },
+      },
       { parse: parseDebugCommand, input: "/debug", expected: { action: "show" } },
       { parse: parseDebugCommand, input: "/debug show", expected: { action: "show" } },
       { parse: parseDebugCommand, input: "/debug reset", expected: { action: "reset" } },

--- a/src/auto-reply/reply/config-value.ts
+++ b/src/auto-reply/reply/config-value.ts
@@ -10,8 +10,8 @@ export function parseConfigValue(raw: string): {
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
     try {
       return { value: JSON.parse(trimmed) };
-    } catch (err) {
-      return { error: `Invalid JSON: ${String(err)}` };
+    } catch {
+      return { value: trimmed };
     }
   }
 

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -18,6 +18,19 @@ describe("stripStructuralPrefixes", () => {
     expect(stripStructuralPrefixes("just a message")).toBe("just a message");
   });
 
+  it("preserves bracketed values inside command arguments", () => {
+    expect(stripStructuralPrefixes('/config set messages.responsePrefix="[cu]"')).toBe(
+      '/config set messages.responsePrefix="[cu]"',
+    );
+    expect(stripStructuralPrefixes('/config set messages.responsePrefix="pre[cu]post"')).toBe(
+      '/config set messages.responsePrefix="pre[cu]post"',
+    );
+  });
+
+  it("strips leading bracketed structural prefixes", () => {
+    expect(stripStructuralPrefixes("[Fri 2026-05-29 00:00 PDT] /status")).toBe("/status");
+  });
+
   it("flattens multiline soft reset commands before downstream parsing", () => {
     expect(stripStructuralPrefixes("/reset soft\nre-read persona files")).toBe(
       "/reset soft re-read persona files",

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -178,7 +178,7 @@ export function stripStructuralPrefixes(text: string): string {
     : text;
 
   return afterMarker
-    .replace(/\[[^\]]+\]\s*/g, "")
+    .replace(/(^|\n)[ \t]*\[[^\]\n]+\][ \t]*/g, "$1")
     .replace(/^[ \t]*[A-Za-z0-9+()\-_. ]+:\s*/gm, "")
     .replace(/\\n/g, " ")
     .replace(/\s+/g, " ")


### PR DESCRIPTION
## Summary
- Reuse the shared command definition when Discord native command handlers rebuild `/config` text so slash args keep their parser and formatter.
- Preserve Telegram native command payloads from raw message text when the framework-provided payload loses bracketed spans.
- Treat non-JSON bracket/object-like config values as literal strings and render config update replies with JSON string labels so stored values are visible.

## Verification
- `git diff --check origin/main...HEAD`
- Prior local proof before the rebase/squash: `node scripts/run-vitest.mjs src/auto-reply/reply/mentions.test.ts extensions/telegram/src/bot-native-commands.test.ts src/auto-reply/commands-args.test.ts src/auto-reply/commands-registry.test.ts src/auto-reply/reply/commands-parse.test.ts extensions/telegram/src/format.test.ts`
- Prior local proof before the rebase/squash: `node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.test.ts`

## Real behavior proof
Behavior addressed: `/config set` should preserve literal string values, including quoted and unquoted bracketed values, instead of dropping them or reporting a missing/invalid value.

Real environment tested: Telegram Desktop against the local gateway running this worktree as `OPENCLAW_REPO_DIR`.

Exact steps or command run after this patch: Sent `/config set messages.responsePrefix="[cu-fixed2]"`, `/config show messages.responsePrefix`, `/config set messages.responsePrefix=[cu-unquoted-fixed]`, and `/config unset messages.responsePrefix` in Telegram Desktop.

Evidence after fix: Telegram replies reported `Config updated: messages.responsePrefix="[cu-fixed2]"`, `Config messages.responsePrefix: "[cu-fixed2]"`, and `Config updated: messages.responsePrefix="[cu-unquoted-fixed]"`.

Observed result after fix: Both quoted and unquoted bracketed prefix values persisted as literal strings, and cleanup removed the key.

What was not tested: The test suite was not rerun after the final rebase/squash per instruction; only `git diff --check origin/main...HEAD` was run after the final commit.
