### PR TITLE
fix(trajectory): keep latest runtime capture within cap

### DIFF
--- a/src/infra/fs-safe-advanced.ts
+++ b/src/infra/fs-safe-advanced.ts
@@ -5,6 +5,7 @@ export {
   assertNoSymlinkParentsSync,
   sameFileIdentity,
   sanitizeUntrustedFileName,
+  writeSiblingTempFile,
   writeViaSiblingTempPath,
   type AssertNoSymlinkParentsOptions,
   type FileIdentityStat,

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -226,6 +226,7 @@ describe("trajectory runtime", () => {
     const raw = fs.readFileSync(runtimeFile, "utf8");
     expect(raw).toContain("old-recorder");
     expect(raw).toContain("new-recorder");
+    expect(raw.indexOf("old-recorder")).toBeLessThan(raw.indexOf("new-recorder"));
   });
 
   it.runIf(process.platform !== "win32")(

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -172,6 +172,28 @@ describe("trajectory runtime", () => {
     expect(raw).toContain("new-3");
   });
 
+  it.runIf(process.platform !== "win32")(
+    "preserves existing trajectory directory permissions",
+    async () => {
+      const tmpDir = makeTempDir();
+      fs.chmodSync(tmpDir, 0o755);
+      const sessionFile = path.join(tmpDir, "session.jsonl");
+      const recorder = createTrajectoryRuntimeRecorder({
+        sessionId: "session-1",
+        sessionFile,
+        maxRuntimeFileBytes: 1_600,
+      });
+
+      const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+      runtimeRecorder.recordEvent("prompt.submitted", {
+        prompt: "hello",
+      });
+      await runtimeRecorder.flush();
+
+      expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o755);
+    },
+  );
+
   it("describes queued writer state for cleanup timeout logs", () => {
     const recorder = createTrajectoryRuntimeRecorder({
       sessionId: "session-1",

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
   createTrajectoryRuntimeRecorder,
@@ -22,6 +22,7 @@ function makeTempDir(): string {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -204,6 +205,8 @@ describe("trajectory runtime", () => {
     });
 
     const staleRuntimeRecorder = expectTrajectoryRuntimeRecorder(staleRecorder);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
     staleRuntimeRecorder.recordEvent("prompt.submitted", {
       marker: "old-recorder",
       prompt: "x".repeat(260),
@@ -219,6 +222,7 @@ describe("trajectory runtime", () => {
       marker: "new-recorder",
       prompt: "y".repeat(260),
     });
+    vi.useRealTimers();
     await newerRuntimeRecorder.flush();
     await staleRuntimeRecorder.flush();
 

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -228,6 +228,30 @@ describe("trajectory runtime", () => {
     expect(raw).toContain("new-recorder");
   });
 
+  it.runIf(process.platform !== "win32")(
+    "refuses runtime capture through symlinked parent directories",
+    async () => {
+      const tmpDir = makeTempDir();
+      const targetDir = path.join(tmpDir, "target");
+      const linkDir = path.join(tmpDir, "link");
+      fs.mkdirSync(targetDir);
+      fs.symlinkSync(targetDir, linkDir);
+      const recorder = createTrajectoryRuntimeRecorder({
+        sessionId: "session-1",
+        sessionFile: path.join(linkDir, "session.jsonl"),
+        maxRuntimeFileBytes: 2_400,
+      });
+
+      const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+      runtimeRecorder.recordEvent("prompt.submitted", {
+        prompt: "hello",
+      });
+      await runtimeRecorder.flush();
+
+      expect(fs.existsSync(path.join(targetDir, "session.trajectory.jsonl"))).toBe(false);
+    },
+  );
+
   it("describes queued writer state for cleanup timeout logs", () => {
     const recorder = createTrajectoryRuntimeRecorder({
       sessionId: "session-1",

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -132,41 +132,44 @@ describe("trajectory runtime", () => {
     );
   });
 
-  it("stops runtime capture at the file budget and records a truncation event", async () => {
-    const writes: string[] = [];
-    const recorder = createTrajectoryRuntimeRecorder({
+  it("rotates runtime capture at the file budget and keeps newer events", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const maxRuntimeFileBytes = 1_600;
+    const firstRecorder = createTrajectoryRuntimeRecorder({
       sessionId: "session-1",
-      sessionFile: "/tmp/session.jsonl",
-      maxRuntimeFileBytes: 900,
-      writer: {
-        filePath: "/tmp/session.trajectory.jsonl",
-        write: (line) => {
-          writes.push(line);
-        },
-        flush: async () => undefined,
-      },
+      sessionFile,
+      maxRuntimeFileBytes,
     });
 
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
-    runtimeRecorder.recordEvent("context.compiled", {
-      prompt: "x".repeat(180),
-    });
-    runtimeRecorder.recordEvent("prompt.submitted", {
-      prompt: "y".repeat(180),
-    });
-    runtimeRecorder.recordEvent("model.completed", {
-      get prompt() {
-        throw new Error("stopped recorder should not read dropped payloads");
-      },
-    });
-    await runtimeRecorder.flush();
+    const firstRuntimeRecorder = expectTrajectoryRuntimeRecorder(firstRecorder);
+    for (const marker of ["old-1", "old-2", "old-3"]) {
+      firstRuntimeRecorder.recordEvent("prompt.submitted", {
+        marker,
+        prompt: "x".repeat(260),
+      });
+    }
+    await firstRuntimeRecorder.flush();
 
-    const parsed = writes.map((line) => JSON.parse(line));
-    expect(parsed.map((event) => event.type)).toContain("trace.truncated");
-    const truncated = parsed.find((event) => event.type === "trace.truncated");
-    expect(truncated?.data.reason).toBe("trajectory-runtime-file-size-limit");
-    expect(truncated?.data.limitBytes).toBe(900);
-    expect(truncated?.data.droppedEvents).toBeGreaterThan(0);
+    const secondRecorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile,
+      maxRuntimeFileBytes,
+    });
+    const secondRuntimeRecorder = expectTrajectoryRuntimeRecorder(secondRecorder);
+    for (const marker of ["new-1", "new-2", "new-3"]) {
+      secondRuntimeRecorder.recordEvent("prompt.submitted", {
+        marker,
+        prompt: "y".repeat(260),
+      });
+    }
+    await secondRuntimeRecorder.flush();
+
+    const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "session-1" });
+    const raw = fs.readFileSync(runtimeFile, "utf8");
+    expect(Buffer.byteLength(raw, "utf8")).toBeLessThanOrEqual(maxRuntimeFileBytes);
+    expect(raw).not.toContain("old-1");
+    expect(raw).toContain("new-3");
   });
 
   it("describes queued writer state for cleanup timeout logs", () => {

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -194,6 +194,40 @@ describe("trajectory runtime", () => {
     },
   );
 
+  it("merges stale recorder flushes with newer runtime events", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const staleRecorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile,
+      maxRuntimeFileBytes: 2_400,
+    });
+
+    const staleRuntimeRecorder = expectTrajectoryRuntimeRecorder(staleRecorder);
+    staleRuntimeRecorder.recordEvent("prompt.submitted", {
+      marker: "old-recorder",
+      prompt: "x".repeat(260),
+    });
+
+    const newerRecorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile,
+      maxRuntimeFileBytes: 2_400,
+    });
+    const newerRuntimeRecorder = expectTrajectoryRuntimeRecorder(newerRecorder);
+    newerRuntimeRecorder.recordEvent("prompt.submitted", {
+      marker: "new-recorder",
+      prompt: "y".repeat(260),
+    });
+    await newerRuntimeRecorder.flush();
+    await staleRuntimeRecorder.flush();
+
+    const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "session-1" });
+    const raw = fs.readFileSync(runtimeFile, "utf8");
+    expect(raw).toContain("old-recorder");
+    expect(raw).toContain("new-recorder");
+  });
+
   it("describes queued writer state for cleanup timeout logs", () => {
     const recorder = createTrajectoryRuntimeRecorder({
       sessionId: "session-1",

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -56,7 +56,6 @@ type TrajectoryRuntimeRecorder = {
 
 const writers = new Map<string, TrajectoryRuntimeWriter>();
 const windowFlushes = new Map<string, Promise<void>>();
-const sourceSeqByFile = new Map<string, number>();
 const MAX_TRAJECTORY_WRITERS = 100;
 const TRAJECTORY_RUNTIME_DATA_STRING_MAX_CHARS = 32_768;
 const TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS = 64;
@@ -69,6 +68,7 @@ type TrajectoryRuntimeWriterDiagnostics = Omit<QueuedFileWriterDiagnostics, "act
 
 type TrajectoryRuntimeWriter = Omit<QueuedFileWriter, "describeQueue"> & {
   describeQueue?: () => TrajectoryRuntimeWriterDiagnostics;
+  nextSourceSeq?: () => number;
 };
 
 function writeTrajectoryPointerBestEffort(params: {
@@ -306,13 +306,6 @@ function readMaxTrajectorySourceSeq(filePath: string): number {
   );
 }
 
-function nextTrajectorySourceSeq(filePath: string): number {
-  const previous = sourceSeqByFile.get(filePath) ?? readMaxTrajectorySourceSeq(filePath);
-  const next = previous + 1;
-  sourceSeqByFile.set(filePath, next);
-  return next;
-}
-
 function readTrajectoryWindowLines(filePath: string, maxBytes: number): string[] {
   try {
     const raw = readRegularFileSync({
@@ -393,6 +386,7 @@ function createTrajectoryWindowWriter(
   let pendingWrites = 0;
   let activeOperation: TrajectoryRuntimeWriterDiagnostics["activeOperation"] = "idle";
   let queue: Promise<unknown> = Promise.resolve();
+  let sourceSeq = readMaxTrajectorySourceSeq(filePath);
 
   return {
     filePath,
@@ -439,6 +433,10 @@ function createTrajectoryWindowWriter(
       maxQueuedBytes: maxFileBytes,
       yieldBeforeWrite: false,
     }),
+    nextSourceSeq: () => {
+      sourceSeq += 1;
+      return sourceSeq;
+    },
   };
 }
 
@@ -512,7 +510,7 @@ export function createTrajectoryRuntimeRecorder(
 
   const buildEventLine = (type: string, data?: Record<string, unknown>): string | undefined => {
     const nextSeq = seq + 1;
-    const sourceSeq = nextTrajectorySourceSeq(filePath);
+    const sourceSeq = writer.nextSourceSeq?.() ?? nextSeq;
     const event: TrajectoryEvent = {
       traceSchema: "openclaw-trajectory",
       schemaVersion: 1,
@@ -555,9 +553,6 @@ export function createTrajectoryRuntimeRecorder(
     },
     flush: async () => {
       await writer.flush();
-      if (!params.writer) {
-        writers.delete(filePath);
-      }
     },
     describeFlushState: () => describeTrajectoryWriterFlushState(writer),
   };

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -260,6 +260,31 @@ function trimJsonlWindow(lines: string[], maxBytes: number): number {
   return bytes;
 }
 
+function compareTrajectoryWindowLines(left: string, right: string): number {
+  const leftEvent = parseTrajectoryWindowLine(left);
+  const rightEvent = parseTrajectoryWindowLine(right);
+  const byTs = leftEvent.ts - rightEvent.ts;
+  if (byTs !== 0) {
+    return byTs;
+  }
+  return leftEvent.seq - rightEvent.seq;
+}
+
+function parseTrajectoryWindowLine(line: string): { ts: number; seq: number } {
+  try {
+    const parsed = JSON.parse(line) as { ts?: unknown; sourceSeq?: unknown; seq?: unknown };
+    const ts = typeof parsed.ts === "string" ? Date.parse(parsed.ts) : Number.POSITIVE_INFINITY;
+    const sourceSeq = typeof parsed.sourceSeq === "number" ? parsed.sourceSeq : undefined;
+    const seq = typeof parsed.seq === "number" ? parsed.seq : undefined;
+    return {
+      ts: Number.isFinite(ts) ? ts : Number.POSITIVE_INFINITY,
+      seq: sourceSeq ?? seq ?? Number.POSITIVE_INFINITY,
+    };
+  } catch {
+    return { ts: Number.POSITIVE_INFINITY, seq: Number.POSITIVE_INFINITY };
+  }
+}
+
 function readTrajectoryWindowLines(filePath: string, maxBytes: number): string[] {
   try {
     const raw = readRegularFileSync({
@@ -294,6 +319,7 @@ async function replaceTrajectoryWindow(params: {
   });
   const lines = readTrajectoryWindowLines(params.filePath, params.maxFileBytes);
   lines.push(...params.appendedLines);
+  lines.sort(compareTrajectoryWindowLines);
   trimJsonlWindow(lines, params.maxFileBytes);
   await writeSiblingTempFile({
     dir,

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -56,6 +56,7 @@ type TrajectoryRuntimeRecorder = {
 
 const writers = new Map<string, TrajectoryRuntimeWriter>();
 const windowFlushes = new Map<string, Promise<void>>();
+const sourceSeqByFile = new Map<string, number>();
 const MAX_TRAJECTORY_WRITERS = 100;
 const TRAJECTORY_RUNTIME_DATA_STRING_MAX_CHARS = 32_768;
 const TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS = 64;
@@ -285,6 +286,33 @@ function parseTrajectoryWindowLine(line: string): { ts: number; seq: number } {
   }
 }
 
+function readMaxTrajectorySourceSeq(filePath: string): number {
+  return readTrajectoryWindowLines(filePath, TRAJECTORY_RUNTIME_FILE_MAX_BYTES).reduce(
+    (max, line) => {
+      try {
+        const parsed = JSON.parse(line) as { sourceSeq?: unknown; seq?: unknown };
+        const seq =
+          typeof parsed.sourceSeq === "number"
+            ? parsed.sourceSeq
+            : typeof parsed.seq === "number"
+              ? parsed.seq
+              : 0;
+        return Math.max(max, seq);
+      } catch {
+        return max;
+      }
+    },
+    0,
+  );
+}
+
+function nextTrajectorySourceSeq(filePath: string): number {
+  const previous = sourceSeqByFile.get(filePath) ?? readMaxTrajectorySourceSeq(filePath);
+  const next = previous + 1;
+  sourceSeqByFile.set(filePath, next);
+  return next;
+}
+
 function readTrajectoryWindowLines(filePath: string, maxBytes: number): string[] {
   try {
     const raw = readRegularFileSync({
@@ -484,6 +512,7 @@ export function createTrajectoryRuntimeRecorder(
 
   const buildEventLine = (type: string, data?: Record<string, unknown>): string | undefined => {
     const nextSeq = seq + 1;
+    const sourceSeq = nextTrajectorySourceSeq(filePath);
     const event: TrajectoryEvent = {
       traceSchema: "openclaw-trajectory",
       schemaVersion: 1,
@@ -492,7 +521,7 @@ export function createTrajectoryRuntimeRecorder(
       type,
       ts: new Date().toISOString(),
       seq: nextSeq,
-      sourceSeq: nextSeq,
+      sourceSeq,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       runId: params.runId,

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -6,7 +6,7 @@ import type {
   QueuedFileWriterDiagnostics,
 } from "../agents/queued-file-writer.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { writeSiblingTempFile } from "../infra/fs-safe-advanced.js";
+import { assertNoSymlinkParents, writeSiblingTempFile } from "../infra/fs-safe-advanced.js";
 import { readRegularFileSync } from "../infra/fs-safe.js";
 import { redactSecrets } from "../logging/redact.js";
 import { parseBooleanValue } from "../utils/boolean.js";
@@ -283,10 +283,18 @@ async function replaceTrajectoryWindow(params: {
   appendedLines: string[];
 }): Promise<void> {
   const dir = path.dirname(params.filePath);
+  await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+  await assertNoSymlinkParents({
+    rootDir: path.parse(path.resolve(dir)).root,
+    targetPath: path.resolve(dir),
+    allowMissing: false,
+    allowRootChildSymlink: true,
+    requireDirectories: true,
+    messagePrefix: "Refusing to write trajectory under",
+  });
   const lines = readTrajectoryWindowLines(params.filePath, params.maxFileBytes);
   lines.push(...params.appendedLines);
   trimJsonlWindow(lines, params.maxFileBytes);
-  await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
   await writeSiblingTempFile({
     dir,
     chmodDir: false,

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -325,6 +325,7 @@ function createTrajectoryWindowWriter(
           activeOperation = "file-replace";
           await writeSiblingTempFile({
             dir,
+            chmodDir: false,
             mode: 0o600,
             tempPrefix: ".openclaw-trajectory-",
             writeTemp: async (tempPath) => {

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -1,14 +1,20 @@
 import fs from "node:fs";
 import path from "node:path";
 import { sanitizeDiagnosticPayload } from "../agents/payload-redaction.js";
-import { getQueuedFileWriter, type QueuedFileWriter } from "../agents/queued-file-writer.js";
+import type {
+  QueuedFileWriter,
+  QueuedFileWriterDiagnostics,
+} from "../agents/queued-file-writer.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { writeSiblingTempFile } from "../infra/fs-safe-advanced.js";
+import { readRegularFileSync } from "../infra/fs-safe.js";
 import { redactSecrets } from "../logging/redact.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
 import {
   TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES,
   TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+  TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
   resolveTrajectoryPointerOpenFlags,
@@ -37,7 +43,7 @@ type TrajectoryRuntimeInit = {
   modelId?: string;
   modelApi?: string | null;
   workspaceDir?: string;
-  writer?: QueuedFileWriter;
+  writer?: TrajectoryRuntimeWriter;
 };
 
 type TrajectoryRuntimeRecorder = {
@@ -48,13 +54,20 @@ type TrajectoryRuntimeRecorder = {
   describeFlushState: () => string | undefined;
 };
 
-const writers = new Map<string, QueuedFileWriter>();
+const writers = new Map<string, TrajectoryRuntimeWriter>();
 const MAX_TRAJECTORY_WRITERS = 100;
-const TRAJECTORY_RUNTIME_TRUNCATION_SENTINEL_RESERVE_BYTES = 2048;
 const TRAJECTORY_RUNTIME_DATA_STRING_MAX_CHARS = 32_768;
 const TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS = 64;
 const TRAJECTORY_RUNTIME_DATA_OBJECT_MAX_KEYS = 64;
 const TRAJECTORY_RUNTIME_DATA_MAX_DEPTH = 6;
+
+type TrajectoryRuntimeWriterDiagnostics = Omit<QueuedFileWriterDiagnostics, "activeOperation"> & {
+  activeOperation: QueuedFileWriterDiagnostics["activeOperation"] | "file-replace";
+};
+
+type TrajectoryRuntimeWriter = Omit<QueuedFileWriter, "describeQueue"> & {
+  describeQueue?: () => TrajectoryRuntimeWriterDiagnostics;
+};
 
 function writeTrajectoryPointerBestEffort(params: {
   filePath: string;
@@ -209,7 +222,7 @@ function sanitizeTrajectoryPayload(data: Record<string, unknown>): Record<string
   >;
 }
 
-function describeTrajectoryWriterFlushState(writer: QueuedFileWriter): string | undefined {
+function describeTrajectoryWriterFlushState(writer: TrajectoryRuntimeWriter): string | undefined {
   const diagnostics = writer.describeQueue?.();
   if (!diagnostics) {
     return undefined;
@@ -230,6 +243,129 @@ function describeTrajectoryWriterFlushState(writer: QueuedFileWriter): string | 
     parts.push(`maxFileBytes=${diagnostics.maxFileBytes}`);
   }
   return parts.join(" ");
+}
+
+function trimJsonlWindow(lines: string[], maxBytes: number): number {
+  let bytes = 0;
+  for (const line of lines) {
+    bytes += Buffer.byteLength(line, "utf8");
+  }
+  while (bytes > maxBytes && lines.length > 0) {
+    const line = lines.shift();
+    if (line !== undefined) {
+      bytes -= Buffer.byteLength(line, "utf8");
+    }
+  }
+  return bytes;
+}
+
+function createTrajectoryWindowWriter(
+  filePath: string,
+  maxFileBytes: number,
+): TrajectoryRuntimeWriter {
+  const dir = path.dirname(filePath);
+  let loaded = false;
+  let dirty = false;
+  let lines: string[] = [];
+  let queuedBytes = 0;
+  let pendingWrites = 0;
+  let activeOperation: TrajectoryRuntimeWriterDiagnostics["activeOperation"] = "idle";
+  let queue: Promise<unknown> = Promise.resolve();
+
+  const load = () => {
+    if (loaded) {
+      return;
+    }
+    loaded = true;
+    try {
+      const raw = readRegularFileSync({
+        filePath,
+        maxBytes: TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
+      }).buffer.toString("utf8");
+      lines = raw
+        .split(/\r?\n/u)
+        .filter((line) => line.length > 0)
+        .map((line) => `${line}\n`);
+      queuedBytes = trimJsonlWindow(lines, maxFileBytes);
+    } catch {
+      lines = [];
+      queuedBytes = 0;
+    }
+  };
+
+  return {
+    filePath,
+    write: (line) => {
+      load();
+      const lineBytes = Buffer.byteLength(line, "utf8");
+      if (lineBytes > maxFileBytes) {
+        return "dropped";
+      }
+      lines.push(line);
+      queuedBytes += lineBytes;
+      queuedBytes = trimJsonlWindow(lines, maxFileBytes);
+      dirty = true;
+      pendingWrites = 1;
+      return "queued";
+    },
+    flush: async () => {
+      load();
+      if (!dirty) {
+        await queue;
+        return;
+      }
+      const content = lines.join("");
+      dirty = false;
+      queue = queue
+        .then(async () => {
+          activeOperation = "mkdir";
+          await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+        })
+        .then(async () => {
+          activeOperation = "file-replace";
+          await writeSiblingTempFile({
+            dir,
+            mode: 0o600,
+            tempPrefix: ".openclaw-trajectory-",
+            writeTemp: async (tempPath) => {
+              await fs.promises.writeFile(tempPath, content, {
+                encoding: "utf8",
+                mode: 0o600,
+              });
+            },
+            resolveFinalPath: () => filePath,
+          });
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          pendingWrites = dirty ? 1 : 0;
+          activeOperation = "idle";
+        });
+      await queue;
+    },
+    describeQueue: () => ({
+      pendingWrites,
+      queuedBytes,
+      activeOperation,
+      maxFileBytes,
+      maxQueuedBytes: maxFileBytes,
+      yieldBeforeWrite: false,
+    }),
+  };
+}
+
+function getTrajectoryWindowWriter(
+  filePath: string,
+  maxFileBytes: number,
+): TrajectoryRuntimeWriter {
+  const existing = writers.get(filePath);
+  if (existing) {
+    return existing;
+  }
+  trimTrajectoryWriterCache();
+  const writer = createTrajectoryWindowWriter(filePath, maxFileBytes);
+  writers.set(filePath, writer);
+  return writer;
 }
 
 export function toTrajectoryToolDefinitions(
@@ -268,20 +404,11 @@ export function createTrajectoryRuntimeRecorder(
     sessionFile: params.sessionFile,
     sessionId: params.sessionId,
   });
-  if (!params.writer) {
-    trimTrajectoryWriterCache();
-  }
   const maxRuntimeFileBytes = Math.max(
     1,
     Math.floor(params.maxRuntimeFileBytes ?? TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES),
   );
-  const writer =
-    params.writer ??
-    getQueuedFileWriter(writers, filePath, {
-      maxFileBytes: maxRuntimeFileBytes,
-      maxQueuedBytes: maxRuntimeFileBytes,
-      yieldBeforeWrite: true,
-    });
+  const writer = params.writer ?? getTrajectoryWindowWriter(filePath, maxRuntimeFileBytes);
   writeTrajectoryPointerBestEffort({
     filePath,
     sessionFile: params.sessionFile,
@@ -289,35 +416,10 @@ export function createTrajectoryRuntimeRecorder(
   });
   let seq = 0;
   const traceId = params.sessionId;
-  const sentinelReserveBytes = Math.min(
-    TRAJECTORY_RUNTIME_TRUNCATION_SENTINEL_RESERVE_BYTES,
-    Math.floor(maxRuntimeFileBytes / 2),
-  );
-  const normalEventLimitBytes = Math.max(1, maxRuntimeFileBytes - sentinelReserveBytes);
-  let acceptedRuntimeBytes = 0;
-  let droppedEvents = 0;
-  let droppedEventBytes = 0;
-  let captureStopped = false;
 
-  const writeBoundedLine = (line: string, options: { reserveSentinel: boolean }): boolean => {
+  const writeBoundedLine = (line: string): void => {
     const jsonlLine = `${line}\n`;
-    const lineBytes = Buffer.byteLength(jsonlLine, "utf8");
-    const limitBytes = options.reserveSentinel ? normalEventLimitBytes : maxRuntimeFileBytes;
-    if (acceptedRuntimeBytes + lineBytes > limitBytes) {
-      captureStopped = true;
-      droppedEvents += 1;
-      droppedEventBytes += lineBytes;
-      return false;
-    }
-    const result = writer.write(jsonlLine);
-    if (result === "dropped") {
-      captureStopped = true;
-      droppedEvents += 1;
-      droppedEventBytes += lineBytes;
-      return false;
-    }
-    acceptedRuntimeBytes += lineBytes;
-    return true;
+    writer.write(jsonlLine);
   };
 
   const buildEventLine = (type: string, data?: Record<string, unknown>): string | undefined => {
@@ -356,30 +458,13 @@ export function createTrajectoryRuntimeRecorder(
     enabled: true,
     filePath,
     recordEvent: (type, data) => {
-      if (captureStopped) {
-        droppedEvents += 1;
-        return;
-      }
       const line = buildEventLine(type, data);
       if (!line) {
         return;
       }
-      writeBoundedLine(line, { reserveSentinel: true });
+      writeBoundedLine(line);
     },
     flush: async () => {
-      if (droppedEvents > 0) {
-        const line = buildEventLine("trace.truncated", {
-          reason: "trajectory-runtime-file-size-limit",
-          droppedEvents,
-          droppedEventBytes,
-          limitBytes: maxRuntimeFileBytes,
-        });
-        if (line) {
-          writeBoundedLine(line, { reserveSentinel: false });
-        }
-        droppedEvents = 0;
-        droppedEventBytes = 0;
-      }
       await writer.flush();
       if (!params.writer) {
         writers.delete(filePath);

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -55,6 +55,7 @@ type TrajectoryRuntimeRecorder = {
 };
 
 const writers = new Map<string, TrajectoryRuntimeWriter>();
+const windowFlushes = new Map<string, Promise<void>>();
 const MAX_TRAJECTORY_WRITERS = 100;
 const TRAJECTORY_RUNTIME_DATA_STRING_MAX_CHARS = 32_768;
 const TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS = 64;
@@ -259,87 +260,111 @@ function trimJsonlWindow(lines: string[], maxBytes: number): number {
   return bytes;
 }
 
+function readTrajectoryWindowLines(filePath: string, maxBytes: number): string[] {
+  try {
+    const raw = readRegularFileSync({
+      filePath,
+      maxBytes: TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
+    }).buffer.toString("utf8");
+    const lines = raw
+      .split(/\r?\n/u)
+      .filter((line) => line.length > 0)
+      .map((line) => `${line}\n`);
+    trimJsonlWindow(lines, maxBytes);
+    return lines;
+  } catch {
+    return [];
+  }
+}
+
+async function replaceTrajectoryWindow(params: {
+  filePath: string;
+  maxFileBytes: number;
+  appendedLines: string[];
+}): Promise<void> {
+  const dir = path.dirname(params.filePath);
+  const lines = readTrajectoryWindowLines(params.filePath, params.maxFileBytes);
+  lines.push(...params.appendedLines);
+  trimJsonlWindow(lines, params.maxFileBytes);
+  await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+  await writeSiblingTempFile({
+    dir,
+    chmodDir: false,
+    mode: 0o600,
+    tempPrefix: ".openclaw-trajectory-",
+    writeTemp: async (tempPath) => {
+      await fs.promises.writeFile(tempPath, lines.join(""), {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+    },
+    resolveFinalPath: () => params.filePath,
+  });
+}
+
+async function queueTrajectoryWindowFlush(params: {
+  filePath: string;
+  maxFileBytes: number;
+  appendedLines: string[];
+}): Promise<void> {
+  const previous = windowFlushes.get(params.filePath) ?? Promise.resolve();
+  const current = previous
+    .catch(() => undefined)
+    .then(async () => {
+      await replaceTrajectoryWindow(params);
+    })
+    .finally(() => {
+      if (windowFlushes.get(params.filePath) === current) {
+        windowFlushes.delete(params.filePath);
+      }
+    });
+  windowFlushes.set(params.filePath, current);
+  await current;
+}
+
 function createTrajectoryWindowWriter(
   filePath: string,
   maxFileBytes: number,
 ): TrajectoryRuntimeWriter {
-  const dir = path.dirname(filePath);
-  let loaded = false;
-  let dirty = false;
-  let lines: string[] = [];
+  let pendingLines: string[] = [];
   let queuedBytes = 0;
   let pendingWrites = 0;
   let activeOperation: TrajectoryRuntimeWriterDiagnostics["activeOperation"] = "idle";
   let queue: Promise<unknown> = Promise.resolve();
 
-  const load = () => {
-    if (loaded) {
-      return;
-    }
-    loaded = true;
-    try {
-      const raw = readRegularFileSync({
-        filePath,
-        maxBytes: TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
-      }).buffer.toString("utf8");
-      lines = raw
-        .split(/\r?\n/u)
-        .filter((line) => line.length > 0)
-        .map((line) => `${line}\n`);
-      queuedBytes = trimJsonlWindow(lines, maxFileBytes);
-    } catch {
-      lines = [];
-      queuedBytes = 0;
-    }
-  };
-
   return {
     filePath,
     write: (line) => {
-      load();
       const lineBytes = Buffer.byteLength(line, "utf8");
       if (lineBytes > maxFileBytes) {
         return "dropped";
       }
-      lines.push(line);
+      pendingLines.push(line);
       queuedBytes += lineBytes;
-      queuedBytes = trimJsonlWindow(lines, maxFileBytes);
-      dirty = true;
+      queuedBytes = trimJsonlWindow(pendingLines, maxFileBytes);
       pendingWrites = 1;
       return "queued";
     },
     flush: async () => {
-      load();
-      if (!dirty) {
+      if (pendingLines.length === 0) {
         await queue;
         return;
       }
-      const content = lines.join("");
-      dirty = false;
+      const appendedLines = pendingLines;
+      pendingLines = [];
+      queuedBytes = 0;
       queue = queue
         .then(async () => {
-          activeOperation = "mkdir";
-          await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-        })
-        .then(async () => {
           activeOperation = "file-replace";
-          await writeSiblingTempFile({
-            dir,
-            chmodDir: false,
-            mode: 0o600,
-            tempPrefix: ".openclaw-trajectory-",
-            writeTemp: async (tempPath) => {
-              await fs.promises.writeFile(tempPath, content, {
-                encoding: "utf8",
-                mode: 0o600,
-              });
-            },
-            resolveFinalPath: () => filePath,
+          await queueTrajectoryWindowFlush({
+            filePath,
+            maxFileBytes,
+            appendedLines,
           });
         })
         .catch(() => undefined)
         .finally(() => {
-          pendingWrites = dirty ? 1 : 0;
+          pendingWrites = pendingLines.length > 0 ? 1 : 0;
           activeOperation = "idle";
         });
       await queue;


### PR DESCRIPTION
## Summary

- Replace stop-on-full runtime trajectory capture with a bounded JSONL window that keeps the newest complete events under the existing capture cap.
- Preserve export/viewer behavior by rewriting the runtime sidecar atomically on flush.
- Add a regression test proving older runtime events rotate out while newer events remain visible across recorder instances.

## Verification

- `node scripts/run-vitest.mjs src/trajectory/export.test.ts src/trajectory/runtime.test.ts src/agents/queued-file-writer.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `./node_modules/.bin/oxfmt --check --threads=1 src/trajectory/runtime.ts src/trajectory/runtime.test.ts src/infra/fs-safe-advanced.ts`
