### PR TITLE
fix(embedded-agent): treat stale thinking-block signature as replay-invalid

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { formatAssistantErrorText, isLikelyContextOverflowError } from "./errors.js";
+import {
+  classifyProviderRuntimeFailureKind,
+  formatAssistantErrorText,
+  isLikelyContextOverflowError,
+} from "./errors.js";
 
 const { toolPolicyAuditInfo } = vi.hoisted(() => ({
   toolPolicyAuditInfo: vi.fn(),
@@ -100,5 +104,20 @@ describe("isLikelyContextOverflowError", () => {
         "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
       ),
     ).toBe(true);
+  });
+});
+
+describe("classifyProviderRuntimeFailureKind replay-invalid", () => {
+  it("classifies Anthropic stale thinking-block signatures as replay_invalid", () => {
+    // Expired extended-thinking signatures must route to replay recovery
+    // (strip stale thinking blocks and retry), not a hard session failure.
+    expect(classifyProviderRuntimeFailureKind("Invalid signature in thinking block")).toBe(
+      "replay_invalid",
+    );
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "messages.3.content.0: Invalid signature in thinking block at index 0",
+      ),
+    ).toBe("replay_invalid");
   });
 });

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -353,7 +353,7 @@ const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
 const REPLAY_INVALID_RE =
-  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b|\binvalid signature\b.*?\bthinking block\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b|\bexec denied\s*\(/i;
 const NO_BODY_HTTP_WRAPPER_RE =


### PR DESCRIPTION
## Summary

Closes #88020.

When a session with extended thinking runs long enough that early thinking-block signatures expire, Anthropic rejects the next API call with `Invalid signature in thinking block`. `REPLAY_INVALID_RE` in `src/agents/embedded-agent-helpers/errors.ts` did not match that wording, so `classifyProviderRuntimeFailureKind` returned a non-replay kind and the session hard-failed instead of routing to replay recovery (strip the stale thinking blocks and retry).

Add an `\binvalid signature\b.*?\bthinking block\b` alternation to `REPLAY_INVALID_RE` so the message classifies as `replay_invalid` and the existing recovery path runs.

This is a generic product rule (matches the provider error class, not a hardcoded one-off string); the regex is intentionally scoped to the signature/thinking-block pairing to avoid false positives.

## Verification

- `pnpm test src/agents/embedded-agent-helpers/errors.test.ts` — 6 passed (incl. 2 new cases for the bare phrase and the `messages.N.content.M:` framed variant).

## Real behavior proof

Behavior addressed: Anthropic `Invalid signature in thinking block` now classifies as `replay_invalid` so the session recovers (strip stale thinking + retry) instead of hard-failing.
Real environment tested: Unit-level via the project test runner (Vitest) against `classifyProviderRuntimeFailureKind`; no paid live Anthropic call.
Exact steps or command run after this patch: `pnpm test src/agents/embedded-agent-helpers/errors.test.ts`
Evidence after fix: `Test Files 1 passed (1) / Tests 6 passed (6)`; new assertions `classifyProviderRuntimeFailureKind("Invalid signature in thinking block") === "replay_invalid"` and the framed-variant both pass.
Observed result after fix: classifier returns `replay_invalid` for the stale-signature message; prior behavior returned a non-replay kind (no recovery).
What was not tested: a full live long-session reproduction against the Anthropic API (would require an expired-signature session); the change is confined to the error-classification regex and is covered by the unit assertions.
