### PR TITLE
feat(ui): add KaTeX math rendering support

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -432,6 +432,7 @@ See [Inferred commitments](/concepts/commitments).
 {
   ui: {
     seamColor: "#FF4500",
+    mathRendering: "off",
     assistant: {
       name: "OpenClaw",
       avatar: "CB", // emoji, short text, image URL, or data URI
@@ -441,6 +442,7 @@ See [Inferred commitments](/concepts/commitments).
 ```
 
 - `seamColor`: accent color for native app UI chrome (Talk Mode bubble tint, etc.).
+- `mathRendering`: math rendering mode for chat messages (`"off"` or `"katex"`). Defaults to `"off"`.
 - `assistant`: Control UI identity override. Falls back to active agent identity.
 
 ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1818,7 +1818,7 @@ importers:
         specifier: 2.2.3
         version: 2.2.3
       katex:
-        specifier: ^0.16.21
+        specifier: 0.16.47
         version: 0.16.47
       lit:
         specifier: 3.3.3
@@ -6764,8 +6764,6 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
-
-
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       signal-utils:
         specifier: 0.21.1
         version: 0.21.1(signal-polyfill@0.2.2)
+      tldts:
+        specifier: ^7.4.0
+        version: 7.4.0
       tsdown:
         specifier: 0.22.0
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260527.2)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.0)
@@ -1817,6 +1820,9 @@ importers:
       json5:
         specifier: 2.2.3
         version: 2.2.3
+      katex:
+        specifier: ^0.16.21
+        version: 0.16.47
       lit:
         specifier: 3.3.3
         version: 3.3.3
@@ -4668,6 +4674,10 @@ packages:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   constantinople@4.0.1:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
 
@@ -5499,6 +5509,10 @@ packages:
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
@@ -6753,6 +6767,13 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.0:
+    resolution: {integrity: sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==}
+
+  tldts@7.4.0:
+    resolution: {integrity: sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==}
+    hasBin: true
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -10269,6 +10290,8 @@ snapshots:
 
   commander@5.1.0: {}
 
+  commander@8.3.0: {}
+
   constantinople@4.0.1:
     dependencies:
       '@babel/parser': 7.29.3
@@ -11235,6 +11258,10 @@ snapshots:
       safe-buffer: 5.2.1
 
   jwt-decode@4.0.0: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
 
   keyv@5.6.0:
     dependencies:
@@ -12771,6 +12798,12 @@ snapshots:
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.0: {}
+
+  tldts@7.4.0:
+    dependencies:
+      tldts-core: 7.4.0
 
   to-regex-range@5.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,9 +300,6 @@ importers:
       signal-utils:
         specifier: 0.21.1
         version: 0.21.1(signal-polyfill@0.2.2)
-      tldts:
-        specifier: ^7.4.0
-        version: 7.4.0
       tsdown:
         specifier: 0.22.0
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260527.2)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.0)
@@ -6768,12 +6765,7 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.4.0:
-    resolution: {integrity: sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==}
 
-  tldts@7.4.0:
-    resolution: {integrity: sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==}
-    hasBin: true
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -12798,12 +12790,6 @@ snapshots:
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
-
-  tldts-core@7.4.0: {}
-
-  tldts@7.4.0:
-    dependencies:
-      tldts-core: 7.4.0
 
   to-regex-range@5.0.1:
     dependencies:

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1337,6 +1337,8 @@ export const FIELD_HELP: Record<string, string> = {
   ui: "UI presentation settings for accenting and assistant identity shown in control surfaces. Use this for branding and readability customization without changing runtime behavior.",
   "ui.seamColor":
     "Primary accent color used by UI surfaces for emphasis, badges, and visual identity cues. Use high-contrast values that remain readable across light/dark themes.",
+  "ui.mathRendering":
+    "Mathematical expression rendering mode for chat messages. Use 'katex' for LaTeX math support or 'off' for plain text display.",
   "ui.assistant":
     "Assistant display identity settings for name and avatar shown in UI surfaces. Keep these values aligned with your operator-facing persona and support expectations.",
   "ui.assistant.name":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -755,6 +755,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "mcp.sessionIdleTtlMs": "MCP Runtime Idle TTL",
   ui: "UI",
   "ui.seamColor": "Accent Color",
+  "ui.mathRendering": "Math Rendering",
   "ui.assistant": "Assistant Appearance",
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -112,6 +112,8 @@ export type OpenClawConfig = {
   ui?: {
     /** Accent color for OpenClaw UI chrome (hex). */
     seamColor?: string;
+    /** Math rendering mode. Default: "off". */
+    mathRendering?: "off" | "katex";
     assistant?: {
       /** Assistant display name for UI surfaces. */
       name?: string;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -628,6 +628,7 @@ export const OpenClawSchema = z
     ui: z
       .object({
         seamColor: HexColorSchema.optional(),
+        mathRendering: z.enum(["off", "katex"]).default("off").optional(),
         assistant: z
           .object({
             name: z.string().max(50).optional(),

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -15,4 +15,5 @@ export type ControlUiBootstrapConfig = {
   embedSandbox?: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;
   chatMessageMaxWidth?: string;
+  mathRendering?: "off" | "katex";
 };

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -891,6 +891,7 @@ export async function handleControlUiHttpRequest(
             : "scripts",
       allowExternalEmbedUrls: config?.gateway?.controlUi?.allowExternalEmbedUrls === true,
       chatMessageMaxWidth: config?.gateway?.controlUi?.chatMessageMaxWidth,
+      mathRendering: config?.ui?.mathRendering,
     } satisfies ControlUiBootstrapConfig);
     return true;
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
     "dompurify": "3.4.6",
     "highlight.js": "11.11.1",
     "json5": "2.2.3",
-    "katex": "^0.16.21",
+    "katex": "0.16.47",
     "lit": "3.3.3",
     "markdown-it": "14.2.0",
     "markdown-it-task-lists": "2.1.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
     "dompurify": "3.4.6",
     "highlight.js": "11.11.1",
     "json5": "2.2.3",
+    "katex": "^0.16.21",
     "lit": "3.3.3",
     "markdown-it": "14.2.0",
     "markdown-it-task-lists": "2.1.1",

--- a/ui/src/css.d.ts
+++ b/ui/src/css.d.ts
@@ -1,1 +1,6 @@
 declare module "*.css";
+
+declare module "*.css?url" {
+  const src: string;
+  export default src;
+}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2904,6 +2904,7 @@ export function renderApp(state: AppViewState) {
                   localMediaPreviewRoots: state.localMediaPreviewRoots,
                   embedSandboxMode: state.embedSandboxMode,
                   allowExternalEmbedUrls: state.allowExternalEmbedUrls,
+                  mathRendering: state.mathRendering,
                   assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
                   basePath: state.basePath ?? "",
                 }),

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -89,6 +89,7 @@ export type AppViewState = {
   embedSandboxMode: EmbedSandboxMode;
   allowExternalEmbedUrls: boolean;
   chatMessageMaxWidth?: string | null;
+  mathRendering: "off" | "katex";
   sessionKey: string;
   chatSessionMessageSubscriptionKey?: string | null;
   chatSessionMessageSubscriptionRequestedKey?: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -215,6 +215,7 @@ export class OpenClawApp extends LitElement {
   @state() embedSandboxMode: "strict" | "scripts" | "trusted" = "scripts";
   @state() allowExternalEmbedUrls = false;
   @state() chatMessageMaxWidth: string | null = null;
+  @state() mathRendering: "off" | "katex" = "off";
   @state() serverVersion: string | null = null;
 
   @state() sessionKey = this.settings.sessionKey;

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -13,7 +13,20 @@ import { normalizeMessage } from "./message-normalizer.ts";
 
 const localStorageValues = vi.hoisted(() => new Map<string, string>());
 const markdownRenderMock = vi.hoisted(() =>
-  vi.fn((value: string, _options?: { codeBlockChrome?: "copy" | "none" }) => value),
+  vi.fn(
+    (
+      value: string,
+      _options?: { codeBlockChrome?: "copy" | "none"; mathRendering?: "off" | "katex" },
+    ) => value,
+  ),
+);
+const markdownWithKatexRenderMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      value: string,
+      _options?: { codeBlockChrome?: "copy" | "none"; mathRendering?: "off" | "katex" },
+    ) => value,
+  ),
 );
 
 vi.mock("../../local-storage.ts", () => ({
@@ -26,6 +39,7 @@ vi.mock("../../local-storage.ts", () => ({
 
 vi.mock("../markdown.ts", () => ({
   toSanitizedMarkdownHtml: markdownRenderMock,
+  toSanitizedMarkdownHtmlWithKatex: markdownWithKatexRenderMock,
 }));
 
 vi.mock("../icons.ts", () => ({
@@ -584,7 +598,10 @@ describe("grouped chat rendering", () => {
       "user",
     );
 
-    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, { codeBlockChrome: "none" });
+    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, {
+      codeBlockChrome: "none",
+      mathRendering: undefined,
+    });
   });
 
   it("keeps assistant markdown code-block copy chrome enabled", () => {
@@ -597,7 +614,7 @@ describe("grouped chat rendering", () => {
       timestamp: 1000,
     });
 
-    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, undefined);
+    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, { mathRendering: undefined });
   });
 
   it("positions delete confirm by message side", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -5,7 +5,8 @@ import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { AssistantIdentity } from "../assistant-identity.ts";
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
-import { toSanitizedMarkdownHtml } from "../markdown.ts";
+import { toSanitizedMarkdownHtml, toSanitizedMarkdownHtmlWithKatex } from "../markdown.ts";
+import type { MarkdownRenderOptions } from "../markdown.ts";
 import { openExternalUrlSafe } from "../open-external-url.ts";
 import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
@@ -44,6 +45,18 @@ const assistantAttachmentAvailabilityCache = new Map<string, AssistantAttachment
 const assistantAttachmentRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
 const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
+
+/**
+ * Render markdown content with optional KaTeX math rendering.
+ * When options.mathRendering === "katex", uses the KaTeX-enabled renderer.
+ * Otherwise, uses the standard renderer (identical behavior to current code).
+ */
+function renderMarkdownContent(markdown: string, options: MarkdownRenderOptions = {}): string {
+  if (options.mathRendering === "katex") {
+    return toSanitizedMarkdownHtmlWithKatex(markdown, options);
+  }
+  return toSanitizedMarkdownHtml(markdown, options);
+}
 
 export type ChatTimestampDisplay = {
   label: string;
@@ -401,6 +414,7 @@ export function renderMessageGroup(
     allowExternalEmbedUrls?: boolean;
     contextWindow?: number | null;
     onDelete?: () => void;
+    mathRendering?: "off" | "katex";
   },
 ) {
   const normalizedRole = normalizeRoleForGrouping(group.role);
@@ -466,6 +480,7 @@ export function renderMessageGroup(
               localMediaPreviewRoots: opts.localMediaPreviewRoots,
               assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
               embedSandboxMode: opts.embedSandboxMode,
+              mathRendering: opts.mathRendering,
             },
             opts.onOpenSidebar,
           ),
@@ -1453,6 +1468,7 @@ function renderGroupedMessage(
     assistantAttachmentAuthToken?: string | null;
     embedSandboxMode?: EmbedSandboxMode;
     allowExternalEmbedUrls?: boolean;
+    mathRendering?: "off" | "katex";
   },
   onOpenSidebar?: (content: SidebarContent) => void,
 ) {
@@ -1628,7 +1644,11 @@ function renderGroupedMessage(
                       )}
                       ${reasoningMarkdown
                         ? html`<div class="chat-thinking">
-                            ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+                            ${unsafeHTML(
+                              renderMarkdownContent(reasoningMarkdown, {
+                                mathRendering: opts.mathRendering,
+                              }),
+                            )}
                           </div>`
                         : nothing}
                       ${jsonResult
@@ -1647,7 +1667,10 @@ function renderGroupedMessage(
                         : markdown
                           ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
                               ${unsafeHTML(
-                                toSanitizedMarkdownHtml(markdown, markdownRenderOptions),
+                                renderMarkdownContent(markdown, {
+                                  ...(markdownRenderOptions ?? {}),
+                                  mathRendering: opts.mathRendering,
+                                }),
                               )}
                             </div>`
                           : nothing}
@@ -1686,7 +1709,9 @@ function renderGroupedMessage(
             )}
             ${reasoningMarkdown
               ? html`<div class="chat-thinking">
-                  ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+                  ${unsafeHTML(
+                    renderMarkdownContent(reasoningMarkdown, { mathRendering: opts.mathRendering }),
+                  )}
                 </div>`
               : nothing}
             ${normalizedRole === "assistant" && assistantViewBlocks.length > 0
@@ -1710,7 +1735,12 @@ function renderGroupedMessage(
                 </details>`
               : markdown
                 ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                    ${unsafeHTML(toSanitizedMarkdownHtml(markdown, markdownRenderOptions))}
+                    ${unsafeHTML(
+                      renderMarkdownContent(markdown, {
+                        ...(markdownRenderOptions ?? {}),
+                        mathRendering: opts.mathRendering,
+                      }),
+                    )}
                   </div>`
                 : nothing}
             ${hasToolCards

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1668,7 +1668,7 @@ function renderGroupedMessage(
                           ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
                               ${unsafeHTML(
                                 renderMarkdownContent(markdown, {
-                                  ...(markdownRenderOptions ?? {}),
+                                  ...markdownRenderOptions,
                                   mathRendering: opts.mathRendering,
                                 }),
                               )}
@@ -1737,7 +1737,7 @@ function renderGroupedMessage(
                 ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
                     ${unsafeHTML(
                       renderMarkdownContent(markdown, {
-                        ...(markdownRenderOptions ?? {}),
+                        ...markdownRenderOptions,
                         mathRendering: opts.mathRendering,
                       }),
                     )}

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -364,6 +364,7 @@ export function renderStreamingGroup(
   assistant?: AssistantIdentity,
   basePath?: string,
   authToken?: string | null,
+  mathRendering?: "off" | "katex",
 ) {
   const name = assistant?.name ?? "Assistant";
 
@@ -378,7 +379,7 @@ export function renderStreamingGroup(
             timestamp: startedAt,
           },
           `stream:${startedAt}`,
-          { isStreaming: true, showReasoning: false },
+          { isStreaming: true, showReasoning: false, mathRendering },
           onOpenSidebar,
         )}
         <div class="chat-group-footer">

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -27,6 +27,7 @@ export type ControlUiBootstrapState = {
   hello?: { auth?: { deviceToken?: string | null } | null } | null;
   settings?: { token?: string | null } | null;
   password?: string | null;
+  mathRendering?: "off" | "katex";
 };
 
 function resolveActiveAgentId(state: ControlUiBootstrapState): string | null {

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -135,6 +135,7 @@ export async function loadControlUiBootstrapConfig(
       typeof parsed.chatMessageMaxWidth === "string" && parsed.chatMessageMaxWidth.trim()
         ? parsed.chatMessageMaxWidth
         : null;
+    state.mathRendering = parsed.mathRendering === "katex" ? "katex" : "off";
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.
   }

--- a/ui/src/ui/katex-renderer.test.ts
+++ b/ui/src/ui/katex-renderer.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  escapeHtml,
+  findInlineMathEnd,
+  extractMathBlocks,
+  preProcessTex,
+  restoreMathBlocksSync,
+  preloadKatex,
+  getKatexModule,
+} from "./katex-renderer.ts";
+
+// ── escapeHtml ──
+
+describe("escapeHtml", () => {
+  it("escapes & to &amp;", () => {
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+
+  it("escapes < and > to &lt; and &gt;", () => {
+    expect(escapeHtml("<div>")).toBe("&lt;div&gt;");
+  });
+
+  it("escapes \" to &quot; and ' to &#39;", () => {
+    expect(escapeHtml("\"hello'")).toBe("&quot;hello&#39;");
+  });
+});
+
+// ── findInlineMathEnd ──
+
+describe("findInlineMathEnd", () => {
+  it("finds closing $ in $x$ (single letter variable)", () => {
+    expect(findInlineMathEnd("$x$", 0)).toBe(2);
+  });
+
+  it("finds closing $ in $\\frac{x}{y}$ (backslash command)", () => {
+    expect(findInlineMathEnd("$\\frac{x}{y}$", 0)).toBe(12);
+  });
+
+  it("returns -1 for $5 and $10 (pure digits = currency)", () => {
+    expect(findInlineMathEnd("$5 and $10", 0)).toBe(-1);
+  });
+
+  it("finds closing $ in $x^2$ (math operator)", () => {
+    expect(findInlineMathEnd("$x^2$", 0)).toBe(4);
+  });
+
+  it("returns -1 for $variable_name (no closing $)", () => {
+    expect(findInlineMathEnd("$variable_name", 0)).toBe(-1);
+  });
+
+  it("returns -1 for content crossing paragraph boundary (two newlines)", () => {
+    expect(findInlineMathEnd("$a\n\nb$", 0)).toBe(-1);
+  });
+
+  it("returns -1 for empty content $$ (no content between $ and $)", () => {
+    expect(findInlineMathEnd("$$", 0)).toBe(-1);
+  });
+
+  it("finds closing $ in $E=mc^2$", () => {
+    expect(findInlineMathEnd("$E=mc^2$", 0)).toBe(7);
+  });
+
+  it("finds closing $ in $a_n$ (subscript)", () => {
+    expect(findInlineMathEnd("$a_n$", 0)).toBe(4);
+  });
+
+  it("returns -1 for $5.99 (currency with decimal, no closing $)", () => {
+    expect(findInlineMathEnd("$5.99", 0)).toBe(-1);
+  });
+
+  it("handles escaped \\$ inside math content $x\\$y$", () => {
+    expect(findInlineMathEnd("$x\\$y$", 0)).toBe(5);
+  });
+});
+
+// ── extractMathBlocks ──
+
+describe("extractMathBlocks", () => {
+  it("extracts one inline math block from $x^2$ with displayMode=false", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("$x^2$");
+    expect(mathBlocks.size).toBe(1);
+    const [ph, info] = mathBlocks.entries().next().value!;
+    expect(info.tex).toBe("x^2");
+    expect(info.displayMode).toBe(false);
+    expect(protectedText).toBe(ph);
+  });
+
+  it("extracts one display math block from $$E=mc^2$$ with displayMode=true", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("$$E=mc^2$$");
+    expect(mathBlocks.size).toBe(1);
+    const [ph, info] = mathBlocks.entries().next().value!;
+    expect(info.tex).toBe("E=mc^2");
+    expect(info.displayMode).toBe(true);
+    expect(protectedText).toBe(ph);
+  });
+
+  it("extracts one display math block from \\[E=mc^2\\] with displayMode=true", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("\\[E=mc^2\\]");
+    expect(mathBlocks.size).toBe(1);
+    const [ph, info] = mathBlocks.entries().next().value!;
+    expect(info.tex).toBe("E=mc^2");
+    expect(info.displayMode).toBe(true);
+    expect(protectedText).toBe(ph);
+  });
+
+  it("extracts one inline math block from \\(\\frac{x}{y}\\) with displayMode=false", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("\\(\\frac{x}{y}\\)");
+    expect(mathBlocks.size).toBe(1);
+    const [ph, info] = mathBlocks.entries().next().value!;
+    expect(info.tex).toBe("\\frac{x}{y}");
+    expect(info.displayMode).toBe(false);
+    expect(protectedText).toBe(ph);
+  });
+
+  it("preserves surrounding text and inserts placeholder at correct position", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("text $x^2$ more text");
+    expect(mathBlocks.size).toBe(1);
+    const [ph, info] = mathBlocks.entries().next().value!;
+    expect(info.tex).toBe("x^2");
+    expect(protectedText).toBe(`text ${ph} more text`);
+  });
+
+  it("extracts two display math blocks from $$a$$ and $$b$$", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("$$a$$ and $$b$$");
+    expect(mathBlocks.size).toBe(2);
+    const entries = [...mathBlocks.entries()];
+    expect(entries[0][1].tex).toBe("a");
+    expect(entries[0][1].displayMode).toBe(true);
+    expect(entries[1][1].tex).toBe("b");
+    expect(entries[1][1].displayMode).toBe(true);
+    const ph0 = entries[0][0];
+    const ph1 = entries[1][0];
+    expect(protectedText).toBe(`${ph0} and ${ph1}`);
+  });
+
+  it("does NOT extract $x^2$ inside inline code", () => {
+    const { mathBlocks } = extractMathBlocks("`$x^2$`");
+    expect(mathBlocks.size).toBe(0);
+  });
+
+  it("does NOT extract $x^2$ inside fenced code block", () => {
+    const { mathBlocks } = extractMathBlocks("```\n$x^2$\n```");
+    expect(mathBlocks.size).toBe(0);
+  });
+
+  it("does NOT extract escaped delimiters \\$5 and \\$10, outputs literal $", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("\\$5 and \\$10");
+    expect(mathBlocks.size).toBe(0);
+    expect(protectedText).toBe("$5 and $10");
+  });
+
+  it("extracts mixed inline and display math: text $x$ and $$y$$", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("text $x$ and $$y$$");
+    expect(mathBlocks.size).toBe(2);
+    const entries = [...mathBlocks.entries()];
+    expect(entries[0][1].tex).toBe("x");
+    expect(entries[0][1].displayMode).toBe(false);
+    expect(entries[1][1].tex).toBe("y");
+    expect(entries[1][1].displayMode).toBe(true);
+    const ph0 = entries[0][0];
+    const ph1 = entries[1][0];
+    expect(protectedText).toBe(`text ${ph0} and ${ph1}`);
+  });
+
+  it("returns empty mathBlocks and unchanged text when no math content", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("just plain text");
+    expect(mathBlocks.size).toBe(0);
+    expect(protectedText).toBe("just plain text");
+  });
+
+  it("does NOT extract $5 and $10 (currency detection via findInlineMathEnd)", () => {
+    const { mathBlocks, protectedText } = extractMathBlocks("$5 and $10");
+    expect(mathBlocks.size).toBe(0);
+    expect(protectedText).toBe("$5 and $10");
+  });
+
+  it("extracts multiple inline math blocks: $x$ and $y$", () => {
+    const { protectedText, mathBlocks } = extractMathBlocks("$x$ and $y$");
+    expect(mathBlocks.size).toBe(2);
+    const entries = [...mathBlocks.entries()];
+    expect(entries[0][1].tex).toBe("x");
+    expect(entries[0][1].displayMode).toBe(false);
+    expect(entries[1][1].tex).toBe("y");
+    expect(entries[1][1].displayMode).toBe(false);
+    const ph0 = entries[0][0];
+    const ph1 = entries[1][0];
+    expect(protectedText).toBe(`${ph0} and ${ph1}`);
+  });
+});
+
+// ── preProcessTex ──
+
+describe("preProcessTex", () => {
+  it("replaces multline* with gather*", () => {
+    const result = preProcessTex("\\begin{multline*}x\\end{multline*}", false);
+    expect(result).toBe("\\begin{gather*}x\\end{gather*}");
+  });
+
+  it("strips \\require{amsmath}", () => {
+    const result = preProcessTex("\\require{amsmath}x", false);
+    expect(result).toBe("x");
+  });
+
+  it("strips \\definecolor{red}{rgb}{1,0,0}", () => {
+    const result = preProcessTex("\\definecolor{red}{rgb}{1,0,0}x", false);
+    expect(result).toBe("x");
+  });
+
+  it("replaces \\ce{H2O} with \\mathrm{H2O}", () => {
+    const result = preProcessTex("\\ce{H2O}", false);
+    expect(result).toBe("\\mathrm{H2O}");
+  });
+
+  it("returns input unchanged when no preprocessing needed", () => {
+    const result = preProcessTex("x^2 + y^2 = z^2", false);
+    expect(result).toBe("x^2 + y^2 = z^2");
+  });
+});
+
+// ── restoreMathBlocksSync (no module loaded) ──
+
+describe("restoreMathBlocksSync — no module loaded", () => {
+  it("returns html unchanged when mathBlocks is empty", () => {
+    const result = restoreMathBlocksSync("<p>Hello</p>", new Map());
+    expect(result).toBe("<p>Hello</p>");
+  });
+
+  it("replaces placeholders with katex-fallback when module not loaded", () => {
+    const mathBlocks = new Map([
+      ["\x00KATEX_PLACEHOLDER_0\x00", { tex: "x^2", displayMode: false }],
+    ]);
+    const result = restoreMathBlocksSync("text \x00KATEX_PLACEHOLDER_0\x00 after", mathBlocks);
+    expect(result).toBe('text <code class="katex-fallback">x^2</code> after');
+  });
+
+  it("replaces multiple placeholders with katex-fallback", () => {
+    const mathBlocks = new Map([
+      ["\x00KATEX_PLACEHOLDER_0\x00", { tex: "x^2", displayMode: false }],
+      ["\x00KATEX_PLACEHOLDER_1\x00", { tex: "E=mc^2", displayMode: true }],
+    ]);
+    const result = restoreMathBlocksSync(
+      "a \x00KATEX_PLACEHOLDER_0\x00 b \x00KATEX_PLACEHOLDER_1\x00 c",
+      mathBlocks,
+    );
+    expect(result).toBe(
+      'a <code class="katex-fallback">x^2</code> b <code class="katex-fallback">E=mc^2</code> c',
+    );
+  });
+});

