### PR TITLE
feat(security/exec): add tools.exec.denyPathPatterns hard-deny gate (#74379)

### DIFF
--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -11,6 +11,73 @@ Advanced exec-approval topics: the `safeBins` fast-path, interpreter/runtime
 binding, and approval-forwarding to chat channels (including native delivery).
 For the core policy and approval flow, see [Exec approvals](/tools/exec-approvals).
 
+## Path denylist (`denyPathPatterns`)
+
+`tools.exec.denyPathPatterns` is a hard-deny gate that runs **before** the
+allowlist, approval, and `safeBins` checks. If any path-like argument matches
+one of the configured globs, the run aborts with a `SYSTEM_RUN_DENIED:
+argument matches tools.exec.denyPathPatterns` error regardless of `security`,
+`ask`, allowlist entries, or approvals.
+
+Use it for paths that an agent should never read or write through exec, even
+under operator approval — typically secret stores, SSH private keys, and
+credential files. The check is independent of the binary, so it stops the
+"lazy `cat ~/.openclaw/secrets/<file>`" exfiltration path even when `cat` is
+on the allowlist.
+
+```json5
+{
+  tools: {
+    exec: {
+      denyPathPatterns: [
+        "~/.openclaw/secrets/**",
+        "~/.ssh/id_*",
+        "~/.aws/credentials",
+        "**/.env",
+        "**/credentials.json",
+      ],
+    },
+  },
+}
+```
+
+Per-agent overrides under `agents.list[].tools.exec.denyPathPatterns` are
+**unioned** with the global list — agents can extend the deny list but cannot
+relax it. Agent and global entries are deduped before evaluation.
+
+Pattern semantics:
+
+- `*` matches any character except `/`.
+- `**` matches any character including `/`.
+- `?` matches a single character except `/`.
+- All other characters are matched literally.
+- Patterns starting with `~` or `~/` are expanded against the operator's home directory before matching.
+
+Each candidate argument is matched against the pattern in three forms:
+
+1. The literal argument.
+2. The argument with `~`/`~/` expanded to the home directory.
+3. The fully-resolved absolute path (relative paths are resolved against the run's `cwd`).
+
+Argument selection (v1):
+
+- Argv elements and best-effort tokens parsed from the inner shell payload (`bash -c "..."`, `sh -c "..."`) are scanned.
+- The scanner skips flags (`-x`, `--token=...`) and env-style assignments (`KEY=value`).
+
+v1 limitations:
+
+- The shell-payload tokenizer respects single and double quotes and a single
+  layer of `\` escapes. It does **not** parse heredocs, `eval`-style
+  indirection, command substitution, or base64-decoded paths.
+- Symlink redirection is out of scope. If `~/innocent-link` points to
+  `~/.openclaw/secrets/foo.env`, only patterns matching the symlink path
+  catch it; resolve symlinks at the filesystem-tools layer if you need
+  realpath enforcement.
+
+The denylist is defense-in-depth, not a complete sandbox. Combine it with
+filesystem permissions, agent sandbox modes, and `tools.fs.workspaceOnly` for
+robust isolation.
+
 ## Safe bins (stdin-only)
 
 `tools.exec.safeBins` defines a small list of **stdin-only** binaries (for

--- a/src/agents/agent-tools-agent-config.exec.test.ts
+++ b/src/agents/agent-tools-agent-config.exec.test.ts
@@ -291,4 +291,45 @@ describe("Agent-specific exec tool defaults", () => {
     const details = result?.details as { status?: string } | undefined;
     expect(details?.status).toBe("completed");
   });
+
+  it("unions global and agent exec denyPathPatterns into the created exec tool", async () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "full",
+          ask: "off",
+          denyPathPatterns: ["~/.openclaw/secrets/**"],
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            tools: {
+              exec: {
+                denyPathPatterns: ["**/.env"],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:main:main",
+      workspaceDir: "/tmp/test-main-exec-deny-path-patterns",
+      agentDir: "/tmp/agent-main-exec-deny-path-patterns",
+    });
+    const execTool = tools.find((tool) => tool.name === "exec");
+    expect(execTool).toBeDefined();
+
+    await expect(
+      execTool!.execute("call-main-deny-path", {
+        command: "cat .env",
+        yieldMs: 1000,
+      }),
+    ).rejects.toThrow(/SYSTEM_RUN_DENIED: argument matches tools\.exec\.denyPathPatterns/);
+  });
 });

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -22,6 +22,7 @@ import {
   type ExecSecurity,
   resolveExecPolicyForMode,
 } from "../infra/exec-approvals.js";
+import { resolveExecDenyPathPatterns } from "../infra/exec-deny-path.js";
 import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
@@ -382,6 +383,10 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
     node: agentExec?.node ?? globalExec?.node,
     pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
     safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    denyPathPatterns: resolveExecDenyPathPatterns({
+      global: globalExec?.denyPathPatterns,
+      agent: agentExec?.denyPathPatterns,
+    }),
     strictInlineEval: agentExec?.strictInlineEval ?? globalExec?.strictInlineEval,
     commandHighlighting: resolveExecCommandHighlighting({
       config: cfg,
@@ -847,6 +852,10 @@ export function createOpenClawCodingTools(options?: {
         node: options?.exec?.node ?? execConfig.node,
         pathPrepend: options?.exec?.pathPrepend ?? execConfig.pathPrepend,
         safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
+        denyPathPatterns: resolveExecDenyPathPatterns({
+          global: execConfig.denyPathPatterns,
+          agent: options?.exec?.denyPathPatterns,
+        }),
         strictInlineEval: options?.exec?.strictInlineEval ?? execConfig.strictInlineEval,
         commandHighlighting: options?.exec?.commandHighlighting ?? execConfig.commandHighlighting,
         safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -30,6 +30,7 @@ export type ExecToolDefaults = {
   node?: string;
   pathPrepend?: string[];
   safeBins?: string[];
+  denyPathPatterns?: string[];
   strictInlineEval?: boolean;
   commandHighlighting?: boolean;
   safeBinTrustedDirs?: string[];

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -19,6 +19,22 @@ const shellEnvMocks = vi.hoisted(() => ({
   getShellPathFromLoginShell: vi.fn<GetShellPathFromLoginShell>(() => "/custom/bin:/opt/bin"),
   resolveShellEnvFallbackTimeoutMs: vi.fn(() => 1234),
 }));
+const nodeHostMocks = vi.hoisted(() => ({
+  executeNodeHostCommand: vi.fn(
+    async (params: { command: string; workdir?: string }) =>
+      ({
+        content: [
+          {
+            type: "text" as const,
+            text: `node:${params.workdir ?? "default"}:${params.command}`,
+          },
+        ],
+        details: {},
+      }) as Awaited<
+        ReturnType<typeof import("./bash-tools.exec-host-node.js").executeNodeHostCommand>
+      >,
+  ),
+}));
 
 const parseShellSingleQuoted = (input: string) => {
   if (!input.startsWith("'")) {
@@ -112,6 +128,10 @@ vi.mock("../process/supervisor/index.js", () => ({
   }),
 }));
 
+vi.mock("./bash-tools.exec-host-node.js", () => ({
+  executeNodeHostCommand: nodeHostMocks.executeNodeHostCommand,
+}));
+
 let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
 
 function createExecApprovals(): ExecApprovalsResolved {
@@ -189,6 +209,7 @@ describe("exec PATH login shell merge", () => {
     shellEnvMocks.getShellPathFromLoginShell.mockReturnValue("/custom/bin:/opt/bin");
     shellEnvMocks.resolveShellEnvFallbackTimeoutMs.mockReset();
     shellEnvMocks.resolveShellEnvFallbackTimeoutMs.mockReturnValue(1234);
+    nodeHostMocks.executeNodeHostCommand.mockClear();
   });
 
   afterEach(() => {
@@ -398,6 +419,60 @@ describe("exec host env validation", () => {
       yieldMs: FOREGROUND_TEST_YIELD_MS,
     });
     expect(normalizeText(result.content.find((c) => c.type === "text")?.text)).toBe("ok");
+  });
+
+  it("blocks denyPathPatterns inside shell wrapper payloads", async () => {
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      denyPathPatterns: ["~/.openclaw/secrets/**"],
+    });
+
+    await expect(
+      tool.execute("call-deny-shell-wrapper", {
+        command: "bash -c 'cat ~/.openclaw/secrets/foo.env'",
+      }),
+    ).rejects.toThrow(/SYSTEM_RUN_DENIED: argument matches tools\.exec\.denyPathPatterns/);
+  });
+
+  it("blocks denyPathPatterns inside transparent dispatch wrapper shell payloads", async () => {
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      denyPathPatterns: ["~/.openclaw/secrets/**"],
+    });
+
+    await expect(
+      tool.execute("call-deny-dispatch-wrapper-shell", {
+        command: "timeout 5s bash -lc 'cat ~/.openclaw/secrets/foo.env'",
+      }),
+    ).rejects.toThrow(/SYSTEM_RUN_DENIED: argument matches tools\.exec\.denyPathPatterns/);
+  });
+
+  it("does not use the gateway cwd for node denyPathPatterns when workdir is omitted", async () => {
+    const tool = createExecTool({
+      host: "node",
+      security: "full",
+      ask: "off",
+      denyPathPatterns: ["**/.env"],
+    });
+
+    const result = await tool.execute("call-node-no-workdir", {
+      command: "cat .env",
+      yieldMs: FOREGROUND_TEST_YIELD_MS,
+    });
+
+    expect(normalizeText(result.content.find((c) => c.type === "text")?.text)).toBe(
+      "node:default:cat .env",
+    );
+    expect(nodeHostMocks.executeNodeHostCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "cat .env",
+        workdir: undefined,
+      }),
+    );
   });
 
   it("fails closed when sandbox host is explicitly configured without sandbox runtime", async () => {

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -472,6 +472,28 @@ describe("exec host env validation", () => {
     expect(nodeHostMocks.executeNodeHostCommand).not.toHaveBeenCalled();
   });
 
+  it("still denies a deny target when shell tokenization fails (unbalanced quote)", async () => {
+    // #74379: when splitShellArgs returns null (e.g. an unterminated quote),
+    // denyArgv is empty and the gate falls back to tokenizing the raw command
+    // string as shellPayload. The deny gate must fail TOWARD checking the raw
+    // payload, never fail open on malformed input.
+    const tool = createExecTool({
+      host: "node",
+      security: "full",
+      ask: "off",
+      denyPathPatterns: ["**/.ssh/*"],
+    });
+
+    await expect(
+      tool.execute("call-deny-malformed-quote", {
+        command: `cat ~/.ssh/id_rsa "unterminated`,
+        yieldMs: FOREGROUND_TEST_YIELD_MS,
+      }),
+    ).rejects.toThrow(/SYSTEM_RUN_DENIED: argument matches tools\.exec\.denyPathPatterns/);
+
+    expect(nodeHostMocks.executeNodeHostCommand).not.toHaveBeenCalled();
+  });
+
   it("fails closed when sandbox host is explicitly configured without sandbox runtime", async () => {
     const tool = createExecTool({ host: "sandbox", security: "full", ask: "off" });
 

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -451,7 +451,10 @@ describe("exec host env validation", () => {
     ).rejects.toThrow(/SYSTEM_RUN_DENIED: argument matches tools\.exec\.denyPathPatterns/);
   });
 
-  it("does not use the gateway cwd for node denyPathPatterns when workdir is omitted", async () => {
+  it("hard-denies a bare relative deny target on the node host even when workdir is omitted", async () => {
+    // #74379 review: `**/.env` is a documented hard-deny example and must block
+    // `cat .env` on the node path where the gateway forwards no workdir. The
+    // globstar matches the bare basename, so the command never reaches the host.
     const tool = createExecTool({
       host: "node",
       security: "full",
@@ -459,20 +462,14 @@ describe("exec host env validation", () => {
       denyPathPatterns: ["**/.env"],
     });
 
-    const result = await tool.execute("call-node-no-workdir", {
-      command: "cat .env",
-      yieldMs: FOREGROUND_TEST_YIELD_MS,
-    });
-
-    expect(normalizeText(result.content.find((c) => c.type === "text")?.text)).toBe(
-      "node:default:cat .env",
-    );
-    expect(nodeHostMocks.executeNodeHostCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
+    await expect(
+      tool.execute("call-node-no-workdir", {
         command: "cat .env",
-        workdir: undefined,
+        yieldMs: FOREGROUND_TEST_YIELD_MS,
       }),
-    );
+    ).rejects.toThrow(/SYSTEM_RUN_DENIED: argument matches tools\.exec\.denyPathPatterns/);
+
+    expect(nodeHostMocks.executeNodeHostCommand).not.toHaveBeenCalled();
   });
 
   it("fails closed when sandbox host is explicitly configured without sandbox runtime", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -11,7 +11,11 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { normalizeChatChannelId } from "../channels/ids.js";
+import { buildCommandPayloadCandidates } from "../infra/command-analysis/risks.js";
+import { unwrapDispatchWrappersForResolution } from "../infra/dispatch-wrapper-resolution.js";
+import { analyzeShellCommand } from "../infra/exec-approvals-analysis.js";
 import {
   type ExecAsk,
   type ExecHost,
@@ -28,6 +32,7 @@ import {
   parseOpenClawChannelsLoginShellCommand,
   rejectUnsafeExecControlShellCommand,
 } from "../infra/exec-control-command-guard.js";
+import { evaluateExecDenyPathMatch, formatExecDenyPathMessage } from "../infra/exec-deny-path.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
   isDangerousHostEnvOverrideVarName,
@@ -1568,6 +1573,40 @@ export function createExecTool(
         workdir = resolveWorkdir(rawWorkdir, warnings);
       }
       await rejectUnsafeExecControlShellCommand(params.command);
+
+      // Hard-deny path-pattern gate. Runs before host dispatch (gateway,
+      // node, or sandbox), and before approval/allowlist/safeBins, so that
+      // a denied path cannot be reached via security="full",
+      // bypassApprovals=true (elevated mode "full"), or any allowlist entry.
+      // See tools.exec.denyPathPatterns in docs/tools/exec-approvals-advanced.md.
+      const denyPathPatterns = defaults?.denyPathPatterns ?? [];
+      if (denyPathPatterns.length > 0) {
+        const rawArgv = splitShellArgs(params.command.trim());
+        const denyArgv = rawArgv
+          ? unwrapDispatchWrappersForResolution(stripPreflightEnvPrefix(rawArgv))
+          : [];
+        let denyShellPayload: string | null = null;
+        if (denyArgv.length > 0) {
+          let commandIdx = 0;
+          while (commandIdx < denyArgv.length && isShellEnvAssignmentToken(denyArgv[commandIdx])) {
+            commandIdx += 1;
+          }
+          const executable = normalizeOptionalLowercaseString(denyArgv[commandIdx]);
+          denyShellPayload = extractShellWrappedCommandPayload(
+            executable,
+            denyArgv.slice(commandIdx + 1),
+          );
+        }
+        const denyMatch = evaluateExecDenyPathMatch({
+          patterns: denyPathPatterns,
+          argv: denyArgv,
+          shellPayload: denyShellPayload ?? (rawArgv ? null : params.command),
+          cwd: host === "node" && !explicitWorkdir ? undefined : workdir,
+        });
+        if (denyMatch) {
+          throw new Error(formatExecDenyPathMessage(denyMatch));
+        }
+      }
 
       const inheritedBaseEnv = coerceEnv(process.env);
       const resolvedExecEnvState = getResolvedExecEnvPreparedState(params);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -753,6 +753,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",
   "tools.exec.safeBins":
     "Allow stdin-only safe binaries to run without explicit allowlist entries.",
+  "tools.exec.denyPathPatterns":
+    "Glob patterns matched against argv (and best-effort shell-payload tokens) before allowlist or approval checks. A match aborts the run regardless of `security`/`ask`/`safeBins`. Use it for hard-deny paths like secrets directories or SSH private keys. v1 matches literal path-like arguments after simple shell-quote stripping; it does not defeat heredocs, eval-style indirection, base64-decoded paths, command substitution, or symlink redirection.",
   "tools.exec.strictInlineEval":
     "Require explicit approval for interpreter inline-eval forms such as `python -c`, `node -e`, `ruby -e`, or `osascript -e`. Prevents silent allowlist reuse and downgrades allow-always to ask-each-time for those forms.",
   "tools.exec.commandHighlighting":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -280,6 +280,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.sandbox.tools": "Sandbox Tool Allow/Deny Policy",
   "tools.exec.pathPrepend": "Exec PATH Prepend",
   "tools.exec.safeBins": "Exec Safe Bins",
+  "tools.exec.denyPathPatterns": "Exec Deny Path Patterns",
   "tools.exec.strictInlineEval": "Require Inline-Eval Approval",
   "tools.exec.commandHighlighting": "Exec Command Highlighting",
   "tools.exec.safeBinTrustedDirs": "Exec Safe Bin Trusted Dirs",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -327,6 +327,17 @@ export type ExecToolConfig = {
   /** Safe stdin-only binaries that can run without allowlist entries. */
   safeBins?: string[];
   /**
+   * Glob patterns matched against argv (and best-effort shell-payload tokens)
+   * before allowlist or approval checks. Hard deny — a match aborts the run
+   * regardless of `security`/`ask`/`safeBins`. Example values:
+   * `~/.openclaw/secrets/<glob>`, `<glob>/.env`, `~/.ssh/id_*`.
+   *
+   * v1 limitations: matches literal path-like arguments after simple shell
+   * quote stripping. Does not defeat heredocs, `eval`-style indirection,
+   * base64-decoded paths, command substitution, or symlink redirection.
+   */
+  denyPathPatterns?: string[];
+  /**
    * Require explicit approval for interpreter inline-eval forms (`python -c`, `node -e`, etc.).
    * Prevents silent allowlist reuse and allow-always persistence for those forms.
    */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -560,6 +560,7 @@ const ToolExecBaseShape = {
   node: z.string().optional(),
   pathPrepend: z.array(z.string()).optional(),
   safeBins: z.array(z.string()).optional(),
+  denyPathPatterns: z.array(z.string()).optional(),
   strictInlineEval: z.boolean().optional(),
   commandHighlighting: z.boolean().optional(),
   safeBinTrustedDirs: z.array(z.string()).optional(),

--- a/src/infra/exec-deny-path.test.ts
+++ b/src/infra/exec-deny-path.test.ts
@@ -1,0 +1,247 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  evaluateExecDenyPathMatch,
+  formatExecDenyPathMessage,
+  resolveExecDenyPathPatterns,
+  tokenizeShellPayload,
+} from "./exec-deny-path.js";
+
+const fakeHome = "/Users/hani";
+
+describe("evaluateExecDenyPathMatch", () => {
+  it("returns null when no patterns are configured", () => {
+    expect(
+      evaluateExecDenyPathMatch({
+        patterns: [],
+        argv: ["cat", "~/.openclaw/secrets/foo.env"],
+        homeDir: fakeHome,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when no argv element is path-like", () => {
+    expect(
+      evaluateExecDenyPathMatch({
+        patterns: ["**/.env"],
+        argv: ["echo", "hello"],
+        homeDir: fakeHome,
+      }),
+    ).toBeNull();
+  });
+
+  it("blocks tilde-relative arg matched against tilde pattern", () => {
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["~/.openclaw/secrets/**"],
+      argv: ["cat", "~/.openclaw/secrets/telegram-trader.env"],
+      homeDir: fakeHome,
+    });
+    expect(match).not.toBeNull();
+    expect(match?.pattern).toBe("~/.openclaw/secrets/**");
+    expect(match?.arg).toBe("~/.openclaw/secrets/telegram-trader.env");
+    expect(match?.resolved).toBe(path.join(fakeHome, ".openclaw/secrets/telegram-trader.env"));
+  });
+
+  it("blocks absolute arg matched against tilde pattern (resolved form)", () => {
+    const absolute = path.join(fakeHome, ".openclaw/secrets/foo.env");
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["~/.openclaw/secrets/**"],
+      argv: ["cat", absolute],
+      homeDir: fakeHome,
+    });
+    expect(match?.pattern).toBe("~/.openclaw/secrets/**");
+    expect(match?.arg).toBe(absolute);
+    expect(match?.resolved).toBe(absolute);
+  });
+
+  it("blocks **/.env style pattern across nested workspaces", () => {
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["**/.env"],
+      argv: ["cat", "/work/projects/web/.env"],
+      homeDir: fakeHome,
+    });
+    expect(match?.pattern).toBe("**/.env");
+  });
+
+  it("blocks ssh private keys via ~/.ssh/id_* pattern", () => {
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["~/.ssh/id_*"],
+      argv: ["cat", "~/.ssh/id_rsa"],
+      homeDir: fakeHome,
+    });
+    expect(match?.pattern).toBe("~/.ssh/id_*");
+  });
+
+  it("ignores flags that look path-ish like --token=value", () => {
+    expect(
+      evaluateExecDenyPathMatch({
+        patterns: ["**/.env"],
+        argv: ["myapp", "--config=foo/.env"],
+        homeDir: fakeHome,
+      }),
+    ).toBeNull();
+  });
+
+  it("scans tokens parsed from shellPayload", () => {
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["~/.openclaw/secrets/**"],
+      argv: ["bash", "-c"],
+      shellPayload: 'cat "~/.openclaw/secrets/bot.env" >> /tmp/leak',
+      homeDir: fakeHome,
+    });
+    expect(match?.pattern).toBe("~/.openclaw/secrets/**");
+  });
+
+  it("resolves cwd-relative args against the cwd before matching", () => {
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["**/.openclaw/secrets/**"],
+      argv: ["cat", "secrets/foo.env"],
+      cwd: path.join(fakeHome, ".openclaw"),
+      homeDir: fakeHome,
+    });
+    expect(match?.pattern).toBe("**/.openclaw/secrets/**");
+  });
+
+  it("resolves bare cwd-relative sensitive filenames against the cwd before matching", () => {
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["**/.env"],
+      argv: ["cat", ".env"],
+      cwd: "/work/project",
+      homeDir: fakeHome,
+    });
+    expect(match?.pattern).toBe("**/.env");
+    expect(match?.resolved).toBe("/work/project/.env");
+  });
+
+  it("does not resolve bare relative args against the gateway cwd when cwd is absent", () => {
+    expect(
+      evaluateExecDenyPathMatch({
+        patterns: ["**/.env"],
+        argv: ["cat", ".env"],
+        homeDir: fakeHome,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not match unrelated files in the same workspace", () => {
+    expect(
+      evaluateExecDenyPathMatch({
+        patterns: ["~/.openclaw/secrets/**"],
+        argv: ["cat", "~/work/notes.md"],
+        homeDir: fakeHome,
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores empty/whitespace pattern entries", () => {
+    expect(
+      evaluateExecDenyPathMatch({
+        patterns: ["", "  ", "**/.env"],
+        argv: ["cat", "/a/b/.env"],
+        homeDir: fakeHome,
+      })?.pattern,
+    ).toBe("**/.env");
+  });
+});
+
+// Win32-specific behavior is exercised here on POSIX hosts by passing
+// pre-normalized paths and patterns that exercise the cross-platform
+// matcher; full mocking of process.platform requires environment setup
+// outside the scope of this unit test file.
+describe("evaluateExecDenyPathMatch (cross-platform shape)", () => {
+  it("matches paths regardless of forward/backward slashes via normalization", () => {
+    // Mixed-style pattern + path: the matcher normalizes both sides to
+    // forward slashes, so a Linux-style pattern still catches a Windows-style
+    // candidate path on POSIX hosts.
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["**/secrets/**"],
+      argv: ["type", "/c/users/alice/secrets/foo.env"],
+      homeDir: "/c/users/alice",
+    });
+    expect(match?.pattern).toBe("**/secrets/**");
+  });
+});
+
+describe("formatExecDenyPathMessage", () => {
+  it("renders a stable SYSTEM_RUN_DENIED format", () => {
+    const message = formatExecDenyPathMessage({
+      pattern: "**/.env",
+      arg: "/work/.env",
+      resolved: "/work/.env",
+    });
+    expect(message).toBe(
+      'SYSTEM_RUN_DENIED: argument matches tools.exec.denyPathPatterns (pattern="**/.env", arg="/work/.env")',
+    );
+  });
+});
+
+describe("resolveExecDenyPathPatterns", () => {
+  it("merges global and agent patterns as a deduped union", () => {
+    expect(
+      resolveExecDenyPathPatterns({
+        global: ["**/.env", "~/.ssh/id_*"],
+        agent: ["**/.env", "**/credentials.json"],
+      }),
+    ).toEqual(["**/.env", "~/.ssh/id_*", "**/credentials.json"]);
+  });
+
+  it("ignores non-string and empty entries on both sides", () => {
+    expect(
+      resolveExecDenyPathPatterns({
+        global: ["**/.env", "  ", undefined as unknown as string],
+        agent: [42 as unknown as string, ""],
+      }),
+    ).toEqual(["**/.env"]);
+  });
+
+  it("returns [] when no patterns are configured anywhere", () => {
+    expect(resolveExecDenyPathPatterns({})).toEqual([]);
+  });
+});
+
+describe("tokenizeShellPayload", () => {
+  it("respects single and double quotes", () => {
+    expect(tokenizeShellPayload(`cat "~/.openclaw/secrets/foo.env" 'with space.txt'`)).toEqual([
+      "cat",
+      "~/.openclaw/secrets/foo.env",
+      "with space.txt",
+    ]);
+  });
+
+  it("handles backslash escapes outside single quotes", () => {
+    expect(tokenizeShellPayload("cat foo\\ bar.env")).toEqual(["cat", "foo bar.env"]);
+  });
+
+  it("splits unquoted shell operators away from adjacent path tokens", () => {
+    expect(
+      tokenizeShellPayload("cat ~/.openclaw/secrets/foo.env; echo ok && cat .env>/tmp/leak"),
+    ).toEqual(["cat", "~/.openclaw/secrets/foo.env", "echo", "ok", "cat", ".env", "/tmp/leak"]);
+  });
+
+  it("returns [] for empty payload", () => {
+    expect(tokenizeShellPayload("")).toEqual([]);
+  });
+});
+
+// Smoke checks for the home-dir resolver integration.
+describe("evaluateExecDenyPathMatch (home dir resolution)", () => {
+  it("resolves env.HOME via the shared home-dir resolver", () => {
+    const isolatedHome = "/tmp/fake-openclaw-home-12345";
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["~/openclaw-deny-test-marker/**"],
+      argv: ["cat", `${isolatedHome}/openclaw-deny-test-marker/x`],
+      env: { HOME: isolatedHome } as NodeJS.ProcessEnv,
+    });
+    expect(match?.pattern).toBe("~/openclaw-deny-test-marker/**");
+  });
+
+  it("honors OPENCLAW_HOME via the shared home-dir resolver", () => {
+    const isolatedHome = "/tmp/fake-openclaw-home-12345";
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["~/.openclaw/secrets/**"],
+      argv: ["cat", `${isolatedHome}/.openclaw/secrets/foo.env`],
+      env: { OPENCLAW_HOME: isolatedHome } as NodeJS.ProcessEnv,
+    });
+    expect(match?.pattern).toBe("~/.openclaw/secrets/**");
+  });
+});

