### PR TITLE
feat(feeds): add read-only feed discovery

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -322,6 +322,11 @@
       - any-glob-to-any-file:
           - "extensions/policy/**"
           - "docs/cli/policy.md"
+"extensions: feeds":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/feeds/**"
+          - "docs/plugins/reference/feeds.md"
 "extensions: open-prose":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-72 plugins
+73 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -88,6 +88,8 @@ Each entry lists the package, distribution route, and description.
 - **[elevenlabs](/plugins/reference/elevenlabs)** (`@openclaw/elevenlabs-speech`) - included in OpenClaw. Adds media understanding provider support. Adds realtime transcription provider support. Adds text-to-speech provider support.
 
 - **[fal](/plugins/reference/fal)** (`@openclaw/fal-provider`) - included in OpenClaw. Adds fal model provider support to OpenClaw.
+
+- **[feeds](/plugins/reference/feeds)** (`@openclaw/feeds`) - included in OpenClaw. Adds configured catalog feed source validation for skills and plugins.
 
 - **[file-transfer](/plugins/reference/file-transfer)** (`@openclaw/file-transfer`) - included in OpenClaw. Fetch, list, and write files on paired nodes via dedicated node commands. Bypasses bash stdout truncation by using base64 over node.invoke for binaries up to 16 MB.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 128
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 129
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/feeds.md
+++ b/docs/plugins/reference/feeds.md
@@ -1,0 +1,19 @@
+---
+summary: "Adds configured catalog feed source validation for skills and plugins."
+read_when:
+  - You are installing, configuring, or auditing the feeds plugin
+title: "Feeds plugin"
+---
+
+# Feeds plugin
+
+Adds configured catalog feed source validation for skills and plugins.
+
+## Distribution
+
+- Package: `@openclaw/feeds`
+- Install route: included in OpenClaw
+
+## Surface
+
+plugin

--- a/extensions/feeds/api.ts
+++ b/extensions/feeds/api.ts
@@ -1,0 +1,1 @@
+export { registerFeedsDoctorChecks } from "./src/doctor/register.js";

--- a/extensions/feeds/index.ts
+++ b/extensions/feeds/index.ts
@@ -1,0 +1,28 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { registerFeedsCli } from "./src/cli.js";
+import { registerFeedsDoctorChecks } from "./src/doctor/register.js";
+
+export default definePluginEntry({
+  id: "feeds",
+  name: "Feeds",
+  description: "Adds configured catalog feed source validation for skills and plugins.",
+  register(api) {
+    api.registerCli(
+      async ({ program }) => {
+        registerFeedsCli(program);
+      },
+      {
+        descriptors: [
+          {
+            name: "feeds",
+            description: "Inspect configured skill and plugin catalog feeds",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    );
+    registerFeedsDoctorChecks();
+  },
+});
+export { registerFeedsCli } from "./src/cli.js";
+export { registerFeedsDoctorChecks } from "./src/doctor/register.js";

--- a/extensions/feeds/openclaw.plugin.json
+++ b/extensions/feeds/openclaw.plugin.json
@@ -1,0 +1,52 @@
+{
+  "id": "feeds",
+  "name": "Feeds",
+  "description": "Adds configured catalog feed source validation for skills and plugins.",
+  "activation": {
+    "onStartup": false,
+    "onCommands": ["doctor", "feeds"]
+  },
+  "commandAliases": [{ "name": "feeds", "kind": "cli" }],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Enable feeds doctor checks."
+      },
+      "sources": {
+        "type": "array",
+        "description": "Catalog feed sources used for curated skill and plugin discovery.",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "url"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Stable local feed identifier."
+            },
+            "url": {
+              "type": "string",
+              "description": "Absolute https:// or file:// feed document URL."
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable this feed source. Defaults to true."
+            },
+            "trust": {
+              "type": "string",
+              "enum": ["unsigned", "pinned"],
+              "description": "Whether this source is accepted unsigned or pinned by integrity hash."
+            },
+            "integrity": {
+              "type": "string",
+              "description": "Optional sha256:<hex> hash for pinned feed documents."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/feeds/package.json
+++ b/extensions/feeds/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@openclaw/feeds",
+  "version": "2026.5.28",
+  "private": true,
+  "description": "OpenClaw feed source configuration and doctor checks",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.5.28"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/feeds/src/cli.test.ts
+++ b/extensions/feeds/src/cli.test.ts
@@ -12,10 +12,15 @@ import {
   feedsSourcesCommand,
   type FeedsCommandRuntime,
 } from "./cli.js";
-import { MAX_FEED_DOCUMENT_BYTES } from "./feed-document.js";
+import {
+  FEED_FETCH_TIMEOUT_MS,
+  FEED_READ_IDLE_TIMEOUT_MS,
+  MAX_FEED_DOCUMENT_BYTES,
+} from "./feed-document.js";
 
 describe("Feeds CLI", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     fetchWithSsrFGuardMock.mockReset();
   });
 
@@ -110,6 +115,7 @@ describe("Feeds CLI", () => {
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
       url: "https://feeds.example.com/feed.json",
       auditContext: "feeds.feed-document",
+      timeoutMs: FEED_FETCH_TIMEOUT_MS,
     });
     expect(release).toHaveBeenCalledTimes(1);
   });
@@ -133,7 +139,12 @@ describe("Feeds CLI", () => {
       release,
     });
     const runtime = createRuntime({
-      sources: [{ id: "large", url: "https://feeds.example.com/large.json" }],
+      sources: [
+        {
+          id: "large",
+          url: "https://user:secret@feeds.example.com/large.json?token=hidden#frag",
+        },
+      ],
     });
 
     const exitCode = await feedsListCommand({ json: true }, runtime);
@@ -144,7 +155,48 @@ describe("Feeds CLI", () => {
         MAX_FEED_DOCUMENT_BYTES +
         " bytes.",
     );
+    expect(runtime.stderr).not.toContain("secret");
+    expect(runtime.stderr).not.toContain("token=hidden");
     expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports stalled HTTPS feed bodies with redacted URLs", async () => {
+    vi.useFakeTimers();
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          start() {
+            // Keep the stream open without chunks so readResponseWithLimit hits its idle timer.
+          },
+        }),
+      ),
+      release,
+    });
+    const runtime = createRuntime({
+      sources: [
+        {
+          id: "slow",
+          url: "https://user:secret@feeds.example.com/slow.json?token=hidden#frag",
+        },
+      ],
+    });
+
+    const run = feedsListCommand({ json: true }, runtime);
+    await vi.advanceTimersByTimeAsync(FEED_READ_IDLE_TIMEOUT_MS);
+    const exitCode = await run;
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain(
+      `Feed URL https://feeds.example.com/slow.json response stalled for ${FEED_READ_IDLE_TIMEOUT_MS}ms.`,
+    );
+    expect(runtime.stderr).not.toContain("secret");
+    expect(runtime.stderr).not.toContain("token=hidden");
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: FEED_FETCH_TIMEOUT_MS }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 
   it("checks pinned feed integrity while loading entries", async () => {

--- a/extensions/feeds/src/cli.test.ts
+++ b/extensions/feeds/src/cli.test.ts
@@ -1,0 +1,234 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  feedsListCommand,
+  feedsSearchCommand,
+  feedsSourcesCommand,
+  type FeedsCommandRuntime,
+} from "./cli.js";
+
+describe("Feeds CLI", () => {
+  it("lists configured sources", async () => {
+    const runtime = createRuntime({ sources: [{ id: "approved", url: "file:///feeds.json" }] });
+    const exitCode = await feedsSourcesCommand({ json: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).sources).toEqual([
+      { id: "approved", url: "file:///feeds.json", enabled: true },
+    ]);
+  });
+
+  it("lists an empty source set when no sources are configured", async () => {
+    const runtime = createRuntime({});
+    const exitCode = await feedsSourcesCommand({ json: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).sources).toEqual([]);
+    expect(runtime.stderr).toBe("");
+  });
+
+  it("loads file-backed feed entries", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        { type: "skill", id: "excel-review", version: "1.2.3", name: "Excel Review" },
+        { type: "plugin", id: "teams-channel", tags: ["m365", "channel"] },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsListCommand({ json: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).entries).toEqual([
+      expect.objectContaining({
+        sourceId: "approved",
+        feedId: "company-approved",
+        id: "excel-review",
+      }),
+      expect.objectContaining({
+        sourceId: "approved",
+        feedId: "company-approved",
+        id: "teams-channel",
+      }),
+    ]);
+  });
+
+  it("searches across entry metadata", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        { type: "skill", id: "excel-review", tags: ["m365"] },
+        { type: "plugin", id: "calendar-helper", tags: ["outlook"] },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsSearchCommand("outlook", { json: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).entries).toEqual([
+      expect.objectContaining({ id: "calendar-helper" }),
+    ]);
+  });
+
+  it("checks pinned feed integrity while loading entries", async () => {
+    const feed = JSON.stringify({ schemaVersion: 1, id: "company-approved", entries: [] });
+    const integrity = `sha256:${createHash("sha256").update(feed).digest("hex").toUpperCase()}`;
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json", trust: "pinned", integrity }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsListCommand({ json: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).entries).toEqual([]);
+  });
+
+  it("rejects pinned feed sources without integrity", async () => {
+    const feed = JSON.stringify({ schemaVersion: 1, id: "company-approved", entries: [] });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json", trust: "pinned" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsListCommand({ json: true }, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("Feed source approved requires integrity for pinned trust.");
+  });
+
+  it("formats install hints without installing feed entries", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          name: "Calendar Helper",
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+        },
+        {
+          type: "skill",
+          id: "excel-review",
+          install: { source: "clawhub", slug: "excel-review" },
+        },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    runtime.isTTY = true;
+
+    const exitCode = await feedsSearchCommand("calendar", { type: "plugin" }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(runtime.stdout).toContain("approved\tplugin\tcalendar-helper - Calendar Helper");
+    expect(runtime.stdout).toContain("Install: openclaw plugins install clawhub:openclaw-calendar");
+    expect(runtime.stdout).not.toContain("excel-review");
+  });
+
+  it("quotes install hint specs from feed metadata", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "unsafe-helper",
+          install: { source: "npm", spec: "safe-package && curl example.invalid" },
+        },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    runtime.isTTY = true;
+
+    const exitCode = await feedsSearchCommand("unsafe", { type: "plugin" }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(runtime.stdout).toContain(
+      "Install: openclaw plugins install 'safe-package && curl example.invalid'",
+    );
+  });
+
+  it("filters search results by entry type", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        { type: "plugin", id: "calendar-helper", tags: ["shared"] },
+        { type: "skill", id: "calendar-review", tags: ["shared"] },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsSearchCommand("shared", { type: "plugin", json: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).entries).toEqual([
+      expect.objectContaining({
+        type: "plugin",
+        id: "calendar-helper",
+      }),
+    ]);
+  });
+
+  it("rejects unsupported type filters", async () => {
+    const runtime = createRuntime({ sources: [{ id: "approved", url: "file:///feeds.json" }] });
+    const exitCode = await feedsListCommand({ type: "tool" }, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("Invalid --type value. Expected skill or plugin.");
+  });
+});
+
+function createRuntime(params: {
+  readonly sources?: readonly Record<string, unknown>[];
+  readonly files?: Readonly<Record<string, string>>;
+}): FeedsCommandRuntime & { stdout: string; stderr: string; isTTY?: boolean } {
+  const runtime: FeedsCommandRuntime & { stdout: string; stderr: string; isTTY?: boolean } = {
+    stdout: "",
+    stderr: "",
+    writeStdout(value) {
+      this.stdout += value;
+    },
+    error(value) {
+      this.stderr += `${value}\n`;
+    },
+    async readConfigSnapshot() {
+      return {
+        valid: true,
+        config: {
+          plugins: { entries: { feeds: { enabled: true, config: { sources: params.sources } } } },
+        },
+      };
+    },
+    async readFile(path) {
+      const value = params.files?.[path];
+      if (value === undefined) {
+        throw new Error(`missing test file ${path}`);
+      }
+      return value;
+    },
+  };
+  return runtime;
+}

--- a/extensions/feeds/src/cli.test.ts
+++ b/extensions/feeds/src/cli.test.ts
@@ -1,5 +1,11 @@
 import { createHash } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
 import {
   feedsListCommand,
   feedsSearchCommand,
@@ -8,6 +14,10 @@ import {
 } from "./cli.js";
 
 describe("Feeds CLI", () => {
+  beforeEach(() => {
+    fetchWithSsrFGuardMock.mockReset();
+  });
+
   it("lists configured sources", async () => {
     const runtime = createRuntime({ sources: [{ id: "approved", url: "file:///feeds.json" }] });
     const exitCode = await feedsSourcesCommand({ json: true }, runtime);
@@ -78,6 +88,41 @@ describe("Feeds CLI", () => {
     expect(JSON.parse(runtime.stdout).entries).toEqual([
       expect.objectContaining({ id: "calendar-helper" }),
     ]);
+  });
+
+  it("loads HTTPS feeds through the SSRF guard", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({ schemaVersion: 1, id: "company-approved", entries: [] }),
+      ),
+      release,
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "https://feeds.example.com/feed.json" }],
+    });
+
+    const exitCode = await feedsListCommand({ json: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).entries).toEqual([]);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+      url: "https://feeds.example.com/feed.json",
+      auditContext: "feeds.feed-document",
+    });
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports SSRF guard blocks for HTTPS feeds", async () => {
+    fetchWithSsrFGuardMock.mockRejectedValue(new Error("SSRF blocked private network target"));
+    const runtime = createRuntime({
+      sources: [{ id: "private", url: "https://127.0.0.1/feed.json" }],
+    });
+
+    const exitCode = await feedsListCommand({ json: true }, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("SSRF blocked private network target");
   });
 
   it("checks pinned feed integrity while loading entries", async () => {

--- a/extensions/feeds/src/cli.test.ts
+++ b/extensions/feeds/src/cli.test.ts
@@ -12,6 +12,7 @@ import {
   feedsSourcesCommand,
   type FeedsCommandRuntime,
 } from "./cli.js";
+import { MAX_FEED_DOCUMENT_BYTES } from "./feed-document.js";
 
 describe("Feeds CLI", () => {
   beforeEach(() => {
@@ -123,6 +124,27 @@ describe("Feeds CLI", () => {
 
     expect(exitCode).toBe(2);
     expect(runtime.stderr).toContain("SSRF blocked private network target");
+  });
+
+  it("reports oversized HTTPS feed documents and releases the guarded dispatcher", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("x".repeat(MAX_FEED_DOCUMENT_BYTES + 1)),
+      release,
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "large", url: "https://feeds.example.com/large.json" }],
+    });
+
+    const exitCode = await feedsListCommand({ json: true }, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain(
+      "Feed URL https://feeds.example.com/large.json response exceeds " +
+        MAX_FEED_DOCUMENT_BYTES +
+        " bytes.",
+    );
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("checks pinned feed integrity while loading entries", async () => {

--- a/extensions/feeds/src/cli.ts
+++ b/extensions/feeds/src/cli.ts
@@ -1,0 +1,330 @@
+import type { Command } from "commander";
+import { readConfigFileSnapshot } from "openclaw/plugin-sdk/health";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  feedEntryMatchesQuery,
+  loadFeedDocument,
+  type FeedDocumentRuntime,
+  type FeedEntry,
+  type FeedSourceConfig,
+  type LoadedFeedDocument,
+} from "./feed-document.js";
+
+type FeedConfigSnapshot = {
+  readonly valid: boolean;
+  readonly issues?: readonly { readonly message?: string }[];
+  readonly config: {
+    readonly plugins?: {
+      readonly entries?: Record<string, { readonly config?: unknown } | undefined>;
+    };
+  };
+};
+
+export type FeedsCommandRuntime = FeedDocumentRuntime & {
+  writeStdout(value: string): void;
+  error(value: string): void;
+  isTTY?: boolean;
+  readConfigSnapshot?: (options: { readonly observe?: boolean }) => Promise<FeedConfigSnapshot>;
+};
+
+export type FeedsCommandOptions = {
+  readonly json?: boolean;
+  readonly source?: string;
+  readonly type?: string;
+};
+
+export type FeedEntryResult = FeedEntry & {
+  readonly sourceId: string;
+  readonly feedId: string;
+};
+
+const defaultRuntime: FeedsCommandRuntime = {
+  isTTY: process.stdout.isTTY,
+  writeStdout(value) {
+    process.stdout.write(value);
+  },
+  error(value) {
+    process.stderr.write(`${value}\n`);
+  },
+};
+
+export function registerFeedsCli(program: Command): void {
+  const feeds = program.command("feeds").description("Inspect configured skill and plugin feeds");
+
+  feeds
+    .command("sources")
+    .description("List configured feed sources")
+    .option("--json", "Emit JSON output")
+    .action(async (options: FeedsCommandOptions) => {
+      process.exitCode = await feedsSourcesCommand(options);
+    });
+
+  feeds
+    .command("list")
+    .description("List entries from configured feed sources")
+    .option("--source <id>", "Limit to one feed source id")
+    .option("--type <type>", "Limit to skill or plugin entries")
+    .option("--json", "Emit JSON output")
+    .action(async (options: FeedsCommandOptions) => {
+      process.exitCode = await feedsListCommand(options);
+    });
+
+  feeds
+    .command("search")
+    .argument("<query>", "Text to match against feed entry metadata")
+    .description("Search entries from configured feed sources")
+    .option("--source <id>", "Limit to one feed source id")
+    .option("--type <type>", "Limit to skill or plugin entries")
+    .option("--json", "Emit JSON output")
+    .action(async (query: string, options: FeedsCommandOptions) => {
+      process.exitCode = await feedsSearchCommand(query, options);
+    });
+}
+
+export async function feedsSourcesCommand(
+  options: FeedsCommandOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    const sources = await readConfiguredFeedSources(runtime);
+    if (options.json === true || runtime.isTTY !== true) {
+      runtime.writeStdout(JSON.stringify({ sources }, null, 2) + "\n");
+    } else {
+      runtime.writeStdout(formatSourceRows(sources));
+    }
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function feedsListCommand(
+  options: FeedsCommandOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    assertFeedEntryType(options.type);
+    const loaded = await loadConfiguredFeedDocuments(options, runtime);
+    const entries = filterEntriesByType(flattenFeedEntries(loaded), options.type);
+    writeEntries(entries, options, runtime);
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function feedsSearchCommand(
+  query: string,
+  options: FeedsCommandOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    assertFeedEntryType(options.type);
+    const loaded = await loadConfiguredFeedDocuments(options, runtime);
+    const entries = filterEntriesByType(
+      flattenFeedEntries(loaded).filter((entry) => feedEntryMatchesQuery(entry, query)),
+      options.type,
+    );
+    writeEntries(entries, options, runtime);
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+async function loadConfiguredFeedDocuments(
+  options: FeedsCommandOptions,
+  runtime: FeedsCommandRuntime,
+): Promise<readonly LoadedFeedDocument[]> {
+  const sources = (await readConfiguredFeedSources(runtime)).filter((source) => source.enabled);
+  const selected = selectSources(sources, options.source);
+  return Promise.all(selected.map((source) => loadFeedDocument(source, runtime)));
+}
+
+async function readConfiguredFeedSources(
+  runtime: FeedsCommandRuntime,
+): Promise<readonly FeedSourceConfig[]> {
+  const readSnapshot = runtime.readConfigSnapshot ?? readConfigFileSnapshot;
+  const snapshot = await readSnapshot({ observe: false });
+  if (!snapshot.valid) {
+    const firstIssue = snapshot.issues?.[0]?.message ?? "unknown config parse error";
+    throw new Error(`OpenClaw config is invalid: ${firstIssue}`);
+  }
+  const config = snapshot.config.plugins?.entries?.feeds?.config;
+  if (config === undefined) {
+    return [];
+  }
+  if (!isRecord(config)) {
+    throw new Error("plugins.entries.feeds.config must be an object.");
+  }
+  if (config.sources === undefined) {
+    return [];
+  }
+  if (!Array.isArray(config.sources)) {
+    throw new Error("plugins.entries.feeds.config.sources must be an array.");
+  }
+  return config.sources.map((source, index) => parseSourceConfig(source, index));
+}
+
+function parseSourceConfig(value: unknown, index: number): FeedSourceConfig {
+  if (!isRecord(value)) {
+    throw new Error(`Feed source ${index} must be an object.`);
+  }
+  if (typeof value.id !== "string" || value.id.trim() === "") {
+    throw new Error(`Feed source ${index} must declare an id.`);
+  }
+  if (typeof value.url !== "string" || value.url.trim() === "") {
+    throw new Error(`Feed source ${value.id} must declare a url.`);
+  }
+  if (value.trust !== undefined && value.trust !== "unsigned" && value.trust !== "pinned") {
+    throw new Error(`Feed source ${value.id} has unsupported trust value.`);
+  }
+  if (value.integrity !== undefined && typeof value.integrity !== "string") {
+    throw new Error(`Feed source ${value.id} integrity must be a string.`);
+  }
+  return {
+    id: value.id,
+    url: value.url,
+    enabled: value.enabled !== false,
+    ...(value.trust === "unsigned" || value.trust === "pinned" ? { trust: value.trust } : {}),
+    ...(typeof value.integrity === "string" ? { integrity: value.integrity } : {}),
+  };
+}
+
+function selectSources(
+  sources: readonly FeedSourceConfig[],
+  selectedId: string | undefined,
+): readonly FeedSourceConfig[] {
+  if (selectedId === undefined) {
+    return sources;
+  }
+  const selected = sources.filter((source) => source.id === selectedId);
+  if (selected.length === 0) {
+    throw new Error(`No enabled feed source found for '${selectedId}'.`);
+  }
+  return selected;
+}
+
+function flattenFeedEntries(loaded: readonly LoadedFeedDocument[]): readonly FeedEntryResult[] {
+  return loaded.flatMap((feed) =>
+    feed.document.entries.map((entry) => ({
+      ...entry,
+      sourceId: feed.source.id,
+      feedId: feed.document.id,
+    })),
+  );
+}
+
+function writeEntries(
+  entries: readonly FeedEntryResult[],
+  options: FeedsCommandOptions,
+  runtime: FeedsCommandRuntime,
+): void {
+  if (options.json === true || runtime.isTTY !== true) {
+    runtime.writeStdout(JSON.stringify({ entries }, null, 2) + "\n");
+    return;
+  }
+  if (entries.length === 0) {
+    runtime.writeStdout("No feed entries found.\n");
+    return;
+  }
+  runtime.writeStdout(
+    entries
+      .map((entry) => {
+        const version = entry.version === undefined ? "" : `@${entry.version}`;
+        const label = entry.name === undefined ? "" : ` - ${entry.name}`;
+        const install = formatFeedInstallCommand(entry);
+        const installHint = install === undefined ? "" : `\n  Install: ${install}`;
+        return `${entry.sourceId}\t${entry.type}\t${entry.id}${version}${label}${installHint}`;
+      })
+      .join("\n") + "\n",
+  );
+}
+
+function filterEntriesByType(
+  entries: readonly FeedEntryResult[],
+  type: string | undefined,
+): readonly FeedEntryResult[] {
+  if (type === undefined) {
+    return entries;
+  }
+  assertFeedEntryType(type);
+  return entries.filter((entry) => entry.type === type);
+}
+
+function assertFeedEntryType(
+  type: string | undefined,
+): asserts type is "skill" | "plugin" | undefined {
+  if (type !== undefined && type !== "skill" && type !== "plugin") {
+    throw new Error("Invalid --type value. Expected skill or plugin.");
+  }
+}
+
+function formatFeedInstallCommand(entry: FeedEntry): string | undefined {
+  const install = entry.install;
+  if (!isRecord(install)) {
+    return undefined;
+  }
+  const source = typeof install.source === "string" ? install.source : undefined;
+  const spec = typeof install.spec === "string" ? install.spec.trim() : "";
+  const clawhubSpec = typeof install.clawhubSpec === "string" ? install.clawhubSpec.trim() : "";
+  const npmSpec = typeof install.npmSpec === "string" ? install.npmSpec.trim() : "";
+  const slug = typeof install.slug === "string" ? install.slug.trim() : "";
+  if (entry.type === "plugin") {
+    if (clawhubSpec) {
+      return formatOpenClawInstallCommand("plugins", normalizeClawHubSpec(clawhubSpec));
+    }
+    if (source === "clawhub" && spec) {
+      return formatOpenClawInstallCommand("plugins", normalizeClawHubSpec(spec));
+    }
+    if (npmSpec) {
+      return formatOpenClawInstallCommand("plugins", npmSpec);
+    }
+    if ((source === "npm" || source === "path" || source === "git") && spec) {
+      return formatOpenClawInstallCommand("plugins", spec);
+    }
+    return undefined;
+  }
+  if (entry.type === "skill") {
+    if (slug) {
+      return formatOpenClawInstallCommand("skills", slug);
+    }
+    if (source === "clawhub" && spec) {
+      return formatOpenClawInstallCommand("skills", spec.replace(/^clawhub:/u, ""));
+    }
+    if ((source === "git" || source === "path" || source === "local") && spec) {
+      return formatOpenClawInstallCommand("skills", spec);
+    }
+  }
+  return undefined;
+}
+
+function formatOpenClawInstallCommand(kind: "plugins" | "skills", spec: string): string {
+  return `openclaw ${kind} install ${quoteCliArg(spec)}`;
+}
+
+function quoteCliArg(value: string): string {
+  return /^[A-Za-z0-9_/:=.,@%+-]+$/u.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function normalizeClawHubSpec(value: string): string {
+  return value.startsWith("clawhub:") ? value : `clawhub:${value}`;
+}
+
+function formatSourceRows(sources: readonly FeedSourceConfig[]): string {
+  if (sources.length === 0) {
+    return "No feed sources configured.\n";
+  }
+  return (
+    sources
+      .map((source) => {
+        const status = source.enabled ? "enabled" : "disabled";
+        const trust = source.trust ?? "unsigned";
+        return `${source.id}\t${status}\t${trust}\t${source.url}`;
+      })
+      .join("\n") + "\n"
+  );
+}

--- a/extensions/feeds/src/doctor/register.test.ts
+++ b/extensions/feeds/src/doctor/register.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateFeedsConfig,
+  FEEDS_CHECK_IDS,
+  registerFeedsDoctorChecks,
+  resetFeedsDoctorChecksForTest,
+} from "./register.js";
+
+describe("Feeds doctor checks", () => {
+  it("registers each feeds health check once", () => {
+    const registered: string[] = [];
+    resetFeedsDoctorChecksForTest();
+
+    registerFeedsDoctorChecks({
+      registerHealthCheck(check) {
+        registered.push(check.id);
+      },
+    });
+
+    expect(registered).toEqual(FEEDS_CHECK_IDS);
+  });
+
+  it("accepts configured https and file feed sources", () => {
+    const findings = evaluateFeedsConfig({
+      cfg: {
+        plugins: {
+          entries: {
+            feeds: {
+              enabled: true,
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/openclaw/feed.json",
+                    trust: "pinned",
+                    integrity:
+                      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                  },
+                  {
+                    id: "local-review",
+                    url: "file:///opt/openclaw/feeds/review.json",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("reports duplicate ids, unsupported urls, and missing pinned integrity", () => {
+    const findings = evaluateFeedsConfig({
+      cfg: {
+        plugins: {
+          entries: {
+            feeds: {
+              enabled: true,
+              config: {
+                sources: [
+                  { id: "company", url: "https://feeds.example.com/openclaw/feed.json" },
+                  { id: "company", url: "http://feeds.example.com/feed.json" },
+                  { id: "pinned", url: "https://feeds.example.com/pinned.json", trust: "pinned" },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "feeds/source-duplicate-id",
+          ocPath: "oc://openclaw.config/plugins/entries/feeds/config/sources/#1/id",
+        }),
+        expect.objectContaining({
+          checkId: "feeds/source-url-invalid",
+          ocPath: "oc://openclaw.config/plugins/entries/feeds/config/sources/#1/url",
+        }),
+        expect.objectContaining({
+          checkId: "feeds/source-integrity-missing",
+          ocPath: "oc://openclaw.config/plugins/entries/feeds/config/sources/#2/integrity",
+        }),
+      ]),
+    );
+  });
+
+  it("warns when the enabled feeds plugin has no sources", () => {
+    const findings = evaluateFeedsConfig({
+      cfg: {
+        plugins: {
+          entries: {
+            feeds: {
+              enabled: true,
+              config: {},
+            },
+          },
+        },
+      },
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "feeds/source-missing",
+        severity: "warning",
+        ocPath: "oc://openclaw.config/plugins/entries/feeds/config/sources",
+      }),
+    ]);
+  });
+});

--- a/extensions/feeds/src/doctor/register.ts
+++ b/extensions/feeds/src/doctor/register.ts
@@ -1,0 +1,295 @@
+import {
+  registerHealthCheck as registerPluginHealthCheck,
+  type HealthCheck,
+  type HealthCheckContext,
+  type HealthFinding,
+} from "openclaw/plugin-sdk/health";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const CHECK_IDS = {
+  configInvalid: "feeds/config-invalid",
+  sourceMissing: "feeds/source-missing",
+  sourceDuplicateId: "feeds/source-duplicate-id",
+  sourceUrlInvalid: "feeds/source-url-invalid",
+  sourceIntegrityInvalid: "feeds/source-integrity-invalid",
+  sourceIntegrityMissing: "feeds/source-integrity-missing",
+} as const;
+
+export const FEEDS_CHECK_IDS = [
+  CHECK_IDS.configInvalid,
+  CHECK_IDS.sourceMissing,
+  CHECK_IDS.sourceDuplicateId,
+  CHECK_IDS.sourceUrlInvalid,
+  CHECK_IDS.sourceIntegrityInvalid,
+  CHECK_IDS.sourceIntegrityMissing,
+] as const;
+
+type FeedsCheckId = (typeof FEEDS_CHECK_IDS)[number];
+
+export type FeedsDoctorRegistrationHost = {
+  readonly registerHealthCheck: (check: HealthCheck) => void;
+};
+
+let registered = false;
+
+export function registerFeedsDoctorChecks(host?: FeedsDoctorRegistrationHost): void {
+  if (registered) {
+    return;
+  }
+  const registerHealthCheck = host?.registerHealthCheck ?? registerPluginHealthCheck;
+  for (const check of feedsHealthChecks) {
+    registerHealthCheck(check);
+  }
+  registered = true;
+}
+
+export function resetFeedsDoctorChecksForTest(): void {
+  registered = false;
+}
+
+const feedsHealthChecks: readonly HealthCheck[] = FEEDS_CHECK_IDS.map((id) => ({
+  id,
+  kind: "plugin",
+  description: feedsCheckDescription(id),
+  source: "feeds",
+  async detect(ctx) {
+    return evaluateFeedsConfig(ctx).filter((finding) => finding.checkId === id);
+  },
+}));
+
+function feedsCheckDescription(id: FeedsCheckId): string {
+  switch (id) {
+    case CHECK_IDS.configInvalid:
+      return "The Feeds plugin configuration is well-formed.";
+    case CHECK_IDS.sourceMissing:
+      return "The enabled Feeds plugin has at least one configured source.";
+    case CHECK_IDS.sourceDuplicateId:
+      return "Feed source ids are unique.";
+    case CHECK_IDS.sourceUrlInvalid:
+      return "Feed source URLs are supported absolute URLs.";
+    case CHECK_IDS.sourceIntegrityInvalid:
+      return "Feed source integrity hashes use sha256:<hex> syntax.";
+    case CHECK_IDS.sourceIntegrityMissing:
+      return "Pinned feed sources declare an integrity hash.";
+  }
+  const exhaustive: never = id;
+  return exhaustive;
+}
+
+export function evaluateFeedsConfig(
+  ctx: Pick<HealthCheckContext, "cfg">,
+): readonly HealthFinding[] {
+  const config = ctx.cfg.plugins?.entries?.feeds?.config;
+  const configPath = "plugins.entries.feeds.config";
+  const configOcPath = "oc://openclaw.config/plugins/entries/feeds/config";
+
+  if (config === undefined) {
+    return [
+      {
+        checkId: CHECK_IDS.sourceMissing,
+        severity: "warning",
+        message: "The enabled Feeds plugin has no configured feed sources.",
+        source: "feeds",
+        path: configPath,
+        ocPath: configOcPath,
+        fixHint: "Add plugins.entries.feeds.config.sources with at least one feed source.",
+      },
+    ];
+  }
+  if (!isRecord(config)) {
+    return [
+      invalidConfigFinding({
+        propertyPath: configPath,
+        target: configOcPath,
+        message: "plugins.entries.feeds.config must be an object.",
+        fixHint: "Set plugins.entries.feeds.config to an object with a sources array.",
+      }),
+    ];
+  }
+
+  const findings: HealthFinding[] = [];
+  const sources = config.sources;
+  if (sources === undefined) {
+    findings.push({
+      checkId: CHECK_IDS.sourceMissing,
+      severity: "warning",
+      message: "The enabled Feeds plugin has no configured feed sources.",
+      source: "feeds",
+      path: `${configPath}.sources`,
+      ocPath: `${configOcPath}/sources`,
+      fixHint: "Add at least one feed source.",
+    });
+    return findings;
+  }
+  if (!Array.isArray(sources)) {
+    findings.push(
+      invalidConfigFinding({
+        propertyPath: `${configPath}.sources`,
+        target: `${configOcPath}/sources`,
+        message: "plugins.entries.feeds.config.sources must be an array.",
+        fixHint: "Set sources to an array of feed source objects.",
+      }),
+    );
+    return findings;
+  }
+  if (sources.length === 0) {
+    findings.push({
+      checkId: CHECK_IDS.sourceMissing,
+      severity: "warning",
+      message: "The enabled Feeds plugin has an empty feed source list.",
+      source: "feeds",
+      path: `${configPath}.sources`,
+      ocPath: `${configOcPath}/sources`,
+      fixHint: "Add at least one feed source or disable the Feeds plugin.",
+    });
+    return findings;
+  }
+
+  const seenIds = new Map<string, number>();
+  sources.forEach((source, index) => {
+    findings.push(...evaluateFeedSource(source, index, seenIds));
+  });
+  return findings;
+}
+
+function evaluateFeedSource(
+  source: unknown,
+  index: number,
+  seenIds: Map<string, number>,
+): readonly HealthFinding[] {
+  const sourcePath = `plugins.entries.feeds.config.sources[${index}]`;
+  const sourceOcPath = `oc://openclaw.config/plugins/entries/feeds/config/sources/#${index}`;
+  if (!isRecord(source)) {
+    return [
+      invalidConfigFinding({
+        propertyPath: sourcePath,
+        target: sourceOcPath,
+        message: `Feed source ${index} must be an object.`,
+        fixHint: "Replace this source with an object containing id and url.",
+      }),
+    ];
+  }
+
+  const findings: HealthFinding[] = [];
+  const id = typeof source.id === "string" ? source.id.trim() : "";
+  if (!/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(id)) {
+    findings.push(
+      invalidConfigFinding({
+        propertyPath: `${sourcePath}.id`,
+        target: `${sourceOcPath}/id`,
+        message: `Feed source ${index} must have a stable lowercase id.`,
+        fixHint: "Use a lowercase id such as company-approved or clawhub-public.",
+      }),
+    );
+  } else {
+    const previous = seenIds.get(id);
+    if (previous !== undefined) {
+      findings.push({
+        checkId: CHECK_IDS.sourceDuplicateId,
+        severity: "error",
+        message: `Feed source id '${id}' duplicates sources[${previous}].`,
+        source: "feeds",
+        path: `${sourcePath}.id`,
+        ocPath: `${sourceOcPath}/id`,
+        fixHint: "Give each feed source a unique id.",
+      });
+    } else {
+      seenIds.set(id, index);
+    }
+  }
+
+  const url = typeof source.url === "string" ? source.url.trim() : "";
+  if (!isSupportedFeedUrl(url)) {
+    findings.push({
+      checkId: CHECK_IDS.sourceUrlInvalid,
+      severity: "error",
+      message: `Feed source ${id || index} must use an absolute https:// or file:// URL.`,
+      source: "feeds",
+      path: `${sourcePath}.url`,
+      ocPath: `${sourceOcPath}/url`,
+      fixHint: "Use an absolute https:// URL for hosted feeds or file:// URL for local feeds.",
+    });
+  }
+
+  const trust = source.trust;
+  if (trust !== undefined && trust !== "unsigned" && trust !== "pinned") {
+    findings.push(
+      invalidConfigFinding({
+        propertyPath: `${sourcePath}.trust`,
+        target: `${sourceOcPath}/trust`,
+        message: `Feed source ${id || index} has unsupported trust value '${formatUnknown(trust)}'.`,
+        fixHint: 'Use trust "unsigned" or "pinned".',
+      }),
+    );
+  }
+
+  const integrity = source.integrity;
+  if (integrity !== undefined && !isSha256Integrity(integrity)) {
+    findings.push({
+      checkId: CHECK_IDS.sourceIntegrityInvalid,
+      severity: "error",
+      message: `Feed source ${id || index} has an invalid integrity hash.`,
+      source: "feeds",
+      path: `${sourcePath}.integrity`,
+      ocPath: `${sourceOcPath}/integrity`,
+      fixHint: "Use sha256:<64 lowercase or uppercase hexadecimal characters>.",
+    });
+  }
+  if (trust === "pinned" && integrity === undefined) {
+    findings.push({
+      checkId: CHECK_IDS.sourceIntegrityMissing,
+      severity: "error",
+      message: `Pinned feed source ${id || index} must declare an integrity hash.`,
+      source: "feeds",
+      path: `${sourcePath}.integrity`,
+      ocPath: `${sourceOcPath}/integrity`,
+      fixHint: 'Add integrity: "sha256:<hex>" or change trust to "unsigned".',
+    });
+  }
+
+  return findings;
+}
+
+function invalidConfigFinding(params: {
+  readonly propertyPath: string;
+  readonly target: string;
+  readonly message: string;
+  readonly fixHint: string;
+}): HealthFinding {
+  return {
+    checkId: CHECK_IDS.configInvalid,
+    severity: "error",
+    message: params.message,
+    source: "feeds",
+    path: params.propertyPath,
+    ocPath: params.target,
+    fixHint: params.fixHint,
+  };
+}
+
+function isSupportedFeedUrl(value: string): boolean {
+  if (value === "") {
+    return false;
+  }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "file:";
+  } catch {
+    return false;
+  }
+}
+
+function isSha256Integrity(value: unknown): boolean {
+  return typeof value === "string" && /^sha256:[a-f0-9]{64}$/iu.test(value);
+}
+
+function formatUnknown(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "<unprintable>";
+  }
+}

--- a/extensions/feeds/src/feed-document.ts
+++ b/extensions/feeds/src/feed-document.ts
@@ -6,6 +6,8 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export const MAX_FEED_DOCUMENT_BYTES = 1024 * 1024;
+export const FEED_FETCH_TIMEOUT_MS = 15_000;
+export const FEED_READ_IDLE_TIMEOUT_MS = 15_000;
 
 export type FeedSourceConfig = {
   readonly id: string;
@@ -120,22 +122,53 @@ async function readFeedBytes(url: string, runtime: FeedDocumentRuntime): Promise
     const fetcher = runtime.fetch ?? defaultFetch;
     const response = await fetcher(url);
     if (!response.ok) {
-      throw new Error(`Feed URL ${url} did not return a successful response.`);
+      throw new Error(
+        `Feed URL ${formatFeedUrlForDiagnostics(url)} did not return a successful response.`,
+      );
     }
     return Buffer.from(response.text, "utf8");
   }
-  throw new Error(`Unsupported feed URL protocol for ${url}.`);
+  throw new Error(`Unsupported feed URL protocol for ${formatFeedUrlForDiagnostics(url)}.`);
+}
+
+function formatFeedUrlForDiagnostics(value: string): string {
+  try {
+    const parsed = new URL(value);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return value.split(/[?#]/u, 1)[0] ?? value;
+  }
 }
 
 async function defaultFetch(url: string): Promise<{ readonly ok: boolean; readonly text: string }> {
   const { response, release } = await fetchWithSsrFGuard({
     url,
     auditContext: "feeds.feed-document",
+    timeoutMs: FEED_FETCH_TIMEOUT_MS,
   });
   try {
     const body = await readResponseWithLimit(response, MAX_FEED_DOCUMENT_BYTES, {
+      chunkTimeoutMs: FEED_READ_IDLE_TIMEOUT_MS,
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(
+          "Feed URL " +
+            formatFeedUrlForDiagnostics(url) +
+            " response stalled for " +
+            chunkTimeoutMs +
+            "ms.",
+        ),
       onOverflow: ({ maxBytes }) =>
-        new Error("Feed URL " + url + " response exceeds " + maxBytes + " bytes."),
+        new Error(
+          "Feed URL " +
+            formatFeedUrlForDiagnostics(url) +
+            " response exceeds " +
+            maxBytes +
+            " bytes.",
+        ),
     });
     return { ok: response.ok, text: body.toString("utf8") };
   } finally {

--- a/extensions/feeds/src/feed-document.ts
+++ b/extensions/feeds/src/feed-document.ts
@@ -1,0 +1,155 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export type FeedSourceConfig = {
+  readonly id: string;
+  readonly url: string;
+  readonly enabled: boolean;
+  readonly trust?: "unsigned" | "pinned";
+  readonly integrity?: string;
+};
+
+export type FeedEntryType = "skill" | "plugin";
+
+export type FeedEntry = {
+  readonly type: FeedEntryType;
+  readonly id: string;
+  readonly version?: string;
+  readonly name?: string;
+  readonly description?: string;
+  readonly tags?: readonly string[];
+  readonly sourceUrl?: string;
+  readonly sha256?: string;
+  readonly install?: Record<string, unknown>;
+  readonly approval?: Record<string, unknown>;
+};
+
+export type FeedDocument = {
+  readonly schemaVersion: 1;
+  readonly id: string;
+  readonly generatedAt?: string;
+  readonly entries: readonly FeedEntry[];
+};
+
+export type LoadedFeedDocument = {
+  readonly source: FeedSourceConfig;
+  readonly document: FeedDocument;
+  readonly sha256: string;
+};
+
+export type FeedFetch = (url: string) => Promise<{ readonly ok: boolean; readonly text: string }>;
+
+export type FeedDocumentRuntime = {
+  readonly fetch?: FeedFetch;
+  readonly readFile?: (path: string) => Promise<Buffer | string>;
+};
+
+export async function loadFeedDocument(
+  source: FeedSourceConfig,
+  runtime: FeedDocumentRuntime = {},
+): Promise<LoadedFeedDocument> {
+  const raw = await readFeedBytes(source.url, runtime);
+  const sha256 = createHash("sha256").update(raw).digest("hex");
+  if (source.trust === "pinned" && source.integrity === undefined) {
+    throw new Error(`Feed source ${source.id} requires integrity for pinned trust.`);
+  }
+  if (source.integrity !== undefined && source.integrity.toLowerCase() !== `sha256:${sha256}`) {
+    throw new Error(`Feed source ${source.id} integrity mismatch.`);
+  }
+  const parsed = parseFeedDocument(JSON.parse(raw.toString("utf8")), source.id);
+  return { source, document: parsed, sha256 };
+}
+
+export function parseFeedDocument(value: unknown, sourceId = "feed"): FeedDocument {
+  if (!isRecord(value)) {
+    throw new Error(`Feed source ${sourceId} must contain a JSON object.`);
+  }
+  if (value.schemaVersion !== 1) {
+    throw new Error(`Feed source ${sourceId} must use schemaVersion 1.`);
+  }
+  if (typeof value.id !== "string" || value.id.trim() === "") {
+    throw new Error(`Feed source ${sourceId} must declare a feed id.`);
+  }
+  if (value.generatedAt !== undefined && typeof value.generatedAt !== "string") {
+    throw new Error(`Feed source ${sourceId} generatedAt must be a string when present.`);
+  }
+  if (!Array.isArray(value.entries)) {
+    throw new Error(`Feed source ${sourceId} entries must be an array.`);
+  }
+  return {
+    schemaVersion: 1,
+    id: value.id,
+    ...(typeof value.generatedAt === "string" ? { generatedAt: value.generatedAt } : {}),
+    entries: value.entries.map((entry, index) => parseFeedEntry(entry, sourceId, index)),
+  };
+}
+
+export function feedEntryMatchesQuery(entry: FeedEntry, query: string): boolean {
+  const normalized = query.trim().toLowerCase();
+  if (normalized === "") {
+    return true;
+  }
+  const haystack = [
+    entry.type,
+    entry.id,
+    entry.version,
+    entry.name,
+    entry.description,
+    ...(entry.tags ?? []),
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join("\n")
+    .toLowerCase();
+  return haystack.includes(normalized);
+}
+
+async function readFeedBytes(url: string, runtime: FeedDocumentRuntime): Promise<Buffer> {
+  const parsed = new URL(url);
+  if (parsed.protocol === "file:") {
+    const read = runtime.readFile ?? readFile;
+    const value = await read(fileURLToPath(parsed));
+    return Buffer.isBuffer(value) ? value : Buffer.from(value);
+  }
+  if (parsed.protocol === "https:") {
+    const fetcher = runtime.fetch ?? defaultFetch;
+    const response = await fetcher(url);
+    if (!response.ok) {
+      throw new Error(`Feed URL ${url} did not return a successful response.`);
+    }
+    return Buffer.from(response.text, "utf8");
+  }
+  throw new Error(`Unsupported feed URL protocol for ${url}.`);
+}
+
+async function defaultFetch(url: string): Promise<{ readonly ok: boolean; readonly text: string }> {
+  const response = await fetch(url);
+  return { ok: response.ok, text: await response.text() };
+}
+
+function parseFeedEntry(value: unknown, sourceId: string, index: number): FeedEntry {
+  if (!isRecord(value)) {
+    throw new Error(`Feed source ${sourceId} entry ${index} must be an object.`);
+  }
+  if (value.type !== "skill" && value.type !== "plugin") {
+    throw new Error(`Feed source ${sourceId} entry ${index} must be a skill or plugin.`);
+  }
+  if (typeof value.id !== "string" || value.id.trim() === "") {
+    throw new Error(`Feed source ${sourceId} entry ${index} must declare an id.`);
+  }
+  return {
+    type: value.type,
+    id: value.id,
+    ...(typeof value.version === "string" ? { version: value.version } : {}),
+    ...(typeof value.name === "string" ? { name: value.name } : {}),
+    ...(typeof value.description === "string" ? { description: value.description } : {}),
+    ...(Array.isArray(value.tags) && value.tags.every((tag) => typeof tag === "string")
+      ? { tags: value.tags }
+      : {}),
+    ...(typeof value.sourceUrl === "string" ? { sourceUrl: value.sourceUrl } : {}),
+    ...(typeof value.sha256 === "string" ? { sha256: value.sha256 } : {}),
+    ...(isRecord(value.install) ? { install: value.install } : {}),
+    ...(isRecord(value.approval) ? { approval: value.approval } : {}),
+  };
+}

--- a/extensions/feeds/src/feed-document.ts
+++ b/extensions/feeds/src/feed-document.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export type FeedSourceConfig = {
@@ -124,8 +125,15 @@ async function readFeedBytes(url: string, runtime: FeedDocumentRuntime): Promise
 }
 
 async function defaultFetch(url: string): Promise<{ readonly ok: boolean; readonly text: string }> {
-  const response = await fetch(url);
-  return { ok: response.ok, text: await response.text() };
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    auditContext: "feeds.feed-document",
+  });
+  try {
+    return { ok: response.ok, text: await response.text() };
+  } finally {
+    await release();
+  }
 }
 
 function parseFeedEntry(value: unknown, sourceId: string, index: number): FeedEntry {

--- a/extensions/feeds/src/feed-document.ts
+++ b/extensions/feeds/src/feed-document.ts
@@ -1,8 +1,11 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export const MAX_FEED_DOCUMENT_BYTES = 1024 * 1024;
 
 export type FeedSourceConfig = {
   readonly id: string;
@@ -130,7 +133,11 @@ async function defaultFetch(url: string): Promise<{ readonly ok: boolean; readon
     auditContext: "feeds.feed-document",
   });
   try {
-    return { ok: response.ok, text: await response.text() };
+    const body = await readResponseWithLimit(response, MAX_FEED_DOCUMENT_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error("Feed URL " + url + " response exceeds " + maxBytes + " bytes."),
+    });
+    return { ok: response.ok, text: body.toString("utf8") };
   } finally {
     await release();
   }

--- a/extensions/feeds/testdata/proof-feed.json
+++ b/extensions/feeds/testdata/proof-feed.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "id": "openclaw-feeds-proof",
+  "generatedAt": "2026-06-19T00:00:00.000Z",
+  "entries": [
+    {
+      "type": "plugin",
+      "id": "proof-calendar-helper",
+      "version": "1.0.0",
+      "name": "Proof Calendar Helper",
+      "description": "Fixture entry used by HTTPS feed behavior proof.",
+      "tags": ["proof", "calendar"],
+      "install": {
+        "source": "clawhub",
+        "spec": "proof-calendar-helper"
+      }
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,6 +736,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/feeds:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/feishu:
     dependencies:
       '@larksuiteoapi/node-sdk':

--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -6,10 +6,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerBundledHealthChecks } from "./bundled-health-checks.js";
 
 const mocks = vi.hoisted(() => ({
+  registerFeedsDoctorChecks: vi.fn(),
   registerPolicyDoctorChecks: vi.fn(),
-  loadBundledPluginPublicArtifactModuleSync: vi.fn(() => ({
-    registerPolicyDoctorChecks: mocks.registerPolicyDoctorChecks,
-  })),
+  loadBundledPluginPublicArtifactModuleSync: vi.fn((params: { dirName: string }) =>
+    params.dirName === "feeds"
+      ? {
+          registerFeedsDoctorChecks: mocks.registerFeedsDoctorChecks,
+        }
+      : {
+          registerPolicyDoctorChecks: mocks.registerPolicyDoctorChecks,
+        },
+  ),
 }));
 
 vi.mock("../plugins/public-surface-loader.js", () => ({
@@ -33,6 +40,21 @@ describe("registerBundledHealthChecks", () => {
     registerBundledHealthChecks({ cfg: {}, cwd: workspaceDir });
 
     expect(mocks.loadBundledPluginPublicArtifactModuleSync).not.toHaveBeenCalled();
+  });
+
+  it("loads bundled feeds health checks when feeds extension is enabled", () => {
+    registerBundledHealthChecks({
+      cfg: { plugins: { entries: { feeds: { enabled: true } } } },
+      cwd: workspaceDir,
+    });
+
+    expect(mocks.loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith({
+      dirName: "feeds",
+      artifactBasename: "api.js",
+    });
+    expect(mocks.registerFeedsDoctorChecks).toHaveBeenCalledWith({
+      registerHealthCheck: expect.any(Function),
+    });
   });
 
   it("loads bundled policy health checks when policy extension is enabled", () => {
@@ -67,11 +89,34 @@ describe("registerBundledHealthChecks", () => {
     expect(mocks.loadBundledPluginPublicArtifactModuleSync).not.toHaveBeenCalled();
   });
 
+  it("honors explicit feeds disablement", () => {
+    registerBundledHealthChecks({
+      cfg: { plugins: { entries: { feeds: { enabled: true, config: { enabled: false } } } } },
+      cwd: workspaceDir,
+    });
+
+    expect(mocks.loadBundledPluginPublicArtifactModuleSync).not.toHaveBeenCalled();
+  });
+
   it("honors plugin control-plane disablement for policy checks", () => {
     for (const plugins of [
       { enabled: false, entries: { policy: { enabled: true } } },
       { deny: ["policy"], entries: { policy: { enabled: true } } },
       { allow: ["telegram"], entries: { policy: { enabled: true } } },
+    ]) {
+      vi.clearAllMocks();
+
+      registerBundledHealthChecks({ cfg: { plugins }, cwd: workspaceDir });
+
+      expect(mocks.loadBundledPluginPublicArtifactModuleSync).not.toHaveBeenCalled();
+    }
+  });
+
+  it("honors plugin control-plane disablement for feeds checks", () => {
+    for (const plugins of [
+      { enabled: false, entries: { feeds: { enabled: true } } },
+      { deny: ["feeds"], entries: { feeds: { enabled: true } } },
+      { allow: ["telegram"], entries: { feeds: { enabled: true } } },
     ]) {
       vi.clearAllMocks();
 

--- a/src/flows/bundled-health-checks.ts
+++ b/src/flows/bundled-health-checks.ts
@@ -8,18 +8,24 @@ import { registerHealthCheck } from "./health-check-registry.js";
 
 // Bridges bundled plugin doctor checks into the core health registry.
 type BundledHealthApi = {
+  registerFeedsDoctorChecks?: (host: { registerHealthCheck: typeof registerHealthCheck }) => void;
   registerPolicyDoctorChecks?: (host: { registerHealthCheck: typeof registerHealthCheck }) => void;
 };
 
 /** Registers bundled health checks that are explicitly enabled by config and owner policy. */
 export function registerBundledHealthChecks(params: { cfg: OpenClawConfig; cwd?: string }): void {
-  if (!shouldRegisterPolicyHealth(params)) {
-    return;
+  if (shouldRegisterFeedsHealth(params)) {
+    loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
+      dirName: "feeds",
+      artifactBasename: "api.js",
+    }).registerFeedsDoctorChecks?.({ registerHealthCheck });
   }
