### PR TITLE
fix(gateway): drop unused transcript option binding

### DIFF
--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -249,7 +249,7 @@ async function readRecentTranscriptTailLinesAsync(
   stat: fs.Stats,
   opts: ReadRecentSessionMessagesOptions,
 ): Promise<string[]> {
-  const { maxMessages, maxBytes, maxLines } = normalizeRecentSessionReadOptions(opts);
+  const { maxBytes, maxLines } = normalizeRecentSessionReadOptions(opts);
   const readLen = Math.min(stat.size, maxBytes);
   const readStart = Math.max(0, stat.size - readLen);
   const handle = await fs.promises.open(filePath, "r");


### PR DESCRIPTION
## Summary
- Drops the unused `maxMessages` destructuring from the async transcript tail reader.
- Fixes the unrelated `check-prod-types` CI failure reported in https://github.com/openclaw/openclaw/actions/runs/26619709352/job/78442809558?pr=87867.

## Verification
- `git diff --check`
- `pnpm tsgo:prod`

## Real behavior proof
Behavior addressed: `check-prod-types` failed on `src/gateway/session-utils.fs.ts(252,11)` with TS6133 for an unused `maxMessages` local.
Real environment tested: local checkout on branch `fix-prod-types-unused-max-messages`.
Exact steps or command run after this patch: `pnpm tsgo:prod`.
Evidence after fix: prod type checking completed successfully after removing the unused async destructuring binding.
Observed result after fix: the previously failing prod type lane passed locally.
What was not tested: no runtime gateway flow was exercised; this is a type-only cleanup for an unused local.
