### PR TITLE
fix(cli): resolve gateway auth SecretRefs for status --deep audit

### DIFF
--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -249,6 +249,7 @@ import {
   getQrRemoteCommandSecretTargetIds,
   getScopedChannelsCommandSecretTargets,
   getSecurityAuditCommandSecretTargetIds,
+  getStatusCommandSecretTargetIds,
 } from "./command-secret-targets.js";
 
 describe("command secret target ids", () => {
@@ -271,6 +272,18 @@ describe("command secret target ids", () => {
     expect(ids.has("plugins.entries.firecrawl.config.webFetch.apiKey")).toBe(true);
     expect(ids.has("plugins.entries.exa.config.webSearch.apiKey")).toBe(true);
     expect(ids.has("channels.discord.token")).toBe(false);
+  });
+
+  it("includes gateway auth targets for status commands so the embedded audit resolves them", () => {
+    const ids = getStatusCommandSecretTargetIds(undefined, undefined, {
+      includeChannelTargets: false,
+    });
+    // Regression for #87815: status --deep runs an embedded security audit that
+    // must see resolved gateway auth, so these must match the security-audit set.
+    expect(ids.has("gateway.auth.token")).toBe(true);
+    expect(ids.has("gateway.auth.password")).toBe(true);
+    // existing status targets stay covered
+    expect(ids.has("agents.defaults.memorySearch.remote.apiKey")).toBe(true);
   });
 
   it("scopes capability web search commands to search credential surfaces only", () => {

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -57,6 +57,12 @@ const STATIC_TTS_TARGET_IDS = [
 const STATIC_STATUS_TARGET_IDS = [
   "agents.defaults.memorySearch.remote.apiKey",
   "agents.list[].memorySearch.remote.apiKey",
+  // `status --deep` runs an embedded security audit that inspects gateway auth.
+  // Without these targets the audit sees unresolved SecretRefs and falsely
+  // reports gateway.auth.mode="none" (issue #87815). Mirrors
+  // STATIC_SECURITY_AUDIT_TARGET_IDS so both surfaces agree.
+  "gateway.auth.token",
+  "gateway.auth.password",
 ] as const;
 const STATIC_SECURITY_AUDIT_TARGET_IDS = [
   "gateway.auth.token",


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**
`openclaw status --deep` falsely reported `gateway.auth.mode="none"` and warned `Gateway HTTP APIs are reachable without auth`, even when token auth was configured via a SecretRef — while `config get gateway`, `status --deep --json`, and `security audit --deep` all correctly saw token auth (#87815).

**Why does this matter now?**
It's a false security/configuration alarm that erodes trust in `status --deep` as a diagnostic surface and can send operators chasing nonexistent auth drift.

**Root cause & fix**
`status --deep` runs an embedded security audit, but its secret-target set (`STATIC_STATUS_TARGET_IDS`) omitted `gateway.auth.token` and `gateway.auth.password`, so the audit evaluated unresolved SecretRefs. The dedicated `security audit` path (`STATIC_SECURITY_AUDIT_TARGET_IDS`) already lists those targets, which is why it stayed clean. This adds the two targets to the status set so both surfaces agree.

**What is intentionally out of scope?**
No schema/config changes; the security-audit findings themselves are untouched. Only the status command's read-only secret-target coverage is widened.

**What does success look like?**
`status --deep` no longer emits `gateway.http.no_auth` / `auth.mode="none"` for a gateway whose auth token/password resolves through a SecretRef.

**What should reviewers focus on?**
That widening `STATIC_STATUS_TARGET_IDS` does not regress the fast status/import path. The change is two static IDs (no registry lookups); `getStatusCommandSecretTargetIds` merges them exactly as before.

## Verification

- `pnpm exec vitest run src/cli/command-secret-targets.test.ts` → **38 passed**.
- Added regression test *"includes gateway auth targets for status commands so the embedded audit resolves them"* which **fails on current `main`** (gateway auth targets absent from the status set) and passes with this change.

## Linked context

Closes #87815
