### PR TITLE
feat: add Fal Krea image model schemas

### DIFF
--- a/docs/providers/fal.md
+++ b/docs/providers/fal.md
@@ -44,14 +44,15 @@ generation.
 The bundled `fal` image-generation provider defaults to
 `fal/fal-ai/flux/dev`.
 
-| Capability     | Value                                                       |
-| -------------- | ----------------------------------------------------------- |
-| Max images     | 4 per request                                               |
-| Edit mode      | Flux: 1 reference image; GPT Image 2: 10; Nano Banana 2: 14 |
-| Size overrides | Supported                                                   |
-| Aspect ratio   | Supported for generate and GPT Image 2/Nano Banana 2 edit   |
-| Resolution     | Supported                                                   |
-| Output format  | `png` or `jpeg`                                             |
+| Capability     | Value                                                              |
+| -------------- | ------------------------------------------------------------------ |
+| Max images     | 4 per request; Krea 2: 1 per request                               |
+| Edit mode      | Flux: 1 reference image; GPT Image 2: 10; Nano Banana 2: 14        |
+| Style refs     | Krea 2: up to 10 style references via `image` / `images`           |
+| Size overrides | Supported                                                          |
+| Aspect ratio   | Supported for generate, Krea 2, and GPT Image 2/Nano Banana 2 edit |
+| Resolution     | Supported                                                          |
+| Output format  | `png` or `jpeg`                                                    |
 
 <Warning>
 Flux image-to-image requests do **not** support `aspectRatio` overrides. GPT
@@ -59,9 +60,28 @@ Image 2 and Nano Banana 2 edit requests use fal's `/edit` endpoint and accept
 aspect-ratio hints.
 </Warning>
 
-Use `outputFormat: "png"` when you want PNG output. fal does not declare an
-explicit transparent-background control in OpenClaw, so `background:
-"transparent"` is reported as an ignored override for fal models.
+Krea 2 models use fal's native Krea payload schema. OpenClaw sends
+`aspect_ratio`, `creativity`, and `image_style_references` instead of the
+generic `image_size` / edit-endpoint payload used by Flux. The model refs are:
+
+- `fal/krea/v2/medium/text-to-image`
+- `fal/krea/v2/large/text-to-image`
+
+Use Medium for faster expressive illustration, anime, painting, and artistic
+styles. Use Large for slower photoreal, raw texture, film grain, and detailed
+looks. Krea defaults to `fal.creativity: "medium"`; supported values are
+`raw`, `low`, `medium`, and `high`.
+
+Krea 2 exposes aspect ratio, not `image_size`, in fal's request schema. Prefer
+`aspectRatio`; OpenClaw maps `size` to the closest supported Krea aspect ratio
+and rejects `resolution` for Krea rather than dropping it.
+
+Use `outputFormat: "png"` when you want PNG output from fal models that expose
+`output_format`. fal does not declare an explicit transparent-background
+control in OpenClaw, so `background: "transparent"` is reported as an ignored
+override for fal models.
+Krea 2 endpoints do not expose an `output_format` request field through fal, so
+OpenClaw rejects `outputFormat` overrides for Krea requests.
 
 To use fal as the default image provider:
 
@@ -71,6 +91,20 @@ To use fal as the default image provider:
     defaults: {
       imageGenerationModel: {
         primary: "fal/fal-ai/flux/dev",
+      },
+    },
+  },
+}
+```
+
+To use Krea 2 Medium:
+
+```json5
+{
+  agents: {
+    defaults: {
+      imageGenerationModel: {
+        primary: "fal/krea/v2/medium/text-to-image",
       },
     },
   },

--- a/docs/providers/fal.md
+++ b/docs/providers/fal.md
@@ -57,7 +57,9 @@ The bundled `fal` image-generation provider defaults to
 <Warning>
 Flux image-to-image requests do **not** support `aspectRatio` overrides. GPT
 Image 2 and Nano Banana 2 edit requests use fal's `/edit` endpoint and accept
-aspect-ratio hints.
+aspect-ratio hints. Nano Banana 2 also accepts extra-native wide/tall ratios
+such as `4:1`, `1:4`, `8:1`, and `1:8`; Krea 2 validates its own smaller
+aspect-ratio subset.
 </Warning>
 
 Krea 2 models use fal's native Krea payload schema. OpenClaw sends

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -156,7 +156,9 @@ current session:
   Size hint: `1024x1024`, `1536x1024`, `1024x1536`, `2048x2048`, `3840x2160`.
 </ParamField>
 <ParamField path="aspectRatio" type="string">
-  Aspect ratio: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`.
+  Aspect ratio: `1:1`, `2:3`, `3:2`, `2.35:1`, `3:4`, `4:3`, `4:5`,
+  `5:4`, `9:16`, `16:9`, `21:9`, `4:1`, `1:4`, `8:1`, `1:8`. Providers
+  validate their model-specific subset.
 </ParamField>
 <ParamField path="resolution" type='"1K" | "2K" | "4K"'>Resolution hint.</ParamField>
 <ParamField path="quality" type='"low" | "medium" | "high" | "auto"'>

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -79,12 +79,15 @@ internal image endpoints remain blocked by default.
 | OpenAI image generation with Codex subscription auth | `openai/gpt-image-2`                               | OpenAI Codex OAuth                     |
 | OpenAI transparent-background PNG/WebP               | `openai/gpt-image-1.5`                             | `OPENAI_API_KEY` or OpenAI Codex OAuth |
 | DeepInfra image generation                           | `deepinfra/black-forest-labs/FLUX-1-schnell`       | `DEEPINFRA_API_KEY`                    |
+| fal Krea 2 expressive/style-directed generation      | `fal/krea/v2/medium/text-to-image`                 | `FAL_KEY`                              |
 | OpenRouter image generation                          | `openrouter/google/gemini-3.1-flash-image-preview` | `OPENROUTER_API_KEY`                   |
 | LiteLLM image generation                             | `litellm/gpt-image-2`                              | `LITELLM_API_KEY`                      |
 | Google Gemini image generation                       | `google/gemini-3.1-flash-image-preview`            | `GEMINI_API_KEY` or `GOOGLE_API_KEY`   |
 
 The same `image_generate` tool handles text-to-image and reference-image
 editing. Use `image` for one reference or `images` for multiple references.
+For Krea 2 models on fal, those references are sent as style references
+instead of edit inputs.
 Provider-supported output hints such as `quality`, `outputFormat`, and
 `background` are forwarded when available and reported as ignored when a
 provider does not support them. Bundled transparent-background support is
@@ -121,13 +124,13 @@ current session:
 
 ## Provider capabilities
 
-| Capability            | ComfyUI            | DeepInfra | fal                       | Google         | MiniMax               | OpenAI         | Vydra | xAI            |
-| --------------------- | ------------------ | --------- | ------------------------- | -------------- | --------------------- | -------------- | ----- | -------------- |
-| Generate (max count)  | Workflow-defined   | 4         | 4                         | 4              | 9                     | 4              | 1     | 4              |
-| Edit / reference      | 1 image (workflow) | 1 image   | Flux: 1; GPT: 10; NB2: 14 | Up to 5 images | 1 image (subject ref) | Up to 5 images | -     | Up to 5 images |
-| Size control          | -                  | ✓         | ✓                         | ✓              | -                     | Up to 4K       | -     | -              |
-| Aspect ratio          | -                  | -         | ✓                         | ✓              | ✓                     | -              | -     | ✓              |
-| Resolution (1K/2K/4K) | -                  | -         | ✓                         | ✓              | -                     | -              | -     | 1K, 2K         |
+| Capability            | ComfyUI            | DeepInfra | fal                                            | Google         | MiniMax               | OpenAI         | Vydra | xAI            |
+| --------------------- | ------------------ | --------- | ---------------------------------------------- | -------------- | --------------------- | -------------- | ----- | -------------- |
+| Generate (max count)  | Workflow-defined   | 4         | 4                                              | 4              | 9                     | 4              | 1     | 4              |
+| Edit / reference      | 1 image (workflow) | 1 image   | Flux: 1; GPT: 10; Krea style refs: 10; NB2: 14 | Up to 5 images | 1 image (subject ref) | Up to 5 images | -     | Up to 5 images |
+| Size control          | -                  | ✓         | ✓                                              | ✓              | -                     | Up to 4K       | -     | -              |
+| Aspect ratio          | -                  | -         | ✓                                              | ✓              | ✓                     | -              | -     | ✓              |
+| Resolution (1K/2K/4K) | -                  | -         | ✓                                              | ✓              | -                     | -              | -     | 1K, 2K         |
 
 ## Tool parameters
 
@@ -146,7 +149,8 @@ current session:
   Single reference image path or URL for edit mode.
 </ParamField>
 <ParamField path="images" type="string[]">
-  Multiple reference images for edit mode (up to 5 on supporting providers).
+  Multiple reference images for edit mode or style-reference models (up to 10
+  through the shared tool; provider-specific limits still apply).
 </ParamField>
 <ParamField path="size" type="string">
   Size hint: `1024x1024`, `1536x1024`, `1024x1536`, `2048x2048`, `3840x2160`.
@@ -174,6 +178,9 @@ current session:
 <ParamField path="filename" type="string">Output filename hint.</ParamField>
 <ParamField path="openai" type="object">
   OpenAI-only hints: `background`, `moderation`, `outputCompression`, and `user`.
+</ParamField>
+<ParamField path="fal.creativity" type='"raw" | "low" | "medium" | "high"'>
+  fal Krea 2 creativity control. Defaults to `medium`.
 </ParamField>
 
 <Note>
@@ -253,7 +260,8 @@ from each attempt.
 ### Image editing
 
 OpenAI, OpenRouter, Google, DeepInfra, fal, MiniMax, ComfyUI, and xAI support editing
-reference images. Pass a reference image path or URL:
+reference images. Krea 2 models on fal use the same `image` / `images` fields
+as style references instead of edit inputs. Pass a reference image path or URL:
 
 ```text
 "Generate a watercolor version of this photo" + image: "/path/to/photo.jpg"
@@ -261,8 +269,8 @@ reference images. Pass a reference image path or URL:
 
 OpenAI, OpenRouter, Google, and xAI support up to 5 reference images via the
 `images` parameter. fal supports 1 reference image for Flux image-to-image, up
-to 10 for GPT Image 2 edits, and up to 14 for Nano Banana 2 edits. MiniMax and
-ComfyUI support 1.
+to 10 for GPT Image 2 edits, up to 10 style references for Krea 2, and up to
+14 for Nano Banana 2 edits. MiniMax and ComfyUI support 1.
 
 ## Provider deep dives
 
@@ -349,6 +357,46 @@ ComfyUI support 1.
     `action: "list"` to see what your configured plugin exposes.
 
   </Accordion>
+  <Accordion title="fal Krea 2">
+    Krea 2 models on fal use fal's native Krea schema instead of the generic
+    `image_size` schema used by Flux. OpenClaw sends:
+
+    - `aspect_ratio` for aspect-ratio hints
+    - `creativity`, defaulting to `medium`
+    - `image_style_references` when `image` or `images` are supplied
+
+    Select Krea 2 Medium for faster expressive illustration and Krea 2 Large
+    for slower, more detailed photoreal and textured looks:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          imageGenerationModel: {
+            primary: "fal/krea/v2/medium/text-to-image",
+          },
+        },
+      },
+    }
+    ```
+
+    Krea 2 currently returns one image per request. Prefer `aspectRatio` for
+    Krea; OpenClaw maps `size` to the closest supported Krea aspect ratio and
+    rejects `resolution` for Krea rather than dropping it. Use `fal.creativity`
+    when you want a native Krea creativity level:
+
+    ```json
+    {
+      "model": "fal/krea/v2/medium/text-to-image",
+      "prompt": "A cyber zine portrait with risograph texture",
+      "aspectRatio": "9:16",
+      "fal": {
+        "creativity": "high"
+      }
+    }
+    ```
+
+  </Accordion>
   <Accordion title="MiniMax dual-auth">
     MiniMax image generation is available through both bundled MiniMax
     auth paths:
@@ -413,6 +461,11 @@ openclaw infer image generate \
   <Tab title="Edit (multiple references)">
 ```text
 /tool image_generate action=generate model=openai/gpt-image-2 prompt="Combine the character identity from the first image with the color palette from the second" images='["/path/to/character.png","/path/to/palette.jpg"]' size=1536x1024
