### PR TITLE
fix(agents): classify expired thinking signatures

### DIFF
--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1561,6 +1561,20 @@ describe("classifyProviderRuntimeFailureKind", () => {
     ).toBe("replay_invalid");
   });
 
+  it("classifies expired Anthropic thinking signatures as replay invalid", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        '{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.440: Invalid `signature` in `thinking` block"}}',
+      ),
+    ).toBe("replay_invalid");
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "ValidationException: invalid signature on thinking block",
+      ),
+    ).toBe("replay_invalid");
+    expect(classifyProviderRuntimeFailureKind("Invalid signature")).not.toBe("replay_invalid");
+  });
+
   it("splits ambiguous provider runtime failures instead of collapsing to unknown", () => {
     expect(classifyProviderRuntimeFailureKind({})).toBe("empty_response");
     expect(classifyProviderRuntimeFailureKind("Unknown error (no error details in response)")).toBe(

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -353,7 +353,7 @@ const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
 const REPLAY_INVALID_RE =
-  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b|\binvalid\b.*\bsignature\b.*\bthinking\b|\bsignature\b.*\bthinking\s+block\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b|\bexec denied\s*\(/i;
 const NO_BODY_HTTP_WRAPPER_RE =


### PR DESCRIPTION
## Summary

Classify Anthropic expired thinking-signature rejections as `replay_invalid` so the existing recovery path can strip stale thinking blocks and retry.

- Add the missing `Invalid signature in thinking block` patterns to the replay-invalid classifier.
- Keep generic `Invalid signature` errors out of replay recovery.
- Add regression coverage for the exact wrapped Anthropic payload shape from the issue.

## Linked context

Closes #88020

## Real behavior proof (required for external PRs)

- Behavior addressed: Anthropic `Invalid signature in thinking block` errors are now classified as `replay_invalid` instead of `unclassified`, allowing the existing stale-thinking replay recovery path to run.
- Real environment tested: Local OpenClaw source checkout on macOS, current `origin/main` base, Node with the repo `tsx` loader, direct classifier import from `src/agents/embedded-agent-helpers/errors.ts`.
- Exact steps or command run after this patch:

```bash
node --import tsx - <<'EOF'
import { classifyProviderRuntimeFailureKind } from './src/agents/embedded-agent-helpers/errors.ts';

const payload = '{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.440: Invalid `signature` in `thinking` block"}}';
console.log(`expired-thinking-signature=${classifyProviderRuntimeFailureKind(payload)}`);
console.log(`generic-invalid-signature=${classifyProviderRuntimeFailureKind('Invalid signature')}`);
EOF
```

- Evidence after fix:

```text
expired-thinking-signature=replay_invalid
generic-invalid-signature=unclassified
```

- Observed result after fix: The issue payload enters the `replay_invalid` path, while a generic invalid-signature message remains unclassified.
- What was not tested: A live 45-60 minute Anthropic extended-thinking session that waits for provider-side signature expiry.
- Proof limitations or environment constraints: The live expiry condition is time-dependent and provider-side. This PR verifies the exact post-rejection classifier boundary that gates the existing recovery retry.
- Before evidence: Issue #88020 shows the same Anthropic payload hard-failing because the classifier did not match it.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
- `git diff --check`

Regression coverage added:

- Wrapped Anthropic `invalid_request_error` with `Invalid signature in thinking block` classifies as `replay_invalid`.
- `ValidationException: invalid signature on thinking block` classifies as `replay_invalid`.
- Generic `Invalid signature` does not classify as `replay_invalid`.

## Risk checklist

Did user-visible behavior change? `Yes`
Did config, environment, or migration behavior change? `No`
Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: Provider runtime failure classification.
Mitigation: The new match requires both signature and thinking-block language, and the test proves generic invalid-signature errors do not enter replay recovery.

## Current review state

Next action: Maintainer review.
Waiting on: CI and any maintainer request for live Anthropic expiry proof.
Bot or reviewer comments addressed: None yet.
