### PR TITLE
fix(codex): keep turn alive after image_generation_call so the idle watchdog does not retire it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: retry recurring jobs after transient model rate limits before waiting for the next scheduled slot.
+- Codex: treat a completed `image_generation_call` as a tool handoff so the app-server idle watchdog no longer retires the turn before the final response is delivered. (#87948)
 
 ## 2026.5.28
 

--- a/extensions/codex/src/app-server/attempt-notifications.test.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { isRawToolOutputCompletionNotification } from "./attempt-notifications.js";
+import type { CodexServerNotification } from "./protocol.js";
+
+function rawResponseItemCompleted(itemType: string): CodexServerNotification {
+  return {
+    method: "rawResponseItem/completed",
+    params: { item: { type: itemType, id: "item-1" } },
+  };
+}
+
+describe("isRawToolOutputCompletionNotification", () => {
+  it("recognizes custom_tool_call_output completions", () => {
+    expect(
+      isRawToolOutputCompletionNotification(rawResponseItemCompleted("custom_tool_call_output")),
+    ).toBe(true);
+  });
+
+  it("recognizes image_generation_call completions so the idle watchdog does not retire the turn", () => {
+    expect(
+      isRawToolOutputCompletionNotification(rawResponseItemCompleted("image_generation_call")),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated raw response item types", () => {
+    expect(isRawToolOutputCompletionNotification(rawResponseItemCompleted("message"))).toBe(false);
+  });
+
+  it("ignores items without a recognized type or non-object params", () => {
+    expect(isRawToolOutputCompletionNotification(rawResponseItemCompleted(""))).toBe(false);
+    expect(isRawToolOutputCompletionNotification({ method: "rawResponseItem/completed" })).toBe(
+      false,
+    );
+  });
+
+  it("ignores other notification methods", () => {
+    expect(
+      isRawToolOutputCompletionNotification({
+        method: "turn/completed",
+        params: { item: { type: "image_generation_call" } },
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -146,6 +146,17 @@ export function isPendingOpenClawDynamicToolCompletionNotification(
   return itemType === undefined || itemType === "dynamicToolCall";
 }
 
+// Raw response item types that signal a built-in/tool call produced output
+// mid-turn. Recognizing one marks the turn as having crossed a tool handoff, so
+// a following raw assistant completion can release the turn instead of being
+// retired by the idle watchdog. `image_generation_call` completes inline like a
+// tool output (the model continues to a final message afterward), so it belongs
+// here alongside `custom_tool_call_output`. (#87948, follows #82274)
+const RAW_TOOL_OUTPUT_COMPLETION_ITEM_TYPES: ReadonlySet<string> = new Set([
+  "custom_tool_call_output",
+  "image_generation_call",
+]);
+
 export function isRawToolOutputCompletionNotification(
   notification: CodexServerNotification,
 ): boolean {
@@ -153,7 +164,8 @@ export function isRawToolOutputCompletionNotification(
     return false;
   }
   const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
-  return item ? readString(item, "type") === "custom_tool_call_output" : false;
+  const itemType = item ? readString(item, "type") : undefined;
+  return itemType !== undefined && RAW_TOOL_OUTPUT_COMPLETION_ITEM_TYPES.has(itemType);
 }
 
 export function isNativeToolProgressNotification(notification: CodexServerNotification): boolean {


### PR DESCRIPTION
## Summary

- On the native Codex app-server, a turn that ends with a completed `image_generation_call` raw item can be retired by the idle watchdog before the final assistant message is delivered. The user sees the task silently stop (for example a Telegram turn after image generation), and the session ends `interrupted`. (#87948)
- Root cause: `isRawToolOutputCompletionNotification` only recognized `custom_tool_call_output` (added in #82274), so an `image_generation_call` completion did not mark the turn as having crossed a tool handoff (`turnCrossedToolHandoff`). Without that flag, the following raw assistant completion cannot release the turn, so the idle watchdog retires it.
- This change recognizes `image_generation_call` as a raw tool-output completion alongside `custom_tool_call_output`, so the post-tool assistant completion can release the turn and deliver the final response.
- Intentionally out of scope: other built-in tool item types (`web_search_call`, `code_interpreter_call`, etc.). Only the reported `image_generation_call` is added; the recognized set is now a single list that is easy to extend if others surface.

## Linked context

Closes #87948

Related #82274 (same watchdog class, for `custom_tool_call_output`).

## Real behavior proof (required for external PRs)

- Behavior addressed: a Codex turn retired by the idle watchdog after `image_generation_call`, with no final response delivered.
- Real environment tested: source trace of the app-server notification-state path (`isRawToolOutputCompletionNotification` → `turnCrossedToolHandoff` in `attempt-notification-state.ts`) plus red/green unit tests. I do **not** have a live Codex app-server + image-generation turn to capture the live retirement.
- Command run after this patch:
  - `pnpm exec vitest run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/attempt-notifications.test.ts`
- Evidence after fix (green): 5/5 pass.

  ```
  Test Files  1 passed (1)
       Tests  5 passed (5)
  ```

- Evidence before fix (red — removing `image_generation_call` from the recognized set): the new case fails.

  ```
  × recognizes image_generation_call completions so the idle watchdog does not retire the turn
  Tests  1 failed | 4 passed (5)
  ```

- What was not tested: a live Codex app-server turn with image generation.
- Proof limitations: no live Codex app-server; relying on source trace + unit tests mirroring the #82274 precedent. The issue is filed from a real Telegram/Codex run.

## Tests and validation

- New `extensions/codex/src/app-server/attempt-notifications.test.ts` (5 cases): recognizes `custom_tool_call_output` (regression), recognizes `image_generation_call` (fix), rejects unrelated item types, rejects missing/empty type and non-`rawResponseItem/completed` methods. Red/green verified.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` — 0 errors.
- `oxlint` and `oxfmt --check` on touched files — clean.
- Note: `pnpm test <path>` reported "no changed test targets" for this brand-new file, so I ran the repo's codex vitest config directly. The codex test root (`extensions/codex`) covers the file, so CI's codex project picks it up.

## Risk checklist

- Did user-visible behavior change? **Yes** — Codex turns that perform image generation are no longer prematurely retired before the final response.
- Did config, environment, or migration behavior change? **No.**
- Did security, auth, secrets, network, or tool execution behavior change? **No.**
- Highest-risk area: incorrectly treating `image_generation_call` as a tool handoff if it were actually terminal. Mitigation: it mirrors the established `custom_tool_call_output` treatment (#82274); `image_generation_call` completes inline and the model continues to a final message, so the tool-handoff semantics are correct.

## Current review state

- Next action: maintainer review. Happy to extend the recognized set to other built-in tool item types, or add a turn-watch integration test, if maintainers prefer broader coverage or have a live repro harness.
- Still waiting on: optional live Codex app-server confirmation (I lack that environment).
