### PR TITLE
fix(dashboard): use role parameter to skip copy chrome for user messages

### DIFF
--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -13,7 +13,7 @@ import { normalizeMessage } from "./message-normalizer.ts";
 
 const localStorageValues = vi.hoisted(() => new Map<string, string>());
 const markdownRenderMock = vi.hoisted(() =>
-  vi.fn((value: string, _options?: { codeBlockChrome?: "copy" | "none" }) => value),
+  vi.fn((value: string, _options?: { codeBlockChrome?: "copy" | "none"; role?: "user" | "assistant" | "tool" }) => value),
 );
 
 vi.mock("../../local-storage.ts", () => ({
@@ -584,7 +584,7 @@ describe("grouped chat rendering", () => {
       "user",
     );
 
-    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, { codeBlockChrome: "none" });
+    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, { role: "user" });
   });
 
   it("keeps assistant markdown code-block copy chrome enabled", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1499,7 +1499,7 @@ function renderGroupedMessage(
   const markdownBase = extractedText?.trim() ? extractedText : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
-  const markdownRenderOptions = role === "user" ? { codeBlockChrome: "none" as const } : undefined;
+  const markdownRenderOptions = role === "user" ? { role: "user" as const } : undefined;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
   const hasActions = canCopyMarkdown || canExpand;

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -388,6 +388,16 @@ PY
       expect(fragment.textContent).toBe(source);
     });
 
+    it("omits copy chrome for user-role messages", () => {
+      const html = toSanitizedMarkdownHtml(
+        "```\necho hello\n```",
+        { role: "user" },
+      );
+      const fragment = htmlFragment(html);
+      expect(fragment.querySelector(".code-block-copy")).toBeNull();
+      expect(fragment.querySelector(".code-block-header")).toBeNull();
+    });
+
     it("keeps the no-chrome code-block cache separate from copy-enabled rendering", () => {
       const markdown = "```\ncode\n```";
       const plain = toSanitizedMarkdownHtml(markdown, { codeBlockChrome: "none" });

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -93,6 +93,7 @@ export type MarkdownCodeBlockChrome = "copy" | "none";
 
 export type MarkdownRenderOptions = {
   codeBlockChrome?: MarkdownCodeBlockChrome;
+  role?: "user" | "assistant" | "tool";
 };
 
 type MarkdownRenderEnv = {
@@ -129,7 +130,8 @@ function setCachedMarkdown(key: string, value: string) {
 
 function normalizeMarkdownRenderOptions(options: MarkdownRenderOptions = {}): MarkdownRenderEnv {
   return {
-    codeBlockChrome: options.codeBlockChrome ?? "copy",
+    codeBlockChrome:
+      options.role === "user" ? "none" : options.codeBlockChrome ?? "copy",
   };
 }
 


### PR DESCRIPTION
## Summary

Supersedes #86127. Fixes #85926.

Refactors code-block copy button control to use an explicit `role` parameter in `MarkdownRenderOptions` instead of manually setting `codeBlockChrome`.

## Changes

### markdown.ts
- Add `role?: "user" | "assistant" | "tool"` to `MarkdownRenderOptions`
- When `role === "user"`, `normalizeMarkdownRenderOptions` automatically sets `codeBlockChrome` to `"none"`
- This skips copy-button injection in `fence` and `code_block` renderers

### grouped-render.ts
- Pass `{ role: "user" }` instead of `{ codeBlockChrome: "none" }` for user messages
- Cleaner API: role semantics instead of low-level chrome flag

### markdown.test.ts
- Added regression test: user-role messages produce no copy button and no code-block header

### grouped-render.test.ts
- Updated mock type and expectations for new role-based options

## Why this is better than #86127

- **Cleaner API**: `role` is semantic; `codeBlockChrome` is an implementation detail
- **Extensible**: future roles can have different defaults
- **No cache key changes needed**: `codeBlockChrome "none"` already differentiates in the cache key

## Conflict note

This PR will conflict with #86335 (custom protocols) and #87568 (KaTeX) when they merge, since all three modify `markdown.ts` and `grouped-render.ts`. The conflicts are mechanical and easy to resolve.
