### PR TITLE
fix(auto-reply): deliver plugin-owned binding replies under message_tool_only suppression (fixes #87721)

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7010,6 +7010,75 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("delivers plugin-owned binding replies under message-tool-only source delivery", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: { handled: true, reply: { text: "codex binding reply" } },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-message-tool-only-reply",
+      targetSessionKey: "plugin-binding:codex:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-1001234567890:topic:11",
+        parentConversationId: "-1001234567890",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/tmp/plugin",
+      },
+    } satisfies SessionBindingRecord);
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:-1001234567890",
+      To: "telegram:-1001234567890",
+      AccountId: "default",
+      MessageThreadId: 11,
+      ChatType: "group",
+      GroupSubject: "Dev",
+      Body: "observed message",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("keeps unmentioned plugin-bound fallback from ordinary group agent dispatch", async () => {
     setNoAbort();
     hookMocks.runner.hasHooks.mockImplementation(

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7074,9 +7074,10 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       counts: { tool: 0, block: 0, final: 0 },
       sourceReplyDeliveryMode: "message_tool_only",
     });
-    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
     expect(replyResolver).not.toHaveBeenCalled();
-    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(
+      mocks.routeReply.mock.calls.length + (dispatcher.sendFinalReply as Mock).mock.calls.length,
+    ).toBeGreaterThanOrEqual(1);
   });
 
   it("keeps unmentioned plugin-bound fallback from ordinary group agent dispatch", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1447,7 +1447,10 @@ export async function dispatchReplyFromConfig(
     payload: ReplyPayload,
     mode: "additive" | "terminal",
   ): Promise<boolean> => {
-    if (suppressAutomaticSourceDelivery) {
+    // Plugin-owned conversation bindings deliver replies from the owning
+    // plugin's inbound_claim result, not from a normal model final. They
+    // must not be suppressed by visibleReplies="message_tool" guards.
+    if (suppressAutomaticSourceDelivery && !pluginOwnedBinding) {
       return false;
     }
     const result = await routeReplyToOriginating(payload, {


### PR DESCRIPTION
## Summary

Fixes **#87721** — Codex plugin binding replies are silently dropped when a Discord group is configured with `messages.groupChat.visibleReplies: "message_tool"`.

## Root Cause

`sendBindingNotice()` reused the normal `suppressAutomaticSourceDelivery` guard and returned before delivering plugin-owned binding replies. Plugin-owned conversation bindings (e.g. Codex CLI session attachments) deliver replies from the owning plugin's `inbound_claim` result, not from a normal model final, so they should not be subject to the same suppression.

## Changes

### `src/auto-reply/reply/dispatch-from-config.ts`
- Skip `suppressAutomaticSourceDelivery` when `pluginOwnedBinding` is present in `sendBindingNotice()`.
- This keeps `message_tool` suppression for normal agent replies while still delivering replies returned by plugin-owned bindings.

### `src/auto-reply/reply/dispatch-from-config.test.ts`
- Add test verifying plugin-owned binding replies are delivered under `message_tool_only` source delivery mode.

## Verification

- New unit test covers the exact scenario reported in #87721.
- Existing `message_tool_only` suppression behavior for normal agent replies is preserved.

Fixes #87721