### PR TITLE
test pr: dependency guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1908,7 +1908,7 @@
     "tsdown": "0.22.0",
     "tsx": "4.22.3",
     "unrun": "0.3.0",
-    "vitest": "4.1.7"
+    "vitest": "4.1.8"
   },
   "optionalDependencies": {
     "sharp": "0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,4 @@
+# Dependency guard renamed-workflow probe: intentional throw-away lockfile diff.
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## Summary

Throw-away dependency guard probe targeting the dependency guard rename branch. This intentionally changes both a package `devDependencies` field and `pnpm-lock.yaml` so the renamed dependency guard CI blocker should fail this PR.

Do not merge.

## Verification

Intentionally not run. This PR exists only to exercise the renamed dependency guard workflow/check.
