### PR TITLE
fix(agents): scale read output for small contexts

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-g.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-g.test.ts
@@ -119,6 +119,28 @@ describe("createOpenClawCodingTools read behavior", () => {
     }
   });
 
+  it("preserves explicit non-positive read limits with small context windows", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-small-context-limit-"));
+    await fs.writeFile(path.join(tmpDir, "notes.txt"), "alpha\nbeta\ngamma", "utf8");
+    try {
+      const readTool = createSandboxedReadTool({
+        root: tmpDir,
+        bridge: createHostSandboxFsBridge(tmpDir),
+        modelContextWindowTokens: 16_000,
+      });
+      const result = await readTool.execute("read-small-context-explicit-limit", {
+        path: "notes.txt",
+        limit: -1,
+      });
+
+      expect(extractToolText(result)).toBe(
+        "alpha\n\n[2 more lines in file. Use offset=2 to continue.]",
+      );
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("enforces the small-context read byte cap for long lines", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-small-context-long-"));
     const filePath = path.join(tmpDir, "huge.txt");
@@ -142,6 +164,32 @@ describe("createOpenClawCodingTools read behavior", () => {
       expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8 * 1024);
       expect(text).not.toContain("line-0128");
       expect(text).not.toContain("line-8000");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves whitespace-only lines before capped continuation guidance", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-small-context-space-"));
+    const filePath = path.join(tmpDir, "huge.txt");
+    const whitespaceLines = Array.from({ length: 5000 }, () => "   ");
+    await fs.writeFile(filePath, `${whitespaceLines.join("\n")}\nvisible`, "utf8");
+    try {
+      const readTool = createSandboxedReadTool({
+        root: tmpDir,
+        bridge: createHostSandboxFsBridge(tmpDir),
+        modelContextWindowTokens: 16_000,
+      });
+      const result = await readTool.execute("read-small-context-space-cap", {
+        path: "huge.txt",
+      });
+      const text = extractToolText(result);
+      const noticeIndex = text.indexOf("[Read output capped at 8KB");
+      const emittedBeforeNotice = text.slice(0, noticeIndex);
+
+      expect(noticeIndex).toBeGreaterThan(0);
+      expect(emittedBeforeNotice).toMatch(/^ {3}\n/);
+      expect(emittedBeforeNotice).toContain("\n   \n");
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
@@ -205,6 +253,7 @@ describe("createOpenClawCodingTools read behavior", () => {
             text: content,
           },
         ],
+        details: {},
       };
     });
     const readTool = createOpenClawReadTool(

--- a/src/agents/agent-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-g.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-g.test.ts
@@ -93,6 +93,141 @@ describe("createOpenClawCodingTools read behavior", () => {
     }
   });
 
