### PR TITLE
fix(cron): retire MCP runtimes on isolated cron timeout and dispose

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1645,3 +1645,99 @@ process.on("SIGINT", shutdown);`,
     expect(disposed).toStrictEqual([]);
   });
 });
+
+describe("disposeSession timeout", () => {
+  it(
+    "completes disposal even when the MCP server process ignores shutdown",
+    { timeout: 15_000 },
+    async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-dispose-timeout-"));
+      const serverPath = path.join(tempDir, "hanging-close.mjs");
+      const logPath = path.join(tempDir, "server.log");
+
+      await writeExecutable(
+        serverPath,
+        `#!/usr/bin/env node
+import fs from "node:fs/promises";
+
+const logPath = ${JSON.stringify(logPath)};
+function log(line) {
+  void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
+}
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) return;
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      const message = JSON.parse(line);
+      if (message.method === "initialize") {
+        send({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+            capabilities: { tools: {} },
+            serverInfo: { name: "hanging-close-server", version: "1.0.0" },
+          },
+        });
+      } else if (message.method === "tools/list") {
+        send({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: { tools: [{ name: "probe", description: "probe", inputSchema: { type: "object" } }] },
+        });
+      }
+    }
+  }
+});
+
+// Ignore all shutdown signals — simulate a stuck process
+process.on("SIGTERM", () => { log("ignored SIGTERM"); });
+process.on("SIGINT", () => { log("ignored SIGINT"); });
+process.stdin.on("end", () => {
+  log("stdin closed but staying alive");
+  // Keep the process alive indefinitely
+  setInterval(() => {}, 60_000);
+});`,
+      );
+
+      const runtime = await getOrCreateSessionMcpRuntime({
+        sessionId: "session-dispose-timeout",
+        sessionKey: "agent:test:session-dispose-timeout",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              hangingClose: {
+                command: process.execPath,
+                args: [serverPath],
+              },
+            },
+          },
+        },
+      });
+
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools).toHaveLength(1);
+
+      const start = Date.now();
+      await runtime.dispose();
+      const elapsed = Date.now() - start;
+
+      // Dispose should complete within DISPOSE_TIMEOUT_MS (5s) + a small buffer,
+      // not hang indefinitely.
+      expect(elapsed).toBeLessThan(8_000);
+
+      await fs.rm(tempDir, { recursive: true, force: true });
+    },
+  );
+});

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1648,6 +1648,106 @@ process.on("SIGINT", shutdown);`,
 
 describe("disposeSession timeout", () => {
   it(
+    "force-closes transport and client when terminateSession hangs past the timeout",
+    { timeout: 15_000 },
+    async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-force-close-"));
+      const serverPath = path.join(tempDir, "hanging-terminate.mjs");
+      const logPath = path.join(tempDir, "server.log");
+
+      await writeExecutable(
+        serverPath,
+        `#!/usr/bin/env node
+import fs from "node:fs/promises";
+
+const logPath = ${JSON.stringify(logPath)};
+function log(line) {
+  void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
+}
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) return;
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      const message = JSON.parse(line);
+      if (message.method === "initialize") {
+        send({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+            capabilities: { tools: {} },
+            serverInfo: { name: "hanging-terminate-server", version: "1.0.0" },
+          },
+        });
+      } else if (message.method === "tools/list") {
+        send({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: { tools: [{ name: "probe", description: "probe", inputSchema: { type: "object" } }] },
+        });
+      } else {
+        log("recv " + String(message.method ?? "response"));
+      }
+    }
+  }
+});
+
+// Keep process alive forever and ignore all shutdown signals
+process.on("SIGTERM", () => { log("ignored SIGTERM"); });
+process.on("SIGINT", () => { log("ignored SIGINT"); });
+process.stdin.on("end", () => {
+  log("stdin-end");
+  setInterval(() => {}, 60_000);
+});`,
+      );
+
+      const runtime = await getOrCreateSessionMcpRuntime({
+        sessionId: "session-force-close-timeout",
+        sessionKey: "agent:test:session-force-close-timeout",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              hangingTerminate: {
+                command: process.execPath,
+                args: [serverPath],
+              },
+            },
+          },
+        },
+      });
+
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools).toHaveLength(1);
+
+      const start = Date.now();
+      await runtime.dispose();
+      const elapsed = Date.now() - start;
+
+      // The timeout fires at 5s and force-closes transport + client,
+      // so disposal must complete well before 8s even when the process
+      // ignores shutdown signals.
+      expect(elapsed).toBeLessThan(8_000);
+
+      await retireSessionMcpRuntime({
+        sessionId: "session-force-close-timeout",
+        reason: "test cleanup",
+      });
+      await fs.rm(tempDir, { recursive: true, force: true });
+    },
+  );
+
+  it(
     "completes disposal even when the MCP server process ignores shutdown",
     { timeout: 15_000 },
     async () => {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -1838,6 +1839,99 @@ process.stdin.on("end", () => {
       expect(elapsed).toBeLessThan(8_000);
 
       await fs.rm(tempDir, { recursive: true, force: true });
+    },
+  );
+
+  it(
+    "force-closes streamable-http transport when DELETE hangs past the timeout",
+    { timeout: 15_000 },
+    async () => {
+      const sessionId = "test-session-" + Date.now();
+      const server = http.createServer((req, res) => {
+        if (req.method === "GET") {
+          res.writeHead(405).end();
+          return;
+        }
+        if (req.method === "DELETE") {
+          // Never respond — simulates a hung terminateSession() DELETE.
+          return;
+        }
+        if (req.method !== "POST") {
+          res.writeHead(405).end();
+          return;
+        }
+        let body = "";
+        req.on("data", (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        req.on("end", () => {
+          const message = JSON.parse(body);
+          res.setHeader("content-type", "application/json");
+          res.setHeader("mcp-session-id", sessionId);
+          if (message.method === "initialize") {
+            res.writeHead(200).end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+                  capabilities: { tools: {} },
+                  serverInfo: { name: "hanging-delete-server", version: "1.0.0" },
+                },
+              }),
+            );
+          } else if (message.method === "notifications/initialized") {
+            res.writeHead(202).end();
+          } else if (message.method === "tools/list") {
+            res.writeHead(200).end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  tools: [{ name: "probe", description: "probe", inputSchema: { type: "object" } }],
+                },
+              }),
+            );
+          } else {
+            res.writeHead(200).end(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: {} }));
+          }
+        });
+      });
+
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const addr = server.address() as { port: number };
+
+      try {
+        const runtime = await getOrCreateSessionMcpRuntime({
+          sessionId: "session-streamable-http-dispose",
+          sessionKey: "agent:test:session-streamable-http-dispose",
+          workspaceDir: "/workspace",
+          cfg: {
+            mcp: {
+              servers: {
+                hangingDelete: {
+                  url: `http://127.0.0.1:${addr.port}/mcp`,
+                  transport: "streamable-http",
+                },
+              },
+            },
+          },
+        });
+
+        const catalog = await runtime.getCatalog();
+        expect(catalog.tools).toHaveLength(1);
+
+        const start = Date.now();
+        await runtime.dispose();
+        const elapsed = Date.now() - start;
+
+        // The timeout fires at 5s and force-closes transport + client,
+        // so disposal must complete well before 8s even when the DELETE
+        // request never receives a response.
+        expect(elapsed).toBeLessThan(8_000);
+      } finally {
+        server.close();
+      }
     },
   );
 });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -381,6 +381,7 @@ const DISPOSE_TIMEOUT_MS = 5_000;
 async function disposeSession(session: BundleMcpSession) {
   session.detachStderr?.();
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
   await Promise.race([
     (async () => {
       if (session.transportType === "streamable-http") {
@@ -390,12 +391,21 @@ async function disposeSession(session: BundleMcpSession) {
       await session.client.close().catch(() => {});
     })(),
     new Promise<void>((resolve) => {
-      timer = setTimeout(resolve, DISPOSE_TIMEOUT_MS);
+      timer = setTimeout(() => {
+        timedOut = true;
+        resolve();
+      }, DISPOSE_TIMEOUT_MS);
       timer.unref?.();
     }),
   ]).finally(() => {
     if (timer) { clearTimeout(timer); }
   });
+  if (timedOut) {
+    // Force-close transport and client so a hung terminateSession() DELETE
+    // gets its AbortSignal triggered by the transport teardown.
+    await session.transport.close().catch(() => {});
+    await session.client.close().catch(() => {});
+  }
 }
 
 function createCatalogFingerprint(servers: Record<string, unknown>): string {

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -394,7 +394,7 @@ async function disposeSession(session: BundleMcpSession) {
       timer.unref?.();
     }),
   ]).finally(() => {
-    if (timer) clearTimeout(timer);
+    if (timer) { clearTimeout(timer); }
   });
 }
 

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -376,14 +376,26 @@ function summarizeServerCapabilities(capabilities: ServerCapabilities | undefine
       : undefined,
   };
 }
