### PR TITLE
fix(agents): count streamed model deltas incrementally

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -190,7 +190,7 @@ message bodies are also approved for export.
 - `gen_ai.client.operation.duration` (histogram, seconds, GenAI semantic-conventions metric, attrs: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, optional `error.type`)
 - `openclaw.model_call.duration_ms` (histogram, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`, plus `openclaw.errorCategory` and `openclaw.failureKind` on classified errors)
 - `openclaw.model_call.request_bytes` (histogram, UTF-8 byte size of the final model request payload; no raw payload content)
-- `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed model response events excluding accumulated `partial` snapshots on delta events; no raw response content)
+- `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed response chunk payloads; high-frequency text, thinking, and tool-call deltas count only incremental `delta` bytes; no raw response content)
 - `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event)
 - `openclaw.model.failover` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.failover.to_provider`, `openclaw.failover.to_model`, `openclaw.failover.reason`, `openclaw.failover.suspended`, `openclaw.lane`)
 - `openclaw.skill.used` (counter, attrs: `openclaw.skill.name`, `openclaw.skill.source`, `openclaw.skill.activation`, optional `openclaw.agent`, optional `openclaw.toolName`)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -233,7 +233,9 @@ Model-call diagnostics record bounded request/response measurements without
 capturing raw prompt or response content:
 
 - `requestPayloadBytes`: UTF-8 byte size of the final model request payload
-- `responseStreamBytes`: UTF-8 byte size of streamed model response events, excluding accumulated `partial` snapshots on delta events
+- `responseStreamBytes`: UTF-8 byte size of streamed model response chunk
+  payloads. High-frequency text, thinking, and tool-call delta events count
+  only the incremental `delta` bytes instead of full `partial` snapshots.
 - `timeToFirstByteMs`: elapsed time before the first streamed response event
 - `durationMs`: total model-call duration
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1464,8 +1464,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         "openclaw.model_call.response_bytes",
         {
           unit: "By",
-          description:
-            "UTF-8 byte size of streamed model response events excluding accumulated partial snapshots",
+          description: "UTF-8 byte size of bounded streamed model response payloads",
         },
       );
       const modelCallTimeToFirstByteHistogram = meter.createHistogram(

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -400,16 +400,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
 
     const completedEvent = getEvent(events, 1);
     expect(completedEvent.type).toBe("model.call.completed");
-    expect(completedEvent.responseStreamBytes).toBe(
-      Buffer.byteLength(
-        JSON.stringify({ type: "text_delta", contentIndex: 0, delta: "a" }),
-        "utf8",
-      ) +
-        Buffer.byteLength(
-          JSON.stringify({ type: "text_delta", contentIndex: 0, delta: "bc" }),
-          "utf8",
-        ),
-    );
+    expect(completedEvent.responseStreamBytes).toBe(Buffer.byteLength("abc", "utf8"));
     expect(serializedPartial).not.toHaveBeenCalled();
   });
 
@@ -457,7 +448,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     const completedEvent = getEvent(events, 1);
     expect(completedEvent.type).toBe("model.call.completed");
     expect(completedEvent.responseStreamBytes).toBe(
-      Buffer.byteLength(JSON.stringify({ type: "text_delta", delta: "ok" }), "utf8"),
+      Buffer.byteLength("ok", "utf8"),
     );
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -447,9 +447,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     expect(chunks[1]).toEqual({ type: "text_delta", delta: "ok" });
     const completedEvent = getEvent(events, 1);
     expect(completedEvent.type).toBe("model.call.completed");
-    expect(completedEvent.responseStreamBytes).toBe(
-      Buffer.byteLength("ok", "utf8"),
-    );
+    expect(completedEvent.responseStreamBytes).toBe(Buffer.byteLength("ok", "utf8"));
   });
 
   it("captures model input, tools, and output only when content capture is enabled", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -109,15 +109,34 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function utf8StringByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function streamDeltaByteLength(chunk: Record<string, unknown>): number | undefined {
+  const type = chunk.type;
+  if (
+    (type === "text_delta" || type === "thinking_delta" || type === "toolcall_delta") &&
+    typeof chunk.delta === "string"
+  ) {
+    return utf8StringByteLength(chunk.delta);
+  }
+  return undefined;
+}
+
 function responseStreamChunkByteLengthUnchecked(chunk: unknown): number | undefined {
   if (!isRecord(chunk)) {
     return utf8JsonByteLength(chunk);
+  }
+  const deltaBytes = streamDeltaByteLength(chunk);
+  if (deltaBytes !== undefined) {
+    return deltaBytes;
   }
   if (!("partial" in chunk)) {
     return utf8JsonByteLength(chunk);
   }
   // Plain stream deltas can carry an accumulated partial snapshot. Byte metrics
-  // count the new stream event shape, not the answer-so-far replay.
+  // count the new stream payload, not the answer-so-far replay.
   const { partial: _partial, ...snapshotlessChunk } = chunk;
   return utf8JsonByteLength(snapshotlessChunk);
 }


### PR DESCRIPTION
## Summary
- Count streamed `text_delta`/`thinking_delta`/`toolcall_delta` diagnostics from their incremental `delta` bytes instead of serializing the full event.
- Drop growing `partial` snapshots from fallback stream byte accounting so diagnostics do not repeatedly walk the accumulated assistant message.
- Add regression coverage proving text-delta accounting does not serialize large partial snapshots and keeps streams alive if byte inspection throws.
- Document the bounded `responseStreamBytes` semantics for high-frequency streamed deltas and align OTEL docs/metric descriptions with that bounded payload contract.

Refs #86599.

## Verification
- Rebasing onto current `origin/main` completed on head `c1783a4997e`.
- `node scripts/check-docs-mdx.mjs docs/gateway/opentelemetry.md docs/logging.md`: passed.
- `node_modules/.bin/oxfmt --check --threads=1 docs/gateway/opentelemetry.md docs/logging.md extensions/diagnostics-otel/src/service.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts`: passed.
- `node scripts/run-oxlint.mjs extensions/diagnostics-otel/src/service.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts`: passed.
- `git diff --check origin/main...HEAD`: passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts --reporter=dot`: passed, 2 shards / 86 tests.
- AWS Crabbox `pnpm check:changed`: passed, `provider=aws`, `lease=cbx_fc87d734de03`, `run=run_dafa0367419e`, exit 0; selected lanes `core`, `coreTests`, `extensions`, `extensionTests`, `docs`.

## Real behavior proof
Behavior addressed: dense model streams no longer make model-call diagnostics serialize the full growing `partial` assistant message on every delta.

Real environment tested: focused local Vitest wrapper in a linked OpenClaw gwt worktree, plus AWS Crabbox Linux changed-gate proof.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts --reporter=dot`; docs mdx, oxfmt, oxlint, diff-check; `node scripts/crabbox-wrapper.mjs run --provider aws --label diagnostic-delta-accounting-check-changed --shell -- "pnpm check:changed"`.

Evidence after fix: focused tests passed, including assertions that `text_delta` accounting does not call `partial.toJSON`, counts incremental `delta` bytes, and keeps stream delivery alive when byte inspection cannot read a chunk. AWS `check:changed` passed the selected core, core test, extension, extension test, and docs lanes.

Observed result after fix: `responseStreamBytes` is computed from incremental delta bytes for high-frequency stream deltas and from snapshotless chunks for other partial-bearing stream events, while OTEL metadata and docs describe the exported histogram as bounded streamed response payload bytes.

What was not tested: a live long-running local-model session.