-  loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
-    dirName: "policy",
-    artifactBasename: "api.js",
-  }).registerPolicyDoctorChecks?.({ registerHealthCheck });
+  if (shouldRegisterPolicyHealth(params)) {
+    loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
+      dirName: "policy",
+      artifactBasename: "api.js",
+    }).registerPolicyDoctorChecks?.({ registerHealthCheck });
+  }
 }
 
 function shouldRegisterPolicyHealth(params: { cfg: OpenClawConfig; cwd?: string }): boolean {
@@ -32,6 +38,23 @@ function shouldRegisterPolicyHealth(params: { cfg: OpenClawConfig; cwd?: string 
   if (
     !passesManifestOwnerBasePolicy({
       plugin: { id: "policy" },
+      normalizedConfig: normalizePluginsConfig(params.cfg.plugins),
+    })
+  ) {
+    return false;
+  }
+  return entry.enabled === true || config.enabled === true;
+}
+
+function shouldRegisterFeedsHealth(params: { cfg: OpenClawConfig; cwd?: string }): boolean {
+  const entry = params.cfg.plugins?.entries?.feeds;
+  const config = readRecord(entry?.config) ?? {};
+  if (entry === undefined || entry.enabled === false || config.enabled === false) {
+    return false;
+  }
+  if (
+    !passesManifestOwnerBasePolicy({
+      plugin: { id: "feeds" },
       normalizedConfig: normalizePluginsConfig(params.cfg.plugins),
     })
   ) {


### PR DESCRIPTION
## Summary

Adds a bundled `feeds` extension for curated skill/plugin catalog sources and read-only discovery.

This PR establishes the primitive without install enforcement:

- Adds `plugins.entries.feeds.config.sources[]` for configured feed documents.
- Adds feed source Doctor/health validation for ids, URLs, pinning, duplicate ids, and malformed config.
- Adds `openclaw feeds sources`, `feeds list`, and `feeds search`.
- Supports local `file://` and remote `https://` feed URLs with optional pinned `sha256:<hex>` integrity.
- Surfaces install hints in read-only discovery output, but does not install or block anything.
- Adds plugin docs and plugin inventory wiring.

## Example syntax

```jsonc
{
  "plugins": {
    "entries": {
      "feeds": {
        "enabled": true,
        "config": {
          "sources": [
            {
              "id": "company-approved",
              "url": "https://feeds.example.com/openclaw/feed.json",
              "trust": "pinned",
              "integrity": "sha256:..."
            }
          ]
        }
      }
    }
  }
}
```

## Commands

```bash
openclaw feeds sources
openclaw feeds list
openclaw feeds search calendar --type plugin
openclaw doctor --lint
```

## Notes

This is intentionally read-only. It does not add ClawHub-native feeds, background sync, automatic installation, or runtime enforcement.

## Real behavior proof

Behavior or issue addressed:
Configured feed discovery now loads `file://` and guarded `https://` feed documents through the bundled `feeds` CLI, with HTTPS reads bounded by SSRF policy, fetch timeout, body idle timeout, and a 1 MiB response cap. HTTPS feed diagnostics redact credentials, query strings, and fragments before surfacing URLs.

Real environment tested:
WSL2 Ubuntu 24.04, source checkout `/root/src/openclaw-feeds-87824` at signed head `41fe48a7dd886dc596b32b5287debae43b80f471` (`fix(feeds): bound and redact remote feed fetches`). The HTTPS proof used the real source CLI and a public GitHub Raw HTTPS feed fixture committed on this PR branch at `extensions/feeds/testdata/proof-feed.json`, with isolated temporary `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and `HOME`.

Exact steps or command run after this patch:
1. Configured isolated `openclaw.json` with feed source URL `https://raw.githubusercontent.com/openclaw/openclaw/feeds-read-only-discovery/extensions/feeds/testdata/proof-feed.json`.
2. Ran `node scripts/run-node.mjs feeds sources --json` with isolated `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and `HOME`.
3. Ran `node scripts/run-node.mjs feeds list --json` with the same isolated state.
4. Ran `node scripts/run-node.mjs feeds search calendar --type plugin --json` with the same isolated state.
5. Ran focused validation: feeds CLI Vitest, full `extensions/feeds/src` Vitest, targeted `oxlint`, targeted `oxfmt --check`, `pnpm tsgo:extensions`, and `git diff --check`.

Evidence after fix:
Real source CLI HTTPS proof:

```json
{
  "rawUrl": "https://raw.githubusercontent.com/openclaw/openclaw/feeds-read-only-discovery/extensions/feeds/testdata/proof-feed.json",
  "sourcesStatus": 0,
  "listStatus": 0,
  "listEntryIds": ["proof-calendar-helper"],
  "listSourceIds": ["github-raw-proof"],
  "listFeedIds": ["openclaw-feeds-proof"],
  "searchStatus": 0,
  "searchEntries": [
    {
      "sourceId": "github-raw-proof",
      "feedId": "openclaw-feeds-proof",
      "type": "plugin",
      "id": "proof-calendar-helper",
      "name": "Proof Calendar Helper",
      "installHint": null
    }
  ]
}
```

Focused tests covered the failure/availability side: HTTPS feed fetches pass `timeoutMs: 15000` to `fetchWithSsrFGuard`, response reads pass `chunkTimeoutMs: 15000`, oversized responses are capped at `1048576` bytes, stalled bodies report a bounded idle-timeout error, and secret-bearing URLs such as `https://user:secret@feeds.example.com/slow.json?token=hidden#frag` are reported as `https://feeds.example.com/slow.json` without the credential, query, or fragment.

Observed result after fix:
The real source CLI successfully loaded the HTTPS feed through the configured feed source, listed the `proof-calendar-helper` plugin entry from feed id `openclaw-feeds-proof`, and found it with `feeds search calendar --type plugin --json`. Focused validation passed: feeds CLI shard 14 tests passed; full `extensions/feeds/src` shard 18 tests passed; targeted `oxlint` found 0 warnings/errors; `oxfmt --check` passed; `pnpm tsgo:extensions` passed; `git diff --check` was clean.

What was not tested:
No private/internal HTTPS endpoint was contacted; that path is intentionally blocked by the SSRF guard and covered by focused tests. The HTTPS success proof used GitHub Raw as a public HTTPS origin, not a production feed registry.

## Validation

```bash
node scripts/run-vitest.mjs extensions/feeds/src/cli.test.ts extensions/feeds/src/doctor/register.test.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts src/flows/bundled-health-checks.test.ts
node scripts/run-tsgo.mjs --noEmit
pnpm exec oxfmt --check extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/feeds/src/feed-document.ts extensions/feeds/src/doctor/register.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts docs/cli/policy.md docs/plugins/reference/feeds.md docs/plugins/reference.md
git diff --check
node scripts/generate-plugin-inventory-doc.mjs --check
```

Focused stack proof on the final condensed branch: 243 tests passed.
Latest cap-fix validation on head `57d27be40d336c62c89a5a7fe2794ddd5170558b`:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/feeds/src/cli.test.ts extensions/feeds/src/doctor/register.test.ts src/flows/bundled-health-checks.test.ts --reporter=dot
pnpm exec oxlint --tsconfig ./tsconfig.json extensions/feeds/src/feed-document.ts extensions/feeds/src/cli.test.ts
pnpm exec oxfmt --check --threads=1 extensions/feeds/src/feed-document.ts extensions/feeds/src/cli.test.ts && git diff --check
pnpm tsgo:extensions
OPENCLAW_CONFIG_PATH=/tmp/openclaw-feeds-proof-87824/openclaw.json OPENCLAW_STATE_DIR=/tmp/openclaw-feeds-proof-87824/state node scripts/run-node.mjs feeds sources --json
OPENCLAW_CONFIG_PATH=/tmp/openclaw-feeds-proof-87824/openclaw.json OPENCLAW_STATE_DIR=/tmp/openclaw-feeds-proof-87824/state node scripts/run-node.mjs feeds list --json
OPENCLAW_CONFIG_PATH=/tmp/openclaw-feeds-proof-87824/openclaw.json OPENCLAW_STATE_DIR=/tmp/openclaw-feeds-proof-87824/state node scripts/run-node.mjs feeds search proof --type plugin --json
```

## Feed PR stack

1. openclaw/openclaw#87824 - read-only feed discovery
2. openclaw/openclaw#87825 - approved feed installs
3. openclaw/openclaw#87826 - feed catalog policy conformance
4. openclaw/openclaw#87827 - feed lifecycle tooling
5. openclaw/openclaw#88732 - native feed search defaults and policy checks
6. openclaw/clawhub#2460 - ClawHub root feed lanes

The stack keeps OpenClaw as a feed consumer. ClawHub root feeds are producer infrastructure; enterprise or tenant feeds can be produced elsewhere using the same schema.

RFC draft: https://github.com/giodl73-repo/rfcs/blob/feeds-rfc-draft/rfcs/0004-feeds.md
