### PR TITLE
Optimize Slack thread history fetch

### DIFF
--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1101,7 +1101,50 @@ describe("resolveSlackThreadHistory", () => {
     vi.restoreAllMocks();
   });
 
-  it("paginates and returns the latest N messages across pages", async () => {
+  it("uses one bounded window before the current message for initial thread history", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        { text: "msg-255", user: "U1", ts: "255.000" },
+        { text: "msg-256", user: "U1", ts: "256.000" },
+        { text: "msg-257", user: "U1", ts: "257.000" },
+        { text: "msg-258", user: "U1", ts: "258.000" },
+        { text: "msg-259", user: "U1", ts: "259.000" },
+        { text: "current message", user: "U1", ts: "260.000" },
+      ],
+      response_metadata: { next_cursor: "cursor-2" },
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      currentMessageTs: "260.000",
+      limit: 5,
+    });
+
+    expect(replies).toHaveBeenCalledTimes(1);
+    const call = requireRecord(
+      requireMockCall(replies, 0, "conversations.replies")[0],
+      "replies params",
+    );
+    expect(call.channel).toBe("C1");
+    expect(call.ts).toBe("1.000");
+    expect(call.limit).toBe(5);
+    expect(call.latest).toBe("260.000");
+    expect(call.inclusive).toBe(false);
+    expect(result.map((entry) => entry.ts)).toEqual([
+      "255.000",
+      "256.000",
+      "257.000",
+      "258.000",
+      "259.000",
+    ]);
+  });
+
+  it("paginates and returns the latest N messages across pages without a current message", async () => {
     const replies = vi
       .fn()
       .mockResolvedValueOnce({
@@ -1128,7 +1171,6 @@ describe("resolveSlackThreadHistory", () => {
       channelId: "C1",
       threadTs: "1.000",
       client,
-      currentMessageTs: "260.000",
       limit: 5,
     });
 
@@ -1151,11 +1193,11 @@ describe("resolveSlackThreadHistory", () => {
     expect(secondCall.inclusive).toBe(true);
     expect(secondCall.cursor).toBe("cursor-2");
     expect(result.map((entry) => entry.ts)).toEqual([
-      "255.000",
       "256.000",
       "257.000",
       "258.000",
       "259.000",
+      "260.000",
     ]);
   });
 

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1101,17 +1101,14 @@ describe("resolveSlackThreadHistory", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses one bounded window before the current message for initial thread history", async () => {
+  it("bounds thread history before the current message while retaining the newest entries", async () => {
     const replies = vi.fn().mockResolvedValueOnce({
-      messages: [
-        { text: "msg-255", user: "U1", ts: "255.000" },
-        { text: "msg-256", user: "U1", ts: "256.000" },
-        { text: "msg-257", user: "U1", ts: "257.000" },
-        { text: "msg-258", user: "U1", ts: "258.000" },
-        { text: "msg-259", user: "U1", ts: "259.000" },
-        { text: "current message", user: "U1", ts: "260.000" },
-      ],
-      response_metadata: { next_cursor: "cursor-2" },
+      messages: Array.from({ length: 10 }, (_, i) => ({
+        text: `msg-${i + 250}`,
+        user: "U1",
+        ts: `${i + 250}.000`,
+      })),
+      response_metadata: { next_cursor: "" },
     });
     const client = {
       conversations: { replies },
@@ -1132,9 +1129,65 @@ describe("resolveSlackThreadHistory", () => {
     );
     expect(call.channel).toBe("C1");
     expect(call.ts).toBe("1.000");
-    expect(call.limit).toBe(5);
+    expect(call.limit).toBe(200);
     expect(call.latest).toBe("260.000");
     expect(call.inclusive).toBe(false);
+    expect(result.map((entry) => entry.ts)).toEqual([
+      "255.000",
+      "256.000",
+      "257.000",
+      "258.000",
+      "259.000",
+    ]);
+  });
+
+  it("paginates with a current message boundary to retain newest replies in long threads", async () => {
+    const replies = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messages: Array.from({ length: 200 }, (_, i) => ({
+          text: `msg-${i + 1}`,
+          user: "U1",
+          ts: `${i + 1}.000`,
+        })),
+        response_metadata: { next_cursor: "cursor-2" },
+      })
+      .mockResolvedValueOnce({
+        messages: Array.from({ length: 59 }, (_, i) => ({
+          text: `msg-${i + 201}`,
+          user: "U1",
+          ts: `${i + 201}.000`,
+        })),
+        response_metadata: { next_cursor: "" },
+      });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      currentMessageTs: "260.000",
+      limit: 5,
+    });
+
+    expect(replies).toHaveBeenCalledTimes(2);
+    const firstCall = requireRecord(
+      requireMockCall(replies, 0, "conversations.replies")[0],
+      "first replies params",
+    );
+    expect(firstCall.latest).toBe("260.000");
+    expect(firstCall.limit).toBe(200);
+    expect(firstCall.inclusive).toBe(false);
+    const secondCall = requireRecord(
+      requireMockCall(replies, 1, "conversations.replies")[0],
+      "second replies params",
+    );
+    expect(secondCall.latest).toBe("260.000");
+    expect(secondCall.limit).toBe(200);
+    expect(secondCall.inclusive).toBe(false);
+    expect(secondCall.cursor).toBe("cursor-2");
     expect(result.map((entry) => entry.ts)).toEqual([
       "255.000",
       "256.000",

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -124,8 +124,9 @@ type SlackRepliesPage = {
  * Fetches the most recent messages in a Slack thread (excluding the current message).
  * Used to populate thread context when a new thread session starts.
  *
- * Uses cursor pagination and keeps only the latest N retained messages so long threads
- * still produce up-to-date context without unbounded memory growth.
+ * When the current message timestamp is known, asks Slack for a bounded window
+ * before that message so long threads do not require walking every reply page.
+ * Falls back to cursor pagination when no current message timestamp is available.
  */
 export async function resolveSlackThreadHistory(params: {
   channelId: string;
@@ -141,6 +142,8 @@ export async function resolveSlackThreadHistory(params: {
 
   // Slack recommends no more than 200 per page.
   const fetchLimit = 200;
+  const useBoundedLatestWindow = Boolean(params.currentMessageTs) && maxMessages <= fetchLimit;
+  const requestLimit = useBoundedLatestWindow ? maxMessages : fetchLimit;
   const retained: SlackRepliesPageMessage[] = [];
   let cursor: string | undefined;
 
@@ -149,8 +152,11 @@ export async function resolveSlackThreadHistory(params: {
       const response = (await params.client.conversations.replies({
         channel: params.channelId,
         ts: params.threadTs,
-        limit: fetchLimit,
-        inclusive: true,
+        limit: requestLimit,
+        inclusive: !useBoundedLatestWindow,
+        ...(useBoundedLatestWindow && params.currentMessageTs
+          ? { latest: params.currentMessageTs }
+          : {}),
         ...(cursor ? { cursor } : {}),
       })) as SlackRepliesPage;
 
@@ -168,8 +174,12 @@ export async function resolveSlackThreadHistory(params: {
         retained.splice(0, retained.length - maxMessages);
       }
 
-      const next = response.response_metadata?.next_cursor;
-      cursor = typeof next === "string" && next.trim().length > 0 ? next.trim() : undefined;
+      if (useBoundedLatestWindow) {
+        cursor = undefined;
+      } else {
+        const next = response.response_metadata?.next_cursor;
+        cursor = typeof next === "string" && next.trim().length > 0 ? next.trim() : undefined;
+      }
     } while (cursor);
 
     return retained.map((msg) => ({

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -124,9 +124,10 @@ type SlackRepliesPage = {
  * Fetches the most recent messages in a Slack thread (excluding the current message).
  * Used to populate thread context when a new thread session starts.
  *
- * When the current message timestamp is known, asks Slack for a bounded window
- * before that message so long threads do not require walking every reply page.
- * Falls back to cursor pagination when no current message timestamp is available.
+ * When the current message timestamp is known, bounds the requested range before
+ * that message while still following cursors. Slack returns the earliest messages
+ * in a time range first, so cursor pagination is required to retain the newest
+ * messages before the current reply on long threads.
  */
 export async function resolveSlackThreadHistory(params: {
   channelId: string;
@@ -142,8 +143,7 @@ export async function resolveSlackThreadHistory(params: {
 
   // Slack recommends no more than 200 per page.
   const fetchLimit = 200;
-  const useBoundedLatestWindow = Boolean(params.currentMessageTs) && maxMessages <= fetchLimit;
-  const requestLimit = useBoundedLatestWindow ? maxMessages : fetchLimit;
+  const hasCurrentMessageBoundary = Boolean(params.currentMessageTs);
   const retained: SlackRepliesPageMessage[] = [];
   let cursor: string | undefined;
 
@@ -152,9 +152,9 @@ export async function resolveSlackThreadHistory(params: {
       const response = (await params.client.conversations.replies({
         channel: params.channelId,
         ts: params.threadTs,
-        limit: requestLimit,
-        inclusive: !useBoundedLatestWindow,
-        ...(useBoundedLatestWindow && params.currentMessageTs
+        limit: fetchLimit,
+        inclusive: !hasCurrentMessageBoundary,
+        ...(hasCurrentMessageBoundary && params.currentMessageTs
           ? { latest: params.currentMessageTs }
           : {}),
         ...(cursor ? { cursor } : {}),
@@ -174,12 +174,8 @@ export async function resolveSlackThreadHistory(params: {
         retained.splice(0, retained.length - maxMessages);
       }
 
-      if (useBoundedLatestWindow) {
-        cursor = undefined;
-      } else {
-        const next = response.response_metadata?.next_cursor;
-        cursor = typeof next === "string" && next.trim().length > 0 ? next.trim() : undefined;
-      }
+      const next = response.response_metadata?.next_cursor;
+      cursor = typeof next === "string" && next.trim().length > 0 ? next.trim() : undefined;
     } while (cursor);
 
     return retained.map((msg) => ({


### PR DESCRIPTION
## Summary
- bound Slack thread-history requests before the current message timestamp when available
- preserve latest-N semantics by continuing Slack cursor pagination when the bounded range spans multiple pages
- add a regression test for Slack's earliest-first time pagination so long threads retain the newest replies before the current message

## Tests
- `pnpm exec vitest run extensions/slack/src/monitor/media.test.ts --testNamePattern='resolveSlackThreadHistory'`
- `pnpm exec oxlint extensions/slack/src/monitor/thread.ts extensions/slack/src/monitor/media.test.ts`
- `pnpm exec oxfmt --check extensions/slack/src/monitor/thread.ts extensions/slack/src/monitor/media.test.ts`
- `pnpm tsgo:test:extensions`

## Notes
- Follow-up to ClawSweeper review: fixed the latest-N pagination semantics blocker and added regression coverage.
- Full extension-slack suite currently fails in this checkout before reaching these changes due unresolved local deps/exports (`@openclaw/proxyline ./dispatcher-brand`, missing `rastermill`).
- Real Slack behavior proof is still pending; this remains draft until that proof is added.
