### PR TITLE
fix(auth-profiles): repair stale auto runtime auth selection

### DIFF
--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1223,6 +1223,57 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBeUndefined();
   });
 
+  it("repairs legacy runtime-only auto auth fallback state", async () => {
+    authProfileStoreMock.store = {
+      version: 1,
+      profiles: {
+        "deepseek:default": {
+          type: "api_key",
+          provider: "deepseek",
+          key: "fallback-key",
+        },
+        "minimax:global": {
+          type: "api_key",
+          provider: "minimax",
+          key: "primary-key",
+        },
+      },
+    };
+    const sessionEntry = makeEntry({
+      modelProvider: "deepseek",
+      model: "deepseek-v4-flash",
+      contextTokens: 64_000,
+      authProfileOverride: "deepseek:default",
+      authProfileOverrideCompactionCount: 2,
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "minimax",
+      defaultModel: "MiniMax-M2.7",
+      primaryProvider: "minimax",
+      primaryModel: "MiniMax-M2.7",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("minimax");
+    expect(state.model).toBe("MiniMax-M2.7");
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("deepseek/deepseek-v4-flash");
+    expect(sessionStore[sessionKey]?.modelProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.model).toBeUndefined();
+    expect(sessionStore[sessionKey]?.contextTokens).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverrideCompactionCount).toBeUndefined();
+  });
+
   it("preserves ordinary auto auth profile rotation when runtime model matches selection", async () => {
     authProfileStoreMock.store = {
       version: 1,

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1274,6 +1274,50 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.authProfileOverrideCompactionCount).toBeUndefined();
   });
 
+  it("does not override an explicit model directive while repairing stale auto auth state", async () => {
+    authProfileStoreMock.store = {
+      version: 1,
+      profiles: {
+        "deepseek:default": {
+          type: "api_key",
+          provider: "deepseek",
+          key: "fallback-key",
+        },
+      },
+    };
+    const sessionEntry = makeEntry({
+      modelProvider: "deepseek",
+      model: "deepseek-v4-flash",
+      contextTokens: 64_000,
+      authProfileOverride: "deepseek:default",
+      authProfileOverrideSource: "auto",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "minimax",
+      defaultModel: "MiniMax-M2.7",
+      primaryProvider: "minimax",
+      primaryModel: "MiniMax-M2.7",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      hasModelDirective: true,
+    });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-opus-4-6");
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("deepseek/deepseek-v4-flash");
+    expect(sessionStore[sessionKey]?.modelProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.model).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
+  });
+
   it("preserves ordinary auto auth profile rotation when runtime model matches selection", async () => {
     authProfileStoreMock.store = {
       version: 1,

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1269,6 +1269,52 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("auto");
   });
 
+  it("preserves runtime-equivalent OpenAI Codex auto auth selections", async () => {
+    authProfileStoreMock.store = {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "api_key",
+          provider: "openai-codex",
+          key: "codex-key",
+        },
+      },
+    };
+    const sessionEntry = makeEntry({
+      modelProvider: "openai-codex",
+      model: "gpt-5.5",
+      contextTokens: 200_000,
+      authProfileOverride: "openai-codex:default",
+      authProfileOverrideSource: "auto",
+      authProfileOverrideCompactionCount: 0,
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: { auth: { order: { openai: ["openai-codex:default"] } } } as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+      provider: "openai",
+      model: "gpt-5.5",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.modelProvider).toBe("openai-codex");
+    expect(sessionStore[sessionKey]?.model).toBe("gpt-5.5");
+    expect(sessionStore[sessionKey]?.contextTokens).toBe(200_000);
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBe("openai-codex:default");
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("auto");
+  });
+
   it("clears stale auto-created legacy openai route pins when primary is canonical openai", async () => {
     const sessionEntry = makeEntry({
       providerOverride: "openai",

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1364,6 +1364,62 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("auto");
   });
 
+  it("preserves auto auth state when it matches an inherited parent model override", async () => {
+    authProfileStoreMock.store = {
+      version: 1,
+      profiles: {
+        "anthropic:work": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "primary-key",
+        },
+      },
+    };
+    const parentSessionKey = "agent:main:telegram:direct:parent";
+    const sessionEntry = makeEntry({
+      parentSessionKey,
+      modelProvider: "anthropic",
+      model: "claude-opus-4-6",
+      contextTokens: 200_000,
+      authProfileOverride: "anthropic:work",
+      authProfileOverrideSource: "auto",
+      authProfileOverrideCompactionCount: 1,
+    });
+    const sessionStore = {
+      [sessionKey]: sessionEntry,
+      [parentSessionKey]: makeEntry({
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-6",
+        modelOverrideSource: "user",
+      }),
+    };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      parentSessionKey,
+      defaultProvider: "minimax",
+      defaultModel: "MiniMax-M2.7",
+      primaryProvider: "minimax",
+      primaryModel: "MiniMax-M2.7",
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-opus-4-6");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.modelProvider).toBe("anthropic");
+    expect(sessionStore[sessionKey]?.model).toBe("claude-opus-4-6");
+    expect(sessionStore[sessionKey]?.contextTokens).toBe(200_000);
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBe("anthropic:work");
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("auto");
+  });
+
   it("preserves runtime-equivalent OpenAI Codex auto auth selections", async () => {
     authProfileStoreMock.store = {
       version: 1,

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.js";
 import { MODEL_CONTEXT_TOKEN_CACHE } from "../../agents/context-cache.js";
 import {
   loadManifestModelCatalog,
@@ -60,6 +61,7 @@ afterEach(() => {
   vi.mocked(loadManifestModelCatalog).mockReset();
   vi.mocked(loadManifestModelCatalog).mockReturnValue([]);
   authProfileStoreMock.reset();
+  cliBackendsTesting.resetDepsForTest();
 });
 
 const makeConfiguredModel = (overrides: Record<string, unknown> = {}) => ({
@@ -1490,49 +1492,71 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
   });
 
-  it("preserves runtime-equivalent OpenAI Codex auto auth selections", async () => {
+  it("preserves runtime-equivalent CLI auto auth selections", async () => {
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: ({ backend }) =>
+        backend === "claude-cli"
+          ? {
+              pluginId: "anthropic",
+              backend: {
+                id: "claude-cli",
+                modelProvider: "anthropic",
+                config: { command: "claude" },
+                bundleMcp: false,
+              },
+            }
+          : undefined,
+    });
     authProfileStoreMock.store = {
       version: 1,
       profiles: {
-        "openai-codex:default": {
+        "anthropic:claude-cli": {
           type: "api_key",
-          provider: "openai-codex",
-          key: "codex-key",
+          provider: "anthropic",
+          key: "anthropic-key",
         },
       },
     };
     const sessionEntry = makeEntry({
-      modelProvider: "openai-codex",
-      model: "gpt-5.5",
+      modelProvider: "claude-cli",
+      model: "claude-opus-4-7",
       contextTokens: 200_000,
-      authProfileOverride: "openai-codex:default",
+      authProfileOverride: "anthropic:claude-cli",
       authProfileOverrideSource: "auto",
       authProfileOverrideCompactionCount: 0,
     });
     const sessionStore = { [sessionKey]: sessionEntry };
 
     const state = await createModelSelectionState({
-      cfg: { auth: { order: { openai: ["openai-codex:default"] } } } as OpenClawConfig,
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
+          },
+        },
+      } as OpenClawConfig,
       agentCfg: undefined,
       sessionEntry,
       sessionStore,
       sessionKey,
-      defaultProvider: "openai",
-      defaultModel: "gpt-5.5",
-      primaryProvider: "openai",
-      primaryModel: "gpt-5.5",
-      provider: "openai",
-      model: "gpt-5.5",
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-7",
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-7",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
       hasModelDirective: false,
     });
 
-    expect(state.provider).toBe("openai");
-    expect(state.model).toBe("gpt-5.5");
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-opus-4-7");
     expect(state.resetModelOverride).toBe(false);
-    expect(sessionStore[sessionKey]?.modelProvider).toBe("openai-codex");
-    expect(sessionStore[sessionKey]?.model).toBe("gpt-5.5");
+    expect(sessionStore[sessionKey]?.modelProvider).toBe("claude-cli");
+    expect(sessionStore[sessionKey]?.model).toBe("claude-opus-4-7");
     expect(sessionStore[sessionKey]?.contextTokens).toBe(200_000);
-    expect(sessionStore[sessionKey]?.authProfileOverride).toBe("openai-codex:default");
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBe("anthropic:claude-cli");
     expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("auto");
   });
 

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1223,6 +1223,52 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBeUndefined();
   });
 
+  it("preserves ordinary auto auth profile rotation when runtime model matches selection", async () => {
+    authProfileStoreMock.store = {
+      version: 1,
+      profiles: {
+        "minimax:global": {
+          type: "api_key",
+          provider: "minimax",
+          key: "primary-key",
+        },
+      },
+    };
+    const sessionEntry = makeEntry({
+      modelProvider: "minimax",
+      model: "MiniMax-M2.7",
+      contextTokens: 128_000,
+      authProfileOverride: "minimax:global",
+      authProfileOverrideSource: "auto",
+      authProfileOverrideCompactionCount: 0,
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "minimax",
+      defaultModel: "MiniMax-M2.7",
+      primaryProvider: "minimax",
+      primaryModel: "MiniMax-M2.7",
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("minimax");
+    expect(state.model).toBe("MiniMax-M2.7");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.modelProvider).toBe("minimax");
+    expect(sessionStore[sessionKey]?.model).toBe("MiniMax-M2.7");
+    expect(sessionStore[sessionKey]?.contextTokens).toBe(128_000);
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBe("minimax:global");
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("auto");
+  });
+
   it("clears stale auto-created legacy openai route pins when primary is canonical openai", async () => {
     const sessionEntry = makeEntry({
       providerOverride: "openai",

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1420,6 +1420,76 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("auto");
   });
 
+  it("repairs auto auth state when an inherited parent override is no longer allowed", async () => {
+    authProfileStoreMock.store = {
+      version: 1,
+      profiles: {
+        "anthropic:work": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "old-key",
+        },
+        "minimax:global": {
+          type: "api_key",
+          provider: "minimax",
+          key: "primary-key",
+        },
+      },
+    };
+    const parentSessionKey = "agent:main:telegram:direct:parent";
+    const sessionEntry = makeEntry({
+      parentSessionKey,
+      modelProvider: "anthropic",
+      model: "claude-opus-4-6",
+      contextTokens: 200_000,
+      authProfileOverride: "anthropic:work",
+      authProfileOverrideSource: "auto",
+    });
+    const sessionStore = {
+      [sessionKey]: sessionEntry,
+      [parentSessionKey]: makeEntry({
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-6",
+        modelOverrideSource: "user",
+      }),
+    };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "minimax/MiniMax-M2.7": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const agentCfg = cfg.agents?.defaults;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      parentSessionKey,
+      defaultProvider: "minimax",
+      defaultModel: "MiniMax-M2.7",
+      primaryProvider: "minimax",
+      primaryModel: "MiniMax-M2.7",
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("minimax");
+    expect(state.model).toBe("MiniMax-M2.7");
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("anthropic/claude-opus-4-6");
+    expect(sessionStore[sessionKey]?.modelProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.model).toBeUndefined();
+    expect(sessionStore[sessionKey]?.contextTokens).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
+  });
+
   it("preserves runtime-equivalent OpenAI Codex auto auth selections", async () => {
     authProfileStoreMock.store = {
       version: 1,

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1172,6 +1172,57 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
   });
 
+  it("repairs runtime-only auto auth fallback state back to the configured primary", async () => {
+    authProfileStoreMock.store = {
+      version: 1,
+      profiles: {
+        "deepseek:default": {
+          type: "api_key",
+          provider: "deepseek",
+          key: "fallback-key",
+        },
+        "minimax:global": {
+          type: "api_key",
+          provider: "minimax",
+          key: "primary-key",
+        },
+      },
+    };
+    const sessionEntry = makeEntry({
+      modelProvider: "deepseek",
+      model: "deepseek-v4-flash",
+      contextTokens: 64_000,
+      authProfileOverride: "deepseek:default",
+      authProfileOverrideSource: "auto",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "minimax",
+      defaultModel: "MiniMax-M2.7",
+      primaryProvider: "minimax",
+      primaryModel: "MiniMax-M2.7",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("minimax");
+    expect(state.model).toBe("MiniMax-M2.7");
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("deepseek/deepseek-v4-flash");
+    expect(sessionStore[sessionKey]?.modelProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.model).toBeUndefined();
+    expect(sessionStore[sessionKey]?.contextTokens).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBeUndefined();
+  });
+
   it("clears stale auto-created legacy openai route pins when primary is canonical openai", async () => {
     const sessionEntry = makeEntry({
       providerOverride: "openai",

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -324,7 +324,7 @@ export async function createModelSelectionState(params: {
       model = primaryModel;
     }
   }
-  if (staleAutoRuntimeAuthProfileSelection) {
+  if (staleAutoRuntimeAuthProfileSelection && !params.hasModelDirective) {
     provider = primaryProvider;
     model = primaryModel;
   }

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -244,6 +244,7 @@ export async function createModelSelectionState(params: {
     hasStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
       provider: primaryProvider,
       model: primaryModel,
+      config: cfg,
     });
 
   if (needsModelCatalog) {
@@ -376,6 +377,7 @@ export async function createModelSelectionState(params: {
     const { updated } = clearStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
       provider: primaryProvider,
       model: primaryModel,
+      config: cfg,
     });
     if (updated) {
       sessionStore[sessionKey] = sessionEntry;

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -239,11 +239,30 @@ export async function createModelSelectionState(params: {
     staleHeartbeatAutoFallbackOverride ||
     staleLegacyOpenAICodexAutoOverride ||
     staleLegacyAutoFallbackWithoutOrigin;
+  const storedOverride = resolveStoredModelOverride({
+    sessionEntry,
+    sessionStore,
+    sessionKey,
+    parentSessionKey,
+    defaultProvider,
+  });
+  const staleAutoRuntimeAuthProfileExpectedSelection =
+    params.skipStoredModelOverride !== true &&
+    params.hasResolvedHeartbeatModelOverride !== true &&
+    storedOverride?.model
+      ? {
+          provider: storedOverride.provider || defaultProvider,
+          model: storedOverride.model,
+        }
+      : {
+          provider: primaryProvider,
+          model: primaryModel,
+        };
   const staleAutoRuntimeAuthProfileSelection =
     params.skipStoredModelOverride !== true &&
     hasStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
-      provider: primaryProvider,
-      model: primaryModel,
+      provider: staleAutoRuntimeAuthProfileExpectedSelection.provider,
+      model: staleAutoRuntimeAuthProfileExpectedSelection.model,
       config: cfg,
     });
 
@@ -325,17 +344,9 @@ export async function createModelSelectionState(params: {
     }
   }
   if (staleAutoRuntimeAuthProfileSelection && !params.hasModelDirective) {
-    provider = primaryProvider;
-    model = primaryModel;
+    provider = staleAutoRuntimeAuthProfileExpectedSelection.provider;
+    model = staleAutoRuntimeAuthProfileExpectedSelection.model;
   }
-
-  const storedOverride = resolveStoredModelOverride({
-    sessionEntry,
-    sessionStore,
-    sessionKey,
-    parentSessionKey,
-    defaultProvider,
-  });
   // Skip stored session model override only when an explicit heartbeat.model
   // was resolved. Heartbeats without heartbeat.model still inherit normal
   // overrides unless a direct auto fallback override is stale for the current
@@ -375,8 +386,8 @@ export async function createModelSelectionState(params: {
     const runtimeProvider = sessionEntry.modelProvider;
     const runtimeModel = sessionEntry.model;
     const { updated } = clearStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
-      provider: primaryProvider,
-      model: primaryModel,
+      provider: staleAutoRuntimeAuthProfileExpectedSelection.provider,
+      model: staleAutoRuntimeAuthProfileExpectedSelection.model,
       config: cfg,
     });
     if (updated) {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -32,8 +32,8 @@ import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   applyModelOverrideToSessionEntry,
-  clearAutoRuntimeAuthProfileSelection,
-  hasAutoRuntimeAuthProfileSelection,
+  clearStaleAutoRuntimeAuthProfileSelection,
+  hasStaleAutoRuntimeAuthProfileSelection,
 } from "../../sessions/model-overrides.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { ThinkLevel } from "./directives.js";
@@ -240,7 +240,11 @@ export async function createModelSelectionState(params: {
     staleLegacyOpenAICodexAutoOverride ||
     staleLegacyAutoFallbackWithoutOrigin;
   const staleAutoRuntimeAuthProfileSelection =
-    params.skipStoredModelOverride !== true && hasAutoRuntimeAuthProfileSelection(sessionEntry);
+    params.skipStoredModelOverride !== true &&
+    hasStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
+      provider: primaryProvider,
+      model: primaryModel,
+    });
 
   if (needsModelCatalog) {
     modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
@@ -369,7 +373,10 @@ export async function createModelSelectionState(params: {
   if (staleAutoRuntimeAuthProfileSelection && sessionEntry && sessionStore && sessionKey) {
     const runtimeProvider = sessionEntry.modelProvider;
     const runtimeModel = sessionEntry.model;
-    const { updated } = clearAutoRuntimeAuthProfileSelection(sessionEntry);
+    const { updated } = clearStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
+      provider: primaryProvider,
+      model: primaryModel,
+    });
     if (updated) {
       sessionStore[sessionKey] = sessionEntry;
       if (storePath) {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -246,7 +246,7 @@ export async function createModelSelectionState(params: {
     parentSessionKey,
     defaultProvider,
   });
-  const staleAutoRuntimeAuthProfileExpectedSelection =
+  const preliminaryAutoRuntimeAuthProfileExpectedSelection =
     params.skipStoredModelOverride !== true &&
     params.hasResolvedHeartbeatModelOverride !== true &&
     storedOverride?.model
@@ -258,11 +258,11 @@ export async function createModelSelectionState(params: {
           provider: primaryProvider,
           model: primaryModel,
         };
-  const staleAutoRuntimeAuthProfileSelection =
+  const preliminaryStaleAutoRuntimeAuthProfileSelection =
     params.skipStoredModelOverride !== true &&
     hasStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
-      provider: staleAutoRuntimeAuthProfileExpectedSelection.provider,
-      model: staleAutoRuntimeAuthProfileExpectedSelection.model,
+      provider: preliminaryAutoRuntimeAuthProfileExpectedSelection.provider,
+      model: preliminaryAutoRuntimeAuthProfileExpectedSelection.model,
       config: cfg,
     });
 
@@ -343,9 +343,9 @@ export async function createModelSelectionState(params: {
       model = primaryModel;
     }
   }
-  if (staleAutoRuntimeAuthProfileSelection && !params.hasModelDirective) {
-    provider = staleAutoRuntimeAuthProfileExpectedSelection.provider;
-    model = staleAutoRuntimeAuthProfileExpectedSelection.model;
+  if (preliminaryStaleAutoRuntimeAuthProfileSelection && !params.hasModelDirective) {
+    provider = preliminaryAutoRuntimeAuthProfileExpectedSelection.provider;
+    model = preliminaryAutoRuntimeAuthProfileExpectedSelection.model;
   }
   // Skip stored session model override only when an explicit heartbeat.model
   // was resolved. Heartbeats without heartbeat.model still inherit normal
@@ -382,12 +382,20 @@ export async function createModelSelectionState(params: {
     model = allowedInitialSelection.model;
   }
 
+  const staleAutoRuntimeAuthProfileSelection =
+    params.skipStoredModelOverride !== true &&
+    hasStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
+      provider,
+      model,
+      config: cfg,
+    });
+
   if (staleAutoRuntimeAuthProfileSelection && sessionEntry && sessionStore && sessionKey) {
     const runtimeProvider = sessionEntry.modelProvider;
     const runtimeModel = sessionEntry.model;
     const { updated } = clearStaleAutoRuntimeAuthProfileSelection(sessionEntry, {
-      provider: staleAutoRuntimeAuthProfileExpectedSelection.provider,
-      model: staleAutoRuntimeAuthProfileExpectedSelection.model,
+      provider,
+      model,
       config: cfg,
     });
     if (updated) {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -30,7 +30,11 @@ import {
 } from "../../agents/openai-routing.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  clearAutoRuntimeAuthProfileSelection,
+  hasAutoRuntimeAuthProfileSelection,
+} from "../../sessions/model-overrides.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { ThinkLevel } from "./directives.js";
 export {
@@ -235,6 +239,8 @@ export async function createModelSelectionState(params: {
     staleHeartbeatAutoFallbackOverride ||
     staleLegacyOpenAICodexAutoOverride ||
     staleLegacyAutoFallbackWithoutOrigin;
+  const staleAutoRuntimeAuthProfileSelection =
+    params.skipStoredModelOverride !== true && hasAutoRuntimeAuthProfileSelection(sessionEntry);
 
   if (needsModelCatalog) {
     modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
@@ -313,6 +319,10 @@ export async function createModelSelectionState(params: {
       model = primaryModel;
     }
   }
+  if (staleAutoRuntimeAuthProfileSelection) {
+    provider = primaryProvider;
+    model = primaryModel;
+  }
 
   const storedOverride = resolveStoredModelOverride({
     sessionEntry,
@@ -354,6 +364,26 @@ export async function createModelSelectionState(params: {
     }
     provider = allowedInitialSelection.provider;
     model = allowedInitialSelection.model;
+  }
+
+  if (staleAutoRuntimeAuthProfileSelection && sessionEntry && sessionStore && sessionKey) {
+    const runtimeProvider = sessionEntry.modelProvider;
+    const runtimeModel = sessionEntry.model;
+    const { updated } = clearAutoRuntimeAuthProfileSelection(sessionEntry);
+    if (updated) {
+      sessionStore[sessionKey] = sessionEntry;
+      if (storePath) {
+        await (
+          await loadSessionStoreRuntime()
+        ).updateSessionStore(storePath, (store) => {
+          store[sessionKey] = sessionEntry;
+        });
+      }
+      resetModelOverride = true;
+      if (!resetModelOverrideRef && runtimeProvider && runtimeModel) {
+        resetModelOverrideRef = modelKey(runtimeProvider, runtimeModel);
+      }
+    }
   }
 
   if (

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -140,6 +140,7 @@ import {
   resolveGatewaySessionStoreTarget,
   resolveGatewayModelSupportsImages,
   resolveSessionStoreKey,
+  resolveSessionNextRunModelRef,
   resolveSessionModelRef,
 } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
@@ -1361,7 +1362,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             sessCanonicalKey === "global" && agentId
               ? agentId
               : resolveAgentIdFromSessionKey(sessCanonicalKey);
-          const modelRef = resolveSessionModelRef(sessCfg, sessEntry, sessionAgentId);
+          const modelRef = resolveSessionNextRunModelRef(sessCfg, sessEntry, sessionAgentId);
           baseProvider = modelRef.provider;
           baseModel = modelRef.model;
           requestedAcpMeta = readAcpSessionMeta({ sessionKey: sessCanonicalKey });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -143,6 +143,7 @@ import {
   resolveGatewayModelSupportsImages,
   resolveDeletedAgentIdFromSessionKey,
   readRecentSessionMessagesAsync,
+  resolveSessionNextRunModelRef,
   resolveSessionModelRef,
   resolveSessionStoreKey,
 } from "../session-utils.js";
@@ -2997,7 +2998,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       agentId: selectedAgent.agentId,
       mainKey: cfg.session?.mainKey,
     });
-    const resolvedSessionModel = resolveSessionModelRef(cfg, entry, agentId);
+    const resolvedSessionModel = resolveSessionNextRunModelRef(cfg, entry, agentId);
     const resolvedSessionAuthProvider = resolveProviderIdForAuth(resolvedSessionModel.provider, {
       config: cfg,
     });

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -164,7 +164,7 @@ function filterSessionStoreToConfiguredAgents(
 
 function inheritSessionRuntimeSelection(
   parentEntry: SessionEntry | undefined,
-  expectedSelection: { provider: string; model: string },
+  expectedSelection: { provider: string; model: string; config?: OpenClawConfig },
 ): Partial<SessionEntry> {
   if (!parentEntry) {
     return {};
@@ -1605,10 +1605,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       const inheritedSelection = normalizeOptionalString(p.model)
         ? {}
-        : inheritSessionRuntimeSelection(
-            parentSessionEntry,
-            resolveSessionModelRef(cfg, parentSessionEntry, parentAgentId ?? targetAgentId),
-          );
+        : inheritSessionRuntimeSelection(parentSessionEntry, {
+            ...resolveSessionModelRef(cfg, parentSessionEntry, parentAgentId ?? targetAgentId),
+            config: cfg,
+          });
       const nextEntry: SessionEntry = {
         ...patched.entry,
         ...inheritedSelection,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -44,8 +44,10 @@ import {
   waitForEmbeddedAgentRunEnd,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { compactEmbeddedAgentSession } from "../../agents/embedded-agent.js";
+import { resolveModelRefFromString } from "../../agents/model-selection-shared.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
+import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import {
   loadSessionStore,
   runSessionsCleanup,
@@ -201,6 +203,53 @@ function inheritSessionRuntimeSelection(
     ...(inheritRuntimeAuthSelection && parentEntry.authProfileOverrideSource
       ? { authProfileOverrideSource: parentEntry.authProfileOverrideSource }
       : {}),
+  };
+}
+
+function resolveParentExpectedRuntimeSelection(
+  cfg: OpenClawConfig,
+  parentEntry: SessionEntry | undefined,
+  agentId: string,
+): { provider: string; model: string; config: OpenClawConfig } {
+  const explicitProviderOverride = normalizeOptionalString(parentEntry?.providerOverride);
+  const explicitModelOverride = normalizeOptionalString(parentEntry?.modelOverride);
+  if (explicitProviderOverride || explicitModelOverride) {
+    return {
+      ...resolveSessionModelRef(
+        cfg,
+        {
+          providerOverride: explicitProviderOverride,
+          modelOverride: explicitModelOverride,
+        },
+        agentId,
+      ),
+      config: cfg,
+    };
+  }
+
+  const defaultSelection = resolveSessionModelRef(cfg, undefined, agentId);
+  const channelModelOverride =
+    cfg.channels?.modelByChannel && parentEntry
+      ? resolveChannelModelOverride({
+          cfg,
+          channel: parentEntry.channel ?? parentEntry.origin?.provider ?? parentEntry.lastChannel,
+          groupId: parentEntry.groupId,
+          groupChatType: parentEntry.chatType,
+          groupChannel: parentEntry.groupChannel,
+          groupSubject: parentEntry.subject,
+          parentSessionKey: parentEntry.parentSessionKey,
+        })
+      : null;
+  const channelSelection = channelModelOverride
+    ? resolveModelRefFromString({
+        cfg,
+        raw: channelModelOverride.model,
+        defaultProvider: defaultSelection.provider,
+      })?.ref
+    : null;
+  return {
+    ...(channelSelection ?? defaultSelection),
+    config: cfg,
   };
 }
 
@@ -1605,10 +1654,14 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       const inheritedSelection = normalizeOptionalString(p.model)
         ? {}
-        : inheritSessionRuntimeSelection(parentSessionEntry, {
-            ...resolveSessionModelRef(cfg, parentSessionEntry, parentAgentId ?? targetAgentId),
-            config: cfg,
-          });
+        : inheritSessionRuntimeSelection(
+            parentSessionEntry,
+            resolveParentExpectedRuntimeSelection(
+              cfg,
+              parentSessionEntry,
+              parentAgentId ?? targetAgentId,
+            ),
+          );
       const nextEntry: SessionEntry = {
         ...patched.entry,
         ...inheritedSelection,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -44,10 +44,8 @@ import {
   waitForEmbeddedAgentRunEnd,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { compactEmbeddedAgentSession } from "../../agents/embedded-agent.js";
-import { resolveModelRefFromString } from "../../agents/model-selection-shared.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
-import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import {
   loadSessionStore,
   runSessionsCleanup,
@@ -109,6 +107,7 @@ import {
   readSessionMessageCountAsync,
   readSessionPreviewItemsFromTranscript,
   resolveDeletedAgentIdFromSessionKey,
+  resolveSessionExpectedSelectedModelRef,
   resolveFreshestSessionEntryFromStoreKeys,
   resolveGatewaySessionStoreTarget,
   resolveGatewaySessionStoreTargetWithStore,
@@ -212,53 +211,28 @@ function resolveParentExpectedRuntimeSelection(
   agentId: string,
   store?: Record<string, SessionEntry>,
 ): { provider: string; model: string; config: OpenClawConfig } {
-  const defaultSelection = resolveSessionModelRef(cfg, undefined, agentId);
+  const defaultSelection = resolveSessionExpectedSelectedModelRef({ cfg, agentId });
   const visited = new Set<string>();
   let currentEntry = parentEntry;
   let currentAgentId = agentId;
 
   for (let depth = 0; currentEntry && depth < 8; depth += 1) {
-    const explicitProviderOverride = normalizeOptionalString(currentEntry.providerOverride);
-    const explicitModelOverride = normalizeOptionalString(currentEntry.modelOverride);
-    if (explicitProviderOverride || explicitModelOverride) {
-      return {
-        ...resolveSessionModelRef(
-          cfg,
-          {
-            providerOverride: explicitProviderOverride,
-            modelOverride: explicitModelOverride,
-          },
-          currentAgentId,
-        ),
-        config: cfg,
-      };
-    }
-
-    const entryDefaultSelection = resolveSessionModelRef(cfg, undefined, currentAgentId);
-    const channelModelOverride = cfg.channels?.modelByChannel
-      ? resolveChannelModelOverride({
-          cfg,
-          channel:
-            currentEntry.channel ?? currentEntry.origin?.provider ?? currentEntry.lastChannel,
-          groupId: currentEntry.groupId,
-          groupChatType: currentEntry.chatType,
-          groupChannel: currentEntry.groupChannel,
-          groupSubject: currentEntry.subject,
-          parentSessionKey: currentEntry.parentSessionKey,
-        })
-      : null;
-    const channelSelection = channelModelOverride
-      ? resolveModelRefFromString({
-          cfg,
-          raw: channelModelOverride.model,
-          defaultProvider: entryDefaultSelection.provider,
-        })?.ref
-      : null;
-    if (channelSelection) {
-      return {
-        ...channelSelection,
-        config: cfg,
-      };
+    const currentDefaultSelection = resolveSessionExpectedSelectedModelRef({
+      cfg,
+      agentId: currentAgentId,
+    });
+    const currentSelection = resolveSessionExpectedSelectedModelRef({
+      cfg,
+      entry: currentEntry,
+      agentId: currentAgentId,
+    });
+    if (
+      normalizeOptionalString(currentEntry.providerOverride) ||
+      normalizeOptionalString(currentEntry.modelOverride) ||
+      currentSelection.provider !== currentDefaultSelection.provider ||
+      currentSelection.model !== currentDefaultSelection.model
+    ) {
+      return { ...currentSelection, config: cfg };
     }
 
     const parentKey = normalizeOptionalString(currentEntry.parentSessionKey);

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -78,7 +78,7 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
-import { hasAutoRuntimeAuthProfileSelection } from "../../sessions/model-overrides.js";
+import { hasStaleAutoRuntimeAuthProfileSelection } from "../../sessions/model-overrides.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
 import {
@@ -164,11 +164,15 @@ function filterSessionStoreToConfiguredAgents(
 
 function inheritSessionRuntimeSelection(
   parentEntry: SessionEntry | undefined,
+  expectedSelection: { provider: string; model: string },
 ): Partial<SessionEntry> {
   if (!parentEntry) {
     return {};
   }
-  const inheritRuntimeAuthSelection = !hasAutoRuntimeAuthProfileSelection(parentEntry);
+  const inheritRuntimeAuthSelection = !hasStaleAutoRuntimeAuthProfileSelection(
+    parentEntry,
+    expectedSelection,
+  );
   return {
     ...(parentEntry.providerOverride ? { providerOverride: parentEntry.providerOverride } : {}),
     ...(parentEntry.modelOverride ? { modelOverride: parentEntry.modelOverride } : {}),
@@ -1456,6 +1460,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     let canonicalParentSessionKey: string | undefined;
     let parentSessionEntry: SessionEntry | undefined;
     let parentSelectedAgentId: string | undefined;
+    let parentAgentId: string | undefined;
     if (parentSessionKey) {
       const parentCanonicalKey = resolveSessionStoreKey({ cfg, sessionKey: parentSessionKey });
       if (parentCanonicalKey === "global") {
@@ -1484,6 +1489,11 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       canonicalParentSessionKey = parent.canonicalKey;
       parentSessionEntry = parent.entry;
+      parentAgentId = normalizeAgentId(
+        parentSelectedAgentId ??
+          resolveAgentIdFromSessionKey(canonicalParentSessionKey) ??
+          resolveDefaultAgentId(cfg),
+      );
     }
     if (
       canonicalParentSessionKey &&
@@ -1492,12 +1502,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       !resolveOptionalInitialSessionMessage(p) &&
       cfg.session?.dmScope === "main"
     ) {
-      const parentAgentId = normalizeAgentId(
-        parentSelectedAgentId ??
-          resolveAgentIdFromSessionKey(canonicalParentSessionKey) ??
-          resolveDefaultAgentId(cfg),
-      );
-      const parentMainKey = resolveAgentMainSessionKey({ cfg, agentId: parentAgentId });
+      const parentMainKey = resolveAgentMainSessionKey({
+        cfg,
+        agentId: parentAgentId ?? resolveDefaultAgentId(cfg),
+      });
       if (canonicalParentSessionKey === parentMainKey) {
         const { performGatewaySessionReset } = await loadSessionsRuntimeModule();
         const resetResult = await performGatewaySessionReset({
@@ -1536,12 +1544,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         canonicalParentSessionKey,
         parentSelectedAgentId ? { agentId: parentSelectedAgentId } : undefined,
       );
-      const parentAgentId = normalizeAgentId(
-        parentSelectedAgentId ??
-          resolveAgentIdFromSessionKey(canonicalParentSessionKey) ??
-          resolveDefaultAgentId(cfg),
+      const workspaceDir = resolveAgentWorkspaceDir(
+        cfg,
+        parentAgentId ?? resolveDefaultAgentId(cfg),
       );
-      const workspaceDir = resolveAgentWorkspaceDir(cfg, parentAgentId);
       if (hasInternalHookListeners("command", "new")) {
         const hookEvent = createInternalHookEvent("command", "new", canonicalParentSessionKey, {
           sessionEntry: parentEntry,
@@ -1599,7 +1605,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       const inheritedSelection = normalizeOptionalString(p.model)
         ? {}
-        : inheritSessionRuntimeSelection(parentSessionEntry);
+        : inheritSessionRuntimeSelection(
+            parentSessionEntry,
+            resolveSessionModelRef(cfg, parentSessionEntry, parentAgentId ?? targetAgentId),
+          );
       const nextEntry: SessionEntry = {
         ...patched.entry,
         ...inheritedSelection,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -210,45 +210,69 @@ function resolveParentExpectedRuntimeSelection(
   cfg: OpenClawConfig,
   parentEntry: SessionEntry | undefined,
   agentId: string,
+  store?: Record<string, SessionEntry>,
 ): { provider: string; model: string; config: OpenClawConfig } {
-  const explicitProviderOverride = normalizeOptionalString(parentEntry?.providerOverride);
-  const explicitModelOverride = normalizeOptionalString(parentEntry?.modelOverride);
-  if (explicitProviderOverride || explicitModelOverride) {
-    return {
-      ...resolveSessionModelRef(
-        cfg,
-        {
-          providerOverride: explicitProviderOverride,
-          modelOverride: explicitModelOverride,
-        },
-        agentId,
-      ),
-      config: cfg,
-    };
-  }
-
   const defaultSelection = resolveSessionModelRef(cfg, undefined, agentId);
-  const channelModelOverride =
-    cfg.channels?.modelByChannel && parentEntry
+  const visited = new Set<string>();
+  let currentEntry = parentEntry;
+  let currentAgentId = agentId;
+
+  for (let depth = 0; currentEntry && depth < 8; depth += 1) {
+    const explicitProviderOverride = normalizeOptionalString(currentEntry.providerOverride);
+    const explicitModelOverride = normalizeOptionalString(currentEntry.modelOverride);
+    if (explicitProviderOverride || explicitModelOverride) {
+      return {
+        ...resolveSessionModelRef(
+          cfg,
+          {
+            providerOverride: explicitProviderOverride,
+            modelOverride: explicitModelOverride,
+          },
+          currentAgentId,
+        ),
+        config: cfg,
+      };
+    }
+
+    const entryDefaultSelection = resolveSessionModelRef(cfg, undefined, currentAgentId);
+    const channelModelOverride = cfg.channels?.modelByChannel
       ? resolveChannelModelOverride({
           cfg,
-          channel: parentEntry.channel ?? parentEntry.origin?.provider ?? parentEntry.lastChannel,
-          groupId: parentEntry.groupId,
-          groupChatType: parentEntry.chatType,
-          groupChannel: parentEntry.groupChannel,
-          groupSubject: parentEntry.subject,
-          parentSessionKey: parentEntry.parentSessionKey,
+          channel:
+            currentEntry.channel ?? currentEntry.origin?.provider ?? currentEntry.lastChannel,
+          groupId: currentEntry.groupId,
+          groupChatType: currentEntry.chatType,
+          groupChannel: currentEntry.groupChannel,
+          groupSubject: currentEntry.subject,
+          parentSessionKey: currentEntry.parentSessionKey,
         })
       : null;
-  const channelSelection = channelModelOverride
-    ? resolveModelRefFromString({
-        cfg,
-        raw: channelModelOverride.model,
-        defaultProvider: defaultSelection.provider,
-      })?.ref
-    : null;
+    const channelSelection = channelModelOverride
+      ? resolveModelRefFromString({
+          cfg,
+          raw: channelModelOverride.model,
+          defaultProvider: entryDefaultSelection.provider,
+        })?.ref
+      : null;
+    if (channelSelection) {
+      return {
+        ...channelSelection,
+        config: cfg,
+      };
+    }
+
+    const parentKey = normalizeOptionalString(currentEntry.parentSessionKey);
+    if (!parentKey || !store || visited.has(parentKey)) {
+      break;
+    }
+    visited.add(parentKey);
+    const parentStoreKey = resolveSessionStoreKey({ cfg, sessionKey: parentKey });
+    currentEntry = store[parentStoreKey] ?? store[parentKey];
+    currentAgentId = normalizeAgentId(resolveAgentIdFromSessionKey(parentStoreKey) ?? agentId);
+  }
+
   return {
-    ...(channelSelection ?? defaultSelection),
+    ...defaultSelection,
     config: cfg,
   };
 }
@@ -1660,6 +1684,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
               cfg,
               parentSessionEntry,
               parentAgentId ?? targetAgentId,
+              store,
             ),
           );
       const nextEntry: SessionEntry = {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -78,6 +78,7 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
+import { hasAutoRuntimeAuthProfileSelection } from "../../sessions/model-overrides.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
 import {
@@ -167,6 +168,7 @@ function inheritSessionRuntimeSelection(
   if (!parentEntry) {
     return {};
   }
+  const inheritRuntimeAuthSelection = !hasAutoRuntimeAuthProfileSelection(parentEntry);
   return {
     ...(parentEntry.providerOverride ? { providerOverride: parentEntry.providerOverride } : {}),
     ...(parentEntry.modelOverride ? { modelOverride: parentEntry.modelOverride } : {}),
@@ -176,9 +178,11 @@ function inheritSessionRuntimeSelection(
     ...(parentEntry.agentRuntimeOverride
       ? { agentRuntimeOverride: parentEntry.agentRuntimeOverride }
       : {}),
-    ...(parentEntry.modelProvider ? { modelProvider: parentEntry.modelProvider } : {}),
-    ...(parentEntry.model ? { model: parentEntry.model } : {}),
-    ...(typeof parentEntry.contextTokens === "number"
+    ...(inheritRuntimeAuthSelection && parentEntry.modelProvider
+      ? { modelProvider: parentEntry.modelProvider }
+      : {}),
+    ...(inheritRuntimeAuthSelection && parentEntry.model ? { model: parentEntry.model } : {}),
+    ...(inheritRuntimeAuthSelection && typeof parentEntry.contextTokens === "number"
       ? { contextTokens: parentEntry.contextTokens }
       : {}),
     ...(parentEntry.thinkingLevel ? { thinkingLevel: parentEntry.thinkingLevel } : {}),
@@ -187,10 +191,10 @@ function inheritSessionRuntimeSelection(
     ...(parentEntry.traceLevel ? { traceLevel: parentEntry.traceLevel } : {}),
     ...(parentEntry.reasoningLevel ? { reasoningLevel: parentEntry.reasoningLevel } : {}),
     ...(parentEntry.elevatedLevel ? { elevatedLevel: parentEntry.elevatedLevel } : {}),
-    ...(parentEntry.authProfileOverride
+    ...(inheritRuntimeAuthSelection && parentEntry.authProfileOverride
       ? { authProfileOverride: parentEntry.authProfileOverride }
       : {}),
-    ...(parentEntry.authProfileOverrideSource
+    ...(inheritRuntimeAuthSelection && parentEntry.authProfileOverrideSource
       ? { authProfileOverrideSource: parentEntry.authProfileOverrideSource }
       : {}),
   };

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -21,6 +21,7 @@ export {
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
   resolveGatewayModelSupportsImages,
+  resolveSessionNextRunModelRef,
   resolveSessionModelRef,
 } from "./session-utils.js";
 export { formatForLog } from "./ws-log.js";

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -11,6 +11,8 @@ const buildSessionLookup = (
     sessionId?: string;
     model?: string;
     modelProvider?: string;
+    authProfileOverride?: string;
+    authProfileOverrideSource?: "auto" | "user";
     lastChannel?: string;
     lastTo?: string;
     lastAccountId?: string;
@@ -29,6 +31,8 @@ const buildSessionLookup = (
     updatedAt: entry.updatedAt ?? Date.now(),
     model: entry.model,
     modelProvider: entry.modelProvider,
+    authProfileOverride: entry.authProfileOverride,
+    authProfileOverrideSource: entry.authProfileOverrideSource,
     lastChannel: entry.lastChannel,
     lastTo: entry.lastTo,
     lastAccountId: entry.lastAccountId,
@@ -120,6 +124,12 @@ const runtimeMocks = vi.hoisted(() => ({
   ),
   resolveOutboundTarget: vi.fn(({ to }: { to: string }) => ({ ok: true, to })),
   resolveSessionAgentId: vi.fn(() => "main"),
+  resolveSessionNextRunModelRef: vi.fn(
+    (_cfg: OpenClawConfig, entry?: { model?: string; modelProvider?: string }) => ({
+      provider: entry?.modelProvider ?? "test-provider",
+      model: entry?.model ?? "default-model",
+    }),
+  ),
   resolveSessionModelRef: vi.fn(
     (_cfg: OpenClawConfig, entry?: { model?: string; modelProvider?: string }) => ({
       provider: entry?.modelProvider ?? "test-provider",
@@ -159,6 +169,7 @@ const loadConfigMock = runtimeMocks.getRuntimeConfig;
 const agentCommandMock = runtimeMocks.agentCommandFromIngress;
 const updateSessionStoreMock = runtimeMocks.updateSessionStore;
 const loadSessionEntryMock = runtimeMocks.loadSessionEntry;
+const resolveSessionNextRunModelRefMock = runtimeMocks.resolveSessionNextRunModelRef;
 const registerApnsRegistrationVi = runtimeMocks.registerApnsRegistration;
 const normalizeChannelIdVi = runtimeMocks.normalizeChannelId;
 
@@ -1106,6 +1117,13 @@ describe("agent request events", () => {
     parseMessageWithAttachmentsMock.mockReset();
     updateSessionStoreMock.mockClear();
     loadSessionEntryMock.mockClear();
+    resolveSessionNextRunModelRefMock.mockClear();
+    resolveSessionNextRunModelRefMock.mockImplementation(
+      (_cfg: OpenClawConfig, entry?: { model?: string; modelProvider?: string }) => ({
+        provider: entry?.modelProvider ?? "test-provider",
+        model: entry?.model ?? "default-model",
+      }),
+    );
     normalizeChannelIdVi.mockClear();
     normalizeChannelIdVi.mockImplementation((channel?: string | null) => channel ?? null);
     parseMessageWithAttachmentsMock.mockResolvedValue({
@@ -1219,6 +1237,58 @@ describe("agent request events", () => {
     const parseCall = mockCall(parseMessageWithAttachmentsMock);
     expect(parseCall?.[0]).toBe("describe");
     expect(Array.isArray(parseCall?.[1])).toBe(true);
+    expectFields(parseCall?.[2], { supportsInlineImages: false });
+  });
+
+  it("checks attachments against the selected next-run model when runtime metadata is stale", async () => {
+    const ctx = buildCtx();
+    ctx.loadGatewayModelCatalog = async () => [
+      {
+        id: "default-model",
+        name: "Default text model",
+        provider: "test-provider",
+        input: ["text"],
+      },
+      {
+        id: "vision-model",
+        name: "Stale vision model",
+        provider: "test-provider",
+        input: ["text", "image"],
+      },
+    ];
+    loadSessionEntryMock.mockReturnValueOnce({
+      ...buildSessionLookup("agent:main:main", {
+        model: "vision-model",
+        modelProvider: "test-provider",
+        authProfileOverride: "test-provider:default",
+        authProfileOverrideSource: "auto",
+      }),
+      canonicalKey: "agent:main:main",
+    });
+    resolveSessionNextRunModelRefMock.mockReturnValueOnce({
+      provider: "test-provider",
+      model: "default-model",
+    });
+
+    await handleNodeEvent(ctx, "node-stale-runtime-image", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "describe",
+        sessionKey: "agent:main:main",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "dot.png",
+            content: "AAAA",
+          },
+        ],
+      }),
+    });
+
+    expect(resolveSessionNextRunModelRefMock).toHaveBeenCalledTimes(1);
+    expect(parseMessageWithAttachmentsMock).toHaveBeenCalledTimes(1);
+    const parseCall = mockCall(parseMessageWithAttachmentsMock);
     expectFields(parseCall?.[2], { supportsInlineImages: false });
   });
 

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -40,7 +40,7 @@ import {
   resolveGatewayModelSupportsImages,
   resolveOutboundTarget,
   resolveSessionAgentId,
-  resolveSessionModelRef,
+  resolveSessionNextRunModelRef,
   sanitizeInboundSystemTags,
   sendDurableMessageBatch,
   updateSessionStore,
@@ -485,7 +485,7 @@ export const handleNodeEvent = async (
       }
       if (normalizedAttachments.length > 0) {
         const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
-        const modelRef = resolveSessionModelRef(cfg, entry, sessionAgentId);
+        const modelRef = resolveSessionNextRunModelRef(cfg, entry, sessionAgentId);
         const supportsInlineImages = await resolveGatewayModelSupportsImages({
           loadGatewayModelCatalog: ctx.loadGatewayModelCatalog,
           provider: modelRef.provider,

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -513,6 +513,41 @@ describe("gateway server agent", () => {
     expect(images?.[0]?.data).toBe(BASE_IMAGE_PNG);
   });
 
+  test("agent validates image attachments against selected model when auto auth runtime metadata is stale", async () => {
+    testState.agentConfig = { model: { primary: "ollama-cloud/deepseek-v4-flash" } };
+    await setGatewayModelCatalogForTest([TEXT_ONLY_AGENT_MODEL, VISION_AGENT_MODEL]);
+    await setTestSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main-stale-image-runtime",
+          updatedAt: Date.now(),
+          modelProvider: "ollama-cloud",
+          model: "gemma4:31b",
+          authProfileOverride: "ollama-cloud:default",
+          authProfileOverrideSource: "auto",
+        },
+      },
+    });
+
+    const res = await rpcReq(ws, "agent", {
+      message: "what is in the image?",
+      sessionKey: "main",
+      attachments: [
+        {
+          mimeType: "image/png",
+          fileName: "tiny.png",
+          content: BASE_IMAGE_PNG,
+        },
+      ],
+      idempotencyKey: "idem-agent-stale-runtime-image",
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.error?.code).toBe("INVALID_REQUEST");
+    expect(res.error?.message).toContain("active model does not accept image inputs");
+    expect(vi.mocked(agentCommand)).not.toHaveBeenCalled();
+  });
+
   test("agent errors when delivery requested and no last channel exists", async () => {
     testState.allowFrom = ["+1555"];
     try {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -654,6 +654,145 @@ describe("gateway server chat", () => {
     },
   );
 
+  test("chat.send checks attachments against selected model when auto auth runtime metadata is stale", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      testState.agentConfig = {
+        model: {
+          primary: "minimax/MiniMax-M2.7",
+        },
+        models: {
+          "minimax/MiniMax-M2.7": {},
+          "deepseek/deepseek-v4-flash": {},
+        },
+      };
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            modelProvider: "deepseek",
+            model: "deepseek-v4-flash",
+            authProfileOverride: "deepseek:default",
+            authProfileOverrideSource: "auto",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const context = {
+        loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(
+          async () => [
+            {
+              id: "MiniMax-M2.7",
+              name: "MiniMax M2.7",
+              provider: "minimax",
+              input: ["text"],
+            },
+            {
+              id: "deepseek-v4-flash",
+              name: "DeepSeek V4 Flash",
+              provider: "deepseek",
+              input: ["text", "image"],
+            },
+          ],
+        ),
+        logGateway: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        agentRunSeq: new Map<string, number>(),
+        chatAbortControllers: new Map(),
+        chatAbortedRuns: new Map(),
+        chatRunBuffers: new Map(),
+        chatDeltaSentAt: new Map(),
+        chatDeltaLastBroadcastLen: new Map(),
+        chatDeltaLastBroadcastText: new Map(),
+        addChatRun: vi.fn(),
+        removeChatRun: vi.fn(),
+        broadcast: vi.fn(),
+        nodeSendToSession: vi.fn(),
+        registerToolEventRecipient: vi.fn(),
+        dedupe: new Map(),
+      } as unknown as GatewayRequestContext;
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+      let captured: { ctx?: Record<string, unknown>; replyOptions?: GetReplyOptions } | undefined;
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: Record<string, unknown>;
+            replyOptions?: GetReplyOptions;
+          },
+        ];
+        captured = {
+          ctx: params.ctx,
+          replyOptions: params.replyOptions,
+        };
+      });
+
+      const { chatHandlers } = await import("./server-methods/chat.js");
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      await chatHandlers["chat.send"]({
+        req: {
+          type: "req",
+          id: "stale-auto-auth-image-preflight",
+          method: "chat.send",
+          params: {
+            sessionKey: "main",
+            message: "see image",
+            idempotencyKey: "idem-stale-auto-auth-image-preflight",
+            attachments: [
+              {
+                type: "image",
+                mimeType: "image/png",
+                fileName: "dot.png",
+                content: pngB64,
+              },
+            ],
+          },
+        },
+        params: {
+          sessionKey: "main",
+          message: "see image",
+          idempotencyKey: "idem-stale-auto-auth-image-preflight",
+          attachments: [
+            {
+              type: "image",
+              mimeType: "image/png",
+              fileName: "dot.png",
+              content: pngB64,
+            },
+          ],
+        },
+        client: null,
+        isWebchatConnect: () => false,
+        respond: ((ok, payload, error) => {
+          responses.push({ ok, payload, error });
+        }) as RespondFn,
+        context,
+      });
+
+      expect(responses[0]?.ok).toBe(true);
+      await vi.waitFor(() => expect(captured).toBeDefined(), FAST_WAIT_OPTS);
+      expect(captured?.replyOptions?.images).toBeUndefined();
+      expect(captured?.ctx?.MediaPath).toEqual(expect.any(String));
+      expect(captured?.ctx?.MediaPaths).toEqual([expect.any(String)]);
+      expect(captured?.ctx?.MediaType).toBe("image/png");
+      expect(captured?.ctx?.MediaTypes).toEqual(["image/png"]);
+      expect(captured?.ctx?.MediaStaged).toBe(true);
+      await vi.waitFor(() => expect(context.removeChatRun).toHaveBeenCalledTimes(1));
+    } finally {
+      dispatchInboundMessageMock.mockReset();
+      testState.agentConfig = undefined;
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
   test("chat.send reuses an active internal run for duplicate WebChat text sends", async () => {
     const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     const dispatchRelease = createDeferred<void>();

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -195,6 +195,44 @@ test("sessions.create does not inherit runtime-only auto auth fallback selection
   expect(created.payload?.entry?.authProfileOverrideSource).toBeUndefined();
 });
 
+test("sessions.create does not inherit legacy runtime-only auto auth fallback selection", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent", {
+        modelProvider: "deepseek",
+        model: "deepseek-v4-flash",
+        contextTokens: 64000,
+        authProfileOverride: "deepseek:default",
+        authProfileOverrideCompactionCount: 2,
+      }),
+    },
+  });
+
+  const created = await directSessionReq<{
+    entry?: {
+      modelProvider?: string;
+      model?: string;
+      contextTokens?: number;
+      authProfileOverride?: string;
+      authProfileOverrideSource?: string;
+      parentSessionKey?: string;
+    };
+  }>("sessions.create", {
+    agentId: "main",
+    label: "Fresh Chat",
+    parentSessionKey: "main",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+  expect(created.payload?.entry?.modelProvider).toBeUndefined();
+  expect(created.payload?.entry?.model).toBeUndefined();
+  expect(created.payload?.entry?.contextTokens).toBeUndefined();
+  expect(created.payload?.entry?.authProfileOverride).toBeUndefined();
+  expect(created.payload?.entry?.authProfileOverrideSource).toBeUndefined();
+});
+
 test("sessions.create inherits healthy auto auth runtime selection", async () => {
   await createSessionStoreDir();
   await writeSessionStore({

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -233,6 +233,45 @@ test("sessions.create inherits healthy auto auth runtime selection", async () =>
   expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
 });
 
+test("sessions.create inherits runtime-equivalent OpenAI Codex auth aliases", async () => {
+  await createSessionStoreDir();
+  testState.agentConfig = { model: { primary: "openai/gpt-5.5" } };
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent", {
+        modelProvider: "openai-codex",
+        model: "gpt-5.5",
+        contextTokens: 200000,
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      }),
+    },
+  });
+
+  const created = await directSessionReq<{
+    entry?: {
+      modelProvider?: string;
+      model?: string;
+      contextTokens?: number;
+      authProfileOverride?: string;
+      authProfileOverrideSource?: string;
+      parentSessionKey?: string;
+    };
+  }>("sessions.create", {
+    agentId: "main",
+    label: "Fresh Chat",
+    parentSessionKey: "main",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+  expect(created.payload?.entry?.modelProvider).toBe("openai-codex");
+  expect(created.payload?.entry?.model).toBe("gpt-5.5");
+  expect(created.payload?.entry?.contextTokens).toBe(200000);
+  expect(created.payload?.entry?.authProfileOverride).toBe("openai-codex:default");
+  expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
+});
+
 test("sessions.create accepts an explicit key for persistent dashboard sessions", async () => {
   await createSessionStoreDir();
 

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -370,16 +370,18 @@ test("sessions.create follows inherited channel selection for nested parents", a
   expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
 });
 
-test("sessions.create inherits runtime-equivalent OpenAI Codex auth aliases", async () => {
+test("sessions.create inherits matching CLI runtime auth selection", async () => {
   await createSessionStoreDir();
-  testState.agentConfig = { model: { primary: "openai/gpt-5.5" } };
+  testState.agentConfig = {
+    model: { primary: "claude-cli/claude-opus-4-7" },
+  };
   await writeSessionStore({
     entries: {
       main: sessionStoreEntry("sess-parent", {
-        modelProvider: "openai-codex",
-        model: "gpt-5.5",
+        modelProvider: "claude-cli",
+        model: "claude-opus-4-7",
         contextTokens: 200000,
-        authProfileOverride: "openai-codex:default",
+        authProfileOverride: "claude-cli:default",
         authProfileOverrideSource: "auto",
       }),
     },
@@ -402,10 +404,10 @@ test("sessions.create inherits runtime-equivalent OpenAI Codex auth aliases", as
 
   expect(created.ok).toBe(true);
   expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
-  expect(created.payload?.entry?.modelProvider).toBe("openai-codex");
-  expect(created.payload?.entry?.model).toBe("gpt-5.5");
+  expect(created.payload?.entry?.modelProvider).toBe("claude-cli");
+  expect(created.payload?.entry?.model).toBe("claude-opus-4-7");
   expect(created.payload?.entry?.contextTokens).toBe(200000);
-  expect(created.payload?.entry?.authProfileOverride).toBe("openai-codex:default");
+  expect(created.payload?.entry?.authProfileOverride).toBe("claude-cli:default");
   expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
 });
 

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -271,6 +271,54 @@ test("sessions.create inherits healthy auto auth runtime selection", async () =>
   expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
 });
 
+test("sessions.create inherits auto auth runtime selection for a channel primary", async () => {
+  await createSessionStoreDir();
+  testState.agentConfig = { model: { primary: "minimax/MiniMax-M2.7" } };
+  testState.channelsConfig = {
+    modelByChannel: {
+      telegram: {
+        "*": "anthropic/claude-opus-4-6",
+      },
+    },
+  };
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent", {
+        channel: "telegram",
+        chatType: "direct",
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
+        contextTokens: 200000,
+        authProfileOverride: "anthropic:work",
+        authProfileOverrideSource: "auto",
+      }),
+    },
+  });
+
+  const created = await directSessionReq<{
+    entry?: {
+      modelProvider?: string;
+      model?: string;
+      contextTokens?: number;
+      authProfileOverride?: string;
+      authProfileOverrideSource?: string;
+      parentSessionKey?: string;
+    };
+  }>("sessions.create", {
+    agentId: "main",
+    label: "Fresh Chat",
+    parentSessionKey: "main",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+  expect(created.payload?.entry?.modelProvider).toBe("anthropic");
+  expect(created.payload?.entry?.model).toBe("claude-opus-4-6");
+  expect(created.payload?.entry?.contextTokens).toBe(200000);
+  expect(created.payload?.entry?.authProfileOverride).toBe("anthropic:work");
+  expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
+});
+
 test("sessions.create inherits runtime-equivalent OpenAI Codex auth aliases", async () => {
   await createSessionStoreDir();
   testState.agentConfig = { model: { primary: "openai/gpt-5.5" } };

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -319,6 +319,57 @@ test("sessions.create inherits auto auth runtime selection for a channel primary
   expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
 });
 
+test("sessions.create follows inherited channel selection for nested parents", async () => {
+  await createSessionStoreDir();
+  testState.agentConfig = { model: { primary: "minimax/MiniMax-M2.7" } };
+  testState.channelsConfig = {
+    modelByChannel: {
+      telegram: {
+        "*": "anthropic/claude-opus-4-6",
+      },
+    },
+  };
+  await writeSessionStore({
+    entries: {
+      "agent:main:telegram:direct:root": sessionStoreEntry("sess-root", {
+        channel: "telegram",
+        chatType: "direct",
+      }),
+      "agent:main:dashboard:parent": sessionStoreEntry("sess-parent", {
+        parentSessionKey: "agent:main:telegram:direct:root",
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
+        contextTokens: 200000,
+        authProfileOverride: "anthropic:work",
+        authProfileOverrideSource: "auto",
+      }),
+    },
+  });
+
+  const created = await directSessionReq<{
+    entry?: {
+      modelProvider?: string;
+      model?: string;
+      contextTokens?: number;
+      authProfileOverride?: string;
+      authProfileOverrideSource?: string;
+      parentSessionKey?: string;
+    };
+  }>("sessions.create", {
+    agentId: "main",
+    label: "Fresh Chat",
+    parentSessionKey: "agent:main:dashboard:parent",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:dashboard:parent");
+  expect(created.payload?.entry?.modelProvider).toBe("anthropic");
+  expect(created.payload?.entry?.model).toBe("claude-opus-4-6");
+  expect(created.payload?.entry?.contextTokens).toBe(200000);
+  expect(created.payload?.entry?.authProfileOverride).toBe("anthropic:work");
+  expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
+});
+
 test("sessions.create inherits runtime-equivalent OpenAI Codex auth aliases", async () => {
   await createSessionStoreDir();
   testState.agentConfig = { model: { primary: "openai/gpt-5.5" } };

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -195,6 +195,44 @@ test("sessions.create does not inherit runtime-only auto auth fallback selection
   expect(created.payload?.entry?.authProfileOverrideSource).toBeUndefined();
 });
 
+test("sessions.create inherits healthy auto auth runtime selection", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent", {
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
+        contextTokens: 200000,
+        authProfileOverride: "anthropic:work",
+        authProfileOverrideSource: "auto",
+      }),
+    },
+  });
+
+  const created = await directSessionReq<{
+    entry?: {
+      modelProvider?: string;
+      model?: string;
+      contextTokens?: number;
+      authProfileOverride?: string;
+      authProfileOverrideSource?: string;
+      parentSessionKey?: string;
+    };
+  }>("sessions.create", {
+    agentId: "main",
+    label: "Fresh Chat",
+    parentSessionKey: "main",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+  expect(created.payload?.entry?.modelProvider).toBe("anthropic");
+  expect(created.payload?.entry?.model).toBe("claude-opus-4-6");
+  expect(created.payload?.entry?.contextTokens).toBe(200000);
+  expect(created.payload?.entry?.authProfileOverride).toBe("anthropic:work");
+  expect(created.payload?.entry?.authProfileOverrideSource).toBe("auto");
+});
+
 test("sessions.create accepts an explicit key for persistent dashboard sessions", async () => {
   await createSessionStoreDir();
 

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -157,6 +157,44 @@ test("sessions.create inherits parent runtime model selection when model is omit
   expect(rawStore[key]?.parentSessionKey).toBe("agent:main:main");
 });
 
+test("sessions.create does not inherit runtime-only auto auth fallback selection", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent", {
+        modelProvider: "deepseek",
+        model: "deepseek-v4-flash",
+        contextTokens: 64000,
+        authProfileOverride: "deepseek:default",
+        authProfileOverrideSource: "auto",
+      }),
+    },
+  });
+
+  const created = await directSessionReq<{
+    entry?: {
+      modelProvider?: string;
+      model?: string;
+      contextTokens?: number;
+      authProfileOverride?: string;
+      authProfileOverrideSource?: string;
+      parentSessionKey?: string;
+    };
+  }>("sessions.create", {
+    agentId: "main",
+    label: "Fresh Chat",
+    parentSessionKey: "main",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+  expect(created.payload?.entry?.modelProvider).toBeUndefined();
+  expect(created.payload?.entry?.model).toBeUndefined();
+  expect(created.payload?.entry?.contextTokens).toBeUndefined();
+  expect(created.payload?.entry?.authProfileOverride).toBeUndefined();
+  expect(created.payload?.entry?.authProfileOverrideSource).toBeUndefined();
+});
+
 test("sessions.create accepts an explicit key for persistent dashboard sessions", async () => {
   await createSessionStoreDir();
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1670,6 +1670,23 @@ describe("resolveSessionModelRef", () => {
     expect(resolved).toEqual({ provider: "minimax", model: "MiniMax-M2.7" });
   });
 
+  test("ignores legacy runtime-only model fields tied to auto auth fallback", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "minimax/MiniMax-M2.7",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-legacy-auto-fallback-runtime",
+      updatedAt: Date.now(),
+      modelProvider: "deepseek",
+      model: "deepseek-v4-flash",
+      authProfileOverride: "deepseek:default",
+      authProfileOverrideCompactionCount: 2,
+    });
+
+    expect(resolved).toEqual({ provider: "minimax", model: "MiniMax-M2.7" });
+  });
+
   test("preserves auto auth profile runtime fields when they match the selected model", () => {
     const cfg = createModelDefaultsConfig({
       primary: "minimax/MiniMax-M2.7",

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -2182,6 +2182,43 @@ describe("listSessionsFromStore selected model display", () => {
     expect(result.sessions[0]?.model).toBe("MiniMax-M2.7");
   });
 
+  test("respects channel-selected model when checking stale auto auth runtime metadata", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.4" } },
+        list: [{ id: "main", model: { primary: "minimax/MiniMax-M2.7" } }],
+      },
+      channels: {
+        modelByChannel: {
+          telegram: {
+            "*": "anthropic/claude-opus-4-6",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          channel: "telegram",
+          chatType: "direct",
+          modelProvider: "anthropic",
+          model: "claude-opus-4-6",
+          authProfileOverride: "anthropic:default",
+          authProfileOverrideSource: "auto",
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.modelProvider).toBe("anthropic");
+    expect(result.sessions[0]?.model).toBe("claude-opus-4-6");
+  });
+
   test("uses complete model overrides without default-model fallback", () => {
     const cfg = {
       agents: {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1687,6 +1687,23 @@ describe("resolveSessionModelRef", () => {
     expect(resolved).toEqual({ provider: "minimax", model: "MiniMax-M2.7" });
   });
 
+  test("preserves runtime-equivalent OpenAI Codex auth aliases", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "openai/gpt-5.5",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-auto-auth-runtime-alias",
+      updatedAt: Date.now(),
+      modelProvider: "openai-codex",
+      model: "gpt-5.5",
+      authProfileOverride: "openai-codex:default",
+      authProfileOverrideSource: "auto",
+    });
+
+    expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.5" });
+  });
+
   test("falls back to override when runtime model is not recorded yet", () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1653,7 +1653,7 @@ describe("resolveSessionModelRef", () => {
     });
   });
 
-  test("ignores runtime-only model fields that are tied to an auto auth fallback", () => {
+  test("preserves runtime-only auto auth model fields in the generic resolver", () => {
     const cfg = createModelDefaultsConfig({
       primary: "minimax/MiniMax-M2.7",
     });
@@ -1667,10 +1667,10 @@ describe("resolveSessionModelRef", () => {
       authProfileOverrideSource: "auto",
     });
 
-    expect(resolved).toEqual({ provider: "minimax", model: "MiniMax-M2.7" });
+    expect(resolved).toEqual({ provider: "deepseek", model: "deepseek-v4-flash" });
   });
 
-  test("ignores legacy runtime-only model fields tied to auto auth fallback", () => {
+  test("preserves legacy runtime-only auto auth model fields in the generic resolver", () => {
     const cfg = createModelDefaultsConfig({
       primary: "minimax/MiniMax-M2.7",
     });
@@ -1684,7 +1684,7 @@ describe("resolveSessionModelRef", () => {
       authProfileOverrideCompactionCount: 2,
     });
 
-    expect(resolved).toEqual({ provider: "minimax", model: "MiniMax-M2.7" });
+    expect(resolved).toEqual({ provider: "deepseek", model: "deepseek-v4-flash" });
   });
 
   test("preserves auto auth profile runtime fields when they match the selected model", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -2154,6 +2154,34 @@ describe("listSessionsFromStore selected model display", () => {
     expect(result.sessions[0]?.model).toBe("gpt-5.5");
   });
 
+  test("ignores stale auto auth runtime model metadata in row display", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.4" } },
+        list: [{ id: "main", model: { primary: "minimax/MiniMax-M2.7" } }],
+      },
+    } as OpenClawConfig;
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          modelProvider: "deepseek",
+          model: "deepseek-v4-flash",
+          authProfileOverride: "deepseek:default",
+          authProfileOverrideSource: "auto",
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.modelProvider).toBe("minimax");
+    expect(result.sessions[0]?.model).toBe("MiniMax-M2.7");
+  });
+
   test("uses complete model overrides without default-model fallback", () => {
     const cfg = {
       agents: {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1670,6 +1670,23 @@ describe("resolveSessionModelRef", () => {
     expect(resolved).toEqual({ provider: "minimax", model: "MiniMax-M2.7" });
   });
 
+  test("preserves auto auth profile runtime fields when they match the selected model", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "minimax/MiniMax-M2.7",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-auto-auth-runtime",
+      updatedAt: Date.now(),
+      modelProvider: "minimax",
+      model: "MiniMax-M2.7",
+      authProfileOverride: "minimax:global",
+      authProfileOverrideSource: "auto",
+    });
+
+    expect(resolved).toEqual({ provider: "minimax", model: "MiniMax-M2.7" });
+  });
+
   test("falls back to override when runtime model is not recorded yet", () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1653,6 +1653,23 @@ describe("resolveSessionModelRef", () => {
     });
   });
 
+  test("ignores runtime-only model fields that are tied to an auto auth fallback", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "minimax/MiniMax-M2.7",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-auto-fallback-runtime",
+      updatedAt: Date.now(),
+      modelProvider: "deepseek",
+      model: "deepseek-v4-flash",
+      authProfileOverride: "deepseek:default",
+      authProfileOverrideSource: "auto",
+    });
+
+    expect(resolved).toEqual({ provider: "minimax", model: "MiniMax-M2.7" });
+  });
+
   test("falls back to override when runtime model is not recorded yet", () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1616,6 +1616,7 @@ export function resolveSessionModelRef(
         | "modelOverride"
         | "providerOverride"
         | "authProfileOverride"
+        | "authProfileOverrideCompactionCount"
         | "authProfileOverrideSource"
       >,
   agentId?: string,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -24,6 +24,7 @@ import {
   modelSupportsInput,
   type ModelCatalogEntry,
 } from "../agents/model-catalog.js";
+import { resolveModelRefFromString } from "../agents/model-selection-shared.js";
 import {
   inferUniqueProviderFromConfiguredModels,
   isCliProvider,
@@ -49,6 +50,7 @@ import {
   shouldKeepSubagentRunChildLink,
 } from "../agents/subagent-run-liveness.js";
 import { listThinkingLevelOptions } from "../auto-reply/thinking.js";
+import { resolveChannelModelOverride } from "../channels/model-overrides.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -778,11 +780,19 @@ function resolveStaleAutoRuntimeExpectedModelRef(params: {
         | "modelOverride"
         | "modelProvider"
         | "model"
+        | "channel"
+        | "origin"
+        | "lastChannel"
+        | "groupId"
+        | "chatType"
+        | "groupChannel"
+        | "subject"
+        | "parentSessionKey"
       >;
   agentId?: string;
   allowPluginNormalization?: boolean;
 }): ReturnType<typeof resolveSessionModelRef> | null {
-  const expected = params.agentId
+  const defaultSelection = params.agentId
     ? resolveDefaultModelForAgent({
         cfg: params.cfg,
         agentId: params.agentId,
@@ -794,6 +804,26 @@ function resolveStaleAutoRuntimeExpectedModelRef(params: {
         defaultModel: DEFAULT_MODEL,
         allowPluginNormalization: params.allowPluginNormalization,
       });
+  const channelModelOverride = params.entry
+    ? resolveChannelModelOverride({
+        cfg: params.cfg,
+        channel: params.entry.channel ?? params.entry.origin?.provider ?? params.entry.lastChannel,
+        groupId: params.entry.groupId,
+        groupChatType: params.entry.chatType,
+        groupChannel: params.entry.groupChannel,
+        groupSubject: params.entry.subject,
+        parentSessionKey: params.entry.parentSessionKey,
+      })
+    : null;
+  const channelSelection = channelModelOverride
+    ? resolveModelRefFromString({
+        cfg: params.cfg,
+        raw: channelModelOverride.model,
+        defaultProvider: defaultSelection.provider,
+        allowPluginNormalization: params.allowPluginNormalization,
+      })?.ref
+    : null;
+  const expected = channelSelection ?? defaultSelection;
   return hasStaleAutoRuntimeAuthProfileSelection(params.entry, {
     ...expected,
     config: params.cfg,
@@ -1692,6 +1722,45 @@ export function resolveSessionModelRef(
     return persisted;
   }
   return resolved;
+}
+
+export function resolveSessionNextRunModelRef(
+  cfg: OpenClawConfig,
+  entry?:
+    | SessionEntry
+    | Pick<
+        SessionEntry,
+        | "authProfileOverride"
+        | "authProfileOverrideCompactionCount"
+        | "authProfileOverrideSource"
+        | "providerOverride"
+        | "modelOverride"
+        | "modelProvider"
+        | "model"
+        | "channel"
+        | "origin"
+        | "lastChannel"
+        | "groupId"
+        | "chatType"
+        | "groupChannel"
+        | "subject"
+        | "parentSessionKey"
+      >,
+  agentId?: string,
+  options?: { allowPluginNormalization?: boolean },
+): { provider: string; model: string } {
+  const staleRuntimeExpected = resolveStaleAutoRuntimeExpectedModelRef({
+    cfg,
+    entry,
+    agentId,
+    allowPluginNormalization: options?.allowPluginNormalization,
+  });
+  if (staleRuntimeExpected) {
+    return staleRuntimeExpected;
+  }
+  return resolveSessionModelRef(cfg, entry, agentId, {
+    allowPluginNormalization: options?.allowPluginNormalization,
+  });
 }
 
 export async function resolveGatewayModelSupportsImages(params: {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1645,7 +1645,10 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
         allowPluginNormalization: options?.allowPluginNormalization,
       });
-  const ignoreRuntimeModel = hasStaleAutoRuntimeAuthProfileSelection(entry, resolved);
+  const ignoreRuntimeModel = hasStaleAutoRuntimeAuthProfileSelection(entry, {
+    ...resolved,
+    config: cfg,
+  });
   const runtimeProvider = ignoreRuntimeModel
     ? undefined
     : normalizeOptionalString(entry?.modelProvider);

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -74,6 +74,7 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { hasStaleAutoRuntimeAuthProfileSelection } from "../sessions/model-overrides.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
@@ -762,6 +763,43 @@ function resolveSessionSelectedModelRef(params: {
   });
   params.rowContext.selectedModelByOverrideRef.set(key, selected);
   return selected;
+}
+
+function resolveStaleAutoRuntimeExpectedModelRef(params: {
+  cfg: OpenClawConfig;
+  entry?:
+    | SessionEntry
+    | Pick<
+        SessionEntry,
+        | "authProfileOverride"
+        | "authProfileOverrideCompactionCount"
+        | "authProfileOverrideSource"
+        | "providerOverride"
+        | "modelOverride"
+        | "modelProvider"
+        | "model"
+      >;
+  agentId?: string;
+  allowPluginNormalization?: boolean;
+}): ReturnType<typeof resolveSessionModelRef> | null {
+  const expected = params.agentId
+    ? resolveDefaultModelForAgent({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        allowPluginNormalization: params.allowPluginNormalization,
+      })
+    : resolveConfiguredModelRef({
+        cfg: params.cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+        allowPluginNormalization: params.allowPluginNormalization,
+      });
+  return hasStaleAutoRuntimeAuthProfileSelection(params.entry, {
+    ...expected,
+    config: params.cfg,
+  })
+    ? expected
+    : null;
 }
 
 function resolveSessionRowThinkingMetadata(params: {
@@ -1733,14 +1771,29 @@ export function resolveSessionModelIdentityRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+    | Pick<
+        SessionEntry,
+        | "model"
+        | "modelProvider"
+        | "modelOverride"
+        | "providerOverride"
+        | "authProfileOverride"
+        | "authProfileOverrideSource"
+        | "authProfileOverrideCompactionCount"
+      >,
   agentId?: string,
   fallbackModelRef?: string,
   options?: { allowPluginNormalization?: boolean },
 ): { provider?: string; model: string } {
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
-  if (runtimeModel) {
+  const staleRuntimeExpected = resolveStaleAutoRuntimeExpectedModelRef({
+    cfg,
+    entry,
+    agentId,
+    allowPluginNormalization: options?.allowPluginNormalization,
+  });
+  if (runtimeModel && !staleRuntimeExpected) {
     if (runtimeProvider) {
       return { provider: runtimeProvider, model: runtimeModel };
     }
@@ -1782,7 +1835,8 @@ export function resolveSessionModelIdentityRef(
   const resolved = resolveSessionModelRef(cfg, entry, agentId, {
     allowPluginNormalization: options?.allowPluginNormalization,
   });
-  return { provider: resolved.provider, model: resolved.model };
+  const selected = staleRuntimeExpected ?? resolved;
+  return { provider: selected.provider, model: selected.model };
 }
 
 function resolveSessionDisplayModelIdentityRefCached(params: {
@@ -1964,8 +2018,15 @@ export function buildGatewaySessionRow(params: {
     subagentRun?.model,
     { allowPluginNormalization: !lightweight },
   );
+  const staleRuntimeExpected = resolveStaleAutoRuntimeExpectedModelRef({
+    cfg,
+    entry,
+    agentId: sessionAgentId,
+    allowPluginNormalization: !lightweight,
+  });
   const runtimeModelPresent =
-    Boolean(entry?.model?.trim()) || Boolean(entry?.modelProvider?.trim());
+    !staleRuntimeExpected &&
+    (Boolean(entry?.model?.trim()) || Boolean(entry?.modelProvider?.trim()));
   const needsTranscriptTotalTokens =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) === undefined;
   const needsTranscriptContextTokens = resolvePositiveNumber(entry?.contextTokens) === undefined;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -74,7 +74,6 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { hasStaleAutoRuntimeAuthProfileSelection } from "../sessions/model-overrides.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
@@ -1609,16 +1608,7 @@ export function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<
-        SessionEntry,
-        | "model"
-        | "modelProvider"
-        | "modelOverride"
-        | "providerOverride"
-        | "authProfileOverride"
-        | "authProfileOverrideCompactionCount"
-        | "authProfileOverrideSource"
-      >,
+    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
   agentId?: string,
   options?: { allowPluginNormalization?: boolean },
 ): { provider: string; model: string } {
@@ -1646,14 +1636,8 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
         allowPluginNormalization: options?.allowPluginNormalization,
       });
-  const ignoreRuntimeModel = hasStaleAutoRuntimeAuthProfileSelection(entry, {
-    ...resolved,
-    config: cfg,
-  });
-  const runtimeProvider = ignoreRuntimeModel
-    ? undefined
-    : normalizeOptionalString(entry?.modelProvider);
-  const runtimeModel = ignoreRuntimeModel ? undefined : normalizeOptionalString(entry?.model);
+  const runtimeProvider = normalizeOptionalString(entry?.modelProvider);
+  const runtimeModel = normalizeOptionalString(entry?.model);
   if (runtimeProvider && runtimeModel) {
     return { provider: runtimeProvider, model: runtimeModel };
   }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -76,7 +76,10 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { hasStaleAutoRuntimeAuthProfileSelection } from "../sessions/model-overrides.js";
+import {
+  hasStaleAutoRuntimeAuthProfileSelection,
+  type StaleAutoRuntimeAuthProfileEntry,
+} from "../sessions/model-overrides.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
@@ -140,6 +143,26 @@ export type {
   SessionsPreviewEntry,
   SessionsPreviewResult,
 } from "./session-utils.types.js";
+
+type SessionRuntimeModelEntry = Pick<
+  SessionEntry,
+  "model" | "modelProvider" | "modelOverride" | "providerOverride"
+>;
+
+type SessionChannelModelSelectionEntry = Pick<
+  SessionEntry,
+  | "channel"
+  | "origin"
+  | "lastChannel"
+  | "groupId"
+  | "chatType"
+  | "groupChannel"
+  | "subject"
+  | "parentSessionKey"
+>;
+
+export type SessionExpectedModelEntry = StaleAutoRuntimeAuthProfileEntry &
+  SessionChannelModelSelectionEntry;
 
 const DERIVED_TITLE_MAX_LEN = 60;
 
@@ -767,31 +790,14 @@ function resolveSessionSelectedModelRef(params: {
   return selected;
 }
 
-function resolveStaleAutoRuntimeExpectedModelRef(params: {
+// Expected selection ignores transient runtime fields; callers use it to decide
+// whether auto-owned runtime/auth state should be repaired or inherited.
+export function resolveSessionExpectedSelectedModelRef(params: {
   cfg: OpenClawConfig;
-  entry?:
-    | SessionEntry
-    | Pick<
-        SessionEntry,
-        | "authProfileOverride"
-        | "authProfileOverrideCompactionCount"
-        | "authProfileOverrideSource"
-        | "providerOverride"
-        | "modelOverride"
-        | "modelProvider"
-        | "model"
-        | "channel"
-        | "origin"
-        | "lastChannel"
-        | "groupId"
-        | "chatType"
-        | "groupChannel"
-        | "subject"
-        | "parentSessionKey"
-      >;
+  entry?: SessionExpectedModelEntry;
   agentId?: string;
   allowPluginNormalization?: boolean;
-}): ReturnType<typeof resolveSessionModelRef> | null {
+}): { provider: string; model: string } {
   const defaultSelection = params.agentId
     ? resolveDefaultModelForAgent({
         cfg: params.cfg,
@@ -804,6 +810,23 @@ function resolveStaleAutoRuntimeExpectedModelRef(params: {
         defaultModel: DEFAULT_MODEL,
         allowPluginNormalization: params.allowPluginNormalization,
       });
+
+  const normalizedOverride = normalizeStoredOverrideModel({
+    providerOverride: params.entry?.providerOverride,
+    modelOverride: params.entry?.modelOverride,
+  });
+  if (normalizedOverride.modelOverride) {
+    return resolveSessionModelRef(
+      params.cfg,
+      {
+        providerOverride: normalizedOverride.providerOverride,
+        modelOverride: normalizedOverride.modelOverride,
+      },
+      params.agentId,
+      { allowPluginNormalization: params.allowPluginNormalization },
+    );
+  }
+
   const channelModelOverride = params.entry
     ? resolveChannelModelOverride({
         cfg: params.cfg,
@@ -823,7 +846,16 @@ function resolveStaleAutoRuntimeExpectedModelRef(params: {
         allowPluginNormalization: params.allowPluginNormalization,
       })?.ref
     : null;
-  const expected = channelSelection ?? defaultSelection;
+  return channelSelection ?? defaultSelection;
+}
+
+function resolveStaleAutoRuntimeExpectedModelRef(params: {
+  cfg: OpenClawConfig;
+  entry?: SessionExpectedModelEntry;
+  agentId?: string;
+  allowPluginNormalization?: boolean;
+}): ReturnType<typeof resolveSessionModelRef> | null {
+  const expected = resolveSessionExpectedSelectedModelRef(params);
   return hasStaleAutoRuntimeAuthProfileSelection(params.entry, {
     ...expected,
     config: params.cfg,
@@ -1674,9 +1706,7 @@ export function getSessionDefaults(
 
 export function resolveSessionModelRef(
   cfg: OpenClawConfig,
-  entry?:
-    | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+  entry?: SessionRuntimeModelEntry,
   agentId?: string,
   options?: { allowPluginNormalization?: boolean },
 ): { provider: string; model: string } {
@@ -1726,29 +1756,12 @@ export function resolveSessionModelRef(
 
 export function resolveSessionNextRunModelRef(
   cfg: OpenClawConfig,
-  entry?:
-    | SessionEntry
-    | Pick<
-        SessionEntry,
-        | "authProfileOverride"
-        | "authProfileOverrideCompactionCount"
-        | "authProfileOverrideSource"
-        | "providerOverride"
-        | "modelOverride"
-        | "modelProvider"
-        | "model"
-        | "channel"
-        | "origin"
-        | "lastChannel"
-        | "groupId"
-        | "chatType"
-        | "groupChannel"
-        | "subject"
-        | "parentSessionKey"
-      >,
+  entry?: SessionExpectedModelEntry,
   agentId?: string,
   options?: { allowPluginNormalization?: boolean },
 ): { provider: string; model: string } {
+  // Dispatch/preflight wants the model the next run should use; generic row and
+  // history callers may still need the stored runtime model exactly as recorded.
   const staleRuntimeExpected = resolveStaleAutoRuntimeExpectedModelRef({
     cfg,
     entry,
@@ -1838,18 +1851,7 @@ export async function resolveGatewayModelSupportsImages(params: {
 
 export function resolveSessionModelIdentityRef(
   cfg: OpenClawConfig,
-  entry?:
-    | SessionEntry
-    | Pick<
-        SessionEntry,
-        | "model"
-        | "modelProvider"
-        | "modelOverride"
-        | "providerOverride"
-        | "authProfileOverride"
-        | "authProfileOverrideSource"
-        | "authProfileOverrideCompactionCount"
-      >,
+  entry?: SessionExpectedModelEntry,
   agentId?: string,
   fallbackModelRef?: string,
   options?: { allowPluginNormalization?: boolean },

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -74,7 +74,7 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { hasAutoRuntimeAuthProfileSelection } from "../sessions/model-overrides.js";
+import { hasStaleAutoRuntimeAuthProfileSelection } from "../sessions/model-overrides.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
@@ -1633,15 +1633,6 @@ export function resolveSessionModelRef(
       allowPluginNormalization: options?.allowPluginNormalization,
     })!;
   }
-  const ignoreRuntimeModel = hasAutoRuntimeAuthProfileSelection(entry);
-  const runtimeProvider = ignoreRuntimeModel
-    ? undefined
-    : normalizeOptionalString(entry?.modelProvider);
-  const runtimeModel = ignoreRuntimeModel ? undefined : normalizeOptionalString(entry?.model);
-  if (runtimeProvider && runtimeModel) {
-    return { provider: runtimeProvider, model: runtimeModel };
-  }
-
   const resolved = agentId
     ? resolveDefaultModelForAgent({
         cfg,
@@ -1654,6 +1645,14 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
         allowPluginNormalization: options?.allowPluginNormalization,
       });
+  const ignoreRuntimeModel = hasStaleAutoRuntimeAuthProfileSelection(entry, resolved);
+  const runtimeProvider = ignoreRuntimeModel
+    ? undefined
+    : normalizeOptionalString(entry?.modelProvider);
+  const runtimeModel = ignoreRuntimeModel ? undefined : normalizeOptionalString(entry?.model);
+  if (runtimeProvider && runtimeModel) {
+    return { provider: runtimeProvider, model: runtimeModel };
+  }
 
   const persisted = resolvePersistedSelectedModelRef({
     defaultProvider: resolved.provider || DEFAULT_PROVIDER,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -74,6 +74,7 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { hasAutoRuntimeAuthProfileSelection } from "../sessions/model-overrides.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
@@ -1608,7 +1609,15 @@ export function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+    | Pick<
+        SessionEntry,
+        | "model"
+        | "modelProvider"
+        | "modelOverride"
+        | "providerOverride"
+        | "authProfileOverride"
+        | "authProfileOverrideSource"
+      >,
   agentId?: string,
   options?: { allowPluginNormalization?: boolean },
 ): { provider: string; model: string } {
@@ -1624,8 +1633,11 @@ export function resolveSessionModelRef(
       allowPluginNormalization: options?.allowPluginNormalization,
     })!;
   }
-  const runtimeProvider = normalizeOptionalString(entry?.modelProvider);
-  const runtimeModel = normalizeOptionalString(entry?.model);
+  const ignoreRuntimeModel = hasAutoRuntimeAuthProfileSelection(entry);
+  const runtimeProvider = ignoreRuntimeModel
+    ? undefined
+    : normalizeOptionalString(entry?.modelProvider);
+  const runtimeModel = ignoreRuntimeModel ? undefined : normalizeOptionalString(entry?.model);
   if (runtimeProvider && runtimeModel) {
     return { provider: runtimeProvider, model: runtimeModel };
   }

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -53,6 +53,37 @@ function contextBudgetStatus(params: {
 }
 
 describe("stale auto runtime auth profile selection", () => {
+  it("treats legacy compaction-count auth provenance as auto-owned", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-legacy-auto-auth",
+      updatedAt: before,
+      modelProvider: "deepseek",
+      model: "deepseek-v4-flash",
+      contextTokens: 64_000,
+      authProfileOverride: "deepseek:default",
+      authProfileOverrideCompactionCount: 2,
+    };
+
+    const isStale = hasStaleAutoRuntimeAuthProfileSelection(entry, {
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+    });
+    const result = clearStaleAutoRuntimeAuthProfileSelection(entry, {
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+    });
+
+    expect(isStale).toBe(true);
+    expect(result.updated).toBe(true);
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.contextTokens).toBeUndefined();
+    expect(entry.authProfileOverride).toBeUndefined();
+    expect(entry.authProfileOverrideCompactionCount).toBeUndefined();
+    expect((entry.updatedAt ?? 0) > before).toBe(true);
+  });
+
   it("does not treat runtime-equivalent OpenAI Codex aliases as stale", () => {
     const entry: SessionEntry = {
       sessionId: "sess-openai-codex-alias",

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import {
   applyModelOverrideToSessionEntry,
+  clearStaleAutoRuntimeAuthProfileSelection,
+  hasStaleAutoRuntimeAuthProfileSelection,
   repairProviderWrappedModelOverride,
 } from "./model-overrides.js";
 
@@ -49,6 +51,35 @@ function contextBudgetStatus(params: {
     unwindowedMessageCount: 2,
   };
 }
+
+describe("stale auto runtime auth profile selection", () => {
+  it("does not treat runtime-equivalent OpenAI Codex aliases as stale", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-openai-codex-alias",
+      updatedAt: Date.now(),
+      modelProvider: "openai-codex",
+      model: "gpt-5.5",
+      contextTokens: 200_000,
+      authProfileOverride: "openai-codex:default",
+      authProfileOverrideSource: "auto",
+    };
+
+    const isStale = hasStaleAutoRuntimeAuthProfileSelection(entry, {
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+    const result = clearStaleAutoRuntimeAuthProfileSelection(entry, {
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+
+    expect(isStale).toBe(false);
+    expect(result.updated).toBe(false);
+    expect(entry.modelProvider).toBe("openai-codex");
+    expect(entry.model).toBe("gpt-5.5");
+    expect(entry.authProfileOverride).toBe("openai-codex:default");
+  });
+});
 
 describe("applyModelOverrideToSessionEntry", () => {
   it("clears stale runtime model fields when switching overrides", () => {

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -84,31 +84,42 @@ describe("stale auto runtime auth profile selection", () => {
     expect((entry.updatedAt ?? 0) > before).toBe(true);
   });
 
-  it("does not treat runtime-equivalent OpenAI Codex aliases as stale", () => {
+  it("does not treat configured runtime-equivalent CLI aliases as stale", () => {
     const entry: SessionEntry = {
-      sessionId: "sess-openai-codex-alias",
+      sessionId: "sess-cli-runtime-alias",
       updatedAt: Date.now(),
-      modelProvider: "openai-codex",
-      model: "gpt-5.5",
+      modelProvider: "claude-cli",
+      model: "claude-opus-4-7",
       contextTokens: 200_000,
-      authProfileOverride: "openai-codex:default",
+      authProfileOverride: "claude-cli:default",
       authProfileOverrideSource: "auto",
+    };
+    const config = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+        },
+      },
     };
 
     const isStale = hasStaleAutoRuntimeAuthProfileSelection(entry, {
-      provider: "openai",
-      model: "gpt-5.5",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      config,
     });
     const result = clearStaleAutoRuntimeAuthProfileSelection(entry, {
-      provider: "openai",
-      model: "gpt-5.5",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      config,
     });
 
     expect(isStale).toBe(false);
     expect(result.updated).toBe(false);
-    expect(entry.modelProvider).toBe("openai-codex");
-    expect(entry.model).toBe("gpt-5.5");
-    expect(entry.authProfileOverride).toBe("openai-codex:default");
+    expect(entry.modelProvider).toBe("claude-cli");
+    expect(entry.model).toBe("claude-opus-4-7");
+    expect(entry.authProfileOverride).toBe("claude-cli:default");
   });
 });
 

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -252,6 +252,42 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect((entry.updatedAt ?? 0) > before).toBe(true);
   });
 
+  it("clears stale runtime model fields when selecting the default model", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-default-runtime",
+      updatedAt: before,
+      modelProvider: "opencode-go",
+      model: "deepseek-v4-pro",
+      contextTokens: 64_000,
+      contextBudgetStatus: contextBudgetStatus({
+        updatedAt: before,
+        provider: "opencode-go",
+        model: "deepseek-v4-pro",
+        contextTokenBudget: 64_000,
+      }),
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "opencode-go",
+        model: "qwen3.6-plus",
+        isDefault: true,
+      },
+    });
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.modelOverrideSource).toBeUndefined();
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.contextTokens).toBeUndefined();
+    expect(entry.contextBudgetStatus).toBeUndefined();
+    expect((entry.updatedAt ?? 0) > before).toBe(true);
+  });
+
   it("marks non-default overrides with the provided source", () => {
     const entry: SessionEntry = {
       sessionId: "sess-5a",

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -14,6 +14,7 @@ export function hasStaleAutoRuntimeAuthProfileSelection(
     | Pick<
         SessionEntry,
         | "authProfileOverride"
+        | "authProfileOverrideCompactionCount"
         | "authProfileOverrideSource"
         | "providerOverride"
         | "modelOverride"
@@ -23,8 +24,12 @@ export function hasStaleAutoRuntimeAuthProfileSelection(
     | undefined,
   expectedSelection: { provider: string; model: string; config?: OpenClawConfig },
 ): boolean {
+  const hasAutoAuthProfileSelection =
+    entry?.authProfileOverrideSource === "auto" ||
+    (entry?.authProfileOverrideSource === undefined &&
+      typeof entry?.authProfileOverrideCompactionCount === "number");
   if (
-    entry?.authProfileOverrideSource !== "auto" ||
+    !hasAutoAuthProfileSelection ||
     normalizeOptionalString(entry.authProfileOverride) === undefined ||
     normalizeOptionalString(entry.providerOverride) !== undefined ||
     normalizeOptionalString(entry.modelOverride) !== undefined

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,5 +1,7 @@
+import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 export type ModelOverrideSelection = {
   provider: string;
@@ -19,12 +21,22 @@ export function hasStaleAutoRuntimeAuthProfileSelection(
         | "model"
       >
     | undefined,
-  expectedSelection: { provider: string; model: string },
+  expectedSelection: { provider: string; model: string; config?: OpenClawConfig },
 ): boolean {
   const runtimeProvider = normalizeOptionalString(entry?.modelProvider);
   const runtimeModel = normalizeOptionalString(entry?.model);
   const expectedProvider = normalizeOptionalString(expectedSelection.provider);
   const expectedModel = normalizeOptionalString(expectedSelection.model);
+  const runtimeMatchesExpected =
+    runtimeProvider !== undefined &&
+    runtimeModel !== undefined &&
+    expectedProvider !== undefined &&
+    expectedModel !== undefined &&
+    areRuntimeModelRefsEquivalent(
+      `${runtimeProvider}/${runtimeModel}`,
+      `${expectedProvider}/${expectedModel}`,
+      { config: expectedSelection.config },
+    );
   return (
     entry?.authProfileOverrideSource === "auto" &&
     normalizeOptionalString(entry.authProfileOverride) !== undefined &&
@@ -34,13 +46,13 @@ export function hasStaleAutoRuntimeAuthProfileSelection(
     runtimeModel !== undefined &&
     expectedProvider !== undefined &&
     expectedModel !== undefined &&
-    (runtimeProvider !== expectedProvider || runtimeModel !== expectedModel)
+    !runtimeMatchesExpected
   );
 }
 
 export function clearStaleAutoRuntimeAuthProfileSelection(
   entry: SessionEntry,
-  expectedSelection: { provider: string; model: string },
+  expectedSelection: { provider: string; model: string; config?: OpenClawConfig },
 ): { updated: boolean } {
   if (!hasStaleAutoRuntimeAuthProfileSelection(entry, expectedSelection)) {
     return { updated: false };

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -23,30 +23,32 @@ export function hasStaleAutoRuntimeAuthProfileSelection(
     | undefined,
   expectedSelection: { provider: string; model: string; config?: OpenClawConfig },
 ): boolean {
+  if (
+    entry?.authProfileOverrideSource !== "auto" ||
+    normalizeOptionalString(entry.authProfileOverride) === undefined ||
+    normalizeOptionalString(entry.providerOverride) !== undefined ||
+    normalizeOptionalString(entry.modelOverride) !== undefined
+  ) {
+    return false;
+  }
+
   const runtimeProvider = normalizeOptionalString(entry?.modelProvider);
   const runtimeModel = normalizeOptionalString(entry?.model);
   const expectedProvider = normalizeOptionalString(expectedSelection.provider);
   const expectedModel = normalizeOptionalString(expectedSelection.model);
-  const runtimeMatchesExpected =
-    runtimeProvider !== undefined &&
-    runtimeModel !== undefined &&
-    expectedProvider !== undefined &&
-    expectedModel !== undefined &&
-    areRuntimeModelRefsEquivalent(
-      `${runtimeProvider}/${runtimeModel}`,
-      `${expectedProvider}/${expectedModel}`,
-      { config: expectedSelection.config },
-    );
-  return (
-    entry?.authProfileOverrideSource === "auto" &&
-    normalizeOptionalString(entry.authProfileOverride) !== undefined &&
-    normalizeOptionalString(entry.providerOverride) === undefined &&
-    normalizeOptionalString(entry.modelOverride) === undefined &&
-    runtimeProvider !== undefined &&
-    runtimeModel !== undefined &&
-    expectedProvider !== undefined &&
-    expectedModel !== undefined &&
-    !runtimeMatchesExpected
+  if (
+    runtimeProvider === undefined ||
+    runtimeModel === undefined ||
+    expectedProvider === undefined ||
+    expectedModel === undefined
+  ) {
+    return false;
+  }
+
+  return !areRuntimeModelRefsEquivalent(
+    `${runtimeProvider}/${runtimeModel}`,
+    `${expectedProvider}/${expectedModel}`,
+    { config: expectedSelection.config },
   );
 }
 

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -7,6 +7,53 @@ export type ModelOverrideSelection = {
   isDefault?: boolean;
 };
 
+export function hasAutoRuntimeAuthProfileSelection(
+  entry:
+    | Pick<
+        SessionEntry,
+        "authProfileOverride" | "authProfileOverrideSource" | "providerOverride" | "modelOverride"
+      >
+    | undefined,
+): boolean {
+  return (
+    entry?.authProfileOverrideSource === "auto" &&
+    normalizeOptionalString(entry.authProfileOverride) !== undefined &&
+    normalizeOptionalString(entry.providerOverride) === undefined &&
+    normalizeOptionalString(entry.modelOverride) === undefined
+  );
+}
+
+export function clearAutoRuntimeAuthProfileSelection(entry: SessionEntry): { updated: boolean } {
+  if (!hasAutoRuntimeAuthProfileSelection(entry)) {
+    return { updated: false };
+  }
+
+  let updated = false;
+  const clear = (key: keyof SessionEntry) => {
+    if (entry[key] !== undefined) {
+      delete entry[key];
+      updated = true;
+    }
+  };
+
+  clear("modelProvider");
+  clear("model");
+  clear("contextTokens");
+  clear("contextBudgetStatus");
+  clear("authProfileOverride");
+  clear("authProfileOverrideSource");
+  clear("authProfileOverrideCompactionCount");
+  clear("fallbackNoticeSelectedModel");
+  clear("fallbackNoticeActiveModel");
+  clear("fallbackNoticeReason");
+
+  if (updated) {
+    entry.updatedAt = Date.now();
+  }
+
+  return { updated };
+}
+
 function clearFallbackOrigin(entry: SessionEntry): boolean {
   let updated = false;
   if (entry.modelOverrideFallbackOriginProvider !== undefined) {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,5 +1,5 @@
-import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -9,23 +9,44 @@ export type ModelOverrideSelection = {
   isDefault?: boolean;
 };
 
+export type StaleAutoRuntimeAuthProfileEntry = Pick<
+  SessionEntry,
+  | "authProfileOverride"
+  | "authProfileOverrideCompactionCount"
+  | "authProfileOverrideSource"
+  | "providerOverride"
+  | "modelOverride"
+  | "modelProvider"
+  | "model"
+>;
+
+type ExpectedModelSelection = {
+  provider: string;
+  model: string;
+  config?: OpenClawConfig;
+};
+
+const STALE_AUTO_RUNTIME_AUTH_PROFILE_FIELDS = [
+  "modelProvider",
+  "model",
+  "contextTokens",
+  "contextBudgetStatus",
+  "authProfileOverride",
+  "authProfileOverrideSource",
+  "authProfileOverrideCompactionCount",
+  "fallbackNoticeSelectedModel",
+  "fallbackNoticeActiveModel",
+  "fallbackNoticeReason",
+] as const satisfies readonly (keyof SessionEntry)[];
+
 export function hasStaleAutoRuntimeAuthProfileSelection(
-  entry:
-    | Pick<
-        SessionEntry,
-        | "authProfileOverride"
-        | "authProfileOverrideCompactionCount"
-        | "authProfileOverrideSource"
-        | "providerOverride"
-        | "modelOverride"
-        | "modelProvider"
-        | "model"
-      >
-    | undefined,
-  expectedSelection: { provider: string; model: string; config?: OpenClawConfig },
+  entry: StaleAutoRuntimeAuthProfileEntry | undefined,
+  expectedSelection: ExpectedModelSelection,
 ): boolean {
   const hasAutoAuthProfileSelection =
     entry?.authProfileOverrideSource === "auto" ||
+    // Older rows used the compaction counter as the only durable marker that
+    // an auth-profile override came from automatic fallback/rotation.
     (entry?.authProfileOverrideSource === undefined &&
       typeof entry?.authProfileOverrideCompactionCount === "number");
   if (
@@ -59,7 +80,7 @@ export function hasStaleAutoRuntimeAuthProfileSelection(
 
 export function clearStaleAutoRuntimeAuthProfileSelection(
   entry: SessionEntry,
-  expectedSelection: { provider: string; model: string; config?: OpenClawConfig },
+  expectedSelection: ExpectedModelSelection,
 ): { updated: boolean } {
   if (!hasStaleAutoRuntimeAuthProfileSelection(entry, expectedSelection)) {
     return { updated: false };
@@ -73,16 +94,9 @@ export function clearStaleAutoRuntimeAuthProfileSelection(
     }
   };
 
-  clear("modelProvider");
-  clear("model");
-  clear("contextTokens");
-  clear("contextBudgetStatus");
-  clear("authProfileOverride");
-  clear("authProfileOverrideSource");
-  clear("authProfileOverrideCompactionCount");
-  clear("fallbackNoticeSelectedModel");
-  clear("fallbackNoticeActiveModel");
-  clear("fallbackNoticeReason");
+  for (const key of STALE_AUTO_RUNTIME_AUTH_PROFILE_FIELDS) {
+    clear(key);
+  }
 
   if (updated) {
     entry.updatedAt = Date.now();

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -7,24 +7,42 @@ export type ModelOverrideSelection = {
   isDefault?: boolean;
 };
 
-export function hasAutoRuntimeAuthProfileSelection(
+export function hasStaleAutoRuntimeAuthProfileSelection(
   entry:
     | Pick<
         SessionEntry,
-        "authProfileOverride" | "authProfileOverrideSource" | "providerOverride" | "modelOverride"
+        | "authProfileOverride"
+        | "authProfileOverrideSource"
+        | "providerOverride"
+        | "modelOverride"
+        | "modelProvider"
+        | "model"
       >
     | undefined,
+  expectedSelection: { provider: string; model: string },
 ): boolean {
+  const runtimeProvider = normalizeOptionalString(entry?.modelProvider);
+  const runtimeModel = normalizeOptionalString(entry?.model);
+  const expectedProvider = normalizeOptionalString(expectedSelection.provider);
+  const expectedModel = normalizeOptionalString(expectedSelection.model);
   return (
     entry?.authProfileOverrideSource === "auto" &&
     normalizeOptionalString(entry.authProfileOverride) !== undefined &&
     normalizeOptionalString(entry.providerOverride) === undefined &&
-    normalizeOptionalString(entry.modelOverride) === undefined
+    normalizeOptionalString(entry.modelOverride) === undefined &&
+    runtimeProvider !== undefined &&
+    runtimeModel !== undefined &&
+    expectedProvider !== undefined &&
+    expectedModel !== undefined &&
+    (runtimeProvider !== expectedProvider || runtimeModel !== expectedModel)
   );
 }
 
-export function clearAutoRuntimeAuthProfileSelection(entry: SessionEntry): { updated: boolean } {
-  if (!hasAutoRuntimeAuthProfileSelection(entry)) {
+export function clearStaleAutoRuntimeAuthProfileSelection(
+  entry: SessionEntry,
+  expectedSelection: { provider: string; model: string },
+): { updated: boolean } {
+  if (!hasStaleAutoRuntimeAuthProfileSelection(entry, expectedSelection)) {
     return { updated: false };
   }
 


### PR DESCRIPTION
## Summary

Control UI sessions could inherit a temporary fallback auth/model choice as if it were a real user choice.
That made a fresh WebChat/TUI session show or start from the fallback provider instead of the agent primary.
This change treats runtime-only auto auth fallback state as temporary, repairs it back to the configured primary, and keeps the auth resolver provider-scoped.

AI-assisted: yes.

Fixes #85126.

## What Changed

The fix stays inside core session/model selection.
It does not add config, plugin SDK, plugin runtime, manifest, or provider contract surface.

- Added an internal helper for the bad persisted shape: auto auth profile plus runtime provider/model, with no durable model override.
- Made `createModelSelectionState` switch that shape back to the configured primary and clear stale runtime/auth fields together.
- Made gateway model resolution ignore those stale runtime fields before dispatch/preflight code uses them.
- Stopped `sessions.create` from copying runtime-only auto fallback auth/model state from a parent into a fresh dashboard session.
- Added regressions for MiniMax primary plus DeepSeek runtime/auth fallback, gateway model resolution, and dashboard session creation.

## Testing

I tested the focused state repair path locally, then ran the changed type/lint/guard gate remotely.
The remote broad proof used AWS Crabbox because Blacksmith Testbox was unavailable in this environment (`blacksmith` CLI was missing).

- `./node_modules/.bin/oxfmt --write --threads=1 src/sessions/model-overrides.ts src/auto-reply/reply/model-selection.ts src/gateway/session-utils.ts src/gateway/server-methods/sessions.ts src/auto-reply/reply/model-selection.test.ts src/gateway/session-utils.test.ts src/gateway/server.sessions.create.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/auto-reply/reply/model-selection.test.ts src/gateway/session-utils.test.ts src/gateway/server.sessions.create.test.ts src/sessions/model-overrides.test.ts src/agents/auth-profiles/session-override.test.ts src/agents/agent-scope.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts -t "auto fallback"`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`

Behavior addressed: runtime-only auto fallback auth/model state no longer pins a session to the fallback provider when the configured primary should be selected.
Real environment tested: local macOS worktree with synthetic session-store regressions; AWS Crabbox Linux changed gate.
Exact steps or command run after this patch: the commands listed above.
Evidence after fix: focused Vitest regressions passed; `pnpm check:changed` passed on AWS Crabbox provider `aws`, lease `cbx_0417338a2dcb`, run `run_9b21f45d5a7d`, exit code 0.
Observed result after fix: a session with primary `minimax/MiniMax-M2.7`, runtime `deepseek/deepseek-v4-flash`, and auto `deepseek:default` auth resolves back to MiniMax and clears stale runtime/auth fields before the next dispatch.
What was not tested: live MiniMax/DeepSeek provider credentials and a forced real provider fallback were not used; the proof is synthetic plus type/lint/guard coverage.

## Risks

The behavior change is narrow and source-gated.
It only applies when the auth profile source is `auto`, an auth profile is present, and there is no persisted model override.

- User model overrides still win through `providerOverride`/`modelOverride`.
- User auth profiles are not treated as auto fallback state.
- Normal auto fallback overrides with persisted provider/model provenance still use the existing primary-probe path.
