### PR TITLE
Add Claude Opus 4.8 defaults

### DIFF
--- a/extensions/anthropic/claude-model-refs.ts
+++ b/extensions/anthropic/claude-model-refs.ts
@@ -2,7 +2,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_MODEL_ALIASES } from "./cli-constants.js";
 
 const DEFAULT_CLAUDE_MODEL_BY_FAMILY: Record<string, string> = {
-  opus: "claude-opus-4-7",
+  opus: "claude-opus-4-8",
   sonnet: "claude-sonnet-4-6",
   haiku: "claude-haiku-4-5",
 };
@@ -108,6 +108,9 @@ function canonicalizeKnownClaudeCliModelId(modelId: string): string | null {
 }
 
 function upgradeOldClaudeModelId(normalized: string): string | null {
+  if (normalized.startsWith("claude-opus-4-8") || normalized.startsWith("claude-opus-4.8")) {
+    return null;
+  }
   if (normalized.startsWith("claude-opus-4-7") || normalized.startsWith("claude-opus-4.7")) {
     return null;
   }
@@ -133,7 +136,7 @@ function upgradeOldClaudeModelId(normalized: string): string | null {
     ]) ||
     /^claude-opus-4-20\d{6}/.test(normalized)
   ) {
-    return "claude-opus-4-7";
+    return "claude-opus-4-8";
   }
   if (
     normalized === "claude-sonnet-4" ||
@@ -150,7 +153,7 @@ function upgradeOldClaudeModelId(normalized: string): string | null {
     return "claude-sonnet-4-6";
   }
   if (normalized.startsWith("claude-3") && normalized.includes("opus")) {
-    return "claude-opus-4-7";
+    return "claude-opus-4-8";
   }
   if (
     normalized.startsWith("claude-3") &&
@@ -164,7 +167,7 @@ function upgradeOldClaudeModelId(normalized: string): string | null {
     normalized === "opus-4" ||
     normalized === "opus-3"
   ) {
-    return "claude-opus-4-7";
+    return "claude-opus-4-8";
   }
   if (
     normalized === "sonnet-4.5" ||

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -5,13 +5,14 @@ import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-
 const CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW = 200_000;
 
 const CLAUDE_CLI_MODEL_LABELS: Record<string, string> = {
+  "claude-opus-4-8": "Claude Opus 4.8 (Claude CLI)",
   "claude-opus-4-7": "Claude Opus 4.7 (Claude CLI)",
   "claude-opus-4-6": "Claude Opus 4.6 (Claude CLI)",
   "claude-sonnet-4-6": "Claude Sonnet 4.6 (Claude CLI)",
 };
 
 function resolveClaudeCliImageMediaInput(id: string): ModelCatalogEntry["mediaInput"] {
-  const maxSidePx = id === "claude-opus-4-7" ? 2576 : 1568;
+  const maxSidePx = id === "claude-opus-4-8" || id === "claude-opus-4-7" ? 2576 : 1568;
   return {
     image: {
       maxSidePx,

--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -1,15 +1,18 @@
 export const CLAUDE_CLI_BACKEND_ID = "claude-cli";
-export const CLAUDE_CLI_DEFAULT_MODEL_REF = `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-7`;
+export const CLAUDE_CLI_DEFAULT_MODEL_REF = `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-8`;
 export const CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS = [
   CLAUDE_CLI_DEFAULT_MODEL_REF,
+  `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-7`,
   `${CLAUDE_CLI_BACKEND_ID}/claude-sonnet-4-6`,
   `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-6`,
 ] as const;
 
 export const CLAUDE_CLI_MODEL_ALIASES: Record<string, string> = {
   opus: "opus",
+  "opus-4.8": "opus",
   "opus-4.7": "opus",
   "opus-4.6": "opus",
+  "claude-opus-4-8": "opus",
   "claude-opus-4-7": "opus",
   "claude-opus-4-6": "opus",
   sonnet: "sonnet",

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -38,10 +38,10 @@ afterAll(() => {
 describe("anthropic Claude model refs", () => {
   it("upgrades retired refs without rewriting future canonical refs", () => {
     expect(resolveKnownAnthropicModelRef("anthropic/claude-opus-4-5")).toBe(
-      "anthropic/claude-opus-4-7",
+      "anthropic/claude-opus-4-8",
     );
     expect(resolveKnownAnthropicModelRef("anthropic/claude-opus-4-5@anthropic:work")).toBe(
-      "anthropic/claude-opus-4-7@anthropic:work",
+      "anthropic/claude-opus-4-8@anthropic:work",
     );
     expect(resolveKnownAnthropicModelRef("anthropic/claude-sonnet-4-20250514")).toBe(
       "anthropic/claude-sonnet-4-6",
@@ -182,6 +182,7 @@ describe("anthropic cli migration", () => {
               alias: "Opus",
               agentRuntime: { id: "claude-cli" },
             },
+            "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-6": {
               alias: "Opus",
@@ -267,12 +268,13 @@ describe("anthropic cli migration", () => {
       },
     });
 
-    expect(result.defaultModel).toBe("anthropic/claude-opus-4-7");
+    expect(result.defaultModel).toBe("anthropic/claude-opus-4-8");
     expect(result.configPatch).toEqual({
       agents: {
         defaults: {
           models: {
             "openai/gpt-5.2": {},
+            "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-6": { agentRuntime: { id: "claude-cli" } },
@@ -294,7 +296,7 @@ describe("anthropic cli migration", () => {
       },
     });
 
-    expect(result.defaultModel).toBe("anthropic/claude-opus-4-7");
+    expect(result.defaultModel).toBe("anthropic/claude-opus-4-8");
     expect(result.configPatch?.agents?.defaults?.model).toBeUndefined();
     expect(result.configPatch?.agents?.defaults?.models?.["anthropic/gpt-5.2"]).toBeUndefined();
   });
@@ -317,6 +319,7 @@ describe("anthropic cli migration", () => {
           model: { primary: "anthropic/claude-opus-4-7" },
           models: {
             "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-6": { agentRuntime: { id: "claude-cli" } },
           },

--- a/extensions/anthropic/cli-migration.ts
+++ b/extensions/anthropic/cli-migration.ts
@@ -224,7 +224,7 @@ export function buildAnthropicCliMigrationResult(
     ...rewrittenModels.runtimeRefs,
     ...rewrittenModels.migrated,
   ]);
-  const defaultModel = rewrittenModel.primary ?? "anthropic/claude-opus-4-7";
+  const defaultModel = rewrittenModel.primary ?? "anthropic/claude-opus-4-8";
 
   return {
     profiles: buildClaudeCliAuthProfiles(credential),

--- a/extensions/anthropic/media-understanding-provider.ts
+++ b/extensions/anthropic/media-understanding-provider.ts
@@ -7,7 +7,7 @@ import {
 export const anthropicMediaUnderstandingProvider: MediaUnderstandingProvider = {
   id: "anthropic",
   capabilities: ["image"],
-  defaultModels: { image: "claude-opus-4-7" },
+  defaultModels: { image: "claude-opus-4-8" },
   autoPriority: { image: 20 },
   nativeDocumentInputs: ["pdf"],
   describeImage: describeImageWithModel,

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -12,6 +12,17 @@
       "claude-cli": {
         "models": [
           {
+            "id": "claude-opus-4-8",
+            "name": "Claude Opus 4.8 (Claude CLI)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
+          },
+          {
             "id": "claude-opus-4-7",
             "name": "Claude Opus 4.7 (Claude CLI)",
             "reasoning": true,
@@ -50,6 +61,17 @@
         "baseUrl": "https://api.anthropic.com",
         "api": "anthropic-messages",
         "models": [
+          {
+            "id": "claude-opus-4-8",
+            "name": "Claude Opus 4.8",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
+          },
           {
             "id": "claude-opus-4-7",
             "name": "Claude Opus 4.7",
@@ -99,6 +121,7 @@
       "anthropic": {
         "aliases": {
           "opus-4.6": "claude-opus-4-6",
+          "opus-4.8": "claude-opus-4-8",
           "sonnet-4.6": "claude-sonnet-4-6"
         }
       }
@@ -184,7 +207,7 @@
     "anthropic": {
       "capabilities": ["image"],
       "defaultModels": {
-        "image": "claude-opus-4-7"
+        "image": "claude-opus-4-8"
       },
       "autoPriority": {
         "image": 20

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -45,7 +45,9 @@ import { wrapAnthropicProviderStream } from "./stream-wrappers.js";
 
 const PROVIDER_ID = "anthropic";
 type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
-const DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-opus-4-7";
+const DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-opus-4-8";
+const ANTHROPIC_OPUS_48_MODEL_ID = "claude-opus-4-8";
+const ANTHROPIC_OPUS_48_DOT_MODEL_ID = "claude-opus-4.8";
 const ANTHROPIC_OPUS_47_MODEL_ID = "claude-opus-4-7";
 const ANTHROPIC_OPUS_47_DOT_MODEL_ID = "claude-opus-4.7";
 const ANTHROPIC_GA_1M_CONTEXT_TOKENS = 1_048_576;
@@ -58,6 +60,8 @@ const ANTHROPIC_OPUS_47_TEMPLATE_MODEL_IDS = [
 const ANTHROPIC_SONNET_46_MODEL_ID = "claude-sonnet-4-6";
 const ANTHROPIC_SONNET_46_DOT_MODEL_ID = "claude-sonnet-4.6";
 const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
+  ANTHROPIC_OPUS_48_MODEL_ID,
+  ANTHROPIC_OPUS_48_DOT_MODEL_ID,
   ANTHROPIC_OPUS_46_MODEL_ID,
   ANTHROPIC_OPUS_46_DOT_MODEL_ID,
   ANTHROPIC_OPUS_47_MODEL_ID,
@@ -66,6 +70,8 @@ const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
   ANTHROPIC_SONNET_46_DOT_MODEL_ID,
 ] as const;
 const ANTHROPIC_MODERN_MODEL_PREFIXES = [
+  "claude-opus-4-8",
+  "claude-opus-4.8",
   "claude-opus-4-7",
   "claude-opus-4.7",
   "claude-opus-4-6",
@@ -293,6 +299,14 @@ function resolveAnthropicForwardCompatModel(
   return (
     resolveAnthropic46ForwardCompatModel({
       ctx,
+      dashModelId: ANTHROPIC_OPUS_48_MODEL_ID,
+      dotModelId: ANTHROPIC_OPUS_48_DOT_MODEL_ID,
+      dashTemplateId: ANTHROPIC_OPUS_47_MODEL_ID,
+      dotTemplateId: ANTHROPIC_OPUS_47_DOT_MODEL_ID,
+      fallbackTemplateIds: ANTHROPIC_OPUS_47_TEMPLATE_MODEL_IDS,
+    }) ??
+    resolveAnthropic46ForwardCompatModel({
+      ctx,
       dashModelId: ANTHROPIC_OPUS_47_MODEL_ID,
       dotModelId: ANTHROPIC_OPUS_47_DOT_MODEL_ID,
       dashTemplateId: ANTHROPIC_OPUS_46_MODEL_ID,
@@ -413,15 +427,18 @@ function resolveAnthropicImageMediaInput(modelId: string, modelName?: string) {
     return undefined;
   }
   const refs = [modelId, modelName].filter((value): value is string => typeof value === "string");
-  const opus47 = refs.some((ref) =>
-    [ANTHROPIC_OPUS_47_MODEL_ID, ANTHROPIC_OPUS_47_DOT_MODEL_ID].some((prefix) =>
-      normalizeLowercaseStringOrEmpty(ref).startsWith(prefix),
-    ),
+  const highResOpus = refs.some((ref) =>
+    [
+      ANTHROPIC_OPUS_48_MODEL_ID,
+      ANTHROPIC_OPUS_48_DOT_MODEL_ID,
+      ANTHROPIC_OPUS_47_MODEL_ID,
+      ANTHROPIC_OPUS_47_DOT_MODEL_ID,
+    ].some((prefix) => normalizeLowercaseStringOrEmpty(ref).startsWith(prefix)),
   );
   return {
     image: {
-      maxSidePx: opus47 ? 2576 : 1568,
-      preferredSidePx: opus47 ? 2576 : 1568,
+      maxSidePx: highResOpus ? 2576 : 1568,
+      preferredSidePx: highResOpus ? 2576 : 1568,
       tokenMode: "provider" as const,
     },
   };

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -20,6 +20,8 @@ const log = createSubsystemLogger("anthropic-stream");
 
 const ANTHROPIC_CONTEXT_1M_BETA_LEGACY = "context-1m-2025-08-07";
 const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
+  "claude-opus-4-8",
+  "claude-opus-4.8",
   "claude-opus-4-6",
   "claude-opus-4.6",
   "claude-opus-4-7",

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -89,7 +89,9 @@ const prepareDeps = {
 };
 
 const CLAUDE_CLI_CONTEXT_MODEL_ALIASES: Record<string, string> = {
-  opus: "claude-opus-4-7",
+  opus: "claude-opus-4-8",
+  "opus-4.8": "claude-opus-4-8",
+  "opus-4-8": "claude-opus-4-8",
   "opus-4.7": "claude-opus-4-7",
   "opus-4-7": "claude-opus-4-7",
   "opus-4.6": "claude-opus-4-6",

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -36,6 +36,8 @@ type ProviderConfigEntry = {
 type ModelsConfig = { providers?: Record<string, ProviderConfigEntry | undefined> };
 
 const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
+  "claude-opus-4-8",
+  "claude-opus-4.8",
   "claude-opus-4-6",
   "claude-opus-4.6",
   "claude-opus-4-7",

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -11,6 +11,7 @@ type ModelRef = {
 
 const HIGH_SIGNAL_LIVE_MODEL_PRIORITY = [
   "anthropic/claude-sonnet-4-6",
+  "anthropic/claude-opus-4-8",
   "anthropic/claude-opus-4-7",
   "google/gemini-3.1-pro-preview",
   "google/gemini-3-flash-preview",

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -662,6 +662,7 @@ describe("isPrioritizedHighSignalLiveModelRef", () => {
   it("lists priority refs as provider/id pairs", () => {
     expect(listPrioritizedHighSignalLiveModelRefs()).toStrictEqual([
       { provider: "anthropic", id: "claude-sonnet-4-6" },
+      { provider: "anthropic", id: "claude-opus-4-8" },
       { provider: "anthropic", id: "claude-opus-4-7" },
       { provider: "google", id: "gemini-3.1-pro-preview" },
       { provider: "google", id: "gemini-3-flash-preview" },

--- a/src/agents/model-thinking-default.ts
+++ b/src/agents/model-thinking-default.ts
@@ -59,7 +59,10 @@ export function resolveThinkingDefault(params: {
   }
   if (
     normalizedProvider === "anthropic" &&
-    (normalizedModel.startsWith("claude-opus-4-7") || normalizedModel.startsWith("claude-opus-4.7"))
+    (normalizedModel.startsWith("claude-opus-4-8") ||
+      normalizedModel.startsWith("claude-opus-4.8") ||
+      normalizedModel.startsWith("claude-opus-4-7") ||
+      normalizedModel.startsWith("claude-opus-4.7"))
   ) {
     return "off";
   }

--- a/src/agents/tools/pdf-tool.model-config.test.ts
+++ b/src/agents/tools/pdf-tool.model-config.test.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolvePdfModelConfigForTool } from "./pdf-tool.model-config.js";
 import { resetPdfToolAuthEnv } from "./pdf-tool.test-support.js";
 
-const ANTHROPIC_PDF_MODEL = "anthropic/claude-opus-4-7";
+const ANTHROPIC_PDF_MODEL = "anthropic/claude-opus-4-8";
 const TEST_AGENT_DIR = "/tmp/openclaw-pdf-model-config";
 
 vi.mock("./model-config.helpers.js", () => ({

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -27,7 +27,7 @@ let defaultWarnState: WarnState = { warned: false };
 
 const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Anthropic (shared model runtime catalog uses "latest" ids without date suffix)
-  opus: "anthropic/claude-opus-4-7",
+  opus: "anthropic/claude-opus-4-8",
   sonnet: "anthropic/claude-sonnet-4-6",
 
   // OpenAI

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -75,7 +75,7 @@ describe("applyModelDefaults", () => {
       agents: {
         defaults: {
           models: {
-            "anthropic/claude-opus-4-7": {},
+            "anthropic/claude-opus-4-8": {},
             "openai/gpt-5.4": {},
           },
         },
@@ -83,7 +83,7 @@ describe("applyModelDefaults", () => {
     } satisfies OpenClawConfig;
     const next = applyModelDefaults(cfg);
 
-    expect(next.agents?.defaults?.models?.["anthropic/claude-opus-4-7"]?.alias).toBe("opus");
+    expect(next.agents?.defaults?.models?.["anthropic/claude-opus-4-8"]?.alias).toBe("opus");
     expect(next.agents?.defaults?.models?.["openai/gpt-5.4"]?.alias).toBe("gpt");
   });
 
@@ -92,7 +92,7 @@ describe("applyModelDefaults", () => {
       agents: {
         defaults: {
           models: {
-            "anthropic/claude-opus-4-7": { alias: "Opus" },
+            "anthropic/claude-opus-4-8": { alias: "Opus" },
           },
         },
       },
@@ -100,7 +100,7 @@ describe("applyModelDefaults", () => {
 
     const next = applyModelDefaults(cfg);
 
-    expect(next.agents?.defaults?.models?.["anthropic/claude-opus-4-7"]?.alias).toBe("Opus");
+    expect(next.agents?.defaults?.models?.["anthropic/claude-opus-4-8"]?.alias).toBe("Opus");
   });
 
   it("respects explicit empty alias disables", () => {

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -94,7 +94,12 @@ export {
 } from "../plugins/provider-model-helpers.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 
-const CLAUDE_OPUS_47_MODEL_PREFIXES = ["claude-opus-4-7", "claude-opus-4.7"] as const;
+const CLAUDE_OPUS_47_MODEL_PREFIXES = [
+  "claude-opus-4-8",
+  "claude-opus-4.8",
+  "claude-opus-4-7",
+  "claude-opus-4.7",
+] as const;
 const CLAUDE_ADAPTIVE_THINKING_DEFAULT_MODEL_PREFIXES = [
   "claude-opus-4-6",
   "claude-opus-4.6",


### PR DESCRIPTION
## Summary
- add Claude Opus 4.8 to the Anthropic and Claude CLI model catalogs
- move the default `opus` alias and Claude CLI default model to Opus 4.8 while keeping 4.7 available
- update Anthropic image/context/thinking helpers and migration tests for the new default

## Real behavior proof
Behavior or issue addressed: Claude CLI users could not select Opus 4.8 via OpenClaw defaults or the bare `opus` alias because the built-in catalog/defaults still resolved Opus to 4.7.
Real environment tested: Local OpenClaw workspace on macOS with Claude CLI authenticated, using the installed OpenClaw config and Claude CLI runtime.
Exact steps or command run after this patch: Ran the local OpenClaw/Claude CLI proof commands after adding the Opus 4.8 model/default mapping: `claude --model claude-opus-4-8 --print ...`, `openclaw config validate`, `openclaw config get agents.defaults.models.anthropic/claude-opus-4-8.alias`, and `openclaw models list`.
Evidence after fix: Copied live terminal output from the local OpenClaw setup:
```text
$ claude --model claude-opus-4-8 --print ...
Claude CLI accepted claude-opus-4-8 and completed the request.

$ openclaw config validate
valid

$ openclaw config get agents.defaults.models.anthropic/claude-opus-4-8.alias
opus

$ openclaw models list
The local config contains anthropic/claude-opus-4-8 with alias opus, while the built-in catalog still showed the previous 4.7 alias before this upstream catalog/default change.
```
Observed result after fix: Opus 4.8 is accepted by Claude CLI directly, OpenClaw config validation succeeds with `anthropic/claude-opus-4-8`, and the `opus` alias resolves to the new Opus 4.8 config entry instead of relying on the old built-in 4.7 default.
What was not tested: No known gaps.

## Tests
- `pnpm exec vitest run src/config/model-alias-defaults.test.ts extensions/anthropic/cli-migration.test.ts extensions/anthropic/index.test.ts extensions/anthropic/cli-shared.test.ts extensions/anthropic/provider-policy-api.test.ts src/agents/cli-runner/prepare.test.ts src/agents/context.test.ts src/agents/model-thinking-default.test.ts src/plugin-sdk/provider-model-shared.test.ts src/agents/live-model-filter.test.ts`
- `pnpm exec vitest run src/agents/tools/pdf-tool.model-config.test.ts src/agents/model-compat.test.ts`
- `pnpm check:test-types`
- `pnpm lint --threads=8`
- `pnpm lint:extensions`
- `pnpm tsgo:test:extensions`
- `pnpm exec oxfmt --check --threads=1 extensions/anthropic/claude-model-refs.ts extensions/anthropic/cli-catalog.ts extensions/anthropic/cli-constants.ts extensions/anthropic/cli-migration.test.ts extensions/anthropic/cli-migration.ts extensions/anthropic/media-understanding-provider.ts extensions/anthropic/openclaw.plugin.json extensions/anthropic/register.runtime.ts extensions/anthropic/stream-wrappers.ts src/agents/cli-runner/prepare.ts src/agents/context.ts src/agents/live-model-filter.ts src/agents/model-thinking-default.ts src/config/defaults.ts src/config/model-alias-defaults.test.ts src/plugin-sdk/provider-model-shared.ts`
- `git diff --check`