+  it("uses a smaller default read cap for small context windows", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-small-context-"));
+    const filePath = path.join(tmpDir, "huge.txt");
+    const lines = Array.from(
+      { length: 8000 },
+      (_unused, i) => `line-${String(i + 1).padStart(4, "0")}-abcdefghijklmnopqrstuvwxyz`,
+    );
+    await fs.writeFile(filePath, lines.join("\n"), "utf8");
+    try {
+      const readTool = createSandboxedReadTool({
+        root: tmpDir,
+        bridge: createHostSandboxFsBridge(tmpDir),
+        modelContextWindowTokens: 16_000,
+      });
+      const result = await readTool.execute("read-small-context-cap", { path: "huge.txt" });
+      const text = extractToolText(result);
+      expect(text).toContain("line-0001");
+      expect(text).toContain("line-0129");
+      expect(text).toContain("Use offset=");
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8 * 1024);
+      expect(text).not.toContain("line-8000");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("enforces the small-context read byte cap for long lines", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-small-context-long-"));
+    const filePath = path.join(tmpDir, "huge.txt");
+    const lines = Array.from(
+      { length: 8000 },
+      (_unused, i) => `line-${String(i + 1).padStart(4, "0")}-${"x".repeat(220)}`,
+    );
+    await fs.writeFile(filePath, lines.join("\n"), "utf8");
+    try {
+      const readTool = createSandboxedReadTool({
+        root: tmpDir,
+        bridge: createHostSandboxFsBridge(tmpDir),
+        modelContextWindowTokens: 16_000,
+      });
+      const result = await readTool.execute("read-small-context-long-line-cap", {
+        path: "huge.txt",
+      });
+      const text = extractToolText(result);
+      expect(text).toContain("line-0001");
+      expect(text).toContain("[Read output capped at 8KB for this call. Use offset=");
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8 * 1024);
+      expect(text).not.toContain("line-0128");
+      expect(text).not.toContain("line-8000");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not advertise a later offset after capping an over-budget first line", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-small-context-line-"));
+    await fs.writeFile(path.join(tmpDir, "huge.txt"), `line-0001-${"x".repeat(20_000)}`, "utf8");
+    try {
+      const readTool = createSandboxedReadTool({
+        root: tmpDir,
+        bridge: createHostSandboxFsBridge(tmpDir),
+        modelContextWindowTokens: 16_000,
+      });
+      const result = await readTool.execute("read-small-context-first-line-cap", {
+        path: "huge.txt",
+      });
+      const text = extractToolText(result);
+      expect(text).toContain("before line 1 because that line exceeds the budget");
+      expect(text).toContain("Use offset=1 and limit=1 to read it explicitly.");
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8 * 1024);
+      expect(text).not.toContain("offset=2");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not loop on the same offset when a first line needs the full cap", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-small-context-full-"));
+    await fs.writeFile(
+      path.join(tmpDir, "huge.txt"),
+      `${"x".repeat(8 * 1024 - 20)}\n${"y".repeat(200)}`,
+      "utf8",
+    );
+    try {
+      const readTool = createSandboxedReadTool({
+        root: tmpDir,
+        bridge: createHostSandboxFsBridge(tmpDir),
+        modelContextWindowTokens: 16_000,
+      });
+      const result = await readTool.execute("read-small-context-full-line-cap", {
+        path: "huge.txt",
+      });
+      const text = extractToolText(result);
+      expect(text).toContain("before line 1 because that line leaves no room");
+      expect(text).toContain("Use offset=1 and limit=1 to read it explicitly.");
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8 * 1024);
+      expect(text).not.toContain("Use offset=1 to continue.");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat continuation text in file content as pagination metadata", async () => {
+    const content = "this is file content\n\n[1 more lines in file. Use offset=129 to continue.]";
+    const execute = vi.fn(async (): Promise<AgentToolResult<unknown>> => {
+      return {
+        content: [
+          {
+            type: "text",
+            text: content,
+          },
+        ],
+      };
+    });
+    const readTool = createOpenClawReadTool(
+      {
+        name: "read",
+        label: "read",
+        description: "test read",
+        parameters: Type.Object({
+          path: Type.String(),
+          offset: Type.Optional(Type.Number()),
+          limit: Type.Optional(Type.Number()),
+        }),
+        execute,
+      },
+      { modelContextWindowTokens: 16_000 },
+    );
+
+    const result = await readTool.execute("read-content-offset-phrase", { path: "notes.txt" });
+
+    expect(extractToolText(result)).toBe(content);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   it("returns empty content for explicit offsets beyond EOF", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-offset-eof-"));
     await fs.writeFile(path.join(tmpDir, "notes.txt"), "one\ntwo\nthree", "utf8");

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -159,7 +159,7 @@ function truncateReadTextToByteBudget(
   }
 
   if (output) {
-    return { text: output.trimEnd(), outputLines, firstLineExceedsBudget: false };
+    return { text: output, outputLines, firstLineExceedsBudget: false };
   }
 
   return { text: "", outputLines: 0, firstLineExceedsBudget: true };
@@ -386,8 +386,7 @@ async function executeReadWithAdaptivePaging(params: {
   maxBytes: number;
 }): Promise<AgentToolResult<unknown>> {
   const userLimit = params.args.limit;
-  const hasExplicitLimit =
-    typeof userLimit === "number" && Number.isFinite(userLimit) && userLimit > 0;
+  const hasExplicitLimit = typeof userLimit === "number" && Number.isFinite(userLimit);
   if (hasExplicitLimit) {
     return await executeReadPage(params);
   }

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -42,6 +42,7 @@ type ImageContentBlock = Extract<ToolContentBlock, { type: "image" }>;
 type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;
 
 const DEFAULT_READ_PAGE_MAX_BYTES = 32 * 1024;
+const MIN_CONTEXT_AWARE_READ_PAGE_MAX_BYTES = 8 * 1024;
 const MAX_ADAPTIVE_READ_MAX_BYTES = 128 * 1024;
 const ADAPTIVE_READ_CONTEXT_SHARE = 0.1;
 const CHARS_PER_TOKEN_ESTIMATE = 4;
@@ -79,7 +80,14 @@ function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number 
   const fromContext = Math.floor(
     contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * ADAPTIVE_READ_CONTEXT_SHARE,
   );
-  return clamp(fromContext, DEFAULT_READ_PAGE_MAX_BYTES, MAX_ADAPTIVE_READ_MAX_BYTES);
+  return clamp(fromContext, MIN_CONTEXT_AWARE_READ_PAGE_MAX_BYTES, MAX_ADAPTIVE_READ_MAX_BYTES);
+}
+
+function resolveAdaptiveReadLineLimit(maxBytes: number): number | undefined {
+  if (maxBytes >= DEFAULT_READ_PAGE_MAX_BYTES) {
+    return undefined;
+  }
+  return maxBytes;
 }
 
 function malformedXmlArgValuePathError(key: string): Error {
@@ -94,6 +102,95 @@ function formatBytes(bytes: number): string {
     return `${Math.round(bytes / 1024)}KB`;
   }
   return `${bytes}B`;
+}
+
+function readOutputCapNotice(maxBytes: number, continuationOffset: number): string {
+  return `[Read output capped at ${formatBytes(maxBytes)} for this call. Use offset=${continuationOffset} to continue.]`;
+}
+
+function readOutputLineExceedsCapNotice(maxBytes: number, offset: number): string {
+  return `[Read output capped at ${formatBytes(maxBytes)} for this call before line ${offset} because that line exceeds the budget. Use offset=${offset} and limit=1 to read it explicitly.]`;
+}
+
+function readOutputLineNeedsFullBudgetNotice(maxBytes: number, offset: number): string {
+  return `[Read output capped at ${formatBytes(maxBytes)} for this call before line ${offset} because that line leaves no room for continuation guidance. Use offset=${offset} and limit=1 to read it explicitly.]`;
+}
+
+function maxReadOutputCapNoticeBytes(maxBytes: number, continuationOffset: number): number {
+  return Math.max(
+    Buffer.byteLength(readOutputCapNotice(maxBytes, continuationOffset), "utf-8"),
+    Buffer.byteLength(readOutputLineExceedsCapNotice(maxBytes, continuationOffset), "utf-8"),
+    Buffer.byteLength(readOutputLineNeedsFullBudgetNotice(maxBytes, continuationOffset), "utf-8"),
+  );
+}
+
+function splitLinesPreservingBreaks(text: string): string[] {
+  return text.match(/[^\n]*(?:\n|$)/gu)?.filter((part) => part.length > 0) ?? [];
+}
+
+function firstLineExceedsByteBudget(text: string, maxBytes: number): boolean {
+  const firstLine = splitLinesPreservingBreaks(text)[0];
+  return firstLine ? Buffer.byteLength(firstLine, "utf-8") > maxBytes : false;
+}
+
+function truncateReadTextToByteBudget(
+  text: string,
+  maxBytes: number,
+): { text: string; outputLines: number; firstLineExceedsBudget: boolean } {
+  if (Buffer.byteLength(text, "utf-8") <= maxBytes) {
+    return {
+      text,
+      outputLines: text ? splitLinesPreservingBreaks(text).length : 0,
+      firstLineExceedsBudget: false,
+    };
+  }
+
+  let output = "";
+  let outputBytes = 0;
+  let outputLines = 0;
+  for (const line of splitLinesPreservingBreaks(text)) {
+    const lineBytes = Buffer.byteLength(line, "utf-8");
+    if (outputBytes + lineBytes > maxBytes) {
+      break;
+    }
+    output += line;
+    outputBytes += lineBytes;
+    outputLines += 1;
+  }
+
+  if (output) {
+    return { text: output.trimEnd(), outputLines, firstLineExceedsBudget: false };
+  }
+
+  return { text: "", outputLines: 0, firstLineExceedsBudget: true };
+}
+
+function capReadTextForContinuation(params: {
+  availableBytes?: number;
+  maxBytes: number;
+  startOffset: number;
+  text: string;
+}): { text: string; notice: string } {
+  const budgetBytes = params.availableBytes ?? params.maxBytes;
+  const firstPass = truncateReadTextToByteBudget(params.text, budgetBytes);
+  const firstOffset =
+    firstPass.outputLines > 0 ? params.startOffset + firstPass.outputLines : params.startOffset;
+  const firstLineExceedsMaxBytes = firstLineExceedsByteBudget(params.text, params.maxBytes);
+  const separatorBytes = firstPass.text ? Buffer.byteLength("\n\n", "utf-8") : 0;
+  const noticeBudgetBytes = maxReadOutputCapNoticeBytes(params.maxBytes, firstOffset);
+  const textBudget = Math.max(0, budgetBytes - separatorBytes - noticeBudgetBytes);
+  const finalPass = truncateReadTextToByteBudget(params.text, textBudget);
+  const finalOffset =
+    finalPass.outputLines > 0 ? params.startOffset + finalPass.outputLines : params.startOffset;
+  const notice = finalPass.firstLineExceedsBudget
+    ? firstLineExceedsMaxBytes
+      ? readOutputLineExceedsCapNotice(params.maxBytes, finalOffset)
+      : readOutputLineNeedsFullBudgetNotice(params.maxBytes, finalOffset)
+    : readOutputCapNotice(params.maxBytes, finalOffset);
+  return {
+    text: finalPass.text,
+    notice,
+  };
 }
 
 function getToolResultText(result: AgentToolResult<unknown>): string | undefined {
@@ -305,9 +402,14 @@ async function executeReadWithAdaptivePaging(params: {
   let aggregatedBytes = 0;
   let capped = false;
   let continuationOffset: number | undefined;
+  let capNotice: string | undefined;
+  const internalPageLineLimit = resolveAdaptiveReadLineLimit(params.maxBytes);
 
   for (let page = 0; page < MAX_ADAPTIVE_READ_PAGES; page += 1) {
-    const pageArgs = { ...params.args, offset: nextOffset };
+    const pageArgs =
+      internalPageLineLimit === undefined
+        ? { ...params.args, offset: nextOffset }
+        : { ...params.args, offset: nextOffset, limit: internalPageLineLimit };
     const pageResult = await executeReadPage({
       base: params.base,
       toolCallId: params.toolCallId,
@@ -322,29 +424,61 @@ async function executeReadWithAdaptivePaging(params: {
     }
 
     const truncation = extractReadTruncationDetails(pageResult);
-    const canContinue =
+    const canContinueFromTruncation =
       Boolean(truncation?.truncated) &&
       !truncation?.firstLineExceedsLimit &&
       (truncation?.outputLines ?? 0) > 0 &&
       page < MAX_ADAPTIVE_READ_PAGES - 1;
+    const nextContinuationOffset = canContinueFromTruncation
+      ? nextOffset + (truncation?.outputLines ?? 0)
+      : undefined;
+    const canContinue = nextContinuationOffset !== undefined;
     const pageText = canContinue ? stripReadContinuationNotice(rawText) : rawText;
     const delimiter = aggregatedText && pageText ? "\n\n" : "";
     const nextBytes = Buffer.byteLength(`${delimiter}${pageText}`, "utf-8");
+    const continuationNoticeBytes = canContinue
+      ? Buffer.byteLength(aggregatedText || pageText ? "\n\n" : "", "utf-8") +
+        maxReadOutputCapNoticeBytes(params.maxBytes, nextContinuationOffset)
+      : 0;
 
-    if (aggregatedText && aggregatedBytes + nextBytes > params.maxBytes) {
+    if (aggregatedBytes + nextBytes + continuationNoticeBytes > params.maxBytes) {
       capped = true;
-      continuationOffset = nextOffset;
+      if (!aggregatedText) {
+        const cappedPage = capReadTextForContinuation({
+          maxBytes: params.maxBytes,
+          startOffset: nextOffset,
+          text: pageText,
+        });
+        aggregatedText = cappedPage.text;
+        aggregatedBytes = Buffer.byteLength(aggregatedText, "utf-8");
+        capNotice = cappedPage.notice;
+      } else {
+        const cappedPage = capReadTextForContinuation({
+          availableBytes: Math.max(
+            0,
+            params.maxBytes - aggregatedBytes - Buffer.byteLength(delimiter, "utf-8"),
+          ),
+          maxBytes: params.maxBytes,
+          startOffset: nextOffset,
+          text: pageText,
+        });
+        if (cappedPage.text) {
+          aggregatedText += `${delimiter}${cappedPage.text}`;
+          aggregatedBytes = Buffer.byteLength(aggregatedText, "utf-8");
+        }
+        capNotice = cappedPage.notice;
+      }
       break;
     }
 
     aggregatedText += `${delimiter}${pageText}`;
     aggregatedBytes += nextBytes;
 
-    if (!canContinue || !truncation) {
+    if (!canContinue || nextContinuationOffset === undefined) {
       return withToolResultText(pageResult, aggregatedText);
     }
 
-    nextOffset += truncation.outputLines;
+    nextOffset = nextContinuationOffset;
     continuationOffset = nextOffset;
 
     if (aggregatedBytes >= params.maxBytes) {
@@ -359,7 +493,11 @@ async function executeReadWithAdaptivePaging(params: {
 
   let finalText = aggregatedText;
   if (capped && continuationOffset) {
-    finalText += `\n\n[Read output capped at ${formatBytes(params.maxBytes)} for this call. Use offset=${continuationOffset} to continue.]`;
+    capNotice ??= readOutputCapNotice(params.maxBytes, continuationOffset);
+  }
+  if (capNotice) {
+    const separator = finalText ? "\n\n" : "";
+    finalText = `${finalText}${separator}${capNotice}`;
   }
   return withToolResultText(firstResult, finalText);
 }


### PR DESCRIPTION
This keeps default `read` output smaller for small-context local models without changing explicit caller limits. It is part of the small-model stability work: smaller models were getting oversized file reads by default, then losing useful context or stalling around follow-up tool use.

Refs https://github.com/openclaw/openclaw/issues/86599.

## Summary

- Scale the adaptive default `read` byte cap from the active model context window, with an 8KB floor and 128KB ceiling.
- Preserve explicit `limit` values, including `0` and negative values that the base read tool normalizes to one line.
- Keep continuation guidance inside the byte budget and avoid misleading offsets when the first line or trailing whitespace-only lines hit the cap.
- Add focused coverage for small-context caps, long lines, explicit limits, whitespace-only capped content, EOF pagination, and continuation-text-in-file false positives.

## Verification

Behavior addressed: small-context models get a smaller default file-read payload, while explicit caller limits keep the existing read contract.

Real environment tested: local focused node-wrapper tests for read-tool behavior; AWS Crabbox Linux changed-gate runner.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs src/agents/agent-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-g.test.ts src/agents/agent-tools.read.arg-value-suffix.test.ts src/agents/agent-tools.read.host-edit-access.test.ts src/agents/agent-tools.read.host-tilde-expansion.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts --reporter=dot
git diff --check origin/main...HEAD
node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"
```

Evidence after fix: refreshed head `c1c0e492b5f71867a9891f1385c082cbca0a111b`; focused local wrapper passed 5 files / 41 tests; diff check passed. AWS Crabbox `pnpm check:changed` passed with provider `aws`, lease `cbx_170dfd1a4fe3`, slug `blue-shrimp`, run `run_83d62fc1cda9`, machine `c7a.8xlarge`, exit `0`, `leaseStopped=true`, selected lanes `core` and `coreTests`.

Observed result after fix: adaptive reads cap output for small context windows, explicit limits still delegate to the base read tool, capped whitespace-only pages keep emitted content aligned with continuation offsets, and continuation-looking file text is not treated as pagination metadata.

What was not tested: real Ollama/model-provider live chat; this PR changes read-tool context sizing, not provider streaming.
