### PR TITLE
chore: revert dependency guard backfill machinery

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -19,13 +19,6 @@ permissions: {}
 
 jobs:
   auto-response:
-    if: >-
-      ${{
-        !(
-          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-          github.event.label.name == 'dependency-guard-backfill'
-        )
-      }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -24,7 +24,14 @@ concurrency:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'issue_comment' || !(endsWith(github.actor, '[bot]') && (github.event.action == 'labeled' || github.event.action == 'unlabeled')) }}
+    if: >-
+      ${{
+        github.event_name == 'issue_comment' ||
+        !(
+          endsWith(github.actor, '[bot]') &&
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+        )
+      }}
     env:
       HAS_CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY != '' }}
       CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093

--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -24,17 +24,7 @@ concurrency:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event_name == 'issue_comment' ||
-        (
-          !(
-            (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-            github.event.label.name == 'dependency-guard-backfill'
-          ) &&
-          !(endsWith(github.actor, '[bot]') && (github.event.action == 'labeled' || github.event.action == 'unlabeled'))
-        )
-      }}
+    if: ${{ github.event_name == 'issue_comment' || !(endsWith(github.actor, '[bot]') && (github.event.action == 'labeled' || github.event.action == 'unlabeled')) }}
     env:
       HAS_CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY != '' }}
       CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -2,7 +2,7 @@ name: Dependency Guard
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] checks trusted base script only; never checks out PR head
-    types: [opened, reopened, synchronize, ready_for_review, labeled]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   dependency-guard:
-    if: ${{ !github.event.pull_request.draft && (github.event.action != 'labeled' || github.event.label.name == 'dependency-guard-backfill') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -16,13 +16,6 @@ permissions: {}
 jobs:
   real-behavior-proof:
     name: Real behavior proof
-    if: >-
-      ${{
-        !(
-          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-          github.event.label.name == 'dependency-guard-backfill'
-        )
-      }}
     permissions:
       contents: read
       issues: read

--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -13,7 +13,6 @@ type WorkflowStep = {
 };
 
 type WorkflowJob = {
-  if?: string;
   name?: string;
   steps?: WorkflowStep[];
 };
@@ -21,11 +20,6 @@ type WorkflowJob = {
 type Workflow = {
   jobs?: Record<string, WorkflowJob>;
   name?: string;
-  on?: {
-    pull_request_target?: {
-      types?: string[];
-    };
-  };
   permissions?: Record<string, string>;
 };
 
@@ -40,21 +34,6 @@ describe("dependency guard workflow", () => {
     expect(parsed.name).toBe("Dependency Guard");
     expect(parsed.jobs).toHaveProperty("dependency-guard");
     expect(parsed.jobs?.["dependency-guard"]?.name).toBeUndefined();
-  });
-
-  it("allows one temporary label trigger for required-check backfill", () => {
-    const parsed = readWorkflow();
-    const job = parsed.jobs?.["dependency-guard"];
-
-    expect(parsed.on?.pull_request_target?.types).toEqual([
-      "opened",
-      "reopened",
-      "synchronize",
-      "ready_for_review",
-      "labeled",
-    ]);
-    expect(job?.if).toContain("github.event.action != 'labeled'");
-    expect(job?.if).toContain("github.event.label.name == 'dependency-guard-backfill'");
   });
 
   it("uses a metadata-only pull_request_target workflow with minimal write permissions", () => {

--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -4,11 +4,6 @@ import { parse } from "yaml";
 
 const WORKFLOW = ".github/workflows/dependency-guard.yml";
 const CODEOWNERS = ".github/CODEOWNERS";
-const BACKFILL_EXCLUDED_WORKFLOWS = [
-  [".github/workflows/auto-response.yml", "auto-response"],
-  [".github/workflows/clawsweeper-dispatch.yml", "dispatch"],
-  [".github/workflows/real-behavior-proof.yml", "real-behavior-proof"],
-];
 
 type WorkflowStep = {
   name?: string;
@@ -38,10 +33,6 @@ function readWorkflow(): Workflow {
   return parse(readFileSync(WORKFLOW, "utf8")) as Workflow;
 }
 
-function readWorkflowFile(path: string): Workflow {
-  return parse(readFileSync(path, "utf8")) as Workflow;
-}
-
 describe("dependency guard workflow", () => {
   it("uses the dependency guard check name", () => {
     const parsed = readWorkflow();
@@ -64,16 +55,6 @@ describe("dependency guard workflow", () => {
     ]);
     expect(job?.if).toContain("github.event.action != 'labeled'");
     expect(job?.if).toContain("github.event.label.name == 'dependency-guard-backfill'");
-  });
-
-  it("keeps the temporary backfill label from waking unrelated PR automation", () => {
-    for (const [workflowFile, jobName] of BACKFILL_EXCLUDED_WORKFLOWS) {
-      const job = readWorkflowFile(workflowFile).jobs?.[jobName];
-
-      expect(job?.if).toContain("github.event.action == 'labeled'");
-      expect(job?.if).toContain("github.event.action == 'unlabeled'");
-      expect(job?.if).toContain("github.event.label.name == 'dependency-guard-backfill'");
-    }
   });
 
   it("uses a metadata-only pull_request_target workflow with minimal write permissions", () => {


### PR DESCRIPTION
## Summary

Cleanly revert the two temporary dependency guard backfill PRs after the required-check backfill window is done:

- Revert #87882: `ci: isolate dependency guard backfill label`
- Revert #87866: `ci: add dependency guard backfill label trigger`

After this lands, Dependency Guard returns to normal PR lifecycle events only:

- opened
- reopened
- synchronize
- ready_for_review

## Verification

- `git diff --check`
- Parsed dependency guard, auto-response, ClawSweeper dispatch, and real behavior proof workflow YAML files.
