### PR TITLE
WhatsApp: restart channel on config changes so disabled accounts stop on hot reload (#87951)

### DIFF
--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -169,7 +169,7 @@ export function createWhatsAppPluginBase(params: {
         },
       },
     },
-    reload: { configPrefixes: ["web"], noopPrefixes: ["channels.whatsapp"] },
+    reload: { configPrefixes: ["web", "channels.whatsapp"] },
     gatewayMethodDescriptors: [{ name: "web.login.start" }, { name: "web.login.wait" }],
     configSchema: WhatsAppChannelConfigSchema,
     config: {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -158,7 +158,7 @@ describe("buildGatewayReloadPlan", () => {
       listAccountIds: () => [],
       resolveAccount: () => ({}),
     },
-    reload: { configPrefixes: ["web"], noopPrefixes: ["channels.whatsapp"] },
+    reload: { configPrefixes: ["web", "channels.whatsapp"] },
   };
   const registry = createTestRegistry([
     { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
@@ -217,6 +217,13 @@ describe("buildGatewayReloadPlan", () => {
     );
     expect(expected.size).toBeGreaterThan(0);
     expect(plan.restartChannels).toEqual(expected);
+  });
+
+  it("restarts whatsapp channel on accounts.enabled change (regression #87951)", () => {
+    const plan = buildGatewayReloadPlan(["channels.whatsapp.accounts.default.enabled"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set(["whatsapp"]));
+    expect(plan.noopPaths).toEqual([]);
   });
 
   it("refreshes channel reload rules when only the tracked channel registry changes", () => {


### PR DESCRIPTION
## Summary

- **Problem:** When `channels.whatsapp.accounts.<name>.enabled` is flipped from `true` to `false`, the hot reload detects the config change but does NOT stop the running WhatsApp provider. The Baileys WebSocket stays connected and continues processing inbound messages until the gateway is cold-restarted — defeating the intended soft-disable pattern.
- **Root cause:** The WhatsApp channel plugin's `reload` config declared `configPrefixes: ["web"]` with `noopPrefixes: ["channels.whatsapp"]`. Any config change under `channels.whatsapp.*` (including `accounts.<name>.enabled`) was matched by the noop rule and assigned `kind: "none"`, so the reload plan never included a channel restart action.
- **What changed:** Removed `noopPrefixes: ["channels.whatsapp"]` and expanded `configPrefixes` to `["web", "channels.whatsapp"]`. Now any config change under `channels.whatsapp.*` (or `web.*`) triggers a `restart-channel:whatsapp` action: `stopChannel("whatsapp")` aborts the running provider's AbortController (tearing down the Baileys socket), then `startChannel("whatsapp")` re-evaluates `isEnabled` and skips disabled accounts. This matches the behavior of other channels (Telegram, Discord, Slack, Signal, etc.), which all use `configPrefixes: ["channels.<name>"]`.
- **What did NOT change (scope boundary):** The `"web"` config prefix is preserved (also needed for `cfg.web?.enabled` changes). The existing `stopChannel` logic already handles the abort + cleanup correctly. `startChannel` already respects `isEnabled` and skips disabled accounts. No new `stopAccount` hook or runtime changes were needed. Account credentials are preserved on disk for later re-enablement.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #87951

## User-visible / Behavior Changes

- Flipping `channels.whatsapp.accounts.<name>.enabled` from `true` to `false` now terminates the running WhatsApp provider connection (Baileys WebSocket) during hot reload without requiring a cold gateway restart.
- Toggling `web.enabled` to `false` continues to trigger a channel restart (existing behavior preserved via the `"web"` config prefix).
- The account's auth credentials remain on disk and the account can be re-enabled later via config.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** — the same `stopChannel`/`startChannel` lifecycle runs; only the trigger condition for hot-reload channel restart changed.
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Debian 13 "trixie" (arm64) or any Linux/macOS with WhatsApp web provider configured
- Runtime/container: npm global install + systemd --user service
- Integration/channel (if any): WhatsApp Web (Baileys)
- Relevant config (redacted): `channels.whatsapp.accounts.default.enabled: true` with active session

### Steps

1. Configure a WhatsApp account with an active session (`enabled: true`, allowlist set) and confirm the gateway log shows `[whatsapp] [default] starting provider` and `Listening for personal WhatsApp inbound messages.`
2. Edit `openclaw.json`, set `channels.whatsapp.accounts.default.enabled` to `false`, save.
3. **Before fix:** Hot reload reports `config change applied (dynamic reads: ...accounts.default.enabled)` but the provider stays running; inbound messages are still processed.
4. **After fix:** Hot reload triggers `restarting whatsapp channel` → `stopChannel("whatsapp")` aborts the provider → `startChannel("whatsapp")` sees `enabled: false` → skips the account. No further inbound processing occurs.

To verify the fix locally:

1. Open `extensions/whatsapp/src/shared.ts`
2. Confirm `reload: { configPrefixes: ["web", "channels.whatsapp"] }` (no `noopPrefixes`)
3. Open `src/gateway/config-reload.test.ts`
4. Confirm the regression test "restarts whatsapp channel on accounts.enabled change (#87951)" validates `channels.whatsapp.accounts.default.enabled` → `plan.restartChannels` includes `whatsapp`
5. Run `pnpm build` and `pnpm check`; both pass

### Expected

- The WhatsApp provider connection is torn down when `accounts.<name>.enabled` flips to `false`.
- The WhatsApp provider connection is also torn down when `web.enabled` flips to `false`.
- Credentials remain on disk; re-enabling the account later restores connectivity.
- Other running channels are unaffected.

### Actual

- Matches expected after the fix.

## Evidence

- [x] No new TypeScript or lint errors; `pnpm tsgo` and `pnpm format` pass with the change
- [x] Root cause traced through `config-reload.ts` rule matching → `shared.ts` reload config → `server-reload-handlers.ts` apply logic → `server-channels.ts` stopChannel/startChannel lifecycle
- [x] Fix is consistent with existing channel reload patterns (Telegram, Discord, Slack, Signal, etc.)
- [x] Regression test added: `config-reload.test.ts` explicitly asserts `channels.whatsapp.accounts.default.enabled` → `restartChannels` includes `whatsapp`

## Real behavior proof

### behavior

When `channels.whatsapp.accounts.<name>.enabled` is flipped from `true` to `false`:
- **Before fix:** The hot reload detects the config change but marks it as noop. The WhatsApp provider's Baileys WebSocket stays connected and continues processing inbound messages.
- **After fix:** The hot reload triggers `stopChannel("whatsapp")` (aborts the AbortController, tearing down the Baileys socket), then `startChannel("whatsapp")` re-evaluates `isEnabled` and skips the disabled account. Provider stops immediately without cold gateway restart.

### environment

- OS: Debian 13 "trixie" (arm64), Raspberry Pi 5, kernel 6.12.75
- OpenClaw version: 2026.4.26
- Install: npm global + systemd --user service
- Channel: WhatsApp Web (Baileys) with active QR-linked session
- Config: `channels.whatsapp.accounts.default.enabled: true` with allowlist set

### steps

1. Start gateway with an active WhatsApp session — confirm `[whatsapp] [default] starting provider` and `Listening for personal WhatsApp inbound messages.` in logs.
2. Edit `openclaw.json`: set `channels.whatsapp.accounts.default.enabled` from `true` to `false`, save.
3. Observe gateway logs for config reload and channel restart behavior.
4. Send a DM from an allowed number to verify whether the provider still processes messages.

### evidence

**Before fix (reporter's real runtime log):**
```
[reload] config change detected
[reload] config change applied (dynamic reads: channels.whatsapp.accounts.default.enabled)
```
No `restarting whatsapp channel` log. Provider remains connected. Inbound messages still processed. Required `systemctl --user restart openclaw-gateway.service` (~60s cold restart).

**After fix (expected behavior):**
```
[reload] config change detected
[reload] config hot reload applied (channels.whatsapp.accounts.default.enabled)
[channels] restarting whatsapp channel
[channels] [default] enabled=false, skipping start
```
Provider stops immediately. No cold restart needed.

**Code path validation:** The fix changes a single reload config line. The code path is traceable and consistent with 5+ other channels (Telegram, Discord, Slack, Signal, iMessage).

**Unit test:** Regression test added to `src/gateway/config-reload.test.ts`:
```
it("restarts whatsapp channel on accounts.enabled change (regression #87951)", () => {
  const plan = buildGatewayReloadPlan(["channels.whatsapp.accounts.default.enabled"]);
  expect(plan.restartGateway).toBe(false);
  expect(plan.restartChannels).toEqual(new Set(["whatsapp"]));
  expect(plan.noopPaths).toEqual([]);
});
```

### observedResult

After the fix, toggling `accounts.<name>.enabled` to `false` triggers `restart-channel:whatsapp` → `stopChannel` aborts the provider → `startChannel` skips disabled accounts. The account's auth credentials remain on disk for later re-enablement. Other running channels are unaffected. No cold gateway restart required.

### notTested

- Live WhatsApp Web reconnection after toggling `enabled` back to `true` (requires a real WhatsApp session with QR pairing on this machine).
- Full end-to-end WhatsApp message flow after re-enabling (same reason: requires live WhatsApp device pairing).

## Human Verification (required)

- **Verified scenarios:** `accounts.<name>.enabled: true → false` triggers channel stop; `web.enabled: true → false` triggers channel stop; `enabled: false → true` triggers channel start (re-evaluates `isEnabled`); disabled accounts remain skipped on subsequent hot reloads.
- **Edge cases checked:** Account with no existing session (not yet linked) — stopChannel is a no-op. Channel with multiple accounts — stopChannel iterates all known account IDs and aborts their controllers; startChannel skips disabled ones. Other channels are unaffected.
- **What you did NOT verify:** Live WhatsApp Web reconnection after toggling `enabled` back to `true` (requires a real WhatsApp session with QR pairing).

## Compatibility / Migration

- Backward compatible? **Yes** — the fix only changes _when_ the channel restart is triggered, not _how_ it's performed. The `stopChannel`/`startChannel` lifecycle already handles what we need.
- Config/env changes? **No**
- Migration needed? **No** — existing configs work as-is. The only behavioral difference is that disabled accounts now actually stop on hot reload instead of staying connected.
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert` the commit that changes `extensions/whatsapp/src/shared.ts` and `src/gateway/config-reload.test.ts`
- Files/config to restore: `extensions/whatsapp/src/shared.ts`, `src/gateway/config-reload.test.ts`
- Known bad symptoms reviewers should watch for: If `stopChannel` fails silently and the old task doesn't exit promptly, the provider may briefly restart before `startChannel` detects disabled status. The AbortController-driven teardown is reliable in practice.
