### PR TITLE
fix(cron): preserve plugin delivery targets

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -624,6 +624,67 @@ describe("resolveDeliveryTarget", () => {
     expect(result.threadId).toBeUndefined();
   });
 
+  it("preserves plugin-canonical targets returned for aliases", async () => {
+    setMainSessionEntry(undefined);
+    const canonicalTarget = "Bncr:tgBot:-1003891624016:6278285192";
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "bncr",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "bncr",
+            outbound: createStubOutbound("Bncr"),
+            messaging: {
+              targetPrefixes: ["bncr"],
+              targetResolver: {
+                resolveTarget: async ({ input }) =>
+                  input === "alerts"
+                    ? { to: canonicalTarget, kind: "group" as const, source: "normalized" as const }
+                    : null,
+              },
+            },
+          }),
+        },
+      ]),
+    );
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "bncr",
+      to: "alerts",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe(canonicalTarget);
+    expect(result.threadId).toBeUndefined();
+  });
+
+  it("still strips selected prefixes from generic normalized fallback targets", async () => {
+    setMainSessionEntry(undefined);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "alpha",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "alpha",
+            outbound: createStubOutbound("Alpha"),
+            messaging: { targetPrefixes: ["alpha"] },
+          }),
+        },
+      ]),
+    );
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "alpha",
+      to: "alpha:room-a",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("room-a");
+    expect(result.threadId).toBeUndefined();
+  });
+
   it("uses plugin-resolved directory targets for route parsing", async () => {
     setMainSessionEntry(undefined);
     setActivePluginRegistry(

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -432,6 +432,7 @@ describe("resolveDeliveryTarget", () => {
       to: "user:123456789",
       kind: "user",
       source: "directory",
+      resolutionSource: "plugin",
     });
 
     const cfg = makeCfg({ bindings: [] });
@@ -585,6 +586,88 @@ describe("resolveDeliveryTarget", () => {
 
     expect(result.ok).toBe(true);
     expect(result.to).toBe("room-b");
+    expect(result.threadId).toBeUndefined();
+  });
+
+  it("preserves plugin-canonical targets that begin with the selected channel prefix", async () => {
+    setMainSessionEntry(undefined);
+    const canonicalTarget = "Bncr:tgBot:-1003891624016:6278285192";
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "bncr",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "bncr",
+            outbound: createStubOutbound("Bncr"),
+            messaging: {
+              targetPrefixes: ["bncr"],
+              targetResolver: {
+                resolveTarget: async ({ input }) =>
+                  input === canonicalTarget
+                    ? { to: canonicalTarget, kind: "group" as const, source: "normalized" as const }
+                    : null,
+              },
+            },
+          }),
+        },
+      ]),
+    );
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "bncr",
+      to: canonicalTarget,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe(canonicalTarget);
+    expect(result.threadId).toBeUndefined();
+  });
+
+  it("uses plugin-resolved directory targets for route parsing", async () => {
+    setMainSessionEntry(undefined);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "alpha",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "alpha",
+            outbound: createStubOutbound("Alpha"),
+            messaging: {
+              targetPrefixes: ["alpha"],
+              targetResolver: {
+                resolveTarget: async ({ input }) =>
+                  input === "alice"
+                    ? { to: "user:123", kind: "user" as const, source: "directory" as const }
+                    : null,
+              },
+              resolveOutboundSessionRoute: ({ cfg, agentId, accountId, target }) => {
+                const isUser = target.startsWith("user:");
+                return buildChannelOutboundSessionRoute({
+                  cfg,
+                  agentId,
+                  channel: "alpha",
+                  accountId,
+                  peer: { kind: isUser ? "direct" : "channel", id: target },
+                  chatType: isUser ? "direct" : "channel",
+                  from: target,
+                  to: isUser ? target : `channel:${target}`,
+                });
+              },
+            },
+          }),
+        },
+      ]),
+    );
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "alpha",
+      to: "alice",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("user:123");
     expect(result.threadId).toBeUndefined();
   });
 

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -122,6 +122,11 @@ function stripSelectedProviderPrefix(params: {
   const stripped = stripTargetProviderPrefix(trimmed, params.channel).trim();
   return stripped || undefined;
 }
+
+function shouldStripResolvedTargetProviderPrefix(target: ResolvedMessagingTarget): boolean {
+  return target.resolutionSource === "normalized";
+}
+
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
   agentId: string,
@@ -329,10 +334,12 @@ export async function resolveDeliveryTarget(
     resolvedTarget.source === "directory"
       ? resolvedTarget.to
       : (preResolvedRouteTargetCandidate ?? toCandidate);
-  const selectedTarget = stripSelectedProviderPrefix({
-    channel,
-    to: resolvedTarget.to,
-  });
+  const selectedTarget = shouldStripResolvedTargetProviderPrefix(resolvedTarget)
+    ? stripSelectedProviderPrefix({
+        channel,
+        to: resolvedTarget.to,
+      })
+    : resolvedTarget.to.trim();
   if (!selectedTarget) {
     return {
       ok: false,

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -422,6 +422,7 @@ describe("resolveOutboundSessionRoute", () => {
         to: "user:123",
         kind: "user" as const,
         source: "directory" as const,
+        resolutionSource: "directory" as const,
       },
       expected: {
         sessionKey: "agent:main:guildchat:direct:123",
@@ -438,6 +439,7 @@ describe("resolveOutboundSessionRoute", () => {
         to: "channel:456",
         kind: "channel" as const,
         source: "directory" as const,
+        resolutionSource: "directory" as const,
       },
       expected: {
         sessionKey: "agent:main:guildchat:channel:456",
@@ -456,6 +458,7 @@ describe("resolveOutboundSessionRoute", () => {
         to: "user:dthcxgoxhifn3pwh65cut3ud3w",
         kind: "user" as const,
         source: "directory" as const,
+        resolutionSource: "directory" as const,
       },
       expected: {
         sessionKey: "agent:main:boardchat:direct:dthcxgoxhifn3pwh65cut3ud3w",

--- a/src/infra/outbound/target-id-resolution.ts
+++ b/src/infra/outbound/target-id-resolution.ts
@@ -7,6 +7,7 @@ export type ResolvedIdLikeTarget = {
   kind: ChannelDirectoryEntryKind | "channel";
   display?: string;
   source: "normalized" | "directory";
+  resolutionSource: "plugin";
 };
 
 export async function maybeResolveIdLikeTarget(params: {

--- a/src/infra/outbound/target-normalization.test.ts
+++ b/src/infra/outbound/target-normalization.test.ts
@@ -264,6 +264,7 @@ describe("maybeResolvePluginMessagingTarget", () => {
       kind: "group",
       display: "general",
       source: "normalized",
+      resolutionSource: "plugin",
     });
 
     expect(resolveTarget).toHaveBeenCalledWith({

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -68,6 +68,7 @@ export type ResolvedPluginMessagingTarget = {
   kind: TargetResolveKindLike;
   display?: string;
   source: "normalized" | "directory";
+  resolutionSource: "plugin";
 };
 
 export function resolveNormalizedTargetInput(
@@ -152,6 +153,7 @@ export async function maybeResolvePluginMessagingTarget(params: {
     kind: resolved.kind,
     display: resolved.display,
     source: resolved.source ?? "normalized",
+    resolutionSource: "plugin",
   };
 }
 

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -162,6 +162,7 @@ describe("resolveMessagingTarget (directory fallback)", () => {
       to: "user:dm-user-id",
       kind: "user",
       source: "directory",
+      resolutionSource: "plugin",
       display: undefined,
     });
     expect(mocks.resolveTarget).toHaveBeenCalledOnce();
@@ -200,6 +201,7 @@ describe("resolveMessagingTarget (directory fallback)", () => {
       kind: "group",
       display: "telegram:-1001234567890:topic:42",
       source: "normalized",
+      resolutionSource: "normalized",
     });
     expect(mocks.listGroups).not.toHaveBeenCalled();
     expect(mocks.listGroupsLive).not.toHaveBeenCalled();
@@ -236,6 +238,7 @@ describe("resolveMessagingTarget (directory fallback)", () => {
       to: "+15551234567",
       kind: "user",
       source: "normalized",
+      resolutionSource: "plugin",
       display: undefined,
     });
     expect(mocks.listPeers).toHaveBeenCalledTimes(1);

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -28,6 +28,7 @@ export type ResolvedMessagingTarget = {
   kind: TargetResolveKind;
   display?: string;
   source: "normalized" | "directory";
+  resolutionSource: "plugin" | "directory" | "normalized";
 };
 
 export type ResolveMessagingTargetResult =
@@ -314,6 +315,7 @@ function buildNormalizedResolveResult(params: {
       kind: params.kind,
       display: stripTargetPrefixes(params.normalized),
       source: "normalized",
+      resolutionSource: "normalized",
     },
   };
 }
@@ -403,6 +405,7 @@ export async function resolveMessagingTarget(params: {
         kind,
         display: entry.name ?? entry.handle ?? stripTargetPrefixes(entry.id),
         source: "directory",
+        resolutionSource: "directory",
       },
     };
   }
@@ -418,6 +421,7 @@ export async function resolveMessagingTarget(params: {
             kind,
             display: best.name ?? best.handle ?? stripTargetPrefixes(best.id),
             source: "directory",
+            resolutionSource: "directory",
           },
         };
       }


### PR DESCRIPTION
## Summary
- Preserve plugin-resolved cron announce targets instead of stripping a matching channel/provider prefix after target resolution.
- Track whether a resolved messaging target came from a plugin, directory lookup, or generic normalized fallback.
- Add regression coverage for a BNCR-style canonical target whose grammar intentionally starts with the selected channel prefix.

Fixes #87905

## Root Cause
`resolveDeliveryTarget()` stripped the selected channel/provider prefix from every resolved target. That was correct for generic normalized fallback targets, but wrong after a plugin resolver had already returned a canonical target such as `Bncr:tgBot:-1003891624016:6278285192`.

## Verification
- `node --import tsx ./openclaw-87905-proof-*.mjs` (temporary local runtime proof script, removed after run)
- `node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-target.test.ts`
- `node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-target.test.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/target-normalization.test.ts src/infra/outbound/outbound-session.test.ts src/infra/outbound/targets.test.ts src/infra/outbound/message-action-runner.poll.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/cron/isolated-agent/delivery-target.test.ts src/cron/isolated-agent/delivery-target.ts src/infra/outbound/outbound-session.test.ts src/infra/outbound/target-id-resolution.ts src/infra/outbound/target-normalization.test.ts src/infra/outbound/target-normalization.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/target-resolver.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: Cron announce delivery no longer strips a provider-looking prefix from a plugin-canonical resolved target.

Real environment tested: Local OpenClaw worktree on this branch with installed dependencies, using the actual `resolveDeliveryTarget()` cron delivery runtime path and a temporary local runtime channel plugin registered through the OpenClaw plugin registry.

Exact steps or command run after this patch: ran a temporary local proof script with `node --import tsx`, registering a `bncr` runtime channel plugin whose target resolver returns `Bncr:tgBot:-1003891624016:6278285192`, then calling `resolveDeliveryTarget(..., { dryRun: true })` for `channel=bncr` and that target.

Evidence after fix:

```json
{
  "command": "resolveDeliveryTarget dry-run with local runtime channel plugin",
  "issue": 87905,
  "input": {
    "channel": "bncr",
    "to": "Bncr:tgBot:-1003891624016:6278285192"
  },
  "result": {
    "ok": true,
    "channel": "bncr",
    "to": "Bncr:tgBot:-1003891624016:6278285192",
    "mode": "explicit"
  },
  "preservedCanonicalTarget": true
}
```

Observed result after fix: the resolved dry-run delivery target kept the full canonical `Bncr:` target, and `preservedCanonicalTarget` was `true`.

What was not tested: No live BNCR network send was performed; this verifies the host-side cron target resolution path that previously stripped the canonical target before outbound delivery.

## Supplemental tests
- The new regression `preserves plugin-canonical targets that begin with the selected channel prefix` covers the same target shape in the focused cron suite.
- Focused suite result: `Test Files 1 passed (1)`, `Tests 50 passed (50)`.
- Adjacent resolver/session suite result: `Test Files 6 passed (6)`, `Tests 188 passed (188)`.

## Author attribution
If this PR is squash-merged or reworked, please preserve author attribution for `Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>` or include:
`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
