### PR TITLE
fix(ui): wire session switch into chat header session selector

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1894,7 +1894,7 @@ export function renderApp(state: AppViewState) {
             >
               <div>
                 ${isChat
-                  ? renderChatSessionSelect(state)
+                  ? renderChatSessionSelect(state, switchChatSession)
                   : html`<div class="page-title">${titleForTab(state.tab)}</div>`}
                 ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
               </div>


### PR DESCRIPTION
## Summary

The chat content-header rendered the conversation selector with `renderChatSessionSelect(state)` — no switch handler — so it used the no-op default (`session-controls.ts:56`). Clicking a conversation in the top-of-page selector did nothing, while the left sidebar (which calls the same component with a real handler) worked.

The sibling desktop/mobile call sites already pass the handler (`app-render.helpers.ts:269`, `:573`). This change passes `switchChatSession` at the header call site too, so selecting a conversation there switches the active chat, matching the left sidebar.

One line, no new import — `switchChatSession` is already imported and used throughout `app-render.ts`.

Fixes #87984

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts` → 60 passed (picker option click → switch behavior already covered there).
- Static: the two sibling call sites in `app-render.helpers.ts` pass `switchChatSession`; the header call site was the only one falling back to the no-op default.

## Real behavior proof

Behavior addressed: ControlUI top-of-page (content-header) conversation selector did not switch the active chat on click.
Real environment tested: jsdom unit suite for the session-select component; no live ControlUI session.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts`
Evidence after fix: Test Files 1 passed (1); Tests 60 passed (60).
Observed result after fix: existing session-select behavior coverage stays green with the header now wired to `switchChatSession`.
What was not tested: live ControlUI click-through (no running gateway/UI here); no `pnpm build`/full typecheck run (worktree without installed deps). The change adds an already-imported function as an argument, so build/module-boundary risk is nil.
