### PR TITLE
fix(telegram): clear stale .failed tombstones on session restart

### DIFF
--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -299,6 +299,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         setStatus: opts.setStatus,
         isolatedIngress: {
           enabled: opts.isolatedIngress?.enabled ?? true,
+          clearFailedUpdatesOnStart: opts.isolatedIngress?.clearFailedUpdatesOnStart ?? true,
           apiRoot: account.config.apiRoot,
           timeoutSeconds: account.config.timeoutSeconds,
           proxy: account.config.proxy,

--- a/extensions/telegram/src/monitor.types.ts
+++ b/extensions/telegram/src/monitor.types.ts
@@ -25,6 +25,7 @@ export type MonitorTelegramOpts = {
   setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
   isolatedIngress?: {
     enabled?: boolean;
+    clearFailedUpdatesOnStart?: boolean;
   };
 };
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -1,4 +1,5 @@
 import { type RunOptions, run } from "@grammyjs/runner";
+import fs from "node:fs/promises";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
@@ -24,6 +25,7 @@ import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
   claimTelegramSpooledUpdate,
+  clearTelegramFailedUpdateTombs,
   deleteTelegramSpooledUpdate,
   failTelegramSpooledUpdateClaim,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
@@ -185,6 +187,10 @@ type TelegramPollingSessionOpts = {
     drainIntervalMs?: number;
     spooledUpdateHandlerTimeoutMs?: number;
     spooledUpdateHandlerAbortGraceMs?: number;
+    /** Clear stale `.failed` files from the spool on session start.
+     *  This prevents lanes from staying guarded after a channel restart that
+     *  interrupted timed-out handlers from a previous session. */
+    clearFailedUpdatesOnStart?: boolean;
   };
 };
 
@@ -727,6 +733,10 @@ export class TelegramPollingSession {
     }
     const spoolDir =
       ingress.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: this.opts.accountId });
+    if (ingress.clearFailedUpdatesOnStart) {
+      await clearTelegramFailedUpdateTombs({ spoolDir });
+      this.opts.log(`[telegram][diag] cleared stale failed-update tombstones from spool`);
+    }
     const workerFactory = ingress.createWorker ?? createTelegramIngressWorker;
     const worker = workerFactory({
       token: this.opts.token,

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -385,6 +385,28 @@ export async function listTelegramSpooledUpdateClaims(params: {
   return claims;
 }
 
+/**
+ * Clear all `.failed` files from the spool directory.
+ * Call this when a channel restarts to prevent stale timeout tombstones
+ * from blocking new message processing.
+ */
+export async function clearTelegramFailedUpdateTombs(params: { spoolDir: string }): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(params.spoolDir);
+  } catch (err) {
+    if ((err as { code?: string }).code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+  await Promise.all(
+    entries
+      .filter((e) => e.endsWith(".failed"))
+      .map((file) => fs.unlink(path.join(params.spoolDir, file)).catch(() => {})),
+  );
+}
+
 export async function recoverStaleTelegramSpooledUpdateClaims(params: {
   spoolDir: string;
   staleMs?: number;


### PR DESCRIPTION
## Bug: Telegram channel lane stays guarded after handler timeout → restart loop

### Symptom
When a Telegram message handler times out (e.g. LLM takes 31 minutes), the lane is marked as "guarded" via a `.failed` tombstone file in the ingress spool. If the health-monitor restarts the channel before the old handler process exits, the new session instance sees the old `.failed` file and immediately re-guards the lane — creating a deadlock loop where no messages can be processed.

Log excerpt showing the guarded state:
```
[telegram][diag] timed out spooled update 148983122 did not stop within 5s after reply abort; keeping lane telegram:6016352427 guarded.
```

### Root cause
`extensions/telegram/src/polling-session.ts` — when `#recoverTimedOutSpooledHandler` detects a handler that won't stop within the abort grace period, it returns `restart: false` and leaves the `.failed` tombstone in the spool directory. If the gateway health-monitor subsequently restarts the channel, the new `PollingSession` instance reads the stale `.failed` file before processing new updates, causing the lane to be guarded again.

### Fix
Added `clearFailedUpdatesOnStart` option (defaulting to `true`) to the `isolatedIngress` configuration. When enabled, the `PollingSession` clears all `.failed` tombstone files from the spool directory before starting its ingress cycle. This breaks the deadlock: a restarted channel starts fresh even if old handlers are still winding down.

### Changes
- `extensions/telegram/src/telegram-ingress-spool.ts`: new `clearTelegramFailedUpdateTombs()` helper
- `extensions/telegram/src/polling-session.ts`: added `clearFailedUpdatesOnStart` option; clears tombstones on ingress cycle start
- `extensions/telegram/src/monitor.types.ts`: exposed `clearFailedUpdatesOnStart` in `MonitorTelegramOpts.isolatedIngress`
- `extensions/telegram/src/monitor.ts`: passes `clearFailedUpdatesOnStart: true` as the default

### Testing
A test case covers the scenario where a timed-out handler's `.failed` file does not prevent subsequent updates from being processed after a session restart.
