### PR TITLE
fix(agents): avoid constructing lean local model tools

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -578,6 +578,34 @@ describe("createOpenClawCodingTools", () => {
     expectListIncludes(latestCreateOpenClawToolsOptions().pluginToolDenylist, ["pdf"]);
   });
 
+  it("pushes local-model lean tool cuts into construction", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+
+    const tools = createOpenClawCodingTools({
+      config: {
+        agents: {
+          defaults: {
+            experimental: {
+              localModelLean: true,
+            },
+          },
+        },
+      },
+    });
+
+    const names = toolNameList(tools);
+    expect(names).not.toContain("browser");
+    expect(names).not.toContain("cron");
+    expect(names).not.toContain("message");
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const options = latestCreateOpenClawToolsOptions();
+    expect(options.disableMessageTool).toBe(true);
+    expect(options.disableCronTool).toBe(true);
+    expectListIncludes(options.pluginToolDenylist, ["browser", "cron", "message"]);
+    expectListIncludes(options.inheritedToolDenylist, ["browser", "cron", "message"]);
+  });
+
   it("passes inherited allowlist entries to OpenClaw plugin discovery", async () => {
     const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
     createOpenClawToolsMock.mockClear();

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -56,7 +56,11 @@ import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
-import { filterLocalModelLeanTools } from "./local-model-lean.js";
+import {
+  filterLocalModelLeanTools,
+  isLocalModelLeanEnabled,
+  listLocalModelLeanDeniedToolNames,
+} from "./local-model-lean.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
@@ -648,6 +652,14 @@ export function createOpenClawCodingTools(options?: {
   const includeOpenClawTools = includeCoreTools && toolConstructionPlan.includeOpenClawTools;
   const includeChannelTools = toolConstructionPlan.includeChannelTools;
   const includePluginTools = toolConstructionPlan.includePluginTools;
+  const localModelLeanEnabled = isLocalModelLeanEnabled({
+    config: options?.config,
+    agentId: options?.agentId,
+    sessionKey: options?.sessionKey,
+  });
+  const localModelLeanDeniedToolNames = localModelLeanEnabled
+    ? listLocalModelLeanDeniedToolNames()
+    : [];
   const workspaceOnly = fsPolicy.workspaceOnly;
   const skillReadRoots = sandboxRoot ? undefined : resolveSkillReadRoots(options?.skillsSnapshot);
   const applyPatchConfig = execConfig.applyPatch;
@@ -810,7 +822,7 @@ export function createOpenClawCodingTools(options?: {
     inheritedToolPolicy,
     options?.runtimeToolAllowlist ? { allow: options.runtimeToolAllowlist } : undefined,
   ]);
-  const pluginToolDenylist = collectExplicitDenylist([
+  const configuredPluginToolDenylist = collectExplicitDenylist([
     profilePolicy,
     providerProfilePolicy,
     globalPolicy,
@@ -823,6 +835,10 @@ export function createOpenClawCodingTools(options?: {
     subagentPolicy,
     inheritedToolPolicy,
   ]);
+  const pluginToolDenylist =
+    localModelLeanDeniedToolNames.length > 0
+      ? [...new Set([...configuredPluginToolDenylist, ...localModelLeanDeniedToolNames])]
+      : configuredPluginToolDenylist;
   const inheritedToolDenylist = [...pluginToolDenylist];
   // Passed by reference to sessions_spawn and populated after the final policy
   // pass so child sessions inherit the actual parent tool surface.
@@ -869,7 +885,7 @@ export function createOpenClawCodingTools(options?: {
             modelId: options?.modelId,
             modelHasVision: options?.modelHasVision,
             requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
-            disableMessageTool: options?.disableMessageTool,
+            disableMessageTool: options?.disableMessageTool || localModelLeanEnabled,
             requesterAgentIdOverride: agentId,
             allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
             authProfileStore: options?.authProfileStore,
@@ -959,7 +975,8 @@ export function createOpenClawCodingTools(options?: {
           requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
           sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
-          disableMessageTool: options?.disableMessageTool,
+          disableMessageTool: options?.disableMessageTool || localModelLeanEnabled,
+          disableCronTool: localModelLeanEnabled,
           enableHeartbeatTool,
           disablePluginTools: !includePluginTools,
           wrapBeforeToolCallHook: false,

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
-import { filterLocalModelLeanTools, isLocalModelLeanEnabled } from "./local-model-lean.js";
+import {
+  filterLocalModelLeanTools,
+  isLocalModelLeanEnabled,
+  listLocalModelLeanDeniedToolNames,
+} from "./local-model-lean.js";
 
 function tools(names: string[]): AnyAgentTool[] {
   return names.map((name) => ({ name })) as AnyAgentTool[];
 }
 
 describe("local model lean tool filtering", () => {
+  it("keeps the construction denylist aligned with the final filter", () => {
+    expect(listLocalModelLeanDeniedToolNames()).toEqual(["browser", "cron", "message"]);
+  });
+
   it("filters heavyweight tools for one configured agent", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -3,7 +3,12 @@ import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.j
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope-config.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 
-const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set(["browser", "cron", "message"]);
+const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = ["browser", "cron", "message"] as const;
+const LOCAL_MODEL_LEAN_DENY_TOOL_NAME_SET = new Set<string>(LOCAL_MODEL_LEAN_DENY_TOOL_NAMES);
+
+export function listLocalModelLeanDeniedToolNames(): string[] {
+  return [...LOCAL_MODEL_LEAN_DENY_TOOL_NAMES];
+}
 
 function resolveLocalModelLeanAgentId(params: {
   config?: OpenClawConfig;
@@ -47,5 +52,5 @@ export function filterLocalModelLeanTools(params: {
   if (!isLocalModelLeanEnabled(params)) {
     return params.tools;
   }
-  return params.tools.filter((tool) => !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(tool.name));
+  return params.tools.filter((tool) => !LOCAL_MODEL_LEAN_DENY_TOOL_NAME_SET.has(tool.name));
 }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -130,6 +130,8 @@ export function createOpenClawTools(
     inboundEventKind?: InboundEventKind;
     /** If true, omit the message tool from the tool list. */
     disableMessageTool?: boolean;
+    /** If true, omit the cron tool from the tool list. */
+    disableCronTool?: boolean;
     /** If true, include the heartbeat response tool for structured heartbeat outcomes. */
     enableHeartbeatTool?: boolean;
     /** If true, skip plugin tool resolution and return only shipped core tools. */
@@ -346,6 +348,21 @@ export function createOpenClawTools(
   });
   options?.recordToolPrepStage?.("openclaw-tools:nodes-tool");
   const embedded = isEmbeddedMode();
+  const cronTool =
+    embedded || options?.disableCronTool
+      ? null
+      : createCronTool({
+          agentSessionKey: options?.agentSessionKey,
+          currentDeliveryContext: {
+            channel: options?.agentChannel,
+            to: options?.currentChannelId ?? options?.agentTo,
+            accountId: options?.agentAccountId,
+            threadId: options?.currentThreadTs ?? options?.agentThreadId,
+          },
+          ...(options?.cronSelfRemoveOnlyJobId
+            ? { selfRemoveOnlyJobId: options.cronSelfRemoveOnlyJobId }
+            : {}),
+        });
   const explicitFactoryAllowlist = mergeFactoryPolicyList(
     resolvedConfig?.tools?.allow,
     resolvedConfig?.tools?.alsoAllow,
@@ -379,23 +396,7 @@ export function createOpenClawTools(
   });
   const includeTranscriptsTool = resolveTranscriptsConfig(resolvedConfig?.transcripts).enabled;
   const tools: AnyAgentTool[] = [
-    ...(embedded
-      ? []
-      : [
-          nodesTool,
-          createCronTool({
-            agentSessionKey: options?.agentSessionKey,
-            currentDeliveryContext: {
-              channel: options?.agentChannel,
-              to: options?.currentChannelId ?? options?.agentTo,
-              accountId: options?.agentAccountId,
-              threadId: options?.currentThreadTs ?? options?.agentThreadId,
-            },
-            ...(options?.cronSelfRemoveOnlyJobId
-              ? { selfRemoveOnlyJobId: options.cronSelfRemoveOnlyJobId }
-              : {}),
-          }),
-        ]),
+    ...(embedded ? [] : collectPresentOpenClawTools([nodesTool, cronTool])),
     ...(messageTool && includeMessageTool ? [messageTool] : []),
     ...collectPresentOpenClawTools([heartbeatTool]),
     createTtsTool({

--- a/src/agents/openclaw-tools.update-plan.test.ts
+++ b/src/agents/openclaw-tools.update-plan.test.ts
@@ -85,6 +85,16 @@ describe("openclaw-tools update_plan gating", () => {
     expect(shouldIncludeUpdatePlanToolForOpenClawTools(emptyAllowlistParams)).toBe(false);
   });
 
+  it("can skip cron tool construction", () => {
+    const tools = createFastToolNames({
+      config: {} as OpenClawConfig,
+      disableCronTool: true,
+    });
+
+    expect(tools).toContain("nodes");
+    expect(tools).not.toContain("cron");
+  });
+
   it("wraps constructed tools with before-tool-call hooks by default", () => {
     const tools = createOpenClawTools({
       config: {} as OpenClawConfig,


### PR DESCRIPTION
## Summary
- Apply `localModelLean` before constructing the heavyweight built-in tool surface.
- Skip constructing `browser`, `cron`, and `message` tools when lean mode denies them.
- Pass the same lean denylist through plugin and inherited tool construction so local models do not pay for tools they cannot use.

Refs #86599.

## Verification
- `git diff --check origin/main...HEAD`
- `node_modules/.bin/oxfmt --check src/agents/agent-tools.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/local-model-lean.ts src/agents/local-model-lean.test.ts src/agents/openclaw-tools.ts src/agents/openclaw-tools.update-plan.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/agents/local-model-lean.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/openclaw-tools.update-plan.test.ts --reporter=dot` (142 tests passed after rebase onto `f3cfd752`)
- AWS Crabbox `check:changed`: provider `aws`, lease `cbx_22f45e709982`, run `run_f5df43a422d5`, exit 0 on base `6f9d5e1b`

## Real behavior proof
Behavior addressed: local-model lean mode no longer constructs the denied `browser`, `cron`, or `message` tool surfaces before filtering them away.
Real environment tested: focused local Vitest wrapper in a Codex worktree plus AWS Crabbox Linux changed gate.
Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --timing-json --idle-timeout 60m --ttl 120m --shell -- "pnpm check:changed"`
Evidence after fix: `run_f5df43a422d5` completed with exit 0 on provider `aws`, lease `cbx_22f45e709982`; clean rebases through `f3cfd752` then passed diff/format and the 142-test focused suite.
Observed result after fix: core/coreTests changed lanes passed, including typecheck, lint, guards, and import-cycle checks.
What was not tested: a live Windows local-model starvation repro; this PR reduces lean-mode tool construction pressure but does not claim to close every #86599 contributor.
