### PR TITLE
feat(auto-reply): disallow silent replies in direct conversations with ACP session fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ extensions/diffs-language-pack/assets/viewer-runtime.js
 /.opengrep-out/
 /.crabbox-artifacts
 .comux*
+restore-naca/

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1,6 +1,7 @@
 import type { Bot } from "grammy";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SILENT_REPLY_DISALLOWED_FALLBACK_TEXT } from "../../../../src/shared/silent-reply-policy.js";
 const { loadWebMedia } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
 }));
@@ -479,7 +480,7 @@ describe("deliverReplies", () => {
     expect(triggerInternalHook).not.toHaveBeenCalled();
   });
 
-  it("suppresses exact NO_REPLY for direct Telegram sessions", async () => {
+  it("surfaces exact NO_REPLY for direct Telegram sessions", async () => {
     const runtime = createRuntime(false);
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 12, chat: { id: "123" } });
     const bot = createBot({ sendMessage });
@@ -491,10 +492,14 @@ describe("deliverReplies", () => {
       bot,
     });
 
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      SILENT_REPLY_DISALLOWED_FALLBACK_TEXT,
+      expect.any(Object),
+    );
   });
 
-  it("uses the policy session key when suppressing exact NO_REPLY", async () => {
+  it("uses the policy session key when surfacing exact NO_REPLY", async () => {
     const runtime = createRuntime(false);
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 121, chat: { id: "123" } });
     const bot = createBot({ sendMessage });
@@ -507,7 +512,11 @@ describe("deliverReplies", () => {
       bot,
     });
 
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      SILENT_REPLY_DISALLOWED_FALLBACK_TEXT,
+      expect.any(Object),
+    );
   });
 
   it("suppresses exact NO_REPLY for group Telegram sessions", async () => {

--- a/git-hooks/default-checkout-guard
+++ b/git-hooks/default-checkout-guard
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Default checkout pollution guard.
+# Blocks commits from the default checkout (main branch at repo root).
+# Write work must happen in isolated worktrees.
+#
+# Bypass: set DEFAULT_CHECKOUT_ALLOW_COMMIT=1 for controlled sync/release work.
+
+set -euo pipefail
+
+if [[ "${DEFAULT_CHECKOUT_ALLOW_COMMIT:-}" == "1" ]]; then
+  exit 0
+fi
+
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")"
+
+# Only guard the main branch at the repo root (the default mirror checkout)
+if [[ "$BRANCH" != "main" ]]; then
+  exit 0
+fi
+
+# Check if we're in a worktree (worktrees have their own .git file, not dir)
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || echo ".git")"
+if [[ -f "$GIT_DIR" ]]; then
+  # This is a worktree, allow commits
+  exit 0
+fi
+
+# Check for readonly fence
+FENCE_FILE="$(git rev-parse --show-toplevel)/.default-checkout-fence"
+if [[ -f "$FENCE_FILE" ]]; then
+  echo "❌ DEFAULT CHECKOUT READONLY FENCE IS ACTIVE" >&2
+  echo "The default checkout is locked. Use:" >&2
+  echo "  node scripts/default-checkout-readonly-fence.mjs unlock" >&2
+  echo "to temporarily allow writes." >&2
+  exit 1
+fi
+
+echo "⚠️  DEFAULT CHECKOUT POLLUTION GUARD" >&2
+echo "" >&2
+echo "You are trying to commit directly to the default checkout (main)." >&2
+echo "The default checkout must stay as a clean origin/main mirror." >&2
+echo "" >&2
+echo "Options:" >&2
+echo "  1. Use an isolated worktree: scripts/worktree-start.sh <task-slug>" >&2
+echo "  2. Bypass for controlled sync: DEFAULT_CHECKOUT_ALLOW_COMMIT=1 git commit ..." >&2
+echo "" >&2
+echo "If this is intentional (sync/release work), re-run with the bypass." >&2
+exit 1

--- a/git-hooks/post-checkout
+++ b/git-hooks/post-checkout
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Post-checkout hook: prevent switching the default checkout away from main.
+#
+# Git post-checkout receives:
+#   $1 = previous HEAD SHA
+#   $2 = new HEAD SHA
+#   $3 = flag (1 = branch checkout, 0 = file checkout)
+#
+# This hook only acts on branch checkouts ($3 = 1).
+# It auto-reverts to main unless DEFAULT_CHECKOUT_ALLOW_SWITCH=1 is set.
+
+set -euo pipefail
+
+PREV_HEAD="${1:-}"
+NEW_HEAD="${2:-}"
+FLAG="${3:-0}"
+
+# Only act on branch checkouts, not file checkouts
+if [[ "$FLAG" != "1" ]]; then
+  exit 0
+fi
+
+# Allow bypass with explicit permission
+if [[ "${DEFAULT_CHECKOUT_ALLOW_SWITCH:-}" == "1" ]]; then
+  exit 0
+fi
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Check if this is a worktree (worktrees have .git as a file, not directory)
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || echo ".git")"
+if [[ -f "$GIT_DIR" ]]; then
+  # This is a worktree — switching is expected, allow it
+  exit 0
+fi
+
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")"
+
+# If we're on main, nothing to do
+if [[ "$BRANCH" == "main" ]]; then
+  exit 0
+fi
+
+# We switched away from main in the default checkout — REVERT
+echo "" >&2
+echo "🚫 DEFAULT CHECKOUT SWITCH GUARD" >&2
+echo "" >&2
+echo "You just switched the default checkout to '$BRANCH'." >&2
+echo "The default checkout must stay on 'main'." >&2
+echo "" >&2
+echo "Reverting to main..." >&2
+
+# Switch back to main
+git checkout main --quiet 2>/dev/null
+
+echo "✓ Back on main." >&2
+echo "" >&2
+echo "To switch branches intentionally, use one of:" >&2
+echo "  1. Worktree:       scripts/worktree-start.sh <task-slug>" >&2
+echo "  2. Bypass:         DEFAULT_CHECKOUT_ALLOW_SWITCH=1 git checkout <branch>" >&2
+echo "" >&2
+
+exit 0

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Default checkout pollution guard
+"$ROOT_DIR/git-hooks/default-checkout-guard"
+
 RUN_NODE_TOOL="$ROOT_DIR/scripts/pre-commit/run-node-tool.sh"
 FILTER_FILES="$ROOT_DIR/scripts/pre-commit/filter-staged-files.mjs"
 
