### PR TITLE
fix(agents): preserve logical OpenAI session routes

### DIFF
--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -13,6 +13,7 @@ import type * as ManifestRegistryModule from "../plugins/manifest-registry.js";
 import { runAgentAttempt } from "./command/attempt-execution.js";
 import type { RunEmbeddedAgentParams } from "./embedded-agent-runner/run/params.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent.js";
+import { resolveOpenAIRuntimeProvider } from "./openai-codex-routing.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 type LoadPluginManifestRegistry = typeof ManifestRegistryModule.loadPluginManifestRegistry;
@@ -410,7 +411,7 @@ describe("Auth profile runtime contract - embedded OpenClaw and CLI adapter", ()
     );
   });
 
-  it("routes explicit OpenAI OpenClaw runs with Codex OAuth through OpenAI Codex transport", async () => {
+  it("keeps explicit OpenAI OpenClaw runs logical while preserving Codex OAuth transport", async () => {
     await runAuthContractAttempt({
       tmpDir,
       storePath,
@@ -421,8 +422,27 @@ describe("Auth profile runtime contract - embedded OpenClaw and CLI adapter", ()
     });
 
     const params = capturedEmbeddedRunParams();
-    expect(params.provider).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider);
+    expect(params.provider).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider);
+    expect(params.agentHarnessId).toBe("openclaw");
     expect(params.authProfileId).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId);
+    const provider = params.provider;
+    const authProfileId = params.authProfileId;
+    if (!provider) {
+      throw new Error("expected logical provider to be forwarded");
+    }
+    if (!authProfileId) {
+      throw new Error("expected Codex auth profile to be forwarded");
+    }
+    expect(
+      resolveOpenAIRuntimeProvider({
+        provider,
+        harnessRuntime: params.agentHarnessId,
+        authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+        authProfileId,
+        config: providerRuntimeConfig(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider, "openclaw"),
+        workspaceDir: tmpDir,
+      }),
+    ).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider);
   });
 
   it("preserves OpenAI Codex auth profiles through the real codex/* harness startup path", async () => {

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1763,7 +1763,7 @@ describe("embedded attempt harness pinning", () => {
     });
   });
 
