### PR TITLE
fix(whatsapp): restart channel when a per-account config field changes so disabled accounts are torn down

### DIFF
--- a/extensions/whatsapp/index.test.ts
+++ b/extensions/whatsapp/index.test.ts
@@ -1,5 +1,6 @@
 import { assertBundledChannelEntries } from "openclaw/plugin-sdk/channel-test-helpers";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
+import { whatsappPlugin } from "./channel-plugin-api.js";
 import entry from "./index.js";
 import setupEntry from "./setup-entry.js";
 
@@ -9,5 +10,12 @@ describe("whatsapp bundled entries", () => {
     expectedId: "whatsapp",
     expectedName: "WhatsApp",
     setupEntry,
+  });
+
+  it("declares account config as channel-restart reload metadata", () => {
+    expect(whatsappPlugin.reload).toEqual({
+      configPrefixes: ["web", "channels.whatsapp.accounts"],
+      noopPrefixes: ["channels.whatsapp"],
+    });
   });
 });

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -178,7 +178,7 @@ export function createWhatsAppPluginBase(params: {
     // `channels.whatsapp.accounts.*` (account add/remove, and `enabled` flips)
     // must restart the channel so a disabled account's provider is torn down;
     // the broad `channels.whatsapp` noop prefix below otherwise swallows it as a
-    // hot no-op and leaves the account connected until a full restart. (#87951)
+    // hot no-op and leaves the account connected until a full restart.
     reload: {
       configPrefixes: ["web", "channels.whatsapp.accounts"],
       noopPrefixes: ["channels.whatsapp"],

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -175,7 +175,14 @@ export function createWhatsAppPluginBase(params: {
         },
       },
     },
-    reload: { configPrefixes: ["web"], noopPrefixes: ["channels.whatsapp"] },
+    // `channels.whatsapp.accounts.*` (account add/remove, and `enabled` flips)
+    // must restart the channel so a disabled account's provider is torn down;
+    // the broad `channels.whatsapp` noop prefix below otherwise swallows it as a
+    // hot no-op and leaves the account connected until a full restart. (#87951)
+    reload: {
+      configPrefixes: ["web", "channels.whatsapp.accounts"],
+      noopPrefixes: ["channels.whatsapp"],
+    },
     gatewayMethodDescriptors: [{ name: "web.login.start" }, { name: "web.login.wait" }],
     configSchema: WhatsAppChannelConfigSchema,
     config: {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -223,10 +223,15 @@ describe("buildGatewayReloadPlan", () => {
   });
 
   it("restarts the channel when a per-account config field changes (more specific configPrefix wins over the broad noop prefix)", () => {
-    const plan = buildGatewayReloadPlan(["channels.whatsapp.accounts.default.enabled"]);
+    const changedPaths = [
+      "channels.whatsapp.accounts.default.enabled",
+      "channels.whatsapp.accounts.default.authDir",
+    ];
+    const plan = buildGatewayReloadPlan(changedPaths);
     expect(plan.restartGateway).toBe(false);
     expect(plan.restartChannels).toEqual(new Set(["whatsapp"]));
-    expect(plan.noopPaths).not.toContain("channels.whatsapp.accounts.default.enabled");
+    expect(plan.hotReasons).toEqual(changedPaths);
+    expect(plan.noopPaths).toStrictEqual([]);
   });
 
   it("keeps other channels.whatsapp.* changes as hot no-ops", () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -158,7 +158,10 @@ describe("buildGatewayReloadPlan", () => {
       listAccountIds: () => [],
       resolveAccount: () => ({}),
     },
-    reload: { configPrefixes: ["web"], noopPrefixes: ["channels.whatsapp"] },
+    reload: {
+      configPrefixes: ["web", "channels.whatsapp.accounts"],
+      noopPrefixes: ["channels.whatsapp"],
+    },
   };
   const registry = createTestRegistry([
     { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
@@ -217,6 +220,20 @@ describe("buildGatewayReloadPlan", () => {
     );
     expect(expected.size).toBeGreaterThan(0);
     expect(plan.restartChannels).toEqual(expected);
+  });
+
+  it("restarts the channel when a per-account config field changes (more specific configPrefix wins over the broad noop prefix)", () => {
+    const plan = buildGatewayReloadPlan(["channels.whatsapp.accounts.default.enabled"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set(["whatsapp"]));
+    expect(plan.noopPaths).not.toContain("channels.whatsapp.accounts.default.enabled");
+  });
+
+  it("keeps other channels.whatsapp.* changes as hot no-ops", () => {
+    const plan = buildGatewayReloadPlan(["channels.whatsapp.replyToMode"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set());
+    expect(plan.noopPaths).toContain("channels.whatsapp.replyToMode");
   });
 
   it("refreshes channel reload rules when only the tracked channel registry changes", () => {


### PR DESCRIPTION
## Summary

- On hot config reload, flipping `accounts.<name>.enabled` true→false for WhatsApp was classified as a no-op, so the channel never restarted and the running Baileys provider kept processing inbound messages until a full gateway restart. (#87951)
- Root cause: WhatsApp's reload declaration used `noopPrefixes: ["channels.whatsapp"]`, which swallows **every** `channels.whatsapp.*` change (including per-account `enabled`) as a hot no-op. Its restart prefix `["web"]` only covers the provider-level `web.*` config, not per-account config under `channels.whatsapp.accounts.*`.
- Fix: add `channels.whatsapp.accounts` to `configPrefixes`. The reload classifier (`buildGatewayReloadPlan`) is first-match, and a plugin's `configPrefixes` (restart-channel) are evaluated before its `noopPrefixes`, so the more-specific account prefix now wins: per-account changes restart the WhatsApp channel (tearing down a disabled account) while other `channels.whatsapp.*` settings stay hot no-ops.
- Intentionally out of scope: a per-account stop that leaves sibling accounts connected. The reload plan operates at channel granularity, so this restarts the whole WhatsApp channel; credentials stay on disk for re-enable. Account-config changes are infrequent, so the brief reconnect of other accounts is acceptable.

## Linked context

Closes #87951

## Real behavior proof (required for external PRs)

- Behavior addressed: `accounts.<name>.enabled: false` on hot reload did not tear down the WhatsApp provider.
- Real environment tested: source trace of the reload classifier (first-match rule precedence, `configPrefixes` before `noopPrefixes` in `config-reload-plan.ts`) plus red/green unit tests. I do **not** have a live WhatsApp account to capture the live socket teardown.
- Command run after this patch:
  - `pnpm test src/gateway/config-reload.test.ts`
- Evidence after fix (green): 77/77 pass.

  ```
  Test Files  1 passed (1)
       Tests  77 passed (77)
  ```

- Evidence before fix (red — reverting the new `configPrefix` on the test's mock WhatsApp plugin): the per-account case fails.

  ```
  × restarts the channel when a per-account config field changes ...
  Tests  1 failed | 76 passed (77)
  ```

- Observed after fix: `buildGatewayReloadPlan(["channels.whatsapp.accounts.default.enabled"])` → `restartChannels = {whatsapp}` and the path is not a no-op; `channels.whatsapp.replyToMode` stays a hot no-op (no regression for other settings).
- What was not tested: a live WhatsApp account reload + Baileys socket teardown.
- Proof limitations: no live WhatsApp. The classification behavior is proven via the core reload-plan test, which uses a mock channel plugin mirroring the real `extensions/whatsapp/src/shared.ts` declaration.

## Tests and validation

- Updated the core reload-plan test's mock WhatsApp declaration to mirror the real fix, and added 2 cases: a per-account change restarts the channel; other `channels.whatsapp.*` changes stay hot no-ops. Red/green verified.
- `pnpm test src/gateway/config-reload.test.ts` — 77 pass.
- `pnpm tsgo:extensions` and `pnpm tsgo:core:test` — 0 errors.
- `oxlint` and `oxfmt --check` on touched files — clean.

## Risk checklist

- Did user-visible behavior change? **Yes** — WhatsApp per-account config changes (`enabled`, account add/remove, and other `accounts.*` fields) now restart the channel on hot reload instead of being silently hot-applied or ignored.
- Did config, environment, or migration behavior change? **No.**
- Did security, auth, secrets, network, or tool execution behavior change? **No.**
- Highest-risk area: over-restarting the WhatsApp channel on benign per-account field edits (e.g. `allowFrom`). Mitigation: a channel restart is the safe, correct way to apply account changes; only `channels.whatsapp.accounts.*` is affected, other WhatsApp settings stay hot, and the prefix lives in WhatsApp's own declaration (no cross-channel impact).

## Current review state

- Next action: maintainer review. If a per-account stop (without restarting sibling accounts) is preferred, that is a larger change to the reload plan's granularity; happy to follow up.
- Still waiting on: optional live WhatsApp confirmation (I lack a linked account).
