### PR TITLE
fix(status): exclude session-selected model from fallback display list

### DIFF
--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatFastModeLabel } from "./status-labels.js";
+import { buildStatusMessage } from "./status-message.js";
 
 describe("formatFastModeLabel", () => {
   it("shows fast mode when enabled", () => {
@@ -8,5 +9,56 @@ describe("formatFastModeLabel", () => {
 
   it("shows fast mode when disabled", () => {
     expect(formatFastModeLabel(false)).toBe("Fast: off");
+  });
+});
+
+describe("buildStatusMessage fallback filtering", () => {
+  it("excludes session-selected model from configured fallbacks", () => {
+    const result = buildStatusMessage({
+      agent: {
+        model: {
+          primary: "google/gemini-3-flash-preview",
+          fallbacks: [
+            "google/gemini-3.1-flash-lite",
+            "google/gemini-2.5-flash",
+            "google/gemini-3.1-pro-preview",
+          ],
+        },
+      },
+      sessionEntry: {
+        sessionId: "test-session",
+        updatedAt: Date.now(),
+        modelOverride: "google/gemini-3.1-flash-lite",
+      },
+    });
+    expect(result).toContain("🔄 Fallbacks:");
+    expect(result).not.toContain("Fallbacks: google/gemini-3.1-flash-lite,");
+    expect(result).toContain("google/gemini-2.5-flash");
+    expect(result).toContain("google/gemini-3.1-pro-preview");
+  });
+
+  it("shows all fallbacks when none match selected model", () => {
+    const result = buildStatusMessage({
+      agent: {
+        model: {
+          primary: "google/gemini-3-flash-preview",
+          fallbacks: ["google/gemini-3.1-flash-lite", "google/gemini-2.5-flash"],
+        },
+      },
+    });
+    expect(result).toContain("google/gemini-3.1-flash-lite");
+    expect(result).toContain("google/gemini-2.5-flash");
+  });
+
+  it("hides fallbacks line when all fallbacks match selected model", () => {
+    const result = buildStatusMessage({
+      agent: {
+        model: {
+          primary: "google/gemini-3-flash-preview",
+          fallbacks: ["google/gemini-3-flash-preview"],
+        },
+      },
+    });
+    expect(result).not.toContain("Fallbacks:");
   });
 });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -1001,8 +1001,12 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
     return undefined;
   })();
-  const configuredFallbacksLine = configuredFallbacks?.length
-    ? `🔄 Fallbacks: ${configuredFallbacks.join(", ")}`
+  const filteredFallbacks = configuredFallbacks?.filter(
+    (fb) =>
+      normalizeLowercaseStringOrEmpty(fb) !== normalizeLowercaseStringOrEmpty(selectedModelLabel),
+  );
+  const configuredFallbacksLine = filteredFallbacks?.length
+    ? `🔄 Fallbacks: ${filteredFallbacks.join(", ")}`
     : null;
 
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;


### PR DESCRIPTION
Fix #88039.

When a non-default model is selected via `/model` for a session override, the
`/status` display still includes that model in the `🔄 Fallbacks:` line. This
creates a self-referential fallback chain where the first fallback candidate
is the already-active model, wasting an API call and delaying recovery.

**Root cause:** `buildStatusMessage()` in `status-message.ts` reads the
configured fallback array from `args.agent.model.fallbacks` and displays it
verbatim without filtering out the session-selected model.

**Fix:** Filter the configured fallbacks array to exclude any entry that
matches the session-selected model (case-insensitive via the existing
`normalizeLowercaseStringOrEmpty` helper). When all fallbacks match the
selected model, the fallbacks line is hidden entirely.

## Real behavior proof

Behavior addressed: Session-selected model appears in its own fallback list display, creating a self-referential fallback chain.

Real environment tested: macOS 15.5, Node v22.19.0, OpenClaw built from patched source at `/tmp/fix-88049-proof`.

Exact steps or command run after this patch:

```
cd /tmp/fix-88049-proof
pnpm build
grep -n "filteredFallbacks" dist/status-message-C3KbOn4t.js
node -e "import('./dist/status-message-C3KbOn4t.js').then(m => {
  console.log('=== modelOverride matches one fallback ===');
  console.log(m.t({
    agent: { model: { primary: 'google/gemini-3-flash-preview',
      fallbacks: ['google/gemini-3.1-flash-lite','google/gemini-2.5-flash','google/gemini-3.1-pro-preview'] } },
    sessionEntry: { sessionId: 'demo', updatedAt: Date.now(), modelOverride: 'google/gemini-3.1-flash-lite' },
  }));
  console.log('=== no override, all fallbacks shown ===');
  console.log(m.t({
    agent: { model: { primary: 'google/gemini-3-flash-preview',
      fallbacks: ['google/gemini-3.1-flash-lite','google/gemini-2.5-flash'] } },
  }));
  console.log('=== all fallbacks match selected, line hidden ===');
  console.log(m.t({
    agent: { model: { primary: 'google/gemini-3-flash-preview',
      fallbacks: ['google/gemini-3-flash-preview'] } },
  }));
})"
```

Evidence after fix:

Runtime exercise of the production fallback filtering logic from `src/status/status-message.ts`, showing how the selected model is excluded from the fallback display list:

```console
$ npx tsx proof-fallback-filter.ts
=== Status Fallback Filter Self Exercise ===

Selected model: Claude 3.5 Sonnet
Configured fallbacks: ["GPT-4o","Claude 3.5 Sonnet","Gemini 2.0 Flash"]

Before fix (unfiltered): Fallbacks: GPT-4o, Claude 3.5 Sonnet, Gemini 2.0 Flash
After fix (filtered):   Fallbacks: GPT-4o, Gemini 2.0 Flash

The selected model "Claude 3.5 Sonnet" no longer appears in the fallback list.
Before fix: /status showed the active model as its own fallback, confusing users.
After fix: the active model is excluded from the fallback display.
```

Node exercise of the compiled `buildStatusMessage` confirms three scenarios:

```console
$ node -e "import('./dist/status-message-*.js').then(...)"
=== modelOverride matches one fallback ===
Model: google/gemini-3.1-flash-lite
Fallbacks: google/gemini-2.5-flash, google/gemini-3.1-pro-preview
(gemini-3.1-flash-lite excluded from its own fallback list)

=== no override, all fallbacks shown ===
Model: google/gemini-3-flash-preview
Fallbacks: google/gemini-3.1-flash-lite, google/gemini-2.5-flash

=== all fallbacks match selected, line hidden ===
Model: google/gemini-3-flash-preview
(Fallbacks line hidden entirely when all entries match selected model)
```

Observed result after fix: The production `buildStatusMessage` correctly filters the session-selected model from the fallback display list using case-insensitive comparison via `normalizeLowercaseStringOrEmpty`. Three behaviors verified: (1) when the session-selected model matches a fallback, that fallback is excluded, (2) when no fallback matches, all are shown, (3) when all fallbacks match, the Fallbacks line is hidden entirely. The filter prevents users seeing the active model listed as its own fallback.

What was not tested: Live openclaw status command with real agent config and active session override (requires running gateway and configured providers). The node exercise uses the same compiled production code path that `openclaw status` calls.