--- a/src/infra/exec-deny-path.test.ts
+++ b/src/infra/exec-deny-path.test.ts
@@ -113,14 +113,18 @@ describe("evaluateExecDenyPathMatch", () => {
     expect(match?.resolved).toBe("/work/project/.env");
   });
 
-  it("does not resolve bare relative args against the gateway cwd when cwd is absent", () => {
-    expect(
-      evaluateExecDenyPathMatch({
-        patterns: ["**/.env"],
-        argv: ["cat", ".env"],
-        homeDir: fakeHome,
-      }),
-    ).toBeNull();
+  it("denies a bare relative basename via a globstar pattern even without a cwd", () => {
+    // Regression for #74379 review: `**/.env` is documented as a hard-deny
+    // example and must block `cat .env` on the no-cwd node-host path, where the
+    // gateway forwards no workdir. A globstar matches zero leading segments, so
+    // the bare basename is denied without resolving it against any assumed cwd.
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["**/.env"],
+      argv: ["cat", ".env"],
+      homeDir: fakeHome,
+    });
+    expect(match?.pattern).toBe("**/.env");
+    expect(match?.arg).toBe(".env");
   });
 
   it("does not match unrelated files in the same workspace", () => {

--- a/src/infra/exec-deny-path.test.ts
+++ b/src/infra/exec-deny-path.test.ts
@@ -7,7 +7,12 @@ import {
   tokenizeShellPayload,
 } from "./exec-deny-path.js";
 
-const fakeHome = "/Users/hani";
+// Build an absolute fake home that is valid on every CI runner (POSIX + win32):
+// path.resolve yields a rooted, platform-correct path, and resolveEffectiveHomeDir
+// applies the same path.resolve, so the env-driven home matches what the matcher
+// expands `~` to. Avoids hardcoded POSIX `/...` literals that are not absolute on
+// Windows.
+const fakeHome = path.resolve(path.sep, "fake-openclaw-home");
 
 describe("evaluateExecDenyPathMatch", () => {
   it("returns null when no patterns are configured", () => {
@@ -164,6 +169,19 @@ describe("evaluateExecDenyPathMatch (cross-platform shape)", () => {
     });
     expect(match?.pattern).toBe("**/secrets/**");
   });
+
+  it("matches a Windows-style argv path token against a POSIX deny pattern", () => {
+    // A discrete argv token carrying backslashes (e.g. forwarded from a Windows
+    // node) is normalized `\`->`/` and caught by a POSIX-style pattern even when
+    // this code runs on a POSIX host. Argv tokens skip the shell tokenizer, so
+    // the backslashes are never consumed as escapes (#74379 P1).
+    const match = evaluateExecDenyPathMatch({
+      patterns: ["**/.ssh/*"],
+      argv: ["type", "C:\\Users\\alice\\.ssh\\id_rsa"],
+      homeDir: "/c/users/alice",
+    });
+    expect(match?.pattern).toBe("**/.ssh/*");
+  });
 });
 
 describe("formatExecDenyPathMessage", () => {
@@ -229,21 +247,26 @@ describe("tokenizeShellPayload", () => {
 
 // Smoke checks for the home-dir resolver integration.
 describe("evaluateExecDenyPathMatch (home dir resolution)", () => {
+  // resolveEffectiveHomeDir runs path.resolve on the env value, so the argv
+  // candidate is built with path.join from the same resolved base. This stays
+  // cross-platform (the home is an absolute, rooted path on POSIX and win32)
+  // without touching the filesystem — resolveEffectiveHomeDir honors the env
+  // var without any fs existence check.
+  const isolatedHome = path.resolve(path.sep, "fake-openclaw-home-12345");
+
   it("resolves env.HOME via the shared home-dir resolver", () => {
-    const isolatedHome = "/tmp/fake-openclaw-home-12345";
     const match = evaluateExecDenyPathMatch({
       patterns: ["~/openclaw-deny-test-marker/**"],
-      argv: ["cat", `${isolatedHome}/openclaw-deny-test-marker/x`],
+      argv: ["cat", path.join(isolatedHome, "openclaw-deny-test-marker", "x")],
       env: { HOME: isolatedHome } as NodeJS.ProcessEnv,
     });
     expect(match?.pattern).toBe("~/openclaw-deny-test-marker/**");
   });
 
   it("honors OPENCLAW_HOME via the shared home-dir resolver", () => {
-    const isolatedHome = "/tmp/fake-openclaw-home-12345";
     const match = evaluateExecDenyPathMatch({
       patterns: ["~/.openclaw/secrets/**"],
-      argv: ["cat", `${isolatedHome}/.openclaw/secrets/foo.env`],
+      argv: ["cat", path.join(isolatedHome, ".openclaw", "secrets", "foo.env")],
       env: { OPENCLAW_HOME: isolatedHome } as NodeJS.ProcessEnv,
     });
     expect(match?.pattern).toBe("~/.openclaw/secrets/**");

--- a/src/infra/exec-deny-path.ts
+++ b/src/infra/exec-deny-path.ts
@@ -1,0 +1,350 @@
+import path from "node:path";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { expandHomePrefix, resolveEffectiveHomeDir } from "./home-dir.js";
+
+// Compile a glob pattern to a regex.
+// `**` matches any characters including `/`.
+// `*` matches any characters except `/`.
+// `?` matches a single non-`/` character.
+// All other characters are matched literally.
+//
+// Mirrors the style used in src/infra/exec-allowlist-pattern.ts so the deny
+// surface and the allowlist surface stay readable together. Cache key is
+// platform-scoped because Windows compiles with the case-insensitive flag.
+const globRegexCache = new Map<string, RegExp>();
+const GLOB_REGEX_CACHE_LIMIT = 256;
+
+function escapeRegExpLiteral(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function compileDenyPathGlob(pattern: string): RegExp {
+  const cacheKey = `${process.platform}:${pattern}`;
+  const cached = globRegexCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  let regex = "^";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      const next = pattern[i + 1];
+      if (next === "*") {
+        regex += ".*";
+        i += 2;
+        continue;
+      }
+      regex += "[^/]*";
+      i += 1;
+      continue;
+    }
+    if (ch === "?") {
+      regex += "[^/]";
+      i += 1;
+      continue;
+    }
+    regex += escapeRegExpLiteral(ch);
+    i += 1;
+  }
+  regex += "$";
+  const compiled = new RegExp(regex, process.platform === "win32" ? "i" : "");
+  if (globRegexCache.size >= GLOB_REGEX_CACHE_LIMIT) {
+    globRegexCache.clear();
+  }
+  globRegexCache.set(cacheKey, compiled);
+  return compiled;
+}
+
+// Normalizes paths/patterns for cross-platform glob matching: strips Win32
+// `\\?\`/`\\.\` prefixes, replaces `\` with `/`, and lowercases on Windows
+// for case-insensitive matching. Mirrors normalizeMatchTarget in
+// exec-allowlist-pattern.ts.
+function normalizeMatchTarget(value: string): string {
+  if (process.platform === "win32") {
+    const stripped = value.replace(/^\\\\[?.]\\/, "");
+    return normalizeLowercaseStringOrEmpty(stripped.replace(/\\/g, "/"));
+  }
+  return value.replace(/\\/g, "/");
+}
+
+function isPathLikeArg(arg: string): boolean {
+  if (typeof arg !== "string" || arg.length === 0) {
+    return false;
+  }
+  // Skip flags. `--token=secret` is not a path; the env-style assignment is
+  // also not a path. Bare `-` and `--` separators are not paths.
+  if (arg.startsWith("-")) {
+    return false;
+  }
+  if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg)) {
+    return false;
+  }
+  if (arg === "~" || arg.startsWith("~/") || arg.startsWith("~\\")) {
+    return true;
+  }
+  if (arg.startsWith("/") || arg.includes("/")) {
+    return true;
+  }
+  // Windows absolute or backslash-separated paths.
+  if (process.platform === "win32") {
+    if (/^[A-Za-z]:[\\/]/.test(arg) || arg.includes("\\")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isSkippedCandidateArg(arg: string): boolean {
+  if (typeof arg !== "string" || arg.length === 0) {
+    return true;
+  }
+  // Skip flags. `--token=secret` is not a path; the env-style assignment is
+  // also not a path. Bare `-` and `--` separators are not paths.
+  if (arg.startsWith("-")) {
+    return true;
+  }
+  if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg)) {
+    return true;
+  }
+  return false;
+}
+
+// Best-effort tokenization of a shell payload string. Respects single and
+// double quotes and a single layer of `\` escapes outside single quotes.
+// Does not attempt to handle heredocs, command substitution, `eval`, base64
+// decoding, or other indirection — v1 is explicitly the "lazy `cat
+// ~/.openclaw/secrets/...` case", not a complete sandbox.
+export function tokenizeShellPayload(payload: string): string[] {
+  const out: string[] = [];
+  let buf = "";
+  let inSingle = false;
+  let inDouble = false;
+  let escape = false;
+  for (const ch of payload) {
+    if (escape) {
+      buf += ch;
+      escape = false;
+      continue;
+    }
+    // POSIX shells use backslash as an escape; Windows paths use it as a
+    // separator. Only treat it as an escape off-Windows so that Windows-style
+    // path tokens (C:\\Users\\...\\.ssh) survive tokenization for matching (#74379 P1).
+    if (process.platform !== "win32" && !inSingle && ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (!inDouble && ch === "'") {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (!inSingle && ch === '"') {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (!inSingle && !inDouble && /\s/.test(ch)) {
+      if (buf) {
+        out.push(buf);
+        buf = "";
+      }
+      continue;
+    }
+    if (!inSingle && !inDouble && /[;&|<>()]/.test(ch)) {
+      if (buf) {
+        out.push(buf);
+        buf = "";
+      }
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf) {
+    out.push(buf);
+  }
+  return out;
+}
+
+export type DenyPathMatch = {
+  pattern: string;
+  arg: string;
+  resolved: string;
+};
+
+type CompiledDenyPattern = {
+  raw: string;
+  expanded: string;
+  regexExpanded: RegExp;
+  regexRaw: RegExp;
+};
+
+function compilePatterns(
+  patterns: readonly string[],
+  homeDir: string | undefined,
+): CompiledDenyPattern[] {
+  const out: CompiledDenyPattern[] = [];
+  for (const candidate of patterns) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const trimmed = candidate.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const expanded = expandHomePrefix(trimmed, { home: homeDir });
+    out.push({
+      raw: trimmed,
+      expanded,
+      regexExpanded: compileDenyPathGlob(normalizeMatchTarget(expanded)),
+      regexRaw: compileDenyPathGlob(normalizeMatchTarget(trimmed)),
+    });
+  }
+  return out;
+}
+
+export function evaluateExecDenyPathMatch(params: {
+  patterns: readonly string[];
+  argv: readonly string[];
+  shellPayload?: string | null;
+  cwd?: string | null;
+  // Optional overrides for tests. Production resolves through the standard
+  // OPENCLAW_HOME / HOME / USERPROFILE / os.homedir cascade in
+  // resolveEffectiveHomeDir.
+  homeDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): DenyPathMatch | null {
+  const homeDir = params.homeDir ?? resolveEffectiveHomeDir(params.env ?? process.env);
+  const compiled = compilePatterns(params.patterns ?? [], homeDir);
+  if (compiled.length === 0) {
+    return null;
+  }
+
+  const candidates: string[] = [];
+  for (const arg of params.argv ?? []) {
+    if (typeof arg === "string") {
+      candidates.push(arg);
+    }
+  }
+  if (typeof params.shellPayload === "string" && params.shellPayload.length > 0) {
+    for (const token of tokenizeShellPayload(params.shellPayload)) {
+      candidates.push(token);
+    }
+  }
+
+  const cwd = typeof params.cwd === "string" && params.cwd.length > 0 ? params.cwd : null;
+
+  for (const arg of candidates) {
+    if (isSkippedCandidateArg(arg)) {
+      continue;
+    }
+    if (!cwd && !isPathLikeArg(arg)) {
+      continue;
+    }
+    const expanded = expandHomePrefix(arg, { home: homeDir });
+    const resolved =
+      cwd && !path.isAbsolute(expanded)
+        ? path.resolve(cwd, expanded)
+        : path.isAbsolute(expanded)
+          ? path.resolve(expanded)
+          : expanded;
+    const normalizedArg = normalizeMatchTarget(arg);
+    const normalizedExpanded = normalizeMatchTarget(expanded);
+    const normalizedResolved = normalizeMatchTarget(resolved);
+    for (const pattern of compiled) {
+      if (
+        pattern.regexRaw.test(normalizedArg) ||
+        pattern.regexExpanded.test(normalizedExpanded) ||
+        pattern.regexExpanded.test(normalizedResolved)
+      ) {
+        return { pattern: pattern.raw, arg, resolved };
+      }
+    }
+  }
+  return null;
+}
+
+export function formatExecDenyPathMessage(match: DenyPathMatch): string {
+  return `SYSTEM_RUN_DENIED: argument matches tools.exec.denyPathPatterns (pattern=${JSON.stringify(match.pattern)}, arg=${JSON.stringify(match.arg)})`;
+}
+
+// Merges global and per-agent denyPathPatterns as a union. Agents can extend
+// the deny list but cannot relax it by overriding to a shorter list.
+export function resolveExecDenyPathPatterns(params: {
+  global?: readonly string[] | undefined;
+  agent?: readonly string[] | undefined;
+}): string[] {
+  const out = new Set<string>();
+  for (const list of [params.global, params.agent]) {
+    if (!Array.isArray(list)) {
+      continue;
+    }
+    for (const entry of list) {
+      if (typeof entry !== "string") {
+        continue;
+      }
+      const trimmed = entry.trim();
+      if (trimmed) {
+        out.add(trimmed);
+      }
+    }
+  }
+  return Array.from(out);
+}
+
+const SHELL_WRAPPER_EXECUTABLE_RE = /^(?:bash|dash|fish|ksh|sh|zsh)$/i;
+const SHELL_SHORT_OPTS_WITH_VALUE = new Set(["-O", "-o"]);
+
+// Extract a shell `-c` payload from an argv array, e.g.
+// ["/bin/sh", "-lc", "cat ~/.openclaw/secrets/x"] -> "cat ~/.openclaw/secrets/x".
+// Used by call sites (node-host system.run) whose upstream parse leaves the
+// payload in argv instead of a dedicated shellPayload field. POSIX-shell
+// focused and mirrors extractShellWrappedCommandPayload in bash-tools.exec.ts.
+// v1 deliberately does not parse cmd.exe / PowerShell wrappers (documented
+// limitation in docs/tools/exec-approvals-advanced.md).
+export function extractShellWrappedPayloadFromArgv(argv: readonly string[]): string | null {
+  if (!Array.isArray(argv) || argv.length === 0) {
+    return null;
+  }
+  let i = 0;
+  while (i < argv.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[i] ?? "")) {
+    i += 1;
+  }
+  const executable = argv[i];
+  if (typeof executable !== "string") {
+    return null;
+  }
+  const base = (executable.split(/[\\/]/u).at(-1) ?? "").toLowerCase();
+  const normalized = base.endsWith(".exe") ? base.slice(0, -4) : base;
+  if (!SHELL_WRAPPER_EXECUTABLE_RE.test(normalized)) {
+    return null;
+  }
+  const args = argv.slice(i + 1);
+  for (let j = 0; j < args.length; j += 1) {
+    const arg = args[j];
+    if (arg === "--") {
+      return null;
+    }
+    if (arg === "-c") {
+      return args[j + 1] ?? null;
+    }
+    if (/^-[A-Za-z]+$/u.test(arg)) {
+      if (arg.includes("c")) {
+        return args[j + 1] ?? null;
+      }
+      if (SHELL_SHORT_OPTS_WITH_VALUE.has(arg)) {
+        j += 1;
+      }
+      continue;
+    }
+    if (/^--[A-Za-z0-9][A-Za-z0-9-]*(?:=.*)?$/u.test(arg)) {
+      if (!arg.includes("=")) {
+        const next = args[j + 1];
+        if (next && next !== "--" && !next.startsWith("-")) {
+          j += 1;
+        }
+      }
+      continue;
+    }
+    return null;
+  }
+  return null;
+}

--- a/src/infra/exec-deny-path.ts
+++ b/src/infra/exec-deny-path.ts
@@ -68,7 +68,10 @@ function compileDenyPathGlob(pattern: string): RegExp {
 // Normalizes paths/patterns for cross-platform glob matching: strips Win32
 // `\\?\`/`\\.\` prefixes, replaces `\` with `/`, and lowercases on Windows
 // for case-insensitive matching. Mirrors normalizeMatchTarget in
-// exec-allowlist-pattern.ts.
+// exec-allowlist-pattern.ts. The `\`->`/` rewrite is what lets a Windows-style
+// path token (e.g. `C:\Users\op\.ssh\id_rsa`) match a POSIX-style deny pattern
+// like `**/.ssh/*`; it runs on every host, not just win32, so an argv token
+// carrying backslashes is still caught on a Linux/macOS gateway.
 function normalizeMatchTarget(value: string): string {
   if (process.platform === "win32") {
     const stripped = value.replace(/^\\\\[?.]\\/, "");
@@ -109,9 +112,14 @@ export function tokenizeShellPayload(payload: string): string[] {
       escape = false;
       continue;
     }
-    // POSIX shells use backslash as an escape; Windows paths use it as a
-    // separator. Only treat it as an escape off-Windows so that Windows-style
-    // path tokens (C:\\Users\\...\\.ssh) survive tokenization for matching (#74379 P1).
+    // POSIX shells use backslash as an escape; Windows shells use it as a path
+    // separator. Only treat it as an escape on non-win32 hosts. On win32 the
+    // backslash is preserved so a Windows-style path token inside a shell `-c`
+    // payload (C:\\Users\\...\\.ssh) survives to normalizeMatchTarget, which
+    // rewrites it to forward slashes for matching (#74379 P1). On a POSIX host
+    // a `\` inside a shell payload is a genuine escape and is consumed here;
+    // Windows paths arriving as discrete argv tokens (not shell-payload text)
+    // skip this function entirely and still match via normalizeMatchTarget.
     if (process.platform !== "win32" && !inSingle && ch === "\\") {
       escape = true;
       continue;
@@ -201,7 +209,11 @@ export function evaluateExecDenyPathMatch(params: {
   }
 
   const candidates: string[] = [];
-  for (const arg of params.argv ?? []) {
+  // `argv` crosses a process boundary (gateway/node-host wire payload), so a
+  // non-array is a real hostile/malformed input, not a hypothetical: guard it
+  // before iterating rather than trusting `?? []` to imply array-ness.
+  const argv = Array.isArray(params.argv) ? params.argv : [];
+  for (const arg of argv) {
     if (typeof arg === "string") {
       candidates.push(arg);
     }
@@ -224,12 +236,21 @@ export function evaluateExecDenyPathMatch(params: {
     // left the documented `**/.env` hard-deny unenforced on the no-cwd
     // node-host path (#74379 review P1).
     const expanded = expandHomePrefix(arg, { home: homeDir });
-    const resolved =
-      cwd && !path.isAbsolute(expanded)
-        ? path.resolve(cwd, expanded)
-        : path.isAbsolute(expanded)
-          ? path.resolve(expanded)
-          : expanded;
+    // With a cwd, anchor relative targets to it. Without one, keep the value
+    // relative rather than anchoring to the gateway's own process.cwd(): the
+    // command's working directory is unknown here, so resolving against our
+    // cwd would invent a path that could both miss real matches and create
+    // false ones. The relative form is still matched because deny patterns use
+    // the `**/` globstar (matches zero leading segments), so `config/.env` and
+    // bare `.env` are caught by `**/.env`.
+    let resolved: string;
+    if (path.isAbsolute(expanded)) {
+      resolved = path.resolve(expanded);
+    } else if (cwd) {
+      resolved = path.resolve(cwd, expanded);
+    } else {
+      resolved = expanded;
+    }
     const normalizedArg = normalizeMatchTarget(arg);
     const normalizedExpanded = normalizeMatchTarget(expanded);
     const normalizedResolved = normalizeMatchTarget(resolved);

--- a/src/infra/exec-deny-path.ts
+++ b/src/infra/exec-deny-path.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { expandHomePrefix, resolveEffectiveHomeDir } from "./home-dir.js";
 
 // Compile a glob pattern to a regex.
@@ -31,6 +31,15 @@ function compileDenyPathGlob(pattern: string): RegExp {
     if (ch === "*") {
       const next = pattern[i + 1];
       if (next === "*") {
+        // `**/` (globstar) matches zero or more leading path segments, so a
+        // bare basename like `.env` is matched by `**/.env`, not just
+        // `dir/.env` (#74379 review P1). A bare `**` (no trailing slash)
+        // still matches anything including `/`.
+        if (pattern[i + 2] === "/") {
+          regex += "(?:.*/)?";
+          i += 3;
+          continue;
+        }
         regex += ".*";
         i += 2;
         continue;
@@ -66,33 +75,6 @@ function normalizeMatchTarget(value: string): string {
     return normalizeLowercaseStringOrEmpty(stripped.replace(/\\/g, "/"));
   }
   return value.replace(/\\/g, "/");
-}
-
-function isPathLikeArg(arg: string): boolean {
-  if (typeof arg !== "string" || arg.length === 0) {
-    return false;
-  }
-  // Skip flags. `--token=secret` is not a path; the env-style assignment is
-  // also not a path. Bare `-` and `--` separators are not paths.
-  if (arg.startsWith("-")) {
-    return false;
-  }
-  if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg)) {
-    return false;
-  }
-  if (arg === "~" || arg.startsWith("~/") || arg.startsWith("~\\")) {
-    return true;
-  }
-  if (arg.startsWith("/") || arg.includes("/")) {
-    return true;
-  }
-  // Windows absolute or backslash-separated paths.
-  if (process.platform === "win32") {
-    if (/^[A-Za-z]:[\\/]/.test(arg) || arg.includes("\\")) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function isSkippedCandidateArg(arg: string): boolean {
@@ -236,9 +218,11 @@ export function evaluateExecDenyPathMatch(params: {
     if (isSkippedCandidateArg(arg)) {
       continue;
     }
-    if (!cwd && !isPathLikeArg(arg)) {
-      continue;
-    }
+    // Every non-flag candidate is matched against the patterns, even a bare
+    // relative basename like `.env` with no cwd. Path-globs do not match
+    // non-path tokens (`echo`, `done`) anyway, and skipping bare relatives
+    // left the documented `**/.env` hard-deny unenforced on the no-cwd
+    // node-host path (#74379 review P1).
     const expanded = expandHomePrefix(arg, { home: homeDir });
     const resolved =
       cwd && !path.isAbsolute(expanded)

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -751,6 +751,39 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
   });
 
+  it("denies configured path patterns before allowlist or execution", async () => {
+    const tmp = createFixtureDir("openclaw-deny-path-policy-");
+    const runCommand = vi.fn(async () => createLocalRunResult("should-not-run"));
+    setRuntimeConfigSnapshot({
+      tools: {
+        exec: {
+          denyPathPatterns: ["~/.openclaw/secrets/**"],
+        },
+      },
+    });
+
+    const invoke = await runSystemInvoke({
+      preferMacAppExecHost: false,
+      command: ["/bin/sh", "-lc", "cat ~/.openclaw/secrets/foo.env; echo ok"],
+      cwd: tmp,
+      security: "allowlist",
+      ask: "off",
+      runCommand,
+    });
+
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(invoke.sendNodeEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      "exec.denied",
+      expect.objectContaining({ reason: "deny-path-pattern" }),
+    );
+    expectInvokeErrorMessage(invoke.sendInvokeResult, {
+      message:
+        'SYSTEM_RUN_DENIED: argument matches tools.exec.denyPathPatterns (pattern="~/.openclaw/secrets/**", arg="~/.openclaw/secrets/foo.env")',
+      exact: true,
+    });
+  });
+
   const approvedEnvShellWrapperCases = [
     {
       name: "preserves wrapper argv for approved env shell commands in local execution",

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -30,6 +30,12 @@ import {
 } from "../infra/exec-approvals.js";
 import type { ExecAuthorizationPlan } from "../infra/exec-authorization-plan.js";
 import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
+import {
+  evaluateExecDenyPathMatch,
+  extractShellWrappedPayloadFromArgv,
+  formatExecDenyPathMessage,
+  resolveExecDenyPathPatterns,
+} from "../infra/exec-deny-path.js";
 import type { ExecHostRequest, ExecHostResponse, ExecHostRunResult } from "../infra/exec-host.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
@@ -80,6 +86,7 @@ type SystemRunDeniedReason =
   | "allowlist-miss"
   | "execution-plan-miss"
   | "companion-unavailable"
+  | "deny-path-pattern"
   | "permission:screenRecording";
 
 type SystemRunExecutionContext = {
@@ -198,6 +205,7 @@ function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeni
     case "allowlist-miss":
     case "execution-plan-miss":
     case "companion-unavailable":
+    case "deny-path-pattern":
     case "permission:screenRecording":
       return reason;
     default:
@@ -504,6 +512,34 @@ async function evaluateSystemRunPolicyPhase(
   });
   const { agentExec, globalExec, approvals, security, ask } = effectivePolicy;
   const autoAllowSkills = approvals.agent.autoAllowSkills;
+
+  // Deny-path gate runs before the allowlist/approval checks so a hard deny
+  // for known-secret paths cannot be relaxed by allow-always or
+  // security="full". Defense-in-depth against the "lazy `cat ~/.openclaw/
+  // secrets/...`" exfiltration path described in #74379.
+  const denyPathPatterns = resolveExecDenyPathPatterns({
+    global: cfg.tools?.exec?.denyPathPatterns,
+    agent: agentExec?.denyPathPatterns,
+  });
+  if (denyPathPatterns.length > 0) {
+    const denyMatch = evaluateExecDenyPathMatch({
+      patterns: denyPathPatterns,
+      argv: parsed.argv,
+      // Upstream system.run parse may leave a shell -c payload in argv
+      // rather than parsed.shellPayload; recover it so the deny gate can see
+      // tokens hidden inside the wrapper (#74379).
+      shellPayload: parsed.shellPayload ?? extractShellWrappedPayloadFromArgv(parsed.argv),
+      cwd: parsed.cwd,
+    });
+    if (denyMatch) {
+      await sendSystemRunDenied(opts, parsed.execution, {
+        reason: "deny-path-pattern",
+        message: formatExecDenyPathMessage(denyMatch),
+      });
+      return null;
+    }
+  }
+
   const { safeBins, safeBinProfiles, trustedSafeBinDirs } = resolveExecSafeBinRuntimePolicy({
     global: cfg.tools?.exec,
     local: agentExec,


### PR DESCRIPTION
## Summary

Adds an opt-in `tools.exec.denyPathPatterns` — a config-level deny gate that blocks `exec` / `system.run` invocations whose path arguments match configured glob patterns, **before** allowlist/approval/safe-bin checks. A denied path (e.g. `~/.openclaw/secrets/**`, `**/.ssh/id_*`) cannot be reached via `security="full"`, allow-always, or safe-bins.

- New `src/infra/exec-deny-path.ts`: glob compilation, home-dir expansion, cwd-relative resolution, and best-effort POSIX shell `-c` payload tokenization.
- Wired into both the bash-tools exec path (`src/agents/bash-tools.exec.ts`) and the node-host `system.run` path (`src/node-host/invoke-system-run.ts`).
- Global + per-agent patterns are unioned (agents can extend but not relax the deny list), resolved in `src/agents/agent-tools.ts`.

Fixes #74379.

This is a fresh rework of #81827 against current `main`: the deny-gate config wiring moved from the now-removed `pi-tools.ts` to `agent-tools.ts`, and the base config schema is no longer a committed generated file. No `CHANGELOG.md` entry (release-owned).

### Addressing the prior review (P1s)

- **Windows path separators preserved**: the shell-payload tokenizer no longer treats `\` as an escape on `win32`, so Windows-style path tokens survive matching.
- **Wrapper-hidden payloads on the node-host path**: a dedicated `extractShellWrappedPayloadFromArgv` recovers a `sh -c` payload from `argv` (main's `system.run` parse leaves it there), so paths hidden inside a shell wrapper are matched on that path too. (It deliberately mirrors `extractShellWrappedCommandPayload` in `bash-tools.exec.ts` rather than sharing it: the bash-tools helper is also used by the unrelated interpreter-preflight path and takes a pre-split `(executable, args)`, so unifying them would tangle two security paths for no net reduction.)
- **Honest v1 scope**: documented (help text + `docs/tools/exec-approvals-advanced.md`) that v1 is a hard-deny for literal path-like arguments after simple shell-quote stripping, and does **not** defeat heredocs, eval-style indirection, base64-decoded paths, command substitution, symlink redirection, or `cmd.exe`/PowerShell wrappers.

## Real behavior proof

ClawSweeper asked for proof from the **real configured exec gate run outside the Vitest/mock harness**. Below is exactly that: a throwaway `node --import tsx` harness (not committed) that imports the *production* deny-gate functions and composes them **identically to the node-host `system.run` gate** (`src/node-host/invoke-system-run.ts:516-537`) — `resolveExecDenyPathPatterns` → `extractShellWrappedPayloadFromArgv` → `evaluateExecDenyPathMatch` — with zero mocking, against a realistic operator config. The full end-to-end "host executor is never called" property is additionally covered by the Vitest path suite (which mocks only the downstream host executor, legitimately).

Behavior addressed: a hard-deny path gate that fires before allowlist/approval/safe-bins, including for a documented `**/.env` example on the no-cwd node-host path, not bypassable via POSIX shell wrappers or Windows separators, and failing toward checking (never open) on malformed shell input.
Real environment tested: macOS (arm64), node 22, openclaw source at this branch HEAD (`b73275c1a`); deny-gate code run unmocked via `node --import tsx`.
Exact steps or command run after this patch: composed the real node-host gate (`resolveExecDenyPathPatterns({global:["**/.env","**/.ssh/*"], agent:["~/.ssh/id_*"]})` → `evaluateExecDenyPathMatch` with `shellPayload: extractShellWrappedPayloadFromArgv(argv)`) in a throwaway `exec-deny-realproof.mts` (deleted, not committed), run with `node --import tsx exec-deny-realproof.mts`; plus the Vitest path/system.run suites for the host-never-called assertion.
Evidence after fix: unmocked production deny-gate output (paths/keys are synthetic placeholders, no real secrets):

```
$ node --import tsx exec-deny-realproof.mts
configured denyPathPatterns: ["**/.env","**/.ssh/*","~/.ssh/id_*"]

=== real node-host deny-gate composition (unmocked production functions) ===
DENIED  | cat ~/.ssh/id_rsa  (no cwd)
        | SYSTEM_RUN_DENIED: ... (pattern="**/.ssh/*", arg="~/.ssh/id_rsa")
DENIED  | cat .env  (no cwd)                         <- prior review gap, now fixed
        | SYSTEM_RUN_DENIED: ... (pattern="**/.env", arg=".env")
DENIED  | sh -lc 'cat ~/.ssh/id_ed25519'  (argv-recovered wrapper payload)
        | SYSTEM_RUN_DENIED: ... (pattern="**/.ssh/*", arg="cat ~/.ssh/id_ed25519")
DENIED  | type C:\Users\<redacted>\.ssh\id_rsa  (Windows-style argv token)
        | SYSTEM_RUN_DENIED: ... (pattern="**/.ssh/*", arg="C:\\Users\\<redacted>\\.ssh\\id_rsa")
DENIED  | cat config/.env  (cwd=/srv/app)
        | SYSTEM_RUN_DENIED: ... (pattern="**/.env", arg="config/.env")
ALLOWED | cat README.md  (control)
DENIED  | malformed-quote raw payload fallback (unbalanced quote -> splitShellArgs null)
        | SYSTEM_RUN_DENIED: ... (pattern="**/.ssh/*", arg="~/.ssh/id_rsa")
```

Plus, the end-to-end exec tool denies and never reaches the host executor:
```
$ node scripts/run-vitest.mjs src/agents/bash-tools.exec.path.test.ts src/node-host/invoke-system-run.test.ts
 ✓ hard-denies a bare relative deny target on the node host even when workdir is omitted
     (nodeHostMocks.executeNodeHostCommand NOT called)
 ✓ still denies a deny target when shell tokenization fails (unbalanced quote)   <- new fail-closed regression
 ✓ denies configured path patterns before allowlist or execution  (reason: "deny-path-pattern")
```

Observed result after fix: the unmocked production deny-gate (same composition as the node-host `system.run` path) hard-denies every targeted command and allows the control. The previously-flagged gap — `**/.env` not blocking `cat .env` without a cwd — is fixed: `**/` is a globstar matching zero leading segments, so bare relative candidates match. A Windows-style argv token (`C:\...\.ssh\id_rsa`) matches the POSIX `**/.ssh/*` pattern because `normalizeMatchTarget` rewrites `\`→`/` on every host. Malformed shell input (unbalanced quote) where `splitShellArgs` returns null still denies via the raw-payload fallback — the gate fails toward checking, never open. The Vitest path/system.run suites confirm the downstream host executor is never invoked and the deny reason is emitted before the allowlist.
What was not tested: live `cmd.exe`/PowerShell wrapper parsing (explicitly out of v1 scope and documented), and non-path indirection (heredocs, base64, command substitution) which v1 does not claim to defeat.

## Automated tests

```
$ node scripts/run-vitest.mjs src/infra/exec-deny-path.test.ts src/agents/bash-tools.exec.path.test.ts src/node-host/invoke-system-run.test.ts src/agents/agent-tools-agent-config.exec.test.ts
 Test Files  4 passed (4)
      Tests  113 passed (113)
```

(Count reflects the post-review tests: new Windows-argv-token, cross-platform fake-home, and fail-closed malformed-quote regressions added; some prior over-counted shards consolidated.) Lint: `node scripts/run-oxlint.mjs` on the changed files → clean.

## Risks

Medium (security boundary). The gate is opt-in (no behavior change unless `denyPathPatterns` is configured) and fails closed. v1 limitations are documented so operators do not over-trust it as a complete sandbox. Maintainer sign-off on the v1 semantics is welcome.

