### PR TITLE
test(agents): broaden small live hosted model matrix

### DIFF
--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -74,7 +74,7 @@ Live tests are split into two layers so we can isolate failures:
 - Set `OPENCLAW_LIVE_MODELS=modern`, `small`, or `all` (alias for modern) to actually run this suite; otherwise it skips to keep `pnpm test:live` focused on gateway smoke
 - How to select models:
   - `OPENCLAW_LIVE_MODELS=modern` to run the modern allowlist (Opus/Sonnet 4.6+, GPT-5.2 + Codex, Gemini 3, DeepSeek V4, GLM 4.7, MiniMax M2.7, Grok 4.3)
-  - `OPENCLAW_LIVE_MODELS=small` to run the constrained small-model allowlist (Qwen 8B/9B local-compatible routes, OpenRouter Qwen/GLM, and Z.AI GLM)
+  - `OPENCLAW_LIVE_MODELS=small` to run the constrained small-model allowlist (Qwen 8B/9B local-compatible routes, Groq-hosted Llama/GPT-OSS API routes, OpenRouter Qwen/GLM, and Z.AI GLM)
   - `OPENCLAW_LIVE_MODELS=all` is an alias for the modern allowlist
   - or `OPENCLAW_LIVE_MODELS="openai/gpt-5.5,openai-codex/gpt-5.5,anthropic/claude-opus-4-6,..."` (comma allowlist)
   - Modern/all and small sweeps default to their curated caps; set `OPENCLAW_LIVE_MAX_MODELS=0` for an exhaustive selected-profile sweep or a positive number for a smaller cap.

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -37,6 +37,8 @@ const SMALL_LIVE_MODEL_PRIORITY = [
   "vllm/qwen/qwen3-8b",
   "sglang/qwen/qwen3-8b",
   "openrouter/qwen/qwen3.5-9b",
+  "groq/llama-3.1-8b-instant",
+  "groq/openai/gpt-oss-20b",
   "openrouter/z-ai/glm-5.1",
   "openrouter/z-ai/glm-5",
   "zai/glm-5.1",

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -677,6 +677,8 @@ describe("isSmallLiveModelRef", () => {
   it("matches the small-model live matrix without requiring provider modern hooks", () => {
     expect(isSmallLiveModelRef({ provider: "lmstudio", id: "Qwen/Qwen3.5-9B" })).toBe(true);
     expect(isSmallLiveModelRef({ provider: "openrouter", id: "qwen/qwen3.5-9b" })).toBe(true);
+    expect(isSmallLiveModelRef({ provider: "groq", id: "llama-3.1-8b-instant" })).toBe(true);
+    expect(isSmallLiveModelRef({ provider: "groq", id: "openai/gpt-oss-20b" })).toBe(true);
     expect(isSmallLiveModelRef({ provider: "openrouter", id: "z-ai/glm-5.1" })).toBe(true);
     expect(isSmallLiveModelRef({ provider: "openai", id: "gpt-5.5" })).toBe(false);
     expect(providerRuntimeMocks.resolveProviderModernModelRef).not.toHaveBeenCalled();
@@ -693,6 +695,8 @@ describe("isPrioritizedSmallLiveModelRef", () => {
       { provider: "vllm", id: "qwen/qwen3-8b" },
       { provider: "sglang", id: "qwen/qwen3-8b" },
       { provider: "openrouter", id: "qwen/qwen3.5-9b" },
+      { provider: "groq", id: "llama-3.1-8b-instant" },
+      { provider: "groq", id: "openai/gpt-oss-20b" },
       { provider: "openrouter", id: "z-ai/glm-5.1" },
       { provider: "openrouter", id: "z-ai/glm-5" },
       { provider: "zai", id: "glm-5.1" },
@@ -779,12 +783,14 @@ describe("selectSmallLiveItems", () => {
       { provider: "vllm", id: "qwen/qwen3-8b" },
       { provider: "lmstudio", id: "qwen/qwen3.5-9b" },
       { provider: "openrouter", id: "qwen/qwen3.5-9b" },
+      { provider: "groq", id: "openai/gpt-oss-20b" },
+      { provider: "groq", id: "llama-3.1-8b-instant" },
     ];
 
     expect(
       selectSmallLiveItems(
         items,
-        3,
+        5,
         (item) => item,
         (item) => item.provider,
       ),
@@ -792,6 +798,8 @@ describe("selectSmallLiveItems", () => {
       { provider: "lmstudio", id: "qwen/qwen3.5-9b" },
       { provider: "vllm", id: "qwen/qwen3-8b" },
       { provider: "openrouter", id: "qwen/qwen3.5-9b" },
+      { provider: "groq", id: "llama-3.1-8b-instant" },
+      { provider: "groq", id: "openai/gpt-oss-20b" },
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- Add hosted small-model coverage for `groq/llama-3.1-8b-instant` and `groq/openai/gpt-oss-20b` to the small live model priority matrix.
- Keep this PR focused on hosted provider selection/test coverage; the Ollama runtime matrix work remains in #87838.
- Update the live testing help page to mention hosted small model families.

## Verification
- `git diff --check origin/main...HEAD`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/live-model-filter.ts src/agents/model-compat.test.ts docs/help/testing-live.md`
- `./node_modules/.bin/oxlint src/agents/live-model-filter.ts src/agents/model-compat.test.ts`
- `node scripts/format-docs.mjs --check docs/help/testing-live.md`
- `node scripts/check-docs-mdx.mjs docs/help/testing-live.md`
- `node scripts/run-vitest.mjs src/agents/model-compat.test.ts --reporter=dot` - 57 tests passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings, overall `0.9`.
- AWS Crabbox `check:changed`: provider `aws`, lease `cbx_5a36085d3b6c`, slug `blue-barnacle`, run `run_9c9aee70dc27`, type `c7a.8xlarge`, exit `0`, cleanup `leaseStopped=true`.

## Rebase note
Rebased onto `origin/main` `28eb4cfa12e547c7c580464d7adb5128749eaa50`; the latest pushed head is `8008626c0cfd15b79ef5baa53932b433a3ce7836`. The AWS Crabbox changed gate passed after that rebase. `main` has moved again since then, but this PR is a one-commit docs/test matrix change with current GitHub checks passing on the pushed head.

## Real behavior proof
Behavior addressed: the small live model priority matrix now includes hosted small-model families, so the live compatibility lane can exercise API-style small-model behavior.
Real environment tested: local Codex worktree with shared `node_modules` symlink plus AWS Crabbox Linux changed gate.
Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 45m --ttl 90m --timing-json --shell -- "pnpm check:changed"`
Evidence after fix: `run_9c9aee70dc27` completed with exit `0` on provider `aws`, lease `cbx_5a36085d3b6c`, slug `blue-barnacle`; local focused Vitest reported 57 tests passed; autoreview reported no accepted/actionable findings.
Observed result after fix: `core`, `coreTests`, and `docs` changed lanes passed, including typecheck, test typecheck, lint, docs formatting, guards, and import-cycle checks.
What was not tested: no live Groq/OpenRouter/Z.ai paid provider calls; no relevant hosted-provider credentials were present locally for this shell.
