### PR TITLE
test pr: dependency guard: devDependency field plus lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1908,7 +1908,7 @@
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
     "unrun": "0.3.0",
-    "vitest": "4.1.7"
+    "vitest": "4.1.8"
   },
   "optionalDependencies": {
     "sharp": "0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,4 @@
+# Dependency guard probe: intentional throw-away devDependency lockfile diff.
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## Summary

Throw-away dependency guard probe. This intentionally changes both a package `devDependencies` field and `pnpm-lock.yaml` so the dependency graph change CI blocker should fail this PR.

Do not merge.

## Verification

Intentionally not run. This PR exists only to exercise the dependency graph guard.
