### PR TITLE
fix(agents): skip tool prep when models disable tools

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -199,6 +199,28 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
     });
   });
 
+  it("short-circuits all local tool construction when the model disables tools", () => {
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({
+        toolsEnabled: false,
+        toolsAllow: ["message"],
+        forceMessageTool: true,
+      }),
+      {
+        constructTools: false,
+        includeCoreTools: false,
+        runtimeToolAllowlist: undefined,
+        coding: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: false,
+        },
+      },
+    );
+  });
+
   it("constructs message tool for forced message delivery on explicit no-tools runs", () => {
     expectConstructionPlan(
       resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: [], forceMessageTool: true }),

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -170,6 +170,7 @@ function resolveCodingToolConstructionPlanForAllowlist(
 export function resolveEmbeddedAttemptToolConstructionPlan(params: {
   disableTools?: boolean;
   isRawModelRun?: boolean;
+  toolsEnabled?: boolean;
   toolsAllow?: string[];
   forceMessageTool?: boolean;
 }): {
@@ -178,7 +179,11 @@ export function resolveEmbeddedAttemptToolConstructionPlan(params: {
   runtimeToolAllowlist?: string[];
   codingToolConstructionPlan: OpenClawCodingToolConstructionPlan;
 } {
-  if (params.disableTools === true || params.isRawModelRun === true) {
+  if (
+    params.disableTools === true ||
+    params.isRawModelRun === true ||
+    params.toolsEnabled === false
+  ) {
     return {
       constructTools: false,
       includeCoreTools: false,

--- a/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
@@ -62,6 +62,21 @@ describe("runEmbeddedAttempt cwd/workspace split", () => {
     expect(resourceLoaderInit?.cwd).toBe(taskRepo);
   });
 
+  it("skips runtime tool construction when the selected model does not support tools", async () => {
+    hoisted.supportsModelToolsMock.mockReturnValueOnce(false);
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:main:main",
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+      },
+    });
+
+    expect(hoisted.createOpenClawCodingToolsMock).not.toHaveBeenCalled();
+  });
+
   it("rejects cwd overrides for sandboxed runs instead of silently ignoring them", async () => {
     hoisted.resolveSandboxContextMock.mockResolvedValueOnce({
       enabled: true,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1098,12 +1098,13 @@ export async function runEmbeddedAttempt(
           params.sourceReplyDeliveryMode === "message_tool_only",
       },
     );
+    const toolsEnabled = supportsModelTools(params.model);
     const toolConstructionPlan = resolveEmbeddedAttemptToolConstructionPlan({
       disableTools: params.disableTools,
       isRawModelRun,
+      toolsEnabled,
       toolsAllow: toolsAllowWithForcedRuntimeTools,
     });
-    const toolsEnabled = supportsModelTools(params.model);
     const codeModeConfig = resolveCodeModeConfig(params.config, sessionAgentId);
     const codeModeControlsEnabledForRun =
       toolsEnabled &&


### PR DESCRIPTION
## Summary

- Skip core/plugin tool construction when the active model declares `compat.supportsTools: false`.
- Keep existing raw-model and explicit no-tools behavior, while making the documented no-tools small-model fallback avoid tool-prep overhead too.
- Add planner and runner-level coverage proving forced message delivery cannot re-enable tool construction for tool-disabled models.

Refs #86599.
Related: #88142 covers the same optimization at a later call site; this PR keeps the decision in the construction plan so downstream code sees the correct no-tools state.

## Verification

- `git diff --check origin/main...HEAD` passed on pushed SHA `e5f59b7a63c`.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts --reporter=dot` passed on pushed SHA `e5f59b7a63c`: 2 routed Vitest shards, 25 tests, 9.16s.
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts` passed.
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts` passed.
- AWS Crabbox `pnpm check:changed` passed with exit 0 on pushed SHA `e5f59b7a63c`: provider `aws`, lease `cbx_e3f7d477f364`, run `run_eaaf1556be1f`, machine `c7a.8xlarge`, lanes `core`, `coreTests`.
- Branch autoreview clean: no accepted/actionable findings; overall patch correct 0.85.

## Real behavior proof

Behavior addressed: models configured with `compat.supportsTools: false` no longer pay to construct the OpenClaw tool surface before the runner discards it.

Real environment tested: focused local node-wrapper Vitest in a Codex worktree; AWS Crabbox Linux `c7a.8xlarge` changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 60m --ttl 120m --timing-json --shell -- "pnpm check:changed"`; `git diff --check origin/main...HEAD`.

Evidence after fix: focused planner and runner regressions passed 25 tests on pushed SHA `e5f59b7a63c`; AWS Crabbox `run_eaaf1556be1f` completed `pnpm check:changed` with exit 0 and covered the `core`/`coreTests` lanes.

Observed result after fix: `resolveEmbeddedAttemptToolConstructionPlan` returns `constructTools: false`, `includeCoreTools: false`, and no runtime allowlist when `toolsEnabled: false`; the runner-level regression confirms `createOpenClawCodingTools` is not called when the selected model reports no tool support.

What was not tested: no live Ollama/API small-model agent turn in this PR; this PR removes local tool-prep overhead for toolless model metadata and does not change provider transport or model output handling.
