### PR TITLE
docs: fix accuracy drift across docs (config defaults, model aliases, anchors, terminology)

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -325,7 +325,7 @@ A sweeper runs every **60 seconds** and handles four things:
     Closes terminal or orphaned parent-owned one-shot ACP sessions, and closes stale terminal or orphaned persistent ACP sessions only when no active conversation binding remains.
   </Step>
   <Step title="Cleanup stamping">
-    Sets a `cleanupAfter` timestamp on terminal tasks (endedAt + 7 days). During retention, lost tasks still appear in audit as warnings; after `cleanupAfter` expires or when cleanup metadata is missing, they are errors.
+    Sets a `cleanupAfter` timestamp on terminal tasks (endedAt + 7 days; `lost` tasks use a shorter 1-day retention). During retention, lost tasks still appear in audit as warnings; after `cleanupAfter` expires or when cleanup metadata is missing, they are errors.
   </Step>
   <Step title="Pruning">
     Deletes records past their `cleanupAfter` date.
@@ -333,7 +333,7 @@ A sweeper runs every **60 seconds** and handles four things:
 </Steps>
 
 <Note>
-**Retention:** terminal task records are kept for **7 days**, then automatically pruned. No configuration needed.
+**Retention:** terminal task records are kept for **7 days** (`lost` tasks for **1 day**), then automatically pruned. No configuration needed.
 </Note>
 
 ## How tasks relate to other systems

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -266,7 +266,7 @@ per account.
 
 ### Message limits
 
-- `textChunkLimit` - outbound text chunk size (default: `2000` chars)
+- `textChunkLimit` - outbound text chunk size (default: `4000` chars)
 - `mediaMaxMb` - media upload/download limit (default: `30` MB)
 
 ### Streaming
@@ -578,7 +578,7 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 | `channels.feishu.dynamicAgentCreation.workspaceTemplate` | Path template for dynamic agent workspaces                                       | `~/.openclaw/workspace-{agentId}`    |
 | `channels.feishu.dynamicAgentCreation.agentDirTemplate`  | Agent directory name template                                                    | `~/.openclaw/agents/{agentId}/agent` |
 | `channels.feishu.dynamicAgentCreation.maxAgents`         | Maximum number of dynamic agents to create                                       | unlimited                            |
-| `channels.feishu.textChunkLimit`                         | Message chunk size                                                               | `2000`                               |
+| `channels.feishu.textChunkLimit`                         | Message chunk size                                                               | `4000`                               |
 | `channels.feishu.mediaMaxMb`                             | Media size limit                                                                 | `30`                                 |
 | `channels.feishu.streaming`                              | Streaming card output                                                            | `true`                               |
 | `channels.feishu.blockStreaming`                         | Completed-block reply streaming                                                  | `false`                              |

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -617,6 +617,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `off` (default)
     - `first`
     - `all`
+    - `batched`
 
     When reply threading is enabled and the original Telegram text or caption is available, OpenClaw includes a native Telegram quote excerpt automatically. Telegram caps native quote text at 1024 UTF-16 code units, so longer messages are quoted from the start and fall back to a plain reply if Telegram rejects the quote.
 

--- a/docs/channels/tlon.md
+++ b/docs/channels/tlon.md
@@ -10,7 +10,7 @@ respond to DMs and group chat messages. Group replies require an @ mention by de
 be further restricted via allowlists.
 
 Status: bundled plugin. DMs, group mentions, thread replies, rich text formatting, and
-image uploads are supported. Reactions and polls are not yet supported.
+image uploads are supported. Reactions are available via a bundled skill; polls are not yet supported.
 
 ## Bundled plugin
 

--- a/docs/channels/zalouser.md
+++ b/docs/channels/zalouser.md
@@ -92,8 +92,8 @@ Approve via:
 
 ## Group access (optional)
 
-- Default: `channels.zalouser.groupPolicy = "open"` (groups allowed). Use `channels.defaults.groupPolicy` to override the default when unset.
-- Restrict to an allowlist with:
+- Default: `channels.zalouser.groupPolicy = "allowlist"` (groups are blocked unless explicitly allowlisted; fail-closed). Set `channels.zalouser.groupPolicy = "open"` to allow all groups.
+- Configure the allowlist with:
   - `channels.zalouser.groupPolicy = "allowlist"`
   - `channels.zalouser.groups` (keys should be stable group IDs; names are resolved to IDs on startup only when `channels.zalouser.dangerouslyAllowNameMatching: true` is enabled)
   - `channels.zalouser.groupAllowFrom` (controls which senders in allowed groups can trigger the bot; static sender access groups can be referenced with `accessGroup:<name>`)

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -35,7 +35,7 @@ openclaw agents delete work
 
 Use routing bindings to pin inbound channel traffic to a specific agent.
 
