### PR TITLE
fix(android): filter thinking and reasoning blocks from chat message display

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -654,6 +654,8 @@ internal fun parseChatMessageContent(el: JsonElement): ChatMessageContent? {
         base64 = obj["content"].asStringOrNull()?.takeIf { it.isNotBlank() },
       )
 
+    "thinking", "reasoning", "redacted_thinking" -> null
+
     else -> null
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -120,10 +120,11 @@ private fun ChatMessageBody(
           val text = part.text ?: continue
           ChatMarkdown(text = text, textColor = textColor)
         }
-        else -> {
+        "image" -> {
           val b64 = part.base64 ?: continue
           ChatBase64Image(base64 = b64, mimeType = part.mimeType)
         }
+        else -> continue
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -502,10 +502,10 @@ private fun ChatBubble(
           color = ClawTheme.colors.text,
         )
         displayableContent.forEach { part ->
-          if (part.type == "text") {
-            ChatText(text = part.text.orEmpty(), textColor = ClawTheme.colors.text)
-          } else {
-            Text(text = part.fileName ?: "Attachment", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+          when (part.type) {
+            "text" -> ChatText(text = part.text.orEmpty(), textColor = ClawTheme.colors.text)
+            "image" -> Text(text = part.fileName ?: "Attachment", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+            else -> { /* skip non-displayable types */ }
           }
         }
         timestampMs?.let {


### PR DESCRIPTION
## Summary

Prevent LLM thinking/reasoning content from appearing as visible chat
message bubbles in the Android app. The fix adds explicit handling for
thinking-related content block types at both the parsing and rendering layers.

### Changes

- **ChatController.kt**: Add explicit `"thinking"`, `"reasoning"`,
  `"redacted_thinking"` cases to `parseChatMessageContent()` that return
  `null` instead of relying on the generic `else` branch
- **ChatMessageViews.kt**: Tighten `ChatMessageBody` rendering to only
  handle explicit `"text"` and `"image"` types, with `else -> continue`
  to skip any unknown types
- **ChatScreen.kt**: Replace `if/else` rendering with explicit `when`
  branches for `"text"` and `"image"` types, skipping non-displayable
  types in `else`

### Design rationale

The existing `else -> null` branch in `parseChatMessageContent()`
already drops unrecognized content types. This change makes thinking
filtering explicit rather than implicit, preventing future regressions
if content type handling evolves. The rendering-layer changes add
defense-in-depth by ensuring only known displayable types can render.

Fixes #87918