### PR TITLE
fix(agents): downgrade thinking blocks with empty signatures to text before anthropic-messages replay

### DIFF
--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -294,3 +294,151 @@ describe("transformTransportMessages synthetic tool-result policy", () => {
     expect(bedrockCanonical.map((msg) => msg.role)).toEqual(["assistant", "toolResult", "user"]);
   });
 });
+
+describe("transformTransportMessages thinking block replay", () => {
+  function assistantWithThinking(
+    thinkingBlocks: Array<{
+      thinking: string;
+      thinkingSignature?: string;
+      redacted?: boolean;
+    }>,
+    provider = "anthropic",
+    api: Api = "anthropic-messages",
+    model = "claude-opus-4-6",
+  ): Extract<Context["messages"][number], { role: "assistant" }> {
+    return {
+      role: "assistant",
+      provider,
+      api,
+      model,
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: thinkingBlocks.map((b) =>
+        b.redacted
+          ? {
+              type: "thinking",
+              thinking: b.thinking,
+              redacted: true,
+              thinkingSignature: b.thinkingSignature,
+            }
+          : { type: "thinking", thinking: b.thinking, thinkingSignature: b.thinkingSignature },
+      ),
+    } as Extract<Context["messages"][number], { role: "assistant" }>;
+  }
+
+  it("preserves signed thinking blocks on same-model replay", () => {
+    const messages: Context["messages"] = [
+      assistantWithThinking([{ thinking: "analysis", thinkingSignature: "sig_abc" }]),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+    const result = transformTransportMessages(
+      messages,
+      makeModel("anthropic-messages", "anthropic", "claude-opus-4-6"),
+    );
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "analysis", thinkingSignature: "sig_abc" }],
+    });
+  });
+
+  it("downgrades thinking blocks with empty signatures to text on same-model replay", () => {
+    const messages: Context["messages"] = [
+      assistantWithThinking([{ thinking: "analysis", thinkingSignature: "" }]),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+    const result = transformTransportMessages(
+      messages,
+      makeModel("anthropic-messages", "anthropic", "claude-opus-4-6"),
+    );
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "analysis" }],
+    });
+  });
+
+  it("downgrades thinking blocks with missing signatures to text on same-model replay", () => {
+    const messages: Context["messages"] = [
+      assistantWithThinking([{ thinking: "analysis" }]),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+    const result = transformTransportMessages(
+      messages,
+      makeModel("anthropic-messages", "anthropic", "claude-opus-4-6"),
+    );
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "analysis" }],
+    });
+  });
+
+  it("downgrades thinking blocks to text on cross-model replay", () => {
+    const messages: Context["messages"] = [
+      assistantWithThinking(
+        [{ thinking: "analysis", thinkingSignature: "sig_abc" }],
+        "anthropic",
+        "anthropic-messages",
+        "claude-opus-4-6",
+      ),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+    const result = transformTransportMessages(
+      messages,
+      makeModel("anthropic-messages", "anthropic", "claude-sonnet-4-6"),
+    );
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "analysis" }],
+    });
+  });
+
+  it("preserves redacted thinking blocks on same-model replay", () => {
+    const messages: Context["messages"] = [
+      assistantWithThinking([
+        { thinking: "redacted", redacted: true, thinkingSignature: "enc_xyz" },
+      ]),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+    const result = transformTransportMessages(
+      messages,
+      makeModel("anthropic-messages", "anthropic", "claude-opus-4-6"),
+    );
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "redacted", redacted: true, thinkingSignature: "enc_xyz" },
+      ],
+    });
+  });
+
+  it("drops redacted thinking blocks on cross-model replay", () => {
+    const messages: Context["messages"] = [
+      assistantWithThinking([
+        { thinking: "redacted", redacted: true, thinkingSignature: "enc_xyz" },
+      ]),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+    const result = transformTransportMessages(
+      messages,
+      makeModel("anthropic-messages", "anthropic", "claude-sonnet-4-6"),
+    );
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [],
+    });
+  });
+
+  it("skips thinking blocks with only whitespace content", () => {
+    const messages: Context["messages"] = [
+      assistantWithThinking([{ thinking: "   " }]),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+    const result = transformTransportMessages(
+      messages,
+      makeModel("anthropic-messages", "anthropic", "claude-opus-4-6"),
+    );
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [],
+    });
+  });
+});

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -91,7 +91,7 @@ export function transformTransportMessages(
         if (!block.thinking.trim()) {
           continue;
         }
-        content.push(isSameModel ? block : { type: "text", text: block.thinking });
+        content.push({ type: "text", text: block.thinking });
         continue;
       }
       if (block.type === "text") {


### PR DESCRIPTION
## Summary

Fixes #86886.

#70054 added a guard to strip thinking blocks with invalid (missing/empty/blank) signatures for the Bedrock Anthropic path, but the standard `anthropic-messages` transport (direct Anthropic API) was not covered. When a session contains thinking blocks with empty `thinkingSignature: ""`, replaying them to the Anthropic API on follow-up turns causes a permanent `Invalid signature in thinking block` error, bricking the session.

## Change

In `transformTransportMessages`, when a `thinking` block has no valid `thinkingSignature`, downgrade it to a `text` block instead of preserving the empty-signature `thinking` block on same-model replay. This aligns the direct Anthropic transport behavior with the existing Bedrock guard.

**Before:**
- Same model + empty `thinkingSignature` -> preserved as `thinking` block with `"signature": ""` -> Anthropic API rejects on replay

**After:**
- Same model + empty `thinkingSignature` -> downgraded to `text` block -> safe replay

## Files changed

- `src/agents/transport-message-transform.ts` -- 1 line: always downgrade unsigned thinking to `text`
- `src/agents/transport-message-transform.test.ts` -- 7 new regression tests covering signed, empty, missing, cross-model, redacted, and whitespace-only thinking blocks

## Verification

```
node scripts/run-vitest.mjs src/agents/transport-message-transform.test.ts

Test Files  1 passed (1)
Tests       16 passed (16)
Duration    355ms
```

## Real behavior proof

- Behavior addressed: Empty thinking-block signatures poison Anthropic Messages sessions on replay (#86886)
- Real environment tested: Local repo checkout, Linux Node 22
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/transport-message-transform.test.ts`
- Evidence after fix: 16 tests pass, including new regression tests for empty/missing signature downgrade paths
- Observed result after fix: Thinking blocks with `thinkingSignature: ""` are converted to `text` blocks on same-model replay; valid signatures are preserved; redacted blocks remain intact
- What was not tested: Live Anthropic API replay (unit tests only)

Refs: #86886, #70054