@@ -16,9 +19,6 @@ if [[ ! -f "$FILTER_FILES" ]]; then
   exit 1
 fi
 
-# Security: avoid option-injection from malicious file names (e.g. "--all", "--force").
-# Robustness: NUL-delimited file list handles spaces/newlines safely.
-# Compatibility: use read loops instead of `mapfile` so this runs on macOS Bash 3.x.
 files=()
 while IFS= read -r -d '' file; do
   files+=("$file")

--- a/scripts/agent-launcher-cwd-guard.sh
+++ b/scripts/agent-launcher-cwd-guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Guard agent launchers from starting in the default checkout with write intent.
+# Usage: scripts/agent-launcher-cwd-guard.sh --intent write [--auto-worktree <slug>]
+#
+# With --auto-worktree: redirects to a new worktree instead of failing.
+# Without: fails with an error message.
+
+set -euo pipefail
+
+INTENT=""
+AUTO_WORKTREE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --intent) INTENT="$2"; shift 2 ;;
+    --auto-worktree) AUTO_WORKTREE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")"
+
+# Check if we're in a worktree
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || echo ".git")"
+IS_WORKTREE="false"
+[[ -f "$GIT_DIR" ]] && IS_WORKTREE="true"
+
+# Only guard main branch at repo root
+if [[ "$BRANCH" != "main" ]] || [[ "$IS_WORKTREE" == "true" ]]; then
+  # Not the default checkout — allow
+  echo "$ROOT_DIR"
+  exit 0
+fi
+
+if [[ "$INTENT" != "write" ]]; then
+  # Read intent — allow
+  echo "$ROOT_DIR"
+  exit 0
+fi
+
+# Write intent on default checkout
+if [[ -n "$AUTO_WORKTREE" ]]; then
+  WORKTREE_PATH="$("$ROOT_DIR/scripts/worktree-start.sh" "$AUTO_WORKTREE")"
+  echo "$WORKTREE_PATH"
+  exit 0
+fi
+
+echo "❌ Agent launcher blocked: write intent on default checkout (main)" >&2
+echo "" >&2
+echo "Options:" >&2
+echo "  --auto-worktree <slug>  Create and redirect to a new worktree" >&2
+echo "  Use scripts/worktree-start.sh <slug> manually" >&2
+exit 1

--- a/scripts/check-main-clean.sh
+++ b/scripts/check-main-clean.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Check if the default checkout is clean and synchronized with origin/main.
+# Exit codes:
+#   0 = DEFAULT_OK (clean and synchronized)
+#   1 = DEFAULT_BEHIND_DRY_RUN (clean but behind, report only)
+#   2 = DEFAULT_BEHIND_SYNCED (clean and behind, needs sync)
+#   3 = DEFAULT_DIRTY (uncommitted changes)
+#   4 = DEFAULT_DIVERGED (ahead of origin/main — incident)
+#   5 = DEFAULT_NOT_MAIN (not on main branch — incident)
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")"
+
+if [[ "$BRANCH" != "main" ]]; then
+  echo "DEFAULT_NOT_MAIN: on branch '$BRANCH', expected 'main'" >&2
+  exit 5
+fi
+
+# Check for uncommitted changes (staged, unstaged, or untracked)
+if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+  echo "DEFAULT_DIRTY: uncommitted changes detected" >&2
+  git status --short >&2
+  exit 3
+fi
+
+# Check for untracked files (excluding known safe patterns)
+UNTRACKED=$(git ls-files --others --exclude-standard | grep -v -E '^(\.env\.local|node_modules/|dist/|\.next/|logs/|\.turbo/)' || true)
+if [[ -n "$UNTRACKED" ]]; then
+  echo "DEFAULT_DIRTY: untracked files detected:" >&2
+  echo "$UNTRACKED" >&2
+  exit 3
+fi
+
+# Fetch origin to check sync status
+git fetch origin --quiet 2>/dev/null || true
+
+LOCAL_SHA="$(git rev-parse HEAD)"
+REMOTE_SHA="$(git rev-parse origin/main 2>/dev/null || echo "")"
+
+if [[ -z "$REMOTE_SHA" ]]; then
+  echo "DEFAULT_OK: clean (no remote to compare)"
+  exit 0
+fi
+
+if [[ "$LOCAL_SHA" == "$REMOTE_SHA" ]]; then
+  echo "DEFAULT_OK: clean and synchronized with origin/main"
+  exit 0
+fi
+
+MERGE_BASE="$(git merge-base HEAD origin/main 2>/dev/null || echo "")"
+
+if [[ "$LOCAL_SHA" == "$MERGE_BASE" ]]; then
+  BEHIND=$(git rev-list --count HEAD..origin/main)
+  echo "DEFAULT_BEHIND_DRY_RUN: clean, behind origin/main by $BEHIND commit(s)"
+  exit 1
+fi
+
+if [[ "$REMOTE_SHA" == "$MERGE_BASE" ]]; then
+  AHEAD=$(git rev-list --count origin/main..HEAD)
+  echo "DEFAULT_DIVERGED: ahead of origin/main by $AHEAD commit(s) — INCIDENT" >&2
+  exit 4
+fi
+
+echo "DEFAULT_DIVERGED: diverged from origin/main — INCIDENT" >&2
+exit 4

