### PR TITLE
Handle Codex toolResult blocks in tool-result truncation

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -163,6 +163,26 @@ describe("getToolResultTextLength", () => {
     expect(getToolResultTextLength(msg)).toBe(8);
   });
 
+  it("counts Codex protocol toolResult content blocks", () => {
+    const msg = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "exec",
+      isError: false,
+      content: [
+        {
+          type: "toolResult",
+          toolUseId: "call_1",
+          text: "codex output",
+          content: "codex output",
+        },
+      ],
+      timestamp: nextTimestamp(),
+    } as unknown as ToolResultMessage;
+
+    expect(getToolResultTextLength(msg)).toBe("codex output".length);
+  });
+
   it("returns zero for non-toolResult messages", () => {
     expect(getToolResultTextLength(makeAssistantMessage("hello"))).toBe(0);
   });
@@ -188,6 +208,39 @@ describe("truncateToolResultMessage", () => {
       throw new Error("expected toolResult");
     }
     expect(getFirstToolResultText(result)).toContain("[persist-truncated]");
+  });
+
+  it("truncates Codex protocol toolResult content blocks and mirrored content", () => {
+    const oversized = "x".repeat(50_000);
+    const msg = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "exec",
+      content: [
+        {
+          type: "toolResult",
+          toolUseId: "call_1",
+          text: oversized,
+          content: oversized,
+        },
+      ],
+      isError: false,
+      timestamp: nextTimestamp(),
+    } as unknown as ToolResultMessage;
+
+    const result = truncateToolResultMessage(msg, 10_000, {
+      suffix: "\n\n[persist-truncated]",
+      minKeepChars: 2_000,
+    });
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const firstBlock = result.content[0] as unknown as { text?: unknown; content?: unknown };
+    expect(typeof firstBlock.text).toBe("string");
+    expect(firstBlock.text).toContain("[persist-truncated]");
+    expect(String(firstBlock.text).length).toBeLessThan(oversized.length);
+    expect(firstBlock.content).toBe(firstBlock.text);
   });
 });
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -259,8 +259,8 @@ export function getToolResultTextLength(msg: AgentMessage): number {
   }
   let totalLength = 0;
   for (const block of content) {
-    if (block && typeof block === "object" && (block as { type?: string }).type === "text") {
-      const text = (block as TextContent).text;
+    if (isToolResultTextBlock(block)) {
+      const text = block.text;
       if (typeof text === "string") {
         totalLength += text.length;
       }
@@ -297,10 +297,10 @@ export function truncateToolResultMessage(
 
   // Distribute the budget proportionally among text blocks
   const newContent = content.map((block: unknown) => {
-    if (!block || typeof block !== "object" || (block as { type?: string }).type !== "text") {
+    if (!isToolResultTextBlock(block)) {
       return block; // Keep non-text blocks (images) as-is
     }
-    const textBlock = block as TextContent;
+    const textBlock = block;
     if (typeof textBlock.text !== "string") {
       return block;
     }
@@ -314,15 +314,31 @@ export function truncateToolResultMessage(
       1,
       Math.min(maxChars, Math.max(minKeepChars + defaultSuffix.length, proportionalBudget)),
     );
-    return Object.assign({}, textBlock, {
-      text: truncateToolResultText(textBlock.text, blockBudget, {
-        suffix: suffixFactory,
-        minKeepChars,
-      }),
+    const truncatedText = truncateToolResultText(textBlock.text, blockBudget, {
+      suffix: suffixFactory,
+      minKeepChars,
     });
+    const nextBlock = Object.assign({}, textBlock, { text: truncatedText });
+    if (typeof textBlock.content === "string") {
+      nextBlock.content = truncatedText;
+    }
+    return nextBlock;
   });
 
   return { ...msg, content: newContent } as AgentMessage;
+}
+
+function isToolResultTextBlock(
+  block: unknown,
+): block is TextContent & { content?: unknown; type: "text" | "toolResult" } {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return (
+    (type === "text" || type === "toolResult") &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR makes the existing tool-result truncation helpers treat Codex protocol blocks with `type: "toolResult"` as text-bearing tool output.

- Count `type: "toolResult"` content blocks when measuring tool-result text length.
- Truncate those blocks through the existing tool-result truncation path.
- Keep mirrored string `content` synchronized with the truncated `text` value.
- Keep non-text blocks, including images, on the existing path.

Why this matters now: recent upstream work bounds aggregate persisted `toolResult` text, but the shared helper still only accounts for content blocks whose type is exactly `text`. Codex-shaped blocks can carry large output in `text` while using `type: "toolResult"`, so they should participate in the same cap.

Intended outcome: Codex-shaped tool-result content is bounded by the same helper as ordinary text blocks.

Out of scope: changing cap sizes, transcript persistence policy, image/media handling, or app-server projection behavior.

Review focus: the narrow block-shape predicate and whether mirrored string `content` should stay synchronized when `text` is truncated.

## Linked context

Closes: none.

Related: #87639, because this builds on the same shared truncation helper area but covers a different content-block shape.

Maintainer request: none.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A real Codex/OpenClaw run can persist tool output as a content block shaped as `type: "toolResult"` with a string `text` payload and mirrored string `content`. Before this patch, the shared truncation helper only counted blocks whose type is exactly `text`, so that real block shape was skipped by helper-level text measurement and truncation.
- Real environment tested: local OpenClaw CLI run using the Codex harness with a fresh synthetic session. The command generated only a public synthetic payload; no private prompts, transcripts, logs, or session contents are copied here.
- Exact steps or command run after this patch: ran `openclaw agent --agent main --session-id public-proof-codex-toolresult-block-20260529 ... --json --timeout 300` with a prompt that asked the agent to execute `node -e "process.stdout.write(JSON.stringify({kind:\"public-proof\",payload:\"x\".repeat(50000)}))"`, then ran a local `node` inspector that printed only sanitized metrics for the stored tool-result block.
- Evidence after fix: copied live console output from that synthetic OpenClaw run and sanitized inspector:

```text
openclaw agent sanitized result:
{
  "status": "ok",
  "provider": "openai-codex",
  "model": "gpt-5.5",
  "finalText": "The command was run.",
  "toolCalls": 1,
  "toolFailures": 0
}

sanitized session inspector output:
{
  "status": "ok",
  "sessionRows": 5,
  "toolResultRows": 1,
  "firstBlockType": "toolResult",
  "textChars": 12018,
  "mirroredContentMatches": true,
  "containsSyntheticMarker": true,
  "containsTruncationNotice": true,
  "rawSyntheticPayloadWouldHaveExceededChars": 50000
}
```

- Observed result after fix: the live synthetic OpenClaw run confirms the real persisted Codex block shape this helper needs to handle: `type: "toolResult"`, string `text`, and mirrored string `content`. The branch then covers that shape in the shared helper so it is counted and truncated like ordinary text blocks, with mirrored string `content` synchronized after truncation.
- What was not tested: I did not paste raw session files, private runtime logs, or user transcripts. I also did not replay a private long-running session.
- Proof limitations or environment constraints: the live proof demonstrates the real Codex/OpenClaw block shape with synthetic data; the helper-level before/after behavior is validated by the focused regression cases added in this PR.
- Before evidence: current `main` only checks for `block.type === "text"` in this helper path, so the real `type: "toolResult"` shape shown above is not counted by the shared helper.

## Tests and validation

Commands run:

```bash
corepack pnpm vitest run src/agents/embedded-agent-runner/tool-result-truncation.test.ts
corepack pnpm exec oxfmt --check src/agents/embedded-agent-runner/tool-result-truncation.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts
git diff --check origin/main...HEAD
```

Regression coverage added:

- `getToolResultTextLength` counts Codex protocol `toolResult` content blocks.
- `truncateToolResultMessage` truncates Codex protocol `toolResult` blocks and keeps mirrored string `content` in sync with truncated `text`.

What failed before this fix: the new cases fail against the old helper behavior because those blocks are skipped unless their type is `text`.

If no test was added, why not: tests were added.

## Risk checklist

Did user-visible behavior change? `Yes`, for oversized Codex-shaped tool-result text that was previously skipped by this helper.

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `No`.

Highest-risk area: accidentally treating a non-text tool-result block as truncatable text.

Mitigation: the predicate requires `type` to be either `text` or `toolResult` and also requires `text` to be a string. Existing non-text blocks stay unchanged.

## Current review state

Next action: maintainer review and CI.

Still waiting on: CI and maintainer judgment on the narrow block-shape handling.

Bot or reviewer comments addressed: initial real-behavior proof gate response was addressed by adding a public-safe synthetic OpenClaw run and sanitized inspector output.