### PR TITLE
fix: match session reset commands case-insensitively

### DIFF
--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -1108,6 +1108,7 @@ describe("control command parsing", () => {
     expect(hasControlCommand("/commands:")).toBe(true);
     expect(hasControlCommand("commands")).toBe(false);
     expect(hasControlCommand("/status")).toBe(true);
+    expect(hasControlCommand("/STATUS")).toBe(true);
     expect(hasControlCommand("/status:")).toBe(true);
     expect(hasControlCommand("status")).toBe(false);
     expect(hasControlCommand("usage")).toBe(false);
@@ -1119,6 +1120,7 @@ describe("control command parsing", () => {
       }
     }
     expect(hasControlCommand("/compact")).toBe(true);
+    expect(hasControlCommand("/COMPACT keep CaseSensitivePath")).toBe(true);
     expect(hasControlCommand("/compact:")).toBe(true);
     expect(hasControlCommand("compact")).toBe(false);
   });

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -19,6 +19,7 @@ import {
   parseCommandArgs,
   resolveCommandArgChoices,
   resolveCommandArgMenu,
+  resolveTextCommand,
   serializeCommandArgs,
   shouldHandleTextCommands,
 } from "./commands-registry.js";
@@ -231,6 +232,17 @@ describe("commands registry", () => {
     const sideNativeSpec = requireNativeSpec(listNativeCommandSpecs(), "side");
     expect(sideNativeSpec.acceptsArgs).toBe(true);
     expect(sideNativeSpec.isAlias).toBe(true);
+  });
+
+  it("matches text command names case-insensitively without changing args", () => {
+    expect(normalizeCommandBody("/STATUS")).toBe("/status");
+    expect(normalizeCommandBody("/Model OpenAI-Codex/GPT-5.5")).toBe("/model OpenAI-Codex/GPT-5.5");
+    expect(normalizeCommandBody("/T HIGH")).toBe("/think HIGH");
+
+    expect(resolveTextCommand("/COMPACT Keep CaseSensitivePath")?.command.key).toBe("compact");
+    expect(resolveTextCommand("/COMPACT Keep CaseSensitivePath")?.args).toBe(
+      "Keep CaseSensitivePath",
+    );
   });
 
   it("filters commands based on config flags", () => {

--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -459,7 +459,7 @@ describe("handleCommands reset hooks", () => {
   });
 
   it("acknowledges bare /reset without falling through to model execution", async () => {
-    const params = buildResetParams("/reset", {
+    const params = buildResetParams("/RESET", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as OpenClawConfig);
@@ -474,7 +474,7 @@ describe("handleCommands reset hooks", () => {
   });
 
   it("acknowledges bare /new without falling through to model execution", async () => {
-    const params = buildResetParams("/new", {
+    const params = buildResetParams("/NEW", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as OpenClawConfig);
@@ -489,7 +489,7 @@ describe("handleCommands reset hooks", () => {
   });
 
   it("keeps reset tails falling through so the model receives the user input", async () => {
-    const params = buildResetParams("/new take notes", {
+    const params = buildResetParams("/Reset take notes", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as OpenClawConfig);
@@ -497,6 +497,6 @@ describe("handleCommands reset hooks", () => {
     const result = await maybeHandleResetCommand(params);
 
     expect(result).toBeNull();
-    expectObjectFields(firstHookEvent(), { type: "command", action: "new" }, "hook event");
+    expectObjectFields(firstHookEvent(), { type: "command", action: "reset" }, "hook event");
   });
 });

--- a/src/auto-reply/reply/commands-reset-mode.test.ts
+++ b/src/auto-reply/reply/commands-reset-mode.test.ts
@@ -16,6 +16,10 @@ describe("parseSoftResetCommand", () => {
       matched: true,
       tail: "re-read persona files",
     });
+    expect(parseSoftResetCommand("/RESET soft re-read persona files")).toEqual({
+      matched: true,
+      tail: "re-read persona files",
+    });
   });
 
   it("rejects reset-prefixed typos without a command boundary", () => {

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -106,7 +106,7 @@ export async function maybeHandleResetCommand(
     return null;
   }
 
-  const resetMatch = params.command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/);
+  const resetMatch = params.command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/i);
   if (!resetMatch) {
     return null;
   }
@@ -117,7 +117,8 @@ export async function maybeHandleResetCommand(
     return { shouldContinue: false };
   }
 
-  const commandAction: ResetCommandAction = resetMatch[1] === "reset" ? "reset" : "new";
+  const commandAction: ResetCommandAction =
+    resetMatch[1]?.toLowerCase() === "reset" ? "reset" : "new";
   const resetTail = params.command.commandBodyNormalized.slice(resetMatch[0].length).trimStart();
   const boundAcpSessionKey = resolveBoundAcpThreadSessionKey(params);
   const boundAcpKey =

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -623,7 +623,7 @@ export async function runPreparedReply(
   const isWholeMessageCommand =
     normalizedCommandBody === rawBodyTrimmed ||
     normalizedCommandBody === rawBodyTrimmed.toLowerCase();
-  const isResetOrNewCommand = /^\/(new|reset)(?:\s|$)/.test(normalizedCommandBody);
+  const isResetOrNewCommand = /^\/(new|reset)(?:\s|$)/i.test(normalizedCommandBody);
   if (
     allowTextCommands &&
     (!commandAuthorized || !command.isAuthorizedSender) &&
@@ -633,7 +633,7 @@ export async function runPreparedReply(
     typing.cleanup();
     return undefined;
   }
-  const isBareNewOrReset = /^\/(new|reset)$/.test(normalizedCommandBody);
+  const isBareNewOrReset = /^\/(new|reset)$/i.test(normalizedCommandBody);
   const isBareSessionReset =
     softResetTriggered ||
     (isNewSession &&
@@ -642,7 +642,7 @@ export async function runPreparedReply(
           baseBodyTrimmedRaw.length === 0 &&
           rawBodyTrimmed.length > 0)));
   const startupAction =
-    softResetTriggered || /^\/reset(?:\s|$)/.test(normalizedCommandBody) ? "reset" : "new";
+    softResetTriggered || /^\/reset(?:\s|$)/i.test(normalizedCommandBody) ? "reset" : "new";
   const spawnedWorkspaceOverride = resolveIngressWorkspaceOverrideForSpawnedRun({
     spawnedBy: sessionEntry?.spawnedBy,
     workspaceDir: sessionEntry?.spawnedWorkspaceDir,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -789,12 +789,12 @@ export async function getReplyFromConfig(
     if (!resetTriggered || !command.isAuthorizedSender || command.resetHookTriggered) {
       return;
     }
-    const resetMatch = command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/);
+    const resetMatch = command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/i);
     if (!resetMatch) {
       return;
     }
     const { emitResetCommandHooks } = await loadCommandsCoreRuntime();
-    const action: ResetCommandAction = resetMatch[1] === "reset" ? "reset" : "new";
+    const action: ResetCommandAction = resetMatch[1]?.toLowerCase() === "reset" ? "reset" : "new";
     await emitResetCommandHooks({
       action,
       ctx,


### PR DESCRIPTION
Summary
- Match `/new` and `/reset` case-insensitively in lower-level reset fallback paths that can receive raw command bodies.
- Preserve the shared text slash-command contract: command names are case-insensitive, while command arguments keep their original casing.
- Add regression coverage for uppercase `/NEW`, `/RESET`, mixed-case `/Reset <reason>`, and non-reset registered commands such as `/STATUS`, `/Model ...`, `/T ...`, and `/COMPACT ...`.

Provenance
- Internal source commit: `9ab04d9942` (`fix: make /NEW /RESET command matching case-insensitive`, author zhangtong26).
- Rebased PR implementation commit: `da9f2debcb` keeps the reset/new fallback matching behavior on current `origin/main`.
- Rebased PR test commit: `4f15cb7be0` covers uppercase and mixed-case reset commands.
- Maintainer follow-up commit: `ae446d896c` adds shared slash-command normalization/control detection coverage for non-reset commands.

Verification
- `node scripts/run-vitest.mjs src/auto-reply/commands-registry.test.ts src/auto-reply/command-control.test.ts src/auto-reply/reply/commands-reset-mode.test.ts src/auto-reply/reply/commands-reset-hooks.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: uppercase and mixed-case text slash command names are handled as registered commands instead of falling through as normal user text; command arguments preserve their original casing.
Real environment tested: local OpenClaw source checkout on the PR branch, using the repo Vitest wrapper against the shared command registry/control-detection path and reset fallback handlers.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/commands-registry.test.ts src/auto-reply/command-control.test.ts src/auto-reply/reply/commands-reset-mode.test.ts src/auto-reply/reply/commands-reset-hooks.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.
Evidence after fix: focused tests cover uppercase registered slash commands, mixed-case model command arguments, uppercase aliases, uppercase reset/new hooks, and mixed-case reset with a reason tail; autoreview reported no accepted/actionable findings.
Observed result after fix: Vitest passed with 4 test files and 92 tests; diff whitespace check was clean; autoreview clean.
What was not tested: no live channel roundtrip was performed; maintainer override applies for this small parser hardening.