--- a/ui/src/ui/katex-renderer.test.ts
+++ b/ui/src/ui/katex-renderer.test.ts
@@ -72,6 +72,22 @@ describe("findInlineMathEnd", () => {
   it("handles escaped \\$ inside math content $x\\$y$", () => {
     expect(findInlineMathEnd("$x\\$y$", 0)).toBe(5);
   });
+
+  it("finds closing $ before fullwidth comma (U+FF0C)", () => {
+    expect(findInlineMathEnd("$E=mc^2$\uff0c", 0)).toBe(7);
+  });
+
+  it("finds closing $ before CJK ideograph", () => {
+    expect(findInlineMathEnd("$x^2$\u7684", 0)).toBe(4);
+  });
+
+  it("finds closing $ before CJK period (U+3002)", () => {
+    expect(findInlineMathEnd("$x^2$\u3002", 0)).toBe(4);
+  });
+
+  it("finds closing $ before fullwidth right paren (U+FF09)", () => {
+    expect(findInlineMathEnd("($x^2$\uff09", 1)).toBe(5);
+  });
 });
 
 // ── extractMathBlocks ──
@@ -186,6 +202,22 @@ describe("extractMathBlocks", () => {
     const ph0 = entries[0][0];
     const ph1 = entries[1][0];
     expect(protectedText).toBe(`${ph0} and ${ph1}`);
+  });
+
+  it("extracts inline math followed by fullwidth comma: $E=mc^2$\uff0c", () => {
+    const { mathBlocks } = extractMathBlocks(`\u8d28\u80fd\u65b9\u7a0b $E=mc^2$\uff0c\u4ee5\u53ca`);
+    expect(mathBlocks.size).toBe(1);
+    const [ph, info] = mathBlocks.entries().next().value!;
+    expect(info.tex).toBe("E=mc^2");
+    expect(info.displayMode).toBe(false);
+  });
+
+  it("extracts inline math followed by CJK ideograph: $x^2$\u7684\u503c", () => {
+    const { mathBlocks } = extractMathBlocks(`\u8ba1\u7b97 $x^2$ \u7684\u503c`);
+    expect(mathBlocks.size).toBe(1);
+    const [ph, info] = mathBlocks.entries().next().value!;
+    expect(info.tex).toBe("x^2");
+    expect(info.displayMode).toBe(false);
   });
 });
 
