### PR TITLE
Add dependency guard backfill label trigger

### DIFF
--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -2,7 +2,7 @@ name: Dependency Guard
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] checks trusted base script only; never checks out PR head
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   dependency-guard:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && (github.event.action != 'labeled' || github.event.label.name == 'dependency-guard-backfill') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -13,6 +13,7 @@ type WorkflowStep = {
 };
 
 type WorkflowJob = {
+  if?: string;
   name?: string;
   steps?: WorkflowStep[];
 };
@@ -20,6 +21,11 @@ type WorkflowJob = {
 type Workflow = {
   jobs?: Record<string, WorkflowJob>;
   name?: string;
+  on?: {
+    pull_request_target?: {
+      types?: string[];
+    };
+  };
   permissions?: Record<string, string>;
 };
 
@@ -34,6 +40,21 @@ describe("dependency guard workflow", () => {
     expect(parsed.name).toBe("Dependency Guard");
     expect(parsed.jobs).toHaveProperty("dependency-guard");
     expect(parsed.jobs?.["dependency-guard"]?.name).toBeUndefined();
+  });
+
+  it("allows one temporary label trigger for required-check backfill", () => {
+    const parsed = readWorkflow();
+    const job = parsed.jobs?.["dependency-guard"];
+
+    expect(parsed.on?.pull_request_target?.types).toEqual([
+      "opened",
+      "reopened",
+      "synchronize",
+      "ready_for_review",
+      "labeled",
+    ]);
+    expect(job?.if).toContain("github.event.action != 'labeled'");
+    expect(job?.if).toContain("github.event.label.name == 'dependency-guard-backfill'");
   });
 
   it("uses a metadata-only pull_request_target workflow with minimal write permissions", () => {


### PR DESCRIPTION
## Summary

Add a temporary `dependency-guard-backfill` label trigger to the Dependency Guard workflow so maintainers can backfill the required `dependency-guard` check on old open PR heads without requiring contributors to push, rebase, close/reopen, or rerun the rest of CI.

- Adds `labeled` to the `pull_request_target` activity types.
- Gates labeled events to only run for `dependency-guard-backfill`.
- Keeps normal opened/reopened/synchronize/ready_for_review behavior unchanged.

## Backfill Plan

This is the first step in a temporary three-PR backfill flow:

1. This PR teaches Dependency Guard to run when maintainers add `dependency-guard-backfill`.
2. #87882 prevents broad label-triggered workflows from reacting to that label, so the batch labeler only wakes Dependency Guard and does not fan out unrelated automation.
3. Maintainers run the attached local batch script against the frozen audit set of old PRs that already have a real failing non-dependency check or a local merge conflict, then #87867 removes the temporary trigger once the backfill window is complete.

The script/artifact bundle is attached in this PR's comments as a secret gist. It is resumable, dry-run by default, and applies the label in batches using local `gh` auth unless `GH_TOKEN` is set.

## Verification

- Parsed `.github/workflows/dependency-guard.yml` with `yaml` and confirmed the trigger and job condition.
- `git diff --check -- .github/workflows/dependency-guard.yml test/scripts/dependency-guard-workflow.test.ts`
