### PR TITLE
fix(secrets): skip PLAINTEXT_FOUND for apiKey values that look like env var references

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -771,4 +771,36 @@ describe("secrets audit", () => {
       ),
     ).toBe(true);
   });
+
+  it("flags known apiKey marker on non-model-provider apiKey surfaces (Sweeper P1 regression)", async () => {
+    // messages.tts.providers.*.apiKey is NOT models.providers.*.apiKey,
+    // so OPENAI_API_KEY here must still produce PLAINTEXT_FOUND.
+    await writeJsonFile(fixture.configPath, {
+      messages: {
+        tts: {
+          providers: {
+            openai: {
+              apiKey: OPENAI_API_KEY_MARKER, // pragma: allowlist secret
+            },
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "messages.tts.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+  });
 });

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -224,6 +224,12 @@ function collectConfigSecrets(params: {
     if (!hasPlaintext) {
       continue;
     }
+    // Only apply the non-secret apiKey marker exemption to the model-provider
+    // apiKey target. Other apiKey surfaces (TTS, skills, memory, web tools, etc.)
+    // must still warn when they carry a known marker value.
+    if (target.entry.id === "models.providers.*.apiKey" && isNonSecretApiKeyMarker(target.value)) {
+      continue;
+    }
     addFinding(params.collector, {
       code: "PLAINTEXT_FOUND",
       severity: "warn",


### PR DESCRIPTION
## Summary

When `apiKey` config fields contain environment variable names (e.g. `OPENCLAW_DEEPSEEK_API_KEY`, `OPENAI_API_KEY`) instead of actual secret values, `openclaw secrets audit --check` still reports PLAINTEXT_FOUND warnings. Users with multiple providers see several false positives on every audit run.

This change adds a heuristic to skip env-var-like values: a string matching `^[A-Z_][A-Z0-9_]*$` that ends in `_KEY`, `_TOKEN`, `_SECRET`, or `_PASSWORD` is treated as an environment variable reference and skipped.

Closes #87723

## Change Type

- [x] Bug fix

## Scope

- [x] Secrets / audit

**Behavior or issue addressed**: `openclaw secrets audit --check` reports PLAINTEXT_FOUND for apiKey fields whose values are environment variable names (e.g. `OPENCLAW_DEEPSEEK_API_KEY`) instead of actual secret values.

**Real environment tested**: macOS 26.6, Node v22.22.0, OpenClaw 2026.5.27 source checkout

**Exact steps or command run after this patch**:

1. Configure a model provider with an env-var-like apiKey value in openclaw.json:
```json
{
  "models": {
    "providers": {
      "deepseek": {
        "baseUrl": "https://api.deepseek.com/v1",
        "apiKey": "OPENCLAW_DEEPSEEK_API_KEY"
      }
    }
  }
}
```
2. Run: `openclaw secrets audit --check`

**Evidence after fix**:

Before (on main):
```
[PLAINTEXT_FOUND] warn models.providers.deepseek.apiKey is stored as plaintext.
# exit code: 1
```

After (this PR):
```
// No finding for deepseek.apiKey — recognized as env var reference
# exit code: 0
```

Regression test: `vitest src/secrets/audit.test.ts`
```
 ✓ does not flag bare env-var-style apiKey values as plaintext
 ✓ keeps request headers in openclaw config covered by plaintext audit
 Test Files  1 passed (1)
      Tests  26 passed (26)
```

**Observed result after fix**: Env-var-style apiKey values (`OPENAI_API_KEY`, `OPENCLAW_DEEPSEEK_API_KEY`) no longer trigger PLAINTEXT_FOUND. Real secret values continue to be flagged as before.

**What was not tested**: Non-ASCII env var names, edge cases with mixed-case suffixes.

@clawsweeper re-review
