### PR TITLE
fix(telegram): handle vanished claim race in isolated polling spool drain

### DIFF
--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -242,6 +242,69 @@ describe("Telegram ingress spool", () => {
     });
   });
 
+  it("recovers cleanly when a processing file vanishes mid-recovery (ENOENT race)", async () => {
+    await withTempSpool(async (spoolDir) => {
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 60, message: { text: "racing" } },
+      });
+      const update = (await listTelegramSpooledUpdates({ spoolDir }))[0];
+      if (!update) {
+        throw new Error("Expected a spooled update");
+      }
+      const claimed = await claimTelegramSpooledUpdate(update);
+      if (!claimed) {
+        throw new Error("Expected a claimed update");
+      }
+
+      // Simulate a concurrent drain lane / release / multi-process recovery
+      // removing the .processing file in the window before the recovery rename.
+      const recovered = await recoverStaleTelegramSpooledUpdateClaims({
+        spoolDir,
+        staleMs: 0,
+        shouldRecover: async () => {
+          await fs.rm(claimed.path, { force: true });
+          return true;
+        },
+      });
+
+      expect(recovered).toBe(0);
+      expect(await fs.readdir(spoolDir)).toEqual([]);
+    });
+  });
+
+  it("skips an unreadable claim during active drain instead of renaming it", async () => {
+    await withTempSpool(async (spoolDir) => {
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 61, message: { text: "corrupt" } },
+      });
+      const update = (await listTelegramSpooledUpdates({ spoolDir }))[0];
+      if (!update) {
+        throw new Error("Expected a spooled update");
+      }
+      const claimed = await claimTelegramSpooledUpdate(update);
+      if (!claimed) {
+        throw new Error("Expected a claimed update");
+      }
+      await fs.writeFile(claimed.path, "{ not valid json");
+
+      let shouldRecoverCalls = 0;
+      const recovered = await recoverStaleTelegramSpooledUpdateClaims({
+        spoolDir,
+        staleMs: 0,
+        shouldRecover: () => {
+          shouldRecoverCalls += 1;
+          return true;
+        },
+      });
+
+      expect(recovered).toBe(0);
+      expect(shouldRecoverCalls).toBe(0);
+      expect(await fs.readdir(spoolDir)).toEqual(["0000000000000061.json.processing"]);
+    });
+  });
+
   it("does not treat stale claims with reused pids as live-owned", () => {
     const now = Date.now();
     expect(

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -430,20 +430,30 @@ export async function recoverStaleTelegramSpooledUpdateClaims(params: {
     if (params.shouldRecover) {
       const { value } = await readJsonFileWithFallback<unknown>(claimedPath, null);
       const parsed = parseSpooledUpdate(value, claimedPath);
-      if (
-        parsed &&
-        !(await params.shouldRecover({
-          ...parsed,
-          pendingPath,
-        }))
-      ) {
+      // A null parse means the claim file vanished or is unreadable; a concurrent
+      // op already owns it, so never blind-rename it back to pending below.
+      if (!parsed || !(await params.shouldRecover({ ...parsed, pendingPath }))) {
         continue;
       }
     }
-    if (await pathExists(pendingPath)) {
-      await unlinkIfPresent(claimedPath);
-    } else {
-      await fs.rename(claimedPath, pendingPath);
+    try {
+      if (await pathExists(pendingPath)) {
+        await unlinkIfPresent(claimedPath);
+      } else {
+        await fs.rename(claimedPath, pendingPath);
+      }
+    } catch (err) {
+      // TOCTOU: another drain lane, release, fail, or process removed/recreated
+      // the claim between readdir and rename. Mirror releaseTelegramSpooledUpdateClaim.
+      const code = (err as { code?: string }).code;
+      if (code === "ENOENT") {
+        continue;
+      }
+      if (code === "EEXIST") {
+        await unlinkIfPresent(claimedPath);
+        continue;
+      }
+      throw err;
     }
     recovered += 1;
   }


### PR DESCRIPTION
## Summary

`recoverStaleTelegramSpooledUpdateClaims` in `extensions/telegram/src/telegram-ingress-spool.ts` could throw `ENOENT` when a `.processing` claim file was removed concurrently between the directory scan and the final `fs.rename(claimedPath, pendingPath)`. The isolated-polling drain loop catches that throw, logs `[telegram][diag] isolated polling spool drain failed (N): ENOENT: ... rename '...processing' -> '...json'`, and increments `consecutiveDrainFailures`. The drain recovers on the next interval, so no updates are lost, but it produces recurring error noise and spurious failure counters under normal isolated-polling load.

Fixes #87847

## Root cause

The recovery loop reads the spool directory, then for each `.processing` entry stats it, optionally consults `shouldRecover`, and finally either deletes the claim (if a pending file already exists) or renames it back to pending. Two concurrent paths can remove or recreate the claim inside that window — another drain lane calling `claimTelegramSpooledUpdate`, `releaseTelegramSpooledUpdateClaim`, `failTelegramSpooledUpdateClaim`, or a second process running the same recovery:

1. The file vanishes after the scan/stat, so the final `fs.rename` throws `ENOENT` (the reported symptom). The sibling `releaseTelegramSpooledUpdateClaim` already guards its own rename against `ENOENT`/`EEXIST`; this path did not.
2. When `readJsonFileWithFallback` returns `null` (file already gone or unreadable), `parsed` is `null`; the old `parsed && !(await shouldRecover(...))` guard short-circuited to `false`, so no `continue` ran and execution fell into the unguarded rename.

## Fix

- Wrap the recovery `pathExists`/`rename` step in the same `ENOENT` (skip) / `EEXIST` (drop the claim, skip) handling that `releaseTelegramSpooledUpdateClaim` already uses.
- Skip a claim whose payload no longer parses instead of blind-renaming a vanished/unreadable file back to pending (the optional hardening called out in the issue). The time-based stale sweep still recovers genuinely stale claims, and `listTelegramSpooledUpdateClaims` already ignores unparseable claims, so this stays consistent.

## Why this is safe

- The change is confined to error handling at the end of one recovery branch; the happy path (rename eligible stale claims back to pending) is unchanged.
- `ENOENT`/`EEXIST` from the rename mean a concurrent op already finalized the claim, so skipping is the correct outcome — the entry is no longer this loop's to recover. Any other error code still propagates via `throw err`.
- No update is dropped: a vanished claim was already handled elsewhere, and a still-present stale claim is unaffected. `recovered` is only incremented after a successful transition, so the returned count stays accurate.

## Security / runtime controls unchanged

- No change to claim ownership semantics: `isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess`, the process-liveness check, and the stale-claim window (`TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS`) are untouched.
- No config, default, schema, or public API/SDK surface changes; no new permissions or operator actions. File modes (`0o600`) and the claim/release/fail protocol are unchanged. Behavior is runtime-enforced FS error handling, not prompt-driven.

## Real behavior proof

The defect is a nondeterministic filesystem TOCTOU that emits an internal diagnostic log (not channel-visible message content) and cannot be triggered on demand by a live Telegram message. I forced the exact race window deterministically with a `shouldRecover` callback that removes the `.processing` claim before the recovery rename — exactly what a concurrent drain lane / release / multi-process recovery does in production (`staleMs: 0` matches the isolated-polling drain caller in `polling-session.ts`).

Behavior addressed: `recoverStaleTelegramSpooledUpdateClaims` no longer throws when a claim file vanishes/recreates mid-recovery, so the drain stops logging `[telegram][diag] isolated polling spool drain failed` and stops bumping `consecutiveDrainFailures` for this race.

Real environment tested: Local source checkout (Telegram plugin loads from TS source in the gateway), macOS, Node v24.8.0. The harness uses an ephemeral `os.tmpdir()` spool directory; no tokens, accounts, or personal data were involved, so nothing required redaction.

Exact steps or command run after this patch:
- Before patch (unpatched recovery): `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-spool.test.ts -t "ENOENT race"`
- After patch: `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-spool.test.ts`
- Extension lane: `pnpm test:extension telegram`
- Repo changed-file gate: `pnpm check:changed` and `git diff --check`

Evidence after fix:

Before the fix, recovery throws the issue's exact error (temp path is a generated scratch dir):

```
FAIL  Telegram ingress spool > recovers cleanly when a processing file vanishes mid-recovery (ENOENT race)
Error: ENOENT: no such file or directory, rename '<tmp>/openclaw-telegram-spool-XXXXXX/0000000000000060.json.processing' -> '<tmp>/openclaw-telegram-spool-XXXXXX/0000000000000060.json'
 ❯ recoverStaleTelegramSpooledUpdateClaims extensions/telegram/src/telegram-ingress-spool.ts:446:7
 Test Files  1 failed (1)
      Tests  1 failed | 7 skipped (8)
```

This is the same throw the drain loop wraps as `[telegram][diag] isolated polling spool drain failed (N): ENOENT: no such file or directory, rename '...processing' -> '...json'` while bumping `consecutiveDrainFailures`.

After the fix, the race path resolves cleanly and the full file (plus a second test covering the unreadable-claim skip) is green:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Extension lane and changed-file gate after the fix:

```
pnpm test:extension telegram   -> Test Files 123 passed (123) | Tests 1926 passed (1926)
pnpm check:changed             -> typecheck/lint/import-cycles/dependency+patch guards all PASS
git diff --check               -> clean
```

Observed result after fix: recovery returns `0` (no eligible recovery) and the spool directory ends empty for the vanished-claim case; the unreadable-claim case leaves the `.processing` file untouched without consulting `shouldRecover`. No throw, the drain loop completes normally, and `consecutiveDrainFailures` stays at 0.

## Out of scope (intentional)

- General-purpose garbage collection of orphaned/corrupt `.processing` files beyond the existing time-based stale sweep.
- The `EEXIST` branch mirrors `releaseTelegramSpooledUpdateClaim` for parity; it is hardening for the rename collision case and is not separately covered by a deterministic test (the window is not reachable via `shouldRecover`).

---

AI-assisted change. The fix, tests, and the before/after proof above were produced and run locally on the setup described.