@@ -464,9 +496,16 @@ describe("maxSize option in KaTeX rendering", () => {
     });
 
     expect(renderToStringMock).toHaveBeenCalled();
-    const lastCall = renderToStringMock.mock.calls[renderToStringMock.mock.calls.length - 1]!;
-    const options = lastCall[1] as Record<string, unknown>;
-    expect(options.maxSize).toBe(100);
+    const calls = renderToStringMock.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    if (!lastCall) {
+      throw new Error("no mock calls");
+    }
+    const opts = lastCall[1];
+    if (!opts) {
+      throw new Error("no options argument");
+    }
+    expect(opts.maxSize).toBe(100);
   });
 
   it("hostile LaTeX size is capped by maxSize", async () => {
@@ -479,9 +518,16 @@ describe("maxSize option in KaTeX rendering", () => {
 
     expect(html).toContain('class="katex"');
     expect(renderToStringMock).toHaveBeenCalled();
-    const lastCall = renderToStringMock.mock.calls[renderToStringMock.mock.calls.length - 1]!;
-    const options = lastCall[1] as Record<string, unknown>;
-    expect(options.maxSize).toBe(100);
+    const calls = renderToStringMock.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    if (!lastCall) {
+      throw new Error("no mock calls");
+    }
+    const opts = lastCall[1];
+    if (!opts) {
+      throw new Error("no options argument");
+    }
+    expect(opts.maxSize).toBe(100);
   });
 
   it("normal formulas unaffected by maxSize", async () => {

--- a/ui/src/ui/katex-renderer.test.ts
+++ b/ui/src/ui/katex-renderer.test.ts
@@ -160,6 +160,39 @@ describe("extractMathBlocks", () => {
     expect(mathBlocks.size).toBe(0);
   });
 
+  it("does NOT extract $x^2$ inside tilde fence (~~~)", () => {
+    const { mathBlocks } = extractMathBlocks("~~~\n$x^2$\n~~~");
+    expect(mathBlocks.size).toBe(0);
+  });
+
+  it("does NOT extract $x^2$ inside longer tilde fence (~~~~)", () => {
+    const { mathBlocks } = extractMathBlocks("~~~~\n$x^2$\n~~~~");
+    expect(mathBlocks.size).toBe(0);
+  });
+
+  it("does NOT extract $x^2$ inside 4-backtick fence", () => {
+    const { mathBlocks } = extractMathBlocks("````\n$x^2$\n````");
+    expect(mathBlocks.size).toBe(0);
+  });
+
+  it("does NOT extract $x^2$ inside tilde fence with info string", () => {
+    const { mathBlocks } = extractMathBlocks("~~~python\n$x^2$\n~~~");
+    expect(mathBlocks.size).toBe(0);
+  });
+
+  it("preserves math outside a closed tilde fence", () => {
+    const { mathBlocks, protectedText } = extractMathBlocks("~~~\ncode\n~~~\n$x^2$");
+    expect(mathBlocks.size).toBe(1);
+    const [[ph, { tex }]] = [...mathBlocks.entries()];
+    expect(tex).toBe("x^2");
+    expect(protectedText).toBe(`~~~\ncode\n~~~\n${ph}`);
+  });
+
+  it("does NOT extract $x^2$ when tilde fence closed by shorter fence", () => {
+    const { mathBlocks } = extractMathBlocks("~~~~\n$x^2$\n~~~");
+    expect(mathBlocks.size).toBe(0);
+  });
+
   it("does NOT extract escaped delimiters \\$5 and \\$10, outputs literal $", () => {
     const { protectedText, mathBlocks } = extractMathBlocks("\\$5 and \\$10");
     expect(mathBlocks.size).toBe(0);

--- a/ui/src/ui/katex-renderer.test.ts
+++ b/ui/src/ui/katex-renderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   escapeHtml,
   findInlineMathEnd,
@@ -8,6 +8,7 @@ import {
   preloadKatex,
   getKatexModule,
 } from "./katex-renderer.ts";
+import { toSanitizedMarkdownHtmlWithKatex, clearMarkdownCache } from "./markdown.ts";
 
 // ── escapeHtml ──
 
@@ -245,5 +246,173 @@ describe("restoreMathBlocksSync — no module loaded", () => {
     expect(result).toBe(
       'a <code class="katex-fallback">x^2</code> b <code class="katex-fallback">E=mc^2</code> c',
     );
+  });
+});
+
+// ── preloadKatex & getKatexModule ──
+
+describe("preloadKatex & getKatexModule", () => {
+  it("preloadKatex() returns a Promise", () => {
+    const result = preloadKatex();
+    expect(result).toBeInstanceOf(Promise);
+    result.catch(() => {});
+  });
+
+  it("preloadKatex() resolves and makes getKatexModule() return the module", async () => {
+    const result = await preloadKatex();
+    expect(result).toBeDefined();
+    expect(getKatexModule()).not.toBeNull();
+  });
+});
+
+// ── toSanitizedMarkdownHtmlWithKatex — KaTeX integration ──
+
+// Mock katex module for integration tests
+vi.mock("katex", () => {
+  const renderToString = (
+    tex: string,
+    options?: { displayMode?: boolean; throwOnError?: boolean; trust?: boolean; strict?: boolean },
+  ) => {
+    // Simulate KaTeX trust:false — block dangerous commands
+    if (options?.trust === false && /\\href\s*\{javascript:/i.test(tex)) {
+      return `<span class="katex-error">${tex}</span>`;
+    }
+    if (options?.displayMode) {
+      return `<span class="katex-display"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><mi>${tex}</mi></mrow></semantics></math></span><span class="katex-html">${tex}</span></span></span>`;
+    }
+    return `<span class="katex"><span class="katex-mathml"><math><semantics><mrow><mi>${tex}</mi></mrow></semantics></math></span><span class="katex-html">${tex}</span></span>`;
+  };
+  return {
+    default: { renderToString },
+    renderToString,
+  };
+});
+
+vi.mock("katex/dist/katex.min.css?url", () => ({
+  default: "katex.min.css",
+}));
+
+describe("toSanitizedMarkdownHtmlWithKatex — KaTeX rendering", () => {
+  beforeEach(() => {
+    clearMarkdownCache();
+  });
+
+  it("renders inline KaTeX math and output survives DOMPurify (sanitizer boundary)", async () => {
+    // Preload the mocked katex module
+    await preloadKatex();
+
+    const html = toSanitizedMarkdownHtmlWithKatex("$E=mc^2$", {
+      mathRendering: "katex",
+    });
+
+    // KaTeX HTML must survive DOMPurify (prove restore-before-sanitize works)
+    expect(html).toContain('class="katex"');
+    expect(html).toContain("<math>");
+  });
+
+  it("blocks XSS vectors in LaTeX (\\href with javascript:)", async () => {
+    await preloadKatex();
+
+    const html = toSanitizedMarkdownHtmlWithKatex("$\\href{javascript:alert(1)}{click}$", {
+      mathRendering: "katex",
+    });
+
+    // Must NOT produce executable XSS links
+    expect(html).not.toContain('href="javascript:');
+    // KaTeX trust:false blocks \href → katex-error → katex-fallback
+    expect(html).toContain("katex-fallback");
+  });
+
+  it("renders display mode math with katex-display class", async () => {
+    await preloadKatex();
+
+    const html = toSanitizedMarkdownHtmlWithKatex("$$\\frac{a}{b}$$", {
+      mathRendering: "katex",
+    });
+
+    expect(html).toContain("katex-display");
+  });
+
+  it("does NOT render KaTeX when mathRendering=off", () => {
+    const html = toSanitizedMarkdownHtmlWithKatex("$E=mc^2$", {
+      mathRendering: "off",
+    });
+
+    expect(html).not.toContain('class="katex"');
+  });
+
+  it("does NOT render KaTeX when mathRendering is undefined", () => {
+    const html = toSanitizedMarkdownHtmlWithKatex("$E=mc^2$");
+
+    expect(html).not.toContain('class="katex"');
+  });
+});
+
+// ── Cache tests ──
+
+describe("Markdown cache", () => {
+  beforeEach(() => {
+    clearMarkdownCache();
+  });
+
+  it("clearMarkdownCache() empties the cache", () => {
+    // Render something to populate cache
+    const html1 = toSanitizedMarkdownHtmlWithKatex("Hello **world**", {
+      mathRendering: "off",
+    });
+    expect(html1).toContain("<strong>world</strong>");
+
+    // Clear cache
+    clearMarkdownCache();
+
+    // Render again — should still work (just not from cache)
+    const html2 = toSanitizedMarkdownHtmlWithKatex("Hello **world**", {
+      mathRendering: "off",
+    });
+    expect(html2).toBe(html1);
+  });
+
+  it("skips cache when KaTeX is requested but not loaded", async () => {
+    // Reset module state by forcing katexModule to null
+    // We test the cache skip behavior by verifying that calling
+    // with mathRendering="katex" when getKatexModule() returns null
+    // still returns valid output (fallback), and subsequent calls
+    // with katex loaded produce different (rendered) output.
+
+    // First: render with katex not loaded (getKatexModule() === null)
+    // The mock is loaded via vi.mock, but getKatexModule checks the
+    // internal module variable. Since we vi.mock'd the dynamic import,
+    // preloadKatex will resolve with the mock, making getKatexModule
+    // return non-null. So we test the cache skip by verifying the
+    // output does not permanently cache the fallback.
+
+    // Render with katex loaded
+    await preloadKatex();
+    const htmlWithKatex = toSanitizedMarkdownHtmlWithKatex("$x^2$", {
+      mathRendering: "katex",
+    });
+    expect(htmlWithKatex).toContain('class="katex"');
+
+    // Clear and re-render — should produce same result (katex loaded now)
+    clearMarkdownCache();
+    const htmlAgain = toSanitizedMarkdownHtmlWithKatex("$x^2$", {
+      mathRendering: "katex",
+    });
+    expect(htmlAgain).toContain('class="katex"');
+    expect(htmlAgain).toBe(htmlWithKatex);
+  });
+
+  it("caches results when KaTeX is loaded", async () => {
+    await preloadKatex();
+
+    const html1 = toSanitizedMarkdownHtmlWithKatex("$x^2$", {
+      mathRendering: "katex",
+    });
+    const html2 = toSanitizedMarkdownHtmlWithKatex("$x^2$", {
+      mathRendering: "katex",
+    });
+
+    // Second call should return cached result
+    expect(html2).toBe(html1);
   });
 });

--- a/ui/src/ui/katex-renderer.test.ts
+++ b/ui/src/ui/katex-renderer.test.ts
@@ -268,10 +268,16 @@ describe("preloadKatex & getKatexModule", () => {
 // ── toSanitizedMarkdownHtmlWithKatex — KaTeX integration ──
 
 // Mock katex module for integration tests
-vi.mock("katex", () => {
-  const renderToString = (
+const renderToStringMock = vi.fn(
+  (
     tex: string,
-    options?: { displayMode?: boolean; throwOnError?: boolean; trust?: boolean; strict?: boolean },
+    options?: {
+      displayMode?: boolean;
+      throwOnError?: boolean;
+      trust?: boolean;
+      strict?: boolean;
+      maxSize?: number;
+    },
   ) => {
     // Simulate KaTeX trust:false — block dangerous commands
     if (options?.trust === false && /\\href\s*\{javascript:/i.test(tex)) {
@@ -281,10 +287,13 @@ vi.mock("katex", () => {
       return `<span class="katex-display"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><mi>${tex}</mi></mrow></semantics></math></span><span class="katex-html">${tex}</span></span></span>`;
     }
     return `<span class="katex"><span class="katex-mathml"><math><semantics><mrow><mi>${tex}</mi></mrow></semantics></math></span><span class="katex-html">${tex}</span></span>`;
-  };
+  },
+);
+
+vi.mock("katex", () => {
   return {
-    default: { renderToString },
-    renderToString,
+    default: { renderToString: renderToStringMock },
+    renderToString: renderToStringMock,
   };
 });
 
@@ -414,5 +423,83 @@ describe("Markdown cache", () => {
 
     // Second call should return cached result
     expect(html2).toBe(html1);
+  });
+});
+
+// ── Render loop guard ──
+
+describe("render loop guard prevents multiple preloadKatex calls", () => {
+  it("preloadKatex is idempotent — calling it repeatedly resolves safely without errors", async () => {
+    const results = await Promise.all([preloadKatex(), preloadKatex(), preloadKatex()]);
+
+    expect(results[0]).toBeDefined();
+    expect(results[1]).toBeDefined();
+    expect(results[2]).toBeDefined();
+    expect(results[0]).toBe(results[1]);
+    expect(results[1]).toBe(results[2]);
+  });
+
+  it("preloadKatex returns the same resolved module on subsequent calls after initial load", async () => {
+    const first = await preloadKatex();
+    const second = await preloadKatex();
+
+    expect(first).toBe(second);
+    expect(getKatexModule()).toBe(first);
+  });
+});
+
+// ── maxSize cap ──
+
+describe("maxSize option in KaTeX rendering", () => {
+  beforeEach(() => {
+    clearMarkdownCache();
+  });
+
+  it("maxSize option is passed to renderToString", async () => {
+    await preloadKatex();
+    renderToStringMock.mockClear();
+
+    toSanitizedMarkdownHtmlWithKatex("$x^2$", {
+      mathRendering: "katex",
+    });
+
+    expect(renderToStringMock).toHaveBeenCalled();
+    const lastCall = renderToStringMock.mock.calls[renderToStringMock.mock.calls.length - 1]!;
+    const options = lastCall[1] as Record<string, unknown>;
+    expect(options.maxSize).toBe(100);
+  });
+
+  it("hostile LaTeX size is capped by maxSize", async () => {
+    await preloadKatex();
+    renderToStringMock.mockClear();
+
+    const html = toSanitizedMarkdownHtmlWithKatex("$\\rule{500em}{500em}$", {
+      mathRendering: "katex",
+    });
+
+    expect(html).toContain('class="katex"');
+    expect(renderToStringMock).toHaveBeenCalled();
+    const lastCall = renderToStringMock.mock.calls[renderToStringMock.mock.calls.length - 1]!;
+    const options = lastCall[1] as Record<string, unknown>;
+    expect(options.maxSize).toBe(100);
+  });
+
+  it("normal formulas unaffected by maxSize", async () => {
+    await preloadKatex();
+    clearMarkdownCache();
+
+    const inlineHtml = toSanitizedMarkdownHtmlWithKatex("$E=mc^2$", {
+      mathRendering: "katex",
+    });
+    expect(inlineHtml).toContain('class="katex"');
+    expect(inlineHtml).toContain("<math>");
+    expect(inlineHtml).toContain("E=mc^2");
+
+    clearMarkdownCache();
+    const displayHtml = toSanitizedMarkdownHtmlWithKatex("$$\\frac{a}{b}$$", {
+      mathRendering: "katex",
+    });
+    expect(displayHtml).toContain("katex-display");
+    expect(displayHtml).toContain("\\frac{a}{b}");
   });
 });

--- a/ui/src/ui/katex-renderer.ts
+++ b/ui/src/ui/katex-renderer.ts
@@ -36,6 +36,43 @@ function isSingleLetterVariable(content: string): boolean {
   return (ch >= 65 && ch <= 90) || (ch >= 97 && ch <= 122);
 }
 
+/**
+ * Check if a character following a closing `$` is a CJK punctuation
+ * or ideograph that should count as a valid boundary for inline math.
+ * This covers fullwidth punctuation (U+FF00–FFEF), CJK punctuation
+ * (U+3000–303F), and CJK ideographs (U+4E00–9FFF, U+3400–4DBF).
+ */
+function isCJKBoundary(nextChar: string): boolean {
+  const cp = nextChar.codePointAt(0);
+  if (cp === undefined) {
+    return false;
+  }
+  // Fullwidth punctuation: ，．！？）：；、
+  if (cp >= 0xff01 && cp <= 0xff60) {
+    return true;
+  }
+  // CJK punctuation: 。、「」【】
+  if (cp >= 0x3001 && cp <= 0x303f) {
+    return true;
+  }
+  // CJK ideographs — a closing $ before a CJK character is a valid boundary
+  if (cp >= 0x4e00 && cp <= 0x9fff) {
+    return true;
+  }
+  if (cp >= 0x3400 && cp <= 0x4dbf) {
+    return true;
+  }
+  // Korean Hangul
+  if (cp >= 0xac00 && cp <= 0xd7af) {
+    return true;
+  }
+  // Katakana / Hiragana
+  if (cp >= 0x3040 && cp <= 0x30ff) {
+    return true;
+  }
+  return false;
+}
+
 // ── findInlineMathEnd ──
 
 /**
@@ -70,7 +107,8 @@ export function findInlineMathEnd(text: string, start: number): number {
         nextChar === null ||
         /[\s.,;:!?)\]}"'`-]/.test(nextChar) ||
         nextChar === "$" ||
-        nextChar === "\n";
+        nextChar === "\n" ||
+        isCJKBoundary(nextChar);
 
       if (isBoundary) {
         if (content.length === 0) {

--- a/ui/src/ui/katex-renderer.ts
+++ b/ui/src/ui/katex-renderer.ts
@@ -1,0 +1,364 @@
+// ── KaTeX Rendering Core Module ──
+
+let katexModule: typeof import("katex") | null = null;
+let katexLoading: Promise<typeof import("katex")> | null = null;
+let cssLoaded = false;
+
+// ── Helpers ──
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function looksLikeMath(content: string): boolean {
+  if (content.length === 0) return false;
+  if (/\\[a-zA-Z]+/.test(content)) return true;
+  if (/[\^_{}]/.test(content)) return true;
+  return false;
+}
+
+function isSingleLetterVariable(content: string): boolean {
+  if (content.length !== 1) return false;
+  const ch = content.charCodeAt(0);
+  return (ch >= 65 && ch <= 90) || (ch >= 97 && ch <= 122);
+}
+
+// ── findInlineMathEnd ──
+
+/**
+ * Find the closing `$` for an inline math block starting at `start`
+ * (position of the opening `$`). Returns the index of the closing `$`,
+ * or -1 if none found or the content is not valid math.
+ */
+export function findInlineMathEnd(text: string, start: number): number {
+  let hasBackslashCommand = false;
+  let content = "";
+
+  for (let i = start + 1; i < text.length; i++) {
+    const ch = text[i];
+
+    if (ch === "\n" && i + 1 < text.length && text[i + 1] === "\n") {
+      return -1;
+    }
+
+    if (ch === "\\" && i + 1 < text.length && text[i + 1] === "$") {
+      content += "\\$";
+      i++;
+      continue;
+    }
+
+    if (ch === "\\" && i + 1 < text.length && /[a-zA-Z]/.test(text[i + 1])) {
+      hasBackslashCommand = true;
+    }
+
+    if (ch === "$") {
+      const nextChar = i + 1 < text.length ? text[i + 1] : null;
+      const isBoundary =
+        nextChar === null ||
+        /[\s.,;:!?)\]}"'`\-]/.test(nextChar) ||
+        nextChar === "$" ||
+        nextChar === "\n";
+
+      if (isBoundary) {
+        if (content.length === 0) return -1;
+        if (hasBackslashCommand) return i;
+        if (looksLikeMath(content)) return i;
+        if (isSingleLetterVariable(content)) return i;
+        if (/^[\d., ]+$/.test(content)) return -1;
+        return i;
+      }
+    }
+
+    content += ch;
+  }
+
+  return -1;
+}
+
+// ── extractMathBlocks ──
+
+/**
+ * Scan a markdown string, extract all math blocks (display and inline),
+ * and replace them with null-byte-delimited placeholder tokens.
+ *
+ * Placeholder format: \x00KATEX_PLACEHOLDER_N\x00
+ *
+ * Returns the protected text and a Map from placeholder → { tex, displayMode }.
+ */
+export function extractMathBlocks(markdown: string): {
+  protectedText: string;
+  mathBlocks: Map<string, { tex: string; displayMode: boolean }>;
+} {
+  const mathBlocks = new Map<string, { tex: string; displayMode: boolean }>();
+  let placeholderId = 0;
+
+  const result: string[] = [];
+  let i = 0;
+  const len = markdown.length;
+
+  while (i < len) {
+    if (markdown[i] === "`" && markdown[i + 1] === "`" && markdown[i + 2] === "`") {
+      const start = i;
+      i += 3;
+      while (i < len && markdown[i] !== "\n") i++;
+      if (i < len) i++;
+      while (i < len) {
+        if (markdown[i] === "`" && markdown[i + 1] === "`" && markdown[i + 2] === "`") {
+          i += 3;
+          break;
+        }
+        i++;
+      }
+      result.push(markdown.slice(start, i));
+      continue;
+    }
+
+    if (markdown[i] === "`") {
+      let tickCount = 0;
+      while (i + tickCount < len && markdown[i + tickCount] === "`") {
+        tickCount++;
+      }
+      const closingStart = findClosingBackticks(markdown, i + tickCount, tickCount);
+      if (closingStart !== -1) {
+        result.push(markdown.slice(i, closingStart + tickCount));
+        i = closingStart + tickCount;
+        continue;
+      }
+      result.push("`");
+      i++;
+      continue;
+    }
+
+    if (markdown[i] === "\\" && i + 1 < len && markdown[i + 1] === "$") {
+      result.push("$");
+      i += 2;
+      continue;
+    }
+
+    if (markdown[i] === "\\" && i + 1 < len && markdown[i + 1] === "[" && i + 2 < len) {
+      const contentStart = i + 2;
+      let j = contentStart;
+      while (j < len) {
+        if (markdown[j] === "\\" && j + 1 < len && markdown[j + 1] === "]") {
+          const tex = markdown.slice(contentStart, j).trim();
+          const ph = `\x00KATEX_PLACEHOLDER_${placeholderId++}\x00`;
+          mathBlocks.set(ph, { tex, displayMode: true });
+          result.push(ph);
+          i = j + 2;
+          break;
+        }
+        j++;
+      }
+      if (j >= len) {
+        result.push("\\[");
+        i += 2;
+      }
+      continue;
+    }
+
+    if (markdown[i] === "\\" && i + 1 < len && markdown[i + 1] === "(" && i + 2 < len) {
+      const contentStart = i + 2;
+      let j = contentStart;
+      while (j < len) {
+        if (markdown[j] === "\\" && j + 1 < len && markdown[j + 1] === ")") {
+          const tex = markdown.slice(contentStart, j).trim();
+          const ph = `\x00KATEX_PLACEHOLDER_${placeholderId++}\x00`;
+          mathBlocks.set(ph, { tex, displayMode: false });
+          result.push(ph);
+          i = j + 2;
+          break;
+        }
+        j++;
+      }
+      if (j >= len) {
+        result.push("\\(");
+        i += 2;
+      }
+      continue;
+    }
+
+    if (markdown[i] === "$" && i + 1 < len && markdown[i + 1] === "$") {
+      const contentStart = i + 2;
+      let j = contentStart;
+      while (j < len) {
+        if (markdown[j] === "$" && j + 1 < len && markdown[j + 1] === "$") {
+          const tex = markdown.slice(contentStart, j).trim();
+          const ph = `\x00KATEX_PLACEHOLDER_${placeholderId++}\x00`;
+          mathBlocks.set(ph, { tex, displayMode: true });
+          result.push(ph);
+          i = j + 2;
+          break;
+        }
+        j++;
+      }
+      if (j >= len) {
+        result.push("$$");
+        i += 2;
+      }
+      continue;
+    }
+
+    if (markdown[i] === "$") {
+      const end = findInlineMathEnd(markdown, i);
+      if (end !== -1) {
+        const tex = markdown.slice(i + 1, end).trim();
+        const ph = `\x00KATEX_PLACEHOLDER_${placeholderId++}\x00`;
+        mathBlocks.set(ph, { tex, displayMode: false });
+        result.push(ph);
+        i = end + 1;
+        continue;
+      }
+      result.push("$");
+      i++;
+      continue;
+    }
+
+    result.push(markdown[i]);
+    i++;
+  }
+
+  return {
+    protectedText: result.join(""),
+    mathBlocks,
+  };
+}
+
+function findClosingBackticks(text: string, start: number, count: number): number {
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === "`") {
+      let tickCount = 0;
+      while (i + tickCount < text.length && text[i + tickCount] === "`") {
+        tickCount++;
+      }
+      if (tickCount === count) {
+        if (i + tickCount < text.length && text[i + tickCount] === "`") {
+          i += tickCount - 1;
+          continue;
+        }
+        return i;
+      }
+      i += tickCount - 1;
+    }
+  }
+  return -1;
+}
+
+// ── preProcessTex ──
+
+/**
+ * Preprocess LaTeX source before rendering. Normalizes constructs
+ * that KaTeX does not support:
+ * - multline* → gather*
+ * - Strips \require{...} and \definecolor{...}
+ * - \ce{...} → \mathrm{...}
+ */
+export function preProcessTex(tex: string, _displayMode: boolean): string {
+  let result = tex;
+  result = result.replace(/\\begin\{multline\*?\}/g, "\\begin{gather*}");
+  result = result.replace(/\\end\{multline\*?\}/g, "\\end{gather*}");
+  result = result.replace(/\\require\{[^}]*\}/g, "");
+  result = result.replace(/\\definecolor\{[^}]*\}\{[^}]*\}\{[^}]*\}/g, "");
+  result = result.replace(/\\ce\{([^}]*(?:\{[^}]*\}[^}]*)*)\}/g, "\\mathrm{$1}");
+  return result;
+}
+
+// ── restoreMathBlocksSync ──
+
+/**
+ * Replace math placeholders in rendered HTML with KaTeX output.
+ * Must be called synchronously during rendering — katexModule must
+ * be preloaded first via preloadKatex().
+ *
+ * Falls back to <code class="katex-fallback"> when katex is not yet
+ * loaded or rendering produces an error.
+ */
+export function restoreMathBlocksSync(
+  html: string,
+  mathBlocks: Map<string, { tex: string; displayMode: boolean }>,
+): string {
+  if (mathBlocks.size === 0) return html;
+
+  if (!katexModule) {
+    let result = html;
+    for (const [ph, { tex }] of mathBlocks) {
+      result = result.replaceAll(ph, `<code class="katex-fallback">${escapeHtml(tex)}</code>`);
+    }
+    return result;
+  }
+
+  let result = html;
+  for (const [ph, { tex, displayMode }] of mathBlocks) {
+    const processedTex = preProcessTex(tex, displayMode);
+    let rendered: string;
+    try {
+      rendered = katexModule.renderToString(processedTex, {
+        displayMode,
+        throwOnError: false,
+        trust: false,
+        strict: false,
+      });
+    } catch {
+      rendered = `<code class="katex-fallback">${escapeHtml(tex)}</code>`;
+    }
+    if (rendered.includes("katex-error")) {
+      rendered = `<code class="katex-fallback">${escapeHtml(tex)}</code>`;
+    }
+    result = result.replaceAll(ph, rendered);
+  }
+  return result;
+}
+
+// ── Module loading ──
+
+/**
+ * Preload the KaTeX module asynchronously. Once loaded, the module
+ * is available synchronously via getKatexModule(). Safe to call
+ * multiple times.
+ */
+export function preloadKatex(): void {
+  if (katexModule) return;
+  if (katexLoading) return;
+  katexLoading = import("katex").then((mod) => {
+    katexModule = mod;
+    return mod;
+  });
+  katexLoading.catch(() => {
+    katexLoading = null;
+  });
+}
+
+/**
+ * Return the loaded KaTeX module, or null if not yet loaded.
+ */
+export function getKatexModule(): typeof import("katex") | null {
+  return katexModule;
+}
+
+// ── CSS loading ──
+
+/**
+ * Dynamically load the KaTeX CSS stylesheet. Does nothing in SSR
+ * environments (where `document` is undefined). Safe to call
+ * multiple times.
+ */
+export function loadKatexCss(): void {
+  if (cssLoaded) return;
+  if (typeof document === "undefined") return;
+  cssLoaded = true;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  import("katex/dist/katex.min.css?url")
+    .then((url) => {
+      link.href = url.default;
+      document.head.appendChild(link);
+    })
+    .catch((err) => {
+      console.warn("[katex] Failed to load CSS:", err);
+      cssLoaded = false;
+    });
+}

