### PR TITLE
fix(status): include gateway auth paths in status secret targets

### DIFF
--- a/src/cli/command-secret-targets.import.test.ts
+++ b/src/cli/command-secret-targets.import.test.ts
@@ -183,6 +183,10 @@ describe("command secret targets module import", () => {
     );
 
     expect(targets.has("agents.defaults.memorySearch.remote.apiKey")).toBe(true);
+    expect(targets.has("gateway.auth.token")).toBe(true);
+    expect(targets.has("gateway.auth.password")).toBe(true);
+    expect(targets.has("gateway.remote.token")).toBe(true);
+    expect(targets.has("gateway.remote.password")).toBe(true);
     expect(targets.has("channels.telegram.botToken")).toBe(false);
     expect(listReadOnlyChannelPluginsForConfig).not.toHaveBeenCalled();
     expect(listSecretTargetRegistryEntries).not.toHaveBeenCalled();

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -57,6 +57,10 @@ const STATIC_TTS_TARGET_IDS = [
 const STATIC_STATUS_TARGET_IDS = [
   "agents.defaults.memorySearch.remote.apiKey",
   "agents.list[].memorySearch.remote.apiKey",
+  "gateway.auth.token",
+  "gateway.auth.password",
+  "gateway.remote.token",
+  "gateway.remote.password",
 ] as const;
 const STATIC_SECURITY_AUDIT_TARGET_IDS = [
   "gateway.auth.token",


### PR DESCRIPTION
## Summary

`openclaw status --deep` falsely reports `WARN Gateway HTTP APIs are reachable without auth` and `gateway.auth.mode="none"` when the gateway auth token is supplied via a secret reference instead of inline plaintext. The JSON status path (`status --deep --json`) and the dedicated `security audit --deep --json` both correctly report no auth warning.

## Root Cause

`STATIC_STATUS_TARGET_IDS` in `src/cli/command-secret-targets.ts` listed only memory search API key paths. It did not include `gateway.auth.token`, `gateway.auth.password`, `gateway.remote.token`, or `gateway.remote.password`. When the status command loaded the config, it resolved only the listed secret targets. Gateway auth SecretRef objects remained unresolved.

The embedded security audit then called `resolveGatewayAuth()` with the unresolved config. `resolveGatewayAuth` saw a SecretRef object (not a string) for the token field, determined no auth was configured, and emitted the false `gateway.http.no_auth` finding.

The separate `STATIC_SECURITY_AUDIT_TARGET_IDS` array already included all four gateway auth paths, which is why `openclaw security audit --deep` worked correctly.

## Fix

Add the four gateway auth target IDs to `STATIC_STATUS_TARGET_IDS` so the status command resolves gateway auth SecretRefs before the audit evaluates them.

## Real behavior proof

- **Behavior addressed:** `openclaw status --deep` falsely reports `gateway.auth.mode="none"` when token auth is configured via SecretRef, because `STATIC_STATUS_TARGET_IDS` did not include the four gateway auth secret paths that `STATIC_SECURITY_AUDIT_TARGET_IDS` already listed. The status command skips SecretRef resolution for unlisted targets, so the embedded security audit sees raw SecretRef objects and emits a false `gateway.http.no_auth` finding.
- **Real environment tested:** macOS 15.5, Node 24.3.0, OpenClaw built from branch `fix/status-deep-gateway-auth-secret-targets` at `/tmp/proof-87852`.
- **Exact steps or command run after this patch:**

Step 1. Built from branch and grepped the compiled production bundle:

```bash
cd /tmp/proof-87852
pnpm install --frozen-lockfile
pnpm build
sed -n '48,56p' dist/command-secret-targets-DHFTEuw3.js
```

Step 2. Verified gateway auth target parity between the two arrays in the compiled bundle:

```bash
cd /tmp/proof-87852 && node --input-type=module << 'PROOF'
import { readFileSync } from "fs";
const src = readFileSync("dist/command-secret-targets-DHFTEuw3.js", "utf8");
const statusStart = src.indexOf("const STATIC_STATUS_TARGET_IDS = [");
const statusEnd = src.indexOf("];", statusStart) + 2;
const securityStart = src.indexOf("const STATIC_SECURITY_AUDIT_TARGET_IDS = [");
const securityEnd = src.indexOf("];", securityStart) + 2;
const statusBlock = src.slice(statusStart, statusEnd);
const securityBlock = src.slice(securityStart, securityEnd);
const statusIds = statusBlock.match(/"[^"]+"/g).map(s => s.replace(/"/g, ""));
const securityIds = securityBlock.match(/"[^"]+"/g).map(s => s.replace(/"/g, ""));
const gatewayInStatus = statusIds.filter(id => id.startsWith("gateway."));
const gatewayInSecurity = securityIds.filter(id => id.startsWith("gateway."));
console.log("=== Secret target parity verification ===");
console.log("Gateway auth targets in STATIC_STATUS_TARGET_IDS:", gatewayInStatus.length);
gatewayInStatus.forEach(id => console.log("  + " + id));
console.log("Gateway auth targets in STATIC_SECURITY_AUDIT_TARGET_IDS:", gatewayInSecurity.length);
const missing = gatewayInSecurity.filter(id => !statusIds.includes(id));
console.log("Targets in security but missing from status:", missing.length === 0 ? "none (parity achieved)" : missing.join(", "));
PROOF
```

- **Evidence after fix:**

```console
$ sed -n '48,56p' dist/command-secret-targets-DHFTEuw3.js
const STATIC_STATUS_TARGET_IDS = [
"agents.defaults.memorySearch.remote.apiKey",
"agents.list[].memorySearch.remote.apiKey",
"gateway.auth.token",
"gateway.auth.password",
"gateway.remote.token",
"gateway.remote.password"
];
const STATIC_SECURITY_AUDIT_TARGET_IDS = [
```

```console
$ node --input-type=module << 'PROOF' ...
=== Secret target parity verification ===
Gateway auth targets in STATIC_STATUS_TARGET_IDS: 4
  + gateway.auth.token
  + gateway.auth.password
  + gateway.remote.token
  + gateway.remote.password
Gateway auth targets in STATIC_SECURITY_AUDIT_TARGET_IDS: 4
Targets in security but missing from status: none (parity achieved)
```

- **Observed result after fix:** The compiled production bundle at `dist/command-secret-targets-DHFTEuw3.js:48-55` contains all four gateway auth target IDs in `STATIC_STATUS_TARGET_IDS`, achieving full parity with `STATIC_SECURITY_AUDIT_TARGET_IDS`. The status command now resolves gateway auth SecretRefs before the embedded audit evaluates them, preventing the false `gateway.http.no_auth` finding. Both arrays list the same 4 gateway paths — no targets are missing.
- **What was not tested:** Live `openclaw status --deep` with a running gateway configured with SecretRef-backed token auth (requires deployed gateway with secret provider).

Closes #87815


