### PR TITLE
fix: probe stale rate-limit cooldown primaries

### DIFF
--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -135,19 +135,6 @@ async function loadModelFallbackProbeModules() {
 
 beforeAll(loadModelFallbackProbeModules);
 
-function expectFallbackUsed(
-  result: { result: unknown; attempts: Array<{ reason?: string }> },
-  run: {
-    (...args: unknown[]): unknown;
-    mock: { calls: unknown[][] };
-  },
-) {
-  expect(result.result).toBe("ok");
-  expect(run).toHaveBeenCalledTimes(1);
-  expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5");
-  expect(result.attempts[0]?.reason).toBe("rate_limit");
-}
-
 function expectPrimarySkippedForReason(
   result: { result: unknown; attempts: Array<{ reason?: string }> },
   run: {
@@ -259,9 +246,14 @@ describe("runWithModelFallback – probe logic", () => {
     hasFallbackCandidates?: boolean;
     requestedModel?: boolean;
     throttleKey?: string;
+    usageStats?: AuthProfileStore["usageStats"];
   }) {
     mockedGetSoonestCooldownExpiry.mockReturnValue(params.soonest);
     mockedResolveProfilesUnavailableReason.mockReturnValue(params.reason);
+    const authStore: AuthProfileStore = { version: 1, profiles: {} };
+    if (params.usageStats) {
+      authStore.usageStats = params.usageStats;
+    }
     return modelFallbackTesting.resolveCooldownDecision({
       candidate: OPENAI_PROBE_CANDIDATE,
       isPrimary: params.isPrimary ?? true,
@@ -275,7 +267,7 @@ describe("runWithModelFallback – probe logic", () => {
       } as unknown as Parameters<
         typeof modelFallbackTesting.resolveCooldownDecision
       >[0]["authRuntime"],
-      authStore: { version: 1, profiles: {} },
+      authStore,
       profileIds: ["openai-profile-1"],
     });
   }
@@ -291,7 +283,7 @@ describe("runWithModelFallback – probe logic", () => {
     });
   }
 
-  async function expectPrimarySkippedAfterLongCooldown(reason: "billing" | "rate_limit") {
+  async function expectPrimarySkippedAfterLongCooldown(reason: "billing") {
     const cfg = makeCfg();
     const expiresIn30Min = NOW + 30 * 60 * 1000;
     mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn30Min);
@@ -348,9 +340,8 @@ describe("runWithModelFallback – probe logic", () => {
     vi.restoreAllMocks();
   });
 
-  it("skips primary model when far from cooldown expiry (30 min remaining)", async () => {
+  it("probes rate-limited primary model when far from cooldown expiry", async () => {
     const cfg = makeCfg();
-    // Cooldown expires in 30 min — well beyond the 2-min margin
     const expiresIn30Min = NOW + 30 * 60 * 1000;
     mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn30Min);
 
@@ -358,8 +349,7 @@ describe("runWithModelFallback – probe logic", () => {
 
     const result = await runPrimaryCandidate(cfg, run);
 
-    // Should skip primary and use fallback
-    expectFallbackUsed(result, run);
+    expectPrimaryProbeSuccess(result, run, "ok");
   });
 
   it("uses inferred unavailable reason when skipping a cooldowned primary model", async () => {
@@ -367,6 +357,26 @@ describe("runWithModelFallback – probe logic", () => {
   });
 
   it("decides when cooldowned primary probes are allowed", () => {
+    expect(
+      resolveOpenAiCooldownDecision({
+        reason: "rate_limit",
+        soonest: NOW + 30 * 60 * 1000,
+      }),
+    ).toEqual({ type: "attempt", reason: "rate_limit", markProbe: true });
+    expectOpenAiProbeSuspension(
+      resolveOpenAiCooldownDecision({
+        reason: "rate_limit",
+        soonest: NOW + 30 * 60 * 1000,
+        usageStats: {
+          "openai-profile-1": {
+            blockedUntil: NOW + 30 * 60 * 1000,
+            blockedReason: "subscription_limit",
+            blockedSource: "wham",
+          },
+        },
+      }),
+      "rate_limit",
+    );
     expect(
       resolveOpenAiCooldownDecision({
         reason: "rate_limit",

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2519,7 +2519,7 @@ describe("runWithModelFallback", () => {
       });
     });
 
-    it("keeps alias-resolved primary models subject to transient cooldowns", async () => {
+    it("probes alias-resolved primary models during rate-limit cooldowns", async () => {
       const { dir } = await makeAuthStoreWithCooldown("anthropic", "rate_limit");
       const cfg = makeCfg({
         agents: {
@@ -2535,7 +2535,7 @@ describe("runWithModelFallback", () => {
         },
       });
 
-      const run = vi.fn().mockResolvedValueOnce("haiku success");
+      const run = vi.fn().mockResolvedValueOnce("sonnet success");
 
       const result = await runWithModelFallback({
         cfg,
@@ -2545,9 +2545,9 @@ describe("runWithModelFallback", () => {
         agentDir: dir,
       });
 
-      expect(result.result).toBe("haiku success");
+      expect(result.result).toBe("sonnet success");
       expect(run).toHaveBeenCalledTimes(1);
-      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-haiku-3-5", {
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-6", {
         allowTransientCooldownProbe: true,
       });
     });
@@ -2623,7 +2623,7 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-opus-4-6", {
         allowTransientCooldownProbe: true,
       });
       expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
@@ -2661,7 +2661,7 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-opus-4-6", {
         allowTransientCooldownProbe: true,
       });
       expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
@@ -2686,8 +2686,8 @@ describe("runWithModelFallback", () => {
 
       const run = vi
         .fn()
-        .mockRejectedValueOnce(new Error("Model not found: anthropic/claude-sonnet-4-5"))
-        .mockResolvedValueOnce("haiku success");
+        .mockRejectedValueOnce(new Error("Model not found: anthropic/claude-opus-4-6"))
+        .mockResolvedValueOnce("sonnet success");
 
       const result = await runWithModelFallback({
         cfg,
@@ -2697,12 +2697,12 @@ describe("runWithModelFallback", () => {
         agentDir: dir,
       });
 
-      expect(result.result).toBe("haiku success");
+      expect(result.result).toBe("sonnet success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-opus-4-6", {
         allowTransientCooldownProbe: true,
       });
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
       });
     });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -22,6 +22,7 @@ import { normalizeOptionalAgentRuntimeId } from "./agent-runtime-id.js";
 import { externalCliDiscoveryForProviders } from "./auth-profiles/external-cli-discovery.js";
 import { hasAnyAuthProfileStoreSource } from "./auth-profiles/source-check.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { isActiveUnusableWindow } from "./auth-profiles/usage-state.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { isLikelyContextOverflowError } from "./embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "./embedded-agent-helpers/types.js";
@@ -943,9 +944,31 @@ function markProbeAttempt(now: number, throttleKey: string): void {
   enforceProbeStateCap();
 }
 
+function hasActiveProviderRateLimitResetWindow(params: {
+  authStore: AuthProfileStore;
+  profileIds: string[];
+  now: number;
+  model: string;
+}): boolean {
+  return params.profileIds.some((profileId) => {
+    const stats = params.authStore.usageStats?.[profileId];
+    if (!stats) {
+      return false;
+    }
+    if (!isActiveUnusableWindow(stats.blockedUntil, params.now)) {
+      return false;
+    }
+    if (stats.blockedReason !== "subscription_limit" || !stats.blockedSource) {
+      return false;
+    }
+    return !stats.blockedModel || stats.blockedModel === params.model;
+  });
+}
+
 function shouldProbePrimaryDuringCooldown(params: {
   isPrimary: boolean;
   hasFallbackCandidates: boolean;
+  reason: FailoverReason | null | undefined;
   now: number;
   throttleKey: string;
   authRuntime: ModelFallbackAuthRuntime;
@@ -965,6 +988,20 @@ function shouldProbePrimaryDuringCooldown(params: {
     now: params.now,
     forModel: params.model,
   });
+  // Generic 429 backoff can become stale before its local cooldown expires.
+  // Provider-recorded reset windows still remain authoritative until near expiry.
+  if (
+    params.reason === "rate_limit" &&
+    !hasActiveProviderRateLimitResetWindow({
+      authStore: params.authStore,
+      profileIds: params.profileIds,
+      now: params.now,
+      model: params.model,
+    })
+  ) {
+    return true;
+  }
+
   if (soonest === null || !Number.isFinite(soonest)) {
     return true;
   }
@@ -1014,9 +1051,16 @@ function resolveCooldownDecision(params: {
   authStore: AuthProfileStore;
   profileIds: string[];
 }): CooldownDecision {
+  const inferredReason =
+    params.authRuntime.resolveProfilesUnavailableReason({
+      store: params.authStore,
+      profileIds: params.profileIds,
+      now: params.now,
+    }) ?? "unknown";
   const shouldProbe = shouldProbePrimaryDuringCooldown({
     isPrimary: params.isPrimary,
     hasFallbackCandidates: params.hasFallbackCandidates,
+    reason: inferredReason,
     now: params.now,
     throttleKey: params.probeThrottleKey,
     authRuntime: params.authRuntime,
@@ -1025,12 +1069,6 @@ function resolveCooldownDecision(params: {
     model: params.candidate.model,
   });
 
-  const inferredReason =
-    params.authRuntime.resolveProfilesUnavailableReason({
-      store: params.authStore,
-      profileIds: params.profileIds,
-      now: params.now,
-    }) ?? "unknown";
   const isPersistentAuthIssue = inferredReason === "auth" || inferredReason === "auth_permanent";
   if (isPersistentAuthIssue) {
     return {


### PR DESCRIPTION
## Summary

- Allow throttled half-open probes for stale generic `rate_limit` cooldowns on primary model candidates even when fallbacks are configured.
- Preserve provider-recorded reset windows (`blockedUntil` with provider block metadata) so known future quota windows still keep the fallback path preferred until near expiry.
- Update model fallback tests for the new probe behavior and the recorded-window guard.

Fixes #87608

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Clean: no accepted/actionable findings.
- `node scripts/run-vitest.mjs src/agents/model-fallback.probe.test.ts src/agents/model-fallback.test.ts -- --reporter=verbose`
  - 4 files passed, 170 tests passed.
- AWS Crabbox live repro with Ollama Cloud:
  - provider: `aws`
  - lease: `cbx_33d131797efc`
  - run: `run_4f42fc0b825a`
  - result: passed

## Real behavior proof

Behavior addressed: A primary model with a stale generic `rate_limit` cooldown could remain bypassed behind configured fallbacks even after the provider recovered.

Real environment tested: AWS Crabbox Linux runner using live Ollama Cloud credentials, Gateway, and a real `ollama-cloud/gemma3:4b` model request.

Exact steps or command run after this patch: seeded an agent auth profile with a 30-minute generic `cooldownUntil`/`cooldownReason: rate_limit`, configured primary `ollama-cloud/gemma3:4b` plus a synthetic missing fallback, started Gateway, and sent a raw Gateway agent model-run request through Ollama Cloud.

Evidence after fix: Crabbox run `run_4f42fc0b825a` on AWS lease `cbx_33d131797efc` logged `decision=probe_cooldown_candidate` for `ollama-cloud/gemma3:4b`, then `decision=candidate_succeeded` for the same primary model.

Observed result after fix: The primary Ollama model was probed and succeeded; the seeded cooldown state was cleared (`hasCooldownUntil: false`, `errorCount: 0`, `failureCounts: null`), and the script ended with `live_regression_repro_passed=true`.

What was not tested: Full repository test suite; this change was covered with focused model fallback tests plus the live Gateway/Ollama regression repro.
