### PR TITLE
fix(config): preserve empty plugin allowlist

### DIFF
--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -289,6 +289,23 @@ describe("applyPluginAutoEnable core", () => {
     expect(result.config.plugins?.allow).toBeUndefined();
   });
 
+  it("preserves an empty plugins.allow as nonrestrictive during auto-enable", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: { slack: { botToken: "x" } },
+        plugins: {
+          allow: [],
+          bundledDiscovery: "compat",
+        },
+      },
+      env,
+    });
+
+    expect(result.config.channels?.slack?.enabled).toBe(true);
+    expect(result.config.plugins?.allow).toEqual([]);
+    expect(result.changes.join("\n")).toContain("Slack configured, enabled automatically.");
+  });
+
   it("does not auto-enable Slack from unrelated Slack-prefixed env vars", () => {
     const result = applyPluginAutoEnable({
       config: {},

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -1041,7 +1041,8 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
     }
 
     const allow = next.plugins?.allow;
-    const allowMissing = Array.isArray(allow) && !allow.includes(entry.pluginId);
+    const hasRestrictiveAllowlist = Array.isArray(allow) && allow.length > 0;
+    const allowMissing = hasRestrictiveAllowlist && !allow.includes(entry.pluginId);
     const alreadyEnabled =
       builtInChannelId != null
         ? isBuiltInChannelAlreadyEnabled(next, builtInChannelId)
@@ -1051,7 +1052,9 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
     }
 
     next = registerPluginEntry(next, entry, params.manifestRegistry);
-    next = ensurePluginAllowlisted(next, entry.pluginId);
+    if (hasRestrictiveAllowlist) {
+      next = ensurePluginAllowlisted(next, entry.pluginId);
+    }
     const reason = resolvePluginAutoEnableCandidateReason(entry);
     autoEnabledReasons.set(entry.pluginId, [
       ...(autoEnabledReasons.get(entry.pluginId) ?? []),


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor --fix` could turn an explicit empty `plugins.allow` into a restrictive allowlist when auto-enabling configured bundled plugins under `plugins.bundledDiscovery: "compat"`.
- Solution: Preserve empty `plugins.allow` as nonrestrictive while still extending non-empty restrictive allowlists.
- What changed: Updated plugin auto-enable allowlist materialization and added regression coverage for explicit empty allowlists.
- What did NOT change: Existing restrictive non-empty `plugins.allow` behavior remains unchanged.

Fixes #87869

## Real behavior proof

- **Behavior or issue addressed:** Doctor/plugin auto-enable should not convert `plugins.allow: []` into a restrictive list that blocks bundled plugins under compat discovery.
- **Real environment tested:** Local OpenClaw source checkout in `/media/vdc/code/ai/aispace/openclaw-worktrees/issue-87869`, using `node --import tsx` against the real OpenClaw `applyPluginAutoEnable` implementation.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx --input-type=module <<'NODE'
  import { applyPluginAutoEnable } from './src/config/plugin-auto-enable.apply.ts';
  const result = applyPluginAutoEnable({
    config: {
      channels: { slack: { botToken: 'x' } },
      plugins: { allow: [], bundledDiscovery: 'compat' },
    },
    env: {},
  });
  console.log('openclaw config materialization output');
  console.log('after allow:', JSON.stringify(result.config.plugins?.allow));
  console.log('after slack enabled:', result.config.channels?.slack?.enabled === true);
  console.log('after changes:', result.changes.join(' | '));
  NODE
  ```
- **Evidence after fix:**
  ```text
  openclaw config materialization output
  after allow: []
  after slack enabled: true
  after changes: Slack configured, enabled automatically.
  ```
- **Observed result after fix:** The explicit empty allowlist remains `[]`, while the configured bundled Slack channel still auto-enables.
- **What was not tested:** Did not run a full live gateway because this fix is in pure config materialization; the proof calls the real OpenClaw config function directly and the regression test covers the same invariant.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `src/config/plugin-auto-enable.core.test.ts`
- Scenario locked in: `plugins.allow: []` with `plugins.bundledDiscovery: "compat"` remains empty after auto-enable.
- Why this is the smallest reliable guardrail: The regression is caused by config materialization, so this test directly covers the root invariant without requiring external services.

## Root Cause

- Root cause: `materializePluginAutoEnableCandidatesInternal` called `ensurePluginAllowlisted` whenever `plugins.allow` was an array, including the explicit empty array case, which changed a nonrestrictive allowlist into a restrictive one.
- Missing detection / guardrail: Existing tests covered unset allowlists and non-empty restrictive allowlists, but not explicit empty allowlists under compat bundled discovery.
