### PR TITLE
feat(hooks): emit session:aborted + opt-in auto-continue hook

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -292,7 +292,9 @@ Runs `BOOT.md` at gateway startup for each configured agent scope, if the file e
 
 ### auto-continue details
 
-Disabled by default. When the stuck-session watchdog hard-aborts an embedded run, the run would otherwise go silent: queued progress is dropped and the agent never resumes on its own. With `auto-continue` enabled, the `session:aborted` event re-injects a short continuation instruction and wakes a fresh turn so an autonomous run picks its work loop back up. Resumes are capped at 3 per session per 30 minutes, and the gateway logs an `auto-continue` event when a session exhausts that budget. Enable with `openclaw hooks enable auto-continue`.
+Disabled by default. When the stuck-session watchdog hard-aborts an embedded run, the run would otherwise go silent: queued progress is dropped and the agent never resumes on its own. With `auto-continue` enabled, the `session:aborted` event re-injects a short continuation instruction and wakes a fresh turn so an autonomous run picks its work loop back up. Resumes are capped at 3 per session per 30 minutes, and the gateway logs an `auto-continue` event both when it queues a continuation and when a session exhausts that budget. Enable with `openclaw hooks enable auto-continue`.
+
+The continuation rides the heartbeat: it is queued as a system event and delivered by the next heartbeat turn. The agent therefore needs a heartbeat cadence (`agents.defaults.heartbeat.every`) - with heartbeats disabled the continuation is queued and never delivered.
 
 ## Plugin hooks
 

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -62,6 +62,7 @@ hook that never runs is diagnosable.
 | `session:compact:before` | Before compaction summarizes history                       |
 | `session:compact:after`  | After compaction completes                                 |
 | `session:patch`          | When session properties are modified                       |
+| `session:aborted`        | After the stuck-session watchdog hard-aborts a run         |
 | `agent:bootstrap`        | Before workspace bootstrap files are injected              |
 | `gateway:startup`        | After channels start and hooks are loaded                  |
 | `gateway:shutdown`       | When gateway shutdown begins                               |
@@ -113,6 +114,13 @@ Detailed documentation goes here.
 | `hookKey`  | Config key override (defaults to the hook name)      |
 | `homepage` | Docs URL shown by `openclaw hooks info`              |
 | `install`  | Installation methods                                 |
+
+`defaultEnableMode` (`"default-on"` or `"explicit-opt-in"`) lets a hook ship with
+a different default than its source: a bundled or managed hook can declare
+`"explicit-opt-in"` so it stays off until `openclaw hooks enable <name>`. It is
+read only for bundled and managed hooks. Workspace hooks are untrusted local code
+and always require explicit opt-in, and plugin hooks are enabled by their own
+install step, so the field is ignored for both.
 
 ### Handler implementation
 
@@ -227,6 +235,7 @@ Npm specs are registry-only (package name + optional exact version or dist-tag).
 | command-logger        | `command`                                         | Logs all commands to `~/.openclaw/logs/commands.log`           |
 | compaction-notifier   | `session:compact:before`, `session:compact:after` | Sends visible chat notices when session compaction starts/ends |
 | boot-md               | `gateway:startup`                                 | Runs `BOOT.md` when the gateway starts                         |
+| auto-continue         | `session:aborted`                                 | Resumes a run the stuck-session watchdog aborted (opt-in)      |
 
 Enable any bundled hook:
 
@@ -278,6 +287,12 @@ Sends short status messages into the current conversation when OpenClaw starts a
 ### boot-md details
 
 Runs `BOOT.md` at gateway startup for each configured agent scope, if the file exists in that agent's resolved workspace.
+
+<a id="auto-continue"></a>
+
+### auto-continue details
+
+Disabled by default. When the stuck-session watchdog hard-aborts an embedded run, the run would otherwise go silent: queued progress is dropped and the agent never resumes on its own. With `auto-continue` enabled, the `session:aborted` event re-injects a short continuation instruction and wakes a fresh turn so an autonomous run picks its work loop back up. Resumes are capped at 3 per session per 30 minutes, and the gateway logs an `auto-continue` event when a session exhausts that budget. Enable with `openclaw hooks enable auto-continue`.
 
 ## Plugin hooks
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -123,6 +123,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: command-logger details
   - H3: compaction-notifier details
   - H3: boot-md details
+  - H3: auto-continue details
   - H2: Plugin hooks
   - H2: Configuration
   - H2: CLI reference