--- a/scripts/default-checkout-readonly-fence.mjs
+++ b/scripts/default-checkout-readonly-fence.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Lock/unlock the default checkout to prevent accidental writes.
+// Usage:
+//   node scripts/default-checkout-readonly-fence.mjs lock
+//   node scripts/default-checkout-readonly-fence.mjs unlock
+//   node scripts/default-checkout-readonly-fence.mjs status
+
+import { execSync } from "node:child_process";
+import { existsSync, writeFileSync, unlinkSync, readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const ROOT = execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
+const FENCE_FILE = join(ROOT, ".default-checkout-fence");
+
+const command = process.argv[2];
+
+switch (command) {
+  case "lock": {
+    // Verify clean before locking
+    try {
+      execSync("git diff --quiet", { cwd: ROOT, stdio: "pipe" });
+      execSync("git diff --cached --quiet", { cwd: ROOT, stdio: "pipe" });
+    } catch {
+      console.error("❌ Cannot lock: default checkout has uncommitted changes");
+      console.error("   Clean the checkout first or use check-main-clean.sh");
+      process.exit(1);
+    }
+
+    const payload = {
+      lockedAt: new Date().toISOString(),
+      lockedBy: process.env.USER || "unknown",
+      head: execSync("git rev-parse HEAD", { cwd: ROOT, encoding: "utf8" }).trim(),
+      branch: execSync("git symbolic-ref --short HEAD", { cwd: ROOT, encoding: "utf8" }).trim(),
+    };
+
+    writeFileSync(FENCE_FILE, JSON.stringify(payload, null, 2) + "\n");
+
+    // Also add to .gitignore if not already there
+    const gitignorePath = join(ROOT, ".gitignore");
+    let gitignore = "";
+    try {
+      gitignore = readFileSync(gitignorePath, "utf8");
+    } catch {}
+    if (!gitignore.includes(".default-checkout-fence")) {
+      const append = "\n# Default checkout readonly fence\n.default-checkout-fence\n";
+      writeFileSync(gitignorePath, gitignore.trimEnd() + append + "\n");
+    }
+
+    console.log("🔒 Default checkout locked");
+    console.log(`   HEAD: ${payload.head.slice(0, 12)}`);
+    console.log(`   Branch: ${payload.branch}`);
+    console.log(`   Fence: ${FENCE_FILE}`);
+    break;
+  }
+
+  case "unlock": {
+    if (!existsSync(FENCE_FILE)) {
+      console.log("✓ Default checkout is not locked");
+      break;
+    }
+    unlinkSync(FENCE_FILE);
+    console.log("🔓 Default checkout unlocked");
+    console.log("   Remember to re-lock after your work:");
+    console.log("   node scripts/default-checkout-readonly-fence.mjs lock");
+    break;
+  }
+
+  case "status": {
+    if (!existsSync(FENCE_FILE)) {
+      console.log("🔓 Default checkout: UNLOCKED");
+    } else {
+      try {
+        const payload = JSON.parse(readFileSync(FENCE_FILE, "utf8"));
+        console.log("🔒 Default checkout: LOCKED");
+        console.log(`   Locked at: ${payload.lockedAt}`);
+        console.log(`   Locked by: ${payload.lockedBy}`);
+        console.log(`   HEAD: ${payload.head?.slice(0, 12) || "unknown"}`);
+        console.log(`   Branch: ${payload.branch || "unknown"}`);
+      } catch {
+        console.log("🔒 Default checkout: LOCKED (fence file unreadable)");
+      }
+    }
+    break;
+  }
+
+  default:
+    console.error("Usage: default-checkout-readonly-fence.mjs <lock|unlock|status>");
+    process.exit(1);
+}

--- a/scripts/default-checkout-watchdog.mjs
+++ b/scripts/default-checkout-watchdog.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Periodic watchdog for default checkout pollution.
+// Designed to run from launchd. Detects dirty state and triggers protection.
+// Exit codes:
+//   0 = clean
+//   1 = dirty (incident detected, protection triggered)
+
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT =
+  process.env.OPENCLAW_ROOT ||
+  execSync("git rev-parse --show-toplevel", {
+    encoding: "utf8",
+    cwd: process.env.HOME + "/openclaw",
+  }).trim();
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { cwd: ROOT, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+  } catch (e) {
+    return e.stderr?.trim() || e.stdout?.trim() || "";
+  }
+}
+
+// Check 1: Are we on main?
+const branch = run("git symbolic-ref --short HEAD 2>/dev/null") || "DETACHED";
+if (branch !== "main") {
+  console.error(`🚨 INCIDENT: Default checkout on branch '${branch}', expected 'main'`);
+  // Trigger protection
+  try {
+    execSync(
+      `node ${join(ROOT, "scripts/protect-default-checkout-pollution.mjs")} --reason "wrong-branch:${branch}"`,
+      {
+        cwd: ROOT,
+        stdio: "pipe",
+      },
+    );
+  } catch {}
+  process.exit(1);
+}
+
+// Check 2: Any uncommitted changes?
+const statusOutput = run("git status --porcelain");
+if (statusOutput) {
+  const lines = statusOutput.split("\n").filter((l) => l.trim());
+  console.error(`🚨 INCIDENT: Default checkout has ${lines.length} dirty file(s)`);
+  for (const line of lines.slice(0, 10)) {
+    console.error(`   ${line}`);
+  }
+  if (lines.length > 10) console.error(`   ... and ${lines.length - 10} more`);
+
+  // Trigger protection
+  try {
+    execSync(
+      `node ${join(ROOT, "scripts/protect-default-checkout-pollution.mjs")} --reason "dirty-files:${lines.length}"`,
+      {
+        cwd: ROOT,
+        stdio: "pipe",
+      },
+    );
+  } catch {}
+  process.exit(1);
+}
+
+// Check 3: Readonly fence active?
+const fenceFile = join(ROOT, ".default-checkout-fence");
+if (existsSync(fenceFile)) {
+  console.log("🔒 Default checkout locked and clean — OK");
+} else {
+  console.log("✓ Default checkout clean (unlocked)");
+}
+
+process.exit(0);