-If you also want different visible skills per agent, configure `agents.defaults.skills` and `agents.list[].skills` in `openclaw.json`. See [Skills config](/tools/skills-config) and [Configuration reference](/gateway/config-agents#agents-defaults-skills).
+If you also want different visible skills per agent, configure `agents.defaults.skills` and `agents.list[].skills` in `openclaw.json`. See [Skills config](/tools/skills-config) and [Configuration reference](/gateway/config-agents#agentsdefaultsskills).
 
 List bindings:
 

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -126,7 +126,7 @@ openclaw channels capabilities --channel discord --target channel:123
 
 Notes:
 
-- `--channel` is optional; omit it to list every channel (including extensions).
+- `--channel` is optional; omit it to list every channel (including plugins).
 - `--account` is only valid with `--channel`.
 - `--target` accepts `channel:<id>` or a raw numeric channel id and only applies to Discord. For Discord voice channels, the permission check flags missing `ViewChannel`, `Connect`, `Speak`, `SendMessages`, and `ReadMessageHistory`.
 - Probes are provider-specific: Discord intents + optional channel permissions; Slack bot + user scopes; Telegram bot flags + webhook; Signal daemon version; Microsoft Teams app token + Graph roles/scopes (annotated where known). Channels without probes report `Probe: unavailable`.

--- a/docs/concepts/agent-runtimes.md
+++ b/docs/concepts/agent-runtimes.md
@@ -207,7 +207,7 @@ If `openclaw doctor` warns that the `codex` plugin is enabled while
 
 ## GitHub Copilot agent runtime
 
-The bundled `copilot` extension registers an opt-in `copilot` runtime
+The bundled `copilot` plugin registers an opt-in `copilot` runtime
 backed by the GitHub Copilot CLI (`@github/copilot-sdk`). It claims the
 canonical subscription `github-copilot` provider and is **never** selected by
 `auto`. Opt in per-model or per-provider via `agentRuntime.id`:

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -202,12 +202,11 @@ When a profile fails due to auth/rate-limit errors (or a timeout that looks like
   </Accordion>
 </AccordionGroup>
 
-Cooldowns use exponential backoff:
+Cooldowns use a stepped backoff based on consecutive error count:
 
+- 30 seconds
 - 1 minute
-- 5 minutes
-- 25 minutes
-- 1 hour (cap)
+- 5 minutes (cap)
 
 State is stored in `auth-state.json` under `usageStats`:
 

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -184,7 +184,7 @@ Example (session override):
 
 How to see what profile IDs exist:
 
-- `openclaw channels list --json` (shows `auth[]`)
+- `openclaw models auth list --json`
 
 Related docs:
 

--- a/docs/concepts/typebox.md
+++ b/docs/concepts/typebox.md
@@ -59,7 +59,7 @@ Authoritative advertised **discovery** inventory lives in
 - Server handshake + method dispatch: `src/gateway/server.impl.ts`
 - Node client: `src/gateway/client.ts`
 - Generated JSON Schema: `dist/protocol.schema.json`
-- Generated Swift models: `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift`
+- Generated Swift models: `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`
 
 ## Current pipeline
 

--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -24,7 +24,6 @@ title: "Usage tracking"
 - `/usage off|tokens|full` in chats: per-response usage footer (OAuth shows tokens only).
 - `/usage cost` in chats: local cost summary aggregated from OpenClaw session logs.
 - CLI: `openclaw status --usage` prints a full per-provider breakdown.
-- CLI: `openclaw channels list` prints the same usage snapshot alongside provider config (use `--no-usage` to skip).
 - macOS menu bar: "Usage" section under Context (only if available).
 
 ## Providers + credentials

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -315,8 +315,8 @@ The bundled Anthropic plugin registers a default for `claude-cli`:
 The bundled Google plugin also registers a default for `google-gemini-cli`:
 
 - `command: "gemini"`
-- `args: ["--output-format", "json", "--prompt", "{prompt}"]`
-- `resumeArgs: ["--resume", "{sessionId}", "--output-format", "json", "--prompt", "{prompt}"]`
+- `args: ["--skip-trust", "--output-format", "json", "--prompt", "{prompt}"]`
+- `resumeArgs: ["--skip-trust", "--resume", "{sessionId}", "--output-format", "json", "--prompt", "{prompt}"]`
 - `imageArg: "@"`
 - `imagePathScope: "workspace"`
 - `modelArg: "--model"`

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -508,9 +508,9 @@ Time format in system prompt. Default: `auto` (OS preference).
 
 | Alias               | Model                           |
 | ------------------- | ------------------------------- |
-| `opus`              | `anthropic/claude-opus-4-6`     |
+| `opus`              | `anthropic/claude-opus-4-8`     |
 | `sonnet`            | `anthropic/claude-sonnet-4-6`   |
-| `gpt`               | `openai/gpt-5.5`                |
+| `gpt`               | `openai/gpt-5.4`                |
 | `gpt-mini`          | `openai/gpt-5.4-mini`           |
 | `gpt-nano`          | `openai/gpt-5.4-nano`           |
 | `gemini`            | `google/gemini-3.1-pro-preview` |

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -234,7 +234,7 @@ candidate contains redacted secret placeholders such as `***`.
     - Omit `agents.list[].skills` to inherit the defaults.
     - Set `agents.list[].skills: []` for no skills.
     - See [Skills](/tools/skills), [Skills config](/tools/skills-config), and
-      the [Configuration Reference](/gateway/config-agents#agents-defaults-skills).
+      the [Configuration Reference](/gateway/config-agents#agentsdefaultsskills).
 
   </Accordion>
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -252,7 +252,7 @@ Defaults when omitted:
 - `maxBodyBytes`: 20MB
 - `maxUrlParts`: 8
 - `files.maxBytes`: 5MB
-- `files.maxChars`: 200k
+- `files.maxChars`: 60k
 - `files.maxRedirects`: 3
 - `files.timeoutMs`: 10s
 - `files.pdf.maxPages`: 4

--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -118,7 +118,6 @@ Gateway HTTP also applies a hard deny list by default (even if session policy al
 - `cron` - persistent automation control plane
 - `gateway` - gateway control plane; prevents reconfiguration via HTTP
 - `nodes` - node command relay can reach system.run on paired hosts
-- `whatsapp_login` - interactive setup requiring terminal QR scan; hangs on HTTP
 
 You can customize this deny list via `gateway.tools`:
 

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -313,7 +313,7 @@ Use one TLS termination point and apply HSTS there.
 
 OpenClaw rejects ambiguous configurations where both a `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`) and `trusted-proxy` mode are active at the same time. Mixed token configs can cause loopback requests to silently authenticate on the wrong auth path.
 
-If you see a `mixed_trusted_proxy_token` error on startup:
+If the gateway refuses to start because both a shared token and trusted-proxy mode are configured:
 
 - Remove the shared token when using trusted-proxy mode, or
 - Switch `gateway.auth.mode` to `"token"` if you intend token-based auth.

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -290,12 +290,12 @@ OPENCLAW_RAW_STREAM=1
 Optional path:
 
 ```bash
-OPENCLAW_RAW_STREAM_PATH=~/.openclaw/logs/raw-openai-completions.jsonl
+OPENCLAW_RAW_STREAM_PATH=~/.openclaw/logs/raw-stream.jsonl
 ```
 
 Default file:
 
-`~/.openclaw/logs/raw-openai-completions.jsonl`
+`~/.openclaw/logs/raw-stream.jsonl`
 
 ## Safety notes
 

--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -73,7 +73,7 @@ Live tests are split into two layers so we can isolate failures:
   - `pnpm test:live` (or `OPENCLAW_LIVE_TEST=1` if invoking Vitest directly)
 - Set `OPENCLAW_LIVE_MODELS=modern`, `small`, or `all` (alias for modern) to actually run this suite; otherwise it skips to keep `pnpm test:live` focused on gateway smoke
 - How to select models:
-  - `OPENCLAW_LIVE_MODELS=modern` to run the modern allowlist (Opus/Sonnet 4.6+, GPT-5.2 + Codex, Gemini 3, DeepSeek V4, GLM 4.7, MiniMax M2.7, Grok 4.3)
+  - `OPENCLAW_LIVE_MODELS=modern` to run the modern allowlist (Opus/Sonnet 4.6+, GPT-5.2 + Codex, Gemini 3, DeepSeek V4, GLM 5.1, MiniMax M2.7, Grok 4.3)
   - `OPENCLAW_LIVE_MODELS=small` to run the constrained small-model allowlist (Qwen 8B/9B local-compatible routes, OpenRouter Qwen/GLM, and Z.AI GLM)
   - `OPENCLAW_LIVE_MODELS=all` is an alias for the modern allowlist
   - or `OPENCLAW_LIVE_MODELS="openai/gpt-5.5,openai-codex/gpt-5.5,anthropic/claude-opus-4-6,..."` (comma allowlist)

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -424,7 +424,7 @@ flowchart TD
     - `browser.executablePath not found` → configured binary path is wrong.
     - `browser.cdpUrl must be http(s) or ws(s)` → the configured CDP URL uses an unsupported scheme.
     - `browser.cdpUrl has invalid port` → the configured CDP URL has a bad or out-of-range port.
-    - `No Chrome tabs found for profile="user"` → the Chrome MCP attach profile has no open local Chrome tabs.
+    - `No browser tabs found for profile="<name>"` → the attach profile has no open local browser tabs.
     - `Remote CDP for profile "<name>" is not reachable` → the configured remote CDP endpoint is not reachable from this host.
     - `Browser attachOnly is enabled ... not reachable` or `Browser attachOnly is enabled and CDP websocket ... is not reachable` → attach-only profile has no live CDP target.
     - stale viewport / dark-mode / locale / offline overrides on attach-only or remote CDP profiles → run `openclaw browser stop --browser-profile <name>` to close the active control session and release emulation state without restarting the gateway.

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -277,6 +277,28 @@ For the generic Docker flow, see [Docker](/install/docker).
             "${OPENCLAW_GATEWAY_PORT}",
             "--allow-unconfigured",
           ]
+
+      openclaw-cli:
+        image: ${OPENCLAW_IMAGE}
+        network_mode: "service:openclaw-gateway"
+        env_file:
+          - .env
+        environment:
+          - HOME=/home/node
+          - OPENCLAW_STATE_DIR=/home/node/.openclaw
+          - OPENCLAW_CONFIG_PATH=/home/node/.openclaw/openclaw.json
+          - OPENCLAW_CONFIG_DIR=/home/node/.openclaw
+          - OPENCLAW_WORKSPACE_DIR=/home/node/.openclaw/workspace
+          - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+        volumes:
+          - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
+          - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+        stdin_open: true
+        tty: true
+        init: true
+        entrypoint: ["node", "dist/index.js"]
+        depends_on:
+          - openclaw-gateway
     ```
 
     `--allow-unconfigured` is only for bootstrap convenience, it is not a replacement for a proper gateway configuration. Still set auth (`gateway.auth.token` or password) and use safe bind settings for your deployment.

--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -28,7 +28,7 @@ OpenClaw auto-detects in this order and stops at the first working option:
    - `whisper` (Python CLI; downloads models automatically)
 3. **Provider auth**
    - Configured `models.providers.*` entries that support audio are tried first
-   - Bundled fallback order: OpenAI → Groq → xAI → Deepgram → Google → SenseAudio → ElevenLabs → Mistral
+   - Bundled fallback order: OpenAI → Groq → xAI → Deepgram → OpenRouter → Google → SenseAudio → ElevenLabs → Mistral
 
 As of 2026-05-22, Gemini CLI auto-detect is no longer supported for media understanding. Google is transitioning Gemini CLI users to Antigravity CLI; audio should use local or provider transcription, while image/video CLI fallback should move to Antigravity CLI (`agy`).
 
@@ -156,7 +156,7 @@ Note: Binary detection is best-effort across macOS/Linux/Windows; ensure the CLI
 - Default size cap is 20MB (`tools.media.audio.maxBytes`). Oversize audio is skipped for that model and the next entry is tried.
 - Tiny/empty audio files below 1024 bytes are skipped before provider/CLI transcription.
 - Default `maxChars` for audio is **unset** (full transcript). Set `tools.media.audio.maxChars` or per-entry `maxChars` to trim output.
-- OpenAI auto default is `gpt-4o-mini-transcribe`; set `model: "gpt-4o-transcribe"` for higher accuracy.
+- OpenAI auto default is `gpt-4o-transcribe`; set `model: "gpt-4o-mini-transcribe"` for lower cost and latency.
 - Use `tools.media.audio.attachments` to process multiple voice notes (`mode: "all"` + `maxAttachments`).
 - Transcript is available to templates as `{{Transcript}}`.
 - `tools.media.audio.echoTranscript` is off by default; enable it to send transcript confirmation back to the originating chat before agent processing.

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -246,7 +246,7 @@ and whether the user has set OpenClaw as the default assistant app.
 
 ## Notification forwarding
 
-Android can forward device notifications to the gateway as events. Forwarding is configured **on the device** in the OpenClaw Android app settings (stored locally in the app's secure preferences). There are no gateway `openclaw.json` keys for it.
+Android can forward device notifications to the gateway as events. Forwarding is configured **on the device** in the OpenClaw Android app settings (stored locally in the app's preferences). There are no gateway `openclaw.json` keys for it.
 
 Available controls:
 

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -246,33 +246,19 @@ and whether the user has set OpenClaw as the default assistant app.
 
 ## Notification forwarding
 
-Android can forward device notifications to the gateway as events. Several controls let you scope which notifications are forwarded and when.
+Android can forward device notifications to the gateway as events. Forwarding is configured **on the device** in the OpenClaw Android app settings (stored locally in the app's secure preferences). There are no gateway `openclaw.json` keys for it.
 
-| Key                              | Type           | Description                                                                                       |
-| -------------------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
-| `notifications.allowPackages`    | string[]       | Only forward notifications from these package names. If set, all other packages are ignored.      |
-| `notifications.denyPackages`     | string[]       | Never forward notifications from these package names. Applied after `allowPackages`.              |
-| `notifications.quietHours.start` | string (HH:mm) | Start of quiet hours window (local device time). Notifications are suppressed during this window. |
-| `notifications.quietHours.end`   | string (HH:mm) | End of quiet hours window.                                                                        |
-| `notifications.rateLimit`        | number         | Maximum forwarded notifications per package per minute. Excess notifications are dropped.         |
+Available controls:
+
+| Setting               | Description                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------ |
+| Enable forwarding     | Master toggle; off by default.                                                                         |
+| Filter mode           | `Allowlist` (forward only listed packages) or `Blocklist` (forward everything except listed packages). |
+| Packages              | A single list of app package names, interpreted according to the selected filter mode.                 |
+| Quiet hours           | Optional window (start/end in local device time, `HH:mm`) during which notifications are suppressed.   |
+| Max events per minute | Rate limit on forwarded notifications; excess events are dropped.                                      |
 
 The notification picker also uses safer behavior for forwarded notification events, preventing accidental forwarding of sensitive system notifications.
-
-Example configuration:
-
-```json5
-{
-  notifications: {
-    allowPackages: ["com.slack", "com.whatsapp"],
-    denyPackages: ["com.android.systemui"],
-    quietHours: {
-      start: "22:00",
-      end: "07:00",
-    },
-    rateLimit: 5,
-  },
-}
-```
 
 <Note>
 Notification forwarding requires the Android Notification Listener permission. The app prompts for this during setup.

--- a/docs/platforms/mac/voicewake.md
+++ b/docs/platforms/mac/voicewake.md
@@ -47,7 +47,7 @@ Hardening:
 ## User-facing settings
 
 - **Voice Wake** toggle: enables wake-word runtime.
-- **Hold Cmd+Fn to talk**: enables the push-to-talk monitor. Disabled on macOS < 26.
+- **Hold Right Option to talk**: enables the push-to-talk monitor. Disabled on macOS < 26.
 - Language & mic pickers, live level meter, trigger-word table, tester (local-only; does not forward).
 - Mic picker preserves the last selection if a device disconnects, shows a disconnected hint, and temporarily falls back to the system default until it returns.
 - **Sounds**: chimes on trigger detect and on send; defaults to the macOS "Glass" system sound. You can pick any `NSSound`-loadable file (e.g. MP3/WAV/AIFF) for each event or choose **No Sound**.
@@ -63,7 +63,7 @@ Hardening:
 
 ## Quick verification
 
-- Toggle push-to-talk on, hold Cmd+Fn, speak, release: overlay should show partials then send.
+- Toggle push-to-talk on, hold Right Option, speak, release: overlay should show partials then send.
 - While holding, menu-bar ears should stay enlarged (uses `triggerVoiceEars(ttl:nil)`); they drop after release.
 
 ## Related

--- a/docs/plugins/admin-http-rpc.md
+++ b/docs/plugins/admin-http-rpc.md
@@ -212,5 +212,5 @@ Shared-token WebSocket clients without a trusted device identity cannot self-dec
 - [Operator scopes](/gateway/operator-scopes)
 - [Gateway security](/gateway/security)
 - [Remote access](/gateway/remote)
-- [Plugin manifest](/plugins/manifest#contracts)
+- [Plugin manifest](/plugins/manifest#contracts-reference)
 - [SDK subpaths](/plugins/sdk-subpaths)

--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -7,7 +7,7 @@ read_when:
   - You are wiring an agent to subscription Copilot (github / openclaw / copilot) and want it to run through the Copilot CLI
 ---
 
-The bundled `copilot` extension lets OpenClaw run embedded subscription
+The bundled `copilot` plugin lets OpenClaw run embedded subscription
 Copilot agent turns through the GitHub Copilot CLI (`@github/copilot-sdk`)
 instead of the built-in PI harness.
 
@@ -24,7 +24,7 @@ For the broader model/provider/runtime split, start with
 
 ## Requirements
 
-- OpenClaw with the bundled `copilot` extension available.
+- OpenClaw with the bundled `copilot` plugin available.
 - If your config uses `plugins.allow`, include `copilot` (the manifest
   id in `extensions/copilot/openclaw.plugin.json`). A restrictive
   allowlist that uses the npm-style `@openclaw/copilot` package name
@@ -39,7 +39,7 @@ For the broader model/provider/runtime split, start with
   no explicit home is set.
 
 `openclaw doctor` runs the bundled
-[doctor contract](#doctor-and-probes) for the extension; failures there are
+[doctor contract](#doctor-and-probes) for the plugin; failures there are
 the canonical way to confirm the environment is ready before opting an agent
 in.
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1308,7 +1308,7 @@ hook instead.
 
 OpenClaw discovers plugins from several roots. For the raw filesystem scan
 order, see [Plugin scan
-order](/gateway/configuration-reference#plugin-scan-order). If two discoveries
+order](/gateway/configuration-reference#plugins). If two discoveries
 share the same `id`, only the **highest-precedence** manifest is kept;
 lower-precedence duplicates are dropped instead of loading beside it.
 

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -368,7 +368,7 @@ Use `resolveInboundMentionDecision({ facts, policy })` for mention gating.
   <Step title="Package and manifest">
     Create the standard plugin files. The `channel` field in `package.json` is
     what makes this a channel plugin. For the full package-metadata surface,
-    see [Plugin Setup and Config](/plugins/sdk-setup#openclaw-channel):
+    see [Plugin Setup and Config](/plugins/sdk-setup#openclawchannel):
 
     <CodeGroup>
     ```json package.json

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -309,8 +309,7 @@ and pairing-path families.
     | `plugin-sdk/media-store` | Narrow media store helpers such as `saveMediaBuffer` and `saveMediaStream` |
     | `plugin-sdk/media-generation-runtime` | Shared media-generation failover helpers, candidate selection, and missing-model messaging |
     | `plugin-sdk/media-understanding` | Media understanding provider types plus provider-facing image/audio/structured-extraction helper exports |
-    | `plugin-sdk/text-chunking` | Text and markdown chunking/render helpers, markdown table conversion, directive-tag stripping, and safe-text utilities |
-    | `plugin-sdk/text-chunking` | Outbound text chunking helper |
+    | `plugin-sdk/text-chunking` | Text and markdown chunking/render helpers (including outbound chunking), markdown table conversion, directive-tag stripping, and safe-text utilities |
     | `plugin-sdk/speech` | Speech provider types plus provider-facing directive, registry, validation, OpenAI-compatible TTS builder, and speech helper exports |
     | `plugin-sdk/speech-core` | Shared speech provider types, registry, directive, normalization, and speech helper exports |
     | `plugin-sdk/realtime-transcription` | Realtime transcription provider types, registry helpers, and shared WebSocket session helper |

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -79,7 +79,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 ## Shared overview pages
 
-- [Additional bundled variants](/providers/models#additional-bundled-provider-variants) - Anthropic Vertex, Copilot Proxy, and Gemini CLI OAuth
+- [Additional bundled variants](/providers/models#additional-provider-variants) - Anthropic Vertex, Copilot Proxy, and Gemini CLI OAuth
 - [Image Generation](/tools/image-generation) - Shared `image_generate` tool, provider selection, and failover
 - [Music Generation](/tools/music-generation) - Shared `music_generate` tool, provider selection, and failover
 - [Video Generation](/tools/video-generation) - Shared `video_generate` tool, provider selection, and failover

--- a/docs/reference/credits.md
+++ b/docs/reference/credits.md
@@ -12,7 +12,7 @@ OpenClaw = CLAW + TARDIS, because every space lobster needs a time and space mac
 ## Credits
 
 - **Peter Steinberger** ([@steipete](https://x.com/steipete)) - Creator, lobster whisperer
-- **Mario Zechner** ([@badlogicc](https://x.com/badlogicgames)) - Pi creator, security pen tester
+- **Mario Zechner** ([@badlogicgames](https://x.com/badlogicgames)) - Pi creator, security pen tester
 - **Clawd** - The space lobster who demanded a better name
 
 ## Core contributors

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -591,15 +591,15 @@ T-EXEC-002 → T-EXFIL-001 → External exfiltration
 
 ### 7.3 Glossary
 
-| Term                 | Definition                                                |
-| -------------------- | --------------------------------------------------------- |
-| **ATLAS**            | MITRE's Adversarial Threat Landscape for AI Systems       |
-| **ClawHub**          | OpenClaw's skill marketplace                              |
-| **Gateway**          | OpenClaw's message routing and authentication layer       |
-| **MCP**              | Model Context Protocol - tool provider interface          |
-| **Prompt Injection** | Attack where malicious instructions are embedded in input |
-| **Skill**            | Downloadable extension for OpenClaw agents                |
-| **SSRF**             | Server-Side Request Forgery                               |
+| Term                 | Definition                                                                        |
+| -------------------- | --------------------------------------------------------------------------------- |
+| **ATLAS**            | MITRE's Adversarial Threat Landscape for AI Systems                               |
+| **ClawHub**          | OpenClaw's skill marketplace                                                      |
+| **Gateway**          | OpenClaw's message routing and authentication layer                               |
+| **MCP**              | Model Context Protocol - tool provider interface                                  |
+| **Prompt Injection** | Attack where malicious instructions are embedded in input                         |
+| **Skill**            | Reusable capability bundle (instructions plus optional tools) for OpenClaw agents |
+| **SSRF**             | Server-Side Request Forgery                                                       |
 
 ---
 

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -103,11 +103,14 @@ Then set:
   "gateway": {
     "controlUi": {
       "enabled": true,
-      "root": "$HOME/.openclaw/control-ui-custom"
+      "root": "/home/youruser/.openclaw/control-ui-custom"
     }
   }
 }
 ```
+
+`gateway.controlUi.root` must be an absolute path. It is not shell-expanded,
+so `$HOME` and `~` are taken literally — use the resolved absolute path.
 
 Restart the gateway and reopen the dashboard:
 

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -78,7 +78,6 @@ Core ACP baseline:
       "kiro",
       "openclaw",
       "opencode",
-      "openclaw",
       "qwen",
     ],
     maxConcurrentSessions: 8,

--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -112,13 +112,13 @@ Once a basic skill works, these fields help make it reliable and portable:
 
 - **Conditional activation** — use `requires.bins`, `requires.env`, or
   `requires.config` to load the skill only when required dependencies are
-  available. See [Skills reference: gating](/tools/skills#gating).
+  available. See [Skills reference: gating](/tools/skills#gating-load-time-filters).
 - **Environment and API-key wiring** — use `skills.entries.<name>.env` and
   `skills.entries.<name>.apiKey` to inject host-side environment for a skill
-  turn. See [Skills reference: config wiring](/tools/skills#config-wiring).
+  turn. See [Skills reference: config wiring](/tools/skills#environment-injection).
 - **Invocation control** — set `user-invocable: false` to hide a slash command,
   or `disable-model-invocation: true` to keep a command-style skill out of the
-  model prompt. See [Skills reference: frontmatter](/tools/skills#frontmatter).
+  model prompt. See [Skills reference: frontmatter](/tools/skills#optional-frontmatter-keys).
 - **Direct command dispatch** — use `command-dispatch: tool` with
   `command-tool` when a slash command should call a tool directly instead of
   routing through the model.

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -488,7 +488,7 @@ This live file uses already-exported provider env vars ahead of stored auth
 profiles by default, and runs a release-safe smoke by default:
 
 - `generate` for every non-FAL provider in the sweep.
-- One-second lobster prompt.
+- One-second blue-cube prompt.
 - Per-provider operation cap from
   `OPENCLAW_LIVE_VIDEO_GENERATION_TIMEOUT_MS` (`180000` by default).
 


### PR DESCRIPTION
## Summary

Audited all of `docs/**` against the current codebase and fixed factual drift where the documentation no longer matched shipped behavior. Grouped into 8 commits by area. **Docs only — no source/runtime changes.**

### Correctness / safety
- `channels/zalouser`: group-policy default is `allowlist` (fail-closed), not `open`; removed the wrong "use `channels.defaults.groupPolicy` to override" note (the plugin hard-defaults to `allowlist` and never reads it — `extensions/zalouser/src/{accounts,config-schema}.ts`).
- `platforms/mac/voicewake`: push-to-talk hotkey is **Right Option**, not `Cmd+Fn` (real UI label is "Hold Right Option to talk" — `apps/macos/.../VoiceWakeSettings.swift`).
- `nodes/audio`: OpenAI transcription default is `gpt-4o-transcribe` (the doc had it backwards); added OpenRouter to the bundled fallback order.

### Config / API drift
- `gateway/config-agents`: `opus` → `claude-opus-4-8`, `gpt` → `gpt-5.4` (`src/config/defaults.ts`).
- `gateway/openresponses-http-api`: `files.maxChars` default is 60k, not 200k (`src/media/input-files.ts`).
- `gateway/cli-backends`: bundled `google-gemini-cli` `args`/`resumeArgs` include `--skip-trust`.
- `gateway/tools-invoke-http-api`: `whatsapp_login` is not in the HTTP `/tools/invoke` deny list.
- `gateway/trusted-proxy-auth`: removed the non-existent `mixed_trusted_proxy_token` error code.
- `channels/feishu`: `textChunkLimit` default is 4000, not 2000.
- `channels/telegram`: `replyToMode` also accepts `batched`.
- `concepts/model-failover`: cooldown is a stepped 30s / 1m / 5m backoff (`src/agents/auth-profiles/usage.ts`).
- `concepts/typebox`: generated Swift models live under `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`.
- `concepts/usage-tracking` & `concepts/oauth`: `channels list` no longer prints usage / `auth[]`; use `openclaw status --usage` / `openclaw models auth list`.
- `automation/tasks`: `lost` tasks are retained 1 day, not 7 (`src/tasks/task-retention.ts`).
- `help/debugging`: raw-stream default path is `logs/raw-stream.jsonl`.
- `install/gcp`: added the `openclaw-cli` sidecar so the documented `docker compose run --rm openclaw-cli ...` steps resolve a service.
- `platforms/android`: notification forwarding is configured device-side (filter mode + single package list), not via `openclaw.json` keys. Storage description corrected from "secure preferences" to "preferences" to match actual `plainPrefs` implementation.
- `start/getting-started`: `gateway.controlUi.root` must be an absolute path (no `$HOME` / `~` expansion).

### Anchors / terminology / cleanup
- Fixed stale section anchors across `cli/agents`, `gateway/configuration`, `plugins/{admin-http-rpc,manifest,sdk-channel-plugins}`, `providers/index`, `tools/creating-skills`.
- "extension" → "plugin" in user-facing copy (`copilot`, `cli/channels`, THREAT-MODEL Skill glossary).
- Removed duplicate `openclaw` in acp-agents `allowedAgents`; merged the duplicate `plugin-sdk/text-chunking` row; fixed the `@badlogicgames` credit handle; GLM 4.7 → 5.1 in the modern live allowlist; corrected the browser "no tabs" log line; resolved the tlon reactions contradiction; video smoke prompt is a blue cube, not a lobster.

## Verification

Docs-only change. Ran the repo's doc checks on the rebased branch:

- `node scripts/docs-link-audit.mjs` → 4478 internal links, **0 broken**
- `node scripts/check-docs-mdx.mjs docs` → **663 files passed**
- local github-slugger anchor audit (mirrors `mint broken-links --check-anchors`) → **0 broken anchors**
- `git diff --check` → clean

Each factual change was checked against current source (aliases in `src/config/defaults.ts`, group policy in `extensions/zalouser/src/*`, transcription default in `extensions/openai/default-models.ts`, PTT label in `apps/macos/.../VoiceWakeSettings.swift`, `files.maxChars` in `src/media/input-files.ts`, retention in `src/tasks/task-retention.ts`, deny list in `src/security/dangerous-tools.ts`, Android notification prefs in `apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt`).

## Real behavior proof

**Behavior addressed:** Documentation across `docs/**` was corrected to match current source behavior for config defaults, model aliases, anchors, terminology, and Android notification storage description.

**Real environment tested:** Local source checkout on macOS with current `main` branch (commit `bd1ad733eb`). Docs-only change — no runtime behavior modified.

**Exact steps or command run after this patch:**
1. `node scripts/docs-link-audit.mjs`
2. `node scripts/check-docs-mdx.mjs docs`
3. `git diff --check`

**Evidence after fix:**

```
$ node scripts/docs-link-audit.mjs
checked_internal_links=4529
broken_links=0

$ node scripts/check-docs-mdx.mjs docs
Docs MDX check passed (671 files, 1757ms).

$ git diff --check
(no output — clean)
```

Android notification forwarding paragraph now says "stored locally in the app's preferences" matching the actual `plainPrefs` implementation in `SecurePrefs.kt:113`.

**Observed result after fix:** All doc checks pass with zero broken links and zero MDX errors; Android storage wording matches source (`plainPrefs` not `securePrefs`); all other corrections align with current source behavior.

**What was not tested:** No runtime behavior tested — this PR changes only documentation files.