--- a/ui/src/ui/katex-renderer.ts
+++ b/ui/src/ui/katex-renderer.ts
@@ -158,23 +158,64 @@ export function extractMathBlocks(markdown: string): {
   const len = markdown.length;
 
   while (i < len) {
-    if (markdown[i] === "`" && markdown[i + 1] === "`" && markdown[i + 2] === "`") {
-      const start = i;
-      i += 3;
+    // Fenced code blocks: markdown-it accepts 3+ backticks or 3+ tildes as fence openers.
+    // The closing fence must use the same character and have length >= opener length.
+    const ch = markdown[i];
+    if ((ch === "`" || ch === "~") && markdown[i + 1] === ch && markdown[i + 2] === ch) {
+      let fenceLen = 3;
+      while (i + fenceLen < len && markdown[i + fenceLen] === ch) {
+        fenceLen++;
+      }
+      const fenceStart = i;
+      i += fenceLen;
+      // Skip the info string (rest of the opening line)
       while (i < len && markdown[i] !== "\n") {
         i++;
       }
       if (i < len) {
         i++;
       }
+      // Find closing fence: same char, length >= fenceLen, on its own line
+      let closed = false;
       while (i < len) {
-        if (markdown[i] === "`" && markdown[i + 1] === "`" && markdown[i + 2] === "`") {
-          i += 3;
-          break;
+        const lineStart = i;
+        // Skip leading spaces (markdown-it allows up to 3 spaces before closing fence)
+        while (i < len && markdown[i] === " " && i - lineStart < 3) {
+          i++;
         }
-        i++;
+        if (markdown[i] === ch) {
+          let closeLen = 0;
+          while (i + closeLen < len && markdown[i + closeLen] === ch) {
+            closeLen++;
+          }
+          if (closeLen >= fenceLen) {
+            // Closing fence must be followed by whitespace or newline only
+            const afterFence = i + closeLen;
+            if (
+              afterFence >= len ||
+              markdown[afterFence] === "\n" ||
+              markdown[afterFence] === " "
+            ) {
+              i = afterFence;
+              while (i < len && markdown[i] !== "\n") {
+                i++;
+              }
+              if (i < len) {
+                i++;
+              }
+              closed = true;
+              break;
+            }
+          }
+        }
+        while (i < len && markdown[i] !== "\n") {
+          i++;
+        }
+        if (i < len) {
+          i++;
+        }
       }
-      result.push(markdown.slice(start, i));
+      result.push(markdown.slice(fenceStart, i));
       continue;
     }
 
@@ -183,14 +224,28 @@ export function extractMathBlocks(markdown: string): {
       while (i + tickCount < len && markdown[i + tickCount] === "`") {
         tickCount++;
       }
+      // 1-2 backticks: inline code (not a fence)
+      if (tickCount < 3) {
+        const closingStart = findClosingBackticks(markdown, i + tickCount, tickCount);
+        if (closingStart !== -1) {
+          result.push(markdown.slice(i, closingStart + tickCount));
+          i = closingStart + tickCount;
+          continue;
+        }
+        result.push("`");
+        i++;
+        continue;
+      }
+      // 3+ backticks without a newline after → treat as inline code (not a fence)
+      // This path is rare; the fence block above already handled the normal case
       const closingStart = findClosingBackticks(markdown, i + tickCount, tickCount);
       if (closingStart !== -1) {
         result.push(markdown.slice(i, closingStart + tickCount));
         i = closingStart + tickCount;
         continue;
       }
-      result.push("`");
-      i++;
+      result.push(markdown.slice(i, i + tickCount));
+      i += tickCount;
       continue;
     }
 
@@ -434,16 +489,26 @@ export function loadKatexCss(): void {
   if (typeof document === "undefined") {
     return;
   }
+  // Mark pending so loadKatexCss() is not re-entered while the <link> is loading
   cssLoaded = true;
   const link = document.createElement("link");
   link.rel = "stylesheet";
   import("katex/dist/katex.min.css?url")
     .then((url) => {
       link.href = url.default;
+      // The ?url import resolves once the bundler emits the asset URL,
+      // but the browser may still fail to fetch the stylesheet itself.
+      // Attach load/error handlers so failures reset cssLoaded for retry.
+      link.addEventListener("load", () => {});
+      link.addEventListener("error", () => {
+        console.warn("[katex] Browser failed to load stylesheet from", url.default);
+        cssLoaded = false;
+        link.remove();
+      });
       document.head.appendChild(link);
     })
     .catch((err) => {
-      console.warn("[katex] Failed to load CSS:", err);
+      console.warn("[katex] Failed to resolve CSS URL:", err);
       cssLoaded = false;
     });
 }

--- a/ui/src/ui/katex-renderer.ts
+++ b/ui/src/ui/katex-renderer.ts
@@ -16,14 +16,22 @@ export function escapeHtml(value: string): string {
 }
 
 function looksLikeMath(content: string): boolean {
-  if (content.length === 0) return false;
-  if (/\\[a-zA-Z]+/.test(content)) return true;
-  if (/[\^_{}]/.test(content)) return true;
+  if (content.length === 0) {
+    return false;
+  }
+  if (/\\[a-zA-Z]+/.test(content)) {
+    return true;
+  }
+  if (/[\^_{}]/.test(content)) {
+    return true;
+  }
   return false;
 }
 
 function isSingleLetterVariable(content: string): boolean {
-  if (content.length !== 1) return false;
+  if (content.length !== 1) {
+    return false;
+  }
   const ch = content.charCodeAt(0);
   return (ch >= 65 && ch <= 90) || (ch >= 97 && ch <= 122);
 }
@@ -60,16 +68,26 @@ export function findInlineMathEnd(text: string, start: number): number {
       const nextChar = i + 1 < text.length ? text[i + 1] : null;
       const isBoundary =
         nextChar === null ||
-        /[\s.,;:!?)\]}"'`\-]/.test(nextChar) ||
+        /[\s.,;:!?)\]}"'`-]/.test(nextChar) ||
         nextChar === "$" ||
         nextChar === "\n";
 
       if (isBoundary) {
-        if (content.length === 0) return -1;
-        if (hasBackslashCommand) return i;
-        if (looksLikeMath(content)) return i;
-        if (isSingleLetterVariable(content)) return i;
-        if (/^[\d., ]+$/.test(content)) return -1;
+        if (content.length === 0) {
+          return -1;
+        }
+        if (hasBackslashCommand) {
+          return i;
+        }
+        if (looksLikeMath(content)) {
+          return i;
+        }
+        if (isSingleLetterVariable(content)) {
+          return i;
+        }
+        if (/^[\d., ]+$/.test(content)) {
+          return -1;
+        }
         return i;
       }
     }
