### PR TITLE
fix(thinking): keep explicit session thinkingLevel when runtime downgrades (#87740)

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -40,6 +40,7 @@ const state = vi.hoisted(() => ({
   persistSessionEntryMock: vi.fn(async (..._args: unknown[]): Promise<unknown> => undefined),
   clearSessionAuthProfileOverrideMock: vi.fn(),
   isThinkingLevelSupportedMock: vi.fn((_args: unknown) => true),
+  resolveSupportedThinkingLevelMock: vi.fn((args: { level?: string }) => args.level),
   resolveThinkingDefaultMock: vi.fn((_args: unknown) => "low"),
   loadManifestModelCatalogMock: vi.fn(() => []),
   buildWorkspaceSkillSnapshotMock: vi.fn((..._args: unknown[]): unknown => ({
@@ -54,6 +55,7 @@ const state = vi.hoisted(() => ({
   sessionEntryMock: undefined as unknown,
   sessionStoreMock: undefined as unknown,
   storePathMock: undefined as string | undefined,
+  persistedThinkingMock: undefined as string | undefined,
 }));
 
 vi.mock("./model-fallback.js", () => ({
@@ -120,7 +122,7 @@ vi.mock("./command/session.js", () => ({
     sessionStore: state.sessionStoreMock,
     storePath: state.storePathMock,
     isNewSession: false,
-    persistedThinking: undefined,
+    persistedThinking: state.persistedThinkingMock,
     persistedVerbose: undefined,
   }),
 }));
@@ -154,7 +156,8 @@ vi.mock("../auto-reply/thinking.js", () => ({
   normalizeThinkLevel: (v?: string) => v || undefined,
   normalizeVerboseLevel: (v?: string) => v || undefined,
   isThinkingLevelSupported: (args: unknown) => state.isThinkingLevelSupportedMock(args),
-  resolveSupportedThinkingLevel: ({ level }: { level?: string }) => level,
+  resolveSupportedThinkingLevel: (args: { level?: string }) =>
+    state.resolveSupportedThinkingLevelMock(args),
   supportsXHighThinking: () => false,
 }));
 
@@ -771,6 +774,8 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.resolveAcpExplicitTurnPolicyErrorMock.mockReturnValue(null);
     state.runtimeConfigMock = undefined;
     state.isThinkingLevelSupportedMock.mockReturnValue(true);
+    state.resolveSupportedThinkingLevelMock.mockImplementation((args) => args.level);
+    state.persistedThinkingMock = undefined;
     state.resolveThinkingDefaultMock.mockReturnValue("low");
     state.resolveAgentSkillsFilterMock.mockReturnValue(undefined);
     state.loadManifestModelCatalogMock.mockReturnValue([]);
@@ -940,6 +945,37 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(touchWrite.entry?.thinkingLevel).toBe("medium");
     expect(touchWrite.entry?.lastInteractionAt).toBeDefined();
     expect(state.updateSessionStoreAfterAgentRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves an explicit session thinkingLevel override when the level is unsupported", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      thinkingLevel: "high",
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.persistedThinkingMock = "high";
+    // The model rejects the stored level, so the turn downgrades at runtime.
+    state.isThinkingLevelSupportedMock.mockReturnValue(false);
+    state.resolveSupportedThinkingLevelMock.mockReturnValue("off");
+
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+    });
+
+    // Runtime downgrade is per-turn; it must not persist the fallback level back
+    // onto the user's explicit stored override.
+    const downgradeWrite = state.persistSessionEntryMock.mock.calls.find((call) => {
+      const entry = (call[0] as { entry?: { thinkingLevel?: string } } | undefined)?.entry;
+      return entry?.thinkingLevel === "off";
+    });
+    expect(downgradeWrite).toBeUndefined();
   });
 
   it("clears stale flag-only pending final delivery when there is no final payload", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1197,27 +1197,10 @@ async function agentCommandInternal(
         level: resolvedThinkLevel,
         catalog: thinkingCatalog,
       });
-      if (fallbackThinkLevel !== resolvedThinkLevel) {
-        const previousThinkLevel = resolvedThinkLevel;
-        resolvedThinkLevel = fallbackThinkLevel;
-        if (
-          sessionEntry &&
-          sessionStore &&
-          sessionKey &&
-          sessionEntry.thinkingLevel === previousThinkLevel &&
-          !suppressVisibleSessionEffects
-        ) {
-          const entry = sessionEntry;
-          entry.thinkingLevel = fallbackThinkLevel;
-          entry.updatedAt = Date.now();
-          await persistSessionEntry({
-            sessionStore,
-            sessionKey,
-            storePath,
-            entry,
-          });
-        }
-      }
+      // Downgrade only the level used for this turn. The explicit session
+      // override is the user's stored intent; persisting the fallback here would
+      // permanently reset it to the supported level on every turn (#87740).
+      resolvedThinkLevel = fallbackThinkLevel;
     }
     const { resolveSessionTranscriptFile } = await loadTranscriptResolveRuntime();
     let sessionFile: string | undefined;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -311,9 +311,6 @@ const agentRunnerRuntimeLoader = createLazyImportLoader(() => import("./agent-ru
 const sessionUpdatesRuntimeLoader = createLazyImportLoader(
   () => import("./session-updates.runtime.js"),
 );
-const sessionStoreRuntimeLoader = createLazyImportLoader(
-  () => import("../../config/sessions/store.runtime.js"),
-);
 
 function loadEmbeddedAgentRuntime() {
   return embeddedAgentRuntimeLoader.load();
@@ -325,10 +322,6 @@ function loadAgentRunnerRuntime() {
 
 function loadSessionUpdatesRuntime() {
   return sessionUpdatesRuntimeLoader.load();
-}
-
-function loadSessionStoreRuntime() {
-  return sessionStoreRuntimeLoader.load();
 }
 
 function stripPromptThinkingDirectives(body: string): string {
@@ -880,26 +873,10 @@ export async function runPreparedReply(
       level: resolvedThinkLevel,
       catalog: thinkingCatalog,
     });
-    if (fallbackThinkLevel !== resolvedThinkLevel) {
-      const previousThinkLevel = resolvedThinkLevel;
-      resolvedThinkLevel = fallbackThinkLevel;
-      if (
-        sessionEntry &&
-        sessionStore &&
-        sessionKey &&
-        sessionEntry.thinkingLevel === previousThinkLevel
-      ) {
-        sessionEntry.thinkingLevel = fallbackThinkLevel;
-        sessionEntry.updatedAt = Date.now();
-        sessionStore[sessionKey] = sessionEntry;
-        if (storePath) {
-          const { updateSessionStore } = await loadSessionStoreRuntime();
-          await updateSessionStore(storePath, (store) => {
-            store[sessionKey] = sessionEntry;
-          });
-        }
-      }
-    }
+    // Downgrade only the level used for this turn. The explicit session override
+    // is the user's stored intent; persisting the fallback here would permanently
+    // reset it to the supported level on every turn (#87740).
+    resolvedThinkLevel = fallbackThinkLevel;
   }
   const internalOpts = opts as InternalGetReplyOptions | undefined;
   const providedReplyOperation = internalOpts?.replyOperation;


### PR DESCRIPTION
## Summary

Fixes #87740. An explicit session `thinkingLevel` override (e.g. `high`) was permanently reset to a supported level (e.g. `off`) after every agent turn whenever the active model didn't support the stored level.

Root cause: when the stored level was unsupported, the runtime correctly fell back to a supported level for the turn, but **also wrote that fallback back onto the persisted session override**. The write-back condition fired precisely when the stored value was the user's explicit override, so the explicit choice was clobbered every turn — re-setting it just got overwritten again next turn. Leaving the level `inherited`/null was unaffected, which matches the report.

Fix: downgrade only the level used for the current turn (`resolvedThinkLevel`); never persist the support fallback onto the stored override. The same duplicated write-back lived in both the reply path (`src/auto-reply/reply/get-reply-run.ts`) and the agent-command path (`src/agents/agent-command.ts`); both are fixed. Removed the now-dead `loadSessionStoreRuntime` loader in `get-reply-run.ts`. Production code shrinks (-17 / -23 lines). An explicit `off` set via directive/`sessions.patch` still persists through the normal path; only the involuntary support downgrade no longer persists.

## Out of scope (sibling sites)

Two sites also persist a support-driven downgrade onto the stored level, but only on a user-initiated **model switch** (not the per-turn reset this issue reports), and one already notifies the client:

- `src/gateway/sessions-patch.ts:604` — a PATCH that changes model (without an explicit `thinkingLevel`) downgrades an inherited unsupported level and persists it (no notification).
- `src/auto-reply/reply/directive-handling.persist.ts:326` — a `/model` switch remaps the stored level and persists it, returning a `thinkingRemap` notice.

These are deliberately coded (explicit-vs-inherited branching); whether a model switch should preserve the original preference is a product/compat decision, so they're intentionally left out. Follow-up: #87925.

## Verification

- `pnpm test src/agents/agent-command.live-model-switch.test.ts` — 27 passed, incl. new regression test `preserves an explicit session thinkingLevel override when the level is unsupported` (red before fix, green after).
- Siblings `thinking` / `directive-handling.levels` / `commands-status.thinking-default` / `get-reply.config-override` — 58 passed.
- Regression: `directive-handling.model` (50) + `gateway/sessions-patch` (72) green — confirms an explicit `off` still persists; only the involuntary downgrade stops.
- `pnpm check:changed` — clean (oxlint, import cycles, typecheck, guards), exit 0.

### Real behavior proof

Behavior addressed: An explicit session `thinkingLevel: "high"` override is no longer reset to the support fallback after a turn when the active model rejects that level at runtime; the stored override survives the turn.

Real environment tested: A live agent turn against a real OpenAI-compatible Xiaomi MiMo model (`xiaomi/mimo-v2.5-pro`, real `/v1/chat/completions` API, genuine replies) using a source build of this branch (`pnpm build`) in an isolated profile. The model is configured `reasoning: false`, so `high` is unsupported at runtime and the per-turn support downgrade fires — reproducing the #87740 condition with a real model. This exercises the embedded agent path (`openclaw agent --local` → `src/agents/agent-command.ts`). The `get-reply-run.ts` (WebChat) site was not driven through a live inbound channel; it is the byte-identical removal and is covered by the A/B below plus the existing get-reply suites.

A/B method: identical isolated profile, identical session pre-seeded with `thinkingLevel: "high"`, identical model. Only the two fixed source files (`src/agents/agent-command.ts`, `src/auto-reply/reply/get-reply-run.ts`) were reverted to the pre-fix parent (`2e042fbca8`) and rebuilt for the "before" run, then restored and rebuilt for the "after" run — so this PR's change is the only variable.

Exact steps or command run after this patch:
1. Configure `xiaomi/mimo-v2.5-pro` with `reasoning: false` (makes `high` unsupported at runtime) in an isolated profile; pre-seed session `agent:main:main` with `thinkingLevel: "high"` in `agents/main/sessions/sessions.json`.
2. `XIAOMI_API_KEY=… pnpm openclaw --profile <p> agent --local --to +15555550123 -m "Reply with a single word: …" --json`
3. Re-read `agents/main/sessions/sessions.json` → `["agent:main:main"].thinkingLevel` before and after the turn.

Evidence after fix (live turns, real model replies, same model `xiaomi/mimo-v2.5-pro`):

| code under test | turn result | real reply | per-turn thinking | stored `thinkingLevel` after turn |
| --- | --- | --- | --- | --- |
| before fix (parent `2e042fbca8`) | success | `pong` | `off` (downgraded) | `off` ← bug reproduced |
| after fix (this branch) | success | `ok` | `off` (downgraded) | `high` ← override preserved |

Observed result after fix: with stored `thinkingLevel: "high"` on a model that rejects it at runtime, the turn runs normally (real reply, `meta.requestShaping.thinking: "off"`) and the stored override stays `high`. Reverting only the two fixed files flips the stored value back to `off`, confirming this change is what preserves the override.

What was not tested: a live WebChat/Control UI or Voice UI round-trip against a running gateway — the `get-reply-run.ts` path was not executed via an inbound channel. It carries the identical removed block and is covered by the A/B above and the existing get-reply suites.

