### PR TITLE
fix(doctor): emit tool-policy profile audit at debug level

### DIFF
--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -176,7 +176,9 @@ export function auditToolPolicyFilter(params: {
       tools: matchedRuleSourceTools,
     });
     const matchedRuleSuffix = matchedRules.length > 0 ? `; matched ${matchedRules.join(", ")}` : "";
-    toolPolicyAuditLogger.info(
+    const isProfileFilter = params.stepLabel.startsWith("tools.profile");
+    const logLevel = isProfileFilter ? "debug" : "info";
+    toolPolicyAuditLogger[logLevel](
       `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}${matchedRuleSuffix}`,
       {
         rule,


### PR DESCRIPTION
## Summary

`openclaw doctor` emits repeated audit lines at info/console level for expected tool-profile filtering:

```
[agents/tool-policy] tool policy removed 5 tool(s) via tools.profile (coding): agents_list, gateway, message, nodes, tts
```

These are expected and non-actionable — the tools are correctly removed by the profile filter. Emitting them at info level makes normal doctor output look noisy.

## Root Cause

`auditToolPolicyFilter` in `tool-policy-audit.ts` always uses `info` level regardless of step type. Profile-filter steps (whose `stepLabel` starts with `tools.profile`) are routine housekeeping, not doctor findings.

## Fix

When `stepLabel` starts with `tools.profile`, emit the audit log at `debug` level instead of `info`. This preserves the diagnostic path for verbose/debug logging while cleaning up normal doctor output.

All other audit paths (`agents.allow`, `tools.deny`, sandbox policies, etc.) continue to log at `info` level unchanged.

## Verification

- TypeScript compiles without errors
- Logic change is isolated to a single conditional in `auditToolPolicyFilter`
- No behavioral change for non-profile audit paths
- No changes to function signatures or public APIs

Closes #87798