### PR TITLE
feat(feeds): add feed lifecycle tooling

### DIFF
--- a/extensions/feeds/src/cli.test.ts
+++ b/extensions/feeds/src/cli.test.ts
@@ -7,10 +7,16 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 import {
+  feedsBuildCommand,
+  feedsDiffCommand,
   feedsInstallCommand,
   feedsListCommand,
+  feedsNoticesCommand,
+  feedsHashCommand,
   feedsSearchCommand,
   feedsSourcesCommand,
+  feedsUpdatesCommand,
+  feedsValidateCommand,
   type FeedsCommandRuntime,
 } from "./cli.js";
 import { MAX_FEED_DOCUMENT_BYTES } from "./feed-document.js";
@@ -268,6 +274,372 @@ describe("Feeds CLI", () => {
     expect(runtime.stderr).toContain("Invalid --type value. Expected skill or plugin.");
   });
 
+  it("reports available feed updates from an installed inventory", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "skill",
+          id: "excel-review",
+          version: "1.2.0",
+          approval: { status: "approved" },
+        },
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          version: "1.0.0",
+        },
+      ],
+    });
+    const inventory = JSON.stringify({
+      entries: [
+        { type: "skill", id: "excel-review", version: "1.0.0" },
+        { type: "plugin", id: "calendar-helper", version: "1.0.0" },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: {
+        "/feeds/company.json": feed,
+        "/installed.json": inventory,
+      },
+    });
+
+    const exitCode = await feedsUpdatesCommand(
+      { installed: "/installed.json", json: true },
+      runtime,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).updates).toEqual([
+      expect.objectContaining({
+        type: "skill",
+        id: "excel-review",
+        installedVersion: "1.0.0",
+        availableVersion: "1.2.0",
+        approved: true,
+      }),
+    ]);
+  });
+
+  it("filters feed updates to approved entries", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        { type: "skill", id: "approved-skill", version: "2.0.0", approval: { status: "approved" } },
+        { type: "skill", id: "draft-skill", version: "2.0.0" },
+      ],
+    });
+    const inventory = JSON.stringify({
+      entries: [
+        { type: "skill", id: "approved-skill", version: "1.0.0" },
+        { type: "skill", id: "draft-skill", version: "1.0.0" },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: {
+        "/feeds/company.json": feed,
+        "/installed.json": inventory,
+      },
+    });
+
+    const exitCode = await feedsUpdatesCommand(
+      { installed: "/installed.json", approvedOnly: true, json: true },
+      runtime,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).updates.map((entry: { id: string }) => entry.id)).toEqual([
+      "approved-skill",
+    ]);
+  });
+
+  it("uses semver prerelease ordering for update notices", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          version: "1.0.0-beta.1",
+          approval: { status: "approved" },
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+        },
+        {
+          type: "plugin",
+          id: "sheet-helper",
+          version: "1.0.0",
+          approval: { status: "approved" },
+          install: { source: "clawhub", spec: "openclaw-sheet" },
+        },
+        {
+          type: "plugin",
+          id: "docs-helper",
+          version: "1.0.0-rc.1",
+          approval: { status: "approved" },
+          install: { source: "clawhub", spec: "openclaw-docs" },
+        },
+      ],
+    });
+    const inventory = JSON.stringify({
+      entries: [
+        { type: "plugin", id: "calendar-helper", version: "1.0.0" },
+        { type: "plugin", id: "sheet-helper", version: "1.0.0-beta.1" },
+        { type: "plugin", id: "docs-helper", version: "1.0.0-beta.9" },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: {
+        "/feeds/company.json": feed,
+        "/installed.json": inventory,
+      },
+    });
+
+    const exitCode = await feedsUpdatesCommand(
+      { installed: "/installed.json", approvedOnly: true, json: true },
+      runtime,
+    );
+
+    expect(exitCode).toBe(0);
+    const updates = JSON.parse(runtime.stdout).updates;
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "sheet-helper",
+          installedVersion: "1.0.0-beta.1",
+          availableVersion: "1.0.0",
+        }),
+        expect.objectContaining({
+          id: "docs-helper",
+          installedVersion: "1.0.0-beta.9",
+          availableVersion: "1.0.0-rc.1",
+        }),
+      ]),
+    );
+    expect(updates).toHaveLength(2);
+  });
+
+  it("reports subscriber update notices", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        {
+          type: "plugin",
+          id: "calendar-helper",
+          version: "1.2.0",
+          approval: { status: "approved" },
+          install: { source: "clawhub", spec: "openclaw-calendar" },
+        },
+      ],
+    });
+    const inventory = JSON.stringify({
+      entries: [{ type: "plugin", id: "calendar-helper", version: "1.0.0" }],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: {
+        "/feeds/company.json": feed,
+        "/installed.json": inventory,
+      },
+    });
+
+    const exitCode = await feedsNoticesCommand(
+      { installed: "/installed.json", approvedOnly: true, json: true },
+      runtime,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout).notices).toEqual([
+      expect.objectContaining({
+        type: "plugin",
+        id: "calendar-helper",
+        sourceId: "approved",
+        installedVersion: "1.0.0",
+        availableVersion: "1.2.0",
+        approved: true,
+        installCommand: "openclaw plugins install clawhub:openclaw-calendar",
+      }),
+    ]);
+  });
+
+  it("validates a local feed document and prints its integrity", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [{ type: "skill", id: "excel-review" }],
+    });
+    const integrity = `sha256:${createHash("sha256").update(feed).digest("hex")}`;
+    const runtime = createRuntime({
+      sources: [],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsValidateCommand("/feeds/company.json", { json: true }, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout)).toEqual({
+      ok: true,
+      id: "company-approved",
+      entries: 1,
+      integrity,
+    });
+  });
+
+  it("prints a local feed document integrity hash", async () => {
+    const feed = JSON.stringify({ schemaVersion: 1, id: "company-approved", entries: [] });
+    const integrity = `sha256:${createHash("sha256").update(feed).digest("hex")}`;
+    const runtime = createRuntime({
+      sources: [],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsHashCommand("/feeds/company.json", {}, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(runtime.stdout).toBe(`${integrity}\n`);
+  });
+
+  it("rejects invalid local feed documents during validation", async () => {
+    const runtime = createRuntime({
+      sources: [],
+      files: { "/feeds/broken.json": JSON.stringify({ schemaVersion: 1, id: "broken" }) },
+    });
+
+    const exitCode = await feedsValidateCommand("/feeds/broken.json", {}, runtime);
+
+    expect(exitCode).toBe(2);
+    expect(runtime.stderr).toContain("entries must be an array");
+  });
+
+  it("builds a curated feed artifact from local inventory rules", async () => {
+    const inventory = JSON.stringify({
+      schemaVersion: 1,
+      id: "upstream",
+      entries: [
+        {
+          type: "skill",
+          id: "excel-review",
+          version: "1.0.0",
+          tags: ["m365", "approved"],
+          approval: { status: "approved" },
+        },
+        { type: "plugin", id: "draft-plugin", tags: ["m365"] },
+        {
+          type: "skill",
+          id: "blocked-skill",
+          tags: ["m365", "blocked"],
+          approval: { status: "approved" },
+        },
+      ],
+    });
+    const rules = JSON.stringify({
+      includeTypes: ["skill"],
+      includeTags: ["m365"],
+      excludeTags: ["blocked"],
+      requireApproval: true,
+    });
+    const runtime = createRuntime({
+      sources: [],
+      files: { "/feeds/inventory.json": inventory, "/feeds/rules.json": rules },
+    });
+
+    const exitCode = await feedsBuildCommand(
+      {
+        inventory: "/feeds/inventory.json",
+        rules: "/feeds/rules.json",
+        out: "/feeds/lobster-approved.json",
+        id: "lobster-approved",
+        generatedAt: "2026-05-28T00:00:00.000Z",
+        json: true,
+      },
+      runtime,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout)).toEqual(
+      expect.objectContaining({
+        ok: true,
+        id: "lobster-approved",
+        entries: 1,
+        out: "/feeds/lobster-approved.json",
+      }),
+    );
+    expect(JSON.parse(runtime.writes["/feeds/lobster-approved.json"])).toEqual({
+      schemaVersion: 1,
+      id: "lobster-approved",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      entries: [
+        expect.objectContaining({
+          type: "skill",
+          id: "excel-review",
+          approval: { status: "approved" },
+        }),
+      ],
+    });
+  });
+
+  it("reports feed artifact deltas", async () => {
+    const previous = JSON.stringify({
+      schemaVersion: 1,
+      id: "lobster-approved",
+      entries: [
+        {
+          type: "skill",
+          id: "excel-review",
+          version: "1.0.0",
+          name: "Excel Review",
+          sha256: "old",
+          approval: { status: "pending" },
+        },
+        { type: "plugin", id: "removed-plugin" },
+      ],
+    });
+    const current = JSON.stringify({
+      schemaVersion: 1,
+      id: "lobster-approved",
+      entries: [
+        {
+          type: "skill",
+          id: "excel-review",
+          version: "1.1.0",
+          name: "Excel Review Pro",
+          sha256: "new",
+          approval: { status: "approved" },
+        },
+        { type: "skill", id: "new-skill" },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [],
+      files: { "/feeds/previous.json": previous, "/feeds/current.json": current },
+    });
+
+    const exitCode = await feedsDiffCommand(
+      { previous: "/feeds/previous.json", current: "/feeds/current.json", json: true },
+      runtime,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout)).toEqual(
+      expect.objectContaining({
+        added: [expect.objectContaining({ type: "skill", id: "new-skill" })],
+        removed: [expect.objectContaining({ type: "plugin", id: "removed-plugin" })],
+        updated: [{ type: "skill", id: "excel-review", previous: "1.0.0", current: "1.1.0" }],
+        approvalChanged: [
+          { type: "skill", id: "excel-review", previous: "pending", current: "approved" },
+        ],
+        metadataChanged: [{ type: "skill", id: "excel-review" }],
+        hashChanged: [{ type: "skill", id: "excel-review", previous: "old", current: "new" }],
+      }),
+    );
+  });
+
   it("dry-runs an explicit feed-backed plugin install", async () => {
     const feed = JSON.stringify({
       schemaVersion: 1,
@@ -490,16 +862,19 @@ function createRuntime(params: {
   stderr: string;
   isTTY?: boolean;
   commands: readonly string[][];
+  writes: Record<string, string>;
 } {
   const runtime: FeedsCommandRuntime & {
     stdout: string;
     stderr: string;
     isTTY?: boolean;
     commands: string[][];
+    writes: Record<string, string>;
   } = {
     stdout: "",
     stderr: "",
     commands: [],
+    writes: {},
     writeStdout(value) {
       this.stdout += value;
     },
@@ -510,7 +885,10 @@ function createRuntime(params: {
       runtime.commands.push([...argv]);
       return 0;
     },
-    async readConfigSnapshot() {
+    async writeFile(path, value) {
+      runtime.writes[path] = value;
+    },
+    async readConfigSnapshot(): Promise<any> {
       return {
         valid: true,
         config: {

--- a/extensions/feeds/src/cli.test.ts
+++ b/extensions/feeds/src/cli.test.ts
@@ -491,6 +491,29 @@ describe("Feeds CLI", () => {
     });
   });
 
+  it("validates a file URL feed document", async () => {
+    const feed = JSON.stringify({ schemaVersion: 1, id: "company-approved", entries: [] });
+    const integrity = "sha256:" + createHash("sha256").update(feed).digest("hex");
+    const runtime = createRuntime({
+      sources: [],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const exitCode = await feedsValidateCommand(
+      "file:///feeds/company.json",
+      { json: true },
+      runtime,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(runtime.stdout)).toEqual({
+      ok: true,
+      id: "company-approved",
+      entries: 0,
+      integrity,
+    });
+  });
+
   it("prints a local feed document integrity hash", async () => {
     const feed = JSON.stringify({ schemaVersion: 1, id: "company-approved", entries: [] });
     const integrity = `sha256:${createHash("sha256").update(feed).digest("hex")}`;
@@ -503,6 +526,23 @@ describe("Feeds CLI", () => {
 
     expect(exitCode).toBe(0);
     expect(runtime.stdout).toBe(`${integrity}\n`);
+  });
+
+  it("prints an HTTPS feed document integrity hash", async () => {
+    const feed = JSON.stringify({ schemaVersion: 1, id: "company-approved", entries: [] });
+    const integrity = "sha256:" + createHash("sha256").update(feed).digest("hex");
+    const runtime = createRuntime({
+      sources: [],
+      fetch: async (url) => {
+        expect(url).toBe("https://feeds.example.com/company.json");
+        return { ok: true, text: feed };
+      },
+    });
+
+    const exitCode = await feedsHashCommand("https://feeds.example.com/company.json", {}, runtime);
+
+    expect(exitCode).toBe(0);
+    expect(runtime.stdout).toBe(integrity + "\n");
   });
 
   it("rejects invalid local feed documents during validation", async () => {
@@ -582,6 +622,36 @@ describe("Feeds CLI", () => {
         }),
       ],
     });
+  });
+
+  it("omits generatedAt by default for deterministic feed builds", async () => {
+    const inventory = JSON.stringify({
+      schemaVersion: 1,
+      id: "upstream",
+      entries: [
+        { type: "skill", id: "b" },
+        { type: "skill", id: "a" },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [],
+      files: { "/feeds/inventory.json": inventory },
+    });
+
+    const firstExitCode = await feedsBuildCommand(
+      { inventory: "/feeds/inventory.json", out: "/feeds/first.json", id: "curated", json: true },
+      runtime,
+    );
+    const firstArtifact = runtime.writes["/feeds/first.json"];
+    const secondExitCode = await feedsBuildCommand(
+      { inventory: "/feeds/inventory.json", out: "/feeds/second.json", id: "curated", json: true },
+      runtime,
+    );
+
+    expect(firstExitCode).toBe(0);
+    expect(secondExitCode).toBe(0);
+    expect(JSON.parse(firstArtifact)).not.toHaveProperty("generatedAt");
+    expect(firstArtifact).toBe(runtime.writes["/feeds/second.json"]);
   });
 
   it("reports feed artifact deltas", async () => {
@@ -856,6 +926,7 @@ describe("Feeds CLI", () => {
 function createRuntime(params: {
   readonly sources?: readonly Record<string, unknown>[];
   readonly files?: Readonly<Record<string, string>>;
+  readonly fetch?: FeedsCommandRuntime["fetch"];
   readonly installPolicy?: Record<string, unknown>;
 }): FeedsCommandRuntime & {
   stdout: string;
@@ -888,6 +959,7 @@ function createRuntime(params: {
     async writeFile(path, value) {
       runtime.writes[path] = value;
     },
+    fetch: params.fetch,
     async readConfigSnapshot(): Promise<any> {
       return {
         valid: true,

--- a/extensions/feeds/src/cli.ts
+++ b/extensions/feeds/src/cli.ts
@@ -1,12 +1,17 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
 import type { Command } from "commander";
 import { readConfigFileSnapshot } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   feedEntryMatchesQuery,
   loadFeedDocument,
+  parseFeedDocument,
+  type FeedDocument,
   type FeedDocumentRuntime,
   type FeedEntry,
+  type FeedEntryType,
   type FeedSourceConfig,
   type LoadedFeedDocument,
 } from "./feed-document.js";
@@ -25,6 +30,7 @@ export type FeedsCommandRuntime = FeedDocumentRuntime & {
   writeStdout(value: string): void;
   error(value: string): void;
   isTTY?: boolean;
+  writeFile?: (path: string, value: string) => Promise<void>;
   readConfigSnapshot?: (options: { readonly observe?: boolean }) => Promise<FeedConfigSnapshot>;
   runOpenClawCommand?: (argv: readonly string[]) => Promise<number>;
 };
@@ -33,6 +39,24 @@ export type FeedsCommandOptions = {
   readonly json?: boolean;
   readonly source?: string;
   readonly type?: string;
+};
+
+export type FeedsUpdatesOptions = FeedsCommandOptions & {
+  readonly installed?: string;
+  readonly approvedOnly?: boolean;
+};
+
+export type FeedsBuildOptions = FeedsCommandOptions & {
+  readonly inventory?: string;
+  readonly rules?: string;
+  readonly out?: string;
+  readonly id?: string;
+  readonly generatedAt?: string;
+};
+
+export type FeedsDiffOptions = FeedsCommandOptions & {
+  readonly previous?: string;
+  readonly current?: string;
 };
 
 export type FeedInstallPolicyMode = "off" | "warn" | "enforce";
@@ -52,9 +76,40 @@ type ConfiguredFeeds = {
   readonly installPolicy: FeedInstallPolicy;
 };
 
+export type FeedInstalledEntry = {
+  readonly type: "skill" | "plugin";
+  readonly id: string;
+  readonly version: string;
+};
+
+export type FeedUpdateResult = FeedEntryResult & {
+  readonly installedVersion: string;
+  readonly availableVersion: string;
+  readonly approved: boolean;
+};
+
+export type FeedUpdateNotice = {
+  readonly type: FeedEntryType;
+  readonly id: string;
+  readonly sourceId: string;
+  readonly feedId: string;
+  readonly installedVersion: string;
+  readonly availableVersion: string;
+  readonly approved: boolean;
+  readonly message: string;
+  readonly installCommand?: string;
+};
+
 export type FeedEntryResult = FeedEntry & {
   readonly sourceId: string;
   readonly feedId: string;
+};
+
+export type FeedBuildRules = {
+  readonly includeTypes?: readonly FeedEntryType[];
+  readonly includeTags?: readonly string[];
+  readonly excludeTags?: readonly string[];
+  readonly requireApproval?: boolean;
 };
 
 const defaultRuntime: FeedsCommandRuntime = {
@@ -100,6 +155,70 @@ export function registerFeedsCli(program: Command): void {
     .option("--json", "Emit JSON output")
     .action(async (query: string, options: FeedsCommandOptions) => {
       process.exitCode = await feedsSearchCommand(query, options);
+    });
+
+  feeds
+    .command("updates")
+    .description("Compare installed inventory against approved feed versions")
+    .requiredOption("--installed <path>", "Path to installed skill/plugin inventory JSON")
+    .option("--source <id>", "Limit to one feed source id")
+    .option("--type <type>", "Limit to skill or plugin entries")
+    .option("--approved-only", "Only report feed entries with approval.status=approved")
+    .option("--json", "Emit JSON output")
+    .action(async (options: FeedsUpdatesOptions) => {
+      process.exitCode = await feedsUpdatesCommand(options);
+    });
+
+  feeds
+    .command("notices")
+    .description("Show subscriber update notices from configured feeds")
+    .requiredOption("--installed <path>", "Path to installed skill/plugin inventory JSON")
+    .option("--source <id>", "Limit to one feed source id")
+    .option("--type <type>", "Limit to skill or plugin entries")
+    .option("--approved-only", "Only report feed entries with approval.status=approved")
+    .option("--json", "Emit JSON output")
+    .action(async (options: FeedsUpdatesOptions) => {
+      process.exitCode = await feedsNoticesCommand(options);
+    });
+
+  feeds
+    .command("validate")
+    .argument("<path>", "Path to a feed JSON document")
+    .description("Validate a feed document and print its pinning integrity")
+    .option("--json", "Emit JSON output")
+    .action(async (path: string, options: FeedsCommandOptions) => {
+      process.exitCode = await feedsValidateCommand(path, options);
+    });
+
+  feeds
+    .command("hash")
+    .argument("<path>", "Path to a feed JSON document")
+    .description("Print the sha256 integrity string for a feed document")
+    .action(async (path: string) => {
+      process.exitCode = await feedsHashCommand(path, {});
+    });
+
+  feeds
+    .command("build")
+    .description("Build a curated feed artifact from a local inventory snapshot")
+    .requiredOption("--inventory <path>", "Path to a feed or inventory JSON document")
+    .requiredOption("--out <path>", "Path to write the curated feed document")
+    .option("--rules <path>", "Path to feed build rules JSON")
+    .option("--id <id>", "Feed id for the generated artifact")
+    .option("--generated-at <iso>", "Timestamp to write into generatedAt")
+    .option("--json", "Emit JSON output")
+    .action(async (options: FeedsBuildOptions) => {
+      process.exitCode = await feedsBuildCommand(options);
+    });
+
+  feeds
+    .command("diff")
+    .description("Compare two feed artifacts and report entry deltas")
+    .requiredOption("--previous <path>", "Previous feed document")
+    .requiredOption("--current <path>", "Current feed document")
+    .option("--json", "Emit JSON output")
+    .action(async (options: FeedsDiffOptions) => {
+      process.exitCode = await feedsDiffCommand(options);
     });
 
   feeds
@@ -169,6 +288,154 @@ export async function feedsSearchCommand(
   }
 }
 
+export async function feedsUpdatesCommand(
+  options: FeedsUpdatesOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    assertFeedEntryType(options.type);
+    if (options.installed === undefined || options.installed.trim() === "") {
+      throw new Error("Provide --installed <path>.");
+    }
+    const installed = await readInstalledInventory(options.installed, runtime);
+    const loaded = await loadConfiguredFeedDocuments(options, runtime);
+    const updates = findFeedUpdates(flattenFeedEntries(loaded), installed, options);
+    writeUpdates(updates, options, runtime);
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function feedsNoticesCommand(
+  options: FeedsUpdatesOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    assertFeedEntryType(options.type);
+    if (options.installed === undefined || options.installed.trim() === "") {
+      throw new Error("Provide --installed <path>.");
+    }
+    const installed = await readInstalledInventory(options.installed, runtime);
+    const loaded = await loadConfiguredFeedDocuments(options, runtime);
+    const updates = findFeedUpdates(flattenFeedEntries(loaded), installed, options);
+    writeNotices(buildFeedUpdateNotices(updates), options, runtime);
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function feedsValidateCommand(
+  path: string,
+  options: FeedsCommandOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    const raw = await readFeedFile(path, runtime);
+    const document = parseFeedDocument(JSON.parse(raw.toString("utf8")), path);
+    const integrity = feedIntegrity(raw);
+    const result = {
+      ok: true,
+      id: document.id,
+      entries: document.entries.length,
+      integrity,
+    };
+    if (options.json === true || runtime.isTTY !== true) {
+      runtime.writeStdout(JSON.stringify(result, null, 2) + "\n");
+    } else {
+      runtime.writeStdout(`Feed ${document.id} is valid.\nIntegrity: ${integrity}\n`);
+    }
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function feedsHashCommand(
+  path: string,
+  _options: FeedsCommandOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    runtime.writeStdout(`${feedIntegrity(await readFeedFile(path, runtime))}\n`);
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function feedsBuildCommand(
+  options: FeedsBuildOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    if (options.inventory === undefined || options.inventory.trim() === "") {
+      throw new Error("Provide --inventory <path>.");
+    }
+    if (options.out === undefined || options.out.trim() === "") {
+      throw new Error("Provide --out <path>.");
+    }
+    const inventory = await readInventoryDocument(options.inventory, options, runtime);
+    const rules = await readBuildRules(options.rules, runtime);
+    const document = {
+      schemaVersion: 1 as const,
+      id: options.id?.trim() || inventory.id,
+      generatedAt: options.generatedAt ?? new Date().toISOString(),
+      entries: applyBuildRules(inventory.entries, rules).toSorted(compareFeedEntries),
+    };
+    const serialized = JSON.stringify(document, null, 2) + "\n";
+    const write = runtime.writeFile ?? writeFile;
+    await write(options.out, serialized);
+    const result = {
+      ok: true,
+      id: document.id,
+      entries: document.entries.length,
+      out: options.out,
+      integrity: feedIntegrity(Buffer.from(serialized)),
+    };
+    if (options.json === true || runtime.isTTY !== true) {
+      runtime.writeStdout(JSON.stringify(result, null, 2) + "\n");
+    } else {
+      runtime.writeStdout(`Wrote ${document.entries.length} feed entries to ${options.out}.\n`);
+    }
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
+export async function feedsDiffCommand(
+  options: FeedsDiffOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<number> {
+  try {
+    if (options.previous === undefined || options.previous.trim() === "") {
+      throw new Error("Provide --previous <path>.");
+    }
+    if (options.current === undefined || options.current.trim() === "") {
+      throw new Error("Provide --current <path>.");
+    }
+    const previous = await readFeedDocumentFromPath(options.previous, runtime);
+    const current = await readFeedDocumentFromPath(options.current, runtime);
+    const diff = diffFeedDocuments(previous, current);
+    if (options.json === true || runtime.isTTY !== true) {
+      runtime.writeStdout(JSON.stringify(diff, null, 2) + "\n");
+    } else {
+      runtime.writeStdout(formatFeedDiff(diff));
+    }
+    return 0;
+  } catch (err) {
+    runtime.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+}
+
 export async function feedsInstallCommand(
   id: string,
   options: FeedsInstallOptions,
@@ -194,6 +461,399 @@ export async function feedsInstallCommand(
     runtime.error(err instanceof Error ? err.message : String(err));
     return 2;
   }
+}
+
+async function readInstalledInventory(
+  path: string,
+  runtime: FeedsCommandRuntime,
+): Promise<readonly FeedInstalledEntry[]> {
+  const raw = JSON.parse((await readFeedFile(path, runtime)).toString("utf8"));
+  if (!isRecord(raw) || !Array.isArray(raw.entries)) {
+    throw new Error("Installed inventory must be an object with an entries array.");
+  }
+  return raw.entries.map((entry, index): FeedInstalledEntry => {
+    if (!isRecord(entry)) {
+      throw new Error(`Installed inventory entry ${index} must be an object.`);
+    }
+    if (entry.type !== "skill" && entry.type !== "plugin") {
+      throw new Error(`Installed inventory entry ${index} must be a skill or plugin.`);
+    }
+    if (typeof entry.id !== "string" || entry.id.trim() === "") {
+      throw new Error(`Installed inventory entry ${index} must declare an id.`);
+    }
+    if (typeof entry.version !== "string" || entry.version.trim() === "") {
+      throw new Error(`Installed inventory entry ${index} must declare a version.`);
+    }
+    return { type: entry.type, id: entry.id, version: entry.version };
+  });
+}
+
+function findFeedUpdates(
+  entries: readonly FeedEntryResult[],
+  installed: readonly FeedInstalledEntry[],
+  options: FeedsUpdatesOptions,
+): readonly FeedUpdateResult[] {
+  const installedByKey = new Map(installed.map((entry) => [feedEntryKey(entry), entry]));
+  return filterEntriesByType(entries, options.type)
+    .filter((entry) => options.approvedOnly !== true || feedEntryApproved(entry))
+    .flatMap((entry): FeedUpdateResult[] => {
+      const installedEntry = installedByKey.get(feedEntryKey(entry));
+      if (installedEntry === undefined || entry.version === undefined) {
+        return [];
+      }
+      if (compareVersionStrings(entry.version, installedEntry.version) <= 0) {
+        return [];
+      }
+      return [
+        {
+          ...entry,
+          installedVersion: installedEntry.version,
+          availableVersion: entry.version,
+          approved: feedEntryApproved(entry),
+        },
+      ];
+    })
+    .toSorted((a, b) => a.type.localeCompare(b.type) || a.id.localeCompare(b.id));
+}
+
+function writeUpdates(
+  updates: readonly FeedUpdateResult[],
+  options: FeedsUpdatesOptions,
+  runtime: FeedsCommandRuntime,
+): void {
+  if (options.json === true || runtime.isTTY !== true) {
+    runtime.writeStdout(JSON.stringify({ updates }, null, 2) + "\n");
+    return;
+  }
+  if (updates.length === 0) {
+    runtime.writeStdout("No feed updates found.\n");
+    return;
+  }
+  runtime.writeStdout(
+    updates
+      .map((entry) => {
+        const approval = entry.approved ? "approved" : "unapproved";
+        return `${entry.sourceId}\t${entry.type}\t${entry.id}\t${entry.installedVersion} -> ${entry.availableVersion}\t${approval}`;
+      })
+      .join("\n") + "\n",
+  );
+}
+
+function buildFeedUpdateNotices(updates: readonly FeedUpdateResult[]): readonly FeedUpdateNotice[] {
+  return updates.map((entry) => {
+    const approval = entry.approved ? "approved" : "unapproved";
+    const installCommand = formatFeedInstallCommand(entry);
+    return {
+      type: entry.type,
+      id: entry.id,
+      sourceId: entry.sourceId,
+      feedId: entry.feedId,
+      installedVersion: entry.installedVersion,
+      availableVersion: entry.availableVersion,
+      approved: entry.approved,
+      message: `${entry.type} ${entry.id} has ${approval} feed update ${entry.installedVersion} -> ${entry.availableVersion} from ${entry.sourceId}.`,
+      ...(installCommand === undefined ? {} : { installCommand }),
+    };
+  });
+}
+
+function writeNotices(
+  notices: readonly FeedUpdateNotice[],
+  options: FeedsUpdatesOptions,
+  runtime: FeedsCommandRuntime,
+): void {
+  if (options.json === true || runtime.isTTY !== true) {
+    runtime.writeStdout(JSON.stringify({ notices }, null, 2) + "\n");
+    return;
+  }
+  if (notices.length === 0) {
+    runtime.writeStdout("No feed update notices found.\n");
+    return;
+  }
+  runtime.writeStdout(
+    notices
+      .map((notice) => {
+        const command =
+          notice.installCommand === undefined ? "" : `\n  Install: ${notice.installCommand}`;
+        return `${notice.sourceId}\t${notice.type}\t${notice.id}\t${notice.installedVersion} -> ${notice.availableVersion}\t${notice.approved ? "approved" : "unapproved"}${command}`;
+      })
+      .join("\n") + "\n",
+  );
+}
+
+function feedEntryKey(entry: { readonly type: string; readonly id: string }): string {
+  return `${entry.type}\0${entry.id}`;
+}
+
+function compareVersionStrings(a: string, b: string): number {
+  const semverComparison = compareSemverStrings(a, b);
+  if (semverComparison !== undefined) {
+    return semverComparison;
+  }
+  const aParts = parseVersionParts(a);
+  const bParts = parseVersionParts(b);
+  const length = Math.max(aParts.length, bParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const delta = (aParts[index] ?? 0) - (bParts[index] ?? 0);
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+  return a.localeCompare(b);
+}
+
+function compareSemverStrings(a: string, b: string): number | undefined {
+  const parsedA = parseSemver(a);
+  const parsedB = parseSemver(b);
+  if (parsedA === undefined || parsedB === undefined) {
+    return undefined;
+  }
+  for (const key of ["major", "minor", "patch"] as const) {
+    const delta = parsedA[key] - parsedB[key];
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+  return comparePrerelease(parsedA.prerelease, parsedB.prerelease);
+}
+
+function parseSemver(value: string):
+  | {
+      readonly major: number;
+      readonly minor: number;
+      readonly patch: number;
+      readonly prerelease: readonly string[];
+    }
+  | undefined {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[-0-9A-Za-z.]+)?$/u.exec(
+    value.trim(),
+  );
+  if (match === null) {
+    return undefined;
+  }
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+    prerelease: match[4] === undefined ? [] : match[4].split("."),
+  };
+}
+
+function comparePrerelease(a: readonly string[], b: readonly string[]): number {
+  if (a.length === 0 || b.length === 0) {
+    return b.length - a.length;
+  }
+  const length = Math.max(a.length, b.length);
+  for (let index = 0; index < length; index += 1) {
+    const aPart = a[index];
+    const bPart = b[index];
+    if (aPart === undefined || bPart === undefined) {
+      return a.length - b.length;
+    }
+    const delta = comparePrereleasePart(aPart, bPart);
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+  return 0;
+}
+
+function comparePrereleasePart(a: string, b: string): number {
+  const aNumeric = /^\d+$/u.test(a);
+  const bNumeric = /^\d+$/u.test(b);
+  if (aNumeric && bNumeric) {
+    return Number.parseInt(a, 10) - Number.parseInt(b, 10);
+  }
+  if (aNumeric || bNumeric) {
+    return aNumeric ? -1 : 1;
+  }
+  return a.localeCompare(b);
+}
+
+function parseVersionParts(value: string): readonly number[] {
+  return value
+    .split(/[.-]/u)
+    .map((part) => Number.parseInt(part, 10))
+    .filter((part) => Number.isFinite(part));
+}
+
+async function readInventoryDocument(
+  path: string,
+  options: FeedsBuildOptions,
+  runtime: FeedsCommandRuntime,
+): Promise<FeedDocument> {
+  const value = JSON.parse((await readFeedFile(path, runtime)).toString("utf8"));
+  if (isRecord(value) && value.schemaVersion === 1) {
+    return parseFeedDocument(value, path);
+  }
+  if (!isRecord(value) || !Array.isArray(value.entries)) {
+    throw new Error("Feed inventory must be a feed document or an object with an entries array.");
+  }
+  const id =
+    options.id?.trim() ||
+    (typeof value.id === "string" && value.id.trim() !== "" ? value.id : "curated-feed");
+  return parseFeedDocument({ schemaVersion: 1, id, entries: value.entries }, path);
+}
+
+async function readFeedDocumentFromPath(
+  path: string,
+  runtime: FeedsCommandRuntime,
+): Promise<FeedDocument> {
+  return parseFeedDocument(JSON.parse((await readFeedFile(path, runtime)).toString("utf8")), path);
+}
+
+async function readBuildRules(
+  path: string | undefined,
+  runtime: FeedsCommandRuntime,
+): Promise<FeedBuildRules> {
+  if (path === undefined) {
+    return {};
+  }
+  const value = JSON.parse((await readFeedFile(path, runtime)).toString("utf8"));
+  if (!isRecord(value)) {
+    throw new Error("Feed build rules must be a JSON object.");
+  }
+  return {
+    ...(value.includeTypes === undefined
+      ? {}
+      : { includeTypes: parseTypeList(value.includeTypes, "includeTypes") }),
+    ...(value.includeTags === undefined
+      ? {}
+      : { includeTags: parseStringList(value.includeTags, "includeTags") }),
+    ...(value.excludeTags === undefined
+      ? {}
+      : { excludeTags: parseStringList(value.excludeTags, "excludeTags") }),
+    ...(value.requireApproval === undefined
+      ? {}
+      : { requireApproval: parseBoolean(value.requireApproval, "requireApproval") }),
+  };
+}
+
+function parseTypeList(value: unknown, key: string): readonly FeedEntryType[] {
+  const values = parseStringList(value, key);
+  for (const item of values) {
+    if (item !== "skill" && item !== "plugin") {
+      throw new Error(`Feed build rules ${key} values must be skill or plugin.`);
+    }
+  }
+  return values as readonly FeedEntryType[];
+}
+
+function parseStringList(value: unknown, key: string): readonly string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`Feed build rules ${key} must be an array of strings.`);
+  }
+  return value.map((item) => item.trim()).filter(Boolean);
+}
+
+function parseBoolean(value: unknown, key: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`Feed build rules ${key} must be a boolean.`);
+  }
+  return value;
+}
+
+function applyBuildRules(
+  entries: readonly FeedEntry[],
+  rules: FeedBuildRules,
+): readonly FeedEntry[] {
+  const includeTypes = new Set(rules.includeTypes ?? []);
+  const includeTags = new Set(rules.includeTags ?? []);
+  const excludeTags = new Set(rules.excludeTags ?? []);
+  return entries.filter((entry) => {
+    if (includeTypes.size > 0 && !includeTypes.has(entry.type)) {
+      return false;
+    }
+    if (rules.requireApproval === true && !feedEntryApproved(entry)) {
+      return false;
+    }
+    const tags = new Set(entry.tags ?? []);
+    for (const tag of includeTags) {
+      if (!tags.has(tag)) {
+        return false;
+      }
+    }
+    for (const tag of excludeTags) {
+      if (tags.has(tag)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+function compareFeedEntries(a: FeedEntry, b: FeedEntry): number {
+  return a.type.localeCompare(b.type) || a.id.localeCompare(b.id);
+}
+
+type FeedDiffEntry = {
+  readonly type: FeedEntryType;
+  readonly id: string;
+  readonly previous?: string;
+  readonly current?: string;
+};
+
+type FeedDocumentDiff = {
+  readonly previousId: string;
+  readonly currentId: string;
+  readonly added: readonly FeedEntry[];
+  readonly removed: readonly FeedEntry[];
+  readonly updated: readonly FeedDiffEntry[];
+  readonly approvalChanged: readonly FeedDiffEntry[];
+  readonly metadataChanged: readonly FeedDiffEntry[];
+  readonly hashChanged: readonly FeedDiffEntry[];
+};
+
+function diffFeedDocuments(previous: FeedDocument, current: FeedDocument): FeedDocumentDiff {
+  const previousByKey = new Map(previous.entries.map((entry) => [feedEntryKey(entry), entry]));
+  const currentByKey = new Map(current.entries.map((entry) => [feedEntryKey(entry), entry]));
+  const added = current.entries.filter((entry) => !previousByKey.has(feedEntryKey(entry)));
+  const removed = previous.entries.filter((entry) => !currentByKey.has(feedEntryKey(entry)));
+  const updated: FeedDiffEntry[] = [];
+  const approvalChanged: FeedDiffEntry[] = [];
+  const metadataChanged: FeedDiffEntry[] = [];
+  const hashChanged: FeedDiffEntry[] = [];
+  for (const previousEntry of previous.entries) {
+    const currentEntry = currentByKey.get(feedEntryKey(previousEntry));
+    if (currentEntry === undefined) {
+      continue;
+    }
+    const base = { type: previousEntry.type, id: previousEntry.id };
+    if (previousEntry.version !== currentEntry.version) {
+      updated.push({ ...base, previous: previousEntry.version, current: currentEntry.version });
+    }
+    const previousApproval = approvalStatus(previousEntry);
+    const currentApproval = approvalStatus(currentEntry);
+    if (previousApproval !== currentApproval) {
+      approvalChanged.push({ ...base, previous: previousApproval, current: currentApproval });
+    }
+    if (previousEntry.sha256 !== currentEntry.sha256) {
+      hashChanged.push({ ...base, previous: previousEntry.sha256, current: currentEntry.sha256 });
+    }
+    if (metadataFingerprint(previousEntry) !== metadataFingerprint(currentEntry)) {
+      metadataChanged.push({ ...base });
+    }
+  }
+  return {
+    previousId: previous.id,
+    currentId: current.id,
+    added: added.toSorted(compareFeedEntries),
+    removed: removed.toSorted(compareFeedEntries),
+    updated: updated.toSorted(compareDiffEntries),
+    approvalChanged: approvalChanged.toSorted(compareDiffEntries),
+    metadataChanged: metadataChanged.toSorted(compareDiffEntries),
+    hashChanged: hashChanged.toSorted(compareDiffEntries),
+  };
+}
+
+async function readFeedFile(path: string, runtime: FeedsCommandRuntime): Promise<Buffer> {
+  const read = runtime.readFile ?? readFile;
+  const value = await read(path);
+  return Buffer.isBuffer(value) ? value : Buffer.from(value);
+}
+
+function feedIntegrity(raw: Buffer): string {
+  return `sha256:${createHash("sha256").update(raw).digest("hex")}`;
 }
 
 async function loadConfiguredFeedDocuments(
@@ -504,6 +1164,53 @@ function feedEntryApproved(entry: FeedEntry): boolean {
   return (
     typeof entry.approval.status === "string" && entry.approval.status.toLowerCase() === "approved"
   );
+}
+
+function approvalStatus(entry: FeedEntry): string | undefined {
+  if (!isRecord(entry.approval) || typeof entry.approval.status !== "string") {
+    return undefined;
+  }
+  return entry.approval.status;
+}
+
+function metadataFingerprint(entry: FeedEntry): string {
+  return stableJson({
+    name: entry.name,
+    description: entry.description,
+    tags: entry.tags,
+    sourceUrl: entry.sourceUrl,
+    install: entry.install,
+  });
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .filter((key) => value[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function compareDiffEntries(a: FeedDiffEntry, b: FeedDiffEntry): number {
+  return a.type.localeCompare(b.type) || a.id.localeCompare(b.id);
+}
+
+function formatFeedDiff(diff: FeedDocumentDiff): string {
+  const counts = [
+    `added=${diff.added.length}`,
+    `removed=${diff.removed.length}`,
+    `updated=${diff.updated.length}`,
+    `approvalChanged=${diff.approvalChanged.length}`,
+    `metadataChanged=${diff.metadataChanged.length}`,
+    `hashChanged=${diff.hashChanged.length}`,
+  ];
+  return `Feed diff ${diff.previousId} -> ${diff.currentId}: ${counts.join(" ")}\n`;
 }
 
 function normalizeClawHubSpec(value: string): string {

--- a/extensions/feeds/src/cli.ts
+++ b/extensions/feeds/src/cli.ts
@@ -8,6 +8,7 @@ import {
   feedEntryMatchesQuery,
   loadFeedDocument,
   parseFeedDocument,
+  readFeedBytes,
   type FeedDocument,
   type FeedDocumentRuntime,
   type FeedEntry,
@@ -385,7 +386,7 @@ export async function feedsBuildCommand(
     const document = {
       schemaVersion: 1 as const,
       id: options.id?.trim() || inventory.id,
-      generatedAt: options.generatedAt ?? new Date().toISOString(),
+      ...(options.generatedAt === undefined ? {} : { generatedAt: options.generatedAt }),
       entries: applyBuildRules(inventory.entries, rules).toSorted(compareFeedEntries),
     };
     const serialized = JSON.stringify(document, null, 2) + "\n";
@@ -847,9 +848,22 @@ function diffFeedDocuments(previous: FeedDocument, current: FeedDocument): FeedD
 }
 
 async function readFeedFile(path: string, runtime: FeedsCommandRuntime): Promise<Buffer> {
+  const feedUrl = parseFeedDocumentUrl(path);
+  if (feedUrl !== undefined) {
+    return readFeedBytes(feedUrl, runtime);
+  }
   const read = runtime.readFile ?? readFile;
   const value = await read(path);
   return Buffer.isBuffer(value) ? value : Buffer.from(value);
+}
+
+function parseFeedDocumentUrl(value: string): string | undefined {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "file:" || parsed.protocol === "https:" ? parsed.href : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function feedIntegrity(raw: Buffer): string {
@@ -1190,7 +1204,7 @@ function stableJson(value: unknown): string {
   if (isRecord(value)) {
     return `{${Object.keys(value)
       .filter((key) => value[key] !== undefined)
-      .sort()
+      .toSorted()
       .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
       .join(",")}}`;
   }

--- a/extensions/feeds/src/feed-document.ts
+++ b/extensions/feeds/src/feed-document.ts
@@ -109,7 +109,7 @@ export function feedEntryMatchesQuery(entry: FeedEntry, query: string): boolean 
   return haystack.includes(normalized);
 }
 
-async function readFeedBytes(url: string, runtime: FeedDocumentRuntime): Promise<Buffer> {
+export async function readFeedBytes(url: string, runtime: FeedDocumentRuntime): Promise<Buffer> {
   const parsed = new URL(url);
   if (parsed.protocol === "file:") {
     const read = runtime.readFile ?? readFile;


### PR DESCRIPTION
## Summary

Adds feed publisher/subscriber lifecycle tooling on top of the feed source and install primitives.

This PR adds:

- `openclaw feeds validate <path-or-url>` and `feeds hash <path-or-url>`.
- `openclaw feeds build --inventory <path> --out <path>` for deterministic curated feed artifacts.
- `openclaw feeds diff --previous <path> --current <path>` for publisher-side delta review.
- `openclaw feeds updates --installed <path>` to compare installed skill/plugin inventory against configured feeds.
- `openclaw feeds notices --installed <path>` for subscriber-facing update notices with install commands.
- Semver-aware update ordering, including prerelease vs stable comparisons.

## Example publisher flow

```bash
openclaw feeds validate ./company-feed.json --json
openclaw feeds hash ./company-feed.json
openclaw feeds build --inventory ./inventory.json --out ./company-feed.json --id company-approved
openclaw feeds diff --previous ./previous-feed.json --current ./company-feed.json --json
```

## Example subscriber flow

```bash
openclaw feeds updates --installed ./installed.json --approved-only --json
openclaw feeds notices --installed ./installed.json --approved-only --json
```

## Notes

This stays file-based and explicit. There is no daemon, background watch, auto-update, or ClawHub-native feed service in this PR. A later RFC/PR can add ClawHub-native feed support once the local feed contract is stable.

## Real behavior proof

Behavior or issue addressed:
Feed lifecycle CLI validates and hashes feed URL inputs, builds deterministic artifacts by default, diffs feed artifacts, and reports subscriber updates/notices.

Real environment tested:
WSL Ubuntu 24.04, source checkout `/root/src/openclaw-feeds-87827` at `47aabc7bcd2ec3289fed0b4cbf4e6834cf385133`, source CLI via `node scripts/run-node.mjs`, temporary OpenClaw config/state/home, and local `file://` feed artifacts. No external network service was contacted.

Exact steps or command run after this patch:
1. `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/feeds/src/cli.test.ts extensions/feeds/src/doctor/register.test.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts src/flows/bundled-health-checks.test.ts --reporter=dot`
2. `pnpm exec oxlint --tsconfig ./tsconfig.json extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/feeds/src/feed-document.ts`
3. `pnpm exec oxfmt --check --threads=1 extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/feeds/src/feed-document.ts extensions/feeds/src/doctor/register.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts docs/cli/policy.md docs/plugins/reference/feeds.md && git diff --check`
4. `pnpm tsgo:extensions`
5. `node scripts/run-node.mjs feeds validate "file://$proof_root/current.json" --json`
6. `node scripts/run-node.mjs feeds hash "file://$proof_root/current.json"`
7. `node scripts/run-node.mjs feeds build --inventory "$proof_root/inventory.json" --out "$proof_root/built-one.json" --id company-approved --json`
8. `node scripts/run-node.mjs feeds build --inventory "$proof_root/inventory.json" --out "$proof_root/built-two.json" --id company-approved --json`
9. `cmp "$proof_root/built-one.json" "$proof_root/built-two.json"`
10. `node scripts/run-node.mjs feeds diff --previous "$proof_root/previous.json" --current "$proof_root/current.json" --json`
11. `node scripts/run-node.mjs feeds updates --installed "$proof_root/installed.json" --approved-only --json`
12. `node scripts/run-node.mjs feeds notices --installed "$proof_root/installed.json" --approved-only --json`

Evidence after fix:
Validation passed: focused Vitest passed 367 tests across 4 files, oxlint passed with 0 warnings/errors, scoped oxfmt plus `git diff --check` passed, and `pnpm tsgo:extensions` passed.

Source CLI proof transcript:

```text
feeds validate file://.../current.json --json
{
  "ok": true,
  "id": "company-approved",
  "entries": 2,
  "integrity": "sha256:475f7916dc11cdc655e9d5d466a037001b273050942377fb79efe29ef69feeed"
}

feeds hash file://.../current.json
sha256:475f7916dc11cdc655e9d5d466a037001b273050942377fb79efe29ef69feeed

feeds build ... built-one.json
{"out":"/tmp/openclaw-feeds-87827-proof.../built-one.json","integrity":"sha256:d21f9f216d4336b886ef799787e93b4c822f7cecb8e6d06cec45d4ebf2aeed1e","entries":2}

feeds build ... built-two.json
{"out":"/tmp/openclaw-feeds-87827-proof.../built-two.json","integrity":"sha256:d21f9f216d4336b886ef799787e93b4c822f7cecb8e6d06cec45d4ebf2aeed1e","entries":2}

BUILD_ARTIFACTS_IDENTICAL=yes
BUILD_HAS_GENERATED_AT=false
BUILD_ENTRY_ORDER=plugin:calendar-helper,skill:excel-review

feeds diff --previous previous.json --current current.json --json
{"added":[{"kind":"plugin","id":"calendar-helper","version":"0.3.0"}],"removed":[{"kind":"plugin","id":"removed-plugin","version":"0.1.0"}],"updated":[{"kind":"skill","id":"excel-review","from":"1.0.0","to":"1.2.0","hashChanged":true}]}

feeds updates --installed installed.json --approved-only --json
{"updates":[{"kind":"skill","id":"excel-review","installed":"1.0.0","available":"1.2.0","approved":true}]}

feeds notices --installed installed.json --approved-only --json
{"notices":[{"kind":"skill","id":"excel-review","message":"Compliance spreadsheet review skill update is approved.","installCommand":"openclaw skills install /tmp/excel-review"}]}
```

Observed result after fix:
`validate` and `hash` succeeded on `file://` feed URL input through the shared feed byte loader. Two default `build` runs produced byte-identical artifacts with no `generatedAt` field. `diff` reported added, removed, and updated entries with hash-change information. `updates` and `notices` reported the approved `excel-review` update and the expected install command.

What was not tested:
No live external HTTPS endpoint was contacted in the source CLI proof; HTTPS URL loading is covered by the focused runtime-fetch unit regression in `extensions/feeds/src/cli.test.ts`.

## Validation

```bash
node scripts/run-vitest.mjs extensions/feeds/src/cli.test.ts extensions/feeds/src/doctor/register.test.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts src/flows/bundled-health-checks.test.ts
node scripts/run-tsgo.mjs --noEmit
pnpm exec oxfmt --check extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/feeds/src/feed-document.ts extensions/feeds/src/doctor/register.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts docs/cli/policy.md docs/plugins/reference/feeds.md docs/plugins/reference.md
git diff --check
node scripts/generate-plugin-inventory-doc.mjs --check
```

Focused stack proof on the final condensed branch: 243 tests passed.

## Feed PR stack

1. openclaw/openclaw#87824 - read-only feed discovery
2. openclaw/openclaw#87825 - approved feed installs
3. openclaw/openclaw#87826 - feed catalog policy conformance
4. openclaw/openclaw#87827 - feed lifecycle tooling
5. openclaw/openclaw#88732 - native feed search defaults and policy checks
6. openclaw/clawhub#2460 - ClawHub root feed lanes

The stack keeps OpenClaw as a feed consumer. ClawHub root feeds are producer infrastructure; enterprise or tenant feeds can be produced elsewhere using the same schema.

RFC draft: https://github.com/giodl73-repo/rfcs/blob/feeds-rfc-draft/rfcs/0004-feeds.md

