### PR TITLE
fix(doctor): keep empty plugin allowlists open

### DIFF
--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -962,6 +962,101 @@ describe("applyPluginAutoEnable core", () => {
     expect(result.changes).toContain("discord plugin config present, added to plugin allowlist.");
   });
 
+  it("preserves empty compat allowlists while enabling configured provider plugins", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        auth: {
+          profiles: {
+            "minimax:default": {
+              provider: "minimax",
+              mode: "api_key",
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "opencode-go/deepseek-v4-pro",
+          },
+        },
+        tools: {
+          web: {
+            search: {
+              provider: "tavily",
+            },
+          },
+        },
+        plugins: {
+          allow: [],
+          bundledDiscovery: "compat",
+          entries: {
+            ollama: {
+              config: {
+                endpoint: "http://127.0.0.1:11434",
+              },
+            },
+          },
+        },
+      },
+      env,
+      manifestRegistry: makeRegistry([
+        {
+          id: "minimax",
+          channels: [],
+          providers: ["minimax"],
+          autoEnableWhenConfiguredProviders: ["minimax"],
+        },
+        { id: "opencode-go", channels: [], providers: ["opencode-go"] },
+        {
+          id: "tavily",
+          channels: [],
+          contracts: {
+            webSearchProviders: ["tavily"],
+          },
+        },
+        { id: "ollama", channels: [] },
+      ]),
+    });
+
+    expect(result.config.plugins?.allow).toEqual([]);
+    expect(result.config.plugins?.entries?.minimax?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.["opencode-go"]?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.tavily?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.ollama?.config).toEqual({
+      endpoint: "http://127.0.0.1:11434",
+    });
+    expect(result.config.plugins?.entries?.ollama?.enabled).toBeUndefined();
+    expect(result.changes).toEqual([
+      "minimax auth configured, enabled automatically.",
+      "opencode-go/deepseek-v4-pro model configured, enabled automatically.",
+      "tavily web search provider selected, enabled automatically.",
+    ]);
+
+    const rerun = applyPluginAutoEnable({
+      config: result.config,
+      env,
+      manifestRegistry: makeRegistry([
+        {
+          id: "minimax",
+          channels: [],
+          providers: ["minimax"],
+          autoEnableWhenConfiguredProviders: ["minimax"],
+        },
+        { id: "opencode-go", channels: [], providers: ["opencode-go"] },
+        {
+          id: "tavily",
+          channels: [],
+          contracts: {
+            webSearchProviders: ["tavily"],
+          },
+        },
+        { id: "ollama", channels: [] },
+      ]),
+    });
+
+    expect(rerun.config.plugins?.allow).toEqual([]);
+    expect(rerun.changes).toEqual([]);
+  });
+
   it("does not preserve stale configured plugin entries in restrictive plugins.allow", () => {
     const result = materializePluginAutoEnableCandidates({
       config: {

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -1041,7 +1041,8 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
     }
 
     const allow = next.plugins?.allow;
-    const allowMissing = Array.isArray(allow) && !allow.includes(entry.pluginId);
+    const allowMissing =
+      Array.isArray(allow) && allow.length > 0 && !allow.includes(entry.pluginId);
     const alreadyEnabled =
       builtInChannelId != null
         ? isBuiltInChannelAlreadyEnabled(next, builtInChannelId)

--- a/src/config/plugins-allowlist.ts
+++ b/src/config/plugins-allowlist.ts
@@ -9,7 +9,7 @@ export function ensurePluginAllowlisted<T extends PluginAllowlistConfigCarrier>(
   pluginId: string,
 ): T {
   const allow = cfg.plugins?.allow;
-  if (!Array.isArray(allow) || allow.includes(pluginId)) {
+  if (!Array.isArray(allow) || allow.length === 0 || allow.includes(pluginId)) {
     return cfg;
   }
   return {

--- a/src/plugin-sdk/provider-enable-config.test.ts
+++ b/src/plugin-sdk/provider-enable-config.test.ts
@@ -31,6 +31,28 @@ describe("provider contract enablePluginInConfig", () => {
     });
   });
 
+  it("preserves empty plugin allowlists as open while enabling provider plugins", () => {
+    const config = {
+      plugins: {
+        allow: [],
+      },
+    };
+
+    const result = enableSearchPluginInConfig(config, "brave");
+
+    expect(result).toEqual({
+      enabled: true,
+      config: {
+        plugins: {
+          allow: [],
+          entries: {
+            brave: { enabled: true },
+          },
+        },
+      },
+    });
+  });
+
   it("shares denylist behavior across provider contract subpaths", () => {
     const config = {
       plugins: {


### PR DESCRIPTION
## Summary

Fixes #87869.

- keep `plugins.allow: []` as the existing open/nonrestrictive policy when auto-enabling configured plugins
- still add plugin ids to an already non-empty restrictive `plugins.allow`
- make the empty-allowlist auto-enable path idempotent so a second `doctor --fix`/auto-enable pass emits no repeated changes

## Real behavior proof

Behavior addressed: `openclaw doctor --fix` could turn an open `plugins.allow: []` config into a restrictive allowlist when auto-enabling configured provider/search plugins under `plugins.bundledDiscovery: "compat"`.

Real environment tested: local Linux source checkout, Node with repo dependencies installed, using the production `applyPluginAutoEnable` path and a manifest registry matching the reported configured plugin categories.

Exact steps or command run after this patch:

```bash
node --import tsx --input-type=module <<'NODEPROOF'
import { applyPluginAutoEnable } from './src/config/plugin-auto-enable.js';

const manifestRegistry = {
  diagnostics: [],
  plugins: [
    { id: 'minimax', channels: [], providers: ['minimax'], autoEnableWhenConfiguredProviders: ['minimax'], skills: [], hooks: [], contracts: {}, cliBackends: [], origin: 'bundled', rootDir: '/fake/minimax', source: '/fake/minimax/index.js', manifestPath: '/fake/minimax/openclaw.plugin.json' },
    { id: 'opencode-go', channels: [], providers: ['opencode-go'], skills: [], hooks: [], contracts: {}, cliBackends: [], origin: 'bundled', rootDir: '/fake/opencode-go', source: '/fake/opencode-go/index.js', manifestPath: '/fake/opencode-go/openclaw.plugin.json' },
    { id: 'tavily', channels: [], providers: [], skills: [], hooks: [], contracts: { webSearchProviders: ['tavily'] }, cliBackends: [], origin: 'config', rootDir: '/fake/tavily', source: '/fake/tavily/index.js', manifestPath: '/fake/tavily/openclaw.plugin.json' },
    { id: 'ollama', channels: [], providers: [], skills: [], hooks: [], contracts: {}, cliBackends: [], origin: 'bundled', rootDir: '/fake/ollama', source: '/fake/ollama/index.js', manifestPath: '/fake/ollama/openclaw.plugin.json' },
  ],
};
const env = {
  OPENCLAW_STATE_DIR: '/tmp/openclaw-87869-proof-state',
  OPENCLAW_BUNDLED_PLUGINS_DIR: `${process.cwd()}/extensions`,
  OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: '1',
  VITEST: 'true',
};
const first = applyPluginAutoEnable({
  config: {
    auth: { profiles: { 'minimax:default': { provider: 'minimax', mode: 'api_key' } } },
    agents: { defaults: { model: 'opencode-go/deepseek-v4-pro' } },
    tools: { web: { search: { provider: 'tavily' } } },
    plugins: {
      allow: [],
      bundledDiscovery: 'compat',
      entries: { ollama: { config: { endpoint: 'http://127.0.0.1:11434' } } },
    },
  },
  env,
  manifestRegistry,
});
const second = applyPluginAutoEnable({ config: first.config, env, manifestRegistry });
const proof = {
  firstAllow: first.config.plugins?.allow,
  firstEnabledEntries: Object.fromEntries(
    Object.entries(first.config.plugins?.entries ?? {}).map(([id, entry]) => [id, entry?.enabled ?? null]),
  ),
  firstChanges: first.changes,
  secondAllow: second.config.plugins?.allow,
  secondChanges: second.changes,
};
if (JSON.stringify(proof.firstAllow) !== '[]') throw new Error('first pass widened plugins.allow');
if (proof.firstEnabledEntries.minimax !== true) throw new Error('minimax was not enabled');
if (proof.firstEnabledEntries['opencode-go'] !== true) throw new Error('opencode-go was not enabled');
if (proof.firstEnabledEntries.tavily !== true) throw new Error('tavily was not enabled');
if (JSON.stringify(proof.secondAllow) !== '[]') throw new Error('second pass widened plugins.allow');
if (proof.secondChanges.length !== 0) throw new Error('second pass was not idempotent');
console.log(JSON.stringify(proof, null, 2));
NODEPROOF
```

Evidence after fix:

```json
{
  "firstAllow": [],
  "firstEnabledEntries": {
    "ollama": null,
    "minimax": true,
    "opencode-go": true,
    "tavily": true
  },
  "firstChanges": [
    "minimax auth configured, enabled automatically.",
    "opencode-go/deepseek-v4-pro model configured, enabled automatically.",
    "tavily web search provider selected, enabled automatically."
  ],
  "secondAllow": [],
  "secondChanges": []
}
```

Observed result after fix: configured provider/search plugins are enabled, `plugins.allow` remains `[]`, and a second auto-enable pass emits no repeated changes.

What was not tested: I did not run a live gateway restart with the full installed plugin set. Local `node scripts/run-vitest.mjs run ...` attempts for the new tests started Vitest but produced no test output for more than a minute, so I stopped them rather than leaving a stalled local process. CI should run the focused tests normally.

## Verification

- `pnpm install --frozen-lockfile`
- production-function proof shown above
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/config/plugins-allowlist.ts src/config/plugin-auto-enable.shared.ts src/config/plugin-auto-enable.core.test.ts src/plugin-sdk/provider-enable-config.test.ts`
