### PR TITLE
feat(feeds): install approved feed entries

### DIFF
--- a/docs/plugins/reference/feeds.md
+++ b/docs/plugins/reference/feeds.md
@@ -17,3 +17,91 @@ Adds configured catalog feed source validation for skills and plugins.
 ## Surface
 
 plugin
+
+## Configure feed sources
+
+Feed sources live under the bundled `feeds` plugin config. A source can point at
+an `https://` or `file://` feed document and can optionally be pinned by
+integrity.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "feeds": {
+        "enabled": true,
+        "config": {
+          "sources": [
+            {
+              "id": "company-approved",
+              "url": "https://feeds.example.com/openclaw/feed.json",
+              "trust": "pinned",
+              "integrity": "sha256:...",
+            },
+          ],
+        },
+      },
+    },
+  },
+}
+```
+
+## Discover entries
+
+```bash
+openclaw feeds sources
+openclaw feeds list --source company-approved
+openclaw feeds search calendar --type plugin
+```
+
+## Install from a feed
+
+`openclaw feeds install` resolves exactly one feed entry, checks the configured
+feed install policy, and then hands off to the existing OpenClaw skill or plugin
+install command. The feeds plugin does not introduce a second installer.
+
+```bash
+openclaw feeds install calendar-helper --source company-approved --type plugin --dry-run
+openclaw feeds install calendar-helper --source company-approved --type plugin
+openclaw feeds install calendar-helper --source company-approved --type plugin --force
+```
+
+Use `--dry-run` to print the underlying install command without running it. Use
+`--force` to forward force behavior to the existing installer.
+
+## Install policy
+
+`installPolicy` controls approval checks for explicit feed-backed installs.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "feeds": {
+        "enabled": true,
+        "config": {
+          "installPolicy": {
+            "mode": "enforce",
+            "requireApproval": true,
+          },
+          "sources": [
+            {
+              "id": "company-approved",
+              "url": "file:///opt/openclaw/feeds/company.json",
+            },
+          ],
+        },
+      },
+    },
+  },
+}
+```
+
+- `mode: "off"` performs no approval check.
+- `mode: "warn"` reports unapproved entries and continues.
+- `mode: "enforce"` blocks unapproved entries.
+- `requireApproval: true` requires `approval.status: "approved"` on feed entries.
+
+If `requireApproval` is `true` and `mode` is omitted, OpenClaw treats the policy
+as enforce. If `mode` is `enforce` and `requireApproval` is omitted, approval is
+required.

--- a/extensions/feeds/openclaw.plugin.json
+++ b/extensions/feeds/openclaw.plugin.json
@@ -15,6 +15,22 @@
         "type": "boolean",
         "description": "Enable feeds doctor checks."
       },
