### PR TITLE
Preserve agent hard timeout attribution

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -58,6 +58,10 @@ function runStatusFromWaitPayload(payload: unknown): RunResult["status"] {
       : {};
   const status = typeof record.status === "string" ? record.status.toLowerCase() : undefined;
   const stopReason = typeof record.stopReason === "string" ? record.stopReason.toLowerCase() : "";
+  const hardTimeoutPhase =
+    record.timeoutPhase === "preflight" ||
+    record.timeoutPhase === "provider" ||
+    record.timeoutPhase === "post_turn";
   const pendingError = record.pendingError === true;
   const hasTerminalTimeoutMetadata =
     readOptionalTimestamp(record.endedAt) !== undefined ||
@@ -65,6 +69,9 @@ function runStatusFromWaitPayload(payload: unknown): RunResult["status"] {
     stopReason.length > 0 ||
     typeof record.livenessState === "string" ||
     record.yielded === true;
+  if (status === "timeout" && hardTimeoutPhase) {
+    return stopReason === "auth-revoked" || stopReason === "user" ? "cancelled" : "timed_out";
+  }
   if (
     status === "aborted" ||
     status === "cancelled" ||
@@ -89,6 +96,7 @@ function runStatusFromWaitPayload(payload: unknown): RunResult["status"] {
       stopReason === "timeout" ||
       stopReason === "timed_out" ||
       record.aborted === true ||
+      hardTimeoutPhase ||
       hasTerminalTimeoutMetadata
     ) {
       return "timed_out";

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -230,6 +230,23 @@ describe("OpenClaw SDK", () => {
     expect(result.error).toBeUndefined();
   });
 
+  it("maps hard-timeout-attributed wait snapshots to timed_out", async () => {
+    const transport = new FakeTransport({
+      "agent.wait": {
+        status: "timeout",
+        runId: "run_timeout_phase",
+        timeoutPhase: "provider",
+        stopReason: "rpc",
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const result = await oc.runs.wait("run_timeout_phase");
+
+    expect(result.runId).toBe("run_timeout_phase");
+    expect(result.status).toBe("timed_out");
+  });
+
   it("splits provider-qualified model refs and rejects unsupported run options", async () => {
     const transport = new FakeTransport({
       agent: { status: "accepted", runId: "run_openrouter" },
@@ -1056,5 +1073,37 @@ describe("OpenClaw SDK", () => {
     expect(timedOut.type).toBe("run.timed_out");
     expect(timedOut.runId).toBe("run_1");
     expect(timedOut.data).toEqual({ phase: "end", stopReason: "timeout" });
+
+    const attributedTimeout = normalizeGatewayEvent({
+      event: "agent",
+      seq: 8,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: { phase: "end", timeoutPhase: "provider", stopReason: "rpc" },
+      },
+    });
+    expect(attributedTimeout.type).toBe("run.timed_out");
+    expect(attributedTimeout.runId).toBe("run_1");
+    expect(attributedTimeout.data).toEqual({
+      phase: "end",
+      timeoutPhase: "provider",
+      stopReason: "rpc",
+    });
+
+    const attributedTimeoutError = normalizeGatewayEvent({
+      event: "agent",
+      seq: 9,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: { phase: "error", timeoutPhase: "provider" },
+      },
+    });
+    expect(attributedTimeoutError.type).toBe("run.timed_out");
+    expect(attributedTimeoutError.runId).toBe("run_1");
+    expect(attributedTimeoutError.data).toEqual({ phase: "error", timeoutPhase: "provider" });
   });
 });

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -16,9 +16,19 @@ function readLowerString(value: unknown): string | undefined {
   return readString(value)?.toLowerCase();
 }
 
+function isHardTimeoutPhase(value: unknown): boolean {
+  const phase = readString(value);
+  return phase === "preflight" || phase === "provider" || phase === "post_turn";
+}
+
 function normalizeLifecycleEndEventType(data: JsonObject): OpenClawEventType {
   const status = readLowerString(data.status);
   const stopReason = readLowerString(data.stopReason);
+  if (isHardTimeoutPhase(data.timeoutPhase)) {
+    return stopReason === "auth-revoked" || stopReason === "user"
+      ? "run.cancelled"
+      : "run.timed_out";
+  }
   if (
     status === "aborted" ||
     status === "cancelled" ||
@@ -39,7 +49,8 @@ function normalizeLifecycleEndEventType(data: JsonObject): OpenClawEventType {
     status === "timeout" ||
     status === "timed_out" ||
     stopReason === "timeout" ||
-    stopReason === "timed_out"
+    stopReason === "timed_out" ||
+    isHardTimeoutPhase(data.timeoutPhase)
   ) {
     return "run.timed_out";
   }
@@ -71,7 +82,7 @@ function normalizeAgentEventType(payload: JsonObject): OpenClawEventType {
       return normalizeLifecycleEndEventType(data);
     }
     if (phase === "error") {
-      return "run.failed";
+      return isHardTimeoutPhase(data.timeoutPhase) ? "run.timed_out" : "run.failed";
     }
   }
   if (stream === "tool" || stream === "item" || stream === "command_output") {

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -242,6 +242,45 @@ describe("acp translator stop reason mapping", () => {
     );
   });
 
+  it("reconciles a missed hard timeout event on reconnect via agent.wait", async () => {
+    let runId: string | undefined;
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.send") {
+        runId = params?.idempotencyKey as string | undefined;
+        return {};
+      }
+      if (method === "agent.wait") {
+        return {
+          status: "timeout",
+          timeoutPhase: "provider",
+          error: "Request timed out before a response was generated.",
+        };
+      }
+      return {};
+    }) as GatewayClient["request"];
+    const { agent, sessionId } = createSessionAgentHarness(request);
+    const promptPromise = promptAgent(agent, sessionId);
+
+    await vi.waitFor(() => {
+      expect(runId).toBeTypeOf("string");
+      expect(runId).not.toBe("");
+    });
+    const capturedRunId = requireValue(runId, "chat.send run id");
+
+    agent.handleGatewayDisconnect("1006: connection lost");
+    agent.handleGatewayReconnect();
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(request).toHaveBeenCalledWith(
+      "agent.wait",
+      {
+        runId: capturedRunId,
+        timeoutMs: 0,
+      },
+      { timeoutMs: null },
+    );
+  });
+
   it("rechecks accepted prompts at the disconnect deadline after reconnect timeout", async () => {
     vi.useFakeTimers();
     try {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -34,6 +34,7 @@ import type {
   ToolKind,
 } from "@agentclientprotocol/sdk";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
+import { hasHardAgentRunTimeoutAttribution } from "../agents/run-timeout-attribution.js";
 import { BASE_THINKING_LEVELS } from "../auto-reply/thinking.shared.js";
 import type { GatewayClient } from "../gateway/client.js";
 import type { GatewaySessionRow, SessionsListResult } from "../gateway/session-utils.js";
@@ -237,6 +238,7 @@ type SessionSnapshot = SessionPresentation & {
 type AgentWaitResult = {
   status?: "ok" | "error" | "timeout";
   error?: string;
+  timeoutPhase?: unknown;
 };
 
 type GatewayTranscriptMessage = {
@@ -1706,6 +1708,10 @@ export class AcpGatewayAgent implements Agent {
       return false;
     }
     if (result?.status === "error") {
+      void this.finishPrompt(sessionId, currentPending, "end_turn");
+      return false;
+    }
+    if (result?.status === "timeout" && hasHardAgentRunTimeoutAttribution(result)) {
       void this.finishPrompt(sessionId, currentPending, "end_turn");
       return false;
     }

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -197,6 +197,201 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("relays hard timeout lifecycle ends as failures instead of completions", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-timeout",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-timeout",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-timeout",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        aborted: true,
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "Request timed out before a response was generated.",
+        startedAt: 1_000,
+        endedAt: 9_000,
+      },
+    });
+
+    const texts = collectedTexts();
+    expectTextWithFragment(texts, "codex run timed out");
+    expectNoTextWithFragment(texts, "codex run completed");
+    relay.dispose();
+  });
+
+  it("does not stop relaying on transient aborted lifecycle ends", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-transient-abort",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-transient-abort",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-transient-abort",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        aborted: true,
+        startedAt: 1_000,
+        endedAt: 5_000,
+      },
+    });
+    emitAgentEvent({
+      runId: "run-transient-abort",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 6_000,
+      },
+    });
+
+    const texts = collectedTexts();
+    expectTextWithFragment(texts, "codex run completed");
+    expectNoTextWithFragment(texts, "codex run stopped");
+    relay.dispose();
+  });
+
+  it("relays terminal aborted lifecycle ends as stopped runs", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-terminal-abort",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-terminal-abort",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-terminal-abort",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        aborted: true,
+        stopReason: "aborted",
+        error: "agent run aborted",
+        startedAt: 1_000,
+        endedAt: 5_000,
+      },
+    });
+    emitAgentEvent({
+      runId: "run-terminal-abort",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 6_000,
+      },
+    });
+
+    const texts = collectedTexts();
+    expectTextWithFragment(texts, "codex run stopped");
+    expectNoTextWithFragment(texts, "codex run completed");
+    relay.dispose();
+  });
+
+  it("relays cancelled lifecycle stop reasons as stopped runs instead of timeout grace", () => {
+    for (const stopReason of ["rpc", "user", "stop"]) {
+      enqueueSystemEventMock.mockClear();
+      const relay = startAcpSpawnParentStreamRelay({
+        runId: `run-cancelled-${stopReason}`,
+        parentSessionKey: "agent:main:main",
+        childSessionKey: `agent:codex:acp:child-cancelled-${stopReason}`,
+        agentId: "codex",
+        streamFlushMs: 10,
+        noOutputNoticeMs: 120_000,
+      });
+
+      emitAgentEvent({
+        runId: `run-cancelled-${stopReason}`,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          aborted: true,
+          stopReason,
+          error: "agent run cancelled",
+          startedAt: 1_000,
+          endedAt: 5_000,
+        },
+      });
+      vi.advanceTimersByTime(15_000);
+
+      const texts = collectedTexts();
+      expectTextWithFragment(texts, "codex run stopped");
+      expectNoTextWithFragment(texts, "codex run timed out");
+      expectNoTextWithFragment(texts, "codex run completed");
+      relay.dispose();
+    }
+  });
+
+  it("surfaces unresolved aborted lifecycle ends as timeouts after grace", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-abort-timeout-grace",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-abort-timeout-grace",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-abort-timeout-grace",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        aborted: true,
+        startedAt: 1_000,
+        endedAt: 5_000,
+      },
+    });
+
+    vi.advanceTimersByTime(14_999);
+    expectNoTextWithFragment(collectedTexts(), "codex run timed out");
+
+    vi.advanceTimersByTime(1);
+    const texts = collectedTexts();
+    expectTextWithFragment(texts, "codex run timed out");
+    expectNoTextWithFragment(texts, "codex run completed");
+    relay.dispose();
+  });
+
+  it("relays hard timeout lifecycle errors as timeout failures", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-timeout-error",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-timeout-error",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-timeout-error",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        timeoutPhase: "provider",
+        error: "Request timed out before a response was generated.",
+      },
+    });
+
+    const texts = collectedTexts();
+    expectTextWithFragment(texts, "codex run timed out");
+    expectNoTextWithFragment(texts, "codex run failed");
+    relay.dispose();
+  });
+
   it("remaps cron-run parent session keys while relaying stream events", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-cron",

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -16,11 +16,14 @@ import { asFiniteNumber } from "../shared/number-coercion.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { recordTaskRunProgressByRunId } from "../tasks/detached-task-runtime.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import { isAbortedAgentStopReason } from "./run-termination.js";
+import { hasHardAgentRunTimeoutAttribution } from "./run-timeout-attribution.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
 const DEFAULT_NO_OUTPUT_POLL_MS = 15_000;
 const DEFAULT_MAX_RELAY_LIFETIME_MS = 6 * 60 * 60 * 1000;
+const ABORTED_END_RELAY_GRACE_MS = 15_000;
 const STREAM_BUFFER_MAX_CHARS = 4_000;
 const STREAM_SNIPPET_MAX_CHARS = 220;
 
@@ -43,6 +46,20 @@ function normalizeStringArray(value: unknown): string[] {
     return [];
   }
   return value.filter((item): item is string => typeof item === "string" && item.length > 0);
+}
+
+function isCancelledAgentStopReason(value: unknown): boolean {
+  const stopReason = normalizeOptionalString(value)?.toLowerCase();
+  return (
+    isAbortedAgentStopReason(stopReason) ||
+    stopReason === "cancelled" ||
+    stopReason === "canceled" ||
+    stopReason === "killed" ||
+    stopReason === "auth-revoked" ||
+    stopReason === "rpc" ||
+    stopReason === "user" ||
+    stopReason === "stop"
+  );
 }
 
 function formatProxyEnvSummary(keys: string[]): string {
@@ -267,6 +284,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   let proxyEnvKeysAtPrompt: string[] = [];
   let flushTimer: NodeJS.Timeout | undefined;
   let relayLifetimeTimer: NodeJS.Timeout | undefined;
+  let abortedEndTimer: NodeJS.Timeout | undefined;
 
   const clearFlushTimer = () => {
     if (!flushTimer) {
@@ -281,6 +299,13 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
     clearTimeout(relayLifetimeTimer);
     relayLifetimeTimer = undefined;
+  };
+  const clearAbortedEndTimer = () => {
+    if (!abortedEndTimer) {
+      return;
+    }
+    clearTimeout(abortedEndTimer);
+    abortedEndTimer = undefined;
   };
 
   const flushPending = () => {
@@ -458,14 +483,64 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
 
-    const phase = normalizeOptionalString((event.data as { phase?: unknown } | undefined)?.phase);
+    const lifecycleData = event.data as
+      | {
+          phase?: unknown;
+          startedAt?: unknown;
+          endedAt?: unknown;
+          aborted?: unknown;
+          error?: unknown;
+          stopReason?: unknown;
+          timeoutPhase?: unknown;
+        }
+      | undefined;
+    const phase = normalizeOptionalString(lifecycleData?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
+    if (phase === "start") {
+      clearAbortedEndTimer();
+      return;
+    }
     if (phase === "end") {
       flushPending();
-      const startedAt = asFiniteNumber(
-        (event.data as { startedAt?: unknown } | undefined)?.startedAt,
-      );
-      const endedAt = asFiniteNumber((event.data as { endedAt?: unknown } | undefined)?.endedAt);
+      const errorText = normalizeOptionalString(lifecycleData?.error);
+      if (hasHardAgentRunTimeoutAttribution(lifecycleData)) {
+        emit(
+          errorText ? `${relayLabel} run timed out: ${errorText}` : `${relayLabel} run timed out.`,
+          `${contextPrefix}:error`,
+        );
+        dispose();
+        return;
+      }
+      if (lifecycleData?.aborted === true) {
+        if (isCancelledAgentStopReason(lifecycleData.stopReason)) {
+          emit(
+            errorText ? `${relayLabel} run stopped: ${errorText}` : `${relayLabel} run stopped.`,
+            `${contextPrefix}:error`,
+          );
+          dispose();
+          return;
+        }
+        if (!abortedEndTimer) {
+          abortedEndTimer = setTimeout(() => {
+            abortedEndTimer = undefined;
+            if (disposed) {
+              return;
+            }
+            emit(
+              errorText
+                ? `${relayLabel} run timed out: ${errorText}`
+                : `${relayLabel} run timed out.`,
+              `${contextPrefix}:error`,
+            );
+            dispose();
+          }, ABORTED_END_RELAY_GRACE_MS);
+          abortedEndTimer.unref?.();
+        }
+        return;
+      }
+      clearAbortedEndTimer();
+      const startedAt = asFiniteNumber(lifecycleData?.startedAt);
+      const endedAt = asFiniteNumber(lifecycleData?.endedAt);
       const durationMs =
         startedAt != null && endedAt != null && endedAt >= startedAt
           ? endedAt - startedAt
@@ -483,10 +558,17 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
 
     if (phase === "error") {
+      clearAbortedEndTimer();
       flushPending();
-      const errorText = normalizeOptionalString(
-        (event.data as { error?: unknown } | undefined)?.error,
-      );
+      const errorText = normalizeOptionalString(lifecycleData?.error);
+      if (hasHardAgentRunTimeoutAttribution(lifecycleData)) {
+        emit(
+          errorText ? `${relayLabel} run timed out: ${errorText}` : `${relayLabel} run timed out.`,
+          `${contextPrefix}:error`,
+        );
+        dispose();
+        return;
+      }
       if (errorText) {
         emit(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
       } else {
@@ -503,6 +585,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     disposed = true;
     clearFlushTimer();
     clearRelayLifetimeTimer();
+    clearAbortedEndTimer();
     flushLogBuffer();
     clearInterval(noOutputWatcherTimer);
     unsubscribe();

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -682,7 +682,23 @@ type FallbackRunnerParams = {
 
 type ModelSwitchOptions = ConstructorParameters<typeof LiveSessionModelSwitchError>[0];
 
-function makeSuccessResult(provider: string, model: string) {
+type TestSuccessMeta = {
+  durationMs: number;
+  aborted: boolean;
+  stopReason: string;
+  agentMeta: { provider: string; model: string };
+  livenessState?: string;
+  timeoutPhase?: string;
+  providerStarted?: boolean;
+};
+
+function makeSuccessResult(
+  provider: string,
+  model: string,
+): {
+  payloads: Array<{ text: string }>;
+  meta: TestSuccessMeta;
+} {
   return {
     payloads: [{ text: "ok" }],
     meta: {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -644,7 +644,8 @@ vi.mock("./spawned-context.js", () => ({
   normalizeSpawnedRunMetadata: (meta: unknown) => meta ?? {},
 }));
 
-vi.mock("./timeout.js", () => ({
+vi.mock("./timeout.js", async () => ({
+  ...(await vi.importActual<typeof import("./timeout.js")>("./timeout.js")),
   resolveAgentTimeoutMs: () => 30_000,
 }));
 
@@ -1083,6 +1084,49 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       },
     );
     expect(lifecycleFinishingCalls).toHaveLength(1);
+  });
+
+  it("propagates timeout attribution to deferred terminal lifecycle events", async () => {
+    setupSingleAttemptFallback();
+    const hardTimeoutResult = makeSuccessResult("openai", "gpt-5.4");
+    hardTimeoutResult.meta = {
+      ...hardTimeoutResult.meta,
+      aborted: true,
+      stopReason: "rpc",
+      livenessState: "blocked",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    };
+    state.runAgentAttemptMock.mockResolvedValue(hardTimeoutResult);
+
+    await runBasicAgentCommand();
+
+    const terminalLifecycleData = state.emitAgentEventMock.mock.calls
+      .map((call: unknown[]) => call[0] as { stream?: string; data?: Record<string, unknown> })
+      .filter((event) => event.stream === "lifecycle")
+      .map((event) => event.data)
+      .filter((data) => data?.phase === "finishing" || data?.phase === "end");
+
+    expect(terminalLifecycleData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "finishing",
+          aborted: true,
+          stopReason: "rpc",
+          livenessState: "blocked",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        }),
+        expect.objectContaining({
+          phase: "end",
+          aborted: true,
+          stopReason: "rpc",
+          livenessState: "blocked",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        }),
+      ]),
+    );
   });
 
   it("validates explicit thinking against configured model compat without an allowlist", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1211,6 +1211,14 @@ async function agentCommandInternal(
     };
     const attemptLifecycleCallbacks = createAgentAttemptLifecycleCallbacks(attemptLifecycleState);
     let lifecycleFinishingEmitted = false;
+    const resolveTerminalLifecycleMeta = (runResult: AgentAttemptResult) => ({
+      ...(runResult.meta.livenessState ? { livenessState: runResult.meta.livenessState } : {}),
+      ...(runResult.meta.timeoutPhase ? { timeoutPhase: runResult.meta.timeoutPhase } : {}),
+      ...(runResult.meta.providerStarted !== undefined
+        ? { providerStarted: runResult.meta.providerStarted }
+        : {}),
+      ...(runResult.meta.replayInvalid === true ? { replayInvalid: true } : {}),
+    });
     const emitLifecycleFinishing = (runResult: AgentAttemptResult) => {
       if (
         attemptLifecycleState.lifecycleEnded ||
@@ -1230,6 +1238,7 @@ async function agentCommandInternal(
           endedAt: Date.now(),
           aborted: runResult.meta.aborted ?? false,
           stopReason: runResult.meta.stopReason,
+          ...resolveTerminalLifecycleMeta(runResult),
         },
       });
     };
@@ -1251,6 +1260,7 @@ async function agentCommandInternal(
           endedAt: Date.now(),
           aborted: runResult.meta.aborted ?? false,
           stopReason,
+          ...resolveTerminalLifecycleMeta(runResult),
         },
       });
     };

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -591,6 +591,64 @@ describe("overflow compaction in run loop", () => {
     expect(result.payloads?.[0]?.text).toContain("timed out");
   });
 
+  it("does not make timeout-compaction recovery terminal when the retry succeeds", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          aborted: true,
+          timedOut: true,
+          timedOutDuringCompaction: false,
+          assistantTexts: [],
+          attemptUsage: { input: 150_000, output: 0, total: 150_000 },
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session after timeout",
+        tokensBefore: 150_000,
+        tokensAfter: 20_000,
+      }),
+    );
+
+    const result = await runEmbeddedAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.meta.error).toBeUndefined();
+    expect(result.meta?.timeoutPhase).toBeUndefined();
+  });
+
+  it("returns a post-turn timeout when the run times out during tool execution", async () => {
+    const setTerminalLifecycleMeta = vi.fn();
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        aborted: true,
+        timedOut: true,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: true,
+        clientToolCalls: [{ name: "hosted_tool", params: { arg: "value" } }],
+        setTerminalLifecycleMeta,
+      }),
+    );
+
+    const result = await runEmbeddedAgent(baseParams);
+
+    expect(result.payloads?.at(-1)?.isError).toBe(true);
+    expect(result.payloads?.at(-1)?.text).toContain("timed out");
+    expect(result.meta?.timeoutPhase).toBe("post_turn");
+    expect(result.meta?.providerStarted).toBe(true);
+    expect(result.meta?.livenessState).toBe("blocked");
+    expect(result.meta?.stopReason).toBeUndefined();
+    expect(result.meta?.pendingToolCalls).toBeUndefined();
+    expect(setTerminalLifecycleMeta).toHaveBeenCalledWith({
+      replayInvalid: false,
+      livenessState: "blocked",
+      timeoutPhase: "post_turn",
+      providerStarted: true,
+    });
+  });
+
   it("uses harness-provided prompt timeout outcome metadata", async () => {
     const setTerminalLifecycleMeta = vi.fn();
     mockedRunEmbeddedAttempt.mockResolvedValue(

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3022,6 +3022,57 @@ export async function runEmbeddedAgent(
               acceptedSessionSpawns: attempt.acceptedSessionSpawns,
             };
           }
+          if (timedOut && attempt.timedOutDuringToolExecution === true) {
+            const replayInvalid = resolveReplayInvalidForAttempt(null);
+            const livenessState: EmbeddedRunLivenessState = "blocked";
+            const timeoutPhase = "post_turn" as const;
+            const providerStarted = true;
+            attempt.setTerminalLifecycleMeta?.({
+              replayInvalid,
+              livenessState,
+              timeoutPhase,
+              providerStarted,
+            });
+            const timeoutPayloads = hasMessagingToolDeliveryEvidence(attempt)
+              ? undefined
+              : [
+                  ...(payloadsWithToolMedia || []),
+                  {
+                    text:
+                      "Request timed out while waiting for tool execution to finish. " +
+                      "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+                    isError: true,
+                  },
+                ];
+            return {
+              payloads: timeoutPayloads?.length ? timeoutPayloads : undefined,
+              meta: {
+                durationMs: Date.now() - started,
+                agentMeta,
+                aborted,
+                systemPromptReport: attempt.systemPromptReport,
+                finalPromptText: attempt.finalPromptText,
+                finalAssistantVisibleText,
+                finalAssistantRawText,
+                replayInvalid,
+                livenessState,
+                timeoutPhase,
+                providerStarted,
+                toolSummary: attemptToolSummary,
+                ...(failureSignal ? { failureSignal } : {}),
+                agentHarnessResultClassification: attempt.agentHarnessResultClassification,
+              },
+              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+              messagingToolSentTexts: attempt.messagingToolSentTexts,
+              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+              messagingToolSentTargets: attempt.messagingToolSentTargets,
+              messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
+              heartbeatToolResponse: attempt.heartbeatToolResponse,
+              successfulCronAdds: attempt.successfulCronAdds,
+              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
+            };
+          }
 
           const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
             isCronTrigger: params.trigger === "cron",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -926,6 +926,7 @@ export function resetEmbeddedAttemptHarness(
     });
   }
   hoisted.createAgentSessionMock.mockReset();
+  hoisted.defaultResourceLoaderInitMock.mockReset();
   hoisted.sessionManagerOpenMock.mockReset().mockReturnValue(hoisted.sessionManager);
   hoisted.resolveSandboxContextMock.mockReset();
   hoisted.ensureGlobalUndiciEnvProxyDispatcherMock.mockReset();

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../context-engine/host-compat.js";
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
 import type { AssembleResult } from "../../../context-engine/types.js";
+import { emitAgentEvent } from "../../../infra/agent-events.js";
 import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import { resolveDiagnosticModelContentCapturePolicy } from "../../../infra/diagnostic-llm-content.js";
 import {
@@ -3089,6 +3090,40 @@ export async function runEmbeddedAttempt(
       const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
       let abortTimer: NodeJS.Timeout | undefined;
       let compactionGraceUsed = false;
+      let postTurnTimeoutLifecycleEmitted = false;
+      // Tool execution can keep provider cleanup unwinding after the hard
+      // deadline. Publish the terminal timeout at the deadline so waiters and
+      // subagent delivery do not depend on cleanup or the command-lane guard.
+      const emitPostTurnTimeoutLifecycle = () => {
+        if (postTurnTimeoutLifecycleEmitted) {
+          return;
+        }
+        postTurnTimeoutLifecycleEmitted = true;
+        const endedAt = Date.now();
+        const data = {
+          phase: "end",
+          aborted: true,
+          endedAt,
+          livenessState: "blocked",
+          replayInvalid: false,
+          timeoutPhase: "post_turn",
+          providerStarted: true,
+          error:
+            "Request timed out while waiting for tool execution to finish. " +
+            "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+        };
+        emitAgentEvent({
+          runId: params.runId,
+          stream: "lifecycle",
+          data,
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+        });
+        void params.onAgentEvent?.({
+          stream: "lifecycle",
+          data,
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+        });
+      };
       const scheduleAbortTimer = (delayMs: number, reason: "initial" | "compaction-grace") => {
         abortTimer = setTimeout(
           () => {
@@ -3124,6 +3159,9 @@ export async function runEmbeddedAttempt(
               })
             ) {
               timedOutDuringCompaction = true;
+            }
+            if (!timedOutDuringCompaction && countActiveToolExecutions(params.runId) > 0) {
+              emitPostTurnTimeoutLifecycle();
             }
             abortRun(true);
             if (!abortWarnTimer) {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -81,6 +81,7 @@ beforeAll(async () => {
   ({ resetSubagentRegistryForTests, spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
     callGatewayMock: hoisted.callGatewayMock,
     getRuntimeConfig: () => hoisted.configOverride,
+    createRunIdMock: () => "run-1",
     resolveAgentConfig: (cfg, agentId) => resolveAgentConfigFromList(cfg, agentId),
     resolveSandboxRuntimeStatus: (params: { cfg?: Record<string, unknown>; sessionKey?: string }) =>
       resolveSandboxRuntimeStatusFromConfig(params),

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -264,7 +264,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     await waitForRunCleanup(child.sessionKey);
 
     const childWait = ctx.waitCalls.find((call) => call.runId === child.runId);
-    expect(childWait?.timeoutMs).toBe(1000);
+    expect(childWait?.timeoutMs).toBe(16_000);
     // Cleanup should patch the label
     const labelPatch = patchCalls.find((call) => call.label === "my-task");
     expect(labelPatch?.key).toBe(child.sessionKey);
@@ -312,7 +312,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
       const params = call.params as { lane?: string } | undefined;
       return call.method === "agent" && params?.lane === "subagent";
     });
-    expect(childAgentCall?.timeoutMs).toBe(125_000);
+    expect(childAgentCall?.timeoutMs).toBe(140_000);
   });
 
   it("sessions_spawn retires bundle MCP runtime when run-mode cleanup completes", async () => {
@@ -396,7 +396,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     );
 
     const childWait = ctx.waitCalls.find((call) => call.runId === child.runId);
-    expect(childWait?.timeoutMs).toBe(1000);
+    expect(childWait?.timeoutMs).toBe(16_000);
 
     const agentCalls = ctx.calls.filter((call) => call.method === "agent");
     expect(agentCalls).toHaveLength(2);
@@ -463,7 +463,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     await waitForSessionsSpawnEvent("delete cleanup", () => Boolean(deletedKey));
 
     const childWait = ctx.waitCalls.find((call) => call.runId === child.runId);
-    expect(childWait?.timeoutMs).toBe(1000);
+    expect(childWait?.timeoutMs).toBe(16_000);
     expect(child.sessionKey?.startsWith("agent:main:subagent:")).toBe(true);
 
     // Two agent calls: subagent spawn + main agent trigger
@@ -521,7 +521,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     await waitForRunCleanup(childSessionKey);
 
     const childWait = ctx.waitCalls.find((call) => call.runId === child.runId);
-    expect(childWait?.timeoutMs).toBe(1000);
+    expect(childWait?.timeoutMs).toBe(16_000);
     expect(getLatestSubagentRunByChildSessionKey(childSessionKey)?.outcome?.status).toBe("timeout");
   });
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
@@ -194,6 +194,7 @@ export async function getSessionsSpawnTool(opts: CreateOpenClawToolsOpts) {
   }
   cachedSubagentSpawnTesting.setDepsForTest({
     callGateway: (optsUnknown) => hoisted.callGatewayMock(optsUnknown),
+    createRunId: hoisted.nextRunId,
     getGlobalHookRunner: () => hoisted.state.hookRunnerOverride,
     getRuntimeConfig: () => hoisted.state.configOverride,
     resolveContextEngine: async () => ({
@@ -270,8 +271,13 @@ export function setupSessionsSpawnGatewayMock(setupOpts: SessionsSpawnGatewayMoc
     }
 
     if (request.method === "agent") {
-      const runId = hoisted.nextRunId();
-      const params = request.params as { lane?: string; sessionKey?: string } | undefined;
+      const params = request.params as
+        | { idempotencyKey?: string; lane?: string; sessionKey?: string }
+        | undefined;
+      const runId =
+        typeof params?.idempotencyKey === "string" && params.idempotencyKey.trim()
+          ? params.idempotencyKey
+          : hoisted.nextRunId();
       // Capture only the subagent run metadata.
       if (params?.lane === "subagent") {
         childRunId = runId;

--- a/src/agents/run-timeout-attribution.ts
+++ b/src/agents/run-timeout-attribution.ts
@@ -20,4 +20,16 @@ export function normalizeAgentRunTimeoutPhase(value: unknown): AgentRunTimeoutPh
     : undefined;
 }
 
+export function isHardAgentRunTimeoutPhase(
+  value: AgentRunTimeoutPhase | undefined,
+): value is "preflight" | "provider" | "post_turn" {
+  return value === "preflight" || value === "provider" || value === "post_turn";
+}
+
+export function hasHardAgentRunTimeoutAttribution(
+  data: { timeoutPhase?: unknown } | null | undefined,
+): boolean {
+  return isHardAgentRunTimeoutPhase(normalizeAgentRunTimeoutPhase(data?.timeoutPhase));
+}
+
 export { asBoolean as normalizeProviderStarted } from "../utils/boolean.js";

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -308,6 +308,53 @@ describe("waitForAgentRun", () => {
     });
   });
 
+  it("preserves timeout waits that carry blocked timeout attribution", async () => {
+    callGatewayMock.mockResolvedValue({
+      status: "timeout",
+      startedAt: 100,
+      endedAt: 200,
+      livenessState: "blocked",
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+
+    const result = await waitForAgentRun({ runId: "run-timeout-blocked", timeoutMs: 500 });
+
+    expect(result).toEqual({
+      status: "timeout",
+      error: "Request timed out before a response was generated.",
+      startedAt: 100,
+      endedAt: 200,
+      livenessState: "blocked",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+  });
+
+  it("normalizes blocked timeout waits without hard attribution to errors", async () => {
+    callGatewayMock.mockResolvedValue({
+      status: "timeout",
+      startedAt: 100,
+      endedAt: 200,
+      livenessState: "blocked",
+      error: "Context overflow: prompt too large for the model.",
+    });
+
+    const result = await waitForAgentRun({
+      runId: "run-timeout-blocked-unattributed",
+      timeoutMs: 500,
+    });
+
+    expect(result).toEqual({
+      status: "error",
+      error: "Context overflow: prompt too large for the model.",
+      startedAt: 100,
+      endedAt: 200,
+      livenessState: "blocked",
+    });
+  });
+
   it("normalizes aborted stop reasons to errors even when gateway reports ok", async () => {
     callGatewayMock.mockResolvedValue({
       status: "ok",
@@ -324,6 +371,50 @@ describe("waitForAgentRun", () => {
       startedAt: 100,
       endedAt: 200,
       stopReason: "aborted",
+    });
+  });
+
+  it("normalizes aborted timeout waits without hard attribution to errors", async () => {
+    callGatewayMock.mockResolvedValue({
+      status: "timeout",
+      startedAt: 100,
+      endedAt: 200,
+      stopReason: "aborted",
+    });
+
+    const result = await waitForAgentRun({ runId: "run-aborted-timeout", timeoutMs: 500 });
+
+    expect(result).toEqual({
+      status: "error",
+      error: "agent run aborted",
+      startedAt: 100,
+      endedAt: 200,
+      stopReason: "aborted",
+    });
+  });
+
+  it("does not synthesize aborted errors for hard timeout waits", async () => {
+    callGatewayMock.mockResolvedValue({
+      status: "timeout",
+      startedAt: 100,
+      endedAt: 200,
+      stopReason: "aborted",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+
+    const result = await waitForAgentRun({
+      runId: "run-aborted-hard-timeout",
+      timeoutMs: 500,
+    });
+
+    expect(result).toEqual({
+      status: "timeout",
+      startedAt: 100,
+      endedAt: 200,
+      stopReason: "aborted",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
   });
 });

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -4,6 +4,7 @@ import { normalizeBlockedLivenessWaitStatus } from "../shared/agent-liveness.js"
 import { parseFiniteNumber } from "../shared/number-coercion.js";
 import { AGENT_RUN_ABORTED_ERROR, isAbortedAgentStopReason } from "./run-termination.js";
 import {
+  isHardAgentRunTimeoutPhase,
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
   type AgentRunTimeoutPhase,
@@ -67,12 +68,19 @@ function normalizeAgentWaitResult(
 ): AgentWaitResult {
   const stopReason = typeof wait?.stopReason === "string" ? wait.stopReason : undefined;
   const abortedStopReason = isAbortedAgentStopReason(stopReason);
+  const timeoutPhase = normalizeAgentRunTimeoutPhase(wait?.timeoutPhase);
+  const hardRunTimeout = isHardAgentRunTimeoutPhase(timeoutPhase);
   const error =
-    abortedStopReason && typeof wait?.error !== "string" ? AGENT_RUN_ABORTED_ERROR : wait?.error;
+    abortedStopReason &&
+    !(status === "timeout" && hardRunTimeout) &&
+    typeof wait?.error !== "string"
+      ? AGENT_RUN_ABORTED_ERROR
+      : wait?.error;
   const normalized = normalizeBlockedLivenessWaitStatus({
-    status: abortedStopReason ? "error" : status,
+    status: abortedStopReason && !(status === "timeout" && hardRunTimeout) ? "error" : status,
     livenessState: wait?.livenessState,
     error,
+    preserveBlockedTimeout: hardRunTimeout,
   });
   return {
     status: normalized.status,
@@ -83,7 +91,7 @@ function normalizeAgentWaitResult(
     livenessState: typeof wait?.livenessState === "string" ? wait.livenessState : undefined,
     yielded: wait?.yielded === true ? true : undefined,
     pendingError: wait?.pendingError === true ? true : undefined,
-    timeoutPhase: normalizeAgentRunTimeoutPhase(wait?.timeoutPhase),
+    timeoutPhase,
     providerStarted: normalizeProviderStarted(wait?.providerStarted),
   };
 }

--- a/src/agents/sessions-spawn-hooks.test.ts
+++ b/src/agents/sessions-spawn-hooks.test.ts
@@ -191,6 +191,7 @@ beforeAll(async () => {
       runSubagentSpawned: hookRunnerMocks.runSubagentSpawned,
       runSubagentEnded: hookRunnerMocks.runSubagentEnded,
     },
+    createRunIdMock: () => "run-1",
     resetModules: false,
     sessionStorePath: "/tmp/subagent-spawn-hooks-session-store.json",
   }));

--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -315,6 +315,68 @@ describe("applySubagentWaitOutcome", () => {
     });
   });
 
+  it("keeps timeout wait snapshots as timeouts when liveness is blocked", () => {
+    const applied = applySubagentWaitOutcome({
+      wait: {
+        status: "timeout",
+        startedAt: 100,
+        endedAt: 150,
+        livenessState: "blocked",
+        timeoutPhase: "provider",
+        error: "Request timed out before a response was generated.",
+      },
+      outcome: undefined,
+    });
+
+    expect(applied.outcome).toEqual({
+      status: "timeout",
+      startedAt: 100,
+      endedAt: 150,
+      elapsedMs: 50,
+    });
+  });
+
+  it("treats blocked timeout wait snapshots without hard attribution as errors", () => {
+    const applied = applySubagentWaitOutcome({
+      wait: {
+        status: "timeout",
+        startedAt: 100,
+        endedAt: 150,
+        livenessState: "blocked",
+        error: "Context overflow: prompt too large for the model.",
+      },
+      outcome: undefined,
+    });
+
+    expect(applied.outcome).toEqual({
+      status: "error",
+      error: "Context overflow: prompt too large for the model.",
+      startedAt: 100,
+      endedAt: 150,
+      elapsedMs: 50,
+    });
+  });
+
+  it("treats aborted timeout wait snapshots without hard attribution as terminated errors", () => {
+    const applied = applySubagentWaitOutcome({
+      wait: {
+        status: "timeout",
+        startedAt: 100,
+        endedAt: 150,
+        stopReason: "aborted",
+      },
+      outcome: undefined,
+    });
+
+    expect(applied.outcome).toEqual({
+      status: "error",
+      error: "subagent run terminated",
+      startedAt: 100,
+      endedAt: 150,
+      elapsedMs: 50,
+    });
+  });
+
   it("treats aborted ok wait snapshots as terminated subagent errors", () => {
     const applied = applySubagentWaitOutcome({
       wait: {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -70,6 +70,8 @@ type AgentWaitResult = {
 export type SubagentRunOutcome = {
   status: "ok" | "error" | "timeout" | "unknown";
   error?: string;
+  timeoutPhase?: AgentRunTimeoutPhase;
+  providerStarted?: boolean;
   startedAt?: number;
   endedAt?: number;
   elapsedMs?: number;

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -2,6 +2,10 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatBlockedLivenessError, isBlockedLivenessState } from "../shared/agent-liveness.js";
 import { asFiniteNumber } from "../shared/number-coercion.js";
 import { isAbortedAgentStopReason } from "./run-termination.js";
+import {
+  isHardAgentRunTimeoutPhase,
+  type AgentRunTimeoutPhase,
+} from "./run-timeout-attribution.js";
 import { wrapPromptDataBlock } from "./sanitize-for-prompt.js";
 import {
   captureSubagentCompletionReplyUsing,
@@ -60,6 +64,7 @@ type AgentWaitResult = {
   stopReason?: string;
   livenessState?: string;
   yielded?: boolean;
+  timeoutPhase?: AgentRunTimeoutPhase;
 };
 
 export type SubagentRunOutcome = {
@@ -274,14 +279,17 @@ export function applySubagentWaitOutcome(params: {
     next.endedAt = params.wait.endedAt;
   }
   const waitError = typeof params.wait?.error === "string" ? params.wait.error : undefined;
+  const waitBlocked = isBlockedLivenessState(params.wait?.livenessState);
+  const waitAborted = isAbortedAgentStopReason(params.wait?.stopReason);
+  const hardRunTimeout = isHardAgentRunTimeoutPhase(params.wait?.timeoutPhase);
   let outcome = next.outcome;
   // Capture/announcement callers can pass raw wait snapshots that bypass the primary normalizers.
-  if (isBlockedLivenessState(params.wait?.livenessState)) {
-    outcome = { status: "error", error: formatBlockedLivenessError(waitError) };
-  } else if (isAbortedAgentStopReason(params.wait?.stopReason)) {
-    outcome = { status: "error", error: "subagent run terminated" };
-  } else if (params.wait?.status === "timeout") {
+  if (params.wait?.status === "timeout" && (hardRunTimeout || (!waitBlocked && !waitAborted))) {
     outcome = { status: "timeout" };
+  } else if (waitBlocked) {
+    outcome = { status: "error", error: formatBlockedLivenessError(waitError) };
+  } else if (waitAborted) {
+    outcome = { status: "error", error: "subagent run terminated" };
   } else if (params.wait?.status === "error") {
     outcome = { status: "error", error: waitError };
   } else if (params.wait?.status === "ok") {

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -500,8 +500,9 @@ describe("subagent announce timeout config", () => {
       roundOneReply: undefined,
     });
 
-    expect(didAnnounce).toBe(false);
-    expect(findFinalDirectAgentCall()).toBeUndefined();
+    expect(didAnnounce).toBe(true);
+    expect(waitForEmbeddedAgentRunEndMock).not.toHaveBeenCalled();
+    expect(findFinalDirectAgentCall()).toBeTruthy();
   });
 
   it("does not announce cached reply text when the child run terminally failed", async () => {

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -311,6 +311,26 @@ describe("subagent announce timeout config", () => {
     expect(directAgentCall?.timeoutMs).toBe(120_000);
   });
 
+  it("does not wait for an active embedded child after a terminal timeout outcome", async () => {
+    sessionStore = {
+      "agent:main:subagent:worker": {
+        sessionId: "child-session-timeout",
+      },
+    };
+    isEmbeddedAgentRunActiveMock.mockReturnValue(true);
+    waitForEmbeddedAgentRunEndMock.mockResolvedValue(false);
+
+    const didAnnounce = await runAnnounceFlowForTest("run-terminal-timeout", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+      waitForCompletion: false,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(waitForEmbeddedAgentRunEndMock).not.toHaveBeenCalled();
+    expect(findFinalDirectAgentCall()).toBeTruthy();
+  });
+
   it("honors configured announce timeout for completion direct agent call", async () => {
     setConfiguredAnnounceTimeout(120_000);
     await runAnnounceFlowForTest("run-config-timeout-send", {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -269,7 +269,10 @@ export async function runSubagentAnnounceFlow(params: {
     const settleTimeoutMs = Math.min(Math.max(params.timeoutMs, 1), 120_000);
     let reply = params.roundOneReply;
     let outcome: SubagentRunOutcome | undefined = params.outcome;
-    if (childSessionId && isEmbeddedAgentRunActive(childSessionId)) {
+    // A timeout outcome is already the terminal contract. Waiting for the
+    // still-unwinding embedded run lets command-lane safety timers preempt delivery.
+    const terminalTimeoutOutcome = params.outcome?.status === "timeout";
+    if (childSessionId && !terminalTimeoutOutcome && isEmbeddedAgentRunActive(childSessionId)) {
       const settled = await waitForEmbeddedAgentRunEnd(childSessionId, settleTimeoutMs);
       if (!settled && isEmbeddedAgentRunActive(childSessionId)) {
         shouldDeleteChildSession = false;

--- a/src/agents/subagent-control.test.ts
+++ b/src/agents/subagent-control.test.ts
@@ -1372,9 +1372,7 @@ describe("steerControlledSubagentRun", () => {
     });
 
     setSubagentControlDepsForTest({
-      callGateway: async <T = Record<string, unknown>>(
-        request: CallGatewayOptions,
-      ) => {
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayOptions) => {
         if (request.method === "agent.wait") {
           return {} as T;
         }
@@ -1418,5 +1416,68 @@ describe("steerControlledSubagentRun", () => {
       label: "yielded steer task",
       text: "steered yielded steer task.",
     });
+  });
+
+  it("preserves the current run timeout when steering a subagent restart", async () => {
+    const childSessionKey = "agent:main:subagent:timeout-steer-worker";
+    addSubagentRunForTests({
+      runId: "run-timeout-steer",
+      childSessionKey,
+      controllerSessionKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout steer task",
+      cleanup: "keep",
+      runTimeoutSeconds: 45,
+      createdAt: Date.now() - 5_000,
+      startedAt: Date.now() - 4_000,
+    });
+
+    const requests: CallGatewayOptions[] = [];
+    setSubagentControlDepsForTest({
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayOptions) => {
+        requests.push(request);
+        if (request.method === "agent.wait") {
+          return {} as T;
+        }
+        if (request.method === "agent") {
+          return { runId: "run-timeout-steer-followup" } as T;
+        }
+        throw new Error(`unexpected method: ${request.method}`);
+      },
+    });
+
+    const result = await steerControlledSubagentRun({
+      cfg: cfgWithSessionStore(),
+      controller: {
+        controllerSessionKey: "agent:main:main",
+        callerSessionKey: "agent:main:main",
+        callerIsSubagent: false,
+        controlScope: "children",
+      },
+      entry: {
+        runId: "run-timeout-steer",
+        childSessionKey,
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        controllerSessionKey: "agent:main:main",
+        task: "timeout steer task",
+        cleanup: "keep",
+        runTimeoutSeconds: 45,
+        createdAt: Date.now() - 5_000,
+        startedAt: Date.now() - 4_000,
+      },
+      message: "updated direction",
+    });
+
+    expect(result.status).toBe("accepted");
+    const agentRequest = requests.find((request) => request.method === "agent");
+    expect(agentRequest?.params).toMatchObject({
+      sessionKey: childSessionKey,
+      timeout: 45,
+    });
+    const replacement = getSubagentRunByChildSessionKey(childSessionKey);
+    expect(replacement?.runId).toBe("run-timeout-steer-followup");
+    expect(replacement?.runTimeoutSeconds).toBe(45);
   });
 });

--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -154,15 +154,8 @@ function ensureControllerOwnsRun(params: {
   return "Subagents can only control runs spawned from their own session.";
 }
 
-function isFinishedForSteerControl(
-  entry: SubagentRunRecord,
-  hasPendingDescendants: boolean,
-) {
-  return (
-    Boolean(entry.endedAt) &&
-    entry.pauseReason !== "sessions_yield" &&
-    !hasPendingDescendants
-  );
+function isFinishedForSteerControl(entry: SubagentRunRecord, hasPendingDescendants: boolean) {
+  return Boolean(entry.endedAt) && entry.pauseReason !== "sessions_yield" && !hasPendingDescendants;
 }
 
 async function killSubagentRun(params: {
@@ -568,6 +561,7 @@ export async function steerControlledSubagentRun(params: {
 
   const idempotencyKey = crypto.randomUUID();
   let runId: string = idempotencyKey;
+  const runTimeoutSeconds = currentEntry.runTimeoutSeconds ?? params.entry.runTimeoutSeconds ?? 0;
   try {
     const response = await subagentControlDeps.callGateway<{ runId: string }>({
       method: "agent",
@@ -579,7 +573,7 @@ export async function steerControlledSubagentRun(params: {
         deliver: false,
         channel: INTERNAL_MESSAGE_CHANNEL,
         lane: AGENT_LANE_SUBAGENT,
-        timeout: 0,
+        timeout: runTimeoutSeconds,
       },
       timeoutMs: 10_000,
     });
@@ -602,7 +596,7 @@ export async function steerControlledSubagentRun(params: {
     previousRunId: params.entry.runId,
     nextRunId: runId,
     fallback: params.entry,
-    runTimeoutSeconds: params.entry.runTimeoutSeconds ?? 0,
+    runTimeoutSeconds,
   });
   if (!replaced) {
     clearSubagentRunSteerRestart(params.entry.runId);

--- a/src/agents/subagent-depth.test.ts
+++ b/src/agents/subagent-depth.test.ts
@@ -2,9 +2,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
-import { resolveAgentTimeoutMs, resolveAgentTimeoutSeconds } from "./timeout.js";
+import {
+  MAX_AGENT_TIMEOUT_MS,
+  resolveAgentTimeoutMs,
+  resolveAgentTimeoutSeconds,
+} from "./timeout.js";
 
 describe("getSubagentDepthFromSessionStore", () => {
   it("uses spawnDepth from the session store when available", () => {
@@ -144,12 +147,12 @@ describe("resolveAgentTimeoutMs", () => {
   });
 
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
-    expect(resolveAgentTimeoutMs({ overrideSeconds: 0 })).toBe(MAX_TIMER_TIMEOUT_MS);
-    expect(resolveAgentTimeoutMs({ overrideMs: 0 })).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(resolveAgentTimeoutMs({ overrideSeconds: 0 })).toBe(MAX_AGENT_TIMEOUT_MS);
+    expect(resolveAgentTimeoutMs({ overrideMs: 0 })).toBe(MAX_AGENT_TIMEOUT_MS);
   });
 
   it("clamps very large timeout overrides to timer-safe values", () => {
-    expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(MAX_TIMER_TIMEOUT_MS);
-    expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(resolveAgentTimeoutMs({ overrideSeconds: 9_999_999 })).toBe(MAX_AGENT_TIMEOUT_MS);
+    expect(resolveAgentTimeoutMs({ overrideMs: 9_999_999_999 })).toBe(MAX_AGENT_TIMEOUT_MS);
   });
 });

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -23,6 +23,7 @@ import {
   getSubagentSessionStartedAt,
   resolveSubagentSessionStatus,
 } from "./subagent-session-metrics.js";
+import { MAX_AGENT_TIMEOUT_MS } from "./timeout.js";
 
 export {
   getSubagentSessionRuntimeMs,
@@ -35,6 +36,17 @@ const MAX_ANNOUNCE_RETRY_DELAY_MS = 8_000;
 export const MAX_ANNOUNCE_RETRY_COUNT = 3;
 export const ANNOUNCE_EXPIRY_MS = 5 * 60_000;
 export const ANNOUNCE_COMPLETION_HARD_EXPIRY_MS = 30 * 60_000;
+/**
+ * Embedded runs can also surface an intermediate lifecycle `end` with
+ * `aborted=true` just before the runtime automatically retries the same run.
+ * Give that timeout a short grace window so the parent does not get a stale
+ * `timed out` completion right before the eventual success.
+ */
+export const SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS = 15_000;
+// Subagent waits observe the explicit deadline plus lifecycle reconciliation
+// grace, so every deadline calculation uses the same timer-safe cap.
+export const MAX_SUBAGENT_RUN_TIMEOUT_MS =
+  MAX_AGENT_TIMEOUT_MS - SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS;
 
 const FROZEN_RESULT_TEXT_MAX_BYTES = 100 * 1024;
 
@@ -66,8 +78,7 @@ export function resolveAnnounceRetryDelayMs(retryCount: number) {
   return Math.min(baseDelay, MAX_ANNOUNCE_RETRY_DELAY_MS);
 }
 
-export function resolveSubagentRunTimeoutAt(entry: SubagentRunRecord): number | undefined {
-  const runTimeoutSeconds = entry.runTimeoutSeconds;
+export function resolveSubagentRunTimeoutDurationMs(runTimeoutSeconds: number | undefined) {
   if (
     typeof runTimeoutSeconds !== "number" ||
     !Number.isFinite(runTimeoutSeconds) ||
@@ -75,11 +86,25 @@ export function resolveSubagentRunTimeoutAt(entry: SubagentRunRecord): number | 
   ) {
     return undefined;
   }
-  const startedAt = entry.startedAt ?? entry.createdAt;
+  return Math.min(Math.max(1, Math.floor(runTimeoutSeconds * 1000)), MAX_SUBAGENT_RUN_TIMEOUT_MS);
+}
+
+export function resolveSubagentRunTimeoutAt(
+  entry: SubagentRunRecord,
+  observedStartedAt?: number,
+): number | undefined {
+  const runTimeoutMs = resolveSubagentRunTimeoutDurationMs(entry.runTimeoutSeconds);
+  if (runTimeoutMs === undefined) {
+    return undefined;
+  }
+  const startedAt =
+    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
+      ? observedStartedAt
+      : (entry.startedAt ?? entry.createdAt);
   if (!Number.isFinite(startedAt)) {
     return undefined;
   }
-  return Math.floor(startedAt) + Math.floor(runTimeoutSeconds * 1000);
+  return Math.floor(startedAt) + runTimeoutMs;
 }
 
 export function isAtOrAfterSubagentRunTimeout(

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -66,6 +66,30 @@ export function resolveAnnounceRetryDelayMs(retryCount: number) {
   return Math.min(baseDelay, MAX_ANNOUNCE_RETRY_DELAY_MS);
 }
 
+export function resolveSubagentRunTimeoutAt(entry: SubagentRunRecord): number | undefined {
+  const runTimeoutSeconds = entry.runTimeoutSeconds;
+  if (
+    typeof runTimeoutSeconds !== "number" ||
+    !Number.isFinite(runTimeoutSeconds) ||
+    runTimeoutSeconds <= 0
+  ) {
+    return undefined;
+  }
+  const startedAt = entry.startedAt ?? entry.createdAt;
+  if (!Number.isFinite(startedAt)) {
+    return undefined;
+  }
+  return Math.floor(startedAt) + Math.floor(runTimeoutSeconds * 1000);
+}
+
+export function isAtOrAfterSubagentRunTimeout(
+  entry: SubagentRunRecord,
+  atMs: number = Date.now(),
+): boolean {
+  const timeoutAt = resolveSubagentRunTimeoutAt(entry);
+  return typeof timeoutAt === "number" && atMs >= timeoutAt;
+}
+
 function formatAnnounceGiveUpLogField(value: string): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   return JSON.stringify(normalized.length > 2_000 ? `${normalized.slice(0, 2_000)}…` : normalized);

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -795,7 +795,7 @@ describe("subagent registry lifecycle hardening", () => {
       },
       endedAt: 4_250,
       expectsCompletionMessage: true,
-      completion: { resultText: null, capturedAt: 4_250 },
+      completion: { required: true, resultText: null, capturedAt: 4_250 },
     });
     const controller = createLifecycleController({
       entry,

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -90,12 +90,39 @@ vi.mock("./subagent-registry-helpers.js", () => ({
   ANNOUNCE_COMPLETION_HARD_EXPIRY_MS: 30 * 60_000,
   ANNOUNCE_EXPIRY_MS: 5 * 60_000,
   MAX_ANNOUNCE_RETRY_COUNT: 3,
+  MAX_SUBAGENT_RUN_TIMEOUT_MS: 2_147_000_000 - 15_000,
   MIN_ANNOUNCE_RETRY_DELAY_MS: 1_000,
+  SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS: 15_000,
   capFrozenResultText: (text: string) => text.trim(),
   logAnnounceGiveUp: helperMocks.logAnnounceGiveUp,
   persistSubagentSessionTiming: helperMocks.persistSubagentSessionTiming,
   resolveAnnounceRetryDelayMs: (retryCount: number) =>
     Math.min(1_000 * 2 ** Math.max(0, retryCount - 1), 8_000),
+  resolveSubagentRunTimeoutAt: (
+    entry: { runTimeoutSeconds?: number; startedAt?: number; createdAt?: number },
+    observedStartedAt?: number,
+  ) => {
+    const runTimeoutSeconds = entry.runTimeoutSeconds;
+    if (
+      typeof runTimeoutSeconds !== "number" ||
+      !Number.isFinite(runTimeoutSeconds) ||
+      runTimeoutSeconds <= 0
+    ) {
+      return undefined;
+    }
+    const startedAt =
+      typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
+        ? observedStartedAt
+        : (entry.startedAt ?? entry.createdAt);
+    if (typeof startedAt !== "number" || !Number.isFinite(startedAt)) {
+      return undefined;
+    }
+    const durationMs = Math.min(
+      Math.max(1, Math.floor(runTimeoutSeconds * 1000)),
+      2_147_000_000 - 15_000,
+    );
+    return Math.floor(startedAt) + durationMs;
+  },
   safeRemoveAttachmentsDir: helperMocks.safeRemoveAttachmentsDir,
 }));
 

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -748,11 +748,12 @@ describe("subagent registry lifecycle hardening", () => {
     expect(persist).toHaveBeenCalled();
   });
 
-  it("keeps timeout completion terminal when a late success arrives", async () => {
+  it("keeps published explicit timeout completion terminal when a late success arrives", async () => {
     const persist = vi.fn();
     const runSubagentAnnounceFlow = vi.fn(async () => true);
     const entry = createRunEntry({
       startedAt: 2_000,
+      runTimeoutSeconds: 2,
       expectsCompletionMessage: true,
     });
     const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
@@ -775,10 +776,51 @@ describe("subagent registry lifecycle hardening", () => {
     expect(entry.outcome).toEqual({
       status: "timeout",
       startedAt: 2_000,
-      endedAt: 4_250,
-      elapsedMs: 2_250,
+      endedAt: 4_000,
+      elapsedMs: 2_000,
     });
-    expect(entry.endedAt).toBe(4_250);
+    expect(entry.endedAt).toBe(4_000);
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps published explicit timeout terminal when no authoritative timeout metadata exists", async () => {
+    const persist = vi.fn();
+    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const entry = createRunEntry({
+      startedAt: 2_000,
+      runTimeoutSeconds: 2,
+      expectsCompletionMessage: true,
+    });
+    const getAuthoritativeLifecycleTimeout = vi.fn(() => undefined);
+    const controller = createLifecycleController({
+      entry,
+      persist,
+      runSubagentAnnounceFlow,
+      getAuthoritativeLifecycleTimeout,
+    });
+
+    await controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_250,
+      outcome: { status: "timeout" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: true,
+    });
+    await controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 8_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: true,
+    });
+
+    expect(entry.outcome).toEqual({
+      status: "timeout",
+      startedAt: 2_000,
+      endedAt: 4_000,
+      elapsedMs: 2_000,
+    });
+    expect(entry.endedAt).toBe(4_000);
     expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -181,6 +181,8 @@ function createLifecycleController({
     subagentAnnounceTimeoutMs: 1_000,
     persist: vi.fn(),
     clearPendingLifecycleError: vi.fn(),
+    clearPendingLifecycleTimeout: vi.fn(),
+    getPendingLifecycleTimeout: vi.fn(() => undefined),
     countPendingDescendantRuns: () => 0,
     suppressAnnounceForSteerRestart: () => false,
     shouldEmitEndedHookForRun: () => false,
@@ -746,6 +748,80 @@ describe("subagent registry lifecycle hardening", () => {
     expect(persist).toHaveBeenCalled();
   });
 
+  it("keeps timeout completion terminal when a late success arrives", async () => {
+    const persist = vi.fn();
+    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const entry = createRunEntry({
+      startedAt: 2_000,
+      expectsCompletionMessage: true,
+    });
+    const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
+
+    await controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_250,
+      outcome: { status: "timeout" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: true,
+    });
+    await controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 8_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: true,
+    });
+
+    expect(entry.outcome).toEqual({
+      status: "timeout",
+      startedAt: 2_000,
+      endedAt: 4_250,
+      elapsedMs: 2_250,
+    });
+    expect(entry.endedAt).toBe(4_250);
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows earlier terminal evidence to correct a timeout snapshot", async () => {
+    const persist = vi.fn();
+    const captureSubagentCompletionReply = vi.fn(async () => "real final report");
+    const entry = createRunEntry({
+      startedAt: 2_000,
+      outcome: {
+        status: "timeout",
+        startedAt: 2_000,
+        endedAt: 4_250,
+        elapsedMs: 2_250,
+      },
+      endedAt: 4_250,
+      expectsCompletionMessage: true,
+      completion: { resultText: null, capturedAt: 4_250 },
+    });
+    const controller = createLifecycleController({
+      entry,
+      persist,
+      captureSubagentCompletionReply,
+    });
+
+    await controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    expect(entry.outcome).toEqual({
+      status: "ok",
+      startedAt: 2_000,
+      endedAt: 4_000,
+      elapsedMs: 2_000,
+    });
+    expect(entry.completion?.resultText).toBe("real final report");
+    expect(entry.endedAt).toBe(4_000);
+    expect(persist).toHaveBeenCalled();
+  });
+
   it("persists timing when a preexisting outcome matches without timing", async () => {
     const persist = vi.fn();
     const entry = createRunEntry({
@@ -836,6 +912,38 @@ describe("subagent registry lifecycle hardening", () => {
     expectFields(firstCallArg(taskExecutorMocks.failTaskRunByRunId), {
       status: "failed",
       error: "All models failed (2): timeout",
+      progressSummary: undefined,
+    });
+    expect(persist).toHaveBeenCalled();
+  });
+
+  it("does not wait for a completion reply when timeout outcomes settle", async () => {
+    const persist = vi.fn();
+    const captureSubagentCompletionReply = vi.fn(async () => "stale assistant text");
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+    });
+
+    const controller = createLifecycleController({
+      entry,
+      persist,
+      captureSubagentCompletionReply,
+    });
+
+    await expect(
+      controller.completeSubagentRun({
+        runId: entry.runId,
+        endedAt: 4_000,
+        outcome: { status: "timeout" },
+        reason: SUBAGENT_ENDED_REASON_COMPLETE,
+        triggerCleanup: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(captureSubagentCompletionReply).not.toHaveBeenCalled();
+    expect(entry.completion?.resultText).toBeNull();
+    expectFields(firstCallArg(taskExecutorMocks.failTaskRunByRunId), {
+      status: "timed_out",
       progressSummary: undefined,
     });
     expect(persist).toHaveBeenCalled();

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -23,6 +23,7 @@ import {
   buildAnnounceIdempotencyKey,
 } from "./announce-idempotency.js";
 import { removeInternalSessionEffectsTranscript } from "./internal-session-effects.js";
+import { isHardAgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
 import {
@@ -145,6 +146,14 @@ export function createSubagentRegistryLifecycleController(params: {
         authoritative: boolean;
       }
     | undefined;
+  getAuthoritativeLifecycleTimeout?(runId: string):
+    | {
+        endedAt: number;
+        timeoutPhase: SubagentRunOutcome["timeoutPhase"];
+        providerStarted?: boolean;
+      }
+    | undefined;
+  clearAuthoritativeLifecycleTimeout?(runId: string): void;
   countPendingDescendantRuns(rootSessionKey: string): number;
   suppressAnnounceForSteerRestart(entry?: SubagentRunRecord): boolean;
   shouldEmitEndedHookForRun(args: {
@@ -1103,20 +1112,40 @@ export function createSubagentRegistryLifecycleController(params: {
     startedAt?: number;
   }) => {
     const pendingTimeout = params.getPendingLifecycleTimeout(completeParams.runId);
+    const authoritativeTimeout = params.getAuthoritativeLifecycleTimeout?.(completeParams.runId);
+    const entry = params.runs.get(completeParams.runId);
+    if (!entry) {
+      return;
+    }
+    if (
+      authoritativeTimeout &&
+      completeParams.outcome.status !== "timeout" &&
+      (typeof completeParams.endedAt !== "number" ||
+        completeParams.endedAt > authoritativeTimeout.endedAt)
+    ) {
+      return;
+    }
     if (
       pendingTimeout?.authoritative === true &&
       completeParams.outcome.status !== "timeout" &&
       (typeof completeParams.endedAt !== "number" ||
         completeParams.endedAt > pendingTimeout.endedAt)
     ) {
-      return;
+      const observedDeadline = resolveSubagentRunDeadlineMs(entry, completeParams.startedAt);
+      if (
+        typeof observedDeadline === "number" &&
+        (typeof completeParams.startedAt !== "number" ||
+          completeParams.startedAt < pendingTimeout.endedAt) &&
+        typeof completeParams.endedAt === "number" &&
+        completeParams.endedAt <= observedDeadline
+      ) {
+        params.clearPendingLifecycleTimeout(completeParams.runId);
+      } else {
+        return;
+      }
     }
     params.clearPendingLifecycleError(completeParams.runId);
     params.clearPendingLifecycleTimeout(completeParams.runId);
-    const entry = params.runs.get(completeParams.runId);
-    if (!entry) {
-      return;
-    }
     const replacingTimeoutWithEarlierOk =
       entry.outcome?.status === "timeout" &&
       typeof entry.endedAt === "number" &&
@@ -1124,7 +1153,16 @@ export function createSubagentRegistryLifecycleController(params: {
       typeof completeParams.endedAt === "number" &&
       completeParams.endedAt <= entry.endedAt;
     if (
+      !params.getAuthoritativeLifecycleTimeout &&
       entry.outcome?.status === "timeout" &&
+      typeof entry.endedAt === "number" &&
+      completeParams.outcome.status !== "timeout" &&
+      (typeof completeParams.endedAt !== "number" || completeParams.endedAt > entry.endedAt)
+    ) {
+      return;
+    }
+    if (
+      isHardAgentRunTimeoutPhase(entry.outcome?.timeoutPhase) &&
       typeof entry.endedAt === "number" &&
       completeParams.outcome.status !== "timeout" &&
       (typeof completeParams.endedAt !== "number" || completeParams.endedAt > entry.endedAt)
@@ -1148,6 +1186,19 @@ export function createSubagentRegistryLifecycleController(params: {
     let endedAt = typeof completeParams.endedAt === "number" ? completeParams.endedAt : Date.now();
     let completionOutcome = completeParams.outcome;
     let completionReason = completeParams.reason;
+    if (
+      completionOutcome.status === "timeout" &&
+      authoritativeTimeout &&
+      !completionOutcome.timeoutPhase
+    ) {
+      completionOutcome = {
+        ...completionOutcome,
+        timeoutPhase: authoritativeTimeout.timeoutPhase,
+        ...(authoritativeTimeout.providerStarted !== undefined
+          ? { providerStarted: authoritativeTimeout.providerStarted }
+          : {}),
+      };
+    }
     if (
       shouldPreservePublishedExplicitRunTimeout({
         entry,
@@ -1237,6 +1288,9 @@ export function createSubagentRegistryLifecycleController(params: {
 
     if (mutated) {
       params.persist();
+    }
+    if (completionOutcome.status === "timeout") {
+      params.clearAuthoritativeLifecycleTimeout?.(completeParams.runId);
     }
     safeFinalizeSubagentTaskRun({
       entry,

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -1153,7 +1153,7 @@ export function createSubagentRegistryLifecycleController(params: {
       typeof completeParams.endedAt === "number" &&
       completeParams.endedAt <= entry.endedAt;
     if (
-      !params.getAuthoritativeLifecycleTimeout &&
+      shouldPreservePublishedExplicitRunTimeout({ entry }) &&
       entry.outcome?.status === "timeout" &&
       typeof entry.endedAt === "number" &&
       completeParams.outcome.status !== "timeout" &&

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -51,6 +51,7 @@ import {
   MIN_ANNOUNCE_RETRY_DELAY_MS,
   persistSubagentSessionTiming,
   resolveAnnounceRetryDelayMs,
+  resolveSubagentRunTimeoutAt,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import type { PendingFinalDeliveryPayload, SubagentRunRecord } from "./subagent-registry.types.js";
@@ -76,27 +77,6 @@ async function loadCleanupBrowserSessionsForLifecycleEnd(): Promise<
   return (await browserCleanupLoader.load()).cleanupBrowserSessionsForLifecycleEnd;
 }
 
-function resolveSubagentRunDeadlineMs(
-  entry: SubagentRunRecord,
-  observedStartedAt?: number,
-): number | undefined {
-  const timeoutSeconds = entry.runTimeoutSeconds;
-  if (
-    typeof timeoutSeconds !== "number" ||
-    !Number.isFinite(timeoutSeconds) ||
-    timeoutSeconds <= 0
-  ) {
-    return undefined;
-  }
-  const startedAt =
-    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
-      ? observedStartedAt
-      : typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
-        ? entry.startedAt
-        : entry.createdAt;
-  return Number.isFinite(startedAt) ? startedAt + Math.floor(timeoutSeconds * 1000) : undefined;
-}
-
 function shouldPreservePublishedExplicitRunTimeout(params: { entry: SubagentRunRecord }): boolean {
   if (
     typeof params.entry.runTimeoutSeconds !== "number" ||
@@ -107,7 +87,7 @@ function shouldPreservePublishedExplicitRunTimeout(params: { entry: SubagentRunR
   ) {
     return false;
   }
-  const deadlineMs = resolveSubagentRunDeadlineMs(params.entry);
+  const deadlineMs = resolveSubagentRunTimeoutAt(params.entry);
   if (deadlineMs === undefined || params.entry.endedAt < deadlineMs) {
     return false;
   }
@@ -129,7 +109,7 @@ function resolveExpiredExplicitRunDeadlineMs(params: {
   nextEndedAt: number;
   observedStartedAt?: number;
 }): number | undefined {
-  const deadlineMs = resolveSubagentRunDeadlineMs(params.entry, params.observedStartedAt);
+  const deadlineMs = resolveSubagentRunTimeoutAt(params.entry, params.observedStartedAt);
   return deadlineMs !== undefined && params.nextEndedAt > deadlineMs ? deadlineMs : undefined;
 }
 
@@ -1131,7 +1111,7 @@ export function createSubagentRegistryLifecycleController(params: {
       (typeof completeParams.endedAt !== "number" ||
         completeParams.endedAt > pendingTimeout.endedAt)
     ) {
-      const observedDeadline = resolveSubagentRunDeadlineMs(entry, completeParams.startedAt);
+      const observedDeadline = resolveSubagentRunTimeoutAt(entry, completeParams.startedAt);
       if (
         typeof observedDeadline === "number" &&
         (typeof completeParams.startedAt !== "number" ||

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -138,6 +138,13 @@ export function createSubagentRegistryLifecycleController(params: {
   subagentAnnounceTimeoutMs: number;
   persist(): void;
   clearPendingLifecycleError(runId: string): void;
+  clearPendingLifecycleTimeout(runId: string): void;
+  getPendingLifecycleTimeout(runId: string):
+    | {
+        endedAt: number;
+        authoritative: boolean;
+      }
+    | undefined;
   countPendingDescendantRuns(rootSessionKey: string): number;
   suppressAnnounceForSteerRestart(entry?: SubagentRunRecord): boolean;
   shouldEmitEndedHookForRun(args: {
@@ -412,7 +419,7 @@ export function createSubagentRegistryLifecycleController(params: {
     if (completion.resultText !== undefined) {
       return false;
     }
-    if (outcome.status === "error") {
+    if (outcome.status === "error" || outcome.status === "timeout") {
       completion.resultText = null;
       completion.capturedAt = Date.now();
       return true;
@@ -1095,9 +1102,33 @@ export function createSubagentRegistryLifecycleController(params: {
     triggerCleanup: boolean;
     startedAt?: number;
   }) => {
+    const pendingTimeout = params.getPendingLifecycleTimeout(completeParams.runId);
+    if (
+      pendingTimeout?.authoritative === true &&
+      completeParams.outcome.status !== "timeout" &&
+      (typeof completeParams.endedAt !== "number" ||
+        completeParams.endedAt > pendingTimeout.endedAt)
+    ) {
+      return;
+    }
     params.clearPendingLifecycleError(completeParams.runId);
+    params.clearPendingLifecycleTimeout(completeParams.runId);
     const entry = params.runs.get(completeParams.runId);
     if (!entry) {
+      return;
+    }
+    const replacingTimeoutWithEarlierOk =
+      entry.outcome?.status === "timeout" &&
+      typeof entry.endedAt === "number" &&
+      completeParams.outcome.status === "ok" &&
+      typeof completeParams.endedAt === "number" &&
+      completeParams.endedAt <= entry.endedAt;
+    if (
+      entry.outcome?.status === "timeout" &&
+      typeof entry.endedAt === "number" &&
+      completeParams.outcome.status !== "timeout" &&
+      (typeof completeParams.endedAt !== "number" || completeParams.endedAt > entry.endedAt)
+    ) {
       return;
     }
 
@@ -1187,6 +1218,14 @@ export function createSubagentRegistryLifecycleController(params: {
     if (entry.pauseReason !== undefined) {
       entry.pauseReason = undefined;
       mutated = true;
+    }
+    if (replacingTimeoutWithEarlierOk) {
+      const completion = ensureCompletionState(entry);
+      if (completion.resultText === null) {
+        completion.resultText = undefined;
+        completion.capturedAt = undefined;
+        mutated = true;
+      }
     }
 
     if (await freezeRunResultAtCompletion(entry, outcome)) {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -387,6 +387,8 @@ export function createSubagentRunManager(params: {
       };
       if (waitStatus === "timeout") {
         const now = Date.now();
+        const hardTimeoutObservedAt =
+          hardRunTimeout && typeof wait.endedAt !== "number" ? waitStartedAt : wait.endedAt;
         if (observedStartedAt !== undefined && entry.startedAt !== observedStartedAt) {
           entry.startedAt = observedStartedAt;
           if (typeof entry.sessionStartedAt !== "number") {
@@ -397,11 +399,12 @@ export function createSubagentRunManager(params: {
         // A plain agent.wait timeout has no terminal snapshot. For explicit
         // subagent run timeouts, the stored run deadline is the completion
         // contract so parent sessions are woken instead of retrying forever.
-        const hardRunTimeoutEndedAt = resolveHardRunTimeoutEndedAt(entry, now, observedStartedAt);
         const explicitRunTimeoutAt = resolveSubagentRunDeadlineMs(entry, observedStartedAt);
         const explicitRunTimeoutElapsed =
           typeof explicitRunTimeoutAt === "number" &&
-          now + WAIT_TIMEOUT_DEADLINE_SKEW_MS >= explicitRunTimeoutAt;
+          (hardTimeoutObservedAt ?? now) + WAIT_TIMEOUT_DEADLINE_SKEW_MS >= explicitRunTimeoutAt;
+        const hardRunTimeoutEndedAt =
+          hardTimeoutObservedAt ?? resolveHardRunTimeoutEndedAt(entry, now, observedStartedAt);
         const isTerminalWaitTimeout =
           typeof wait.endedAt === "number" ||
           typeof wait.stopReason === "string" ||
@@ -497,16 +500,24 @@ export function createSubagentRunManager(params: {
           : rawWaitError;
       const baseOutcome: SubagentRunOutcome =
         waitStatus === "error" ? { status: "error", error: waitError } : { status: "ok" };
-      const pendingTimeout = params.getPendingLifecycleTimeout(runId);
-      if (
-        pendingTimeout?.authoritative === true &&
-        baseOutcome.status !== "timeout" &&
-        (typeof wait.endedAt !== "number" || wait.endedAt > pendingTimeout.endedAt)
-      ) {
-        return;
-      }
       const resolvedEndedAt =
         typeof wait.endedAt === "number" ? wait.endedAt : (entry.endedAt ?? Date.now());
+      const pendingTimeout = params.getPendingLifecycleTimeout(runId);
+      if (pendingTimeout?.authoritative === true && baseOutcome.status !== "timeout") {
+        if (typeof wait.endedAt !== "number" && typeof entry.endedAt !== "number") {
+          return;
+        }
+        const observedDeadline = resolveSubagentRunDeadlineMs(entry, observedStartedAt);
+        if (
+          typeof observedDeadline === "number" &&
+          (typeof observedStartedAt !== "number" || observedStartedAt < pendingTimeout.endedAt) &&
+          resolvedEndedAt <= observedDeadline
+        ) {
+          params.clearPendingLifecycleTimeout(runId);
+        } else if (resolvedEndedAt > pendingTimeout.endedAt) {
+          return;
+        }
+      }
       let mutated = false;
       if (typeof observedStartedAt === "number") {
         entry.startedAt = observedStartedAt;

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -180,6 +180,7 @@ export type RegisterSubagentRunParams = {
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;
+  deferCompletionWait?: boolean;
 };
 
 export function createSubagentRunManager(params: {
@@ -825,7 +826,24 @@ export function createSubagentRunManager(params: {
     params.scheduleRunTimeoutFallback(entry, now);
     // Wait for subagent completion via gateway RPC (cross-process).
     // The in-process lifecycle listener is a fallback for embedded runs.
-    void waitForSubagentCompletion(runId, waitTimeoutMs, entry);
+    if (registerParams.deferCompletionWait !== true) {
+      void waitForSubagentCompletion(runId, waitTimeoutMs, entry);
+    }
+  };
+
+  const startSubagentRunCompletionWait = (runId: string): boolean => {
+    const key = runId.trim();
+    if (!key) {
+      return false;
+    }
+    const entry = params.runs.get(key);
+    if (!entry || typeof entry.endedAt === "number" || entry.outcome != null) {
+      return false;
+    }
+    const cfg = params.getRuntimeConfig();
+    const waitTimeoutMs = params.resolveSubagentWaitTimeoutMs(cfg, entry.runTimeoutSeconds);
+    void waitForSubagentCompletion(key, waitTimeoutMs, entry);
+    return true;
   };
 
   const armSubagentRunTimeout = (runId: string, runTimeoutSeconds: number, startedAt?: number) => {
@@ -1031,6 +1049,7 @@ export function createSubagentRunManager(params: {
     registerSubagentRun,
     releaseSubagentRun,
     replaceSubagentRunAfterSteer,
+    startSubagentRunCompletionWait,
     waitForSubagentCompletion,
   };
 }

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -362,7 +362,11 @@ export function createSubagentRunManager(params: {
               childSessionKey: entry.childSessionKey,
               notBeforeMs: entry.startedAt ?? entry.createdAt,
             });
-      const completeAsRunTimeout = async (endedAt?: number, startedAt?: number) => {
+      const completeAsRunTimeout = async (
+        endedAt?: number,
+        startedAt?: number,
+        outcome: SubagentRunOutcome = { status: "timeout" },
+      ) => {
         if (typeof startedAt === "number" && Number.isFinite(startedAt)) {
           entry.startedAt = startedAt;
           if (typeof entry.sessionStartedAt !== "number") {
@@ -371,7 +375,7 @@ export function createSubagentRunManager(params: {
         }
         const timeoutCompletion: Parameters<typeof params.completeSubagentRun>[0] = {
           runId,
-          outcome: { status: "timeout" },
+          outcome,
           reason: SUBAGENT_ENDED_REASON_COMPLETE,
           sendFarewell: true,
           accountId: entry.requesterOrigin?.accountId,
@@ -388,8 +392,19 @@ export function createSubagentRunManager(params: {
       };
       if (waitStatus === "timeout") {
         const now = Date.now();
-        const hardTimeoutObservedAt =
-          hardRunTimeout && typeof wait.endedAt !== "number" ? waitStartedAt : wait.endedAt;
+        const hardTimeoutOutcome: SubagentRunOutcome =
+          hardRunTimeout && wait.timeoutPhase
+            ? {
+                status: "timeout",
+                timeoutPhase: wait.timeoutPhase,
+                ...(wait.providerStarted !== undefined
+                  ? { providerStarted: wait.providerStarted }
+                  : {}),
+              }
+            : { status: "timeout" };
+        const completeAsWaitTimeout = (endedAt?: number, startedAt?: number) =>
+          completeAsRunTimeout(endedAt, startedAt, hardTimeoutOutcome);
+        const hardTimeoutObservedAt = wait.endedAt;
         if (observedStartedAt !== undefined && entry.startedAt !== observedStartedAt) {
           entry.startedAt = observedStartedAt;
           if (typeof entry.sessionStartedAt !== "number") {
@@ -404,8 +419,9 @@ export function createSubagentRunManager(params: {
         const explicitRunTimeoutElapsed =
           typeof explicitRunTimeoutAt === "number" &&
           (hardTimeoutObservedAt ?? now) + WAIT_TIMEOUT_DEADLINE_SKEW_MS >= explicitRunTimeoutAt;
-        const hardRunTimeoutEndedAt =
-          hardTimeoutObservedAt ?? resolveHardRunTimeoutEndedAt(entry, now, observedStartedAt);
+        const hardRunTimeoutEndedAt = hardRunTimeout
+          ? (wait.endedAt ?? resolveHardRunTimeoutEndedAt(entry, now, observedStartedAt) ?? now)
+          : resolveHardRunTimeoutEndedAt(entry, now, observedStartedAt);
         const isTerminalWaitTimeout =
           typeof wait.endedAt === "number" ||
           typeof wait.stopReason === "string" ||
@@ -427,7 +443,7 @@ export function createSubagentRunManager(params: {
             now,
           });
           if (completionAfterDeadline !== undefined) {
-            await completeAsRunTimeout(completionAfterDeadline, completionStartedAt);
+            await completeAsWaitTimeout(completionAfterDeadline, completionStartedAt);
             return;
           }
           const completionPredatesHardTimeout =
@@ -439,7 +455,7 @@ export function createSubagentRunManager(params: {
             (typeof explicitRunTimeoutAt === "number" &&
               completion.endedAt <= explicitRunTimeoutAt);
           if (!completionPredatesHardTimeout || !completionPredatesExplicitTimeout) {
-            await completeAsRunTimeout(
+            await completeAsWaitTimeout(
               typeof wait.endedAt === "number"
                 ? wait.endedAt
                 : (hardRunTimeoutEndedAt ?? explicitRunTimeoutAt ?? now),
@@ -474,7 +490,7 @@ export function createSubagentRunManager(params: {
           if (timeoutAfterDeadline !== undefined) {
             timeoutEndedAt = timeoutAfterDeadline;
           }
-          await completeAsRunTimeout(timeoutEndedAt, observedStartedAt);
+          await completeAsWaitTimeout(timeoutEndedAt, observedStartedAt);
           return;
         }
         scheduleWaitRetry(

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -49,36 +49,12 @@ function shouldDeleteAttachments(entry: SubagentRunRecord) {
   return entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep;
 }
 
-function resolveSubagentRunDeadlineMs(
-  entry: SubagentRunRecord,
-  observedStartedAt?: number,
-): number | undefined {
-  const timeoutSeconds = entry.runTimeoutSeconds;
-  if (
-    typeof timeoutSeconds !== "number" ||
-    !Number.isFinite(timeoutSeconds) ||
-    timeoutSeconds <= 0
-  ) {
-    return undefined;
-  }
-  const startedAt =
-    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
-      ? observedStartedAt
-      : typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
-        ? entry.startedAt
-        : entry.createdAt;
-  if (!Number.isFinite(startedAt)) {
-    return undefined;
-  }
-  return startedAt + Math.floor(timeoutSeconds * 1000);
-}
-
 function resolveHardRunTimeoutEndedAt(
   entry: SubagentRunRecord,
   now: number,
   observedStartedAt?: number,
 ): number | undefined {
-  const deadlineMs = resolveSubagentRunDeadlineMs(entry, observedStartedAt);
+  const deadlineMs = resolveSubagentRunTimeoutAt(entry, observedStartedAt);
   if (deadlineMs === undefined) {
     return undefined;
   }
@@ -91,7 +67,7 @@ function resolveCompletionAfterHardRunDeadline(params: {
   observedEndedAt?: number;
   now: number;
 }): number | undefined {
-  const deadlineMs = resolveSubagentRunDeadlineMs(params.entry, params.observedStartedAt);
+  const deadlineMs = resolveSubagentRunTimeoutAt(params.entry, params.observedStartedAt);
   if (deadlineMs === undefined) {
     return undefined;
   }
@@ -108,7 +84,7 @@ function resolveWaitTimeoutMsForRun(
   now: number,
 ): number {
   const normalizedWaitTimeoutMs = Math.max(1, Math.floor(waitTimeoutMs));
-  const deadlineMs = resolveSubagentRunDeadlineMs(entry);
+  const deadlineMs = resolveSubagentRunTimeoutAt(entry);
   if (deadlineMs === undefined) {
     return normalizedWaitTimeoutMs;
   }
@@ -415,7 +391,7 @@ export function createSubagentRunManager(params: {
         // A plain agent.wait timeout has no terminal snapshot. For explicit
         // subagent run timeouts, the stored run deadline is the completion
         // contract so parent sessions are woken instead of retrying forever.
-        const explicitRunTimeoutAt = resolveSubagentRunDeadlineMs(entry, observedStartedAt);
+        const explicitRunTimeoutAt = resolveSubagentRunTimeoutAt(entry, observedStartedAt);
         const explicitRunTimeoutElapsed =
           typeof explicitRunTimeoutAt === "number" &&
           (hardTimeoutObservedAt ?? now) + WAIT_TIMEOUT_DEADLINE_SKEW_MS >= explicitRunTimeoutAt;
@@ -524,7 +500,7 @@ export function createSubagentRunManager(params: {
         if (typeof wait.endedAt !== "number" && typeof entry.endedAt !== "number") {
           return;
         }
-        const observedDeadline = resolveSubagentRunDeadlineMs(entry, observedStartedAt);
+        const observedDeadline = resolveSubagentRunTimeoutAt(entry, observedStartedAt);
         if (
           typeof observedDeadline === "number" &&
           (typeof observedStartedAt !== "number" || observedStartedAt < pendingTimeout.endedAt) &&

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -4,11 +4,12 @@ import { callGateway } from "../gateway/call.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { formatBlockedLivenessError, isBlockedLivenessState } from "../shared/agent-liveness.js";
-import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
+import { createRunningTaskRun, finalizeTaskRunByRunId } from "../tasks/detached-task-runtime.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { removeInternalSessionEffectsTranscript } from "./internal-session-effects.js";
 import { isAbortedAgentStopReason } from "./run-termination.js";
+import { isHardAgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 import { isRecoverableAgentWaitError, waitForAgentRun } from "./run-wait.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
@@ -31,8 +32,10 @@ import {
 import {
   getSubagentSessionRuntimeMs,
   getSubagentSessionStartedAt,
+  isAtOrAfterSubagentRunTimeout,
   persistSubagentSessionTiming,
   resolveArchiveAfterMs,
+  resolveSubagentRunTimeoutAt,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -199,6 +202,14 @@ export function createSubagentRunManager(params: {
   stopSweeper(): void;
   resumeSubagentRun(runId: string): void;
   clearPendingLifecycleError(runId: string): void;
+  clearPendingLifecycleTimeout(runId: string, opts?: { preserveAuthoritative?: boolean }): void;
+  getPendingLifecycleTimeout(runId: string):
+    | {
+        endedAt: number;
+        authoritative: boolean;
+      }
+    | undefined;
+  scheduleRunTimeoutFallback(entry: SubagentRunRecord, startedAt: number): void;
   resolveSubagentWaitTimeoutMs(cfg: OpenClawConfig, runTimeoutSeconds?: number): number;
   scheduleOrphanRecovery(args?: { delayMs?: number; maxRetries?: number }): void;
   resolveSubagentSessionCompletion(args: {
@@ -279,7 +290,20 @@ export function createSubagentRunManager(params: {
       }
       const waitBlocked = isBlockedLivenessState(wait.livenessState);
       const waitAborted = isAbortedAgentStopReason(wait.stopReason);
-      if (wait.yielded === true && !waitBlocked) {
+      const hardRunTimeout = isHardAgentRunTimeoutPhase(wait.timeoutPhase);
+      const waitTimedOut = wait.status === "timeout";
+      const waitCorrectsExistingTimeout =
+        entry.outcome?.status === "timeout" &&
+        wait.status === "ok" &&
+        typeof wait.endedAt === "number" &&
+        (typeof entry.endedAt !== "number" || wait.endedAt <= entry.endedAt) &&
+        !isAtOrAfterSubagentRunTimeout(entry, wait.endedAt);
+      // Registry/lifecycle completion may win while agent.wait is in flight.
+      // Only earlier successful evidence may correct a provisional timeout.
+      if ((typeof entry.endedAt === "number" || entry.outcome) && !waitCorrectsExistingTimeout) {
+        return;
+      }
+      if (wait.yielded === true && !waitBlocked && !waitTimedOut) {
         if (
           markSubagentRunPausedAfterYield({
             entry,
@@ -287,11 +311,45 @@ export function createSubagentRunManager(params: {
             endedAt: wait.endedAt,
           })
         ) {
+          params.clearPendingLifecycleTimeout(runId, { preserveAuthoritative: true });
           params.persist();
         }
         return;
       }
-      const waitStatus = waitBlocked || waitAborted ? "error" : wait.status;
+      if (
+        wait.yielded === true &&
+        waitTimedOut &&
+        !waitBlocked &&
+        !waitAborted &&
+        !hardRunTimeout
+      ) {
+        scheduleWaitRetry(
+          entry,
+          "subagent yielded wait timed out; deferring terminal state until continuation or run timeout",
+        );
+        return;
+      }
+      const waitStatus =
+        wait.status === "timeout" && ((!waitBlocked && !waitAborted) || hardRunTimeout)
+          ? "timeout"
+          : waitBlocked || waitAborted
+            ? "error"
+            : wait.status;
+      const waitEvidenceAt = typeof wait.endedAt === "number" ? wait.endedAt : Date.now();
+      if (waitStatus === "error" && isAtOrAfterSubagentRunTimeout(entry, waitEvidenceAt)) {
+        const timeoutAt = resolveSubagentRunTimeoutAt(entry) ?? waitEvidenceAt;
+        completionForRetry = {
+          runId,
+          endedAt: timeoutAt,
+          outcome: { status: "timeout" },
+          reason: SUBAGENT_ENDED_REASON_COMPLETE,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
+        };
+        await params.completeSubagentRun(completionForRetry);
+        return;
+      }
       if (waitStatus === "error" && !waitAborted && isRecoverableAgentWaitError(wait.error)) {
         scheduleWaitRetry(entry, "subagent wait interrupted; scheduling recovery", wait.error);
         return;
@@ -328,10 +386,6 @@ export function createSubagentRunManager(params: {
         await params.completeSubagentRun(completionForRetry);
       };
       if (waitStatus === "timeout") {
-        const isTerminalWaitTimeout =
-          typeof wait.endedAt === "number" ||
-          typeof wait.stopReason === "string" ||
-          typeof wait.livenessState === "string";
         const now = Date.now();
         if (observedStartedAt !== undefined && entry.startedAt !== observedStartedAt) {
           entry.startedAt = observedStartedAt;
@@ -344,6 +398,16 @@ export function createSubagentRunManager(params: {
         // subagent run timeouts, the stored run deadline is the completion
         // contract so parent sessions are woken instead of retrying forever.
         const hardRunTimeoutEndedAt = resolveHardRunTimeoutEndedAt(entry, now, observedStartedAt);
+        const explicitRunTimeoutAt = resolveSubagentRunDeadlineMs(entry, observedStartedAt);
+        const explicitRunTimeoutElapsed =
+          typeof explicitRunTimeoutAt === "number" &&
+          now + WAIT_TIMEOUT_DEADLINE_SKEW_MS >= explicitRunTimeoutAt;
+        const isTerminalWaitTimeout =
+          typeof wait.endedAt === "number" ||
+          typeof wait.stopReason === "string" ||
+          typeof wait.livenessState === "string" ||
+          hardRunTimeout ||
+          explicitRunTimeoutElapsed;
         const completion = params.resolveSubagentSessionCompletion({
           childSessionKey: entry.childSessionKey,
           fallbackEndedAt:
@@ -362,6 +426,23 @@ export function createSubagentRunManager(params: {
             await completeAsRunTimeout(completionAfterDeadline, completionStartedAt);
             return;
           }
+          const completionPredatesHardTimeout =
+            !hardRunTimeout ||
+            typeof wait.endedAt !== "number" ||
+            completion.endedAt <= wait.endedAt;
+          const completionPredatesExplicitTimeout =
+            !explicitRunTimeoutElapsed ||
+            (typeof explicitRunTimeoutAt === "number" &&
+              completion.endedAt <= explicitRunTimeoutAt);
+          if (!completionPredatesHardTimeout || !completionPredatesExplicitTimeout) {
+            await completeAsRunTimeout(
+              typeof wait.endedAt === "number"
+                ? wait.endedAt
+                : (hardRunTimeoutEndedAt ?? explicitRunTimeoutAt ?? now),
+              observedStartedAt,
+            );
+            return;
+          }
           completionForRetry = {
             runId,
             endedAt: completion.endedAt,
@@ -377,7 +458,9 @@ export function createSubagentRunManager(params: {
         }
         if (isTerminalWaitTimeout || hardRunTimeoutEndedAt !== undefined) {
           let timeoutEndedAt =
-            typeof wait.endedAt === "number" ? wait.endedAt : hardRunTimeoutEndedAt;
+            typeof wait.endedAt === "number"
+              ? wait.endedAt
+              : (hardRunTimeoutEndedAt ?? explicitRunTimeoutAt ?? now);
           const timeoutAfterDeadline = resolveCompletionAfterHardRunDeadline({
             entry,
             observedStartedAt,
@@ -406,22 +489,6 @@ export function createSubagentRunManager(params: {
         await completeAsRunTimeout(completionAfterDeadline, observedStartedAt);
         return;
       }
-      let mutated = false;
-      if (typeof observedStartedAt === "number") {
-        entry.startedAt = observedStartedAt;
-        if (typeof entry.sessionStartedAt !== "number") {
-          entry.sessionStartedAt = observedStartedAt;
-        }
-        mutated = true;
-      }
-      if (typeof wait.endedAt === "number") {
-        entry.endedAt = wait.endedAt;
-        mutated = true;
-      }
-      if (!entry.endedAt) {
-        entry.endedAt = Date.now();
-        mutated = true;
-      }
       const rawWaitError = typeof wait.error === "string" ? wait.error : undefined;
       const waitError = waitAborted
         ? "subagent run terminated"
@@ -430,6 +497,28 @@ export function createSubagentRunManager(params: {
           : rawWaitError;
       const baseOutcome: SubagentRunOutcome =
         waitStatus === "error" ? { status: "error", error: waitError } : { status: "ok" };
+      const pendingTimeout = params.getPendingLifecycleTimeout(runId);
+      if (
+        pendingTimeout?.authoritative === true &&
+        baseOutcome.status !== "timeout" &&
+        (typeof wait.endedAt !== "number" || wait.endedAt > pendingTimeout.endedAt)
+      ) {
+        return;
+      }
+      const resolvedEndedAt =
+        typeof wait.endedAt === "number" ? wait.endedAt : (entry.endedAt ?? Date.now());
+      let mutated = false;
+      if (typeof observedStartedAt === "number") {
+        entry.startedAt = observedStartedAt;
+        if (typeof entry.sessionStartedAt !== "number") {
+          entry.sessionStartedAt = observedStartedAt;
+        }
+        mutated = true;
+      }
+      if (entry.endedAt !== resolvedEndedAt) {
+        entry.endedAt = resolvedEndedAt;
+        mutated = true;
+      }
       const outcome = withSubagentOutcomeTiming(baseOutcome, {
         startedAt: entry.startedAt,
         endedAt: entry.endedAt,
@@ -550,6 +639,7 @@ export function createSubagentRunManager(params: {
 
     if (previousRunId !== nextRunId) {
       params.clearPendingLifecycleError(previousRunId);
+      params.clearPendingLifecycleTimeout(previousRunId);
       if (shouldDeleteAttachments(source)) {
         void safeRemoveAttachmentsDir(source);
       }
@@ -624,6 +714,7 @@ export function createSubagentRunManager(params: {
     params.persist();
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
     params.startSweeper();
+    params.scheduleRunTimeoutFallback(next, now);
     void waitForSubagentCompletion(nextRunId, waitTimeoutMs, next);
     return true;
   };
@@ -720,15 +811,60 @@ export function createSubagentRunManager(params: {
     params.persist();
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
     params.startSweeper();
+    params.scheduleRunTimeoutFallback(entry, now);
     // Wait for subagent completion via gateway RPC (cross-process).
     // The in-process lifecycle listener is a fallback for embedded runs.
     void waitForSubagentCompletion(runId, waitTimeoutMs, entry);
   };
 
+  const armSubagentRunTimeout = (runId: string, runTimeoutSeconds: number, startedAt?: number) => {
+    const key = runId.trim();
+    if (!key) {
+      return false;
+    }
+    if (
+      typeof runTimeoutSeconds !== "number" ||
+      !Number.isFinite(runTimeoutSeconds) ||
+      runTimeoutSeconds <= 0
+    ) {
+      return false;
+    }
+    const entry = params.runs.get(key);
+    if (!entry || entry.outcome || typeof entry.endedAt === "number") {
+      return false;
+    }
+    const resolvedStartedAt =
+      typeof startedAt === "number" && Number.isFinite(startedAt)
+        ? Math.floor(startedAt)
+        : Date.now();
+    entry.runTimeoutSeconds = runTimeoutSeconds;
+    entry.startedAt = resolvedStartedAt;
+    if (typeof entry.sessionStartedAt !== "number") {
+      entry.sessionStartedAt = resolvedStartedAt;
+    }
+    entry.execution = {
+      ...entry.execution,
+      status: "running",
+      startedAt: resolvedStartedAt,
+    };
+    params.persist();
+    params.clearPendingLifecycleTimeout(runId);
+    params.scheduleRunTimeoutFallback(entry, resolvedStartedAt);
+    return true;
+  };
+
   const releaseSubagentRun = (runId: string) => {
     params.clearPendingLifecycleError(runId);
+    params.clearPendingLifecycleTimeout(runId);
     const entry = params.runs.get(runId);
     if (entry) {
+      finalizeTaskRunByRunId({
+        runId,
+        runtime: "subagent",
+        status: "cancelled",
+        endedAt: Date.now(),
+        terminalSummary: "released",
+      });
       if (shouldDeleteAttachments(entry)) {
         void safeRemoveAttachmentsDir(entry);
       }
@@ -746,6 +882,29 @@ export function createSubagentRunManager(params: {
     if (params.runs.size === 0) {
       params.stopSweeper();
     }
+  };
+
+  const discardFailedSubagentSpawnRun = (runId: string): boolean => {
+    params.clearPendingLifecycleError(runId);
+    params.clearPendingLifecycleTimeout(runId);
+    const entry = params.runs.get(runId);
+    if (entry) {
+      finalizeTaskRunByRunId({
+        runId,
+        runtime: "subagent",
+        status: "failed",
+        endedAt: Date.now(),
+        terminalSummary: "spawn failed",
+      });
+    }
+    const didDelete = params.runs.delete(runId);
+    if (didDelete) {
+      params.persist();
+    }
+    if (params.runs.size === 0) {
+      params.stopSweeper();
+    }
+    return didDelete;
   };
 
   const markSubagentRunTerminated = (markParams: {
@@ -774,6 +933,7 @@ export function createSubagentRunManager(params: {
     const entriesByChildSessionKey = new Map<string, SubagentRunRecord>();
     for (const runId of runIds) {
       params.clearPendingLifecycleError(runId);
+      params.clearPendingLifecycleTimeout(runId);
       const entry = params.runs.get(runId);
       if (!entry) {
         continue;
@@ -855,6 +1015,8 @@ export function createSubagentRunManager(params: {
     clearSubagentRunSteerRestart,
     markSubagentRunForSteerRestart,
     markSubagentRunTerminated,
+    armSubagentRunTimeout,
+    discardFailedSubagentSpawnRun,
     registerSubagentRun,
     releaseSubagentRun,
     replaceSubagentRunAfterSteer,

--- a/src/agents/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagent-registry.announce-loop-guard.test.ts
@@ -58,7 +58,8 @@ vi.mock("./subagent-registry.store.js", () => ({
   saveSubagentRegistryToDisk: mocks.saveSubagentRegistryToDisk,
 }));
 
-vi.mock("./timeout.js", () => ({
+vi.mock("./timeout.js", async () => ({
+  ...(await vi.importActual<typeof import("./timeout.js")>("./timeout.js")),
   resolveAgentTimeoutMs: mocks.resolveAgentTimeoutMs,
 }));
 

--- a/src/agents/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagent-registry.persistence.resume.test.ts
@@ -219,4 +219,258 @@ describe("subagent registry persistence resume", () => {
     expect(restored?.requesterOrigin?.channel).toBe("whatsapp");
     expect(restored?.requesterOrigin?.accountId).toBe("acct-main");
   });
+
+  it("honors restored run timeout fallback from the persisted start time", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.parse("2026-03-24T12:00:00Z");
+      vi.setSystemTime(new Date("2026-03-24T12:00:30Z"));
+      tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+      process.env.OPENCLAW_STATE_DIR = tempStateDir;
+      const registryPath = path.join(tempStateDir, "subagents", "runs.json");
+      hoisted.registryPath = registryPath;
+      await fs.mkdir(path.dirname(registryPath), { recursive: true });
+      await fs.writeFile(
+        registryPath,
+        `${JSON.stringify(
+          {
+            version: 2,
+            runs: {
+              "run-restored-timeout": {
+                runId: "run-restored-timeout",
+                childSessionKey: "agent:main:subagent:timeout",
+                requesterSessionKey: "agent:main:main",
+                requesterDisplayKey: "main",
+                task: "restored timeout task",
+                cleanup: "keep",
+                createdAt: startedAt,
+                startedAt,
+                sessionStartedAt: startedAt,
+                runTimeoutSeconds: 8,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      await writeChildSessionEntry({
+        sessionKey: "agent:main:subagent:timeout",
+        sessionId: "sess-timeout",
+        updatedAt: startedAt,
+      });
+      vi.mocked(callGatewayModule.callGateway).mockResolvedValue({
+        status: "pending",
+      });
+
+      mod.initSubagentRegistry();
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.waitFor(() => expect(announceSpy).toHaveBeenCalled(), {
+        timeout: 1_000,
+        interval: 10,
+      });
+      const restored = mod.listSubagentRunsForRequester("agent:main:main")[0];
+      expect(restored?.endedAt).toBe(startedAt + 8_000);
+      expect(restored?.outcome?.status).toBe("timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps restored run timeout fallback after a yielded wait snapshot", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.parse("2026-03-24T12:00:00Z");
+      vi.setSystemTime(new Date(startedAt));
+      tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+      process.env.OPENCLAW_STATE_DIR = tempStateDir;
+      const registryPath = path.join(tempStateDir, "subagents", "runs.json");
+      hoisted.registryPath = registryPath;
+      await fs.mkdir(path.dirname(registryPath), { recursive: true });
+      await fs.writeFile(
+        registryPath,
+        `${JSON.stringify(
+          {
+            version: 2,
+            runs: {
+              "run-restored-yield-timeout": {
+                runId: "run-restored-yield-timeout",
+                childSessionKey: "agent:main:subagent:yield-timeout",
+                requesterSessionKey: "agent:main:main",
+                requesterDisplayKey: "main",
+                task: "restored yielded timeout task",
+                cleanup: "keep",
+                createdAt: startedAt,
+                startedAt,
+                sessionStartedAt: startedAt,
+                runTimeoutSeconds: 8,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      await writeChildSessionEntry({
+        sessionKey: "agent:main:subagent:yield-timeout",
+        sessionId: "sess-yield-timeout",
+        updatedAt: startedAt,
+      });
+      vi.mocked(callGatewayModule.callGateway).mockResolvedValue({
+        status: "ok",
+        startedAt,
+        endedAt: startedAt + 1_000,
+        stopReason: "end_turn",
+        livenessState: "paused",
+        yielded: true,
+      });
+
+      mod.initSubagentRegistry();
+      await vi.waitFor(() => {
+        const restored = mod.listSubagentRunsForRequester("agent:main:main")[0];
+        expect(restored?.pauseReason).toBe("sessions_yield");
+        expect(restored?.outcome).toBeUndefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(22_999);
+      expect(announceSpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(announceSpy).toHaveBeenCalled(), {
+        timeout: 1_000,
+        interval: 10,
+      });
+      const restored = mod.listSubagentRunsForRequester("agent:main:main")[0];
+      expect(restored?.pauseReason).toBeUndefined();
+      expect(restored?.endedAt).toBe(startedAt + 8_000);
+      expect(restored?.outcome?.status).toBe("timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes run timeout fallback for already-yielded restored runs", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.parse("2026-03-24T12:00:00Z");
+      vi.setSystemTime(new Date("2026-03-24T12:00:30Z"));
+      tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+      process.env.OPENCLAW_STATE_DIR = tempStateDir;
+      const registryPath = path.join(tempStateDir, "subagents", "runs.json");
+      hoisted.registryPath = registryPath;
+      await fs.mkdir(path.dirname(registryPath), { recursive: true });
+      await fs.writeFile(
+        registryPath,
+        `${JSON.stringify(
+          {
+            version: 2,
+            runs: {
+              "run-restored-paused-timeout": {
+                runId: "run-restored-paused-timeout",
+                childSessionKey: "agent:main:subagent:paused-timeout",
+                requesterSessionKey: "agent:main:main",
+                requesterDisplayKey: "main",
+                task: "restored paused timeout task",
+                cleanup: "keep",
+                createdAt: startedAt,
+                startedAt,
+                sessionStartedAt: startedAt,
+                endedAt: startedAt + 1_000,
+                pauseReason: "sessions_yield",
+                runTimeoutSeconds: 8,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      await writeChildSessionEntry({
+        sessionKey: "agent:main:subagent:paused-timeout",
+        sessionId: "sess-paused-timeout",
+        updatedAt: startedAt + 1_000,
+      });
+
+      mod.initSubagentRegistry();
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.waitFor(() => expect(announceSpy).toHaveBeenCalled(), {
+        timeout: 1_000,
+        interval: 10,
+      });
+      const restored = mod.listSubagentRunsForRequester("agent:main:main")[0];
+      expect(restored?.pauseReason).toBeUndefined();
+      expect(restored?.endedAt).toBe(startedAt + 8_000);
+      expect(restored?.outcome?.status).toBe("timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes replacement run timeout fallback from run start instead of session start", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionStartedAt = Date.parse("2026-03-24T12:00:00Z");
+      const runStartedAt = Date.parse("2026-03-24T12:00:25Z");
+      vi.setSystemTime(new Date("2026-03-24T12:00:30Z"));
+      tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+      process.env.OPENCLAW_STATE_DIR = tempStateDir;
+      const registryPath = path.join(tempStateDir, "subagents", "runs.json");
+      hoisted.registryPath = registryPath;
+      await fs.mkdir(path.dirname(registryPath), { recursive: true });
+      await fs.writeFile(
+        registryPath,
+        `${JSON.stringify(
+          {
+            version: 2,
+            runs: {
+              "run-restored-replacement-timeout": {
+                runId: "run-restored-replacement-timeout",
+                childSessionKey: "agent:main:subagent:timeout",
+                requesterSessionKey: "agent:main:main",
+                requesterDisplayKey: "main",
+                task: "restored replacement timeout task",
+                cleanup: "keep",
+                createdAt: runStartedAt,
+                startedAt: runStartedAt,
+                sessionStartedAt,
+                accumulatedRuntimeMs: runStartedAt - sessionStartedAt,
+                runTimeoutSeconds: 8,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      await writeChildSessionEntry({
+        sessionKey: "agent:main:subagent:timeout",
+        sessionId: "sess-timeout",
+        updatedAt: runStartedAt,
+      });
+      vi.mocked(callGatewayModule.callGateway).mockResolvedValue({
+        status: "pending",
+      });
+
+      mod.initSubagentRegistry();
+      await vi.advanceTimersByTimeAsync(17_999);
+      expect(announceSpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(announceSpy).toHaveBeenCalled(), {
+        timeout: 1_000,
+        interval: 10,
+      });
+      const restored = mod.listSubagentRunsForRequester("agent:main:main")[0];
+      expect(restored?.endedAt).toBe(runStartedAt + 8_000);
+      expect(restored?.outcome?.status).toBe("timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -611,7 +611,7 @@ describe("subagent registry seam flow", () => {
       );
     });
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
-    expect(mocks.captureSubagentCompletionReply).toHaveBeenCalledTimes(1);
+    expect(mocks.captureSubagentCompletionReply).not.toHaveBeenCalled();
   });
 
   it("converts first lifecycle success after the explicit run deadline into timeout", async () => {
@@ -3955,7 +3955,7 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps hard timeout lifecycle ends authoritative over later successful lifecycle ends", async () => {
+  it("keeps hard timeout lifecycle events authoritative over later successful lifecycle ends", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
         return { status: "pending" };
@@ -4029,7 +4029,7 @@ describe("subagent registry seam flow", () => {
         endedAt: 20,
         elapsedMs: 10,
       },
-      "late ok timeout announce outcome",
+      "late ok timeout outcome",
     );
 
     const run = mod
@@ -4095,7 +4095,7 @@ describe("subagent registry seam flow", () => {
     });
   });
 
-  it("keeps hard timeout lifecycle ends authoritative over later lifecycle errors", async () => {
+  it("keeps hard timeout lifecycle events authoritative over later lifecycle errors", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
         return { status: "pending" };
@@ -4158,9 +4158,11 @@ describe("subagent registry seam flow", () => {
       announceParams.outcome,
       {
         status: "timeout",
+        startedAt: 10,
         endedAt: 20,
+        elapsedMs: 10,
       },
-      "late error timeout announce outcome",
+      "late error timeout outcome",
     );
 
     const run = mod

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -85,7 +85,7 @@ async function expectPathMissing(targetPath: string): Promise<void> {
 const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   onAgentEvent: vi.fn(() => noop),
-  getAgentRunContext: vi.fn(() => undefined),
+  getAgentRunContext: vi.fn<() => { runId?: string } | undefined>(() => undefined),
   getRuntimeConfig: vi.fn(() => ({
     agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
     session: { mainKey: "main", scope: "per-sender" as const },
@@ -2228,7 +2228,9 @@ describe("subagent registry seam flow", () => {
         updatedAt: startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS,
       },
     });
-    mocks.getAgentRunContext.mockReturnValue({ runId: "run-large-timeout-fallback-late-success" });
+    mocks.getAgentRunContext.mockReturnValue({
+      runId: "run-large-timeout-fallback-late-success",
+    });
 
     registerRun({
       runId: "run-large-timeout-fallback-late-success",

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -4251,6 +4251,7 @@ describe("subagent registry seam flow", () => {
         startedAt: Date.parse("2026-03-24T12:00:00Z"),
         endedAt: Date.parse("2026-03-24T12:00:05Z"),
         aborted: true,
+        error: "Request timed out before a response was generated.",
       },
     });
     lifecycleHandler?.({

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1783,7 +1783,15 @@ describe("subagent registry seam flow", () => {
         .listSubagentRunsForRequester("agent:main:main")
         .find((entry) => entry.runId === "run-terminal-timeout");
       expect(run?.endedAt).toBe(222);
-      expectRecordFields(run?.outcome, { status: "timeout" }, "terminal timeout outcome");
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+        "terminal timeout outcome",
+      );
     });
     const waitCall = mocks.callGateway.mock.calls.find(
       ([request]) => (request as { method?: string }).method === "agent.wait",
@@ -1833,6 +1841,97 @@ describe("subagent registry seam flow", () => {
       expectRecordFields(run?.outcome, { status: "timeout" }, "attributed timeout outcome");
     });
     expect(mocks.scheduleOrphanRecovery).not.toHaveBeenCalled();
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps hard agent.wait timeout attribution over late lifecycle success", async () => {
+    const startedAt = Date.parse("2026-03-24T12:00:00Z");
+    const timeoutAt = Date.parse("2026-03-24T12:00:08Z");
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        vi.setSystemTime(timeoutAt);
+        return {
+          status: "timeout",
+          startedAt,
+          timeoutPhase: "provider",
+          providerStarted: true,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "running",
+        startedAt,
+        updatedAt: startedAt,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-hard-wait-timeout-late-lifecycle-success",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "hard wait timeout then late lifecycle success",
+      cleanup: "keep",
+    });
+
+    let observedTimeoutAt: number | undefined;
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-hard-wait-timeout-late-lifecycle-success");
+      expect(run?.endedAt).toBeGreaterThanOrEqual(timeoutAt);
+      expect(run?.endedAt).toBeLessThan(timeoutAt + 100);
+      observedTimeoutAt = run?.endedAt;
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          timeoutPhase: "provider",
+          providerStarted: true,
+          startedAt,
+          endedAt: run?.endedAt,
+          elapsedMs: typeof run?.endedAt === "number" ? run.endedAt - startedAt : undefined,
+        },
+        "hard wait timeout outcome",
+      );
+    });
+    expect(observedTimeoutAt).toBeTypeOf("number");
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-hard-wait-timeout-late-lifecycle-success",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt,
+        endedAt: timeoutAt + 1_000,
+      },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-hard-wait-timeout-late-lifecycle-success");
+    expect(run?.endedAt).toBe(observedTimeoutAt);
+    expectRecordFields(
+      run?.outcome,
+      {
+        status: "timeout",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+      "preserved hard wait timeout outcome",
+    );
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -12,6 +12,15 @@ const noop = () => {};
 const waitForFast = <T>(callback: () => T | Promise<T>) =>
   vi.waitFor(callback, { timeout: 1_000, interval: 1 });
 
+type LifecycleHandler = (evt: {
+  runId: string;
+  stream: string;
+  data: Record<string, unknown>;
+}) => void;
+type SubagentRegistryModule = typeof import("./subagent-registry.js");
+type RegisterSubagentRunParams = Parameters<SubagentRegistryModule["registerSubagentRun"]>[0];
+type SubagentRunRecord = ReturnType<SubagentRegistryModule["listSubagentRunsForRequester"]>[number];
+
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`expected ${label} to be an object`);
@@ -173,6 +182,57 @@ vi.mock("./subagent-orphan-recovery.js", () => ({
 describe("subagent registry seam flow", () => {
   let mod: typeof import("./subagent-registry.js");
 
+  function registerRun(
+    params: Pick<RegisterSubagentRunParams, "runId"> & Partial<RegisterSubagentRunParams>,
+  ): void {
+    const {
+      runId,
+      childSessionKey = "agent:main:subagent:child",
+      requesterSessionKey = "agent:main:main",
+      requesterDisplayKey = "main",
+      task = runId,
+      cleanup = "keep",
+      ...rest
+    } = params;
+    mod.registerSubagentRun({
+      runId,
+      childSessionKey,
+      requesterSessionKey,
+      requesterDisplayKey,
+      task,
+      cleanup,
+      ...rest,
+    });
+  }
+
+  function findRun(
+    runId: string,
+    requesterSessionKey = "agent:main:main",
+  ): SubagentRunRecord | undefined {
+    return mod
+      .listSubagentRunsForRequester(requesterSessionKey)
+      .find((entry) => entry.runId === runId);
+  }
+
+  function latestLifecycleHandler(): LifecycleHandler {
+    const lastCall = mocks.onAgentEvent.mock.calls.at(-1) as unknown as
+      | [LifecycleHandler]
+      | undefined;
+    const lifecycleHandler = lastCall?.[0];
+    if (typeof lifecycleHandler !== "function") {
+      throw new Error("expected lifecycle handler registration");
+    }
+    return lifecycleHandler;
+  }
+
+  function emitLifecycle(runId: string, data: Record<string, unknown>): void {
+    latestLifecycleHandler()({
+      runId,
+      stream: "lifecycle",
+      data,
+    });
+  }
+
   beforeAll(async () => {
     mod = await import("./subagent-registry.js");
   });
@@ -318,13 +378,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-interrupted-wait",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "resume after transport close",
-      cleanup: "keep",
     });
 
     await waitForFast(() => {
@@ -335,9 +391,7 @@ describe("subagent registry seam flow", () => {
       );
     });
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-interrupted-wait");
+    const run = findRun("run-interrupted-wait");
     expect(run?.endedAt).toBeUndefined();
     expect(run?.outcome).toBeUndefined();
   });
@@ -372,13 +426,9 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-waiter-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "eventually complete",
-      cleanup: "keep",
     });
 
     await waitForFast(() => {
@@ -387,9 +437,7 @@ describe("subagent registry seam flow", () => {
     await waitForFast(() => {
       expect(waitAttempts).toBeGreaterThanOrEqual(2);
     });
-    const activeRun = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-waiter-timeout");
+    const activeRun = findRun("run-waiter-timeout");
     expect(activeRun?.endedAt).toBeUndefined();
     expect(activeRun?.outcome).toBeUndefined();
 
@@ -399,9 +447,7 @@ describe("subagent registry seam flow", () => {
       endedAt: 222,
     });
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-waiter-timeout");
+      const completedRun = findRun("run-waiter-timeout");
       expect(waitAttempts).toBeGreaterThanOrEqual(2);
       expect(completedRun?.endedAt).toBe(222);
       expectRecordFields(completedRun?.outcome, { status: "ok" }, "completed run outcome");
@@ -429,31 +475,23 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-explicit-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "respect explicit timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 1,
     });
 
     await waitForFast(() => {
       expect(waitAttempts).toBeGreaterThanOrEqual(1);
     });
-    const activeRun = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-explicit-timeout");
+    const activeRun = findRun("run-explicit-timeout");
     expect(activeRun?.endedAt).toBeUndefined();
     expect(activeRun?.outcome).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(5_000);
 
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-explicit-timeout");
+      const completedRun = findRun("run-explicit-timeout");
       expect(waitAttempts).toBeGreaterThanOrEqual(2);
       expect(completedRun?.endedAt).toBe(startedAt + 1_000);
       expectRecordFields(
@@ -488,46 +526,25 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-late-lifecycle-ok",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout should stay terminal",
-      cleanup: "keep",
       runTimeoutSeconds: 1,
     });
 
     await vi.advanceTimersByTimeAsync(10_000);
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-late-lifecycle-ok");
+      const completedRun = findRun("run-timeout-late-lifecycle-ok");
       expect(completedRun?.endedAt).toBe(startedAt + 1_000);
       expect(completedRun?.outcome?.status).toBe("timeout");
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-late-lifecycle-ok",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        endedAt: startedAt + 2_000,
-      },
+    emitLifecycle("run-timeout-late-lifecycle-ok", {
+      phase: "end",
+      endedAt: startedAt + 2_000,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-late-lifecycle-ok");
+      const run = findRun("run-timeout-late-lifecycle-ok");
       expect(run?.endedAt).toBe(startedAt + 1_000);
       expectRecordFields(
         run?.outcome,
@@ -561,47 +578,26 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-late-lifecycle-predeadline-ok",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "published timeout should stay stable",
-      cleanup: "keep",
       runTimeoutSeconds: 1,
     });
 
     await vi.advanceTimersByTimeAsync(5_000);
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-late-lifecycle-predeadline-ok");
+      const completedRun = findRun("run-timeout-late-lifecycle-predeadline-ok");
       expect(completedRun?.endedAt).toBe(startedAt + 1_000);
       expect(completedRun?.outcome?.status).toBe("timeout");
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-late-lifecycle-predeadline-ok",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: startedAt + 10,
-        endedAt: startedAt + 500,
-      },
+    emitLifecycle("run-timeout-late-lifecycle-predeadline-ok", {
+      phase: "end",
+      startedAt: startedAt + 10,
+      endedAt: startedAt + 500,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-late-lifecycle-predeadline-ok");
+      const run = findRun("run-timeout-late-lifecycle-predeadline-ok");
       expect(run?.endedAt).toBe(startedAt + 1_000);
       expectRecordFields(
         run?.outcome,
@@ -626,38 +622,19 @@ describe("subagent registry seam flow", () => {
       }
       return {};
     });
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-lifecycle-success-after-deadline",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "post-deadline lifecycle success should timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 1,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-lifecycle-success-after-deadline",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt,
-        endedAt: startedAt + 2_000,
-      },
+    emitLifecycle("run-lifecycle-success-after-deadline", {
+      phase: "end",
+      startedAt,
+      endedAt: startedAt + 2_000,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-lifecycle-success-after-deadline");
+      const run = findRun("run-lifecycle-success-after-deadline");
       expect(run?.endedAt).toBe(startedAt + 1_000);
       expectRecordFields(
         run?.outcome,
@@ -686,38 +663,19 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-lifecycle-observed-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "respect observed lifecycle start",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-lifecycle-observed-start",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: observedStartedAt,
-        endedAt: createdAt + 65_000,
-      },
+    emitLifecycle("run-lifecycle-observed-start", {
+      phase: "end",
+      startedAt: observedStartedAt,
+      endedAt: createdAt + 65_000,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-lifecycle-observed-start");
+      const run = findRun("run-lifecycle-observed-start");
       expect(run?.endedAt).toBe(createdAt + 65_000);
       expectRecordFields(
         run?.outcome,
@@ -737,13 +695,9 @@ describe("subagent registry seam flow", () => {
 
   it("keeps in-flight explicit deadline timeout stable during cleanup", async () => {
     const createdAt = Date.parse("2026-03-24T11:59:00Z");
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-cleanup-lock-observed-success",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "cleanup lock should not freeze stale timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
     const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
@@ -761,29 +715,14 @@ describe("subagent registry seam flow", () => {
       },
       cleanupHandled: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-cleanup-lock-observed-success",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: createdAt + 10_000,
-        endedAt: createdAt + 65_000,
-      },
+    emitLifecycle("run-cleanup-lock-observed-success", {
+      phase: "end",
+      startedAt: createdAt + 10_000,
+      endedAt: createdAt + 65_000,
     });
 
     await waitForFast(() => {
-      const correctedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-cleanup-lock-observed-success");
+      const correctedRun = findRun("run-cleanup-lock-observed-success");
       expect(correctedRun?.endedAt).toBe(createdAt + 60_000);
       expectRecordFields(
         correctedRun?.outcome,
@@ -808,13 +747,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
     mocks.runSubagentAnnounceFlow.mockResolvedValueOnce(false);
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-refresh-pending-timeout-payload",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "pending timeout payload should refresh",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
     const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
@@ -843,23 +778,10 @@ describe("subagent registry seam flow", () => {
         },
       },
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-refresh-pending-timeout-payload",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: createdAt + 10_000,
-        endedAt: createdAt + 65_000,
-      },
+    emitLifecycle("run-refresh-pending-timeout-payload", {
+      phase: "end",
+      startedAt: createdAt + 10_000,
+      endedAt: createdAt + 65_000,
     });
 
     await waitForFast(() => {
@@ -884,13 +806,9 @@ describe("subagent registry seam flow", () => {
 
   it("allows non-explicit published timeouts to be corrected by lifecycle success", async () => {
     const startedAt = Date.parse("2026-03-24T11:59:00Z");
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-non-explicit-timeout-corrected",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "non-explicit timeout remains correctable",
-      cleanup: "keep",
     });
     const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
     expect(run).not.toBeNull();
@@ -910,29 +828,14 @@ describe("subagent registry seam flow", () => {
         deliveredAt: startedAt + 30_000,
       },
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-non-explicit-timeout-corrected",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt,
-        endedAt: startedAt + 35_000,
-      },
+    emitLifecycle("run-non-explicit-timeout-corrected", {
+      phase: "end",
+      startedAt,
+      endedAt: startedAt + 35_000,
     });
 
     await waitForFast(() => {
-      const correctedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-non-explicit-timeout-corrected");
+      const correctedRun = findRun("run-non-explicit-timeout-corrected");
       expect(correctedRun?.endedAt).toBe(startedAt + 35_000);
       expectRecordFields(
         correctedRun?.outcome,
@@ -949,13 +852,9 @@ describe("subagent registry seam flow", () => {
 
   it("allows pre-deadline lifecycle timeouts to be corrected by lifecycle success", async () => {
     const startedAt = Date.parse("2026-03-24T11:59:00Z");
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-predeadline-timeout-corrected",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "pre-deadline timeout remains correctable",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
     const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
@@ -976,29 +875,14 @@ describe("subagent registry seam flow", () => {
         deliveredAt: startedAt + 30_000,
       },
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-predeadline-timeout-corrected",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt,
-        endedAt: startedAt + 35_000,
-      },
+    emitLifecycle("run-predeadline-timeout-corrected", {
+      phase: "end",
+      startedAt,
+      endedAt: startedAt + 35_000,
     });
 
     await waitForFast(() => {
-      const correctedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-predeadline-timeout-corrected");
+      const correctedRun = findRun("run-predeadline-timeout-corrected");
       expect(correctedRun?.endedAt).toBe(startedAt + 35_000);
       expectRecordFields(
         correctedRun?.outcome,
@@ -1022,40 +906,21 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-lifecycle-timeout-after-deadline",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "post-deadline lifecycle timeout should cap",
-      cleanup: "keep",
       runTimeoutSeconds: 1,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-lifecycle-timeout-after-deadline",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt,
-        endedAt: startedAt + 2_000,
-        aborted: true,
-      },
+    emitLifecycle("run-lifecycle-timeout-after-deadline", {
+      phase: "end",
+      startedAt,
+      endedAt: startedAt + 2_000,
+      aborted: true,
     });
     await vi.advanceTimersByTimeAsync(30_000);
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-lifecycle-timeout-after-deadline");
+      const run = findRun("run-lifecycle-timeout-after-deadline");
       expect(run?.endedAt).toBe(startedAt + 1_000);
       expectRecordFields(
         run?.outcome,
@@ -1087,49 +952,28 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-late-lifecycle-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "published timeout should ignore late timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 1,
     });
 
     await vi.advanceTimersByTimeAsync(5_000);
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-late-lifecycle-timeout");
+      const completedRun = findRun("run-timeout-late-lifecycle-timeout");
       expect(completedRun?.endedAt).toBe(startedAt + 1_000);
       expect(completedRun?.outcome?.status).toBe("timeout");
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-late-lifecycle-timeout",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: startedAt + 10,
-        endedAt: startedAt + 2_000,
-        aborted: true,
-      },
+    emitLifecycle("run-timeout-late-lifecycle-timeout", {
+      phase: "end",
+      startedAt: startedAt + 10,
+      endedAt: startedAt + 2_000,
+      aborted: true,
     });
     await vi.advanceTimersByTimeAsync(30_000);
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-late-lifecycle-timeout");
+      const run = findRun("run-timeout-late-lifecycle-timeout");
       expect(run?.endedAt).toBe(startedAt + 1_000);
       expectRecordFields(
         run?.outcome,
@@ -1164,20 +1008,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-boundary-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "deadline skew should still timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 1,
     });
 
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-boundary-timeout");
+      const completedRun = findRun("run-boundary-timeout");
       expect(waitAttempts).toBe(1);
       expect(completedRun?.endedAt).toBe(startedAt + 1_000);
       expectRecordFields(
@@ -1230,9 +1068,7 @@ describe("subagent registry seam flow", () => {
     mod.initSubagentRegistry();
 
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-resumed-late-success");
+      const completedRun = findRun("run-resumed-late-success");
       expect(completedRun?.endedAt).toBe(startedAt + 60_000);
       expectRecordFields(
         completedRun?.outcome,
@@ -1285,9 +1121,7 @@ describe("subagent registry seam flow", () => {
     mod.initSubagentRegistry();
 
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-resumed-observed-start");
+      const completedRun = findRun("run-resumed-observed-start");
       expect(completedRun?.endedAt).toBe(createdAt + 65_000);
       expectRecordFields(
         completedRun?.outcome,
@@ -1327,20 +1161,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-ok-session-store-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "respect restored success start",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-ok-session-store-start");
+      const completedRun = findRun("run-ok-session-store-start");
       expect(completedRun?.endedAt).toBe(createdAt + 65_000);
       expectRecordFields(
         completedRun?.outcome,
@@ -1379,13 +1207,9 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-plain-timeout-observed-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "do not timeout before observed start deadline",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
@@ -1448,20 +1272,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-plain-timeout-session-store-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "do not timeout before session store start deadline",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-plain-timeout-session-store-start");
+      const run = findRun("run-plain-timeout-session-store-start");
       expect(waitAttempts).toBeGreaterThanOrEqual(1);
       expect(run?.endedAt).toBeUndefined();
       expect(run?.outcome).toBeUndefined();
@@ -1472,9 +1290,7 @@ describe("subagent registry seam flow", () => {
     await vi.advanceTimersByTimeAsync(5_000);
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-plain-timeout-session-store-start");
+      const run = findRun("run-plain-timeout-session-store-start");
       expect(run?.endedAt).toBe(sessionStartedAt + 60_000);
       expectRecordFields(
         run?.outcome,
@@ -1513,20 +1329,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-wait-start-over-session-store-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "prefer wait observed start",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-wait-start-over-session-store-start");
+      const run = findRun("run-wait-start-over-session-store-start");
       expect(run?.endedAt).toBe(createdAt + 65_000);
       expectRecordFields(
         run?.outcome,
@@ -1563,20 +1373,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-session-store-start-after-wait-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "use session store observed start",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-session-store-start-after-wait-timeout");
+      const run = findRun("run-session-store-start-after-wait-timeout");
       expect(run?.endedAt).toBe(createdAt + 65_000);
       expectRecordFields(
         run?.outcome,
@@ -1613,20 +1417,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-ignore-stale-session-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "ignore stale session store start",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-ignore-stale-session-start");
+      const run = findRun("run-ignore-stale-session-start");
       expect(run?.endedAt).toBe(createdAt + 30_000);
       expectRecordFields(
         run?.outcome,
@@ -1661,20 +1459,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-session-row-no-start-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "terminal row without start still honors timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-session-row-no-start-timeout");
+      const run = findRun("run-session-row-no-start-timeout");
       expect(run?.endedAt).toBe(createdAt + 60_000);
       expectRecordFields(
         run?.outcome,
@@ -1729,9 +1521,7 @@ describe("subagent registry seam flow", () => {
 
     await waitForFast(() => {
       expect(waitTimeouts).toEqual([1_000]);
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-resumed-near-deadline");
+      const completedRun = findRun("run-resumed-near-deadline");
       expect(completedRun?.endedAt).toBe(startedAt + 60_000);
       expectRecordFields(
         completedRun?.outcome,
@@ -1771,20 +1561,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-terminal-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "time out terminally",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-terminal-timeout");
+      const run = findRun("run-terminal-timeout");
       expect(run?.endedAt).toBe(222);
       expectRecordFields(
         run?.outcome,
@@ -1825,20 +1609,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-attributed-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "time out before session metadata flush",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-attributed-timeout");
+      const run = findRun("run-attributed-timeout");
       expect(waitAttempts).toBe(1);
       expect(run?.endedAt).toBeLessThan(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "attributed timeout outcome");
@@ -1871,20 +1649,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-hard-wait-timeout-late-lifecycle-success",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "hard wait timeout then late lifecycle success",
-      cleanup: "keep",
     });
 
     let observedTimeoutAt: number | undefined;
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-hard-wait-timeout-late-lifecycle-success");
+      const run = findRun("run-hard-wait-timeout-late-lifecycle-success");
       expect(run?.endedAt).toBeGreaterThanOrEqual(timeoutAt);
       expect(run?.endedAt).toBeLessThan(timeoutAt + 100);
       observedTimeoutAt = run?.endedAt;
@@ -1902,29 +1674,14 @@ describe("subagent registry seam flow", () => {
       );
     });
     expect(observedTimeoutAt).toBeTypeOf("number");
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-hard-wait-timeout-late-lifecycle-success",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt,
-        endedAt: timeoutAt + 1_000,
-      },
+    emitLifecycle("run-hard-wait-timeout-late-lifecycle-success", {
+      phase: "end",
+      startedAt,
+      endedAt: timeoutAt + 1_000,
     });
     await vi.advanceTimersByTimeAsync(0);
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-hard-wait-timeout-late-lifecycle-success");
+    const run = findRun("run-hard-wait-timeout-late-lifecycle-success");
     expect(run?.endedAt).toBe(observedTimeoutAt);
     expectRecordFields(
       run?.outcome,
@@ -1959,20 +1716,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-attributed-timeout-with-completion",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "finish before attributed timeout metadata",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-attributed-timeout-with-completion");
+      const run = findRun("run-attributed-timeout-with-completion");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:07Z"));
       expectRecordFields(run?.outcome, { status: "ok" }, "attributed completion outcome");
     });
@@ -2003,20 +1754,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-hard-wait-timeout-late-child-completion",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "late child completion after hard wait timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-hard-wait-timeout-late-child-completion");
+      const run = findRun("run-hard-wait-timeout-late-child-completion");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "late hard wait timeout outcome");
     });
@@ -2031,13 +1776,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
@@ -2046,9 +1787,7 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback");
+      const run = findRun("run-timeout-fallback");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "fallback timeout outcome");
     });
@@ -2070,21 +1809,15 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-late-success",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "late wait success must not overwrite timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await vi.advanceTimersByTimeAsync(23_000);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-late-success");
+      const run = findRun("run-timeout-fallback-late-success");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "fallback timeout outcome");
     });
@@ -2096,9 +1829,7 @@ describe("subagent registry seam flow", () => {
     });
     await vi.advanceTimersByTimeAsync(0);
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-timeout-fallback-late-success");
+    const run = findRun("run-timeout-fallback-late-success");
     expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
     expectRecordFields(run?.outcome, { status: "timeout" }, "late wait preserved outcome");
   });
@@ -2112,29 +1843,13 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-start-untimed",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback after untimed start",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-    lifecycleHandler?.({
-      runId: "run-timeout-fallback-start-untimed",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-      },
+    emitLifecycle("run-timeout-fallback-start-untimed", {
+      phase: "start",
     });
 
     await vi.advanceTimersByTimeAsync(22_999);
@@ -2142,9 +1857,7 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-start-untimed");
+      const run = findRun("run-timeout-fallback-start-untimed");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "untimed start timeout outcome");
     });
@@ -2160,30 +1873,14 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-start-late",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback after late start",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-    lifecycleHandler?.({
-      runId: "run-timeout-fallback-start-late",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: Date.parse("2026-03-24T12:00:20Z"),
-      },
+    emitLifecycle("run-timeout-fallback-start-late", {
+      phase: "start",
+      startedAt: Date.parse("2026-03-24T12:00:20Z"),
     });
 
     await vi.advanceTimersByTimeAsync(22_999);
@@ -2191,9 +1888,7 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-start-late");
+      const run = findRun("run-timeout-fallback-start-late");
       expect(run?.startedAt).toBe(Date.parse("2026-03-24T12:00:00Z"));
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "late start timeout outcome");
@@ -2210,13 +1905,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-accepted-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback after accepted start",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
@@ -2234,9 +1925,7 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-accepted-start");
+      const run = findRun("run-timeout-fallback-accepted-start");
       expect(run?.startedAt).toBe(Date.parse("2026-03-24T12:00:05Z"));
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:13Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "accepted start timeout outcome");
@@ -2256,29 +1945,21 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-late-wait-ok",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback after late wait success",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await vi.advanceTimersByTimeAsync(22_999);
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
-    const pendingRun = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-timeout-fallback-late-wait-ok");
+    const pendingRun = findRun("run-timeout-fallback-late-wait-ok");
     expect(pendingRun?.endedAt).toBeUndefined();
     expect(pendingRun?.outcome).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(1);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-late-wait-ok");
+      const run = findRun("run-timeout-fallback-late-wait-ok");
       expect(run?.startedAt).toBe(Date.parse("2026-03-24T12:00:00Z"));
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "late wait success timeout outcome");
@@ -2299,20 +1980,14 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-late-earlier-wait-ok",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback corrected by late earlier wait success",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-late-earlier-wait-ok");
+      const run = findRun("run-timeout-fallback-late-earlier-wait-ok");
       expect(run?.startedAt).toBe(Date.parse("2026-03-24T12:00:00Z"));
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:07Z"));
       expectRecordFields(run?.outcome, { status: "ok" }, "late earlier wait success outcome");
@@ -2332,20 +2007,14 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-late-wait-error",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback after late wait error",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-late-wait-error");
+      const run = findRun("run-timeout-fallback-late-wait-error");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "late wait error timeout outcome");
     });
@@ -2360,40 +2029,22 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-late-blocked-lifecycle",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback after late blocked lifecycle",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-    lifecycleHandler?.({
-      runId: "run-timeout-fallback-late-blocked-lifecycle",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        aborted: true,
-        endedAt: Date.parse("2026-03-24T12:00:08Z"),
-        livenessState: "blocked",
-        error: "request aborted",
-      },
+    emitLifecycle("run-timeout-fallback-late-blocked-lifecycle", {
+      phase: "end",
+      aborted: true,
+      endedAt: Date.parse("2026-03-24T12:00:08Z"),
+      livenessState: "blocked",
+      error: "request aborted",
     });
 
     await vi.advanceTimersByTimeAsync(0);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-late-blocked-lifecycle");
+      const run = findRun("run-timeout-fallback-late-blocked-lifecycle");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(
         run?.outcome,
@@ -2414,21 +2065,15 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-untimed-wait-ok",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback after untimed wait success",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await vi.advanceTimersByTimeAsync(23_000);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-untimed-wait-ok");
+      const run = findRun("run-timeout-fallback-untimed-wait-ok");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(
         run?.outcome,
@@ -2456,21 +2101,15 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-done",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback done",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await vi.advanceTimersByTimeAsync(23_000);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-done");
+      const run = findRun("run-timeout-fallback-done");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:07Z"));
       expectRecordFields(run?.outcome, { status: "ok" }, "fallback completion outcome");
     });
@@ -2498,20 +2137,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-late-child-completion",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "late child completion",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-late-child-completion");
+      const run = findRun("run-timeout-late-child-completion");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "late completion timeout outcome");
     });
@@ -2535,43 +2168,24 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-hard-event",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback with hard event",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
     await vi.advanceTimersByTimeAsync(10_000);
-    lifecycleHandler?.({
-      runId: "run-timeout-fallback-hard-event",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: Date.parse("2026-03-24T12:00:00Z"),
-        endedAt: Date.parse("2026-03-24T12:00:08Z"),
-        aborted: true,
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-      },
+    emitLifecycle("run-timeout-fallback-hard-event", {
+      phase: "end",
+      startedAt: Date.parse("2026-03-24T12:00:00Z"),
+      endedAt: Date.parse("2026-03-24T12:00:08Z"),
+      aborted: true,
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
     });
 
     await vi.advanceTimersByTimeAsync(13_000);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-hard-event");
+      const run = findRun("run-timeout-fallback-hard-event");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:07Z"));
       expectRecordFields(run?.outcome, { status: "ok" }, "merged fallback completion outcome");
     });
@@ -2585,20 +2199,14 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-large-timeout-fallback",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "large timeout fallback",
-      cleanup: "keep",
       runTimeoutSeconds: 60 * 60 * 24 * 30,
     });
 
     await vi.advanceTimersByTimeAsync(1);
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-large-timeout-fallback");
+    const run = findRun("run-large-timeout-fallback");
     expect(run?.endedAt).toBeUndefined();
     expect(run?.outcome).toBeUndefined();
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
@@ -2622,13 +2230,9 @@ describe("subagent registry seam flow", () => {
     });
     mocks.getAgentRunContext.mockReturnValue({ runId: "run-large-timeout-fallback-late-success" });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-large-timeout-fallback-late-success",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "large timeout fallback should use clamped deadline",
-      cleanup: "keep",
       runTimeoutSeconds: 60 * 60 * 24 * 30,
     });
 
@@ -2636,9 +2240,7 @@ describe("subagent registry seam flow", () => {
       MAX_SUBAGENT_RUN_TIMEOUT_MS + SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS,
     );
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-large-timeout-fallback-late-success");
+      const run = findRun("run-large-timeout-fallback-late-success");
       expect(run?.endedAt).toBe(startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS);
       expectRecordFields(
         run?.outcome,
@@ -2651,29 +2253,14 @@ describe("subagent registry seam flow", () => {
         "clamped timeout fallback outcome",
       );
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-large-timeout-fallback-late-success",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt,
-        endedAt: startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS + 1_000,
-      },
+    emitLifecycle("run-large-timeout-fallback-late-success", {
+      phase: "end",
+      startedAt,
+      endedAt: startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS + 1_000,
     });
     await vi.advanceTimersByTimeAsync(0);
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-large-timeout-fallback-late-success");
+    const run = findRun("run-large-timeout-fallback-late-success");
     expect(run?.endedAt).toBe(startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS);
     expect(run?.outcome?.status).toBe("timeout");
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
@@ -2702,20 +2289,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-hard-timeout-session-failed",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "time out while session store records failure text",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-hard-timeout-session-failed");
+      const run = findRun("run-hard-timeout-session-failed");
       expect(run?.endedAt).toBe(base + 222);
       expectRecordFields(run?.outcome, { status: "timeout" }, "terminal timeout outcome");
     });
@@ -2745,20 +2326,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-hard-timeout-earlier-session-failed",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "fail before timeout attribution",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-hard-timeout-earlier-session-failed");
+      const run = findRun("run-hard-timeout-earlier-session-failed");
       expect(run?.endedAt).toBe(base + 200);
       expectRecordFields(run?.outcome, { status: "error" }, "earlier failure outcome");
     });
@@ -2786,20 +2361,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-terminal-timeout-capped",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "cap terminal timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 1,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-terminal-timeout-capped");
+      const run = findRun("run-terminal-timeout-capped");
       expect(run?.endedAt).toBe(startedAt + 1_000);
       expectRecordFields(
         run?.outcome,
@@ -2838,20 +2407,14 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-terminal-timeout-observed-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "cap timeout using observed start",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-terminal-timeout-observed-start");
+      const run = findRun("run-terminal-timeout-observed-start");
       expect(run?.endedAt).toBe(observedStartedAt + 60_000);
       expectRecordFields(
         run?.outcome,
@@ -2900,21 +2463,15 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-reactivated-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "new run after stale terminal row",
-      cleanup: "keep",
     });
 
     await waitForFast(() => {
       expect(waitAttempts).toBeGreaterThanOrEqual(2);
     });
-    const activeRun = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-reactivated-timeout");
+    const activeRun = findRun("run-reactivated-timeout");
     expect(activeRun?.endedAt).toBeUndefined();
     expect(activeRun?.outcome).toBeUndefined();
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
@@ -2925,9 +2482,7 @@ describe("subagent registry seam flow", () => {
       endedAt: Date.parse("2026-03-24T12:00:02Z"),
     });
     await waitForFast(() => {
-      const completedRun = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-reactivated-timeout");
+      const completedRun = findRun("run-reactivated-timeout");
       expectRecordFields(completedRun?.outcome, { status: "ok" }, "reactivated run outcome");
     });
   });
@@ -2947,20 +2502,14 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-yield-paused",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "wait for child continuation",
-      cleanup: "keep",
       runTimeoutSeconds: 0,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-yield-paused");
+      const run = findRun("run-yield-paused");
       expect(run?.endedAt).toBe(222);
       expect(run?.pauseReason).toBe("sessions_yield");
     });
@@ -2968,9 +2517,7 @@ describe("subagent registry seam flow", () => {
     expect(mod.countPendingDescendantRuns("agent:main:main")).toBe(1);
 
     await vi.advanceTimersByTimeAsync(23_000);
-    const yieldedRun = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-yield-paused");
+    const yieldedRun = findRun("run-yield-paused");
     expect(yieldedRun?.pauseReason).toBe("sessions_yield");
     expect(yieldedRun?.outcome).toBeUndefined();
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
@@ -2981,9 +2528,7 @@ describe("subagent registry seam flow", () => {
         nextRunId: "run-yield-continuation",
       }),
     ).toBe(true);
-    const replacement = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-yield-continuation");
+    const replacement = findRun("run-yield-continuation");
     expect(replacement?.runId).toBe("run-yield-continuation");
     expect(replacement?.pauseReason).toBeUndefined();
     expect(replacement?.endedAt).toBeUndefined();
@@ -3004,29 +2549,21 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-yield-paused-explicit-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "wait for child explicit timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-yield-paused-explicit-timeout");
+      const run = findRun("run-yield-paused-explicit-timeout");
       expect(run?.pauseReason).toBe("sessions_yield");
       expect(run?.outcome).toBeUndefined();
     });
 
     await vi.advanceTimersByTimeAsync(23_000);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-yield-paused-explicit-timeout");
+      const run = findRun("run-yield-paused-explicit-timeout");
       expect(run?.pauseReason).toBeUndefined();
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "paused fallback timeout outcome");
@@ -3049,50 +2586,29 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-yield-paused-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "wait for child timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-yield-paused-timeout");
+      const run = findRun("run-yield-paused-timeout");
       expect(run?.pauseReason).toBe("sessions_yield");
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-yield-paused-timeout",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 111,
-        endedAt: 8_000,
-        livenessState: "blocked",
-        error: "Request timed out while waiting for tool execution to finish.",
-        timeoutPhase: "post_turn",
-        providerStarted: true,
-      },
+    emitLifecycle("run-yield-paused-timeout", {
+      phase: "end",
+      startedAt: 111,
+      endedAt: 8_000,
+      livenessState: "blocked",
+      error: "Request timed out while waiting for tool execution to finish.",
+      timeoutPhase: "post_turn",
+      providerStarted: true,
     });
 
     await vi.advanceTimersByTimeAsync(0);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-yield-paused-timeout");
+      const run = findRun("run-yield-paused-timeout");
       expect(run?.pauseReason).toBeUndefined();
       expect(run?.endedAt).toBe(8_000);
       expectRecordFields(run?.outcome, { status: "timeout" }, "paused hard timeout outcome");
@@ -3115,28 +2631,20 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-with-stale-yield",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout must beat stale yielded metadata",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
     await vi.advanceTimersByTimeAsync(22_999);
-    const pending = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-timeout-with-stale-yield");
+    const pending = findRun("run-timeout-with-stale-yield");
     expect(pending?.pauseReason).toBeUndefined();
     expect(pending?.outcome).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(1);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-with-stale-yield");
+      const run = findRun("run-timeout-with-stale-yield");
       expect(run?.pauseReason).toBeUndefined();
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "stale yield timeout outcome");
@@ -3152,13 +2660,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-replace-old-timeout",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "replace old timeout",
-      cleanup: "keep",
       runTimeoutSeconds: 8,
     });
 
@@ -3168,20 +2672,9 @@ describe("subagent registry seam flow", () => {
         nextRunId: "run-replace-new-no-timeout",
       }),
     ).toBe(true);
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-    lifecycleHandler?.({
-      runId: "run-replace-new-no-timeout",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: Date.now(),
-      },
+    emitLifecycle("run-replace-new-no-timeout", {
+      phase: "start",
+      startedAt: Date.now(),
     });
 
     await vi.advanceTimersByTimeAsync(22_999);
@@ -3189,9 +2682,7 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await waitForFast(() => {
-      const replacement = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-replace-new-no-timeout");
+      const replacement = findRun("run-replace-new-no-timeout");
       expect(replacement?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(
         replacement?.outcome,
@@ -3217,13 +2708,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-blocked-wait",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "overflow wait",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
 
@@ -3247,9 +2734,7 @@ describe("subagent registry seam flow", () => {
       "blocked wait announce outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-blocked-wait");
+    const run = findRun("run-blocked-wait");
     expect(run?.endedReason).toBe("subagent-error");
     expect(run?.outcome?.status).toBe("error");
   });
@@ -3267,13 +2752,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-aborted-wait",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "aborted wait",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
 
@@ -3297,9 +2778,7 @@ describe("subagent registry seam flow", () => {
       "aborted wait announce outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-aborted-wait");
+    const run = findRun("run-aborted-wait");
     expect(run?.endedReason).toBe("subagent-killed");
     expect(run?.outcome?.status).toBe("error");
   });
@@ -3317,13 +2796,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-aborted-timeout-wait",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "aborted timeout wait",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
 
@@ -3347,9 +2822,7 @@ describe("subagent registry seam flow", () => {
       "aborted timeout wait announce outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-aborted-timeout-wait");
+    const run = findRun("run-aborted-timeout-wait");
     expect(run?.endedReason).toBe("subagent-killed");
     expect(run?.outcome?.status).toBe("error");
   });
@@ -3368,13 +2841,9 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-blocked-timeout-wait",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "blocked timeout wait",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
 
@@ -3398,9 +2867,7 @@ describe("subagent registry seam flow", () => {
       "blocked timeout wait announce outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-blocked-timeout-wait");
+    const run = findRun("run-blocked-timeout-wait");
     expect(run?.endedReason).toBe("subagent-error");
     expect(run?.outcome?.status).toBe("error");
   });
@@ -3426,13 +2893,9 @@ describe("subagent registry seam flow", () => {
     });
 
     vi.setSystemTime(persistedStartedAt - 1);
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-stale-terminal",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "settle from persisted terminal state",
-      cleanup: "keep",
     });
 
     vi.setSystemTime(new Date("2026-03-24T12:02:00Z"));
@@ -3457,9 +2920,7 @@ describe("subagent registry seam flow", () => {
       );
     });
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-stale-terminal");
+    const run = findRun("run-stale-terminal");
     expect(run?.endedAt).toBe(persistedEndedAt);
     expectRecordFields(
       run?.outcome,
@@ -3493,13 +2954,9 @@ describe("subagent registry seam flow", () => {
     });
 
     vi.setSystemTime(createdAt);
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-sweep-session-start",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "sweep should respect session store start",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
@@ -3507,9 +2964,7 @@ describe("subagent registry seam flow", () => {
     await mod.testing.sweepOnceForTests();
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-sweep-session-start");
+      const run = findRun("run-sweep-session-start");
       expect(run?.endedAt).toBe(sessionEndedAt);
       expectRecordFields(
         run?.outcome,
@@ -3541,13 +2996,9 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-stale-aborted",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "resume after restart",
-      cleanup: "keep",
     });
 
     vi.setSystemTime(new Date("2026-03-24T12:02:00Z"));
@@ -3561,20 +3012,15 @@ describe("subagent registry seam flow", () => {
       );
     });
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-stale-aborted");
+    const run = findRun("run-stale-aborted");
     expect(run?.endedAt).toBeUndefined();
     expect(run?.outcome).toBeUndefined();
   });
 
   it("completes a registered run across timing persistence, lifecycle status, and announce cleanup", async () => {
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-1",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
       requesterOrigin: { channel: " quietchat ", accountId: " acct-1 " },
-      requesterDisplayKey: "main",
       task: "finish the task",
       cleanup: "delete",
     });
@@ -3648,13 +3094,9 @@ describe("subagent registry seam flow", () => {
     });
 
     expect(() =>
-      mod.registerSubagentRun({
+      registerRun({
         runId: "run-durability-required",
-        childSessionKey: "agent:main:subagent:child",
-        requesterSessionKey: "agent:main:main",
-        requesterDisplayKey: "main",
         task: "must fail closed",
-        cleanup: "keep",
       }),
     ).toThrowError("disk full");
 
@@ -3670,13 +3112,9 @@ describe("subagent registry seam flow", () => {
       new Error("browser cleanup unavailable"),
     );
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-cleanup-warning",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "finish despite cleanup warning",
-      cleanup: "keep",
     });
 
     await waitForFast(() => {
@@ -3694,9 +3132,7 @@ describe("subagent registry seam flow", () => {
       "completion announce params",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-cleanup-warning");
+    const run = findRun("run-cleanup-warning");
     expect(run?.cleanupCompletedAt).toBeTypeOf("number");
   });
 
@@ -3708,42 +3144,21 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-blocked-end",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "overflow task",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-blocked-end",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: 10,
-      },
+    emitLifecycle("run-blocked-end", {
+      phase: "start",
+      startedAt: 10,
     });
-    lifecycleHandler?.({
-      runId: "run-blocked-end",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 10,
-        endedAt: 20,
-        livenessState: "blocked",
-        error: "Context overflow: prompt too large for the model.",
-      },
+    emitLifecycle("run-blocked-end", {
+      phase: "end",
+      startedAt: 10,
+      endedAt: 20,
+      livenessState: "blocked",
+      error: "Context overflow: prompt too large for the model.",
     });
 
     await waitForFast(() => {
@@ -3766,9 +3181,7 @@ describe("subagent registry seam flow", () => {
       "blocked announce outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-blocked-end");
+    const run = findRun("run-blocked-end");
     expect(run?.endedReason).toBe("subagent-error");
     expect(run?.outcome?.status).toBe("error");
   });
@@ -3781,44 +3194,23 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-error",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout error task",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-error",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: 10,
-      },
+    emitLifecycle("run-timeout-error", {
+      phase: "start",
+      startedAt: 10,
     });
-    lifecycleHandler?.({
-      runId: "run-timeout-error",
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        startedAt: 10,
-        endedAt: 20,
-        livenessState: "blocked",
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-timeout-error", {
+      phase: "error",
+      startedAt: 10,
+      endedAt: 20,
+      livenessState: "blocked",
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
 
     await vi.advanceTimersByTimeAsync(0);
@@ -3841,9 +3233,7 @@ describe("subagent registry seam flow", () => {
       "timeout announce outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-timeout-error");
+    const run = findRun("run-timeout-error");
     expect(run?.endedReason).toBe("subagent-complete");
     expect(run?.outcome?.status).toBe("timeout");
   });
@@ -3856,34 +3246,18 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-duplicate-timeout-events",
       childSessionKey: "agent:main:subagent:duplicate-timeout",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "duplicate timeout events",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-duplicate-timeout-events",
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        endedAt: 20,
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-duplicate-timeout-events", {
+      phase: "error",
+      endedAt: 20,
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
 
     await vi.advanceTimersByTimeAsync(0);
@@ -3891,16 +3265,12 @@ describe("subagent registry seam flow", () => {
       expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
     });
 
-    lifecycleHandler?.({
-      runId: "run-duplicate-timeout-events",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        endedAt: 25,
-        livenessState: "blocked",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-duplicate-timeout-events", {
+      phase: "end",
+      endedAt: 25,
+      livenessState: "blocked",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
 
     await vi.advanceTimersByTimeAsync(15_000);
@@ -3928,44 +3298,23 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-end",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout end task",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-end",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: 10,
-      },
+    emitLifecycle("run-timeout-end", {
+      phase: "start",
+      startedAt: 10,
     });
-    lifecycleHandler?.({
-      runId: "run-timeout-end",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 10,
-        endedAt: 20,
-        livenessState: "blocked",
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-timeout-end", {
+      phase: "end",
+      startedAt: 10,
+      endedAt: 20,
+      livenessState: "blocked",
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
 
     await vi.advanceTimersByTimeAsync(0);
@@ -3988,9 +3337,7 @@ describe("subagent registry seam flow", () => {
       "timeout end announce outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-timeout-end");
+    const run = findRun("run-timeout-end");
     expect(run?.endedReason).toBe("subagent-complete");
     expect(run?.outcome?.status).toBe("timeout");
   });
@@ -4012,51 +3359,28 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-end-earlier-session-completion",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout end with earlier session completion",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-end-earlier-session-completion",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: 10,
-      },
+    emitLifecycle("run-timeout-end-earlier-session-completion", {
+      phase: "start",
+      startedAt: 10,
     });
-    lifecycleHandler?.({
-      runId: "run-timeout-end-earlier-session-completion",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 10,
-        endedAt: 20,
-        livenessState: "blocked",
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-timeout-end-earlier-session-completion", {
+      phase: "end",
+      startedAt: 10,
+      endedAt: 20,
+      livenessState: "blocked",
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
 
     await vi.advanceTimersByTimeAsync(0);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-end-earlier-session-completion");
+      const run = findRun("run-timeout-end-earlier-session-completion");
       expect(run?.endedAt).toBe(18);
       expectRecordFields(run?.outcome, { status: "ok" }, "hard timeout corrected outcome");
     });
@@ -4080,52 +3404,29 @@ describe("subagent registry seam flow", () => {
       },
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-end-late-session-completion",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout end with late session completion",
-      cleanup: "keep",
       expectsCompletionMessage: true,
       runTimeoutSeconds: 8,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-end-late-session-completion",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: Date.parse("2026-03-24T12:00:00Z"),
-      },
+    emitLifecycle("run-timeout-end-late-session-completion", {
+      phase: "start",
+      startedAt: Date.parse("2026-03-24T12:00:00Z"),
     });
-    lifecycleHandler?.({
-      runId: "run-timeout-end-late-session-completion",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: Date.parse("2026-03-24T12:00:00Z"),
-        endedAt: Date.parse("2026-03-24T12:00:10Z"),
-        livenessState: "blocked",
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-timeout-end-late-session-completion", {
+      phase: "end",
+      startedAt: Date.parse("2026-03-24T12:00:00Z"),
+      endedAt: Date.parse("2026-03-24T12:00:10Z"),
+      livenessState: "blocked",
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
 
     await vi.advanceTimersByTimeAsync(0);
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-end-late-session-completion");
+      const run = findRun("run-timeout-end-late-session-completion");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
       expectRecordFields(run?.outcome, { status: "timeout" }, "late lifecycle timeout outcome");
     });
@@ -4140,53 +3441,28 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-then-late-ok",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout then late ok task",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-then-late-ok",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: 10,
-      },
+    emitLifecycle("run-timeout-then-late-ok", {
+      phase: "start",
+      startedAt: 10,
     });
-    lifecycleHandler?.({
-      runId: "run-timeout-then-late-ok",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 10,
-        endedAt: 20,
-        aborted: true,
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-timeout-then-late-ok", {
+      phase: "end",
+      startedAt: 10,
+      endedAt: 20,
+      aborted: true,
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
-    lifecycleHandler?.({
-      runId: "run-timeout-then-late-ok",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 10,
-        endedAt: 30,
-      },
+    emitLifecycle("run-timeout-then-late-ok", {
+      phase: "end",
+      startedAt: 10,
+      endedAt: 30,
     });
 
     await vi.advanceTimersByTimeAsync(0);
@@ -4209,9 +3485,7 @@ describe("subagent registry seam flow", () => {
       "late ok timeout outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-timeout-then-late-ok");
+    const run = findRun("run-timeout-then-late-ok");
     expect(run?.endedReason).toBe("subagent-complete");
     expect(run?.outcome?.status).toBe("timeout");
   });
@@ -4224,50 +3498,27 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-fallback-transient-abort",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout fallback transient abort task",
-      cleanup: "keep",
       expectsCompletionMessage: true,
       runTimeoutSeconds: 8,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-fallback-transient-abort",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: Date.parse("2026-03-24T12:00:00Z"),
-        endedAt: Date.parse("2026-03-24T12:00:05Z"),
-        aborted: true,
-        error: "Request timed out before a response was generated.",
-      },
+    emitLifecycle("run-timeout-fallback-transient-abort", {
+      phase: "end",
+      startedAt: Date.parse("2026-03-24T12:00:00Z"),
+      endedAt: Date.parse("2026-03-24T12:00:05Z"),
+      aborted: true,
+      error: "Request timed out before a response was generated.",
     });
-    lifecycleHandler?.({
-      runId: "run-timeout-fallback-transient-abort",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: Date.parse("2026-03-24T12:00:00Z"),
-        endedAt: Date.parse("2026-03-24T12:00:06Z"),
-      },
+    emitLifecycle("run-timeout-fallback-transient-abort", {
+      phase: "end",
+      startedAt: Date.parse("2026-03-24T12:00:00Z"),
+      endedAt: Date.parse("2026-03-24T12:00:06Z"),
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-timeout-fallback-transient-abort");
+      const run = findRun("run-timeout-fallback-transient-abort");
       expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:06Z"));
       expectRecordFields(run?.outcome, { status: "ok" }, "transient abort corrected outcome");
     });
@@ -4281,46 +3532,25 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-then-late-error",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout then late error task",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-then-late-error",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 10,
-        endedAt: 20,
-        aborted: true,
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-timeout-then-late-error", {
+      phase: "end",
+      startedAt: 10,
+      endedAt: 20,
+      aborted: true,
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
-    lifecycleHandler?.({
-      runId: "run-timeout-then-late-error",
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        startedAt: 10,
-        endedAt: 30,
-        error: "agent run aborted",
-      },
+    emitLifecycle("run-timeout-then-late-error", {
+      phase: "error",
+      startedAt: 10,
+      endedAt: 30,
+      error: "agent run aborted",
     });
 
     await vi.advanceTimersByTimeAsync(0);
@@ -4343,9 +3573,7 @@ describe("subagent registry seam flow", () => {
       "late error timeout outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-timeout-then-late-error");
+    const run = findRun("run-timeout-then-late-error");
     expect(run?.outcome?.status).toBe("timeout");
   });
 
@@ -4357,43 +3585,22 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-aborted-end",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "aborted task",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-aborted-end",
-      stream: "lifecycle",
-      data: {
-        phase: "start",
-        startedAt: 10,
-      },
+    emitLifecycle("run-aborted-end", {
+      phase: "start",
+      startedAt: 10,
     });
-    lifecycleHandler?.({
-      runId: "run-aborted-end",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 10,
-        endedAt: 20,
-        aborted: true,
-        livenessState: "blocked",
-        stopReason: "aborted",
-      },
+    emitLifecycle("run-aborted-end", {
+      phase: "end",
+      startedAt: 10,
+      endedAt: 20,
+      aborted: true,
+      livenessState: "blocked",
+      stopReason: "aborted",
     });
 
     await waitForFast(() => {
@@ -4416,9 +3623,7 @@ describe("subagent registry seam flow", () => {
       "aborted announce outcome",
     );
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-aborted-end");
+    const run = findRun("run-aborted-end");
     expect(run?.endedReason).toBe("subagent-killed");
     expect(run?.outcome?.status).toBe("error");
 
@@ -4437,45 +3642,22 @@ describe("subagent registry seam flow", () => {
       .mockRejectedValueOnce(new Error("runtime unavailable before cleanup"))
       .mockRejectedValueOnce(new Error("runtime still unavailable before cleanup"));
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-killed-recovery",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "killed recovery test",
-      cleanup: "keep",
       expectsCompletionMessage: false,
     });
+    emitLifecycle("run-killed-recovery", { phase: "start", startedAt: 100 });
 
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-killed-recovery",
-      stream: "lifecycle",
-      data: { phase: "start", startedAt: 100 },
-    });
-
-    lifecycleHandler?.({
-      runId: "run-killed-recovery",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 100,
-        endedAt: 200,
-        stopReason: "aborted",
-      },
+    emitLifecycle("run-killed-recovery", {
+      phase: "end",
+      startedAt: 100,
+      endedAt: 200,
+      stopReason: "aborted",
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-killed-recovery");
+      const run = findRun("run-killed-recovery");
       expect(mocks.ensureRuntimePluginsLoaded).toHaveBeenCalledTimes(2);
       expect(run?.outcome?.status).toBe("error");
       expect(run?.endedReason).toBe("subagent-killed");
@@ -4485,50 +3667,36 @@ describe("subagent registry seam flow", () => {
   });
 
   it("preserves run-mode keep entries past SESSION_RUN_TTL_MS sweep", async () => {
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-keep-survives-ttl",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "keep me past the session ttl",
-      cleanup: "keep",
       spawnMode: "run",
     });
 
     await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-keep-survives-ttl");
+      const run = findRun("run-keep-survives-ttl");
       expect(run?.cleanupCompletedAt).toBeTypeOf("number");
     });
 
     vi.setSystemTime(new Date(Date.parse("2026-03-24T12:00:00Z") + 10 * 60_000));
     await mod.testing.sweepOnceForTests();
 
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-keep-survives-ttl");
+    const run = findRun("run-keep-survives-ttl");
     expect(run?.runId).toBe("run-keep-survives-ttl");
   });
 
   it("retries completion hooks before resuming ended cleanup", async () => {
     mocks.ensureRuntimePluginsLoaded.mockRejectedValueOnce(new Error("runtime unavailable"));
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-hook-retry",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "finish after hook retry",
-      cleanup: "keep",
       expectsCompletionMessage: false,
     });
 
     await waitForFast(() => {
       expect(mocks.ensureRuntimePluginsLoaded).toHaveBeenCalledTimes(2);
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-hook-retry");
+      const run = findRun("run-hook-retry");
       expect(run?.cleanupCompletedAt).toBeTypeOf("number");
     });
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
@@ -4542,29 +3710,12 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-then-ok",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout retry",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-then-ok",
-      stream: "lifecycle",
-      data: { phase: "end", endedAt: 1_000, aborted: true },
-    });
+    emitLifecycle("run-timeout-then-ok", { phase: "end", endedAt: 1_000, aborted: true });
     await Promise.resolve();
     await Promise.resolve();
 
@@ -4573,11 +3724,7 @@ describe("subagent registry seam flow", () => {
     await vi.advanceTimersByTimeAsync(14_999);
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
 
-    lifecycleHandler?.({
-      runId: "run-timeout-then-ok",
-      stream: "lifecycle",
-      data: { phase: "end", endedAt: 1_250 },
-    });
+    emitLifecycle("run-timeout-then-ok", { phase: "end", endedAt: 1_250 });
 
     await waitForFast(() => {
       expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
@@ -4609,11 +3756,8 @@ describe("subagent registry seam flow", () => {
       endedAt,
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-delete-give-up",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "completion cleanup retry",
       cleanup: "delete",
       expectsCompletionMessage: true,
@@ -4741,9 +3885,7 @@ describe("subagent registry seam flow", () => {
     await Promise.resolve();
 
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-resume-keep");
+    const run = findRun("run-resume-keep");
     expect(run).toMatchObject({
       delivery: {
         status: "suspended",
@@ -4802,9 +3944,7 @@ describe("subagent registry seam flow", () => {
       }),
     ).toBe(true);
 
-    const replacement = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-suspended-new");
+    const replacement = findRun("run-suspended-new");
     expect(replacement).toMatchObject({
       runId: "run-suspended-new",
       cleanup: "keep",
@@ -4843,13 +3983,11 @@ describe("subagent registry seam flow", () => {
       cleanupCompletedAt: undefined,
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-child-finished",
-      childSessionKey: "agent:main:subagent:child",
       requesterSessionKey: "agent:main:subagent:parent",
       requesterDisplayKey: "parent",
       task: "descendant settles",
-      cleanup: "keep",
     });
 
     await waitForFast(() => {
@@ -4885,14 +4023,11 @@ describe("subagent registry seam flow", () => {
       mocks.getGlobalHookRunner.mockReturnValue(endedHookRunner as never);
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-killed-init",
       childSessionKey: "agent:main:subagent:killed",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       requesterOrigin: { channel: "quietchat", accountId: "acct-1" },
       task: "kill after init",
-      cleanup: "keep",
       workspaceDir: "/tmp/killed-workspace",
     });
 
@@ -4902,9 +4037,7 @@ describe("subagent registry seam flow", () => {
     });
 
     expect(updated).toBe(1);
-    const killedRun = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-killed-init");
+    const killedRun = findRun("run-killed-init");
     const killedAt = Date.parse("2026-03-24T12:00:00Z");
     expect(killedRun?.outcome).toEqual({
       status: "error",
@@ -4954,34 +4087,18 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-timeout-then-killed",
       childSessionKey: "agent:main:subagent:timeout-then-killed",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "timeout then killed",
-      cleanup: "keep",
       expectsCompletionMessage: true,
     });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    lifecycleHandler?.({
-      runId: "run-timeout-then-killed",
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        endedAt: Date.parse("2026-03-24T12:00:01Z"),
-        error: "Request timed out before a response was generated.",
-        timeoutPhase: "provider",
-        providerStarted: true,
-      },
+    emitLifecycle("run-timeout-then-killed", {
+      phase: "error",
+      endedAt: Date.parse("2026-03-24T12:00:01Z"),
+      error: "Request timed out before a response was generated.",
+      timeoutPhase: "provider",
+      providerStarted: true,
     });
 
     expect(
@@ -4993,20 +4110,16 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(15_000);
 
-    const killedRun = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-timeout-then-killed");
+    const killedRun = findRun("run-timeout-then-killed");
     expect(killedRun?.outcome?.status).toBe("error");
     expect(killedRun?.outcome?.error).toBe("manual kill");
     expect(killedRun?.endedReason).toBe("subagent-killed");
   });
 
   it("deletes killed delete-mode runs and notifies deleted cleanup", async () => {
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-killed-delete",
       childSessionKey: "agent:main:subagent:killed-delete",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "kill and delete",
       cleanup: "delete",
       workspaceDir: "/tmp/killed-delete-workspace",
@@ -5040,11 +4153,9 @@ describe("subagent registry seam flow", () => {
     await fs.mkdir(attachmentsDir, { recursive: true });
     await fs.writeFile(path.join(attachmentsDir, "artifact.txt"), "artifact");
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-killed-delete-attachments",
       childSessionKey: "agent:main:subagent:killed-delete-attachments",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "kill and delete attachments",
       cleanup: "delete",
       attachmentsDir,
@@ -5112,9 +4223,7 @@ describe("subagent registry seam flow", () => {
       );
       expect(String(outcome.error)).toContain("Automatic recovery failed after 2 attempts");
     });
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-interrupted");
+    const run = findRun("run-interrupted");
     expect(run?.outcome).toEqual({
       status: "error",
       error:
@@ -5228,13 +4337,10 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-release-task",
       childSessionKey: "agent:main:subagent:release-task",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "registered task",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 
@@ -5257,13 +4363,10 @@ describe("subagent registry seam flow", () => {
       return {};
     });
 
-    mod.registerSubagentRun({
+    registerRun({
       runId: "run-discard-spawn-failed-task",
       childSessionKey: "agent:main:subagent:discard-spawn-failed-task",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
       task: "pre-acceptance spawn failed",
-      cleanup: "keep",
       runTimeoutSeconds: 60,
     });
 

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -3,6 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { listTaskRecords, resetTaskRegistryForTests } from "../tasks/task-registry.js";
+import {
+  MAX_SUBAGENT_RUN_TIMEOUT_MS,
+  SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS,
+} from "./subagent-registry-helpers.js";
 
 const noop = () => {};
 const waitForFast = <T>(callback: () => T | Promise<T>) =>
@@ -622,7 +626,6 @@ describe("subagent registry seam flow", () => {
       }
       return {};
     });
-
     mod.registerSubagentRun({
       runId: "run-lifecycle-success-after-deadline",
       childSessionKey: "agent:main:subagent:child",
@@ -2599,6 +2602,81 @@ describe("subagent registry seam flow", () => {
     expect(run?.endedAt).toBeUndefined();
     expect(run?.outcome).toBeUndefined();
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
+  it("keeps clamped explicit timeout fallback authoritative over later lifecycle success", async () => {
+    const startedAt = Date.parse("2026-03-24T12:00:00Z");
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "running",
+        startedAt,
+        updatedAt: startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS,
+      },
+    });
+    mocks.getAgentRunContext.mockReturnValue({ runId: "run-large-timeout-fallback-late-success" });
+
+    mod.registerSubagentRun({
+      runId: "run-large-timeout-fallback-late-success",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "large timeout fallback should use clamped deadline",
+      cleanup: "keep",
+      runTimeoutSeconds: 60 * 60 * 24 * 30,
+    });
+
+    await vi.advanceTimersByTimeAsync(
+      MAX_SUBAGENT_RUN_TIMEOUT_MS + SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS,
+    );
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-large-timeout-fallback-late-success");
+      expect(run?.endedAt).toBe(startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "timeout",
+          startedAt,
+          endedAt: startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS,
+          elapsedMs: MAX_SUBAGENT_RUN_TIMEOUT_MS,
+        },
+        "clamped timeout fallback outcome",
+      );
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-large-timeout-fallback-late-success",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt,
+        endedAt: startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS + 1_000,
+      },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-large-timeout-fallback-late-success");
+    expect(run?.endedAt).toBe(startedAt + MAX_SUBAGENT_RUN_TIMEOUT_MS);
+    expect(run?.outcome?.status).toBe("timeout");
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
   it("keeps hard agent.wait timeouts authoritative over reconstructed session failures", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { listTaskRecords, resetTaskRegistryForTests } from "../tasks/task-registry.js";
 
 const noop = () => {};
 const waitForFast = <T>(callback: () => T | Promise<T>) =>
@@ -156,7 +157,8 @@ vi.mock("../context-engine/registry.js", () => ({
   resolveContextEngine: mocks.resolveContextEngine,
 }));
 
-vi.mock("./timeout.js", () => ({
+vi.mock("./timeout.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./timeout.js")>()),
   resolveAgentTimeoutMs: mocks.resolveAgentTimeoutMs,
 }));
 
@@ -173,6 +175,7 @@ describe("subagent registry seam flow", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetTaskRegistryForTests({ persist: false });
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
     mocks.onAgentEvent.mockReturnValue(noop);
@@ -229,6 +232,7 @@ describe("subagent registry seam flow", () => {
   afterEach(() => {
     mod.testing.setDepsForTest();
     mod.resetSubagentRegistryForTests({ persist: false });
+    resetTaskRegistryForTests({ persist: false });
     vi.useRealTimers();
   });
 
@@ -1741,12 +1745,16 @@ describe("subagent registry seam flow", () => {
   });
 
   it("records terminal agent.wait timeouts even before session store timing is persisted", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
         return {
           status: "timeout",
           startedAt: 111,
           endedAt: 222,
+          livenessState: "blocked",
+          timeoutPhase: "provider",
+          providerStarted: true,
           stopReason: "rpc",
         };
       }
@@ -1767,6 +1775,7 @@ describe("subagent registry seam flow", () => {
       requesterDisplayKey: "main",
       task: "time out terminally",
       cleanup: "keep",
+      runTimeoutSeconds: 8,
     });
 
     await waitForFast(() => {
@@ -1775,6 +1784,806 @@ describe("subagent registry seam flow", () => {
         .find((entry) => entry.runId === "run-terminal-timeout");
       expect(run?.endedAt).toBe(222);
       expectRecordFields(run?.outcome, { status: "timeout" }, "terminal timeout outcome");
+    });
+    const waitCall = mocks.callGateway.mock.calls.find(
+      ([request]) => (request as { method?: string }).method === "agent.wait",
+    )?.[0] as { params?: { timeoutMs?: number }; timeoutMs?: number } | undefined;
+    expect(waitCall?.params?.timeoutMs).toBe(23_000);
+    expect(waitCall?.timeoutMs).toBe(25_000);
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("records hard timeout-attributed agent.wait timeouts before ending metadata arrives", async () => {
+    let waitAttempts = 0;
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        waitAttempts += 1;
+        return {
+          status: "timeout",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: 1,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-attributed-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "time out before session metadata flush",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-attributed-timeout");
+      expect(waitAttempts).toBe(1);
+      expect(run?.endedAt).toBeLessThan(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "attributed timeout outcome");
+    });
+    expect(mocks.scheduleOrphanRecovery).not.toHaveBeenCalled();
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses persisted child completion for hard agent.wait timeouts without endedAt", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:07Z"),
+        updatedAt: Date.parse("2026-03-24T12:00:07Z"),
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-attributed-timeout-with-completion",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "finish before attributed timeout metadata",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-attributed-timeout-with-completion");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:07Z"));
+      expectRecordFields(run?.outcome, { status: "ok" }, "attributed completion outcome");
+    });
+    expect(mocks.scheduleOrphanRecovery).not.toHaveBeenCalled();
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote late child completions for hard agent.wait timeouts without endedAt", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        vi.setSystemTime(new Date("2026-03-24T12:00:08.100Z"));
+        return {
+          status: "timeout",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:09Z"),
+        updatedAt: Date.parse("2026-03-24T12:00:09Z"),
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-hard-wait-timeout-late-child-completion",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "late child completion after hard wait timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-hard-wait-timeout-late-child-completion");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "late hard wait timeout outcome");
+    });
+  });
+
+  it("uses the explicit run timeout as a fallback when wait and lifecycle stay pending", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await vi.advanceTimersByTimeAsync(22_999);
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "fallback timeout outcome");
+    });
+    expect(mocks.captureSubagentCompletionReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps the explicit run timeout fallback authoritative over late agent.wait success", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    let resolveWait: (value: { status: "ok"; startedAt: number; endedAt: number }) => void;
+    const waitPromise = new Promise<{ status: "ok"; startedAt: number; endedAt: number }>(
+      (resolve) => {
+        resolveWait = resolve;
+      },
+    );
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return waitPromise;
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-late-success",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "late wait success must not overwrite timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await vi.advanceTimersByTimeAsync(23_000);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-late-success");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "fallback timeout outcome");
+    });
+
+    resolveWait!({
+      status: "ok",
+      startedAt: Date.parse("2026-03-24T12:00:00Z"),
+      endedAt: Date.parse("2026-03-24T12:00:30Z"),
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-timeout-fallback-late-success");
+    expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+    expectRecordFields(run?.outcome, { status: "timeout" }, "late wait preserved outcome");
+  });
+
+  it("keeps the explicit run timeout fallback after lifecycle starts without timing", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-start-untimed",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback after untimed start",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+    lifecycleHandler?.({
+      runId: "run-timeout-fallback-start-untimed",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(22_999);
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-start-untimed");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "untimed start timeout outcome");
+    });
+    expect(mocks.captureSubagentCompletionReply).not.toHaveBeenCalled();
+  });
+
+  it("does not extend explicit run timeout fallback after a late lifecycle start", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-start-late",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback after late start",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+    lifecycleHandler?.({
+      runId: "run-timeout-fallback-start-late",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+        startedAt: Date.parse("2026-03-24T12:00:20Z"),
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(22_999);
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-start-late");
+      expect(run?.startedAt).toBe(Date.parse("2026-03-24T12:00:00Z"));
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "late start timeout outcome");
+    });
+    expect(mocks.captureSubagentCompletionReply).not.toHaveBeenCalled();
+  });
+
+  it("re-arms provisional explicit run timeout fallback from accepted start time", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-accepted-start",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback after accepted start",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(
+      mod.armSubagentRunTimeout({
+        runId: "run-timeout-fallback-accepted-start",
+        runTimeoutSeconds: 8,
+        startedAt: Date.parse("2026-03-24T12:00:05Z"),
+      }),
+    ).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(22_999);
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-accepted-start");
+      expect(run?.startedAt).toBe(Date.parse("2026-03-24T12:00:05Z"));
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:13Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "accepted start timeout outcome");
+    });
+  });
+
+  it("keeps explicit timeout fallback authoritative over late agent.wait success", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+          startedAt: Date.parse("2026-03-24T12:00:09Z"),
+          endedAt: Date.parse("2026-03-24T12:00:09Z"),
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-late-wait-ok",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback after late wait success",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await vi.advanceTimersByTimeAsync(22_999);
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    const pendingRun = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-timeout-fallback-late-wait-ok");
+    expect(pendingRun?.endedAt).toBeUndefined();
+    expect(pendingRun?.outcome).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-late-wait-ok");
+      expect(run?.startedAt).toBe(Date.parse("2026-03-24T12:00:00Z"));
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "late wait success timeout outcome");
+    });
+  });
+
+  it("lets earlier agent.wait success correct explicit timeout fallback after the response arrives late", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        await vi.advanceTimersByTimeAsync(23_000);
+        return {
+          status: "ok",
+          startedAt: Date.parse("2026-03-24T12:00:00Z"),
+          endedAt: Date.parse("2026-03-24T12:00:07Z"),
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-late-earlier-wait-ok",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback corrected by late earlier wait success",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-late-earlier-wait-ok");
+      expect(run?.startedAt).toBe(Date.parse("2026-03-24T12:00:00Z"));
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:07Z"));
+      expectRecordFields(run?.outcome, { status: "ok" }, "late earlier wait success outcome");
+    });
+  });
+
+  it("keeps explicit timeout authoritative over ambiguous agent.wait errors after the deadline", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        await vi.advanceTimersByTimeAsync(8_000);
+        return {
+          status: "error",
+          error: 'CommandLaneTaskTimeoutError: Command lane "subagent" task timed out',
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-late-wait-error",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback after late wait error",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-late-wait-error");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "late wait error timeout outcome");
+    });
+  });
+
+  it("keeps explicit timeout authoritative over ambiguous blocked lifecycle after the deadline", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-late-blocked-lifecycle",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback after late blocked lifecycle",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+    lifecycleHandler?.({
+      runId: "run-timeout-fallback-late-blocked-lifecycle",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        aborted: true,
+        endedAt: Date.parse("2026-03-24T12:00:08Z"),
+        livenessState: "blocked",
+        error: "request aborted",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-late-blocked-lifecycle");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(
+        run?.outcome,
+        { status: "timeout" },
+        "late blocked lifecycle timeout outcome",
+      );
+    });
+  });
+
+  it("keeps explicit timeout fallback authoritative over untimed agent.wait success", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-untimed-wait-ok",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback after untimed wait success",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await vi.advanceTimersByTimeAsync(23_000);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-untimed-wait-ok");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(
+        run?.outcome,
+        { status: "timeout" },
+        "untimed wait success timeout outcome",
+      );
+    });
+  });
+
+  it("uses persisted child completion when explicit timeout fallback has no hard timeout evidence", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:07Z"),
+        updatedAt: Date.parse("2026-03-24T12:00:07Z"),
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-done",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback done",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await vi.advanceTimersByTimeAsync(23_000);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-done");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:07Z"));
+      expectRecordFields(run?.outcome, { status: "ok" }, "fallback completion outcome");
+    });
+  });
+
+  it("does not promote child completions after the explicit run timeout deadline", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        vi.setSystemTime(new Date("2026-03-24T12:00:08.100Z"));
+        return {
+          status: "timeout",
+          timeoutPhase: "queue",
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:09Z"),
+        updatedAt: Date.parse("2026-03-24T12:00:09Z"),
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-late-child-completion",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "late child completion",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-late-child-completion");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "late completion timeout outcome");
+    });
+  });
+
+  it("keeps fallback session reconciliation after later hard timeout events", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:07Z"),
+        updatedAt: Date.parse("2026-03-24T12:00:07Z"),
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-hard-event",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback with hard event",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    lifecycleHandler?.({
+      runId: "run-timeout-fallback-hard-event",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:08Z"),
+        aborted: true,
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(13_000);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-hard-event");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:07Z"));
+      expectRecordFields(run?.outcome, { status: "ok" }, "merged fallback completion outcome");
+    });
+  });
+
+  it("does not overflow large explicit run timeout fallback timers", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-large-timeout-fallback",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "large timeout fallback",
+      cleanup: "keep",
+      runTimeoutSeconds: 60 * 60 * 24 * 30,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-large-timeout-fallback");
+    expect(run?.endedAt).toBeUndefined();
+    expect(run?.outcome).toBeUndefined();
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
+  it("keeps hard agent.wait timeouts authoritative over reconstructed session failures", async () => {
+    const base = Date.parse("2026-03-24T12:00:00Z");
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          startedAt: base + 111,
+          endedAt: base + 222,
+          timeoutPhase: "provider",
+          providerStarted: true,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: base + 223,
+        endedAt: base + 223,
+        status: "failed",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-hard-timeout-session-failed",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "time out while session store records failure text",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-hard-timeout-session-failed");
+      expect(run?.endedAt).toBe(base + 222);
+      expectRecordFields(run?.outcome, { status: "timeout" }, "terminal timeout outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets earlier reconstructed session failures correct hard agent.wait timeouts", async () => {
+    const base = Date.parse("2026-03-24T12:00:00Z");
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          startedAt: base + 111,
+          endedAt: base + 222,
+          timeoutPhase: "provider",
+          providerStarted: true,
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: base + 200,
+        endedAt: base + 200,
+        status: "failed",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-hard-timeout-earlier-session-failed",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "fail before timeout attribution",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-hard-timeout-earlier-session-failed");
+      expect(run?.endedAt).toBe(base + 200);
+      expectRecordFields(run?.outcome, { status: "error" }, "earlier failure outcome");
     });
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
@@ -1968,6 +2777,7 @@ describe("subagent registry seam flow", () => {
       requesterDisplayKey: "main",
       task: "wait for child continuation",
       cleanup: "keep",
+      runTimeoutSeconds: 0,
     });
 
     await waitForFast(() => {
@@ -1979,6 +2789,14 @@ describe("subagent registry seam flow", () => {
     });
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
     expect(mod.countPendingDescendantRuns("agent:main:main")).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(23_000);
+    const yieldedRun = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-yield-paused");
+    expect(yieldedRun?.pauseReason).toBe("sessions_yield");
+    expect(yieldedRun?.outcome).toBeUndefined();
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
 
     expect(
       mod.replaceSubagentRunAfterSteer({
@@ -1992,6 +2810,220 @@ describe("subagent registry seam flow", () => {
     expect(replacement?.runId).toBe("run-yield-continuation");
     expect(replacement?.pauseReason).toBeUndefined();
     expect(replacement?.endedAt).toBeUndefined();
+  });
+
+  it("lets explicit run timeout fallback complete sessions_yield-paused subagent runs", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+          startedAt: 111,
+          endedAt: 222,
+          stopReason: "end_turn",
+          livenessState: "paused",
+          yielded: true,
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-yield-paused-explicit-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "wait for child explicit timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-yield-paused-explicit-timeout");
+      expect(run?.pauseReason).toBe("sessions_yield");
+      expect(run?.outcome).toBeUndefined();
+    });
+
+    await vi.advanceTimersByTimeAsync(23_000);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-yield-paused-explicit-timeout");
+      expect(run?.pauseReason).toBeUndefined();
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "paused fallback timeout outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets hard timeout lifecycle events complete sessions_yield-paused subagent runs", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+          startedAt: 111,
+          endedAt: 222,
+          stopReason: "end_turn",
+          livenessState: "paused",
+          yielded: true,
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-yield-paused-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "wait for child timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-yield-paused-timeout");
+      expect(run?.pauseReason).toBe("sessions_yield");
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-yield-paused-timeout",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 111,
+        endedAt: 8_000,
+        livenessState: "blocked",
+        error: "Request timed out while waiting for tool execution to finish.",
+        timeoutPhase: "post_turn",
+        providerStarted: true,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-yield-paused-timeout");
+      expect(run?.pauseReason).toBeUndefined();
+      expect(run?.endedAt).toBe(8_000);
+      expectRecordFields(run?.outcome, { status: "timeout" }, "paused hard timeout outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let timeout waits with yielded metadata clear explicit run timeout fallback", async () => {
+    mocks.resolveAgentTimeoutMs.mockReturnValue(8_000);
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          yielded: true,
+          stopReason: "end_turn",
+          livenessState: "paused",
+          timeoutPhase: "queue",
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-with-stale-yield",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout must beat stale yielded metadata",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    await vi.advanceTimersByTimeAsync(22_999);
+    const pending = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-timeout-with-stale-yield");
+    expect(pending?.pauseReason).toBeUndefined();
+    expect(pending?.outcome).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-with-stale-yield");
+      expect(run?.pauseReason).toBeUndefined();
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "stale yield timeout outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves inherited timeout fallback for replacement runs without explicit timeouts", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-replace-old-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "replace old timeout",
+      cleanup: "keep",
+      runTimeoutSeconds: 8,
+    });
+
+    expect(
+      mod.replaceSubagentRunAfterSteer({
+        previousRunId: "run-replace-old-timeout",
+        nextRunId: "run-replace-new-no-timeout",
+      }),
+    ).toBe(true);
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+    lifecycleHandler?.({
+      runId: "run-replace-new-no-timeout",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+        startedAt: Date.now(),
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(22_999);
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForFast(() => {
+      const replacement = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-replace-new-no-timeout");
+      expect(replacement?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(
+        replacement?.outcome,
+        { status: "timeout" },
+        "replacement inherited timeout outcome",
+      );
+      expect(replacement?.runTimeoutSeconds).toBe(8);
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
   it("announces blocked agent.wait snapshots as errors instead of success", async () => {
@@ -2092,6 +3124,107 @@ describe("subagent registry seam flow", () => {
       .listSubagentRunsForRequester("agent:main:main")
       .find((entry) => entry.runId === "run-aborted-wait");
     expect(run?.endedReason).toBe("subagent-killed");
+    expect(run?.outcome?.status).toBe("error");
+  });
+
+  it("announces aborted agent.wait timeout snapshots without hard attribution as killed failures", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          startedAt: 100,
+          endedAt: 250,
+          stopReason: "aborted",
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-aborted-timeout-wait",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "aborted timeout wait",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "aborted timeout wait announce"),
+      { childRunId: "run-aborted-timeout-wait" },
+      "aborted timeout wait announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "error",
+        error: "subagent run terminated",
+        startedAt: 100,
+        endedAt: 250,
+        elapsedMs: 150,
+      },
+      "aborted timeout wait announce outcome",
+    );
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-aborted-timeout-wait");
+    expect(run?.endedReason).toBe("subagent-killed");
+    expect(run?.outcome?.status).toBe("error");
+  });
+
+  it("announces blocked agent.wait timeout snapshots without hard attribution as errors", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          startedAt: 100,
+          endedAt: 250,
+          livenessState: "blocked",
+          error: "Context overflow: prompt too large for the model.",
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-blocked-timeout-wait",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "blocked timeout wait",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "blocked timeout wait announce"),
+      { childRunId: "run-blocked-timeout-wait" },
+      "blocked timeout wait announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "error",
+        error: "Context overflow: prompt too large for the model.",
+        startedAt: 100,
+        endedAt: 250,
+        elapsedMs: 150,
+      },
+      "blocked timeout wait announce outcome",
+    );
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-blocked-timeout-wait");
+    expect(run?.endedReason).toBe("subagent-error");
     expect(run?.outcome?.status).toBe("error");
   });
 
@@ -2461,6 +3594,579 @@ describe("subagent registry seam flow", () => {
       .find((entry) => entry.runId === "run-blocked-end");
     expect(run?.endedReason).toBe("subagent-error");
     expect(run?.outcome?.status).toBe("error");
+  });
+
+  it("announces timeout-attributed lifecycle errors as timeouts", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-error",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout error task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-error",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+        startedAt: 10,
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-timeout-error",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 10,
+        endedAt: 20,
+        livenessState: "blocked",
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "timeout announce"),
+      { childRunId: "run-timeout-error" },
+      "timeout announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "timeout",
+        startedAt: 10,
+        endedAt: 20,
+        elapsedMs: 10,
+      },
+      "timeout announce outcome",
+    );
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-timeout-error");
+    expect(run?.endedReason).toBe("subagent-complete");
+    expect(run?.outcome?.status).toBe("timeout");
+  });
+
+  it("keeps the first authoritative hard-timeout lifecycle event", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-duplicate-timeout-events",
+      childSessionKey: "agent:main:subagent:duplicate-timeout",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "duplicate timeout events",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-duplicate-timeout-events",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        endedAt: 20,
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+
+    lifecycleHandler?.({
+      runId: "run-duplicate-timeout-events",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        endedAt: 25,
+        livenessState: "blocked",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "duplicate timeout announce"),
+      { childRunId: "run-duplicate-timeout-events" },
+      "duplicate timeout announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "timeout",
+        endedAt: 20,
+      },
+      "duplicate timeout announce outcome",
+    );
+  });
+
+  it("announces blocked lifecycle ends with hard timeout attribution as timeouts", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-end",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout end task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-end",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+        startedAt: 10,
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-timeout-end",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 10,
+        endedAt: 20,
+        livenessState: "blocked",
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "timeout end announce"),
+      { childRunId: "run-timeout-end" },
+      "timeout end announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "timeout",
+        startedAt: 10,
+        endedAt: 20,
+        elapsedMs: 10,
+      },
+      "timeout end announce outcome",
+    );
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-timeout-end");
+    expect(run?.endedReason).toBe("subagent-complete");
+    expect(run?.outcome?.status).toBe("timeout");
+  });
+
+  it("lets earlier session completion correct hard timeout lifecycle events", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: 10,
+        endedAt: 18,
+        updatedAt: 18,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-end-earlier-session-completion",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout end with earlier session completion",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-end-earlier-session-completion",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+        startedAt: 10,
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-timeout-end-earlier-session-completion",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 10,
+        endedAt: 20,
+        livenessState: "blocked",
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-end-earlier-session-completion");
+      expect(run?.endedAt).toBe(18);
+      expectRecordFields(run?.outcome, { status: "ok" }, "hard timeout corrected outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let late session completion correct hard timeout lifecycle after explicit deadline", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        status: "done",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:09Z"),
+        updatedAt: Date.parse("2026-03-24T12:00:09Z"),
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-end-late-session-completion",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout end with late session completion",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      runTimeoutSeconds: 8,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-end-late-session-completion",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-timeout-end-late-session-completion",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:10Z"),
+        livenessState: "blocked",
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-end-late-session-completion");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:08Z"));
+      expectRecordFields(run?.outcome, { status: "timeout" }, "late lifecycle timeout outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps hard timeout lifecycle ends authoritative over later successful lifecycle ends", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-then-late-ok",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout then late ok task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-then-late-ok",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+        startedAt: 10,
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-timeout-then-late-ok",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 10,
+        endedAt: 20,
+        aborted: true,
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-timeout-then-late-ok",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 10,
+        endedAt: 30,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "late ok timeout announce"),
+      { childRunId: "run-timeout-then-late-ok" },
+      "late ok timeout announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "timeout",
+        startedAt: 10,
+        endedAt: 20,
+        elapsedMs: 10,
+      },
+      "late ok timeout announce outcome",
+    );
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-timeout-then-late-ok");
+    expect(run?.endedReason).toBe("subagent-complete");
+    expect(run?.outcome?.status).toBe("timeout");
+  });
+
+  it("does not let transient aborted lifecycle ends shorten explicit timeout fallback", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-fallback-transient-abort",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout fallback transient abort task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      runTimeoutSeconds: 8,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-fallback-transient-abort",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:05Z"),
+        aborted: true,
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-timeout-fallback-transient-abort",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:06Z"),
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-timeout-fallback-transient-abort");
+      expect(run?.endedAt).toBe(Date.parse("2026-03-24T12:00:06Z"));
+      expectRecordFields(run?.outcome, { status: "ok" }, "transient abort corrected outcome");
+    });
+  });
+
+  it("keeps hard timeout lifecycle ends authoritative over later lifecycle errors", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-then-late-error",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout then late error task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-then-late-error",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 10,
+        endedAt: 20,
+        aborted: true,
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-timeout-then-late-error",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 10,
+        endedAt: 30,
+        error: "agent run aborted",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "late error timeout announce"),
+      { childRunId: "run-timeout-then-late-error" },
+      "late error timeout announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "timeout",
+        endedAt: 20,
+      },
+      "late error timeout announce outcome",
+    );
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-timeout-then-late-error");
+    expect(run?.outcome?.status).toBe("timeout");
   });
 
   it("announces aborted lifecycle end events as killed subagent failures", async () => {
@@ -3060,6 +4766,61 @@ describe("subagent registry seam flow", () => {
     );
   });
 
+  it("does not let pending timeout grace overwrite a killed subagent", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-then-killed",
+      childSessionKey: "agent:main:subagent:timeout-then-killed",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "timeout then killed",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-timeout-then-killed",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        endedAt: Date.parse("2026-03-24T12:00:01Z"),
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+
+    expect(
+      mod.markSubagentRunTerminated({
+        runId: "run-timeout-then-killed",
+        reason: "manual kill",
+      }),
+    ).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    const killedRun = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-timeout-then-killed");
+    expect(killedRun?.outcome?.status).toBe("error");
+    expect(killedRun?.outcome?.error).toBe("manual kill");
+    expect(killedRun?.endedReason).toBe("subagent-killed");
+  });
+
   it("deletes killed delete-mode runs and notifies deleted cleanup", async () => {
     mod.registerSubagentRun({
       runId: "run-killed-delete",
@@ -3277,6 +5038,69 @@ describe("subagent registry seam flow", () => {
         workspaceDir: "/tmp/workspace",
       },
     );
+  });
+
+  it("finalizes the detached task when an active subagent run is released", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-release-task",
+      childSessionKey: "agent:main:subagent:release-task",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "registered task",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    expect(listTaskRecords().find((task) => task.runId === "run-release-task")?.status).toBe(
+      "running",
+    );
+
+    mod.releaseSubagentRun("run-release-task");
+
+    const task = listTaskRecords().find((entry) => entry.runId === "run-release-task");
+    expect(task?.status).toBe("cancelled");
+    expect(task?.terminalSummary).toBe("released");
+  });
+
+  it("finalizes the detached task as failed when a pre-acceptance spawn run is discarded", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-discard-spawn-failed-task",
+      childSessionKey: "agent:main:subagent:discard-spawn-failed-task",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "pre-acceptance spawn failed",
+      cleanup: "keep",
+      runTimeoutSeconds: 60,
+    });
+
+    expect(
+      listTaskRecords().find((task) => task.runId === "run-discard-spawn-failed-task")?.status,
+    ).toBe("running");
+
+    expect(mod.discardFailedSubagentSpawnRun("run-discard-spawn-failed-task")).toBe(true);
+
+    const task = listTaskRecords().find((entry) => entry.runId === "run-discard-spawn-failed-task");
+    expect(task?.status).toBe("failed");
+    expect(task?.terminalSummary).toBe("spawn failed");
+    expect(
+      mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .some((entry) => entry.runId === "run-discard-spawn-failed-task"),
+    ).toBe(false);
   });
 
   it("passes stored agentDir through swept context-engine cleanup paths", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -16,6 +16,7 @@ import { isAbortedAgentStopReason } from "./run-termination.js";
 import {
   isHardAgentRunTimeoutPhase,
   normalizeAgentRunTimeoutPhase,
+  normalizeProviderStarted,
 } from "./run-timeout-attribution.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
@@ -43,7 +44,6 @@ import {
   reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
   resolveAnnounceRetryDelayMs,
-  resolveSubagentRunTimeoutAt,
   resolveSubagentRunOrphanReason,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
@@ -318,6 +318,16 @@ const pendingLifecycleTimeoutByRunId = new Map<
     dueAt: number;
     reconcileBeforeTimeout: boolean;
     authoritative: boolean;
+    timeoutPhase?: ReturnType<typeof normalizeAgentRunTimeoutPhase>;
+    providerStarted?: boolean;
+  }
+>();
+const authoritativeLifecycleTimeoutByRunId = new Map<
+  string,
+  {
+    endedAt: number;
+    timeoutPhase: NonNullable<ReturnType<typeof normalizeAgentRunTimeoutPhase>>;
+    providerStarted?: boolean;
   }
 >();
 
@@ -342,7 +352,7 @@ function clearPendingLifecycleTimeout(runId: string, opts?: { preserveAuthoritat
   if (!pending) {
     return;
   }
-  if (opts?.preserveAuthoritative === true && pending.authoritative === true) {
+  if (opts?.preserveAuthoritative === true && pending.authoritative) {
     return;
   }
   clearTimeout(pending.timer);
@@ -364,6 +374,14 @@ function getPendingLifecycleTimeout(runId: string) {
         authoritative: pending.authoritative,
       }
     : undefined;
+}
+
+function getAuthoritativeLifecycleTimeout(runId: string) {
+  return authoritativeLifecycleTimeoutByRunId.get(runId);
+}
+
+function clearAuthoritativeLifecycleTimeout(runId: string) {
+  authoritativeLifecycleTimeoutByRunId.delete(runId);
 }
 
 type CompleteSubagentRunParams = {
@@ -437,7 +455,7 @@ function schedulePendingLifecycleError(params: {
   startedAt?: number;
   error?: string;
 }) {
-  clearPendingLifecycleTimeout(params.runId);
+  clearPendingLifecycleTimeout(params.runId, { preserveAuthoritative: true });
   clearPendingLifecycleError(params.runId);
   const timer = setTimeout(() => {
     const pending = pendingLifecycleErrorByRunId.get(params.runId);
@@ -483,6 +501,8 @@ function schedulePendingLifecycleTimeout(params: {
   delayMs?: number;
   reconcileBeforeTimeout?: boolean;
   authoritative?: boolean;
+  timeoutPhase?: ReturnType<typeof normalizeAgentRunTimeoutPhase>;
+  providerStarted?: boolean;
 }) {
   clearPendingLifecycleError(params.runId);
   const delayMs =
@@ -522,7 +542,7 @@ function schedulePendingLifecycleTimeout(params: {
     if (!entry) {
       return;
     }
-    if (entry.pauseReason === "sessions_yield" && pending.authoritative !== true) {
+    if (entry.pauseReason === "sessions_yield" && !pending.authoritative) {
       return;
     }
     if (entry.outcome?.status === "ok") {
@@ -555,6 +575,10 @@ function schedulePendingLifecycleTimeout(params: {
       endedAt: pending.endedAt,
       outcome: {
         status: "timeout" as const,
+        ...(pending.timeoutPhase ? { timeoutPhase: pending.timeoutPhase } : {}),
+        ...(pending.providerStarted !== undefined
+          ? { providerStarted: pending.providerStarted }
+          : {}),
       },
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       sendFarewell: true,
@@ -572,7 +596,16 @@ function schedulePendingLifecycleTimeout(params: {
     dueAt,
     reconcileBeforeTimeout,
     authoritative,
+    timeoutPhase: params.timeoutPhase,
+    providerStarted: params.providerStarted,
   });
+  if (authoritative && params.timeoutPhase) {
+    authoritativeLifecycleTimeoutByRunId.set(params.runId, {
+      endedAt,
+      timeoutPhase: params.timeoutPhase,
+      providerStarted: params.providerStarted,
+    });
+  }
 }
 
 function scheduleRunTimeoutFallback(entry: SubagentRunRecord, startedAt: number) {
@@ -597,6 +630,27 @@ function scheduleRunTimeoutFallback(entry: SubagentRunRecord, startedAt: number)
     authoritative: true,
     startedAt,
   });
+}
+
+function resolveSubagentRunTimeoutAtWithObservedStart(
+  entry: SubagentRunRecord,
+  observedStartedAt?: number,
+) {
+  const runTimeoutSeconds = entry.runTimeoutSeconds;
+  if (
+    typeof runTimeoutSeconds !== "number" ||
+    !Number.isFinite(runTimeoutSeconds) ||
+    runTimeoutSeconds <= 0
+  ) {
+    return undefined;
+  }
+  const startedAt =
+    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
+      ? observedStartedAt
+      : (entry.startedAt ?? entry.createdAt);
+  return Number.isFinite(startedAt)
+    ? Math.floor(startedAt) + Math.floor(runTimeoutSeconds * 1000)
+    : undefined;
 }
 
 async function notifyContextEngineSubagentEnded(params: {
@@ -684,6 +738,8 @@ const subagentLifecycleController = createSubagentRegistryLifecycleController({
   clearPendingLifecycleError,
   clearPendingLifecycleTimeout,
   getPendingLifecycleTimeout,
+  getAuthoritativeLifecycleTimeout,
+  clearAuthoritativeLifecycleTimeout,
   countPendingDescendantRuns,
   suppressAnnounceForSteerRestart,
   shouldEmitEndedHookForRun,
@@ -1214,23 +1270,33 @@ function ensureListener() {
       const livenessState =
         typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
       const stopReason = typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
-      const timeoutPhase = normalizeAgentRunTimeoutPhase(evt.data?.timeoutPhase);
-      const explicitRunTimeoutAt = resolveSubagentRunTimeoutAt(entry);
+      const timeoutPhase =
+        normalizeAgentRunTimeoutPhase(evt.data?.timeoutPhase) ??
+        (evt.data?.aborted === true && /\btimed?\s*out\b|timeout/i.test(error ?? "")
+          ? "provider"
+          : undefined);
+      const explicitRunTimeoutAt = resolveSubagentRunTimeoutAtWithObservedStart(entry, startedAt);
       const explicitRunTimeoutElapsed =
         typeof explicitRunTimeoutAt === "number" && endedAt >= explicitRunTimeoutAt;
       if (isHardAgentRunTimeoutPhase(timeoutPhase)) {
+        const timeoutEndedAt = explicitRunTimeoutElapsed ? explicitRunTimeoutAt : endedAt;
+        const providerStarted = normalizeProviderStarted(evt.data?.providerStarted);
         schedulePendingLifecycleTimeout({
           runId: evt.runId,
-          endedAt: explicitRunTimeoutElapsed ? explicitRunTimeoutAt : endedAt,
+          endedAt: timeoutEndedAt,
+          startedAt,
           delayMs: 0,
           reconcileBeforeTimeout: true,
           authoritative: true,
+          timeoutPhase,
+          providerStarted,
         });
         return;
       }
       if (
         explicitRunTimeoutElapsed &&
-        (phase === "error" ||
+        (phase === "end" ||
+          phase === "error" ||
           evt.data?.aborted === true ||
           isBlockedLivenessState(livenessState) ||
           isAbortedAgentStopReason(stopReason))
@@ -1247,6 +1313,18 @@ function ensureListener() {
       const pendingTimeout = pendingLifecycleTimeoutByRunId.get(evt.runId);
       if (
         pendingTimeout?.authoritative === true &&
+        phase === "end" &&
+        !explicitRunTimeoutElapsed &&
+        typeof startedAt === "number" &&
+        typeof explicitRunTimeoutAt === "number" &&
+        startedAt < pendingTimeout.endedAt &&
+        explicitRunTimeoutAt > pendingTimeout.endedAt
+      ) {
+        clearPendingLifecycleTimeout(evt.runId);
+      }
+      if (
+        pendingTimeout?.authoritative === true &&
+        pendingLifecycleTimeoutByRunId.has(evt.runId) &&
         (typeof endedAt !== "number" || endedAt > pendingTimeout.endedAt)
       ) {
         return;
@@ -1420,6 +1498,7 @@ export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   endedHookInFlightRunIds.clear();
   clearAllPendingLifecycleErrors();
   clearAllPendingLifecycleTimeouts();
+  authoritativeLifecycleTimeoutByRunId.clear();
   contextEngineInitLoader.clear();
   contextEngineRegistryLoader.clear();
   runtimePluginsLoader.clear();

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1234,11 +1234,7 @@ function ensureListener() {
       const livenessState =
         typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
       const stopReason = typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
-      const timeoutPhase =
-        normalizeAgentRunTimeoutPhase(evt.data?.timeoutPhase) ??
-        (evt.data?.aborted === true && /\btimed?\s*out\b|timeout/i.test(error ?? "")
-          ? "provider"
-          : undefined);
+      const timeoutPhase = normalizeAgentRunTimeoutPhase(evt.data?.timeoutPhase);
       const explicitRunTimeoutAt = resolveSubagentRunTimeoutAt(entry, startedAt);
       const explicitRunTimeoutElapsed =
         typeof explicitRunTimeoutAt === "number" && endedAt >= explicitRunTimeoutAt;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1475,6 +1475,10 @@ export function registerSubagentRun(params: RegisterSubagentRunParams) {
   subagentRunManager.registerSubagentRun(params);
 }
 
+export function startSubagentRunCompletionWait(runId: string): boolean {
+  return subagentRunManager.startSubagentRunCompletionWait(runId);
+}
+
 export function armSubagentRunTimeout(params: {
   runId: string;
   runTimeoutSeconds: number;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -44,8 +44,11 @@ import {
   reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
   resolveAnnounceRetryDelayMs,
+  resolveSubagentRunTimeoutAt,
+  resolveSubagentRunTimeoutDurationMs,
   resolveSubagentRunOrphanReason,
   safeRemoveAttachmentsDir,
+  SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS,
 } from "./subagent-registry-helpers.js";
 import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
@@ -89,6 +92,7 @@ export {
   getSubagentSessionRuntimeMs,
   getSubagentSessionStartedAt,
   resolveSubagentSessionStatus,
+  SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS,
 } from "./subagent-registry-helpers.js";
 const log = createSubsystemLogger("agents/subagent-registry");
 
@@ -206,17 +210,6 @@ const SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
  * subsequent lifecycle `start` / `end` can cancel premature failure announces.
  */
 const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
-/**
- * Embedded runs can also surface an intermediate lifecycle `end` with
- * `aborted=true` just before the runtime automatically retries the same run.
- * Give that timeout a short grace window so the parent does not get a stale
- * `timed out` completion right before the eventual success.
- */
-export const SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS = 15_000;
-// Subagent waits observe the explicit deadline plus lifecycle reconciliation
-// grace, so the run deadline itself must leave room under the agent timeout cap.
-const MAX_SUBAGENT_RUN_TIMEOUT_MS =
-  MAX_AGENT_TIMEOUT_MS - SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS;
 /** Absolute TTL for session-mode runs after cleanup completes (no archiveAtMs). */
 const SESSION_RUN_TTL_MS = 5 * 60_000; // 5 minutes
 /** Absolute TTL for orphaned pendingLifecycleError / pendingLifecycleTimeout entries. */
@@ -609,18 +602,10 @@ function schedulePendingLifecycleTimeout(params: {
 }
 
 function scheduleRunTimeoutFallback(entry: SubagentRunRecord, startedAt: number) {
-  const runTimeoutSeconds = entry.runTimeoutSeconds;
-  if (
-    typeof runTimeoutSeconds !== "number" ||
-    !Number.isFinite(runTimeoutSeconds) ||
-    runTimeoutSeconds <= 0
-  ) {
+  const runTimeoutMs = resolveSubagentRunTimeoutDurationMs(entry.runTimeoutSeconds);
+  if (runTimeoutMs === undefined) {
     return;
   }
-  const runTimeoutMs = Math.min(
-    Math.max(1, Math.floor(runTimeoutSeconds * 1000)),
-    MAX_SUBAGENT_RUN_TIMEOUT_MS,
-  );
   const endedAt = startedAt + runTimeoutMs;
   schedulePendingLifecycleTimeout({
     runId: entry.runId,
@@ -630,27 +615,6 @@ function scheduleRunTimeoutFallback(entry: SubagentRunRecord, startedAt: number)
     authoritative: true,
     startedAt,
   });
-}
-
-function resolveSubagentRunTimeoutAtWithObservedStart(
-  entry: SubagentRunRecord,
-  observedStartedAt?: number,
-) {
-  const runTimeoutSeconds = entry.runTimeoutSeconds;
-  if (
-    typeof runTimeoutSeconds !== "number" ||
-    !Number.isFinite(runTimeoutSeconds) ||
-    runTimeoutSeconds <= 0
-  ) {
-    return undefined;
-  }
-  const startedAt =
-    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
-      ? observedStartedAt
-      : (entry.startedAt ?? entry.createdAt);
-  return Number.isFinite(startedAt)
-    ? Math.floor(startedAt) + Math.floor(runTimeoutSeconds * 1000)
-    : undefined;
 }
 
 async function notifyContextEngineSubagentEnded(params: {
@@ -1275,7 +1239,7 @@ function ensureListener() {
         (evt.data?.aborted === true && /\btimed?\s*out\b|timeout/i.test(error ?? "")
           ? "provider"
           : undefined);
-      const explicitRunTimeoutAt = resolveSubagentRunTimeoutAtWithObservedStart(entry, startedAt);
+      const explicitRunTimeoutAt = resolveSubagentRunTimeoutAt(entry, startedAt);
       const explicitRunTimeoutElapsed =
         typeof explicitRunTimeoutAt === "number" && endedAt >= explicitRunTimeoutAt;
       if (isHardAgentRunTimeoutPhase(timeoutPhase)) {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -13,6 +13,10 @@ import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { removeInternalSessionEffectsTranscript } from "./internal-session-effects.js";
 import { isAbortedAgentStopReason } from "./run-termination.js";
+import {
+  isHardAgentRunTimeoutPhase,
+  normalizeAgentRunTimeoutPhase,
+} from "./run-timeout-attribution.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
@@ -39,6 +43,7 @@ import {
   reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
   resolveAnnounceRetryDelayMs,
+  resolveSubagentRunTimeoutAt,
   resolveSubagentRunOrphanReason,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
@@ -77,7 +82,7 @@ import {
   resolveSubagentSessionStartedAt,
   type SubagentSessionStoreCache,
 } from "./subagent-session-reconciliation.js";
-import { resolveAgentTimeoutMs } from "./timeout.js";
+import { MAX_AGENT_TIMEOUT_MS, resolveAgentTimeoutMs } from "./timeout.js";
 
 export type { SubagentRunRecord } from "./subagent-registry.types.js";
 export {
@@ -207,7 +212,11 @@ const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
  * Give that timeout a short grace window so the parent does not get a stale
  * `timed out` completion right before the eventual success.
  */
-const LIFECYCLE_TIMEOUT_RETRY_GRACE_MS = 15_000;
+export const SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS = 15_000;
+// Subagent waits observe the explicit deadline plus lifecycle reconciliation
+// grace, so the run deadline itself must leave room under the agent timeout cap.
+const MAX_SUBAGENT_RUN_TIMEOUT_MS =
+  MAX_AGENT_TIMEOUT_MS - SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS;
 /** Absolute TTL for session-mode runs after cleanup completes (no archiveAtMs). */
 const SESSION_RUN_TTL_MS = 5 * 60_000; // 5 minutes
 /** Absolute TTL for orphaned pendingLifecycleError / pendingLifecycleTimeout entries. */
@@ -306,6 +315,9 @@ const pendingLifecycleTimeoutByRunId = new Map<
     timer: NodeJS.Timeout;
     endedAt: number;
     startedAt?: number;
+    dueAt: number;
+    reconcileBeforeTimeout: boolean;
+    authoritative: boolean;
   }
 >();
 
@@ -325,9 +337,12 @@ function clearAllPendingLifecycleErrors() {
   pendingLifecycleErrorByRunId.clear();
 }
 
-function clearPendingLifecycleTimeout(runId: string) {
+function clearPendingLifecycleTimeout(runId: string, opts?: { preserveAuthoritative?: boolean }) {
   const pending = pendingLifecycleTimeoutByRunId.get(runId);
   if (!pending) {
+    return;
+  }
+  if (opts?.preserveAuthoritative === true && pending.authoritative === true) {
     return;
   }
   clearTimeout(pending.timer);
@@ -339,6 +354,16 @@ function clearAllPendingLifecycleTimeouts() {
     clearTimeout(pending.timer);
   }
   pendingLifecycleTimeoutByRunId.clear();
+}
+
+function getPendingLifecycleTimeout(runId: string) {
+  const pending = pendingLifecycleTimeoutByRunId.get(runId);
+  return pending
+    ? {
+        endedAt: pending.endedAt,
+        authoritative: pending.authoritative,
+      }
+    : undefined;
 }
 
 type CompleteSubagentRunParams = {
@@ -455,9 +480,38 @@ function schedulePendingLifecycleTimeout(params: {
   runId: string;
   endedAt: number;
   startedAt?: number;
+  delayMs?: number;
+  reconcileBeforeTimeout?: boolean;
+  authoritative?: boolean;
 }) {
   clearPendingLifecycleError(params.runId);
-  clearPendingLifecycleTimeout(params.runId);
+  const delayMs =
+    typeof params.delayMs === "number" && Number.isFinite(params.delayMs)
+      ? Math.max(0, Math.floor(params.delayMs))
+      : SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS;
+  const dueAt = Date.now() + delayMs;
+  let endedAt = params.endedAt;
+  let reconcileBeforeTimeout = params.reconcileBeforeTimeout === true;
+  let authoritative = params.authoritative === true;
+  const existing = pendingLifecycleTimeoutByRunId.get(params.runId);
+  if (existing) {
+    const sameAuthority = existing.authoritative === authoritative;
+    if (existing.authoritative && !authoritative) {
+      existing.reconcileBeforeTimeout = existing.reconcileBeforeTimeout || reconcileBeforeTimeout;
+      return;
+    }
+    if (sameAuthority) {
+      endedAt = Math.min(existing.endedAt, params.endedAt);
+      reconcileBeforeTimeout = existing.reconcileBeforeTimeout || reconcileBeforeTimeout;
+    }
+    existing.endedAt = endedAt;
+    existing.reconcileBeforeTimeout = reconcileBeforeTimeout;
+    existing.authoritative = authoritative;
+    if (sameAuthority && dueAt >= existing.dueAt) {
+      return;
+    }
+    clearTimeout(existing.timer);
+  }
   const timer = setTimeout(() => {
     const pending = pendingLifecycleTimeoutByRunId.get(params.runId);
     if (!pending || pending.timer !== timer) {
@@ -468,8 +522,33 @@ function schedulePendingLifecycleTimeout(params: {
     if (!entry) {
       return;
     }
+    if (entry.pauseReason === "sessions_yield" && pending.authoritative !== true) {
+      return;
+    }
     if (entry.outcome?.status === "ok") {
       return;
+    }
+    if (pending.reconcileBeforeTimeout) {
+      const completion = resolveSubagentSessionCompletion({
+        childSessionKey: entry.childSessionKey,
+        fallbackEndedAt: pending.endedAt,
+        notBeforeMs: entry.startedAt ?? entry.createdAt,
+      });
+      if (completion && completion.endedAt <= pending.endedAt) {
+        completeSubagentRunInBackground(
+          {
+            runId: params.runId,
+            endedAt: completion.endedAt,
+            outcome: completion.outcome,
+            reason: completion.reason,
+            sendFarewell: true,
+            accountId: entry.requesterOrigin?.accountId,
+            triggerCleanup: true,
+          },
+          "run-timeout-fallback-session-completion",
+        );
+        return;
+      }
     }
     const completionParams = {
       runId: params.runId,
@@ -484,12 +563,39 @@ function schedulePendingLifecycleTimeout(params: {
       startedAt: pending.startedAt,
     };
     completeSubagentRunInBackground(completionParams, "lifecycle-timeout-grace");
-  }, LIFECYCLE_TIMEOUT_RETRY_GRACE_MS);
+  }, delayMs);
   timer.unref?.();
   pendingLifecycleTimeoutByRunId.set(params.runId, {
     timer,
-    endedAt: params.endedAt,
+    endedAt,
     startedAt: params.startedAt,
+    dueAt,
+    reconcileBeforeTimeout,
+    authoritative,
+  });
+}
+
+function scheduleRunTimeoutFallback(entry: SubagentRunRecord, startedAt: number) {
+  const runTimeoutSeconds = entry.runTimeoutSeconds;
+  if (
+    typeof runTimeoutSeconds !== "number" ||
+    !Number.isFinite(runTimeoutSeconds) ||
+    runTimeoutSeconds <= 0
+  ) {
+    return;
+  }
+  const runTimeoutMs = Math.min(
+    Math.max(1, Math.floor(runTimeoutSeconds * 1000)),
+    MAX_SUBAGENT_RUN_TIMEOUT_MS,
+  );
+  const endedAt = startedAt + runTimeoutMs;
+  schedulePendingLifecycleTimeout({
+    runId: entry.runId,
+    endedAt,
+    delayMs: Math.max(0, endedAt + SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS - Date.now()),
+    reconcileBeforeTimeout: true,
+    authoritative: true,
+    startedAt,
   });
 }
 
@@ -576,6 +682,8 @@ const subagentLifecycleController = createSubagentRegistryLifecycleController({
   subagentAnnounceTimeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
   persist: persistSubagentRuns,
   clearPendingLifecycleError,
+  clearPendingLifecycleTimeout,
+  getPendingLifecycleTimeout,
   countPendingDescendantRuns,
   suppressAnnounceForSteerRestart,
   shouldEmitEndedHookForRun,
@@ -615,6 +723,7 @@ function resumeSubagentRun(runId: string) {
     return;
   }
   if (entry.pauseReason === "sessions_yield") {
+    scheduleRunTimeoutFallback(entry, entry.startedAt ?? entry.createdAt);
     return;
   }
   // Skip entries that have exhausted their retry budget or expired (#18264).
@@ -691,6 +800,7 @@ function resumeSubagentRun(runId: string) {
   // Wait for completion again after restart.
   const cfg = subagentRegistryDeps.getRuntimeConfig();
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, entry.runTimeoutSeconds);
+  scheduleRunTimeoutFallback(entry, entry.startedAt ?? entry.createdAt);
   void subagentRunManager.waitForSubagentCompletion(runId, waitTimeoutMs, entry, true);
   resumedRuns.add(runId);
 }
@@ -738,10 +848,18 @@ function restoreSubagentRunsOnce() {
 }
 
 function resolveSubagentWaitTimeoutMs(cfg: OpenClawConfig, runTimeoutSeconds?: number) {
-  return subagentRegistryDeps.resolveAgentTimeoutMs({
+  const timeoutMs = subagentRegistryDeps.resolveAgentTimeoutMs({
     cfg,
     overrideSeconds: runTimeoutSeconds ?? 0,
   });
+  if (
+    typeof runTimeoutSeconds !== "number" ||
+    !Number.isFinite(runTimeoutSeconds) ||
+    runTimeoutSeconds <= 0
+  ) {
+    return timeoutMs;
+  }
+  return Math.min(MAX_AGENT_TIMEOUT_MS, timeoutMs + SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS);
 }
 
 function startSweeper() {
@@ -1065,15 +1183,26 @@ function ensureListener() {
       }
       if (phase === "start") {
         clearPendingLifecycleError(evt.runId);
-        clearPendingLifecycleTimeout(evt.runId);
+        const pendingTimeout = pendingLifecycleTimeoutByRunId.get(evt.runId);
+        clearPendingLifecycleTimeout(evt.runId, { preserveAuthoritative: true });
         const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
-        if (startedAt) {
-          entry.startedAt = startedAt;
+        const existingStartedAt = entry.startedAt ?? entry.createdAt;
+        const nextStartedAt =
+          typeof startedAt === "number"
+            ? pendingTimeout?.authoritative === true
+              ? Math.min(existingStartedAt, startedAt)
+              : startedAt
+            : typeof entry.startedAt !== "number"
+              ? Date.now()
+              : undefined;
+        if (typeof nextStartedAt === "number") {
+          entry.startedAt = nextStartedAt;
           if (typeof entry.sessionStartedAt !== "number") {
-            entry.sessionStartedAt = startedAt;
+            entry.sessionStartedAt = nextStartedAt;
           }
           persistSubagentRuns();
         }
+        scheduleRunTimeoutFallback(entry, entry.startedAt ?? entry.createdAt);
         return;
       }
       if (phase !== "end" && phase !== "error") {
@@ -1085,6 +1214,43 @@ function ensureListener() {
       const livenessState =
         typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
       const stopReason = typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
+      const timeoutPhase = normalizeAgentRunTimeoutPhase(evt.data?.timeoutPhase);
+      const explicitRunTimeoutAt = resolveSubagentRunTimeoutAt(entry);
+      const explicitRunTimeoutElapsed =
+        typeof explicitRunTimeoutAt === "number" && endedAt >= explicitRunTimeoutAt;
+      if (isHardAgentRunTimeoutPhase(timeoutPhase)) {
+        schedulePendingLifecycleTimeout({
+          runId: evt.runId,
+          endedAt: explicitRunTimeoutElapsed ? explicitRunTimeoutAt : endedAt,
+          delayMs: 0,
+          reconcileBeforeTimeout: true,
+          authoritative: true,
+        });
+        return;
+      }
+      if (
+        explicitRunTimeoutElapsed &&
+        (phase === "error" ||
+          evt.data?.aborted === true ||
+          isBlockedLivenessState(livenessState) ||
+          isAbortedAgentStopReason(stopReason))
+      ) {
+        schedulePendingLifecycleTimeout({
+          runId: evt.runId,
+          endedAt: explicitRunTimeoutAt,
+          delayMs: 0,
+          reconcileBeforeTimeout: true,
+          authoritative: true,
+        });
+        return;
+      }
+      const pendingTimeout = pendingLifecycleTimeoutByRunId.get(evt.runId);
+      if (
+        pendingTimeout?.authoritative === true &&
+        (typeof endedAt !== "number" || endedAt > pendingTimeout.endedAt)
+      ) {
+        return;
+      }
       if (phase === "error") {
         schedulePendingLifecycleError({
           runId: evt.runId,
@@ -1191,6 +1357,9 @@ const subagentRunManager = createSubagentRunManager({
   stopSweeper,
   resumeSubagentRun,
   clearPendingLifecycleError,
+  clearPendingLifecycleTimeout,
+  getPendingLifecycleTimeout,
+  scheduleRunTimeoutFallback,
   resolveSubagentWaitTimeoutMs,
   scheduleOrphanRecovery: (args) => scheduleSubagentOrphanRecovery(args),
   resolveSubagentSessionCompletion,
@@ -1226,6 +1395,18 @@ export function replaceSubagentRunAfterSteer(params: {
 
 export function registerSubagentRun(params: RegisterSubagentRunParams) {
   subagentRunManager.registerSubagentRun(params);
+}
+
+export function armSubagentRunTimeout(params: {
+  runId: string;
+  runTimeoutSeconds: number;
+  startedAt?: number;
+}) {
+  return subagentRunManager.armSubagentRunTimeout(
+    params.runId,
+    params.runTimeoutSeconds,
+    params.startedAt,
+  );
 }
 
 export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
@@ -1277,6 +1458,10 @@ export function addSubagentRunForTests(entry: SubagentRunRecord) {
 
 export function releaseSubagentRun(runId: string) {
   subagentRunManager.releaseSubagentRun(runId);
+}
+
+export function discardFailedSubagentSpawnRun(runId: string): boolean {
+  return subagentRunManager.discardFailedSubagentSpawnRun(runId);
 }
 
 export async function finalizeInterruptedSubagentRun(params: {

--- a/src/agents/subagent-spawn.context.test.ts
+++ b/src/agents/subagent-spawn.context.test.ts
@@ -114,7 +114,7 @@ describe("sessions_spawn context modes", () => {
     );
 
     const accepted = requireAcceptedResult(result);
-    expect(accepted.runId).toBe("run-1");
+    expect(typeof accepted.runId).toBe("string");
     expect(forkSessionFromParentMock).toHaveBeenCalledWith({
       parentEntry: store.main,
       agentId: "main",
@@ -172,7 +172,7 @@ describe("sessions_spawn context modes", () => {
     );
 
     const accepted = requireAcceptedResult(result);
-    expect(accepted.runId).toBe("run-1");
+    expect(typeof accepted.runId).toBe("string");
     expect(accepted.note).toContain("Parent context is too large to fork");
     expect(forkSessionFromParentMock).not.toHaveBeenCalled();
     const prepareContext = requireFirstMockArg(prepareSubagentSpawn);

--- a/src/agents/subagent-spawn.depth-limits.test.ts
+++ b/src/agents/subagent-spawn.depth-limits.test.ts
@@ -60,12 +60,12 @@ function expectForbidden(result: SpawnResult, error: string) {
   expect(result.error).toBe(error);
 }
 
-function expectAccepted(result: SpawnResult, runId: string): AcceptedSpawnResult {
+function expectAccepted(result: SpawnResult): AcceptedSpawnResult {
   expect(result.status).toBe("accepted");
   if (result.status !== "accepted") {
     throw new Error(`Expected accepted spawn result, received ${result.status}`);
   }
-  expect(result.runId).toBe(runId);
+  expect(typeof result.runId).toBe("string");
   expect(typeof result.childSessionKey).toBe("string");
   return result as AcceptedSpawnResult;
 }
@@ -117,7 +117,7 @@ describe("subagent spawn depth + child limits", () => {
 
     const result = await spawnFrom("agent:main:subagent:parent");
 
-    const accepted = expectAccepted(result, "run-1");
+    const accepted = expectAccepted(result);
     expect(accepted.childSessionKey).toMatch(/^agent:main:subagent:/);
 
     const childSession = persistedStore?.[accepted.childSessionKey];
@@ -146,7 +146,7 @@ describe("subagent spawn depth + child limits", () => {
       },
     );
 
-    const accepted = expectAccepted(result, "run-1");
+    const accepted = expectAccepted(result);
     const childSession = persistedStore?.[accepted.childSessionKey];
     if (!childSession) {
       throw new Error("Expected persisted child session");
@@ -194,7 +194,7 @@ describe("subagent spawn depth + child limits", () => {
 
     const result = await spawnFrom("agent:main:subagent:parent");
 
-    expectAccepted(result, "run-1");
+    expectAccepted(result);
   });
 
   it("fails spawn when the initial child session patch rejects the model", async () => {

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -134,6 +134,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
   resolveParentForkDecisionMock?: MockFn;
   pruneLegacyStoreKeysMock?: MockFn;
   registerSubagentRunMock?: MockFn;
+  createRunIdMock?: () => string;
   armSubagentRunTimeoutMock?: MockFn;
   releaseSubagentRunMock?: MockFn;
   discardFailedSubagentSpawnRunMock?: MockFn;
@@ -291,6 +292,11 @@ export async function loadSubagentSpawnModuleForTest(params: {
   }));
 
   const subagentSpawnModule = await import("./subagent-spawn.js");
+  if (params.createRunIdMock) {
+    subagentSpawnModule.testing.setDepsForTest({
+      createRunId: params.createRunIdMock,
+    });
+  }
   return {
     ...subagentSpawnModule,
     resetSubagentRegistryForTests,

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -136,6 +136,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
   registerSubagentRunMock?: MockFn;
   createRunIdMock?: () => string;
   armSubagentRunTimeoutMock?: MockFn;
+  startSubagentRunCompletionWaitMock?: MockFn;
   releaseSubagentRunMock?: MockFn;
   discardFailedSubagentSpawnRunMock?: MockFn;
   emitSessionLifecycleEventMock?: MockFn;
@@ -286,6 +287,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
     registerSubagentRun:
       params.registerSubagentRunMock ?? vi.fn((_record: Record<string, unknown>) => undefined),
     armSubagentRunTimeout: params.armSubagentRunTimeoutMock ?? vi.fn(),
+    startSubagentRunCompletionWait: params.startSubagentRunCompletionWaitMock ?? vi.fn(),
     releaseSubagentRun: params.releaseSubagentRunMock ?? vi.fn(),
     discardFailedSubagentSpawnRun: params.discardFailedSubagentSpawnRunMock ?? vi.fn(),
     resetSubagentRegistryForTests,

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -5,7 +5,9 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 type MockFn = (...args: unknown[]) => unknown;
 type MockImplementationTarget = {
-  mockImplementation: (implementation: (opts: { method?: string }) => Promise<unknown>) => unknown;
+  mockImplementation: (
+    implementation: (opts: { method?: string; params?: unknown }) => Promise<unknown>,
+  ) => unknown;
 };
 type SessionStore = Record<string, Record<string, unknown>>;
 type SessionStoreMutator = (store: SessionStore) => unknown;
@@ -52,7 +54,15 @@ export function setupAcceptedSubagentGatewayMock(callGatewayMock: MockImplementa
       return { ok: true };
     }
     if (opts.method === "agent") {
-      return { runId: "run-1", status: "accepted", acceptedAt: 1000 };
+      const paramsRecord =
+        opts && typeof opts === "object" && "params" in opts && opts.params
+          ? (opts.params as { idempotencyKey?: unknown })
+          : {};
+      const runId =
+        typeof paramsRecord.idempotencyKey === "string" && paramsRecord.idempotencyKey.trim()
+          ? paramsRecord.idempotencyKey
+          : "run-1";
+      return { runId, status: "accepted", acceptedAt: 1000 };
     }
     return {};
   });
@@ -124,6 +134,9 @@ export async function loadSubagentSpawnModuleForTest(params: {
   resolveParentForkDecisionMock?: MockFn;
   pruneLegacyStoreKeysMock?: MockFn;
   registerSubagentRunMock?: MockFn;
+  armSubagentRunTimeoutMock?: MockFn;
+  releaseSubagentRunMock?: MockFn;
+  discardFailedSubagentSpawnRunMock?: MockFn;
   emitSessionLifecycleEventMock?: MockFn;
   hookRunner?: HookRunner;
   resolveAgentConfig?: (cfg: Record<string, unknown>, agentId: string) => unknown;
@@ -131,6 +144,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
   resolveSubagentSpawnModelSelection?: () => string | undefined;
   getSubagentDepthFromSessionStore?: (sessionKey: string, opts?: unknown) => number;
   countActiveRunsForSession?: (sessionKey: string) => number;
+  listSubagentRunsForRequesterMock?: MockFn;
   resolveSandboxRuntimeStatus?: (params: {
     cfg?: Record<string, unknown>;
     sessionKey?: string;
@@ -265,9 +279,14 @@ export async function loadSubagentSpawnModuleForTest(params: {
   }));
 
   vi.doMock("./subagent-registry.js", () => ({
+    SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS: 15_000,
     countActiveRunsForSession: params.countActiveRunsForSession ?? (() => 0),
+    listSubagentRunsForRequester: params.listSubagentRunsForRequesterMock ?? (() => []),
     registerSubagentRun:
       params.registerSubagentRunMock ?? vi.fn((_record: Record<string, unknown>) => undefined),
+    armSubagentRunTimeout: params.armSubagentRunTimeoutMock ?? vi.fn(),
+    releaseSubagentRun: params.releaseSubagentRunMock ?? vi.fn(),
+    discardFailedSubagentSpawnRun: params.discardFailedSubagentSpawnRunMock ?? vi.fn(),
     resetSubagentRegistryForTests,
   }));
 

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -278,7 +278,7 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
   });
 
-  it("preserves a terminal pre-registered run when the child agent RPC fails late", async () => {
+  it("reports a terminal pre-registered timeout when the child agent RPC fails late", async () => {
     let registeredRunId: string | undefined;
     hoisted.registerSubagentRunMock.mockImplementation((record: unknown) => {
       const run = requireRecord(record);
@@ -312,8 +312,11 @@ describe("spawnSubagentDirect seam flow", () => {
       },
     );
 
-    expect(result.status).toBe("accepted");
+    expect(result.status).toBe("error");
     expect(result.runId).toBe(registeredRunId);
+    expect(result.error).toBe(
+      "Subagent run timed out before the child agent accepted the request.",
+    );
     expect(hoisted.releaseSubagentRunMock).not.toHaveBeenCalled();
     expect(gatewayRequestRecords().some((request) => request.method === "sessions.delete")).toBe(
       false,

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -13,6 +13,10 @@ const hoisted = vi.hoisted(() => ({
   updateSessionStoreMock: vi.fn(),
   pruneLegacyStoreKeysMock: vi.fn(),
   registerSubagentRunMock: vi.fn(),
+  armSubagentRunTimeoutMock: vi.fn(),
+  releaseSubagentRunMock: vi.fn(),
+  discardFailedSubagentSpawnRunMock: vi.fn(),
+  listSubagentRunsForRequesterMock: vi.fn(),
   emitSessionLifecycleEventMock: vi.fn(),
   resolveAgentConfigMock: vi.fn(),
   configOverride: {} as Record<string, unknown>,
@@ -66,6 +70,10 @@ describe("spawnSubagentDirect seam flow", () => {
       updateSessionStoreMock: hoisted.updateSessionStoreMock,
       pruneLegacyStoreKeysMock: hoisted.pruneLegacyStoreKeysMock,
       registerSubagentRunMock: hoisted.registerSubagentRunMock,
+      armSubagentRunTimeoutMock: hoisted.armSubagentRunTimeoutMock,
+      releaseSubagentRunMock: hoisted.releaseSubagentRunMock,
+      discardFailedSubagentSpawnRunMock: hoisted.discardFailedSubagentSpawnRunMock,
+      listSubagentRunsForRequesterMock: hoisted.listSubagentRunsForRequesterMock,
       emitSessionLifecycleEventMock: hoisted.emitSessionLifecycleEventMock,
       resolveAgentConfig: hoisted.resolveAgentConfigMock,
       resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
@@ -81,6 +89,10 @@ describe("spawnSubagentDirect seam flow", () => {
     hoisted.updateSessionStoreMock.mockReset();
     hoisted.pruneLegacyStoreKeysMock.mockReset();
     hoisted.registerSubagentRunMock.mockReset();
+    hoisted.armSubagentRunTimeoutMock.mockReset();
+    hoisted.releaseSubagentRunMock.mockReset();
+    hoisted.discardFailedSubagentSpawnRunMock.mockReset();
+    hoisted.listSubagentRunsForRequesterMock.mockReset().mockReturnValue([]);
     hoisted.emitSessionLifecycleEventMock.mockReset();
     hoisted.resolveAgentConfigMock.mockReset();
     hoisted.resolveAgentConfigMock.mockImplementation(
@@ -178,15 +190,21 @@ describe("spawnSubagentDirect seam flow", () => {
     const operations: string[] = [];
     let persistedStore: Record<string, Record<string, unknown>> | undefined;
 
-    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
-      operations.push(`gateway:${request.method ?? "unknown"}`);
-      if (request.method === "agent") {
-        return { runId: "run-1" };
-      }
-      if (request.method?.startsWith("sessions.")) {
-        return { ok: true };
-      }
-      return {};
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: { method?: string; params?: { idempotencyKey?: string } }) => {
+        operations.push(`gateway:${request.method ?? "unknown"}`);
+        if (request.method === "agent") {
+          return { runId: request.params?.idempotencyKey ?? "run-1" };
+        }
+        if (request.method?.startsWith("sessions.")) {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
+    hoisted.registerSubagentRunMock.mockImplementation((record: unknown) => {
+      operations.push("register");
+      return record;
     });
     installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
       operations,
@@ -211,7 +229,7 @@ describe("spawnSubagentDirect seam flow", () => {
     );
 
     expect(result.status).toBe("accepted");
-    expect(result.runId).toBe("run-1");
+    expect(result.runId).toEqual(expect.any(String));
     expect(result.mode).toBe("run");
     expect(result.modelApplied).toBe(true);
     expect(result.childSessionKey).toMatch(/^agent:main:subagent:/);
@@ -221,7 +239,7 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(hoisted.updateSessionStoreMock).toHaveBeenCalledTimes(3);
     const registerInput = firstRegisteredSubagentRun();
     const requesterOrigin = requireRecord(registerInput.requesterOrigin);
-    expect(registerInput.runId).toBe("run-1");
+    expect(registerInput.runId).toBe(result.runId);
     expect(registerInput.childSessionKey).toBe(childSessionKey);
     expect(registerInput.requesterSessionKey).toBe("agent:main:main");
     expect(registerInput.requesterDisplayKey).toBe("agent:main:main");
@@ -233,6 +251,7 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(registerInput.cleanup).toBe("keep");
     expect(registerInput.model).toBe("openai-codex/gpt-5.4");
     expect(registerInput.workspaceDir).toBe("/tmp/requester-workspace");
+    expect(operations.indexOf("register")).toBeLessThan(operations.indexOf("gateway:agent"));
     expect(registerInput.expectsCompletionMessage).toBe(true);
     expect(registerInput.spawnMode).toBe("run");
     expect(hoisted.emitSessionLifecycleEventMock).toHaveBeenCalledWith({
@@ -257,6 +276,126 @@ describe("spawnSubagentDirect seam flow", () => {
     const agentParams = requireRecord(agentRequest.params);
     expect(agentParams.sessionKey).toBe(childSessionKey);
     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
+  });
+
+  it("preserves a terminal pre-registered run when the child agent RPC fails late", async () => {
+    let registeredRunId: string | undefined;
+    hoisted.registerSubagentRunMock.mockImplementation((record: unknown) => {
+      const run = requireRecord(record);
+      registeredRunId = typeof run.runId === "string" ? run.runId : undefined;
+      hoisted.listSubagentRunsForRequesterMock.mockReturnValue([
+        {
+          ...run,
+          endedAt: Date.parse("2026-03-24T12:00:08Z"),
+          outcome: { status: "timeout" },
+        },
+      ]);
+      return record;
+    });
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent") {
+        throw new Error("late child rpc failure");
+      }
+      if (request.method?.startsWith("sessions.")) {
+        return { ok: true };
+      }
+      return {};
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "preserve terminal timeout",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.runId).toBe(registeredRunId);
+    expect(hoisted.releaseSubagentRunMock).not.toHaveBeenCalled();
+    expect(gatewayRequestRecords().some((request) => request.method === "sessions.delete")).toBe(
+      false,
+    );
+  });
+
+  it("discards a pre-registered run without release semantics when the child agent RPC fails before acceptance", async () => {
+    let registeredRunId: string | undefined;
+    hoisted.registerSubagentRunMock.mockImplementation((record: unknown) => {
+      const run = requireRecord(record);
+      registeredRunId = typeof run.runId === "string" ? run.runId : undefined;
+      hoisted.listSubagentRunsForRequesterMock.mockReturnValue([run]);
+      return record;
+    });
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent") {
+        throw new Error("child rpc rejected before acceptance");
+      }
+      if (request.method?.startsWith("sessions.")) {
+        return { ok: true };
+      }
+      return {};
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "fail before acceptance",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.runId).toBe(registeredRunId);
+    expect(hoisted.discardFailedSubagentSpawnRunMock).toHaveBeenCalledWith(registeredRunId);
+    expect(hoisted.releaseSubagentRunMock).not.toHaveBeenCalled();
+    expect(gatewayRequestRecords().some((request) => request.method === "sessions.delete")).toBe(
+      true,
+    );
+  });
+
+  it("registers explicit run timeout before the child agent RPC returns", async () => {
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "arm timeout after accepted",
+        runTimeoutSeconds: 8,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const registerInput = firstRegisteredSubagentRun();
+    expect(registerInput.runTimeoutSeconds).toBe(8);
+    expect(hoisted.armSubagentRunTimeoutMock).toHaveBeenCalledWith({
+      runId: result.runId,
+      runTimeoutSeconds: 8,
+      startedAt: undefined,
+    });
+  });
+
+  it("keeps the child agent RPC alive through explicit timeout reconciliation", async () => {
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "long timeout fallback ordering",
+        runTimeoutSeconds: 120,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const agentRequest = gatewayRequest("agent");
+    expect(agentRequest.timeoutMs).toBe(140_000);
   });
 
   it("keeps controller ownership separate from completion ownership", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -108,6 +108,7 @@ function resolveConfiguredAgentIds(cfg: OpenClawConfig): string[] {
 
 type SubagentSpawnDeps = {
   callGateway: typeof callGateway;
+  createRunId: () => string;
   forkSessionFromParent: typeof forkSessionFromParent;
   getGlobalHookRunner: () => SubagentLifecycleHookRunner | null;
   getRuntimeConfig: typeof getRuntimeConfig;
@@ -119,6 +120,7 @@ type SubagentSpawnDeps = {
 
 const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
   callGateway,
+  createRunId: () => crypto.randomUUID(),
   forkSessionFromParent,
   getGlobalHookRunner,
   getRuntimeConfig,
@@ -1174,7 +1176,7 @@ export async function spawnSubagentDirect(
 
   // Gateway agent runs use the idempotency key as runId. Register before the
   // child RPC so first-turn hangs are covered by the registry timeout deadline.
-  const childIdem = crypto.randomUUID();
+  const childIdem = subagentSpawnDeps.createRunId();
   let childRunId: string = childIdem;
   const deliverInitialChildRunDirectly =
     requestThreadBinding && spawnMode === "session" && hasBoundThreadDeliveryOrigin;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1321,69 +1321,68 @@ export async function spawnSubagentDirect(
         childSessionKey,
         runId: childRunId,
       };
-    } else {
-      discardFailedSubagentSpawnRun(childRunId);
-      await rollbackPreparedContextEngine(contextEnginePreparation);
-      if (attachmentAbsDir) {
-        try {
-          await fs.rm(attachmentAbsDir, { recursive: true, force: true });
-        } catch {
-          // Best-effort cleanup only.
-        }
-      }
-      let emitLifecycleHooks = false;
-      if (threadBindingReady) {
-        const hasEndedHook = hookRunner?.hasHooks("subagent_ended") === true;
-        let endedHookEmitted = false;
-        if (hasEndedHook) {
-          try {
-            await hookRunner?.runSubagentEnded(
-              {
-                targetSessionKey: childSessionKey,
-                targetKind: "subagent",
-                reason: "spawn-failed",
-                sendFarewell: true,
-                accountId: childSessionOrigin?.accountId,
-                runId: childRunId,
-                outcome: "error",
-                error: "Session failed to start",
-              },
-              {
-                runId: childRunId,
-                childSessionKey,
-                requesterSessionKey: requesterInternalKey,
-              },
-            );
-            endedHookEmitted = true;
-          } catch {
-            // Spawn should still return an actionable error even if cleanup hooks fail.
-          }
-        }
-        emitLifecycleHooks = !endedHookEmitted;
-      }
-      // Always delete the provisional child session after a failed spawn attempt.
-      // If we already emitted subagent_ended above, suppress a duplicate lifecycle hook.
-      try {
-        await callSubagentGateway({
-          method: "sessions.delete",
-          params: {
-            key: childSessionKey,
-            deleteTranscript: true,
-            emitLifecycleHooks,
-          },
-          timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
-        });
-      } catch {
-        // Best-effort only.
-      }
-      const messageText = summarizeError(err);
-      return {
-        status: "error",
-        error: messageText,
-        childSessionKey,
-        runId: childRunId,
-      };
     }
+    discardFailedSubagentSpawnRun(childRunId);
+    await rollbackPreparedContextEngine(contextEnginePreparation);
+    if (attachmentAbsDir) {
+      try {
+        await fs.rm(attachmentAbsDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+    let emitLifecycleHooks = false;
+    if (threadBindingReady) {
+      const hasEndedHook = hookRunner?.hasHooks("subagent_ended") === true;
+      let endedHookEmitted = false;
+      if (hasEndedHook) {
+        try {
+          await hookRunner?.runSubagentEnded(
+            {
+              targetSessionKey: childSessionKey,
+              targetKind: "subagent",
+              reason: "spawn-failed",
+              sendFarewell: true,
+              accountId: childSessionOrigin?.accountId,
+              runId: childRunId,
+              outcome: "error",
+              error: "Session failed to start",
+            },
+            {
+              runId: childRunId,
+              childSessionKey,
+              requesterSessionKey: requesterInternalKey,
+            },
+          );
+          endedHookEmitted = true;
+        } catch {
+          // Spawn should still return an actionable error even if cleanup hooks fail.
+        }
+      }
+      emitLifecycleHooks = !endedHookEmitted;
+    }
+    // Always delete the provisional child session after a failed spawn attempt.
+    // If we already emitted subagent_ended above, suppress a duplicate lifecycle hook.
+    try {
+      await callSubagentGateway({
+        method: "sessions.delete",
+        params: {
+          key: childSessionKey,
+          deleteTranscript: true,
+          emitLifecycleHooks,
+        },
+        timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
+      });
+    } catch {
+      // Best-effort only.
+    }
+    const messageText = summarizeError(err);
+    return {
+      status: "error",
+      error: messageText,
+      childSessionKey,
+      runId: childRunId,
+    };
   }
 
   if (hookRunner?.hasHooks("subagent_spawned")) {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1280,7 +1280,21 @@ export async function spawnSubagentDirect(
     ).find((entry) => entry.runId === childRunId);
     const runAlreadyTerminal =
       typeof registeredRun?.endedAt === "number" || registeredRun?.outcome != null;
-    if (!runAlreadyTerminal && runTimeoutSeconds > 0) {
+    if (runAlreadyTerminal) {
+      // Once registry cleanup/announcement wins, a late RPC response must not
+      // re-open the child as accepted without a live completion waiter.
+      const terminalStatus = registeredRun?.outcome?.status;
+      return {
+        status: "error",
+        error:
+          terminalStatus === "timeout"
+            ? "Subagent run timed out before the child agent acceptance was observed."
+            : "Subagent run completed before the child agent acceptance was observed.",
+        childSessionKey,
+        runId: childRunId,
+      };
+    }
+    if (runTimeoutSeconds > 0) {
       armSubagentRunTimeout({
         runId: childRunId,
         runTimeoutSeconds,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1295,8 +1295,18 @@ export async function spawnSubagentDirect(
     const runAlreadyTerminal =
       typeof registeredRun?.endedAt === "number" || registeredRun?.outcome != null;
     if (runAlreadyTerminal) {
-      // The registry timeout won while the child RPC was still unwinding.
-      // Preserve that terminal result instead of turning it into a late spawn failure.
+      // The registry timeout can win while the child RPC is still unwinding,
+      // but without an accepted RPC response this must not look like a spawned child.
+      const terminalStatus = registeredRun?.outcome?.status;
+      return {
+        status: "error",
+        error:
+          terminalStatus === "timeout"
+            ? "Subagent run timed out before the child agent accepted the request."
+            : "Subagent run completed before the child agent accepted the request.",
+        childSessionKey,
+        runId: childRunId,
+      };
     } else {
       discardFailedSubagentSpawnRun(childRunId);
       await rollbackPreparedContextEngine(contextEnginePreparation);

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -41,6 +41,7 @@ import {
   discardFailedSubagentSpawnRun,
   listSubagentRunsForRequester,
   registerSubagentRun,
+  startSubagentRunCompletionWait,
 } from "./subagent-registry.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
 import { resolveSubagentSpawnOwnership } from "./subagent-spawn-ownership.js";
@@ -1205,6 +1206,7 @@ export async function spawnSubagentDirect(
       attachmentsDir: attachmentAbsDir,
       attachmentsRootDir: attachmentRootDir,
       retainAttachmentsOnKeep: retainOnSessionKeep,
+      deferCompletionWait: true,
     });
   } catch (err) {
     await rollbackPreparedContextEngine(contextEnginePreparation);
@@ -1285,6 +1287,7 @@ export async function spawnSubagentDirect(
         startedAt: readGatewayAcceptedAt(response),
       });
     }
+    startSubagentRunCompletionWait(childRunId);
   } catch (err) {
     const registeredRun = listSubagentRunsForRequester(
       ownership.completionRequesterSessionKey,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -34,11 +34,19 @@ import {
 import { resolveSubagentCapabilities } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
-import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
+import {
+  SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS,
+  armSubagentRunTimeout,
+  countActiveRunsForSession,
+  discardFailedSubagentSpawnRun,
+  listSubagentRunsForRequester,
+  registerSubagentRun,
+} from "./subagent-registry.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
 import { resolveSubagentSpawnOwnership } from "./subagent-spawn-ownership.js";
 import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
 import { normalizeSubagentTaskName } from "./subagent-task-name.js";
+import { MAX_AGENT_TIMEOUT_MS } from "./timeout.js";
 export {
   SUBAGENT_SPAWN_ACCEPTED_NOTE,
   SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE,
@@ -123,7 +131,7 @@ const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
 let subagentSpawnDeps: SubagentSpawnDeps = defaultSubagentSpawnDeps;
 const SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS = 60_000;
 const DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS = 60_000;
-const MAX_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS = 300_000;
+const SUBAGENT_AGENT_RPC_SETTLE_AFTER_TIMEOUT_MS = 5_000;
 
 export type SpawnSubagentParams = {
   task: string;
@@ -214,14 +222,6 @@ async function callSubagentGateway(
   });
 }
 
-function readGatewayRunId(response: Awaited<ReturnType<typeof callGateway>>): string | undefined {
-  if (!response || typeof response !== "object") {
-    return undefined;
-  }
-  const { runId } = response as { runId?: unknown };
-  return typeof runId === "string" && runId ? runId : undefined;
-}
-
 function resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds: number): number {
   const runTimeoutMs =
     Number.isFinite(runTimeoutSeconds) && runTimeoutSeconds > 0
@@ -230,10 +230,27 @@ function resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds: number): number
   if (runTimeoutMs <= 0) {
     return DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS;
   }
+  const gatewayTimeoutMs =
+    runTimeoutMs +
+    SUBAGENT_RUN_TIMEOUT_RECONCILIATION_GRACE_MS +
+    SUBAGENT_AGENT_RPC_SETTLE_AFTER_TIMEOUT_MS;
+  // The child RPC must outlive the registry's explicit run-timeout fallback;
+  // otherwise a hung first turn can be released as a spawn failure before its
+  // authoritative timeout settles.
   return Math.min(
-    MAX_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS,
-    Math.max(DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS, runTimeoutMs + 5_000),
+    MAX_AGENT_TIMEOUT_MS,
+    Math.max(DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS, gatewayTimeoutMs),
   );
+}
+
+function readGatewayAcceptedAt(
+  response: Awaited<ReturnType<typeof callGateway>>,
+): number | undefined {
+  if (!response || typeof response !== "object") {
+    return undefined;
+  }
+  const { acceptedAt } = response as { acceptedAt?: unknown };
+  return typeof acceptedAt === "number" && Number.isFinite(acceptedAt) ? acceptedAt : undefined;
 }
 
 function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<SessionEntry> {
@@ -1155,6 +1172,8 @@ export async function spawnSubagentDirect(
   }
   const contextEnginePreparation = contextEnginePrepareResult.preparation;
 
+  // Gateway agent runs use the idempotency key as runId. Register before the
+  // child RPC so first-turn hangs are covered by the registry timeout deadline.
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
   const deliverInitialChildRunDirectly =
@@ -1162,109 +1181,6 @@ export async function spawnSubagentDirect(
   const shouldAnnounceCompletion = deliverInitialChildRunDirectly
     ? false
     : expectsCompletionMessage;
-  try {
-    const {
-      spawnedBy: _spawnedBy,
-      workspaceDir: _workspaceDir,
-      ...publicSpawnedMetadata
-    } = spawnedMetadata;
-    const response = await callSubagentGateway({
-      method: "agent",
-      params: {
-        message: childTaskMessage,
-        sessionKey: childSessionKey,
-        channel: childSessionOrigin?.channel,
-        to: childSessionOrigin?.to ?? undefined,
-        accountId: childSessionOrigin?.accountId ?? undefined,
-        threadId:
-          childSessionOrigin?.threadId != null
-            ? stringifyRouteThreadId(childSessionOrigin.threadId)
-            : undefined,
-        idempotencyKey: childIdem,
-        deliver: deliverInitialChildRunDirectly,
-        lane: AGENT_LANE_SUBAGENT,
-        disableMessageTool: true,
-        cleanupBundleMcpOnRunEnd: spawnMode !== "session",
-        extraSystemPrompt: childSystemPrompt,
-        thinking: thinkingOverride,
-        timeout: runTimeoutSeconds,
-        label: label || undefined,
-        ...(bootstrapContextMode
-          ? {
-              bootstrapContextMode,
-              bootstrapContextRunKind: "default" as const,
-            }
-          : {}),
-        ...publicSpawnedMetadata,
-      },
-      timeoutMs: resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds),
-    });
-    const runId = readGatewayRunId(response);
-    if (runId) {
-      childRunId = runId;
-    }
-  } catch (err) {
-    await rollbackPreparedContextEngine(contextEnginePreparation);
-    if (attachmentAbsDir) {
-      try {
-        await fs.rm(attachmentAbsDir, { recursive: true, force: true });
-      } catch {
-        // Best-effort cleanup only.
-      }
-    }
-    let emitLifecycleHooks = false;
-    if (threadBindingReady) {
-      const hasEndedHook = hookRunner?.hasHooks("subagent_ended") === true;
-      let endedHookEmitted = false;
-      if (hasEndedHook) {
-        try {
-          await hookRunner?.runSubagentEnded(
-            {
-              targetSessionKey: childSessionKey,
-              targetKind: "subagent",
-              reason: "spawn-failed",
-              sendFarewell: true,
-              accountId: childSessionOrigin?.accountId,
-              runId: childRunId,
-              outcome: "error",
-              error: "Session failed to start",
-            },
-            {
-              runId: childRunId,
-              childSessionKey,
-              requesterSessionKey: requesterInternalKey,
-            },
-          );
-          endedHookEmitted = true;
-        } catch {
-          // Spawn should still return an actionable error even if cleanup hooks fail.
-        }
-      }
-      emitLifecycleHooks = !endedHookEmitted;
-    }
-    // Always delete the provisional child session after a failed spawn attempt.
-    // If we already emitted subagent_ended above, suppress a duplicate lifecycle hook.
-    try {
-      await callSubagentGateway({
-        method: "sessions.delete",
-        params: {
-          key: childSessionKey,
-          deleteTranscript: true,
-          emitLifecycleHooks,
-        },
-        timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
-      });
-    } catch {
-      // Best-effort only.
-    }
-    const messageText = summarizeError(err);
-    return {
-      status: "error",
-      error: messageText,
-      childSessionKey,
-      runId: childRunId,
-    };
-  }
 
   try {
     registerSubagentRun({
@@ -1316,6 +1232,129 @@ export async function spawnSubagentDirect(
       childSessionKey,
       runId: childRunId,
     };
+  }
+
+  try {
+    const {
+      spawnedBy: _spawnedBy,
+      workspaceDir: _workspaceDir,
+      ...publicSpawnedMetadata
+    } = spawnedMetadata;
+    const response = await callSubagentGateway({
+      method: "agent",
+      params: {
+        message: childTaskMessage,
+        sessionKey: childSessionKey,
+        channel: childSessionOrigin?.channel,
+        to: childSessionOrigin?.to ?? undefined,
+        accountId: childSessionOrigin?.accountId ?? undefined,
+        threadId:
+          childSessionOrigin?.threadId != null
+            ? stringifyRouteThreadId(childSessionOrigin.threadId)
+            : undefined,
+        idempotencyKey: childIdem,
+        deliver: deliverInitialChildRunDirectly,
+        lane: AGENT_LANE_SUBAGENT,
+        disableMessageTool: true,
+        cleanupBundleMcpOnRunEnd: spawnMode !== "session",
+        extraSystemPrompt: childSystemPrompt,
+        thinking: thinkingOverride,
+        timeout: runTimeoutSeconds,
+        label: label || undefined,
+        ...(bootstrapContextMode
+          ? {
+              bootstrapContextMode,
+              bootstrapContextRunKind: "default" as const,
+            }
+          : {}),
+        ...publicSpawnedMetadata,
+      },
+      timeoutMs: resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds),
+    });
+    const registeredRun = listSubagentRunsForRequester(
+      ownership.completionRequesterSessionKey,
+    ).find((entry) => entry.runId === childRunId);
+    const runAlreadyTerminal =
+      typeof registeredRun?.endedAt === "number" || registeredRun?.outcome != null;
+    if (!runAlreadyTerminal && runTimeoutSeconds > 0) {
+      armSubagentRunTimeout({
+        runId: childRunId,
+        runTimeoutSeconds,
+        startedAt: readGatewayAcceptedAt(response),
+      });
+    }
+  } catch (err) {
+    const registeredRun = listSubagentRunsForRequester(
+      ownership.completionRequesterSessionKey,
+    ).find((entry) => entry.runId === childRunId);
+    const runAlreadyTerminal =
+      typeof registeredRun?.endedAt === "number" || registeredRun?.outcome != null;
+    if (runAlreadyTerminal) {
+      // The registry timeout won while the child RPC was still unwinding.
+      // Preserve that terminal result instead of turning it into a late spawn failure.
+    } else {
+      discardFailedSubagentSpawnRun(childRunId);
+      await rollbackPreparedContextEngine(contextEnginePreparation);
+      if (attachmentAbsDir) {
+        try {
+          await fs.rm(attachmentAbsDir, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup only.
+        }
+      }
+      let emitLifecycleHooks = false;
+      if (threadBindingReady) {
+        const hasEndedHook = hookRunner?.hasHooks("subagent_ended") === true;
+        let endedHookEmitted = false;
+        if (hasEndedHook) {
+          try {
+            await hookRunner?.runSubagentEnded(
+              {
+                targetSessionKey: childSessionKey,
+                targetKind: "subagent",
+                reason: "spawn-failed",
+                sendFarewell: true,
+                accountId: childSessionOrigin?.accountId,
+                runId: childRunId,
+                outcome: "error",
+                error: "Session failed to start",
+              },
+              {
+                runId: childRunId,
+                childSessionKey,
+                requesterSessionKey: requesterInternalKey,
+              },
+            );
+            endedHookEmitted = true;
+          } catch {
+            // Spawn should still return an actionable error even if cleanup hooks fail.
+          }
+        }
+        emitLifecycleHooks = !endedHookEmitted;
+      }
+      // Always delete the provisional child session after a failed spawn attempt.
+      // If we already emitted subagent_ended above, suppress a duplicate lifecycle hook.
+      try {
+        await callSubagentGateway({
+          method: "sessions.delete",
+          params: {
+            key: childSessionKey,
+            deleteTranscript: true,
+            emitLifecycleHooks,
+          },
+          timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
+        });
+      } catch {
+        // Best-effort only.
+      }
+      const messageText = summarizeError(err);
+      return {
+        status: "error",
+        error: messageText,
+        childSessionKey,
+        runId: childRunId,
+      };
+    }
   }
 
   if (hookRunner?.hasHooks("subagent_spawned")) {

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -108,6 +108,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
       getRuntimeConfig: () => hoisted.configOverride,
       registerSubagentRunMock: hoisted.registerSubagentRunMock,
       hookRunner: hoisted.hookRunner,
+      createRunIdMock: () => "run-thread-register-fail",
       resolveAgentConfig: resolveTestAgentConfig,
       resolveAgentWorkspaceDir: resolveTestAgentWorkspace,
       resolveSandboxRuntimeStatus: hoisted.resolveSandboxRuntimeStatusMock,
@@ -314,7 +315,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     expect(result.status).toBe("error");
     expect(result.error).toBe("spawn startup failed");
     expect(result.childSessionKey).toMatch(/^agent:main:subagent:/);
-    expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
 
     const deleteCall = findLastSessionDeleteCall();
     expect(deleteCall?.params?.key).toBe(result.childSessionKey);

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -19,12 +19,16 @@ type TestConfig = {
   };
 };
 
+type SubagentRunRecord = ReturnType<
+  typeof import("./subagent-registry.js").listSubagentRunsForRequester
+>[number];
+
 const hoisted = vi.hoisted(() => ({
   callGatewayMock: vi.fn(),
   configOverride: {} as Record<string, unknown>,
   registerSubagentRunMock: vi.fn(),
   startSubagentRunCompletionWaitMock: vi.fn(),
-  listSubagentRunsForRequesterMock: vi.fn(() => []),
+  listSubagentRunsForRequesterMock: vi.fn<() => SubagentRunRecord[]>(() => []),
   resolveSandboxRuntimeStatusMock: vi.fn<
     (params: { sessionKey?: string }) => { sandboxed: boolean }
   >(() => ({ sandboxed: false })),
@@ -82,6 +86,20 @@ function findLastSessionDeleteCall() {
         };
       }
     | undefined;
+}
+
+function createTerminalTimeoutRun(runId: string): SubagentRunRecord {
+  return {
+    runId,
+    childSessionKey: "agent:main:subagent:child",
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "timeout before child acceptance",
+    cleanup: "keep",
+    createdAt: 0,
+    endedAt: 1000,
+    outcome: { status: "timeout" },
+  };
 }
 
 async function expectAcceptedWorkspace(params: { agentId: string; expectedWorkspaceDir: string }) {
@@ -336,11 +354,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
 
   it("reports a pre-acceptance registry timeout as a spawn error", async () => {
     hoisted.listSubagentRunsForRequesterMock.mockReturnValue([
-      {
-        runId: "run-thread-register-fail",
-        endedAt: 1000,
-        outcome: { status: "timeout" },
-      },
+      createTerminalTimeoutRun("run-thread-register-fail"),
     ]);
     hoisted.callGatewayMock.mockImplementation(
       async (request: {
@@ -386,11 +400,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
 
   it("does not report accepted when the registry timed out before acceptance was observed", async () => {
     hoisted.listSubagentRunsForRequesterMock.mockReturnValue([
-      {
-        runId: "run-thread-register-fail",
-        endedAt: 1000,
-        outcome: { status: "timeout" },
-      },
+      createTerminalTimeoutRun("run-thread-register-fail"),
     ]);
     hoisted.callGatewayMock.mockImplementation(
       async (request: {
@@ -413,7 +423,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     const result = await spawnSubagentDirect(
       {
         task: "accepted after provisional timeout",
-        timeout: 8,
+        runTimeoutSeconds: 8,
       },
       {
         agentSessionKey: "agent:main:main",

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -24,6 +24,7 @@ const hoisted = vi.hoisted(() => ({
   configOverride: {} as Record<string, unknown>,
   registerSubagentRunMock: vi.fn(),
   startSubagentRunCompletionWaitMock: vi.fn(),
+  listSubagentRunsForRequesterMock: vi.fn(() => []),
   resolveSandboxRuntimeStatusMock: vi.fn<
     (params: { sessionKey?: string }) => { sandboxed: boolean }
   >(() => ({ sandboxed: false })),
@@ -111,6 +112,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
       getRuntimeConfig: () => hoisted.configOverride,
       registerSubagentRunMock: hoisted.registerSubagentRunMock,
       startSubagentRunCompletionWaitMock: hoisted.startSubagentRunCompletionWaitMock,
+      listSubagentRunsForRequesterMock: hoisted.listSubagentRunsForRequesterMock,
       hookRunner: hoisted.hookRunner,
       createRunIdMock: () => "run-thread-register-fail",
       resolveAgentConfig: resolveTestAgentConfig,
@@ -125,6 +127,8 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     hoisted.callGatewayMock.mockClear();
     hoisted.registerSubagentRunMock.mockClear();
     hoisted.startSubagentRunCompletionWaitMock.mockClear();
+    hoisted.listSubagentRunsForRequesterMock.mockReset();
+    hoisted.listSubagentRunsForRequesterMock.mockReturnValue([]);
     hoisted.resolveSandboxRuntimeStatusMock.mockReset();
     hoisted.resolveSandboxRuntimeStatusMock.mockImplementation(() => ({ sandboxed: false }));
     hoisted.hookRunner.hasHooks.mockReset();
@@ -328,6 +332,56 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     expect(deleteCall?.params?.key).toBe(result.childSessionKey);
     expect(deleteCall?.params?.deleteTranscript).toBe(true);
     expect(deleteCall?.params?.emitLifecycleHooks).toBe(false);
+  });
+
+  it("reports a pre-acceptance registry timeout as a spawn error", async () => {
+    hoisted.listSubagentRunsForRequesterMock.mockReturnValue([
+      {
+        runId: "run-thread-register-fail",
+        endedAt: 1000,
+        outcome: { status: "timeout" },
+      },
+    ]);
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: {
+        method?: string;
+        params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
+      }) => {
+        if (request.method === "sessions.patch") {
+          return { ok: true };
+        }
+        if (request.method === "agent") {
+          throw new Error("gateway task timed out");
+        }
+        if (request.method === "sessions.delete") {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "timeout before child accepts",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "acct-1",
+        agentTo: "user-1",
+        workspaceDir: "/tmp/requester-workspace",
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe(
+      "Subagent run timed out before the child agent accepted the request.",
+    );
+    expect(result.runId).toBe("run-thread-register-fail");
+    expect(result.childSessionKey).toMatch(/^agent:main:subagent:/);
+    expect(getRegisteredRun()?.deferCompletionWait).toBe(true);
+    expect(hoisted.startSubagentRunCompletionWaitMock).not.toHaveBeenCalled();
+    expect(findLastSessionDeleteCall()).toBeUndefined();
   });
 
   it("keeps lifecycle hooks enabled when registerSubagentRun fails after thread binding succeeds", async () => {

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -23,6 +23,7 @@ const hoisted = vi.hoisted(() => ({
   callGatewayMock: vi.fn(),
   configOverride: {} as Record<string, unknown>,
   registerSubagentRunMock: vi.fn(),
+  startSubagentRunCompletionWaitMock: vi.fn(),
   resolveSandboxRuntimeStatusMock: vi.fn<
     (params: { sessionKey?: string }) => { sandboxed: boolean }
   >(() => ({ sandboxed: false })),
@@ -99,6 +100,8 @@ async function expectAcceptedWorkspace(params: { agentId: string; expectedWorksp
 
   expect(result.status).toBe("accepted");
   expect(getRegisteredRun()?.workspaceDir).toBe(params.expectedWorkspaceDir);
+  expect(getRegisteredRun()?.deferCompletionWait).toBe(true);
+  expect(hoisted.startSubagentRunCompletionWaitMock).toHaveBeenCalledWith(result.runId);
 }
 
 describe("spawnSubagentDirect workspace inheritance", () => {
@@ -107,6 +110,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
       callGatewayMock: hoisted.callGatewayMock,
       getRuntimeConfig: () => hoisted.configOverride,
       registerSubagentRunMock: hoisted.registerSubagentRunMock,
+      startSubagentRunCompletionWaitMock: hoisted.startSubagentRunCompletionWaitMock,
       hookRunner: hoisted.hookRunner,
       createRunIdMock: () => "run-thread-register-fail",
       resolveAgentConfig: resolveTestAgentConfig,
@@ -120,6 +124,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     resetSubagentRegistryForTests();
     hoisted.callGatewayMock.mockClear();
     hoisted.registerSubagentRunMock.mockClear();
+    hoisted.startSubagentRunCompletionWaitMock.mockClear();
     hoisted.resolveSandboxRuntimeStatusMock.mockReset();
     hoisted.resolveSandboxRuntimeStatusMock.mockImplementation(() => ({ sandboxed: false }));
     hoisted.hookRunner.hasHooks.mockReset();
@@ -316,6 +321,8 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     expect(result.error).toBe("spawn startup failed");
     expect(result.childSessionKey).toMatch(/^agent:main:subagent:/);
     expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
+    expect(getRegisteredRun()?.deferCompletionWait).toBe(true);
+    expect(hoisted.startSubagentRunCompletionWaitMock).not.toHaveBeenCalled();
 
     const deleteCall = findLastSessionDeleteCall();
     expect(deleteCall?.params?.key).toBe(result.childSessionKey);
@@ -370,6 +377,8 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     expect(result.error).toBe("Failed to register subagent run: registry unavailable");
     expect(result.childSessionKey).toMatch(/^agent:main:subagent:/);
     expect(result.runId).toBe("run-thread-register-fail");
+    expect(getRegisteredRun()?.deferCompletionWait).toBe(true);
+    expect(hoisted.startSubagentRunCompletionWaitMock).not.toHaveBeenCalled();
 
     const deleteCall = findLastSessionDeleteCall();
     expect(deleteCall?.params?.key).toBe(result.childSessionKey);

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -384,6 +384,57 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     expect(findLastSessionDeleteCall()).toBeUndefined();
   });
 
+  it("does not report accepted when the registry timed out before acceptance was observed", async () => {
+    hoisted.listSubagentRunsForRequesterMock.mockReturnValue([
+      {
+        runId: "run-thread-register-fail",
+        endedAt: 1000,
+        outcome: { status: "timeout" },
+      },
+    ]);
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: {
+        method?: string;
+        params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
+      }) => {
+        if (request.method === "sessions.patch") {
+          return { ok: true };
+        }
+        if (request.method === "agent") {
+          return { runId: "run-thread-register-fail", status: "accepted", acceptedAt: 5000 };
+        }
+        if (request.method === "sessions.delete") {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "accepted after provisional timeout",
+        timeout: 8,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "acct-1",
+        agentTo: "user-1",
+        workspaceDir: "/tmp/requester-workspace",
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe(
+      "Subagent run timed out before the child agent acceptance was observed.",
+    );
+    expect(result.runId).toBe("run-thread-register-fail");
+    expect(result.childSessionKey).toMatch(/^agent:main:subagent:/);
+    expect(getRegisteredRun()?.deferCompletionWait).toBe(true);
+    expect(hoisted.startSubagentRunCompletionWaitMock).not.toHaveBeenCalled();
+    expect(findLastSessionDeleteCall()).toBeUndefined();
+  });
+
   it("keeps lifecycle hooks enabled when registerSubagentRun fails after thread binding succeeds", async () => {
     hoisted.hookRunner.hasHooks.mockImplementation((name?: string) => name === "subagent_spawning");
     hoisted.hookRunner.runSubagentSpawning.mockResolvedValue({

--- a/src/agents/test-helpers/subagent-gateway.ts
+++ b/src/agents/test-helpers/subagent-gateway.ts
@@ -3,7 +3,18 @@ export function installAcceptedSubagentGatewayMock(mock: {
     impl: (opts: { method?: string; params?: unknown }) => Promise<unknown>,
   ) => unknown;
 }) {
-  mock.mockImplementation(async ({ method }) =>
-    method === "agent" ? { runId: "run-1" } : method?.startsWith("sessions.") ? { ok: true } : {},
-  );
+  mock.mockImplementation(async ({ method, params }) => {
+    if (method === "agent") {
+      const runId =
+        params &&
+        typeof params === "object" &&
+        "idempotencyKey" in params &&
+        typeof params.idempotencyKey === "string" &&
+        params.idempotencyKey.trim()
+          ? params.idempotencyKey
+          : "run-1";
+      return { runId };
+    }
+    return method?.startsWith("sessions.") ? { ok: true } : {};
+  });
 }

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { clampTimerTimeoutMs, MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
+export const MAX_AGENT_TIMEOUT_MS = MAX_TIMER_TIMEOUT_MS;
 
 const normalizeNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;
@@ -22,7 +23,7 @@ export function resolveAgentTimeoutMs(opts: {
   const clampTimeoutMs = (valueMs: number) => clampTimerTimeoutMs(valueMs, minMs) ?? minMs;
   const defaultMs = clampTimeoutMs(resolveAgentTimeoutSeconds(opts.cfg) * 1000);
   // Use the maximum timer-safe timeout to represent "no timeout" when explicitly set to 0.
-  const NO_TIMEOUT_MS = MAX_TIMER_TIMEOUT_MS;
+  const NO_TIMEOUT_MS = MAX_AGENT_TIMEOUT_MS;
   const overrideMs = normalizeNumber(opts.overrideMs);
   if (overrideMs !== undefined) {
     if (overrideMs === 0) {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -1,3 +1,4 @@
+import type { AgentRunTimeoutPhase } from "../agents/run-timeout-attribution.js";
 import type { ImageContent } from "../llm/types.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { UserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.js";
@@ -16,6 +17,11 @@ export type ModelSelectedContext = {
   provider: string;
   model: string;
   thinkLevel: string | undefined;
+};
+
+export type AgentRunTerminalMetadata = {
+  timeoutPhase?: AgentRunTimeoutPhase;
+  providerStarted?: boolean;
 };
 
 export type TypingPolicy =
@@ -57,6 +63,8 @@ export type GetReplyOptions = {
   imageOrder?: PromptImageOrderEntry[];
   /** Notifies when an agent run actually starts (useful for webchat command handling). */
   onAgentRunStart?: (runId: string) => void;
+  /** Carries terminal run metadata even when no visible reply payload is returned. */
+  onAgentRunTerminalMetadata?: (metadata: AgentRunTerminalMetadata) => void;
   /** Shared lifecycle owner for the current user-turn transcript append. */
   userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
   onReplyStart?: () => Promise<void> | void;

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -1,3 +1,4 @@
+import type { AgentRunTimeoutPhase } from "../agents/run-timeout-attribution.js";
 import type {
   InteractiveReply,
   MessagePresentation,
@@ -169,6 +170,9 @@ export type ReplyPayloadMetadata = {
   beforeAgentRunBlocked?: boolean;
   /** Warning synthesized from an observed tool error after the run produced assistant output. */
   nonTerminalToolErrorWarning?: boolean;
+  /** Terminal timeout attribution from the agent run that produced this payload. */
+  agentRunTimeoutPhase?: AgentRunTimeoutPhase;
+  agentRunProviderStarted?: boolean;
 };
 
 const replyPayloadMetadata = new WeakMap<object, ReplyPayloadMetadata>();

--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -33,7 +33,8 @@ vi.mock("../agents/model-selection.js", async () => {
     resolveModelRefFromString: vi.fn(() => null),
   };
 });
-vi.mock("../agents/timeout.js", () => ({
+vi.mock("../agents/timeout.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agents/timeout.js")>()),
   resolveAgentTimeoutMs: vi.fn(() => 60_000),
 }));
 vi.mock("../agents/workspace.js", () => ({

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -13,6 +13,10 @@ import {
 } from "../../agents/embedded-agent-runner/runs.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
+import {
+  normalizeAgentRunTimeoutPhase,
+  normalizeProviderStarted,
+} from "../../agents/run-timeout-attribution.js";
 import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
 import { enqueueCommitmentExtraction } from "../../commitments/runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -57,7 +61,7 @@ import {
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { AgentRunTerminalMetadata, GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildKnownAgentRunFailureReplyPayload,
   runAgentTurnWithFallback,
@@ -108,6 +112,37 @@ const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPayload[] {
   return payloads.map((payload) =>
     setReplyPayloadMetadata(payload, { beforeAgentRunBlocked: true }),
+  );
+}
+
+function readAgentRunTerminalMetadata(
+  meta: { timeoutPhase?: unknown; providerStarted?: unknown } | undefined,
+): AgentRunTerminalMetadata | undefined {
+  const timeoutPhase = normalizeAgentRunTimeoutPhase(meta?.timeoutPhase);
+  const providerStarted = normalizeProviderStarted(meta?.providerStarted);
+  if (!timeoutPhase && providerStarted === undefined) {
+    return undefined;
+  }
+  return {
+    ...(timeoutPhase ? { timeoutPhase } : {}),
+    ...(providerStarted !== undefined ? { providerStarted } : {}),
+  };
+}
+
+function markAgentRunTerminalMetadata(
+  payloads: ReplyPayload[],
+  metadata: AgentRunTerminalMetadata | undefined,
+): ReplyPayload[] {
+  if (!metadata) {
+    return payloads;
+  }
+  return payloads.map((payload) =>
+    setReplyPayloadMetadata(payload, {
+      ...(metadata.timeoutPhase ? { agentRunTimeoutPhase: metadata.timeoutPhase } : {}),
+      ...(metadata.providerStarted !== undefined
+        ? { agentRunProviderStarted: metadata.providerStarted }
+        : {}),
+    }),
   );
 }
 
@@ -1534,6 +1569,10 @@ export async function runReplyAgent(params: {
       }
     }
 
+    const runTerminalMetadata = readAgentRunTerminalMetadata(runResult.meta);
+    if (runTerminalMetadata) {
+      params.opts?.onAgentRunTerminalMetadata?.(runTerminalMetadata);
+    }
     const payloadArray = runResult.payloads ?? [];
 
     if (blockReplyPipeline) {
@@ -1772,7 +1811,10 @@ export async function runReplyAgent(params: {
       accountId: sessionCtx.AccountId,
       normalizeMediaPaths: replyMediaContext.normalizePayload,
     });
-    const { replyPayloads } = payloadResult;
+    const replyPayloads = markAgentRunTerminalMetadata(
+      payloadResult.replyPayloads,
+      runTerminalMetadata,
+    );
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
     const hasReplyPayloadBeyondFallbackNotice = replyPayloads.some(

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2350,6 +2350,7 @@ export async function dispatchReplyFromConfig(
             typingPolicy: typing.typingPolicy,
             suppressTyping: typing.suppressTyping,
             onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),
+            onAgentRunTerminalMetadata: params.replyOptions?.onAgentRunTerminalMetadata,
             onReasoningStream: wrapProgressCallback(params.replyOptions?.onReasoningStream),
             onReasoningEnd: wrapProgressCallback(params.replyOptions?.onReasoningEnd),
             onAssistantMessageStart: wrapProgressCallback(

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -24,7 +24,8 @@ vi.mock("../../agents/model-selection.js", async () => {
   };
 });
 
-vi.mock("../../agents/timeout.js", () => ({
+vi.mock("../../agents/timeout.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/timeout.js")>()),
   resolveAgentTimeoutMs: vi.fn(() => 60000),
 }));
 

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -1,5 +1,6 @@
 export type {
   BlockReplyContext,
+  AgentRunTerminalMetadata,
   GetReplyOptions,
   PartialReplyPayload,
   ReplyThreadingPolicy,

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -952,6 +952,188 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
+  it("marks non-streaming hard timeout Responses as failed", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "Request timed out before a response was generated." }],
+      meta: {
+        aborted: true,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      status?: string;
+      output?: Array<{ phase?: string; content?: Array<{ text?: string }> }>;
+    };
+    expect(json.status).toBe("failed");
+    expect(json.output?.[0]?.phase).toBe("commentary");
+    expect(json.output?.[0]?.content?.[0]?.text).toMatch(/timed out/i);
+  });
+
+  it("does not mark ordinary non-streaming aborted Responses as hard-timeout failures", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "Run was cancelled." }],
+      meta: {
+        aborted: true,
+        stopReason: "user",
+      },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      status?: string;
+      output?: Array<{ phase?: string; content?: Array<{ text?: string }> }>;
+    };
+    expect(json.status).toBe("completed");
+    expect(json.output?.[0]?.phase).toBe("final_answer");
+    expect(json.output?.[0]?.content?.[0]?.text).toBe("Run was cancelled.");
+  });
+
+  it("does not mark ordinary streaming aborted Responses as hard-timeout failures", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          aborted: true,
+          stopReason: "user",
+        },
+      });
+      return { payloads: [{ text: "Run was cancelled." }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const completed = findSseEvent(events, "response.completed");
+    const response = (
+      parseSseData(completed) as {
+        response?: { status?: string; output?: Array<{ phase?: string }> };
+      }
+    ).response;
+    expect(response?.status).toBe("completed");
+    expect(response?.output?.[0]?.phase).toBe("final_answer");
+  });
+
+  it("uses actionable text for streaming hard timeout Responses without lifecycle errors", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+      return {
+        payloads: [{ text: "Request timed out before a response was generated." }],
+        meta: {
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const completed = findSseEvent(events, "response.failed");
+    const response = (
+      parseSseData(completed) as {
+        response?: {
+          status?: string;
+          output?: Array<{ phase?: string; content?: Array<{ text?: string }> }>;
+        };
+      }
+    ).response;
+    expect(response?.status).toBe("failed");
+    expect(response?.output?.[0]?.phase).toBe("commentary");
+    expect(response?.output?.[0]?.content?.[0]?.text).toMatch(/timed out/i);
+  });
+
+  it("streams terminal hard timeout Responses before the agent command returns", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId ?? "";
+      setTimeout(() => {
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "end",
+            timeoutPhase: "post_turn",
+            providerStarted: true,
+          },
+        });
+      }, 0);
+      return await new Promise(() => {});
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const text = await Promise.race([
+      res.text(),
+      new Promise<string>((_, reject) =>
+        setTimeout(() => reject(new Error("stream hard timeout response did not finish")), 1_000),
+      ),
+    ]);
+    const events = parseSseEvents(text);
+    const completed = findSseEvent(events, "response.failed");
+    const response = (
+      parseSseData(completed) as {
+        response?: {
+          status?: string;
+          output?: Array<{ phase?: string; content?: Array<{ text?: string }> }>;
+        };
+      }
+    ).response;
+    expect(response?.status).toBe("failed");
+    expect(response?.output?.[0]?.phase).toBe("commentary");
+    expect(response?.output?.[0]?.content?.[0]?.text).toMatch(/timed out/i);
+  });
+
   it("preserves assistant text alongside non-stream function_call output", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -11,6 +11,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { isClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import type { ImageContent } from "../agents/command/types.js";
 import type { ClientToolDefinition } from "../agents/embedded-agent-runner/run/params.js";
+import { hasHardAgentRunTimeoutAttribution } from "../agents/run-timeout-attribution.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
@@ -705,6 +706,9 @@ export async function handleOpenResponsesHttpRequest(
       const usage = extractUsageFromResult(result);
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
+      const metaRecord =
+        meta && typeof meta === "object" ? (meta as { timeoutPhase?: unknown }) : null;
+      const failedRun = hasHardAgentRunTimeoutAttribution(metaRecord);
 
       // If the agent invoked client tools, return one `function_call`
       // output item per call (in arrival order) plus any assistant text the
@@ -765,12 +769,12 @@ export async function handleOpenResponsesHttpRequest(
       const response = createResponseResource({
         id: responseId,
         model,
-        status: "completed",
+        status: failedRun ? "failed" : "completed",
         output: [
           createAssistantOutputItem({
             id: outputItemId,
             text: content,
-            phase: "final_answer",
+            phase: failedRun ? "commentary" : "final_answer",
             status: "completed",
           }),
         ],
@@ -894,7 +898,10 @@ export async function handleOpenResponsesHttpRequest(
     });
 
     rememberResponseSession();
-    writeSseEvent(res, { type: "response.completed", response: finalResponse });
+    writeSseEvent(res, {
+      type: finalResponse.status === "failed" ? "response.failed" : "response.completed",
+      response: finalResponse,
+    });
     writeDone(res);
     res.end();
   };
@@ -975,8 +982,18 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        const finalText = accumulatedText || "No response from OpenClaw.";
-        const finalStatus = phase === "error" ? "failed" : "completed";
+        const errorText = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+        const hardTimeout = hasHardAgentRunTimeoutAttribution(evt.data);
+        const finalText =
+          accumulatedText ||
+          errorText ||
+          (hardTimeout
+            ? "Request timed out before a response was generated."
+            : "No response from OpenClaw.");
+        const finalStatus = phase === "error" || hardTimeout ? "failed" : "completed";
+        if (hardTimeout) {
+          finalUsage = finalUsage ?? createEmptyUsage();
+        }
         requestFinalize(finalStatus, finalText);
       }
     }

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -1,5 +1,6 @@
 import { AGENT_RUN_ABORTED_ERROR, isAbortedAgentStopReason } from "../../agents/run-termination.js";
 import {
+  isHardAgentRunTimeoutPhase,
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
   type AgentRunTimeoutPhase,
@@ -22,6 +23,7 @@ const AGENT_RUN_ERROR_RETRY_GRACE_MS = 15_000;
  * final success is about to arrive.
  */
 const AGENT_RUN_TIMEOUT_RETRY_GRACE_MS = 15_000;
+const MIN_COMPARABLE_EPOCH_MS = Date.parse("2000-01-01T00:00:00Z");
 
 const agentRunCache = new Map<string, AgentRunSnapshot>();
 const agentRunStarts = new Map<string, number>();
@@ -40,6 +42,8 @@ type AgentRunSnapshot = {
   livenessState?: string;
   yielded?: boolean;
   pendingError?: boolean;
+  hardTimeout?: boolean;
+  deferTimeoutSurface?: boolean;
   timeoutPhase?: AgentRunTimeoutPhase;
   providerStarted?: boolean;
   ts: number;
@@ -61,9 +65,30 @@ function pruneAgentRunCache(now = Date.now()) {
   }
 }
 
+function stripPendingOnlySnapshotFields(entry: AgentRunSnapshot): AgentRunSnapshot {
+  if (entry.deferTimeoutSurface !== true) {
+    return entry;
+  }
+  const { deferTimeoutSurface: _deferTimeoutSurface, ...publicEntry } = entry;
+  return publicEntry;
+}
+
 function recordAgentRunSnapshot(entry: AgentRunSnapshot) {
   pruneAgentRunCache(entry.ts);
-  agentRunCache.set(entry.runId, entry);
+  const existing = agentRunCache.get(entry.runId);
+  if (existing?.hardTimeout === true) {
+    if (entry.status === "timeout") {
+      agentRunCache.set(
+        entry.runId,
+        stripPendingOnlySnapshotFields(mergeHardTimeoutSnapshot(existing, entry)),
+      );
+      return;
+    }
+    if (shouldKeepHardTimeoutOverSnapshot(existing, entry)) {
+      return;
+    }
+  }
+  agentRunCache.set(entry.runId, stripPendingOnlySnapshotFields(entry));
 }
 
 function clearPendingAgentRunError(runId: string) {
@@ -100,8 +125,31 @@ function schedulePendingAgentRunError(snapshot: AgentRunSnapshot) {
   pendingAgentRunErrors.set(snapshot.runId, { snapshot, dueAt, timer });
 }
 
+function mergeHardTimeoutSnapshot(
+  existing: AgentRunSnapshot,
+  snapshot: AgentRunSnapshot,
+): AgentRunSnapshot {
+  return {
+    ...existing,
+    error: existing.error ?? snapshot.error,
+    stopReason: existing.stopReason ?? snapshot.stopReason,
+    livenessState: existing.livenessState ?? snapshot.livenessState,
+    yielded: existing.yielded ?? snapshot.yielded,
+    pendingError: existing.pendingError ?? snapshot.pendingError,
+    timeoutPhase: existing.timeoutPhase ?? snapshot.timeoutPhase,
+    providerStarted: existing.providerStarted ?? snapshot.providerStarted,
+    hardTimeout: true,
+    deferTimeoutSurface: existing.deferTimeoutSurface === true,
+  };
+}
+
 function schedulePendingAgentRunTimeout(snapshot: AgentRunSnapshot) {
   clearPendingAgentRunError(snapshot.runId);
+  const existing = pendingAgentRunTimeouts.get(snapshot.runId);
+  if (existing?.snapshot.hardTimeout === true) {
+    existing.snapshot = mergeHardTimeoutSnapshot(existing.snapshot, snapshot);
+    return;
+  }
   clearPendingAgentRunTimeout(snapshot.runId);
   const dueAt = Date.now() + AGENT_RUN_TIMEOUT_RETRY_GRACE_MS;
   const timer = setTimeout(() => {
@@ -154,6 +202,51 @@ function createPendingErrorTimeoutSnapshot(snapshot: AgentRunSnapshot): AgentRun
   };
 }
 
+function shouldSurfacePendingTimeoutSnapshot(
+  snapshot: AgentRunSnapshot,
+  opts?: { dueAt?: number; now?: number },
+): boolean {
+  const now = opts?.now ?? Date.now();
+  return (
+    snapshot.status === "timeout" &&
+    snapshot.hardTimeout === true &&
+    (snapshot.deferTimeoutSurface !== true ||
+      (typeof opts?.dueAt === "number" && opts.dueAt <= now))
+  );
+}
+
+function shouldKeepHardTimeoutOverSnapshot(
+  hardTimeoutSnapshot: AgentRunSnapshot | undefined,
+  snapshot: AgentRunSnapshot,
+): boolean {
+  if (hardTimeoutSnapshot?.hardTimeout !== true || snapshot.status === "timeout") {
+    return false;
+  }
+  if (typeof hardTimeoutSnapshot.endedAt !== "number") {
+    return true;
+  }
+  return typeof snapshot.endedAt !== "number" || snapshot.endedAt > hardTimeoutSnapshot.endedAt;
+}
+
+function isBeforeFreshLifecycleWindow(params: {
+  snapshot: AgentRunSnapshot;
+  ignoreLifecycleEventsBeforeMs?: number;
+}) {
+  const { ignoreLifecycleEventsBeforeMs, snapshot } = params;
+  if (
+    typeof ignoreLifecycleEventsBeforeMs !== "number" ||
+    ignoreLifecycleEventsBeforeMs < MIN_COMPARABLE_EPOCH_MS
+  ) {
+    return false;
+  }
+  const terminalAt = snapshot.endedAt ?? snapshot.startedAt;
+  return (
+    typeof terminalAt === "number" &&
+    terminalAt >= MIN_COMPARABLE_EPOCH_MS &&
+    terminalAt < ignoreLifecycleEventsBeforeMs
+  );
+}
+
 function createSnapshotFromLifecycleEvent(params: {
   runId: string;
   phase: "end" | "error";
@@ -168,11 +261,18 @@ function createSnapshotFromLifecycleEvent(params: {
   const livenessState = typeof data?.livenessState === "string" ? data.livenessState : undefined;
   const blocked = isBlockedLivenessState(livenessState);
   const abortedStopReason = isAbortedAgentStopReason(stopReason);
-  const status =
-    phase === "error" || blocked || abortedStopReason ? "error" : data?.aborted ? "timeout" : "ok";
-  const resolvedError = abortedStopReason && !error ? AGENT_RUN_ABORTED_ERROR : error;
-  const timeoutPhase =
-    status === "timeout" ? normalizeAgentRunTimeoutPhase(data?.timeoutPhase) : undefined;
+  const timeoutPhase = normalizeAgentRunTimeoutPhase(data?.timeoutPhase);
+  const hardTimeoutPhase = isHardAgentRunTimeoutPhase(timeoutPhase);
+  const abortedEnd = phase === "end" && data?.aborted === true;
+  const status = hardTimeoutPhase
+    ? "timeout"
+    : phase === "error" || blocked || abortedStopReason
+      ? "error"
+      : data?.aborted
+        ? "timeout"
+        : "ok";
+  const resolvedError =
+    abortedStopReason && !hardTimeoutPhase && !error ? AGENT_RUN_ABORTED_ERROR : error;
   const providerStarted = normalizeProviderStarted(data?.providerStarted);
   return {
     runId,
@@ -183,6 +283,8 @@ function createSnapshotFromLifecycleEvent(params: {
     stopReason,
     livenessState,
     ...(data?.yielded === true ? { yielded: true } : {}),
+    ...(hardTimeoutPhase ? { hardTimeout: true } : {}),
+    ...(abortedEnd && timeoutPhase !== "post_turn" ? { deferTimeoutSurface: true } : {}),
     ...(timeoutPhase ? { timeoutPhase } : {}),
     ...(providerStarted !== undefined ? { providerStarted } : {}),
     ts: Date.now(),
@@ -221,12 +323,16 @@ function ensureAgentRunListener() {
       data: evt.data,
     });
     agentRunStarts.delete(evt.runId);
-    if (phase === "error") {
-      schedulePendingAgentRunError(snapshot);
-      return;
-    }
     if (snapshot.status === "timeout") {
       schedulePendingAgentRunTimeout(snapshot);
+      return;
+    }
+    const pendingTimeout = pendingAgentRunTimeouts.get(evt.runId);
+    if (shouldKeepHardTimeoutOverSnapshot(pendingTimeout?.snapshot, snapshot)) {
+      return;
+    }
+    if (phase === "error") {
+      schedulePendingAgentRunError(snapshot);
       return;
     }
     clearPendingAgentRunError(evt.runId);
@@ -262,12 +368,38 @@ export async function waitForAgentJob(params: {
   timeoutMs: number;
   signal?: AbortSignal;
   ignoreCachedSnapshot?: boolean;
+  ignoreLifecycleEventsBeforeMs?: number;
 }): Promise<AgentRunSnapshot | null> {
-  const { runId, timeoutMs, signal, ignoreCachedSnapshot = false } = params;
+  const {
+    runId,
+    timeoutMs,
+    signal,
+    ignoreCachedSnapshot = false,
+    ignoreLifecycleEventsBeforeMs,
+  } = params;
   ensureAgentRunListener();
   const cached = ignoreCachedSnapshot ? undefined : getCachedAgentRun(runId);
   if (cached) {
     return cached;
+  }
+  const pendingTimeout = getPendingAgentRunTimeout(runId);
+  if (
+    pendingTimeout &&
+    !isBeforeFreshLifecycleWindow({
+      snapshot: pendingTimeout.snapshot,
+      ignoreLifecycleEventsBeforeMs,
+    }) &&
+    (!ignoreCachedSnapshot ||
+      pendingTimeout.snapshot.hardTimeout === true ||
+      pendingTimeout.snapshot.timeoutPhase) &&
+    shouldSurfacePendingTimeoutSnapshot(pendingTimeout.snapshot, {
+      dueAt: pendingTimeout.dueAt,
+    })
+  ) {
+    const snapshot = pendingTimeout.snapshot;
+    clearPendingAgentRunTimeout(runId);
+    recordAgentRunSnapshot(snapshot);
+    return stripPendingOnlySnapshotFields(snapshot);
   }
   if (timeoutMs <= 0 || signal?.aborted) {
     return null;
@@ -277,6 +409,7 @@ export async function waitForAgentJob(params: {
     let settled = false;
     let pendingErrorTimer: NodeJS.Timeout | undefined;
     let pendingTimeoutTimer: NodeJS.Timeout | undefined;
+    let pendingTimeoutSnapshot: AgentRunSnapshot | undefined;
     let onAbort: (() => void) | undefined;
     let removeWaiter = () => {};
 
@@ -294,6 +427,7 @@ export async function waitForAgentJob(params: {
       }
       clearTimeout(pendingTimeoutTimer);
       pendingTimeoutTimer = undefined;
+      pendingTimeoutSnapshot = undefined;
     };
 
     const finish = (entry: AgentRunSnapshot | null) => {
@@ -309,7 +443,7 @@ export async function waitForAgentJob(params: {
       if (onAbort) {
         signal?.removeEventListener("abort", onAbort);
       }
-      resolve(entry);
+      resolve(entry ? stripPendingOnlySnapshotFields(entry) : null);
     };
 
     const scheduleTerminalFinish = (
@@ -317,16 +451,25 @@ export async function waitForAgentJob(params: {
       snapshot: AgentRunSnapshot,
       delayMs: number,
     ) => {
+      if (kind === "timeout" && pendingTimeoutSnapshot?.hardTimeout === true) {
+        pendingTimeoutSnapshot = mergeHardTimeoutSnapshot(pendingTimeoutSnapshot, snapshot);
+        return;
+      }
       clearPendingErrorTimer();
       clearPendingTimeoutTimer();
+      if (kind === "timeout") {
+        pendingTimeoutSnapshot = snapshot;
+      }
       const timerRef = setSafeTimeout(() => {
         const latest = ignoreCachedSnapshot ? undefined : getCachedAgentRun(runId);
         if (latest) {
           finish(latest);
           return;
         }
-        recordAgentRunSnapshot(snapshot);
-        finish(snapshot);
+        const terminalSnapshot =
+          kind === "timeout" ? (pendingTimeoutSnapshot ?? snapshot) : snapshot;
+        recordAgentRunSnapshot(terminalSnapshot);
+        finish(terminalSnapshot);
       }, delayMs);
       timerRef.unref?.();
       if (kind === "error") {
@@ -345,7 +488,10 @@ export async function waitForAgentJob(params: {
 
     const scheduleTimeoutFinish = (
       snapshot: AgentRunSnapshot,
-      delayMs = AGENT_RUN_TIMEOUT_RETRY_GRACE_MS,
+      delayMs = snapshot.deferTimeoutSurface === true ||
+      (snapshot.hardTimeout === true && snapshot.timeoutPhase !== "post_turn")
+        ? AGENT_RUN_TIMEOUT_RETRY_GRACE_MS
+        : 0,
     ) => {
       scheduleTerminalFinish("timeout", snapshot, delayMs);
     };
@@ -387,12 +533,23 @@ export async function waitForAgentJob(params: {
         phase,
         data: evt.data,
       });
-      if (phase === "error") {
-        scheduleErrorFinish(snapshot);
+      if (
+        isBeforeFreshLifecycleWindow({
+          snapshot,
+          ignoreLifecycleEventsBeforeMs,
+        })
+      ) {
         return;
       }
       if (snapshot.status === "timeout") {
         scheduleTimeoutFinish(snapshot);
+        return;
+      }
+      if (shouldKeepHardTimeoutOverSnapshot(pendingTimeoutSnapshot, snapshot)) {
+        return;
+      }
+      if (phase === "error") {
+        scheduleErrorFinish(snapshot);
         return;
       }
       recordAgentRunSnapshot(snapshot);
@@ -401,7 +558,32 @@ export async function waitForAgentJob(params: {
     removeWaiter = addAgentRunWaiter(runId);
 
     const timer = setSafeTimeout(() => {
+      const pendingTimeout = getPendingAgentRunTimeout(runId);
+      if (
+        pendingTimeout &&
+        !isBeforeFreshLifecycleWindow({
+          snapshot: pendingTimeout.snapshot,
+          ignoreLifecycleEventsBeforeMs,
+        }) &&
+        shouldSurfacePendingTimeoutSnapshot(pendingTimeout.snapshot, {
+          dueAt: pendingTimeout.dueAt,
+        })
+      ) {
+        recordAgentRunSnapshot(pendingTimeout.snapshot);
+        finish(pendingTimeout.snapshot);
+        return;
+      }
       const pendingError = getPendingAgentRunError(runId);
+      if (
+        pendingError &&
+        isBeforeFreshLifecycleWindow({
+          snapshot: pendingError.snapshot,
+          ignoreLifecycleEventsBeforeMs,
+        })
+      ) {
+        finish(null);
+        return;
+      }
       finish(pendingError ? createPendingErrorTimeoutSnapshot(pendingError.snapshot) : null);
     }, timeoutMs);
     onAbort = () => finish(null);

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -123,6 +123,7 @@ describe("agent wait dedupe helper", () => {
         status: "timeout",
         startedAt: 100,
         endedAt: 200,
+        stopReason: "aborted",
         result: {
           meta: {
             timeoutPhase: "provider",
@@ -142,6 +143,42 @@ describe("agent wait dedupe helper", () => {
       startedAt: 100,
       endedAt: 200,
       error: undefined,
+      stopReason: "aborted",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+  });
+
+  it("maps terminal chat hard-timeout error entries to timeout snapshots", () => {
+    const dedupe = new Map();
+    const runId = "run-chat-provider-timeout";
+
+    setRunEntry({
+      dedupe,
+      kind: "chat",
+      runId,
+      ok: false,
+      payload: {
+        runId,
+        status: "error",
+        summary: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "timeout",
+      startedAt: undefined,
+      endedAt: expect.any(Number),
+      error: "Request timed out before a response was generated.",
+      stopReason: undefined,
+      livenessState: undefined,
       timeoutPhase: "provider",
       providerStarted: true,
     });
@@ -158,6 +195,42 @@ describe("agent wait dedupe helper", () => {
       payload: {
         runId,
         status: "ok",
+        startedAt: 100,
+        endedAt: 200,
+        error: "Context overflow: prompt too large for the model.",
+        result: {
+          meta: {
+            livenessState: "blocked",
+          },
+        },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "error",
+      startedAt: 100,
+      endedAt: 200,
+      error: "Context overflow: prompt too large for the model.",
+      livenessState: "blocked",
+    });
+  });
+
+  it("normalizes blocked timeout snapshots without hard attribution to errors", () => {
+    const dedupe = new Map();
+    const runId = "run-blocked-timeout-agent";
+
+    setRunEntry({
+      dedupe,
+      kind: "agent",
+      runId,
+      payload: {
+        runId,
+        status: "timeout",
         startedAt: 100,
         endedAt: 200,
         error: "Context overflow: prompt too large for the model.",

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -1,5 +1,6 @@
 import { AGENT_RUN_ABORTED_ERROR, isAbortedAgentStopReason } from "../../agents/run-termination.js";
 import {
+  isHardAgentRunTimeoutPhase,
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
   type AgentRunTimeoutPhase,
@@ -112,6 +113,7 @@ function readTerminalSnapshotFromDedupeEntry(entry: DedupeEntry): AgentWaitTermi
   const providerStarted =
     normalizeProviderStarted(payload?.providerStarted) ??
     normalizeProviderStarted(resultMeta?.providerStarted);
+  const hardRunTimeout = isHardAgentRunTimeoutPhase(timeoutPhase);
   const errorMessage =
     typeof payload?.error === "string"
       ? payload.error
@@ -119,14 +121,15 @@ function readTerminalSnapshotFromDedupeEntry(entry: DedupeEntry): AgentWaitTermi
         ? payload.summary
         : entry.error?.message;
   const abortedStopReason = isAbortedAgentStopReason(stopReason);
-  const normalizedError =
-    abortedStopReason && !errorMessage ? AGENT_RUN_ABORTED_ERROR : errorMessage;
+  const abortedStatus = abortedStopReason && !(status === "timeout" && hardRunTimeout);
+  const normalizedError = abortedStatus && !errorMessage ? AGENT_RUN_ABORTED_ERROR : errorMessage;
 
   if (status === "ok" || status === "timeout") {
     const normalized = normalizeBlockedLivenessWaitStatus({
-      status: abortedStopReason ? "error" : status,
+      status: abortedStatus ? "error" : status,
       livenessState,
       error: normalizedError,
+      preserveBlockedTimeout: hardRunTimeout,
     });
     return {
       status: normalized.status,
@@ -146,6 +149,19 @@ function readTerminalSnapshotFromDedupeEntry(entry: DedupeEntry): AgentWaitTermi
     };
   }
   if (status === "error" || !entry.ok) {
+    if (hardRunTimeout) {
+      return {
+        status: "timeout",
+        startedAt,
+        endedAt,
+        error: normalizedError,
+        stopReason,
+        livenessState,
+        ...(yielded ? { yielded } : {}),
+        ...(timeoutPhase ? { timeoutPhase } : {}),
+        ...(providerStarted !== undefined ? { providerStarted } : {}),
+      };
+    }
     return {
       status: "error",
       startedAt,

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -5,6 +5,7 @@ import {
   resetExecApprovalFollowupRuntimeHandoffsForTests,
 } from "../../agents/bash-tools.exec-approval-followup-state.js";
 import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
+import { CommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import {
   getDetachedTaskLifecycleRuntime,
   resetDetachedTaskLifecycleRuntimeForTests,
@@ -4613,6 +4614,58 @@ describe("gateway agent handler chat.abort integration", () => {
       stopReason: "rpc",
       timeoutPhase: "queue",
       providerStarted: false,
+    });
+  });
+
+  it("preserves timeout status when the command lane guard rejects after the run deadline", async () => {
+    prime();
+    const runId = "idem-lane-timeout";
+    mocks.agentCommand.mockRejectedValueOnce(new CommandLaneTaskTimeoutError("subagent", 38_000));
+
+    const context = makeContext();
+    const respond = vi.fn();
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: runId,
+      },
+      { context, respond, reqId: runId, flushDispatch: false },
+    );
+
+    await flushScheduledDispatchStep();
+
+    const finalResponse = respond.mock.calls.find(
+      (call: unknown[]) => (call[1] as { status?: unknown } | undefined)?.status === "timeout",
+    );
+    expectRecordFields(requireValue(finalResponse, "terminal response missing")[1], {
+      runId,
+      status: "timeout",
+      summary: 'CommandLaneTaskTimeoutError: Command lane "subagent" task timed out after 38000ms',
+    });
+    expect(mockCallArg(respond, 1, 2)).toBeUndefined();
+    expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
+      runId,
+      status: "timeout",
+      summary: 'CommandLaneTaskTimeoutError: Command lane "subagent" task timed out after 38000ms',
+    });
+    expect(context.dedupe.get(`agent:${runId}`)?.ok).toBe(true);
+
+    const waitRespond = vi.fn();
+    await agentHandlers["agent.wait"]({
+      params: { runId, timeoutMs: 0 },
+      respond: waitRespond as never,
+      context,
+      req: { type: "req", id: "wait-lane-timeout", method: "agent.wait" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expectRecordFields(mockCallArg(waitRespond, 0, 1), {
+      runId,
+      status: "timeout",
+      error: 'CommandLaneTaskTimeoutError: Command lane "subagent" task timed out after 38000ms',
     });
   });
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -644,11 +644,7 @@ function isGatewayAgentAbortRejection(error: unknown, signal: AbortSignal): bool
 }
 
 function isGatewayAgentTimeoutRejection(error: unknown, signal: AbortSignal): boolean {
-  return (
-    isGatewayAgentAbortRejection(error, signal) ||
-    isTimeoutError(error) ||
-    isCommandLaneTaskTimeoutError(error)
-  );
+  return isGatewayAgentAbortRejection(error, signal) || isCommandLaneTaskTimeoutError(error);
 }
 
 function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "rpc" | "timeout" {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -82,6 +82,7 @@ import {
 } from "../../infra/voicewake-routing.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
+import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import {
   classifySessionKeyShape,
   isAcpSessionKey,
@@ -464,7 +465,9 @@ type GatewayAgentTaskTerminalStatus = Extract<
 >;
 
 function resolveFailedTrackedAgentTaskStatus(error: unknown): GatewayAgentTaskTerminalStatus {
-  return isAbortError(error) || isTimeoutError(error) ? "timed_out" : "failed";
+  return isAbortError(error) || isTimeoutError(error) || isCommandLaneTaskTimeoutError(error)
+    ? "timed_out"
+    : "failed";
 }
 
 function tryFinalizeTrackedAgentTask(params: {
@@ -640,6 +643,14 @@ function isGatewayAgentAbortRejection(error: unknown, signal: AbortSignal): bool
   return isAbortError(error) || readErrorName(error) === "TimeoutError";
 }
 
+function isGatewayAgentTimeoutRejection(error: unknown, signal: AbortSignal): boolean {
+  return (
+    isGatewayAgentAbortRejection(error, signal) ||
+    isTimeoutError(error) ||
+    isCommandLaneTaskTimeoutError(error)
+  );
+}
+
 function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "rpc" | "timeout" {
   return readErrorName(signal.reason) === "TimeoutError" ? "timeout" : "rpc";
 }
@@ -735,36 +746,37 @@ function dispatchAgentRunFromGateway(params: {
     })
     .catch((err) => {
       const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
+      const timedOut = isGatewayAgentTimeoutRejection(err, params.abortController.signal);
       const renderedErr = formatForLog(err);
       if (shouldTrackTask) {
         tryFinalizeTrackedAgentTask({
           runId: params.runId,
-          status: aborted ? "timed_out" : resolveFailedTrackedAgentTaskStatus(err),
+          status: timedOut ? "timed_out" : resolveFailedTrackedAgentTaskStatus(err),
           error: renderedErr,
           terminalSummary: renderedErr,
         });
       }
-      const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
       const stopReason = resolveGatewayAgentAbortStopReason(params.abortController.signal);
       const payload = {
         runId: params.runId,
-        status: aborted ? ("timeout" as const) : ("error" as const),
+        status: timedOut ? ("timeout" as const) : ("error" as const),
         summary: aborted ? "aborted" : renderedErr,
         ...(aborted ? { stopReason, timeoutPhase: "gateway_draining" as const } : {}),
       };
+      const error = timedOut ? undefined : errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
       setGatewayDedupeEntries({
         dedupe: params.context.dedupe,
         keys: params.dedupeKeys,
         entry: {
           ts: Date.now(),
-          ok: aborted,
+          ok: timedOut,
           payload,
-          ...(aborted ? {} : { error }),
+          ...(error ? { error } : {}),
         },
       });
-      params.respond(aborted, payload, aborted ? undefined : error, {
+      params.respond(timedOut, payload, error, {
         runId: params.runId,
-        ...(aborted ? {} : { error: formatForLog(err) }),
+        ...(error ? { error: formatForLog(err) } : {}),
       });
     })
     .finally(() => {
@@ -2272,6 +2284,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       // When chat.send is active with the same runId, ignore cached lifecycle
       // snapshots so stale agent results do not preempt the active chat run.
       ignoreCachedSnapshot: hasActiveChatRun,
+      ignoreLifecycleEventsBeforeMs: hasActiveChatRun ? activeChatEntry.startedAtMs : undefined,
     });
     const dedupePromise = waitForTerminalGatewayDedupe({
       dedupe: context.dedupe,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -59,6 +59,10 @@ const mockState = vi.hoisted(() => ({
   triggerAgentRunStart: false,
   triggerUserMessagePersisted: false,
   runtimeUserMessagePersistencePending: null as Promise<void> | null,
+  agentRunTerminalMetadata: null as {
+    timeoutPhase?: "preflight" | "provider" | "post_turn";
+    providerStarted?: boolean;
+  } | null,
   onAfterAgentRunStart: null as (() => void) | null,
   agentRunId: "run-agent-1",
   sessionEntry: {} as Record<string, unknown>,
@@ -201,6 +205,10 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       };
       replyOptions?: {
         onAgentRunStart?: (runId: string) => void;
+        onAgentRunTerminalMetadata?: (metadata: {
+          timeoutPhase?: "preflight" | "provider" | "post_turn";
+          providerStarted?: boolean;
+        }) => void;
         userTurnTranscriptRecorder?: {
           message?: unknown;
           resolveMessage?: () => Promise<unknown>;
@@ -224,6 +232,9 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       if (mockState.triggerAgentRunStart) {
         params.replyOptions?.onAgentRunStart?.(mockState.agentRunId);
         mockState.onAfterAgentRunStart?.();
+      }
+      if (mockState.agentRunTerminalMetadata) {
+        params.replyOptions?.onAgentRunTerminalMetadata?.(mockState.agentRunTerminalMetadata);
       }
       if (mockState.triggerUserMessagePersisted) {
         params.replyOptions?.userTurnTranscriptRecorder?.markRuntimePersisted({
@@ -765,6 +776,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.triggerAgentRunStart = false;
     mockState.triggerUserMessagePersisted = false;
     mockState.runtimeUserMessagePersistencePending = null;
+    mockState.agentRunTerminalMetadata = null;
     mockState.onAfterAgentRunStart = null;
     mockState.agentRunId = "run-agent-1";
     mockState.sessionEntry = {};
@@ -1921,6 +1933,119 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         (update.message as { role?: unknown }).role === "assistant",
     );
     expect(assistantUpdates).toStrictEqual([]);
+  });
+
+  it("keeps returned hard-timeout agent payloads as timeout dedupe snapshots", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-returned-timeout-");
+    const errorMessage = "Request timed out before a response was generated.";
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: errorMessage,
+            isError: true,
+          },
+          {
+            agentRunTimeoutPhase: "provider",
+            agentRunProviderStarted: true,
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const broadcast = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-returned-timeout",
+      message: "please keep working",
+    });
+
+    expect(broadcast).toMatchObject({
+      runId: "idem-agent-returned-timeout",
+      sessionKey: "main",
+      state: "error",
+      errorMessage,
+    });
+    const dedupe = context.dedupe.get("chat:idem-agent-returned-timeout");
+    expect(dedupe?.ok).toBe(true);
+    expect(dedupe?.payload).toMatchObject({
+      runId: "idem-agent-returned-timeout",
+      status: "timeout",
+      summary: errorMessage,
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+    const retryRespond = vi.fn();
+    await runNonStreamingChatSend({
+      context,
+      respond: retryRespond,
+      idempotencyKey: "idem-agent-returned-timeout",
+      message: "please keep working",
+      waitFor: "none",
+    });
+    expect(retryRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        runId: "idem-agent-returned-timeout",
+        status: "timeout",
+        timeoutPhase: "provider",
+      }),
+      undefined,
+      { cached: true },
+    );
+  });
+
+  it("keeps run-level hard-timeout metadata as timeout dedupe without returned error payloads", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-run-timeout-meta-");
+    mockState.triggerAgentRunStart = true;
+    mockState.agentRunTerminalMetadata = {
+      timeoutPhase: "post_turn",
+      providerStarted: true,
+    };
+    mockState.dispatchedReplies = [];
+    mockState.finalPayload = { text: undefined };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-run-timeout-meta",
+      message: "please keep working",
+      waitFor: "dedupe",
+    });
+
+    const dedupe = context.dedupe.get("chat:idem-agent-run-timeout-meta");
+    expect(dedupe?.ok).toBe(true);
+    expect(dedupe?.payload).toMatchObject({
+      runId: "idem-agent-run-timeout-meta",
+      status: "timeout",
+      summary: "agent run timed out",
+      timeoutPhase: "post_turn",
+      providerStarted: true,
+    });
+    const retryRespond = vi.fn();
+    await runNonStreamingChatSend({
+      context,
+      respond: retryRespond,
+      idempotencyKey: "idem-agent-run-timeout-meta",
+      message: "please keep working",
+      waitFor: "none",
+    });
+    expect(retryRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        runId: "idem-agent-run-timeout-meta",
+        status: "timeout",
+        timeoutPhase: "post_turn",
+      }),
+      undefined,
+      { cached: true },
+    );
   });
 
   it("keeps visible text on non-agent TTS final media because no model transcript exists", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -27,6 +27,10 @@ import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/ag
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/embedded-agent-runner/transcript-rewrite.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import {
+  isHardAgentRunTimeoutPhase,
+  type AgentRunTimeoutPhase,
+} from "../../agents/run-timeout-attribution.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
@@ -2780,6 +2784,12 @@ export const chatHandlers: GatewayRequestHandlers = {
       const deliveredReplies: Array<{ payload: ReplyPayload; kind: "block" | "final" }> = [];
       let appendedWebchatAgentMedia = false;
       let agentRunStarted = false;
+      let returnedAgentRunTimeoutMeta:
+        | {
+            agentRunTimeoutPhase?: AgentRunTimeoutPhase;
+            agentRunProviderStarted?: boolean;
+          }
+        | undefined;
       const userTurnRecorder: UserTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
         input: baseUserTurnInput,
         resolveInput: () => userTurnInputPromise,
@@ -2977,6 +2987,17 @@ export const chatHandlers: GatewayRequestHandlers = {
                     }
                   }
                 }
+              },
+              onAgentRunTerminalMetadata: (metadata) => {
+                if (!isHardAgentRunTimeoutPhase(metadata.timeoutPhase)) {
+                  return;
+                }
+                returnedAgentRunTimeoutMeta = {
+                  agentRunTimeoutPhase: metadata.timeoutPhase,
+                  ...(metadata.providerStarted !== undefined
+                    ? { agentRunProviderStarted: metadata.providerStarted }
+                    : {}),
+                };
               },
               onModelSelected: (modelSelection) => {
                 updateChatRunProvider(context.chatAbortControllers, {
@@ -3534,6 +3555,14 @@ export const chatHandlers: GatewayRequestHandlers = {
               }
               const shouldBroadcastAgentError =
                 returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
+              const returnedAgentTimeoutMeta =
+                returnedAgentErrorPayloads
+                  .map((payload) => getReplyPayloadMetadata(payload))
+                  .find((metadata) => isHardAgentRunTimeoutPhase(metadata?.agentRunTimeoutPhase)) ??
+                returnedAgentRunTimeoutMeta;
+              const returnedAgentTimeoutPhase = returnedAgentTimeoutMeta?.agentRunTimeoutPhase;
+              const hasReturnedAgentHardTimeout =
+                isHardAgentRunTimeoutPhase(returnedAgentTimeoutPhase);
               if (shouldBroadcastAgentError) {
                 broadcastChatError({
                   context,
@@ -3543,25 +3572,43 @@ export const chatHandlers: GatewayRequestHandlers = {
                 });
               }
               if (!context.chatAbortedRuns.has(clientRunId)) {
-                const returnedAgentError = shouldBroadcastAgentError
+                const shouldStoreErrorResponse =
+                  shouldBroadcastAgentError && !hasReturnedAgentHardTimeout;
+                const returnedAgentError = shouldStoreErrorResponse
                   ? errorShape(
                       ErrorCodes.UNAVAILABLE,
                       returnedAgentErrorMessage ?? "agent returned an error payload",
                     )
                   : undefined;
+                const terminalSummary =
+                  returnedAgentErrorMessage ??
+                  (hasReturnedAgentHardTimeout
+                    ? "agent run timed out"
+                    : "agent returned an error payload");
                 setGatewayDedupeEntry({
                   dedupe: context.dedupe,
                   key: `chat:${clientRunId}`,
                   entry: {
                     ts: Date.now(),
-                    ok: !shouldBroadcastAgentError,
-                    payload: shouldBroadcastAgentError
-                      ? {
-                          runId: clientRunId,
-                          status: "error" as const,
-                          summary: returnedAgentErrorMessage ?? "agent returned an error payload",
-                        }
-                      : { runId: clientRunId, status: "ok" as const },
+                    ok: !shouldStoreErrorResponse,
+                    payload:
+                      shouldStoreErrorResponse || hasReturnedAgentHardTimeout
+                        ? {
+                            runId: clientRunId,
+                            status: returnedAgentTimeoutPhase
+                              ? ("timeout" as const)
+                              : ("error" as const),
+                            summary: terminalSummary,
+                            ...(returnedAgentTimeoutPhase
+                              ? { timeoutPhase: returnedAgentTimeoutPhase }
+                              : {}),
+                            ...(returnedAgentTimeoutMeta?.agentRunProviderStarted !== undefined
+                              ? {
+                                  providerStarted: returnedAgentTimeoutMeta.agentRunProviderStarted,
+                                }
+                              : {}),
+                          }
+                        : { runId: clientRunId, status: "ok" as const },
                     ...(returnedAgentError ? { error: returnedAgentError } : {}),
                   },
                 });

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -369,7 +369,7 @@ describe("waitForAgentJob", () => {
       const runId = `run-error-timeout-stable-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       let settled = false;
       const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
-      snapshotPromise.then(() => {
+      void snapshotPromise.then(() => {
         settled = true;
       });
 
@@ -427,7 +427,7 @@ describe("waitForAgentJob", () => {
       const runId = `run-aborted-timeout-stable-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       let settled = false;
       const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
-      snapshotPromise.then(() => {
+      void snapshotPromise.then(() => {
         settled = true;
       });
 

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -86,6 +86,8 @@ describe("waitForAgentJob", () => {
     endedAt: number;
     aborted?: boolean;
     stopReason?: string;
+    timeoutPhase?: string;
+    providerStarted?: boolean;
   }) {
     const runId = `${params.runIdPrefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const waitPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
@@ -103,6 +105,10 @@ describe("waitForAgentJob", () => {
         endedAt: params.endedAt,
         aborted: params.aborted,
         ...(params.stopReason ? { stopReason: params.stopReason } : {}),
+        ...(params.timeoutPhase ? { timeoutPhase: params.timeoutPhase } : {}),
+        ...(params.providerStarted !== undefined
+          ? { providerStarted: params.providerStarted }
+          : {}),
       },
     });
 
@@ -146,6 +152,738 @@ describe("waitForAgentJob", () => {
     }
   });
 
+  it("maps lifecycle error events with timeout attribution to timeout after the retry grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-error-timeout-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 20_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt: 150,
+          endedAt: 250,
+          error: "Request timed out before a response was generated.",
+          livenessState: "blocked",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        error: "Request timed out before a response was generated.",
+        livenessState: "blocked",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("maps blocked lifecycle end events with hard timeout attribution to timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-end-timeout-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 20_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 250,
+          error: "Request timed out before a response was generated.",
+          livenessState: "blocked",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        livenessState: "blocked",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces pending timeout-attributed lifecycle errors when the wait deadline wins", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-error-timeout-deadline-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt: 150,
+          endedAt: 250,
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces pending hard-timeout attribution to zero-timeout polls", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-error-timeout-zero-poll-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const longWait = waitForAgentJob({ runId, timeoutMs: 20_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt: 150,
+          endedAt: 250,
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      const snapshot = await waitForAgentJob({ runId, timeoutMs: 0 });
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(longWait).resolves.toMatchObject({
+        status: "timeout",
+        timeoutPhase: "provider",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces pending hard-timeout attribution to fresh zero-timeout polls", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-error-timeout-fresh-zero-poll-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const longWait = waitForAgentJob({ runId, timeoutMs: 20_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: Date.parse("2026-03-24T12:00:00Z") },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt: Date.parse("2026-03-24T12:00:00Z"),
+          endedAt: Date.parse("2026-03-24T12:00:08Z"),
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      const snapshot = await waitForAgentJob({
+        runId,
+        timeoutMs: 0,
+        ignoreCachedSnapshot: true,
+        ignoreLifecycleEventsBeforeMs: Date.parse("2026-03-24T12:00:01Z"),
+      });
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: Date.parse("2026-03-24T12:00:00Z"),
+        endedAt: Date.parse("2026-03-24T12:00:08Z"),
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(longWait).resolves.toMatchObject({
+        status: "timeout",
+        timeoutPhase: "provider",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the first hard-timeout grace deadline when a later timeout event arrives", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-error-timeout-stable-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      let settled = false;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+      snapshotPromise.then(() => {
+        settled = true;
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt: 150,
+          endedAt: 250,
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          endedAt: 350,
+          error: "request timed out",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the first hard-timeout grace deadline after an aborted timeout event", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-aborted-timeout-stable-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      let settled = false;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+      snapshotPromise.then(() => {
+        settled = true;
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 250,
+          aborted: true,
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          endedAt: 350,
+          error: "request timed out",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        error: "Request timed out before a response was generated.",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps hard-timeout snapshots authoritative over later success events", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-timeout-late-ok-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 250,
+          aborted: true,
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 300,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps hard-timeout snapshots without endedAt authoritative over later success events", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-timeout-no-ended-late-ok-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          aborted: true,
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 300,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+      expect(snapshot?.endedAt).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps cached hard-timeout snapshots authoritative over later success events", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-timeout-cached-late-ok-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 250,
+          aborted: true,
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(snapshotPromise).resolves.toMatchObject({
+        status: "timeout",
+        endedAt: 250,
+        timeoutPhase: "provider",
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 300,
+        },
+      });
+
+      const cachedSnapshot = await waitForAgentJob({ runId, timeoutMs: 1_000 });
+      expectRecordFields(cachedSnapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not surface attributed aborted end snapshots before timeout retry grace", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-aborted-timeout-deadline-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 250,
+          aborted: true,
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(snapshotPromise).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps plain aborted end snapshots behind timeout retry grace", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-plain-aborted-timeout-grace-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 250,
+          aborted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(snapshotPromise).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces post-turn aborted hard timeout snapshots without retry grace", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-post-turn-timeout-immediate-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 250,
+          aborted: true,
+          timeoutPhase: "post_turn",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        timeoutPhase: "post_turn",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces deferred aborted hard timeout snapshots at the retry grace deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-aborted-timeout-grace-deadline-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({ runId, timeoutMs: 15_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 150,
+          endedAt: 250,
+          aborted: true,
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      const snapshot = await snapshotPromise;
+      expectRecordFields(snapshot, {
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores timeout-attributed snapshots before the fresh lifecycle window", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-error-timeout-fresh-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({
+        runId,
+        timeoutMs: 1_000,
+        ignoreCachedSnapshot: true,
+        ignoreLifecycleEventsBeforeMs: Date.parse("2026-03-24T12:00:10Z"),
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: Date.parse("2026-03-24T12:00:01Z") },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt: Date.parse("2026-03-24T12:00:01Z"),
+          endedAt: Date.parse("2026-03-24T12:00:02Z"),
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(snapshotPromise).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps fresh lifecycle events with non-epoch timestamps in fresh-wait mode", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-synthetic-timeout-fresh-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({
+        runId,
+        timeoutMs: 20_000,
+        ignoreCachedSnapshot: true,
+        ignoreLifecycleEventsBeforeMs: Date.parse("2026-03-24T12:00:10Z"),
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt: 150,
+          endedAt: 250,
+          error: "Request timed out before a response was generated.",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(snapshotPromise).resolves.toMatchObject({
+        status: "timeout",
+        startedAt: 150,
+        endedAt: 250,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps current hard-timeout lifecycle events in fresh-wait mode", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-post-turn-timeout-fresh-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const snapshotPromise = waitForAgentJob({
+        runId,
+        timeoutMs: 1_000,
+        ignoreCachedSnapshot: true,
+        ignoreLifecycleEventsBeforeMs: 100,
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 150 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 250,
+          aborted: true,
+          timeoutPhase: "post_turn",
+          providerStarted: true,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(snapshotPromise).resolves.toMatchObject({
+        status: "timeout",
+        endedAt: 250,
+        timeoutPhase: "post_turn",
+        providerStarted: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps non-aborted lifecycle end events as ok", async () => {
     const snapshot = await runLifecycleScenario({
       runIdPrefix: "run-ok",
@@ -172,6 +910,26 @@ describe("waitForAgentJob", () => {
       endedAt: 420,
       stopReason: "aborted",
       error: "agent run aborted",
+    });
+  });
+
+  it("does not synthesize aborted errors for hard timeout lifecycle snapshots", async () => {
+    const snapshot = await runLifecycleScenario({
+      runIdPrefix: "run-aborted-hard-timeout",
+      startedAt: 430,
+      endedAt: 440,
+      stopReason: "aborted",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+    expectRecordFields(snapshot, {
+      status: "timeout",
+      startedAt: 430,
+      endedAt: 440,
+      stopReason: "aborted",
+      timeoutPhase: "provider",
+      providerStarted: true,
+      error: undefined,
     });
   });
 

--- a/src/shared/agent-liveness.ts
+++ b/src/shared/agent-liveness.ts
@@ -13,9 +13,13 @@ export function normalizeBlockedLivenessWaitStatus<
   status: TStatus;
   livenessState?: unknown;
   error?: unknown;
+  preserveBlockedTimeout?: boolean;
 }): { status: TStatus | "error"; error?: string } {
   const error = typeof params.error === "string" ? params.error : undefined;
   if (!isBlockedLivenessState(params.livenessState)) {
+    return { status: params.status, error };
+  }
+  if (params.status === "timeout" && params.preserveBlockedTimeout === true) {
     return { status: params.status, error };
   }
   return {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -490,6 +490,274 @@ describe("task-registry", () => {
     });
   });
 
+  it("updates task status from hard-timeout lifecycle end events", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:acp:child-timeout",
+        runId: "run-hard-timeout",
+        task: "Do the timed out thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId: "run-hard-timeout",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          timeoutPhase: "provider",
+          endedAt: 250,
+        },
+      });
+
+      expectRecordFields(requireTaskByRunId("run-hard-timeout"), {
+        runtime: "acp",
+        status: "timed_out",
+        endedAt: 250,
+      });
+    });
+  });
+
+  it("updates task status from hard-timeout lifecycle error events", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:acp:child-timeout-error",
+        runId: "run-hard-timeout-error",
+        task: "Do the timed out thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId: "run-hard-timeout-error",
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          timeoutPhase: "provider",
+          error: "Request timed out before a response was generated.",
+          endedAt: 250,
+        },
+      });
+
+      expectRecordFields(requireTaskByRunId("run-hard-timeout-error"), {
+        runtime: "acp",
+        status: "timed_out",
+        endedAt: 250,
+        error: "Request timed out before a response was generated.",
+      });
+    });
+  });
+
+  it("leaves subagent hard-timeout lifecycle events correctable by the subagent finalizer", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:child-timeout-correctable",
+        runId: "run-subagent-correctable-timeout",
+        task: "Do the correctable timed out thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId: "run-subagent-correctable-timeout",
+        sessionKey: "agent:main:subagent:child-timeout-correctable",
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          timeoutPhase: "provider",
+          error: "Request timed out before a response was generated.",
+          endedAt: 250,
+        },
+      });
+
+      expectRecordFields(requireTaskByRunId("run-subagent-correctable-timeout"), {
+        runtime: "subagent",
+        status: "running",
+        endedAt: undefined,
+        error: undefined,
+      });
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-correctable-timeout",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:child-timeout-correctable",
+        status: "succeeded",
+        endedAt: 240,
+        lastEventAt: 240,
+        terminalSummary: "Finished before timeout.",
+      });
+
+      expectRecordFields(requireTaskByRunId("run-subagent-correctable-timeout"), {
+        runtime: "subagent",
+        status: "succeeded",
+        endedAt: 240,
+        error: undefined,
+        terminalSummary: "Finished before timeout.",
+      });
+    });
+  });
+
+  it("allows subagent finalization to correct a task timeout to success", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:child-timeout-corrected",
+        runId: "run-subagent-timeout-corrected",
+        task: "Do the corrected timed out thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-timeout-corrected",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:child-timeout-corrected",
+        status: "timed_out",
+        endedAt: 260,
+        lastEventAt: 260,
+        error: "Request timed out before a response was generated.",
+      });
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-timeout-corrected",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:child-timeout-corrected",
+        status: "succeeded",
+        endedAt: 240,
+        lastEventAt: 240,
+        terminalSummary: "Finished before timeout.",
+      });
+
+      expectRecordFields(requireTaskByRunId("run-subagent-timeout-corrected"), {
+        runtime: "subagent",
+        status: "succeeded",
+        endedAt: 240,
+        error: undefined,
+        terminalSummary: "Finished before timeout.",
+      });
+    });
+  });
+
+  it("allows earlier subagent failures to correct a task timeout", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:child-failed-before-timeout",
+        runId: "run-subagent-failed-before-timeout",
+        task: "Do the failed before timeout thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-failed-before-timeout",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:child-failed-before-timeout",
+        status: "timed_out",
+        endedAt: 260,
+        lastEventAt: 260,
+        error: "Request timed out before a response was generated.",
+      });
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-failed-before-timeout",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:child-failed-before-timeout",
+        status: "failed",
+        endedAt: 240,
+        lastEventAt: 240,
+        error: "Child failed before timeout.",
+      });
+
+      expectRecordFields(requireTaskByRunId("run-subagent-failed-before-timeout"), {
+        runtime: "subagent",
+        status: "failed",
+        endedAt: 240,
+        error: "Child failed before timeout.",
+      });
+    });
+  });
+
+  it("keeps subagent task timeouts authoritative over late successes", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:child-late-success",
+        runId: "run-subagent-late-success",
+        task: "Do the late success thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-late-success",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:child-late-success",
+        status: "timed_out",
+        endedAt: 260,
+        lastEventAt: 260,
+        error: "Request timed out before a response was generated.",
+      });
+
+      markTaskTerminalByRunId({
+        runId: "run-subagent-late-success",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:child-late-success",
+        status: "succeeded",
+        endedAt: 280,
+        lastEventAt: 280,
+        terminalSummary: "Finished after timeout.",
+      });
+
+      expectRecordFields(requireTaskByRunId("run-subagent-late-success"), {
+        runtime: "subagent",
+        status: "timed_out",
+        endedAt: 260,
+        error: "Request timed out before a response was generated.",
+        terminalSummary: undefined,
+      });
+    });
+  });
+
   it("ignores late agent events for operator-cancelled tasks", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { createRequire } from "node:module";
+import { hasHardAgentRunTimeoutAttribution } from "../agents/run-timeout-attribution.js";
 import { shouldRouteCompletionThroughRequesterSession } from "../auto-reply/reply/completion-delivery-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { onAgentEvent } from "../infra/agent-events.js";
@@ -1451,18 +1452,23 @@ function ensureListener() {
         const startedAt =
           typeof evt.data?.startedAt === "number" ? evt.data.startedAt : current.startedAt;
         const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
+        const hardTimeout = hasHardAgentRunTimeoutAttribution(evt.data);
         if (startedAt) {
           patch.startedAt = startedAt;
         }
         if (phase === "start") {
           patch.status = "running";
         } else if (phase === "end") {
-          patch.status = evt.data?.aborted === true ? "timed_out" : "succeeded";
-          patch.endedAt = endedAt ?? now;
+          if (!(hardTimeout && current.runtime === "subagent")) {
+            patch.status = evt.data?.aborted === true || hardTimeout ? "timed_out" : "succeeded";
+            patch.endedAt = endedAt ?? now;
+          }
         } else if (phase === "error") {
-          patch.status = "failed";
-          patch.endedAt = endedAt ?? now;
-          patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
+          if (!(hardTimeout && current.runtime === "subagent")) {
+            patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
+            patch.status = hardTimeout ? "timed_out" : "failed";
+            patch.endedAt = endedAt ?? now;
+          }
         }
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
@@ -1652,8 +1658,17 @@ function updateTaskStateByRunId(params: {
   for (const current of matches) {
     const patch: Partial<TaskRecord> = {};
     const nextStatus = params.status ? normalizeTaskStatus(params.status) : current.status;
+    const correctsSubagentTimeout =
+      params.runtime === "subagent" &&
+      current.status === "timed_out" &&
+      nextStatus !== "timed_out" &&
+      isTerminalTaskStatus(nextStatus) &&
+      typeof current.endedAt === "number" &&
+      typeof params.endedAt === "number" &&
+      params.endedAt <= current.endedAt;
     if (
       params.status &&
+      !correctsSubagentTimeout &&
       !shouldApplyRunScopedStatusUpdate({
         currentStatus: current.status,
         nextStatus,
@@ -1676,6 +1691,8 @@ function updateTaskStateByRunId(params: {
     }
     if (params.error !== undefined) {
       patch.error = params.error;
+    } else if (nextStatus === "succeeded") {
+      patch.error = undefined;
     }
     if (params.progressSummary !== undefined) {
       patch.progressSummary = normalizeTaskSummary(params.progressSummary);

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1266,6 +1266,58 @@ describe("EmbeddedTuiBackend", () => {
     expect(finalContent[0]?.text).toBe("fallback answer");
   });
 
+  it("reports hard timeout lifecycle errors instead of user aborts", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string; isError?: boolean }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "timeout",
+      runId: "run-local-hard-timeout",
+    });
+
+    registeredListener?.({
+      runId: "run-local-hard-timeout",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        timeoutPhase: "provider",
+        error: "Request timed out before a response was generated.",
+      },
+    });
+    pending.resolve({
+      payloads: [
+        {
+          text: "Request timed out before a response was generated.",
+          isError: true,
+        },
+      ],
+      meta: { aborted: true, timeoutPhase: "provider" },
+    });
+    await flushMicrotasks();
+    vi.advanceTimersByTime(15_001);
+
+    const chatPayloads = events
+      .filter((entry) => entry.event === "chat")
+      .map((entry) => entry.payload as { state?: string; errorMessage?: string });
+    expect(chatPayloads.some((payload) => payload.state === "aborted")).toBe(false);
+    expect(chatPayloads.at(-1)).toMatchObject({
+      state: "error",
+      errorMessage: "Request timed out before a response was generated.",
+    });
+  });
+
   it("emits side-result events for local /btw runs", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     agentCommandFromIngressMock.mockResolvedValueOnce({

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -9,6 +9,7 @@ import {
   buildConfiguredModelCatalog,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
+import { hasHardAgentRunTimeoutAttribution } from "../agents/run-timeout-attribution.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
@@ -763,7 +764,12 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
 
     const phase = lifecyclePhase;
+    const hardTimeout = hasHardAgentRunTimeoutAttribution(evt.data);
     const aborted = evt.data?.aborted === true || run.controller.signal.aborted;
+    const timeoutErrorMessage =
+      typeof evt.data?.error === "string"
+        ? evt.data.error
+        : "Request timed out before a response was generated.";
     if (phase === "finishing") {
       run.finishing = true;
       run.markQueuedRunReady();
@@ -773,6 +779,11 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
     if (phase === "end") {
       run.finishing = false;
+      if (hardTimeout) {
+        run.buffer = "";
+        this.scheduleChatError(evt.runId, run, timeoutErrorMessage);
+        return;
+      }
       if (aborted) {
         this.emitChatAborted(evt.runId, run);
         return;
@@ -786,6 +797,11 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
     if (phase === "error") {
       run.finishing = false;
+      if (hardTimeout) {
+        run.buffer = "";
+        this.scheduleChatError(evt.runId, run, timeoutErrorMessage);
+        return;
+      }
       if (aborted) {
         this.emitChatAborted(evt.runId, run);
         return;
@@ -852,6 +868,15 @@ export class EmbeddedTuiBackend implements TuiBackend {
       );
       const run = this.runs.get(params.runId);
       if (!run) {
+        return;
+      }
+      if (hasHardAgentRunTimeoutAttribution(result?.meta)) {
+        run.buffer = "";
+        this.emitChatError(
+          params.runId,
+          run,
+          payloadText(result?.payloads) || "Request timed out before a response was generated.",
+        );
         return;
       }
       if (params.controller.signal.aborted || result?.meta?.aborted === true) {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,4 +1,5 @@
 import { classifyFailoverReason, isAuthErrorMessage } from "../agents/embedded-agent-helpers.js";
+import { hasHardAgentRunTimeoutAttribution } from "../agents/run-timeout-attribution.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -661,7 +662,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         if (!canUpdateActivityStatus) {
           return;
         }
-        setActivityStatus("idle");
+        setActivityStatus(hasHardAgentRunTimeoutAttribution(evt.data) ? "error" : "idle");
       }
       if (phase === "error") {
         postFinalizingRuns.delete(evt.runId);


### PR DESCRIPTION
## Summary

Fixes #87444 by preserving the distinction between a real run timeout and ordinary abort/cancel/error signals after an agent run crosses its configured hard deadline.

The change carries hard-timeout attribution through the Gateway wait/dedupe paths, subagent lifecycle reconciliation, task registry state, SDK normalization, OpenResponses projection, ACP relay, TUI projection, and persisted session recovery. It also keeps non-timeout aborts distinct, so user/RPC cancellation still normalizes as cancelled instead of timed out.

Related coverage: this also partially addresses #76962 by ensuring a terminal subagent timeout announcement is no longer held behind a still-active embedded child run. It does not claim to fully fix #76962's physical `claude -p` process cleanup, exec approval queue cancellation, or late direct-output leak; those remain separate proof/fix surfaces.

LoC churn: application code `+1457/-248`; non-application code, including tests and test helpers, `+4784/-776`.

## Why This Shape

The reported failure was one symptom of a broader invariant: once a run has hit its hard timeout, later cleanup signals must not erase or reclassify that timeout. Several surfaces observe the same run at different times, so the fix is intentionally cross-path rather than limited to the original `agent.wait` symptom.

The highest-risk sibling behavior is cancellation. This PR adds coverage that cancelled/RPC-stopped runs remain cancelled while hard-timeout runs remain timed out.

The #76962 overlap is intentionally narrow: terminal timeout announcement now proceeds from the already-final timeout outcome instead of waiting for the embedded child process to settle. That removes one path where timeout delivery could be delayed by a still-active child, while leaving process termination and late-output suppression to the dedicated zombie-process cleanup path.


## Practical Impact

This change makes timeout observable and sticky at the orchestration layer. A subagent that crosses its configured hard timeout should be reported as timed out across parent waits, Gateway/SDK/OpenResponses callers, task state, channel delivery, and recovered session state.

That means parent turns can unblock and progress sooner with the right terminal reason instead of waiting behind child cleanup or receiving an ambiguous pending, aborted, cancelled, or generic error state. More accurate logs are a side effect; the main behavior is that user-facing status and parent workflows no longer depend on the still-unwinding child process finishing cleanup first.

This does not introduce process cleanup enforcement. It does not forcibly kill stuck child processes, cancel exec approval queues, suppress every possible late direct-output leak, or guarantee physical `claude -p` process cleanup. The enforced contract here is the parent-facing run outcome, not OS/process reaping.

## Verification

- `$autoreview`: clean, zero accepted/actionable findings.
- `git diff --check`: clean.
- Targeted regression suite on AWS Crabbox `run_3eff1d4287bd`: 31 files passed, 153 tests passed, 909 skipped.
- Live Gateway/API matrix on AWS Crabbox `run_3eff1d4287bd`: all 8 release-candidate scenarios passed.
- Package/channel proof on AWS Crabbox `run_3eff1d4287bd`: built an npm tarball from this branch, installed that package in a Docker environment, and passed the Telegram round-trip channel test using a Convex-leased `telegram` credential.
- Related issue probe on AWS Crabbox `run_68e8283ae722`: latest `origin/main` reproduced the #76962 sub-symptom by calling the embedded-child wait on a terminal timeout; this branch passed the same before/after probe by announcing without that wait.

The live matrix covered:

- The reported subagent hard-timeout path.
- Fresh `agent.wait` and task terminal state.
- SDK `runs.create`, `run.wait`, and cancellation normalization.
- OpenResponses non-streaming and streaming responses.
- Persisted session reconstruction after terminal timeout state is written.
- Package-installed channel delivery through Telegram.
- The #76962-related terminal-timeout announcement path that must not wait behind an active child run.

## Real behavior proof

Behavior addressed: Subagent hard run timeouts now remain terminal timeouts across Gateway wait/dedupe, task registry, SDK, OpenResponses, persisted session reconstruction, and channel delivery, instead of being lost or misclassified after late abort/rejection/completion signals. The branch also prevents terminal timeout announcements from waiting behind an active embedded child run, partially addressing #76962.

Real environment tested: AWS Crabbox Linux `c7a.8xlarge`, provider `aws`, lease `cbx_ab678695114e`, slug `harbor-crab`, run `run_3eff1d4287bd`; related #76962 probe also ran on AWS Crabbox `run_68e8283ae722`.

Exact steps or command run after this patch: Ran autoreview, then ran a release-candidate proof matrix on AWS Crabbox against this branch. The matrix started a real Gateway with live OpenAI model access, exercised the reported subagent timeout behavior and sibling API paths, built the branch into an npm package tarball, installed that tarball in Docker, and verified Telegram channel round-trip delivery. A separate before/after Crabbox probe compared latest `origin/main` with this branch for the #76962 terminal-timeout announcement sub-symptom.

Evidence after fix: The targeted regression suite passed; the live Gateway/API matrix passed all 8 scenarios; the package-installed Telegram Docker E2E passed; and the #76962-related probe passed on this branch after reproducing on latest `origin/main`.

Observed result after fix: The reported path returned a terminal timeout with no active child runs remaining, delivered completion state, `agent.wait` status `timeout`, and timeout outcome preserved after late aborted/rejection signals. For the #76962-related probe, terminal timeout announcement proceeded without waiting for the still-active embedded child run.

What was not tested: The final live matrix used `openai/gpt-5.4-mini` because earlier `gpt-5.5` attempts hit OpenAI TPM limits. The #76962 probe did not prove physical `claude -p` process termination, exec approval queue cancellation, or late direct-output suppression.