+const DISPOSE_TIMEOUT_MS = 5_000;
 
 async function disposeSession(session: BundleMcpSession) {
   session.detachStderr?.();
-  if (session.transportType === "streamable-http") {
-    await (session.transport as StreamableHTTPClientTransport).terminateSession().catch(() => {});
-  }
-  await session.transport.close().catch(() => {});
-  await session.client.close().catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    (async () => {
+      if (session.transportType === "streamable-http") {
+        await (session.transport as StreamableHTTPClientTransport).terminateSession().catch(() => {});
+      }
+      await session.transport.close().catch(() => {});
+      await session.client.close().catch(() => {});
+    })(),
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, DISPOSE_TIMEOUT_MS);
+      timer.unref?.();
+    }),
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }
 
 function createCatalogFingerprint(servers: Record<string, unknown>): string {

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -376,6 +376,7 @@ function summarizeServerCapabilities(capabilities: ServerCapabilities | undefine
       : undefined,
   };
 }
+// Safety net for hung MCP servers, not a tuning parameter.
 const DISPOSE_TIMEOUT_MS = 5_000;
 
 async function disposeSession(session: BundleMcpSession) {
@@ -385,7 +386,9 @@ async function disposeSession(session: BundleMcpSession) {
   await Promise.race([
     (async () => {
       if (session.transportType === "streamable-http") {
-        await (session.transport as StreamableHTTPClientTransport).terminateSession().catch(() => {});
+        await (session.transport as StreamableHTTPClientTransport)
+          .terminateSession()
+          .catch(() => {});
       }
       await session.transport.close().catch(() => {});
       await session.client.close().catch(() => {});
@@ -398,7 +401,9 @@ async function disposeSession(session: BundleMcpSession) {
       timer.unref?.();
     }),
   ]).finally(() => {
-    if (timer) { clearTimeout(timer); }
+    if (timer) {
+      clearTimeout(timer);
+    }
   });
   if (timedOut) {
     // Force-close transport and client so a hung terminateSession() DELETE

--- a/src/cron/isolated-agent/run.fast-mode.test.ts
+++ b/src/cron/isolated-agent/run.fast-mode.test.ts
@@ -112,6 +112,7 @@ async function runFastModeCase(params: {
     params.expectedCleanupBundleMcpOnRunEnd ?? true,
   );
   expect(embeddedRunParams.allowGatewaySubagentBinding).toBe(true);
+  const isIsolated = (params.sessionTarget ?? "isolated") === "isolated";
   if (params.expectedRetiredSessionId) {
     expect(retireSessionMcpRuntimeMock).toHaveBeenCalledOnce();
     const [retireParams] = requireFirstMockCall(
@@ -122,7 +123,17 @@ async function runFastModeCase(params: {
     expect(retireParams.reason).toBe("cron-session-rollover");
     return;
   }
-  expect(retireSessionMcpRuntimeMock).not.toHaveBeenCalled();
+  if (isIsolated) {
+    // disposeCronRunContext now retires MCP for isolated sessions
+    expect(retireSessionMcpRuntimeMock).toHaveBeenCalledOnce();
+    const [disposeRetireParams] = requireFirstMockCall(
+      retireSessionMcpRuntimeMock,
+      "dispose retire session mcp runtime",
+    );
+    expect(disposeRetireParams.reason).toBe("isolated-cron-dispose");
+  } else {
+    expect(retireSessionMcpRuntimeMock).not.toHaveBeenCalled();
+  }
 }
 
 describe("runCronIsolatedAgentTurn — fast mode", () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1185,16 +1185,21 @@ async function finalizeCronRun(params: {
  * O(1) — nulls known large fields without deep traversal.  MUST run after the
  * final `persistSessionEntry()` and delivery construction, never before.
  */
-function disposeCronRunContext(params: {
+async function disposeCronRunContext(params: {
   sessionId: string;
   cronSession: MutableCronSession;
   ownsRunContext: boolean;
-}): void {
+}): Promise<void> {
   if (params.ownsRunContext) {
     clearAgentRunContext(params.sessionId);
+    await retireSessionMcpRuntime({
+      sessionId: params.sessionId,
+      reason: "isolated-cron-dispose",
+      onError: (error, sid) => {
+        logWarn(`[cron] Failed to retire MCP runtime during isolated cron dispose ${sid}: ${String(error)}`);
+      },
+    }).catch(() => {});
   }
-  // Drop the in-memory store reference so GC can collect the session registry.
-  // The on-disk sessions.json is unaffected.
   (params.cronSession as { store?: unknown }).store = undefined;
 }
 
@@ -1353,7 +1358,7 @@ export async function runCronIsolatedAgentTurn(params: {
     // Release runtime references after the run completes (success or failure).
     // The session entry has already been persisted to disk by this point,
     // so the in-memory store and run context can be safely dropped.
-    disposeCronRunContext({
+    await disposeCronRunContext({
       sessionId: initialSessionId,
       cronSession: prepared.context.cronSession,
       ownsRunContext: params.job.sessionTarget === "isolated",

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -15,6 +15,8 @@ const {
   cleanupBrowserSessionsForLifecycleEndMock,
   getGlobalHookRunnerMock,
   runCronChangedMock,
+  abortAndDrainEmbeddedAgentRunMock,
+  retireSessionMcpRuntimeMock,
 } = vi.hoisted(() => ({
   enqueueSystemEventMock: vi.fn(),
   requestHeartbeatMock: vi.fn(),
@@ -30,6 +32,12 @@ const {
     hasHooks: (hookName: string) => hookName === "cron_changed",
     runCronChanged: runCronChangedMock,
   })),
+  abortAndDrainEmbeddedAgentRunMock: vi.fn(async () => ({
+    aborted: true,
+    drained: true,
+    forceCleared: false,
+  })),
+  retireSessionMcpRuntimeMock: vi.fn(async () => true),
 }));
 
 function enqueueSystemEvent(...args: unknown[]) {
@@ -92,6 +100,14 @@ vi.mock("../browser-lifecycle-cleanup.js", () => ({
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: getGlobalHookRunnerMock,
+}));
+
+vi.mock("../agents/embedded-agent.js", () => ({
+  abortAndDrainEmbeddedAgentRun: abortAndDrainEmbeddedAgentRunMock,
+}));
+
+vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
+  retireSessionMcpRuntime: retireSessionMcpRuntimeMock,
 }));
 
 import { buildGatewayCronService } from "./server-cron.js";
@@ -194,6 +210,8 @@ describe("buildGatewayCronService", () => {
     cleanupBrowserSessionsForLifecycleEndMock.mockClear();
     runCronChangedMock.mockClear();
     getGlobalHookRunnerMock.mockClear();
+    abortAndDrainEmbeddedAgentRunMock.mockClear();
+    retireSessionMcpRuntimeMock.mockClear();
     getGlobalHookRunnerMock.mockReturnValue({
       hasHooks: (hookName: string) => hookName === "cron_changed",
       runCronChanged: runCronChangedMock,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1,4 +1,5 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { retireSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
 import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
 import type { CliDeps } from "../cli/deps.types.js";
@@ -400,6 +401,16 @@ export function buildGatewayCronService(params: {
         },
         "cron: cleaned up timed-out agent run",
       );
+      await retireSessionMcpRuntime({
+        sessionId: execution.sessionId,
+        reason: "cron-timeout-cleanup",
+        onError: (error, sid) => {
+          cronLogger.warn(
+            { jobId: job.id, sessionId: sid },
+            `cron: failed to retire MCP runtime for timed-out session: ${String(error)}`,
+          );
+        },
+      }).catch(() => {});
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) =>
       await sendGatewayCronFailureAlert({


### PR DESCRIPTION
## Summary

- Isolated cron runs create a fresh session and MCP runtime per execution. When runs time out, the cleanup path removes the run from the active registry but does not retire the associated MCP runtime. With default concurrency at 8, the scheduler sees empty slots and spawns new runs while orphaned MCP runtimes (with their child processes and transports) accumulate — eventually saturating the event loop and wedging the gateway.

- This PR adds MCP runtime retirement to both the timeout cleanup path and the normal dispose path for isolated cron sessions, and wraps MCP session disposal in a 5-second timeout to prevent hung servers from blocking indefinitely.

- Outcome: orphaned MCP runtimes are retired immediately on cron timeout or completion, preventing resource accumulation that leads to gateway wedge.

- Out of scope: concurrency default value (intentionally raised to 8 in bc12e049), systemd WatchdogSec configuration, MCP idle sweep TTL tuning.

- Success: isolated cron runs with MCP servers configured no longer accumulate orphaned runtimes after timeout or completion; all existing cron tests pass.

- Reviewers should focus on: the three cleanup paths (timeout in server-cron.ts, dispose in run.ts, timeout guard in agent-bundle-mcp-runtime.ts) and whether race conditions exist between active retirement and the idle sweep.

## Linked context

Closes #87821

### Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: Isolated cron runs can wedge gateway due to orphaned MCP runtimes accumulating after timeout cleanup fails to retire them. Additionally, streamable-HTTP MCP servers that hang on DELETE during `terminateSession()` can block disposal indefinitely.

- **Real environment tested**: Docker container (`openclaw-pr87981:test`, built from PR HEAD commit `166d052f`), Linux arm64 (OrbStack on macOS host), Node.js v24.14.0

- **Failing proof before fix**: On upstream/main, `disposeSession` awaits `terminateSession()` and `transport.close()` without a local deadline. `disposeCronRunContext` does not retire MCP runtimes. The timeout cleanup path in `server-cron.ts` does not call `retireSessionMcpRuntime`.

- **Exact steps or command run after this patch**:
  ```bash
  # 1. Build Docker image from PR HEAD
  docker build -t openclaw-pr87981:test --platform linux/arm64 .

  # 2. Configure gateway with MCP server (proof-echo, stdio) + provider
  # 3. Start container
  docker run -d --name openclaw-proof-new \
    -v ./state:/home/node/.openclaw \
    openclaw-pr87981:test node openclaw.mjs gateway --allow-unconfigured

  # 4. Add isolated cron job
  docker exec openclaw-proof-new node openclaw.mjs cron add \
    --name "mcp-proof-job" --agent "cron-mcp-test" \
    --every "60s" --session "isolated" \
    --message "Use the echo tool..." --timeout-seconds 45 --no-deliver

  # 5. Unit tests (all 30 MCP runtime tests pass, including new streamable-HTTP)
  node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts    # 30 tests ✅
  node scripts/run-vitest.mjs src/cron/isolated-agent/run.fast-mode.test.ts  # 5 tests ✅
  node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts      # 43 tests ✅
  node scripts/run-vitest.mjs src/cron/isolated-agent/run.meta-error-status.test.ts  # 4 tests ✅
  node scripts/run-vitest.mjs src/cron/isolated-agent/run.session-key-isolation.test.ts  # 5 tests ✅
  node scripts/run-vitest.mjs src/gateway/server-cron.test.ts                # 21 tests ✅
  ```

### Real behavior proof — Docker container runtime

#### Environment

- Docker image: `openclaw-pr87981:test` (built from PR HEAD at commit `166d052f`)
- Container: `openclaw-proof-new`, Linux arm64, Node.js v24.14.0
- Provider: **REDACTED**/claude-sonnet-4-6 (Anthropic Messages API)
- Config: isolated cron job every 60s, timeoutSeconds=45, delivery=none

#### MCP server configuration

```json
{
  "mcp": {
    "servers": {
      "proof-echo": {
        "command": "node",
        "args": ["/home/node/.openclaw/proof-mcp-server.cjs"]
      }
    }
  }
}
```

MCP tool injection confirmed: `systemPromptChars=24056` (consistent across all 18 runs).

#### 18 consecutive isolated cron runs

| Run | Session ID | Outcome | Duration |
|-----|-----------|---------|----------|
| 1 | 1de562b9 | completed | 33668ms |
| 2 | 90867a97 | completed | 36123ms |
| 3 | 80a19261 | completed | 35642ms |
| 4 | 8b0bbde8 | completed | 38956ms |
| 5 | 73c14e6e | error | 20041ms |
| 6 | edd993d0 | completed | 34601ms |
| 7 | dd6bd314 | completed | 34364ms |
| 8 | 87933c65 | completed | 35805ms |
| 9 | d1bc9cdb | completed | 34316ms |
| 10 | 1181194e | completed | 34211ms |
| 11 | cc5cfeeb | completed | 35795ms |
| 12 | bf65a28b | completed | 34877ms |
| 13 | c14b87e7 | completed | 34356ms |
| 14 | b8b3ae15 | completed | 35308ms |
| 15 | a69b43db | completed | 35340ms |
| 16 | 2f509ef9 | completed | 34528ms |
| 17 | b0c2526e | completed | 36014ms |
| 18 | 1dcf8c79 | completed | 34994ms |

17/18 completed, 1 transient LLM timeout (Run 5). Each run creates a unique session ID. 18 MCP server starts = each run properly retires and re-creates its MCP runtime.

#### Resource stability after 18 runs

**During active run:**
```
CPU: 42.94% | MEM: 350.6MiB / 7.807GiB (4.39%) | PIDS: 12
```

**Idle between runs (30s after last run):**
```
CPU: 0.26% | MEM: 332.2MiB / 7.807GiB (4.16%) | PIDS: 19
```

```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
node           1  0.0  0.0   2220   960 ?        Ss   04:09   0:00 tini -- node openclaw.mjs gateway
node           7  3.6  3.9 10069704 326264 ?     Sl   04:09   0:20 openclaw
node         269  0.0  0.5 1072228 41080 ?       Ssl  04:18   0:00 node proof-mcp-server.cjs
```

Only 1 MCP server process at idle (pre-warmed for next cron run). No orphan accumulation.

#### Streamable-HTTP disposal timeout coverage (new in this commit)

Added test `"force-closes streamable-http transport when DELETE hangs past the timeout"` that spins up a local HTTP server implementing minimal MCP streamable-HTTP protocol where DELETE never responds. Test confirms disposal completes in ~5097ms (at the DISPOSE_TIMEOUT_MS boundary), proving the force-close mechanism works for the streamable-HTTP transport path.

```
✓ force-closes streamable-http transport when DELETE hangs past the timeout (5097ms)
```

#### Key observations

- **18 unique sessions**: Each cron run gets a fresh isolated session
- **MCP tool injection**: `systemPromptChars=24056` consistent across all runs
- **18 MCP server starts**: Runtime properly retired and re-created per session (no accumulation)
- **RSS stable at ~332 MiB idle**: No memory growth across 18 runs (vs reported 1.4-2.2GB in #87821)
- **CPU 0.26% idle**: No sustained CPU load (vs reported ~100% in #87821)
- **3 processes idle**: tini + openclaw + 1 pre-warmed MCP server — no orphans
- **17/18 completed**: 1 transient LLM timeout, all others successful
- **DISPOSE_TIMEOUT_MS = 5000**: Intentionally not configurable — safety net for hung MCP servers, not a tuning parameter. The 5s deadline only fires when a server refuses to shut down; well-behaved servers close in milliseconds.

#### Before/after comparison

| Metric | Before fix (#87821 report) | After fix (this proof) |
|--------|---------------------------|----------------------|
| Memory after multiple runs | 1.4-2.2 GB (growing) | 332 MiB (stable) |
| CPU | ~100% sustained | 0.26% idle |
| Orphaned MCP processes | Accumulating per run | 0 (1 pre-warmed only) |
| Gateway state | Wedged/unresponsive | Healthy, 17/18 runs complete |

#### What was not tested

- Multi-hour soak test at concurrency=8 (the original #87821 scenario ran for hours)
- systemd Watchdog integration
- Live streamable-HTTP MCP server over network (covered by unit test with local HTTP stub)
- Live production environment verification (proof uses Docker with a real Anthropic API provider)

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts` — 30 passed (includes new dispose timeout + streamable-HTTP force-close tests)
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.fast-mode.test.ts` — 5 passed (updated assertions for dispose retirement)
- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts` — 43 passed
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.meta-error-status.test.ts` — 4 passed
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.session-key-isolation.test.ts` — 5 passed
- `node scripts/run-vitest.mjs src/gateway/server-cron.test.ts` — 21 passed
- New tests added: `disposeSession` timeout coverage + streamable-HTTP disposal timeout test in `agent-bundle-mcp-runtime.test.ts`
- Updated test assertions in `run.fast-mode.test.ts` to verify new `"isolated-cron-dispose"` retirement reason
- Mock infrastructure added in `server-cron.test.ts` for `retireSessionMcpRuntime` and `abortAndDrainEmbeddedAgentRun`

Before this fix, the existing `run.fast-mode.test.ts` asserted `expect(retireSessionMcpRuntimeMock).not.toHaveBeenCalled()` for isolated sessions. After this fix, isolated sessions correctly call retirement with reason `"isolated-cron-dispose"`.


## Availability tradeoff (requires maintainer sign-off)

This PR introduces a **bounded 5-second disposal deadline** for MCP session cleanup. This is an intentional tradeoff:

**Before (current main):** `disposeSession` awaits `terminateSession()` → `transport.close()` → `client.close()` with **no timeout**. If any step hangs (e.g. a stuck DELETE request to a remote MCP server, or a zombie child process), the entire disposal chain blocks indefinitely. In the cron path, this eventually saturates the event loop and wedges the gateway.

**After (this PR):** Disposal is bounded to 5 seconds. If the graceful path exceeds the deadline:
1. The timeout fires and the wrapper returns
2. The `.finally()` block force-closes the transport (`transport.close()` aborts the SDK AbortController, cancelling any in-flight HTTP requests) and client
3. For stdio transports, `close()` triggers the existing kill sequence (stdin end → 2s wait → SIGTERM → 2s wait → SIGKILL)

**What could remain alive after timeout:**
- For **streamable-http**: Nothing critical — `transport.close()` is now called in the timeout path, which aborts the AbortController and cancels the hung DELETE
- For **stdio**: The existing kill chain (SIGTERM → SIGKILL) runs inside `close()`, so child processes are actively reaped
- Edge case: if `transport.close()` itself hangs (unlikely but possible with a deeply broken transport implementation), the process could linger until OS reap or gateway restart

**Precedent in codebase:**
- `OpenClawStdioClientTransport.close()` already has 2s+2s+500ms bounded waits with SIGTERM/SIGKILL (`mcp-stdio-transport.ts:113-137`)
- `embeddings-worker.ts:183-204` races worker close against a deadline with `shutdownChild()` in `finally`
- `delivery.ts:155-178` uses AbortController timeout for delivery operations

**Risk assessment:** The tradeoff is strongly favorable — a wedged gateway (the current failure mode) is a complete outage affecting all users, while a lingering MCP process is a bounded resource leak that self-heals on gateway restart. The 5-second deadline is generous enough for normal cleanup but short enough to prevent accumulation.

**Maintainer decision needed:** Please confirm acceptance of bounded disposal semantics. If the 5-second deadline is too aggressive or too lenient, it can be made configurable via `cron.mcpDisposeTimeoutMs`.

## Risk checklist

Did user-visible behavior change? No

Did config, environment, or migration behavior change? No

Did security, auth, secrets, network, or tool execution behavior change? No

What is the highest-risk area? The `disposeSession` timeout wrapper — if the 5s timeout fires, MCP child processes may linger until OS reap or gateway restart.

How is that risk mitigated? Timer uses `.unref()` so it does not keep the event loop alive, and `clearTimeout` in the `.finally()` block prevents timer leaks on normal-speed disposal. Lingering child processes are an acceptable tradeoff vs a wedged gateway.

## Current review state

Lint fix applied (braced-if on line 228). All 108 targeted tests pass across 6 test files (30 MCP runtime including new streamable-HTTP + 78 cron tests). Ready for maintainer review.








## Real behavior proof

- **Behavior or issue addressed**: Isolated cron runs with MCP servers could leave per-session MCP runtimes and child transports alive after timeout or completion, eventually making the gateway unresponsive. This patch retires MCP runtimes on isolated cron timeout/dispose and bounds MCP session teardown when server termination hangs.
- **Real environment tested**: Docker image `openclaw-pr87981:test` built from the PR source after the disposal fix, Linux arm64 under OrbStack on macOS host, Node.js v24.14.0, real OpenClaw gateway with isolated cron, stdio MCP server, and a redacted Anthropic provider.
- **Exact steps or command run after this patch**: Built the Docker image, started `node openclaw.mjs gateway --allow-unconfigured`, configured an MCP stdio server (`proof-echo`), added an isolated cron job every 60s with `--timeout-seconds 45 --no-deliver`, then observed 18 consecutive isolated cron executions and process/resource state. Also ran focused test commands: `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts`, `node scripts/run-vitest.mjs src/cron/isolated-agent/run.fast-mode.test.ts`, `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts`, `node scripts/run-vitest.mjs src/cron/isolated-agent/run.meta-error-status.test.ts`, `node scripts/run-vitest.mjs src/cron/isolated-agent/run.session-key-isolation.test.ts`, and `node scripts/run-vitest.mjs src/gateway/server-cron.test.ts`.
- **Evidence after fix**: Copied live Docker/runtime output in this PR body records 18 isolated cron runs with unique session IDs, 18 MCP server starts, `systemPromptChars=24056` confirming MCP tool injection, idle CPU 0.26%, idle RSS 332.2 MiB, and only one pre-warmed MCP server process after the final run. The focused streamable-HTTP test output also records `force-closes streamable-http transport when DELETE hangs past the timeout (5097ms)`.
- **Observed result after fix**: 17 of 18 cron runs completed, one transient LLM timeout occurred, memory and CPU stayed stable, and no orphan MCP process accumulation was observed; idle process list was `tini`, `openclaw`, and one pre-warmed `proof-mcp-server.cjs` for the next run.
- **What was not tested**: Multi-hour concurrency=8 systemd soak of the exact original outage, systemd WatchdogSec integration, live production host verification, and a live remote streamable-HTTP MCP server over the network.
