### PR TITLE
fix(usage): support agentId 'all' for cross-agent usage queries

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -212,6 +212,22 @@ describe("sessions.usage", () => {
     expect(sessions[0].agentId).toBe("opus");
   });
 
+  it("returns all agent sessions when agentId is 'all'", async () => {
+    const respond = await runSessionsUsage({ ...BASE_USAGE_RANGE, agentId: "all" });
+
+    expect(vi.mocked(loadCombinedSessionStoreForGateway)).toHaveBeenCalledWith(
+      TEST_RUNTIME_CONFIG,
+      {},
+    );
+    // Should discover sessions for all configured agents (main, opus)
+    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
+
+    const sessions = expectSuccessfulSessionsUsage(respond);
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].agentId).toBe("opus");
+    expect(sessions[1].agentId).toBe("main");
+  });
+
   it("loads selected session summaries concurrently and reports cache refresh status", async () => {
     vi.mocked(discoverAllSessions).mockResolvedValueOnce([
       {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -874,9 +874,12 @@ export const usageHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const effectiveAgentId = normalizeAgentId(
-      requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config),
-    );
+    const isAllAgents = requestedAgentId === "all";
+    const effectiveAgentId = isAllAgents
+      ? undefined
+      : normalizeAgentId(
+          requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config),
+        );
     const groupingMode: UsageGroupingMode =
       p.groupBy === "family" || p.includeHistorical === true ? "family" : "instance";
 
@@ -884,11 +887,9 @@ export const usageHandlers: GatewayRequestHandlers = {
     const { storePath, store } = loadCombinedSessionStoreForGateway(config, {
       agentId: effectiveAgentId,
     });
-    const scopedStore = filterSessionStoreByAgent({
-      config,
-      store,
-      agentId: effectiveAgentId,
-    });
+    const scopedStore = effectiveAgentId
+      ? filterSessionStoreByAgent({ config, store, agentId: effectiveAgentId })
+      : store;
     const now = Date.now();
 
     const mergedEntries: MergedEntry[] = [];

--- a/ui/src/ui/controllers/usage.node.test.ts
+++ b/ui/src/ui/controllers/usage.node.test.ts
@@ -36,6 +36,7 @@ function createState(request: RequestFn, overrides: Partial<UsageState> = {}): U
 
 function expectSpecificTimezoneCalls(request: ReturnType<typeof vi.fn>, startCall: number): void {
   expect(request).toHaveBeenNthCalledWith(startCall, "sessions.usage", {
+    agentId: "all",
     startDate: "2026-02-16",
     endDate: "2026-02-16",
     mode: "specific",
@@ -85,6 +86,7 @@ describe("usage controller date interpretation params", () => {
     await loadUsage(state);
 
     expect(request).toHaveBeenNthCalledWith(1, "sessions.usage", {
+      agentId: "all",
       startDate: "2026-02-16",
       endDate: "2026-02-16",
       mode: "utc",
@@ -142,6 +144,7 @@ describe("usage controller date interpretation params", () => {
 
     expectSpecificTimezoneCalls(request, 1);
     expect(request).toHaveBeenNthCalledWith(3, "sessions.usage", {
+      agentId: "all",
       startDate: "2026-02-16",
       endDate: "2026-02-16",
       groupBy: "family",
@@ -158,6 +161,7 @@ describe("usage controller date interpretation params", () => {
     await loadUsage(state);
 
     expect(request).toHaveBeenNthCalledWith(5, "sessions.usage", {
+      agentId: "all",
       startDate: "2026-02-16",
       endDate: "2026-02-16",
       groupBy: "family",
@@ -204,6 +208,7 @@ describe("usage controller date interpretation params", () => {
 
     expectSpecificTimezoneCalls(request, 1);
     expect(request).toHaveBeenNthCalledWith(3, "sessions.usage", {
+      agentId: "all",
       startDate: "2026-02-16",
       endDate: "2026-02-16",
       mode: "specific",
@@ -222,6 +227,7 @@ describe("usage controller date interpretation params", () => {
     await loadUsage(state);
 
     expect(request).toHaveBeenNthCalledWith(5, "sessions.usage", {
+      agentId: "all",
       startDate: "2026-02-16",
       endDate: "2026-02-16",
       mode: "specific",

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -225,6 +225,7 @@ export async function loadUsage(
         : undefined;
       return Promise.all([
         client.request("sessions.usage", {
+          agentId: "all",
           startDate,
           endDate,
           ...dateInterpretation,


### PR DESCRIPTION
## Summary

Supersedes #87335. Fixes #87132.

Adds `agentId: "all"` support to `sessions.usage` so the Control UI can query all agents' sessions while preserving the shipped gateway scoping contract.

## Problem with #87335

The original PR changed the gateway default from scoped (effective agent) to all-agents when `agentId` is omitted. ClawSweeper flagged this as a **security/compatibility concern** — it reverses intentional gateway hardening that scoped session data by default.

## This fix (方案 A)

**Keep the gateway default scoped. Let the UI opt into all-agents explicitly.**

### Gateway (`usage.ts`)
- When `agentId === "all"`: set `effectiveAgentId = undefined`, load all agent stores, skip `filterSessionStoreByAgent`
- When `agentId` is omitted: keep existing behavior (defaults to effective agent)
- **Backwards-compatible**: no change to the default contract

### UI (`controllers/usage.ts`)
- Pass `agentId: "all"` in the `sessions.usage` request
- All agents' sessions are returned, enabling the agent filter to show all options

### Tests
- Gateway: new test for `agentId: "all"` returns all agents
- UI: updated all `sessions.usage` expectations to include `agentId: "all"`

## Why this is better than #87335

- **Preserves security contract**: default scoped behavior unchanged
- **Explicit opt-in**: UI clearly requests all-agent data
- **No compatibility risk**: existing callers that omit `agentId` still get scoped results
- **ClawSweeper compatible**: addresses the P1 concern about broadening default session-data access