+      "installPolicy": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Optional install-time policy for entries discovered through feeds.",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["off", "warn", "enforce"],
+            "description": "Install policy mode. Defaults to off."
+          },
+          "requireApproval": {
+            "type": "boolean",
+            "description": "Require feed entries to declare approval.status=approved before install."
+          }
+        }
+      },
       "sources": {
         "type": "array",
         "description": "Catalog feed sources used for curated skill and plugin discovery.",

--- a/extensions/feeds/src/cli.test.ts
+++ b/extensions/feeds/src/cli.test.ts
@@ -7,6 +7,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 import {
+  feedsInstallCommand,
   feedsListCommand,
   feedsSearchCommand,
   feedsSourcesCommand,
@@ -266,26 +267,261 @@ describe("Feeds CLI", () => {
     expect(exitCode).toBe(2);
     expect(runtime.stderr).toContain("Invalid --type value. Expected skill or plugin.");
   });
+
+  it("dry-runs an explicit feed-backed plugin install", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+        },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand("calendar-helper", { dryRun: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(runtime.stdout).toBe("openclaw plugins install clawhub:openclaw-calendar\n");
+    expect(runtime.commands).toEqual([]);
+  });
+
+  it("runs the existing install command for a selected feed entry", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        { type: "skill", id: "excel-review", install: { source: "clawhub", slug: "excel-review" } },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand(
+      "excel-review",
+      { type: "skill", force: true },
+      runtime,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(runtime.commands).toEqual([["skills", "install", "excel-review", "--force"]]);
+  });
+
+  it("enforces approved feed install metadata when configured", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+        },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      installPolicy: { mode: "enforce", requireApproval: true },
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand("calendar-helper", {}, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("is not approved by feed metadata");
+    expect(runtime.commands).toEqual([]);
+  });
+
+  it("defaults enforce mode to approved-only installs", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+        },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      installPolicy: { mode: "enforce" },
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand("calendar-helper", {}, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("is not approved by feed metadata");
+    expect(runtime.commands).toEqual([]);
+  });
+
+  it("defaults requireApproval without a mode to enforce", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+        },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      installPolicy: { requireApproval: true },
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand("calendar-helper", {}, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("is not approved by feed metadata");
+    expect(runtime.commands).toEqual([]);
+  });
+
+  it("warns but installs unapproved feed entries in warn mode", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+        },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      installPolicy: { mode: "warn", requireApproval: true },
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand("calendar-helper", {}, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(runtime.stderr).toContain("Warning: Feed entry 'calendar-helper' is not approved");
+    expect(runtime.commands).toEqual([["plugins", "install", "clawhub:openclaw-calendar"]]);
+  });
+
+  it("installs approved feed entries when enforcement is enabled", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+          approval: { status: "approved", owner: "platform" },
+        },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      installPolicy: { mode: "enforce", requireApproval: true },
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand("calendar-helper", {}, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(runtime.stderr).toBe("");
+    expect(runtime.commands).toEqual([["plugins", "install", "clawhub:openclaw-calendar"]]);
+  });
+
+  it("requires disambiguation before installing duplicate feed entry ids", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        { type: "skill", id: "shared", install: { source: "clawhub", slug: "shared-skill" } },
+        { type: "plugin", id: "shared", install: { source: "clawhub", spec: "shared-plugin" } },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand("shared", {}, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("Use --source or --type to choose one.");
+    expect(runtime.commands).toEqual([]);
+  });
+
+  it("rejects feed install entries without supported install metadata", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [{ type: "plugin", id: "unknown", install: { source: "container" } }],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsInstallCommand("unknown", {}, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("does not include supported install metadata");
+    expect(runtime.commands).toEqual([]);
+  });
 });
 
 function createRuntime(params: {
   readonly sources?: readonly Record<string, unknown>[];
   readonly files?: Readonly<Record<string, string>>;
-}): FeedsCommandRuntime & { stdout: string; stderr: string; isTTY?: boolean } {
-  const runtime: FeedsCommandRuntime & { stdout: string; stderr: string; isTTY?: boolean } = {
+  readonly installPolicy?: Record<string, unknown>;
+}): FeedsCommandRuntime & {
+  stdout: string;
+  stderr: string;
+  isTTY?: boolean;
+  commands: readonly string[][];
+} {
+  const runtime: FeedsCommandRuntime & {
+    stdout: string;
+    stderr: string;
+    isTTY?: boolean;
+    commands: string[][];
+  } = {
     stdout: "",
     stderr: "",
+    commands: [],
     writeStdout(value) {
       this.stdout += value;
     },
     error(value) {
       this.stderr += `${value}\n`;
     },
+    async runOpenClawCommand(argv) {
+      runtime.commands.push([...argv]);
+      return 0;
+    },
     async readConfigSnapshot() {
       return {
         valid: true,
         config: {
-          plugins: { entries: { feeds: { enabled: true, config: { sources: params.sources } } } },
+          plugins: {
+            entries: {
+              feeds: {
+                enabled: true,
+                config: { sources: params.sources, installPolicy: params.installPolicy },
+              },
+            },
+          },
         },
       };
     },

--- a/extensions/feeds/src/cli.ts
+++ b/extensions/feeds/src/cli.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import type { Command } from "commander";
 import { readConfigFileSnapshot } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -25,12 +26,30 @@ export type FeedsCommandRuntime = FeedDocumentRuntime & {
   error(value: string): void;
   isTTY?: boolean;
   readConfigSnapshot?: (options: { readonly observe?: boolean }) => Promise<FeedConfigSnapshot>;
+  runOpenClawCommand?: (argv: readonly string[]) => Promise<number>;
 };
 
 export type FeedsCommandOptions = {
   readonly json?: boolean;
   readonly source?: string;
   readonly type?: string;
+};
+
+export type FeedInstallPolicyMode = "off" | "warn" | "enforce";
+
+export type FeedInstallPolicy = {
+  readonly mode: FeedInstallPolicyMode;
+  readonly requireApproval: boolean;
+};
+
+export type FeedsInstallOptions = FeedsCommandOptions & {
+  readonly dryRun?: boolean;
+  readonly force?: boolean;
+};
+
+type ConfiguredFeeds = {
+  readonly sources: readonly FeedSourceConfig[];
+  readonly installPolicy: FeedInstallPolicy;
 };
 
 export type FeedEntryResult = FeedEntry & {
@@ -45,6 +64,9 @@ const defaultRuntime: FeedsCommandRuntime = {
   },
   error(value) {
     process.stderr.write(`${value}\n`);
+  },
+  runOpenClawCommand(argv) {
+    return runOpenClawSubcommand(argv);
   },
 };
 
@@ -78,6 +100,18 @@ export function registerFeedsCli(program: Command): void {
     .option("--json", "Emit JSON output")
     .action(async (query: string, options: FeedsCommandOptions) => {
       process.exitCode = await feedsSearchCommand(query, options);
+    });
+
+  feeds
+    .command("install")
+    .argument("<id>", "Feed entry id to install")
+    .description("Install one feed entry through the existing OpenClaw install command")
+    .option("--source <id>", "Limit to one feed source id")
+    .option("--type <type>", "Limit to skill or plugin entries")
+    .option("--dry-run", "Print the install command without running it")
+    .option("--force", "Forward --force to the existing install command")
+    .action(async (id: string, options: FeedsInstallOptions) => {
+      process.exitCode = await feedsInstallCommand(id, options);
     });
 }
 
@@ -135,11 +169,46 @@ export async function feedsSearchCommand(
   }
 }
 
+export async function feedsInstallCommand(
+  id: string,
+  options: FeedsInstallOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    assertFeedEntryType(options.type);
+    const config = await readConfiguredFeedsConfig(runtime);
+    const loaded = await loadFeedDocuments(config.sources, options, runtime);
+    const entry = selectInstallEntry(flattenFeedEntries(loaded), id, options);
+    applyFeedInstallPolicy(entry, config.installPolicy, runtime);
+    const command = buildFeedInstallCommand(entry, { force: options.force === true });
+    if (command === undefined) {
+      throw new Error(`Feed entry '${id}' does not include supported install metadata.`);
+    }
+    if (options.dryRun === true) {
+      runtime.writeStdout(`${command.label}\n`);
+      return 0;
+    }
+    const run = runtime.runOpenClawCommand ?? runOpenClawSubcommand;
+    return await run(command.argv);
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
 async function loadConfiguredFeedDocuments(
   options: FeedsCommandOptions,
   runtime: FeedsCommandRuntime,
 ): Promise<readonly LoadedFeedDocument[]> {
-  const sources = (await readConfiguredFeedSources(runtime)).filter((source) => source.enabled);
+  return loadFeedDocuments(await readConfiguredFeedSources(runtime), options, runtime);
+}
+
+async function loadFeedDocuments(
+  configuredSources: readonly FeedSourceConfig[],
+  options: FeedsCommandOptions,
+  runtime: FeedsCommandRuntime,
+): Promise<readonly LoadedFeedDocument[]> {
+  const sources = configuredSources.filter((source) => source.enabled);
   const selected = selectSources(sources, options.source);
   return Promise.all(selected.map((source) => loadFeedDocument(source, runtime)));
 }
@@ -147,6 +216,10 @@ async function loadConfiguredFeedDocuments(
 async function readConfiguredFeedSources(
   runtime: FeedsCommandRuntime,
 ): Promise<readonly FeedSourceConfig[]> {
+  return (await readConfiguredFeedsConfig(runtime)).sources;
+}
+
+async function readConfiguredFeedsConfig(runtime: FeedsCommandRuntime): Promise<ConfiguredFeeds> {
   const readSnapshot = runtime.readConfigSnapshot ?? readConfigFileSnapshot;
   const snapshot = await readSnapshot({ observe: false });
   if (!snapshot.valid) {
@@ -155,18 +228,41 @@ async function readConfiguredFeedSources(
   }
   const config = snapshot.config.plugins?.entries?.feeds?.config;
   if (config === undefined) {
-    return [];
+    return { sources: [], installPolicy: { mode: "off", requireApproval: false } };
   }
   if (!isRecord(config)) {
     throw new Error("plugins.entries.feeds.config must be an object.");
   }
   if (config.sources === undefined) {
-    return [];
+    return { sources: [], installPolicy: parseInstallPolicy(config.installPolicy) };
   }
   if (!Array.isArray(config.sources)) {
     throw new Error("plugins.entries.feeds.config.sources must be an array.");
   }
-  return config.sources.map((source, index) => parseSourceConfig(source, index));
+  return {
+    sources: config.sources.map((source, index) => parseSourceConfig(source, index)),
+    installPolicy: parseInstallPolicy(config.installPolicy),
+  };
+}
+
+function parseInstallPolicy(value: unknown): FeedInstallPolicy {
+  if (value === undefined) {
+    return { mode: "off", requireApproval: false };
+  }
+  if (!isRecord(value)) {
+    throw new Error("plugins.entries.feeds.config.installPolicy must be an object.");
+  }
+  if (value.requireApproval !== undefined && typeof value.requireApproval !== "boolean") {
+    throw new Error("feeds installPolicy.requireApproval must be a boolean.");
+  }
+  const mode =
+    value.mode === undefined ? (value.requireApproval === true ? "enforce" : "off") : value.mode;
+  if (mode !== "off" && mode !== "warn" && mode !== "enforce") {
+    throw new Error("feeds installPolicy.mode must be off, warn, or enforce.");
+  }
+  const requireApproval =
+    typeof value.requireApproval === "boolean" ? value.requireApproval : mode !== "off";
+  return { mode, requireApproval };
 }
 
 function parseSourceConfig(value: unknown, index: number): FeedSourceConfig {
@@ -263,7 +359,19 @@ function assertFeedEntryType(
   }
 }
 
+type FeedInstallCommand = {
+  readonly argv: readonly string[];
+  readonly label: string;
+};
+
 function formatFeedInstallCommand(entry: FeedEntry): string | undefined {
+  return buildFeedInstallCommand(entry)?.label;
+}
+
+function buildFeedInstallCommand(
+  entry: FeedEntry,
+  options: { readonly force?: boolean } = {},
+): FeedInstallCommand | undefined {
   const install = entry.install;
   if (!isRecord(install)) {
     return undefined;
@@ -274,44 +382,144 @@ function formatFeedInstallCommand(entry: FeedEntry): string | undefined {
   const npmSpec = typeof install.npmSpec === "string" ? install.npmSpec.trim() : "";
   const slug = typeof install.slug === "string" ? install.slug.trim() : "";
   if (entry.type === "plugin") {
-    if (clawhubSpec) {
-      return formatOpenClawInstallCommand("plugins", normalizeClawHubSpec(clawhubSpec));
+    const resolvedSpec = resolvePluginInstallSpec({ clawhubSpec, npmSpec, source, spec });
+    if (resolvedSpec === undefined) {
+      return undefined;
     }
-    if (source === "clawhub" && spec) {
-      return formatOpenClawInstallCommand("plugins", normalizeClawHubSpec(spec));
-    }
-    if (npmSpec) {
-      return formatOpenClawInstallCommand("plugins", npmSpec);
-    }
-    if ((source === "npm" || source === "path" || source === "git") && spec) {
-      return formatOpenClawInstallCommand("plugins", spec);
-    }
-    return undefined;
+    const argv = [
+      "plugins",
+      "install",
+      resolvedSpec,
+      ...(options.force === true ? ["--force"] : []),
+    ];
+    return { argv, label: formatOpenClawCommand(argv) };
   }
   if (entry.type === "skill") {
-    if (slug) {
-      return formatOpenClawInstallCommand("skills", slug);
+    const resolvedSpec = resolveSkillInstallSpec({ source, spec, slug });
+    if (resolvedSpec === undefined) {
+      return undefined;
     }
-    if (source === "clawhub" && spec) {
-      return formatOpenClawInstallCommand("skills", spec.replace(/^clawhub:/u, ""));
-    }
-    if ((source === "git" || source === "path" || source === "local") && spec) {
-      return formatOpenClawInstallCommand("skills", spec);
-    }
+    const argv = [
+      "skills",
+      "install",
+      resolvedSpec,
+      ...(options.force === true ? ["--force"] : []),
+    ];
+    return { argv, label: formatOpenClawCommand(argv) };
   }
   return undefined;
 }
 
-function formatOpenClawInstallCommand(kind: "plugins" | "skills", spec: string): string {
-  return `openclaw ${kind} install ${quoteCliArg(spec)}`;
+function formatOpenClawCommand(argv: readonly string[]): string {
+  return ["openclaw", ...argv].map(quoteCliArg).join(" ");
 }
 
 function quoteCliArg(value: string): string {
   return /^[A-Za-z0-9_/:=.,@%+-]+$/u.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }
 
+function resolvePluginInstallSpec(params: {
+  readonly clawhubSpec: string;
+  readonly npmSpec: string;
+  readonly source: string | undefined;
+  readonly spec: string;
+}): string | undefined {
+  if (params.clawhubSpec) {
+    return normalizeClawHubSpec(params.clawhubSpec);
+  }
+  if (params.source === "clawhub" && params.spec) {
+    return normalizeClawHubSpec(params.spec);
+  }
+  if (params.npmSpec) {
+    return params.npmSpec;
+  }
+  if (
+    (params.source === "npm" || params.source === "path" || params.source === "git") &&
+    params.spec
+  ) {
+    return params.spec;
+  }
+  return undefined;
+}
+
+function resolveSkillInstallSpec(params: {
+  readonly source: string | undefined;
+  readonly spec: string;
+  readonly slug: string;
+}): string | undefined {
+  if (params.slug) {
+    return params.slug;
+  }
+  if (params.source === "clawhub" && params.spec) {
+    return params.spec.replace(/^clawhub:/u, "");
+  }
+  if (
+    (params.source === "git" || params.source === "path" || params.source === "local") &&
+    params.spec
+  ) {
+    return params.spec;
+  }
+  return undefined;
+}
+
+function selectInstallEntry(
+  entries: readonly FeedEntryResult[],
+  id: string,
+  options: FeedsInstallOptions,
+): FeedEntryResult {
+  const matches = filterEntriesByType(entries, options.type).filter(
+    (entry) =>
+      entry.id === id && (options.source === undefined || entry.sourceId === options.source),
+  );
+  if (matches.length === 0) {
+    throw new Error(`No feed entry found for '${id}'.`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Feed entry '${id}' matched ${matches.length} entries. Use --source or --type to choose one.`,
+    );
+  }
+  return matches[0];
+}
+
+function applyFeedInstallPolicy(
+  entry: FeedEntryResult,
+  policy: FeedInstallPolicy,
+  runtime: FeedsCommandRuntime,
+): void {
+  if (policy.mode === "off" || !policy.requireApproval || feedEntryApproved(entry)) {
+    return;
+  }
+  const message = `Feed entry '${entry.id}' is not approved by feed metadata.`;
+  if (policy.mode === "enforce") {
+    throw new Error(`${message} Set approval.status to approved or update feeds installPolicy.`);
+  }
+  runtime.error(`Warning: ${message}`);
+}
+
+function feedEntryApproved(entry: FeedEntry): boolean {
+  if (!isRecord(entry.approval)) {
+    return false;
+  }
+  return (
+    typeof entry.approval.status === "string" && entry.approval.status.toLowerCase() === "approved"
+  );
+}
+
 function normalizeClawHubSpec(value: string): string {
   return value.startsWith("clawhub:") ? value : `clawhub:${value}`;
+}
+
+function runOpenClawSubcommand(argv: readonly string[]): Promise<number> {
+  const entrypoint = process.argv[1];
+  if (entrypoint === undefined) {
+    throw new Error("Unable to resolve the current OpenClaw CLI entrypoint.");
+  }
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [entrypoint, ...argv], { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("close", (code) => resolve(code ?? 1));
+  });
 }
 
 function formatSourceRows(sources: readonly FeedSourceConfig[]): string {

--- a/extensions/feeds/src/doctor/register.test.ts
+++ b/extensions/feeds/src/doctor/register.test.ts
@@ -51,6 +51,31 @@ describe("Feeds doctor checks", () => {
     expect(findings).toEqual([]);
   });
 
+  it("reports invalid install policy config", () => {
+    const findings = evaluateFeedsConfig({
+      cfg: {
+        plugins: {
+          entries: {
+            feeds: {
+              enabled: true,
+              config: {
+                installPolicy: { mode: "block", requireApproval: "yes" },
+                sources: [{ id: "approved", url: "https://feeds.example.com/root.json" }],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "feeds/config-invalid",
+        ocPath: "oc://openclaw.config/plugins/entries/feeds/config/installPolicy/mode",
+      }),
+    ]);
+  });
+
   it("reports duplicate ids, unsupported urls, and missing pinned integrity", () => {
     const findings = evaluateFeedsConfig({
       cfg: {

--- a/extensions/feeds/src/doctor/register.ts
+++ b/extensions/feeds/src/doctor/register.ts
@@ -108,6 +108,10 @@ export function evaluateFeedsConfig(
   }
 
   const findings: HealthFinding[] = [];
+  const installPolicyFinding = evaluateInstallPolicyConfig(config.installPolicy);
+  if (installPolicyFinding !== undefined) {
+    findings.push(installPolicyFinding);
+  }
   const sources = config.sources;
   if (sources === undefined) {
     findings.push({
@@ -150,6 +154,44 @@ export function evaluateFeedsConfig(
     findings.push(...evaluateFeedSource(source, index, seenIds));
   });
   return findings;
+}
+
+function evaluateInstallPolicyConfig(value: unknown): HealthFinding | undefined {
+  const basePath = "plugins.entries.feeds.config.installPolicy";
+  const baseOcPath = "oc://openclaw.config/plugins/entries/feeds/config/installPolicy";
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    return invalidConfigFinding({
+      propertyPath: basePath,
+      target: baseOcPath,
+      message: "plugins.entries.feeds.config.installPolicy must be an object.",
+      fixHint: 'Use installPolicy: { mode: "warn", requireApproval: true } or remove it.',
+    });
+  }
+  if (
+    value.mode !== undefined &&
+    value.mode !== "off" &&
+    value.mode !== "warn" &&
+    value.mode !== "enforce"
+  ) {
+    return invalidConfigFinding({
+      propertyPath: `${basePath}.mode`,
+      target: `${baseOcPath}/mode`,
+      message: "plugins.entries.feeds.config.installPolicy.mode must be off, warn, or enforce.",
+      fixHint: 'Use mode "off", "warn", or "enforce".',
+    });
+  }
+  if (value.requireApproval !== undefined && typeof value.requireApproval !== "boolean") {
+    return invalidConfigFinding({
+      propertyPath: `${basePath}.requireApproval`,
+      target: `${baseOcPath}/requireApproval`,
+      message: "plugins.entries.feeds.config.installPolicy.requireApproval must be a boolean.",
+      fixHint: "Set requireApproval to true or false.",
+    });
+  }
+  return undefined;
 }
 
 function evaluateFeedSource(


### PR DESCRIPTION
## Summary

Builds on the read-only feeds discovery PR by allowing an operator to explicitly install one selected feed entry, then optionally require approved feed metadata for feed-backed installs.

This PR keeps the install path explicit:

- Adds `openclaw feeds install <id>` for selected feed entries.
- Verifies pinned feed integrity before using feed install metadata.
- Resolves one feed entry and hands off to the existing OpenClaw skill/plugin install commands.
- Adds `installPolicy` with `off`, `warn`, and `enforce` modes.
- Makes `mode: "enforce"` and `requireApproval: true` default to approved-only behavior instead of silently no-oping.
- Adds schema and Doctor validation for the new install policy config.

## Example syntax

```jsonc
{
  "plugins": {
    "entries": {
      "feeds": {
        "enabled": true,
        "config": {
          "installPolicy": {
            "mode": "enforce",
            "requireApproval": true
          },
          "sources": [
            {
              "id": "company-approved",
              "url": "file:///opt/openclaw/feeds/company.json"
            }
          ]
        }
      }
    }
  }
}
```

## Commands

```bash
openclaw feeds install calendar-helper --source company-approved --type plugin --dry-run
openclaw feeds install calendar-helper --source company-approved --type plugin
openclaw doctor --lint
```

## Notes

This PR does not auto-install, background-watch, or intercept non-feed install commands. It only constrains explicit feed-backed installs through the new `feeds install` path.

## Real behavior proof

Behavior or issue addressed:
Explicit feed-backed installs now resolve a selected feed entry, honor feed `installPolicy`, dry-run the delegated install command, install approved entries through the existing OpenClaw installer, and block unapproved entries when enforcement is enabled.

Real environment tested:
WSL Ubuntu 24.04, source checkout `/root/src/openclaw-feeds-87825` at `75abd34788ff68c7f62164e2f391d70e23478436`, source CLI via `pnpm openclaw`, temporary `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, `OPENCLAW_HOME`, and `HOME`. The feed was a local `file://` feed fixture with one approved local skill entry and one unapproved local skill entry; the approved install used the real `openclaw skills install <local path>` path and wrote only into a temporary agent workspace.

Exact steps or command run after this patch:
1. `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/feeds/src/cli.test.ts extensions/feeds/src/doctor/register.test.ts src/flows/bundled-health-checks.test.ts --reporter=dot`
2. `pnpm exec oxlint --tsconfig ./tsconfig.json extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/feeds/src/doctor/register.ts extensions/feeds/src/doctor/register.test.ts`
3. `pnpm exec oxfmt --check --threads=1 extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/feeds/src/feed-document.ts extensions/feeds/src/doctor/register.ts extensions/feeds/src/doctor/register.test.ts docs/plugins/reference/feeds.md && git diff --check`
4. `pnpm tsgo:extensions`
5. Source CLI proof with a temporary config/feed/skill fixture: `pnpm openclaw feeds install local-proof-skill --source proof --type skill --dry-run`, `pnpm openclaw feeds install local-proof-skill --source proof --type skill --force`, and `pnpm openclaw feeds install blocked-proof-skill --source proof --type skill`.

Evidence after fix:
```text
Vitest: 2 Vitest shards passed; 35 focused tests passed.
oxlint: Found 0 warnings and 0 errors.
oxfmt: All matched files use the correct format.
tsgo: pnpm tsgo:extensions completed successfully.

CASE dry-run exit=0
openclaw skills install /tmp/openclaw-feeds-87825-proof.oKOgMz/source-skill

CASE approved-install exit=0
Installing to /tmp/openclaw-feeds-87825-proof.oKOgMz/workspace/skills/pr-proof-skill...
Installed pr-proof-skill from path -> /tmp/openclaw-feeds-87825-proof.oKOgMz/workspace/skills/pr-proof-skill

CASE enforcement-block exit=2
Feed entry 'blocked-proof-skill' is not approved by feed metadata. Set approval.status to approved or update feeds installPolicy.
[ELIFECYCLE] Command failed with exit code 2.

INSTALLED_SKILL_EXISTS=yes
---
name: pr-proof-skill
description: Feed install proof fixture.
---
# PR Proof Skill
```

Observed result after fix:
The dry-run printed the delegated existing installer command without installing, the approved feed entry installed through the real source CLI into the temporary workspace, and the unapproved entry was rejected before installer dispatch when `installPolicy` enforced approval.

What was not tested:
No live ClawHub network install was performed; the approved install proof intentionally used a local skill path fixture to avoid external mutation while still exercising the real OpenClaw source CLI and installer dispatch.

## Validation

```bash
node scripts/run-vitest.mjs extensions/feeds/src/cli.test.ts extensions/feeds/src/doctor/register.test.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts src/flows/bundled-health-checks.test.ts
node scripts/run-tsgo.mjs --noEmit
pnpm exec oxfmt --check extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/feeds/src/feed-document.ts extensions/feeds/src/doctor/register.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts docs/cli/policy.md docs/plugins/reference/feeds.md docs/plugins/reference.md
git diff --check
node scripts/generate-plugin-inventory-doc.mjs --check
```

Focused stack proof on the final condensed branch: 243 tests passed.

## Feed PR stack

1. openclaw/openclaw#87824 - read-only feed discovery
2. openclaw/openclaw#87825 - approved feed installs
3. openclaw/openclaw#87826 - feed catalog policy conformance
4. openclaw/openclaw#87827 - feed lifecycle tooling
5. openclaw/openclaw#88732 - native feed search defaults and policy checks
6. openclaw/clawhub#2460 - ClawHub root feed lanes

The stack keeps OpenClaw as a feed consumer. ClawHub root feeds are producer infrastructure; enterprise or tenant feeds can be produced elsewhere using the same schema.

RFC draft: https://github.com/giodl73-repo/rfcs/blob/feeds-rfc-draft/rfcs/0004-feeds.md
