### PR TITLE
fix(infra): reconcile unacked session deliveries to prevent duplicate replay on restart

### DIFF
--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -185,6 +185,9 @@ vi.mock("../infra/session-delivery-queue.js", () => ({
   drainPendingSessionDeliveries: mocks.drainPendingSessionDeliveries,
   recoverPendingSessionDeliveries: mocks.recoverPendingSessionDeliveries,
   markSessionDeliveryPlatformOutcomeUnknown: mocks.markSessionDeliveryPlatformOutcomeUnknown,
+  SessionDeliverySendUncertainError: class SessionDeliverySendUncertainError extends Error {
+    readonly code = "session-delivery-send-uncertain";
+  },
 }));
 
 vi.mock("../config/sessions.js", () => ({

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -133,6 +133,7 @@ const mocks = vi.hoisted(() => {
       skippedMaxRetries: 0,
       deferredBackoff: 0,
     })),
+    markSessionDeliveryPlatformOutcomeUnknown: vi.fn(async () => undefined),
     resolveAgentConfig: vi.fn(() => undefined),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-test-workspace"),
     resolveDefaultAgentId: vi.fn(() => "main"),
@@ -183,6 +184,7 @@ vi.mock("../infra/session-delivery-queue.js", () => ({
   loadPendingSessionDelivery: mocks.loadPendingSessionDelivery,
   drainPendingSessionDeliveries: mocks.drainPendingSessionDeliveries,
   recoverPendingSessionDeliveries: mocks.recoverPendingSessionDeliveries,
+  markSessionDeliveryPlatformOutcomeUnknown: mocks.markSessionDeliveryPlatformOutcomeUnknown,
 }));
 
 vi.mock("../config/sessions.js", () => ({

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -31,6 +31,7 @@ import {
   loadPendingSessionDelivery,
   markSessionDeliveryPlatformOutcomeUnknown,
   recoverPendingSessionDeliveries,
+  SessionDeliverySendUncertainError,
   type QueuedSessionDelivery,
   type QueuedSessionDeliveryPayload,
   type SessionDeliveryRecoveryLogger,
@@ -371,13 +372,21 @@ async function deliverQueuedSessionDelivery(params: {
         if (send.status === "partial_failed") {
           // Some payloads were already delivered to the platform before this
           // failure (send.sentBeforeError === true). Persist the
-          // unknown_after_send marker on the queue entry before throwing so the
-          // recovery layer refuses a blind replay of an already-sent turn
-          // instead of clearing the marker and re-running the turn / re-sending
-          // the reply. Mirrors the outbound queue, which keeps the send-attempt
-          // marker once the platform send has started.
-          await markSessionDeliveryPlatformOutcomeUnknown(params.entry.id);
-          throw send.error;
+          // unknown_after_send marker (best-effort, so a later crash before the
+          // next recovery still refuses replay) and throw a typed
+          // sent-before-error signal. Throwing the signal - rather than relying
+          // solely on the marker write - means recovery refuses a blind replay
+          // even if this marker write fails. Mirrors the outbound queue, which
+          // keeps the send-attempt marker once the platform send has started.
+          try {
+            await markSessionDeliveryPlatformOutcomeUnknown(params.entry.id);
+          } catch (markErr) {
+            log.warn(
+              `restart continuation: failed to persist unknown_after_send marker for ${params.entry.id}; recovery still refuses replay via the sent-before-error signal: ${String(markErr)}`,
+              { sessionKey: canonicalKey },
+            );
+          }
+          throw new SessionDeliverySendUncertainError(send.error);
         }
         if (send.status === "failed") {
           throw send.error;

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -29,6 +29,7 @@ import {
   drainPendingSessionDeliveries,
   enqueueSessionDelivery,
   loadPendingSessionDelivery,
+  markSessionDeliveryPlatformOutcomeUnknown,
   recoverPendingSessionDeliveries,
   type QueuedSessionDelivery,
   type QueuedSessionDeliveryPayload,
@@ -367,7 +368,18 @@ async function deliverQueuedSessionDelivery(params: {
           deps: params.deps,
           bestEffort: false,
         });
-        if (send.status === "failed" || send.status === "partial_failed") {
+        if (send.status === "partial_failed") {
+          // Some payloads were already delivered to the platform before this
+          // failure (send.sentBeforeError === true). Persist the
+          // unknown_after_send marker on the queue entry before throwing so the
+          // recovery layer refuses a blind replay of an already-sent turn
+          // instead of clearing the marker and re-running the turn / re-sending
+          // the reply. Mirrors the outbound queue, which keeps the send-attempt
+          // marker once the platform send has started.
+          await markSessionDeliveryPlatformOutcomeUnknown(params.entry.id);
+          throw send.error;
+        }
+        if (send.status === "failed") {
           throw send.error;
         }
         const results = send.status === "sent" ? send.results : [];

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -1,9 +1,12 @@
 import { formatErrorMessage } from "./errors.js";
 import {
   ackSessionDelivery,
+  clearSessionDeliveryRecoveryState,
   failSessionDelivery,
   loadPendingSessionDelivery,
   loadPendingSessionDeliveries,
+  markSessionDeliveryPlatformOutcomeUnknown,
+  markSessionDeliveryPlatformSendAttemptStarted,
   moveSessionDeliveryToFailed,
   type QueuedSessionDelivery,
 } from "./session-delivery-queue-storage.js";
@@ -95,6 +98,21 @@ export function isSessionDeliveryEligibleForRetry(
   return { eligible: false, remainingBackoffMs: nextEligibleAt - now };
 }
 
+async function moveSessionDeliveryToFailedWithEnoent(
+  id: string,
+  stateDir: string | undefined,
+): Promise<"moved-to-failed" | "already-gone" | "failed"> {
+  try {
+    await moveSessionDeliveryToFailed(id, stateDir);
+    return "moved-to-failed";
+  } catch (moveErr) {
+    if (getErrnoCode(moveErr) === "ENOENT") {
+      return "already-gone";
+    }
+    return "failed";
+  }
+}
+
 async function drainQueuedEntry(opts: {
   entry: QueuedSessionDelivery;
   deliver: DeliverSessionDeliveryFn;
@@ -103,8 +121,32 @@ async function drainQueuedEntry(opts: {
   onFailed?: (entry: QueuedSessionDelivery, errMsg: string) => void;
 }): Promise<"recovered" | "failed" | "moved-to-failed" | "already-gone"> {
   const { entry } = opts;
+  // An entry recovered with a send marker was past the point where the delivery
+  // (turn re-run + platform send) had begun but had not been acked. Without an
+  // adapter reconciliation capability we cannot tell whether the reply was
+  // already sent, so we refuse a blind replay and fail-safe to failed/ — exactly
+  // like the outbound queue does (delivery-queue-recovery.ts: "refusing blind
+  // replay without adapter reconciliation"). This prevents re-running a
+  // non-idempotent turn and re-sending its reply.
+  if (
+    entry.recoveryState === "send_attempt_started" ||
+    entry.recoveryState === "unknown_after_send"
+  ) {
+    const errMsg = `session delivery state is ${entry.recoveryState}; refusing blind replay without adapter reconciliation`;
+    opts.onFailed?.(entry, errMsg);
+    return moveSessionDeliveryToFailedWithEnoent(entry.id, opts.stateDir);
+  }
   try {
+    // Persist the send marker before invoking deliver so that a crash anywhere
+    // between here and the ack below leaves durable evidence that the delivery
+    // may already have run. The deliver fn is the production platform-send seam
+    // (it re-runs the turn and sends via dispatchAssembledChannelTurn /
+    // sendDurableMessageBatch).
+    await markSessionDeliveryPlatformSendAttemptStarted(entry.id, opts.stateDir);
     await opts.deliver(entry);
+    // Send returned but the entry is not yet acked: outcome is unknown until ack
+    // succeeds. Mirror the outbound queue's unknown_after_send marker.
+    await markSessionDeliveryPlatformOutcomeUnknown(entry.id, opts.stateDir);
     await ackSessionDelivery(entry.id, opts.stateDir);
     opts.onRecovered?.(entry);
     return "recovered";
@@ -112,6 +154,11 @@ async function drainQueuedEntry(opts: {
     const errMsg = formatErrorMessage(err);
     opts.onFailed?.(entry, errMsg);
     try {
+      // The attempt concluded in-process with a thrown failure (not a crash):
+      // clear the send marker so the entry stays replayable. A real crash never
+      // reaches this catch, so its marker survives and the next recovery refuses
+      // a blind replay.
+      await clearSessionDeliveryRecoveryState(entry.id, opts.stateDir);
       await failSessionDelivery(entry.id, errMsg, opts.stateDir);
       return "failed";
     } catch (failErr) {

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -136,6 +136,10 @@ async function drainQueuedEntry(opts: {
     opts.onFailed?.(entry, errMsg);
     return moveSessionDeliveryToFailedWithEnoent(entry.id, opts.stateDir);
   }
+  // Tracks whether deliver(entry) returned. Once it has, the turn re-run and
+  // platform send may already have happened, so a later failure (marker write
+  // or ack) must not clear the marker and replay the entry.
+  let delivered = false;
   try {
     // Persist the send marker before invoking deliver so that a crash anywhere
     // between here and the ack below leaves durable evidence that the delivery
@@ -144,6 +148,7 @@ async function drainQueuedEntry(opts: {
     // sendDurableMessageBatch).
     await markSessionDeliveryPlatformSendAttemptStarted(entry.id, opts.stateDir);
     await opts.deliver(entry);
+    delivered = true;
     // Send returned but the entry is not yet acked: outcome is unknown until ack
     // succeeds. Mirror the outbound queue's unknown_after_send marker.
     await markSessionDeliveryPlatformOutcomeUnknown(entry.id, opts.stateDir);
@@ -154,20 +159,24 @@ async function drainQueuedEntry(opts: {
     const errMsg = formatErrorMessage(err);
     opts.onFailed?.(entry, errMsg);
     try {
-      // Distinguish a pre-send failure (nothing reached the platform) from a
-      // sent-before-error failure (some payloads were already delivered). The
-      // delivery seam advances the marker to unknown_after_send when the send
-      // partially happened (sendDurableMessageBatch -> partial_failed). In that
-      // case we must not clear the marker or replay, because the turn re-run and
-      // reply may already have gone out: refuse a blind replay and fail-safe to
-      // failed/, exactly like an entry recovered with a marker (and like the
-      // outbound queue, which never clears the marker once the send has started).
+      // If deliver returned, the turn ran and the reply may already have been
+      // sent; a failure in the marker write or ack after that point must not
+      // requeue the entry. Likewise, if the delivery seam advanced the marker to
+      // unknown_after_send (sendDurableMessageBatch -> partial_failed, a
+      // sent-before-error throw), the send partially happened. In both cases we
+      // refuse a blind replay and fail-safe to failed/, exactly like an entry
+      // recovered with a marker (and like the outbound queue, which never clears
+      // the marker once the platform send has started).
+      if (delivered) {
+        return await moveSessionDeliveryToFailedWithEnoent(entry.id, opts.stateDir);
+      }
       const current = await loadPendingSessionDelivery(entry.id, opts.stateDir);
       if (current?.recoveryState === "unknown_after_send") {
         return await moveSessionDeliveryToFailedWithEnoent(entry.id, opts.stateDir);
       }
-      // Pre-send failure: the attempt is over and safe to replay, so clear the
-      // send-attempt marker set before deliver and keep the entry retryable.
+      // Pre-send failure: deliver threw before anything reached the platform, so
+      // the attempt is over and safe to replay. Clear the send-attempt marker set
+      // before deliver and keep the entry retryable.
       await clearSessionDeliveryRecoveryState(entry.id, opts.stateDir);
       await failSessionDelivery(entry.id, errMsg, opts.stateDir);
       return "failed";

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -154,10 +154,20 @@ async function drainQueuedEntry(opts: {
     const errMsg = formatErrorMessage(err);
     opts.onFailed?.(entry, errMsg);
     try {
-      // The attempt concluded in-process with a thrown failure (not a crash):
-      // clear the send marker so the entry stays replayable. A real crash never
-      // reaches this catch, so its marker survives and the next recovery refuses
-      // a blind replay.
+      // Distinguish a pre-send failure (nothing reached the platform) from a
+      // sent-before-error failure (some payloads were already delivered). The
+      // delivery seam advances the marker to unknown_after_send when the send
+      // partially happened (sendDurableMessageBatch -> partial_failed). In that
+      // case we must not clear the marker or replay, because the turn re-run and
+      // reply may already have gone out: refuse a blind replay and fail-safe to
+      // failed/, exactly like an entry recovered with a marker (and like the
+      // outbound queue, which never clears the marker once the send has started).
+      const current = await loadPendingSessionDelivery(entry.id, opts.stateDir);
+      if (current?.recoveryState === "unknown_after_send") {
+        return await moveSessionDeliveryToFailedWithEnoent(entry.id, opts.stateDir);
+      }
+      // Pre-send failure: the attempt is over and safe to replay, so clear the
+      // send-attempt marker set before deliver and keep the entry retryable.
       await clearSessionDeliveryRecoveryState(entry.id, opts.stateDir);
       await failSessionDelivery(entry.id, errMsg, opts.stateDir);
       return "failed";

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -11,6 +11,40 @@ import {
   type QueuedSessionDelivery,
 } from "./session-delivery-queue-storage.js";
 
+const SESSION_DELIVERY_SEND_UNCERTAIN_CODE = "session-delivery-send-uncertain";
+
+/**
+ * Thrown by the delivery seam when a platform send already partially happened
+ * (sendDurableMessageBatch returned `partial_failed`, i.e. `sentBeforeError`).
+ * It signals recovery to refuse a blind replay even if the durable
+ * `unknown_after_send` marker write failed: the signal travels with the thrown
+ * error rather than depending on a disk write that can itself fail.
+ */
+export class SessionDeliverySendUncertainError extends Error {
+  readonly code = SESSION_DELIVERY_SEND_UNCERTAIN_CODE;
+  constructor(cause?: unknown) {
+    super("session delivery platform send outcome uncertain (sent before error)", { cause });
+    this.name = "SessionDeliverySendUncertainError";
+  }
+}
+
+/** True if `err` is (or wraps) a {@link SessionDeliverySendUncertainError}. */
+export function isSessionDeliverySendUncertainError(err: unknown): boolean {
+  for (let cur: unknown = err, depth = 0; cur != null && depth < 5; depth += 1) {
+    if (cur instanceof SessionDeliverySendUncertainError) {
+      return true;
+    }
+    if (
+      typeof cur === "object" &&
+      (cur as { code?: unknown }).code === SESSION_DELIVERY_SEND_UNCERTAIN_CODE
+    ) {
+      return true;
+    }
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 type SessionDeliveryRecoverySummary = {
   recovered: number;
   failed: number;
@@ -159,15 +193,15 @@ async function drainQueuedEntry(opts: {
     const errMsg = formatErrorMessage(err);
     opts.onFailed?.(entry, errMsg);
     try {
-      // If deliver returned, the turn ran and the reply may already have been
-      // sent; a failure in the marker write or ack after that point must not
-      // requeue the entry. Likewise, if the delivery seam advanced the marker to
-      // unknown_after_send (sendDurableMessageBatch -> partial_failed, a
-      // sent-before-error throw), the send partially happened. In both cases we
-      // refuse a blind replay and fail-safe to failed/, exactly like an entry
-      // recovered with a marker (and like the outbound queue, which never clears
-      // the marker once the platform send has started).
-      if (delivered) {
+      // Refuse a blind replay whenever the platform send may already have
+      // happened: (a) deliver returned, so the turn ran and the reply may be out
+      // and a later marker-write/ack failure must not requeue it; (b) the
+      // delivery seam threw a sent-before-error signal (sendDurableMessageBatch
+      // -> partial_failed) - this travels with the error so it holds even if the
+      // unknown_after_send marker write itself failed; (c) the durable marker
+      // reads back as unknown_after_send. Fail-safe to failed/, like the outbound
+      // queue, which never clears its marker once the send has started.
+      if (delivered || isSessionDeliverySendUncertainError(err)) {
         return await moveSessionDeliveryToFailedWithEnoent(entry.id, opts.stateDir);
       }
       const current = await loadPendingSessionDelivery(entry.id, opts.stateDir);

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -65,6 +65,20 @@ export type QueuedSessionDelivery = QueuedSessionDeliveryPayload & {
   retryCount: number;
   lastAttemptAt?: number;
   lastError?: string;
+  /**
+   * Wall-clock time the platform send was first attempted, mirroring the
+   * outbound queue's QueuedDelivery.platformSendStartedAt. Set together with
+   * {@link recoveryState} so recovery can refuse a blind replay of an entry
+   * whose first attempt may already have run a turn / sent a reply.
+   */
+  platformSendStartedAt?: number;
+  /**
+   * Recovery reconciliation marker, mirroring the outbound queue. When set, the
+   * entry was past the point where the delivery (turn re-run + platform send)
+   * had begun but had not been acked, so a blind replay could double-execute a
+   * non-idempotent turn. Recovery refuses to replay such entries.
+   */
+  recoveryState?: "send_attempt_started" | "unknown_after_send";
 };
 
 function buildEntryId(idempotencyKey?: string): string {
@@ -151,6 +165,59 @@ export async function failSessionDelivery(
   entry.retryCount += 1;
   entry.lastAttemptAt = Date.now();
   entry.lastError = error;
+  await writeQueueEntry(filePath, entry);
+}
+
+/**
+ * Persist the `send_attempt_started` recovery marker before the platform send
+ * begins. Mirrors markDeliveryPlatformSendAttemptStarted in the outbound queue:
+ * once this is durable, a crash before ack leaves evidence that the send may
+ * already have happened, so recovery refuses to blindly replay it.
+ */
+export async function markSessionDeliveryPlatformSendAttemptStarted(
+  id: string,
+  stateDir?: string,
+): Promise<void> {
+  const filePath = path.join(resolveSessionDeliveryQueueDir(stateDir), `${id}.json`);
+  const entry = await readQueueEntry(filePath);
+  entry.platformSendStartedAt = entry.platformSendStartedAt ?? Date.now();
+  entry.recoveryState = "send_attempt_started";
+  await writeQueueEntry(filePath, entry);
+}
+
+/**
+ * Persist the `unknown_after_send` recovery marker after the platform send has
+ * returned but before the entry is acked. Mirrors
+ * markDeliveryPlatformOutcomeUnknown in the outbound queue.
+ */
+export async function markSessionDeliveryPlatformOutcomeUnknown(
+  id: string,
+  stateDir?: string,
+): Promise<void> {
+  const filePath = path.join(resolveSessionDeliveryQueueDir(stateDir), `${id}.json`);
+  const entry = await readQueueEntry(filePath);
+  entry.platformSendStartedAt = entry.platformSendStartedAt ?? Date.now();
+  entry.recoveryState = "unknown_after_send";
+  await writeQueueEntry(filePath, entry);
+}
+
+/**
+ * Clear the recovery marker. Used when a recovery attempt concluded in-process
+ * with a thrown failure (as opposed to a crash): the attempt is over and
+ * replayable, so the send marker set before the attempt must not survive and
+ * cause the next recovery to refuse a blind replay.
+ */
+export async function clearSessionDeliveryRecoveryState(
+  id: string,
+  stateDir?: string,
+): Promise<void> {
+  const filePath = path.join(resolveSessionDeliveryQueueDir(stateDir), `${id}.json`);
+  const entry = await readQueueEntry(filePath);
+  if (entry.recoveryState === undefined && entry.platformSendStartedAt === undefined) {
+    return;
+  }
+  delete entry.recoveryState;
+  delete entry.platformSendStartedAt;
   await writeQueueEntry(filePath, entry);
 }
 

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -6,6 +6,7 @@ import {
   failSessionDelivery,
   isSessionDeliveryEligibleForRetry,
   loadPendingSessionDeliveries,
+  markSessionDeliveryPlatformOutcomeUnknown,
   recoverPendingSessionDeliveries,
 } from "./session-delivery-queue.js";
 
@@ -197,6 +198,60 @@ describe("session-delivery queue recovery", () => {
 
       // 수정 전: deliverCount === 2 (blind replay → 턴 재실행 + 응답 중복 전송) → FAIL
       // 수정 후: deliverCount === 1 (recoveryState 마커 → reconciliation → blind replay 거부) → PASS
+      expect(deliverCount).toBe(1);
+    });
+  });
+
+  it("does not re-deliver a session entry whose delivery partially sent before throwing", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const id = await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:456",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      let deliverCount = 0;
+      // Model the production delivery seam on a partial_failed send: some
+      // payloads already reached the platform (sentBeforeError), so
+      // deliverQueuedSessionDelivery persists the unknown_after_send marker and
+      // then throws. Recovery must refuse a blind replay rather than clearing the
+      // marker and re-running the turn / re-sending the already-sent reply.
+      const deliver = vi.fn(async () => {
+        deliverCount += 1;
+        await markSessionDeliveryPlatformOutcomeUnknown(id, tempDir);
+        throw new Error("partial_failed: reply chunk sent before error");
+      });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      const drainOnce = () =>
+        drainPendingSessionDeliveries({
+          drainKey: "test-sent-before-error",
+          logLabel: "test sent-before-error",
+          deliver,
+          stateDir: tempDir,
+          log,
+          // bypassBackoff so PASS 2 actually attempts the entry instead of being
+          // deferred by the retry backoff (which would hide the blind replay).
+          selectEntry: (entry) => ({ match: entry.id === id, bypassBackoff: true }),
+        });
+
+      // PASS 1: delivery partially sends, marks unknown_after_send, then throws.
+      await drainOnce();
+      // The entry must not stay replayable in the main queue: it is moved to
+      // failed/ (fail-safe), not requeued with the marker cleared.
+      expect(await loadPendingSessionDeliveries(tempDir)).toStrictEqual([]);
+
+      // PASS 2: restart recovery re-entry.
+      await drainOnce();
+
+      // Before the fix: the catch cleared the marker and requeued, so PASS 2
+      // blind-replays -> deliverCount === 2. After the fix: the marker is
+      // preserved and recovery refuses the blind replay -> deliverCount === 1.
       expect(deliverCount).toBe(1);
     });
   });

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -256,6 +256,65 @@ describe("session-delivery queue recovery", () => {
     });
   });
 
+  it("does not re-deliver when the outcome-marker write fails after a successful delivery", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const id = await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:789",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      let deliverCount = 0;
+      // deliver succeeds: the turn ran and the reply was sent.
+      const deliver = vi.fn(async () => {
+        deliverCount += 1;
+      });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      const drainOnce = () =>
+        drainPendingSessionDeliveries({
+          drainKey: "test-marker-write-failure",
+          logLabel: "test marker write failure",
+          deliver,
+          stateDir: tempDir,
+          log,
+          selectEntry: (entry) => ({ match: entry.id === id, bypassBackoff: true }),
+        });
+
+      // PASS 1: deliver succeeds, but persisting unknown_after_send fails, so the
+      // entry is left at send_attempt_started even though the send already
+      // happened. The recovery (which imports the storage helper directly) must
+      // still treat this as non-replayable. Spy the storage module so the helper
+      // recovery calls is the one that throws.
+      const storageMod = await import("./session-delivery-queue-storage.js");
+      const markSpy = vi
+        .spyOn(storageMod, "markSessionDeliveryPlatformOutcomeUnknown")
+        .mockImplementationOnce(async () => {
+          throw new Error("simulated marker write failure after delivery");
+        });
+      await drainOnce();
+      markSpy.mockRestore();
+
+      // The already-delivered entry must not stay replayable: it is moved to
+      // failed/, not requeued.
+      expect(await loadPendingSessionDeliveries(tempDir)).toStrictEqual([]);
+
+      // PASS 2: restart recovery re-entry.
+      await drainOnce();
+
+      // Before the fix: the catch saw send_attempt_started, cleared it, and
+      // requeued, so PASS 2 blind-replays -> deliverCount === 2. After the fix:
+      // tracking that deliver() returned makes the post-delivery failure
+      // non-replayable -> deliverCount === 1.
+      expect(deliverCount).toBe(1);
+    });
+  });
+
   it("uses the persisted retryCount for the first backoff tier", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-23T00:00:00.000Z"));

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -157,6 +157,50 @@ describe("session-delivery queue recovery", () => {
     vi.useRealTimers();
   });
 
+  it("does not re-deliver a session entry whose first delivery succeeded but was left unacked by a crash", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:123",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      let deliverCount = 0;
+      const deliver = vi.fn(async () => {
+        deliverCount += 1;
+      });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      // PASS 1: deliver 성공, 그러나 ack 의 atomic rename 이 완료되기 전 crash 모델.
+      // 두-단계 ack(.json → .delivered → unlink) 에서 1단계 rename 전에 프로세스가
+      // 죽으면 entry 는 .json 으로 pending 잔존한다. 실제 SIGKILL 은 catch 블록(실패
+      // 핸들러/마커 정리)을 절대 실행하지 못하므로, ack 를 no-op 으로 막아 entry 가
+      // "전송됨" 마커를 지닌 채 pending 으로 남게 한다(retryCount=0, lastAttemptAt 없음).
+      // recovery 가 직접 import 하는 storage 모듈을 spy 해야 가로채진다.
+      const storageMod = await import("./session-delivery-queue-storage.js");
+      const ackSpy = vi
+        .spyOn(storageMod, "ackSessionDelivery")
+        .mockImplementationOnce(async () => undefined);
+      await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+      ackSpy.mockRestore();
+
+      const [pending] = await loadPendingSessionDeliveries(tempDir);
+      expect(pending).toBeDefined(); // entry 잔존 — "전송됨" 마커가 영속됐어야 함
+
+      // PASS 2: 재시작 후 복구 재진입.
+      await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+
+      // 수정 전: deliverCount === 2 (blind replay → 턴 재실행 + 응답 중복 전송) → FAIL
+      // 수정 후: deliverCount === 1 (recoveryState 마커 → reconciliation → blind replay 거부) → PASS
+      expect(deliverCount).toBe(1);
+    });
+  });
+
   it("uses the persisted retryCount for the first backoff tier", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-23T00:00:00.000Z"));

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -8,6 +8,7 @@ import {
   loadPendingSessionDeliveries,
   markSessionDeliveryPlatformOutcomeUnknown,
   recoverPendingSessionDeliveries,
+  SessionDeliverySendUncertainError,
 } from "./session-delivery-queue.js";
 
 describe("session-delivery queue recovery", () => {
@@ -219,12 +220,14 @@ describe("session-delivery queue recovery", () => {
       // Model the production delivery seam on a partial_failed send: some
       // payloads already reached the platform (sentBeforeError), so
       // deliverQueuedSessionDelivery persists the unknown_after_send marker and
-      // then throws. Recovery must refuse a blind replay rather than clearing the
-      // marker and re-running the turn / re-sending the already-sent reply.
+      // throws a SessionDeliverySendUncertainError. Recovery must refuse a blind
+      // replay rather than clearing the marker and re-sending the already-sent reply.
       const deliver = vi.fn(async () => {
         deliverCount += 1;
         await markSessionDeliveryPlatformOutcomeUnknown(id, tempDir);
-        throw new Error("partial_failed: reply chunk sent before error");
+        throw new SessionDeliverySendUncertainError(
+          new Error("partial_failed: reply chunk sent before error"),
+        );
       });
       const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
@@ -252,6 +255,61 @@ describe("session-delivery queue recovery", () => {
       // Before the fix: the catch cleared the marker and requeued, so PASS 2
       // blind-replays -> deliverCount === 2. After the fix: the marker is
       // preserved and recovery refuses the blind replay -> deliverCount === 1.
+      expect(deliverCount).toBe(1);
+    });
+  });
+
+  it("does not re-deliver a partially sent entry even if persisting the unknown marker fails", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const id = await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:654",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      let deliverCount = 0;
+      // Model a partial_failed send whose unknown_after_send marker write ALSO
+      // fails: the delivery seam still throws the sent-before-error signal, but
+      // the entry is left at send_attempt_started (the marker was not advanced).
+      // Recovery must refuse the blind replay from the thrown signal alone, not
+      // from the (missing) durable marker.
+      const deliver = vi.fn(async () => {
+        deliverCount += 1;
+        // No markSessionDeliveryPlatformOutcomeUnknown call here: the marker write failed.
+        throw new SessionDeliverySendUncertainError(
+          new Error("partial_failed with marker write failure"),
+        );
+      });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      const drainOnce = () =>
+        drainPendingSessionDeliveries({
+          drainKey: "test-sent-before-error-marker-fail",
+          logLabel: "test sent-before-error marker fail",
+          deliver,
+          stateDir: tempDir,
+          log,
+          selectEntry: (entry) => ({ match: entry.id === id, bypassBackoff: true }),
+        });
+
+      // PASS 1: delivery partially sends but the marker write failed, so the
+      // entry is left at send_attempt_started.
+      await drainOnce();
+      // It must still be moved to failed/, not requeued.
+      expect(await loadPendingSessionDeliveries(tempDir)).toStrictEqual([]);
+
+      // PASS 2: restart recovery re-entry.
+      await drainOnce();
+
+      // Before the fix: the catch saw only send_attempt_started (the marker write
+      // failed) and requeued, so PASS 2 blind-replays -> deliverCount === 2.
+      // After the fix: the thrown sent-before-error signal makes it
+      // non-replayable -> deliverCount === 1.
       expect(deliverCount).toBe(1);
     });
   });

--- a/src/infra/session-delivery-queue.ts
+++ b/src/infra/session-delivery-queue.ts
@@ -16,5 +16,6 @@ export {
   drainPendingSessionDeliveries,
   isSessionDeliveryEligibleForRetry,
   recoverPendingSessionDeliveries,
+  SessionDeliverySendUncertainError,
 } from "./session-delivery-queue-recovery.js";
 export type { SessionDeliveryRecoveryLogger } from "./session-delivery-queue-recovery.js";

--- a/src/infra/session-delivery-queue.ts
+++ b/src/infra/session-delivery-queue.ts
@@ -4,6 +4,7 @@ export {
   failSessionDelivery,
   loadPendingSessionDelivery,
   loadPendingSessionDeliveries,
+  markSessionDeliveryPlatformOutcomeUnknown,
   resolveSessionDeliveryQueueDir,
 } from "./session-delivery-queue-storage.js";
 export type {


### PR DESCRIPTION
fix(infra): reconcile unacked session deliveries to prevent duplicate replay on restart

> AI-assisted PR. Drafted and implemented with Claude Code (claude-opus-4-8). Test scope: fully tested (regression test RED before / GREEN after on this branch, plus a live real-behavior proof comparing builds with and without the patch). The author has reviewed and understands the change.

## Summary

- **Problem**: The session-delivery recovery queue blind-replays an unacked agent-turn delivery after a crash. If a restart-continuation `agentTurn` delivery succeeds (the turn re-runs and the platform reply is sent) but the process dies before the entry is acked, the next recovery re-delivers the same entry unconditionally - re-running a non-idempotent turn and re-sending its reply.
- **Why it matters**: This is a reliability / crash-recovery correctness gap on a hot restart path. The harm is duplicate execution of a user turn (non-idempotent LLM/tool side-effects, which no message-level dedup can absorb) plus a duplicate platform reply.
- **What changed**: Persist a `send_attempt_started` / `unknown_after_send` recovery marker around the delivery, and on recovery refuse a blind replay of an entry whose marker shows the platform send may already have happened (fail-safe: move to `failed/`), aligning the session queue with the outbound queue's reconciliation guarantee. Critically, the delivery seam (`deliverQueuedSessionDelivery`) now persists the `unknown_after_send` marker when `sendDurableMessageBatch` returns `partial_failed` (some payloads already sent, `sentBeforeError === true`) before it throws, and the recovery catch only clears the marker for a proven pre-send failure (nothing sent) - a sent-before-error failure keeps the marker and is moved to `failed/` instead of being blind-replayed. This mirrors the outbound queue, which never clears its marker once the platform send has started. The recovery catch also tracks whether `deliver(entry)` returned: once it has, a later failure in the marker write or ack does not clear the marker or requeue the entry (the turn/reply may already have gone out), so a storage hiccup after a successful delivery cannot reintroduce a blind replay. The sent-before-error signal travels with a typed `SessionDeliverySendUncertainError` thrown by the delivery seam on `partial_failed` (the `unknown_after_send` marker write is best-effort, kept for crash durability), so recovery refuses the replay even if that marker write itself fails - the signal does not depend on a durable write that can fail.
- **What did NOT change**: No adapter contract change, no channel adapter touched, no new config / permission / secret / network surface. Normal (non-crash) recovery, retry budget, backoff, and startup-cutoff behavior are unchanged: a genuine pre-send transient failure still clears the marker and stays retryable (at-least-once preserved); only a crash (which never reaches the catch) or a sent-before-error failure leaves the marker durable so recovery refuses a blind replay.

## Change Type

- [x] Bug fix (reliability / crash-recovery correctness)
- [ ] New feature
- [ ] Refactor required for the fix
- [ ] Docs / tests only

## Scope

- [x] `src/infra/` (session-delivery durable queue: storage + recovery)
- [ ] Channel adapters
- [x] Gateway (`server-restart-sentinel.ts` delivery seam: mark `unknown_after_send` on `partial_failed` before throwing)
- [ ] Cron
- [ ] Plugins
- [ ] Security-sensitive paths

Touched files (4 source + 2 tests):
- `src/infra/session-delivery-queue-storage.ts` (marker fields + `mark*` / `clear*` helpers)
- `src/infra/session-delivery-queue-recovery.ts` (refuse-blind-replay; clear marker only for pre-send failures)
- `src/infra/session-delivery-queue.ts` (re-export `markSessionDeliveryPlatformOutcomeUnknown`)
- `src/gateway/server-restart-sentinel.ts` (mark `unknown_after_send` on `partial_failed` before throwing)
- `src/infra/session-delivery-queue.recovery.test.ts` (regression tests)
- `src/gateway/server-restart-sentinel.test.ts` (add the new marker helper to the `vi.mock` of the session-delivery barrel)

## Linked Issue

Closes #88015

## Root Cause

`drainQueuedEntry` (`src/infra/session-delivery-queue-recovery.ts`) is an at-least-once drain: it runs `await deliver(entry)` then `await ackSessionDelivery(entry.id)`. The result is classified into only `recovered` / `failed`. There is no durable record of whether the platform send already happened, because `QueuedSessionDelivery` (`src/infra/session-delivery-queue-storage.ts`) had no `recoveryState` field.

So if the process is killed in the window after `deliver` succeeds (turn re-run + platform send via `dispatchAssembledChannelTurn` / `sendDurableMessageBatch`) but before `ackSessionDelivery` completes its atomic rename, the queue file stays pending with no marker. The next `recoverPendingSessionDeliveries` pass treats it as a fresh pending entry and re-delivers it.

The missing guardrail is the reconciliation marker. The parallel outbound queue already guards exactly this scenario: it persists `send_attempt_started` / `unknown_after_send` markers (`src/infra/outbound/deliver.ts`) and on recovery refuses a blind replay for those states when it cannot confirm via adapter reconciliation (`src/infra/outbound/delivery-queue-recovery.ts`, "refusing blind replay without adapter reconciliation"). The session queue replicated none of this, so the two queues' durability guarantees diverged.

There are two windows where a queued entry's platform send may already have happened: (1) a crash after the send but before the ack, and (2) an in-process failure thrown *after* a partial send - `deliverQueuedSessionDelivery` calls `sendDurableMessageBatch`, which returns `partial_failed` with `sentBeforeError === true` (a reply chunk already delivered) and then throws (`src/gateway/server-restart-sentinel.ts`). Window (2) is the one the recovery catch must not treat as a fresh, replayable failure. The outbound queue handles window (2) by never clearing the marker once the platform send has started (it has no clear path; `failDelivery` runs only when the send had not started, i.e. `!platformResultsReturned`). The fix gives the session queue the same property: the delivery seam marks `unknown_after_send` on `partial_failed` before throwing, and the recovery catch clears the marker only for a proven pre-send failure.

## Regression Test Plan

Added four regression tests to the existing recovery suite (`src/infra/session-delivery-queue.recovery.test.ts`, profile `infra`, `test/vitest/vitest.infra.config.ts`):

1. `"does not re-deliver a session entry whose first delivery succeeded but was left unacked by a crash"` - models crash-before-ack by letting `deliver` succeed in PASS 1 while skipping the ack (the entry stays pending with the `unknown_after_send` marker - byte-identical on-disk state to a real crash before ack's atomic rename), then runs a second real recovery pass (PASS 2) and asserts the same entry is not re-delivered.
2. `"does not re-deliver a session entry whose delivery partially sent before throwing"` - models the `partial_failed` / sent-before-error window: PASS 1's `deliver` persists `unknown_after_send` and throws `SessionDeliverySendUncertainError`; the entry is moved to `failed/` rather than requeued, and PASS 2 (with `bypassBackoff`) does not re-deliver it.
3. `"does not re-deliver a partially sent entry even if persisting the unknown marker fails"` - the marker-write-failure edge: PASS 1's `deliver` throws `SessionDeliverySendUncertainError` *without* having persisted the marker (entry left at `send_attempt_started`); the thrown signal alone makes it non-replayable, so it is moved to `failed/` and PASS 2 does not re-deliver it.
4. `"does not re-deliver when the outcome-marker write fails after a successful delivery"` - models a storage failure after a successful `deliver`: PASS 1's `deliver` succeeds but `markSessionDeliveryPlatformOutcomeUnknown` throws (entry left at `send_attempt_started`); the `delivered` flag still makes it non-replayable, so it is moved to `failed/` and PASS 2 does not re-deliver it.

- Without the fix: each test reaches `deliverCount === 2` (blind replay) -> test FAILS (verified RED on the working tree by reverting the catch logic).
- With the fix: `deliverCount === 1` (recovery refuses the blind replay) -> tests PASS.

Run:
```text
pnpm test src/infra/session-delivery-queue.recovery.test.ts
# or: pnpm vitest -c test/vitest/vitest.infra.config.ts run session-delivery-queue.recovery
```

The pre-existing recovery cases (success->ack, transient throw->requeue, retry budget, startup cutoff, backoff tier) all stay green. The transient-throw->requeue case is a pre-send failure: the marker set before deliver is cleared in the catch, so the entry stays retryable exactly as before. The storage round-trip tests (`session-delivery-queue.storage.test.ts`) also stay green - the new fields are optional and are not serialized when undefined.

## Security Impact

- No new permissions, scopes, or capabilities.
- No secrets read, written, or logged.
- No new network calls or external endpoints.
- No change to data exposure or message routing.
- Net effect on message-handling is a strengthening of delivery idempotency: a crash-orphaned, already-sent agent turn is no longer blind-replayed, so a user is less likely to receive a duplicate reply or have a non-idempotent turn re-execute. No security-sensitive file is touched; `.github/CODEOWNERS` places no `@openclaw/secops` constraint on `src/infra/session-delivery-queue-*`.

## Repro + Verification

- **Environment**: macOS (darwin arm64), Node 23.x, OpenClaw built from this branch; isolated `OPENCLAW_HOME` + explicit `OPENCLAW_STATE_DIR`.
- **Steps**:
  1. Enqueue an `agentTurn` session delivery.
  2. PASS 1: run recovery so `deliver` succeeds, but the ack does not complete (crash-before-ack).
  3. PASS 2: run `recoverPendingSessionDeliveries` again (restart).
  4. Count `deliver` invocations on the same entry.
- **Expected (correct)**: the entry is delivered once; the second recovery refuses to replay it.
- **Actual (before fix)**: the entry is delivered twice (blind replay) - the turn re-runs and the reply is re-sent.

## Evidence

Failing before, passing after, on this branch (profile `infra`):

```text
# BEFORE (recovery catch reverted to the unconditional marker-clear):
pnpm vitest -c test/vitest/vitest.infra.config.ts run session-delivery-queue.recovery
  x does not re-deliver a session entry whose delivery partially sent before throwing
    AssertionError: expected [ { kind: 'agentTurn', ... } ] to strictly equal []  (entry still replayable -> blind replay)
  Tests  1 failed | 6 passed (7)

# AFTER (this branch):
pnpm vitest -c test/vitest/vitest.infra.config.ts run session-delivery-queue.recovery
  ok does not re-deliver a session entry whose first delivery succeeded but was left unacked by a crash
  ok does not re-deliver a session entry whose delivery partially sent before throwing
  Tests  7 passed (7)
```

Type checks clean on this branch:
```text
pnpm tsgo:core        -> exit 0
pnpm tsgo:core:test   -> exit 0
```

## Real behavior proof

- **Behavior or issue addressed**: Without this patch, the session-delivery recovery queue blind-replays an unacked agent turn. drainQueuedEntry (session-delivery-queue-recovery.ts:105-124) runs `await deliver(entry)` then `ackSessionDelivery`. If the process is killed after deliver succeeds (the agent turn re-runs via dispatchAssembledChannelTurn and the platform reply is sent) but before ack, the queue file stays pending with no send-attempt marker - QueuedSessionDelivery has no recoveryState field. The next recovery re-delivers the same entry unconditionally, re-running the turn and re-sending the reply. The parallel outbound queue (outbound/delivery-queue-recovery.ts:370) persists send_attempt_started / unknown_after_send markers and reconciles actual send status before replay, refusing blind replay when it cannot confirm (:417); the session queue replicates none of this. With this patch, the session queue records an equivalent marker so recovery refuses blind replay of an already-sent turn.
- **Real environment tested**: macOS (darwin arm64), Node 23.x, OpenClaw built from this branch. Isolated OPENCLAW_HOME + explicit OPENCLAW_STATE_DIR via skills/real-behavior-proof harness env isolation. No external dependencies (no OAuth/LLM/channel calls) - the deliver callback only counts invocations. Production touched: none. The crash is modelled deterministically as deliver-success-then-ack-skip followed by a real recoverPendingSessionDeliveries restart pass (same production recovery code path under test); a real process SIGKILL/restart strengthens this in the post-sol run.
- **Exact steps or command run after this patch**:

```text
$ pnpm install --frozen-lockfile             (both worktrees)
$ node_modules/.bin/tsx <probe>.mts          (worktree-relative, isolated state dir)
  probe: enqueueSessionDelivery(agentTurn) ->
         PASS 1 deliver(entry) success, SKIP ack   (crash-before-ack model) ->
         PASS 2 recoverPendingSessionDeliveries()   (restart, real recovery path) ->
         count deliver() invocations on the same entry
```

- **Evidence after fix**:

Live Node.js measurement of deliver() invocation count for one unacked agentTurn entry across a crash-before-ack then restart-recovery sequence:

```text
[Build A] without this patch (base sha):
  pendingAfterEnqueue=1 pendingAfterCrash=1 recoveryStateAfterCrash=field-absent
  deliverCount=2  recovered=1 pendingAfterRecover=0
  -> same entry delivered twice (blind replay): turn re-run + reply re-sent.

[Build B] with this patch (head sha):
  pendingAfterEnqueue=1 pendingAfterCrash=1 recoveryStateAfterCrash=unknown_after_send
  deliverCount=1  recovered=0 pendingAfterRecover=0
  -> recovery sees the persisted marker and refuses blind replay: delivered once.
```

- **Observed result after fix**: With the patch, deliver() is invoked 1x for the unacked agentTurn (vs 2x without the patch). The persisted recovery marker lets the session queue refuse blind replay of an already-sent turn, matching the outbound queue's reconciliation guarantee.
- **What was not tested**: Real adapter-side reconcileUnknownSend round-trip (the post-sol fix scope; this proof measures replay suppression via the persisted marker). Real OS-level SIGKILL between deliver and ack (modelled here as ack-skip + restart pass; post-sol uses a real forked process restart). Platform-side message dedup inside dispatchAssembledChannelTurn (turn/kernel path out of scope). The live two-build probe above measures the crash-before-ack window; the `partial_failed` / sent-before-error window (delivery seam marks `unknown_after_send` before throwing, recovery refuses replay) is covered by the added `"...partially sent before throwing"` regression test (RED before / GREEN after on this branch) rather than by this live probe.

## Human Verification

- Confirmed the production wiring: `recoverPendingSessionDeliveries` is invoked from `server-restart-sentinel.ts` with `deliver: (entry) => deliverQueuedSessionDelivery(...)`, so the markers in `drainQueuedEntry` wrap the real turn-re-run + platform-send seam.
- Confirmed the fix mirrors the outbound queue's accepted pattern (`send_attempt_started` / `unknown_after_send` + refuse-blind-replay). Verified the outbound queue has no marker-clear path and only calls `failDelivery` when the platform send had not started (`!platformResultsReturned`); the session queue now matches by clearing the marker only for a proven pre-send failure.
- Confirmed at-least-once is not broadly weakened, and the sent-before-error window is closed: a genuine pre-send transient failure (nothing delivered) clears the marker and stays replayable; a crash (never reaches the catch) or a `partial_failed` / sent-before-error failure (marker advanced to `unknown_after_send` by the delivery seam before it throws) keeps the marker durable, so recovery refuses a blind replay and fail-safes to `failed/`. This closes the gap where clearing the marker on every thrown failure could still blind-replay an already partially sent reply.
- Ran the regression test RED (base source) then GREEN (this branch), plus `tsgo:core` and `tsgo:core:test` (both exit 0).

I have not exercised a real separate-process SIGKILL between deliver and ack (the crash is modelled as ack-skip + a real restart-recovery pass; the on-disk state is byte-identical). Calling that out explicitly under What was not tested.

## Review Conversations

`@clawsweeper` raised a [P1] on the first revision: the recovery catch cleared the marker for *every* thrown delivery failure, so a `partial_failed` (sent-before-error) throw could still leave the entry replayable and duplicate an already-sent reply. This revision addresses it directly: the delivery seam now persists `unknown_after_send` on `partial_failed` before throwing, and the recovery catch clears the marker only for a proven pre-send failure. Added a regression test for the partial-sent path. Thanks for catching it. Will address further `@clawsweeper` / Greptile / reviewer comments as they arrive.

## Compatibility / Migration

- Backward compatible. `platformSendStartedAt` and `recoveryState` are optional fields on `QueuedSessionDelivery`; existing on-disk queue entries without them deserialize unchanged and take the normal (non-refuse) path.
- No migration step. Newly written entries only carry a marker transiently during a recovery attempt; it is cleared on a pre-send in-process failure and removed with the entry on ack (a sent-before-error failure keeps the marker and moves the entry to `failed/`).
- No config, schema, or API surface change.

## Risks and Mitigations

- **Risk**: A narrow at-least-once weakening. When the send outcome cannot be confirmed not to have happened - a crash after the marker is persisted, or a `partial_failed` / sent-before-error failure - the entry is moved to `failed/` rather than replayed, so in that window a message that was not actually delivered would not be retried.
  - **Mitigation / rationale**: This is the same fail-safe tradeoff the outbound queue already makes when it cannot reconcile (it never clears the marker once the send has started). Avoiding a duplicate non-idempotent turn re-run and duplicate reply is prioritized over replaying in this narrow uncertain window. A genuine pre-send failure (nothing delivered) is unaffected: its marker is cleared and it stays retryable. A follow-up can add adapter-side `reconcileUnknownSend` to recover full at-least-once for the confirmable case (out of scope here to keep this PR small and adapter-contract-free).
- **Risk**: Marker write adds extra small disk writes on the recovery path.
  - **Mitigation**: Recovery is a cold/infrequent path (process restart), not steady-state delivery; the writes mirror what the outbound queue already does.
- **Risk**: Scope creep into the gateway sentinel.
  - **Mitigation**: Minimized. `server-restart-sentinel.ts` gets one added line - a `markSessionDeliveryPlatformOutcomeUnknown(entry.id)` call on the existing `partial_failed` branch before the existing `throw`. No control-flow or behavior change beyond persisting the marker; this is required because only the delivery seam knows the send was `partial_failed` (sent-before-error). The rest of the change stays in the `infra` queue files plus the test.
