### PR TITLE
fix(macos): inherit thinking for voice wake forwarding

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -514,12 +514,16 @@ extension GatewayConnection {
         var params: [String: AnyCodable] = [
             "message": AnyCodable(trimmed),
             "sessionKey": AnyCodable(sessionKey),
-            "thinking": AnyCodable(invocation.thinking ?? "default"),
             "deliver": AnyCodable(invocation.deliver),
             "to": AnyCodable(invocation.to ?? ""),
             "channel": AnyCodable(invocation.channel.rawValue),
             "idempotencyKey": AnyCodable(invocation.idempotencyKey),
         ]
+        if let thinking = invocation.thinking?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !thinking.isEmpty
+        {
+            params["thinking"] = AnyCodable(thinking)
+        }
         if let timeout = invocation.timeoutSeconds {
             params["timeout"] = AnyCodable(timeout)
         }

--- a/apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift
@@ -34,7 +34,7 @@ enum VoiceWakeForwarder {
 
     struct ForwardOptions {
         var sessionKey: String = "main"
-        var thinking: String = "low"
+        var thinking: String?
         var deliver: Bool = true
         var to: String?
         var channel: GatewayAgentChannel = .webchat
@@ -97,7 +97,6 @@ enum VoiceWakeForwarder {
 
         return ForwardOptions(
             sessionKey: sessionKey,
-            thinking: "low",
             deliver: true,
             to: to,
             channel: channel,

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -174,6 +174,7 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
         let json = try JSONSerialization.jsonObject(with: payloadData) as? [String: Any]
         let params = json?["params"] as? [String: Any]
         #expect(params?["voiceWakeTrigger"] as? String == "")
+        #expect(params?["thinking"] == nil)
     }
 
     private static func messageData(_ message: URLSessionWebSocketTask.Message) -> Data? {

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeForwarderTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeForwarderTests.swift
@@ -14,7 +14,7 @@ import Testing
     @Test func `forward options defaults`() {
         let opts = VoiceWakeForwarder.ForwardOptions()
         #expect(opts.sessionKey == "main")
-        #expect(opts.thinking == "low")
+        #expect(opts.thinking == nil)
         #expect(opts.deliver == true)
         #expect(opts.to == nil)
         #expect(opts.channel == .webchat)
@@ -38,6 +38,7 @@ import Testing
         #expect(opts.channel == .telegram)
         #expect(opts.to == "telegram:6812765697")
         #expect(opts.voiceWakeTrigger == "open claw")
+        #expect(opts.thinking == nil)
         #expect(opts.channel.shouldDeliver(opts.deliver) == true)
     }
 


### PR DESCRIPTION
Fixes #87768

## Summary
- stop macOS VoiceWake/PTT forwarding from forcing `thinking: "low"`
- omit empty/nil native agent thinking overrides so the gateway/session/provider policy can choose a supported level
- update VoiceWake forwarding and gateway payload tests for the inherited-thinking path

## Real behavior proof
Behavior addressed: macOS VoiceWake/push-to-talk no longer sends an explicit `low` thinking override; nil/empty native agent thinking is omitted from the gateway request payload.
Real environment tested: Linux source checkout at `ffd4a801454a4dfc1929faa13c61dc9b3d62cbe5`; no local Swift toolchain is installed in this environment.
Exact steps or command run after this patch: `git diff --check`; `node --input-type=module - <<'EOF' ... EOF` to inspect the patched VoiceWake and gateway source; attempted `swift test --package-path apps/macos --filter VoiceWakeForwarderTests`.
Evidence after fix: terminal output copied from the source checkout after the patch:
```json
{"forwardOptionsThinkingOptional":true,"voiceWakeHardCodedLowRemoved":true,"sendAgentOmitsNilThinking":true,"sendAgentDefaultFallbackRemoved":true}
```
Observed result after fix: VoiceWake/PTT forwarding keeps `thinking` nil and `sendAgent` only writes a `thinking` parameter when a non-empty override exists, so the old hard-coded `low`/`default` override path is removed for this flow.
What was not tested: Swift tests were not run locally because `swift` is not installed on this Linux host; macOS/Ollama live PTT remains a CI or maintainer-device proof gap.

## Verification
- `git diff --check`
- `node --input-type=module - <<'EOF' ... EOF`, output shown above
- Not run locally: `swift test --package-path apps/macos --filter VoiceWakeForwarderTests` (`swift: command not found`)
