### PR TITLE
feat(policy): add feed catalog conformance

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -190,8 +190,7 @@ when a concrete rule is present. OpenClaw reads current `channels.*` settings
 settings, direct-message session scope, channel DM policy, channel group policy,
 channel/group mention gates, Gateway bind/auth/Control UI/Tailscale/remote/HTTP
 posture, OpenClaw config agent sandbox workspace access and tool deny posture,
-configured Feeds plugin source declarations, OpenClaw config agent sandbox
-workspace access and tool deny posture, data-handling config posture, config
+configured Feeds plugin source declarations, data-handling config posture, config
 secret provider and SecretRef provenance, config auth profile metadata, configured
 global/per-agent tool posture, and `TOOLS.md` declarations as evidence, then
 reports observed state that does not conform. If a policy denies non-loopback

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -18,8 +18,9 @@ report drift through `doctor --lint`. The final conformance signal is a clean
 instead of creating a separate health gate.
 
 Policy currently manages configured channels, MCP servers, model providers,
-network SSRF posture, ingress/channel access posture, Gateway exposure posture, agent workspace posture,
-data-handling posture, OpenClaw config secret provider/auth profile posture, and governed tool
+network SSRF posture, ingress/channel access posture, Gateway exposure posture,
+feed catalog source posture, agent workspace posture, data-handling posture,
+OpenClaw config secret provider/auth profile posture, and governed tool
 declarations. For example, IT or a workspace operator can record that Telegram
 is not an approved channel provider, restrict MCP servers and model refs to
 approved entries, require private-network fetch/browser access to remain
@@ -115,6 +116,13 @@ file posture, and tool metadata looks like this:
       "requireUrlAllowlists": true,
     },
   },
+  "feeds": {
+    "sources": {
+      "require": ["company-approved"],
+      "requirePinned": true,
+      "allowUnsigned": false,
+    },
+  },
   "agents": {
     "workspace": {
       "allowedAccess": ["none", "ro"],
@@ -182,8 +190,9 @@ when a concrete rule is present. OpenClaw reads current `channels.*` settings
 settings, direct-message session scope, channel DM policy, channel group policy,
 channel/group mention gates, Gateway bind/auth/Control UI/Tailscale/remote/HTTP
 posture, OpenClaw config agent sandbox workspace access and tool deny posture,
-data-handling config posture, config secret
-provider and SecretRef provenance, config auth profile metadata, configured
+configured Feeds plugin source declarations, OpenClaw config agent sandbox
+workspace access and tool deny posture, data-handling config posture, config
+secret provider and SecretRef provenance, config auth profile metadata, configured
 global/per-agent tool posture, and `TOOLS.md` declarations as evidence, then
 reports observed state that does not conform. If a policy denies non-loopback
 Gateway binds, omit `gateway.bind` only when you
@@ -371,6 +380,17 @@ Every scope present in `policy.jsonc` must be valid and enforceable.
 | `gateway.remote.allow`                  | Remote Gateway mode/config                     | Set to `false` to deny remote Gateway mode.                  |
 | `gateway.http.denyEndpoints`            | Gateway HTTP API endpoints                     | Deny endpoint ids such as `chatCompletions` or `responses`.  |
 | `gateway.http.requireUrlAllowlists`     | Gateway HTTP URL-fetch inputs                  | Set to `true` to require URL allowlists on URL-fetch inputs. |
+
+#### Feed catalog sources
+
+| Policy field                  | Observed state                                   | Use when                                                       |
+| ----------------------------- | ------------------------------------------------ | -------------------------------------------------------------- |
+| `feeds.sources.require`       | `plugins.entries.feeds.config.sources[].id`      | Require specific feed source ids to be configured and enabled. |
+| `feeds.sources.requirePinned` | Feed source `trust` and `integrity` declarations | Set to `true` to require enabled feed sources to be pinned.    |
+| `feeds.sources.allowUnsigned` | Feed source `trust` declarations                 | Set to `false` to reject enabled sources using unsigned trust. |
+
+Feed policy observes only configured source declarations. It does not fetch
+feed documents, install entries, or enforce install decisions at runtime.
 
 #### Agent workspace
 
@@ -666,6 +686,16 @@ Example JSON output:
         "value": false
       }
     ],
