### PR TITLE
fix(update): pin post-core plugin compatibility to the downgraded core version (#87914)

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1144,6 +1144,55 @@ describe("update-cli", () => {
     expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
   });
 
+  it("clears stale npm resolution metadata before post-core downgrade resume", async () => {
+    const { root } = setupUpdatedRootRefresh();
+    readPackageVersion.mockImplementation(async (pkgRoot: string) =>
+      pkgRoot === root ? "0.0.1" : "2026.5.28",
+    );
+    const pluginInstallRecords = {
+      msteams: {
+        source: "npm",
+        spec: "@openclaw/msteams",
+        installPath: "/tmp/openclaw-msteams-plugin",
+        version: "1.0.0",
+        resolvedName: "@openclaw/msteams",
+        resolvedVersion: "1.0.0",
+        resolvedSpec: "@openclaw/msteams@1.0.0",
+        integrity: "sha512-newer",
+      },
+    } as const;
+    let capturedRecords: unknown;
+    loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce(pluginInstallRecords);
+    spawn.mockImplementationOnce((_node, _argv, options) => {
+      const env = (options as { env?: NodeJS.ProcessEnv }).env;
+      const recordsPath = env?.OPENCLAW_UPDATE_POST_CORE_INSTALL_RECORDS_PATH;
+      if (!recordsPath) {
+        throw new Error("missing post-core install records path");
+      }
+      capturedRecords = JSON.parse(fsSync.readFileSync(recordsPath, "utf-8"));
+      const child = new EventEmitter() as EventEmitter & {
+        once: EventEmitter["once"];
+      };
+      queueMicrotask(() => {
+        child.emit("exit", 0, null);
+      });
+      return child;
+    });
+
+    await updateCommand({ yes: true, restart: false });
+
+    expect(capturedRecords).toEqual({
+      msteams: {
+        source: "npm",
+        spec: "@openclaw/msteams",
+        installPath: "/tmp/openclaw-msteams-plugin",
+        version: "1.0.0",
+        resolvedName: "@openclaw/msteams",
+        integrity: "sha512-newer",
+      },
+    });
+  });
+
   it("respawns into the updated git root before requested channel persistence", async () => {
     const { entrypoints } = setupUpdatedRootRefresh({
       gatewayUpdateImpl: async (root) =>

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1212,6 +1212,47 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
 
+  it("pins the compatibility host version to the downgraded target during current-process post-core plugin convergence (#87914)", async () => {
+    const downgradedRoot = createCaseDir("openclaw-downgraded-compat-root");
+    setupUpdatedRootRefresh({
+      gatewayUpdateImpl: async () =>
+        makeOkUpdateResult({
+          mode: "npm",
+          root: downgradedRoot,
+          before: { version: "2026.4.14" },
+          after: { version: "2026.4.10" },
+        }),
+    });
+    // The old core is still installed at the invocation root; the freshly
+    // installed downgraded target lives at the post-update root.
+    readPackageVersion.mockImplementation(async (pkgRoot: string) =>
+      pkgRoot === downgradedRoot ? "2026.4.10" : "2026.4.14",
+    );
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag: "latest", version: "2026.4.10" });
+
+    delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+    let hostVersionDuringPluginUpdate: string | undefined = "unset";
+    updateNpmInstalledPlugins.mockImplementation(async () => {
+      hostVersionDuringPluginUpdate = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+      return { changed: false, config: baseConfig, outcomes: [] };
+    });
+
+    try {
+      await updateCommand({ yes: true, tag: "2026.4.10", restart: false });
+
+      expect(spawn).not.toHaveBeenCalled();
+      expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+      // Compatibility is evaluated against the downgraded target core, not the
+      // still-running old VERSION, so incompatible newer plugins are disabled
+      // before restart.
+      expect(hostVersionDuringPluginUpdate).toBe("2026.4.10");
+      // The override is scoped to the plugin convergence and restored afterward.
+      expect(process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBeUndefined();
+    } finally {
+      delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+    }
+  });
+
   it("fails the update when the fresh process exits non-zero", async () => {
     setupUpdatedRootRefresh();
     spawn.mockImplementationOnce(() => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -88,6 +88,7 @@ import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runne
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "../../plugins/config-state.js";
 import {
   loadInstalledPluginIndexInstallRecords,
+  writePersistedInstalledPluginIndexInstallRecords,
   withoutPluginInstallRecords,
   withPluginInstallRecords,
 } from "../../plugins/installed-plugin-index-records.js";
@@ -2714,6 +2715,35 @@ export function resolvePostCoreUpdateChildStdio(
   return platform === "win32" ? "pipe" : "inherit";
 }
 
+function preparePostCorePluginInstallRecordsForFreshProcess(params: {
+  records: Record<string, PluginInstallRecord>;
+  targetVersion: string | null;
+}): Record<string, PluginInstallRecord> {
+  if (!params.targetVersion) {
+    return params.records;
+  }
+  const runtimeComparison = compareSemverStrings(VERSION, params.targetVersion);
+  if (runtimeComparison === null || runtimeComparison <= 0) {
+    return params.records;
+  }
+  let changed = false;
+  const next: Record<string, PluginInstallRecord> = {};
+  for (const [pluginId, record] of Object.entries(params.records)) {
+    const installedVersion = record.resolvedVersion ?? record.version;
+    const comparison = installedVersion
+      ? compareSemverStrings(installedVersion, params.targetVersion)
+      : null;
+    if (record.source !== "npm" || comparison === null || comparison <= 0) {
+      next[pluginId] = record;
+      continue;
+    }
+    const { resolvedSpec: _resolvedSpec, resolvedVersion: _resolvedVersion, ...rest } = record;
+    next[pluginId] = rest;
+    changed = true;
+  }
+  return changed ? next : params.records;
+}
+
 async function continuePostCoreUpdateInFreshProcess(params: {
   root: string;
   channel: "stable" | "beta" | "dev";
@@ -2748,8 +2778,16 @@ async function continuePostCoreUpdateInFreshProcess(params: {
   const sourceConfigPath = path.join(resultDir, "source-config.json");
   const postCoreHostVersion = await readPackageVersion(params.root);
 
+  const pluginInstallRecords = preparePostCorePluginInstallRecordsForFreshProcess({
+    records: params.pluginInstallRecords,
+    targetVersion: postCoreHostVersion,
+  });
+
   try {
-    await writePostCorePluginInstallRecordsFile(installRecordsPath, params.pluginInstallRecords);
+    if (pluginInstallRecords && pluginInstallRecords !== params.pluginInstallRecords) {
+      await writePersistedInstalledPluginIndexInstallRecords(pluginInstallRecords);
+    }
+    await writePostCorePluginInstallRecordsFile(installRecordsPath, pluginInstallRecords);
     await writePostCoreSourceConfigFile(sourceConfigPath, params.preUpdateConfig);
     const childStdio = resolvePostCoreUpdateChildStdio();
     const child = spawn(params.nodeRunner ?? resolveNodeRunner(), argv, {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3556,16 +3556,9 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
         : undefined,
     );
     postUpdateConfigSnapshot = restoredConfig.snapshot;
-    // Post-core plugin convergence runs here in the current (pre-restart)
-    // process, which still reports the old, pre-update VERSION. On a downgrade
-    // the freshly installed core on disk is OLDER than the running VERSION, so
-    // resolving plugin compatibility against VERSION leaves an incompatible
-    // newer plugin enabled; it then loads against the downgraded core after
-    // restart and storms log.record handlers. Pin the compatibility host
-    // version to the freshly installed target so such plugins are disabled
-    // before restart. (Not gated on downgradeRisk: that flag only tracks the
-    // requested package target, and a downgrade can also reach this path with
-    // --no-restart or a bare version tag.) (#87914)
+    // Current-process post-core convergence still reports the pre-update
+    // VERSION. During downgrades, pin compatibility checks to the installed
+    // target so incompatible newer plugins are disabled before restart.
     const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
     const versionComparison =
       postUpdateInstalledVersion && VERSION

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3518,16 +3518,47 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
         : undefined,
     );
     postUpdateConfigSnapshot = restoredConfig.snapshot;
-    postCorePluginUpdate = await runPostCorePluginUpdate({
-      root: postUpdateRoot,
-      channel,
-      configSnapshot: postUpdateConfigSnapshot,
-      configChanged: restoredConfig.changed,
-      restoredAuthoredChannels: restoredConfig.authoredChannels,
-      opts,
-      timeoutMs: updateStepTimeoutMs,
-      pluginInstallRecords: preUpdatePluginInstallRecords,
-    });
+    // Post-core plugin convergence runs here in the current (pre-restart)
+    // process, which still reports the old, pre-update VERSION. On a downgrade
+    // the freshly installed core on disk is OLDER than the running VERSION, so
+    // resolving plugin compatibility against VERSION leaves an incompatible
+    // newer plugin enabled; it then loads against the downgraded core after
+    // restart and storms log.record handlers. Pin the compatibility host
+    // version to the freshly installed target so such plugins are disabled
+    // before restart. (Not gated on downgradeRisk: that flag only tracks the
+    // requested package target, and a downgrade can also reach this path with
+    // --no-restart or a bare version tag.) (#87914)
+    const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
+    const versionComparison =
+      postUpdateInstalledVersion && VERSION
+        ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
+        : null;
+    const compatibilityDowngradeTarget =
+      versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
+    const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+    if (compatibilityDowngradeTarget) {
+      process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
+    }
+    try {
+      postCorePluginUpdate = await runPostCorePluginUpdate({
+        root: postUpdateRoot,
+        channel,
+        configSnapshot: postUpdateConfigSnapshot,
+        configChanged: restoredConfig.changed,
+        restoredAuthoredChannels: restoredConfig.authoredChannels,
+        opts,
+        timeoutMs: updateStepTimeoutMs,
+        pluginInstallRecords: preUpdatePluginInstallRecords,
+      });
+    } finally {
+      if (compatibilityDowngradeTarget) {
+        if (previousCompatibilityHostVersion === undefined) {
+          delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+        } else {
+          process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
+        }
+      }
+    }
   }
 
   const resultWithPostUpdate: UpdateRunResult = postCorePluginUpdate

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1353,6 +1353,44 @@ describe("installPluginFromNpmSpec", () => {
     expect(managedManifest.dependencies?.["@openclaw/msteams"]).toBe("2026.5.28-beta.3");
   });
 
+  it("does not resolve explicit prerelease tags to stable compatible versions", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "2026.5.28-beta.3");
+
+    mockNpmViewAndInstallMany([
+      {
+        spec: "@openclaw/msteams@beta",
+        packageName: "@openclaw/msteams",
+        version: "2026.5.28-beta.4",
+        pluginId: "msteams",
+        npmRoot,
+        versions: ["2026.5.27", "2026.5.28-beta.4"],
+        openclaw: {
+          extensions: ["./dist/index.js"],
+          compat: { pluginApi: ">=2026.5.28-beta.4" },
+        },
+      },
+    ]);
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@openclaw/msteams@beta",
+      npmDir: npmRoot,
+      mode: "update",
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_PLUGIN_API);
+    expect(result.error).toContain("requires plugin API >=2026.5.28-beta.4");
+    expect(
+      runCommandWithTimeoutMock.mock.calls.some(([argv]) => isManagedNpmInstallCommand(argv)),
+    ).toBe(false);
+  });
+
   it.runIf(process.platform !== "win32")(
     "repairs root openclaw materialized by npm peer handling",
     async () => {

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1294,6 +1294,65 @@ describe("installPluginFromNpmSpec", () => {
     ).toBe(true);
   });
 
+  it("resolves incompatible prerelease tags to a compatible prerelease version", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    const warnings: string[] = [];
+    vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "2026.5.28-beta.3");
+
+    mockNpmViewAndInstallMany([
+      {
+        spec: "@openclaw/msteams@beta",
+        packageName: "@openclaw/msteams",
+        version: "2026.5.28-beta.4",
+        pluginId: "msteams",
+        npmRoot,
+        versions: ["2026.5.28-beta.3", "2026.5.28-beta.4"],
+        openclaw: {
+          extensions: ["./dist/index.js"],
+          compat: { pluginApi: ">=2026.5.28-beta.4" },
+        },
+      },
+      {
+        spec: "@openclaw/msteams@2026.5.28-beta.3",
+        packageName: "@openclaw/msteams",
+        version: "2026.5.28-beta.3",
+        pluginId: "msteams",
+        npmRoot,
+        expectedDependencySpec: "2026.5.28-beta.3",
+        openclaw: {
+          extensions: ["./dist/index.js"],
+          compat: { pluginApi: ">=2026.5.28-beta.3" },
+        },
+      },
+    ]);
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@openclaw/msteams@beta",
+      npmDir: npmRoot,
+      mode: "update",
+      logger: { info: () => {}, warn: (message) => warnings.push(message) },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.npmResolution?.resolvedSpec).toBe("@openclaw/msteams@2026.5.28-beta.3");
+    expect(result.npmResolution?.version).toBe("2026.5.28-beta.3");
+    expect(warnings.join("\n")).toContain(
+      "using newest compatible @openclaw/msteams@2026.5.28-beta.3",
+    );
+    const npmProjectRoot = resolvePluginNpmProjectDir({
+      npmDir: npmRoot,
+      packageName: "@openclaw/msteams",
+    });
+    const managedManifest = JSON.parse(
+      fs.readFileSync(path.join(npmProjectRoot, "package.json"), "utf8"),
+    ) as { dependencies?: Record<string, string> };
+    expect(managedManifest.dependencies?.["@openclaw/msteams"]).toBe("2026.5.28-beta.3");
+  });
+
   it.runIf(process.platform !== "win32")(
     "repairs root openclaw materialized by npm peer handling",
     async () => {

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1391,6 +1391,44 @@ describe("installPluginFromNpmSpec", () => {
     ).toBe(false);
   });
 
+  it("does not resolve explicit prerelease tags to a different prerelease channel", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "2026.5.28-beta.3");
+
+    mockNpmViewAndInstallMany([
+      {
+        spec: "@openclaw/msteams@beta",
+        packageName: "@openclaw/msteams",
+        version: "2026.5.28-beta.4",
+        pluginId: "msteams",
+        npmRoot,
+        versions: ["2026.5.28-alpha.10", "2026.5.28-beta.4"],
+        openclaw: {
+          extensions: ["./dist/index.js"],
+          compat: { pluginApi: ">=2026.5.28-beta.4" },
+        },
+      },
+    ]);
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@openclaw/msteams@beta",
+      npmDir: npmRoot,
+      mode: "update",
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_PLUGIN_API);
+    expect(result.error).toContain("requires plugin API >=2026.5.28-beta.4");
+    expect(
+      runCommandWithTimeoutMock.mock.calls.some(([argv]) => isManagedNpmInstallCommand(argv)),
+    ).toBe(false);
+  });
+
   it.runIf(process.platform !== "win32")(
     "repairs root openclaw materialized by npm peer handling",
     async () => {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -395,6 +395,21 @@ function shouldResolveLatestCompatibleNpmVersion(spec: ParsedRegistryNpmSpec): b
   );
 }
 
+function shouldResolveCompatiblePrereleaseNpmVersion(params: {
+  spec: ParsedRegistryNpmSpec;
+  currentVersion: string;
+}): boolean {
+  if (!isPrereleaseSemverVersion(params.currentVersion)) {
+    return false;
+  }
+  if (params.spec.selectorKind === "none") {
+    return true;
+  }
+  return (
+    params.spec.selectorKind === "tag" && (params.spec.selector ?? "").toLowerCase() !== "latest"
+  );
+}
+
 function canResolveAroundCompatibilityError(error: PluginInstallFailureResult): boolean {
   return (
     error.code === PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_HOST_VERSION ||
@@ -423,10 +438,15 @@ async function resolveLatestCompatibleNpmResolution(params: {
   timeoutMs: number;
   logger: PluginInstallLogger;
 }): Promise<NpmSpecResolution | null> {
-  if (
-    !shouldResolveLatestCompatibleNpmVersion(params.parsedSpec) ||
-    !params.currentResolution.version
-  ) {
+  if (!params.currentResolution.version) {
+    return null;
+  }
+  const currentVersion = params.currentResolution.version;
+  const allowPrereleaseCandidates = shouldResolveCompatiblePrereleaseNpmVersion({
+    spec: params.parsedSpec,
+    currentVersion,
+  });
+  if (!shouldResolveLatestCompatibleNpmVersion(params.parsedSpec) && !allowPrereleaseCandidates) {
     return null;
   }
 
@@ -438,9 +458,8 @@ async function resolveLatestCompatibleNpmResolution(params: {
     return null;
   }
 
-  const currentVersion = params.currentResolution.version;
   const candidates = versions
-    .filter((version) => !isPrereleaseSemverVersion(version))
+    .filter((version) => allowPrereleaseCandidates || !isPrereleaseSemverVersion(version))
     .filter((version) => compareNpmSemver(version, currentVersion) < 0)
     .toSorted(compareNpmSemver)
     .toReversed();

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -459,7 +459,11 @@ async function resolveLatestCompatibleNpmResolution(params: {
   }
 
   const candidates = versions
-    .filter((version) => allowPrereleaseCandidates || !isPrereleaseSemverVersion(version))
+    .filter((version) =>
+      allowPrereleaseCandidates
+        ? isPrereleaseSemverVersion(version)
+        : !isPrereleaseSemverVersion(version),
+    )
     .filter((version) => compareNpmSemver(version, currentVersion) < 0)
     .toSorted(compareNpmSemver)
     .toReversed();

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -410,6 +410,14 @@ function shouldResolveCompatiblePrereleaseNpmVersion(params: {
   );
 }
 
+function resolvePrereleaseChannel(version: string): string | null {
+  if (!isPrereleaseSemverVersion(version)) {
+    return null;
+  }
+  const match = /^\s*v?\d+\.\d+\.\d+-([0-9A-Za-z]+)(?:[.-]|$)/.exec(version);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
 function canResolveAroundCompatibilityError(error: PluginInstallFailureResult): boolean {
   return (
     error.code === PLUGIN_INSTALL_ERROR_CODE.INCOMPATIBLE_HOST_VERSION ||
@@ -446,6 +454,9 @@ async function resolveLatestCompatibleNpmResolution(params: {
     spec: params.parsedSpec,
     currentVersion,
   });
+  const prereleaseChannel = allowPrereleaseCandidates
+    ? resolvePrereleaseChannel(currentVersion)
+    : null;
   if (!shouldResolveLatestCompatibleNpmVersion(params.parsedSpec) && !allowPrereleaseCandidates) {
     return null;
   }
@@ -461,7 +472,7 @@ async function resolveLatestCompatibleNpmResolution(params: {
   const candidates = versions
     .filter((version) =>
       allowPrereleaseCandidates
-        ? isPrereleaseSemverVersion(version)
+        ? resolvePrereleaseChannel(version) === prereleaseChannel
         : !isPrereleaseSemverVersion(version),
     )
     .filter((version) => compareNpmSemver(version, currentVersion) < 0)

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -319,6 +319,7 @@ function mockNpmViewMetadata(params: {
   version: string;
   integrity?: string;
   shasum?: string;
+  openclaw?: Record<string, unknown>;
 }) {
   runCommandWithTimeoutMock.mockResolvedValueOnce({
     code: 0,
@@ -327,6 +328,7 @@ function mockNpmViewMetadata(params: {
       version: params.version,
       ...(params.integrity ? { "dist.integrity": params.integrity } : {}),
       ...(params.shasum ? { "dist.shasum": params.shasum } : {}),
+      ...(params.openclaw ? { openclaw: params.openclaw } : {}),
     }),
     stderr: "",
   });
@@ -801,6 +803,71 @@ describe("updateNpmInstalledPlugins", () => {
         currentVersion: "0.9.0",
         nextVersion: "0.9.0",
         message: "lossless-claw is up to date (0.9.0).",
+      },
+    ]);
+  });
+
+  it("does not skip unchanged npm plugins when package metadata requires a newer plugin API", async () => {
+    vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "2026.5.28-beta.3");
+    const installPath = createInstalledPackageDir({
+      name: "@openclaw/msteams",
+      version: "2026.5.28-beta.4",
+    });
+    mockNpmViewMetadata({
+      name: "@openclaw/msteams",
+      version: "2026.5.28-beta.4",
+      integrity: "sha512-newer",
+      shasum: "newer",
+      openclaw: {
+        extensions: ["./dist/index.js"],
+        compat: { pluginApi: ">=2026.5.28-beta.4" },
+      },
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "msteams",
+        targetDir: installPath,
+        version: "2026.5.28-beta.3",
+        npmResolution: {
+          name: "@openclaw/msteams",
+          version: "2026.5.28-beta.3",
+          resolvedSpec: "@openclaw/msteams@2026.5.28-beta.3",
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "msteams",
+        spec: "@openclaw/msteams",
+        installPath,
+        resolvedName: "@openclaw/msteams",
+        resolvedVersion: "2026.5.28-beta.4",
+        resolvedSpec: "@openclaw/msteams@2026.5.28-beta.4",
+        integrity: "sha512-newer",
+        shasum: "newer",
+      }),
+      pluginIds: ["msteams"],
+    });
+
+    expect(npmInstallCall()?.spec).toBe("@openclaw/msteams");
+    expect(npmInstallCall()?.mode).toBe("update");
+    expect(npmInstallCall()?.expectedPluginId).toBe("msteams");
+    expect(result.changed).toBe(true);
+    expectRecordFields(result.config.plugins?.installs?.msteams, {
+      source: "npm",
+      version: "2026.5.28-beta.3",
+      resolvedName: "@openclaw/msteams",
+      resolvedVersion: "2026.5.28-beta.3",
+      resolvedSpec: "@openclaw/msteams@2026.5.28-beta.3",
+    });
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "msteams",
+        status: "updated",
+        currentVersion: "2026.5.28-beta.4",
+        nextVersion: "2026.5.28-beta.3",
+        message: "Updated msteams: 2026.5.28-beta.4 -> 2026.5.28-beta.3.",
       },
     ]);
   });

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -872,6 +872,61 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it("does not skip unchanged npm plugins when package metadata requires a newer host", async () => {
+    vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "2026.5.28-beta.3");
+    const installPath = createInstalledPackageDir({
+      name: "@openclaw/msteams",
+      version: "2026.5.28-beta.4",
+    });
+    mockNpmViewMetadata({
+      name: "@openclaw/msteams",
+      version: "2026.5.28-beta.4",
+      integrity: "sha512-newer",
+      shasum: "newer",
+      openclaw: {
+        extensions: ["./dist/index.js"],
+        install: { minHostVersion: ">=2026.5.28-beta.4" },
+      },
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "msteams",
+        targetDir: installPath,
+        version: "2026.5.28-beta.3",
+        npmResolution: {
+          name: "@openclaw/msteams",
+          version: "2026.5.28-beta.3",
+          resolvedSpec: "@openclaw/msteams@2026.5.28-beta.3",
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "msteams",
+        spec: "@openclaw/msteams",
+        installPath,
+        resolvedName: "@openclaw/msteams",
+        resolvedVersion: "2026.5.28-beta.4",
+        resolvedSpec: "@openclaw/msteams@2026.5.28-beta.4",
+        integrity: "sha512-newer",
+        shasum: "newer",
+      }),
+      pluginIds: ["msteams"],
+    });
+
+    expect(npmInstallCall()?.spec).toBe("@openclaw/msteams");
+    expect(npmInstallCall()?.mode).toBe("update");
+    expect(result.changed).toBe(true);
+    expectRecordFields(result.config.plugins?.installs?.msteams, {
+      source: "npm",
+      version: "2026.5.28-beta.3",
+      resolvedName: "@openclaw/msteams",
+      resolvedVersion: "2026.5.28-beta.3",
+      resolvedSpec: "@openclaw/msteams@2026.5.28-beta.3",
+    });
+  });
+
   it("repairs missing openclaw peer links before skipping unchanged npm plugins", async () => {
     const installPath = createInstalledPackageDir({
       name: "@openclaw/codex",

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
@@ -46,6 +47,7 @@ import {
 } from "./install.js";
 import { buildNpmResolutionInstallFields, recordPluginInstall } from "./installs.js";
 import { installPluginFromMarketplace } from "./marketplace.js";
+import { checkMinHostVersion } from "./min-host-version.js";
 import {
   getOfficialExternalPluginCatalogEntry,
   resolveOfficialExternalPluginInstall,
@@ -214,6 +216,15 @@ function shouldBypassTrustedOfficialUnchangedNpmCheck(params: {
 }
 
 function isNpmMetadataCompatibleWithCurrentHost(metadata: NpmSpecResolution): boolean {
+  const hostVersion = resolveCompatibilityHostVersion();
+  const installMetadata = metadata.packageOpenClaw?.install;
+  const minHostVersionCheck = checkMinHostVersion({
+    currentVersion: hostVersion,
+    minHostVersion: isRecord(installMetadata) ? installMetadata.minHostVersion : undefined,
+  });
+  if (!minHostVersionCheck.ok) {
+    return false;
+  }
   const pluginApiRangeCheck = resolvePackagePluginApiRange(metadata.packageOpenClaw);
   if (!pluginApiRangeCheck.ok) {
     return false;
@@ -222,7 +233,7 @@ function isNpmMetadataCompatibleWithCurrentHost(metadata: NpmSpecResolution): bo
   if (!pluginApiRange) {
     return true;
   }
-  return satisfiesPluginApiRange(resolveCompatibilityHostVersion(), pluginApiRange);
+  return satisfiesPluginApiRange(hostVersion, pluginApiRange);
 }
 
 function isBundledVersionNewer(bundledVersion: string, installedVersion: string): boolean {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
+import { satisfiesPluginApiRange } from "../infra/clawhub.js";
 import type { NpmSpecResolution } from "../infra/install-source-utils.js";
 import { resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
 import {
@@ -19,6 +20,7 @@ import {
 import { compareComparableSemver, parseComparableSemver } from "../infra/semver-compare.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
 import { resolveUserPath } from "../utils.js";
+import { resolveCompatibilityHostVersion } from "../version.js";
 import { resolveBundledPluginSources } from "./bundled-sources.js";
 import { buildClawHubPluginInstallRecordFields } from "./clawhub-install-records.js";
 import { CLAWHUB_INSTALL_ERROR_CODE, installPluginFromClawHub } from "./clawhub.js";
@@ -48,6 +50,7 @@ import {
   getOfficialExternalPluginCatalogEntry,
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
+import { resolvePackagePluginApiRange } from "./package-compat.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
 import { defaultSlotIdForKey } from "./slots.js";
 
@@ -208,6 +211,18 @@ function shouldBypassTrustedOfficialUnchangedNpmCheck(params: {
       resolvedVersion: params.metadata.version,
     }),
   );
+}
+
+function isNpmMetadataCompatibleWithCurrentHost(metadata: NpmSpecResolution): boolean {
+  const pluginApiRangeCheck = resolvePackagePluginApiRange(metadata.packageOpenClaw);
+  if (!pluginApiRangeCheck.ok) {
+    return false;
+  }
+  const pluginApiRange = pluginApiRangeCheck.range;
+  if (!pluginApiRange) {
+    return true;
+  }
+  return satisfiesPluginApiRange(resolveCompatibilityHostVersion(), pluginApiRange);
 }
 
 function isBundledVersionNewer(bundledVersion: string, installedVersion: string): boolean {
@@ -1238,6 +1253,7 @@ export async function updateNpmInstalledPlugins(params: {
             spec: effectiveSpec!,
             trustedSourceLinkedOfficialInstall,
           }) &&
+          isNpmMetadataCompatibleWithCurrentHost(metadataResult.metadata) &&
           !installedPackageNeedsOpenClawPeerLinkRepair(installPath) &&
           shouldSkipUnchangedNpmInstall({
             currentVersion,


### PR DESCRIPTION
## Summary

- **Problem:** After rolling OpenClaw back while an official npm plugin remains on a newer plugin API version, post-update plugin repair can leave that plugin enabled. On restart, the downgraded gateway can load an incompatible plugin and flood runtime handlers such as `log.record`.
- **Root cause:** Two rollback paths could treat the newer npm plugin as unchanged:
  - current-process repair could evaluate npm metadata against the running pre-rollback host version;
  - fresh post-core resume could prefer the persisted installed-plugin index over the parent handoff file, so the downgraded child saw stale `resolvedVersion`/`resolvedSpec` metadata and skipped reinstalling the plugin.
- **Fix:** Check npm package `openclaw.compat.pluginApi` metadata before the unchanged fast path, and on fresh-process downgrade resume clear stale npm resolution metadata for plugin records newer than the target before seeding both the handoff file and installed-plugin index. The older child then runs its existing compatible-version resolver and aligns the plugin before gateway startup.
- **Intentionally out of scope:** new config keys, plugin manifest fields, CLI flags, env knobs, or plugin public API. This only changes internal rollback/update repair behavior.
- **Reviewer focus:** the downgrade-only guard, the temporary install-record metadata clearing, and the metadata compatibility check before skipping npm updates.

## Linked context

Closes #87914

## Real behavior proof

**Behavior or issue addressed:** rollback from OpenClaw `2026.5.28` to `2026.5.28-beta.3` with a real official npm plugin already installed at a newer plugin API version. Before the fix, post-update repair left `msteams@2026.5.28-beta.4` in place and failed with `reason: "post-update-plugins"` because the downgraded host exposed `2026.5.28-beta.3`.

**Real environment tested:** direct AWS Crabbox Linux runner using an isolated OpenClaw home/npm prefix, source checkout at PR head, real npm registry packages, and gateway startup from the downgraded installed package.

**Exact steps or command run after this patch:**

1. Created an isolated OpenClaw home/npm prefix, with no access to the host global install.
2. Ran current PR source OpenClaw `2026.5.28`.
3. Installed the real npm plugin `npm:@openclaw/msteams@2026.5.28-beta.4`.
4. Ran rollback update: `openclaw update --channel beta --tag 2026.5.28-beta.3 --yes --json --no-restart --timeout 900`.
5. After update, ran `openclaw config validate --json`.
6. Started the gateway from the downgraded install and scanned the gateway log.

**Evidence after fix:**

Copied live output from the final direct AWS Crabbox run:

```text
provider=aws
leaseId=cbx_926c730d6e1a
run=run_434cc3cfeb3c
exitCode=0
UPDATE_STATUS=0
installedVersion=OpenClaw 2026.5.28-beta.3 (68601c5)
postUpdate.plugins.status=ok
postUpdate.plugins.warnings=[]
msteams outcome=updated 2026.5.28-beta.4 -> 2026.5.27
integrityDrifts=[]
configValidateOk=true
gatewayReady=true
gatewayLogRecordMentions=0
```

The final Crabbox run also reported `postUpdate.plugins.sync.errors: []` and `msteamsAfter.version: "2026.5.27"`.

**Observed result after fix:** the rollback completes successfully, the newer incompatible plugin is aligned to a compatible npm version before gateway startup, config validation passes, and the gateway starts without any `log.record` handler storm.

**What was not tested:** a real macOS/Windows managed service rollback. The proof covers Linux npm/global-style rollback and gateway startup with the real npm plugin.

### Supplemental validation

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/plugins/update.test.ts --reporter=dot`
  - 2 files passed, 208 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/plugins/update.ts src/plugins/update.test.ts src/cli/update-cli.test.ts src/cli/update-cli/update-command.ts`
- `./node_modules/.bin/oxfmt --check src/plugins/update.ts src/plugins/update.test.ts src/cli/update-cli.test.ts src/cli/update-cli/update-command.ts`
- `git diff --check`
