### PR TITLE
fix: recognize bundle-mcp as known synthetic plugin in tool policy allowlist

### DIFF
--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -190,8 +190,9 @@ export function analyzeAllowlistByToolType(
       hasOnlyPluginEntries = false;
       continue;
     }
+    const KNOWN_SYNTHETIC_PLUGIN_IDS = new Set(["bundle-mcp"]);
     const isPluginEntry =
-      entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
+      entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry) || KNOWN_SYNTHETIC_PLUGIN_IDS.has(entry);
     const expanded = expandToolGroups([entry]);
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
     if (!isPluginEntry) {


### PR DESCRIPTION
## Problem

`openclaw doctor` reports `bundle-mcp` as an "unknown allowlist entry" when it is included in `tools.allow`:

```
[tools] agents.main.tools.allow allowlist contains unknown entries (bundle-mcp).
These entries won't match any tool unless the plugin is enabled.
```

This happens because `analyzeAllowlistByToolType()` only considers entries valid if they match a registered plugin ID or a core tool name. `bundle-mcp` is a synthetic plugin ID used for MCP bundled tools — it is only registered at runtime when MCP servers connect, so it is never visible during doctor's offline tool discovery pass.

## Fix

Add a `KNOWN_SYNTHETIC_PLUGIN_IDS` set (containing `"bundle-mcp"`) to the `isPluginEntry` check in `analyzeAllowlistByToolType()`, so that known synthetic plugin IDs are recognized as valid plugin entries regardless of MCP runtime state.

## Testing

- `openclaw doctor` no longer reports `bundle-mcp` as unknown
- MCP tools continue to function correctly at runtime (the allowlist expansion via `bundle-mcp` still works)
- No behavior change for other tool policy logic