--- a/src/hooks/bundled/auto-continue/HOOK.md
+++ b/src/hooks/bundled/auto-continue/HOOK.md
@@ -1,0 +1,34 @@
+---
+name: auto-continue
+description: "Resume an autonomous run after the stuck-session watchdog hard-aborts it."
+metadata:
+  {
+    "openclaw":
+      { "emoji": "♻️", "events": ["session:aborted"], "defaultEnableMode": "explicit-opt-in" },
+  }
+---
+
+# Auto Continue
+
+When the stuck-session watchdog hard-aborts an embedded run, this hook re-injects
+a short continuation instruction and kicks a fresh turn so the agent resumes its
+work loop on its own instead of going silent. A loop-guard caps resumes at 3 per
+session per 30 minutes so a pathological abort→continue→abort cycle cannot run
+away.
+
+This is a backstop behind the existing protection that stops _false_ aborts in
+the first place (working runs already refresh the watchdog activity timestamp on
+every run event). Auto-continue only matters for a genuine hang.
+
+Because resuming a run automatically is an opinionated behavior change, this hook
+is **disabled by default** (`defaultEnableMode: explicit-opt-in`). Enable it with:
+
+```bash
+openclaw hooks enable auto-continue
+```
+
+Disable with:
+
+```bash
+openclaw hooks disable auto-continue
+```

--- a/src/hooks/bundled/auto-continue/HOOK.md
+++ b/src/hooks/bundled/auto-continue/HOOK.md
@@ -16,6 +16,11 @@ work loop on its own instead of going silent. A loop-guard caps resumes at 3 per
 session per 30 minutes so a pathological abort→continue→abort cycle cannot run
 away.
 
+**Requires heartbeats.** The continuation is queued as a system event and
+delivered by the next heartbeat turn, so the agent needs a heartbeat cadence
+(`agents.defaults.heartbeat.every`). With heartbeats disabled the continuation is
+queued and never delivered, and the aborted run stays silent.
+
 This is a backstop behind the existing protection that stops _false_ aborts in
 the first place (working runs already refresh the watchdog activity timestamp on
 every run event). Auto-continue only matters for a genuine hang.

--- a/src/hooks/bundled/auto-continue/handler.test.ts
+++ b/src/hooks/bundled/auto-continue/handler.test.ts
@@ -50,8 +50,10 @@ describe("auto-continue handler", () => {
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(expect.any(String), {
       sessionKey: "agent:main:main",
     });
+    // "event" would defer to the next scheduled heartbeat for every abort after
+    // the first, which leaves the run silent exactly when it needs resuming.
     expect(mocks.requestHeartbeat).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionKey: "agent:main:main", intent: "event" }),
+      expect.objectContaining({ sessionKey: "agent:main:main", intent: "immediate" }),
     );
   });
 

