### PR TITLE
fix(agents): suppress DeepSeek thinking for Foundry aliases

### DIFF
--- a/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
@@ -57,11 +57,18 @@ describe("extra-params: DeepSeek V4 OpenAI-compatible thinking fallback", () => 
 
   it("does not inject thinking on Microsoft Foundry alias providers", () => {
     const payload = runDeepSeekV4Case({
+      messages: [
+        { role: "user", content: "continue" },
+        { role: "assistant", content: "prior", reasoning_content: "native reasoning" },
+      ],
       provider: "microsoft-foundry-9433",
       thinkingLevel: "high",
     });
     expect(payload).not.toHaveProperty("thinking");
     expect(payload).not.toHaveProperty("reasoning_effort");
+    expect((payload.messages as Array<Record<string, unknown>>)[1]).not.toHaveProperty(
+      "reasoning_content",
+    );
   });
 
   it("does not inject thinking when thinkingFormat is openai (Azure Foundry)", () => {

--- a/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
@@ -8,6 +8,7 @@ vi.mock("../../llm/stream.js", () => createLlmStreamSimpleMock());
 let runExtraParamsCase: typeof import("./extra-params.test-support.js").runExtraParamsCase;
 
 function runDeepSeekV4Case(params: {
+  messages?: Array<Record<string, unknown>>;
   provider?: string;
   thinkingFormat?: ModelCompatConfig["thinkingFormat"];
   thinkingLevel?: "off" | "high";
@@ -25,7 +26,7 @@ function runDeepSeekV4Case(params: {
       id: "DeepSeek-V4-Flash",
       ...(compat ? { compat } : {}),
     } as Model<"openai-completions">,
-    payload: { model: "DeepSeek-V4-Flash", messages: [] },
+    payload: { model: "DeepSeek-V4-Flash", messages: params.messages ?? [] },
   }).payload as Record<string, unknown>;
 }
 
@@ -62,6 +63,20 @@ describe("extra-params: DeepSeek V4 OpenAI-compatible thinking fallback", () => 
     const payload = runDeepSeekV4Case({ thinkingFormat: "openai", thinkingLevel: "high" });
     expect(payload).not.toHaveProperty("thinking");
     expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("strips DeepSeek replay fields when thinkingFormat is openai", () => {
+    const payload = runDeepSeekV4Case({
+      messages: [
+        { role: "user", content: "continue" },
+        { role: "assistant", content: "prior", reasoning_content: "native reasoning" },
+      ],
+      thinkingFormat: "openai",
+      thinkingLevel: "high",
+    });
+    expect((payload.messages as Array<Record<string, unknown>>)[1]).not.toHaveProperty(
+      "reasoning_content",
+    );
   });
 
   it("does not inject thinking:disabled when thinkingFormat is openai and thinking is off", () => {

--- a/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
@@ -9,6 +9,7 @@ let runExtraParamsCase: typeof import("./extra-params.test-support.js").runExtra
 
 function runDeepSeekV4Case(params: {
   messages?: Array<Record<string, unknown>>;
+  payloadExtras?: Record<string, unknown>;
   provider?: string;
   thinkingFormat?: ModelCompatConfig["thinkingFormat"];
   thinkingLevel?: "off" | "high";
@@ -26,7 +27,11 @@ function runDeepSeekV4Case(params: {
       id: "DeepSeek-V4-Flash",
       ...(compat ? { compat } : {}),
     } as Model<"openai-completions">,
-    payload: { model: "DeepSeek-V4-Flash", messages: params.messages ?? [] },
+    payload: {
+      model: "DeepSeek-V4-Flash",
+      messages: params.messages ?? [],
+      ...params.payloadExtras,
+    },
   }).payload as Record<string, unknown>;
 }
 
@@ -74,6 +79,22 @@ describe("extra-params: DeepSeek V4 OpenAI-compatible thinking fallback", () => 
       thinkingFormat: "openai",
       thinkingLevel: "high",
     });
+    expect((payload.messages as Array<Record<string, unknown>>)[1]).not.toHaveProperty(
+      "reasoning_content",
+    );
+  });
+
+  it("preserves non-DeepSeek reasoning controls while stripping replay fields", () => {
+    const payload = runDeepSeekV4Case({
+      messages: [
+        { role: "user", content: "continue" },
+        { role: "assistant", content: "prior", reasoning_content: "native reasoning" },
+      ],
+      payloadExtras: { reasoning: { effort: "high" } },
+      thinkingFormat: "openrouter",
+      thinkingLevel: "high",
+    });
+    expect(payload.reasoning).toEqual({ effort: "high" });
     expect((payload.messages as Array<Record<string, unknown>>)[1]).not.toHaveProperty(
       "reasoning_content",
     );

--- a/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLlmStreamSimpleMock } from "../../../test/helpers/agents/llm-stream-simple-mock.js";
+import type { ModelCompatConfig } from "../../config/types.models.js";
+import type { Model } from "../../llm/types.js";
+
+vi.mock("../../llm/stream.js", () => createLlmStreamSimpleMock());
+
+let runExtraParamsCase: typeof import("./extra-params.test-support.js").runExtraParamsCase;
+
+function runDeepSeekV4Case(params: {
+  provider?: string;
+  thinkingFormat?: ModelCompatConfig["thinkingFormat"];
+  thinkingLevel?: "off" | "high";
+}): Record<string, unknown> {
+  const provider = params.provider ?? "opencode";
+  const compat = params.thinkingFormat ? { thinkingFormat: params.thinkingFormat } : undefined;
+  return runExtraParamsCase({
+    applyProvider: provider,
+    applyModelId: "DeepSeek-V4-Flash",
+    mockProviderRuntime: true,
+    thinkingLevel: params.thinkingLevel ?? "high",
+    model: {
+      api: "openai-completions",
+      provider,
+      id: "DeepSeek-V4-Flash",
+      ...(compat ? { compat } : {}),
+    } as Model<"openai-completions">,
+    payload: { model: "DeepSeek-V4-Flash", messages: [] },
+  }).payload as Record<string, unknown>;
+}
+
+describe("extra-params: DeepSeek V4 OpenAI-compatible thinking fallback", () => {
+  beforeEach(async () => {
+    ({ runExtraParamsCase } = await import("./extra-params.test-support.js"));
+  });
+
+  it("injects deepseek-native thinking for unowned proxy providers", () => {
+    const payload = runDeepSeekV4Case({ thinkingLevel: "high" });
+    expect(payload.thinking).toEqual({ type: "enabled" });
+    expect(payload.reasoning_effort).toBe("high");
+  });
+
+  it("does not inject thinking on canonical Microsoft Foundry", () => {
+    const payload = runDeepSeekV4Case({
+      provider: "microsoft-foundry",
+      thinkingLevel: "high",
+    });
+    expect(payload).not.toHaveProperty("thinking");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("does not inject thinking on Microsoft Foundry alias providers", () => {
+    const payload = runDeepSeekV4Case({
+      provider: "microsoft-foundry-9433",
+      thinkingLevel: "high",
+    });
+    expect(payload).not.toHaveProperty("thinking");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("does not inject thinking when thinkingFormat is openai (Azure Foundry)", () => {
+    const payload = runDeepSeekV4Case({ thinkingFormat: "openai", thinkingLevel: "high" });
+    expect(payload).not.toHaveProperty("thinking");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("does not inject thinking:disabled when thinkingFormat is openai and thinking is off", () => {
+    // Even `thinking: { type: "disabled" }` is rejected by Azure Foundry, so the
+    // override must suppress the parameter entirely, not just disable it.
+    const payload = runDeepSeekV4Case({ thinkingFormat: "openai", thinkingLevel: "off" });
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
+  it("keeps deepseek-native thinking when thinkingFormat is explicitly deepseek", () => {
+    const payload = runDeepSeekV4Case({ thinkingFormat: "deepseek", thinkingLevel: "high" });
+    expect(payload.thinking).toEqual({ type: "enabled" });
+    expect(payload.reasoning_effort).toBe("high");
+  });
+});

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -828,7 +828,8 @@ function applyPostPluginStreamWrappers(
     ctx.agent.streamFn = createDeepSeekV4OpenAICompatibleThinkingWrapper({
       baseStreamFn: ctx.agent.streamFn,
       thinkingLevel: ctx.thinkingLevel,
-      shouldPatchModel: isDeepSeekV4OpenAICompatibleModel,
+      shouldPatchModel: (model) =>
+        isDeepSeekV4OpenAICompatibleModel(model) && deepSeekV4NativeThinkingAllowedByCompat(model),
     });
 
     // MiMo reasoning models use the same DeepSeek-style reasoning_content wire
@@ -923,9 +924,35 @@ function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): bool
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
   return (
     model.api === "openai-completions" &&
-    model.provider !== "microsoft-foundry" &&
+    !isMicrosoftFoundryProviderId(model.provider) &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
+}
+
+function isMicrosoftFoundryProviderId(provider: unknown): boolean {
+  if (typeof provider !== "string") {
+    return false;
+  }
+  const normalizedProvider = provider.trim().toLowerCase();
+  return (
+    normalizedProvider === "microsoft-foundry" ||
+    normalizedProvider.startsWith("microsoft-foundry-")
+  );
+}
+
+/**
+ * The DeepSeek V4 wrapper emits the deepseek-native `thinking: { type }` wire
+ * format (plus `reasoning_effort`). Honor an explicit `compat.thinkingFormat`
+ * override that selects a different reasoning format: some OpenAI-compatible
+ * deployments — notably Azure AI Foundry DeepSeek V4 — reject the `thinking`
+ * parameter outright, even `thinking: { type: "disabled" }`. When the format is
+ * unset we keep id-based auto-detection so genuine DeepSeek V4 endpoints still
+ * receive the native thinking payload; an explicit `"deepseek"` also keeps it.
+ */
+function deepSeekV4NativeThinkingAllowedByCompat(model: Parameters<StreamFn>[0]): boolean {
+  const compat = (model as ProviderRuntimeModel).compat;
+  const thinkingFormat = compat && typeof compat === "object" ? compat.thinkingFormat : undefined;
+  return thinkingFormat === undefined || thinkingFormat === "deepseek";
 }
 
 const MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS = new Set([

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -974,8 +974,6 @@ function createDeepSeekV4NonNativeCompatSanitizerWrapper(
     }
     return streamWithPayloadPatch(baseStreamFn, model, context, options, (payload) => {
       delete payload.thinking;
-      delete payload.reasoning_effort;
-      delete payload.reasoning;
       stripDeepSeekV4ReasoningContent(payload);
     });
   };

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -966,10 +966,7 @@ function createDeepSeekV4NonNativeCompatSanitizerWrapper(
     return undefined;
   }
   return (model, context, options) => {
-    if (
-      !isDeepSeekV4OpenAICompletionsModel(model) ||
-      deepSeekV4NativeThinkingAllowedByCompat(model)
-    ) {
+    if (!shouldSanitizeDeepSeekV4NonNativeFields(model)) {
       return baseStreamFn(model, context, options);
     }
     return streamWithPayloadPatch(baseStreamFn, model, context, options, (payload) => {
@@ -977,6 +974,14 @@ function createDeepSeekV4NonNativeCompatSanitizerWrapper(
       stripDeepSeekV4ReasoningContent(payload);
     });
   };
+}
+
+function shouldSanitizeDeepSeekV4NonNativeFields(model: Parameters<StreamFn>[0]): boolean {
+  return (
+    isDeepSeekV4OpenAICompletionsModel(model) &&
+    (isMicrosoftFoundryProviderId(model.provider) ||
+      !deepSeekV4NativeThinkingAllowedByCompat(model))
+  );
 }
 
 function stripDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -831,6 +831,7 @@ function applyPostPluginStreamWrappers(
       shouldPatchModel: (model) =>
         isDeepSeekV4OpenAICompatibleModel(model) && deepSeekV4NativeThinkingAllowedByCompat(model),
     });
+    ctx.agent.streamFn = createDeepSeekV4NonNativeCompatSanitizerWrapper(ctx.agent.streamFn);
 
     // MiMo reasoning models use the same DeepSeek-style reasoning_content wire
     // format. When MiMo is reached through an unowned proxy/custom provider
@@ -921,10 +922,13 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
 }
 
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
+  return isDeepSeekV4OpenAICompletionsModel(model) && !isMicrosoftFoundryProviderId(model.provider);
+}
+
+function isDeepSeekV4OpenAICompletionsModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
   return (
     model.api === "openai-completions" &&
-    !isMicrosoftFoundryProviderId(model.provider) &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
 }
@@ -953,6 +957,40 @@ function deepSeekV4NativeThinkingAllowedByCompat(model: Parameters<StreamFn>[0])
   const compat = (model as ProviderRuntimeModel).compat;
   const thinkingFormat = compat && typeof compat === "object" ? compat.thinkingFormat : undefined;
   return thinkingFormat === undefined || thinkingFormat === "deepseek";
+}
+
+function createDeepSeekV4NonNativeCompatSanitizerWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn | undefined {
+  if (!baseStreamFn) {
+    return undefined;
+  }
+  return (model, context, options) => {
+    if (
+      !isDeepSeekV4OpenAICompletionsModel(model) ||
+      deepSeekV4NativeThinkingAllowedByCompat(model)
+    ) {
+      return baseStreamFn(model, context, options);
+    }
+    return streamWithPayloadPatch(baseStreamFn, model, context, options, (payload) => {
+      delete payload.thinking;
+      delete payload.reasoning_effort;
+      delete payload.reasoning;
+      stripDeepSeekV4ReasoningContent(payload);
+    });
+  };
+}
+
+function stripDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {
+  if (!Array.isArray(payload.messages)) {
+    return;
+  }
+  for (const message of payload.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    delete (message as Record<string, unknown>).reasoning_content;
+  }
 }
 
 const MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS = new Set([


### PR DESCRIPTION
## Summary

- Treat `microsoft-foundry-*` DeepSeek V4 provider ids as Microsoft Foundry-compatible for the embedded runner DeepSeek fallback, so alias-backed Foundry deployments no longer receive the DeepSeek-native top-level `thinking` parameter.
- Keep unowned OpenAI-compatible DeepSeek V4 proxy routes on the native DeepSeek fallback path.
- Preserve explicit non-DeepSeek `compat.thinkingFormat` routes while stripping DeepSeek-native replay fields (`reasoning_content`) that OpenAI/Azure-style deployments can reject.

Fixes #90520.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts src/agents/embedded-agent-runner-extraparams.test.ts` (139 tests passed)
- `pnpm exec oxfmt --check src/agents/embedded-agent-runner/extra-params.ts src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts`
- `git diff --check`
- `./.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> `autoreview clean: no accepted/actionable findings reported`

## Real behavior proof

Behavior addressed: Microsoft Foundry DeepSeek V4 alias providers no longer receive DeepSeek-native top-level `thinking` or replayed `reasoning_content` fields that Foundry rejects.

Real environment tested: Local OpenClaw checkout with the real CLI/gateway path until provider dispatch, plus issue #90520 reporter's live Foundry A/B provider proof for the same deployment/model alias behavior.

Exact steps or command run after this patch: I checked 1Password Molty metadata for a Foundry credential, then ran `pnpm openclaw infer model run --gateway --model microsoft-foundry-9433/DeepSeek-V4-Pro --prompt 'Reply with exactly FOUNDRY_V4_PRO_OK and nothing else.' --json` from this branch.

Evidence after fix: The local gateway probe produced real terminal output from OpenClaw and failed before provider dispatch with `GatewayClientRequestError: Error: Model override "microsoft-foundry-9433/DeepSeek-V4-Pro" is not allowed for agent "main".` The reporter's issue #90520 live proof shows `microsoft-foundry/DeepSeek-V4-Pro` succeeds while `microsoft-foundry-9433/DeepSeek-V4-Pro` fails with `400 Unrecognized request argument supplied: thinking`; this patch removes that aliased `thinking` injection path and strips DeepSeek replay fields on the same alias-provider route.

Observed result after fix: Focused embedded-runner tests confirm the alias request payload no longer includes top-level `thinking`, no longer includes `reasoning_effort`, and strips assistant-message `reasoning_content`; native DeepSeek-compatible proxy routes still keep the DeepSeek-native fallback, and OpenRouter/Together-style reasoning controls remain preserved.

What was not tested: A complete live Microsoft Foundry round trip from my machine was not tested because no Foundry credential item was available and the local agent config rejected the alias model override before provider dispatch.

## Notes

- This PR intentionally does not edit `CHANGELOG.md`; release generation owns changelog entries.
- The branch was rebased on current `main` and refreshed by a maintainer because the original PR predated the canonical Foundry fix and did not cover alias providers.
