### PR TITLE
fix(webchat): suppress stale active session row racing a completed turn (#87875)

### DIFF
--- a/ui/src/ui/chat/run-lifecycle.test.ts
+++ b/ui/src/ui/chat/run-lifecycle.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { isSessionRunActive } from "../session-run-state.ts";
+import type { SessionsListResult } from "../types.ts";
+import {
+  reconcileChatRunFromCurrentSessionRow,
+  reconcileChatRunLifecycle,
+  STALE_ACTIVE_ROW_RECONCILE_WINDOW_MS,
+} from "./run-lifecycle.ts";
+
+type ReconcileHost = Parameters<typeof reconcileChatRunFromCurrentSessionRow>[0];
+type TestRow = { key: string; hasActiveRun?: boolean; status?: string; startedAt?: number };
+
+function makeSessionsResult(rows: TestRow[]): SessionsListResult {
+  return { sessions: rows } as unknown as SessionsListResult;
+}
+
+function makeHost(over: Partial<ReconcileHost> = {}): ReconcileHost {
+  return {
+    sessionKey: "s1",
+    chatRunId: null,
+    chatStream: null,
+    sessionsResult: makeSessionsResult([{ key: "s1", hasActiveRun: true, status: "running" }]),
+    requestUpdate: () => {},
+    ...over,
+  };
+}
+
+function rowActive(host: ReconcileHost): boolean {
+  const row = host.sessionsResult?.sessions.find((r) => r.key === host.sessionKey);
+  return Boolean(row && isSessionRunActive(row));
+}
+
+describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875)", () => {
+  it("suppresses a stale active row after a recent local completion", () => {
+    const host = makeHost({
+      lastLocalTerminalReconcile: {
+        sessionKey: "s1",
+        runId: "r1",
+        phase: "done",
+        sessionStatus: "done",
+        occurredAt: Date.now(),
+      },
+    });
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(true);
+    expect(rowActive(host)).toBe(false);
+    expect(host.lastLocalTerminalReconcile?.runId).toBe("r1");
+  });
+
+  it("does NOT clear a genuinely recovered active run with no recent local completion", () => {
+    const host = makeHost({ lastLocalTerminalReconcile: null });
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
+    expect(rowActive(host)).toBe(true);
+  });
+
+  it("ignores and clears a local terminal reconcile older than the window", () => {
+    const host = makeHost({
+      lastLocalTerminalReconcile: {
+        sessionKey: "s1",
+        runId: "r1",
+        phase: "done",
+        sessionStatus: "done",
+        occurredAt: Date.now() - STALE_ACTIVE_ROW_RECONCILE_WINDOW_MS - 1_000,
+      },
+    });
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
+    expect(rowActive(host)).toBe(true);
+    expect(host.lastLocalTerminalReconcile).toBeNull();
+  });
+
+  it("does not suppress when the recent completion was for a different session", () => {
+    const host = makeHost({
+      sessionKey: "s2",
+      sessionsResult: makeSessionsResult([{ key: "s2", hasActiveRun: true, status: "running" }]),
+      lastLocalTerminalReconcile: {
+        sessionKey: "s1",
+        runId: "r1",
+        phase: "done",
+        sessionStatus: "done",
+        occurredAt: Date.now(),
+      },
+    });
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
+    expect(rowActive(host)).toBe(true);
+  });
+
+  it("clears the flag once the server poll reports a non-active row", () => {
+    const host = makeHost({
+      sessionsResult: makeSessionsResult([{ key: "s1", hasActiveRun: false, status: "done" }]),
+      lastLocalTerminalReconcile: {
+        sessionKey: "s1",
+        runId: "r1",
+        phase: "done",
+        sessionStatus: "done",
+        occurredAt: Date.now(),
+      },
+    });
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
+    expect(host.lastLocalTerminalReconcile).toBeNull();
+  });
+
+  it("does not arm stale-row suppression from generic lifecycle cleanup", () => {
+    const host = makeHost({
+      chatRunId: "orphaned-run",
+      chatStream: "stale stream",
+    });
+    reconcileChatRunLifecycle(host, {
+      outcome: "interrupted",
+      sessionStatus: "killed",
+      runId: "orphaned-run",
+      sessionKey: "s1",
+      clearLocalRun: true,
+      clearChatStream: true,
+      publishRunStatus: false,
+    });
+    expect(host.lastLocalTerminalReconcile ?? null).toBeNull();
+    host.sessionsResult = makeSessionsResult([
+      { key: "s1", hasActiveRun: true, status: "running" },
+    ]);
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
+    expect(rowActive(host)).toBe(true);
+  });
+
+  it("does not suppress a newer active row after a follow-up run starts", () => {
+    const terminalAt = Date.now();
+    const host = makeHost({
+      sessionsResult: makeSessionsResult([
+        {
+          key: "s1",
+          hasActiveRun: true,
+          status: "running",
+          startedAt: terminalAt + 1,
+        },
+      ]),
+      lastLocalTerminalReconcile: {
+        sessionKey: "s1",
+        runId: "r1",
+        phase: "done",
+        sessionStatus: "done",
+        occurredAt: terminalAt,
+      },
+    });
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
+    expect(rowActive(host)).toBe(true);
+    expect(host.lastLocalTerminalReconcile).toBeNull();
+  });
+
+  it("arms suppression on a completed turn, then suppresses the racing refresh", () => {
+    const host = makeHost({
+      chatRunId: "r1",
+      chatStream: "partial...",
+      sessionsResult: makeSessionsResult([{ key: "s1", hasActiveRun: true, status: "running" }]),
+    });
+    reconcileChatRunLifecycle(host, {
+      outcome: "done",
+      sessionStatus: "done",
+      runId: "r1",
+      sessionKey: "s1",
+      clearLocalRun: true,
+      clearChatStream: true,
+      publishRunStatus: false,
+      armLocalTerminalReconcile: true,
+    });
+    expect(host.lastLocalTerminalReconcile?.sessionKey).toBe("s1");
+    expect(host.chatRunId ?? null).toBeNull();
+    // A racing sessions.list refresh re-introduces a stale active row.
+    host.sessionsResult = makeSessionsResult([
+      { key: "s1", hasActiveRun: true, status: "running" },
+    ]);
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(true);
+    expect(rowActive(host)).toBe(false);
+    expect(host.lastLocalTerminalReconcile?.runId).toBe("r1");
+  });
+
+  it("keeps suppressing multiple stale active refreshes within the window", () => {
+    const terminalAt = Date.now();
+    const host = makeHost({
+      lastLocalTerminalReconcile: {
+        sessionKey: "s1",
+        runId: "r1",
+        phase: "done",
+        sessionStatus: "done",
+        occurredAt: terminalAt,
+      },
+    });
+
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(true);
+    host.sessionsResult = makeSessionsResult([
+      { key: "s1", hasActiveRun: true, status: "running", startedAt: terminalAt - 1 },
+    ]);
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(true);
+    expect(rowActive(host)).toBe(false);
+  });
+});

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -11,6 +11,20 @@ export type ChatRunUiStatus = {
   occurredAt: number;
 };
 
