### PR TITLE
docs: add config unset dry-run documentation

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -330,6 +330,86 @@ openclaw config patch --file ./discord.patch.json5 --replace-path 'channels.disc
 
 `--dry-run` runs schema and SecretRef resolvability checks without writing. Exec-backed SecretRefs are skipped by default during dry-run; add `--allow-exec` when you intentionally want dry-run to execute provider commands.
 
+## `config unset`
+
+Remove a config value by dot path. Use `--dry-run` to validate the removal before committing.
+
+```bash
+openclaw config unset plugins.entries.brave.config.webSearch.apiKey
+openclaw config unset secrets.providers.env-provider --dry-run
+openclaw config unset tools.alsoAllow --dry-run --allow-exec
+```
+
+### Dry-run options
+
+<Tabs>
+  <Tab title="--dry-run">
+    Validate removal without writing `openclaw.json`. Checks that the path exists, validates the post-change config against the schema, and verifies SecretRef fallout for `secrets.providers`/`secrets.defaults` removals.
+
+    ```bash
+    openclaw config unset tools.alsoAllow --dry-run
+    ```
+
+  </Tab>
+  <Tab title="--dry-run --json">
+    Output structured JSON for scripting. Requires `--dry-run`.
+
+    ```bash
+    openclaw config unset tools.alsoAllow --dry-run --json
+    ```
+
+    Returns:
+    ```json
+    {
+      "ok": true,
+      "operations": 1,
+      "configPath": "/home/user/.openclaw/openclaw.json",
+      "inputModes": ["unset"],
+      "checks": { "schema": true, "resolvability": true, "resolvabilityComplete": true },
+      "refsChecked": 0,
+      "skippedExecRefs": 0
+    }
+    ```
+
+  </Tab>
+  <Tab title="--allow-exec">
+    Allow exec SecretRef resolvability checks during dry-run. Exec providers are skipped by default to avoid command side effects. Requires `--dry-run`.
+
+    ```bash
+    openclaw config unset tools.alsoAllow --dry-run --allow-exec
+    ```
+
+  </Tab>
+</Tabs>
+
+<AccordionGroup>
+  <Accordion title="SecretRef fallout detection">
+    When unsetting `secrets.providers.<alias>` or `secrets.defaults`, `config unset --dry-run` checks whether any remaining SecretRefs would become unresolvable. If refs would break, dry-run fails with resolution errors:
+
+    ```bash
+    $ openclaw config unset secrets.providers.env-provider --dry-run
+
+    Dry run failed: 1 SecretRef assignment(s) could not be resolved.
+    - env:env-provider:TEST_API_KEY -> Secret provider "env-provider" is not configured (ref: env:env-provider:TEST_API_KEY).
+    ```
+
+  </Accordion>
+  <Accordion title="Exec SecretRef handling">
+    When the config contains exec-backed SecretRefs, `config unset --dry-run` skips them by default to avoid executing arbitrary commands. Use `--allow-exec` to opt in:
+
+    ```bash
+    # Without --allow-exec: exec refs skipped
+    $ openclaw config unset tools.alsoAllow --dry-run
+
+    Dry run note: skipped 1 exec SecretRef resolvability check(s). Re-run with --allow-exec to execute exec providers during dry-run.
+
+    # With --allow-exec: exec providers are executed
+    $ openclaw config unset tools.alsoAllow --dry-run --allow-exec
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
 ## Dry run
 
 `--dry-run` validates changes without writing `openclaw.json`. Available on `config set`, `config patch`, and `config unset`.


### PR DESCRIPTION
## What Problem This Solves

`config set` and `config patch` each have a dedicated section in `docs/cli/config.md`, but `config unset` does not. Its `--dry-run`, `--allow-exec`, and SecretRef fallout behavior are only mentioned inline in the shared dry-run section, so the unset-specific behavior — especially SecretRef fallout when removing `secrets.providers`/`secrets.defaults` — is not documented in one place. This adds the missing dedicated `config unset` section.

Rebased onto current `main`; the SecretRef fallout example is aligned with the current `(ref: <source>:<provider>:<id>)` error suffix.

## Evidence

- Docs-only change: `docs/cli/config.md`, +80/-0.
- `pnpm docs:check-mdx` passes (662 files).
- `pnpm docs:list` passes.
- The SecretRef fallout transcript matches the current error format in `src/secrets/resolve.ts`: `Secret provider "<alias>" is not configured (ref: <source>:<provider>:<id>).`
- Verified on current `main` that `config set` modes and `config patch` each have a dedicated section while `config unset` does not — the gap this PR fills.

## Summary

Documents `config unset` with:
- Basic usage examples
- `--dry-run` for validation without writing
- `--dry-run --json` for structured output
- `--allow-exec` for exec SecretRef resolvability checks
- SecretRef fallout detection
- Exec SecretRef handling

Refresh of #82723 (closed due to merge conflicts after falling behind main).

## Test plan

- [x] `pnpm docs:check-mdx` passes
- [x] `pnpm docs:list` passes
