### PR TITLE
fix(status): resolve gateway auth secrets for deep audit

### DIFF
--- a/src/cli/command-secret-targets.import.test.ts
+++ b/src/cli/command-secret-targets.import.test.ts
@@ -165,6 +165,10 @@ describe("command secret targets module import", () => {
     expect(targets.has("channels.discord.token")).toBe(false);
     expect(targets.has("channels.telegram.gatewayToken")).toBe(false);
     expect(targets.has("channels.telegram.gatewayTokenRef")).toBe(false);
+    expect(targets.has("gateway.auth.token")).toBe(true);
+    expect(targets.has("gateway.auth.password")).toBe(true);
+    expect(targets.has("gateway.remote.token")).toBe(true);
+    expect(targets.has("gateway.remote.password")).toBe(true);
     expect(targets.has("agents.defaults.memorySearch.remote.apiKey")).toBe(true);
     const pluginCall = listReadOnlyChannelPluginsForConfig.mock.calls[0] as unknown as
       | [unknown, { includePersistedAuthState?: boolean }]
@@ -202,6 +206,10 @@ describe("command secret targets module import", () => {
     );
 
     expect(targets.has("agents.defaults.memorySearch.remote.apiKey")).toBe(true);
+    expect(targets.has("gateway.auth.token")).toBe(true);
+    expect(targets.has("gateway.auth.password")).toBe(true);
+    expect(targets.has("gateway.remote.token")).toBe(true);
+    expect(targets.has("gateway.remote.password")).toBe(true);
     expect(targets.has("channels.telegram.botToken")).toBe(false);
     expect(listReadOnlyChannelPluginsForConfig).not.toHaveBeenCalled();
     expect(listSecretTargetRegistryEntries).not.toHaveBeenCalled();

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -249,6 +249,7 @@ import {
   getQrRemoteCommandSecretTargetIds,
   getScopedChannelsCommandSecretTargets,
   getSecurityAuditCommandSecretTargetIds,
+  getStatusCommandSecretTargetIds,
 } from "./command-secret-targets.js";
 
 describe("command secret target ids", () => {
@@ -270,6 +271,20 @@ describe("command secret target ids", () => {
     expect(ids.has("agents.list[].memorySearch.remote.apiKey")).toBe(true);
     expect(ids.has("plugins.entries.firecrawl.config.webFetch.apiKey")).toBe(true);
     expect(ids.has("plugins.entries.exa.config.webSearch.apiKey")).toBe(true);
+    expect(ids.has("channels.discord.token")).toBe(false);
+  });
+
+  it("includes gateway auth targets for status command scans", () => {
+    const ids = getStatusCommandSecretTargetIds(undefined, undefined, {
+      includeChannelTargets: false,
+    });
+
+    expect(ids.has("gateway.auth.token")).toBe(true);
+    expect(ids.has("gateway.auth.password")).toBe(true);
+    expect(ids.has("gateway.remote.token")).toBe(true);
+    expect(ids.has("gateway.remote.password")).toBe(true);
+    expect(ids.has("agents.defaults.memorySearch.remote.apiKey")).toBe(true);
+    expect(ids.has("agents.list[].memorySearch.remote.apiKey")).toBe(true);
     expect(ids.has("channels.discord.token")).toBe(false);
   });
 

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -54,16 +54,18 @@ const STATIC_TTS_TARGET_IDS = [
   "agents.list[].tts.providers.*.apiKey",
   "messages.tts.providers.*.apiKey",
 ] as const;
-const STATIC_STATUS_TARGET_IDS = [
-  "agents.defaults.memorySearch.remote.apiKey",
-  "agents.list[].memorySearch.remote.apiKey",
-] as const;
-const STATIC_SECURITY_AUDIT_TARGET_IDS = [
+const STATIC_GATEWAY_AUTH_TARGET_IDS = [
   "gateway.auth.token",
   "gateway.auth.password",
   "gateway.remote.token",
   "gateway.remote.password",
 ] as const;
+const STATIC_STATUS_TARGET_IDS = [
+  ...STATIC_GATEWAY_AUTH_TARGET_IDS,
+  "agents.defaults.memorySearch.remote.apiKey",
+  "agents.list[].memorySearch.remote.apiKey",
+] as const;
+const STATIC_SECURITY_AUDIT_TARGET_IDS = [...STATIC_GATEWAY_AUTH_TARGET_IDS] as const;
 
 function idsByPrefix(prefixes: readonly string[]): string[] {
   return listSecretTargetRegistryEntries()


### PR DESCRIPTION
## Summary

- Fix `status --deep` so gateway auth SecretRefs are resolved before the embedded security audit runs.
- Share the gateway auth target list with the security-audit command target list to keep both command paths aligned.
- Add focused coverage for status target selection, including the import-safe path that avoids channel/plugin registry discovery.

Fixes #87815.

## Verification

- `pnpm test src/cli/command-secret-targets.test.ts src/cli/command-secret-targets.import.test.ts`
- `pnpm test src/commands/status.scan-overview.test.ts src/commands/status.scan.test.ts src/commands/status.scan.fast-json.test.ts src/security/audit-gateway-http-auth.test.ts`
- `git diff --check`

## Real behavior proof

content: behavior

environment: Ubuntu 26.04, Node 22.22.2, OpenClaw source checkout at `c3ff31e7`, isolated config/state under `/tmp/openclaw-87815-proof`, gateway token supplied through a SecretRef to `OPENCLAW_GATEWAY_TOKEN`.

steps:
1. Created an isolated config with `gateway.auth.mode="token"` and `gateway.auth.token` as an env SecretRef.
2. Started a real local gateway from the built checkout on port `28815`.
3. Ran `status --deep` against the same isolated config and SecretRef-backed token.

evidence:

```text
Secret diagnostics:
- gateway.auth.token: gateway token env var is configured.

Gateway              local · ws://127.0.0.1:28815 (local loopback) · reachable 908ms · auth token

Security audit
Summary: 0 critical · 1 warn · 1 info
  WARN Reverse proxy headers are not trusted
    gateway.bind is loopback and gateway.trustedProxies is empty.
```

observedResult: `status --deep` reports the gateway as reachable with `auth token`, and the embedded security audit does not emit `gateway.http.no_auth` or claim `gateway.auth.mode="none"` for the SecretRef-backed token config.

notTested: A packaged install/service upgrade E2E was not run. The proof uses a real source-checkout gateway/status run with isolated config and focused regression tests for the command target selection path.
