### PR TITLE
fix(secrets): trust source-managed models env markers

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -480,6 +480,53 @@ describe("secrets audit", () => {
     });
   });
 
+  it("does not flag source-managed custom env apiKey markers in models.json", async () => {
+    const customEnvMarker = "CUSTOM_PROVIDER_API_KEY";
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: { source: "env", provider: "default", id: customEnvMarker },
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+    await writeModelsProvider({ apiKey: customEnvMarker });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.openai.apiKey",
+      present: false,
+    });
+  });
+
+  it("keeps custom env apiKey marker suppression scoped to its source provider", async () => {
+    const customEnvMarker = "CUSTOM_PROVIDER_API_KEY";
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          moonshot: {
+            baseUrl: "https://api.moonshot.cn/v1",
+            api: "openai-completions",
+            apiKey: { source: "env", provider: "default", id: customEnvMarker },
+            models: [{ id: "moonshot-v1-8k", name: "moonshot-v1-8k" }],
+          },
+        },
+      },
+    });
+    await writeModelsProvider({ apiKey: customEnvMarker });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.openai.apiKey",
+    });
+  });
+
   it("does not flag models.json header marker values as plaintext", async () => {
     await writeModelsProvider({
       headers: {

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -99,6 +99,7 @@ type AuditCollector = {
   findings: SecretsAuditFinding[];
   refAssignments: RefAssignment[];
   configProviderRefPaths: Map<string, string[]>;
+  sourceManagedModelsJsonApiKeyMarkers: Map<string, Set<string>>;
   authProviderState: Map<string, ProviderAuthState>;
   filesScanned: Set<string>;
 };
@@ -121,6 +122,26 @@ function collectProviderRefPath(
     return;
   }
   collector.configProviderRefPaths.set(key, [configPath]);
+}
+
+function collectSourceManagedModelsJsonApiKeyMarker(params: {
+  collector: AuditCollector;
+  providerId: string;
+  ref: SecretRef;
+}): void {
+  const { collector, providerId, ref } = params;
+  if (ref.source !== "env") {
+    return;
+  }
+  const marker = ref.id.trim();
+  if (!marker) {
+    return;
+  }
+  const providerKey = normalizeProviderId(providerId);
+  const markers =
+    collector.sourceManagedModelsJsonApiKeyMarkers.get(providerKey) ?? new Set<string>();
+  markers.add(marker);
+  collector.sourceManagedModelsJsonApiKeyMarkers.set(providerKey, markers);
 }
 
 function trackAuthProviderState(
@@ -197,6 +218,13 @@ function collectConfigSecrets(params: {
       });
       if (target.entry.trackProviderShadowing && target.providerId) {
         collectProviderRefPath(params.collector, target.providerId, target.path);
+      }
+      if (target.entry.id === "models.providers.*.apiKey" && target.providerId) {
+        collectSourceManagedModelsJsonApiKeyMarker({
+          collector: params.collector,
+          providerId: target.providerId,
+          ref,
+        });
       }
       continue;
     }
@@ -379,6 +407,12 @@ function collectModelsJsonSecrets(params: {
         provider: providerId,
       });
     } else if (isNonEmptyString(apiKey) && !isNonSecretApiKeyMarker(apiKey)) {
+      const sourceManagedMarker = params.collector.sourceManagedModelsJsonApiKeyMarkers
+        .get(normalizeProviderId(providerId))
+        ?.has(apiKey.trim());
+      if (sourceManagedMarker) {
+        continue;
+      }
       addFinding(params.collector, {
         code: "PLAINTEXT_FOUND",
         severity: "warn",
@@ -623,6 +657,7 @@ export async function runSecretsAudit(
     findings: [],
     refAssignments: [],
     configProviderRefPaths: new Map(),
+    sourceManagedModelsJsonApiKeyMarkers: new Map(),
     authProviderState: new Map(),
     filesScanned: new Set([configPath]),
   };


### PR DESCRIPTION
Fixes #87723

## Summary
- track `models.providers.*.apiKey` env SecretRefs from source config as provider-scoped generated `models.json` markers
- suppress `PLAINTEXT_FOUND` only when the generated marker matches that source provider
- keep arbitrary all-caps strings and cross-provider marker reuse warning as plaintext

## Real behavior proof
Behavior addressed: `secrets audit` distinguishes source-managed generated env markers in `models.json` from plaintext provider keys without broadening the all-caps heuristic.
Real environment tested: Linux source checkout at `ffd4a801454a4dfc1929faa13c61dc9b3d62cbe5` with dependencies installed via `pnpm install --frozen-lockfile`.
Exact steps or command run after this patch: `git diff --check`; one-shot `node --import tsx` script that writes temporary `openclaw.json` and `agents/main/agent/models.json`, then calls `runSecretsAudit` for same-provider and cross-provider marker cases.
Evidence after fix: terminal output copied from the one-shot audit proof:
```json
{"sameProviderSuppressed":true,"crossProviderStillWarns":true}
```
Observed result after fix: the matching source-managed `CUSTOM_PROVIDER_API_KEY` marker is not reported as plaintext for its provider, while the same marker under an unrelated provider still reports `PLAINTEXT_FOUND`.
What was not tested: full `src/secrets/audit.test.ts` did not complete locally within the bounded verification window; CI should run the committed Vitest regression tests.

## Verification
- `git diff --check`
- `node --import tsx - <<'EOF' ... EOF`, output shown above
- Attempted: `node scripts/run-vitest.mjs run src/secrets/audit.test.ts -t "source-managed custom env apiKey markers|custom env apiKey marker suppression" --reporter=verbose`; stopped after it ran over two minutes with no output on this host
