### PR TITLE
fix(inbound-meta): head+tail truncation for reply context body preserves actionable tail content

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -1142,6 +1142,91 @@ describe("sanitizeTranscriptBody — head+tail truncation for reply context", ()
     expect(text).not.toContain("FILLER_ONLY_SENTINEL");
   });
 
+  it("keeps non-reply-target chat_window bodies on the short-field cap", () => {
+    // Per-window untrusted surface: only the reply target gets the larger
+    // body-aware budget. Non-target history entries stay at the 500-char cap
+    // so MAX_UNTRUSTED_HISTORY_ENTRIES × cap does not grow proportionally.
+    const longHead = "EARLY_HEAD_MARKER ".repeat(50); // ~900 chars
+    const longTail = " LATE_TAIL_MARKER".repeat(50); // ~850 chars
+    const nonTargetBody = longHead + " ".repeat(200) + longTail; // > 500
+    expect(nonTargetBody.length).toBeGreaterThan(500);
+
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "m-non-target",
+                sender: "bot",
+                body: nonTargetBody,
+                // is_reply_target deliberately omitted
+              },
+              {
+                message_id: "m-target",
+                sender: "bot",
+                body: "short target",
+                is_reply_target: true,
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    // Non-target body is prefix-truncated, not head+tail
+    expect(text).toContain("EARLY_HEAD_MARKER");
+    expect(text).not.toContain("LATE_TAIL_MARKER");
+    expect(text).not.toContain("chars omitted");
+    // Sanity: reply target framing still applies to the second entry
+    expect(text).toContain("[reply target]");
+  });
+
+  it("enforces hard cap even when neutralizing markdown fences expands the body", () => {
+    // neutralizeMarkdownFences replaces every "```" with "`<ZWSP>``" (3 → 4
+    // chars). An adversarial body of pure backticks under the input cap would
+    // otherwise expand past MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS at render time.
+    const adversarial = "`".repeat(6000); // exactly at the input cap
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "m1",
+                sender: "bot",
+                body: adversarial,
+                is_reply_target: true,
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    // Locate the rendered body line (carries "bot:" + the backtick run) and
+    // assert the hard cap holds. The ```json delimiters of unrelated metadata
+    // blocks live on their own lines, so they don't pollute this match.
+    const bodyLine = text.split("\n").find((line) => line.includes("bot:") && line.includes("`"));
+    expect(bodyLine).toBeDefined();
+    expect((bodyLine ?? "").length).toBeLessThanOrEqual(6100);
+    // No raw triple-backtick survives in the rendered body content.
+    expect((bodyLine ?? "").includes("```")).toBe(false);
+    expect(bodyLine).toContain("…[truncated]");
+  });
+
   it("does not leave a lone surrogate when an emoji straddles the tail window boundary", () => {
     // Build a body whose surrogate pair straddles the tail-window boundary at
     // body.length - BODY_TAIL_CHARS (3500): the high surrogate sits just

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -1014,3 +1014,131 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).not.toContain("private-token");
   });
 });
