### PR TITLE
[codex] fix image completion duplicate sends

### DIFF
--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -478,14 +478,21 @@ describe("waitForAgentRunsToDrain", () => {
     callGatewayMock.mockResolvedValue({ status: "ok" });
     let activeRunIds = ["run-1"];
 
-    const result = await waitForAgentRunsToDrain({
-      timeoutMs: Number.NaN,
-      getPendingRunIds: () => {
-        const current = activeRunIds;
-        activeRunIds = [];
-        return current;
-      },
-    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    let result: Awaited<ReturnType<typeof waitForAgentRunsToDrain>>;
+    try {
+      result = await waitForAgentRunsToDrain({
+        timeoutMs: Number.NaN,
+        getPendingRunIds: () => {
+          const current = activeRunIds;
+          activeRunIds = [];
+          return current;
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(result.timedOut).toBe(false);
     expect(Number.isFinite(result.deadlineAtMs)).toBe(true);

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2146,7 +2146,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("directly delivers generated media DMs when announce-agent returns no visible output", async () => {
+  it("directly delivers generated media DMs before announce-agent handoff", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -2178,14 +2178,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expectGatewayAgentParams(callGateway, {
-      deliver: false,
-      channel: "discord",
-      accountId: "acct-1",
-      to: "dm:U123",
-      threadId: undefined,
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
+    expect(callGateway).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "discord",
@@ -2198,7 +2191,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("does not fallback when announce-agent delivered media through the message tool", async () => {
+  it("falls back to announce-agent when primary direct generated media delivery fails", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -2206,7 +2199,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         messagingToolSentMediaUrls: ["/tmp/generated-night-drive.mp3"],
       },
     });
-    const sendMessage = createSendMessageMock();
+    const sendMessage = vi.fn(async () => {
+      throw new Error("temporary channel upload failure");
+    }) as unknown as typeof runtimeSendMessage;
     const result = await deliverDiscordDirectMessageCompletion({
       callGateway,
       sendMessage,
@@ -2241,7 +2236,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       threadId: undefined,
       sourceReplyDeliveryMode: "message_tool_only",
     });
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
   it("does not fallback when message-tool evidence already contains generated media", async () => {
@@ -2283,10 +2278,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        accountId: "acct-1",
+        to: "dm:U123",
+        content: "The generated music is ready.",
+        mediaUrls: ["/tmp/generated-night-drive.mp3"],
+        idempotencyKey: "announce-dm-fallback-empty:generated-media-direct",
+      }),
+    );
   });
 
-  it("requires generated media completion DMs to use the message tool", async () => {
+  it("directly delivers generated media completion DMs instead of message-tool handoff", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -2329,18 +2334,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expectGatewayAgentParams(callGateway, {
-      deliver: false,
-      channel: "discord",
-      accountId: "acct-1",
-      to: "dm:U123",
-      threadId: undefined,
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        accountId: "acct-1",
+        to: "dm:U123",
+        content: "The generated music is ready.",
+        mediaUrls: ["/tmp/generated-night-drive.mp3"],
+        idempotencyKey: "announce-dm-fallback-empty:generated-media-direct",
+      }),
+    );
   });
 
-  it("stringifies Telegram topic ids for generated video completion handoff", async () => {
+  it("stringifies Telegram topic ids for generated video direct delivery", async () => {
     const callGateway = createGatewayMock({
       payloads: [],
       didSendViaMessagingTool: true,
@@ -2379,18 +2386,21 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expectGatewayAgentParams(callGateway, {
-      deliver: false,
-      channel: "telegram",
-      accountId: "bot-1",
-      to: "telegram:-1003970070733",
-      threadId: "1",
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        accountId: "bot-1",
+        to: "telegram:-1003970070733",
+        threadId: "1",
+        content: "The generated video is ready.",
+        mediaUrls: ["/tmp/generated-corgi.mp4"],
+        idempotencyKey: "announce-telegram-dm-fallback:generated-media-direct",
+      }),
+    );
   });
 
-  it("requires generated image completion DMs to use the message tool", async () => {
+  it("directly delivers generated image completion DMs", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -2433,15 +2443,17 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expectGatewayAgentParams(callGateway, {
-      deliver: false,
-      channel: "discord",
-      accountId: "acct-1",
-      to: "dm:U123",
-      threadId: undefined,
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        accountId: "acct-1",
+        to: "dm:U123",
+        content: "The generated image is ready.",
+        mediaUrls: ["/tmp/generated-robot.png"],
+        idempotencyKey: "announce-dm-fallback-empty:generated-media-direct",
+      }),
+    );
   });
 
   it("accepts failed generated media completion notices without requiring message-tool delivery", async () => {
@@ -2587,7 +2599,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
   });
 
-  it("directly delivers generated media group completions that miss required message-tool delivery", async () => {
+  it("directly delivers generated media group completions before message-tool handoff", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [
@@ -2628,14 +2640,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expectGatewayAgentParams(callGateway, {
-      deliver: false,
-      channel: "slack",
-      accountId: "acct-1",
-      to: "channel:C123",
-      threadId: undefined,
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
+    expect(callGateway).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "slack",
@@ -2699,6 +2704,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
+    expect(callGateway).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "slack",
@@ -2711,7 +2717,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("directly delivers only missing generated media after partial message-tool delivery", async () => {
+  it("directly delivers all generated media before partial message-tool delivery can race", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -2759,19 +2765,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
+    expect(callGateway).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "slack",
         accountId: "acct-1",
         to: "channel:C123",
         content: "The generated image is ready.",
-        mediaUrls: ["/tmp/generated-robot-2.png"],
+        mediaUrls: ["/tmp/generated-robot-1.png", "/tmp/generated-robot-2.png"],
         idempotencyKey: "announce-channel-media-partial-message-tool:generated-media-direct",
       }),
     );
   });
 
-  it("keeps generated media completions on the active requester session path", async () => {
+  it("directly delivers generated media completions without waking the active requester", async () => {
     const callGateway = createGatewayMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
     const sendMessage = createSendMessageMock();
@@ -2804,23 +2811,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expectRecordFields(result, {
       delivered: true,
-      path: "steered",
-      enqueuedAt: 4_100,
-      deliveredAt: 4_200,
+      path: "direct",
     });
-    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledWith(
-      "requester-session-channel",
-      "child done",
-      {
-        steeringMode: "all",
-        sourceReplyDeliveryMode: "message_tool_only",
-        debounceMs: 500,
-        waitForTranscriptCommit: true,
-        deliveryTimeoutMs: 120_000,
-      },
-    );
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
     expect(callGateway).not.toHaveBeenCalled();
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        accountId: "acct-1",
+        to: "channel:C123",
+        content: "The generated video is ready.",
+        mediaUrls: ["/tmp/generated-corgi.mp4"],
+        idempotencyKey: "announce-channel-media-active-direct:generated-media-direct",
+      }),
+    );
   });
 
   it("directly delivers missing generated media after active requester wake failure", async () => {
@@ -2843,7 +2847,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       "transcript_commit_wait_unsupported",
       "no_active_run",
     ]);
-    const sendMessage = createSendMessageMock();
+    let sendAttempts = 0;
+    const sendMessage = vi.fn(async () => {
+      sendAttempts += 1;
+      if (sendAttempts === 1) {
+        throw new Error("temporary channel upload failure");
+      }
+      return {
+        channel: "slack",
+        to: "channel:C123",
+        via: "direct" as const,
+        mediaUrl: null,
+        result: { messageId: "msg-1" },
+      };
+    }) as unknown as typeof runtimeSendMessage;
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       sendMessage,
@@ -2878,7 +2895,19 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
     expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledWith(
+    expect(sendMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        channel: "slack",
+        accountId: "acct-1",
+        to: "channel:C123",
+        content: "The generated image is ready.",
+        mediaUrls: ["/tmp/generated-robot-1.png", "/tmp/generated-robot-2.png"],
+        idempotencyKey: "announce-channel-media-active-wake-failed:generated-media-direct",
+      }),
+    );
+    expect(sendMessage).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         channel: "slack",
         accountId: "acct-1",
@@ -2900,7 +2929,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       "transcript_commit_wait_unsupported",
       "no_active_run",
     ]);
-    const sendMessage = createSendMessageMock();
+    let sendAttempts = 0;
+    const sendMessage = vi.fn(async () => {
+      sendAttempts += 1;
+      if (sendAttempts === 1) {
+        throw new Error("temporary channel upload failure");
+      }
+      return {
+        channel: "slack",
+        to: "channel:C123",
+        via: "direct" as const,
+        mediaUrl: null,
+        result: { messageId: "msg-1" },
+      };
+    }) as unknown as typeof runtimeSendMessage;
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       sendMessage,
@@ -2934,7 +2976,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
     expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledWith(
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
         channel: "slack",
         accountId: "acct-1",
@@ -2954,7 +2997,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       "transcript_commit_wait_unsupported",
       "no_active_run",
     ]);
-    const sendMessage = createSendMessageMock();
+    const sendMessage = vi.fn(async () => {
+      throw new Error("temporary channel upload failure");
+    }) as unknown as typeof runtimeSendMessage;
 
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
@@ -2990,7 +3035,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalled();
     expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
   it("directly delivers stale isolated cron run media completions", async () => {
@@ -3129,7 +3174,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       origin: { channel: "whatsapp", to: "123@g.us", accountId: "acct-1" },
     },
   ])(
-    "requires message-tool delivery for generated media completions in $name sessions",
+    "directly delivers generated media completions in $name sessions",
     async ({ requesterSessionKey, origin }) => {
       const callGateway = createGatewayMock({
         result: {
@@ -3173,14 +3218,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         delivered: true,
         path: "direct",
       });
-      expectGatewayAgentParams(callGateway, {
-        deliver: false,
-        channel: origin.channel,
-        accountId: "acct-1",
-        to: origin.to,
-        threadId: undefined,
-        sourceReplyDeliveryMode: "message_tool_only",
-      });
+      expect(callGateway).not.toHaveBeenCalled();
       expect(sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           channel: origin.channel,
@@ -3194,7 +3232,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
   );
 
-  it("does not fallback for generated media group completions when message tool evidence exists", async () => {
+  it("directly delivers generated media group completions before message-tool evidence is needed", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -3241,10 +3279,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        accountId: "acct-1",
+        to: "channel:C123",
+        content: "The generated music is ready.",
+        mediaUrls: ["/tmp/generated-night-drive.mp3"],
+        idempotencyKey: "announce-channel-media-message-tool-evidence:generated-media-direct",
+      }),
+    );
   });
 
-  it("preserves pending announce delivery without direct generated media fallback", async () => {
+  it("directly delivers generated media instead of starting a pending announce handoff", async () => {
     const callGateway = createGatewayMock({
       runId: "video_generate:task-123:ok",
       status: "accepted",
@@ -3280,11 +3328,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
     });
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        accountId: "acct-1",
+        to: "channel:C123",
+        content: "The generated video is ready.",
+        mediaUrls: ["/tmp/lobster-trailer.mp4"],
+        idempotencyKey: "announce-channel-media-pending:generated-media-direct",
+      }),
+    );
   });
 
-  it("does not race pending announce delivery with direct generated media fallback", async () => {
+  it("preserves pending announce delivery when primary generated media direct delivery fails", async () => {
     const callGateway = createGatewayMock({
       runId: "video_generate:task-123:ok",
       status: "accepted",
@@ -3323,7 +3380,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       path: "direct",
     });
     expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
   it("does not fail stale channel subagent completions only because the parent stayed private", async () => {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { OutboundDeliveryError } from "../infra/outbound/deliver-types.js";
 import {
   testing as sessionBindingServiceTesting,
   registerSessionBindingAdapter,
@@ -2191,14 +2192,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("falls back to announce-agent when primary direct generated media delivery fails", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-        didSendViaMessagingTool: false,
-        messagingToolSentMediaUrls: ["/tmp/generated-night-drive.mp3"],
-      },
-    });
+  it("stops after failed primary direct generated media delivery", async () => {
+    const callGateway = createGatewayMock();
     const sendMessage = vi.fn(async () => {
       throw new Error("temporary channel upload failure");
     }) as unknown as typeof runtimeSendMessage;
@@ -2224,18 +2219,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectRecordFields(result, {
-      delivered: true,
+      delivered: false,
       path: "direct",
+      error: "generated media direct delivery failed: temporary channel upload failure",
     });
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expectGatewayAgentParams(callGateway, {
-      deliver: false,
-      channel: "discord",
-      accountId: "acct-1",
-      to: "dm:U123",
-      threadId: undefined,
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
+    expect(callGateway).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
@@ -2827,39 +2815,17 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("directly delivers missing generated media after active requester wake failure", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-        messagingToolSentTargets: [
-          {
-            tool: "message",
-            provider: "slack",
-            accountId: "acct-1",
-            to: "channel:C123",
-            text: "The first image is ready.",
-            mediaUrls: ["/tmp/generated-robot-1.png"],
-          },
-        ],
-      },
-    });
+  it("does not hand off after primary direct media delivery partially fails", async () => {
+    const callGateway = createGatewayMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
       "transcript_commit_wait_unsupported",
       "no_active_run",
     ]);
-    let sendAttempts = 0;
     const sendMessage = vi.fn(async () => {
-      sendAttempts += 1;
-      if (sendAttempts === 1) {
-        throw new Error("temporary channel upload failure");
-      }
-      return {
-        channel: "slack",
-        to: "channel:C123",
-        via: "direct" as const,
-        mediaUrl: null,
-        result: { messageId: "msg-1" },
-      };
+      throw new OutboundDeliveryError("partial_failed", {
+        cause: new Error("second media upload failed"),
+        results: [{ channel: "slack", messageId: "msg-partial" }],
+      });
     }) as unknown as typeof runtimeSendMessage;
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
@@ -2890,13 +2856,14 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectRecordFields(result, {
-      delivered: true,
+      delivered: false,
       path: "direct",
+      error: "generated media direct delivery failed: partial_failed",
     });
-    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenNthCalledWith(
-      1,
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "slack",
         accountId: "acct-1",
@@ -2906,20 +2873,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         idempotencyKey: "announce-channel-media-active-wake-failed:generated-media-direct",
       }),
     );
-    expect(sendMessage).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        channel: "slack",
-        accountId: "acct-1",
-        to: "channel:C123",
-        content: "The generated image is ready.",
-        mediaUrls: ["/tmp/generated-robot-2.png"],
-        idempotencyKey: "announce-channel-media-active-wake-failed:generated-media-direct",
-      }),
-    );
   });
 
-  it("directly delivers generated media after active wake failure when requester handoff locks", async () => {
+  it("stops before requester handoff when primary direct media delivery fails", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error(
         "SessionWriteLockTimeoutError: session file locked (timeout 60000ms): pid=43",
@@ -2971,13 +2927,14 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectRecordFields(result, {
-      delivered: true,
+      delivered: false,
       path: "direct",
+      error: "generated media direct delivery failed: temporary channel upload failure",
     });
-    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledTimes(2);
-    expect(sendMessage).toHaveBeenLastCalledWith(
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "slack",
         accountId: "acct-1",
@@ -2989,7 +2946,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("keeps generic requester handoff errors visible after active wake failure", async () => {
+  it("stops before generic requester handoff after failed primary direct delivery", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("requester handoff exploded after dispatch");
     }) as unknown as typeof runtimeCallGateway;
@@ -3031,10 +2988,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: false,
       path: "direct",
-      error: "requester handoff exploded after dispatch",
+      error: "generated media direct delivery failed: temporary channel upload failure",
     });
-    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalled();
-    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
@@ -3341,7 +3298,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("preserves pending announce delivery when primary generated media direct delivery fails", async () => {
+  it("stops before pending announce fallback when primary generated media direct delivery fails", async () => {
     const callGateway = createGatewayMock({
       runId: "video_generate:task-123:ok",
       status: "accepted",
@@ -3376,10 +3333,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectRecordFields(result, {
-      delivered: true,
+      delivered: false,
       path: "direct",
+      error: "generated media direct delivery failed: temporary channel upload failure",
     });
-    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(callGateway).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -823,6 +823,7 @@ async function deliverGeneratedMediaCompletionDirect(params: {
       delivered: false,
       path: "direct",
       error: `generated media direct delivery failed: ${summarizeDeliveryError(err)}`,
+      terminal: true,
     };
   }
 }
@@ -1132,7 +1133,9 @@ async function sendSubagentAnnounceDirectly(params: {
     });
     if (agentMediatedCompletion && expectedMediaUrls.length > 0) {
       const generatedMediaDelivery = await tryGeneratedMediaPrimaryDirectDelivery();
-      if (generatedMediaDelivery?.delivered) {
+      // Do not fall through to requester-agent handoff after an attempted media send:
+      // platform sends can fail after posting some media, and the handoff can duplicate it.
+      if (generatedMediaDelivery) {
         return generatedMediaDelivery;
       }
     }

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1105,6 +1105,17 @@ async function sendSubagentAnnounceDirectly(params: {
         sourceTool: params.sourceTool,
       });
     };
+    const tryGeneratedMediaPrimaryDirectDelivery = async () => {
+      return await deliverGeneratedMediaCompletionDirect({
+        cfg,
+        requesterSessionKey: canonicalRequesterSessionKey,
+        directIdempotencyKey: params.directIdempotencyKey,
+        deliveryTarget,
+        mediaUrls: expectedMediaUrls,
+        internalEvents: params.internalEvents,
+        sourceTool: params.sourceTool,
+      });
+    };
     const completionSourceReplyDeliveryMode = requiresMessageToolDelivery
       ? "message_tool_only"
       : undefined;
@@ -1119,6 +1130,12 @@ async function sendSubagentAnnounceDirectly(params: {
         directOrigin?.channel,
       sessionEntry: requesterEntry,
     });
+    if (agentMediatedCompletion && expectedMediaUrls.length > 0) {
+      const generatedMediaDelivery = await tryGeneratedMediaPrimaryDirectDelivery();
+      if (generatedMediaDelivery?.delivered) {
+        return generatedMediaDelivery;
+      }
+    }
     if (
       params.expectsCompletionMessage &&
       requesterActivity.sessionId &&

--- a/src/agents/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagent-announce-dispatch.test.ts
@@ -103,6 +103,36 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
+  it("does not fallback-steer after terminal completion direct failure", async () => {
+    const steer = vi.fn(async () => ({ status: "steered" }) as const);
+    const direct = vi.fn(async () => ({
+      delivered: false,
+      path: "direct" as const,
+      error: "media send may have partially succeeded",
+      terminal: true,
+    }));
+
+    const result = await runSubagentAnnounceDispatch({
+      expectsCompletionMessage: true,
+      steer,
+      direct,
+    });
+
+    expect(direct).toHaveBeenCalledTimes(1);
+    expect(steer).not.toHaveBeenCalled();
+    expect(result.delivered).toBe(false);
+    expect(result.path).toBe("direct");
+    expect(result.error).toBe("media send may have partially succeeded");
+    expect(result.phases).toEqual([
+      {
+        phase: "direct-primary",
+        delivered: false,
+        path: "direct",
+        error: "media send may have partially succeeded",
+      },
+    ]);
+  });
+
   it("returns direct failure when completion fallback steering cannot deliver", async () => {
     const steer = vi.fn(async () => ({ status: "none" }) as const);
     const direct = vi.fn(async () => ({

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -10,6 +10,7 @@ export type SubagentAnnounceDeliveryResult = {
   deliveredAt?: number;
   enqueuedAt?: number;
   error?: string;
+  terminal?: boolean;
   phases?: SubagentAnnounceDispatchPhaseResult[];
 };
 
@@ -91,7 +92,7 @@ export async function runSubagentAnnounceDispatch(params: {
 
   const primaryDirect = await params.direct();
   appendPhase("direct-primary", primaryDirect);
-  if (primaryDirect.delivered) {
+  if (primaryDirect.delivered || primaryDirect.terminal) {
     return withPhases(primaryDirect);
   }
 


### PR DESCRIPTION
## Summary

Fixes generated-media completion delivery so successful `image_generate` / `music_generate` / `video_generate` completions with expected media URLs are delivered directly and idempotently before waking the requester agent.

## Root Cause

The completion path already had deterministic generated-media direct delivery, but only as a fallback after the requester-agent/message-tool handoff. That left successful media completions dependent on prompt obedience: the requester agent was told to call `message.send` once, then remain silent. If the completion session context already contained repeated historical `message` tool calls, the model could copy that pattern and send the same media attachment multiple times.

## Changes

- Prefer direct generated-media delivery when expected media URLs are present.
- Treat generated-media direct delivery failures as terminal after the send is attempted, so a partial platform send cannot fall back into the requester-agent/message-tool path and duplicate media.
- Update completion-delivery and dispatch tests for direct-first media delivery, active requester sessions, legacy group routes, topic thread IDs, terminal direct failures, and fallback behavior.

Fixes #87995.

Follow-up to closed #87989; GitHub did not allow reopening the closed issue, and the bug reproduced on `2026.5.28-beta.1`.

## Validation

- `OPENCLAW_TEST_FAST=1 node_modules/.bin/vitest run src/agents/run-wait.test.ts src/agents/subagent-announce-dispatch.test.ts src/agents/subagent-announce-delivery.test.ts --reporter=dot` (214 passed)
- `node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern src/agents/run-wait.test.ts src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce-dispatch.ts src/agents/subagent-announce-dispatch.test.ts`
- `git diff --cached --check`

## Real behavior proof

- **Behavior or issue addressed:** Generated-media completion delivery for `image_generate` / `music_generate` / `video_generate` could wake the requester agent and cause repeated `message.send` calls with the same media attachment. This proof verifies the fixed direct delivery path on a real OpenClaw instance.
- **Real environment tested:** Dicky VPS, OpenClaw `2026.5.28-beta.1 (84fd629)`, patched with this PR's runtime change.
- **Exact steps or command run after this patch:** Patched Dicky's installed runtime file, restarted Dicky's gateway, verified the gateway RPC probe, then triggered from Discord: `@Dicky make an image of the last hour of this channel`.
- **Evidence after fix:** Copied live output from Dicky/Discord after the patched run:

```text
Patched file: /home/dicky/.npm-global/lib/node_modules/openclaw/dist/subagent-announce-delivery-meOMMrhe.js
Patched sha256: 54be39526423c74139c17b32c4e73c287b83dc9bda7ea8d2f73066289a77f3b0
Backup: /home/dicky/.openclaw/state/backups/openclaw-pr87991-runtime/20260529T110329Z/subagent-announce-delivery-meOMMrhe.js
Gateway: running, RPC probe ok

Prompt: @Dicky make an image of the last hour of this channel
Run: image_generate:26e54be5-8afb-4736-8534-d8c6fb52b902:ok
Media path: ~/.openclaw/media/tool-image-generation/image-1---815ea96c-e360-4b6e-9b0a-5522e5c730cb.jpg
Public Discord posts with that attachment filename: 1
Discord message id: 1509876170701799486
Attachment id: 1509876164879974593
Caption/content: The generated image is ready.
Requester session message tool calls with that image: 0
Requester session message tool results with that image: 0
Delivery mirrors: 1
Delivery mirror idempotency key: image_generate:26e54be5-8afb-4736-8534-d8c6fb52b902:ok:generated-media-direct
```

- **Observed result after fix:** The generated image was posted exactly once, via deterministic direct delivery. The requester session did not call the `message` tool for that image, so the previous repeated-send path was not entered.
- **What was not tested:** A real partial platform upload failure was not forced on Dicky; that edge is covered by the regression tests added in this PR because inducing a live half-successful Discord upload is not deterministic.
