### PR TITLE
fix(slack): avoid forced threads for replyToMode off

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -93,6 +93,7 @@ const statusReactionControllerMock = {
 let mockedReplyThreadTs: string | undefined = THREAD_TS;
 let mockedReplyThreadTsSequence: Array<string | undefined> | undefined;
 let mockedSlackReplyBlocks: unknown[] | undefined;
+let mockedSlackIsThreadReply = true;
 let capturedTyping:
   | {
       start: () => Promise<void>;
@@ -819,7 +820,7 @@ vi.mock("../../streaming.js", () => ({
 vi.mock("../../threading.js", () => ({
   resolveSlackThreadTargets: () => ({
     statusThreadTs: THREAD_TS,
-    isThreadReply: true,
+    isThreadReply: mockedSlackIsThreadReply,
   }),
 }));
 
@@ -1166,6 +1167,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedReplyThreadTs = THREAD_TS;
     mockedReplyThreadTsSequence = undefined;
     mockedSlackReplyBlocks = undefined;
+    mockedSlackIsThreadReply = true;
     mockedDispatchSequence = [{ kind: "final", payload: { text: FINAL_REPLY_TEXT } }];
     mockedQueuedDispatchCounts = { tool: 0, block: 0, final: 0 };
     mockedProgressEvents = [];
@@ -1190,6 +1192,26 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("does not create a Slack thread for top-level messages when replyToMode is off", async () => {
+    mockedSlackStreamingMode = "off";
+    mockedSlackIsThreadReply = false;
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage({ replyToMode: "off" }));
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT, { replyThreadTs: undefined });
+  });
+
+  it("stays in an existing Slack thread when replyToMode is off", async () => {
+    mockedSlackStreamingMode = "off";
+    mockedSlackIsThreadReply = true;
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage({ replyToMode: "off" }));
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT, { replyThreadTs: THREAD_TS });
   });
 
   it("passes accepted Slack bot messages through the shared bot loop guard", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -780,11 +780,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       return;
     }
     const replyThreadTs = resolveDeliveryThreadTs(params);
+    const deliveryReplyThreadTs =
+      replyDeliveryMode === "off" && !forcedReplyThreadTs && !isThreadReply
+        ? undefined
+        : replyThreadTs;
     if (
       deliveryTracker.hasDelivered({
         kind: params.kind,
         payload: params.payload,
-        threadTs: replyThreadTs,
+        threadTs: deliveryReplyThreadTs,
       })
     ) {
       logVerbose("slack: suppressed duplicate normal delivery within the same turn");
@@ -798,7 +802,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       accountId: account.accountId,
       runtime,
       textLimit: ctx.textLimit,
-      replyThreadTs,
+      replyThreadTs: deliveryReplyThreadTs,
       replyToMode: replyDeliveryMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
       ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
@@ -810,7 +814,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     const deliveredThreadTs = resolveDeliveredSlackReplyThreadTs({
       replyToMode: replyDeliveryMode,
       payloadReplyToId: params.payload.replyToId,
-      replyThreadTs,
+      replyThreadTs: deliveryReplyThreadTs,
     });
     // Record the thread ts only after confirmed delivery success.
     rememberDeliveredThreadTs(params.kind, deliveredThreadTs);
@@ -818,7 +822,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     deliveryTracker.markDelivered({
       kind: params.kind,
       payload: params.payload,
-      threadTs: replyThreadTs,
+      threadTs: deliveryReplyThreadTs,
     });
   };
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -267,6 +267,64 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared.ctxPayload.TransportThreadId).toBeUndefined();
   });
 