+
+describe("sanitizeTranscriptBody — head+tail truncation for reply context", () => {
+  it("passes a body under the cap through unchanged (apart from whitespace collapse)", () => {
+    const body = "Short bot reply with HEAD_MARK and TAIL_MARK.";
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "m1",
+                sender: "bot",
+                body,
+                is_reply_target: true,
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    expect(text).toContain(body);
+    expect(text).not.toContain("chars omitted");
+  });
+
+  it("preserves both head and tail when body exceeds cap, with explicit omission marker", () => {
+    // Head padding exceeds BODY_HEAD_CHARS (2000) so MIDDLE never reaches the head window;
+    // tail padding exceeds BODY_TAIL_CHARS (3500) so MIDDLE never reaches the tail window.
+    const headPart = "HEAD_MARKER ".repeat(400); // ~4800 chars
+    const middlePart = "MIDDLE_ONLY_SENTINEL ".repeat(800); // ~16800 chars, must be dropped
+    const tailPart = " TAIL_MARKER".repeat(500); // ~6000 chars
+    const longBody = headPart + middlePart + tailPart;
+    expect(longBody.length).toBeGreaterThan(6000);
+
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "m1",
+                sender: "bot",
+                body: longBody,
+                is_reply_target: true,
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    // Head and tail content survive
+    expect(text).toContain("HEAD_MARKER");
+    expect(text).toContain("TAIL_MARKER");
+    // Middle is dropped, replaced by omission marker
+    expect(text).toContain("chars omitted");
+    expect(text).not.toContain("MIDDLE_ONLY_SENTINEL");
+    // Reply target framing is intact
+    expect(text).toContain("[reply target]");
+  });
+
+  it("does not relax the 500-char cap on short metadata fields like sender", () => {
+    const longSender = "x".repeat(900);
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "m1",
+                sender: longSender,
+                body: "hi",
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    // Sender is still capped, not extended to body-size budget
+    expect(text).not.toContain("x".repeat(600));
+    expect(text).toContain("…[truncated]");
+  });
+
+  it("uses head+tail cap for Telegram inline ReplyToBody quote", () => {
+    // Padding exceeds BODY_HEAD_CHARS / BODY_TAIL_CHARS so middle sentinel is strictly inside dropped zone.
+    const head = "OPENING_CONTEXT ".repeat(400); // ~6400 chars
+    const middle = "FILLER_ONLY_SENTINEL ".repeat(800); // ~16800 chars, must be dropped
+    const tail = " CLOSING_OPTIONS".repeat(400); // ~6400 chars
+    const longReplyBody = head + middle + tail;
+    expect(longReplyBody.length).toBeGreaterThan(6000);
+
+    const text = buildInboundUserContextPrefix({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      ChatType: "group",
+      MessageSid: "u-1",
+      ReplyToId: "b-1",
+      ReplyToBody: longReplyBody,
+      SenderName: "user",
+    } as TemplateContext);
+
+    expect(text).toContain("[Replying to:");
+    expect(text).toContain("OPENING_CONTEXT");
+    expect(text).toContain("CLOSING_OPTIONS");
+    expect(text).toContain("chars omitted");
+    expect(text).not.toContain("FILLER_ONLY_SENTINEL");
+  });
+});

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -1141,4 +1141,60 @@ describe("sanitizeTranscriptBody — head+tail truncation for reply context", ()
     expect(text).toContain("chars omitted");
     expect(text).not.toContain("FILLER_ONLY_SENTINEL");
   });