+```
+  </Tab>
+  <Tab title="Krea style references">
+```text
+/tool image_generate action=generate model=fal/krea/v2/medium/text-to-image prompt="An expressive editorial portrait using this color palette and print texture" images='["/path/to/palette.png","/path/to/texture.jpg"]' aspectRatio=9:16 fal='{"creativity":"high"}'
 ```
   </Tab>
 </Tabs>

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -373,7 +373,7 @@ describe("fal image-generation provider", () => {
       model: "fal-ai/nano-banana-2",
       prompt: "ultrawide banana test",
       cfg: {},
-      aspectRatio: "21:9",
+      aspectRatio: "4:1",
       resolution: "2K",
     });
 
@@ -382,7 +382,7 @@ describe("fal image-generation provider", () => {
       url: "https://fal.run/fal-ai/nano-banana-2",
       body: {
         prompt: "ultrawide banana test",
-        aspect_ratio: "21:9",
+        aspect_ratio: "4:1",
         resolution: "2K",
         num_images: 1,
         output_format: "png",

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -339,6 +339,57 @@ describe("fal image-generation provider", () => {
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
+  it("routes Nano Banana 2 text generation with native resolution", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/nb2-wide.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("nb2-wide-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "fal-ai/nano-banana-2",
+      prompt: "ultrawide banana test",
+      cfg: {},
+      aspectRatio: "21:9",
+      resolution: "2K",
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/fal-ai/nano-banana-2",
+      body: {
+        prompt: "ultrawide banana test",
+        aspect_ratio: "21:9",
+        resolution: "2K",
+        num_images: 1,
+        output_format: "png",
+      },
+    });
+  });
+
   it("routes Nano Banana 2 edits through /edit with NB2 geometry", async () => {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "fal-test-key",
@@ -418,7 +469,28 @@ describe("fal image-generation provider", () => {
           mimeType: "image/png",
         })),
       }),
-    ).rejects.toThrow("fal Nano Banana edit supports at most 14 reference images");
+    ).rejects.toThrow("fal Nano Banana 2 supports at most 14 reference images");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects Krea-only aspect ratios for Nano Banana 2", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "fal-ai/nano-banana-2",
+        prompt: "unsupported ratio",
+        cfg: {},
+        aspectRatio: "2.35:1",
+      }),
+    ).rejects.toThrow("fal Nano Banana 2 supports aspectRatio values");
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
@@ -568,6 +640,231 @@ describe("fal image-generation provider", () => {
         output_format: "png",
       },
     });
+  });
+
+  it("uses Krea 2 native aspect-ratio and creativity payload schema", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/krea.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("krea-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "fal",
+      model: "krea/v2/medium/text-to-image",
+      prompt: "expressive risograph poster",
+      cfg: {},
+      aspectRatio: "9:16",
+      providerOptions: {
+        fal: {
+          creativity: "high",
+        },
+      },
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/krea/v2/medium/text-to-image",
+      body: {
+        prompt: "expressive risograph poster",
+        creativity: "high",
+        aspect_ratio: "9:16",
+      },
+    });
+    expect(result.model).toBe("krea/v2/medium/text-to-image");
+  });
+
+  it("passes reference images to Krea 2 as style references without edit suffix", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/krea-style.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("krea-style-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "krea/v2/large/text-to-image",
+      prompt: "portrait with the same palette and texture",
+      cfg: {},
+      size: "1024x1536",
+      inputImages: [
+        { buffer: Buffer.from("style-a"), mimeType: "image/png" },
+        { buffer: Buffer.from("style-b"), mimeType: "image/jpeg" },
+      ],
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/krea/v2/large/text-to-image",
+      body: {
+        prompt: "portrait with the same palette and texture",
+        creativity: "medium",
+        aspect_ratio: "2:3",
+        image_style_references: [
+          { image_url: `data:image/png;base64,${Buffer.from("style-a").toString("base64")}` },
+          { image_url: `data:image/jpeg;base64,${Buffer.from("style-b").toString("base64")}` },
+        ],
+      },
+    });
+  });
+
+  it("maps Krea 2 size hints to the closest native aspect ratio", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/krea-sized.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("krea-sized-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "krea/v2/medium/text-to-image",
+      prompt: "portrait poster",
+      cfg: {},
+      size: "1024x1536",
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/krea/v2/medium/text-to-image",
+      body: {
+        prompt: "portrait poster",
+        creativity: "medium",
+        aspect_ratio: "2:3",
+      },
+    });
+  });
+
+  it("rejects Krea 2 resolution hints instead of dropping them", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "krea/v2/medium/text-to-image",
+        prompt: "too many pixels",
+        cfg: {},
+        resolution: "2K",
+      }),
+    ).rejects.toThrow("fal Krea 2 supports aspectRatio but not resolution overrides");
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "krea/v2/medium/text-to-image",
+        prompt: "style refs with unsupported pixels",
+        cfg: {},
+        resolution: "1K",
+        inputImages: [{ buffer: Buffer.from("style"), mimeType: "image/png" }],
+      }),
+    ).rejects.toThrow("fal Krea 2 supports aspectRatio but not resolution overrides");
+  });
+
+  it("rejects multi-image count for Krea 2 single-image endpoints", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "krea/v2/medium/text-to-image",
+        prompt: "too many outputs",
+        cfg: {},
+        count: 2,
+      }),
+    ).rejects.toThrow("supports one output image per request");
+  });
+
+  it("rejects output format overrides for Krea 2", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "krea/v2/medium/text-to-image",
+        prompt: "jpeg please",
+        cfg: {},
+        outputFormat: "jpeg",
+      }),
+    ).rejects.toThrow("does not support outputFormat overrides");
   });
 
   it("rejects multi-image for Flux edit", async () => {

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -390,6 +390,55 @@ describe("fal image-generation provider", () => {
     });
   });
 
+  it("does not synthesize Nano Banana 2 aspect ratio from resolution alone", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/nb2-auto.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("nb2-auto-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "fal-ai/nano-banana-2",
+      prompt: "auto aspect banana test",
+      cfg: {},
+      resolution: "2K",
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/fal-ai/nano-banana-2",
+      body: {
+        prompt: "auto aspect banana test",
+        resolution: "2K",
+        num_images: 1,
+        output_format: "png",
+      },
+    });
+  });
+
   it("routes Nano Banana 2 edits through /edit with NB2 geometry", async () => {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "fal-test-key",

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -539,6 +539,10 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       },
       geometry: {
         sizes: [...FAL_SUPPORTED_SIZES],
+        sizesByModel: {
+          [FAL_KREA_2_MEDIUM_MODEL]: [],
+          [FAL_KREA_2_LARGE_MODEL]: [],
+        },
         aspectRatios: [...FAL_SUPPORTED_ASPECT_RATIOS],
         resolutions: ["1K", "2K", "4K"],
       },

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -426,7 +426,7 @@ function applyFalImageGeometry(params: {
     const nativeAspectRatio = resolveNativeFalAspectRatio({
       schema: params.schema,
       aspectRatio: params.aspectRatio,
-      imageSize: params.hasInputImages && !params.size ? undefined : params.imageSize,
+      imageSize: params.size ? params.imageSize : undefined,
     });
     if (nativeAspectRatio) {
       params.requestBody.aspect_ratio = nativeAspectRatio;

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -57,6 +57,10 @@ const FAL_SUPPORTED_ASPECT_RATIOS = [
   "9:16",
   "16:9",
   "21:9",
+  "4:1",
+  "1:4",
+  "8:1",
+  "1:8",
 ] as const;
 const KREA_SUPPORTED_ASPECT_RATIOS = [
   "1:1",

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -1,6 +1,7 @@
 import type {
   GeneratedImageAsset,
   ImageGenerationProvider,
+  ImageGenerationSourceImage,
 } from "openclaw/plugin-sdk/image-generation";
 import {
   imageFileExtensionForMimeType,
@@ -29,9 +30,13 @@ import {
 const DEFAULT_FAL_BASE_URL = "https://fal.run";
 const DEFAULT_FAL_IMAGE_MODEL = "fal-ai/flux/dev";
 const DEFAULT_FAL_EDIT_SUBPATH = "image-to-image";
+const FAL_KREA_2_MODEL_PREFIX = "krea/v2/";
+const FAL_KREA_2_MEDIUM_MODEL = "krea/v2/medium/text-to-image";
+const FAL_KREA_2_LARGE_MODEL = "krea/v2/large/text-to-image";
 const DEFAULT_OUTPUT_FORMAT = "png";
 const GPT_IMAGE_EDIT_MAX_INPUT_IMAGES = 10;
 const NANO_BANANA_EDIT_MAX_INPUT_IMAGES = 14;
+const KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES = 10;
 const FAL_OUTPUT_FORMATS = ["png", "jpeg"] as const;
 const FAL_SUPPORTED_SIZES = [
   "1024x1024",
@@ -40,11 +45,62 @@ const FAL_SUPPORTED_SIZES = [
   "1024x1792",
   "1792x1024",
 ] as const;
-const FAL_SUPPORTED_ASPECT_RATIOS = ["1:1", "4:3", "3:4", "16:9", "9:16"] as const;
+const FAL_SUPPORTED_ASPECT_RATIOS = [
+  "1:1",
+  "2:3",
+  "3:2",
+  "2.35:1",
+  "3:4",
+  "4:3",
+  "4:5",
+  "5:4",
+  "9:16",
+  "16:9",
+  "21:9",
+] as const;
+const KREA_SUPPORTED_ASPECT_RATIOS = [
+  "1:1",
+  "4:3",
+  "3:2",
+  "16:9",
+  "2.35:1",
+  "4:5",
+  "2:3",
+  "9:16",
+] as const;
+const NANO_BANANA_SUPPORTED_ASPECT_RATIOS = [
+  "21:9",
+  "16:9",
+  "3:2",
+  "4:3",
+  "5:4",
+  "1:1",
+  "4:5",
+  "3:4",
+  "2:3",
+  "9:16",
+  "4:1",
+  "1:4",
+  "8:1",
+  "1:8",
+] as const;
+const KREA_CREATIVITY_LEVELS = ["raw", "low", "medium", "high"] as const;
 
 const FAL_IMAGE_MALFORMED_RESPONSE = "fal image generation response malformed";
 
 type FalImageSize = string | { width: number; height: number };
+type FalImageModelSchema = {
+  geometry: "image_size" | "native_aspect_ratio";
+  aspectRatios?: readonly string[];
+  referenceImages: "image_url" | "image_urls" | "image_style_references";
+  maxInputImages: number;
+  referenceLimitLabel: string;
+  referenceLimitNoun: "reference image" | "style reference";
+  appendEditPath: false | "edit" | "image-to-image";
+  supportsCount: boolean;
+  supportsOutputFormat: boolean;
+  defaultBody?: Record<string, unknown>;
+};
 type FalNetworkPolicy = {
   apiPolicy?: SsrFPolicy;
   trustedDownloadHostSuffix?: string;
@@ -115,6 +171,10 @@ function resolveFalNetworkPolicy(params: {
 
 function ensureFalModelPath(model: string | undefined, hasInputImages: boolean): string {
   const trimmed = model?.trim() || DEFAULT_FAL_IMAGE_MODEL;
+  const schema = resolveFalImageModelSchema(trimmed);
+  if (hasInputImages && schema.appendEditPath === false) {
+    return trimmed;
+  }
   if (!hasInputImages) {
     return trimmed;
   }
@@ -130,6 +190,49 @@ function ensureFalModelPath(model: string | undefined, hasInputImages: boolean):
     return `${trimmed}/edit`;
   }
   return `${trimmed}/${DEFAULT_FAL_EDIT_SUBPATH}`;
+}
+
+function resolveFalImageModelSchema(model: string): FalImageModelSchema {
+  if (model.startsWith(FAL_KREA_2_MODEL_PREFIX)) {
+    return {
+      geometry: "native_aspect_ratio",
+      aspectRatios: KREA_SUPPORTED_ASPECT_RATIOS,
+      referenceImages: "image_style_references",
+      maxInputImages: KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES,
+      referenceLimitLabel: "fal Krea 2",
+      referenceLimitNoun: "style reference",
+      appendEditPath: false,
+      supportsCount: false,
+      supportsOutputFormat: false,
+      defaultBody: { creativity: "medium" },
+    };
+  }
+  if (model.startsWith("openai/gpt-image-") || model.startsWith("fal-ai/nano-banana-")) {
+    const isNanoBanana = model.startsWith("fal-ai/nano-banana-");
+    return {
+      geometry: isNanoBanana ? "native_aspect_ratio" : "image_size",
+      ...(isNanoBanana ? { aspectRatios: NANO_BANANA_SUPPORTED_ASPECT_RATIOS } : {}),
+      referenceImages: "image_urls",
+      maxInputImages: isNanoBanana
+        ? NANO_BANANA_EDIT_MAX_INPUT_IMAGES
+        : GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+      referenceLimitLabel: isNanoBanana ? "fal Nano Banana 2" : "fal GPT Image edit",
+      referenceLimitNoun: "reference image",
+      appendEditPath: "edit",
+      supportsCount: true,
+      supportsOutputFormat: true,
+    };
+  }
+  return {
+    geometry: "image_size",
+    referenceImages: "image_url",
+    maxInputImages: 1,
+    referenceLimitLabel: "fal flux image generation currently",
+    referenceLimitNoun: "reference image",
+    appendEditPath: "image-to-image",
+    supportsCount: true,
+    supportsOutputFormat: true,
+  };
 }
 
 function parseSize(raw: string | undefined): { width: number; height: number } | null {
@@ -179,16 +282,13 @@ function aspectRatioToEnum(aspectRatio: string | undefined): string | undefined 
   return undefined;
 }
 
-function aspectRatioToDimensions(
-  aspectRatio: string,
-  edge: number,
-): { width: number; height: number } {
-  const match = /^(\d+):(\d+)$/u.exec(aspectRatio.trim());
+function parseAspectRatioParts(aspectRatio: string): { widthRatio: number; heightRatio: number } {
+  const match = /^(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)$/u.exec(aspectRatio.trim());
   if (!match) {
     throw new Error(`Invalid fal aspect ratio: ${aspectRatio}`);
   }
-  const widthRatio = Number.parseInt(match[1] ?? "", 10);
-  const heightRatio = Number.parseInt(match[2] ?? "", 10);
+  const widthRatio = Number.parseFloat(match[1] ?? "");
+  const heightRatio = Number.parseFloat(match[2] ?? "");
   if (
     !Number.isFinite(widthRatio) ||
     !Number.isFinite(heightRatio) ||
@@ -197,6 +297,14 @@ function aspectRatioToDimensions(
   ) {
     throw new Error(`Invalid fal aspect ratio: ${aspectRatio}`);
   }
+  return { widthRatio, heightRatio };
+}
+
+function aspectRatioToDimensions(
+  aspectRatio: string,
+  edge: number,
+): { width: number; height: number } {
+  const { widthRatio, heightRatio } = parseAspectRatioParts(aspectRatio);
   if (widthRatio >= heightRatio) {
     return {
       width: edge,
@@ -244,6 +352,124 @@ function resolveFalImageSize(params: {
   return undefined;
 }
 
+function aspectRatioScore(aspectRatio: string, targetRatio: number): number {
+  const { widthRatio, heightRatio } = parseAspectRatioParts(aspectRatio);
+  return Math.abs(Math.log(widthRatio / heightRatio) - Math.log(targetRatio));
+}
+
+function resolveClosestFalAspectRatioForSize(
+  imageSize: FalImageSize | undefined,
+  aspectRatios: readonly string[],
+): string | undefined {
+  if (!imageSize || typeof imageSize === "string") {
+    return undefined;
+  }
+  const targetRatio = imageSize.width / imageSize.height;
+  return aspectRatios.reduce<string | undefined>((best, candidate) => {
+    if (!best) {
+      return candidate;
+    }
+    return aspectRatioScore(candidate, targetRatio) < aspectRatioScore(best, targetRatio)
+      ? candidate
+      : best;
+  }, undefined);
+}
+
+function resolveKreaCreativity(raw: string | undefined): string {
+  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  return (KREA_CREATIVITY_LEVELS as readonly string[]).includes(normalized) ? normalized : "medium";
+}
+
+function resolveFalCreativityOption(providerOptions: Record<string, unknown> | undefined): string {
+  const falOptions = isRecord(providerOptions?.fal) ? providerOptions.fal : undefined;
+  return typeof falOptions?.creativity === "string" ? falOptions.creativity : "";
+}
+
+function resolveNativeFalAspectRatio(params: {
+  schema: FalImageModelSchema;
+  aspectRatio?: string;
+  imageSize?: FalImageSize;
+}): string | undefined {
+  const requestedAspectRatio = params.aspectRatio?.trim();
+  const allowedAspectRatios = params.schema.aspectRatios;
+  if (requestedAspectRatio) {
+    if (allowedAspectRatios && !allowedAspectRatios.includes(requestedAspectRatio)) {
+      throw new Error(
+        `${params.schema.referenceLimitLabel} supports aspectRatio values: ${allowedAspectRatios.join(", ")}`,
+      );
+    }
+    return requestedAspectRatio;
+  }
+  if (allowedAspectRatios) {
+    return resolveClosestFalAspectRatioForSize(params.imageSize, allowedAspectRatios);
+  }
+  return undefined;
+}
+
+function applyFalImageGeometry(params: {
+  requestBody: Record<string, unknown>;
+  schema: FalImageModelSchema;
+  imageSize?: FalImageSize;
+  size?: string;
+  aspectRatio?: string;
+  resolution?: "1K" | "2K" | "4K";
+  hasInputImages: boolean;
+}) {
+  if (params.schema.geometry === "native_aspect_ratio") {
+    if (params.resolution && params.schema.referenceImages === "image_style_references") {
+      throw new Error("fal Krea 2 supports aspectRatio but not resolution overrides");
+    }
+    const nativeAspectRatio = resolveNativeFalAspectRatio({
+      schema: params.schema,
+      aspectRatio: params.aspectRatio,
+      imageSize: params.hasInputImages && !params.size ? undefined : params.imageSize,
+    });
+    if (nativeAspectRatio) {
+      params.requestBody.aspect_ratio = nativeAspectRatio;
+    }
+    if (params.resolution && params.schema.referenceImages === "image_urls") {
+      params.requestBody.resolution = params.resolution;
+    }
+    return;
+  }
+  if (params.imageSize !== undefined) {
+    params.requestBody.image_size = params.imageSize;
+  }
+}
+
+function applyFalReferenceImages(params: {
+  requestBody: Record<string, unknown>;
+  schema: FalImageModelSchema;
+  inputImages: ImageGenerationSourceImage[];
+}) {
+  const encoded = params.inputImages.map((img) => toImageDataUrl(img));
+  if (params.schema.referenceImages === "image_urls") {
+    params.requestBody.image_urls = encoded;
+    return;
+  }
+  if (params.schema.referenceImages === "image_style_references") {
+    params.requestBody.image_style_references = encoded.map((imageUrl) => ({
+      image_url: imageUrl,
+    }));
+    return;
+  }
+  const [input] = encoded;
+  if (!input) {
+    throw new Error("fal image edit request missing reference image");
+  }
+  params.requestBody.image_url = input;
+}
+
+function formatFalReferenceLimitError(
+  schema: FalImageModelSchema,
+  inputImageCount: number,
+): string {
+  const limit = schema.maxInputImages === 1 ? "one" : String(schema.maxInputImages);
+  const noun =
+    schema.maxInputImages === 1 ? schema.referenceLimitNoun : `${schema.referenceLimitNoun}s`;
+  return `${schema.referenceLimitLabel} supports at most ${limit} ${noun} (requested ${inputImageCount})`;
+}
+
 async function fetchImageBuffer(
   url: string,
   networkPolicy?: FalNetworkPolicy,
@@ -281,7 +507,12 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
     id: "fal",
     label: "fal",
     defaultModel: DEFAULT_FAL_IMAGE_MODEL,
-    models: [DEFAULT_FAL_IMAGE_MODEL, `${DEFAULT_FAL_IMAGE_MODEL}/${DEFAULT_FAL_EDIT_SUBPATH}`],
+    models: [
+      DEFAULT_FAL_IMAGE_MODEL,
+      `${DEFAULT_FAL_IMAGE_MODEL}/${DEFAULT_FAL_EDIT_SUBPATH}`,
+      FAL_KREA_2_MEDIUM_MODEL,
+      FAL_KREA_2_LARGE_MODEL,
+    ],
     isConfigured: ({ agentDir }) =>
       isProviderApiKeyConfigured({
         provider: "fal",
@@ -323,6 +554,8 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       }
       const inputImageCount = req.inputImages?.length ?? 0;
       const hasInputImages = inputImageCount > 0;
+      const requestedModel = req.model?.trim() || DEFAULT_FAL_IMAGE_MODEL;
+      const schema = resolveFalImageModelSchema(requestedModel);
       const imageSize = resolveFalImageSize({
         size: req.size,
         resolution: req.resolution,
@@ -331,37 +564,21 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       });
       const model = ensureFalModelPath(req.model, hasInputImages);
 
-      const isGptImageEditModel = model.startsWith("openai/gpt-image-");
-      const isNanoBananaEditModel = model.startsWith("fal-ai/nano-banana-");
-      if (
-        hasInputImages &&
-        isGptImageEditModel &&
-        inputImageCount > GPT_IMAGE_EDIT_MAX_INPUT_IMAGES
-      ) {
-        throw new Error(
-          `fal GPT Image edit supports at most ${GPT_IMAGE_EDIT_MAX_INPUT_IMAGES} reference images (requested ${inputImageCount})`,
-        );
-      }
-      if (
-        hasInputImages &&
-        isNanoBananaEditModel &&
-        inputImageCount > NANO_BANANA_EDIT_MAX_INPUT_IMAGES
-      ) {
-        throw new Error(
-          `fal Nano Banana edit supports at most ${NANO_BANANA_EDIT_MAX_INPUT_IMAGES} reference images (requested ${inputImageCount})`,
-        );
+      if (hasInputImages && inputImageCount > schema.maxInputImages) {
+        throw new Error(formatFalReferenceLimitError(schema, inputImageCount));
       }
 
       // Flux/custom edit endpoints use the singular image_url contract.
-      if (hasInputImages && !isGptImageEditModel && !isNanoBananaEditModel) {
-        if (inputImageCount > 1) {
-          throw new Error(
-            "fal flux image generation currently supports at most one reference image",
-          );
-        }
+      if (hasInputImages && schema.referenceImages === "image_url") {
         if (req.aspectRatio) {
           throw new Error("fal flux image edit endpoint does not support aspectRatio overrides");
         }
+      }
+      if (!schema.supportsCount && (req.count ?? 1) > 1) {
+        throw new Error(`fal ${requestedModel} supports one output image per request`);
+      }
+      if (!schema.supportsOutputFormat && req.outputFormat) {
+        throw new Error(`fal ${requestedModel} does not support outputFormat overrides`);
       }
       const explicitBaseUrl = req.cfg?.models?.providers?.fal?.baseUrl?.trim();
       const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
@@ -380,34 +597,33 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       const networkPolicy = resolveFalNetworkPolicy({ baseUrl, allowPrivateNetwork });
       const requestBody: Record<string, unknown> = {
         prompt: req.prompt,
-        num_images: req.count ?? 1,
-        output_format: req.outputFormat ?? DEFAULT_OUTPUT_FORMAT,
+        ...(schema.supportsCount ? { num_images: req.count ?? 1 } : {}),
+        ...(schema.supportsOutputFormat
+          ? { output_format: req.outputFormat ?? DEFAULT_OUTPUT_FORMAT }
+          : {}),
+        ...schema.defaultBody,
       };
-      if (imageSize !== undefined) {
-        // NB2 edit uses its own geometry schema; GPT Image 2 and Flux use image_size
-        if (model.startsWith("fal-ai/nano-banana-") && hasInputImages) {
-          if (req.aspectRatio) {
-            requestBody.aspect_ratio = req.aspectRatio;
-          }
-          if (req.resolution) {
-            requestBody.resolution = req.resolution;
-          }
-        } else {
-          requestBody.image_size = imageSize;
-        }
+      if (schema.referenceImages === "image_style_references") {
+        requestBody.creativity = resolveKreaCreativity(
+          resolveFalCreativityOption(req.providerOptions),
+        );
       }
+      applyFalImageGeometry({
+        requestBody,
+        schema,
+        imageSize,
+        size: req.size,
+        aspectRatio: req.aspectRatio,
+        resolution: req.resolution,
+        hasInputImages,
+      });
 
       if (hasInputImages) {
-        const [input] = req.inputImages ?? [];
-        if (!input) {
-          throw new Error("fal image edit request missing reference image");
-        }
-        // GPT Image 2 and NB2 use image_urls (array); Flux uses image_url (singular)
-        if (isGptImageEditModel || isNanoBananaEditModel) {
-          requestBody.image_urls = req.inputImages!.map((img) => toImageDataUrl(img));
-        } else {
-          requestBody.image_url = toImageDataUrl(input);
-        }
+        applyFalReferenceImages({
+          requestBody,
+          schema,
+          inputImages: req.inputImages ?? [],
+        });
       }
       const { response, release } = await falFetchGuard({
         url: `${baseUrl}/${model}`,

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -2172,7 +2172,7 @@ describe("createImageGenerateTool", () => {
       createFalEditProvider(),
     ]);
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage");
-    vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+    const loadWebMedia = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
       kind: "image",
       buffer: Buffer.from("input-image"),
       contentType: "image/png",
@@ -2185,9 +2185,10 @@ describe("createImageGenerateTool", () => {
     await expect(
       tool.execute("call-fal-edit", {
         prompt: "combine",
-        images: ["./fixtures/a.png", "./fixtures/b.png"],
+        images: ["https://example.test/a.png", "https://example.test/b.png"],
       }),
     ).rejects.toThrow("fal edit supports at most 1 reference image");
+    expect(loadWebMedia).not.toHaveBeenCalled();
     expect(generateImage).not.toHaveBeenCalled();
   });
 

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -2064,7 +2064,7 @@ describe("createImageGenerateTool", () => {
     await expect(
       tool.execute("call-bad-aspect", { prompt: "portrait", aspectRatio: "7:5" }),
     ).rejects.toThrow(
-      "aspectRatio must be one of 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9",
+      "aspectRatio must be one of 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9, 4:1, 1:4, 8:1, or 1:8",
     );
   });
 

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -246,14 +246,16 @@ function stubEditedImageFlow(params?: { width?: number; height?: number }) {
 }
 
 function createFalEditProvider(params?: {
+  defaultModel?: string;
   maxInputImages?: number;
+  models?: string[];
   supportsAspectRatio?: boolean;
   aspectRatios?: string[];
 }) {
   return {
     id: "fal",
-    defaultModel: "fal-ai/flux/dev",
-    models: ["fal-ai/flux/dev", "fal-ai/flux/dev/image-to-image"],
+    defaultModel: params?.defaultModel ?? "fal-ai/flux/dev",
+    models: params?.models ?? ["fal-ai/flux/dev", "fal-ai/flux/dev/image-to-image"],
     capabilities: {
       generate: {
         maxCount: 4,
@@ -1300,6 +1302,96 @@ describe("createImageGenerateTool", () => {
     expect(details.outputFormat).toBe("jpeg");
   });
 
+  it("forwards generic fal provider options", async () => {
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "fal",
+      model: "krea/v2/medium/text-to-image",
+      attempts: [],
+      ignoredOverrides: [],
+      images: [
+        {
+          buffer: Buffer.from("krea-out"),
+          mimeType: "image/png",
+          fileName: "krea.png",
+        },
+      ],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/krea.png",
+      id: "krea.png",
+      size: 8,
+      contentType: "image/png",
+    });
+
+    const tool = createToolWithPrimaryImageModel("fal/krea/v2/medium/text-to-image");
+    await tool.execute("call-fal-krea-options", {
+      prompt: "Expressive print portrait",
+      aspectRatio: "2.35:1",
+      fal: {
+        creativity: "high",
+      },
+    });
+
+    const generateArgs = mockCallArg(generateImage, 0, "generateImage");
+    expect(generateArgs.providerOptions).toEqual({
+      fal: {
+        creativity: "high",
+      },
+    });
+    expect(generateArgs.aspectRatio).toBe("2.35:1");
+  });
+
+  it("does not infer edit resolution for fal Krea style references", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        defaultModel: "krea/v2/medium/text-to-image",
+        models: ["krea/v2/medium/text-to-image"],
+        maxInputImages: 10,
+        supportsAspectRatio: true,
+      }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "fal",
+      model: "krea/v2/medium/text-to-image",
+      attempts: [],
+      ignoredOverrides: [],
+      images: [
+        {
+          buffer: Buffer.from("krea-style-out"),
+          mimeType: "image/png",
+          fileName: "krea-style.png",
+        },
+      ],
+    });
+    vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      kind: "image",
+      buffer: Buffer.from("style-ref"),
+      contentType: "image/png",
+    });
+    vi.spyOn(imageOps, "getImageMetadata").mockResolvedValue({
+      width: 2048,
+      height: 2048,
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/krea-style.png",
+      id: "krea-style.png",
+      size: 14,
+      contentType: "image/png",
+    });
+
+    const tool = createToolWithPrimaryImageModel("fal/krea/v2/medium/text-to-image", {
+      workspaceDir: process.cwd(),
+    });
+    await tool.execute("call-fal-krea-style", {
+      prompt: "Style-directed portrait",
+      image: "./fixtures/style.png",
+    });
+
+    const generateArgs = mockCallArg(generateImage, 0, "generateImage");
+    expect(generateArgs.resolution).toBeUndefined();
+    expect(generateArgs.inputImages).toHaveLength(1);
+  });
+
   it.each([60.5, "60px", null])("rejects malformed OpenAI output compression %s", async (value) => {
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
       provider: "openai",
@@ -1972,7 +2064,7 @@ describe("createImageGenerateTool", () => {
     await expect(
       tool.execute("call-bad-aspect", { prompt: "portrait", aspectRatio: "7:5" }),
     ).rejects.toThrow(
-      "aspectRatio must be one of 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9",
+      "aspectRatio must be one of 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9",
     );
   });
 

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -121,6 +121,10 @@ const SUPPORTED_ASPECT_RATIOS = new Set([
   "9:16",
   "16:9",
   "21:9",
+  "4:1",
+  "1:4",
+  "8:1",
+  "1:8",
 ]);
 
 const log = createSubsystemLogger("agents/tools/image-generate");
@@ -160,7 +164,8 @@ const ImageGenerateToolSchema = Type.Object({
   ),
   aspectRatio: Type.Optional(
     Type.String({
-      description: "Aspect ratio: 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9.",
+      description:
+        "Aspect ratio: 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9, 4:1, 1:4, 8:1, 1:8.",
     }),
   ),
   resolution: Type.Optional(
@@ -286,7 +291,7 @@ function normalizeAspectRatio(raw: string | undefined): string | undefined {
     return normalized;
   }
   throw new ToolInputError(
-    "aspectRatio must be one of 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9",
+    "aspectRatio must be one of 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9, 4:1, 1:4, 8:1, or 1:8",
   );
 }
 

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -101,16 +101,19 @@ import {
 
 const DEFAULT_COUNT = 1;
 const MAX_COUNT = 4;
-const MAX_INPUT_IMAGES = 5;
+const MAX_INPUT_IMAGES = 10;
 const DEFAULT_RESOLUTION: ImageGenerationResolution = "1K";
 const SUPPORTED_QUALITIES = ["low", "medium", "high", "auto"] as const;
 const SUPPORTED_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const SUPPORTED_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
 const SUPPORTED_OPENAI_MODERATIONS = ["low", "auto"] as const;
+const SUPPORTED_FAL_CREATIVITY = ["raw", "low", "medium", "high"] as const;
+type FalCreativity = (typeof SUPPORTED_FAL_CREATIVITY)[number];
 const SUPPORTED_ASPECT_RATIOS = new Set([
   "1:1",
   "2:3",
   "3:2",
+  "2.35:1",
   "3:4",
   "4:3",
   "4:5",
@@ -136,7 +139,7 @@ const ImageGenerateToolSchema = Type.Object({
   ),
   images: Type.Optional(
     Type.Array(Type.String(), {
-      description: `Reference images for edit; max ${MAX_INPUT_IMAGES}.`,
+      description: `Reference images for edit or style reference; max ${MAX_INPUT_IMAGES}.`,
     }),
   ),
   model: Type.Optional(
@@ -157,7 +160,7 @@ const ImageGenerateToolSchema = Type.Object({
   ),
   aspectRatio: Type.Optional(
     Type.String({
-      description: "Aspect ratio: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9.",
+      description: "Aspect ratio: 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9.",
     }),
   ),
   resolution: Type.Optional(
@@ -195,6 +198,13 @@ const ImageGenerateToolSchema = Type.Object({
           description: "OpenAI stable end-user id.",
         }),
       ),
+    }),
+  ),
+  fal: Type.Optional(
+    Type.Object({
+      creativity: optionalStringEnum(SUPPORTED_FAL_CREATIVITY, {
+        description: "fal Krea creativity: raw, low, medium, high.",
+      }),
     }),
   ),
   count: Type.Optional(
@@ -276,7 +286,7 @@ function normalizeAspectRatio(raw: string | undefined): string | undefined {
     return normalized;
   }
   throw new ToolInputError(
-    "aspectRatio must be one of 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9",
+    "aspectRatio must be one of 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9",
   );
 }
 
@@ -339,6 +349,17 @@ function normalizeOpenAIModeration(
   throw new ToolInputError("openai.moderation must be one of low or auto");
 }
 
+function normalizeFalCreativity(raw: string | undefined): FalCreativity | undefined {
+  const normalized = raw?.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if ((SUPPORTED_FAL_CREATIVITY as readonly string[]).includes(normalized)) {
+    return normalized as FalCreativity;
+  }
+  throw new ToolInputError("fal.creativity must be one of raw, low, medium, or high");
+}
+
 function readRecordParam(params: Record<string, unknown>, key: string): Record<string, unknown> {
   const raw = params[key];
   return raw && typeof raw === "object" && !Array.isArray(raw)
@@ -371,8 +392,13 @@ function normalizeOpenAIOptions(args: Record<string, unknown>): ImageGenerationO
 function normalizeProviderOptions(
   args: Record<string, unknown>,
 ): ImageGenerationProviderOptions | undefined {
+  const falRaw = readRecordParam(args, "fal");
+  const falCreativity = normalizeFalCreativity(readStringParam(falRaw, "creativity"));
   const openai = normalizeOpenAIOptions(args);
-  return Object.keys(openai).length > 0 ? { openai } : undefined;
+  const fal = falCreativity ? { creativity: falCreativity } : undefined;
+  return fal || Object.keys(openai).length > 0
+    ? { ...(fal ? { fal } : {}), ...(Object.keys(openai).length > 0 ? { openai } : {}) }
+    : undefined;
 }
 
 function normalizeReferenceImages(args: Record<string, unknown>): string[] {
@@ -396,6 +422,35 @@ function resolveSelectedImageGenerationProvider(params: {
     modelOverride: params.modelOverride,
     parseModelRef: parseImageGenerationModelRef,
   });
+}
+
+function resolveSelectedImageGenerationModelId(params: {
+  selectedProvider: ImageGenerationProvider | undefined;
+  imageGenerationModelConfig: ToolModelConfig;
+  modelOverride?: string;
+  explicitModelRef: { provider: string; model: string } | null;
+  primaryModelRef: { provider: string; model: string } | null;
+}): string | undefined {
+  const selectedProviderId = params.selectedProvider?.id;
+  const explicitModelRef = params.explicitModelRef;
+  const primaryModelRef = params.primaryModelRef;
+  if (params.modelOverride !== undefined) {
+    if (explicitModelRef && explicitModelRef.provider === selectedProviderId) {
+      return explicitModelRef.model;
+    }
+    if (params.selectedProvider?.models?.includes(params.modelOverride)) {
+      return params.modelOverride;
+    }
+    return explicitModelRef?.model ?? params.modelOverride;
+  }
+  if (primaryModelRef && primaryModelRef.provider === selectedProviderId) {
+    return primaryModelRef.model;
+  }
+  return params.imageGenerationModelConfig.primary ?? params.selectedProvider?.defaultModel;
+}
+
+function isFalKreaImageModel(provider: ImageGenerationProvider | undefined, modelId?: string) {
+  return provider?.id === "fal" && modelId?.startsWith("krea/v2/") === true;
 }
 
 function formatIgnoredImageGenerationOverride(override: ImageGenerationIgnoredOverride): string {
@@ -874,6 +929,13 @@ export function createImageGenerateTool(options?: {
       });
       const explicitModelRef = parseImageGenerationModelRef(model);
       const primaryModelRef = parseImageGenerationModelRef(imageGenerationModelConfig.primary);
+      const selectedModelId = resolveSelectedImageGenerationModelId({
+        selectedProvider,
+        imageGenerationModelConfig,
+        modelOverride: model,
+        explicitModelRef,
+        primaryModelRef,
+      });
       const count = resolveRequestedCount(params);
       const requestKey = buildMediaGenerationRequestKey({
         tool: "image_generate",
@@ -916,9 +978,13 @@ export function createImageGenerateTool(options?: {
         inputImages.length > 0
           ? selectedProvider?.capabilities.edit
           : selectedProvider?.capabilities.generate;
+      const suppressInferredResolution =
+        inputImages.length > 0 &&
+        !explicitResolution &&
+        isFalKreaImageModel(selectedProvider, selectedModelId);
       const resolution =
         explicitResolution ??
-        (size || modeCaps?.supportsResolution === false
+        (size || suppressInferredResolution || modeCaps?.supportsResolution === false
           ? undefined
           : inputImages.length > 0
             ? await inferResolutionFromInputImages(inputImages)

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -970,6 +970,15 @@ export function createImageGenerateTool(options?: {
       if (duplicateGuardResult) {
         return duplicateGuardResult;
       }
+      validateImageGenerationCapabilities({
+        provider: selectedProvider,
+        count,
+        inputImageCount: imageInputs.length,
+        size,
+        aspectRatio,
+        resolution: explicitResolution,
+        explicitResolution: Boolean(explicitResolution),
+      });
       const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(effectiveCfg);
       const loadedReferenceImages = await loadReferenceImages({
         imageInputs,

--- a/src/image-generation/normalization.ts
+++ b/src/image-generation/normalization.ts
@@ -39,6 +39,7 @@ function finalizeImageNormalization(
 
 export function resolveImageGenerationOverrides(params: {
   provider: ImageGenerationProvider;
+  model?: string;
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
@@ -52,6 +53,17 @@ export function resolveImageGenerationOverrides(params: {
     ? params.provider.capabilities.edit
     : params.provider.capabilities.generate;
   const geometry = params.provider.capabilities.geometry;
+  const modelGeometry = {
+    sizes: params.model
+      ? (geometry?.sizesByModel?.[params.model] ?? geometry?.sizes)
+      : geometry?.sizes,
+    aspectRatios: params.model
+      ? (geometry?.aspectRatiosByModel?.[params.model] ?? geometry?.aspectRatios)
+      : geometry?.aspectRatios,
+    resolutions: params.model
+      ? (geometry?.resolutionsByModel?.[params.model] ?? geometry?.resolutions)
+      : geometry?.resolutions,
+  };
   const ignoredOverrides: ImageGenerationIgnoredOverride[] = [];
   const normalization: ImageGenerationNormalization = {};
   let size = params.size;
@@ -61,10 +73,10 @@ export function resolveImageGenerationOverrides(params: {
   let outputFormat = params.outputFormat;
   let background = params.background;
 
-  if (size && (geometry?.sizes?.length ?? 0) > 0 && modeCaps.supportsSize) {
+  if (size && (modelGeometry.sizes?.length ?? 0) > 0 && modeCaps.supportsSize) {
     const normalizedSize = resolveClosestSize({
       requestedSize: size,
-      supportedSizes: geometry?.sizes,
+      supportedSizes: modelGeometry.sizes,
     });
     if (normalizedSize && normalizedSize !== size) {
       normalization.size = {
@@ -81,7 +93,7 @@ export function resolveImageGenerationOverrides(params: {
       const normalizedAspectRatio = resolveClosestAspectRatio({
         requestedAspectRatio: aspectRatio,
         requestedSize: size,
-        supportedAspectRatios: geometry?.aspectRatios,
+        supportedAspectRatios: modelGeometry.aspectRatios,
       });
       if (normalizedAspectRatio) {
         aspectRatio = normalizedAspectRatio;
@@ -98,11 +110,15 @@ export function resolveImageGenerationOverrides(params: {
     size = undefined;
   }
 
-  if (aspectRatio && (geometry?.aspectRatios?.length ?? 0) > 0 && modeCaps.supportsAspectRatio) {
+  if (
+    aspectRatio &&
+    (modelGeometry.aspectRatios?.length ?? 0) > 0 &&
+    modeCaps.supportsAspectRatio
+  ) {
     const normalizedAspectRatio = resolveClosestAspectRatio({
       requestedAspectRatio: aspectRatio,
       requestedSize: size,
-      supportedAspectRatios: geometry?.aspectRatios,
+      supportedAspectRatios: modelGeometry.aspectRatios,
     });
     if (normalizedAspectRatio && normalizedAspectRatio !== aspectRatio) {
       normalization.aspectRatio = {
@@ -117,7 +133,7 @@ export function resolveImageGenerationOverrides(params: {
         ? resolveClosestSize({
             requestedSize: params.size,
             requestedAspectRatio: aspectRatio,
-            supportedSizes: geometry?.sizes,
+            supportedSizes: modelGeometry.sizes,
           })
         : undefined;
     let translated = false;
@@ -135,10 +151,10 @@ export function resolveImageGenerationOverrides(params: {
     aspectRatio = undefined;
   }
 
-  if (resolution && (geometry?.resolutions?.length ?? 0) > 0 && modeCaps.supportsResolution) {
+  if (resolution && (modelGeometry.resolutions?.length ?? 0) > 0 && modeCaps.supportsResolution) {
     const normalizedResolution = resolveClosestResolution({
       requestedResolution: resolution,
-      supportedResolutions: geometry?.resolutions,
+      supportedResolutions: modelGeometry.resolutions,
     });
     if (normalizedResolution && normalizedResolution !== resolution) {
       normalization.resolution = {

--- a/src/image-generation/runtime.test.ts
+++ b/src/image-generation/runtime.test.ts
@@ -537,6 +537,64 @@ describe("image-generation runtime", () => {
     expect(result.metadata.aspectRatioDerivedFromSize).toBe("16:9");
   });
 
+  it("uses model-specific geometry lists before provider normalization", async () => {
+    let seenRequest:
+      | {
+          size?: string;
+          aspectRatio?: string;
+        }
+      | undefined;
+    providers = [
+      {
+        id: "fal",
+        capabilities: {
+          generate: {
+            supportsSize: true,
+            supportsAspectRatio: true,
+          },
+          edit: {
+            enabled: true,
+            supportsSize: true,
+            supportsAspectRatio: true,
+          },
+          geometry: {
+            sizes: ["1024x1024", "1536x1024", "1024x1536"],
+            sizesByModel: {
+              "krea/v2/medium/text-to-image": [],
+            },
+            aspectRatios: ["1:1", "4:3", "3:2", "16:9"],
+          },
+        },
+        async generateImage(req) {
+          seenRequest = {
+            size: req.size,
+            aspectRatio: req.aspectRatio,
+          };
+          return {
+            images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+          };
+        },
+      },
+    ];
+
+    await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: { primary: "fal/krea/v2/medium/text-to-image" },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "draw a cat",
+      size: "1024x768",
+    });
+
+    expect(seenRequest).toEqual({
+      size: "1024x768",
+      aspectRatio: undefined,
+    });
+  });
+
   it("lists runtime image-generation providers through the provider registry", () => {
     const registryProviders: ImageGenerationProvider[] = [
       {

--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -98,6 +98,7 @@ export async function generateImage(
       });
       const sanitized = resolveImageGenerationOverrides({
         provider,
+        model: candidate.model,
         size: params.size,
         aspectRatio: params.aspectRatio,
         resolution: params.resolution,

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -30,7 +30,7 @@ export type ImageGenerationOpenAIOptions = {
   user?: string;
 };
 
-export type ImageGenerationProviderOptions = {
+export type ImageGenerationProviderOptions = Record<string, unknown> & {
   openai?: ImageGenerationOpenAIOptions;
 };
 

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -99,8 +99,11 @@ type ImageGenerationEditCapabilities = ImageGenerationModeCapabilities & {
 
 type ImageGenerationGeometryCapabilities = {
   sizes?: string[];
+  sizesByModel?: Record<string, string[]>;
   aspectRatios?: string[];
+  aspectRatiosByModel?: Record<string, string[]>;
   resolutions?: ImageGenerationResolution[];
+  resolutionsByModel?: Record<string, ImageGenerationResolution[]>;
 };
 
 type ImageGenerationOutputCapabilities = {

--- a/src/plugin-sdk/image-generation-core.ts
+++ b/src/plugin-sdk/image-generation-core.ts
@@ -7,6 +7,7 @@ export type {
   GeneratedImageAsset,
   ImageGenerationProvider,
   ImageGenerationProviderConfiguredContext,
+  ImageGenerationProviderOptions,
   ImageGenerationResolution,
   ImageGenerationRequest,
   ImageGenerationResult,

--- a/test/image-generation.runtime.live.test.ts
+++ b/test/image-generation.runtime.live.test.ts
@@ -175,12 +175,16 @@ function buildLiveCases(params: {
     },
   ];
   if (params.editEnabled) {
+    const providerModel = resolveProviderModelForLiveTest(params.providerId, params.modelRef);
+    const useReferenceResolution = !(
+      params.providerId === "fal" && providerModel.startsWith("krea/v2/")
+    );
     cases.push({
       id: `${params.providerId}:edit`,
       providerId: params.providerId,
       modelRef: params.modelRef,
       prompt: editPrompt,
-      resolution: "1K",
+      ...(useReferenceResolution ? { resolution: "1K" as const } : {}),
       inputImages: [
         {
           buffer: createEditReferencePng(),


### PR DESCRIPTION
## Summary

- Add a Fal image model payload registry so Krea 2 uses native `aspect_ratio`, `creativity`, and `image_style_references` instead of Flux-style `image_size` / edit endpoint payloads.
- Register canonical Fal Krea 2 Medium/Large refs and keep Nano Banana/GPT/Flux payload behavior model-specific, including model-specific geometry normalization.
- Add generic Fal provider options at the image tool layer, docs for Krea Medium/Large, and live-test handling for Krea style references.

## Verification

- `node scripts/run-vitest.mjs extensions/fal/image-generation-provider.test.ts src/agents/tools/image-generate-tool.test.ts src/image-generation/runtime.test.ts test/image-generation.runtime.live.test.ts --reporter=verbose` (126 tests passed)
- `OPENCLAW_TESTBOX=0 pnpm check:changed` (passed after rebase onto `origin/main` at `6e25112aad`)
- `pnpm check:docs` (passed)
- `git diff --check origin/main...HEAD` (passed)
- `pnpm build` (passed; existing `packages/agent-core/src/harness/messages.d.ts` relative module declaration warning)
- `FAL_KEY=<redacted from 1Password> OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_IMAGE_GENERATION_PROVIDERS=fal OPENCLAW_LIVE_IMAGE_GENERATION_MODELS='fal/krea/v2/medium/text-to-image' OPENCLAW_LIVE_IMAGE_GENERATION_CASES='fal:generate,fal:edit' OPENCLAW_LIVE_IMAGE_GENERATION_TIMEOUT_MS=180000 pnpm test:live test/image-generation.runtime.live.test.ts --reporter=verbose` (generate/edit passed)
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)

Testbox note: delegated `pnpm check:changed` runs `tbx_01ksrkzeabhkns0029mbz0wbhg` and `tbx_01ksrm1ce8rk16nmj4h4rvh3x9` failed before checks with `fatal: origin/main...HEAD: no merge base`; local and CI checks are the usable proof for this branch.

## Real behavior proof

Behavior addressed: Fal Krea 2 Medium/Large now use model-specific payload schemas, including canonical `fal/krea/v2/...` refs, style references, native aspect ratio, creativity, unsupported override rejection, and model-specific Fal geometry handling.
Real environment tested: Local OpenClaw checkout plus live Fal API with FAL_KEY read from 1Password and redacted in logs.
Exact steps or command run after this patch: `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_IMAGE_GENERATION_PROVIDERS=fal OPENCLAW_LIVE_IMAGE_GENERATION_MODELS='fal/krea/v2/medium/text-to-image' OPENCLAW_LIVE_IMAGE_GENERATION_CASES='fal:generate,fal:edit' OPENCLAW_LIVE_IMAGE_GENERATION_TIMEOUT_MS=180000 pnpm test:live test/image-generation.runtime.live.test.ts --reporter=verbose`.
Evidence after fix: Live output reported `fal:generate:krea/v2/medium/text-to-image` and `fal:edit:krea/v2/medium/text-to-image`, skipped none, failures none.
Observed result after fix: Both live generate and style-reference edit returned image buffers.
What was not tested: Live Krea Large and live Nano Banana were not run; their payload behavior is covered by focused provider/runtime tests.