--- a/src/hooks/bundled/auto-continue/handler.test.ts
+++ b/src/hooks/bundled/auto-continue/handler.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  enqueueSystemEvent: vi.fn(),
+  requestHeartbeat: vi.fn(),
+}));
+
+vi.mock("../../../infra/system-events.js", () => ({
+  enqueueSystemEvent: mocks.enqueueSystemEvent,
+}));
+
+vi.mock("../../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeat: mocks.requestHeartbeat,
+}));
+
+vi.mock("../../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: vi.fn() }),
+}));
+
+import handler from "./handler.js";
+
+const CONTINUE_HISTORY_KEY = Symbol.for("openclaw.autoContinueHistory");
+
+function abortEvent(sessionKey: string) {
+  return {
+    type: "session" as const,
+    action: "aborted",
+    sessionKey,
+    context: {},
+    timestamp: new Date(),
+    messages: [],
+  };
+}
+
+function resetHistory() {
+  (globalThis as Record<symbol, unknown>)[CONTINUE_HISTORY_KEY] = new Map();
+}
+
+describe("auto-continue handler", () => {
+  beforeEach(() => {
+    mocks.enqueueSystemEvent.mockReset();
+    mocks.requestHeartbeat.mockReset();
+    resetHistory();
+  });
+
+  it("queues a continuation and wakes the heartbeat on session:aborted", async () => {
+    await handler(abortEvent("agent:main:main"));
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(expect.any(String), {
+      sessionKey: "agent:main:main",
+    });
+    expect(mocks.requestHeartbeat).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: "agent:main:main", intent: "event" }),
+    );
+  });
+
+  it("ignores non-aborted session events", async () => {
+    await handler({ ...abortEvent("agent:main:main"), action: "started" });
+    await handler({ ...abortEvent("agent:main:main"), type: "command" });
+
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it("ignores events without a session key", async () => {
+    await handler({ ...abortEvent("   "), sessionKey: "" });
+
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("stops resuming after the per-session budget is exhausted", async () => {
+    for (let i = 0; i < 3; i++) {
+      await handler(abortEvent("agent:main:main"));
+    }
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(3);
+
+    await handler(abortEvent("agent:main:main"));
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(3);
+    expect(mocks.requestHeartbeat).toHaveBeenCalledTimes(3);
+  });
+
+  it("tracks the budget per session key independently", async () => {
+    for (let i = 0; i < 3; i++) {
+      await handler(abortEvent("agent:main:main"));
+    }
+    await handler(abortEvent("agent:main:main"));
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(3);
+
+    await handler(abortEvent("agent:other:lane"));
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/hooks/bundled/auto-continue/handler.ts
+++ b/src/hooks/bundled/auto-continue/handler.ts
@@ -1,0 +1,74 @@
+import { requestHeartbeat } from "../../../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../../../infra/system-events.js";
+import type { HookHandler } from "../../hooks.js";
+
+// Loop-guard: cap how often a single session may be auto-continued so a
+// pathological abort -> continue -> abort cycle can never run away. State is a
+// globalThis singleton so it survives bundle splitting (same pattern the
+// internal-hook registry uses).
+const MAX_CONTINUES = 3;
+const WINDOW_MS = 30 * 60 * 1000;
+const CONTINUE_HISTORY_KEY = Symbol.for("openclaw.autoContinueHistory");
+
+function getHistory(): Map<string, number[]> {
+  const g = globalThis as Record<symbol, unknown>;
+  let map = g[CONTINUE_HISTORY_KEY] as Map<string, number[]> | undefined;
+  if (!map) {
+    map = new Map<string, number[]>();
+    g[CONTINUE_HISTORY_KEY] = map;
+  }
+  return map;
+}
+
+function withinBudget(sessionKey: string, now: number): boolean {
+  const history = getHistory();
+  const recent = (history.get(sessionKey) ?? []).filter((ts) => now - ts < WINDOW_MS);
+  if (recent.length >= MAX_CONTINUES) {
+    history.set(sessionKey, recent);
+    return false;
+  }
+  recent.push(now);
+  history.set(sessionKey, recent);
+  return true;
+}
+
+const handler: HookHandler = async (event) => {
+  try {
+    if (event.type !== "session" || event.action !== "aborted") {
+      return;
+    }
+    const sessionKey = event.sessionKey?.trim();
+    if (!sessionKey) {
+      return;
+    }
+    if (!withinBudget(sessionKey, Date.now())) {
+      console.warn(
+        `[auto-continue] budget exhausted for session ${sessionKey} (>=${MAX_CONTINUES} continues / ${Math.round(
+          WINDOW_MS / 60000,
+        )}min) — not resuming to avoid an abort loop.`,
+      );
+      return;
+    }
+
+    enqueueSystemEvent(
+      "Your previous run was interrupted by the stuck-session watchdog before it finished. " +
+        "Pick up exactly where you left off: re-check the state of the work you were doing " +
+        "(files, queues, tasks), figure out what still needs to happen, and continue " +
+        "autonomously. Do not wait for a new instruction. Flush short progress text often so " +
+        "the run is not misclassified as stalled again.",
+      { sessionKey },
+    );
+    requestHeartbeat({
+      source: "hook",
+      intent: "event",
+      reason: "auto-continue:session-aborted",
+      sessionKey,
+    });
+  } catch (error) {
+    console.warn(
+      `[auto-continue] failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+};
+
+export default handler;

--- a/src/hooks/bundled/auto-continue/handler.ts
+++ b/src/hooks/bundled/auto-continue/handler.ts
@@ -64,9 +64,14 @@ const handler: HookHandler = async (event) => {
         "the run is not misclassified as stalled again.",
       { sessionKey },
     );
+    // "immediate", not "event": an event wake defers to `nextDueMs` once the
+    // agent has run before (see heartbeat-cooldown.ts), so every abort after the
+    // first would wait out the whole heartbeat interval and the run stays silent
+    // exactly when the backstop is needed. Immediate keeps the flood guard, and
+    // the loop-guard above is what bounds resumes.
     requestHeartbeat({
       source: "hook",
-      intent: "event",
+      intent: "immediate",
       reason: "auto-continue:session-aborted",
       sessionKey,
     });

--- a/src/hooks/bundled/auto-continue/handler.ts
+++ b/src/hooks/bundled/auto-continue/handler.ts
@@ -1,6 +1,9 @@
 import { requestHeartbeat } from "../../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import type { HookHandler } from "../../hooks.js";
+
+const log = createSubsystemLogger("auto-continue");
 
 // Loop-guard: cap how often a single session may be auto-continued so a
 // pathological abort -> continue -> abort cycle can never run away. State is a
@@ -42,10 +45,13 @@ const handler: HookHandler = async (event) => {
       return;
     }
     if (!withinBudget(sessionKey, Date.now())) {
-      console.warn(
-        `[auto-continue] budget exhausted for session ${sessionKey} (>=${MAX_CONTINUES} continues / ${Math.round(
-          WINDOW_MS / 60000,
-        )}min) — not resuming to avoid an abort loop.`,
+      log.warn(
+        `auto-continue budget exhausted for session ${sessionKey} — not resuming to avoid an abort loop`,
+        {
+          sessionKey,
+          maxContinues: MAX_CONTINUES,
+          windowMinutes: Math.round(WINDOW_MS / 60000),
+        },
       );
       return;
     }
@@ -65,9 +71,7 @@ const handler: HookHandler = async (event) => {
       sessionKey,
     });
   } catch (error) {
-    console.warn(
-      `[auto-continue] failed: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    log.warn(`auto-continue failed: ${error instanceof Error ? error.message : String(error)}`);
   }
 };
 

--- a/src/hooks/bundled/auto-continue/handler.ts
+++ b/src/hooks/bundled/auto-continue/handler.ts
@@ -70,6 +70,13 @@ const handler: HookHandler = async (event) => {
       reason: "auto-continue:session-aborted",
       sessionKey,
     });
+    // Queuing is silent otherwise, so an operator cannot tell a hook that never
+    // ran from a continuation that was queued but never woken.
+    log.info(`auto-continue queued a continuation for session ${sessionKey}`, {
+      sessionKey,
+      maxContinues: MAX_CONTINUES,
+      windowMinutes: Math.round(WINDOW_MS / 60000),
+    });
   } catch (error) {
     log.warn(`auto-continue failed: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/src/hooks/frontmatter.ts
+++ b/src/hooks/frontmatter.ts
@@ -59,12 +59,17 @@ export function resolveOpenClawMetadata(
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
   const eventsRaw = normalizeStringList(metadataObj.events);
+  const defaultEnableMode = readStringValue(metadataObj.defaultEnableMode);
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
     emoji: readStringValue(metadataObj.emoji),
     homepage: readStringValue(metadataObj.homepage),
     hookKey: readStringValue(metadataObj.hookKey),
     export: readStringValue(metadataObj.export),
+    defaultEnableMode:
+      defaultEnableMode === "explicit-opt-in" || defaultEnableMode === "default-on"
+        ? defaultEnableMode
+        : undefined,
     os: osRaw.length > 0 ? osRaw : undefined,
     events: eventsRaw.length > 0 ? eventsRaw : [],
     requires,

--- a/src/hooks/internal-hook-types.test.ts
+++ b/src/hooks/internal-hook-types.test.ts
@@ -16,6 +16,7 @@ describe("isKnownInternalHookEventKey", () => {
       "message:received",
       "message:sent",
       "message:transcribed",
+      "session:aborted",
       "session:compact:after",
       "session:compact:before",
       "session:patch",

--- a/src/hooks/internal-hook-types.ts
+++ b/src/hooks/internal-hook-types.ts
@@ -29,6 +29,7 @@ const KNOWN_INTERNAL_HOOK_EVENT_KEYS = [
   "message:received",
   "message:sent",
   "message:transcribed",
+  "session:aborted",
   "session:compact:after",
   "session:compact:before",
   "session:patch",

--- a/src/hooks/policy.test.ts
+++ b/src/hooks/policy.test.ts
@@ -56,6 +56,39 @@ describe("hook policy", () => {
       const entry = makeHookEntry("plugin-hook", "openclaw-plugin");
       expect(resolveHookEnableState({ entry })).toEqual({ enabled: true });
     });
+
+    it("keeps bundled hooks enabled by default", () => {
+      const entry = makeHookEntry("bundled-hook", "openclaw-bundled");
+      expect(resolveHookEnableState({ entry })).toEqual({ enabled: true });
+    });
+
+    it("honors a per-hook explicit-opt-in override on a bundled hook", () => {
+      const entry = makeHookEntry("opt-in-hook", "openclaw-bundled");
+      entry.metadata = { ...entry.metadata, events: ["session:aborted"] };
+      entry.metadata.defaultEnableMode = "explicit-opt-in";
+      expect(resolveHookEnableState({ entry })).toEqual({
+        enabled: false,
+        reason: "hook disabled by default (opt-in)",
+      });
+    });
+
+    it("enables an opt-in bundled hook when explicitly turned on", () => {
+      const entry = makeHookEntry("opt-in-hook", "openclaw-bundled");
+      entry.metadata = { ...entry.metadata, events: ["session:aborted"] };
+      entry.metadata.defaultEnableMode = "explicit-opt-in";
+      const config: OpenClawConfig = {
+        hooks: {
+          internal: {
+            entries: {
+              "opt-in-hook": {
+                enabled: true,
+              },
+            },
+          },
+        },
+      };
+      expect(resolveHookEnableState({ entry, config })).toEqual({ enabled: true });
+    });
   });
 
   describe("resolveHookEntries", () => {

--- a/src/hooks/policy.test.ts
+++ b/src/hooks/policy.test.ts
@@ -81,6 +81,12 @@ describe("hook policy", () => {
       });
     });
 
+    it("ignores defaultEnableMode metadata on plugin hooks", () => {
+      const entry = makeHookEntry("plugin-hook", "openclaw-plugin");
+      entry.metadata = { events: ["command:new"], defaultEnableMode: "explicit-opt-in" };
+      expect(resolveHookEnableState({ entry })).toEqual({ enabled: true });
+    });
+
     it("honors defaultEnableMode metadata on trusted managed hooks", () => {
       const entry = makeHookEntry("managed-hook", "openclaw-managed");
       entry.metadata = { events: ["command:new"], defaultEnableMode: "explicit-opt-in" };

--- a/src/hooks/policy.test.ts
+++ b/src/hooks/policy.test.ts
@@ -72,6 +72,24 @@ describe("hook policy", () => {
       });
     });
 
+    it("ignores defaultEnableMode metadata on workspace hooks", () => {
+      const entry = makeHookEntry("workspace-hook", "openclaw-workspace");
+      entry.metadata = { events: ["command:new"], defaultEnableMode: "default-on" };
+      expect(resolveHookEnableState({ entry })).toEqual({
+        enabled: false,
+        reason: "workspace hook (disabled by default)",
+      });
+    });
+
+    it("honors defaultEnableMode metadata on trusted managed hooks", () => {
+      const entry = makeHookEntry("managed-hook", "openclaw-managed");
+      entry.metadata = { events: ["command:new"], defaultEnableMode: "explicit-opt-in" };
+      expect(resolveHookEnableState({ entry })).toEqual({
+        enabled: false,
+        reason: "hook disabled by default (opt-in)",
+      });
+    });
+
     it("enables an opt-in bundled hook when explicitly turned on", () => {
       const entry = makeHookEntry("opt-in-hook", "openclaw-bundled");
       entry.metadata = { ...entry.metadata, events: ["session:aborted"] };

--- a/src/hooks/policy.ts
+++ b/src/hooks/policy.ts
@@ -4,7 +4,10 @@ import { resolveHookKey } from "./frontmatter.js";
 import type { HookEntry, HookSource } from "./types.js";
 
 /** Human-readable reason for disabling a hook at policy resolution time. */
-export type HookEnableStateReason = "disabled in config" | "workspace hook (disabled by default)";
+export type HookEnableStateReason =
+  | "disabled in config"
+  | "workspace hook (disabled by default)"
+  | "hook disabled by default (opt-in)";
 
 type HookEnableState = {
   enabled: boolean;
@@ -95,8 +98,13 @@ export function resolveHookEnableState(params: {
   }
 
   const sourcePolicy = getHookSourcePolicy(entry.hook.source);
-  if (sourcePolicy.defaultEnableMode === "explicit-opt-in" && hookConfig?.enabled !== true) {
-    return { enabled: false, reason: "workspace hook (disabled by default)" };
+  const effectiveEnableMode = entry.metadata?.defaultEnableMode ?? sourcePolicy.defaultEnableMode;
+  if (effectiveEnableMode === "explicit-opt-in" && hookConfig?.enabled !== true) {
+    const reason: HookEnableStateReason =
+      entry.hook.source === "openclaw-workspace"
+        ? "workspace hook (disabled by default)"
+        : "hook disabled by default (opt-in)";
+    return { enabled: false, reason };
   }
 
   return { enabled: true };

--- a/src/hooks/policy.ts
+++ b/src/hooks/policy.ts
@@ -18,6 +18,11 @@ type HookSourcePolicy = {
   precedence: number;
   trustedLocalCode: boolean;
   defaultEnableMode: "default-on" | "explicit-opt-in";
+  // Whether a hook's own frontmatter may override its default-enable mode.
+  // Only safe for sources whose code ships with (or is installed into) the
+  // binary; workspace hooks are untrusted local code and must stay explicit
+  // opt-in regardless of what their HOOK.md declares.
+  allowMetadataEnableOverride: boolean;
   canOverride: HookSource[];
   canBeOverriddenBy: HookSource[];
 };
@@ -33,6 +38,7 @@ const HOOK_SOURCE_POLICIES: Record<HookSource, HookSourcePolicy> = {
     precedence: 10,
     trustedLocalCode: true,
     defaultEnableMode: "default-on",
+    allowMetadataEnableOverride: true,
     canOverride: ["openclaw-bundled"],
     canBeOverriddenBy: ["openclaw-managed", "openclaw-plugin"],
   },
@@ -40,6 +46,7 @@ const HOOK_SOURCE_POLICIES: Record<HookSource, HookSourcePolicy> = {
     precedence: 20,
     trustedLocalCode: true,
     defaultEnableMode: "default-on",
+    allowMetadataEnableOverride: true,
     canOverride: ["openclaw-bundled", "openclaw-plugin"],
     canBeOverriddenBy: ["openclaw-managed"],
   },
@@ -47,6 +54,7 @@ const HOOK_SOURCE_POLICIES: Record<HookSource, HookSourcePolicy> = {
     precedence: 30,
     trustedLocalCode: true,
     defaultEnableMode: "default-on",
+    allowMetadataEnableOverride: true,
     canOverride: ["openclaw-bundled", "openclaw-managed", "openclaw-plugin"],
     canBeOverriddenBy: ["openclaw-managed"],
   },
@@ -54,6 +62,7 @@ const HOOK_SOURCE_POLICIES: Record<HookSource, HookSourcePolicy> = {
     precedence: 40,
     trustedLocalCode: true,
     defaultEnableMode: "explicit-opt-in",
+    allowMetadataEnableOverride: false,
     canOverride: ["openclaw-workspace"],
     canBeOverriddenBy: ["openclaw-workspace"],
   },
@@ -98,7 +107,10 @@ export function resolveHookEnableState(params: {
   }
 
   const sourcePolicy = getHookSourcePolicy(entry.hook.source);
-  const effectiveEnableMode = entry.metadata?.defaultEnableMode ?? sourcePolicy.defaultEnableMode;
+  const effectiveEnableMode =
+    sourcePolicy.allowMetadataEnableOverride && entry.metadata?.defaultEnableMode
+      ? entry.metadata.defaultEnableMode
+      : sourcePolicy.defaultEnableMode;
   if (effectiveEnableMode === "explicit-opt-in" && hookConfig?.enabled !== true) {
     const reason: HookEnableStateReason =
       entry.hook.source === "openclaw-workspace"

--- a/src/hooks/policy.ts
+++ b/src/hooks/policy.ts
@@ -21,7 +21,9 @@ type HookSourcePolicy = {
   // Whether a hook's own frontmatter may override its default-enable mode.
   // Only safe for sources whose code ships with (or is installed into) the
   // binary; workspace hooks are untrusted local code and must stay explicit
-  // opt-in regardless of what their HOOK.md declares.
+  // opt-in regardless of what their HOOK.md declares. Plugin hooks are enabled
+  // by their own loader before this policy runs, so the flag stays false there
+  // rather than advertising an override the runtime never reads.
   allowMetadataEnableOverride: boolean;
   canOverride: HookSource[];
   canBeOverriddenBy: HookSource[];
@@ -46,7 +48,7 @@ const HOOK_SOURCE_POLICIES: Record<HookSource, HookSourcePolicy> = {
     precedence: 20,
     trustedLocalCode: true,
     defaultEnableMode: "default-on",
-    allowMetadataEnableOverride: true,
+    allowMetadataEnableOverride: false,
     canOverride: ["openclaw-bundled", "openclaw-plugin"],
     canBeOverriddenBy: ["openclaw-managed"],
   },

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -17,6 +17,12 @@ export type OpenClawHookMetadata = {
   events: string[];
   /** Optional export name (default: "default") */
   export?: string;
+  /**
+   * Overrides the source-level default enable mode for this hook. A bundled hook
+   * can set "explicit-opt-in" to ship disabled-by-default (users enable it via
+   * `openclaw hooks enable <name>`) instead of inheriting the bundled "default-on".
+   */
+  defaultEnableMode?: "default-on" | "explicit-opt-in";
   os?: string[];
   requires?: {
     bins?: string[];

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   resolveEmbeddedSessionLane: vi.fn((key: string) => `session:${key}`),
   waitForEmbeddedAgentRunEnd: vi.fn(),
   getDiagnosticSessionActivitySnapshot: vi.fn(),
+  triggerInternalHook: vi.fn(),
   diag: {
     debug: vi.fn(),
     warn: vi.fn(),
@@ -69,6 +70,16 @@ vi.mock("../process/command-queue.js", () => ({
   resetCommandLane: mocks.resetCommandLane,
 }));
 
+vi.mock("../hooks/internal-hooks.js", () => ({
+  triggerInternalHook: mocks.triggerInternalHook,
+  createInternalHookEvent: (
+    type: string,
+    action: string,
+    sessionKey: string,
+    context: Record<string, unknown> = {},
+  ) => ({ type, action, sessionKey, context, timestamp: new Date(), messages: [] }),
+}));
+
 vi.mock("./diagnostic-runtime.js", () => ({
   diagnosticLogger: mocks.diag,
 }));
@@ -109,6 +120,8 @@ function resetMocks() {
   mocks.waitForEmbeddedAgentRunEnd.mockReset();
   mocks.getDiagnosticSessionActivitySnapshot.mockReset();
   mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({});
+  mocks.triggerInternalHook.mockReset();
+  mocks.triggerInternalHook.mockResolvedValue(undefined);
   mocks.diag.debug.mockReset();
   mocks.diag.warn.mockReset();
 }
@@ -814,5 +827,44 @@ describe("stuck session recovery", () => {
     }
     resolveWait(true);
     await first;
+  });
+
+  it("emits a session:aborted hook event when it aborts a real run", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+
+    await recoverStuckDiagnosticSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      allowActiveAbort: true,
+    });
+
+    expect(mocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+    expect(mocks.triggerInternalHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session",
+        action: "aborted",
+        sessionKey: "agent:main:main",
+        context: expect.objectContaining({ reason: "stuck_recovery", sessionId: "session-1" }),
+      }),
+    );
+  });
+
+  it("does not emit a session:aborted hook event when only releasing a lane", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.resetCommandLane.mockReturnValue(0);
+
+    await recoverStuckDiagnosticSession({
+      sessionId: "stale-session",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 2,
+    });
+
+    expect(mocks.triggerInternalHook).not.toHaveBeenCalled();
   });
 });

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -10,6 +10,7 @@ import {
   resolveActiveEmbeddedRunHandleSessionId,
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
 } from "../agents/embedded-agent-runner/runs.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import {
   getCommandLaneActiveTaskIds,
   getCommandLaneSnapshot,
@@ -355,6 +356,16 @@ export async function recoverStuckDiagnosticSession(
               lane: sessionLane ?? undefined,
             };
       diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+      if (outcome.status === "aborted" && params.sessionKey) {
+        await triggerInternalHook(
+          createInternalHookEvent("session", "aborted", params.sessionKey, {
+            sessionId: params.sessionId ?? activeSessionId,
+            ageMs: params.ageMs,
+            lane: sessionLane ?? undefined,
+            reason: "stuck_recovery",
+          }),
+        );
+      }
       return outcome;
     }
     const outcome: StuckSessionRecoveryOutcome = {


### PR DESCRIPTION
## What Problem This Solves

When the stuck-session watchdog hard-aborts an embedded run, the run goes silent: queued progress is dropped and the agent never resumes on its own, so an autonomous work loop stalls until a human re-instructs it. False aborts are already prevented (working runs refresh the watchdog activity timestamp on every run event via the ACP projector's `onProgress`); this PR is the backstop for a run that genuinely hangs.

It adds:

1. **`session:aborted`** — `recoverStuckDiagnosticSession` fires an internal hook event with session id, age, lane, and `reason: "stuck_recovery"` when it actually aborts a run.
2. **An opt-in bundled `auto-continue` hook** — on `session:aborted` it re-injects a short continuation instruction and wakes a fresh turn, capped at 3 resumes per session per 30 minutes so an abort→continue→abort cycle cannot run away.

Because resuming a run automatically is an opinionated behavior change, the hook ships **disabled by default** via a new declarative `defaultEnableMode` metadata field:

```bash
openclaw hooks enable auto-continue
```

## Evidence

Verified on an isolated gateway built from this branch (Node 24.18.0, own state dir and config, port 18901, `agents.defaults.heartbeat.every: 30m`). The configured model provider points at a local OpenAI-compatible endpoint that accepts the request and never responds, so the run hangs for real rather than being mocked. One turn was started and then left alone for ~35 minutes.

```
11:36:41  [agent/embedded] embedded run start: provider=stall messageChannel=webchat
11:43:01  [diagnostic] stuck session recovery: sessionKey=agent:main:proof age=379s action=abort_embedded_run aborted=true drained=true
11:43:01  [auto-continue] queued a continuation for session agent:main:proof
11:43:05  [diagnostic] session turn created: sessionKey=agent:main:proof channel=heartbeat trigger=heartbeat
11:43:05  [agent/embedded] embedded run start: provider=stall messageChannel=heartbeat
11:49:31  [diagnostic] stuck session recovery: age=386s action=abort_embedded_run aborted=true
11:49:34  [diagnostic] session turn created: trigger=heartbeat
11:56:01  [diagnostic] stuck session recovery: age=387s action=abort_embedded_run aborted=true
11:56:02  [diagnostic] session turn created: trigger=heartbeat
12:02:31  [diagnostic] stuck session recovery: age=389s action=abort_embedded_run aborted=true
12:02:31  [auto-continue] budget exhausted for session agent:main:proof — not resuming to avoid an abort loop
```

The stalled endpoint logged four `POST /v1/chat/completions` (initial run plus three resumes), so every resume really re-entered the model call. The fourth abort is refused by the loop-guard.

Opt-in default on the same binary:

```
$ openclaw hooks info auto-continue     # no explicit enable entry in config
♻️ auto-continue Disabled
  Events: session:aborted
  Blocked reason: hook disabled by default (opt-in)
```

Automated checks on this branch:

```
$ node scripts/run-vitest.mjs run src/hooks/policy.test.ts \
    src/hooks/bundled/auto-continue/handler.test.ts
  12 passed + 5 passed

$ node scripts/run-vitest.mjs run src/hooks/internal-hook-types.test.ts
  3 passed

$ node scripts/run-vitest.mjs run src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
  27 passed, 1 failed

$ node scripts/run-tsgo.mjs -p tsconfig.core.json                    # no errors
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json # no errors
$ node scripts/run-oxlint.mjs src/hooks/                             # exit 0
$ oxfmt --check <changed files>                                      # clean
```

The one failing test is `logs stopped cron context when aborting an active embedded run`, which also exists unchanged on `main`. It fails on this machine's Node 22.22.2 because of the SQLite WAL-reset guard (`OpenClaw requires SQLite 3.51.3+ ... Node 22.22.2 embeds SQLite 3.51.2`), not because of this branch; both new tests in that file pass. The gateway proof above ran on Node 24.18.0, where that guard is satisfied.

## Real behavior proof

Behavior addressed: a stuck-session watchdog abort leaves an embedded run silent; `auto-continue` should resume it, bounded by a loop-guard.
Real environment tested: isolated OpenClaw gateway built from this branch (Node 24.18.0, dedicated state dir and config, port 18901, `gateway.auth.mode: none`, `agents.defaults.heartbeat.every: 30m`), with a local OpenAI-compatible endpoint that accepts the chat completion request and never responds.
Exact steps or command run after this patch: start the stalling endpoint and the gateway, run `openclaw agent --session-key agent:main:proof -m "..."`, then leave the session untouched for ~35 minutes.
Evidence after fix: see the gateway log excerpt in the Evidence section above (abort at 379s, queued continuation, heartbeat-triggered resume, repeated three times, loop-guard refusal on the fourth abort) plus four model requests observed at the stalled endpoint.
Observed result after fix: the abort fires `session:aborted`, the hook queues a continuation and wakes the session, the run resumes three times, and the fourth abort is refused with `budget exhausted`.
What was not tested: a production gateway with real channels and a real model provider, multi-agent setups, and the compaction-safety interaction.

## Review follow-up

Addressing ClawSweeper and @joelnishanth:

1. **Trust boundary closed.** The hook source policy table carries an explicit `allowMetadataEnableOverride` flag. Bundled and managed sources may honor frontmatter `defaultEnableMode`; `openclaw-workspace` is `false` and always falls back to explicit opt-in regardless of what its `HOOK.md` declares. `openclaw-plugin` is also `false`, because plugin hooks are enabled by their loader before `resolveHookEnableState` evaluates metadata — the table no longer advertises an override the runtime never reads (ClawSweeper P1 on `src/hooks/policy.ts`).
2. **Structured budget log.** The loop-guard emits a structured `auto-continue` subsystem log event when the per-session budget is exhausted instead of `console.warn`.
3. **Public docs.** `session:aborted`, `defaultEnableMode`, and the bundled `auto-continue` hook are documented in `docs/automation/hooks.md` (ClawSweeper P3).
4. **Rebased** onto current `main`; the branch no longer conflicts.

## Two fixes the live run surfaced

1. **The wake deferred to the heartbeat schedule.** The hook woke with `intent: "event"`. Per `shouldDeferWake` in `src/infra/heartbeat-cooldown.ts`, an event wake runs only when the agent has no prior run and otherwise defers while `now < nextDueMs`. The first abort resumed, but every later abort waited out the whole heartbeat interval — the backstop was silent exactly when it was needed, and the advertised 3-per-30-min loop-guard never governed anything. Switched to `intent: "immediate"`, the documented wake-now path, which keeps the flood guard and makes the loop-guard the real bound. With `"event"` the same scenario stopped resuming after the second abort.
2. **`session:aborted` was not a known event key.** `openclaw hooks info auto-continue` warned `⚠ Event not emitted by core (likely typo): session:aborted` because the event was missing from `KNOWN_INTERNAL_HOOK_EVENT_KEYS`. Registered it, with coverage.

Related: the continuation rides the heartbeat, so the hook needs a heartbeat cadence to be effective. With heartbeats disabled the continuation is queued and never delivered — now documented in `HOOK.md` and the hooks page instead of being a silent precondition. `auto-continue` also logs when it *queues* a continuation, not only when the budget is exhausted, so an operator can tell "hook never ran" from "queued but never woken".