### PR TITLE
fix(qqbot): send user-facing error message when lane dispatch fails

### DIFF
--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -700,10 +700,20 @@ export async function dispatchOutbound(
 
   try {
     await Promise.race([dispatchPromise, timeoutPromise]);
-  } catch {
+  } catch (err) {
     if (timeoutId) {
       clearTimeout(timeoutId);
       timeoutId = null;
+    }
+    const errMsg = err instanceof Error ? err.message : String(err);
+    if (!hasResponse && errMsg !== undefined) {
+      let userText: string;
+      if (errMsg.includes("timeout") || errMsg === "Response timeout") {
+        userText = "⏱️ 响应超时，请重新发送";
+      } else {
+        userText = "❌ 处理失败，请稍后重试";
+      }
+      await sendErrorMessage(userText);
     }
   } finally {
     if (timeoutId) {


### PR DESCRIPTION
## Summary

QQ Bot silently swallows lane errors (rate limit, timeout, FailoverError) — the user receives no feedback at all, and the message simply disappears into the void. Unlike other channels (Telegram, Feishu), the QQ Bot has no "thinking" indicator, so a silent failure is indistinguishable from "the bot is offline".

## Root Cause

In the `Promise.race([dispatchPromise, timeoutPromise])` catch block in `outbound-dispatch.ts`, the error was caught with an empty handler that only cleared the timeout. The `sendErrorMessage` helper (already available in scope) was never called for lane-level failures.

## Fix

The catch block now:
1. Captures the error and extracts its message
2. Checks whether a response has already been sent (`hasResponse`)
3. If not, sends a brief user-friendly message via `sendErrorMessage`:
   - Timeout errors → "⏱️ 响应超时，请重新发送"
   - Other errors → "❌ 处理失败，请稍后重试"

## Verification

- TypeScript type check passes on the modified file
- Change is isolated to the catch block with no side effects on existing error paths
- No changes to function signatures or external interfaces

Closes #87860