### PR TITLE
test pr: dependency guard: package script only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1404,6 +1404,7 @@
     "canvas:a2ui:bundle": "node scripts/bundle-a2ui.mjs",
     "changed:lanes": "node scripts/changed-lanes.mjs",
     "check": "node scripts/check.mjs",
+    "check:dependency-guard-script-probe": "node -e \"process.exit(0)\"",
     "check:architecture": "pnpm check:import-cycles && pnpm check:madge-import-cycles && pnpm check:deprecated-api-usage && pnpm check:deprecated-jsdoc",
     "check:base-config-schema": "node --import tsx scripts/generate-base-config-schema.ts --check",
     "check:bundled-channel-config-metadata": "node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check",


### PR DESCRIPTION
## Summary

Throw-away dependency guard probe targeting the dependency guard rename branch. This intentionally changes only a `scripts` entry in `package.json` and does not change dependency fields or lockfiles.

Do not merge.

## Verification

Intentionally not run. This PR exists only to confirm script-only package manifest changes do not trigger the dependency graph blocker.
