### PR TITLE
fix(qqbot): guard token fetch

### DIFF
--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -1,8 +1,25 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TokenManager } from "./token.js";
 
+const ssrfMocks = vi.hoisted(() => {
+  const release = vi.fn();
+  const fetchWithSsrFGuard = vi.fn(
+    async (params: { url: string; init?: RequestInit }) => ({
+      response: await globalThis.fetch(params.url, params.init),
+      release,
+    }),
+  );
+  return { fetchWithSsrFGuard, release };
+});
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: ssrfMocks.fetchWithSsrFGuard,
+}));
+
 describe("QQBot token manager", () => {
   afterEach(() => {
+    ssrfMocks.fetchWithSsrFGuard.mockClear();
+    ssrfMocks.release.mockClear();
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });
@@ -21,6 +38,19 @@ describe("QQBot token manager", () => {
     await expect(new TokenManager().getAccessToken("app-id", "secret")).rejects.toThrow(
       "QQBot access_token response was malformed JSON",
     );
+    expect(ssrfMocks.fetchWithSsrFGuard).toHaveBeenCalledWith({
+      url: "https://bots.qq.com/app/getAppAccessToken",
+      auditContext: "qqbot-token-fetch",
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": "QQBotPlugin/unknown",
+        },
+        body: JSON.stringify({ appId: "app-id", clientSecret: "secret" }),
+      },
+    });
+    expect(ssrfMocks.release).toHaveBeenCalledTimes(1);
   });
 
   it("does not cache access tokens forever when expires_in is unsafe", async () => {

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -7,6 +7,7 @@
  */
 
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { EngineLogger } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 
@@ -220,15 +221,22 @@ export class TokenManager {
     this.logger?.debug?.(`[qqbot:token:${appId}] >>> POST ${TOKEN_URL}`);
 
     let response: Response;
+    let releaseGuardedFetch: (() => Promise<void>) | undefined;
     try {
-      response = await fetch(TOKEN_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "User-Agent": this.resolveUserAgent(),
+      const guarded = await fetchWithSsrFGuard({
+        url: TOKEN_URL,
+        auditContext: "qqbot-token-fetch",
+        init: {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "User-Agent": this.resolveUserAgent(),
+          },
+          body: JSON.stringify({ appId, clientSecret }),
         },
-        body: JSON.stringify({ appId, clientSecret }),
       });
+      response = guarded.response;
+      releaseGuardedFetch = guarded.release;
     } catch (err) {
       this.logger?.error?.(`[qqbot:token:${appId}] Network error: ${formatErrorMessage(err)}`);
       throw new Error(`Network error getting access_token: ${formatErrorMessage(err)}`, {
@@ -248,6 +256,8 @@ export class TokenManager {
       throw new Error(`Failed to read access_token response: ${formatErrorMessage(err)}`, {
         cause: err,
       });
+    } finally {
+      await releaseGuardedFetch?.();
     }
     const logBody = rawBody.replace(/"access_token"\s*:\s*"[^"]+"/g, '"access_token": "***"');
     this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${logBody}`);


### PR DESCRIPTION
## Summary
- Route QQBot app access-token requests through the shared SSRF-guarded fetch helper.
- Keep token response handling and cache behavior unchanged while releasing the guarded dispatcher after the response body is read.
- Add token-manager test coverage that asserts the guarded fetch path and release call.

## Verification
- `node scripts/check-no-raw-channel-fetch.mjs`
- `git diff --check`
- `./node_modules/.bin/oxlint extensions/qqbot/src/engine/api/token.ts extensions/qqbot/src/engine/api/token.test.ts`
- Attempted: `node scripts/run-vitest.mjs extensions/qqbot/src/engine/api/token.test.ts` locally, but the temp worktree Vitest runner stayed CPU-bound with no output and was stopped. CI should run the focused test in a hydrated checkout.

## Real behavior proof
Behavior addressed: QQBot plugin runtime no longer uses raw `fetch()` for app access-token retrieval, satisfying the channel/plugin network boundary guard.
Real environment tested: Local OpenClaw source checkout on Node-backed tooling with current `origin/main` plus this patch.
Exact steps or command run after this patch: `node scripts/check-no-raw-channel-fetch.mjs`; `git diff --check`; `./node_modules/.bin/oxlint extensions/qqbot/src/engine/api/token.ts extensions/qqbot/src/engine/api/token.test.ts`
Evidence after fix: The raw-channel-fetch guard exits 0 after previously flagging `extensions/qqbot/src/engine/api/token.ts:224`.
Observed result after fix: Boundary guard no longer reports QQBot token fetch as a raw channel/plugin runtime fetch.
What was not tested: Full Vitest locally; the temp worktree runner hung without output, so CI remains the authoritative test run.


### After-fix terminal capture

```text
$ node scripts/check-no-raw-channel-fetch.mjs && git diff --check
# exit 0

Before this patch, CI reported:
Found raw fetch() usage in channel/plugin runtime sources outside allowlist:
- extensions/qqbot/src/engine/api/token.ts:224
Use fetchWithSsrFGuard() or existing channel/plugin SDK wrappers for network calls.

After this patch, the raw-channel-fetch guard completes with no QQBot violations.
```
