### PR TITLE
fix: allow hyphenated subagent task names

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -178,7 +178,7 @@ Per-agent overrides use `agents.list[].subagents.delegationMode`.
   The task description for the sub-agent.
 </ParamField>
 <ParamField path="taskName" type="string">
-  Optional stable handle for identifying a specific child in later status output. Must match `[a-z][a-z0-9_]{0,63}` and cannot be reserved targets such as `last` or `all`.
+  Optional stable handle for identifying a specific child in later status output. Must match `[a-z][a-z0-9_-]{0,63}` and cannot be reserved targets such as `last` or `all`.
 </ParamField>
 <ParamField path="label" type="string">
   Optional human-readable label.

--- a/src/agents/subagent-task-name.ts
+++ b/src/agents/subagent-task-name.ts
@@ -14,7 +14,7 @@ export function normalizeSubagentTaskName(value: unknown): NormalizeSubagentTask
   }
   if (!SUBAGENT_TASK_NAME_RE.test(taskName)) {
     return {
-      error: `Invalid taskName "${taskName}". Use 1-64 chars matching [a-z][a-z0-9_]*.`,
+      error: `Invalid taskName "${taskName}". Use 1-64 chars matching [a-z][a-z0-9_-]*.`,
     };
   }
   if (RESERVED_SUBAGENT_TASK_NAMES.has(taskName)) {

--- a/src/agents/subagent-task-name.ts
+++ b/src/agents/subagent-task-name.ts
@@ -1,6 +1,6 @@
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
-const SUBAGENT_TASK_NAME_RE = /^[a-z][a-z0-9_]{0,63}$/;
+const SUBAGENT_TASK_NAME_RE = /^[a-z][a-z0-9_-]{0,63}$/;
 const RESERVED_SUBAGENT_TASK_NAMES = new Set(["all", "last"]);
 
 type NormalizeSubagentTaskNameResult =

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -866,6 +866,7 @@ describe("buildAgentSystemPrompt", () => {
       "Anything requiring more work than a direct reply should go through `sessions_spawn`",
     );
     expect(preferPrompt).toContain("objective, expected output, relevant files/inputs");
+    expect(preferPrompt).toContain("keep it lowercase with underscores or hyphens");
     expect(preferPrompt).toContain("Treat child outputs as reports/evidence");
     expect(preferPrompt).toContain(
       "Use `subagents(action=list)` only when explicitly asked for sub-agent status",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -96,7 +96,7 @@ function buildSubagentDelegationPreferenceSection(params: {
     "- Anything requiring more work than a direct reply should go through `sessions_spawn`; avoid doing expensive tool calls yourself.",
     "- Delegate file/code inspection, shell commands, web/browser use, long reads, debugging, coding, multi-step analysis, comparisons, non-trivial summarization, and background waiting.",
     "- Before spawning, decide what stays local and what is delegated. Give each child a clear objective, expected output, relevant files/inputs, write scope, verification ask, and whether it blocks your final answer.",
-    '- Set `taskName` when you will need a stable handle later; keep it lowercase with underscores. Omit `context` for isolated children; set `context:"fork"` only when current transcript details matter.',
+    '- Set `taskName` when you will need a stable handle later; keep it lowercase with underscores or hyphens. Omit `context` for isolated children; set `context:"fork"` only when current transcript details matter.',
     params.hasSessionsYield
       ? "- After spawning required work, call `sessions_yield` if you need completion events before answering. Do not poll for completion."
       : "- After spawning, do not poll for completion. Child completion is push-based and returns as a runtime event; synthesize that result for the user.",

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -355,7 +355,7 @@ describe("sessions_spawn tool", () => {
 
     const result = await tool.execute("call-task-name", {
       task: "review subagent handling",
-      taskName: "review_subagents",
+      taskName: "review-subagents",
     });
 
     expectDetailFields(result.details, {
@@ -364,23 +364,44 @@ describe("sessions_spawn tool", () => {
     });
     const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
     expect(spawnArgs.task).toBe("review subagent handling");
-    expect(spawnArgs.taskName).toBe("review_subagents");
+    expect(spawnArgs.taskName).toBe("review-subagents");
   });
 
-  it("rejects invalid taskName before spawning", async () => {
+  it("accepts underscore taskName aliases", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
 
-    const result = await tool.execute("call-bad-task-name", {
+    const result = await tool.execute("call-underscore-task-name", {
       task: "review subagent handling",
-      taskName: "Bad-Name",
+      taskName: "review_subagents",
     });
 
-    expectDetailFields(result.details, { status: "error" });
-    expect(JSON.stringify(result.details)).toContain("Invalid taskName");
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expectDetailFields(result.details, {
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+    });
+    const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
+    expect(spawnArgs.taskName).toBe("review_subagents");
   });
+
+  it.each(["Bad-Name", "code review", "-bad"])(
+    "rejects invalid taskName %s before spawning",
+    async (taskName) => {
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+      });
+
+      const result = await tool.execute("call-bad-task-name", {
+        task: "review subagent handling",
+        taskName,
+      });
+
+      expectDetailFields(result.details, { status: "error" });
+      expect(JSON.stringify(result.details)).toContain("Invalid taskName");
+      expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    },
+  );
 
   it.each(["last", "all"])("rejects reserved taskName %s before spawning", async (taskName) => {
     const tool = createSessionsSpawnTool({

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -159,7 +159,7 @@ function createSessionsSpawnToolSchema(params: {
     taskName: Type.Optional(
       Type.String({
         description:
-          "Stable alias for later targeting; lowercase letters/digits/underscores, starts letter.",
+          "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
       }),
     ),
     label: Type.Optional(Type.String()),

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1064,7 +1064,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores, starts letter.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
           "type": "string"
         },
         "thinking": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1100,7 +1100,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores, starts letter.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
           "type": "string"
         },
         "thinking": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1064,7 +1064,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores, starts letter.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
           "type": "string"
         },
         "thinking": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41138,
-    "roughTokens": 10285
+    "chars": 41146,
+    "roughTokens": 10287
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68840,
-    "roughTokens": 17210
+    "chars": 68848,
+    "roughTokens": 17212
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40859,
-    "roughTokens": 10215
+    "chars": 40867,
+    "roughTokens": 10217
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67037,
-    "roughTokens": 16760
+    "chars": 67045,
+    "roughTokens": 16762
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41954,
-    "roughTokens": 10489
+    "chars": 41962,
+    "roughTokens": 10491
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69075,
-    "roughTokens": 17269
+    "chars": 69083,
+    "roughTokens": 17271
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
Summary
- Allow hyphenated `sessions_spawn.taskName` values by widening the shared validator.
- Update the tool schema, system prompt, subagents docs, focused tests, and generated prompt snapshots so the user/model-facing contract matches the accepted grammar.
- Preserve underscore aliases and rejection of invalid uppercase/space/leading-hyphen/reserved task names.

Provenance
- Internal source commits: `3b15bd33e6` and `b40bf3fbf4` (`fix(agents): allow hyphens in sessions_spawn taskName`, `fix(agents): sync taskName error message with relaxed regex`, author chenhaoqiang).
- Follow-ups on this PR branch: `238f2d6a7c` adds schema/test coverage; `23c73981ea` updates docs and system prompt contract after autoreview caught the stale underscores-only wording.
- Maintainer follow-up: `7452627406` regenerates prompt snapshots after CI reported drift.

Verification
- `pnpm docs:list`
- `node scripts/run-vitest.mjs src/agents/tools/sessions-spawn-tool.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/sessions-spawn-tool.test.ts src/agents/system-prompt.test.ts`
- `git diff --check`
- `pnpm prompt:snapshots:gen`
- `pnpm prompt:snapshots:check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `pnpm openclaw agent --agent main --session-key pr-87945-proof-hyphen --local --json --timeout 300 --message 'PR #87945 proof run. Call sessions_spawn exactly once with taskName "review-subagents" and task "Reply OK only for PR #87945 proof." Do not wait for the child. Then answer with the sessions_spawn status and childSessionKey only.'`

Behavior addressed: `sessions_spawn.taskName` accepts common hyphenated task slugs while preserving rejection for invalid names.
Real environment tested: local OpenClaw checkout on macOS using `pnpm openclaw agent --local` against agent `main` with model `openai/gpt-5.5`; local focused Vitest, prompt snapshot, docs-list, whitespace, and autoreview checks in this PR checkout.
Exact steps or command run after this patch: `pnpm prompt:snapshots:check`; `node scripts/run-vitest.mjs src/agents/tools/sessions-spawn-tool.test.ts src/agents/system-prompt.test.ts`; `pnpm docs:list`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; local `pnpm openclaw agent ...` proof command listed above.
Evidence after fix: prompt snapshots are current (7 files); Vitest passed with 3 files and 179 tests; both autoreview runs reported no accepted/actionable findings; the real local agent run produced one `sessions_spawn` tool call with `taskName: "review-subagents"`, so the hyphenated name passed `sessions_spawn` validation instead of returning `Invalid taskName`.
Observed result after fix: the real local run advanced past taskName validation and returned child session key `agent:main:subagent:b4f3dbdf-3dab-4517-93c5-b3fec2663524`. The spawned child then failed during local child startup because this machine has a stale local `clawdbot/dist/...` module path, which is unrelated to taskName validation.
What was not tested: full successful child subagent completion on this machine, because the local host install has the stale local module path noted above; CI and targeted tests cover the validator/schema/prompt path.

