### PR TITLE
fix(mattermost): fail loudly when a tool send drops an unsupported file attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: retry recurring jobs after transient model rate limits before waiting for the next scheduled slot.
+- Mattermost: fail with a clear error when a `message` tool send carries a file attachment (`filePath`, `path`, `buffer`, or `attachments[]`) that the send path cannot upload, instead of reporting success with no file attached. (#87930)
 
 ## 2026.5.28
 

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -505,6 +505,58 @@ describe("mattermostPlugin", () => {
       expect(options.accountId).toBe("default");
       expect(options.replyToId).toBe("post-root");
     });
+
+    it("rejects a send carrying attachments[] instead of silently dropping the file", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await expect(
+        mattermostPlugin.actions?.handleAction?.(
+          createMattermostActionContext({
+            action: "send",
+            params: {
+              to: "channel:CHAN1",
+              message: "see attached",
+              attachments: [{ filePath: "/tmp/report.md" }],
+            },
+            cfg,
+            accountId: "default",
+          }),
+        ),
+      ).rejects.toThrow(/attachment/i);
+      expect(sendMessageMattermostMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a send carrying a top-level filePath attachment", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await expect(
+        mattermostPlugin.actions?.handleAction?.(
+          createMattermostActionContext({
+            action: "send",
+            params: { to: "channel:CHAN1", message: "doc", filePath: "/tmp/report.md" },
+            cfg,
+            accountId: "default",
+          }),
+        ),
+      ).rejects.toThrow(/attachment/i);
+      expect(sendMessageMattermostMock).not.toHaveBeenCalled();
+    });
+
+    it("still uploads media supplied as a string URL", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: { to: "channel:CHAN1", message: "pic", media: "https://example.com/x.png" },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "pic");
+      expect(options.mediaUrl).toBe("https://example.com/x.png");
+    });
   });
 
   describe("outbound", () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -275,6 +275,19 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     const mediaUrl =
       typeof params.media === "string" ? params.media.trim() || undefined : undefined;
 
+    // The tool send path can only upload media supplied as a string `media`
+    // URL. If the caller passed a file attachment (filePath, path, buffer, or
+    // attachments[]) that we will not upload, fail loudly instead of silently
+    // posting text-only and reporting success with an empty file_ids post.
+    // (#87930)
+    if (!mediaUrl && hasUnsupportedMattermostAttachmentInput(params)) {
+      throw new Error(
+        "Mattermost send received a file attachment (filePath, path, buffer, or attachments[]) " +
+          "that the message tool send path cannot upload; it only supports `media` as a string URL. " +
+          "Refusing to report success without attaching the file.",
+      );
+    }
+
     const result = await (
       await loadMattermostChannelRuntime()
     ).sendMessageMattermost(to, message, {
@@ -324,6 +337,23 @@ function parseMattermostReactActionParams(params: Record<string, unknown>): {
     emojiName,
     remove: params.remove === true,
   };
+}
+
+/**
+ * The Mattermost `message` tool send path only uploads media supplied as a
+ * string `media` URL. Detect attachment-bearing inputs (filePath, path, buffer,
+ * or attachments[]) that this path silently drops so the handler can fail
+ * loudly instead of reporting success with an empty `file_ids` post. (#87930)
+ */
+function hasUnsupportedMattermostAttachmentInput(params: Record<string, unknown>): boolean {
+  const nonEmptyString = (value: unknown): boolean =>
+    typeof value === "string" && value.trim().length > 0;
+  return (
+    nonEmptyString(params.filePath) ||
+    nonEmptyString(params.path) ||
+    nonEmptyString(params.buffer) ||
+    (Array.isArray(params.attachments) && params.attachments.length > 0)
+  );
 }
 
 const mattermostOutbound: ChannelOutboundAdapter = {


### PR DESCRIPTION
## Summary

- The Mattermost `message` tool send action only uploads media passed as a string `media` URL. When a caller attaches a file via `filePath`, `attachments[].filePath`/`path`, or `buffer`, those inputs were silently dropped and the tool still returned `ok:true` with a post that had `file_ids: []` — silent data loss the agent reads as success. (#87930)
- This change makes the send action **fail loudly**: when an attachment-bearing input is present but no uploadable string `media` URL was derived, it throws an explicit error instead of reporting success without the file.
- Intentionally out of scope: actually uploading local files through the tool-action path. That path does not thread the media-read deps (`mediaReadFile`/`mediaLocalRoots`) that the reply/payload delivery path uses, and resolving local file paths there is security-sensitive (local path access is gated by `mediaLocalRoots`). Wiring that safely is a larger follow-up; failing loudly is the issue's explicitly-accepted alternative and stops the silent data loss now.
- Reviewers: confirm the guard only fires when no usable string `media` URL was derived (so URL media and text-only sends are unaffected) and only on the tool-action path — the reply/payload `sendPayload` path is untouched.

## Linked context

Closes #87930

The issue is maintainer-triaged `clawsweeper:queueable-fix` + `clawsweeper:source-repro`.

## Real behavior proof (required for external PRs)

- Behavior addressed: `message(action="send")` to Mattermost with `filePath` / `attachments[]` / `buffer` returned `ok:true` with no file attached (`file_ids: []`).
- Real environment tested: source trace of the tool-action send path (`extensions/mattermost/src/channel.ts` `handleAction`) plus red/green unit tests. I do **not** have a live Mattermost server/bot, so I could not capture the live post `file_ids`.
- Command run after this patch:
  - `pnpm test extensions/mattermost/src/channel.test.ts`
- Evidence after fix (green): 30/30 pass.

  ```
  Test Files  1 passed (1)
       Tests  30 passed (30)
  ```

- Evidence before fix (red — removing just the new guard): the two attachment cases fail because the handler sends instead of throwing.

  ```
  × rejects a send carrying attachments[] instead of silently dropping the file
  × rejects a send carrying a top-level filePath attachment
  Tests  2 failed | 28 skipped (30)
  ```

- Observed after fix: a send carrying `attachments[]`/`filePath` throws an explicit attachment error and never calls the Mattermost send; a string `media` URL still sends normally.
- What was not tested: live Mattermost round-trip / real `file_ids` (no server access).
- Proof limitations: no live Mattermost; relying on source trace + unit tests. The issue is labeled `clawsweeper:source-repro`.

## Tests and validation

Commands run:

- `pnpm test extensions/mattermost/src/channel.test.ts` — 30 pass (3 new)
- `pnpm tsgo:core`, `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test` — 0 errors
- `oxlint` and `oxfmt --check` on touched files — clean

Regression coverage added: (1) send with `attachments[]` rejects and never calls send, (2) send with top-level `filePath` rejects and never calls send, (3) a string `media` URL still uploads via the existing path (guard does not over-trigger). Red/green verified.

What failed before this fix: cases (1) and (2) — the unpatched handler silently dropped the attachment and proceeded to send (red output shown above).

## Risk checklist

- Did user-visible behavior change? **Yes** — Mattermost tool sends that carry an unsupported attachment now error instead of returning success with no file. This is strictly better than silent data loss (the agent previously believed the file was delivered).
- Did config, environment, or migration behavior change? **No.**
- Did security, auth, secrets, network, or tool execution behavior change? **No** — no new media/file access is introduced (deliberately; see scope).
- Highest-risk area: over-triggering on legitimate sends. Mitigation: the guard only fires when no usable string `media` URL was derived **and** an attachment field (`filePath`/`path`/`buffer`/`attachments[]`) is present; text-only and URL-media sends are covered by existing and new tests.

## Current review state

- Next action: maintainer review. If preferred, I can follow up with full local-file upload support once the media-read/security wiring for the tool-action path is agreed.
- Still waiting on: optional live Mattermost confirmation (I lack access to a server).
- Bot or reviewer comments addressed: none yet.
