### PR TITLE
test pr: dependency guard: dependency field plus lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1833,7 +1833,7 @@
     "@openclaw/fs-safe": "0.3.0",
     "@openclaw/proxyline": "0.3.3",
     "@silvia-odwyer/photon-node": "0.3.4",
-    "chalk": "5.6.2",
+    "chalk": "5.6.3",
     "chokidar": "5.0.0",
     "clawpdf": "0.2.0",
     "commander": "14.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,4 @@
+# Dependency guard probe: intentional throw-away lockfile diff.
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## Summary

Throw-away dependency guard probe. This intentionally changes both a package dependency field and `pnpm-lock.yaml` so the dependency graph change CI blocker should fail this PR.

Do not merge.

## Verification

Intentionally not run. This PR exists only to exercise the dependency graph guard.
