### PR TITLE
fix(agents): update session store with rotated session id after post-compaction transcript rotation

### DIFF
--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -1,0 +1,282 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSessionStore, type SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const state = vi.hoisted(() => ({
+  cfg: undefined as OpenClawConfig | undefined,
+  workspaceDir: undefined as string | undefined,
+  agentDir: undefined as string | undefined,
+  runAgentAttemptMock: vi.fn(),
+  deliveryFreshEntries: [] as Array<SessionEntry | undefined>,
+}));
+
+vi.mock("../config/io.js", () => ({
+  getRuntimeConfig: () => state.cfg,
+  readConfigFileSnapshotForWrite: async () => ({ snapshot: { valid: false } }),
+}));
+
+vi.mock("./agent-runtime-config.js", () => ({
+  resolveAgentRuntimeConfig: async () => ({
+    loadedRaw: state.cfg,
+    sourceConfig: state.cfg,
+    cfg: state.cfg,
+  }),
+}));
+
+vi.mock("./agent-scope.js", async () => {
+  const actual = await vi.importActual<typeof import("./agent-scope.js")>("./agent-scope.js");
+  return {
+    ...actual,
+    clearAutoFallbackPrimaryProbeSelection: vi.fn(),
+    entryMatchesAutoFallbackPrimaryProbe: () => false,
+    hasSessionAutoModelFallbackProvenance: () => false,
+    listAgentIds: () => ["main"],
+    markAutoFallbackPrimaryProbe: vi.fn(),
+    resolveAutoFallbackPrimaryProbe: () => undefined,
+    resolveAgentConfig: () => undefined,
+    resolveAgentDir: () => state.agentDir ?? "/tmp/openclaw-agent",
+    resolveDefaultAgentId: () => "main",
+    resolveEffectiveModelFallbacks: () => undefined,
+    resolveSessionAgentId: () => "main",
+    resolveAgentWorkspaceDir: () => state.workspaceDir ?? "/tmp/openclaw-workspace",
+  };
+});
+
+vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: () => ({ plugins: [] }),
+}));
+
+vi.mock("./model-catalog.js", () => ({
+  loadManifestModelCatalog: () => [],
+}));
+
+vi.mock("./harness/runtime-plugin.js", () => ({
+  ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+}));
+
+vi.mock("./workspace.js", () => ({
+  ensureAgentWorkspace: vi.fn(async () => undefined),
+}));
+
+vi.mock("./auth-profiles/store.js", async () => {
+  const actual = await vi.importActual<typeof import("./auth-profiles/store.js")>(
+    "./auth-profiles/store.js",
+  );
+  return {
+    ...actual,
+    ensureAuthProfileStore: () => ({ profiles: {} }),
+    saveAuthProfileStore: vi.fn(),
+    updateAuthProfileStoreWithLock: vi.fn(async () => ({ profiles: {} })),
+  };
+});
+
+vi.mock("../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    resolveSession: () => null,
+  }),
+}));
+
+vi.mock("../skills/runtime/remote.js", () => ({
+  getRemoteSkillEligibility: () => ({ enabled: false, reason: "test" }),
+}));
+
+vi.mock("../skills/runtime/session-snapshot.js", () => ({
+  resolveReusableWorkspaceSkillSnapshot: () => ({
+    shouldRefresh: true,
+    snapshot: {
+      prompt: "",
+      skills: [],
+      resolvedSkills: [],
+      version: 0,
+    },
+  }),
+}));
+
+vi.mock("./exec-defaults.js", () => ({
+  canExecRequestNode: () => false,
+}));
+
+vi.mock("./model-fallback.js", () => ({
+  runWithModelFallback: async (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => ({
+    result: await params.run(params.provider, params.model),
+    provider: params.provider,
+    model: params.model,
+    attempts: [],
+  }),
+}));
+
+vi.mock("./command/attempt-execution.runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("./command/attempt-execution.runtime.js")>(
+    "./command/attempt-execution.runtime.js",
+  );
+  return {
+    ...actual,
+    runAgentAttempt: (...args: unknown[]) => state.runAgentAttemptMock(...args),
+  };
+});
+
+vi.mock("./command/cli-compaction.js", () => ({
+  runCliTurnCompactionLifecycle: async (params: { sessionEntry?: SessionEntry }) =>
+    params.sessionEntry,
+}));
+
+vi.mock("./command/delivery.runtime.js", () => ({
+  deliverAgentCommandResult: async (params: {
+    resolveFreshSessionEntryForDelivery?: () => Promise<SessionEntry | undefined>;
+  }) => {
+    state.deliveryFreshEntries.push(await params.resolveFreshSessionEntryForDelivery?.());
+    return { deliverySucceeded: true };
+  },
+}));
+
+let agentCommand: typeof import("./agent-command.js").agentCommand;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  state.deliveryFreshEntries = [];
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rotation-e2e-"));
+  state.workspaceDir = path.join(tmpDir, "workspace");
+  state.agentDir = path.join(tmpDir, "agent");
+  await fs.mkdir(state.workspaceDir, { recursive: true });
+  await fs.mkdir(state.agentDir, { recursive: true });
+  state.cfg = {
+    session: {
+      store: path.join(tmpDir, "sessions.json"),
+    },
+    agents: {
+      defaults: {
+        models: {
+          "openai/gpt-5.5": {},
+        },
+      },
+    },
+  } as OpenClawConfig;
+  agentCommand ??= (await import("./agent-command.js")).agentCommand;
+});
+
+afterEach(async () => {
+  const storePath = state.cfg?.session?.store;
+  state.cfg = undefined;
+  state.workspaceDir = undefined;
+  state.agentDir = undefined;
+  if (storePath) {
+    await fs.rm(path.dirname(storePath), { recursive: true, force: true });
+  }
+});
+
+function makeResult(params: {
+  sessionId: string;
+  sessionFile?: string;
+  text: string;
+  compactionCount?: number;
+}) {
+  return {
+    payloads: [{ text: params.text }],
+    meta: {
+      durationMs: 1,
+      stopReason: "end_turn",
+      executionTrace: {
+        runner: "embedded",
+        fallbackUsed: false,
+        winnerProvider: "openai",
+        winnerModel: "gpt-5.5",
+      },
+      finalAssistantVisibleText: params.text,
+      agentMeta: {
+        sessionId: params.sessionId,
+        ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
+        provider: "openai",
+        model: "gpt-5.5",
+        ...(params.compactionCount ? { compactionCount: params.compactionCount } : {}),
+      },
+    },
+  };
+}
+
+async function readSessionMessages(sessionFile: string) {
+  const raw = await fs.readFile(sessionFile, "utf-8");
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { type?: string; message?: { role?: string } })
+    .filter((entry) => entry.type === "message")
+    .map((entry) => entry.message);
+}
+
+describe("agentCommand compaction transcript rotation", () => {
+  it("keeps sessions.json on the rotated successor and resumes the next turn from it", async () => {
+    const storePath = state.cfg?.session?.store;
+    if (!storePath) {
+      throw new Error("missing test session store path");
+    }
+    const sessionsDir = await fs.realpath(path.dirname(storePath));
+    const rotatedSessionFile = path.join(sessionsDir, "rotated-session.jsonl");
+    state.runAgentAttemptMock
+      .mockResolvedValueOnce(
+        makeResult({
+          sessionId: "rotated-session",
+          sessionFile: rotatedSessionFile,
+          text: "first answer after rotation",
+          compactionCount: 1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResult({
+          sessionId: "rotated-session",
+          text: "second answer",
+        }),
+      );
+
+    await agentCommand({
+      message: "first prompt",
+      sessionId: "old-session",
+      cwd: state.workspaceDir,
+    });
+
+    const storeAfterRotation = loadSessionStore(storePath, { skipCache: true });
+    const entriesAfterRotation = Object.entries(storeAfterRotation);
+    expect(entriesAfterRotation).toHaveLength(1);
+    const [sessionKey, rotatedEntry] = entriesAfterRotation[0] ?? [];
+    expect(sessionKey).toBe("agent:main:explicit:old-session");
+    expect(rotatedEntry).toMatchObject({
+      sessionId: "rotated-session",
+      sessionFile: rotatedSessionFile,
+      usageFamilyKey: "agent:main:explicit:old-session",
+      usageFamilySessionIds: ["old-session", "rotated-session"],
+      compactionCount: 1,
+    });
+    await expect(readSessionMessages(rotatedSessionFile)).resolves.toEqual([
+      expect.objectContaining({ role: "assistant" }),
+    ]);
+
+    await agentCommand({
+      message: "second prompt",
+      sessionId: "rotated-session",
+      cwd: state.workspaceDir,
+    });
+
+    const secondAttempt = state.runAgentAttemptMock.mock.calls[1]?.[0] as
+      | { sessionId?: string; sessionFile?: string; sessionKey?: string }
+      | undefined;
+    expect(secondAttempt).toMatchObject({
+      sessionId: "rotated-session",
+      sessionKey,
+      sessionFile: rotatedSessionFile,
+    });
+    expect(state.deliveryFreshEntries.at(-1)).toMatchObject({
+      sessionId: "rotated-session",
+      sessionFile: rotatedSessionFile,
+    });
+    expect(loadSessionStore(storePath, { skipCache: true })[sessionKey ?? ""]).toMatchObject({
+      sessionId: "rotated-session",
+      sessionFile: rotatedSessionFile,
+    });
+  });
+});

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -20,7 +20,9 @@ const state = vi.hoisted(() => ({
   acpRunTurnMock: vi.fn((..._args: unknown[]): unknown => undefined),
   buildAcpResultMock: vi.fn(),
   createAcpVisibleTextAccumulatorMock: vi.fn(),
+  persistCliTurnTranscriptMock: vi.fn(),
   persistAcpTurnTranscriptMock: vi.fn(),
+  runCliTurnCompactionLifecycleMock: vi.fn(),
   resolveAcpAgentPolicyErrorMock: vi.fn(),
   resolveAcpDispatchPolicyErrorMock: vi.fn(),
   resolveAcpExplicitTurnPolicyErrorMock: vi.fn(),
@@ -68,6 +70,7 @@ vi.mock("./command/attempt-execution.runtime.js", () => ({
   emitAcpLifecycleError: vi.fn(),
   emitAcpLifecycleStart: vi.fn(),
   emitAcpRuntimeEvent: vi.fn(),
+  persistCliTurnTranscript: (...args: unknown[]) => state.persistCliTurnTranscriptMock(...args),
   persistAcpTurnTranscript: (...args: unknown[]) => state.persistAcpTurnTranscriptMock(...args),
   persistSessionEntry: vi.fn(),
   prependInternalEventContext: (body: string) => body,
@@ -87,6 +90,11 @@ vi.mock("./command/attempt-execution.shared.js", async () => {
 
 vi.mock("./command/delivery.runtime.js", () => ({
   deliverAgentCommandResult: (...args: unknown[]) => state.deliverAgentCommandResultMock(...args),
+}));
+
+vi.mock("./command/cli-compaction.js", () => ({
+  runCliTurnCompactionLifecycle: (...args: unknown[]) =>
+    state.runCliTurnCompactionLifecycleMock(...args),
 }));
 
 vi.mock("./command/run-context.js", () => ({
@@ -824,7 +832,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       payloads: params.payloadText ? [{ text: params.payloadText }] : [],
       meta: { durationMs: 0, stopReason: "end_turn" },
     }));
+    state.persistCliTurnTranscriptMock.mockImplementation(
+      async (params: { sessionEntry?: unknown }) => params.sessionEntry,
+    );
     state.persistAcpTurnTranscriptMock.mockImplementation(
+      async (params: { sessionEntry?: unknown }) => params.sessionEntry,
+    );
+    state.runCliTurnCompactionLifecycleMock.mockImplementation(
       async (params: { sessionEntry?: unknown }) => params.sessionEntry,
     );
     state.authProfileStoreMock = { profiles: {} };
@@ -950,6 +964,81 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
     expect(state.persistSessionEntryMock).not.toHaveBeenCalled();
     expect(state.updateSessionStoreAfterAgentRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses rotated session identity for all post-run session persistence", async () => {
+    setupSingleAttemptFallback();
+    setupSessionTouchStore();
+    const rotatedEntry: SessionEntry = {
+      sessionId: "rotated-session",
+      sessionFile: "/tmp/rotated-session.jsonl",
+      updatedAt: 2,
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
+      typeof makeSuccessResult
+    > & {
+      meta: Record<string, unknown> & { agentMeta: Record<string, unknown> };
+    };
+    result.meta.executionTrace = {
+      runner: "embedded",
+      fallbackUsed: false,
+      winnerProvider: "openai",
+      winnerModel: "gpt-5.4",
+    };
+    result.meta.finalAssistantVisibleText = "ok";
+    result.meta.agentMeta = {
+      ...result.meta.agentMeta,
+      sessionId: "rotated-session",
+      sessionFile: "/tmp/rotated-session.jsonl",
+    };
+    state.runAgentAttemptMock.mockResolvedValue(result);
+    state.updateSessionStoreAfterAgentRunMock.mockImplementation(async () => {
+      state.sessionStoreMock = { "agent:main:main": rotatedEntry };
+    });
+    state.persistCliTurnTranscriptMock.mockResolvedValue(rotatedEntry);
+    state.runCliTurnCompactionLifecycleMock.mockResolvedValue(rotatedEntry);
+
+    await runBasicAgentCommand();
+
+    expectRecordFields(mockCallArg(state.updateSessionStoreAfterAgentRunMock), {
+      sessionId: "rotated-session",
+    });
+    expectRecordFields(mockCallArg(state.persistCliTurnTranscriptMock), {
+      sessionId: "rotated-session",
+      sessionKey: "agent:main:main",
+    });
+    expectRecordFields(mockCallArg(state.runCliTurnCompactionLifecycleMock), {
+      sessionId: "rotated-session",
+      sessionKey: "agent:main:main",
+    });
+    expectRecordFields(mockCallArg(state.deliverAgentCommandResultMock), {
+      expectedSessionIdForFreshDelivery: "rotated-session",
+    });
+  });
+
+  it("does not treat backend CLI session id as OpenClaw session identity", async () => {
+    setupSingleAttemptFallback();
+    setupSessionTouchStore();
+    const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
+      typeof makeSuccessResult
+    > & {
+      meta: Record<string, unknown> & { agentMeta: Record<string, unknown> };
+    };
+    result.meta.agentMeta = {
+      ...result.meta.agentMeta,
+      sessionId: "backend-cli-session",
+    };
+    state.runAgentAttemptMock.mockResolvedValue(result);
+
+    await runBasicAgentCommand();
+
+    expectRecordFields(mockCallArg(state.updateSessionStoreAfterAgentRunMock), {
+      sessionId: "session-1",
+    });
+    expectRecordFields(mockCallArg(state.deliverAgentCommandResultMock), {
+      expectedSessionIdForFreshDelivery: "session-1",
+    });
   });
 
   it("persists explicit overrides even when ingress skips the initial touch", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1575,13 +1575,19 @@ async function agentCommandInternal(
     try {
       await fallbackTrajectoryRecorder?.flush();
 
+      const rotatedSessionFile = result.meta.agentMeta?.sessionFile;
+      const effectiveSessionId = rotatedSessionFile
+        ? (result.meta.agentMeta?.sessionId ?? sessionId)
+        : sessionId;
+      const effectiveSessionFile = rotatedSessionFile ?? attemptSessionFile;
+
       // Update token+model fields in the session store.
       if (sessionStore && sessionKey && !suppressVisibleSessionEffects) {
         const { updateSessionStoreAfterAgentRun } = await loadSessionStoreRuntime();
         await updateSessionStoreAfterAgentRun({
           cfg,
           contextTokensOverride: agentCfg?.contextTokens,
-          sessionId,
+          sessionId: effectiveSessionId,
           sessionKey,
           storePath,
           sessionStore,
@@ -1612,20 +1618,20 @@ async function agentCommandInternal(
           const transcriptSessionEntry: SessionEntry | undefined = suppressVisibleSessionEffects
             ? {
                 ...(sessionEntry ?? {
-                  sessionId,
+                  sessionId: effectiveSessionId,
                   updatedAt: Date.now(),
                   sessionStartedAt: Date.now(),
                 }),
-                sessionId,
-                sessionFile: attemptSessionFile,
+                sessionId: effectiveSessionId,
+                sessionFile: effectiveSessionFile,
               }
             : sessionEntry;
           sessionEntry = await attemptExecutionRuntime.persistCliTurnTranscript({
             body,
             transcriptBody,
             result,
-            sessionId,
-            sessionKey: sessionKey ?? sessionId,
+            sessionId: effectiveSessionId,
+            sessionKey: sessionKey ?? effectiveSessionId,
             sessionEntry: transcriptSessionEntry,
             sessionStore: suppressVisibleSessionEffects ? undefined : sessionStore,
             storePath: suppressVisibleSessionEffects ? undefined : storePath,
@@ -1649,8 +1655,8 @@ async function agentCommandInternal(
             await loadCliCompactionRuntime()
           ).runCliTurnCompactionLifecycle({
             cfg,
-            sessionId,
-            sessionKey: sessionKey ?? sessionId,
+            sessionId: effectiveSessionId,
+            sessionKey: sessionKey ?? effectiveSessionId,
             sessionEntry,
             sessionStore,
             storePath,
@@ -1721,7 +1727,7 @@ async function agentCommandInternal(
                 clone: false,
               });
               const freshEntry = freshStore[sessionKey];
-              if (!freshEntry || freshEntry.sessionId !== sessionId) {
+              if (!freshEntry || freshEntry.sessionId !== effectiveSessionId) {
                 return undefined;
               }
               sessionStore[sessionKey] = freshEntry;
@@ -1742,7 +1748,7 @@ async function agentCommandInternal(
         resolveFreshSessionEntryForDelivery
           ? {
               ...deliveryParams,
-              expectedSessionIdForFreshDelivery: sessionId,
+              expectedSessionIdForFreshDelivery: effectiveSessionId,
               resolveFreshSessionEntryForDelivery,
             }
           : deliveryParams,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -270,6 +270,55 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("persists rotated compaction session identity and transcript file", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-rotated-session";
+      const sessionId = "test-rotated-session-old";
+      const rotatedSessionId = "test-rotated-session-new";
+      const rotatedSessionFile = path.join(path.dirname(storePath), "rotated-session.jsonl");
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          sessionFile: path.join(path.dirname(storePath), "old-session.jsonl"),
+          updatedAt: 1,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId: rotatedSessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+        result: {
+          meta: {
+            durationMs: 1,
+            agentMeta: {
+              sessionId: rotatedSessionId,
+              sessionFile: rotatedSessionFile,
+              provider: "openai",
+              model: "gpt-5.5",
+              compactionCount: 1,
+            },
+          },
+        },
+      });
+
+      expect(sessionStore[sessionKey]).toMatchObject({
+        sessionId: rotatedSessionId,
+        sessionFile: rotatedSessionFile,
+        usageFamilyKey: sessionKey,
+        usageFamilySessionIds: [sessionId, rotatedSessionId],
+        compactionCount: 1,
+      });
+      expect(sessionStore[sessionKey]?.sessionStartedAt).toBeGreaterThan(1);
+    });
+  });
+
   it("uses the runtime context budget from agent metadata instead of cold fallback", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;
@@ -415,6 +464,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toEqual({
         sessionId: "cli-session-123",
       });
+      expect(sessionStore[sessionKey]?.sessionId).toBe(sessionId);
       expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe("cli-session-123");
       expect(sessionStore[sessionKey]?.claudeCliSessionId).toBe("cli-session-123");
 
@@ -422,6 +472,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toEqual({
         sessionId: "cli-session-123",
       });
+      expect(persisted[sessionKey]?.sessionId).toBe(sessionId);
       expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe("cli-session-123");
       expect(persisted[sessionKey]?.claudeCliSessionId).toBe("cli-session-123");
     });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -102,6 +102,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
+  const activeSessionFile = normalizeOptionalString(result.meta.agentMeta?.sessionFile);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
   const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;
   const contextTokens =
@@ -136,6 +137,22 @@ export async function updateSessionStoreAfterAgentRun(params: {
           contextTokens,
         }),
   };
+  if (entry.sessionId !== sessionId) {
+    next.sessionFile =
+      activeSessionFile ??
+      resolveCompactionSessionFile({
+        entry,
+        sessionKey,
+        storePath,
+        newSessionId: sessionId,
+      });
+    next.usageFamilyKey = entry.usageFamilyKey ?? sessionKey;
+    next.usageFamilySessionIds = Array.from(
+      new Set([...(entry.usageFamilySessionIds ?? []), entry.sessionId, sessionId]),
+    );
+  } else if (activeSessionFile) {
+    next.sessionFile = activeSessionFile;
+  }
   if (preserveRuntimeModel) {
     // Keep the pre-existing runtime model and context window so a background
     // heartbeat turn using a different model does not bleed into the main


### PR DESCRIPTION
## Summary

When `truncateAfterCompaction: true` rotates an OpenClaw transcript during an agent run, the embedded runner reports the new OpenClaw session ID and transcript file in `result.meta.agentMeta.sessionId/sessionFile`. The previous patch updated only the first session-store write, leaving later transcript persistence, CLI compaction lifecycle, and delivery freshness checks on the old pre-rotation session ID.

This change carries one effective rotated OpenClaw session identity through the full post-run path, persists the rotated transcript file/family metadata, and keeps backend CLI session IDs in their existing CLI binding fields instead of treating them as OpenClaw session IDs.

Closes #88040

## Change Type

- [x] Bug fix

## Scope

- [x] Agents / session store

## Real behavior proof

Behavior addressed: automatic compaction transcript rotation no longer leaves post-run session persistence on the stale pre-rotation OpenClaw session ID.

Real environment tested: local OpenClaw checkout on macOS; branch rebased onto `origin/main` at `07870dff45`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/agent-command.compaction-rotation.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/command/session-store.test.ts`

Evidence after fix: 6 Vitest project-files passed, 128 tests passed. The new regression runs two `agentCommand` turns through real session resolution, `sessions.json`, and transcript persistence: the first turn simulates automatic rotation to a successor transcript, then the second turn resumes by the rotated session ID and verifies it uses the rotated transcript file.

Observed result after fix: post-run store update, transcript persistence, CLI compaction lifecycle, and delivery freshness all receive the rotated OpenClaw session ID only when a rotated `sessionFile` is reported; backend CLI session IDs remain CLI bindings.

What was not tested: no live model/provider compaction run. `pnpm check:changed` was attempted through Blacksmith Testbox `tbx_01kstjya6zkexr2xqpv0mfth91`, but current `origin/main` failed core-test typecheck in unrelated `src/config/sessions.cache.test.ts` lines 743, 772, 791, and 796.

Autoreview: `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` on the added regression reported no accepted/actionable findings. Earlier branch review of the implementation also reported no accepted/actionable findings.