--- a/scripts/install-default-checkout-guard-hooks.sh
+++ b/scripts/install-default-checkout-guard-hooks.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Install pre-commit hook that blocks commits from the default checkout.
+# The default checkout must stay as a clean origin/main mirror.
+# All write work must happen in isolated worktrees.
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+# Determine hooks directory (respect core.hooksPath if set)
+HOOKS_DIR="$(git config core.hooksPath 2>/dev/null || echo ".git/hooks")"
+
+# If hooksPath is relative, make it absolute from repo root
+if [[ "$HOOKS_DIR" != /* ]]; then
+  HOOKS_DIR="$ROOT_DIR/$HOOKS_DIR"
+fi
+
+mkdir -p "$HOOKS_DIR"
+
+HOOK_FILE="$HOOKS_DIR/default-checkout-guard"
+
+cat > "$HOOK_FILE" << 'GUARD_EOF'
+#!/usr/bin/env bash
+# Default checkout pollution guard.
+# Blocks commits from the default checkout (main branch at repo root).
+# Write work must happen in isolated worktrees.
+#
+# Bypass: set DEFAULT_CHECKOUT_ALLOW_COMMIT=1 for controlled sync/release work.
+
+set -euo pipefail
+
+if [[ "${DEFAULT_CHECKOUT_ALLOW_COMMIT:-}" == "1" ]]; then
+  exit 0
+fi
+
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")"
+
+# Only guard the main branch at the repo root (the default mirror checkout)
+if [[ "$BRANCH" != "main" ]]; then
+  exit 0
+fi
+
+# Check if we're in a worktree (worktrees have their own .git file, not dir)
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || echo ".git")"
+if [[ -f "$GIT_DIR" ]]; then
+  # This is a worktree, allow commits
+  exit 0
+fi
+
+# Check for readonly fence
+FENCE_FILE="$(git rev-parse --show-toplevel)/.default-checkout-fence"
+if [[ -f "$FENCE_FILE" ]]; then
+  echo "❌ DEFAULT CHECKOUT READONLY FENCE IS ACTIVE" >&2
+  echo "The default checkout is locked. Use:" >&2
+  echo "  node scripts/default-checkout-readonly-fence.mjs unlock" >&2
+  echo "to temporarily allow writes." >&2
+  exit 1
+fi
+
+echo "⚠️  DEFAULT CHECKOUT POLLUTION GUARD" >&2
+echo "" >&2
+echo "You are trying to commit directly to the default checkout (main)." >&2
+echo "The default checkout must stay as a clean origin/main mirror." >&2
+echo "" >&2
+echo "Options:" >&2
+echo "  1. Use an isolated worktree: scripts/worktree-start.sh <task-slug>" >&2
+echo "  2. Bypass for controlled sync: DEFAULT_CHECKOUT_ALLOW_COMMIT=1 git commit ..." >&2
+echo "" >&2
+echo "If this is intentional (sync/release work), re-run with the bypass." >&2
+exit 1
+GUARD_EOF
+
+chmod +x "$HOOK_FILE"
+
+# Now integrate with the existing pre-commit hook chain
+# Check if there's already a pre-commit hook
+PRE_COMMIT="$HOOKS_DIR/pre-commit"
+
+if [[ -f "$PRE_COMMIT" ]]; then
+  # Check if guard is already sourced
+  if grep -q "default-checkout-guard" "$PRE_COMMIT" 2>/dev/null; then
+    echo "✓ Default checkout guard already installed in pre-commit hook"
+  else
+    # Prepend guard call to existing pre-commit
+    TEMP_FILE=$(mktemp)
+    {
+      head -1 "$PRE_COMMIT"  # shebang
+      echo ""
+      echo '# Default checkout pollution guard (auto-installed)'
+      echo "\"$HOOK_FILE\""
+      echo ""
+      tail -n +2 "$PRE_COMMIT"
+    } > "$TEMP_FILE"
+    mv "$TEMP_FILE" "$PRE_COMMIT"
+    chmod +x "$PRE_COMMIT"
+    echo "✓ Default checkout guard added to existing pre-commit hook"
+  fi
+else
+  echo "✓ Default checkout guard installed at $HOOK_FILE"
+  echo "  (no existing pre-commit hook found; create one that calls this guard)"
+fi
+
+echo ""
+echo "Installed at: $HOOK_FILE"
+echo "Hooks dir:    $HOOKS_DIR"

--- a/scripts/protect-default-checkout-pollution.mjs
+++ b/scripts/protect-default-checkout-pollution.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Preserve evidence of default checkout pollution without modifying the checkout.
+// Copies git status, diff, and log to a timestamped protection directory.
+// Does NOT stash, reset, or otherwise alter the checkout.
+
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const ROOT = execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
+const PROTECTION_DIR = resolve(process.env.HOME, ".openclaw/default-checkout-protection");
+
+const reason = process.argv.find((_, i, a) => a[i - 1] === "--reason") || "unknown";
+const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+const evidenceDir = join(PROTECTION_DIR, timestamp);
+
+mkdirSync(evidenceDir, { recursive: true });
+
+function capture(label, cmd) {
+  try {
+    const output = execSync(cmd, {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    writeFileSync(join(evidenceDir, `${label}.txt`), output);
+    return true;
+  } catch (e) {
+    const combined = (e.stdout || "") + "\n" + (e.stderr || "");
+    writeFileSync(join(evidenceDir, `${label}.txt`), combined);
+    return false;
+  }
+}
+
+console.log(`📋 Preserving pollution evidence → ${evidenceDir}`);
+console.log(`   Reason: ${reason}`);
+
+// Write metadata
+const meta = {
+  timestamp: new Date().toISOString(),
+  reason,
+  root: ROOT,
+  hostname: execSync("hostname", { encoding: "utf8" }).trim(),
+  user: process.env.USER || "unknown",
+};
+writeFileSync(join(evidenceDir, "metadata.json"), JSON.stringify(meta, null, 2) + "\n");
+
+// Capture evidence
+capture("status", "git status");
+capture("status-porcelain", "git status --porcelain");
+capture("diff", "git diff");
+capture("diff-cached", "git diff --cached");
+capture("log", "git log --oneline -20");
+capture("branch", "git branch -vv");
+capture("reflog", "git reflog -20");
+capture("untracked", "git ls-files --others --exclude-standard");
+
+console.log(`   Evidence files written:`);
+const { readdirSync } = await import("node:fs");
+for (const f of readdirSync(evidenceDir)) {
+  console.log(`   - ${f}`);
+}
+
+console.log("");
+console.log("⚠️  Default checkout was NOT modified.");
+console.log("   Resolve manually: stash changes, switch to main, sync with origin/main.");

--- a/scripts/worktree-start.sh
+++ b/scripts/worktree-start.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Create an isolated worktree for a task.
+# Usage: scripts/worktree-start.sh <task-slug>
+#
+# Creates ../openclaw-worktrees/<task-slug> with a new branch
+# based on origin/main, and prints the worktree path.
+
+set -euo pipefail
+
+SLUG="${1:?Usage: worktree-start.sh <task-slug>}"
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+WORKTREE_BASE="$(dirname "$ROOT_DIR")/openclaw-worktrees"
+WORKTREE_PATH="$WORKTREE_BASE/$SLUG"
+BRANCH_NAME="feat/$SLUG"
+
+if [[ -d "$WORKTREE_PATH" ]]; then
+  echo "Worktree already exists: $WORKTREE_PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$WORKTREE_BASE"
+
+cd "$ROOT_DIR"
+
+# Ensure origin/main is up to date
+git fetch origin --quiet 2>/dev/null || true
+
+# Create branch from origin/main
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME" 2>/dev/null; then
+  echo "Branch '$BRANCH_NAME' already exists, using it" >&2
+else
+  git branch "$BRANCH_NAME" origin/main 2>/dev/null || git branch "$BRANCH_NAME" HEAD
+fi
+
+# Create worktree
+git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null
+
+echo "$WORKTREE_PATH"

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -482,6 +482,120 @@ describe("tryDispatchAcpReply", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("routes ACP session-store assistant output when the stream produced no visible text", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementationOnce(
+      async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
+        await onEvent?.({ type: "done" });
+      },
+    );
+    sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
+      cfg: createAcpTestConfig(),
+      storePath: "/tmp/openclaw-acp-session.json",
+      sessionKey,
+      storeSessionKey: sessionKey,
+      entry: {
+        messages: [
+          { User: { content: [{ Text: "上海的天气怎么样" }] } },
+          { Agent: { content: [{ Text: "上海今天多云，气温大约 20 到 25 度。" }] } },
+        ],
+      } as never,
+      acp: createAcpSessionMeta(),
+    });
+
+    const { dispatcher } = createDispatcher();
+    const result = await runDispatch({
+      bodyForAgent: "上海的天气怎么样",
+      dispatcher,
+      shouldRouteToOriginating: true,
+      originatingChannel: "telegram",
+      originatingTo: "8524721791",
+      ctxOverrides: {
+        Provider: "telegram",
+        Surface: "telegram",
+        AccountId: "solbi",
+        SenderId: "8524721791",
+      },
+    });
+
+    expect(result?.queuedFinal).toBe(true);
+    expect(result?.counts.final).toBe(1);
+    expect(routeMocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(routeCall().channel).toBe("telegram");
+    expect(routeCall().to).toBe("8524721791");
+    expect(routePayload().text).toBe("上海今天多云，气温大约 20 到 25 度。");
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("routes ACPX runtime assistant output when only ACP metadata is in the OpenClaw session store", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementationOnce(
+      async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
+        await onEvent?.({ type: "done" });
+      },
+    );
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acpx-fallback-"));
+    const sessionsDir = path.join(stateDir, "workspace", "state", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionsDir, `${encodeURIComponent(sessionKey)}.json`),
+      JSON.stringify({
+        messages: [
+          { User: { content: [{ Text: "hello" }] } },
+          { Agent: { content: [{ Text: "runtime fallback reply" }] } },
+        ],
+      }),
+      "utf8",
+    );
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
+      cfg: createAcpTestConfig(),
+      storePath: "/tmp/openclaw-agent-session-store.json",
+      sessionKey,
+      storeSessionKey: sessionKey,
+      entry: {
+        acp: createAcpSessionMeta({
+          identity: {
+            state: "resolved",
+            acpxRecordId: sessionKey,
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+        }),
+        sessionId: "agent-store-session",
+        updatedAt: Date.now(),
+      },
+      acp: createAcpSessionMeta({
+        identity: {
+          state: "resolved",
+          acpxRecordId: sessionKey,
+          source: "status",
+          lastUpdatedAt: Date.now(),
+        },
+      }),
+    });
+
+    try {
+      const result = await runDispatch({
+        bodyForAgent: "hello",
+        shouldRouteToOriginating: true,
+        originatingChannel: "telegram",
+        originatingTo: "8524721791",
+      });
+
+      expect(result?.queuedFinal).toBe(true);
+      expect(routeMocks.routeReply).toHaveBeenCalledTimes(1);
+      expect(routePayload().text).toBe("runtime fallback reply");
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
   it("persists ACP transcript when routed delivery fails", async () => {
     setReadyAcpResolution();
     mockRoutedTextTurn("hello");

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../../acp/policy.js";
 import { formatAcpRuntimeErrorText } from "../../acp/runtime/error-text.js";
 import { toAcpRuntimeError } from "../../acp/runtime/errors.js";
@@ -7,6 +9,7 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -169,6 +172,149 @@ export type AcpDispatchAttemptResult = {
 };
 
 const ACP_STALE_BINDING_UNBIND_REASON = "acp-session-init-failed";
+
+function extractAcpTextContent(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const parts: string[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    const text =
+      typeof record.Text === "string"
+        ? record.Text
+        : typeof record.text === "string" && record.type === "text"
+          ? record.text
+          : undefined;
+    if (text?.trim()) {
+      parts.push(text);
+    }
+  }
+  return parts;
+}
+
+function extractLatestAcpAssistantTextFromEntry(entry: unknown): string {
+  if (!entry || typeof entry !== "object") {
+    return "";
+  }
+  const messages = (entry as Record<string, unknown>).messages;
+  if (!Array.isArray(messages)) {
+    return "";
+  }
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    const acpxAgent = record.Agent;
+    if (acpxAgent && typeof acpxAgent === "object") {
+      const text = extractAcpTextContent((acpxAgent as Record<string, unknown>).content).join("\n");
+      if (text.trim()) {
+        return text;
+      }
+    }
+    if (record.role === "assistant") {
+      const text = extractAcpTextContent(record.content).join("\n");
+      if (text.trim()) {
+        return text;
+      }
+    }
+  }
+  return "";
+}
+
+async function readAcpxRuntimeSessionRecord(recordId: string): Promise<unknown> {
+  const normalizedRecordId = normalizeOptionalString(recordId);
+  if (!normalizedRecordId) {
+    return null;
+  }
+  const filePath = path.join(
+    resolveStateDir(),
+    "workspace",
+    "state",
+    "sessions",
+    `${encodeURIComponent(normalizedRecordId)}.json`,
+  );
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function extractLatestAcpAssistantTextFromSessionStores(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}): Promise<string> {
+  const { readAcpSessionEntry } = await loadDispatchAcpSessionRuntime();
+  const sessionEntry = readAcpSessionEntry({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+  });
+  const sessionStoreText = extractLatestAcpAssistantTextFromEntry(sessionEntry?.entry);
+  if (sessionStoreText.trim()) {
+    return sessionStoreText;
+  }
+
+  const acpMeta = sessionEntry?.acp;
+  const acpxRecordCandidates = new Set(
+    [acpMeta?.identity?.acpxRecordId, params.sessionKey].flatMap((value) => {
+      const normalized = normalizeOptionalString(value);
+      return normalized ? [normalized] : [];
+    }),
+  );
+  for (const recordId of acpxRecordCandidates) {
+    const runtimeRecord = await readAcpxRuntimeSessionRecord(recordId);
+    const runtimeText = extractLatestAcpAssistantTextFromEntry(runtimeRecord);
+    if (runtimeText.trim()) {
+      return runtimeText;
+    }
+  }
+  return "";
+}
+
+async function maybeDeliverSessionStoreFinalFallback(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  delivery: AcpDispatchDeliveryCoordinator;
+  suppressUserDelivery?: boolean;
+}): Promise<boolean> {
+  if (params.suppressUserDelivery) {
+    return false;
+  }
+  if (
+    params.delivery.hasDeliveredFinalReply() ||
+    params.delivery.hasDeliveredVisibleText() ||
+    params.delivery.getAccumulatedFinalText().trim() ||
+    params.delivery.getAccumulatedBlockText().trim()
+  ) {
+    return false;
+  }
+  try {
+    const text = await extractLatestAcpAssistantTextFromSessionStores({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+    });
+    if (!text.trim()) {
+      return false;
+    }
+    logVerbose(
+      `dispatch-acp: delivering session-store final fallback for ${params.sessionKey} after empty stream output`,
+    );
+    return await params.delivery.deliver("final", { text });
+  } catch (error) {
+    logVerbose(
+      `dispatch-acp: session-store final fallback failed for ${params.sessionKey}: ${formatErrorMessage(
+        error,
+      )}`,
+    );
+    return false;
+  }
+}
 
 function isStaleSessionInitError(params: { code: string; message: string }): boolean {
   if (params.code !== "ACP_SESSION_INIT_FAILED") {
@@ -542,6 +688,13 @@ export async function tryDispatchAcpReply(params: {
       params.markIdle("message_aborted");
       return { queuedFinal, counts };
     }
+    queuedFinal =
+      (await maybeDeliverSessionStoreFinalFallback({
+        cfg: params.cfg,
+        sessionKey: canonicalSessionKey,
+        delivery,
+        suppressUserDelivery: params.suppressUserDelivery,
+      })) || queuedFinal;
     try {
       const { persistAcpDispatchTranscript } = await loadDispatchAcpTranscriptRuntime();
       await persistAcpDispatchTranscript({

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,9 +1,13 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
+import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
 import type { HumanDelayConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
+import {
+  SILENT_REPLY_DISALLOWED_FALLBACK_TEXT,
+  type SilentReplyConversationType,
+} from "../../shared/silent-reply-policy.js";
 import { sleep } from "../../utils.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -156,6 +160,15 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
 
   const enqueue = (kind: ReplyDispatchKind, payload: ReplyPayload) => {
     const originalWasExactSilent = isSilentReplyText(payload.text, SILENT_REPLY_TOKEN);
+    const shouldSurfaceDisallowedSilent =
+      kind === "final" &&
+      originalWasExactSilent &&
+      resolveSilentReplyPolicy({
+        cfg: options.silentReplyContext?.cfg,
+        sessionKey: options.silentReplyContext?.sessionKey,
+        surface: options.silentReplyContext?.surface,
+        conversationType: options.silentReplyContext?.conversationType,
+      }) === "disallow";
     const normalized = normalizeReplyPayloadInternal(payload, {
       responsePrefix: options.responsePrefix,
       responsePrefixContext: options.responsePrefixContext,
@@ -164,7 +177,11 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       onHeartbeatStrip: options.onHeartbeatStrip,
       onSkip: (reason) => options.onSkip?.(payload, { kind, reason }),
     });
-    if (!normalized) {
+    const deliverable =
+      shouldSurfaceDisallowedSilent && !normalized
+        ? ({ ...payload, text: SILENT_REPLY_DISALLOWED_FALLBACK_TEXT } satisfies ReplyPayload)
+        : normalized;
+    if (!deliverable) {
       if (kind === "final" && originalWasExactSilent) {
         silentReplyLogger.debug("exact NO_REPLY final payload was skipped before delivery", {
           hasSessionKey: Boolean(options.silentReplyContext?.sessionKey),
@@ -192,9 +209,9 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             await sleep(delayMs);
           }
         }
-        let deliverPayload: ReplyPayload | null = normalized;
+        let deliverPayload: ReplyPayload | null = deliverable;
         if (options.beforeDeliver) {
-          deliverPayload = await options.beforeDeliver(normalized, { kind });
+          deliverPayload = await options.beforeDeliver(deliverPayload, { kind });
           if (!deliverPayload) {
             cancelledCounts[kind] += 1;
             return;

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { SILENT_REPLY_DISALLOWED_FALLBACK_TEXT } from "../../shared/silent-reply-policy.js";
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../tokens.js";
 import { createReplyDispatcher, waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import { createReplyToModeFilter } from "./reply-threading.js";
@@ -29,7 +30,7 @@ describe("createReplyDispatcher", () => {
     expect(deliveredText(deliver, 1)).toBe(`interject.${SILENT_REPLY_TOKEN}`);
   });
 
-  it("drops exact NO_REPLY final payloads for direct sessions", async () => {
+  it("surfaces exact NO_REPLY final payloads for direct sessions", async () => {
     const deliver = vi.fn().mockResolvedValue(undefined);
     const cfg: OpenClawConfig = {
       agents: {
@@ -50,10 +51,11 @@ describe("createReplyDispatcher", () => {
       },
     });
 
-    expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
+    expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(true);
 
     await dispatcher.waitForIdle();
-    expect(deliver).not.toHaveBeenCalled();
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliveredText(deliver)).toBe(SILENT_REPLY_DISALLOWED_FALLBACK_TEXT);
   });
 
   it("still drops exact NO_REPLY final payloads for group sessions where silence is allowed", async () => {

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -1,6 +1,7 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { describe, expect, it } from "vitest";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import { SILENT_REPLY_DISALLOWED_FALLBACK_TEXT } from "../../shared/silent-reply-policy.js";
 import { typedCases } from "../../test-utils/typed-cases.js";
 import {
   createOutboundPayloadPlan,
@@ -214,15 +215,15 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
-  it("drops bare silent replies for direct conversations", () => {
-    expect(
-      projectOutboundPayloadPlanForDelivery(
-        createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-          sessionKey: "agent:main:telegram:direct:123",
-          surface: "telegram",
-        }),
-      ),
-    ).toStrictEqual([]);
+  it("surfaces bare silent replies for direct conversations", () => {
+    const delivery = projectOutboundPayloadPlanForDelivery(
+      createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
+        sessionKey: "agent:main:telegram:direct:123",
+        surface: "telegram",
+      }),
+    );
+    expect(delivery).toHaveLength(1);
+    expect(delivery[0]?.text).toBe(SILENT_REPLY_DISALLOWED_FALLBACK_TEXT);
   });
 
   it("drops bare silent replies for groups", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -6,6 +6,7 @@ import {
   shouldSuppressReasoningPayload,
 } from "../../auto-reply/reply/reply-payloads.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   hasInteractiveReplyBlocks,
@@ -18,7 +19,10 @@ import {
   type MessagePresentation,
   type ReplyPayloadDelivery,
 } from "../../interactive/payload.js";
-import { type SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
+import {
+  SILENT_REPLY_DISALLOWED_FALLBACK_TEXT,
+  type SilentReplyConversationType,
+} from "../../shared/silent-reply-policy.js";
 import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
 
 export type NormalizedOutboundPayload = {
@@ -199,6 +203,7 @@ type PreparedOutboundPayloadPlanEntry = {
   hasInteractive: boolean;
   hasChannelData: boolean;
   isSilent: boolean;
+  surfaceIfOnlySilent: boolean;
 };
 
 type IndexedPreparedOutboundPayloadPlanEntry = PreparedOutboundPayloadPlanEntry & {
@@ -207,7 +212,7 @@ type IndexedPreparedOutboundPayloadPlanEntry = PreparedOutboundPayloadPlanEntry 
 
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
-  context: Pick<OutboundPayloadPlanContext, "extractMarkdownImages"> = {},
+  context: OutboundPayloadPlanContext = {},
 ): PreparedOutboundPayloadPlanEntry | null {
   if (shouldSuppressReasoningPayload(payload)) {
     return null;
@@ -224,11 +229,22 @@ function createOutboundPayloadPlanEntry(
   const strippedText = stripUnsupportedCitationControlMarkers(parsed.text ?? "");
   const strippedParsed =
     strippedText === (parsed.text ?? "") ? parsed : parseReplyDirectives(strippedText);
-  const parsedText = strippedParsed.text ?? "";
+  const originalIsSilent = strippedParsed.isSilent && mergedMedia.length === 0;
+  const shouldSurfaceDisallowedSilent =
+    originalIsSilent &&
+    resolveSilentReplyPolicy({
+      cfg: context.cfg,
+      sessionKey: context.sessionKey,
+      surface: context.surface,
+      conversationType: context.conversationType,
+    }) === "disallow";
+  const parsedText = shouldSurfaceDisallowedSilent
+    ? SILENT_REPLY_DISALLOWED_FALLBACK_TEXT
+    : (strippedParsed.text ?? "");
   if (isSuppressedRelayStatusText(parsedText) && mergedMedia.length === 0) {
     return null;
   }
-  const isSilent = strippedParsed.isSilent && mergedMedia.length === 0;
+  const isSilent = originalIsSilent;
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
   const normalizedPayload: ReplyPayload = {
@@ -255,6 +271,7 @@ function createOutboundPayloadPlanEntry(
     hasInteractive: hasInteractiveReplyBlocks(normalizedPayload.interactive),
     hasChannelData,
     isSilent,
+    surfaceIfOnlySilent: shouldSurfaceDisallowedSilent,
   };
 }
 
@@ -269,6 +286,10 @@ export function createOutboundPayloadPlan(
   for (const [sourceIndex, payload] of payloads.entries()) {
     const entry = createOutboundPayloadPlanEntry(payload, {
       extractMarkdownImages: context.extractMarkdownImages,
+      cfg: context.cfg,
+      sessionKey: context.sessionKey,
+      surface: context.surface,
+      conversationType: context.conversationType,
     });
     if (!entry) {
       continue;
@@ -276,17 +297,25 @@ export function createOutboundPayloadPlan(
     prepared.push({ ...entry, sourceIndex });
   }
   const plan: OutboundPayloadPlan[] = [];
+  const pushEntry = (entry: IndexedPreparedOutboundPayloadPlanEntry) => {
+    plan.push({
+      sourceIndex: entry.sourceIndex,
+      payload: entry.payload,
+      parts: resolveSendableOutboundReplyParts(entry.payload),
+      hasPresentation: entry.hasPresentation,
+      hasInteractive: entry.hasInteractive,
+      hasChannelData: entry.hasChannelData,
+    });
+  };
   for (const entry of prepared) {
     if (!entry.isSilent) {
-      plan.push({
-        sourceIndex: entry.sourceIndex,
-        payload: entry.payload,
-        parts: resolveSendableOutboundReplyParts(entry.payload),
-        hasPresentation: entry.hasPresentation,
-        hasInteractive: entry.hasInteractive,
-        hasChannelData: entry.hasChannelData,
-      });
-      continue;
+      pushEntry(entry);
+    }
+  }
+  if (plan.length === 0) {
+    const fallbackEntry = prepared.find((entry) => entry.surfaceIfOnlySilent);
+    if (fallbackEntry) {
+      pushEntry(fallbackEntry);
     }
   }
   return plan;

--- a/src/shared/silent-reply-policy.ts
+++ b/src/shared/silent-reply-policy.ts
@@ -12,6 +12,9 @@ export const DEFAULT_SILENT_REPLY_POLICY: Record<SilentReplyConversationType, Si
   internal: "allow",
 };
 
+export const SILENT_REPLY_DISALLOWED_FALLBACK_TEXT =
+  "I received this, but the model returned an empty reply. Please send it again.";
+
 export function classifySilentReplyConversationType(params: {
   sessionKey?: string;
   surface?: string;


### PR DESCRIPTION
## Summary

When silent reply policy disallows NO_REPLY in direct conversations, surface fallback text instead of dropping the message. Additionally, when the ACP stream produces no visible text, fall back to reading the latest assistant output from the ACP session store.

## Changes

### 1. Silent reply disallow in direct conversations
- Added `SILENT_REPLY_DISALLOWED_FALLBACK_TEXT` to `src/shared/silent-reply-policy.ts`
- Modified `src/auto-reply/reply/reply-dispatcher.ts` to route fallback text when silent reply is disallowed in direct (non-group) conversations
- Updated `src/infra/outbound/payloads.ts` to preserve fallback delivery through the outbound pipeline

### 2. ACP session store fallback
- Added `extractAcpTextContent()`, `extractLatestAcpAssistantTextFromEntry()`, and `readAcpxRuntimeSessionRecord()` to `src/auto-reply/reply/dispatch-acp.ts`
- When `runTurn` completes via `onEvent({ type: "done" })` with no visible text captured, reads the ACP session store to find the latest assistant/Agent text output
- Routes the recovered text through the normal delivery pipeline

### Tests
- Added test case: routes ACP session-store assistant output when the stream produced no visible text
- Existing reply-flow and outbound payload tests updated to cover the new fallback paths

## Motivation

In direct conversations (e.g., Telegram DMs), users should never see a silent response when the agent processed their message but the reply pipeline decided to suppress it. This is particularly important for ACP-based agents where the stream may complete successfully but produce no visible text in the event stream — the session store reliably captures the agent's output as a fallback source.