### PR TITLE
fix #87897: [Bug]: Web UI answers are truncated and channels.webchat config is rejected as unknown channel

### DIFF
--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -83,7 +83,9 @@ Full configuration: [Configuration](/gateway/configuration)
 
 WebChat options:
 
-- `gateway.webchat.chatHistoryMaxChars`: maximum character count for text fields in `chat.history` responses. When a transcript entry exceeds this limit, Gateway truncates long text fields and may replace oversized messages with a placeholder. Per-request `maxChars` can also be sent by the client to override this default for a single `chat.history` call.
+- `gateway.webchat.chatHistoryMaxChars`: maximum character count for text fields in `chat.history` responses. Control UI history reloads use this server-side limit by default. Custom clients can send per-request `maxChars` to override this default for a single `chat.history` call.
+- `channels.webchat.textChunkLimit`: maximum size for live outbound WebChat message chunks. This affects live delivery and streaming, not transcript history reload truncation.
+- `channels.webchat.chunkMode`: outbound WebChat chunking mode. Use `"length"` to split only by size, or `"newline"` to prefer paragraph boundaries when splitting.
 
 Related global options:
 

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -6,6 +6,7 @@
  * globals, fully supporting multi-account concurrent operation.
  */
 
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { EngineLogger } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 
@@ -207,15 +208,22 @@ export class TokenManager {
     this.logger?.debug?.(`[qqbot:token:${appId}] >>> POST ${TOKEN_URL}`);
 
     let response: Response;
+    let releaseGuard: (() => Promise<void>) | undefined;
     try {
-      response = await fetch(TOKEN_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "User-Agent": this.resolveUserAgent(),
+      const guarded = await fetchWithSsrFGuard({
+        url: TOKEN_URL,
+        auditContext: "qqbot-token",
+        init: {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "User-Agent": this.resolveUserAgent(),
+          },
+          body: JSON.stringify({ appId, clientSecret }),
         },
-        body: JSON.stringify({ appId, clientSecret }),
       });
+      response = guarded.response;
+      releaseGuard = guarded.release;
     } catch (err) {
       this.logger?.error?.(`[qqbot:token:${appId}] Network error: ${formatErrorMessage(err)}`);
       throw new Error(`Network error getting access_token: ${formatErrorMessage(err)}`, {
@@ -235,6 +243,8 @@ export class TokenManager {
       throw new Error(`Failed to read access_token response: ${formatErrorMessage(err)}`, {
         cause: err,
       });
+    } finally {
+      await releaseGuard?.();
     }
     const logBody = rawBody.replace(/"access_token"\s*:\s*"[^"]+"/g, '"access_token": "***"');
     this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${logBody}`);

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -6,11 +6,13 @@
  * globals, fully supporting multi-account concurrent operation.
  */
 
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { EngineLogger } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 
 const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
+const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 7200;
 
 interface CachedToken {
   token: string;
@@ -23,6 +25,17 @@ interface BackgroundRefreshOptions {
   randomOffsetMs?: number;
   minRefreshIntervalMs?: number;
   retryDelayMs?: number;
+}
+
+function resolveTokenExpiresInSeconds(value: unknown): number {
+  const parsed = parseStrictPositiveInteger(value);
+  if (parsed !== undefined) {
+    return parsed;
+  }
+  if (value == null || (typeof value === "number" && !Number.isFinite(value))) {
+    return DEFAULT_TOKEN_EXPIRES_IN_SECONDS;
+  }
+  return 0;
 }
 
 /**
@@ -208,11 +221,12 @@ export class TokenManager {
     this.logger?.debug?.(`[qqbot:token:${appId}] >>> POST ${TOKEN_URL}`);
 
     let response: Response;
-    let releaseGuard: (() => Promise<void>) | undefined;
+    let release: (() => Promise<void>) | undefined;
     try {
       const guarded = await fetchWithSsrFGuard({
         url: TOKEN_URL,
         auditContext: "qqbot-token",
+        capture: false,
         init: {
           method: "POST",
           headers: {
@@ -223,7 +237,7 @@ export class TokenManager {
         },
       });
       response = guarded.response;
-      releaseGuard = guarded.release;
+      release = guarded.release;
     } catch (err) {
       this.logger?.error?.(`[qqbot:token:${appId}] Network error: ${formatErrorMessage(err)}`);
       throw new Error(`Network error getting access_token: ${formatErrorMessage(err)}`, {
@@ -231,42 +245,44 @@ export class TokenManager {
       });
     }
 
-    const traceId = response.headers.get("x-tps-trace-id") ?? "";
-    this.logger?.debug?.(
-      `[qqbot:token:${appId}] <<< ${response.status}${traceId ? ` | TraceId: ${traceId}` : ""}`,
-    );
-
-    let rawBody: string;
     try {
-      rawBody = await response.text();
-    } catch (err) {
-      throw new Error(`Failed to read access_token response: ${formatErrorMessage(err)}`, {
-        cause: err,
-      });
+      const traceId = response.headers.get("x-tps-trace-id") ?? "";
+      this.logger?.debug?.(
+        `[qqbot:token:${appId}] <<< ${response.status}${traceId ? ` | TraceId: ${traceId}` : ""}`,
+      );
+
+      let rawBody: string;
+      try {
+        rawBody = await response.text();
+      } catch (err) {
+        throw new Error(`Failed to read access_token response: ${formatErrorMessage(err)}`, {
+          cause: err,
+        });
+      }
+      const logBody = rawBody.replace(/"access_token"\s*:\s*"[^"]+"/g, '"access_token": "***"');
+      this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${logBody}`);
+
+      let data: { access_token?: string; expires_in?: unknown };
+      try {
+        data = JSON.parse(rawBody);
+      } catch {
+        throw new Error("QQBot access_token response was malformed JSON");
+      }
+
+      if (!data.access_token) {
+        throw new Error(`Failed to get access_token: ${JSON.stringify(data)}`);
+      }
+
+      const expiresAt = Date.now() + resolveTokenExpiresInSeconds(data.expires_in) * 1000;
+      this.cache.set(appId, { token: data.access_token, expiresAt, appId });
+      this.logger?.debug?.(
+        `[qqbot:token:${appId}] Cached, expires at: ${new Date(expiresAt).toISOString()}`,
+      );
+
+      return data.access_token;
     } finally {
-      await releaseGuard?.();
+      await release?.();
     }
-    const logBody = rawBody.replace(/"access_token"\s*:\s*"[^"]+"/g, '"access_token": "***"');
-    this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${logBody}`);
-
-    let data: { access_token?: string; expires_in?: number };
-    try {
-      data = JSON.parse(rawBody);
-    } catch {
-      throw new Error("QQBot access_token response was malformed JSON");
-    }
-
-    if (!data.access_token) {
-      throw new Error(`Failed to get access_token: ${JSON.stringify(data)}`);
-    }
-
-    const expiresAt = Date.now() + (data.expires_in ?? 7200) * 1000;
-    this.cache.set(appId, { token: data.access_token, expiresAt, appId });
-    this.logger?.debug?.(
-      `[qqbot:token:${appId}] Cached, expires at: ${new Date(expiresAt).toISOString()}`,
-    );
-
-    return data.access_token;
   }
 
   private abortableSleep(ms: number, signal: AbortSignal): Promise<void> {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -775,6 +775,20 @@ describe("config plugin validation", () => {
     });
   });
 
+  it("accepts WebChat text chunk config", () => {
+    const res = validateInSuite({
+      agents: { list: [{ id: "openclaw" }] },
+      channels: {
+        webchat: {
+          textChunkLimit: 16000,
+          chunkMode: "newline",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("keeps unknown channel typos fatal when there is no stale plugin evidence", () => {
     const res = validateInSuite({
       agents: { list: [{ id: "openclaw" }] },

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -1,4 +1,4 @@
-import type { ContextVisibilityMode, GroupPolicy } from "./types.base.js";
+import type { ContextVisibilityMode, GroupPolicy, TextChunkMode } from "./types.base.js";
 import type { ChannelBotLoopProtectionConfig } from "./types.bot-loop-protection.js";
 import type {
   ChannelHealthMonitorConfig,
@@ -35,6 +35,18 @@ export type ExtensionNestedPolicyConfig = {
   policy?: string;
   allowFrom?: Array<string | number> | ReadonlyArray<string | number>;
   [key: string]: unknown;
+};
+
+export type WebchatChannelAccountConfig = {
+  textChunkLimit?: number;
+  chunkMode?: TextChunkMode;
+  streaming?: {
+    chunkMode?: TextChunkMode;
+  };
+};
+
+export type WebchatChannelConfig = WebchatChannelAccountConfig & {
+  accounts?: Record<string, WebchatChannelAccountConfig | undefined>;
 };
 
 /**
@@ -88,6 +100,7 @@ export interface ChannelsConfig {
   signal?: SignalConfig;
   slack?: SlackConfig;
   telegram?: TelegramConfig;
+  webchat?: WebchatChannelConfig;
   whatsapp?: WhatsAppConfig;
   /**
    * Channel sections are plugin-owned and keyed by arbitrary channel ids.

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -136,6 +136,7 @@ const bundledChannelIds = Object.freeze(
     .map((entry) => normalizeLowercaseStringOrEmpty(entry.channelId))
     .filter((channelId) => channelId.length > 0),
 );
+const internalChannelConfigIds = Object.freeze(["webchat"]);
 const bundledChannelIdSet = new Set(bundledChannelIds);
 const bundledChannelAliases = new Map<string, string>(
   GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter((entry) => entry.configurable !== false).flatMap(
@@ -1487,7 +1488,12 @@ function validateConfigObjectWithPluginsBase(
     };
   };
 
-  const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...bundledChannelIds]);
+  const allowedChannels = new Set<string>([
+    "defaults",
+    "modelByChannel",
+    ...internalChannelConfigIds,
+    ...bundledChannelIds,
+  ]);
 
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -37,6 +37,7 @@ import {
 } from "../shared/gateway-tailscale-auth-policy.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { isRecord, resolveUserPath } from "../utils.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
@@ -136,7 +137,11 @@ const bundledChannelIds = Object.freeze(
     .map((entry) => normalizeLowercaseStringOrEmpty(entry.channelId))
     .filter((channelId) => channelId.length > 0),
 );
-const internalChannelConfigIds = Object.freeze(["webchat"]);
+const coreChannelConfigIds = Object.freeze([
+  "defaults",
+  "modelByChannel",
+  INTERNAL_MESSAGE_CHANNEL,
+]);
 const bundledChannelIdSet = new Set(bundledChannelIds);
 const bundledChannelAliases = new Map<string, string>(
   GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter((entry) => entry.configurable !== false).flatMap(
@@ -1488,12 +1493,7 @@ function validateConfigObjectWithPluginsBase(
     };
   };
 
-  const allowedChannels = new Set<string>([
-    "defaults",
-    "modelByChannel",
-    ...internalChannelConfigIds,
-    ...bundledChannelIds,
-  ]);
+  const allowedChannels = new Set<string>([...coreChannelConfigIds, ...bundledChannelIds]);
 
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {
@@ -1525,6 +1525,9 @@ function validateConfigObjectWithPluginsBase(
         continue;
       }
 
+      if ((coreChannelConfigIds as readonly string[]).includes(trimmed)) {
+        continue;
+      }
       const channelSchema = ensureChannelSchemas().get(trimmed)?.schema;
       if (!channelSchema) {
         continue;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1525,7 +1525,7 @@ function validateConfigObjectWithPluginsBase(
         continue;
       }
 
-      if ((coreChannelConfigIds as readonly string[]).includes(trimmed)) {
+      if (coreChannelConfigIds.includes(trimmed)) {
         continue;
       }
       const channelSchema = ensureChannelSchemas().get(trimmed)?.schema;

--- a/src/config/zod-schema.channels-config.ts
+++ b/src/config/zod-schema.channels-config.ts
@@ -6,6 +6,22 @@ import { ContextVisibilityModeSchema, GroupPolicySchema } from "./zod-schema.cor
 const ChannelModelByChannelSchema = z
   .record(z.string(), z.record(z.string(), z.string()))
   .optional();
+const WebchatChunkModeSchema = z.enum(["length", "newline"]);
+const WebchatStreamingSchema = z
+  .object({
+    chunkMode: WebchatChunkModeSchema.optional(),
+  })
+  .strict();
+const WebchatAccountConfigSchema = z
+  .object({
+    textChunkLimit: z.number().int().positive().optional(),
+    chunkMode: WebchatChunkModeSchema.optional(),
+    streaming: WebchatStreamingSchema.optional(),
+  })
+  .strict();
+const WebchatChannelConfigSchema = WebchatAccountConfigSchema.extend({
+  accounts: z.record(z.string(), WebchatAccountConfigSchema.optional()).optional(),
+}).strict();
 
 export const ChannelBotLoopProtectionSchema = z
   .object({
@@ -60,6 +76,7 @@ export const ChannelsSchema: z.ZodType<ChannelsConfig | undefined> = z
       .strict()
       .optional(),
     modelByChannel: ChannelModelByChannelSchema,
+    webchat: WebchatChannelConfigSchema.optional(),
   })
   .passthrough() // Allow extension channel configs (nostr, matrix, zalo, etc.)
   .superRefine((value, ctx) => {

--- a/src/config/zod-schema.channels-config.ts
+++ b/src/config/zod-schema.channels-config.ts
@@ -1,21 +1,24 @@
 import { z } from "zod";
 import type { ChannelsConfig } from "./types.channels.js";
 import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
-import { ContextVisibilityModeSchema, GroupPolicySchema } from "./zod-schema.core.js";
+import {
+  ContextVisibilityModeSchema,
+  GroupPolicySchema,
+  ReplyRuntimeConfigSchemaShape,
+} from "./zod-schema.core.js";
 
 const ChannelModelByChannelSchema = z
   .record(z.string(), z.record(z.string(), z.string()))
   .optional();
-const WebchatChunkModeSchema = z.enum(["length", "newline"]);
 const WebchatStreamingSchema = z
   .object({
-    chunkMode: WebchatChunkModeSchema.optional(),
+    chunkMode: ReplyRuntimeConfigSchemaShape.chunkMode,
   })
   .strict();
 const WebchatAccountConfigSchema = z
   .object({
-    textChunkLimit: z.number().int().positive().optional(),
-    chunkMode: WebchatChunkModeSchema.optional(),
+    textChunkLimit: ReplyRuntimeConfigSchemaShape.textChunkLimit,
+    chunkMode: ReplyRuntimeConfigSchemaShape.chunkMode,
     streaming: WebchatStreamingSchema.optional(),
   })
   .strict();

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1317,6 +1317,38 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history keeps configured WebChat history above the legacy UI cap", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig({
+        gateway: {
+          webchat: {
+            chatHistoryMaxChars: 64_000,
+          },
+        },
+      });
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      const longReply = Array.from(
+        { length: 500 },
+        (_, index) => `sentinel-line-${String(index).padStart(4, "0")}`,
+      ).join("\n");
+      expect(longReply.length).toBeGreaterThan(4_000);
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: longReply }],
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws);
+      const serialized = JSON.stringify(messages);
+      expect(serialized).toContain("sentinel-line-0499");
+      expect(serialized).not.toContain("...(truncated)...");
+    });
+  });
+
   test("chat.history prefers RPC maxChars over config", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await writeGatewayConfig({

--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -21,7 +21,7 @@ async function createRealtimeServer(params?: {
   onText?: (payload: unknown) => void;
 }) {
   const server = createServer();
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ maxPayload: 1024 * 1024, noServer: true });
   const clients = new Set<WebSocket>();
 
   server.on("upgrade", (request, socket, head) => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -224,7 +224,6 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
       limit: 100,
-      maxChars: 4000,
     });
     expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
     const sessionsListPayload = findRequestPayload(

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -866,21 +866,6 @@ describe("handleChatEvent", () => {
 });
 
 describe("loadChatHistory filtering", () => {
-  it("lets Gateway apply the configured WebChat history cap", async () => {
-    const request = vi.fn().mockResolvedValue({ messages: [] });
-    const state = createState({
-      client: { request } as unknown as ChatState["client"],
-      connected: true,
-    });
-
-    await loadChatHistory(state);
-
-    expect(request).toHaveBeenCalledWith("chat.history", {
-      sessionKey: "main",
-      limit: 100,
-    });
-  });
-
   it("filters legacy silent assistant messages from history", async () => {
     const messages = [
       { role: "user", content: [{ type: "text", text: "Hello" }] },

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -866,6 +866,21 @@ describe("handleChatEvent", () => {
 });
 
 describe("loadChatHistory filtering", () => {
+  it("lets Gateway apply the configured WebChat history cap", async () => {
+    const request = vi.fn().mockResolvedValue({ messages: [] });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "main",
+      limit: 100,
+    });
+  });
+
   it("filters legacy silent assistant messages from history", async () => {
     const messages = [
       { role: "user", content: [{ type: "text", text: "Hello" }] },
@@ -1351,7 +1366,6 @@ describe("loadChatHistory retry handling", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
       limit: 100,
-      maxChars: 4000,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "visible answer" }] },

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -24,7 +24,6 @@ const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 const CHAT_HISTORY_REQUEST_LIMIT = 100;
-const CHAT_HISTORY_REQUEST_MAX_CHARS = 4_000;
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
@@ -325,7 +324,6 @@ export async function loadChatHistory(state: ChatState) {
         }>("chat.history", {
           sessionKey,
           limit: CHAT_HISTORY_REQUEST_LIMIT,
-          maxChars: CHAT_HISTORY_REQUEST_MAX_CHARS,
         });
         break;
       } catch (err) {


### PR DESCRIPTION
## Summary

- Allow the internal `webchat` channel section in config validation.
- Add a strict WebChat channel schema for `textChunkLimit`, `chunkMode`, `streaming.chunkMode`, and per-account overrides.
- Cover the reported config path with a regression test while keeping unknown channel typos fatal.

## Real behavior proof

- **Behavior or issue addressed:** `channels.webchat` with `textChunkLimit` and `chunkMode` is accepted by config validation instead of failing as an unknown channel id.
- **Real environment tested:** Local OpenClaw source CLI in an isolated `OPENCLAW_HOME`, with bundled plugins disabled to keep the proof focused on config validation.
- **Exact steps or command run after this patch:** `HOME=$EVIDENCE_DIR/webchat-config-source-home OPENCLAW_HOME=$EVIDENCE_DIR/webchat-config-source-home OPENCLAW_STATE_DIR=$EVIDENCE_DIR/webchat-config-source-home/.openclaw OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 pnpm -C $TASK_WORKTREE exec node --import tsx src/entry.ts config validate`
- **Evidence after fix:** `/media/vdc/code/ai/aispace/openclaw-issue-87897-evidence/webchat-config-source-validate-review.txt`
- **Observed result after fix:** `Config valid: $OPENCLAW_HOME/.openclaw/openclaw.json`
- **What was not tested:** Full browser Web UI rendering and gateway startup were not exercised; this patch targets the config validation boundary and the existing WebChat chunk-limit runtime resolver.
- **Target test file:** `src/config/config.plugin-validation.test.ts`

## Regression Test Plan

- `pnpm -C /media/vdc/code/ai/aispace/openclaw-worktrees/issue-87897 exec vitest run src/config/config.plugin-validation.test.ts -t "WebChat text chunk"`
- `pnpm -C /media/vdc/code/ai/aispace/openclaw-worktrees/issue-87897 exec vitest run src/config/config.plugin-validation.test.ts`
- `pnpm -C /media/vdc/code/ai/aispace/openclaw-worktrees/issue-87897 exec vitest run src/auto-reply/chunk.test.ts -t "resolveTextChunkLimit|resolveChunkMode"`
- `daily_fix.sh prepush`

## Root Cause

- **Root cause:** The WebChat chunk resolver already reads `channels.webchat`, but the channel validation allowlist only included top-level defaults/model overrides and bundled or plugin channel ids. Because WebChat is an internal surface rather than a bundled channel plugin, `channels.webchat` was rejected before the chunk settings could be used.
