### PR TITLE
Fix Codex zero-cost usage accounting

### DIFF
--- a/extensions/codex/provider-catalog.ts
+++ b/extensions/codex/provider-catalog.ts
@@ -10,6 +10,17 @@ export const CODEX_APP_SERVER_AUTH_MARKER = "codex-app-server";
 
 const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
+const KNOWN_CODEX_MODEL_COSTS: Record<
+  string,
+  { input: number; output: number; cacheRead: number; cacheWrite: number }
+> = {
+  "gpt-5.5": { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+  "gpt-5.5-pro": { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
+  "gpt-5.4": { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+  "gpt-5.4-pro": { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
+  "gpt-5.4-mini": { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
+  "gpt-5.2": { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+};
 
 export const FALLBACK_CODEX_MODELS = [
   {
@@ -29,6 +40,13 @@ export const FALLBACK_CODEX_MODELS = [
     inputModalities: ["text", "image"],
     supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
   },
+  {
+    id: "gpt-5.2",
+    model: "gpt-5.2",
+    displayName: "gpt-5.2",
+    inputModalities: ["text", "image"],
+    supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+  },
 ] satisfies CodexAppServerModel[];
 
 export function buildCodexModelDefinition(model: {
@@ -39,13 +57,19 @@ export function buildCodexModelDefinition(model: {
   supportedReasoningEfforts: string[];
 }): ModelDefinitionConfig {
   const id = model.id.trim() || model.model.trim();
+  const normalizedId = id.toLowerCase();
   return {
     id,
     name: model.displayName?.trim() || id,
     api: "openai-codex-responses",
     reasoning: model.supportedReasoningEfforts.length > 0 || shouldDefaultToReasoningModel(id),
     input: model.inputModalities.includes("image") ? ["text", "image"] : ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    cost: KNOWN_CODEX_MODEL_COSTS[normalizedId] ?? {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MAX_TOKENS,
     compat: {

--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -18,7 +18,22 @@ afterEach(() => {
 function expectStaticFallbackCatalog(
   result: Awaited<ReturnType<typeof buildCodexProviderCatalog>>,
 ) {
-  expect(result.provider.models.map((model) => model.id)).toEqual(["gpt-5.5", "gpt-5.4-mini"]);
+  const modelIds = result.provider.models.map((model) => model.id);
+  expect(modelIds).toEqual(["gpt-5.5", "gpt-5.4-mini", "gpt-5.2"]);
+  expect(result.provider.models[0]?.cost).toEqual({
+    input: 5,
+    output: 30,
+    cacheRead: 0.5,
+    cacheWrite: 0,
+  });
+  for (const model of result.provider.models) {
+    expect(model.cost).not.toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+  }
 }
 
 function createFakeCodexClient(): CodexAppServerClient {
@@ -26,6 +41,7 @@ function createFakeCodexClient(): CodexAppServerClient {
     initialize: vi.fn(async () => undefined),
     request: vi.fn(async () => ({ data: [] })),
     addCloseHandler: vi.fn(() => () => undefined),
+    setActiveSharedLeaseCountProviderForUnscopedNotifications: vi.fn(),
     close: vi.fn(),
   } as unknown as CodexAppServerClient;
 }
@@ -119,6 +135,7 @@ describe("codex provider", () => {
       name: "gpt-5.4",
       reasoning: true,
       input: ["text", "image"],
+      cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
       compat: { supportsReasoningEffort: true, supportsUsageInStreaming: true },
     });
   });
@@ -396,7 +413,7 @@ describe("codex provider", () => {
 
     expect(
       result && "provider" in result ? result.provider.models.map((model) => model.id) : [],
-    ).toEqual(["gpt-5.5", "gpt-5.4-mini"]);
+    ).toEqual(["gpt-5.5", "gpt-5.4-mini", "gpt-5.2"]);
   });
 
   it("adds the GPT-5 prompt overlay to Codex provider runs", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -83,8 +83,12 @@ import {
 } from "../shared/string-coerce.js";
 import { uniqueStrings } from "../shared/string-normalization.js";
 import { normalizeSessionDeliveryFields } from "../utils/delivery-context.shared.js";
-import type { ModelCostConfig } from "../utils/usage-format.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
+import type { ExplicitZeroCostSource, ModelCostConfig } from "../utils/usage-format.js";
+import {
+  resolveExplicitZeroCostSource,
+  resolveModelCostConfig,
+  resolveUsageCostUsd,
+} from "../utils/usage-format.js";
 import {
   resolveSessionStoreAgentId,
   resolveSessionStoreKey,
@@ -259,6 +263,19 @@ function resolveNonNegativeNumber(value: number | null | undefined): number | un
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
+function resolveSessionExplicitZeroCostSource(params: {
+  provider?: string;
+  entryEstimatedCostUsd?: number | null;
+  explicitCostUsd?: number;
+}): ExplicitZeroCostSource | undefined {
+  // The stale zero bug came from persisted session rows. Transcript/runtime
+  // costs are explicit observations, and configured free pricing should stay 0.
+  if (params.explicitCostUsd !== undefined || params.entryEstimatedCostUsd !== 0) {
+    return undefined;
+  }
+  return resolveExplicitZeroCostSource({ provider: params.provider });
+}
+
 type SessionCompactionCheckpointEntry = NonNullable<SessionEntry["compactionCheckpoints"]>[number];
 
 function isProjectableCompactionCheckpoint(
@@ -362,9 +379,6 @@ function resolveEstimatedSessionCostUsd(params: {
   const explicitCostUsd = resolveNonNegativeNumber(
     params.explicitCostUsd ?? params.entry?.estimatedCostUsd,
   );
-  if (explicitCostUsd !== undefined) {
-    return explicitCostUsd;
-  }
   const input = resolvePositiveNumber(params.entry?.inputTokens);
   const output = resolvePositiveNumber(params.entry?.outputTokens);
   const cacheRead = resolvePositiveNumber(params.entry?.cacheRead);
@@ -375,7 +389,7 @@ function resolveEstimatedSessionCostUsd(params: {
     cacheRead === undefined &&
     cacheWrite === undefined
   ) {
-    return undefined;
+    return explicitCostUsd;
   }
   const cost = resolveModelCostConfigCached(
     params.provider,
@@ -384,18 +398,25 @@ function resolveEstimatedSessionCostUsd(params: {
     params.rowContext,
   );
   if (!cost) {
-    return undefined;
+    return explicitCostUsd;
   }
-  const estimated = estimateUsageCost({
-    usage: {
-      ...(input !== undefined ? { input } : {}),
-      ...(output !== undefined ? { output } : {}),
-      ...(cacheRead !== undefined ? { cacheRead } : {}),
-      ...(cacheWrite !== undefined ? { cacheWrite } : {}),
-    },
-    cost,
-  });
-  return resolveNonNegativeNumber(estimated);
+  return resolveNonNegativeNumber(
+    resolveUsageCostUsd({
+      explicitCostUsd,
+      usage: {
+        ...(input !== undefined ? { input } : {}),
+        ...(output !== undefined ? { output } : {}),
+        ...(cacheRead !== undefined ? { cacheRead } : {}),
+        ...(cacheWrite !== undefined ? { cacheWrite } : {}),
+      },
+      cost,
+      explicitZeroCostSource: resolveSessionExplicitZeroCostSource({
+        provider: params.provider,
+        explicitCostUsd: params.explicitCostUsd,
+        entryEstimatedCostUsd: params.entry?.estimatedCostUsd,
+      }),
+    }),
+  );
 }
 
 const STALE_STORE_ONLY_CHILD_LINK_MS = 60 * 60 * 1_000;

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -440,6 +440,169 @@ describe("session cost usage", () => {
     });
   });
 
+  it("recomputes persisted zero transcript cost when pricing is configured", async () => {
+    const root = await makeSessionCostRoot("cost-zero-recompute");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    const agentDir = path.join(root, "agents", "main", "agent");
+    const now = new Date();
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify(
+        {
+          providers: {
+            "openai-codex": {
+              models: [
+                {
+                  id: "gpt-5.4",
+                  cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const entry = {
+      type: "message",
+      timestamp: now.toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        usage: {
+          input: 1000,
+          output: 500,
+          cacheRead: 2000,
+          totalTokens: 3500,
+          cost: { total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-zero-recompute.jsonl"),
+      transcriptText("sess-zero-recompute", entry),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30 });
+      expect(summary.totals.totalTokens).toBe(3500);
+      expect(summary.totals.totalCost).toBeCloseTo(0.0105, 8);
+    });
+  });
+
+  it("preserves non-Codex explicit zero transcript cost when pricing is configured", async () => {
+    const root = await makeSessionCostRoot("cost-zero-trusted");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    const now = new Date();
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-zero-trusted.jsonl"),
+      transcriptText("sess-zero-trusted", {
+        type: "message",
+        timestamp: now.toISOString(),
+        message: {
+          role: "assistant",
+          provider: "free-provider",
+          model: "free-model",
+          usage: {
+            input: 1000,
+            output: 500,
+            totalTokens: 1500,
+            cost: { total: 0 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const config = {
+      models: {
+        providers: {
+          "free-provider": {
+            models: [
+              {
+                id: "free-model",
+                cost: { input: 10, output: 20, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(1500);
+      expect(summary.totals.totalCost).toBe(0);
+      expect(summary.totals.missingCostEntries).toBe(0);
+    });
+  });
+
+  it("treats Codex generated all-zero pricing as missing cost for token usage", async () => {
+    const root = await makeSessionCostRoot("cost-zero-codex-missing");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    const agentDir = path.join(root, "agents", "main", "agent");
+    const now = new Date();
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify(
+        {
+          providers: {
+            "openai-codex": {
+              models: [
+                {
+                  id: "gpt-unknown-codex",
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-zero-codex-missing.jsonl"),
+      transcriptText("sess-zero-codex-missing", {
+        type: "message",
+        timestamp: now.toISOString(),
+        message: {
+          role: "assistant",
+          provider: "openai-codex",
+          model: "gpt-unknown-codex",
+          usage: {
+            input: 1000,
+            output: 500,
+            totalTokens: 1500,
+            cost: { total: 0 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30 });
+      expect(summary.totals.totalTokens).toBe(1500);
+      expect(summary.totals.totalCost).toBe(0);
+      expect(summary.totals.missingCostEntries).toBe(1);
+    });
+  });
+
   it("refreshes append-only durable aggregate cache by scanning only appended bytes", async () => {
     const root = await makeSessionCostRoot("cost-cache-append");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -25,8 +25,10 @@ import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
 import {
   estimateUsageCost,
+  resolveExplicitZeroCostSource,
   resolveModelCostConfig,
   resolveModelCostConfigFingerprint,
+  resolveUsageCostUsd,
 } from "../utils/usage-format.js";
 import { formatErrorMessage } from "./errors.js";
 import { replaceFileAtomic } from "./replace-file.js";
@@ -1155,23 +1157,34 @@ async function scanTranscriptFile(params: {
         // instead of the stale flat-rate breakdown from the transport layer.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
         entry.costBreakdown = undefined;
-      } else if (
-        !isModelPricingKnown(cost) &&
-        (entry.costTotal === undefined || entry.costTotal === 0) &&
-        computeUsageTokenTotals(entry.usage).totalTokens > 0
-      ) {
-        // Pricing for this model is unknown: it has no positive per-token rate and no
-        // trustworthy recorded cost. The transport either recorded nothing or a
-        // fabricated $0 derived from an all-zero/default catalog entry. Surface this
-        // token-burning turn as a missing-cost entry instead of recording a confident
-        // $0, so budget and spike safeguards that read totalCost are not left blind to
-        // it. A turn carrying a real positive recorded cost is preserved by the guard
-        // above.
-        entry.costTotal = undefined;
-        entry.costBreakdown = undefined;
-      } else if (entry.costTotal === undefined) {
-        // Fill in missing cost estimates.
-        entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+      } else {
+        const resolvedCost = resolveUsageCostUsd({
+          explicitCostUsd: entry.costTotal,
+          usage: entry.usage,
+          cost,
+          explicitZeroCostSource: resolveExplicitZeroCostSource({ provider: entry.provider }),
+        });
+        if (resolvedCost !== entry.costTotal) {
+          entry.costTotal = resolvedCost;
+          entry.costBreakdown = undefined;
+        } else if (
+          !isModelPricingKnown(cost) &&
+          (entry.costTotal === undefined || entry.costTotal === 0) &&
+          computeUsageTokenTotals(entry.usage).totalTokens > 0
+        ) {
+          // Pricing for this model is unknown: it has no positive per-token rate and no
+          // trustworthy recorded cost. The transport either recorded nothing or a
+          // fabricated $0 derived from an all-zero/default catalog entry. Surface this
+          // token-burning turn as a missing-cost entry instead of recording a confident
+          // $0, so budget and spike safeguards that read totalCost are not left blind to
+          // it. A turn carrying a real positive recorded cost is preserved by the guard
+          // above.
+          entry.costTotal = undefined;
+          entry.costBreakdown = undefined;
+        } else if (entry.costTotal === undefined) {
+          // Fill in missing cost estimates.
+          entry.costTotal = resolvedCost;
+        }
       }
     }
 
@@ -2525,15 +2538,18 @@ export async function loadSessionLogs(params: {
               (usage.cacheRead ?? 0) +
               (usage.cacheWrite ?? 0);
           const breakdown = extractCostBreakdown(usageRaw);
-          if (breakdown?.total !== undefined) {
-            cost = breakdown.total;
-          } else {
-            const costConfig = resolveCost({
-              provider: message.provider as string | undefined,
-              model: message.model as string | undefined,
-            });
-            cost = estimateUsageCost({ usage, cost: costConfig });
-          }
+          const provider = message.provider as string | undefined;
+          const model = message.model as string | undefined;
+          const costConfig = resolveCost({
+            provider,
+            model,
+          });
+          cost = resolveUsageCostUsd({
+            explicitCostUsd: breakdown?.total,
+            usage,
+            cost: costConfig,
+            explicitZeroCostSource: resolveExplicitZeroCostSource({ provider }),
+          });
         }
       }
 

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -25,15 +25,15 @@ const cfg = {
   },
 } satisfies OpenClawConfig;
 
-function createPreparedModel(modelId = "gpt-5.5") {
+function createPreparedModel(modelId = "gpt-5.5", provider = "openai") {
   return {
     selection: {
-      provider: "openai",
+      provider,
       modelId,
       agentDir: "/tmp/openclaw-agent",
     },
     model: {
-      provider: "openai",
+      provider,
       id: modelId,
       name: modelId,
       api: "openai",
@@ -638,6 +638,58 @@ describe("runtime.llm.complete", () => {
       caller: { kind: "plugin", id: "trusted-plugin" },
       purpose: "identity-test",
     });
+  });
+
+  it("re-estimates generated Codex explicit zero cost when configured pricing is nonzero", async () => {
+    hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce(
+      createPreparedModel("gpt-5.5", "openai-codex"),
+    );
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+      content: [{ type: "text", text: "done" }],
+      usage: {
+        input: 1000,
+        output: 500,
+        cacheRead: 2000,
+        total: 3500,
+        cost: { total: 0 },
+      },
+    });
+
+    const llm = createRuntimeLlm({
+      getConfig: () =>
+        ({
+          agents: { defaults: { model: "openai-codex/gpt-5.5" } },
+          models: {
+            providers: {
+              "openai-codex": {
+                baseUrl: "https://chatgpt.com/backend-api",
+                models: [
+                  {
+                    id: "gpt-5.5",
+                    name: "gpt-5.5",
+                    reasoning: true,
+                    input: ["text"],
+                    contextWindow: 128_000,
+                    maxTokens: 4096,
+                    cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 },
+                  },
+                ],
+              },
+            },
+          },
+        }) satisfies OpenClawConfig,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+
+    const result = await llm.complete({
+      messages: [{ role: "user", content: "Ping" }],
+      purpose: "test-purpose",
+    });
+
+    expect(result.usage.costUsd).toBeCloseTo(0.003, 8);
   });
 
   it("denies plugin model overrides by default", async () => {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -8,7 +8,11 @@ import { getChildLogger } from "../../logging.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { asFiniteNumber } from "../../shared/number-coercion.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
+import {
+  resolveExplicitZeroCostSource,
+  resolveModelCostConfig,
+  resolveUsageCostUsd,
+} from "../../utils/usage-format.js";
 import { normalizePluginsConfig } from "../config-state.js";
 import { getPluginRuntimeGatewayRequestScope } from "./gateway-request-scope.js";
 import type {
@@ -199,9 +203,12 @@ function buildUsage(params: {
     model: params.model,
     config: params.cfg,
   });
-  const costUsd =
-    readExplicitCostUsd(params.rawUsage) ??
-    estimateUsageCost({ usage: params.normalized, cost: costConfig });
+  const costUsd = resolveUsageCostUsd({
+    explicitCostUsd: readExplicitCostUsd(params.rawUsage),
+    usage: params.normalized,
+    cost: costConfig,
+    explicitZeroCostSource: resolveExplicitZeroCostSource({ provider: params.provider }),
+  });
   return {
     ...(params.normalized?.input !== undefined ? { inputTokens: params.normalized.input } : {}),
     ...(params.normalized?.output !== undefined ? { outputTokens: params.normalized.output } : {}),

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -14,6 +14,8 @@ import {
   estimateUsageCost,
   formatTokenCount,
   formatUsd,
+  resolveExplicitZeroCostSource,
+  resolveUsageCostUsd,
   resolveModelCostConfig,
   resolveModelCostConfigFingerprint,
   type PricingTier,
@@ -123,6 +125,46 @@ describe("usage-format", () => {
     });
 
     expect(total).toBeCloseTo(0.003);
+  });
+
+  it("preserves explicit zero by default when pricing is known", () => {
+    expect(
+      resolveUsageCostUsd({
+        explicitCostUsd: 0,
+        usage: { input: 1000, output: 500, cacheRead: 2000 },
+        cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 },
+      }),
+    ).toBe(0);
+  });
+
+  it("recomputes generated Codex explicit zero when pricing is known", () => {
+    expect(
+      resolveUsageCostUsd({
+        explicitCostUsd: 0,
+        usage: { input: 1000, output: 500, cacheRead: 2000 },
+        cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 },
+        explicitZeroCostSource: resolveExplicitZeroCostSource({ provider: "openai-codex" }),
+      }),
+    ).toBeCloseTo(0.003);
+  });
+
+  it("treats generated Codex all-zero pricing as missing cost for token usage", () => {
+    expect(
+      resolveUsageCostUsd({
+        explicitCostUsd: 0,
+        usage: { input: 1000, output: 500 },
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        explicitZeroCostSource: resolveExplicitZeroCostSource({ provider: "codex" }),
+      }),
+    ).toBeUndefined();
+
+    expect(
+      resolveUsageCostUsd({
+        usage: { input: 1000, output: 500 },
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        explicitZeroCostSource: resolveExplicitZeroCostSource({ provider: "codex" }),
+      }),
+    ).toBeUndefined();
   });
 
   it("returns undefined when model pricing is not configured", () => {

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -54,6 +54,8 @@ export type UsageTotals = {
   total?: number;
 };
 
+export type ExplicitZeroCostSource = "generated-codex-pricing";
+
 type ModelsJsonCostCache = {
   path: string;
   providers: Record<string, ModelProviderConfig> | undefined;
@@ -736,6 +738,74 @@ export function estimateUsageCost(params: {
     return undefined;
   }
   return total / 1_000_000;
+}
+
+function hasUsageTokens(usage?: NormalizedUsage | UsageTotals | null): boolean {
+  if (!usage) {
+    return false;
+  }
+  return (
+    toNumber(usage.input) > 0 ||
+    toNumber(usage.output) > 0 ||
+    toNumber(usage.cacheRead) > 0 ||
+    toNumber(usage.cacheWrite) > 0 ||
+    toNumber(usage.total) > 0
+  );
+}
+
+function hasPositiveConfiguredPricing(cost?: ModelCostConfig): boolean {
+  if (!cost) {
+    return false;
+  }
+  if (cost.input > 0 || cost.output > 0 || cost.cacheRead > 0 || cost.cacheWrite > 0) {
+    return true;
+  }
+  return (
+    cost.tieredPricing?.some(
+      (tier) => tier.input > 0 || tier.output > 0 || tier.cacheRead > 0 || tier.cacheWrite > 0,
+    ) ?? false
+  );
+}
+
+export function resolveExplicitZeroCostSource(params: {
+  provider?: string;
+}): ExplicitZeroCostSource | undefined {
+  const provider = normalizeProviderId(normalizeOptionalString(params.provider) ?? "");
+  return provider === "codex" || provider === "openai-codex" || provider === "codex-cli"
+    ? "generated-codex-pricing"
+    : undefined;
+}
+
+export function resolveUsageCostUsd(params: {
+  explicitCostUsd?: number;
+  usage?: NormalizedUsage | UsageTotals | null;
+  cost?: ModelCostConfig;
+  explicitZeroCostSource?: ExplicitZeroCostSource;
+}): number | undefined {
+  const estimated = estimateUsageCost({ usage: params.usage, cost: params.cost });
+  const hasTokens = hasUsageTokens(params.usage);
+  const hasPositivePricing = hasPositiveConfiguredPricing(params.cost);
+  const generatedCodexZero = params.explicitZeroCostSource === "generated-codex-pricing";
+  if (params.explicitCostUsd === undefined) {
+    if (generatedCodexZero && hasTokens && estimated === 0 && !hasPositivePricing) {
+      return undefined;
+    }
+    return estimated;
+  }
+  if (
+    generatedCodexZero &&
+    params.explicitCostUsd === 0 &&
+    estimated !== undefined &&
+    estimated > 0 &&
+    hasTokens &&
+    hasPositivePricing
+  ) {
+    return estimated;
+  }
+  if (generatedCodexZero && params.explicitCostUsd === 0 && hasTokens && !hasPositivePricing) {
+    return undefined;
+  }
+  return params.explicitCostUsd;
 }
 
 export function resetUsageFormatCachesForTest(): void {


### PR DESCRIPTION
## Summary
- assign known pricing to native Codex catalog rows instead of hardcoding zero cost for GPT-5 family models
- fall back to local cost estimation when persisted Codex usage contains generated `$0` cost and configured pricing is nonzero
- keep explicitly configured free Codex pricing and transcript-observed zero costs as `0`
- cover the regression with Codex catalog, runtime usage, session listing, and transcript aggregation tests

## Notes
- This targets the Codex/OpenAI cost regression where real token usage can be persisted with `usage.cost.total = 0`, causing dashboard and usage summaries to report false zero cost.
- The follow-up fix narrows Gateway session rows so only persisted session-store zeros are treated as stale Codex-generated zeros. Transcript/runtime explicit costs and configured free pricing remain authoritative.
- The branch is rebased onto current `main`; the earlier agent gateway lint failure is now fixed on `main`, so the PR stack stays scoped to Codex accounting.

## Real behavior proof
Behavior addressed: Codex token usage with provider-reported `usage.cost.total = 0` is re-estimated from configured pricing, while a configured free Codex model still reports an explicit `0` session cost.

Real environment tested: Local OpenClaw source checkout at `fc7d7cb03fca1b65aa47e2546bd155a1320208ed`, isolated `OPENCLAW_STATE_DIR`, real session transcript JSONL under `agents/main/sessions/`, and the production `loadCostUsageSummary` plus Gateway session row code paths.

Exact steps or command run after this patch: Ran a Node/TSX one-shot that created an isolated state dir, wrote `agents/main/sessions/codex-cost-proof.jsonl` with `openai-codex/gpt-5.5` usage `{ input: 1000, output: 500, cacheRead: 2000, cost: { total: 0 } }`, loaded usage cost with configured nonzero Codex pricing, and listed a configured-free `openai-codex/gpt-5.3-codex-spark` session row.

Evidence after fix:
```json
{
  "environment": "isolated OpenClaw state dir with real session transcript JSONL",
  "stateDirBasename": "openclaw-pr-87872-proof-iNOo9O",
  "transcriptFile": "agents/main/sessions/codex-cost-proof.jsonl",
  "costSummary": {
    "input": 1000,
    "output": 500,
    "cacheRead": 2000,
    "totalTokens": 3500,
    "totalCost": 0.003,
    "missingCostEntries": 0
  },
  "freeConfiguredSessionEstimatedCostUsd": 0
}
```

Observed result after fix: The transcript-backed usage summary no longer trusts the stale Codex `$0`; it reports `totalCost: 0.003` from configured pricing. The configured-free Gateway session row still reports `freeConfiguredSessionEstimatedCostUsd: 0` instead of missing cost.

What was not tested: I did not run a live paid Codex API call; the proof uses a redacted local transcript fixture in an isolated real OpenClaw state dir.

## Verification
- `git diff --check`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- `node scripts/run-vitest.mjs src/gateway/session-utils.search.test.ts src/utils/usage-format.test.ts src/plugins/runtime/runtime-llm.runtime.test.ts`
- `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts src/gateway/server.sessions.list-changed.test.ts src/infra/session-cost-usage.test.ts`