+
+  it("does not leave a lone surrogate when an emoji straddles the tail window boundary", () => {
+    // Build a body whose surrogate pair straddles the tail-window boundary at
+    // body.length - BODY_TAIL_CHARS (3500): the high surrogate sits just
+    // outside the tail window, the low surrogate sits just inside it. Without
+    // surrogate-safe slicing, the preserved tail would begin with a lone low
+    // surrogate, producing invalid UTF-16 in the injected prompt.
+    const LOBSTER_HIGH = String.fromCharCode(0xd83e);
+    const LOBSTER_LOW = String.fromCharCode(0xdd9e); // pair = "🦞" U+1F99E
+    const headFiller = "h".repeat(2500); // > BODY_HEAD_CHARS so head window is pure
+    const middleFiller = "m".repeat(7000) + LOBSTER_HIGH;
+    const tailMarker = "TAIL_AFTER_LOBSTER";
+    const tailFiller = LOBSTER_LOW + tailMarker + "t".repeat(3500 - 1 - tailMarker.length);
+    const longBody = headFiller + middleFiller + tailFiller;
+    expect(longBody.length).toBeGreaterThan(6000);
+    // Sanity: surrogate pair really straddles the boundary at length - 3500.
+    expect(longBody.charCodeAt(longBody.length - 3501)).toBe(0xd83e);
+    expect(longBody.charCodeAt(longBody.length - 3500)).toBe(0xdd9e);
+
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      UntrustedStructuredContext: [
+        {
+          label: "Conversation context",
+          source: "telegram",
+          type: "chat_window",
+          payload: {
+            order: "chronological",
+            relation: "before_current_message",
+            messages: [
+              {
+                message_id: "m1",
+                sender: "bot",
+                body: longBody,
+                is_reply_target: true,
+              },
+            ],
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    // No lone surrogate anywhere in the rendered output.
+    for (let i = 0; i < text.length; i += 1) {
+      const c = text.charCodeAt(i);
+      if (c >= 0xd800 && c <= 0xdbff) {
+        const next = text.charCodeAt(i + 1);
+        expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
+        i += 1;
+      } else {
+        expect(c >= 0xdc00 && c <= 0xdfff).toBe(false);
+      }
+    }
+    // Tail content immediately following the would-be-split boundary survives.
+    expect(text).toContain(tailMarker);
+  });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -14,6 +14,12 @@ import type { TemplateContext } from "../templating.js";
 const MAX_UNTRUSTED_JSON_STRING_CHARS = 2_000;
 const MAX_UNTRUSTED_HISTORY_ENTRIES = 20;
 const MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS = 500;
+// Body-specific caps — long-form bot replies need head+tail preservation,
+// not a simple prefix truncation that silently drops actionable content
+// (options, conclusions, next steps) at the tail of multi-paragraph messages.
+const MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS = 6000;
+const BODY_HEAD_CHARS = 2000;
+const BODY_TAIL_CHARS = 3500;
 const MESSAGE_TOOL_DELIVERY_HINT =
   "Delivery: Final assistant text is not automatically delivered in this run. Use the `message` tool to send user-visible output.";
 
@@ -98,6 +104,30 @@ function sanitizeTranscriptField(value: unknown): string | undefined {
     .trim();
 }
 
+// Sanitize a long-form message body for use in reply-context injection.
+// Unlike sanitizeTranscriptField (designed for short metadata fields),
+// this preserves both opening context and the trailing actionable content
+// (options, conclusions, next steps) typical of multi-paragraph bot replies.
+// When the body exceeds the cap, the middle is replaced with an explicit
+// "[N chars omitted]" marker so the model knows truncation occurred rather
+// than silently receiving a truncated prefix.
+function sanitizeTranscriptBody(value: unknown): string | undefined {
+  const body = sanitizePromptBody(value);
+  if (!body) {
+    return undefined;
+  }
+  if (body.length <= MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS) {
+    return neutralizeMarkdownFences(body).replace(/\s+/g, " ").trim();
+  }
+  const head = truncateUtf16Safe(body, BODY_HEAD_CHARS).trimEnd();
+  const tail = body.slice(-BODY_TAIL_CHARS).trimStart();
+  const omittedChars = body.length - head.length - tail.length;
+  const middle = ` …[${omittedChars} chars omitted]… `;
+  return neutralizeMarkdownFences(head + middle + tail)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function formatUntrustedStructuredContextLabel(label: unknown): string {
   const normalized = normalizePromptMetadataString(label);
   return normalized
@@ -154,7 +184,7 @@ function formatChatWindowMessage(
   const replyToId = sanitizeTranscriptField(value["reply_to_id"]);
   const mediaType = sanitizeTranscriptField(value["media_type"]);
   const mediaRef = sanitizeTranscriptField(value["media_ref"]);
-  const body = sanitizeTranscriptField(value["body"]);
+  const body = sanitizeTranscriptBody(value["body"]);
   const details = [
     messageId ? `#${messageId}` : undefined,
     timestamp,
@@ -310,7 +340,7 @@ function isTelegramInboundContext(ctx: TemplateContext): boolean {
 }
 
 function resolveInlineReplyQuote(ctx: TemplateContext): string | undefined {
-  return sanitizeTranscriptField(ctx.ReplyToQuoteText) ?? sanitizeTranscriptField(ctx.ReplyToBody);
+  return sanitizeTranscriptBody(ctx.ReplyToQuoteText) ?? sanitizeTranscriptBody(ctx.ReplyToBody);
 }
 
 function formatTelegramCurrentMessageContext(ctx: TemplateContext): string | undefined {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -5,7 +5,7 @@ import { getLoadedChannelPluginById } from "../../channels/plugins/registry-load
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import { resolveSenderLabel } from "../../channels/sender-label.js";
-import { truncateUtf16Safe } from "../../utils.js";
+import { sliceUtf16Safe, truncateUtf16Safe } from "../../utils.js";
 import type { EnvelopeFormatOptions } from "../envelope.js";
 import { formatEnvelopeTimestamp } from "../envelope.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
@@ -120,7 +120,10 @@ function sanitizeTranscriptBody(value: unknown): string | undefined {
     return neutralizeMarkdownFences(body).replace(/\s+/g, " ").trim();
   }
   const head = truncateUtf16Safe(body, BODY_HEAD_CHARS).trimEnd();
-  const tail = body.slice(-BODY_TAIL_CHARS).trimStart();
+  // sliceUtf16Safe (not raw .slice) so an emoji or other surrogate pair that
+  // straddles the tail window boundary cannot leave a lone low surrogate at
+  // the start of the preserved tail.
+  const tail = sliceUtf16Safe(body, -BODY_TAIL_CHARS).trimStart();
   const omittedChars = body.length - head.length - tail.length;
   const middle = ` …[${omittedChars} chars omitted]… `;
   return neutralizeMarkdownFences(head + middle + tail)

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -59,7 +59,15 @@ function sanitizePromptBody(value: unknown): string | undefined {
 }
 
 function neutralizeMarkdownFences(value: string): string {
-  return value.replaceAll("```", "`\u200b``");
+  // Loop until no raw triple remains. replaceAll is non-overlapping, so for
+  // adversarial input like "``````" the first pass leaves a fresh "```" at the
+  // seam between adjacent replacements. Pure-backtick runs converge in two
+  // passes (the second pass breaks any seam triples into \u22642-char runs).
+  let result = value;
+  while (result.includes("```")) {
+    result = result.replaceAll("```", "`\u200b``");
+  }
+  return result;
 }
 
 function truncateUntrustedJsonString(value: string): string {
@@ -116,19 +124,31 @@ function sanitizeTranscriptBody(value: unknown): string | undefined {
   if (!body) {
     return undefined;
   }
+  let combined: string;
   if (body.length <= MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS) {
-    return neutralizeMarkdownFences(body).replace(/\s+/g, " ").trim();
+    combined = body;
+  } else {
+    const head = truncateUtf16Safe(body, BODY_HEAD_CHARS).trimEnd();
+    // sliceUtf16Safe (not raw .slice) so an emoji or other surrogate pair that
+    // straddles the tail window boundary cannot leave a lone low surrogate at
+    // the start of the preserved tail.
+    const tail = sliceUtf16Safe(body, -BODY_TAIL_CHARS).trimStart();
+    const omittedChars = body.length - head.length - tail.length;
+    combined = `${head} …[${omittedChars} chars omitted]… ${tail}`;
   }
-  const head = truncateUtf16Safe(body, BODY_HEAD_CHARS).trimEnd();
-  // sliceUtf16Safe (not raw .slice) so an emoji or other surrogate pair that
-  // straddles the tail window boundary cannot leave a lone low surrogate at
-  // the start of the preserved tail.
-  const tail = sliceUtf16Safe(body, -BODY_TAIL_CHARS).trimStart();
-  const omittedChars = body.length - head.length - tail.length;
-  const middle = ` …[${omittedChars} chars omitted]… `;
-  return neutralizeMarkdownFences(head + middle + tail)
-    .replace(/\s+/g, " ")
-    .trim();
+  const rendered = neutralizeMarkdownFences(combined).replace(/\s+/g, " ").trim();
+  // Defensive hard cap. neutralizeMarkdownFences expands every "```" run by 1
+  // char (worst case ratio 4:3), so an adversarial body of mostly-backticks can
+  // push the rendered output above MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS even when
+  // the pre-neutralization input fits the cap. Truncate the already-neutralized
+  // string at the end so the cap is honored as a hard contract.
+  if (rendered.length <= MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS) {
+    return rendered;
+  }
+  return `${truncateUtf16Safe(
+    rendered,
+    Math.max(0, MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS - 14),
+  ).trimEnd()}…[truncated]`;
 }
 
 function formatUntrustedStructuredContextLabel(label: unknown): string {
@@ -187,11 +207,17 @@ function formatChatWindowMessage(
   const replyToId = sanitizeTranscriptField(value["reply_to_id"]);
   const mediaType = sanitizeTranscriptField(value["media_type"]);
   const mediaRef = sanitizeTranscriptField(value["media_ref"]);
-  const body = sanitizeTranscriptBody(value["body"]);
+  // Only the reply-target entry warrants the larger body-aware budget — non-target
+  // history entries stay on the short-field sanitizer so the per-window untrusted
+  // surface (MAX_UNTRUSTED_HISTORY_ENTRIES × cap) does not grow proportionally.
+  const isReplyTarget = value["is_reply_target"] === true;
+  const body = isReplyTarget
+    ? sanitizeTranscriptBody(value["body"])
+    : sanitizeTranscriptField(value["body"]);
   const details = [
     messageId ? `#${messageId}` : undefined,
     timestamp,
-    value["is_reply_target"] === true ? "[reply target]" : undefined,
+    isReplyTarget ? "[reply target]" : undefined,
     replyToId ? `->#${replyToId}` : undefined,
   ].filter(Boolean);
   const media = mediaType ? `[${mediaType}${mediaRef ? ` ${mediaRef}` : ""}]` : undefined;


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**
When a user replies to a long bot message, the reply target's body was sanitized through the same 500-char metadata-field truncator (`MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS`) as short fields like `sender`, `message_id`, and `media_type`. For multi-paragraph bot replies whose actionable content (Option lists, conclusions, next steps) lives at the end, prefix truncation silently discarded exactly the part the next turn needed.

**Why does this matter now?**
It hits hardest on Telegram, where `session.reset.idleMinutes = 15` plus the known memory-hook gap (#50891) makes the injected `[reply target]` line the only surviving cross-session signal. ClawSweeper's codex review on #87291 reached the same conclusion independently: *"Split short metadata-field sanitization from long-form reply/body sanitization, use a bounded body cap that preserves multi-paragraph reply targets, and add regression coverage for a >500-character reply target whose actionable tail survives."* PR #87311 raises the same cap from 500 to 8000 with the existing prefix-only sanitizer; that fixes the immediate symptom but not the root cause — prefix truncation always discards the tail, which is exactly where actionable content lives, so a future bot message longer than the new cap hits the same failure mode at 8000 instead of 500.

**What is the intended outcome?**
Long reply-target bodies preserve both the opening context and the trailing actionable content. When a body exceeds the cap, the middle is replaced by an explicit `…[N chars omitted]…` marker so the model knows truncation occurred rather than silently receiving a prefix.

**What is intentionally out of scope?**
- Slack / Discord live multi-channel proof (changed call sites are channel-agnostic and unit-tested, but only Telegram was driven live in this PR).
- Touching `session.reset.idleMinutes` or the memory-hook gap (#50891) themselves — this PR mitigates the symptom by preserving the cross-session reply context, not the underlying idle-reset behavior.
- Raising the cap for short metadata fields (`sender`, `message_id`, etc.) — those keep the existing 500-char cap; this PR only changes the body sanitizer.

**What does success look like?**
After this patch, a user can reply to a multi-paragraph bot message after an idle session reset and the next bot turn still understands the original Options / recommendation / next-step content that was at the tail of the prior message.

**What should reviewers focus on?**
- The split between `sanitizeTranscriptField` (short metadata, 500 cap, unchanged) and the new `sanitizeTranscriptBody` (long-form body, 6000 cap, head+tail preservation with explicit omission marker).
- The three call-site swaps (`formatChatWindowMessage` body, plus `resolveInlineReplyQuote` for both `ReplyToQuoteText` and `ReplyToBody`).
- Whether `BODY_HEAD_CHARS = 2000` / `BODY_TAIL_CHARS = 3500` / `MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS = 6000` is the right budget for prompt-cost vs context-preservation, and whether the head+tail pattern matches the analogous one in `truncateToolText()` in `pi-embedded-subscribe.tools.ts`.

## Linked context

Closes #87291.

Related #87311 (alternative fix, raises cap from 500 to 8000 with the existing prefix-only sanitizer — same symptom, but does not preserve tail content).

Not requested by a maintainer or owner — opened by the issue author after ClawSweeper's codex review on #87291 outlined the same split-and-preserve-tail shape.

## Real behavior proof

**Behavior or issue addressed:** Closes #87291. Reply-target bodies longer than 500 chars were silently truncated by `MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS = 500`, so when a user replied to a long bot message after an idle session reset the bot lost the actionable tail (Options, recommendation, next steps) and asked the user to re-explain. Hits hardest on Telegram because `session.reset.idleMinutes = 15` plus the known memory-hook gap (#50891) makes the injected `[reply target]` line the only surviving cross-session signal.

**Real environment tested:** macOS Darwin 24.6.0, openclaw built from this branch (`fix/reply-context-body-head-tail-truncation`), launched via `node ~/Documents/work/openclaw/dist/index.js gateway --port 18789` against the production Telegram bot token (the prod launchd gateway was temporarily booted out so the same port and bot identity could be served by the dev build). Live Telegram chat with `@Johomelab_bot`, real `session.reset.idleMinutes = 15` config, real `/reset` issued between turns.

**Exact steps or command run after this patch:** Built the patched dev gateway, stopped prod in-place, started the dev build on the same port and Telegram token, drove a real Telegram conversation, then restored prod:

```
pnpm build
launchctl bootout gui/501/ai.openclaw.gateway
( set -a; source ~/.openclaw/service-env/ai.openclaw.gateway.env; set +a; \
  node ~/Documents/work/openclaw/dist/index.js gateway --port 18789 \
    > /tmp/openclaw-dev-gateway.log 2>&1 ) &
launchctl bootstrap gui/501 ~/Library/LaunchAgents/ai.openclaw.gateway.plist
```

On the Telegram side: sent a ~960-char prompt asking for "Option A / Option B / Option C" advice. Waited for the long bot analysis (Options + recommendation + week-1 first steps). Issued `/reset` to force a fresh session. Then reply-quoted the original long bot analysis with a short follow-up: `I'm leaning toward Option B. What's the first thing I should do this week?`

Inspected the trajectory file the patched gateway wrote for that new session:

```
grep -c "Replying to" \
  ~/.openclaw/agents/main/sessions/765f29b4-...trajectory.jsonl
grep -c "Option A\|Option B\|Option C" \
  ~/.openclaw/agents/main/sessions/765f29b4-...trajectory.jsonl
```

**Evidence after fix:** Reply-target body that the patched gateway actually injected into the post-reset session — extracted directly from the trajectory jsonl that the dev build wrote (`~/.openclaw/agents/main/sessions/765f29b4-b3b1-4431-8be4-a115150bc0c7.trajectory.jsonl`):

```
Current message:
[Replying to: "這個問題很清晰，我直接給分析。 ─── 底層判斷：你的優先順序已經透露了答案
你自己列出來的順序是：家庭財務穩定 > Staff Engineer 目標 > 技術成長 > 工作生活平衡。
這個排序不支持冒險。 ─── 三個選項分析 Option A：留下來的條件 ... Option B：30% 不夠 ...
Option C：這個 offer 的戰術價值 ... ─── 我的觀點 如果必須現在選，Options A（留下談）
勝過 B ... ─── 本週第一步 Option A → 找獵頭 ... Option C → 同上 ..."]
#5948 (sender): I'm leaning toward Option B. What's the first thing I should do this week?
```

```
$ grep -c "Replying to" .../765f29b4-...trajectory.jsonl
4
$ grep -c "Option A\|Option B\|Option C" .../765f29b4-...trajectory.jsonl
4
```

Measured length of the injected `[Replying to: …]` payload body: **911 characters**. Under the previous 500-char cap this body would have been truncated at char 486 + `…[truncated]`, which falls inside Option A's analysis — Options B and C, the recommendation, and the `本週第一步` steps would all have been stripped before the model saw the prompt. With this patch the full body passes through (well under the new 6000-char body cap, so head+tail compaction did not need to fire).

**Observed result after fix:** In the new post-reset session, the model's thinking trace shows it understands the full prior message (`John is saying he's leaning toward Option B (Pre-PMF startup + mortgage + young kids). … re-reading my previous message more carefully — I said the first step should be 要求對方提供詳細的財務狀況 and 找一個在這家擔任類似職位的人問真實評價`) and produces a concrete Option-B-specific first-week plan (equity term sheet, vest schedule, option pool dilution, acceleration clauses, liquidation preference) instead of asking the user to re-explain what Option B is. Compare to the pre-patch dry run of the same flow where the bot answered `我看不到你之前的 MEMORY..hd 也沒有 Option B` and could not act on the user's choice.

**What was not tested:** Did not exercise the > 6000-char head+tail truncation path against live Telegram in this run — the captured reply-target body was 911 chars, comfortably under the new `MAX_UNTRUSTED_TRANSCRIPT_BODY_CHARS = 6000` cap, so head+tail compaction did not fire. The head+tail truncation behavior itself, including the `…[N chars omitted]…` marker and middle dropping, is covered by the new unit tests at `src/auto-reply/reply/inbound-meta.test.ts`. Did not run cross-channel proof on Slack or Discord — the changed call sites (`formatChatWindowMessage`, `resolveInlineReplyQuote`) are channel-agnostic and unit-tested but a live multi-channel sweep was out of scope for this PR.

**Proof limitations or environment constraints:** The live test could only exercise one Telegram bot identity at a time because the dev gateway shared the production Telegram token with the launchd-managed prod gateway; the prod gateway had to be booted out for the duration of the live test and was restored immediately after. A `> 6000` char reply-target body is awkward to produce in normal Telegram conversation without long copy-paste payloads, so the head+tail truncation path was verified by unit test rather than by live Telegram traffic.

**Before evidence (optional):** Telegram screenshots of the pre-fix flow (same `/reset` + reply-quote of a long bot message produced `我看不到你之前的 MEMORY..hd 也沒有 Option B`) and the post-fix flow (correct Option-B-specific first-week plan) can be added in a follow-up comment with personal identifiers (chat id, sender name, bot handle) redacted.

## Tests and validation

**Which commands did you run?**

```
node scripts/run-vitest.mjs \
  src/auto-reply/reply/inbound-meta.test.ts \
  src/auto-reply/reply/strip-inbound-meta.test.ts \
  src/auto-reply/reply.raw-body.test.ts \
  src/auto-reply/reply/get-reply-run.media-only.test.ts
# Test Files  4 passed (4)
# Tests       158 passed (158)

pnpm format:check src/auto-reply/reply/inbound-meta.ts src/auto-reply/reply/inbound-meta.test.ts
node scripts/run-oxlint.mjs src/auto-reply/reply/inbound-meta.ts src/auto-reply/reply/inbound-meta.test.ts
pnpm build
```

`pnpm check:changed` was also run; the only failure is `typecheck core` on `src/gateway/session-utils.fs.ts:252` (`maxMessages` declared but never read), which is a pre-existing red on `main` (file last touched by `0e86ca1352 fix(gateway): default non-finite recent transcript limits`, untouched by this PR). Per CONTRIBUTING.md "Do not submit test/CI-config fixes for failures already red on main CI", this PR does not address it.

**What regression coverage was added or updated?** New `describe("sanitizeTranscriptBody — head+tail truncation for reply context")` block in `src/auto-reply/reply/inbound-meta.test.ts` with four tests:

1. body under cap passes through unchanged (modulo whitespace collapse).
2. body over cap preserves both head and tail with `…[N chars omitted]…` marker; middle sentinel is dropped.
3. short metadata fields (sender) still capped at 500 with `…[truncated]` — regression guard so we did not accidentally raise the cap for short fields.
4. Telegram inline `ReplyToBody` quote also uses the head+tail cap.

**What failed before this fix, if known?** Reproducible in the trajectory captured for the user's own session `65fe0a30-1ccd-45a4-a3c3-311f912447c4` (referenced in #87291): the injected `[reply target]` body ended at `food-japan Writer | 7 次…[truncated]` after 486 chars, dropping the multi-paragraph analysis tail. The bot in the next turn could not act on the prior reply.

**If no test was added, why not?** N/A — tests added (see above).

## Risk checklist

**Did user-visible behavior change?** Yes. Reply-target bodies > 500 chars now reach the model with up to ~5500 chars of preserved content (head + tail) instead of the first 486 chars + `…[truncated]`. Bodies between 500 and 6000 chars pass through completely. Bodies > 6000 chars get the new head+tail+omission-marker shape instead of a silent prefix.

**Did config, environment, or migration behavior change?** No. No new config keys, no migration, no doctor flow. Constants are inline and not user-tunable.

**Did security, auth, secrets, network, or tool execution behavior change?** No. The body is still NUL-stripped, markdown-fence-neutralized, and whitespace-collapsed; the cap is still a hard ceiling on untrusted Telegram body bytes that reach the prompt. The cap is raised for body only, not for short metadata fields. Total bytes-per-message budget grows from ~500 to at most ~6050 (6000 body + small marker), well under the existing `MAX_UNTRUSTED_JSON_STRING_CHARS = 2000` per JSON string limit for other untrusted fields.

**What is the highest-risk area?** Prompt budget impact on agents that receive very large reply-target bodies — a 6000-char body inside `[Replying to: …]` is ~1500-2000 tokens depending on the model. For agents that already run close to context limits this could shift the budget noticeably.

**How is that risk mitigated?** The 6000-char hard cap keeps the worst case bounded. Head+tail compaction kicks in for anything over 6000 and still emits ~5500 chars of content (2000 head + 3500 tail) plus the explicit `…[N chars omitted]…` marker, so the upper bound for context bytes consumed by a single reply-target body is stable regardless of the underlying message length. Short metadata fields keep the 500-char cap so a malicious sender filling `sender` or `media_type` cannot blow up the budget through this PR.

## Current review state

**What is the next action?** Awaiting ClawSweeper verdict (placeholder review comment posted; will edit same comment with actual verdict). Maintainer review from `@steipete` / `@vincentkoc` (area history per `git blame`) and `@obviyus` / `@joshp123` (Telegram subsystem owners per CONTRIBUTING.md) welcome once ClawSweeper lands.

**What is still waiting on author, maintainer, CI, or external proof?** Eight CI checks still running at PR open (`checks-node-agentic-agents`, `checks-node-agentic-gateway-core`, others); no failures so far in the 64 already-green checks. Real behavior proof gate has passed and `proof: supplied` label is applied. Optional follow-up: redact and attach Telegram screenshot pair (before-fix `我看不到你之前的 MEMORY..hd` vs after-fix Option-B-specific plan) as a PR comment.

**Which bot or reviewer comments were addressed?** None yet — only ClawSweeper's "review started" placeholder is posted. Will reply to / resolve bot threads as they appear per CONTRIBUTING.md "Review Conversations Are Author-Owned".

## AI-assisted

This PR was drafted with Claude Code (sonnet/opus session). Code changes, unit tests, the live-test prod-swap procedure, and this PR body were AI-assisted. I (myps6415) ran the live Telegram test end-to-end on my homelab, captured the screenshots, and reviewed every line of the diff and the proof body. The fix shape (split short-field vs body sanitizer, head+tail preservation) matches ClawSweeper's codex review recommendation on #87291.
