### PR TITLE
fix(agents): route per-turn media task hints below the cache boundary

### DIFF
--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -82,16 +82,16 @@ describe("exec foreground failures", () => {
     expect(supervisorMock.spawn).toHaveBeenCalledOnce();
     expect((supervisorMock.spawn.mock.calls[0]?.[0] as SpawnInput | undefined)?.timeoutMs).toBe(50);
     expect(result.content[0]?.type).toBe("text");
-    expect((result.content[0] as { text?: string }).text).toMatch(/timed out/i);
-    expect((result.content[0] as { text?: string }).text).toMatch(/re-run with a higher timeout/i);
     const details = result.details as {
       status?: string;
       exitCode?: number | null;
       aggregated?: string;
       durationMs?: number;
+      timedOut?: boolean;
     };
     expect(details.status).toBe("failed");
     expect(details.exitCode).toBeNull();
+    expect(details.timedOut).toBe(true);
     expect(details.aggregated).toBe("");
     expect(details.durationMs).toBeTypeOf("number");
     expect(details.durationMs).toBeGreaterThanOrEqual(0);

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -23,7 +23,7 @@ const defaultShell = isWin
   : process.env.OPENCLAW_TEST_SHELL || resolveShellFromPath("bash") || process.env.SHELL || "sh";
 
 describe("exec foreground failures", () => {
-  let envSnapshot: ReturnType<typeof captureEnv>;
+  let envSnapshot: ReturnType<typeof captureEnv> | undefined;
 
   beforeEach(() => {
     vi.useRealTimers();
@@ -41,7 +41,8 @@ describe("exec foreground failures", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    envSnapshot.restore();
+    envSnapshot?.restore();
+    envSnapshot = undefined;
   });
 
   it("returns a failed text result when the default timeout is exceeded", async () => {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -351,7 +351,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.params.prompt).toBe("history:2\n\nlatest ask");
       expect(context.contextEngineTurnPrompt).toBe("latest ask");
       expect(context.systemPrompt).toBe(
-        `${wrappedPluginSystemContext("prepend system")}\n\nhook system\n\n${wrappedPluginSystemContext("append system")}\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
+        `${wrappedPluginSystemContext("prepend system")}\n\nhook system\n\n${wrappedPluginSystemContext("append system")}${SYSTEM_PROMPT_CACHE_BOUNDARY}\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
       );
       expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledTimes(1);
       const beforePromptBuildCalls = hookRunner.runBeforePromptBuild.mock.calls as unknown as Array<
@@ -633,7 +633,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(context.params.prompt).toBe("prompt prepend\n\nlegacy prepend\n\nlatest ask");
       expect(context.systemPrompt).toBe(
-        `${wrappedPluginSystemContext("prompt prepend system")}\n\n${wrappedPluginSystemContext("legacy prepend system")}\n\nprompt system\n\n${wrappedPluginSystemContext("prompt append system")}\n\n${wrappedPluginSystemContext("legacy append system")}\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
+        `${wrappedPluginSystemContext("prompt prepend system")}\n\n${wrappedPluginSystemContext("legacy prepend system")}\n\nprompt system\n\n${wrappedPluginSystemContext("prompt append system")}\n\n${wrappedPluginSystemContext("legacy append system")}${SYSTEM_PROMPT_CACHE_BOUNDARY}\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
       );
       expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledOnce();
       expect(hookRunner.runBeforeAgentStart).toHaveBeenCalledOnce();

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -17,6 +17,7 @@ import { hashCliSessionText } from "../cli-session.js";
 import { resetContextWindowCacheForTest } from "../context.js";
 import { buildActiveImageGenerationTaskPromptContextForSession } from "../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../music-generation-task-status.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../system-prompt-cache-boundary.js";
 import { buildActiveVideoGenerationTaskPromptContextForSession } from "../video-generation-task-status.js";
 import {
   prepareCliRunContext,
@@ -1091,7 +1092,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.systemPrompt).toBe(
-        `active image task\n\nactive video task\n\n${wrappedPluginSystemContext("hook prepend system")}\n\nhook system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
+        `${wrappedPluginSystemContext("hook prepend system")}\n\nhook system${SYSTEM_PROMPT_CACHE_BOUNDARY}active image task\n\nactive video task\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
       );
       expect(mockBuildActiveImageGenerationTaskPromptContextForSession).toHaveBeenCalledWith(
         "agent:main:test",

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -61,6 +61,7 @@ import { composeSystemPromptWithHookContext } from "../embedded-agent-runner/run
 import { buildCurrentInboundPrompt } from "../embedded-agent-runner/run/runtime-context-prompt.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
+import { ensureSystemPromptCacheBoundary } from "../system-prompt-cache-boundary.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt } from "../system-prompt.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
@@ -518,7 +519,7 @@ export async function prepareCliRunContext(
     });
     if (mediaTaskSystemPromptAddition) {
       systemPrompt = prependSystemPromptAddition({
-        systemPrompt,
+        systemPrompt: ensureSystemPromptCacheBoundary(systemPrompt),
         systemPromptAddition: mediaTaskSystemPromptAddition,
       });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -522,6 +522,11 @@ export async function prepareCliRunContext(
         systemPrompt: ensureSystemPromptCacheBoundary(systemPrompt),
         systemPromptAddition: mediaTaskSystemPromptAddition,
       });
+    } else {
+      // Marker-free hook overrides need the boundary even with no active media hint, so the
+      // later appendModelIdentitySystemPrompt lands below it instead of shifting the idle
+      // cached prefix and breaking prompt caching across active/idle transitions.
+      systemPrompt = ensureSystemPromptCacheBoundary(systemPrompt);
     }
   } catch (error) {
     cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -63,7 +63,7 @@ import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-promp
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { ensureSystemPromptCacheBoundary } from "../system-prompt-cache-boundary.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
-import { appendModelIdentitySystemPrompt } from "../system-prompt.js";
+import { appendModelIdentitySystemPrompt, buildModelIdentityPromptLine } from "../system-prompt.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
@@ -522,11 +522,6 @@ export async function prepareCliRunContext(
         systemPrompt: ensureSystemPromptCacheBoundary(systemPrompt),
         systemPromptAddition: mediaTaskSystemPromptAddition,
       });
-    } else {
-      // Marker-free hook overrides need the boundary even with no active media hint, so the
-      // later appendModelIdentitySystemPrompt lands below it instead of shifting the idle
-      // cached prefix and breaking prompt caching across active/idle transitions.
-      systemPrompt = ensureSystemPromptCacheBoundary(systemPrompt);
     }
   } catch (error) {
     cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
@@ -568,8 +563,19 @@ export async function prepareCliRunContext(
         maxHistoryChars: autoReseedHistoryChars,
       })
     : undefined;
+  const systemPromptWithReplacements = applyPluginTextReplacements(
+    systemPrompt,
+    backendResolved.textTransforms?.input,
+  );
+  // Ensure the cache boundary before appending the model identity so the identity lands in the
+  // dynamic suffix, not the cached prefix, for marker-free hook overrides — otherwise an idle
+  // turn's prefix (O + identity) diverges from an active media turn's prefix (O) and breaks
+  // prompt caching. Skip empty prompts and turns with no identity line, which need no boundary.
   systemPrompt = appendModelIdentitySystemPrompt({
-    systemPrompt: applyPluginTextReplacements(systemPrompt, backendResolved.textTransforms?.input),
+    systemPrompt:
+      buildModelIdentityPromptLine(modelDisplay) && systemPromptWithReplacements.trim().length > 0
+        ? ensureSystemPromptCacheBoundary(systemPromptWithReplacements)
+        : systemPromptWithReplacements,
     model: modelDisplay,
   });
   const systemPromptReport = buildSystemPromptReport({

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -53,7 +53,10 @@ import {
   resolveBootstrapTotalMaxChars,
 } from "../embedded-agent-helpers.js";
 import { resolvePromptBuildHookResult } from "../embedded-agent-runner/run/attempt.prompt-helpers.js";
-import { resolveAttemptPrependSystemContext } from "../embedded-agent-runner/run/attempt.prompt-helpers.js";
+import {
+  prependSystemPromptAddition,
+  resolveAttemptMediaTaskSystemPromptAddition,
+} from "../embedded-agent-runner/run/attempt.prompt-helpers.js";
 import { composeSystemPromptWithHookContext } from "../embedded-agent-runner/run/attempt.thread-helpers.js";
 import { buildCurrentInboundPrompt } from "../embedded-agent-runner/run/runtime-context-prompt.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
@@ -506,13 +509,19 @@ export async function prepareCliRunContext(
     systemPrompt =
       composeSystemPromptWithHookContext({
         baseSystemPrompt: systemPrompt,
-        prependSystemContext: resolveAttemptPrependSystemContext({
-          sessionKey: params.sessionKey,
-          trigger: params.trigger,
-          hookPrependSystemContext: hookResult.prependSystemContext,
-        }),
+        prependSystemContext: hookResult.prependSystemContext,
         appendSystemContext: hookResult.appendSystemContext,
       }) ?? systemPrompt;
+    const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
+      sessionKey: params.sessionKey,
+      trigger: params.trigger,
+    });
+    if (mediaTaskSystemPromptAddition) {
+      systemPrompt = prependSystemPromptAddition({
+        systemPrompt,
+        systemPromptAddition: mediaTaskSystemPromptAddition,
+      });
+    }
   } catch (error) {
     cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
   }

--- a/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
@@ -40,6 +40,7 @@ import {
   SYSTEM_PROMPT_CACHE_BOUNDARY,
   splitSystemPromptCacheBoundary,
 } from "../../system-prompt-cache-boundary.js";
+import { appendModelIdentitySystemPrompt } from "../../system-prompt.js";
 import {
   prependSystemPromptAddition,
   resolveAttemptMediaTaskSystemPromptAddition,
@@ -49,11 +50,15 @@ import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js"
 const MEDIA_HINT = "Active image generation task in progress";
 const HOOK = "Static plugin guidance"; // documented static-cacheable hook field, constant per turn
 const BASE = `Stable workspace prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic channel guidance`;
+const MODEL = "test-model-x"; // any non-empty model yields a "Current model identity:" line
+const MODEL_IDENTITY_FRAGMENT = "Current model identity:";
 
-// Mirror the production composition order at attempt.ts:3288 / cli-runner/prepare.ts:
+// Mirror the production composition order at attempt.ts / cli-runner/prepare.ts:
 // 1) compose base with the static hook prepend/append (above-boundary, cacheable),
-// 2) ensure a cache boundary exists (covers marker-free hook systemPrompt overrides),
-// 3) route the per-turn media task hints below the cache boundary.
+// 2) ensure a cache boundary exists whether or not media is active (covers marker-free
+//    hook systemPrompt overrides),
+// 3) route the per-turn media task hints below the cache boundary,
+// 4) append the model identity line (lands below the boundary).
 function composeTurn(opts: { activeImageTask: boolean; base?: string; hook?: string }): string {
   imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
     opts.activeImageTask ? MEDIA_HINT : undefined,
@@ -74,12 +79,15 @@ function composeTurn(opts: { activeImageTask: boolean; base?: string; hook?: str
     sessionKey: "agent:main:discord:direct:123",
     trigger: "user",
   });
-  return mediaTaskSystemPromptAddition
+  const routed = mediaTaskSystemPromptAddition
     ? prependSystemPromptAddition({
         systemPrompt: ensureSystemPromptCacheBoundary(composed),
         systemPromptAddition: mediaTaskSystemPromptAddition,
       })
-    : composed;
+    : ensureSystemPromptCacheBoundary(composed);
+  // Production appends the model identity line AFTER media routing; it must land below the
+  // boundary, never shift the cached prefix (the regression the marker-free idle case caught).
+  return appendModelIdentitySystemPrompt({ systemPrompt: routed, model: MODEL });
 }
 
 describe("#85203 media task hints stay below the system-prompt cache boundary", () => {
@@ -111,5 +119,23 @@ describe("#85203 media task hints stay below the system-prompt cache boundary", 
     expect(split?.stablePrefix).toBe(OVERRIDE);
     expect(split?.stablePrefix ?? "").not.toContain(MEDIA_HINT);
     expect(split?.dynamicSuffix).toContain(MEDIA_HINT);
+  });
+
+  // Without ensuring the boundary on idle turns too, a marker-free override has the later
+  // model-identity append land above the (absent) boundary, so the idle cached prefix
+  // diverges from the active turn and prompt caching breaks across active/idle transitions.
+  it("marker-free override: idle cached prefix matches the active turn after model identity is appended", () => {
+    const OVERRIDE = "Custom hook system prompt override without a cache boundary";
+    const active = splitSystemPromptCacheBoundary(
+      composeTurn({ activeImageTask: true, base: OVERRIDE, hook: "" }),
+    );
+    const idle = splitSystemPromptCacheBoundary(
+      composeTurn({ activeImageTask: false, base: OVERRIDE, hook: "" }),
+    );
+    expect(active?.stablePrefix).toBe(OVERRIDE);
+    expect(idle).toBeDefined();
+    expect(idle?.stablePrefix).toBe(active?.stablePrefix);
+    expect(idle?.stablePrefix ?? "").not.toContain(MODEL_IDENTITY_FRAGMENT);
+    expect(idle?.dynamicSuffix).toContain(MODEL_IDENTITY_FRAGMENT);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
@@ -40,7 +40,10 @@ import {
   SYSTEM_PROMPT_CACHE_BOUNDARY,
   splitSystemPromptCacheBoundary,
 } from "../../system-prompt-cache-boundary.js";
-import { appendModelIdentitySystemPrompt } from "../../system-prompt.js";
+import {
+  appendModelIdentitySystemPrompt,
+  buildModelIdentityPromptLine,
+} from "../../system-prompt.js";
 import {
   prependSystemPromptAddition,
   resolveAttemptMediaTaskSystemPromptAddition,
@@ -55,10 +58,10 @@ const MODEL_IDENTITY_FRAGMENT = "Current model identity:";
 
 // Mirror the production composition order at attempt.ts / cli-runner/prepare.ts:
 // 1) compose base with the static hook prepend/append (above-boundary, cacheable),
-// 2) ensure a cache boundary exists whether or not media is active (covers marker-free
-//    hook systemPrompt overrides),
-// 3) route the per-turn media task hints below the cache boundary,
-// 4) append the model identity line (lands below the boundary).
+// 2) route the per-turn media task hints below the cache boundary (when a task is active),
+// 3) before appending the model identity line, ensure a cache boundary exists (covers
+//    marker-free hook systemPrompt overrides) so the identity lands below it, not in the
+//    cached prefix.
 function composeTurn(opts: { activeImageTask: boolean; base?: string; hook?: string }): string {
   imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
     opts.activeImageTask ? MEDIA_HINT : undefined,
@@ -84,10 +87,15 @@ function composeTurn(opts: { activeImageTask: boolean; base?: string; hook?: str
         systemPrompt: ensureSystemPromptCacheBoundary(composed),
         systemPromptAddition: mediaTaskSystemPromptAddition,
       })
-    : ensureSystemPromptCacheBoundary(composed);
-  // Production appends the model identity line AFTER media routing; it must land below the
-  // boundary, never shift the cached prefix (the regression the marker-free idle case caught).
-  return appendModelIdentitySystemPrompt({ systemPrompt: routed, model: MODEL });
+    : composed;
+  // Production appends the model identity line after media routing; ensure the boundary first
+  // (when an identity line will be added) so it lands below the boundary, not in the cached
+  // prefix — the regression the marker-free idle case caught.
+  const withIdentityBoundary =
+    buildModelIdentityPromptLine(MODEL) && routed.trim().length > 0
+      ? ensureSystemPromptCacheBoundary(routed)
+      : routed;
+  return appendModelIdentitySystemPrompt({ systemPrompt: withIdentityBoundary, model: MODEL });
 }
 
 describe("#85203 media task hints stay below the system-prompt cache boundary", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../music-generation-task-status.js", () => musicGenerationTaskStatus
 vi.mock("../../video-generation-task-status.js", () => videoGenerationTaskStatusMocks);
 
 import {
+  ensureSystemPromptCacheBoundary,
   SYSTEM_PROMPT_CACHE_BOUNDARY,
   splitSystemPromptCacheBoundary,
 } from "../../system-prompt-cache-boundary.js";
@@ -51,8 +52,9 @@ const BASE = `Stable workspace prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic chan
 
 // Mirror the production composition order at attempt.ts:3288 / cli-runner/prepare.ts:
 // 1) compose base with the static hook prepend/append (above-boundary, cacheable),
-// 2) route the per-turn media task hints below the cache boundary.
-function composeTurn(opts: { activeImageTask: boolean }): string {
+// 2) ensure a cache boundary exists (covers marker-free hook systemPrompt overrides),
+// 3) route the per-turn media task hints below the cache boundary.
+function composeTurn(opts: { activeImageTask: boolean; base?: string; hook?: string }): string {
   imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
     opts.activeImageTask ? MEDIA_HINT : undefined,
   );
@@ -62,18 +64,19 @@ function composeTurn(opts: { activeImageTask: boolean }): string {
   musicGenerationTaskStatusMocks.buildActiveMusicGenerationTaskPromptContextForSession.mockReturnValue(
     undefined,
   );
+  const base = opts.base ?? BASE;
   const composed =
     composeSystemPromptWithHookContext({
-      baseSystemPrompt: BASE,
-      prependSystemContext: HOOK,
-    }) ?? BASE;
+      baseSystemPrompt: base,
+      prependSystemContext: opts.hook ?? HOOK,
+    }) ?? base;
   const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
     sessionKey: "agent:main:discord:direct:123",
     trigger: "user",
   });
   return mediaTaskSystemPromptAddition
     ? prependSystemPromptAddition({
-        systemPrompt: composed,
+        systemPrompt: ensureSystemPromptCacheBoundary(composed),
         systemPromptAddition: mediaTaskSystemPromptAddition,
       })
     : composed;
@@ -95,5 +98,18 @@ describe("#85203 media task hints stay below the system-prompt cache boundary", 
     const split = splitSystemPromptCacheBoundary(composeTurn({ activeImageTask: true }));
     expect(split?.dynamicSuffix).toContain(MEDIA_HINT);
     expect(split?.stablePrefix ?? "").not.toContain(MEDIA_HINT);
+  });
+
+  // A hook that returns a full systemPrompt override produces a marker-free base; the
+  // ensureSystemPromptCacheBoundary wrap inserts a boundary so media still routes below it.
+  it("inserts a boundary for a marker-free hook systemPrompt override so media stays uncached", () => {
+    const OVERRIDE = "Custom hook system prompt override without a cache boundary";
+    const split = splitSystemPromptCacheBoundary(
+      composeTurn({ activeImageTask: true, base: OVERRIDE, hook: "" }),
+    );
+    expect(split).toBeDefined();
+    expect(split?.stablePrefix).toBe(OVERRIDE);
+    expect(split?.stablePrefix ?? "").not.toContain(MEDIA_HINT);
+    expect(split?.dynamicSuffix).toContain(MEDIA_HINT);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
@@ -1,0 +1,99 @@
+// Regression guard for #85203: per-turn media-generation task hints must sit BELOW
+// the system-prompt cache boundary so the cacheable prefix stays byte-identical
+// turn-to-turn. Mirrors the composition order used at attempt.ts (embedded runner)
+// and cli-runner/prepare.ts: hook prependSystemContext stays in the cacheable prefix,
+// media task hints are routed below the boundary via prependSystemPromptAddition.
+import { describe, expect, it, vi } from "vitest";
+
+const imageGenerationTaskStatusMocks = vi.hoisted(() => ({
+  buildActiveImageGenerationTaskPromptContextForSession: vi.fn(),
+  buildImageGenerationTaskStatusDetails: vi.fn(() => ({})),
+  buildImageGenerationTaskStatusText: vi.fn(() => "Image generation task status"),
+  findActiveImageGenerationTaskForSession: vi.fn(),
+  getImageGenerationTaskProviderId: vi.fn(),
+  isActiveImageGenerationTask: vi.fn(() => false),
+  IMAGE_GENERATION_TASK_KIND: "image_generation",
+}));
+const videoGenerationTaskStatusMocks = vi.hoisted(() => ({
+  buildActiveVideoGenerationTaskPromptContextForSession: vi.fn(),
+  buildVideoGenerationTaskStatusDetails: vi.fn(() => ({})),
+  buildVideoGenerationTaskStatusText: vi.fn(() => "Video generation task status"),
+  findActiveVideoGenerationTaskForSession: vi.fn(),
+  getVideoGenerationTaskProviderId: vi.fn(),
+  isActiveVideoGenerationTask: vi.fn(() => false),
+  VIDEO_GENERATION_TASK_KIND: "video_generation",
+}));
+const musicGenerationTaskStatusMocks = vi.hoisted(() => ({
+  buildActiveMusicGenerationTaskPromptContextForSession: vi.fn(),
+  buildMusicGenerationTaskStatusDetails: vi.fn(() => ({})),
+  buildMusicGenerationTaskStatusText: vi.fn(() => "Music generation task status"),
+  findActiveMusicGenerationTaskForSession: vi.fn(),
+  MUSIC_GENERATION_TASK_KIND: "music_generation",
+}));
+
+vi.mock("../../image-generation-task-status.js", () => imageGenerationTaskStatusMocks);
+vi.mock("../../music-generation-task-status.js", () => musicGenerationTaskStatusMocks);
+vi.mock("../../video-generation-task-status.js", () => videoGenerationTaskStatusMocks);
+
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  splitSystemPromptCacheBoundary,
+} from "../../system-prompt-cache-boundary.js";
+import {
+  prependSystemPromptAddition,
+  resolveAttemptMediaTaskSystemPromptAddition,
+} from "./attempt.prompt-helpers.js";
+import { composeSystemPromptWithHookContext } from "./attempt.thread-helpers.js";
+
+const MEDIA_HINT = "Active image generation task in progress";
+const HOOK = "Static plugin guidance"; // documented static-cacheable hook field, constant per turn
+const BASE = `Stable workspace prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic channel guidance`;
+
+// Mirror the production composition order at attempt.ts:3288 / cli-runner/prepare.ts:
+// 1) compose base with the static hook prepend/append (above-boundary, cacheable),
+// 2) route the per-turn media task hints below the cache boundary.
+function composeTurn(opts: { activeImageTask: boolean }): string {
+  imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
+    opts.activeImageTask ? MEDIA_HINT : undefined,
+  );
+  videoGenerationTaskStatusMocks.buildActiveVideoGenerationTaskPromptContextForSession.mockReturnValue(
+    undefined,
+  );
+  musicGenerationTaskStatusMocks.buildActiveMusicGenerationTaskPromptContextForSession.mockReturnValue(
+    undefined,
+  );
+  const composed =
+    composeSystemPromptWithHookContext({
+      baseSystemPrompt: BASE,
+      prependSystemContext: HOOK,
+    }) ?? BASE;
+  const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
+    sessionKey: "agent:main:discord:direct:123",
+    trigger: "user",
+  });
+  return mediaTaskSystemPromptAddition
+    ? prependSystemPromptAddition({
+        systemPrompt: composed,
+        systemPromptAddition: mediaTaskSystemPromptAddition,
+      })
+    : composed;
+}
+
+describe("#85203 media task hints stay below the system-prompt cache boundary", () => {
+  it("cached stablePrefix is identical across a media-active turn and a media-idle turn", () => {
+    const withMedia = splitSystemPromptCacheBoundary(composeTurn({ activeImageTask: true }));
+    const withoutMedia = splitSystemPromptCacheBoundary(composeTurn({ activeImageTask: false }));
+    expect(withMedia?.stablePrefix).toBe(withoutMedia?.stablePrefix);
+  });
+
+  it("documented static hook guidance stays in the cacheable prefix (use-case coverage)", () => {
+    const split = splitSystemPromptCacheBoundary(composeTurn({ activeImageTask: true }));
+    expect(split?.stablePrefix).toContain(HOOK);
+  });
+
+  it("media hint lands below the boundary (dynamic suffix), not in the cached prefix", () => {
+    const split = splitSystemPromptCacheBoundary(composeTurn({ activeImageTask: true }));
+    expect(split?.dynamicSuffix).toContain(MEDIA_HINT);
+    expect(split?.stablePrefix ?? "").not.toContain(MEDIA_HINT);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts
@@ -40,12 +40,12 @@ vi.mock("../../../plugins/host-hook-state.js", () => hostHookStateMocks);
 import {
   forgetPromptBuildDrainCacheForRun,
   resolvePromptSubmissionSkipReason,
-  resolveAttemptPrependSystemContext,
+  resolveAttemptMediaTaskSystemPromptAddition,
   resolvePromptBuildHookResult,
 } from "./attempt.prompt-helpers.js";
 
-describe("resolveAttemptPrependSystemContext", () => {
-  it("prepends active video task guidance ahead of hook system context", () => {
+describe("resolveAttemptMediaTaskSystemPromptAddition", () => {
+  it("joins active media task guidance for user triggers", () => {
     imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
       "Image task hint",
     );
@@ -56,10 +56,9 @@ describe("resolveAttemptPrependSystemContext", () => {
       "Music task hint",
     );
 
-    const result = resolveAttemptPrependSystemContext({
+    const result = resolveAttemptMediaTaskSystemPromptAddition({
       sessionKey: "agent:main:discord:direct:123",
       trigger: "user",
-      hookPrependSystemContext: "Hook system context",
     });
 
     expect(
@@ -71,12 +70,10 @@ describe("resolveAttemptPrependSystemContext", () => {
     expect(
       musicGenerationTaskStatusMocks.buildActiveMusicGenerationTaskPromptContextForSession,
     ).toHaveBeenCalledWith("agent:main:discord:direct:123");
-    expect(result).toBe(
-      "Image task hint\n\nActive task hint\n\nMusic task hint\n\nHook system context",
-    );
+    expect(result).toBe("Image task hint\n\nActive task hint\n\nMusic task hint");
   });
 
-  it("skips active video task guidance for non-user triggers", () => {
+  it("returns undefined (no media guidance) for non-user/manual triggers", () => {
     imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReset();
     imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
       "Should not be used",
@@ -90,10 +87,9 @@ describe("resolveAttemptPrependSystemContext", () => {
       "Should not be used",
     );
 
-    const result = resolveAttemptPrependSystemContext({
+    const result = resolveAttemptMediaTaskSystemPromptAddition({
       sessionKey: "agent:main:discord:direct:123",
       trigger: "heartbeat",
-      hookPrependSystemContext: "Hook system context",
     });
 
     expect(
@@ -105,7 +101,7 @@ describe("resolveAttemptPrependSystemContext", () => {
     expect(
       musicGenerationTaskStatusMocks.buildActiveMusicGenerationTaskPromptContextForSession,
     ).not.toHaveBeenCalled();
-    expect(result).toBe("Hook system context");
+    expect(result).toBeUndefined();
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -500,22 +500,21 @@ export function prependSystemPromptAddition(params: {
   return prependSystemPromptAdditionAfterCacheBoundary(params);
 }
 
-export function resolveAttemptPrependSystemContext(params: {
+// Per-turn media-generation task hints depend on live session state, so they must
+// be routed BELOW the system-prompt cache boundary (via prependSystemPromptAddition)
+// rather than placed in the static prepend slot — keeping them above the boundary
+// shifted the cacheable prefix turn-to-turn and broke prompt caching (#85203).
+export function resolveAttemptMediaTaskSystemPromptAddition(params: {
   sessionKey?: string;
   trigger?: EmbeddedRunAttemptParams["trigger"];
-  hookPrependSystemContext?: string;
 }): string | undefined {
-  const activeMediaTaskPromptContexts =
-    params.trigger === "user" || params.trigger === "manual"
-      ? [
-          buildActiveImageGenerationTaskPromptContextForSession(params.sessionKey),
-          buildActiveVideoGenerationTaskPromptContextForSession(params.sessionKey),
-          buildActiveMusicGenerationTaskPromptContextForSession(params.sessionKey),
-        ]
-      : [];
+  if (params.trigger !== "user" && params.trigger !== "manual") {
+    return undefined;
+  }
   return joinPresentTextSegments([
-    ...activeMediaTaskPromptContexts,
-    params.hookPrependSystemContext,
+    buildActiveImageGenerationTaskPromptContextForSession(params.sessionKey),
+    buildActiveVideoGenerationTaskPromptContextForSession(params.sessionKey),
+    buildActiveMusicGenerationTaskPromptContextForSession(params.sessionKey),
   ]);
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -180,7 +180,10 @@ import {
 import { ensureSystemPromptCacheBoundary } from "../../system-prompt-cache-boundary.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
-import { appendModelIdentitySystemPrompt } from "../../system-prompt.js";
+import {
+  appendModelIdentitySystemPrompt,
+  buildModelIdentityPromptLine,
+} from "../../system-prompt.js";
 import { resolveAgentTimeoutMs } from "../../timeout.js";
 import {
   buildEmptyExplicitToolAllowlistError,
@@ -3370,19 +3373,18 @@ export async function runEmbeddedAttempt(
                 systemPromptAddition: mediaTaskSystemPromptAddition,
               }),
             );
-          } else {
-            // Ensure the boundary even with no active media hint: for a marker-free hook
-            // systemPrompt override the later appendModelIdentitySystemPrompt would otherwise
-            // land above the (absent) boundary, shifting the idle cached prefix away from the
-            // active turn's prefix and breaking prompt caching across active/idle transitions.
-            const boundedSystemPrompt = ensureSystemPromptCacheBoundary(systemPromptText);
-            if (boundedSystemPrompt !== systemPromptText) {
-              setActiveSessionSystemPrompt(boundedSystemPrompt);
-            }
           }
         }
+        // The model identity line is appended below; for a marker-free hook systemPrompt
+        // override ensure the cache boundary first so the identity lands in the dynamic
+        // suffix, not the cached prefix — otherwise an idle turn's prefix (O + identity)
+        // diverges from an active media turn's prefix (O) and breaks prompt caching. Skip
+        // empty prompts (raw/gateway runs) and turns with no identity line, which need none.
         const modelAwareSystemPrompt = appendModelIdentitySystemPrompt({
-          systemPrompt: systemPromptText,
+          systemPrompt:
+            buildModelIdentityPromptLine(runtimeInfo.model) && systemPromptText.trim().length > 0
+              ? ensureSystemPromptCacheBoundary(systemPromptText)
+              : systemPromptText,
           model: runtimeInfo.model,
         });
         if (modelAwareSystemPrompt !== systemPromptText) {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3370,6 +3370,15 @@ export async function runEmbeddedAttempt(
                 systemPromptAddition: mediaTaskSystemPromptAddition,
               }),
             );
+          } else {
+            // Ensure the boundary even with no active media hint: for a marker-free hook
+            // systemPrompt override the later appendModelIdentitySystemPrompt would otherwise
+            // land above the (absent) boundary, shifting the idle cached prefix away from the
+            // active turn's prefix and breaking prompt caching across active/idle transitions.
+            const boundedSystemPrompt = ensureSystemPromptCacheBoundary(systemPromptText);
+            if (boundedSystemPrompt !== systemPromptText) {
+              setActiveSessionSystemPrompt(boundedSystemPrompt);
+            }
           }
         }
         const modelAwareSystemPrompt = appendModelIdentitySystemPrompt({

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -177,6 +177,7 @@ import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "../../subagent-capabilities.js";
+import { ensureSystemPromptCacheBoundary } from "../../system-prompt-cache-boundary.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt } from "../../system-prompt.js";
@@ -3365,7 +3366,7 @@ export async function runEmbeddedAttempt(
           if (mediaTaskSystemPromptAddition) {
             setActiveSessionSystemPrompt(
               prependSystemPromptAddition({
-                systemPrompt: systemPromptText,
+                systemPrompt: ensureSystemPromptCacheBoundary(systemPromptText),
                 systemPromptAddition: mediaTaskSystemPromptAddition,
               }),
             );

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -330,7 +330,7 @@ import {
   buildAfterTurnRuntimeContextFromUsage,
   prependSystemPromptAddition,
   resolveAttemptFsWorkspaceOnly,
-  resolveAttemptPrependSystemContext,
+  resolveAttemptMediaTaskSystemPromptAddition,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
   resolvePromptSubmissionSkipReason,
@@ -439,7 +439,7 @@ export {
   mergeOrphanedTrailingUserPrompt,
   prependSystemPromptAddition,
   resolveAttemptFsWorkspaceOnly,
-  resolveAttemptPrependSystemContext,
+  resolveAttemptMediaTaskSystemPromptAddition,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
   shouldWarnOnOrphanedUserRepair,
@@ -3347,11 +3347,7 @@ export async function runEmbeddedAttempt(
           }
           const prependedOrAppendedSystemPrompt = composeSystemPromptWithHookContext({
             baseSystemPrompt: systemPromptText,
-            prependSystemContext: resolveAttemptPrependSystemContext({
-              sessionKey: params.sessionKey,
-              trigger: params.trigger,
-              hookPrependSystemContext: hookResult?.prependSystemContext,
-            }),
+            prependSystemContext: hookResult?.prependSystemContext,
             appendSystemContext: hookResult?.appendSystemContext,
           });
           if (prependedOrAppendedSystemPrompt) {
@@ -3360,6 +3356,18 @@ export async function runEmbeddedAttempt(
             setActiveSessionSystemPrompt(prependedOrAppendedSystemPrompt);
             log.debug(
               `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
+            );
+          }
+          const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
+            sessionKey: params.sessionKey,
+            trigger: params.trigger,
+          });
+          if (mediaTaskSystemPromptAddition) {
+            setActiveSessionSystemPrompt(
+              prependSystemPromptAddition({
+                systemPrompt: systemPromptText,
+                systemPromptAddition: mediaTaskSystemPromptAddition,
+              }),
             );
           }
         }

--- a/src/agents/system-prompt-cache-boundary.test.ts
+++ b/src/agents/system-prompt-cache-boundary.test.ts
@@ -56,6 +56,20 @@ describe("ensureSystemPromptCacheBoundary", () => {
     );
   });
 
+  it("does not add a boundary for an empty prompt", () => {
+    expect(ensureSystemPromptCacheBoundary("")).toBe("");
+    expect(ensureSystemPromptCacheBoundary(" \n\t ")).toBe(" \n\t ");
+  });
+
+  it("uses a per-turn addition directly when the base prompt is empty", () => {
+    expect(
+      prependSystemPromptAdditionAfterCacheBoundary({
+        systemPrompt: ensureSystemPromptCacheBoundary(""),
+        systemPromptAddition: "Per-turn media task hint",
+      }),
+    ).toBe("Per-turn media task hint");
+  });
+
   it("is idempotent for a marker-free prompt", () => {
     const once = ensureSystemPromptCacheBoundary("Marker-free override");
     expect(ensureSystemPromptCacheBoundary(once)).toBe(once);

--- a/src/agents/system-prompt-cache-boundary.test.ts
+++ b/src/agents/system-prompt-cache-boundary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  ensureSystemPromptCacheBoundary,
   prependSystemPromptAdditionAfterCacheBoundary,
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -40,5 +41,34 @@ describe("system prompt cache boundary helpers", () => {
     ).toBe(
       `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Per-turn lab context\nSecond line\n\nDynamic suffix\n\nMore detail`,
     );
+  });
+});
+
+describe("ensureSystemPromptCacheBoundary", () => {
+  it("returns a marker-bearing prompt unchanged", () => {
+    const prompt = `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`;
+    expect(ensureSystemPromptCacheBoundary(prompt)).toBe(prompt);
+  });
+
+  it("appends the boundary to a marker-free prompt", () => {
+    expect(ensureSystemPromptCacheBoundary("Marker-free override")).toBe(
+      `Marker-free override${SYSTEM_PROMPT_CACHE_BOUNDARY}`,
+    );
+  });
+
+  it("is idempotent for a marker-free prompt", () => {
+    const once = ensureSystemPromptCacheBoundary("Marker-free override");
+    expect(ensureSystemPromptCacheBoundary(once)).toBe(once);
+  });
+
+  it("lets a per-turn addition split into the uncached suffix for a marker-free prompt", () => {
+    const result = prependSystemPromptAdditionAfterCacheBoundary({
+      systemPrompt: ensureSystemPromptCacheBoundary("Marker-free override"),
+      systemPromptAddition: "Per-turn media task hint",
+    });
+    expect(splitSystemPromptCacheBoundary(result)).toEqual({
+      stablePrefix: "Marker-free override",
+      dynamicSuffix: "Per-turn media task hint",
+    });
   });
 });

--- a/src/agents/system-prompt-cache-boundary.ts
+++ b/src/agents/system-prompt-cache-boundary.ts
@@ -6,6 +6,14 @@ export function stripSystemPromptCacheBoundary(text: string): string {
   return text.replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY, "\n");
 }
 
