### PR TITLE
test(doctor): preserve unresolved SecretRef diagnostics

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -97,7 +97,8 @@ vi.mock("../config/logging.js", () => ({
   logConfigUpdated: mocks.logConfigUpdated,
 }));
 
-vi.mock("../utils.js", () => ({
+vi.mock("../utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils.js")>()),
   shortenHomePath: mocks.shortenHomePath,
   isRecord: (value: unknown) =>
     typeof value === "object" && value !== null && !Array.isArray(value),
@@ -338,34 +339,7 @@ describe("doctor health contributions", () => {
     );
   });
 
-  it("does not probe gateway health for inline token auth", async () => {
-    const contribution = requireDoctorContribution("doctor:gateway-auth");
-    const ctx = {
-      cfg: {
-        gateway: {
-          mode: "local",
-          auth: {
-            mode: "token",
-            token: "inline-token",
-          },
-        },
-      },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: { nonInteractive: true },
-      env: {},
-      configResult: { cfg: {} },
-      cfgForPersistence: {},
-      configPath: "/tmp/fake-openclaw.json",
-    } as Parameters<(typeof contribution)["run"]>[0];
-
-    await contribution.run(ctx);
-
-    expect(mocks.callGateway).not.toHaveBeenCalled();
-  });
-
-  it("suppresses unresolved SecretRef token warning when the gateway is already healthy", async () => {
+  it("keeps unresolved SecretRef token warning even when fallback gateway token is present", async () => {
     const contribution = requireDoctorContribution("doctor:gateway-auth");
     const ctx = {
       cfg: {
@@ -390,7 +364,7 @@ describe("doctor health contributions", () => {
       prompter: buildDoctorPrompter(false),
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
-      env: {},
+      env: { OPENCLAW_GATEWAY_TOKEN: "fallback-token" },
       configResult: { cfg: {} },
       cfgForPersistence: {},
       configPath: "/tmp/fake-openclaw.json",
@@ -398,13 +372,8 @@ describe("doctor health contributions", () => {
 
     await contribution.run(ctx);
 
-    expect(mocks.callGateway).toHaveBeenCalledWith({
-      method: "status",
-      params: { includeChannelSummary: false },
-      timeoutMs: 3000,
-      config: ctx.cfg,
-    });
-    expect(mocks.note).not.toHaveBeenCalledWith(
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("Gateway token SecretRef could not be resolved"),
       "Gateway auth",
     );

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   applyWizardMetadata: vi.fn((cfg: unknown) => cfg),
   logConfigUpdated: vi.fn(),
   shortenHomePath: vi.fn((p: string) => p),
+  checkGatewayHealth: vi.fn(),
   formatCliCommand: vi.fn((cmd: string) => cmd),
 }));
 
@@ -39,6 +40,10 @@ vi.mock("../commands/doctor/shared/release-configured-plugin-installs.js", () =>
 
 vi.mock("./doctor-core-checks.js", () => ({
   registerCoreHealthChecks: mocks.registerCoreHealthChecks,
+  buildGatewayTokenSecretRefFixHint: vi.fn(() => "Fix the SecretRef."),
+  buildGatewayTokenSecretRefUnavailableMessage: vi.fn(
+    () => "Gateway token SecretRef could not be resolved.",
+  ),
 }));
 
 vi.mock("./bundled-health-checks.js", () => ({
@@ -85,6 +90,7 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("../commands/onboard-helpers.js", () => ({
   applyWizardMetadata: mocks.applyWizardMetadata,
+  randomToken: vi.fn(() => "generated-token"),
 }));
 
 vi.mock("../config/logging.js", () => ({
@@ -93,6 +99,12 @@ vi.mock("../config/logging.js", () => ({
 
 vi.mock("../utils.js", () => ({
   shortenHomePath: mocks.shortenHomePath,
+  isRecord: (value: unknown) =>
+    typeof value === "object" && value !== null && !Array.isArray(value),
+}));
+
+vi.mock("../commands/doctor-gateway-health.js", () => ({
+  checkGatewayHealth: mocks.checkGatewayHealth,
 }));
 
 vi.mock("../cli/command-format.js", () => ({
@@ -175,6 +187,8 @@ describe("doctor health contributions", () => {
       config: {},
       issues: [],
     });
+    mocks.checkGatewayHealth.mockReset();
+    mocks.checkGatewayHealth.mockResolvedValue({ healthOk: false });
   });
 
   afterEach(() => {
@@ -316,6 +330,72 @@ describe("doctor health contributions", () => {
     );
     expect(ids.indexOf("doctor:structured-health-repairs")).toBeLessThan(
       ids.indexOf("doctor:write-config"),
+    );
+  });
+
+  it("does not probe gateway health for inline token auth", async () => {
+    const contribution = requireDoctorContribution("doctor:gateway-auth");
+    const ctx = {
+      cfg: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: "inline-token",
+          },
+        },
+      },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: { nonInteractive: true },
+      env: {},
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.checkGatewayHealth).not.toHaveBeenCalled();
+  });
+
+  it("suppresses unresolved SecretRef token warning when the gateway is already healthy", async () => {
+    const contribution = requireDoctorContribution("doctor:gateway-auth");
+    mocks.checkGatewayHealth.mockResolvedValue({ healthOk: true });
+    const ctx = {
+      cfg: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "env",
+              provider: "default",
+              id: "MISSING_GATEWAY_TOKEN",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: { nonInteractive: true },
+      env: {},
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.checkGatewayHealth).toHaveBeenCalledWith({
+      runtime: ctx.runtime,
+      cfg: ctx.cfg,
+      timeoutMs: 3000,
+    });
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Gateway token SecretRef could not be resolved"),
+      "Gateway auth",
     );
   });
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -355,6 +355,9 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
       env: {},
+      configResult: { cfg: {} },
+      cfgForPersistence: {},
+      configPath: "/tmp/fake-openclaw.json",
     } as Parameters<(typeof contribution)["run"]>[0];
 
     await contribution.run(ctx);
@@ -388,6 +391,9 @@ describe("doctor health contributions", () => {
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
       env: {},
+      configResult: { cfg: {} },
+      cfgForPersistence: {},
+      configPath: "/tmp/fake-openclaw.json",
     } as Parameters<(typeof contribution)["run"]>[0];
 
     await contribution.run(ctx);

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   applyWizardMetadata: vi.fn((cfg: unknown) => cfg),
   logConfigUpdated: vi.fn(),
   shortenHomePath: vi.fn((p: string) => p),
-  checkGatewayHealth: vi.fn(),
+  callGateway: vi.fn(),
   formatCliCommand: vi.fn((cmd: string) => cmd),
 }));
 
@@ -103,8 +103,13 @@ vi.mock("../utils.js", () => ({
     typeof value === "object" && value !== null && !Array.isArray(value),
 }));
 
-vi.mock("../commands/doctor-gateway-health.js", () => ({
-  checkGatewayHealth: mocks.checkGatewayHealth,
+vi.mock("../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
+  buildGatewayConnectionDetails: vi.fn(() => ({
+    message: "Gateway connection",
+    url: "ws://127.0.0.1:18789",
+    urlSource: "config",
+  })),
 }));
 
 vi.mock("../cli/command-format.js", () => ({
@@ -187,8 +192,8 @@ describe("doctor health contributions", () => {
       config: {},
       issues: [],
     });
-    mocks.checkGatewayHealth.mockReset();
-    mocks.checkGatewayHealth.mockResolvedValue({ healthOk: false });
+    mocks.callGateway.mockReset();
+    mocks.callGateway.mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
@@ -354,12 +359,11 @@ describe("doctor health contributions", () => {
 
     await contribution.run(ctx);
 
-    expect(mocks.checkGatewayHealth).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
   });
 
   it("suppresses unresolved SecretRef token warning when the gateway is already healthy", async () => {
     const contribution = requireDoctorContribution("doctor:gateway-auth");
-    mocks.checkGatewayHealth.mockResolvedValue({ healthOk: true });
     const ctx = {
       cfg: {
         gateway: {
@@ -388,10 +392,11 @@ describe("doctor health contributions", () => {
 
     await contribution.run(ctx);
 
-    expect(mocks.checkGatewayHealth).toHaveBeenCalledWith({
-      runtime: ctx.runtime,
-      cfg: ctx.cfg,
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "status",
+      params: { includeChannelSummary: false },
       timeoutMs: 3000,
+      config: ctx.cfg,
     });
     expect(mocks.note).not.toHaveBeenCalledWith(
       expect.stringContaining("Gateway token SecretRef could not be resolved"),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -183,21 +183,6 @@ async function runAuthProfileHealth(ctx: DoctorHealthFlowContext): Promise<void>
   }
 }
 
-async function probeGatewayHealthForAuthWarning(ctx: DoctorHealthFlowContext): Promise<boolean> {
-  const { callGateway } = await import("../gateway/call.js");
-  try {
-    await callGateway({
-      method: "status",
-      params: { includeChannelSummary: false },
-      timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
-      config: ctx.cfg,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { resolveSecretInputRef } = await loadSecretTypesModule();
   const { buildGatewayTokenSecretRefFixHint, buildGatewayTokenSecretRefUnavailableMessage } =
@@ -206,7 +191,6 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
   const { resolveGatewayAuthToken } = await import("../gateway/auth-token-resolution.js");
   const { note } = await loadNoteModule();
   const { randomToken } = await loadOnboardHelpersModule();
-
   if (resolveDoctorMode(ctx.cfg) !== "local" || !ctx.sourceConfigValid) {
     return;
   }
@@ -264,12 +248,6 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     unresolvedRefReason = resolvedToken.unresolvedRefReason;
   }
   if (gatewayTokenRef) {
-    // Skip warning when gateway is confirmed healthy — the SecretRef resolves fine
-    // at Gateway runtime even if the CLI doctor cannot resolve it in audit mode.
-    const healthOk = ctx.healthOk ?? (await probeGatewayHealthForAuthWarning(ctx));
-    if (healthOk) {
-      return;
-    }
     const reason = buildGatewayTokenSecretRefUnavailableMessage({
       cfg: ctx.cfg,
       ref: gatewayTokenRef,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -191,6 +191,23 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
   const { resolveGatewayAuthToken } = await import("../gateway/auth-token-resolution.js");
   const { note } = await loadNoteModule();
   const { randomToken } = await loadOnboardHelpersModule();
+
+  // Probe gateway health inline so we know if it's healthy before deciding
+  // whether to warn about a SecretRef token. The contribution order runs
+  // doctor:gateway-auth before doctor:gateway-health, so ctx.healthOk is not
+  // yet populated. We only probe when we have a SecretRef to avoid adding
+  // latency for simple inline-token cases.
+  let healthOk = ctx.healthOk;
+  if (healthOk === undefined) {
+    const { checkGatewayHealth } = await import("../commands/doctor-gateway-health.js");
+    const probeResult = await checkGatewayHealth({
+      runtime: ctx.runtime,
+      cfg: ctx.cfg,
+      timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
+    });
+    healthOk = probeResult.healthOk;
+  }
+
   if (resolveDoctorMode(ctx.cfg) !== "local" || !ctx.sourceConfigValid) {
     return;
   }
@@ -248,6 +265,11 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     unresolvedRefReason = resolvedToken.unresolvedRefReason;
   }
   if (gatewayTokenRef) {
+    // Skip warning when gateway is confirmed healthy — the SecretRef resolves fine
+    // at Gateway runtime even if the CLI doctor cannot resolve it in audit mode.
+    if (healthOk === true) {
+      return;
+    }
     const reason = buildGatewayTokenSecretRefUnavailableMessage({
       cfg: ctx.cfg,
       ref: gatewayTokenRef,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -183,6 +183,21 @@ async function runAuthProfileHealth(ctx: DoctorHealthFlowContext): Promise<void>
   }
 }
 
+async function probeGatewayHealthForAuthWarning(ctx: DoctorHealthFlowContext): Promise<boolean> {
+  const { callGateway } = await import("../gateway/call.js");
+  try {
+    await callGateway({
+      method: "status",
+      params: { includeChannelSummary: false },
+      timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
+      config: ctx.cfg,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { resolveSecretInputRef } = await loadSecretTypesModule();
   const { buildGatewayTokenSecretRefFixHint, buildGatewayTokenSecretRefUnavailableMessage } =
@@ -251,16 +266,7 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
   if (gatewayTokenRef) {
     // Skip warning when gateway is confirmed healthy — the SecretRef resolves fine
     // at Gateway runtime even if the CLI doctor cannot resolve it in audit mode.
-    let healthOk = ctx.healthOk;
-    if (healthOk === undefined) {
-      const { checkGatewayHealth } = await import("../commands/doctor-gateway-health.js");
-      const probeResult = await checkGatewayHealth({
-        runtime: ctx.runtime,
-        cfg: ctx.cfg,
-        timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
-      });
-      healthOk = probeResult.healthOk;
-    }
+    const healthOk = ctx.healthOk ?? (await probeGatewayHealthForAuthWarning(ctx));
     if (healthOk === true) {
       return;
     }

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -267,7 +267,7 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     // Skip warning when gateway is confirmed healthy — the SecretRef resolves fine
     // at Gateway runtime even if the CLI doctor cannot resolve it in audit mode.
     const healthOk = ctx.healthOk ?? (await probeGatewayHealthForAuthWarning(ctx));
-    if (healthOk === true) {
+    if (healthOk) {
       return;
     }
     const reason = buildGatewayTokenSecretRefUnavailableMessage({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -192,22 +192,6 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
   const { note } = await loadNoteModule();
   const { randomToken } = await loadOnboardHelpersModule();
 
-  // Probe gateway health inline so we know if it's healthy before deciding
-  // whether to warn about a SecretRef token. The contribution order runs
-  // doctor:gateway-auth before doctor:gateway-health, so ctx.healthOk is not
-  // yet populated. We only probe when we have a SecretRef to avoid adding
-  // latency for simple inline-token cases.
-  let healthOk = ctx.healthOk;
-  if (healthOk === undefined) {
-    const { checkGatewayHealth } = await import("../commands/doctor-gateway-health.js");
-    const probeResult = await checkGatewayHealth({
-      runtime: ctx.runtime,
-      cfg: ctx.cfg,
-      timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
-    });
-    healthOk = probeResult.healthOk;
-  }
-
   if (resolveDoctorMode(ctx.cfg) !== "local" || !ctx.sourceConfigValid) {
     return;
   }
@@ -267,6 +251,16 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
   if (gatewayTokenRef) {
     // Skip warning when gateway is confirmed healthy — the SecretRef resolves fine
     // at Gateway runtime even if the CLI doctor cannot resolve it in audit mode.
+    let healthOk = ctx.healthOk;
+    if (healthOk === undefined) {
+      const { checkGatewayHealth } = await import("../commands/doctor-gateway-health.js");
+      const probeResult = await checkGatewayHealth({
+        runtime: ctx.runtime,
+        cfg: ctx.cfg,
+        timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
+      });
+      healthOk = probeResult.healthOk;
+    }
     if (healthOk === true) {
       return;
     }


### PR DESCRIPTION
## Summary

This PR is now a test-only doctor auth-policy guard.

It adds regression coverage proving that an unresolved configured `gateway.auth.token`
SecretRef still produces the doctor warning even when `OPENCLAW_GATEWAY_TOKEN` is
present as fallback auth.

No runtime behavior change remains in this branch. The earlier health-probe
suppression approach was backed out because suppressing a configured SecretRef
warning based on a generic gateway status call needs an explicit maintainer
auth-policy decision.

Fixes #88022 only for the fallback-masking regression guard. The positive
healthy-gateway suppression behavior remains a maintainer decision and should not
be added here without auth-policy approval.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Doctor's gateway auth path must not let fallback
  `OPENCLAW_GATEWAY_TOKEN` hide an unresolved configured `gateway.auth.token`
  SecretRef.
- Real environment tested: Local OpenClaw Linux/WSL source worktree on PR head
  `bcc85f6cfcb125dcad779c99d55d24a82d1c794a`, Node v24.15.0, repository
  `tsx` loader. Proof body refreshed 2026-05-31 02:24 UTC.
- Exact steps or command run after this patch:

```sh
cd /root/src/openclaw-pr-88054
node --import tsx /mnt/c/tmp/openclaw-88054-token-proof.ts
```

- Evidence after fix: terminal capture / copied live output from the command:

```text
{
  "secretRefConfigured": true,
  "unresolvedRefReason": "gateway.auth.token SecretRef is unresolved (env:default:MISSING_GATEWAY_TOKEN)."
}
```

- Observed result after fix: with `gateway.auth.token` configured as
  `env:default:MISSING_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_TOKEN` present in the
  process environment, the gateway auth resolver used by doctor reports the
  configured SecretRef as unresolved and does not return the fallback token.
- What was not tested: a live healthy-gateway SecretRef suppression path, because
  this PR intentionally does not implement that product behavior.
- Proof limitations or environment constraints: this branch is test-only. The
  live command above proves the existing auth-resolution behavior that the new
  doctor regression test protects; it does not prove a runtime suppression change.
- Before evidence (optional but encouraged): before this regression guard, the
  fallback-masking behavior could regress without focused doctor contribution
  coverage.

## Tests and validation

Commands run after the final test-only patch:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts --reporter=dot
./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/flows/doctor-health-contributions.test.ts
./node_modules/.bin/oxfmt --check src/flows/doctor-health-contributions.test.ts
git diff --check
bash /mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode branch
```

Validation result:

```text
src/flows/doctor-health-contributions.test.ts: 25 tests passed
oxlint: Found 0 warnings and 0 errors
oxfmt: All matched files use the correct format
git diff --check: passed
autoreview: clean, no accepted/actionable findings reported
```

## Boundary note

This PR adds no config key, plugin API, CLI flag, environment variable, migration,
Gateway auth behavior, or public/semi-public surface. It is test-only coverage for
the existing fail-closed SecretRef policy.