### PR TITLE
fix(agents): add typed tool progress updates

### DIFF
--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -178,6 +178,50 @@ Progress lines are enabled by default in progress mode. They come from real run
 events: tool starts, item updates, task plans, approvals, command output, patch
 summaries, and similar agent activity.
 
+Tools can also emit typed progress while a single tool call is still running.
+That is how a slow fetch or search can update the visible draft before the tool
+returns its final result. The progress update is a partial tool result with
+empty model content and explicit public channel metadata:
+
+```json
+{
+  "content": [],
+  "progress": {
+    "text": "Fetching page content...",
+    "visibility": "channel",
+    "privacy": "public",
+    "id": "web_fetch:fetching"
+  }
+}
+```
+
+OpenClaw renders only the `progress.text` in the channel progress UI. The
+normal tool result still arrives later as `content` and `details`, and is the
+only part returned to the model.
+
+When adding progress to a tool, use a short, generic message and delay it until
+the operation has been pending long enough to be useful:
+
+```typescript
+const clearProgressTimer = scheduleToolProgress(
+  onUpdate,
+  { text: "Fetching page content...", id: "web_fetch:fetching" },
+  5_000,
+  { signal },
+);
+
+try {
+  return await runToolWork();
+} finally {
+  clearProgressTimer();
+}
+```
+
+This pattern means fast calls do not show a progress line, long calls show one
+while they are still pending, and canceled calls clear the timer before stale
+progress can appear. Progress text is a public UI side channel, so it must not
+include secrets, raw arguments, fetched content, command output, or page text.
+
 OpenClaw uses the same formatter for progress drafts and `/verbose`:
 
 ```json5

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -197,6 +197,12 @@ Matrix:
 
 Preview streaming can also include **tool-progress** updates - short status lines like "searching the web", "reading file", or "calling tool" - that appear in the same preview message while tools are running, ahead of the final reply. In Codex app-server mode, Codex preamble/commentary messages use this same preview path, so short "I am checking..." progress notes can stream into the editable draft without becoming part of the final answer. This keeps multi-step tool turns visually alive rather than silent between the first thinking preview and the final answer.
 
+Long-running tools may emit typed progress before they return. For example,
+`web_fetch` arms a five-second timer when it starts: if the fetch is still
+pending, the preview can show `Fetching page content...`; if the fetch finishes
+or is canceled before then, no progress line is emitted. The later final tool
+result is still delivered normally to the model.
+
 Supported surfaces:
 
 - **Discord**, **Slack**, **Telegram**, and **Matrix** stream tool-progress and Codex preamble updates into the live preview edit by default when preview streaming is active. Microsoft Teams uses its native progress stream in personal chats.

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -57,6 +57,21 @@ Truncate output to this many characters.
   </Step>
 </Steps>
 
+## Progress updates
+
+`web_fetch` emits a public progress line only when the fetch is still pending
+after five seconds:
+
+```text
+Fetching page content...
+```
+
+Fast cache hits and quick network responses finish before the timer fires, so
+they do not show a progress line. If the call is canceled, the timer is cleared.
+When the fetch eventually completes, the agent receives the normal tool result;
+the progress line is only channel UI state and never contains fetched page
+content.
+
 ## Config
 
 ```json5

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -363,7 +363,7 @@ export interface AgentToolResult<T> {
   content: (TextContent | ImageContent)[];
   /** Arbitrary structured details for logs or UI rendering. */
   details: T;
-  /** Optional public progress hint for partial tool updates. */
+  /** Optional public progress hint for partial tool updates; never model content. */
   progress?: AgentToolProgress;
   /**
    * Hint that the agent should stop after the current tool batch.

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -345,12 +345,26 @@ export interface AgentState {
   readonly errorMessage?: string;
 }
 
+/** Channel-safe progress text emitted by a running tool. */
+export interface AgentToolProgress {
+  /** Public text suitable for user-facing progress surfaces. */
+  text: string;
+  /** Tool progress is rendered by channel progress UIs. */
+  visibility: "channel";
+  /** Progress text must not contain secrets, private args, or fetched content. */
+  privacy: "public";
+  /** Optional stable id for progress line replacement. */
+  id?: string;
+}
+
 /** Final or partial result produced by a tool. */
 export interface AgentToolResult<T> {
   /** Text or image content returned to the model. */
   content: (TextContent | ImageContent)[];
   /** Arbitrary structured details for logs or UI rendering. */
   details: T;
+  /** Optional public progress hint for partial tool updates. */
+  progress?: AgentToolProgress;
   /**
    * Hint that the agent should stop after the current tool batch.
    * Early termination only happens when every finalized tool result in the batch sets this to true.

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1087,6 +1087,138 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
 });
 
 describe("handleToolExecutionEnd derived tool events", () => {
+  it("surfaces typed public tool progress for any non-exec tool", () => {
+    resetAgentEventsForTest();
+    const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+    const { ctx, onAgentEvent } = createTestContext();
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "custom_fetcher",
+        toolCallId: "tool-custom-progress",
+        partialResult: {
+          content: [],
+          details: undefined,
+          progress: {
+            text: "Loading remote resource...",
+            visibility: "channel",
+            privacy: "public",
+          },
+        },
+      } as never,
+    );
+
+    expect(
+      events.filter(
+        (event) =>
+          event.stream === "tool" &&
+          (event.data as { phase?: string } | undefined)?.phase === "update",
+      ),
+    ).toHaveLength(0);
+    const itemEvent = requireRecord(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .find((event) => (event as { stream?: string })?.stream === "item"),
+      "progress item event",
+    );
+    expectRecordFields(itemEvent.data, "progress item event data", {
+      itemId: "tool:tool-custom-progress",
+      phase: "update",
+      kind: "tool",
+      name: "custom_fetcher",
+      progressText: "Loading remote resource...",
+      status: "running",
+    });
+    expect(requireRecord(itemEvent.data, "progress item event data").meta).toBeUndefined();
+
+    resetAgentEventsForTest();
+  });
+
+  it("does not promote untyped non-exec content into channel progress", () => {
+    resetAgentEventsForTest();
+    const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+    const { ctx, onAgentEvent } = createTestContext();
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "web_fetch",
+        toolCallId: "tool-web-fetch-untyped",
+        partialResult: {
+          content: [{ type: "text", text: "Fetching page content..." }],
+          details: undefined,
+        },
+      } as never,
+    );
+
+    expect(
+      events.filter(
+        (event) =>
+          event.stream === "tool" &&
+          (event.data as { phase?: string } | undefined)?.phase === "update",
+      ),
+    ).toHaveLength(1);
+    const itemEvent = requireRecord(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .find((event) => (event as { stream?: string })?.stream === "item"),
+      "tool item event",
+    );
+    expect(requireRecord(itemEvent.data, "tool item event data").progressText).toBeUndefined();
+    expect(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .filter((event) => (event as { stream?: string })?.stream === "tool"),
+    ).toHaveLength(1);
+
+    resetAgentEventsForTest();
+  });
+
+  it("caps typed public tool progress before channel item events", () => {
+    const { ctx, onAgentEvent } = createTestContext();
+    const largeProgress = "x".repeat(9000);
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "custom_fetcher",
+        toolCallId: "tool-large-progress",
+        partialResult: {
+          content: [],
+          details: undefined,
+          progress: {
+            text: largeProgress,
+            visibility: "channel",
+            privacy: "public",
+          },
+        },
+      } as never,
+    );
+
+    const itemEvent = requireRecord(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .find((event) => (event as { stream?: string })?.stream === "item"),
+      "large progress item event",
+    );
+    const progressText = requireString(
+      requireRecord(itemEvent.data, "large progress item event data").progressText,
+      "progress text",
+    );
+    expect(progressText).toContain("...(live output truncated)...");
+    expect(progressText.length).toBeLessThan(largeProgress.length);
+  });
+
   it("emits command output deltas for exec update results", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -351,6 +351,8 @@ function extractLiveExecOutput(result: unknown): string | undefined {
 
 function readChannelToolProgress(result: unknown): ChannelToolProgress | undefined {
   const progress = readRecordField(asOptionalObjectRecord(result)?.progress);
+  // Only an explicit typed progress field crosses into channel UI. Tool output
+  // and details may contain fetched content or private args, so never infer.
   if (progress?.visibility !== "channel" || progress.privacy !== "public") {
     return undefined;
   }
@@ -1078,6 +1080,8 @@ export function handleToolExecutionUpdate(
   const isExecTool = isExecToolName(toolName);
   const liveResult = isExecTool ? capLiveExecResult(sanitized) : sanitized;
   const toolProgress = isExecTool ? undefined : readChannelToolProgress(liveResult);
+  // Typed progress already has a sanitized item update path. Suppress the raw
+  // partial-result event for those updates to avoid duplicate preview lines.
   const emitDetailedLiveUpdate =
     !toolProgress && (!isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId));
   if (emitDetailedLiveUpdate) {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -26,6 +26,7 @@ import {
 import { normalizeOptionalLowercaseString, readStringValue } from "../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
+import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
@@ -53,7 +54,6 @@ import {
 import { inferToolMetaFromArgs } from "./embedded-agent-utils.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
 import type { AgentEvent } from "./runtime/index.js";
-import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 
@@ -61,6 +61,9 @@ type ExecApprovalReplyModule = typeof import("../infra/exec-approval-reply.js");
 type HookRunnerGlobalModule = typeof import("../plugins/hook-runner-global.js");
 type MediaParseModule = typeof import("../media/parse.js");
 type BeforeToolCallModule = typeof import("./agent-tools.before-tool-call.js");
+type ChannelToolProgress = {
+  text: string;
+};
 
 const execApprovalReplyModuleLoader = createLazyImportLoader<ExecApprovalReplyModule>(
   () => import("../infra/exec-approval-reply.js"),
@@ -344,6 +347,18 @@ function extractExecOutput(result: unknown): string | undefined {
 function extractLiveExecOutput(result: unknown): string | undefined {
   const output = extractExecOutput(result);
   return typeof output === "string" ? truncateLiveExecOutput(output) : undefined;
+}
+
+function readChannelToolProgress(result: unknown): ChannelToolProgress | undefined {
+  const progress = readRecordField(asOptionalObjectRecord(result)?.progress);
+  if (progress?.visibility !== "channel" || progress.privacy !== "public") {
+    return undefined;
+  }
+  const text = readStringValue(progress.text)?.trim();
+  if (!text) {
+    return undefined;
+  }
+  return { text: truncateLiveExecOutput(text) };
 }
 
 function shouldEmitLiveExecUpdate(ctx: ToolHandlerContext, toolCallId: string): boolean {
@@ -1062,7 +1077,9 @@ export function handleToolExecutionUpdate(
   const sanitized = sanitizeToolResult(partial);
   const isExecTool = isExecToolName(toolName);
   const liveResult = isExecTool ? capLiveExecResult(sanitized) : sanitized;
-  const emitDetailedLiveUpdate = !isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId);
+  const toolProgress = isExecTool ? undefined : readChannelToolProgress(liveResult);
+  const emitDetailedLiveUpdate =
+    !toolProgress && (!isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId));
   if (emitDetailedLiveUpdate) {
     emitAgentEvent({
       runId: ctx.params.runId,
@@ -1082,18 +1099,22 @@ export function handleToolExecutionUpdate(
     title: buildToolItemTitle(toolName, ctx.state.toolMetaById.get(toolCallId)?.meta),
     status: "running",
     name: toolName,
-    meta: ctx.state.toolMetaById.get(toolCallId)?.meta,
     toolCallId,
+    ...(toolProgress
+      ? { progressText: toolProgress.text }
+      : { meta: ctx.state.toolMetaById.get(toolCallId)?.meta }),
   };
   emitTrackedItemEvent(ctx, itemData);
-  void ctx.params.onAgentEvent?.({
-    stream: "tool",
-    data: {
-      phase: "update",
-      name: toolName,
-      toolCallId,
-    },
-  });
+  if (!toolProgress) {
+    void ctx.params.onAgentEvent?.({
+      stream: "tool",
+      data: {
+        phase: "update",
+        name: toolName,
+        toolCallId,
+      },
+    });
+  }
   if (isExecTool) {
     const output = extractLiveExecOutput(liveResult);
     const commandData: AgentItemEventData = {

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -415,6 +415,8 @@ export function toolProgressResult(progress: PublicToolProgress): AgentToolResul
   };
 }
 
+// Tool progress is a UI side channel. The model-facing tool result remains in
+// `content`; progress text must already be safe to show in channel previews.
 export function emitToolProgress(
   onUpdate: AgentToolUpdateCallback | undefined,
   progress: PublicToolProgress,
@@ -430,6 +432,8 @@ export function emitToolProgress(
   }
 }
 
+// Long-running tools can arm delayed progress and cancel it on completion or
+// abort. This avoids stale "still working" lines after a fast or canceled call.
 export function scheduleToolProgress(
   onUpdate: AgentToolUpdateCallback | undefined,
   progress: PublicToolProgress,

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -9,7 +9,12 @@ import {
 } from "../../shared/number-coercion.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import type { ImageSanitizationLimits } from "../image-sanitization.js";
-import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "../runtime/index.js";
+import type {
+  AgentTool,
+  AgentToolProgress,
+  AgentToolResult,
+  AgentToolUpdateCallback,
+} from "../runtime/index.js";
 import { sanitizeToolResultImages } from "../tool-images.js";
 
 export type AgentToolWithMeta<TParameters extends TSchema, TResult> = AgentTool<
@@ -393,6 +398,63 @@ export function payloadTextResult<TDetails>(payload: TDetails): AgentToolResult<
 
 export function jsonResult(payload: unknown): AgentToolResult<unknown> {
   return textResult(JSON.stringify(payload, null, 2), payload);
+}
+
+export type PublicToolProgress = Pick<AgentToolProgress, "text" | "id">;
+
+export function toolProgressResult(progress: PublicToolProgress): AgentToolResult<undefined> {
+  return {
+    content: [],
+    details: undefined,
+    progress: {
+      text: progress.text,
+      visibility: "channel",
+      privacy: "public",
+      ...(progress.id ? { id: progress.id } : {}),
+    },
+  };
+}
+
+export function emitToolProgress(
+  onUpdate: AgentToolUpdateCallback | undefined,
+  progress: PublicToolProgress,
+): void {
+  const text = progress.text.trim();
+  if (!onUpdate || !text) {
+    return;
+  }
+  try {
+    onUpdate(toolProgressResult({ ...progress, text }));
+  } catch {
+    // Progress is best-effort UI state; tool execution must not depend on subscribers.
+  }
+}
+
+export function scheduleToolProgress(
+  onUpdate: AgentToolUpdateCallback | undefined,
+  progress: PublicToolProgress,
+  delayMs: number,
+  options: { signal?: AbortSignal } = {},
+): () => void {
+  if (!onUpdate || options.signal?.aborted) {
+    return () => {};
+  }
+  let cleared = false;
+  let timer: ReturnType<typeof setTimeout>;
+  const clear = () => {
+    if (cleared) {
+      return;
+    }
+    cleared = true;
+    clearTimeout(timer);
+    options.signal?.removeEventListener("abort", clear);
+  };
+  timer = setTimeout(() => {
+    clear();
+    emitToolProgress(onUpdate, progress);
+  }, delayMs);
+  options.signal?.addEventListener("abort", clear, { once: true });
+  return clear;
 }
 
 export async function imageResult(params: {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -15,7 +15,12 @@ import { extractReadableContent } from "../../web-fetch/content-extractors.runti
 import { resolveWebProviderConfig } from "../../web/provider-runtime-shared.js";
 import { stringEnum } from "../schema/string-enum.js";
 import type { AnyAgentTool } from "./common.js";
-import { jsonResult, readPositiveIntegerParam, readStringParam } from "./common.js";
+import {
+  jsonResult,
+  readPositiveIntegerParam,
+  readStringParam,
+  scheduleToolProgress,
+} from "./common.js";
 import {
   extractBasicHtmlContent,
   htmlToMarkdown,
@@ -43,6 +48,8 @@ const DEFAULT_FETCH_MAX_RESPONSE_BYTES = 750_000;
 const FETCH_MAX_RESPONSE_BYTES_MIN = 32_000;
 const FETCH_MAX_RESPONSE_BYTES_MAX = 10_000_000;
 const DEFAULT_FETCH_MAX_REDIRECTS = 3;
+const WEB_FETCH_PROGRESS_THRESHOLD_MS = 5_000;
+const WEB_FETCH_PROGRESS_TEXT = "Fetching page content...";
 const DEFAULT_ERROR_MAX_CHARS = 4_000;
 const DEFAULT_ERROR_MAX_BYTES = 64_000;
 const DEFAULT_FETCH_USER_AGENT =
@@ -285,6 +292,7 @@ type WebFetchRuntimeParams = {
   };
   providerCacheKey?: string;
   lookupFn?: LookupFn;
+  signal?: AbortSignal;
   resolveProviderFallback: () => Promise<WebFetchProviderFallback>;
 };
 
@@ -308,6 +316,13 @@ function normalizeProviderFinalUrl(value: unknown): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function throwIfFetchAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw signal.reason instanceof Error ? signal.reason : new Error("aborted");
 }
 
 function normalizeProviderWebFetchPayload(params: {
@@ -435,6 +450,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      signal: params.signal,
       lookupFn: params.lookupFn,
       useEnvProxy: useTrustedEnvProxy,
       policy: ssrfPolicy,
@@ -461,6 +477,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     if (error instanceof SsrFBlockedError) {
       throw error;
     }
+    if (params.signal?.aborted) {
+      throw error;
+    }
     const payload = await maybeFetchProviderWebFetchPayload({
       ...params,
       urlToFetch: finalUrl,
@@ -475,6 +494,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
 
   try {
     if (!res.ok) {
+      if (params.signal?.aborted) {
+        throw params.signal.reason instanceof Error ? params.signal.reason : new Error("aborted");
+      }
       const payload = await maybeFetchProviderWebFetchPayload({
         ...params,
         urlToFetch: params.url,
@@ -485,6 +507,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
         return payload;
       }
       const rawDetailResult = await readResponseText(res, { maxBytes: DEFAULT_ERROR_MAX_BYTES });
+      throwIfFetchAborted(params.signal);
       const rawDetail = rawDetailResult.text;
       const detail = formatWebFetchErrorDetail({
         detail: rawDetail,
@@ -498,6 +521,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     const contentType = res.headers.get("content-type") ?? "application/octet-stream";
     const normalizedContentType = normalizeContentType(contentType) ?? "application/octet-stream";
     const bodyResult = await readResponseText(res, { maxBytes: params.maxResponseBytes });
+    throwIfFetchAborted(params.signal);
     const body = bodyResult.text;
     const responseTruncatedWarning = bodyResult.truncated
       ? `Response body truncated after ${params.maxResponseBytes} bytes.`
@@ -630,7 +654,7 @@ export function createWebFetchTool(options?: {
     description:
       "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
     parameters: WebFetchSchema,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, signal, onUpdate) => {
       const { config, preferRuntimeProviders, runtimeWebFetch } = resolveWebFetchToolRuntimeContext(
         {
           config: options?.config,
@@ -676,34 +700,45 @@ export function createWebFetchTool(options?: {
       const extractMode = readStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readPositiveIntegerParam(params, "maxChars");
       const maxCharsCap = resolveFetchMaxCharsCap(executionFetch);
-      const result = await runWebFetch({
-        url,
-        extractMode,
-        maxChars: resolveMaxChars(
-          maxChars ?? executionFetch?.maxChars,
-          DEFAULT_FETCH_MAX_CHARS,
-          maxCharsCap,
-        ),
-        maxResponseBytes,
-        maxRedirects: resolveMaxRedirects(
-          executionFetch?.maxRedirects,
-          DEFAULT_FETCH_MAX_REDIRECTS,
-        ),
-        timeoutSeconds: resolveTimeoutSeconds(
-          executionFetch?.timeoutSeconds,
-          DEFAULT_TIMEOUT_SECONDS,
-        ),
-        cacheTtlMs: resolveCacheTtlMs(executionFetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
-        userAgent,
-        readabilityEnabled,
-        config,
-        useTrustedEnvProxy: resolveFetchUseTrustedEnvProxy(executionFetch),
-        ssrfPolicy: executionFetch?.ssrfPolicy,
-        ...(providerCacheKey ? { providerCacheKey } : {}),
-        lookupFn: options?.lookupFn,
-        resolveProviderFallback,
-      });
-      return jsonResult(result);
+      const clearProgressTimer = scheduleToolProgress(
+        onUpdate,
+        { text: WEB_FETCH_PROGRESS_TEXT, id: "web_fetch:fetching" },
+        WEB_FETCH_PROGRESS_THRESHOLD_MS,
+        { signal },
+      );
+      try {
+        const result = await runWebFetch({
+          url,
+          extractMode,
+          maxChars: resolveMaxChars(
+            maxChars ?? executionFetch?.maxChars,
+            DEFAULT_FETCH_MAX_CHARS,
+            maxCharsCap,
+          ),
+          maxResponseBytes,
+          maxRedirects: resolveMaxRedirects(
+            executionFetch?.maxRedirects,
+            DEFAULT_FETCH_MAX_REDIRECTS,
+          ),
+          timeoutSeconds: resolveTimeoutSeconds(
+            executionFetch?.timeoutSeconds,
+            DEFAULT_TIMEOUT_SECONDS,
+          ),
+          cacheTtlMs: resolveCacheTtlMs(executionFetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
+          userAgent,
+          readabilityEnabled,
+          config,
+          useTrustedEnvProxy: resolveFetchUseTrustedEnvProxy(executionFetch),
+          ssrfPolicy: executionFetch?.ssrfPolicy,
+          ...(providerCacheKey ? { providerCacheKey } : {}),
+          lookupFn: options?.lookupFn,
+          signal,
+          resolveProviderFallback,
+        });
+        return jsonResult(result);
+      } finally {
+        clearProgressTimer();
+      }
     },
   };
 }

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -322,6 +322,8 @@ function throwIfFetchAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) {
     return;
   }
+  // readResponseText may finish after an abort races with body reading. Recheck
+  // before wrapping, caching, or returning content from a canceled tool call.
   throw signal.reason instanceof Error ? signal.reason : new Error("aborted");
 }
 
@@ -700,6 +702,8 @@ export function createWebFetchTool(options?: {
       const extractMode = readStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readPositiveIntegerParam(params, "maxChars");
       const maxCharsCap = resolveFetchMaxCharsCap(executionFetch);
+      // The progress line is emitted only if the fetch is still pending after
+      // the threshold; fast cache/network hits clear the timer before it fires.
       const clearProgressTimer = scheduleToolProgress(
         onUpdate,
         { text: WEB_FETCH_PROGRESS_TEXT, id: "web_fetch:fetching" },

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -196,6 +196,207 @@ describe("web_fetch extraction fallbacks", () => {
     expect(details.wrappedLength).toBe(details.text?.length);
   });
 
+  it("emits typed public progress for slow fetches", async () => {
+    vi.useFakeTimers();
+    try {
+      installMockFetch(async (input: RequestInfo | URL) => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 6000));
+        return textResponse("Loaded page", resolveRequestUrl(input)) as Response;
+      });
+      const updates: unknown[] = [];
+      const tool = createFetchTool({ firecrawl: { enabled: false } });
+      const resultPromise = tool?.execute?.(
+        "call",
+        { url: "https://example.com/" },
+        undefined,
+        (partialResult) => {
+          updates.push(partialResult);
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(updates).toEqual([
+        {
+          content: [],
+          details: undefined,
+          progress: {
+            text: "Fetching page content...",
+            visibility: "channel",
+            privacy: "public",
+            id: "web_fetch:fetching",
+          },
+        },
+      ]);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await resultPromise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels typed progress when fetches finish before the progress threshold", async () => {
+    vi.useFakeTimers();
+    try {
+      installPlainTextFetch("Loaded quickly");
+      const updates: unknown[] = [];
+      const tool = createFetchTool({ firecrawl: { enabled: false } });
+
+      await tool?.execute?.("call", { url: "https://example.com/" }, undefined, (partial) => {
+        updates.push(partial);
+      });
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(updates).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels typed progress when fetches are aborted", async () => {
+    vi.useFakeTimers();
+    try {
+      const providerExecute = vi.fn(async () => ({ text: "provider fallback" }));
+      resolveWebFetchDefinitionMock.mockReturnValue({
+        provider: { id: "firecrawl" },
+        definition: {
+          description: "firecrawl",
+          parameters: {},
+          execute: providerExecute,
+        },
+      });
+      installMockFetch(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        return await new Promise<Response>((resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+          setTimeout(() => {
+            resolve(textResponse("Loaded page") as Response);
+          }, 6000);
+        });
+      });
+      const updates: unknown[] = [];
+      const controller = new AbortController();
+      const tool = createFetchTool({ firecrawl: { enabled: false } });
+      const resultPromise = tool?.execute?.(
+        "call",
+        { url: "https://example.com/" },
+        controller.signal,
+        (partial) => {
+          updates.push(partial);
+        },
+      );
+      const observedResultPromise = resultPromise?.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(0);
+      controller.abort();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const error = await observedResultPromise;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("aborted");
+      expect(updates).toHaveLength(0);
+      expect(resolveWebFetchDefinitionMock).not.toHaveBeenCalled();
+      expect(providerExecute).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels typed progress when fetch body reads are aborted", async () => {
+    vi.useFakeTimers();
+    try {
+      const providerExecute = vi.fn(async () => ({ text: "provider fallback" }));
+      resolveWebFetchDefinitionMock.mockReturnValue({
+        provider: { id: "firecrawl" },
+        definition: {
+          description: "firecrawl",
+          parameters: {},
+          execute: providerExecute,
+        },
+      });
+      installMockFetch(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("partial body"));
+            const lateTimer = setTimeout(() => {
+              controller.enqueue(new TextEncoder().encode("late body"));
+              controller.close();
+            }, 6000);
+            init?.signal?.addEventListener(
+              "abort",
+              () => {
+                clearTimeout(lateTimer);
+                controller.error(new Error("body aborted"));
+              },
+              { once: true },
+            );
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      });
+      const updates: unknown[] = [];
+      const controller = new AbortController();
+      const tool = createFetchTool({ firecrawl: { enabled: false } });
+      const resultPromise = tool?.execute?.(
+        "call",
+        { url: "https://example.com/" },
+        controller.signal,
+        (partial) => {
+          updates.push(partial);
+        },
+      );
+      const observedResultPromise = resultPromise?.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(0);
+      controller.abort(new Error("cancelled"));
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const error = await observedResultPromise;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("cancelled");
+      expect(updates).toHaveLength(0);
+      expect(providerExecute).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps fetch execution alive when progress subscribers throw", async () => {
+    vi.useFakeTimers();
+    try {
+      installMockFetch(async (input: RequestInfo | URL) => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 6000));
+        return textResponse("Loaded page", resolveRequestUrl(input)) as Response;
+      });
+      const tool = createFetchTool({ firecrawl: { enabled: false } });
+      const onUpdate = vi.fn(() => {
+        throw new Error("subscriber failed");
+      });
+      const resultPromise = tool?.execute?.(
+        "call",
+        { url: "https://example.com/" },
+        undefined,
+        onUpdate,
+      );
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(resultPromise).resolves.toBeTruthy();
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("enforces maxChars after wrapping", async () => {
     const longText = "x".repeat(5_000);
     installMockFetch((input: RequestInfo | URL) =>


### PR DESCRIPTION
## Summary

This is a replacement for #86965. The goal is the same user-visible outcome - show useful progress while an agent is still working - but the implementation makes that a general tool-progress contract instead of a `web_fetch` special case.

The original PR was directionally useful but too narrow: it detected `web_fetch`, pulled text out of a partial tool result, and turned that into channel progress. That works for one tool, but it teaches the subscriber layer to infer UI-safe progress from arbitrary tool content. This PR moves the contract to the producer side: a tool must explicitly emit public, channel-safe progress metadata before the channel layer will render it as progress text.

## Why this is needed

Channels already have generic progress surfaces. The agent runner forwards item events, and the channel streaming layer can render `progressText` as part of the existing progress draft / item update flow. The missing piece was a safe way for non-exec tools to say, "this is progress text for the user," without overloading model-facing tool result content.

Without this, long-running non-exec tools are mostly silent until completion. That makes the agent look stuck even when it is actively waiting on network or provider work. `web_fetch` exposed the problem because page fetches can take several seconds, but the underlying need is broader: any tool should be able to emit a small public status update while it runs.

## Design

This adds an optional typed progress field to `AgentToolResult`:

- `progress.text`: user-facing progress text.
- `progress.visibility: "channel"`: this is intended for channel progress surfaces.
- `progress.privacy: "public"`: producer asserts the text is safe to show to the user.
- `progress.id`: optional stable progress identity for replacement/deduping.

Tools should not put fetched content, secrets, raw arguments, URLs with tokens, or private provider details into this field. The current helper only builds `visibility: "channel"` and `privacy: "public"`, so call sites have to opt into this intentionally.

## Implementation

- `packages/agent-core/src/types.ts` defines `AgentToolProgress` and adds optional `progress` to `AgentToolResult`.
- `src/agents/tools/common.ts` adds reusable helpers for public progress results, best-effort progress emission, and delayed progress timers.
- `src/agents/embedded-agent-subscribe.handlers.tools.ts` reads only typed public channel progress from sanitized tool results, truncates it, and forwards it as item `progressText`.
- Untyped non-exec partials keep the existing raw `stream: "tool"` behavior and are not promoted into channel progress.
- Exec tools keep their existing command-output path.
- `src/agents/tools/web-fetch.ts` uses the generic delayed progress helper as the first producer.
- Inline comments now mark the trust boundary, duplicate-suppression path, delayed-timer lifecycle, and abort recheck that prevents canceled body reads from becoming cached success.
- `docs/concepts/progress-drafts.md`, `docs/concepts/streaming.md`, and `docs/tools/web-fetch.md` document typed tool progress, include producer examples, and spell out the five-second `web_fetch` behavior.

## How a slow one-call tool shows progress

`web_fetch` is still one tool call. At call start it arms a delayed timer through `scheduleToolProgress(...)`. If the fetch is still pending after five seconds, the callback receives a partial tool result shaped like this:

```json
{
  "content": [],
  "progress": {
    "text": "Fetching page content...",
    "visibility": "channel",
    "privacy": "public",
    "id": "web_fetch:fetching"
  }
}
```

That partial result is routed as channel progress only. It is not returned to the model as tool content. When the fetch later completes, the normal final tool result is returned as before. If the fetch completes in under five seconds, or is canceled before the timer fires, no progress line is emitted.

## Why this shape is safer than #86965

This does not maintain a hardcoded allowlist such as "`web_fetch` content block means progress." The subscriber layer does not inspect `content[0].text` and guess whether it is safe to display. Instead, only an explicit typed progress field is rendered.

That distinction matters because tool result content is model-facing and may contain fetched page text, error details, provider payloads, or other data that was never intended as channel UI. Progress text is now a separate contract with an explicit public privacy marker.

## Cancellation and lifecycle behavior

The delayed progress timer is abort-aware and completion-aware:

- Fast fetches finish before the threshold and emit no progress update.
- Aborted fetches clear the delayed progress timer.
- The abort signal is passed into the guarded fetch path.
- If abort happens before provider fallback, provider fallback is skipped.
- If abort happens while reading the response body, `web_fetch` rechecks the signal before wrapping, caching, or returning a successful result.

Autoreview found several cancellation edge cases during development; this PR includes the fixes and regression tests for them.

## Behavior covered by tests

- A typed public progress update from an arbitrary non-exec tool becomes item `progressText`.
- Untyped `web_fetch` content is not promoted into progress text.
- Long typed progress text is capped before item emission.
- Slow `web_fetch` emits typed public progress after the threshold.
- Fast `web_fetch` cancels the timer before progress emits.
- Subscriber exceptions do not fail the tool.
- Aborted native fetches emit no stale progress and do not enter provider fallback.
- Aborted body reads do not return/cache a partial successful result.
- Docs examples describe the partial progress result shape and the delayed producer pattern.

Alternative to #86965.

## Real behavior proof

Behavior addressed: Long-running tools can show user-facing progress through a general typed progress contract instead of a `web_fetch` content-text special case.
Real environment tested: Local OpenClaw source checkout on macOS; local repo test router with Testbox env unset for `check:changed` retry.
Exact steps or command run after this patch: `pnpm test src/agents/tools/web-tools.fetch.test.ts -- --run`; `pnpm test src/agents/embedded-agent-subscribe.handlers.tools.test.ts -- --run`; `pnpm test src/agents/tools/web-tools.fetch.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts -- --run`; `pnpm docs:check-mdx`; `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`; `pnpm exec oxlint packages/agent-core/src/types.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-subscribe.handlers.tools.ts src/agents/tools/common.ts src/agents/tools/web-fetch.ts src/agents/tools/web-tools.fetch.test.ts`; `git diff --check`; `env -u OPENCLAW_TESTBOX pnpm check:changed`.
Evidence after fix: Focused tests passed: web fetch suite 24 tests, embedded tool handler suite 47 tests, and the combined rerun passed 71 tests. Docs MDX check passed across 662 files. Autoreview reran until clean with no accepted/actionable findings. Changed-file oxlint and `git diff --check` passed. `check:changed` passed guard checks and core/core-test typechecks before the local split oxlint issue below.
Observed result after fix: Typed public tool progress renders as item `progressText`, untyped `web_fetch` content is not promoted, long progress text is capped, fast/aborted fetches do not emit stale progress, and aborted native/body fetches do not fall through to provider fallback or cached success.
What was not tested: Full local `check:changed` did not complete green because local ignored `src/canvas-host/.DS_Store` makes the split oxlint runner create an empty `src/canvas-host` shard that exits with `No files found to lint`; changed-file oxlint passed, and the prior Testbox attempt ended with infrastructure-style `exit=255` before giving a code diagnostic.
