### PR TITLE
fix(tui): preserve pending local runs during session sync

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -101,6 +101,7 @@ function createHarness(params?: {
   const refreshSessionInfo = params?.refreshSessionInfo ?? vi.fn().mockResolvedValue(undefined);
   const applySessionInfoFromPatch = params?.applySessionInfoFromPatch ?? vi.fn();
   const setActivityStatus = params?.setActivityStatus ?? (vi.fn() as SetActivityStatusMock);
+  const forgetLocalRunId = vi.fn();
   const openOverlay = vi.fn();
   const closeOverlay = vi.fn();
   const requestExit = vi.fn();
@@ -150,7 +151,7 @@ function createHarness(params?: {
     applySessionInfoFromPatch: applySessionInfoFromPatch as never,
     noteLocalRunId,
     noteLocalBtwRunId,
-    forgetLocalRunId: vi.fn(),
+    forgetLocalRunId,
     forgetLocalBtwRunId: vi.fn(),
     runAuthFlow,
     requestExit,
@@ -180,6 +181,7 @@ function createHarness(params?: {
     setActivityStatus,
     noteLocalRunId,
     noteLocalBtwRunId,
+    forgetLocalRunId,
     requestExit,
     abortActive,
     state,
@@ -520,7 +522,9 @@ describe("tui command handlers", () => {
   });
 
   it("tracks the in-flight runId so escape can abort during the wait", async () => {
-    const sendChat = vi.fn().mockResolvedValue({ runId: "ignored" });
+    const sendChat = vi.fn().mockImplementation(async (opts: { runId: string }) => ({
+      runId: opts.runId,
+    }));
     const { handleCommand, state } = createHarness({ sendChat });
 
     await handleCommand("hello");
@@ -530,6 +534,32 @@ describe("tui command handlers", () => {
     expect(sentRunId.length).toBeGreaterThan(0);
     expect(state.activeChatRunId).toBeNull();
     expect(state.pendingChatRunId).toBe(sentRunId);
+  });
+
+  it("does not reintroduce the pending runId when an early event already consumed it", async () => {
+    const sendChat = vi.fn();
+    const { handleCommand, state } = createHarness({ sendChat });
+    sendChat.mockImplementation(async (opts: { runId: string }) => {
+      state.pendingOptimisticUserMessage = false;
+      return { runId: opts.runId };
+    });
+
+    await handleCommand("hello");
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+  });
+
+  it("tracks the backend-accepted runId when it differs from the generated runId", async () => {
+    const sendChat = vi.fn().mockResolvedValue({ runId: "run-accepted" });
+    const { handleCommand, state, noteLocalRunId, forgetLocalRunId } = createHarness({ sendChat });
+
+    await handleCommand("hello");
+
+    const sentRunId = (firstMockArg(sendChat, "sendChat") as { runId: string }).runId;
+    expect(state.pendingChatRunId).toBe("run-accepted");
+    expect(forgetLocalRunId).toHaveBeenCalledWith(sentRunId);
+    expect(noteLocalRunId).toHaveBeenCalledWith("run-accepted");
   });
 
   it("clears the pending runId if sendChat fails", async () => {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -508,12 +508,13 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("agent set to work; use /crestodian to return");
   });
 
-  it("defers local run binding until gateway events provide a real run id", async () => {
-    const { handleCommand, noteLocalRunId, state } = createHarness();
+  it("marks the generated runId as local before gateway events arrive", async () => {
+    const { handleCommand, sendChat, noteLocalRunId, state } = createHarness();
 
     await handleCommand("/context detail");
 
-    expect(noteLocalRunId).not.toHaveBeenCalled();
+    const sentRunId = (firstMockArg(sendChat, "sendChat") as { runId: string }).runId;
+    expect(noteLocalRunId).toHaveBeenCalledWith(sentRunId);
     expect(state.activeChatRunId).toBeNull();
     expect(state.pendingOptimisticUserMessage).toBe(true);
   });

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -15,6 +15,8 @@ type SelectableOverlay = {
 };
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
 type SetSessionMock = ReturnType<typeof vi.fn> & ((key: string) => Promise<void>);
+type ConsumeCompletedRunMock = ReturnType<typeof vi.fn> & ((runId: string) => boolean);
+type FlushPendingHistoryRefreshMock = ReturnType<typeof vi.fn> & (() => void);
 
 async function flushAsyncSelect() {
   await new Promise<void>((resolve) => setImmediate(resolve));
@@ -81,6 +83,8 @@ function createHarness(params?: {
   currentAgentId?: string;
   currentSessionKey?: string;
   abortActive?: AbortActiveMock;
+  consumeCompletedRunForPendingSend?: ConsumeCompletedRunMock;
+  flushPendingHistoryRefreshIfIdle?: FlushPendingHistoryRefreshMock;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
   const getGatewayStatus = params?.getGatewayStatus ?? vi.fn().mockResolvedValue({});
@@ -153,6 +157,8 @@ function createHarness(params?: {
     noteLocalBtwRunId,
     forgetLocalRunId,
     forgetLocalBtwRunId: vi.fn(),
+    consumeCompletedRunForPendingSend: params?.consumeCompletedRunForPendingSend,
+    flushPendingHistoryRefreshIfIdle: params?.flushPendingHistoryRefreshIfIdle,
     runAuthFlow,
     requestExit,
   });
@@ -560,6 +566,29 @@ describe("tui command handlers", () => {
     expect(state.pendingChatRunId).toBe("run-accepted");
     expect(forgetLocalRunId).toHaveBeenCalledWith(sentRunId);
     expect(noteLocalRunId).toHaveBeenCalledWith("run-accepted");
+  });
+
+  it("does not reintroduce a backend-accepted runId after an early terminal event", async () => {
+    const sendChat = vi.fn().mockResolvedValue({ runId: "run-accepted" });
+    const consumeCompletedRunForPendingSend = vi.fn((runId: string) => runId === "run-accepted");
+    const flushPendingHistoryRefreshIfIdle = vi.fn();
+    const { handleCommand, state, noteLocalRunId, forgetLocalRunId, setActivityStatus } =
+      createHarness({
+        sendChat,
+        consumeCompletedRunForPendingSend,
+        flushPendingHistoryRefreshIfIdle,
+      });
+
+    await handleCommand("hello");
+
+    const sentRunId = (firstMockArg(sendChat, "sendChat") as { runId: string }).runId;
+    expect(consumeCompletedRunForPendingSend).toHaveBeenCalledWith("run-accepted");
+    expect(forgetLocalRunId).toHaveBeenCalledWith(sentRunId);
+    expect(noteLocalRunId).not.toHaveBeenCalledWith("run-accepted");
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+    expect(flushPendingHistoryRefreshIfIdle).toHaveBeenCalledTimes(1);
   });
 
   it("clears the pending runId if sendChat fails", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -738,7 +738,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         noteLocalBtwRunId?.(runId);
       }
       tui.requestRender();
-      await client.sendChat({
+      const sendResult = await client.sendChat({
         sessionKey: state.currentSessionKey,
         ...(state.currentSessionKey === "global" ? { agentId: state.currentAgentId } : {}),
         sessionId: state.currentSessionId,
@@ -749,9 +749,16 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         runId,
       });
       if (!isBtw) {
-        state.pendingChatRunId = runId;
-        setActivityStatus("waiting");
-        tui.requestRender();
+        const acceptedRunId = sendResult.runId || runId;
+        if (acceptedRunId !== runId) {
+          forgetLocalRunId?.(runId);
+          noteLocalRunId?.(acceptedRunId);
+        }
+        if (state.pendingOptimisticUserMessage) {
+          state.pendingChatRunId = acceptedRunId;
+          setActivityStatus("waiting");
+          tui.requestRender();
+        }
       }
     } catch (err) {
       if (isBtw) {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -107,6 +107,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     setActivityStatus,
     formatSessionKey,
     applySessionInfoFromPatch,
+    noteLocalRunId,
     noteLocalBtwRunId,
     forgetLocalRunId,
     forgetLocalBtwRunId,
@@ -730,6 +731,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.reserveAssistantSlot(state.activeChatRunId);
         }
         chatLog.addUser(text);
+        noteLocalRunId?.(runId);
         state.pendingOptimisticUserMessage = true;
         setActivityStatus("sending");
       } else {
@@ -757,6 +759,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       }
       if (!isBtw && state.activeChatRunId) {
         forgetLocalRunId?.(state.activeChatRunId);
+      }
+      if (!isBtw) {
+        forgetLocalRunId?.(runId);
       }
       if (!isBtw) {
         state.pendingOptimisticUserMessage = false;

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -59,6 +59,8 @@ type CommandHandlerContext = {
   noteLocalBtwRunId?: (runId: string) => void;
   forgetLocalRunId?: (runId: string) => void;
   forgetLocalBtwRunId?: (runId: string) => void;
+  consumeCompletedRunForPendingSend?: (runId: string) => boolean;
+  flushPendingHistoryRefreshIfIdle?: () => void;
   runAuthFlow?: (params: {
     provider?: string;
   }) => Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>;
@@ -111,6 +113,8 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     noteLocalBtwRunId,
     forgetLocalRunId,
     forgetLocalBtwRunId,
+    consumeCompletedRunForPendingSend,
+    flushPendingHistoryRefreshIfIdle,
     runAuthFlow,
     requestExit,
   } = context;
@@ -750,13 +754,24 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       });
       if (!isBtw) {
         const acceptedRunId = sendResult.runId || runId;
+        const acceptedRunAlreadyCompleted =
+          acceptedRunId !== runId && (consumeCompletedRunForPendingSend?.(acceptedRunId) ?? false);
         if (acceptedRunId !== runId) {
           forgetLocalRunId?.(runId);
-          noteLocalRunId?.(acceptedRunId);
+          if (!acceptedRunAlreadyCompleted) {
+            noteLocalRunId?.(acceptedRunId);
+          }
         }
         if (state.pendingOptimisticUserMessage) {
-          state.pendingChatRunId = acceptedRunId;
-          setActivityStatus("waiting");
+          if (acceptedRunAlreadyCompleted) {
+            state.pendingOptimisticUserMessage = false;
+            state.pendingChatRunId = null;
+            setActivityStatus("idle");
+            flushPendingHistoryRefreshIfIdle?.();
+          } else {
+            state.pendingChatRunId = acceptedRunId;
+            setActivityStatus("waiting");
+          }
           tui.requestRender();
         }
       }

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -951,9 +951,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("binds optimistic pending messages to the first gateway run id and skips history reload", () => {
-    const { state, loadHistory, isLocalRunId, handleChatEvent } = createHandlersHarness({
-      state: { activeChatRunId: null, pendingOptimisticUserMessage: true },
-    });
+    const { state, loadHistory, noteLocalRunId, isLocalRunId, handleChatEvent } =
+      createHandlersHarness({
+        state: { activeChatRunId: null, pendingOptimisticUserMessage: true },
+      });
+    noteLocalRunId("run-gateway");
 
     handleChatEvent({
       runId: "run-gateway",
@@ -965,6 +967,24 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(state.pendingOptimisticUserMessage).toBe(false);
     expect(state.activeChatRunId).toBeNull();
     expect(isLocalRunId("run-gateway")).toBe(false);
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("does not bind unknown gateway run ids while an optimistic message is pending", () => {
+    const { state, loadHistory, isLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null, pendingOptimisticUserMessage: true },
+    });
+
+    handleChatEvent({
+      runId: "run-unknown",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(state.pendingOptimisticUserMessage).toBe(true);
+    expect(state.activeChatRunId).toBeNull();
+    expect(isLocalRunId("run-unknown")).toBe(false);
     expect(loadHistory).not.toHaveBeenCalled();
   });
 
@@ -992,14 +1012,78 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(loadHistory).not.toHaveBeenCalled();
   });
 
-  it("binds an early final to the optimistic message before pendingChatRunId is assigned", () => {
-    const { state, chatLog, loadHistory, isLocalRunId, handleChatEvent } = createHandlersHarness({
-      state: {
-        activeChatRunId: "run-active",
-        pendingChatRunId: null,
-        pendingOptimisticUserMessage: true,
-      },
+  it("does not let unrelated same-session events claim a pending optimistic run", () => {
+    const { state, chatLog, loadHistory, noteLocalRunId, isLocalRunId, handleChatEvent } =
+      createHandlersHarness({
+        state: {
+          activeChatRunId: null,
+          pendingChatRunId: "run-pending",
+          pendingOptimisticUserMessage: true,
+        },
+      });
+    noteLocalRunId("run-pending");
+
+    handleChatEvent({
+      runId: "run-other",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "other done" }] },
     });
+
+    expect(state.pendingChatRunId).toBe("run-pending");
+    expect(state.pendingOptimisticUserMessage).toBe(true);
+    expect(isLocalRunId("run-other")).toBe(false);
+    expect(loadHistory).not.toHaveBeenCalled();
+
+    handleChatEvent({
+      runId: "run-pending",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("done", "run-pending");
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let the active local run claim a queued optimistic run", () => {
+    const { state, loadHistory, noteLocalRunId, isLocalRunId, handleChatEvent } =
+      createHandlersHarness({
+        state: {
+          activeChatRunId: "run-active",
+          pendingChatRunId: "run-pending",
+          pendingOptimisticUserMessage: true,
+        },
+      });
+    noteLocalRunId("run-active");
+    noteLocalRunId("run-pending");
+
+    handleChatEvent({
+      runId: "run-active",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "active done" }] },
+    });
+
+    expect(state.pendingChatRunId).toBe("run-pending");
+    expect(state.pendingOptimisticUserMessage).toBe(true);
+    expect(isLocalRunId("run-active")).toBe(false);
+    expect(isLocalRunId("run-pending")).toBe(true);
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("binds an early final to the optimistic message before pendingChatRunId is assigned", () => {
+    const { state, chatLog, loadHistory, noteLocalRunId, isLocalRunId, handleChatEvent } =
+      createHandlersHarness({
+        state: {
+          activeChatRunId: "run-active",
+          pendingChatRunId: null,
+          pendingOptimisticUserMessage: true,
+        },
+      });
+    noteLocalRunId("run-early-final");
 
     handleChatEvent({
       runId: "run-early-final",

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -376,7 +376,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   it("shows finishing context for a pending run before chat registration", () => {
     const { state, tui, setActivityStatus, handleAgentEvent, isLocalRunId } = createHandlersHarness(
       {
-        localMode: true,
         state: {
           activeChatRunId: null,
           pendingChatRunId: "run-pending",
@@ -397,6 +396,63 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(isLocalRunId("run-pending")).toBe(true);
     expect(setActivityStatus).toHaveBeenCalledWith("finishing context");
     expect(tui.requestRender).toHaveBeenCalled();
+  });
+
+  it("does not reload history after lifecycle binds a gateway pending run", () => {
+    const { state, chatLog, loadHistory, handleAgentEvent, handleChatEvent, isLocalRunId } =
+      createHandlersHarness({
+        state: {
+          activeChatRunId: null,
+          pendingChatRunId: "run-pending",
+          pendingOptimisticUserMessage: true,
+        },
+      });
+
+    handleAgentEvent({
+      runId: "run-pending",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+
+    handleChatEvent({
+      runId: "run-pending",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(isLocalRunId("run-pending")).toBe(false);
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("done", "run-pending");
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("preserves a pending local run when the session key catches up before the first event", () => {
+    const { state, chatLog, loadHistory, noteLocalRunId, handleChatEvent, isLocalRunId } =
+      createHandlersHarness({
+        state: {
+          currentSessionKey: "agent:main:initial",
+          activeChatRunId: null,
+          pendingChatRunId: "run-pending",
+          pendingOptimisticUserMessage: true,
+        },
+      });
+    noteLocalRunId("run-pending");
+    state.currentSessionKey = "agent:main:restored";
+
+    handleChatEvent({
+      runId: "run-pending",
+      sessionKey: "agent:main:restored",
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(isLocalRunId("run-pending")).toBe(false);
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("done", "run-pending");
+    expect(loadHistory).not.toHaveBeenCalled();
   });
 
   it("shows finishing context for a known run after assistant final", () => {
@@ -909,6 +965,54 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(state.pendingOptimisticUserMessage).toBe(false);
     expect(state.activeChatRunId).toBeNull();
     expect(isLocalRunId("run-gateway")).toBe(false);
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("binds a pending run final to the optimistic message even while another run is active", () => {
+    const { state, chatLog, loadHistory, isLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-active",
+        pendingChatRunId: "run-pending",
+        pendingOptimisticUserMessage: true,
+      },
+    });
+
+    handleChatEvent({
+      runId: "run-pending",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(state.activeChatRunId).toBe("run-active");
+    expect(isLocalRunId("run-pending")).toBe(false);
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("done", "run-pending");
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("binds an early final to the optimistic message before pendingChatRunId is assigned", () => {
+    const { state, chatLog, loadHistory, isLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-active",
+        pendingChatRunId: null,
+        pendingOptimisticUserMessage: true,
+      },
+    });
+
+    handleChatEvent({
+      runId: "run-early-final",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(state.activeChatRunId).toBe("run-active");
+    expect(isLocalRunId("run-early-final")).toBe(false);
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("done", "run-early-final");
     expect(loadHistory).not.toHaveBeenCalled();
   });
 

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -96,7 +96,12 @@ export function createEventHandlers(context: EventHandlerContext) {
   let streamingWatchdogRunId: string | null = null;
 
   const flushPendingHistoryRefreshIfIdle = () => {
-    if (!pendingHistoryRefresh || state.activeChatRunId) {
+    if (
+      !pendingHistoryRefresh ||
+      state.activeChatRunId ||
+      state.pendingChatRunId ||
+      state.pendingOptimisticUserMessage
+    ) {
       return;
     }
     pendingHistoryRefresh = false;
@@ -432,6 +437,10 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (opts?.hasDisplayableFinal) {
       return;
     }
+    if (state.pendingChatRunId || state.pendingOptimisticUserMessage) {
+      pendingHistoryRefresh = true;
+      return;
+    }
     if (hasConcurrentActiveRun(runId)) {
       return;
     }
@@ -552,22 +561,19 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearPendingTerminalLifecycleError(evt.runId);
     chatLog.dismissPendingSystem(evt.runId);
     noteSessionRun(evt.runId);
-    const activeRunId = state.activeChatRunId;
     const isPendingChatRun = state.pendingChatRunId === evt.runId;
+    const isLocalChatRun = isLocalRunId?.(evt.runId) ?? false;
+    const isLocalBtwRun = isLocalBtwRunId?.(evt.runId) ?? false;
     const isNewOptimisticRun =
       state.pendingOptimisticUserMessage &&
-      !isLocalBtwRunId?.(evt.runId) &&
-      (isPendingChatRun || !activeRunId || activeRunId !== evt.runId);
+      !isLocalBtwRun &&
+      (isPendingChatRun || (isLocalChatRun && evt.runId !== state.activeChatRunId));
     if (isNewOptimisticRun) {
       noteLocalRunId?.(evt.runId);
       state.pendingOptimisticUserMessage = false;
     }
-    if (!state.activeChatRunId && !isLocalBtwRunId?.(evt.runId)) {
+    if (!state.activeChatRunId && !isLocalBtwRun) {
       state.activeChatRunId = evt.runId;
-      if (state.pendingOptimisticUserMessage) {
-        noteLocalRunId?.(evt.runId);
-        state.pendingOptimisticUserMessage = false;
-      }
     }
     if (isPendingChatRun) {
       state.pendingChatRunId = null;

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -420,8 +420,13 @@ export function createEventHandlers(context: EventHandlerContext) {
 
   const maybeRefreshHistoryForRun = (
     runId: string,
-    opts?: { allowLocalWithoutDisplayableFinal?: boolean; hasDisplayableFinal?: boolean },
+    opts?: {
+      allowLocalWithoutDisplayableFinal?: boolean;
+      hasDisplayableFinal?: boolean;
+      wasPendingChatRun?: boolean;
+    },
   ) => {
+    const isPendingChatRun = opts?.wasPendingChatRun === true || state.pendingChatRunId === runId;
     const isLocalRun = isLocalRunId?.(runId) ?? false;
     if (isLocalRun) {
       forgetLocalRunId?.(runId);
@@ -436,15 +441,15 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
     }
+    if (!isPendingChatRun && (state.pendingChatRunId || state.pendingOptimisticUserMessage)) {
+      pendingHistoryRefresh = true;
+      return;
+    }
     // When the final event already produced displayable output, skip the
     // reload. loadHistory() does clearAll() + rebuild from server, but the
     // server may not have persisted this message yet, causing the
     // just-rendered final message to vanish (#87922).
     if (opts?.hasDisplayableFinal) {
-      return;
-    }
-    if (state.pendingChatRunId || state.pendingOptimisticUserMessage) {
-      pendingHistoryRefresh = true;
       return;
     }
     if (hasConcurrentActiveRun(runId)) {
@@ -611,6 +616,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       if (!evt.message) {
         maybeRefreshHistoryForRun(evt.runId, {
           allowLocalWithoutDisplayableFinal: true,
+          wasPendingChatRun: isPendingChatRun,
         });
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
@@ -618,7 +624,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
       if (isCommandMessage(evt.message)) {
-        maybeRefreshHistoryForRun(evt.runId);
+        maybeRefreshHistoryForRun(evt.runId, { wasPendingChatRun: isPendingChatRun });
         const text = extractTextFromMessage(evt.message);
         if (text) {
           chatLog.addSystem(text);
@@ -648,6 +654,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       // the just-rendered final message to vanish (#87922).
       maybeRefreshHistoryForRun(evt.runId, {
         hasDisplayableFinal: !suppressEmptyExternalPlaceholder,
+        wasPendingChatRun: isPendingChatRun,
       });
       if (suppressEmptyExternalPlaceholder) {
         chatLog.dropAssistant(evt.runId);

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -192,6 +192,9 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     lastSessionKey = state.currentSessionKey;
+    if (state.activeChatRunId || state.pendingChatRunId || state.pendingOptimisticUserMessage) {
+      return;
+    }
     finalizedRuns.clear();
     finalizedRunsWithDisplay.clear();
     sessionRuns.clear();
@@ -549,6 +552,16 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearPendingTerminalLifecycleError(evt.runId);
     chatLog.dismissPendingSystem(evt.runId);
     noteSessionRun(evt.runId);
+    const activeRunId = state.activeChatRunId;
+    const isPendingChatRun = state.pendingChatRunId === evt.runId;
+    const isNewOptimisticRun =
+      state.pendingOptimisticUserMessage &&
+      !isLocalBtwRunId?.(evt.runId) &&
+      (isPendingChatRun || !activeRunId || activeRunId !== evt.runId);
+    if (isNewOptimisticRun) {
+      noteLocalRunId?.(evt.runId);
+      state.pendingOptimisticUserMessage = false;
+    }
     if (!state.activeChatRunId && !isLocalBtwRunId?.(evt.runId)) {
       state.activeChatRunId = evt.runId;
       if (state.pendingOptimisticUserMessage) {
@@ -556,7 +569,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         state.pendingOptimisticUserMessage = false;
       }
     }
-    if (state.pendingChatRunId === evt.runId) {
+    if (isPendingChatRun) {
       state.pendingChatRunId = null;
     }
     if (evt.state === "delta") {
@@ -720,9 +733,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         state.activeChatRunId = evt.runId;
         state.pendingChatRunId = null;
         if (state.pendingOptimisticUserMessage) {
-          if (localMode) {
-            noteLocalRunId?.(evt.runId);
-          }
+          noteLocalRunId?.(evt.runId);
           state.pendingOptimisticUserMessage = false;
         }
       }

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -76,6 +76,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   const sessionRuns = new Map<string, number>();
   const finalizedRuns = new Map<string, number>();
   const finalizedRunsWithDisplay = new Map<string, number>();
+  const completedRuns = new Map<string, number>();
   const postFinalizingRuns = new Map<string, number>();
   let streamAssembler = new TuiStreamAssembler();
   let lastSessionKey = state.currentSessionKey;
@@ -202,6 +203,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     finalizedRuns.clear();
     finalizedRunsWithDisplay.clear();
+    completedRuns.clear();
     sessionRuns.clear();
     postFinalizingRuns.clear();
     streamAssembler = new TuiStreamAssembler();
@@ -270,6 +272,7 @@ export function createEventHandlers(context: EventHandlerContext) {
 
   const noteFinalizedRun = (runId: string, opts?: { displayedFinal?: boolean }) => {
     finalizedRuns.set(runId, Date.now());
+    completedRuns.set(runId, Date.now());
     if (opts?.displayedFinal === true) {
       finalizedRunsWithDisplay.set(runId, Date.now());
     }
@@ -277,6 +280,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     streamAssembler.drop(runId);
     pruneRunMap(finalizedRuns);
     pruneRunMap(finalizedRunsWithDisplay);
+    pruneRunMap(completedRuns);
   };
 
   const notePostFinalizingRun = (runId: string) => {
@@ -351,6 +355,8 @@ export function createEventHandlers(context: EventHandlerContext) {
     wasActiveRun: boolean;
     status: "aborted" | "error";
   }) => {
+    completedRuns.set(params.runId, Date.now());
+    pruneRunMap(completedRuns);
     streamAssembler.drop(params.runId);
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
@@ -834,12 +840,22 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearPendingTerminalLifecycleErrors();
   };
 
+  const consumeCompletedRunForPendingSend = (runId: string) => {
+    if (!completedRuns.has(runId)) {
+      return false;
+    }
+    completedRuns.delete(runId);
+    return true;
+  };
+
   return {
     handleChatEvent,
     handleAgentEvent,
     handleBtwEvent,
     pauseStreamingWatchdog,
     reconnectStreamingWatchdog,
+    consumeCompletedRunForPendingSend,
+    flushPendingHistoryRefreshIfIdle,
     dispose,
   };
 }

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -440,6 +440,38 @@ describe("tui session actions", () => {
     expect(state.activeChatRunId).toBeNull();
   });
 
+  it("clears optimistic pending state when switching sessions", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 0,
+      defaults: {},
+      sessions: [],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-b",
+      messages: [],
+    });
+    const state = createBaseState({
+      activeChatRunId: null,
+      pendingChatRunId: null,
+      pendingOptimisticUserMessage: true,
+    });
+
+    const { setSession } = createTestSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as TuiBackend,
+      state,
+    });
+
+    await setSession("agent:main:other");
+
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(state.pendingChatRunId).toBeNull();
+  });
+
   it("aborts the in-flight runId when only pendingChatRunId is set", async () => {
     const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
     const addSystem = vi.fn();

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -389,6 +389,7 @@ export function createSessionActions(context: SessionActionContext) {
     state.currentSessionKey = nextKey;
     state.activeChatRunId = null;
     state.pendingChatRunId = null;
+    state.pendingOptimisticUserMessage = false;
     setActivityStatus("idle");
     state.currentSessionId = null;
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1225,6 +1225,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     handleBtwEvent,
     pauseStreamingWatchdog,
     reconnectStreamingWatchdog,
+    consumeCompletedRunForPendingSend,
+    flushPendingHistoryRefreshIfIdle,
   } = createEventHandlers({
     chatLog,
     btw,
@@ -1314,6 +1316,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       noteLocalBtwRunId,
       forgetLocalRunId,
       forgetLocalBtwRunId,
+      consumeCompletedRunForPendingSend,
+      flushPendingHistoryRefreshIfIdle,
       runAuthFlow,
       requestExit,
     });


### PR DESCRIPTION
## Summary

- Keep locally submitted TUI chat runs bound to their generated `runId` while gateway/session state catches up.
- Prevent current-turn chat finals from being classified as external history updates.
- Let pending lifecycle and early chat final events claim the optimistic user message for the current turn.
- Add regression coverage for session-key catch-up, pending lifecycle binding, and early final events.

## User-visible bug

The original bug was a one-turn-lagging TUI render, not a simple first-turn-only disappearance.

Observed sequence before the fix:

1. Turn 1: the user submits prompt 1.
2. The TUI shows prompt 1, but assistant response 1 does not render in the current turn.
3. Turn 2: after the user submits prompt 2, the TUI shows prompt 1, assistant response 1, and prompt 2.
4. Assistant response 2 then does not render in the current turn.

So the newest assistant response was missing until a later turn or history refresh made the previous response visible.

During debugging, some intermediate patches exposed a narrower "first turn only" symptom. That was not the root user-facing bug; it was an artifact of isolating the same local-run/session-sync race.

## Prior attempt

An earlier PR, [#85948](https://github.com/openclaw/openclaw/pull/85948), was closed because it targeted a misidentified cause. That PR treated the symptom as a stale history-refresh/final-response issue. The later diagnostic logs showed the actual problem was that the TUI lost pending/local run state while the session key caught up, causing current-turn finals to be treated as non-local history updates.

## Root cause

Diagnostic logging showed that the TUI could lose the local association for an in-flight run while the session key caught up:

1. `sendChat()` created an optimistic user message for a TUI-generated `runId`.
2. Before the relevant chat event was bound to that optimistic message, `syncSessionKey()` cleared pending/local run state.
3. The chat final for the local turn was then classified as non-local.
4. Because it looked external, the TUI used `loadHistory()` instead of updating the current optimistic turn.

That made the current assistant response disappear from the live turn and only show up later when history was refreshed.

## Fix

This patch keeps the local-run binding tied to the in-flight send lifecycle:

- `sendChat()` records the generated `runId` as local immediately after adding the optimistic user message.
- `syncSessionKey()` no longer clears run/session tracking while an active or pending chat run exists.
- Pending lifecycle and chat final events can claim the optimistic run even when registration arrives before the normal active-run path.
- Failed sends still forget the generated local `runId`.

## Real behavior proof

- Behavior or issue addressed: The TUI rendered assistant responses one turn late for locally submitted chat runs. Before the fix, prompt 1 was visible while assistant response 1 was missing; after prompt 2, assistant response 1 appeared but assistant response 2 was then missing.
- Real environment tested: A real OpenClaw TUI bundle from 2026-05-22 was used for the after-fix verification, with only this final patch applied and diagnostic logging removed.
- Exact steps or command run after this patch: Submitted consecutive prompts in the TUI using a deliberately simple prompt setup where the agent was instructed to repeat the user's message. Matching user/assistant text in the recording is expected and is part of the repro setup.
- Evidence after fix: [After fix: current-turn render verified on a clean bundle](https://raw.githubusercontent.com/nao860226-rgb/openclaw/2e5aeadf918f7c50a8939b42be5dc2d5bef2d4fb/evidence/pr-87959/current-turn-render-after-fix.mov)
- Observed result after fix: Each submitted prompt and its assistant response remained visible in the current turn; the latest assistant response no longer lagged until the next prompt or history refresh.
- What was not tested: Broader live Gateway/PTY matrix coverage beyond this focused TUI repro was not run.

Reporter-provided before/after recordings are available here:

- [Before fix: one-turn-lag repro](https://raw.githubusercontent.com/nao860226-rgb/openclaw/2e5aeadf918f7c50a8939b42be5dc2d5bef2d4fb/evidence/pr-87959/one-turn-lag-before-fix.mov)
- [After fix: current-turn render verified on a clean bundle](https://raw.githubusercontent.com/nao860226-rgb/openclaw/2e5aeadf918f7c50a8939b42be5dc2d5bef2d4fb/evidence/pr-87959/current-turn-render-after-fix.mov)

## Tests

- `pnpm vitest run src/tui/tui-event-handlers.test.ts src/tui/tui-command-handlers.test.ts --config test/vitest/vitest.tui.config.ts`: 97 passed
- `git diff --check`