+export type LocalTerminalReconcile = {
+  sessionKey: string;
+  runId: string | null;
+  phase: ChatRunUiStatus["phase"];
+  sessionStatus: SessionRunStatus;
+  occurredAt: number;
+};
+
+// A terminal chat event clears local run state before the periodic
+// sessions.list poll catches up. Within this window a stale "active" row for
+// the just-completed selected session is treated as poll lag and reconciled
+// back to terminal, so the composer does not snap back to in-progress. (#87875)
+export const STALE_ACTIVE_ROW_RECONCILE_WINDOW_MS = 10_000;
+
 type TimerHandle = ReturnType<typeof globalThis.setTimeout>;
 
 type RunLifecycleHost = Omit<Partial<Parameters<typeof resetToolStream>[0]>, "hello"> & {
@@ -26,6 +40,7 @@ type RunLifecycleHost = Omit<Partial<Parameters<typeof resetToolStream>[0]>, "he
   chatRunStatus?: ChatRunUiStatus | null;
   chatRunStatusClearTimer?: TimerHandle | number | null;
   sessionsResult?: SessionsListResult | null;
+  lastLocalTerminalReconcile?: LocalTerminalReconcile | null;
   requestUpdate?: () => void;
 };
 
@@ -42,6 +57,7 @@ type ReconcileOptions = {
   clearSideResultTerminalRuns?: boolean;
   clearRunStatus?: boolean;
   publishRunStatus?: boolean;
+  armLocalTerminalReconcile?: boolean;
 };
 
 function toSessionKey(value: string | null | undefined): string | null {
@@ -184,6 +200,15 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
       occurredAt,
     };
     reconcileSessionRows(host, options, occurredAt);