@@ -105,8 +123,12 @@ export function extractMathBlocks(markdown: string): {
     if (markdown[i] === "`" && markdown[i + 1] === "`" && markdown[i + 2] === "`") {
       const start = i;
       i += 3;
-      while (i < len && markdown[i] !== "\n") i++;
-      if (i < len) i++;
+      while (i < len && markdown[i] !== "\n") {
+        i++;
+      }
+      if (i < len) {
+        i++;
+      }
       while (i < len) {
         if (markdown[i] === "`" && markdown[i + 1] === "`" && markdown[i + 2] === "`") {
           i += 3;
@@ -290,7 +312,9 @@ export function restoreMathBlocksSync(
   html: string,
   mathBlocks: Map<string, { tex: string; displayMode: boolean }>,
 ): string {
-  if (mathBlocks.size === 0) return html;
+  if (mathBlocks.size === 0) {
+    return html;
+  }
 
   if (!katexModule) {
     let result = html;
@@ -335,8 +359,12 @@ export function restoreMathBlocksSync(
  * multiple times.
  */
 export function preloadKatex(): Promise<typeof import("katex")> {
-  if (katexModule) return Promise.resolve(katexModule);
-  if (katexLoading) return katexLoading;
+  if (katexModule) {
+    return Promise.resolve(katexModule);
+  }
+  if (katexLoading) {
+    return katexLoading;
+  }
   katexLoading = import("katex").then((mod) => {
     katexModule = mod;
     return mod;
@@ -362,8 +390,12 @@ export function getKatexModule(): typeof import("katex") | null {
  * multiple times.
  */
 export function loadKatexCss(): void {
-  if (cssLoaded) return;
-  if (typeof document === "undefined") return;
+  if (cssLoaded) {
+    return;
+  }
+  if (typeof document === "undefined") {
+    return;
+  }
   cssLoaded = true;
   const link = document.createElement("link");
   link.rel = "stylesheet";

--- a/ui/src/ui/katex-renderer.ts
+++ b/ui/src/ui/katex-renderer.ts
@@ -314,6 +314,7 @@ export function restoreMathBlocksSync(
         throwOnError: false,
         trust: false,
         strict: false,
+        maxSize: 100,
       });
     } catch {
       rendered = `<code class="katex-fallback">${escapeHtml(tex)}</code>`;

--- a/ui/src/ui/katex-renderer.ts
+++ b/ui/src/ui/katex-renderer.ts
@@ -320,9 +320,9 @@ export function restoreMathBlocksSync(
  * is available synchronously via getKatexModule(). Safe to call
  * multiple times.
  */
-export function preloadKatex(): void {
-  if (katexModule) return;
-  if (katexLoading) return;
+export function preloadKatex(): Promise<typeof import("katex")> {
+  if (katexModule) return Promise.resolve(katexModule);
+  if (katexLoading) return katexLoading;
   katexLoading = import("katex").then((mod) => {
     katexModule = mod;
     return mod;
@@ -330,6 +330,7 @@ export function preloadKatex(): void {
   katexLoading.catch(() => {
     katexLoading = null;
   });
+  return katexLoading;
 }
 
 /**

--- a/ui/src/ui/katex-renderer.ts
+++ b/ui/src/ui/katex-renderer.ts
@@ -277,6 +277,15 @@ export function preProcessTex(tex: string, _displayMode: boolean): string {
  * Falls back to <code class="katex-fallback"> when katex is not yet
  * loaded or rendering produces an error.
  */
+/** Handle both \x00 and \ufffd variants — markdown-it converts \x00 → \ufffd. */
+function replacePlaceholder(html: string, ph: string, replacement: string): string {
+  let result = html.replaceAll(ph, replacement);
+  if (ph.includes("\x00")) {
+    result = result.replaceAll(ph.replaceAll("\x00", "\ufffd"), replacement);
+  }
+  return result;
+}
+
 export function restoreMathBlocksSync(
   html: string,
   mathBlocks: Map<string, { tex: string; displayMode: boolean }>,
@@ -286,7 +295,11 @@ export function restoreMathBlocksSync(
   if (!katexModule) {
     let result = html;
     for (const [ph, { tex }] of mathBlocks) {
-      result = result.replaceAll(ph, `<code class="katex-fallback">${escapeHtml(tex)}</code>`);
+      result = replacePlaceholder(
+        result,
+        ph,
+        `<code class="katex-fallback">${escapeHtml(tex)}</code>`,
+      );
     }
     return result;
   }
@@ -308,7 +321,7 @@ export function restoreMathBlocksSync(
     if (rendered.includes("katex-error")) {
       rendered = `<code class="katex-fallback">${escapeHtml(tex)}</code>`;
     }
-    result = result.replaceAll(ph, rendered);
+    result = replacePlaceholder(result, ph, rendered);
   }
   return result;
 }

--- a/ui/src/ui/katex-renderer.ts
+++ b/ui/src/ui/katex-renderer.ts
@@ -176,7 +176,6 @@ export function extractMathBlocks(markdown: string): {
         i++;
       }
       // Find closing fence: same char, length >= fenceLen, on its own line
-      let closed = false;
       while (i < len) {
         const lineStart = i;
         // Skip leading spaces (markdown-it allows up to 3 spaces before closing fence)
@@ -203,7 +202,6 @@ export function extractMathBlocks(markdown: string): {
               if (i < len) {
                 i++;
               }
-              closed = true;
               break;
             }
           }

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -19,6 +19,7 @@ import markdownItTaskLists from "markdown-it-task-lists";
 import { stripUnsupportedCitationControlMarkers } from "../../../src/shared/text/citation-control-markers.js";
 import { i18n, t } from "../i18n/index.ts";
 import { truncateText } from "./format.ts";
+import { extractMathBlocks, restoreMathBlocksSync } from "./katex-renderer.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 
 const allowedTags = [
@@ -78,6 +79,76 @@ const sanitizeOptions = {
   ADD_DATA_URI_TAGS: ["img"],
 };
 
+// ── KaTeX: additional tags and attributes (only used when mathRendering === "katex") ──
+
+const katexAllowedTags = [
+  // SVG (KaTeX renderToString output: stretchy elements, radicals, tall delimiters, \cancel, \vec)
+  "svg",
+  "path",
+  "line",
+  // MathML (KaTeX htmlAndMathml default output mode)
+  "math",
+  "mi",
+  "mo",
+  "mn",
+  "msup",
+  "msub",
+  "msubsup",
+  "mfrac",
+  "mrow",
+  "munder",
+  "mover",
+  "munderover",
+  "mtable",
+  "mtr",
+  "mtd",
+  "mtext",
+  "mspace",
+  "mpadded",
+  "mphantom",
+  "mfenced",
+  // Metis review additions: missing MathML tags
+  "msqrt",
+  "mroot",
+  "menclose",
+  "mstyle",
+  "mlabeledtr",
+  "mglyph",
+  "semantics",
+  "annotation",
+];
+
+const katexAllowedAttrs = [
+  // SVG attributes
+  "xmlns",
+  "viewBox",
+  "d",
+  "x1",
+  "y1",
+  "x2",
+  "y2",
+  "stroke",
+  "stroke-width",
+  "fill",
+  "transform",
+  // MathML attributes
+  "mathvariant",
+  "displaystyle",
+  "scriptlevel",
+  "linethickness",
+  "lspace",
+  "rspace",
+  "stretchy",
+  "symmetric",
+  "maxsize",
+  "minsize",
+  "movablelimits",
+];
+
+// Security: <use> href/xlink:href is a known XSS vector (CVE-2023-26485).
+// KaTeX does not produce <use> tags. DOMPurify already blocks them by default.
+// This comment serves as explicit documentation of the security decision.
+
 let hooksInstalled = false;
 const MARKDOWN_CHAR_LIMIT = 140_000;
 const MARKDOWN_PARSE_LIMIT = 40_000;
@@ -93,6 +164,8 @@ export type MarkdownCodeBlockChrome = "copy" | "none";
 
 export type MarkdownRenderOptions = {
   codeBlockChrome?: MarkdownCodeBlockChrome;
+  /** Math rendering mode. When "katex", enables KaTeX rendering. */
+  mathRendering?: "off" | "katex";
 };
 
 type MarkdownRenderEnv = {
@@ -178,6 +251,19 @@ function installHooks() {
     node.setAttribute("target", "_blank");
     if (normalizeLowercaseStringOrEmpty(href).includes("tail")) {
       node.classList.add(TAIL_LINK_BLUR_CLASS);
+    }
+  });
+
+  // ── KaTeX style attribute protection ──
+  // uponSanitizeAttribute fires BEFORE _isValidAttribute check,
+  // so forceKeepAttr = true bypasses ALLOWED_ATTR check.
+  // Using node.closest('.katex') instead of classList.contains
+  // because style may appear on a CHILD of .katex (e.g., <span class="katex-html" style="...">)
+  DOMPurify.addHook("uponSanitizeAttribute", (node, hookEvent) => {
+    if (hookEvent.attrName === "style") {
+      if (node instanceof HTMLElement && node.closest(".katex")) {
+        hookEvent.forceKeepAttr = true;
+      }
     }
   });
 }
@@ -655,6 +741,86 @@ export function toSanitizedMarkdownHtml(
     rendered = `<pre class="code-block">${escaped}</pre>`;
   }
   const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
+  if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
+    setCachedMarkdown(cacheKey, sanitized);
+  }
+  return sanitized;
+}
+
+/**
+ * KaTeX-enabled variant of toSanitizedMarkdownHtml.
+ * When mathRendering === "katex", extracts math blocks before markdown-it rendering,
+ * then restores them as KaTeX HTML after DOMPurify sanitization.
+ * When mathRendering === "off" or undefined, behaves identically to toSanitizedMarkdownHtml.
+ */
+export function toSanitizedMarkdownHtmlWithKatex(
+  markdown: string,
+  options: MarkdownRenderOptions = {},
+): string {
+  const renderOptions = normalizeMarkdownRenderOptions(options);
+  const input = stripUnsupportedCitationControlMarkers(markdown).trim();
+  if (!input) {
+    return "";
+  }
+  installHooks();
+
+  const mathMode = options.mathRendering ?? "off";
+  const cacheKey = `${i18n.getLocale()}\0${renderOptions.codeBlockChrome}\0${mathMode}\0${input}`;
+  if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
+    const cached = getCachedMarkdown(cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+  }
+
+  // ── Math extraction (pre-source protection) ──
+  let mathBlocks = new Map<string, { tex: string; displayMode: boolean }>();
+  let processedInput = input;
+  if (mathMode === "katex") {
+    const extraction = extractMathBlocks(input);
+    processedInput = extraction.protectedText;
+    mathBlocks = extraction.mathBlocks;
+  }
+
+  // ── Build sanitize options (conditionally extend for KaTeX) ──
+  const activeSanitizeOptions =
+    mathMode === "katex"
+      ? {
+          ...sanitizeOptions,
+          ALLOWED_TAGS: [...allowedTags, ...katexAllowedTags],
+          ALLOWED_ATTR: [...allowedAttrs, ...katexAllowedAttrs],
+        }
+      : sanitizeOptions;
+
+  const truncated = truncateText(processedInput, MARKDOWN_CHAR_LIMIT);
+  const suffix = truncated.truncated
+    ? `\n\n… truncated (${truncated.total} chars, showing first ${truncated.text.length}).`
+    : "";
+  if (truncated.text.length > MARKDOWN_PARSE_LIMIT) {
+    const html = renderEscapedPlainTextHtml(`${truncated.text}${suffix}`);
+    const sanitized = DOMPurify.sanitize(html, activeSanitizeOptions);
+    let result = sanitized;
+    if (mathBlocks.size > 0) {
+      result = restoreMathBlocksSync(sanitized, mathBlocks);
+    }
+    if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
+      setCachedMarkdown(cacheKey, result);
+    }
+    return result;
+  }
+
+  let rendered: string;
+  try {
+    rendered = md.render(`${truncated.text}${suffix}`, renderOptions);
+  } catch (err) {
+    console.warn("[markdown] md.render failed, falling back to plain text:", err);
+    const escaped = escapeHtml(`${truncated.text}${suffix}`);
+    rendered = `<pre class="code-block">${escaped}</pre>`;
+  }
+  let sanitized = DOMPurify.sanitize(rendered, activeSanitizeOptions);
+  if (mathBlocks.size > 0) {
+    sanitized = restoreMathBlocksSync(sanitized, mathBlocks);
+  }
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
     setCachedMarkdown(cacheKey, sanitized);
   }

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -19,7 +19,7 @@ import markdownItTaskLists from "markdown-it-task-lists";
 import { stripUnsupportedCitationControlMarkers } from "../../../src/shared/text/citation-control-markers.js";
 import { i18n, t } from "../i18n/index.ts";
 import { truncateText } from "./format.ts";
-import { extractMathBlocks, restoreMathBlocksSync } from "./katex-renderer.ts";
+import { extractMathBlocks, getKatexModule, restoreMathBlocksSync } from "./katex-renderer.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 
 const allowedTags = [
@@ -750,7 +750,7 @@ export function toSanitizedMarkdownHtml(
 /**
  * KaTeX-enabled variant of toSanitizedMarkdownHtml.
  * When mathRendering === "katex", extracts math blocks before markdown-it rendering,
- * then restores them as KaTeX HTML after DOMPurify sanitization.
+ * restores them as KaTeX HTML, then sanitizes the final output through DOMPurify.
  * When mathRendering === "off" or undefined, behaves identically to toSanitizedMarkdownHtml.
  */
 export function toSanitizedMarkdownHtmlWithKatex(
@@ -797,12 +797,11 @@ export function toSanitizedMarkdownHtmlWithKatex(
     ? `\n\n… truncated (${truncated.total} chars, showing first ${truncated.text.length}).`
     : "";
   if (truncated.text.length > MARKDOWN_PARSE_LIMIT) {
-    const html = renderEscapedPlainTextHtml(`${truncated.text}${suffix}`);
-    const sanitized = DOMPurify.sanitize(html, activeSanitizeOptions);
-    let result = sanitized;
+    let html = renderEscapedPlainTextHtml(`${truncated.text}${suffix}`);
     if (mathBlocks.size > 0) {
-      result = restoreMathBlocksSync(sanitized, mathBlocks);
+      html = restoreMathBlocksSync(html, mathBlocks);
     }
+    const result = DOMPurify.sanitize(html, activeSanitizeOptions);
     if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
       setCachedMarkdown(cacheKey, result);
     }
@@ -817,16 +816,27 @@ export function toSanitizedMarkdownHtmlWithKatex(
     const escaped = escapeHtml(`${truncated.text}${suffix}`);
     rendered = `<pre class="code-block">${escaped}</pre>`;
   }
-  let sanitized = DOMPurify.sanitize(rendered, activeSanitizeOptions);
+  // Restore math blocks BEFORE sanitizing so the KaTeX HTML
+  // passes through DOMPurify with the conditional allowlists.
   if (mathBlocks.size > 0) {
-    sanitized = restoreMathBlocksSync(sanitized, mathBlocks);
+    rendered = restoreMathBlocksSync(rendered, mathBlocks);
   }
+  const sanitized = DOMPurify.sanitize(rendered, activeSanitizeOptions);
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
-    setCachedMarkdown(cacheKey, sanitized);
+    // Skip caching when KaTeX is not yet loaded — the fallback result
+    // (raw LaTeX text) would be cached permanently, preventing proper
+    // rendering once KaTeX finishes loading.
+    if (!(mathMode === "katex" && getKatexModule() === null)) {
+      setCachedMarkdown(cacheKey, sanitized);
+    }
   }
   return sanitized;
 }
 
 function renderEscapedPlainTextHtml(value: string): string {
   return `<div class="markdown-plain-text-fallback">${escapeHtml(value.replace(/\r\n?/g, "\n"))}</div>`;
+}
+
+export function clearMarkdownCache(): void {
+  markdownCache.clear();
 }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1072,11 +1072,16 @@ export function renderChat(props: ChatProps) {
   // Preload KaTeX when math rendering is enabled (one-shot guard to prevent infinite render loop)
   if (props.mathRendering === "katex" && !katexPreloadTriggered) {
     katexPreloadTriggered = true;
-    void preloadKatex().then(() => {
-      clearMarkdownCache();
-      const requestUpdate = props.onRequestUpdate ?? (() => {});
-      requestUpdate();
-    });
+    void preloadKatex()
+      .then(() => {
+        clearMarkdownCache();
+        const requestUpdate = props.onRequestUpdate ?? (() => {});
+        requestUpdate();
+      })
+      .catch(() => {
+        // Reset guard so a transient chunk failure allows retry on next render
+        katexPreloadTriggered = false;
+      });
     loadKatexCss();
   }
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1273,6 +1273,7 @@ export function renderChat(props: ChatProps) {
                 canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
                 embedSandboxMode: props.embedSandboxMode ?? "scripts",
                 allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
+                mathRendering: props.mathRendering,
                 contextWindow:
                   activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null,
                 onDelete: () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1066,9 +1066,12 @@ function renderSlashMenu(
   `;
 }
 
+let katexPreloadTriggered = false;
+
 export function renderChat(props: ChatProps) {
-  // Preload KaTeX when math rendering is enabled
-  if (props.mathRendering === "katex") {
+  // Preload KaTeX when math rendering is enabled (one-shot guard to prevent infinite render loop)
+  if (props.mathRendering === "katex" && !katexPreloadTriggered) {
+    katexPreloadTriggered = true;
     preloadKatex().then(() => {
       clearMarkdownCache();
       const requestUpdate = props.onRequestUpdate ?? (() => {});

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -51,6 +51,7 @@ import {
 import { getExpandedToolCards, syncToolCardExpansionState } from "../chat/tool-expansion-state.ts";
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
+import { preloadKatex, loadKatexCss } from "../katex-renderer.ts";
 import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { SessionsListResult } from "../types.ts";
@@ -171,6 +172,7 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  mathRendering?: "off" | "katex";
   basePath?: string;
 };
 
@@ -1064,6 +1066,12 @@ function renderSlashMenu(
 }
 
 export function renderChat(props: ChatProps) {
+  // Preload KaTeX when math rendering is enabled
+  if (props.mathRendering === "katex") {
+    preloadKatex();
+    loadKatexCss();
+  }
+
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1072,7 +1072,7 @@ export function renderChat(props: ChatProps) {
   // Preload KaTeX when math rendering is enabled (one-shot guard to prevent infinite render loop)
   if (props.mathRendering === "katex" && !katexPreloadTriggered) {
     katexPreloadTriggered = true;
-    preloadKatex().then(() => {
+    void preloadKatex().then(() => {
       clearMarkdownCache();
       const requestUpdate = props.onRequestUpdate ?? (() => {});
       requestUpdate();
@@ -1251,6 +1251,7 @@ export function renderChat(props: ChatProps) {
                 assistantIdentity,
                 props.basePath,
                 props.assistantAttachmentAuthToken ?? null,
+                props.mathRendering,
               );
             }
             if (item.kind === "group") {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -52,6 +52,7 @@ import { getExpandedToolCards, syncToolCardExpansionState } from "../chat/tool-e
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
 import { preloadKatex, loadKatexCss } from "../katex-renderer.ts";
+import { clearMarkdownCache } from "../markdown.ts";
 import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { SessionsListResult } from "../types.ts";
@@ -1068,7 +1069,11 @@ function renderSlashMenu(
 export function renderChat(props: ChatProps) {
   // Preload KaTeX when math rendering is enabled
   if (props.mathRendering === "katex") {
-    preloadKatex();
+    preloadKatex().then(() => {
+      clearMarkdownCache();
+      const requestUpdate = props.onRequestUpdate ?? (() => {});
+      requestUpdate();
+    });
     loadKatexCss();
   }
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1070,18 +1070,21 @@ let katexPreloadTriggered = false;
 
 export function renderChat(props: ChatProps) {
   // Preload KaTeX when math rendering is enabled (one-shot guard to prevent infinite render loop)
-  if (props.mathRendering === "katex" && !katexPreloadTriggered) {
-    katexPreloadTriggered = true;
-    void preloadKatex()
-      .then(() => {
-        clearMarkdownCache();
-        const requestUpdate = props.onRequestUpdate ?? (() => {});
-        requestUpdate();
-      })
-      .catch(() => {
-        // Reset guard so a transient chunk failure allows retry on next render
-        katexPreloadTriggered = false;
-      });
+  if (props.mathRendering === "katex") {
+    // One-shot JS preload guard prevents infinite render loop on cache clear + requestUpdate
+    if (!katexPreloadTriggered) {
+      katexPreloadTriggered = true;
+      void preloadKatex()
+        .then(() => {
+          clearMarkdownCache();
+          const requestUpdate = props.onRequestUpdate ?? (() => {});
+          requestUpdate();
+        })
+        .catch(() => {
+          katexPreloadTriggered = false;
+        });
+    }
+    // CSS load is guarded internally by cssLoaded, so it retries on transient failures
     loadKatexCss();
   }
 


### PR DESCRIPTION
## Summary

Rebased fix of PR #87568 by @tered12114-bot with conflicts resolved.

- Adds KaTeX math rendering support to the chat UI
- Adds mathRendering config option
- Threads mathRendering through render pipeline
- Adds toSanitizedMarkdownHtmlWithKatex with DOMPurify extensions
- Handles \ufffd placeholder variant
- Clears markdown cache and re-renders after KaTeX loads

Rebased onto latest main (8363d6596c).