### PR TITLE
fix(media): allow trusted generated html attachments

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import JSZip from "jszip";
@@ -650,9 +651,111 @@ describe("loadWebMedia", () => {
     expect(result.contentType).toBe("text/markdown");
   });
 
-  it("rejects host-read HTML files without a separate security-boundary approval", async () => {
+  it("allows trusted generated host-read HTML reports under OpenClaw temp root", async () => {
     const htmlFile = path.join(fixtureRoot, "report.html");
     await fs.writeFile(htmlFile, "<!doctype html><title>Report</title><h1>Report</h1>\n", "utf8");
+    const result = await loadWebMedia(htmlFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: "any",
+      readFile: async (filePath) => await fs.readFile(filePath),
+      hostReadCapability: true,
+    });
+    expect(result.kind).toBe("document");
+    expect(result.contentType).toBe("text/html");
+  });
+
+  it("rejects host-read HTML files outside the trusted OpenClaw temp root", async () => {
+    const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-host-html-"));
+    const htmlFile = path.join(outsideRoot, "report.html");
+    await fs.writeFile(htmlFile, "<!doctype html><title>Report</title><h1>Report</h1>\n", "utf8");
+    try {
+      await expectLoadWebMediaErrorCode(
+        loadWebMedia(htmlFile, {
+          maxBytes: 1024 * 1024,
+          localRoots: "any",
+          readFile: async (filePath) => await fs.readFile(filePath),
+          hostReadCapability: true,
+        }),
+        "path-not-allowed",
+      );
+    } finally {
+      await fs.rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects trusted host-read HTML symlinks that resolve outside OpenClaw temp root", async () => {
+    const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-host-html-"));
+    const outsideHtml = path.join(outsideRoot, "report.html");
+    const htmlLink = path.join(fixtureRoot, "linked-report.html");
+    await fs.writeFile(
+      outsideHtml,
+      "<!doctype html><title>Outside</title><body>secret</body>\n",
+      "utf8",
+    );
+    try {
+      await fs.symlink(outsideHtml, htmlLink);
+    } catch (error) {
+      await fs.rm(outsideRoot, { recursive: true, force: true });
+      if ((error as NodeJS.ErrnoException).code === "EPERM") {
+        return;
+      }
+      throw error;
+    }
+    try {
+      await expectLoadWebMediaErrorCode(
+        loadWebMedia(htmlLink, {
+          maxBytes: 1024 * 1024,
+          localRoots: "any",
+          readFile: async (filePath) => await fs.readFile(filePath),
+          hostReadCapability: true,
+        }),
+        "path-not-allowed",
+      );
+    } finally {
+      await fs.rm(htmlLink, { force: true });
+      await fs.rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects trusted host-read HTML hardlinks to files outside OpenClaw temp root", async () => {
+    const outsideRoot = await fs.mkdtemp(
+      path.join(path.dirname(resolvePreferredOpenClawTmpDir()), "web-media-host-html-"),
+    );
+    const outsideHtml = path.join(outsideRoot, "report.html");
+    const htmlLink = path.join(fixtureRoot, "hardlinked-report.html");
+    await fs.writeFile(
+      outsideHtml,
+      "<!doctype html><title>Outside</title><body>secret</body>\n",
+      "utf8",
+    );
+    try {
+      await fs.link(outsideHtml, htmlLink);
+    } catch (error) {
+      await fs.rm(outsideRoot, { recursive: true, force: true });
+      if ((error as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw error;
+    }
+    try {
+      await expectLoadWebMediaErrorCode(
+        loadWebMedia(htmlLink, {
+          maxBytes: 1024 * 1024,
+          localRoots: "any",
+          readFile: async (filePath) => await fs.readFile(filePath),
+          hostReadCapability: true,
+        }),
+        "path-not-allowed",
+      );
+    } finally {
+      await fs.rm(htmlLink, { force: true });
+      await fs.rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects trusted host-read HTML paths without HTML document shape", async () => {
+    const htmlFile = path.join(fixtureRoot, "report.html");
+    await fs.writeFile(htmlFile, "status,value\nok,1\n", "utf8");
     await expectLoadWebMediaErrorCode(
       loadWebMedia(htmlFile, {
         maxBytes: 1024 * 1024,

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -1,9 +1,11 @@
+import { lstat, realpath } from "node:fs/promises";
 import path from "node:path";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { FsSafeError, readLocalFileSafely } from "../infra/fs-safe.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-file-access.js";
 import type { PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { uniqueValues } from "../shared/string-normalization.js";
 import { resolveUserPath } from "../utils.js";
@@ -157,6 +159,9 @@ const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown"]);
 // security-boundary review, but extension-declared .html files still need to
 // fail closed instead of falling through to binary/media sniffing.
 const HOST_READ_DECLARED_TEXT_MIMES = new Set([...HOST_READ_TEXT_PLAIN_ALIASES, "text/html"]);
+const HOST_READ_DECLARED_TEXT_ERROR =
+  "hostReadCapability permits only validated plain-text CSV/Markdown documents " +
+  "and trusted generated HTML reports for local reads";
 const MB = 1024 * 1024;
 
 function getTextStats(text: string): { printableRatio: number } {
@@ -226,18 +231,71 @@ function decodeHostReadText(buffer: Buffer): string | undefined {
 }
 
 function isValidatedHostReadText(buffer?: Buffer): boolean {
+  return getValidatedHostReadText(buffer) !== undefined;
+}
+
+function getValidatedHostReadText(buffer?: Buffer): string | undefined {
   if (!buffer) {
-    return false;
+    return undefined;
   }
   if (buffer.length === 0) {
-    return true;
+    return "";
   }
   const text = decodeHostReadText(buffer);
   if (text === undefined) {
-    return false;
+    return undefined;
   }
   const { printableRatio } = getTextStats(text);
-  return printableRatio > 0.95;
+  return printableRatio > 0.95 ? text : undefined;
+}
+
+function isPathInsideRoot(filePath: string | undefined, root: string): boolean {
+  if (!filePath) {
+    return false;
+  }
+  const relative = path.relative(path.resolve(root), path.resolve(filePath));
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function hasHtmlDocumentShape(text: string): boolean {
+  const sample = text.trimStart().slice(0, 8192);
+  return /^(?:<!doctype\s+html\b|<html\b)/iu.test(sample) || /<\/(?:html|body)>/iu.test(sample);
+}
+
+async function isTrustedGeneratedHostReadHtmlPath(filePath: string | undefined): Promise<boolean> {
+  if (!filePath) {
+    return false;
+  }
+  const info = await lstat(filePath).catch(() => undefined);
+  if (!info?.isFile() || info.isSymbolicLink() || info.nlink !== 1) {
+    return false;
+  }
+  const [resolvedFilePath, resolvedTmpRoot] = await Promise.all([
+    realpath(filePath).catch(() => undefined),
+    realpath(resolvePreferredOpenClawTmpDir()).catch(() => undefined),
+  ]);
+  return Boolean(
+    resolvedFilePath && resolvedTmpRoot && isPathInsideRoot(resolvedFilePath, resolvedTmpRoot),
+  );
+}
+
+function isTrustedGeneratedHostReadHtml(params: {
+  filePath?: string;
+  sniffedContentType?: string;
+  buffer?: Buffer;
+  trustedGeneratedHtmlPath?: boolean;
+}): boolean {
+  const sniffedMime = normalizeMimeType(params.sniffedContentType);
+  if (sniffedMime && sniffedMime !== "text/html") {
+    return false;
+  }
+  if (!params.trustedGeneratedHtmlPath) {
+    return false;
+  }
+  const text = getValidatedHostReadText(params.buffer);
+  return text !== undefined && hasHtmlDocumentShape(text);
 }
 
 function formatMb(bytes: number, digits = 2): string {
@@ -268,6 +326,7 @@ function assertHostReadMediaAllowed(params: {
   filePath?: string;
   kind: MediaKind | undefined;
   buffer?: Buffer;
+  trustedGeneratedHtmlPath?: boolean;
 }): void {
   const declaredMime = normalizeMimeType(mimeTypeFromFilePath(params.filePath));
   const normalizedMime = normalizeMimeType(params.contentType);
@@ -277,6 +336,17 @@ function assertHostReadMediaAllowed(params: {
   // host-read should reject those instead of returning early on the sniff.
   if (declaredMime && HOST_READ_DECLARED_TEXT_MIMES.has(declaredMime)) {
     if (
+      declaredMime === "text/html" &&
+      isTrustedGeneratedHostReadHtml({
+        filePath: params.filePath,
+        sniffedContentType: params.sniffedContentType,
+        buffer: params.buffer,
+        trustedGeneratedHtmlPath: params.trustedGeneratedHtmlPath,
+      })
+    ) {
+      return;
+    }
+    if (
       HOST_READ_TEXT_PLAIN_ALIASES.has(declaredMime) &&
       !params.sniffedContentType &&
       params.buffer &&
@@ -284,10 +354,7 @@ function assertHostReadMediaAllowed(params: {
     ) {
       return;
     }
-    throw new LocalMediaAccessError(
-      "path-not-allowed",
-      "hostReadCapability permits only validated plain-text CSV/Markdown documents for local reads",
-    );
+    throw new LocalMediaAccessError("path-not-allowed", HOST_READ_DECLARED_TEXT_ERROR);
   }
   const sniffedKind = kindFromMime(params.sniffedContentType);
   if (sniffedKind === "image" || sniffedKind === "audio" || sniffedKind === "video") {
@@ -915,6 +982,17 @@ async function loadWebMediaInternal(
     await assertLocalMediaAllowed(mediaUrl, localRoots, { inboundRoots });
   }
 
+  const hostReadDeclaredMime = hostReadCapability
+    ? normalizeMimeType(mimeTypeFromFilePath(mediaUrl))
+    : undefined;
+  const trustedGeneratedHtmlPath =
+    hostReadDeclaredMime === "text/html"
+      ? await isTrustedGeneratedHostReadHtmlPath(mediaUrl)
+      : false;
+  if (hostReadDeclaredMime === "text/html" && !trustedGeneratedHtmlPath) {
+    throw new LocalMediaAccessError("path-not-allowed", HOST_READ_DECLARED_TEXT_ERROR);
+  }
+
   // Local path
   let data: Buffer;
   if (readFileOverride) {
@@ -955,6 +1033,7 @@ async function loadWebMediaInternal(
       filePath: mediaUrl,
       kind,
       buffer: data,
+      trustedGeneratedHtmlPath,
     });
   }
   let fileName = basenameFromAnyPath(mediaUrl) || undefined;


### PR DESCRIPTION
## Summary

- Allows host-read `.html` attachments only when they are trusted generated reports under the resolved OpenClaw temp root.
- Keeps arbitrary host-local HTML blocked, including symlink and hardlink attempts into the temp root.
- Adds regression coverage for trusted generated HTML, outside-root HTML, non-HTML text, symlink, hardlink, and binary disguised `.html` cases.

## Verification

- `node scripts/run-vitest.mjs src/media/web-media.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/media/load-options.test.ts src/media/read-capability.test.ts src/media/outbound-attachment.test.ts`
- `node scripts/run-vitest.mjs src/media/web-media.test.ts src/media/load-options.test.ts src/media/read-capability.test.ts src/media/outbound-attachment.test.ts --reporter=verbose`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Telegram delivery of generated HTML report attachments regressed after PR #86531 because host-read `.html` files were blocked and fell back to Markdown. This change restores generated HTML report attachment delivery without reopening arbitrary host-local HTML reads.

Real environment tested: Local OpenClaw checkout on branch `fix/telegram-generated-html-attachments`; remote Testbox check also passed before the autoreview hardening follow-up, and the final rebased diff passed local changed gates.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs src/media/web-media.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/media/load-options.test.ts src/media/read-capability.test.ts src/media/outbound-attachment.test.ts
node scripts/run-vitest.mjs src/media/web-media.test.ts src/media/load-options.test.ts src/media/read-capability.test.ts src/media/outbound-attachment.test.ts --reporter=verbose
env -u OPENCLAW_TESTBOX pnpm check:changed
/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:

```text
Test Files  1 passed (1)
Tests  64 passed (64)
```

```text
Test Files  3 passed (3)
Tests  17 passed (17)
```

```text
Test Files  4 passed (4)
Tests  81 passed (81)
```

```text
Import cycle check: 0 runtime value cycle(s).
```

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.86)
```

Observed result after fix: valid generated `.html` reports under the OpenClaw temp root load as `text/html` documents for host-read delivery; `.html` files outside that root, symlinked files, hardlinked files, non-HTML text, and binary disguised as HTML are rejected with `path-not-allowed`.

What was not tested: live Telegram Bot API delivery, because channel credentials were not available in this checkout.