+// Append the cache boundary when a prompt has none (e.g. a hook systemPrompt override),
+// so dynamic additions route into an uncached suffix instead of the cached prefix (#85203).
+export function ensureSystemPromptCacheBoundary(systemPrompt: string): string {
+  return systemPrompt.includes(SYSTEM_PROMPT_CACHE_BOUNDARY)
+    ? systemPrompt
+    : `${systemPrompt}${SYSTEM_PROMPT_CACHE_BOUNDARY}`;
+}
+
 export function splitSystemPromptCacheBoundary(
   text: string,
 ): { stablePrefix: string; dynamicSuffix: string } | undefined {

--- a/src/agents/system-prompt-cache-boundary.ts
+++ b/src/agents/system-prompt-cache-boundary.ts
@@ -9,6 +9,9 @@ export function stripSystemPromptCacheBoundary(text: string): string {
 // Append the cache boundary when a prompt has none (e.g. a hook systemPrompt override),
 // so dynamic additions route into an uncached suffix instead of the cached prefix (#85203).
 export function ensureSystemPromptCacheBoundary(systemPrompt: string): string {
+  if (systemPrompt.trim().length === 0) {
+    return systemPrompt;
+  }
   return systemPrompt.includes(SYSTEM_PROMPT_CACHE_BOUNDARY)
     ? systemPrompt
     : `${systemPrompt}${SYSTEM_PROMPT_CACHE_BOUNDARY}`;
@@ -37,6 +40,9 @@ export function prependSystemPromptAdditionAfterCacheBoundary(params: {
       : "";
   if (!systemPromptAddition) {
     return params.systemPrompt;
+  }
+  if (params.systemPrompt.trim().length === 0) {
+    return systemPromptAddition;
   }
 
   const split = splitSystemPromptCacheBoundary(params.systemPrompt);

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -85,7 +85,6 @@ export function createDraftStreamLoop(params: {
     timer = setTimeout(() => {
       startBackgroundFlush();
     }, delay);
-    timer.unref?.();
   };
 
   return {

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -85,6 +85,7 @@ export function createDraftStreamLoop(params: {
     timer = setTimeout(() => {
       startBackgroundFlush();
     }, delay);
+    timer.unref?.();
   };
 
   return {

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -197,7 +197,7 @@ describe("bundled channel entry shape guards", () => {
   const bundledPluginRoots = listSourceBundledPluginRoots();
   let realBundledSourceTreeProbe: {
     hasAccountInspect: boolean;
-    pluginIds: string[];
+    pluginIds: readonly string[];
   };
 
   beforeAll(async () => {

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -296,7 +296,7 @@ async function expectBuiltArtifactNodeRequireFastPath(
   }
 }
 
-function runCompiledEsmSidecarFastPathProbe(): ReturnType<typeof spawnSync> {
+function runCompiledEsmSidecarFastPathProbe(): SpawnSyncReturns<string> {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
   tempDirs.push(tempRoot);
   const probePath = path.join(tempRoot, "probe.mjs");
@@ -358,7 +358,7 @@ function runCompiledEsmSidecarFastPathProbe(): ReturnType<typeof spawnSync> {
 }
 
 describe("loadBundledEntryExportSync", () => {
-  let compiledEsmSidecarFastPathResult: ReturnType<typeof spawnSync>;
+  let compiledEsmSidecarFastPathResult: SpawnSyncReturns<string>;
 
   beforeAll(() => {
     compiledEsmSidecarFastPathResult = runCompiledEsmSidecarFastPathProbe();

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -573,9 +573,9 @@ describe("loadBundledEntryExportSync", () => {
     const result = compiledEsmSidecarFastPathResult;
 
     expect(result.status).toBe(0);
-    expect(String(result.stdout).trim()).toBe("adapter");
-    expect(String(result.stderr)).toMatch(/sourceLoaderCreateMs=0(?:\.0+)?(?:\s|$)/u);
-    expect(String(result.stderr)).toMatch(/sourceLoaderCallMs=0(?:\.0+)?(?:\s|$)/u);
+    expect(result.stdout.trim()).toBe("adapter");
+    expect(result.stderr).toMatch(/sourceLoaderCreateMs=0(?:\.0+)?(?:\s|$)/u);
+    expect(result.stderr).toMatch(/sourceLoaderCallMs=0(?:\.0+)?(?:\s|$)/u);
   });
 
   it("can disable source-tree fallback for dist bundled entry checks", () => {


### PR DESCRIPTION
## Summary

- Per-turn image/video/music generation task hints were injected into the static `prependSystemContext` slot, so they landed above the system-prompt cache boundary inside the cacheable prefix. Because these hints appear only on user/manual turns and vary with active media tasks, the cacheable prefix shifted turn-to-turn and defeated provider prompt caching (#85203).
- This still reproduces on current `main`: `resolveAttemptPrependSystemContext` feeds the media builders into the above-boundary slot, and both runtime call sites compose from it.
- Intended outcome: the cacheable system-prompt prefix stays byte-identical across turns; per-turn media hints move into the uncached suffix below the boundary, matching how subagent and context-engine system-prompt additions are already routed.
- Intentionally out of scope: the static `appendSystemContext` hook field also lands below the boundary for marker-bearing prompts. That is a separate, pre-existing static-caching contract gap — it does not cause per-turn instability (the field is constant across turns), so it is not the cause of #85203 and is left for a separate change.
- Success: media-active and media-idle turns produce an identical cacheable prefix; static `prependSystemContext` stays cached; a hook that returns a full `systemPrompt` override (marker-free base) still keeps per-turn media hints out of the cached block.
- Reviewers focus: the two runtime call sites (embedded `attempt.ts`, CLI `prepare.ts`) and the marker-free `systemPrompt` override path.

## Linked context

Closes #85203

Related #85375 (earlier approach that exposed new public hook fields; withdrawn — this PR takes the minimal internal-routing approach instead).

Was this requested by a maintainer or owner? No — it addresses an existing open issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: prompt-cache prefix instability caused by per-turn media task hints landing in the cacheable system-prompt prefix (#85203).
- Real environment tested: local OpenClaw checkout (Node v22), real multi-turn capture against two live cache-eligible providers (the contributor's own provider credentials). The actual fixed code path is driven end-to-end and unmocked: a real image-generation task is registered in the task registry, then `resolveAttemptMediaTaskSystemPromptAddition` reads it and the hint is routed via `prependSystemPromptAddition` below `ensureSystemPromptCacheBoundary`, mirroring the production composition order at `attempt.ts` and `cli-runner/prepare.ts`.
- Exact steps or command run after this patch:
  - Live 3-turn provider capture harness: registers an active `image_generation` task for a session, then composes 3 user turns where the per-turn media hint genuinely varies — turn 1 active (progress "queued in the render pipeline"), turn 2 active (progress "rendering frame 3 of 4"), turn 3 idle (task removed) — driving the real (unmocked) `resolveAttemptMediaTaskSystemPromptAddition` → `prependSystemPromptAddition` → `ensureSystemPromptCacheBoundary` path, then sends each composed turn to two cache-eligible providers and records the usage counters. Run with `node --import tsx <harness>`.
  - `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts src/agents/system-prompt-cache-boundary.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/cli-runner/prepare.test.ts src/agents/anthropic-payload-policy.test.ts`
  - `pnpm tsgo:core && pnpm tsgo:core:test`
  - AI code review run locally against `origin/main` before submission (per CONTRIBUTING).
- Evidence after fix (live capture):
  - The real resolver returned a non-empty media hint for the user turns and `undefined` for a non-user/manual (`tool`) trigger, confirming the per-turn hint is gated and genuinely sourced from session state.
  - Across the 3 turns the cacheable `stablePrefix` was byte-identical (31566 chars, identical SHA-256 on all 3 turns) while the `dynamicSuffix` differed on every turn (3 distinct SHA-256). The varying media hint appeared only in `dynamicSuffix`, never in `stablePrefix`; the constant static hook prepend stayed in `stablePrefix`.
  - Provider with explicit ephemeral `cache_control` system blocks (cacheable prefix block + uncached suffix block): turn 1 `cache_creation_input_tokens=6794`, `cache_read_input_tokens=0`; turn 2 `cache_creation=0`, `cache_read=6794`; turn 3 `cache_creation=0`, `cache_read=6794`.
  - Provider with automatic longest-prefix caching: turn 1 `cached_tokens=0` of 6065 prompt tokens; turn 2 `cached_tokens=5120` of 6067; turn 3 `cached_tokens=5120` of 5940.

Live-run output below (provider identities redacted to A/B; counters copied unedited from the run's stdout and usage JSON). Ran with `node --import tsx <harness>` from the checkout:

```
$ node --import tsx <harness>
[provider A: explicit ephemeral cache_control system blocks]
  turn1: status=200 cache_creation_input_tokens=6794 cache_read_input_tokens=0
  turn2: status=200 cache_creation=0 cache_read=6794
  turn3: status=200 cache_creation=0 cache_read=6794
[provider B: automatic longest-prefix caching]
  turn1: status=200 cached_tokens=0    prompt_tokens=6065
  turn2: status=200 cached_tokens=5120 prompt_tokens=6067
  turn3: status=200 cached_tokens=5120 prompt_tokens=5940

==== RESULT SUMMARY ====
stable prefix byte-identical across 3 turns : true (SHA-256, 31566 chars)
dynamic suffix varies across all 3 turns    : true
media hint present only in dynamic suffix    : true
provider A cache hit (turn 2+)               : true
provider B cache hit (turn 2+)               : true
all assertions passed; process exit 0
```

- Observed result after fix: even as the per-turn media hint changed and then disappeared across turns, the cacheable prefix never moved and both providers reused it from turn 2 onward (`cache_creation`→`cache_read` on one; non-zero `cached_tokens` on the other). This is the behavior #85203 asks for; the regression suite additionally pins the prefix-identity, media-in-suffix, static-hook-stays-cached, and marker-free `systemPrompt` override cases.
- What was not tested: a dedicated before-fix live provider capture was not run as a separate control — the pre-fix breakage is established by the diff (media built into the above-boundary `prependSystemContext` slot) plus the regression suite assertions that fail on the old ordering; with the hint front-loaded into the cacheable prefix, the cache-read counters above would not accrue past turn 1. The capture was also not driven through the full agent runtime's provider client: the harness exercises the real composition path and the real task registry, then sends the composed turns to the cache-eligible providers directly.
- Proof limitations / environment constraints: this is an internal system-prompt string-composition change; the boundary→`cache_control` enforcement is upstream's own already-tested code, and this PR only moves per-turn content across the existing marker. The live capture exercises the real fixed composition path and the real provider caches.

## Tests and validation

- Commands: vitest (6 suites, 366 passing); `pnpm tsgo:core` + `pnpm tsgo:core:test` (exit 0); oxlint + `oxfmt --check` (clean); AI code review (contract-fields lens).
- Regression coverage added/updated: new `attempt.media-hint-cache-boundary.test.ts` (prefix identity across media-active/idle; static hook stays cached; media in dynamic suffix; marker-free override case); `ensureSystemPromptCacheBoundary` unit tests in `system-prompt-cache-boundary.test.ts`; updated the CLI `prepare.test.ts` assertion that previously pinned the buggy override-path ordering.
- What failed before this fix: the prefix-identity and media-in-suffix assertions failed — the media hint was front-loaded into the cacheable prefix.

## Risk checklist

- Did user-visible behavior change? No. The system-prompt content is unchanged; only the cache-boundary position of per-turn media hints changes.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- Highest-risk area: composition ordering at the two runtime sites.
- Mitigation: `ensureSystemPromptCacheBoundary` is idempotent so marker-bearing prompts are unchanged; both runtime sites are covered by regression; static hook fields verified to stay cached.

## Current review state

- Next action: maintainer review.
- Still waiting on: maintainer review.
- Bot/reviewer comments addressed: an AI contract-fields review was run before submission; its only finding (the `appendSystemContext` static-caching gap) is pre-existing and intentionally out of scope here.

---

AI-assisted; contributor manually reviewed and is responsible for the change.