-  it("routes explicit OpenAI native runs with Codex OAuth through OpenClaw and the legacy Codex auth transport", async () => {
+  it("routes explicit OpenAI native runs with Codex OAuth through OpenClaw without changing the logical provider", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "explicit-agent-codex-oauth-session",
       updatedAt: Date.now(),
@@ -1813,7 +1813,7 @@ describe("embedded attempt harness pinning", () => {
     });
 
     expectMockArgFields(runEmbeddedAgentMock, {
-      provider: "openai-codex",
+      provider: "openai",
       model: "gpt-5.4",
       agentHarnessId: "openclaw",
       agentHarnessRuntimeOverride: "openclaw",

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -678,7 +678,7 @@ export function runAgentAttempt(params: {
     images: params.isFallbackRetry ? undefined : params.opts.images,
     imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
     clientTools: params.opts.clientTools,
-    provider: embeddedAgentProvider,
+    provider: params.providerOverride,
     model: params.modelOverride,
     modelFallbacksOverride: params.modelFallbacksOverride,
     authProfileId,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -238,6 +238,55 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("persists logical OpenAI provider for Codex-backed OpenAI runtime metadata", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-codex-route-normalize";
+      const sessionId = "test-codex-route-normalize-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedAgentRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            sessionId,
+            provider: "openai-codex",
+            model: "gpt-5.5",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+        result,
+      });
+
+      expect(sessionStore[sessionKey]?.modelProvider).toBe("openai");
+      expect(sessionStore[sessionKey]?.model).toBe("gpt-5.5");
+      expect(loadSessionStore(storePath)[sessionKey]?.modelProvider).toBe("openai");
+    });
+  });
+
   it("clears the embedded harness pin after a CLI run", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -16,6 +16,7 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { clearCliSession, setCliSessionBinding, setCliSessionId } from "../cli-session.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isCliProvider } from "../model-selection.js";
+import { resolveUserFacingSessionProvider } from "../openai-codex-routing.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../usage.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../embedded-agent.js"))["runEmbeddedAgent"]>>;
@@ -100,6 +101,13 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const compactionsThisRun = Math.max(0, result.meta.agentMeta?.compactionCount ?? 0);
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
+  const sessionRouteProviderUsed = resolveUserFacingSessionProvider({
+    provider: providerUsed,
+    model: modelUsed,
+    configuredProvider: defaultProvider,
+    fallbackProvider,
+    config: cfg,
+  });
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
   const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;
@@ -159,7 +167,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
     // should not establish initial model state on an empty session.
   } else {
     setSessionRuntimeModel(next, {
-      provider: providerUsed,
+      provider: sessionRouteProviderUsed,
       model: modelUsed,
     });
   }

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2838,7 +2838,8 @@ export async function runEmbeddedAgent(
             lastTurnTotal,
           });
           const reportedModelRef = resolveReportedModelRef({
-            provider,
+            provider: modelConfigProvider,
+            runtimeProvider: provider,
             model: model.id,
             assistant: sessionLastAssistant,
           });

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   buildErrorAgentMeta,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
+  resolveReportedModelRef,
 } from "./helpers.js";
 
 function makeAssistantMessage(
@@ -76,6 +77,41 @@ describe("resolveFinalAssistantVisibleText", () => {
     ]);
 
     expect(resolveFinalAssistantRawText(lastAssistant)).toBe("<final>keep this</final>");
+  });
+});
+
+describe("resolveReportedModelRef", () => {
+  it("reports the logical provider when Codex is only the runtime transport", () => {
+    expect(
+      resolveReportedModelRef({
+        provider: "openai",
+        runtimeProvider: "openai-codex",
+        model: "gpt-5.5",
+        assistant: { provider: "openai-codex", model: "gpt-5.5" },
+      }),
+    ).toEqual({ provider: "openai", model: "gpt-5.5" });
+  });
+
+  it("preserves explicit openai-codex selections", () => {
+    expect(
+      resolveReportedModelRef({
+        provider: "openai-codex",
+        runtimeProvider: "openai-codex",
+        model: "gpt-5.5",
+        assistant: { provider: "openai-codex", model: "gpt-5.5" },
+      }),
+    ).toEqual({ provider: "openai-codex", model: "gpt-5.5" });
+  });
+
+  it("keeps true cross-provider fallback reports", () => {
+    expect(
+      resolveReportedModelRef({
+        provider: "openai",
+        runtimeProvider: "openai-codex",
+        model: "gpt-5.5",
+        assistant: { provider: "anthropic", model: "claude-sonnet-4-6" },
+      }),
+    ).toEqual({ provider: "anthropic", model: "claude-sonnet-4-6" });
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -121,6 +121,7 @@ function isEmbeddedHarnessProvider(provider: string): boolean {
 
 export function resolveReportedModelRef(params: {
   provider: string;
+  runtimeProvider?: string;
   model: string;
   assistant?: { provider?: string; model?: string } | null;
 }): {
@@ -139,6 +140,17 @@ export function resolveReportedModelRef(params: {
     return {
       provider: params.provider,
       model: params.model,
+    };
+  }
+  const runtimeProvider = params.runtimeProvider?.trim();
+  if (
+    runtimeProvider &&
+    assistantProvider === runtimeProvider &&
+    runtimeProvider !== params.provider
+  ) {
+    return {
+      provider: params.provider,
+      model: assistantModel || params.model,
     };
   }
   return {

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -204,4 +204,15 @@ describe("OpenAI Codex routing policy", () => {
       }),
     ).toBe("openai-codex");
   });
+
+  it("preserves explicit final openai-codex fallbacks from configured OpenAI routes", () => {
+    expect(
+      resolveUserFacingSessionProvider({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        configuredProvider: "openai",
+        fallbackProvider: "openai-codex",
+      }),
+    ).toBe("openai-codex");
+  });
 });

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -6,6 +6,7 @@ import {
   openAIProviderUsesCodexRuntimeByDefault,
   resolveOpenAIRuntimeProvider,
   resolveSelectedOpenAIRuntimeProvider,
+  resolveUserFacingSessionProvider,
 } from "./openai-codex-routing.js";
 
 describe("OpenAI Codex routing policy", () => {
@@ -167,5 +168,40 @@ describe("OpenAI Codex routing policy", () => {
         harnessRuntime: "codex",
       }),
     ).toBe("anthropic");
+  });
+
+  it("normalizes internal Codex transport providers back to configured OpenAI session routes", () => {
+    expect(
+      resolveUserFacingSessionProvider({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        configuredProvider: "openai",
+      }),
+    ).toBe("openai");
+    expect(
+      resolveUserFacingSessionProvider({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
+      }),
+    ).toBe("openai");
+  });
+
+  it("preserves explicit openai-codex session routes", () => {
+    expect(
+      resolveUserFacingSessionProvider({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        configuredProvider: "openai-codex",
+      }),
+    ).toBe("openai-codex");
   });
 });

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -195,6 +195,9 @@ export function resolveUserFacingSessionProvider(params: {
   }
   const configuredProvider = normalizeProviderId(params.configuredProvider ?? "");
   const fallbackProvider = normalizeProviderId(params.fallbackProvider ?? "");
+  if (fallbackProvider === OPENAI_CODEX_PROVIDER_ID) {
+    return params.provider;
+  }
   if (
     configuredProvider === OPENAI_PROVIDER_ID ||
     fallbackProvider === OPENAI_PROVIDER_ID ||

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -169,6 +169,46 @@ export function resolveOpenAIRuntimeProvider(params: {
     : params.provider;
 }
 
+function configRouteUsesCodexRuntime(params: {
+  config?: OpenClawConfig;
+  provider: string;
+  model?: string;
+}): boolean {
+  const model = params.model?.trim();
+  if (!model || normalizeProviderId(params.provider) !== OPENAI_PROVIDER_ID) {
+    return false;
+  }
+  const route = params.config?.agents?.defaults?.models?.[`${OPENAI_PROVIDER_ID}/${model}`];
+  return normalizeOptionalAgentRuntimeId(route?.agentRuntime?.id) === "codex";
+}
+
+export function resolveUserFacingSessionProvider(params: {
+  provider: string;
+  model?: string;
+  configuredProvider?: string;
+  fallbackProvider?: string;
+  config?: OpenClawConfig;
+}): string {
+  const provider = normalizeProviderId(params.provider);
+  if (provider !== OPENAI_CODEX_PROVIDER_ID) {
+    return params.provider;
+  }
+  const configuredProvider = normalizeProviderId(params.configuredProvider ?? "");
+  const fallbackProvider = normalizeProviderId(params.fallbackProvider ?? "");
+  if (
+    configuredProvider === OPENAI_PROVIDER_ID ||
+    fallbackProvider === OPENAI_PROVIDER_ID ||
+    configRouteUsesCodexRuntime({
+      config: params.config,
+      provider: OPENAI_PROVIDER_ID,
+      model: params.model,
+    })
+  ) {
+    return OPENAI_PROVIDER_ID;
+  }
+  return params.provider;
+}
+
 export function resolveSelectedOpenAIRuntimeProvider(params: {
   provider: string;
   harnessRuntime?: string;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2169,7 +2169,7 @@ export async function runAgentTurnWithFallback(params: {
                     groupSpace: normalizeOptionalString(params.sessionCtx.GroupSpace),
                     ...senderContext,
                     ...runBaseParams,
-                    provider: embeddedRunProvider,
+                    provider,
                     agentHarnessId: embeddedRunHarnessOverride,
                     agentHarnessRuntimeOverride: embeddedRunHarnessOverride,
                     sandboxSessionKey: params.runtimePolicySessionKey,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
 import {
@@ -407,6 +408,46 @@ describe("runReplyAgent heartbeat followup guard", () => {
       const { run } = createMinimalRun();
       await expect(run()).rejects.toThrow("persist exploded");
       expect(vi.mocked(scheduleFollowupDrain)).toHaveBeenCalledTimes(1);
+    } finally {
+      persistSpy.mockRestore();
+    }
+  });
+
+  it("keeps Codex runtime provider separate from the persisted OpenAI session route", async () => {
+    const accounting = await import("./session-run-accounting.js");
+    const persistSpy = vi.spyOn(accounting, "persistRunSessionUsage");
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          usage: { input: 1, output: 1 },
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        },
+      },
+    });
+
+    try {
+      const { run } = createMinimalRun({
+        runOverrides: {
+          provider: "openai",
+          model: "gpt-5.5",
+          config: {
+            agents: {
+              defaults: {
+                models: {
+                  "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+                },
+              },
+            },
+          } as OpenClawConfig,
+        },
+      });
+      await run();
+
+      const persistCall = persistSpy.mock.calls[0]?.[0];
+      expect(persistCall?.providerUsed).toBe("openai-codex");
+      expect(persistCall?.sessionRouteProviderUsed).toBe("openai");
     } finally {
       persistSpy.mockRestore();
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -13,6 +13,7 @@ import {
 } from "../../agents/embedded-agent-runner/runs.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
+import { resolveUserFacingSessionProvider } from "../../agents/openai-codex-routing.js";
 import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
 import { enqueueCommitmentExtraction } from "../../commitments/runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -1552,6 +1553,13 @@ export async function runReplyAgent(params: {
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
     const providerUsed =
       runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
+    const sessionRouteProviderUsed = resolveUserFacingSessionProvider({
+      provider: providerUsed,
+      model: modelUsed,
+      configuredProvider: followupRun.run.provider,
+      fallbackProvider,
+      config: followupRun.run.config,
+    });
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const preserveUserFacingSessionState = shouldPreserveUserFacingSessionStateForInputProvenance(
       followupRun.run.inputProvenance,
@@ -1634,6 +1642,7 @@ export async function runReplyAgent(params: {
       preserveUserFacingSessionModelState: preserveUserFacingSessionState,
       modelUsed,
       providerUsed,
+      sessionRouteProviderUsed,
       contextTokensUsed,
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2527,6 +2527,60 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     persistSpy.mockRestore();
   });
 
+  it("keeps Codex runtime provider separate from the persisted OpenAI session route", async () => {
+    const storePath = "/tmp/openclaw-followup-codex-route-provider.json";
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = { sessionId: "session", updatedAt: Date.now() };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    const persistSpy = vi.spyOn(sessionRunAccounting, "persistRunSessionUsage");
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      meta: {
+        agentMeta: {
+          usage: { input: 10, output: 5 },
+          model: "gpt-5.5",
+          provider: "openai-codex",
+        },
+      },
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply: createAsyncReplySpy() },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "openai/gpt-5.5",
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+    });
+
+    await expect(
+      runner(
+        createQueuedRun({
+          run: {
+            provider: "openai",
+            model: "gpt-5.5",
+            config: {
+              agents: {
+                defaults: {
+                  models: {
+                    "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+                  },
+                },
+              },
+            } as OpenClawConfig,
+          },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    const persistCall = requireMockCallArg(persistSpy, 0);
+    expect(persistCall.providerUsed).toBe("openai-codex");
+    expect(persistCall.sessionRouteProviderUsed).toBe("openai");
+    persistSpy.mockRestore();
+  });
+
   it("preserves user-facing session model state for queued internal announce fallback", async () => {
     const storePath = "/tmp/openclaw-followup-internal-announce-usage.json";
     const sessionKey = "main";

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -14,6 +14,7 @@ import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-p
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection-cli.js";
+import { resolveUserFacingSessionProvider } from "../../agents/openai-codex-routing.js";
 import {
   buildAgentRuntimeDeliveryPlan,
   buildAgentRuntimeOutcomePlan,
@@ -970,6 +971,13 @@ export function createFollowupRunner(params: {
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const providerUsed =
         runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider;
+      const sessionRouteProviderUsed = resolveUserFacingSessionProvider({
+        provider: providerUsed,
+        model: modelUsed,
+        configuredProvider: queued.run.provider,
+        fallbackProvider,
+        config: queued.run.config,
+      });
       const contextTokensUsed =
         resolveContextTokensForModel({
           cfg: queued.run.config,
@@ -993,6 +1001,7 @@ export function createFollowupRunner(params: {
           preserveUserFacingSessionModelState: preserveUserFacingSessionState,
           modelUsed,
           providerUsed,
+          sessionRouteProviderUsed,
           contextTokensUsed,
           systemPromptReport: runResult.meta?.systemPromptReport,
           cliSessionBinding: runResult.meta?.agentMeta?.cliSessionBinding,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -87,6 +87,7 @@ export async function persistSessionUsageUpdate(params: {
   lastCallUsage?: NormalizedUsage;
   modelUsed?: string;
   providerUsed?: string;
+  sessionRouteProviderUsed?: string;
   contextTokensUsed?: number;
   promptTokens?: number;
   usageIsContextSnapshot?: boolean;
@@ -162,10 +163,10 @@ export async function persistSessionUsageUpdate(params: {
                 providerUsed: params.providerUsed ?? entry.modelProvider,
                 modelUsed: params.modelUsed ?? entry.model,
               });
+          const sessionRouteProvider =
+            params.sessionRouteProviderUsed ?? params.providerUsed ?? entry.modelProvider;
           const patch: Partial<SessionEntry> = {
-            modelProvider: preserveSessionModelState
-              ? entry.modelProvider
-              : (params.providerUsed ?? entry.modelProvider),
+            modelProvider: preserveSessionModelState ? entry.modelProvider : sessionRouteProvider,
             model: preserveSessionModelState ? entry.model : (params.modelUsed ?? entry.model),
             ...(resolvedContextTokens !== undefined
               ? { contextTokens: resolvedContextTokens }
@@ -232,10 +233,10 @@ export async function persistSessionUsageUpdate(params: {
           const contextTokens = preserveUserFacingRunState
             ? entry.contextTokens
             : (params.contextTokensUsed ?? entry.contextTokens);
+          const sessionRouteProvider =
+            params.sessionRouteProviderUsed ?? params.providerUsed ?? entry.modelProvider;
           const patch: Partial<SessionEntry> = {
-            modelProvider: preserveSessionModelState
-              ? entry.modelProvider
-              : (params.providerUsed ?? entry.modelProvider),
+            modelProvider: preserveSessionModelState ? entry.modelProvider : sessionRouteProvider,
             model: preserveSessionModelState ? entry.model : (params.modelUsed ?? entry.model),
             ...(contextTokens !== undefined ? { contextTokens } : {}),
             systemPromptReport: preserveUserFacingRunState

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3479,6 +3479,65 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored2[sessionKey].estimatedCostUsd).toBeCloseTo(0.007725, 8);
   });
 
+  it("can persist a canonical session route while costing the raw runtime provider", async () => {
+    const storePath = await createStorePath("openclaw-usage-route-provider-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: { sessionId: "s1", updatedAt: Date.now() },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT-5.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 400_000,
+                  maxTokens: 8_192,
+                },
+              ],
+            },
+            "openai-codex": {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT-5.5 Codex",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 2, output: 4, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 400_000,
+                  maxTokens: 8_192,
+                },
+              ],
+            },
+          },
+        },
+      } satisfies OpenClawConfig,
+      usage: { input: 1_000, output: 500 },
+      providerUsed: "openai-codex",
+      sessionRouteProviderUsed: "openai",
+      modelUsed: "gpt-5.5",
+      contextTokensUsed: 400_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].modelProvider).toBe("openai");
+    expect(stored[sessionKey].model).toBe("gpt-5.5");
+    expect(stored[sessionKey].estimatedCostUsd).toBeCloseTo(0.004, 8);
+  });
+
   it("preserves the displayed session model when heartbeat usage uses a heartbeat model", async () => {
     const storePath = await createStorePath("openclaw-usage-heartbeat-model-");
     const sessionKey = "main";

--- a/src/cron/isolated-agent/run.live-session-model-switch.test.ts
+++ b/src/cron/isolated-agent/run.live-session-model-switch.test.ts
@@ -182,6 +182,61 @@ describe("runCronIsolatedAgentTurn — LiveSessionModelSwitchError retry (#57206
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
 
+  it("persists logical OpenAI route after Codex-backed cron finalization", async () => {
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+    const cronSession = makeCronSession({
+      sessionEntry: makeCronSessionEntry({
+        model: undefined,
+        modelProvider: undefined,
+      }),
+      isNewSession: true,
+    });
+    resolveCronSessionMock.mockReturnValue(cronSession);
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model }) => ({
+      result: {
+        payloads: [{ text: "task complete" }],
+        meta: {
+          agentMeta: {
+            provider: "openai-codex",
+            model: "gpt-5.5",
+            usage: { input: 100, output: 50 },
+          },
+        },
+      },
+      provider,
+      model,
+      attempts: [],
+    }));
+
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          agents: {
+            defaults: {
+              models: {
+                "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+              },
+            },
+          },
+        },
+        job: makeJob({
+          payload: {
+            kind: "agentTurn",
+            message: "run task",
+            model: "openai/gpt-5.5",
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(cronSession.sessionEntry.model).toBe("gpt-5.5");
+    expect(cronSession.sessionEntry.modelProvider).toBe("openai");
+  });
+
   it("retries with switched auth profile state from LiveSessionModelSwitchError", async () => {
     resolveSessionAuthProfileOverrideMock.mockResolvedValue("profile-a");
     const cronSession = makeCronSession({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,7 +1,10 @@
 import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import { hasAnyAuthProfileStoreSource } from "../../agents/auth-profiles/source-check.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
-import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
+import {
+  listOpenAIAuthProfileProvidersForAgentRuntime,
+  resolveUserFacingSessionProvider,
+} from "../../agents/openai-codex-routing.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
 import { expandToolGroups, normalizeToolName } from "../../agents/tool-policy.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
@@ -882,10 +885,17 @@ async function finalizeCronRun(params: {
     finalRunResult.meta?.agentMeta?.model ??
     execution.fallbackModel ??
     execution.liveSelection.model;
-  const providerUsed =
+  const rawProviderUsed =
     finalRunResult.meta?.agentMeta?.provider ??
     execution.fallbackProvider ??
     execution.liveSelection.provider;
+  const sessionRouteProviderUsed = resolveUserFacingSessionProvider({
+    provider: rawProviderUsed,
+    model: modelUsed,
+    configuredProvider: execution.liveSelection.provider,
+    fallbackProvider: execution.fallbackProvider,
+    config: prepared.cfgWithAgentDefaults,
+  });
   const contextTokens =
     resolvePositiveContextTokens(prepared.agentCfg?.contextTokens) ??
     (await loadCronContextRuntime()).lookupContextTokens(modelUsed, {
@@ -895,15 +905,15 @@ async function finalizeCronRun(params: {
     DEFAULT_CONTEXT_TOKENS;
 
   setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
-    provider: providerUsed,
+    provider: sessionRouteProviderUsed,
     model: modelUsed,
   });
   prepared.cronSession.sessionEntry.contextTokens = contextTokens;
-  if (isCliProvider(providerUsed, prepared.cfgWithAgentDefaults)) {
+  if (isCliProvider(rawProviderUsed, prepared.cfgWithAgentDefaults)) {
     const cliSessionId = finalRunResult.meta?.agentMeta?.sessionId?.trim();
     if (cliSessionId) {
       const { setCliSessionId } = await loadCliRunnerRuntime();
-      setCliSessionId(prepared.cronSession.sessionEntry, providerUsed, cliSessionId);
+      setCliSessionId(prepared.cronSession.sessionEntry, rawProviderUsed, cliSessionId);
     }
   }
   if (hasNonzeroUsage(usage)) {
@@ -919,7 +929,7 @@ async function finalizeCronRun(params: {
       estimateUsageCost({
         usage,
         cost: resolveModelCostConfig({
-          provider: providerUsed,
+          provider: rawProviderUsed,
           model: modelUsed,
           config: prepared.cfgWithAgentDefaults,
         }),
@@ -949,11 +959,11 @@ async function finalizeCronRun(params: {
     }
     telemetry = {
       model: modelUsed,
-      provider: providerUsed,
+      provider: rawProviderUsed,
       usage: telemetryUsage,
     };
   } else {
-    telemetry = { model: modelUsed, provider: providerUsed };
+    telemetry = { model: modelUsed, provider: rawProviderUsed };
   }
   await prepared.persistSessionEntry();
 


### PR DESCRIPTION
## Summary

This PR fixes Codex-backed OpenAI routes recreating legacy `openai-codex` session-route state after `openclaw doctor --fix` has already repaired it.

The bug is a provider-identity leak across two concepts that need to stay separate:

- the user-facing configured route, such as `openai/gpt-5.5`;
- the internal runtime/auth transport, which may use the Codex harness and report `openai-codex`.
- the selected agent harness/runtime, which may be user-pinned to a non-Codex path such as `pi`.

Before this change, a successful Codex-backed `openai/*` run could report `agentMeta.provider = "openai-codex"`, and that internal provider could be persisted back into session state as `modelProvider: "openai-codex"`. Doctor then correctly treated the row as stale legacy session-route state and warned again, even though the durable config had already migrated to the canonical `openai/*` route.

The same ambiguity also affected harness selection: once `openai-codex` was treated as the logical provider instead of the runtime/auth provider, code that compared "resolved runtime provider" against the configured provider could infer that OpenClaw needed to force a Codex/OpenClaw harness override. That could defeat an explicit user harness selection by moving the run back toward the Codex/OpenClaw path. This PR keeps the logical provider stable and carries runtime/auth decisions through the dedicated harness override fields, so user-specified harness intent is not overwritten by provider normalization.

What changes:

- Keeps embedded command and auto-reply execution on the logical configured provider while using harness override fields for Codex/OpenClaw runtime routing.
- Makes embedded run reporting distinguish the logical selected provider from the runtime/auth provider.
- Avoids using the internal Codex auth provider as evidence to override explicit harness/runtime selection.
- Adds route-aware session persistence so only the persisted session route is normalized back to `openai` for Codex-backed logical `openai/*` runs.
- Preserves raw runtime provider identity for fallback notices, context lookup, cost calculation, diagnostics, telemetry, CLI binding, and auth-sensitive runtime logic.
- Covers command sessions, auto-reply sessions, follow-up sessions, and isolated cron finalization, because all four paths can write session-route state.
- Preserves explicit `openai-codex/*` selections and true cross-provider fallbacks instead of rewriting them as `openai`.

Why this matters:

- `doctor --fix` should stay fixed after subsequent Codex-backed agent turns.
- Operators should not see repeated stale-route warnings when durable config is already canonical.
- Runtime diagnostics should still truthfully record the actual Codex harness/auth path.
- Session route state should reflect the public model route that users configured, not the private transport used to execute it.
- User-selected harness/runtime policy should win over provider-identity ambiguity.

Why these changes belong together:

- The repeated doctor warning and the harness override regression share the same underlying boundary bug: OpenClaw was sometimes treating the internal `openai-codex` transport provider as the logical selected provider.
- Fixing only persistence would stop one visible symptom while leaving embedded runs vulnerable to incorrect harness override decisions.
- Fixing only embedded-run provider selection would reduce future bad metadata but leave existing session writers and cron finalization without a clear persistence boundary.
- The touched files are the adjacent ingress, reporting, and persistence paths for the same agent turn state, so this PR keeps the fix small while closing the full loop.

## Linked context

Closes https://github.com/openclaw/openclaw/issues/87436.

Related PR:

- https://github.com/openclaw/openclaw/pull/87463 also addresses the same reported symptom. This branch incorporates the useful persistence-boundary direction from that discussion while keeping runtime provider identity separate from stored session-route identity and broadening coverage to the additional root-cause and cron paths identified in the issue follow-ups.

Supporting review and follow-up context:

- https://github.com/openclaw/openclaw/issues/87436#issuecomment-4559137854 identified the core issue at source level: `agentMeta.provider` can win over the configured route during session-store and auto-reply persistence, allowing `openai-codex` to be written back into session route state.
- https://github.com/openclaw/openclaw/issues/87436#issuecomment-4559688174 identified the isolated cron finalization path as an additional writer that can recreate the same doctor warning if it normalizes only the command/auto-reply/follow-up writers.
- https://github.com/openclaw/openclaw/issues/87436#issuecomment-4569569567 identified the deeper embedded-run boundary issue: some callers were passing the resolved runtime provider into `runEmbeddedAgent(...)` as though it were the logical selected provider.
- https://github.com/openclaw/openclaw/pull/87463#issuecomment-4559829617 called out the important compatibility constraint: keep raw runtime provider identity for fallback/context/diagnostics/auth-sensitive behavior and derive a separate persisted route provider only when the configured route proves canonical `openai` is intended.
- https://github.com/openclaw/openclaw/pull/87463#issuecomment-4562309376 flagged shared auto-reply/follow-up functions across several active PRs. This PR touches those paths narrowly and keeps the provider-identity change isolated to session-route handling.

No other issue is intentionally closed by this PR.

Bundling note:

- This PR intentionally includes both the embedded-run provider/harness separation and the session-route persistence normalization because they are two sides of the same provider-identity ambiguity. The code surface is adjacent and the regression coverage crosses the same command, auto-reply, follow-up, cron, and doctor paths.

## Real behavior proof

- Behavior or issue addressed: PR #87851 fixes stale session-route persistence for logical `openai/*` routes executed through the Codex harness. A logical `openai/gpt-5.5` run should keep persisted route state as logical provider `openai` and model `gpt-5.5`, while still recording Codex runtime/auth metadata internally as `openai-codex`. `doctor --fix` should repair old leaked `openai-codex/*` route state and later live runs should not recreate stale route warnings for the new logical OpenAI session.
- Exact PR head being proven: `d17be916b03c635f39a238a1a9a92bb762a92a07` (`fix(agents): preserve explicit codex fallbacks`). The installed live stack is `1b1f5eccdd8625cff79728b0d87a3706e6aa593d`, built from #86210 `23a29722524c982f9ed410610395e1db0363857e` plus #87851 commits `1980d188ff24647ede6bb10afe39d05ec4c7f239`, `f44301e67e9045ed0276ab2c1fbd29312c2713cd`, and `d17be916b03c635f39a238a1a9a92bb762a92a07` cherry-picked in order on release base `d2319d718c9c0340c750fc564532ffa9f5f1b7eb`.
- Real environment tested: Dev-01 installed OpenClaw gateway, OpenClaw `2026.5.28 (1b1f5ec)`, source checkout `/home/kklouzal/openclaw-git/openclaw`, gateway service active, global CLI linked to that checkout. Full raw and redacted artifacts are preserved on Dev-01 at `~/openclaw-live-proofs/pr87851-d17be916-20260529T045541Z`.
- Exact steps or command run after this patch: installed the controlled stack through `~/update.sh`; verified gateway reachability with `openclaw status --json`; verified model/auth routing with `openclaw models status --probe --json`; ran `openclaw doctor --fix --non-interactive`; ran an installed-runtime helper check proving logical OpenAI normalization and explicit `openai-codex` fallback preservation; ran a live gateway-backed route proof using `openclaw agent --agent openclaw-dev --session-key agent:openclaw-dev:pr87851-live-route-proof-d17be916-050203 --model openai/gpt-5.5 --thinking low --json --message ...`; captured the gateway log excerpt; inspected the session-store row for the live run; reran doctor cleanup and a read-only doctor scan after live activity.
- Evidence after fix: The live agent turn returned `PR87851 live route proof OK`, reported logical provider `openai`, model `gpt-5.5`, and `agentHarnessId=codex`. The same run's system prompt/runtime report recorded raw provider `openai-codex`, model `gpt-5.5`. The session-store entry for that live session persisted `modelProvider: "openai"`, not `openai-codex`. The installed runtime helper preserved explicit `openai-codex` selections and explicit final `openai-codex` fallbacks.

```text
[live environment] redacted/environment.env
timestamp=20260529T045541Z
proof_dir=~/openclaw-live-proofs/pr87851-d17be916-20260529T045541Z
repo=~/openclaw-git/openclaw
installed_stack_head=1b1f5eccdd8625cff79728b0d87a3706e6aa593d
installed_stack_head_short=1b1f5eccdd
pr87851_head=d17be916b03c635f39a238a1a9a92bb762a92a07
pr87851_commits=1980d188ff24647ede6bb10afe39d05ec4c7f239 f44301e67e9045ed0276ab2c1fbd29312c2713cd d17be916b03c635f39a238a1a9a92bb762a92a07
pr86210_head=23a29722524c982f9ed410610395e1db0363857e
release_base=d2319d718c9c0340c750fc564532ffa9f5f1b7eb
openclaw_version=OpenClaw 2026.5.28 (1b1f5ec)
global_bin=~/openclaw-git/openclaw/openclaw.mjs
service_active=active
```

```json
[live environment] redacted/02-models-status-probe-excerpt.json
{
  "runtimeAuthRoutes": [
    { "provider": "openai", "runtime": "codex", "authProvider": "openai-codex", "status": "usable", "effective": { "kind": "profiles" } }
  ],
  "probeResults": [
    { "provider": "github-copilot", "model": "github-copilot/gpt-5.5", "source": "profile", "mode": "token", "status": "ok", "error": null, "latencyMs": 4586 },
    { "provider": "llama-cpp-compaction", "model": "llama-cpp-compaction/gemma-4-E2B-it-IQ4_NL.gguf", "source": "models.json", "mode": "api_key", "status": "ok", "error": null, "latencyMs": 3906 },
    { "provider": "openai-codex", "model": "openai-codex/gpt-5.4", "source": "profile", "mode": "oauth", "status": "ok", "error": null, "latencyMs": 6398 },
    { "provider": "vllm-gemma", "model": "vllm-gemma/gb10-live", "source": "models.json", "mode": "api_key", "status": "timeout", "error": "LLM request failed: network connection error.", "latencyMs": 3856 },
    { "provider": "vllm-qwen36", "model": "vllm-qwen36/qwen36-35b-heretic", "source": "models.json", "mode": "api_key", "status": "ok", "error": null, "latencyMs": 4974 }
  ]
}
```

```json
[installed runtime helper] redacted/04-installed-runtime-fallback-preservation.json
{
  "logicalOpenAI": "openai",
  "configRouteOpenAI": "openai",
  "explicitOpenAICodex": "openai-codex",
  "explicitOpenAICodexFallback": "openai-codex"
}
```

```json
[live environment] redacted/06-openai-gpt55-agent-turn-excerpt.json
{
  "status": "ok",
  "summary": "completed",
  "runId": "3faa8479-2e7d-4bc0-9dad-e9fe5c9f4978",
  "payloads": [{ "text": "PR87851 live route proof OK", "mediaUrl": null }],
  "agentMeta": {
    "sessionId": "cf0b3dd0-797d-4c90-ad08-ddc1dc60a32a",
    "provider": "openai",
    "model": "gpt-5.5",
    "contextTokens": 272000,
    "agentHarnessId": "codex",
    "usage": { "input": 49598, "output": 22, "cacheRead": 7552, "total": 57172 },
    "lastCallUsage": { "input": 49598, "output": 22, "cacheRead": 7552, "cacheWrite": 0, "total": 57172 },
    "promptTokens": 57150
  },
  "systemPromptReport": {
    "sessionKey": "agent:openclaw-dev:pr87851-live-route-proof-d17be916-050203",
    "provider": "openai-codex",
    "model": "gpt-5.5",
    "workspaceDir": "~/.openclaw/workspace/projects/openclaw-dev",
    "systemPrompt": { "chars": 41166, "projectContextChars": 0, "nonProjectContextChars": 41166, "hash": "01bf63bcce3fe24bc155ecbc398c212935a0dd44ab97bdc4d791ae28dc51ef72" }
  },
  "executionTrace": {
    "winnerProvider": "openai",
    "winnerModel": "gpt-5.5",
    "attempts": [{ "provider": "openai", "model": "gpt-5.5", "result": "success", "stage": "assistant" }],
    "fallbackUsed": false,
    "runner": "embedded"
  },
  "requestShaping": { "authMode": "auth-profile", "thinking": "low" }
}
```

```json
[live environment] redacted/09-live-session-store-entry.json
{
  "key": "agent:openclaw-dev:pr87851-live-route-proof-d17be916-050203",
  "sessionId": "cf0b3dd0-797d-4c90-ad08-ddc1dc60a32a",
  "modelProvider": "openai",
  "modelName": null,
  "configuredModel": null,
  "selectedModel": null,
  "agentHarnessId": "codex",
  "agentHarnessRuntime": null,
  "runtime": null,
  "updatedAt": 1780030933850
}
```

```text
[live environment] redacted/10-gateway-live-turn.log
May 29 05:02:13 dev-01 node[1967002]: 2026-05-29T05:02:13.974+00:00 PR87851 live route proof OK
```

```text
[live environment] redacted/11-doctor-route-summary.txt
before-live doctor cleanup:
- Found stale Codex session routing state in 3 sessions outside the current configured model/runtime route.
- Cleared stale Codex session routing state for 3 sessions.

after-live doctor cleanup:
- No stale Codex session routing state was reported after the PR #87851 live run.

read-only clean scan after live:
- No stale Codex session routing state was reported after the PR #87851 live run.
- The read-only doctor still reported unrelated existing environment warnings such as plugin allowlist wildcard behavior, native Codex compaction override notices, expiring OpenAI Codex OAuth, stale cached skill metadata paths, cron model overrides, source-checkout service entrypoint, plaintext secret-bearing config fields, LAN gateway binding, missing Chromium, tool result cap tuning, and bootstrap size.
```

- Observed result after fix: The installed runtime preserved the expected split identity. User-facing route metadata stayed logical `openai/gpt-5.5`, runtime/auth metadata remained `openai-codex/gpt-5.5` under the Codex harness, and the persisted session-store row for the new live session kept `modelProvider: "openai"`. The installed runtime helper showed explicit `openai-codex` route and final fallback preservation. Doctor cleared older stale route state before the live run and did not report stale Codex route state after the live run.
- What was not tested: The installed live proof was run from the stacked checkout because this Dev-01 lane currently needs PR #86210 plus PR #87851 together. The exact #87851 head `d17be916b03c635f39a238a1a9a92bb762a92a07` is included in that installed stack and was also covered by deterministic tests and GitHub Actions. The `vllm-gemma/gb10-live` probe timed out with a network connection error; `github-copilot`, llama compaction, `openai-codex`, and `vllm-qwen36` probes succeeded. The read-only doctor scan still reports unrelated environment warnings listed above, but no stale Codex session-route warning after the live run.

## Implementation notes

- Adds shared OpenAI/Codex route helpers in `src/agents/openai-codex-routing.ts`.
- Preserves the configured logical provider when command and auto-reply paths invoke `runEmbeddedAgent(...)`; runtime routing continues through `agentHarnessId` and `agentHarnessRuntimeOverride`.
- Keeps harness override decisions tied to explicit harness/runtime policy instead of letting an internal `openai-codex` auth provider masquerade as a logical provider change.
- Extends `resolveReportedModelRef(...)` so an assistant report from the internal runtime provider can be mapped back to the logical provider only when the runtime provider differs from the configured provider.
- Keeps explicit `openai-codex` routes intact by only mapping runtime-provider reports back when `runtimeProvider !== provider`.
- Updates command session persistence to store the logical session route while continuing to use raw provider identity for runtime-sensitive behavior.
- Adds `sessionRouteProviderUsed` to the auto-reply session usage persistence boundary so route normalization affects persisted `modelProvider`, not the broader `providerUsed` value.
- Updates normal auto-reply and follow-up runners to pass raw `providerUsed` plus a separate normalized session route provider.
- Updates isolated cron finalization to persist the user-facing route provider while preserving raw runtime provider identity for CLI session binding, usage cost lookup, and telemetry.
- Adds regression coverage for command session-store, embedded provider reporting, command embedded invocation, auto-reply embedded invocation, runReplyAgent persistence, follow-up persistence, session usage costing, cron finalization, and doctor warning compatibility.

## Compatibility and risk

Backward compatibility preserved:

- Existing canonical `openai/*` routes remain `openai/*` in persisted session state.
- Internal Codex harness/runtime metadata can still report `openai-codex` where that is the actual execution/auth transport.
- Explicit user harness/runtime selections are not converted back to Codex/OpenClaw just because OpenAI auth uses the internal Codex provider.
- Explicit `openai-codex/*` selections are not silently rewritten to `openai`.
- True fallback to another provider still reports the fallback provider.
- Runtime provider identity remains available for context-window lookup, cost calculation, fallback notices, diagnostics, telemetry, CLI session binding, and auth-sensitive logic.
- No new config keys or public SDK/API surface are added.

Compatibility changes reviewers should inspect:

- Session-route persistence now derives a separate user-facing route provider where Codex-backed logical OpenAI routes previously allowed internal `openai-codex` runtime identity to leak into `modelProvider`.
- Cron finalization now stores the logical route provider while keeping raw runtime provider for CLI and telemetry behavior.
- The embedded runner now treats logical provider and runtime provider as distinct inputs when resolving final reported model metadata.
- Embedded command and auto-reply call sites now keep logical provider selection separate from harness override routing, which protects explicit harness intent such as a `pi` runtime selection.

Primary risks:

- Provider identity is shared across several execution paths, so a too-broad normalization would risk hiding real fallback/runtime information. This PR intentionally keeps raw provider identity except at the session-route persistence boundary.
- Harness routing is similarly sensitive: using runtime/auth provider identity as logical provider identity can force a different harness than the user selected. This PR narrows the boundary, but reviewers should still inspect the command and auto-reply embedded-run call sites carefully.
- Auto-reply and follow-up functions are active merge-conflict areas across other PRs. The changed lines here are narrow, but this branch may need a careful conflict refresh before merge.
- Live installed-runtime proof is still needed before claiming the full observed operator loop is closed outside deterministic tests.

## Verification

Current PR head:

- `d17be916b03c635f39a238a1a9a92bb762a92a07 fix(agents): preserve explicit codex fallbacks`

Local deterministic validation on Dev-01:

- `corepack pnpm test -- src/agents/openai-codex-routing.test.ts src/agents/embedded-agent-runner/run/helpers.test.ts src/agents/command/attempt-execution.cli.test.ts src/agents/command/session-store.test.ts src/cron/isolated-agent/run.live-session-model-switch.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/session.test.ts src/commands/doctor/shared/codex-route-warnings.test.ts`: passed, 6 Vitest shards, 528 tests, 195.68s.
- `corepack pnpm tsgo:test:src --pretty false`: passed.
- `corepack pnpm exec oxfmt --check src/agents/openai-codex-routing.ts src/agents/openai-codex-routing.test.ts src/agents/command/session-store.ts src/agents/command/session-store.test.ts src/auto-reply/reply/session-usage.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/followup-runner.ts src/cron/isolated-agent/run.ts`: passed.
- `git diff --check`: passed.

Installed live-runtime validation on Dev-01:

- `~/update.sh`: installed #86210 + #87851 stack and built OpenClaw `2026.5.28 (1b1f5ec)`.
- `openclaw status --json`: gateway reachable, service active, checkout clean at `1b1f5eccdd8625cff79728b0d87a3706e6aa593d`.
- `openclaw models status --probe --json`: OpenAI logical route uses Codex runtime auth provider `openai-codex` and is usable; `openai-codex`, `github-copilot`, llama compaction, and `vllm-qwen36` probes succeeded; `vllm-gemma/gb10-live` timed out with a network connection error.
- Installed runtime helper check: logical OpenAI routes normalize to `openai`; explicit `openai-codex` selections and explicit final `openai-codex` fallbacks remain `openai-codex`.
- Live `openclaw agent --agent openclaw-dev --session-key agent:openclaw-dev:pr87851-live-route-proof-d17be916-050203 --model openai/gpt-5.5 --thinking low --json --message ...`: passed and returned `PR87851 live route proof OK`.
- Session-store inspection for that live session: persisted `modelProvider: "openai"` with `agentHarnessId: "codex"`.
- Doctor after the live run: no stale Codex session-route state reported.

GitHub Actions:

- `gh pr checks 87851 --repo openclaw/openclaw`: reported required checks passing for the current PR head; all ran CI passing green.

Artifact index:

- Redacted/live proof package: `~/openclaw-live-proofs/pr87851-d17be916-20260529T045541Z/redacted`
- Raw local proof package on Dev-01: `~/openclaw-live-proofs/pr87851-d17be916-20260529T045541Z/raw`