+  it("keeps Slack assistant DM thread targets when replyToMode is off", async () => {
+    const prepared = await prepareMessageWith(
+      createDefaultSlackCtx(),
+      createSlackAccount({ replyToMode: "off" }),
+      createSlackMessage({
+        ts: "10.100",
+        parent_user_id: "B1",
+        text: "assistant thread message",
+        assistant_thread: {
+          channel_id: "D123",
+          thread_ts: "10.000",
+          context: {
+            channel_id: "C999",
+            team_id: "T1",
+          },
+        },
+      }),
+    );
+
+    assertPrepared(prepared);
+    const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
+    expect(prepared.ctxPayload.SessionKey).toBe("agent:main:main:thread:10.000");
+    expect(prepared.ctxPayload.MessageThreadId).toBe("10.000");
+    expect(prepared.forcedReplyThreadTs).toBe("10.000");
+    expect(payload.SlackAssistantThread).toBe(true);
+    expect(payload.SlackAssistantThreadContextChannelId).toBe("C999");
+    expect(payload.SlackAssistantThreadContextTeamId).toBe("T1");
+    expect(prepared.ctxPayload.TransportThreadId).toBeUndefined();
+  });
+
+  it("does not force Slack assistant context onto top-level channel replies when replyToMode is off", async () => {
+    const prepared = await prepareMessageWith(
+      createDefaultSlackCtx(),
+      createSlackAccount({ replyToMode: "off" }),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        ts: "10.100",
+        text: "<@B1> top-level assistant context",
+        assistant_thread: {
+          channel_id: "D123",
+          thread_ts: "10.000",
+          context: {
+            channel_id: "C999",
+            team_id: "T1",
+          },
+        },
+      }),
+    );
+
+    assertPrepared(prepared);
+    const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
+    expect(prepared.forcedReplyThreadTs).toBeUndefined();
+    expect(payload.SlackAssistantThread).toBe(true);
+    expect(payload.SlackAssistantThreadContextChannelId).toBe("C999");
+    expect(payload.SlackAssistantThreadContextTeamId).toBe("T1");
+  });
+
   it("prefers Slack assistant message context over stale lifecycle cache", async () => {
     const ctx = createDefaultSlackCtx();
     ctx.saveSlackAssistantThreadContext({

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1439,7 +1439,7 @@ export async function prepareSlackMessage(params: {
           : undefined,
     },
     replyToMode,
-    ...(assistantThreadContext?.threadTs
+    ...(assistantThreadContext?.threadTs && (isThreadReply || replyToMode !== "off")
       ? { forcedReplyThreadTs: assistantThreadContext.threadTs }
       : {}),
     ...(assistantThreadContext

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -774,6 +774,14 @@ export async function prepareSlackMessage(params: {
     sessionKey,
     historyKey,
   } = routing;
+  const isAssistantThreadMessage = Boolean(isDirectMessage && messageAssistantThreadContext);
+  const shouldForceAssistantReplyThread = Boolean(
+    assistantThreadContext?.threadTs &&
+    (isThreadReply || isAssistantThreadMessage || replyToMode !== "off"),
+  );
+  const forcedAssistantReplyThreadTs = shouldForceAssistantReplyThread
+    ? assistantThreadContext?.threadTs
+    : undefined;
   if (runtimeBinding && shouldLogVerbose()) {
     logVerbose(
       `slack: routed via bound conversation ${runtimeBinding.conversation.conversationId} -> ${runtimeBinding.targetSessionKey}`,
@@ -1439,9 +1447,7 @@ export async function prepareSlackMessage(params: {
           : undefined,
     },
     replyToMode,
-    ...(assistantThreadContext?.threadTs && (isThreadReply || replyToMode !== "off")
-      ? { forcedReplyThreadTs: assistantThreadContext.threadTs }
-      : {}),
+    ...(forcedAssistantReplyThreadTs ? { forcedReplyThreadTs: forcedAssistantReplyThreadTs } : {}),
     ...(assistantThreadContext
       ? { slackMessageMetadata: buildSlackAssistantThreadMetadata(assistantThreadContext) }
       : {}),


### PR DESCRIPTION
## Summary

- Fixes Slack top-level channel mentions being delivered into threads when `channels.slack.replyToMode` is `"off"`.
- Preserves real Slack thread behavior: replies inside an existing Slack thread still stay in that thread, even with `replyToMode: "off"`.
- Preserves real Slack assistant DM thread targets when `replyToMode: "off"`, addressing the review finding.
- Prevents stale/top-level Slack assistant context from forcing top-level channel replies into threads when reply threading is disabled.
- Out of scope: config shape changes, migrations, Slack HTTP Events transport changes, or changing `replyToMode: "all"` behavior.

## Linked Context

Related #61835

This was found while testing Slack channel behavior with `replyToMode: "off"`.

## Examples

| Scenario | Input | Expected reply target | Proof |
|---|---|---|---|
| Top-level channel mention, `replyToMode: "off"` | `<@bot> oc-slack-thread-matrix TOP 20260529T182513Z` | Top-level channel message | Live Slack API shows bot message `1780079277.624529` with no `thread_ts` / no `parent_user_id`. |
| Existing Slack thread reply, `replyToMode: "off"` | `<@bot> oc-slack-thread-matrix THREAD 20260529T182513Z` inside thread root `1780079268.276939` | Reply under thread root `1780079268.276939` | Live Slack API shows bot message `1780079424.831409` with `thread_ts: "1780079268.276939"`. |
| Real Slack assistant DM thread, `replyToMode: "off"` | Assistant-thread context with `assistant_thread.thread_ts` | Preserve `forcedReplyThreadTs` | Focused regression test covers this compatibility case. |
| Top-level channel message with assistant context, `replyToMode: "off"` | Top-level channel message plus assistant context | Do not force a reply thread | Focused regression test covers the stale/top-level context case. |

## Real Behavior Proof

Behavior addressed: Slack top-level channel mentions no longer receive threaded bot replies when `replyToMode: "off"`. Existing Slack thread replies still stay in their thread. Real Slack assistant DM thread targets are preserved when reply mode is off.

Real environment tested:

- OpenClaw CLI/Gateway: `2026.5.26`
- `@openclaw/slack`: `2026.5.26` local gateway with this branch's Slack fix active for live verification
- Node: `v22.22.2`
- OS: macOS arm64
- Slack mode: Socket Mode
- Local gateway: LaunchAgent, loopback gateway
- Branch head after review repair: `49c5db1f88`

Exact steps or command run after this patch:

1. Restarted the real local gateway with this branch's Slack fix active and confirmed Slack Socket Mode was connected.
2. Configured Slack with `replyToMode: "off"` and `replyToModeByChatType` set to `"off"` for direct, group, and channel chat types.
3. Sent a fresh top-level Slack channel mention with nonce `20260529T182513Z`.
4. Sent a Slack mention inside the same top-level message's thread with the same nonce.
5. Queried Slack `conversations.history` and `conversations.replies` with the real bot token, redacting IDs in this PR body.
6. Ran focused local Slack regression tests from the source checkout.

Commands used:

```text
openclaw gateway restart
openclaw gateway status --deep
git diff --check
node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/monitor/replies.test.ts
```

Relevant Slack config for the primary fixed behavior:

```json
{
  "replyToMode": "off",
  "replyToModeByChatType": {
    "direct": "off",
    "group": "off",
    "channel": "off"
  },
  "streaming": {
    "mode": "partial",
    "nativeTransport": true
  }
}
```

Evidence after fix:

Top-level channel mention stayed top-level. The bot reply appears in channel history without `thread_ts` or `parent_user_id`.

```json
{
  "ts": "1780079268.276939",
  "user": "USER",
  "thread_ts": "1780079268.276939",
  "reply_count": 2,
  "text": "<@bot> oc-slack-thread-matrix TOP 20260529T182513Z"
}
{
  "ts": "1780079277.624529",
  "user": "BOT",
  "text": "Acknowledged, Captain. oc-slack-thread-matrix TOP 20260529T182513Z"
}
```

Existing Slack thread reply stayed in the existing thread root.

```json
{
  "ts": "1780079303.009759",
  "user": "USER",
  "thread_ts": "1780079268.276939",
  "parent_user_id": "USER",
  "text": "<@bot> oc-slack-thread-matrix THREAD 20260529T182513Z"
}
{
  "ts": "1780079424.831409",
  "user": "BOT",
  "thread_ts": "1780079268.276939",
  "parent_user_id": "USER",
  "text": "Thread received: `oc-slack-thread-matrix THREAD 20260529T182513Z`"
}
```

Before evidence: before the refined fix, a top-level channel mention could produce a bot reply with `thread_ts` and `parent_user_id`, placing the reply under the top-level message's thread despite `replyToMode: "off"`.

```json
{
  "ts": "1780009688.940449",
  "thread_ts": "1780009688.940449",
  "user": "USER",
  "text": "<@bot> testing a top level thread"
}
{
  "ts": "1780009698.748129",
  "thread_ts": "1780009688.940449",
  "parent_user_id": "USER",
  "user": "BOT",
  "text": "Received at top level..."
}
```

Observed result after fix: The live Slack Socket Mode matrix behaved as expected:

| Config | Inbound context | Expected | Result |
|---|---|---|---|
| `replyToMode: "off"`, streaming partial/native on | Top-level channel mention | Top-level bot reply | Pass |
| `replyToMode: "off"`, streaming partial/native on | Existing Slack thread reply | Bot reply stays in thread | Pass |

What was not tested: Slack HTTP Events mode live roundtrip and a live Slack assistant DM thread roundtrip. HTTP Events shares the same normalized prepare/dispatch path after Slack event normalization. The assistant DM compatibility case is covered by focused unit regression coverage.

## Tests and Validation

Commands run:

```text
git diff --check
node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/monitor/replies.test.ts
```

Result:

```text
Test Files  3 passed (3)
Tests       159 passed (159)
```

Regression coverage added:

- Top-level `replyToMode: "off"` delivery clears the reply thread target instead of passing Slack's auto-created top-level `thread_ts`.
- Existing Slack thread replies preserve `replyThreadTs` when `replyToMode` is `"off"`.
- Real Slack assistant DM thread messages preserve `forcedReplyThreadTs` when `replyToMode` is `"off"`.
- Top-level channel messages with assistant context do not force a reply thread when `replyToMode` is `"off"`.

What failed before this fix: top-level Slack messages could still route through a resolved or forced thread target and be delivered with `thread_ts`.

If no test was added, why not? Not applicable.

## Risk Checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area? Slack reply delivery targeting, especially preserving existing-thread and assistant-thread behavior while suppressing accidental top-level thread creation.

How is that risk mitigated? The change uses a single computed delivery thread target for delivery, duplicate tracking, delivered-thread tracking, and sent marking. Focused tests cover top-level off-mode, existing thread off-mode, assistant DM thread preservation, and top-level assistant-context suppression.

## Current Review State

What is the next action? Ready for CI and maintainer/reviewer re-review.

What is still waiting on author, maintainer, CI, or external proof? CI and maintainer review. Optional extra live proof would be a Slack assistant DM thread smoke, but the compatibility case is covered by unit tests.

Which bot or reviewer comments were addressed? The review finding to preserve real Slack assistant thread targets when `replyToMode: "off"` was addressed.
