### PR TITLE
fix(chat): preserve keyboard activation while preventing picker blur race

### DIFF
--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -604,6 +604,7 @@ function renderChatSessionPickerPopover(
           title=${t("common.search")}
           aria-label=${t("common.search")}
           ?disabled=${controlsDisabled}
+          @mousedown=${(e: MouseEvent) => { if (e.button === 0) e.preventDefault(); }}
           @click=${() => void applyChatSessionPickerSearch(state)}
         >
           ${icons.search}
@@ -616,6 +617,7 @@ function renderChatSessionPickerPopover(
               title=${t("chat.selectors.clearSessionSearch")}
               aria-label=${t("chat.selectors.clearSessionSearch")}
               ?disabled=${controlsDisabled}
+              @mousedown=${(e: MouseEvent) => { if (e.button === 0) e.preventDefault(); }}
               @click=${() => clearChatSessionPickerSearch(state)}
             >
               ${icons.x}
@@ -652,6 +654,7 @@ function renderChatSessionPickerPopover(
                 aria-selected=${selected ? "true" : "false"}
                 title=${label}
                 type="button"
+                @mousedown=${(e: MouseEvent) => { if (e.button === 0) e.preventDefault(); }}
                 @click=${() => {
                   closeChatSessionPicker(state);
                   if (row.key !== state.sessionKey) {
@@ -681,6 +684,7 @@ function renderChatSessionPickerPopover(
               data-chat-session-load-more="true"
               type="button"
               ?disabled=${loadMoreDisabled}
+              @mousedown=${(e: MouseEvent) => { if (e.button === 0) e.preventDefault(); }}
               @click=${() => void loadMoreChatSessionPickerResults(state)}
             >
               ${t("chat.selectors.loadMoreSessions")}


### PR DESCRIPTION
## Summary

Supersedes #87557. Fixes #87554.

The session picker's `@blur` handler clears picker results before `@click` fires, causing a race where Lit re-renders remove option buttons before click handlers execute.

## Problem with #87557

The original fix replaced all `@click` handlers with `@mousedown`-only handlers. This prevents the blur race but **breaks keyboard accessibility** — native buttons fire `click` for Enter/Space, not `mousedown`, so keyboard users cannot activate picker controls.

## This fix

Add `@mousedown` with `preventDefault()` to suppress the focus-shift blur, **while keeping `@click` handlers** for keyboard activation:

- **`@mousedown` + `preventDefault()`**: Stops browser focus shift → prevents blur → DOM stays stable
- **`@click` preserved**: Keyboard Enter/Space still works (fires click, not mousedown)

This is exactly what ClawSweeper recommended: *"Use mouse-down only to prevent the focus-shift blur, and keep click or keyboard handlers as the activation path."*

## Changes

4 lines added to `ui/src/ui/chat/session-controls.ts`:
- Search submit button: +1 line
- Clear search button: +1 line  
- Session option button: +1 line
- Load more button: +1 line

## Testing

- Mouse: all 4 buttons respond on first click (blur race prevented)
- Keyboard: Enter/Space on focused buttons still activates (click handler preserved)
- Existing e2e tests should pass (Playwright dispatches both mousedown + click)