### PR TITLE
ci: isolate dependency guard backfill label

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -19,6 +19,13 @@ permissions: {}
 
 jobs:
   auto-response:
+    if: >-
+      ${{
+        !(
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+          github.event.label.name == 'dependency-guard-backfill'
+        )
+      }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -24,7 +24,17 @@ concurrency:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'issue_comment' || !(endsWith(github.actor, '[bot]') && (github.event.action == 'labeled' || github.event.action == 'unlabeled')) }}
+    if: >-
+      ${{
+        github.event_name == 'issue_comment' ||
+        (
+          !(
+            (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+            github.event.label.name == 'dependency-guard-backfill'
+          ) &&
+          !(endsWith(github.actor, '[bot]') && (github.event.action == 'labeled' || github.event.action == 'unlabeled'))
+        )
+      }}
     env:
       HAS_CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY != '' }}
       CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093

--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -16,6 +16,13 @@ permissions: {}
 jobs:
   real-behavior-proof:
     name: Real behavior proof
+    if: >-
+      ${{
+        !(
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+          github.event.label.name == 'dependency-guard-backfill'
+        )
+      }}
     permissions:
       contents: read
       issues: read

--- a/test/scripts/dependency-guard-workflow.test.ts
+++ b/test/scripts/dependency-guard-workflow.test.ts
@@ -4,6 +4,11 @@ import { parse } from "yaml";
 
 const WORKFLOW = ".github/workflows/dependency-guard.yml";
 const CODEOWNERS = ".github/CODEOWNERS";
+const BACKFILL_EXCLUDED_WORKFLOWS = [
+  [".github/workflows/auto-response.yml", "auto-response"],
+  [".github/workflows/clawsweeper-dispatch.yml", "dispatch"],
+  [".github/workflows/real-behavior-proof.yml", "real-behavior-proof"],
+];
 
 type WorkflowStep = {
   name?: string;
@@ -33,6 +38,10 @@ function readWorkflow(): Workflow {
   return parse(readFileSync(WORKFLOW, "utf8")) as Workflow;
 }
 
+function readWorkflowFile(path: string): Workflow {
+  return parse(readFileSync(path, "utf8")) as Workflow;
+}
+
 describe("dependency guard workflow", () => {
   it("uses the dependency guard check name", () => {
     const parsed = readWorkflow();
@@ -55,6 +64,16 @@ describe("dependency guard workflow", () => {
     ]);
     expect(job?.if).toContain("github.event.action != 'labeled'");
     expect(job?.if).toContain("github.event.label.name == 'dependency-guard-backfill'");
+  });
+
+  it("keeps the temporary backfill label from waking unrelated PR automation", () => {
+    for (const [workflowFile, jobName] of BACKFILL_EXCLUDED_WORKFLOWS) {
+      const job = readWorkflowFile(workflowFile).jobs?.[jobName];
+
+      expect(job?.if).toContain("github.event.action == 'labeled'");
+      expect(job?.if).toContain("github.event.action == 'unlabeled'");
+      expect(job?.if).toContain("github.event.label.name == 'dependency-guard-backfill'");
+    }
   });
 
   it("uses a metadata-only pull_request_target workflow with minimal write permissions", () => {


### PR DESCRIPTION
## Summary

Isolate the temporary `dependency-guard-backfill` label so using it for old PR backfill only triggers Dependency Guard and does not accidentally wake broad PR automation.

- Skip `dependency-guard-backfill` label mutations in ClawSweeper Dispatch, Auto response, and Real behavior proof.
- Keep `dependency-guard` as the only workflow that intentionally runs from the temporary backfill label.
- Add workflow coverage so the temporary backfill exclusion stays paired with the dependency guard label trigger.

## Backfill Plan

#87866 introduced the temporary label trigger that lets maintainers create the missing required `dependency-guard` check on old PR heads without contributor branch churn. This PR makes that safe to use at scale by ensuring the backfill label does not kick off unrelated label-driven automation.

With #87866 and this PR landed, maintainers can run the local batch labeler from the artifact bundle linked on #87866. The batch targets are the frozen audit set of old non-draft PRs that already have either a real failing non-dependency check or a local merge conflict, excluding the dependency guard check itself from the check-health decision. After the backfill run is complete, #87867 removes both the temporary trigger and these temporary exclusions.

## Verification

- `git diff --check`
- Parsed dependency guard, auto-response, ClawSweeper dispatch, and real behavior proof workflow YAML files.
- Verified each excluded workflow job condition references `dependency-guard-backfill`.

Note: `node scripts/run-vitest.mjs test/scripts/dependency-guard-workflow.test.ts` was started but did not emit completion in this Codex worktree before I stopped it; the static YAML assertions above cover the changed workflow surface.
