### PR TITLE
docs(skills): allow model-usage with Linux codexbar

### DIFF
--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -51,7 +51,7 @@ python {baseDir}/scripts/model_usage.py --provider claude --mode all --format js
 ## Inputs
 
 - Default: runs `codexbar cost --format json --provider <codex|claude>`.
-- macOS and Linux: use the bundled Homebrew formula installer above for live local usage reads. Linux users can also use CodexBar's AUR package or official release tarballs.
+- macOS and Linux: use the bundled Homebrew formula installer above for live local usage reads. Linux users can also use CodexBar's [AUR package](https://aur.archlinux.org/packages/codexbar-cli) or [official release tarballs](https://github.com/steipete/CodexBar/releases).
 - Other platforms: use `--input` with exported CodexBar JSON.
 - File or stdin:
 

--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -6,7 +6,7 @@ metadata:
     "openclaw":
       {
         "emoji": "📊",
-        "os": ["darwin"],
+        "os": ["darwin", "linux"],
         "requires": { "bins": ["codexbar"] },
         "install":
           [
@@ -15,7 +15,7 @@ metadata:
               "kind": "brew",
               "formula": "steipete/tap/codexbar",
               "bins": ["codexbar"],
-              "label": "Install CodexBar (brew cask)",
+              "label": "Install CodexBar CLI (Homebrew)",
             },
           ],
       },
@@ -28,7 +28,7 @@ metadata:
 
 Get per-model usage cost from CodexBar's local cost logs. Supports "current model" (most recent daily entry) or "all models" summaries for Codex or Claude.
 
-Live CodexBar CLI invocation is currently documented for macOS only. The bundled Python summarizer is portable: if you already have exported CodexBar JSON, `--input` mode works anywhere Python is available.
+CodexBar ships CLI builds for macOS and Linux. When `codexbar` is on `PATH`, the skill reads local usage directly; the bundled Python summarizer also accepts exported CodexBar JSON through `--input` anywhere Python is available.
 
 ## Quick start
 
@@ -51,8 +51,8 @@ python {baseDir}/scripts/model_usage.py --provider claude --mode all --format js
 ## Inputs
 
 - Default: runs `codexbar cost --format json --provider <codex|claude>`.
-- macOS: use the bundled CodexBar CLI install path above for live local usage reads.
-- Linux/other platforms: use `--input` with exported CodexBar JSON until this skill documents a supported local CodexBar install path for that platform.
+- macOS and Linux: use the bundled Homebrew formula installer above for live local usage reads. Linux users can also use CodexBar's AUR package or official release tarballs.
+- Other platforms: use `--input` with exported CodexBar JSON.
 - File or stdin:
 
 ```bash

--- a/skills/model-usage/references/codexbar-cli.md
+++ b/skills/model-usage/references/codexbar-cli.md
@@ -2,8 +2,10 @@
 
 ## Install
 
-- App: Preferences -> Advanced -> Install CLI
-- Repo: ./bin/install-codexbar-cli.sh
+- macOS and Linux Homebrew formula: `brew install steipete/tap/codexbar`
+- Linux AUR package: `yay -S codexbar-cli`
+- macOS and Linux tarballs: [CodexBar releases](https://github.com/steipete/CodexBar/releases)
+- macOS app: Preferences -> Advanced -> Install CLI
 
 ## Commands
 


### PR DESCRIPTION
## What Problem This Solves

The bundled `model-usage` skill is currently Darwin-only even though current CodexBar releases ship a Linux CLI and support local Codex/Claude cost reads there. Linux hosts with a working `codexbar` binary therefore fail the skill OS gate unnecessarily.

Closes #87985.

## Why This Change Was Made

- Add Linux to the skill's supported OS metadata while retaining the existing `codexbar` binary requirement.
- Keep the existing Homebrew formula installer available on macOS and Linux; OpenClaw runs `brew install steipete/tap/codexbar`, and that formula has explicit macOS and Linux assets.
- Rename the installer label from the inaccurate "brew cask" wording to "CodexBar CLI (Homebrew)".
- Document CodexBar's supported Homebrew, AUR, and release-tarball Linux install paths in the skill and quick reference.

## User Impact

On Linux, `model-usage` becomes eligible only when `codexbar` is available on `PATH`. Hosts without the binary remain ineligible. Linux users with Homebrew can use the bundled installer; AUR and official release tarballs remain documented alternatives.

## Evidence

- CodexBar v0.45.2 publishes glibc and static-musl Linux CLI assets for arm64 and x86_64.
- The current `steipete/tap/codexbar` formula has explicit `on_linux` assets and installs the `codexbar` executable.
- Current CodexBar `CLICostCommand` supports Codex and Claude outside macOS.
- OpenClaw's skill installer resolves this metadata to `brew install steipete/tap/codexbar`.
- The contributor's Linux proof on the original PR head showed the positive `codexbar`-present case, the negative missing-binary case, and no missing OS requirement.

## Validation

- `node scripts/docs-list.js`
- `node scripts/check-no-conflict-markers.mjs`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean

This intentionally expands bundled skill availability on Linux and remains queued for maintainer product-scope approval.
