### PR TITLE
ci: require human Mantis proof label trigger

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -61,6 +61,7 @@ jobs:
         (
           github.event_name == 'pull_request_target' &&
           github.event.action == 'labeled' &&
+          !endsWith(github.actor, '[bot]') &&
           github.event.label.name == 'mantis: telegram-visible-proof'
         ) ||
         (


### PR DESCRIPTION
## Summary
- Require a non-bot label actor before `mantis: telegram-visible-proof` can trigger the expensive Mantis Telegram proof workflow.
- Leave `Auto response` unchanged because Barnacle intentionally uses bot-applied labels as a command path.
- Leave `Real behavior proof` unchanged because its label-triggered reruns are part of the proof/override state contract.

## Verification
- `git diff --check`
- Parsed `.github/workflows/mantis-telegram-desktop-proof.yml` with the repository YAML parser and verified the bot-label guard is present.