+    "feeds": [
+      {
+        "id": "company-approved",
+        "source": "oc://openclaw.config/plugins/entries/feeds/config/sources/#0",
+        "enabled": true,
+        "url": "https://feeds.example.com#0123456789ab",
+        "trust": "pinned",
+        "integrityPresent": true
+      }
+    ],
     "gatewayExposure": [
       {
         "id": "gateway-bind",
@@ -815,6 +845,9 @@ Policy currently verifies:
 | `policy/gateway-remote-enabled`                          | Gateway remote mode is active when policy denies it.                              |
 | `policy/gateway-http-endpoint-enabled`                   | A Gateway HTTP API endpoint is enabled while denied by policy.                    |
 | `policy/gateway-http-url-fetch-unrestricted`             | Gateway HTTP URL-fetch input lacks a required URL allowlist.                      |
+| `policy/feeds-required-source-missing`                   | A required feed source id is not configured and enabled.                          |
+| `policy/feeds-source-unpinned`                           | An enabled feed source is not pinned when policy requires pinned feeds.           |
+| `policy/feeds-source-unsigned`                           | An enabled feed source uses unsigned trust when policy denies unsigned feeds.     |
 | `policy/agents-workspace-access-denied`                  | Agent sandbox mode or workspace access is outside the policy allowlist.           |
 | `policy/agents-tool-not-denied`                          | An agent or default config does not deny a tool required by policy.               |
 | `policy/tools-profile-unapproved`                        | A configured global or per-agent tool profile is outside the allowlist.           |

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -935,7 +935,7 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
-  it("satisfies required feed sources when feeds is enabled by plugin allowlist", async () => {
+  it("satisfies required feed sources when feeds is explicitly enabled and allowlisted", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
@@ -961,6 +961,7 @@ describe("registerPolicyDoctorChecks", () => {
               config: { enabled: true },
             },
             feeds: {
+              enabled: true,
               config: {
                 sources: [
                   {
@@ -987,12 +988,11 @@ describe("registerPolicyDoctorChecks", () => {
 
   const disabledFeedSourceCases: readonly [
     string,
-    { readonly plugins?: Record<string, unknown>; readonly feedConfigEnabled?: boolean },
+    { readonly plugins?: Record<string, unknown> },
   ][] = [
     ["global plugins disabled", { plugins: { enabled: false } }],
     ["feeds denied", { plugins: { deny: ["feeds"] } }],
     ["feeds missing from allowlist", { plugins: { allow: ["other-plugin"] } }],
-    ["feed config disabled", { feedConfigEnabled: false }],
   ];
 
   it.each(disabledFeedSourceCases)(
@@ -1025,7 +1025,6 @@ describe("registerPolicyDoctorChecks", () => {
               feeds: {
                 enabled: true,
                 config: {
-                  enabled: pluginSettings.feedConfigEnabled,
                   sources: [
                     {
                       id: "company-approved",

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1016,7 +1016,7 @@ describe("registerPolicyDoctorChecks", () => {
         ctx(configPath, {
           ...cfgWithPolicy(),
           plugins: {
-            ...(pluginSettings.plugins ?? {}),
+            ...pluginSettings.plugins,
             entries: {
               policy: {
                 enabled: true,

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -665,6 +665,57 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
+  it("satisfies mixed-case required feed source ids", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            require: ["Company-Approved"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                enabled: true,
+                sources: [
+                  {
+                    id: "Company-Approved",
+                    url: "https://feeds.example.com/company.json",
+                    trust: "pinned",
+                    integrity:
+                      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkId: "policy/feeds-required-source-missing" }),
+      ]),
+    );
+  });
+
   it("checks configured feed source trust posture against policy", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");
@@ -880,6 +931,56 @@ describe("registerPolicyDoctorChecks", () => {
         expect.objectContaining({
           checkId: "policy/feeds-required-source-missing",
         }),
+      ]),
+    );
+  });
+
+  it("satisfies required feed sources when feeds is enabled by plugin allowlist", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            require: ["company-approved"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          allow: ["feeds", "policy"],
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                    trust: "pinned",
+                    integrity:
+                      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkId: "policy/feeds-required-source-missing" }),
       ]),
     );
   });

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -781,6 +781,57 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
+  it("does not satisfy required feed sources from an inactive Feeds plugin", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            require: ["company-approved"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                    trust: "pinned",
+                    integrity:
+                      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-required-source-missing",
+        }),
+      ]),
+    );
+  });
+
   it("does not satisfy required feed sources from a disabled Feeds plugin", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -581,6 +581,9 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/gateway-remote-enabled",
       "policy/gateway-http-endpoint-enabled",
       "policy/gateway-http-url-fetch-unrestricted",
+      "policy/feeds-required-source-missing",
+      "policy/feeds-source-unpinned",
+      "policy/feeds-source-unsigned",
       "policy/agents-workspace-access-denied",
       "policy/agents-tool-not-denied",
       "policy/tools-profile-unapproved",
@@ -624,6 +627,409 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/tools-unknown-sensitivity-token",
     ]);
     expect(duplicateChecks).toEqual([]);
+  });
+
+  it("reports feed source policy conformance findings", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            require: ["company-approved"],
+            requirePinned: true,
+            allowUnsigned: false,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(
+        configPath,
+        cfgWithPolicy({
+          path: "policy.jsonc",
+        }),
+      ),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-required-source-missing",
+          requirement: "oc://policy.jsonc/feeds/sources/require",
+        }),
+      ]),
+    );
+  });
+
+  it("checks configured feed source trust posture against policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            require: ["company-approved"],
+            requirePinned: true,
+            allowUnsigned: false,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                    trust: "unsigned",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-source-unpinned",
+          ocPath: "oc://openclaw.config/plugins/entries/feeds/config/sources/#0",
+        }),
+        expect.objectContaining({
+          checkId: "policy/feeds-source-unsigned",
+          ocPath: "oc://openclaw.config/plugins/entries/feeds/config/sources/#0",
+        }),
+      ]),
+    );
+    expect(result.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkId: "policy/feeds-required-source-missing" }),
+      ]),
+    );
+  });
+
+  it("accepts pinned configured feed sources required by policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            require: ["company-approved"],
+            requirePinned: true,
+            allowUnsigned: false,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                    trust: "pinned",
+                    integrity:
+                      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkId: "policy/feeds-required-source-missing" }),
+        expect.objectContaining({ checkId: "policy/feeds-source-unpinned" }),
+        expect.objectContaining({ checkId: "policy/feeds-source-unsigned" }),
+      ]),
+    );
+  });
+
+  it("does not satisfy required feed sources from a disabled Feeds plugin", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            require: ["company-approved"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: false,
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                    trust: "pinned",
+                    integrity:
+                      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-required-source-missing",
+        }),
+      ]),
+    );
+  });
+
+  const disabledFeedSourceCases: readonly [
+    string,
+    { readonly plugins?: Record<string, unknown>; readonly feedConfigEnabled?: boolean },
+  ][] = [
+    ["global plugins disabled", { plugins: { enabled: false } }],
+    ["feeds denied", { plugins: { deny: ["feeds"] } }],
+    ["feeds missing from allowlist", { plugins: { allow: ["other-plugin"] } }],
+    ["feed config disabled", { feedConfigEnabled: false }],
+  ];
+
+  it.each(disabledFeedSourceCases)(
+    "does not satisfy required feed sources when %s",
+    async (_name, pluginSettings) => {
+      const configPath = join(workspaceDir, "openclaw.jsonc");
+      await fs.writeFile(configPath, "{}", "utf-8");
+      await fs.writeFile(
+        join(workspaceDir, "policy.jsonc"),
+        JSON.stringify({
+          feeds: {
+            sources: {
+              require: ["company-approved"],
+            },
+          },
+        }),
+        "utf-8",
+      );
+
+      const result = await runPolicyChecks(
+        ctx(configPath, {
+          ...cfgWithPolicy(),
+          plugins: {
+            ...(pluginSettings.plugins ?? {}),
+            entries: {
+              policy: {
+                enabled: true,
+                config: { enabled: true },
+              },
+              feeds: {
+                enabled: true,
+                config: {
+                  enabled: pluginSettings.feedConfigEnabled,
+                  sources: [
+                    {
+                      id: "company-approved",
+                      url: "https://feeds.example.com/company.json",
+                      trust: "pinned",
+                      integrity:
+                        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      );
+
+      expect(result.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            checkId: "policy/feeds-required-source-missing",
+          }),
+        ]),
+      );
+    },
+  );
+
+  it("does not accept malformed pinned feed integrity", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            requirePinned: true,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                    trust: "pinned",
+                    integrity: "not-a-hash",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkId: "policy/feeds-source-unpinned" }),
+      ]),
+    );
+  });
+
+  it("redacts feed source URLs in policy evidence", () => {
+    const evidence = collectPolicyEvidence(
+      {
+        plugins: {
+          entries: {
+            feeds: {
+              enabled: true,
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://user:token@feeds.example.com/company.json?sig=secret",
+                    trust: "pinned",
+                    integrity:
+                      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      { includeFeeds: true },
+    );
+
+    expect(evidence.feeds).toEqual([
+      expect.objectContaining({
+        id: "company-approved",
+        url: expect.stringMatching(/^https:\/\/feeds\.example\.com#[0-9a-f]{12}$/u),
+      }),
+    ]);
+  });
+
+  it("does not accept padded pinned feed integrity", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          sources: {
+            requirePinned: true,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                    trust: "pinned",
+                    integrity:
+                      " sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef ",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkId: "policy/feeds-source-unpinned" }),
+      ]),
+    );
   });
 
   it("reports a missing policy file when the Policy plugin is enabled", async () => {
@@ -749,6 +1155,23 @@ describe("registerPolicyDoctorChecks", () => {
       "tools denyTools blank entry",
       { tools: { denyTools: ["exec", " "] } },
       "oc://policy.jsonc/tools/denyTools/#1",
+    ],
+    ["feeds array", { feeds: [] }, "oc://policy.jsonc/feeds"],
+    ["feeds sources array", { feeds: { sources: [] } }, "oc://policy.jsonc/feeds/sources"],
+    [
+      "feeds sources require string",
+      { feeds: { sources: { require: "company" } } },
+      "oc://policy.jsonc/feeds/sources/require",
+    ],
+    [
+      "feeds sources requirePinned string",
+      { feeds: { sources: { requirePinned: "true" } } },
+      "oc://policy.jsonc/feeds/sources/requirePinned",
+    ],
+    [
+      "feeds sources allowUnsigned string",
+      { feeds: { sources: { allowUnsigned: "false" } } },
+      "oc://policy.jsonc/feeds/sources/allowUnsigned",
     ],
     ["scopes array", { scopes: [] }, "oc://policy.jsonc/scopes"],
     [
@@ -1363,6 +1786,7 @@ describe("registerPolicyDoctorChecks", () => {
         {
           includeIngress: false,
           includeGatewayExposure: false,
+          includeFeeds: false,
           includeAgentWorkspace: false,
           includeDataHandling: false,
           includeToolPosture: false,
@@ -1397,6 +1821,7 @@ describe("registerPolicyDoctorChecks", () => {
         {
           includeIngress: false,
           includeGatewayExposure: false,
+          includeFeeds: false,
           includeAgentWorkspace: false,
           includeDataHandling: false,
           includeToolPosture: false,
@@ -1443,6 +1868,7 @@ describe("registerPolicyDoctorChecks", () => {
         {
           includeIngress: false,
           includeGatewayExposure: false,
+          includeFeeds: false,
           includeAgentWorkspace: false,
           includeDataHandling: false,
           includeToolPosture: false,
@@ -1475,6 +1901,7 @@ describe("registerPolicyDoctorChecks", () => {
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>, {
       includeIngress: false,
       includeGatewayExposure: false,
+      includeFeeds: false,
       includeAgentWorkspace: false,
       includeDataHandling: false,
       includeToolPosture: false,

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -4318,7 +4318,7 @@ function feedSourceFindings(
   if (shapeFinding !== undefined) {
     return [];
   }
-  const required = readStringList(policy, ["feeds", "sources", "require"]);
+  const required = readStringList(policy, ["feeds", "sources", "require"], { lowercase: false });
   const requirePinned = readPolicyBoolean(policy, ["feeds", "sources", "requirePinned"]) === true;
   const allowUnsigned = readPolicyBoolean(policy, ["feeds", "sources", "allowUnsigned"]) !== false;
   if (required.length === 0 && !requirePinned && allowUnsigned) {

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -596,6 +596,7 @@ const SUPPORTED_POLICY_SECTIONS = [
   "channels",
   "dataHandling",
   "execApprovals",
+  "feeds",
   "gateway",
   "ingress",
   "mcp",

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -20,6 +20,7 @@ import {
   type PolicyDataHandlingEvidence,
   type PolicyEvidence,
   type PolicyExecApprovalEvidence,
+  type PolicyFeedSourceEvidence,
   type PolicyIngressEvidence,
   type PolicySandboxPostureEvidence,
   type PolicyToolPostureEvidence,
@@ -56,6 +57,9 @@ const CHECK_IDS = {
   policyGatewayRemoteEnabled: "policy/gateway-remote-enabled",
   policyGatewayHttpEndpointEnabled: "policy/gateway-http-endpoint-enabled",
   policyGatewayHttpUrlFetchUnrestricted: "policy/gateway-http-url-fetch-unrestricted",
+  policyFeedsRequiredSourceMissing: "policy/feeds-required-source-missing",
+  policyFeedsSourceUnpinned: "policy/feeds-source-unpinned",
+  policyFeedsSourceUnsigned: "policy/feeds-source-unsigned",
   policyAgentsWorkspaceAccessDenied: "policy/agents-workspace-access-denied",
   policyAgentsToolNotDenied: "policy/agents-tool-not-denied",
   policyToolsElevatedEnabled: "policy/tools-elevated-enabled",
@@ -124,6 +128,9 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyGatewayRemoteEnabled,
   CHECK_IDS.policyGatewayHttpEndpointEnabled,
   CHECK_IDS.policyGatewayHttpUrlFetchUnrestricted,
+  CHECK_IDS.policyFeedsRequiredSourceMissing,
+  CHECK_IDS.policyFeedsSourceUnpinned,
+  CHECK_IDS.policyFeedsSourceUnsigned,
   CHECK_IDS.policyAgentsWorkspaceAccessDenied,
   CHECK_IDS.policyAgentsToolNotDenied,
   CHECK_IDS.policyToolsProfileUnapproved,
@@ -673,6 +680,9 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyGatewayRemoteEnabledCheck);
   registerHealthCheck(policyGatewayHttpEndpointEnabledCheck);
   registerHealthCheck(policyGatewayHttpUrlFetchUnrestrictedCheck);
+  registerHealthCheck(policyFeedsRequiredSourceMissingCheck);
+  registerHealthCheck(policyFeedsSourceUnpinnedCheck);
+  registerHealthCheck(policyFeedsSourceUnsignedCheck);
   registerHealthCheck(policyAgentsWorkspaceAccessDeniedCheck);
   registerHealthCheck(policyAgentsToolNotDeniedCheck);
   registerHealthCheck(policyToolsProfileUnapprovedCheck);
@@ -976,6 +986,36 @@ const policyGatewayHttpUrlFetchUnrestrictedCheck: HealthCheck = {
       await evaluatePolicy(ctx),
       CHECK_IDS.policyGatewayHttpUrlFetchUnrestricted,
     );
+  },
+};
+
+const policyFeedsRequiredSourceMissingCheck: HealthCheck = {
+  id: CHECK_IDS.policyFeedsRequiredSourceMissing,
+  kind: "plugin",
+  description: "Required catalog feed sources are configured and enabled.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyFeedsRequiredSourceMissing);
+  },
+};
+
+const policyFeedsSourceUnpinnedCheck: HealthCheck = {
+  id: CHECK_IDS.policyFeedsSourceUnpinned,
+  kind: "plugin",
+  description: "Enabled catalog feed sources use pinned trust when policy requires it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyFeedsSourceUnpinned);
+  },
+};
+
+const policyFeedsSourceUnsignedCheck: HealthCheck = {
+  id: CHECK_IDS.policyFeedsSourceUnsigned,
+  kind: "plugin",
+  description: "Enabled catalog feed sources do not use unsigned trust when policy denies it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyFeedsSourceUnsigned);
   },
 };
 
@@ -1450,6 +1490,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   let evidence: PolicyEvidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
     includeIngress: false,
     includeGatewayExposure: false,
+    includeFeeds: false,
     includeAgentWorkspace: false,
     includeToolPosture: false,
     includeSandboxPosture: false,
@@ -1544,6 +1585,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   const includeAuthProfiles = policyHasAuthProfileRules(policy);
   const includeIngress = policyHasIngressRules(policy);
   const includeGatewayExposure = policyHasGatewayRules(policy);
+  const includeFeeds = policyHasFeedRules(policy);
   const includeAgentWorkspace = policyHasAgentWorkspaceRules(policy);
   const includeDataHandling = policyHasDataHandlingRules(policy);
   const includeSandboxPosture = policyHasSandboxPostureRules(policy);
@@ -1555,6 +1597,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
       toolsRaw: toolsFile?.raw ?? "",
       includeIngress,
       includeGatewayExposure,
+      includeFeeds,
       includeAgentWorkspace,
       includeDataHandling,
       includeToolPosture: policyHasToolPostureRules(policy),
@@ -1568,6 +1611,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     evidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
       includeIngress,
       includeGatewayExposure,
+      includeFeeds,
       includeAgentWorkspace,
       includeDataHandling,
       includeToolPosture: policyHasToolPostureRules(policy),
@@ -1586,6 +1630,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     ...networkFindings(policy, policyFile.ocDocName, evidence),
     ...ingressFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...gatewayExposureFindings(policy, policyFile.ocDocName, evidence),
+    ...feedSourceFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...agentWorkspaceFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...toolPostureFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...sandboxPostureFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
@@ -2010,6 +2055,13 @@ export function policyContainerShapeFindings(
       ];
     }
   }
+  const feedsFinding = feedsPolicyShapeFinding(policy.feeds, {
+    policyDocName,
+    policyPath,
+  });
+  if (feedsFinding !== undefined) {
+    return [feedsFinding];
+  }
   if (policy.secrets !== undefined && !isRecord(policy.secrets)) {
     return [
       policyShapeFinding(
@@ -2135,6 +2187,56 @@ export function policyContainerShapeFindings(
     return [scopesFinding];
   }
   return [];
+}
+
+function feedsPolicyShapeFinding(
+  value: unknown,
+  params: {
+    readonly policyDocName: string;
+    readonly policyPath: string;
+  },
+): HealthFinding | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/feeds`,
+      `${params.policyPath} feeds must be an object.`,
+      `Fix ${params.policyPath} so feeds is an object.`,
+    );
+  }
+  if (value.sources !== undefined && !isRecord(value.sources)) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/feeds/sources`,
+      `${params.policyPath} feeds.sources must be an object.`,
+      `Fix ${params.policyPath} so feeds.sources is an object.`,
+    );
+  }
+  const sources = isRecord(value.sources) ? value.sources : {};
+  const requireFinding = policyStringArrayPropertyShapeFinding(sources.require, {
+    policyDocName: params.policyDocName,
+    policyPath: params.policyPath,
+    property: "feeds.sources.require",
+    target: "feeds/sources/require",
+    valueName: "feed source id",
+  });
+  if (requireFinding !== undefined) {
+    return requireFinding;
+  }
+  for (const key of ["requirePinned", "allowUnsigned"] as const) {
+    if (sources[key] !== undefined && typeof sources[key] !== "boolean") {
+      return policyShapeFinding(
+        params.policyPath,
+        `oc://${params.policyDocName}/feeds/sources/${key}`,
+        `${params.policyPath} feeds.sources.${key} must be a boolean.`,
+        `Set feeds.sources.${key} to true or false.`,
+      );
+    }
+  }
+  return undefined;
 }
 
 function ingressPolicyShapeFinding(
@@ -4203,6 +4305,100 @@ function gatewayHttpUrlFetchFindings(
     });
 }
 
+function feedSourceFindings(
+  policy: unknown,
+  policyPath: string,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const shapeFinding = feedsPolicyShapeFinding(isRecord(policy) ? policy.feeds : undefined, {
+    policyDocName,
+    policyPath,
+  });
+  if (shapeFinding !== undefined) {
+    return [];
+  }
+  const required = readStringList(policy, ["feeds", "sources", "require"]);
+  const requirePinned = readPolicyBoolean(policy, ["feeds", "sources", "requirePinned"]) === true;
+  const allowUnsigned = readPolicyBoolean(policy, ["feeds", "sources", "allowUnsigned"]) !== false;
+  if (required.length === 0 && !requirePinned && allowUnsigned) {
+    return [];
+  }
+
+  const enabledSources = (evidence.feeds ?? []).filter((source) => source.enabled !== false);
+  const enabledById = new Map(enabledSources.map((source) => [source.id, source]));
+  const findings: HealthFinding[] = [];
+
+  for (const sourceId of required) {
+    const source = enabledById.get(sourceId);
+    if (source !== undefined) {
+      continue;
+    }
+    findings.push({
+      checkId: CHECK_IDS.policyFeedsRequiredSourceMissing,
+      severity: "error",
+      message: `Required feed source '${sourceId}' is not configured and enabled.`,
+      source: "policy",
+      path: "openclaw config",
+      target: "oc://openclaw.config/plugins/entries/feeds/config/sources",
+      requirement: `oc://${policyDocName}/feeds/sources/require`,
+      fixHint:
+        "Add the required feed source under plugins.entries.feeds.config.sources or update policy after review.",
+    });
+  }
+
+  for (const source of enabledSources) {
+    if (requirePinned && !feedSourceIsPinned(source)) {
+      findings.push(
+        feedSourceFinding(source, {
+          checkId: CHECK_IDS.policyFeedsSourceUnpinned,
+          message: `Feed source '${source.id}' is not pinned with an integrity hash.`,
+          requirement: `oc://${policyDocName}/feeds/sources/requirePinned`,
+          fixHint:
+            "Set trust to pinned and add integrity: sha256:<hex>, or update policy after review.",
+        }),
+      );
+    }
+    if (!allowUnsigned && (source.trust ?? "unsigned") === "unsigned") {
+      findings.push(
+        feedSourceFinding(source, {
+          checkId: CHECK_IDS.policyFeedsSourceUnsigned,
+          message: `Feed source '${source.id}' uses unsigned trust.`,
+          requirement: `oc://${policyDocName}/feeds/sources/allowUnsigned`,
+          fixHint: "Set trust to pinned with an integrity hash, or update policy after review.",
+        }),
+      );
+    }
+  }
+  return findings;
+}
+
+function feedSourceFinding(
+  source: PolicyFeedSourceEvidence,
+  params: {
+    readonly checkId: (typeof POLICY_CHECK_IDS)[number];
+    readonly message: string;
+    readonly requirement: string;
+    readonly fixHint: string;
+  },
+): HealthFinding {
+  return {
+    checkId: params.checkId,
+    severity: "error",
+    message: params.message,
+    source: "policy",
+    path: "openclaw config",
+    ocPath: source.source,
+    target: source.source,
+    requirement: params.requirement,
+    fixHint: params.fixHint,
+  };
+}
+
+function feedSourceIsPinned(source: PolicyFeedSourceEvidence): boolean {
+  return source.trust === "pinned" && source.integrityPresent === true;
+}
+
 function agentWorkspaceFindings(
   policy: unknown,
   policyPath: string,
@@ -6180,6 +6376,17 @@ function policyHasGatewayRules(policy: unknown): boolean {
     (isRecord(gateway.remote) && gateway.remote.allow !== undefined) ||
     (isRecord(gateway.http) &&
       (gateway.http.denyEndpoints !== undefined || gateway.http.requireUrlAllowlists !== undefined))
+  );
+}
+
+function policyHasFeedRules(policy: unknown): boolean {
+  return (
+    isRecord(policy) &&
+    isRecord(policy.feeds) &&
+    isRecord(policy.feeds.sources) &&
+    (policy.feeds.sources.require !== undefined ||
+      policy.feeds.sources.requirePinned !== undefined ||
+      policy.feeds.sources.allowUnsigned !== undefined)
   );
 }
 

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -855,9 +855,7 @@ export function scanPolicyFeeds(cfg: Record<string, unknown>): readonly PolicyFe
   const deny = readStringArray(plugins.deny);
   if (
     plugins.enabled === false ||
-    feeds.enabled === false ||
-    config.enabled === false ||
-    !(feeds.enabled === true || config.enabled === true || allow.includes("feeds")) ||
+    feeds.enabled !== true ||
     deny.includes("feeds") ||
     (allow.length > 0 && !allow.includes("feeds"))
   ) {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -857,7 +857,7 @@ export function scanPolicyFeeds(cfg: Record<string, unknown>): readonly PolicyFe
     plugins.enabled === false ||
     feeds.enabled === false ||
     config.enabled === false ||
-    (feeds.enabled !== true && config.enabled !== true) ||
+    !(feeds.enabled === true || config.enabled === true || allow.includes("feeds")) ||
     deny.includes("feeds") ||
     (allow.length > 0 && !allow.includes("feeds"))
   ) {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -857,6 +857,7 @@ export function scanPolicyFeeds(cfg: Record<string, unknown>): readonly PolicyFe
     plugins.enabled === false ||
     feeds.enabled === false ||
     config.enabled === false ||
+    (feeds.enabled !== true && config.enabled !== true) ||
     deny.includes("feeds") ||
     (allow.length > 0 && !allow.includes("feeds"))
   ) {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -50,6 +50,7 @@ export type PolicyEvidence = {
   readonly network: readonly PolicyNetworkEvidence[];
   readonly ingress?: readonly PolicyIngressEvidence[];
   readonly gatewayExposure?: readonly PolicyGatewayExposureEvidence[];
+  readonly feeds?: readonly PolicyFeedSourceEvidence[];
   readonly agentWorkspace?: readonly PolicyAgentWorkspaceEvidence[];
   readonly dataHandling?: readonly PolicyDataHandlingEvidence[];
   readonly secrets?: readonly PolicySecretEvidence[];
@@ -156,6 +157,15 @@ export type PolicyIngressEvidence = {
   readonly groupId?: string;
   readonly value?: boolean | string;
   readonly explicit?: boolean;
+};
+
+export type PolicyFeedSourceEvidence = {
+  readonly id: string;
+  readonly source: string;
+  readonly enabled?: boolean;
+  readonly url?: string;
+  readonly trust?: string;
+  readonly integrityPresent?: boolean;
 };
 
 export type PolicyGatewayExposureEvidence = {
@@ -313,6 +323,7 @@ export function collectPolicyEvidence(
     readonly toolsRaw?: undefined;
     readonly includeIngress?: boolean;
     readonly includeGatewayExposure?: boolean;
+    readonly includeFeeds?: boolean;
     readonly includeAgentWorkspace?: boolean;
     readonly includeDataHandling?: boolean;
     readonly includeToolPosture?: boolean;
@@ -329,6 +340,7 @@ export function collectPolicyEvidence(
     readonly toolsRaw: string;
     readonly includeIngress?: boolean;
     readonly includeGatewayExposure?: boolean;
+    readonly includeFeeds?: boolean;
     readonly includeAgentWorkspace?: boolean;
     readonly includeDataHandling?: boolean;
     readonly includeToolPosture?: boolean;
@@ -345,6 +357,7 @@ export function collectPolicyEvidence(
     readonly toolsRaw?: string;
     readonly includeIngress?: boolean;
     readonly includeGatewayExposure?: boolean;
+    readonly includeFeeds?: boolean;
     readonly includeAgentWorkspace?: boolean;
     readonly includeDataHandling?: boolean;
     readonly includeToolPosture?: boolean;
@@ -365,6 +378,7 @@ export function collectPolicyEvidence(
     ...(options.includeGatewayExposure === false
       ? {}
       : { gatewayExposure: scanPolicyGatewayExposure(cfg) }),
+    ...(options.includeFeeds === false ? {} : { feeds: scanPolicyFeeds(cfg) }),
     ...(options.includeAgentWorkspace === false
       ? {}
       : { agentWorkspace: scanPolicyAgentWorkspace(cfg) }),
@@ -830,6 +844,64 @@ export function scanPolicyIngress(cfg: Record<string, unknown>): readonly Policy
     }
   }
   return entries.toSorted((a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id));
+}
+
+export function scanPolicyFeeds(cfg: Record<string, unknown>): readonly PolicyFeedSourceEvidence[] {
+  const plugins = isRecord(cfg.plugins) ? cfg.plugins : {};
+  const entries = isRecord(plugins.entries) ? plugins.entries : {};
+  const feeds = isRecord(entries.feeds) ? entries.feeds : {};
+  const config = isRecord(feeds.config) ? feeds.config : {};
+  const allow = readStringArray(plugins.allow);
+  const deny = readStringArray(plugins.deny);
+  if (
+    plugins.enabled === false ||
+    feeds.enabled === false ||
+    config.enabled === false ||
+    deny.includes("feeds") ||
+    (allow.length > 0 && !allow.includes("feeds"))
+  ) {
+    return [];
+  }
+  const sources = Array.isArray(config.sources) ? config.sources : [];
+  return sources
+    .map((source, index): PolicyFeedSourceEvidence | undefined => {
+      if (!isRecord(source)) {
+        return undefined;
+      }
+      const id =
+        typeof source.id === "string" && source.id.trim() !== ""
+          ? source.id.trim()
+          : `source-${index}`;
+      const entry: {
+        id: string;
+        source: string;
+        enabled?: boolean;
+        url?: string;
+        trust?: string;
+        integrityPresent?: boolean;
+      } = {
+        id,
+        source: `oc://openclaw.config/plugins/entries/feeds/config/sources/#${index}`,
+      };
+      if (typeof source.enabled === "boolean") {
+        entry.enabled = source.enabled;
+      }
+      if (typeof source.url === "string") {
+        entry.url = redactFeedUrlForEvidence(source.url);
+      }
+      if (typeof source.trust === "string") {
+        entry.trust = source.trust;
+      }
+      if (
+        typeof source.integrity === "string" &&
+        /^sha256:[0-9a-f]{64}$/iu.test(source.integrity)
+      ) {
+        entry.integrityPresent = true;
+      }
+      return entry;
+    })
+    .filter((entry): entry is PolicyFeedSourceEvidence => entry !== undefined)
+    .toSorted((a, b) => a.id.localeCompare(b.id) || a.source.localeCompare(b.source));
 }
 
 export function scanPolicyGatewayExposure(
@@ -2416,6 +2488,22 @@ function redactMcpUrlForEvidence(raw: string): string {
   } catch {
     return "[redacted-url]";
   }
+}
+
+function redactFeedUrlForEvidence(raw: string): string {
+  try {
+    const url = new URL(raw);
+    if (url.protocol === "file:") {
+      return `file://[redacted-path]#${shortEvidenceHash(raw)}`;
+    }
+    return `${url.protocol}//${url.host}#${shortEvidenceHash(raw)}`;
+  } catch {
+    return `[redacted-url]#${shortEvidenceHash(raw)}`;
+  }
+}
+
+function shortEvidenceHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
 }
 
 function configuredModelProviders(cfg: Record<string, unknown>): Record<string, unknown> {


### PR DESCRIPTION
## Summary

Adds Policy conformance checks for feed catalog posture.

This is config conformance, not runtime enforcement:

- Adds `policy.jsonc` feed rules for required feed source ids.
- Adds pinned-source and unsigned-source posture checks.
- Adds feed evidence to policy output only when feed policy rules are present.
- Redacts feed source URLs while preserving attestation drift detection with a stable evidence hash.
- Honors all feed activation gates before treating a configured feed source as enabled evidence.
- Adds policy docs, check ids, shape validation, and focused tests.

## Example syntax

```jsonc
{
  "feeds": {
    "sources": {
      "require": ["company-approved"],
      "requirePinned": true,
      "allowUnsigned": false
    }
  }
}
```

## Commands

```bash
openclaw policy check
openclaw policy check --json
openclaw doctor --lint
```

## Evidence shape

Feed evidence records the configured source id, config source path, enabled posture, trust mode, and whether valid pinned integrity is present. URLs are redacted to origin plus a short hash so policy attestation detects URL drift without exposing path, query, credentials, or local file paths.

## Notes

Policy reports findings when the active OpenClaw config does not conform to the approved `policy.jsonc`. It does not enforce install behavior; explicit feed install enforcement lives in the preceding feeds PR.

## Real behavior proof

Behavior or issue addressed:
Policy feed catalog conformance now recognizes `feeds.sources` policy rules, reports pinned/unsigned feed source posture findings, exposes redacted feed evidence, and surfaces the same feed policy findings through Doctor lint.

Real environment tested:
WSL Ubuntu 24.04, source checkout `/root/src/openclaw-feeds-87826` at `bb7ed067731bd79429081e74bf54032fd4a681e3`, source CLI via `node scripts/run-node.mjs`, temporary `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, `OPENCLAW_HOME`, and `HOME`. The temporary config enabled the bundled Policy and Feeds plugins, declared one unsigned feed source with credentials/query in the URL, and used a temporary `policy.jsonc` requiring that feed source to be pinned and disallowing unsigned trust.

Exact steps or command run after this patch:
1. `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts extensions/feeds/src/doctor/register.test.ts extensions/feeds/src/cli.test.ts src/flows/bundled-health-checks.test.ts --reporter=dot`
2. `pnpm exec oxlint --tsconfig ./tsconfig.json extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts extensions/policy/src/cli.test.ts extensions/feeds/src/doctor/register.ts extensions/feeds/src/cli.ts`
3. `pnpm exec oxfmt --check --threads=1 extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts extensions/policy/src/cli.test.ts extensions/feeds/src/doctor/register.ts extensions/feeds/src/cli.ts docs/cli/policy.md docs/plugins/reference/feeds.md && git diff --check`
4. `pnpm tsgo:extensions`
5. `node scripts/run-node.mjs policy check --json`
6. `node scripts/run-node.mjs doctor --lint --only policy/feeds-source-unpinned --only policy/feeds-source-unsigned --json`

Evidence after fix:
```text
Vitest: 4 files passed, 355 tests passed.
oxlint: Found 0 warnings and 0 errors.
oxfmt: All matched files use the correct format.
tsgo: pnpm tsgo:extensions completed successfully.

CASE policy-json exit=1
POLICY_JSON_SUMMARY
{
  "ok": false,
  "feedEvidence": [
    {
      "id": "company-approved",
      "source": "oc://openclaw.config/plugins/entries/feeds/config/sources/#0",
      "url": "https://feeds.example.com#02cb882471a6",
      "trust": "unsigned"
    }
  ],
  "findingIds": [
    "policy/feeds-source-unpinned",
    "policy/feeds-source-unsigned"
  ],
  "findingTargets": [
    "oc://openclaw.config/plugins/entries/feeds/config/sources/#0",
    "oc://openclaw.config/plugins/entries/feeds/config/sources/#0"
  ]
}

CASE doctor-lint exit=1
DOCTOR_JSON_SUMMARY
{
  "ok": false,
  "findingIds": [
    "policy/feeds-source-unpinned",
    "policy/feeds-source-unsigned"
  ],
  "findingTargets": [
    "oc://openclaw.config/plugins/entries/feeds/config/sources/#0",
    "oc://openclaw.config/plugins/entries/feeds/config/sources/#0"
  ]
}
```

Observed result after fix:
`policy check --json` emitted feed evidence with the sensitive feed URL redacted to origin plus hash and reported the expected unpinned/unsigned feed posture findings. `doctor --lint` reported the same feed policy checks through the health-check surface.

What was not tested:
No live external feed endpoint was contacted; this proof intentionally uses local temporary config and policy files to exercise the source CLI policy/doctor behavior without network dependency.

## Validation

```bash
node scripts/run-vitest.mjs extensions/feeds/src/cli.test.ts extensions/feeds/src/doctor/register.test.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts src/flows/bundled-health-checks.test.ts
node scripts/run-tsgo.mjs --noEmit
pnpm exec oxfmt --check extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/feeds/src/feed-document.ts extensions/feeds/src/doctor/register.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts docs/cli/policy.md docs/plugins/reference/feeds.md docs/plugins/reference.md
git diff --check
node scripts/generate-plugin-inventory-doc.mjs --check
```

Focused stack proof on the final condensed branch: 243 tests passed.

## Feed PR stack

1. openclaw/openclaw#87824 - read-only feed discovery
2. openclaw/openclaw#87825 - approved feed installs
3. openclaw/openclaw#87826 - feed catalog policy conformance
4. openclaw/openclaw#87827 - feed lifecycle tooling
5. openclaw/openclaw#88732 - native feed search defaults and policy checks
6. openclaw/clawhub#2460 - ClawHub root feed lanes

The stack keeps OpenClaw as a feed consumer. ClawHub root feeds are producer infrastructure; enterprise or tenant feeds can be produced elsewhere using the same schema.

RFC draft: https://github.com/giodl73-repo/rfcs/blob/feeds-rfc-draft/rfcs/0004-feeds.md