+    if (options.armLocalTerminalReconcile) {
+      host.lastLocalTerminalReconcile = {
+        sessionKey,
+        runId,
+        phase: options.outcome,
+        sessionStatus: options.sessionStatus ?? (options.outcome === "done" ? "done" : "killed"),
+        occurredAt,
+      };
+    }
     if (options.publishRunStatus !== false) {
       host.chatRunStatus = status;
       scheduleRunStatusClear(host, status);
@@ -198,12 +223,48 @@ function currentSessionRow(host: RunLifecycleHost) {
   return host.sessionsResult?.sessions.find((row) => row.key === host.sessionKey);
 }
 
+// After a terminal chat event clears local run state, a racing sessions.list
+// refresh can still carry a stale "active" row for the session we just
+// finished, which would drive the composer back to in-progress. Re-apply
+// terminal to that row — but only while we hold a recent LOCAL terminal
+// reconcile for the currently selected session, so a genuinely recovered
+// active run (e.g. opening WebChat to a session already running elsewhere) is
+// never cleared. (#87875)
+function reconcileStaleSelectedSessionRunAfterLocalCompletion(host: RunLifecycleHost): boolean {
+  const recent = host.lastLocalTerminalReconcile;
+  if (!recent || recent.sessionKey !== host.sessionKey) {
+    return false;
+  }
+  if (Date.now() - recent.occurredAt > STALE_ACTIVE_ROW_RECONCILE_WINDOW_MS) {
+    host.lastLocalTerminalReconcile = null;
+    return false;
+  }
+  const row = currentSessionRow(host);
+  if (!row || !isSessionRunActive(row)) {
+    // No row, or the server already reflects a non-active state — the poll has
+    // caught up, so stop suppressing.
+    host.lastLocalTerminalReconcile = null;
+    return false;
+  }
+  if (typeof row.startedAt === "number" && row.startedAt > recent.occurredAt) {
+    host.lastLocalTerminalReconcile = null;
+    return false;
+  }
+  reconcileSessionRows(
+    host,
+    { outcome: recent.phase, sessionStatus: recent.sessionStatus, sessionKey: recent.sessionKey },
+    Date.now(),
+  );
+  host.requestUpdate?.();
+  return true;
+}
+
 export function reconcileChatRunFromCurrentSessionRow(
   host: RunLifecycleHost,
   options: { publishRunStatus?: boolean } = {},
 ): boolean {
   if (!host.chatRunId && host.chatStream == null) {
-    return false;
+    return reconcileStaleSelectedSessionRunAfterLocalCompletion(host);
   }
   const row = currentSessionRow(host);
   if (!row) {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -114,6 +114,24 @@ describe("handleChatEvent", () => {
     expect(handleChatEvent(state, payload)).toBe(null);
   });
 
+  it("does not arm stale active-row suppression for an unowned selected-session final", () => {
+    const state = createState({ sessionKey: "main" }) as ChatState & {
+      lastLocalTerminalReconcile?: unknown;
+    };
+    const payload: ChatEventPayload = {
+      runId: "observed-run",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Observed reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.lastLocalTerminalReconcile).toBeUndefined();
+  });
+
   it("ignores selected-agent global events for another agent", () => {
     const state = createState({
       sessionKey: "global",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -881,6 +881,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       sessionKeys: sessionMatches ? [state.sessionKey, payload.sessionKey] : [],
       clearLocalRun: true,
       clearChatStream: true,
+      armLocalTerminalReconcile: hadActiveRunBeforeEvent && activeRunMatches,
     });
 
   if (payload.state === "delta") {


### PR DESCRIPTION
## Summary

- **Problem:** In WebChat, after a model reply completes, the composer can stay stuck showing "in progress" (with an Abort button) even though the turn is done.
- **Root cause:** A terminal chat event clears local run state (`chatRunId`/`chatStream`) and marks the selected session row terminal. The periodic `sessions.list` poll then overwrites `sessionsResult` with a row the server still reports as active (persistence lag), and `reconcileChatRunFromCurrentSessionRow` bails because local run state is already gone — so the stale active row drives `hasAbortableSessionRun` back to in-progress.
- **Fix:** Track the most recent **local** terminal reconcile for the selected session (bounded 10s window, cleared once the poll catches up). When local run state is already cleared and a racing `sessions.list` refresh carries a stale active row for that just-completed session, re-apply terminal to the row. Gating on a recent *local* reconcile is what distinguishes poll lag from a genuinely recovered active run (e.g. opening WebChat to a session already running elsewhere) — the latter is never cleared.
- **Reviewer focus:** the gate in `reconcileStaleSelectedSessionRunAfterLocalCompletion` (recent + same selected session + still-active row) and the window / clear lifecycle.

The session row carries no run id, so the gate keys on a recent local terminal reconcile rather than run identity — matching the ClawSweeper review's guidance ("gated on a recent local terminal reconcile") and explicitly avoiding the naive "clear any active row with no local run" patch it flagged as breaking recovered runs.

## Linked context

Closes #87875

(The same root cause likely underlies the related reports #87649 and #87699.)

## Real behavior proof

- **Behavior addressed:** WebChat composer stuck on "in progress" after a completed reply.
- **Environment tested:** isolated clone of `openclaw/main`, `pnpm test` (UI vitest project).
- **Commands run after this patch:**
  - `pnpm test ui/src/ui/chat/run-lifecycle.test.ts` → **6 passed** — new direct unit tests covering: stale-active suppression after completion; **a genuinely recovered active run is NOT cleared**; window expiry; different-session non-match; flag clears once the server poll reports non-active; and the full arm-then-suppress flow via `reconcileChatRunLifecycle`.
  - `pnpm test ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/session-run-state.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/app-gateway.sessions.node.test.ts` → **184 passed** (ClawSweeper's acceptance set).
  - `pnpm tsgo` → **0 errors**; `oxlint` / `oxfmt --check` → clean.
- **Observed result after fix:** a stale active row racing a completed turn is reconciled back to terminal, so the composer leaves in-progress; a genuinely active session (no recent local completion) still shows abort.
- **What was not tested / limitations:** a live browser WebChat session. Verified at the controller-logic level via the existing UI vitest harness, not an end-to-end browser run.


## Maintainer Real Behavior Proof Update

Behavior addressed: stale selected-session active rows in WebChat are locally suppressed after the terminal-owned run completes, so a late session-list refresh cannot bring back a finished turn as "in progress".

Real environment tested: local WebChat browser validation from a local OpenClaw source build, plus Linux Blacksmith Testbox through Crabbox for the rebased PR head.

Exact steps or command run after this patch:

```text
1. Open WebChat against a local OpenClaw source build containing the selected-session active-row suppression fix.
2. Send a text-only turn: HEALTH_OK.
3. Wait after completion and verify the live toolbar/composer remains idle.
4. Send a tool-backed turn: Run pwd only and report PASS/FAIL.
5. Wait after the PASS response and verify the live toolbar/composer remains idle with no delayed Stop / In progress relapse.
6. On the rebased PR head, run Linux Testbox focused regression proof:
   node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json --shell -- "node scripts/run-vitest.mjs ui/src/ui/chat/run-lifecycle.test.ts ui/src/ui/controllers/chat.test.ts"
```

Evidence after fix: live WebChat validation observed `HEALTH_OK` complete and stay idle; `Run pwd only and report PASS/FAIL` returned `PASS` and stayed idle after waiting; the live toolbar/composer did not relapse into `Stop` / `In progress`. Testbox proof also passed on the rebased head with provider `blacksmith-testbox`, lease `tbx_01ksx32c0bkvq0xq9ymgz01mtt`, exit code 0, and 85 focused tests passed.

Observed result after fix: stale active rows are suppressed only for the locally completed selected session; newer active rows, different sessions, server non-active rows, and unowned finals are preserved. The live browser path stayed idle after both text-only and tool-backed completed turns.

What was not tested: no full broad CI sweep was run for this PR; the proof is live local WebChat browser validation plus focused Linux Testbox regression coverage.

## Real behavior proof

Behavior addressed: stale selected-session active rows in WebChat are locally suppressed after the terminal-owned run completes, so a late session-list refresh cannot bring back a finished turn as "in progress".

Real environment tested: local WebChat browser validation from a local OpenClaw source build, plus Linux Blacksmith Testbox through Crabbox for the rebased PR head.

Exact steps or command run after this patch:

```text
1. Open WebChat against a local OpenClaw source build containing the selected-session active-row suppression fix.
2. Send a text-only turn: HEALTH_OK.
3. Wait after completion and verify the live toolbar/composer remains idle.
4. Send a tool-backed turn: Run pwd only and report PASS/FAIL.
5. Wait after the PASS response and verify the live toolbar/composer remains idle with no delayed Stop / In progress relapse.
6. On the rebased PR head, run Linux Testbox focused regression proof:
   node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json --shell -- "node scripts/run-vitest.mjs ui/src/ui/chat/run-lifecycle.test.ts ui/src/ui/controllers/chat.test.ts"
```

Evidence after fix: live WebChat validation observed actual browser output where `HEALTH_OK` completed and stayed idle; `Run pwd only and report PASS/FAIL` returned `PASS` and stayed idle after waiting; the live toolbar/composer did not relapse into `Stop` / `In progress`. Testbox proof also passed on the rebased head with provider `blacksmith-testbox`, lease `tbx_01ksx32c0bkvq0xq9ymgz01mtt`, exit code 0, and 85 focused tests passed.

Observed result after fix: stale active rows are suppressed only for the locally completed selected session; newer active rows, different sessions, server non-active rows, and unowned finals are preserved. The live browser path stayed idle after both text-only and tool-backed completed turns.

What was not tested: no full broad CI sweep was run for this PR; the proof is live local WebChat browser validation plus focused Linux Testbox regression coverage.

## Real behavior proof

Behavior addressed: stale selected-session active rows in WebChat are locally suppressed after the terminal-owned run completes, so a late session-list refresh cannot bring back a finished turn as "in progress".

Real environment tested: local WebChat browser session against a local OpenClaw source build containing the selected-session active-row suppression fix.

Exact steps or command run after this patch:

```text
1. Open WebChat against the local OpenClaw source build.
2. Send this text-only prompt: HEALTH_OK.
3. After the reply completes, wait and watch the live toolbar/composer state.
4. Send this tool-backed prompt: Run pwd only and report PASS/FAIL.
5. After the PASS reply appears, wait and watch the live toolbar/composer state again.
```

Evidence after fix: browser live output transcript:

```text
Prompt: HEALTH_OK
Observed browser state after completion: composer idle, toolbar idle, no delayed Stop control.
Prompt: Run pwd only and report PASS/FAIL
Assistant output: PASS
Observed browser state after waiting: composer idle, toolbar idle, no delayed Stop or In progress relapse.
```

Observed result after fix: the live browser path stayed idle after both the text-only turn and the tool-backed turn. Stale active rows are suppressed only for the locally completed selected session; newer active rows, different sessions, server non-active rows, and unowned finals are preserved.

What was not tested: no additional live browser permutations beyond the text-only and tool-backed WebChat completion paths above.
