### PR TITLE
fix: qualify reasoning stream preview wording

### DIFF
--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -105,7 +105,7 @@ title: "Thinking levels"
 - Levels: `on|off|stream`.
 - Directive-only message toggles whether thinking blocks are shown in replies.
 - When enabled, reasoning is sent as a **separate message** prefixed with `Thinking`.
-- `stream`: streams reasoning while the reply is generating when the active channel supports reasoning previews, then sends the final answer without reasoning.
+- `stream`: streams reasoning while the reply is generating when the active channel supports reasoning previews. Final reasoning visibility is channel-specific; use `/reasoning on` when reasoning must remain visible after the reply finishes.
 - Alias: `/reason`.
 - Send `/reasoning` (or `/reasoning:`) with no argument to see the current reasoning level.
 - Resolution order: inline directive, then session override, then per-agent default (`agents.list[].reasoningDefault`), then global default (`agents.defaults.reasoningDefault`), then fallback (`off`).

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -580,7 +580,9 @@ export async function handleDirectiveOnly(
       directives.reasoningLevel === "off"
         ? formatDirectiveAck("Reasoning visibility disabled.")
         : directives.reasoningLevel === "stream"
-          ? formatDirectiveAck("Reasoning stream enabled.")
+          ? formatDirectiveAck(
+              "Reasoning stream enabled when this channel supports reasoning previews.",
+            )
           : formatDirectiveAck("Reasoning visibility enabled."),
     );
   }

--- a/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
+++ b/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
@@ -239,7 +239,7 @@ describe("mixed inline directives", () => {
     });
 
     expect(fastLane.directiveAck).toEqual({
-      text: "⚙️ Reasoning stream enabled.",
+      text: "⚙️ Reasoning stream enabled when this channel supports reasoning previews.",
     });
   });
 


### PR DESCRIPTION
Summary
- Qualify the `/reasoning stream` acknowledgement so it no longer promises visible streaming on channels that do not provide reasoning-preview callbacks.
- Clarify the shared thinking docs so final reasoning visibility is channel-specific, while `/reasoning stream` remains channel-support gated.
- Update the focused directive test expectation for the new acknowledgement.

Follow-up to #87944, which removed the stale Telegram-only wording but was merged before these two review follow-ups landed.

Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.mixed-inline.test.ts`
- `node scripts/docs-list.js`
- `git diff --check upstream/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

Notes
- `pnpm docs:list` was attempted in this worktree, but pnpm entered a long optional-platform package download retry loop during dependency reconciliation, so I stopped it and ran the underlying docs inventory script directly.

Behavior addressed: `/reasoning stream` now acknowledges that streaming is enabled when the active channel supports reasoning previews, and docs no longer overgeneralize Telegram final-answer behavior to Feishu or other channels.
Real environment tested: local upstream/main-based worktree under `.claude/worktrees/fix-reasoning-stream-ack`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.mixed-inline.test.ts`; `node scripts/docs-list.js`; `git diff --check upstream/main..HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`.
Evidence after fix: the directive test asserts `Reasoning stream enabled when this channel supports reasoning previews.`; shared docs now state final reasoning visibility is channel-specific; autoreview reported no accepted/actionable findings.
Observed result after fix: Vitest passed with 1 test file and 5 tests; docs inventory script passed; diff whitespace check was clean; autoreview clean.
What was not tested: no live Telegram, Feishu, or Lark channel run was performed.
