### PR TITLE
perf: skip manifest normalization in status summary

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -95,6 +95,7 @@ export function resolvePersistedOverrideModelRef(params: {
   defaultProvider?: unknown;
   overrideProvider?: unknown;
   overrideModel?: unknown;
+  allowManifestNormalization?: boolean;
   allowPluginNormalization?: boolean;
 }): ModelRef | null {
   const defaultProvider = normalizePersistedDefaultProvider(params.defaultProvider);
@@ -106,6 +107,7 @@ export function resolvePersistedOverrideModelRef(params: {
   const encodedOverride = overrideProvider ? `${overrideProvider}/${overrideModel}` : overrideModel;
   return (
     parseModelRef(encodedOverride, defaultProvider, {
+      allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
     }) ?? {
       provider: overrideProvider || defaultProvider,
@@ -124,6 +126,7 @@ export function resolvePersistedModelRef(params: {
   runtimeModel?: unknown;
   overrideProvider?: unknown;
   overrideModel?: unknown;
+  allowManifestNormalization?: boolean;
   allowPluginNormalization?: boolean;
 }): ModelRef | null {
   const defaultProvider = normalizePersistedDefaultProvider(params.defaultProvider);
@@ -135,6 +138,7 @@ export function resolvePersistedModelRef(params: {
     }
     return (
       parseModelRef(runtimeModel, defaultProvider, {
+        allowManifestNormalization: params.allowManifestNormalization,
         allowPluginNormalization: params.allowPluginNormalization,
       }) ?? {
         provider: defaultProvider,
@@ -146,6 +150,7 @@ export function resolvePersistedModelRef(params: {
     defaultProvider,
     overrideProvider: params.overrideProvider,
     overrideModel: params.overrideModel,
+    allowManifestNormalization: params.allowManifestNormalization,
     allowPluginNormalization: params.allowPluginNormalization,
   });
 }
@@ -161,12 +166,14 @@ export function resolvePersistedSelectedModelRef(params: {
   runtimeModel?: unknown;
   overrideProvider?: unknown;
   overrideModel?: unknown;
+  allowManifestNormalization?: boolean;
   allowPluginNormalization?: boolean;
 }): ModelRef | null {
   const override = resolvePersistedOverrideModelRef({
     defaultProvider: params.defaultProvider,
     overrideProvider: params.overrideProvider,
     overrideModel: params.overrideModel,
+    allowManifestNormalization: params.allowManifestNormalization,
     allowPluginNormalization: params.allowPluginNormalization,
   });
   if (override) {
@@ -176,6 +183,7 @@ export function resolvePersistedSelectedModelRef(params: {
     defaultProvider: params.defaultProvider,
     runtimeProvider: params.runtimeProvider,
     runtimeModel: params.runtimeModel,
+    allowManifestNormalization: params.allowManifestNormalization,
     allowPluginNormalization: params.allowPluginNormalization,
   });
 }

--- a/src/commands/status.summary.runtime.normalization.test.ts
+++ b/src/commands/status.summary.runtime.normalization.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const normalizeProviderModelIdWithManifestMock = vi.hoisted(() => vi.fn());
+const normalizeProviderModelIdWithRuntimeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../plugins/manifest-model-id-normalization.js", () => ({
+  normalizeProviderModelIdWithManifest: normalizeProviderModelIdWithManifestMock,
+}));
+
+vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: normalizeProviderModelIdWithRuntimeMock,
+}));
+
+describe("statusSummaryRuntime configured model normalization", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    normalizeProviderModelIdWithManifestMock.mockReset();
+    normalizeProviderModelIdWithRuntimeMock.mockReset();
+  });
+
+  it("skips manifest and plugin model normalization for configured model refs", async () => {
+    const { statusSummaryRuntime } = await import("./status.summary.runtime.js");
+
+    expect(
+      statusSummaryRuntime.resolveConfiguredStatusModelRef({
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "openai-codex/gpt-5.5" },
+            },
+          },
+        } as never,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+      }),
+    ).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.5",
+    });
+
+    expect(
+      statusSummaryRuntime.resolveConfiguredStatusModelRef({
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "fast-codex" },
+              models: {
+                "openai-codex/gpt-5.5": { alias: "fast-codex" },
+              },
+            },
+          },
+        } as never,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+      }),
+    ).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.5",
+    });
+
+    expect(normalizeProviderModelIdWithManifestMock).not.toHaveBeenCalled();
+    expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
+  });
+
+  it("skips manifest and plugin model normalization for providerless persisted session models", async () => {
+    const { statusSummaryRuntime } = await import("./status.summary.runtime.js");
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+        },
+      },
+    } as never;
+
+    normalizeProviderModelIdWithManifestMock.mockReturnValue("claude-opus-4-6");
+    normalizeProviderModelIdWithRuntimeMock.mockReturnValue("runtime-normalized-opus");
+
+    expect(
+      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+        model: "opus-4.6",
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "opus-4.6",
+    });
+
+    expect(
+      statusSummaryRuntime.resolveSessionModelRef(cfg, {
+        model: "fallback-runtime-model",
+        modelOverride: "opus-4.6",
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "opus-4.6",
+    });
+
+    expect(normalizeProviderModelIdWithManifestMock).not.toHaveBeenCalled();
+    expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -33,6 +33,7 @@ function resolveStatusModelRefFromRaw(params: {
         continue;
       }
       const parsed = parseModelRef(modelKey, params.defaultProvider, {
+        allowManifestNormalization: false,
         allowPluginNormalization: false,
       });
       if (parsed) {
@@ -42,6 +43,7 @@ function resolveStatusModelRefFromRaw(params: {
     return { provider: params.defaultProvider, model: trimmed };
   }
   return parseModelRef(trimmed, params.defaultProvider, {
+    allowManifestNormalization: false,
     allowPluginNormalization: false,
   });
 }
@@ -145,6 +147,7 @@ function resolveSessionModelRef(
       runtimeModel: entry?.model,
       overrideProvider: entry?.providerOverride,
       overrideModel: entry?.modelOverride,
+      allowManifestNormalization: false,
       allowPluginNormalization: false,
     }) ?? resolved
   );


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `status`/`status --json` builds model labels for configured and persisted
  session rows in a shallow read-only path.
- That path already avoids plugin/runtime model normalization, but it still let
  manifest model-id normalization run repeatedly while building status rows.

Why does this matter now?

- Status commands are used as operational readbacks, including during incidents
  and package validation.
- Current `main` is much better than the original local slowdown, but repeated
  status row parsing still pays avoidable manifest-normalization cost.

What is the intended outcome?

- Keep status summary model parsing on the cheap literal/configured path.
- Preserve existing model resolver behavior for callers that do not opt out.
- Add regression coverage that status summary does not call manifest or
  plugin/runtime normalization for configured or providerless persisted session
  model values.

What is intentionally out of scope?

- No full status-summary row-construction refactor.
- No duplicate-row caching change.
- No provider/model catalog behavior change outside status summary.
- No `CHANGELOG.md` edit.

What does success look like?

- `statusSummaryRuntime` passes `allowManifestNormalization:false` in its shallow
  configured and persisted session model paths.
- Persisted resolver helpers thread the optional flag without changing defaults.
- Focused tests, formatting, diff check, package build, package integrity, and
  temp-prefix install pass on the rebased branch.

What should reviewers focus on?

- Whether the shallow status path is the right caller to skip manifest
  normalization.
- Whether the persisted resolver option remains safely defaulted for all other
  callers.
- Whether the real-behavior proof is sufficient for this bounded performance
  improvement.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #80611
Related #80614

Was this requested by a maintainer or owner?

No maintainer request. This is a narrow follow-up from local status-summary
performance investigation and current-main package proof.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: shallow status-summary model-label rendering can
  repeatedly invoke manifest model-id normalization even though status is a
  read-only display path that already opts out of plugin/runtime normalization.
- Real environment tested: local Linux OpenClaw source checkout rebased onto
  `origin/main` at `5d8cf28578a1c5b4025a7d8da1b73d1dffc047c3`, head
  `50bc288c4dabaac33b8675ec54818eed7e9520fc`, Node `v22.22.2`, packaged
  OpenClaw `2026.5.28 (50bc288)` installed into a temporary npm prefix.
- Exact steps or command run after this patch: ran focused Vitest targets via
  `node scripts/test-projects.mjs`, checked formatting with `oxfmt`, ran
  `git diff --check`, rebuilt with `node --import tsx scripts/openclaw-prepack.ts`,
  ran `npm pack`, checked the tarball with
  `node scripts/check-openclaw-package-tarball.mjs`, installed the tarball in a
  temp prefix, read back `openclaw --version`, and checked built markers.
- Evidence after fix:
  Copied terminal output from the rebased source and package proof:

```text
Current base main: 5d8cf28578a1c5b4025a7d8da1b73d1dffc047c3
Current source head: 50bc288c4dabaac33b8675ec54818eed7e9520fc

Focused post-rebase tests:
- status.summary.runtime.test.ts: 11/11 passed
- test-live-shard.test.ts: 9/9 passed
- status.summary.runtime.normalization.test.ts: 2/2 passed
- model-selection.test.ts: 106/106 passed

Post-rebase checks:
- oxfmt check passed on the three touched files
- git diff --check passed

Package:
- temp-prefix version: OpenClaw 2026.5.28 (50bc288)
- tarball SHA256: 1f5f47945401a97c73320c6b17cae109235c91ace9159f242ad34cc96f0813e9
- tarball integrity: passed
- status runtime markers: three allowManifestNormalization:false paths
- persisted resolver threading markers: present
- generated .d.ts allowManifestNormalization?: boolean: present

Previously generated source benchmark from the same narrow patch lane:
- synthetic workload: 11 agents x 20 sessions each
- baseline median: 54.5ms
- patched median: 18.4ms
- median improvement: 66.2%
- baseline cold: 447ms
- patched cold: 397.2ms
- parseModelRef default manifest-normalization median: 45.5ms / 500 parses
- parseModelRef allowManifestNormalization:false median: 0.2ms / 500 parses
```

- Observed result after fix: status summary configured-model and persisted
  session model parsing stay on the shallow path, the package installs in a
  temp prefix, and the direct hot operation avoids manifest-normalization cost.
- What was not tested: no live Gateway install of this PR package, no full CI,
  no Kova workflow dispatch, no live-provider run, and no broad status-summary
  refactor.
- Proof limitations or environment constraints: the synthetic source benchmark
  uses local generated session stores so it is reproducible and private-data
  free. It was generated earlier in this current-main prep lane; after PR review
  and upstream drift, the branch was rebased onto `5d8cf285`, and focused
  tests/package proof were rerun on the rebased head.
- Before evidence (optional but encouraged): before patch on the refreshed
  benchmark base, the same synthetic status workload had `54.5ms` warm median
  and the direct parse microbench had `45.5ms` median for 500 calls with default
  manifest normalization.

## Tests and validation

Which commands did you run?

- `node scripts/test-projects.mjs src/commands/status.summary.runtime.normalization.test.ts src/commands/status.summary.runtime.test.ts src/agents/model-selection.test.ts test/scripts/test-live-shard.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/model-selection.ts src/commands/status.summary.runtime.ts src/commands/status.summary.runtime.normalization.test.ts`
- `git diff --check origin/main...HEAD`
- `PATH=/usr/lib/node_modules/corepack/shims:$PATH node --import tsx scripts/openclaw-prepack.ts`
- `npm pack --ignore-scripts --pack-destination <artifact-dir>`
- `node scripts/check-openclaw-package-tarball.mjs <tarball>`
- `npm install --global --prefix <temp-prefix> <tarball>`
- `<temp-prefix>/bin/openclaw --version`
- built marker readback with `rg`

What regression coverage was added or updated?

- Added `src/commands/status.summary.runtime.normalization.test.ts`.
- The new test mocks both manifest normalization and plugin/runtime
  normalization and verifies status summary does not call either path for:
  - configured direct model refs
  - configured aliases
  - providerless persisted runtime models
  - providerless persisted model overrides

What failed before this fix, if known?

- Current `main` still calls manifest normalization from the status summary
  configured and persisted session model parse paths.
- In direct source benchmarking, default manifest normalization took `45.5ms`
  median per 500 `parseModelRef` calls, while the status opt-out path took
  `0.2ms`.

If no test was added, why not?

- A targeted regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, narrowly: status summary may display providerless persisted session model
values literally, for example `anthropic/opus-4.6`, instead of applying plugin
manifest aliases in this shallow status path.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The intentional status-display tradeoff for providerless persisted model aliases.

How is that risk mitigated?

- The option defaults to existing behavior for all other callers.
- Only status summary passes `allowManifestNormalization:false` into the
  persisted model resolver chain.
- Focused tests cover configured and persisted status paths.
- Built package marker readback confirms the expected status path and type
  surface are present.

## Current review state

What is the next action?

Maintainer review after CI reruns on the rebased head. ClawSweeper says no
contributor repair is needed; the maintainer decision is whether to accept the
shallow-status display tradeoff.

What is still waiting on author, maintainer, CI, or external proof?

- CI: rerun on the rebased head after the branch update.
- Maintainers: judge whether shallow status should skip manifest normalization
  and display providerless persisted model values literally in this read-only
  status path.

Which bot or reviewer comments were addressed?

- ClawSweeper reviewed the previous head, marked proof sufficient, rated the PR
  `platinum hermit`, and said no ClawSweeper repair is needed before maintainer
  review.
- ClawSweeper's only rank-up move is maintainer acceptance of the literal-label
  status tradeoff before merge.
- The old `build-artifacts` failure was traced to upstream drift in
  `test/scripts/test-live-shard.test.ts`. Current `origin/main` includes the
  upstream fix (`f09b69a7 test: drop removed gateway live shard fixture`), and
  the rebased branch now passes that focused test locally.
