### PR TITLE
fix(cron): route generated media callbacks back to run

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -351,6 +351,7 @@ async function deliverSlackChannelAnnouncement(params: {
   internalEvents?: AgentInternalEvent[];
   sourceTool?: string;
   runtimeConfig?: Record<string, unknown>;
+  requesterAbandoned?: boolean;
 }) {
   const origin = {
     channel: "slack",
@@ -364,6 +365,7 @@ async function deliverSlackChannelAnnouncement(params: {
       sessionId: params.sessionId,
       isActive: params.isActive,
     }),
+    isRequesterSessionAbandoned: () => params.requesterAbandoned === true,
     getRuntimeConfig: () => (params.runtimeConfig ?? {}) as never,
     sendMessage: params.sendMessage ?? runtimeSendMessage,
     ...(params.queueEmbeddedAgentMessageWithOutcome
@@ -2993,6 +2995,63 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("hands inactive isolated cron run media completions back to the requester agent", async () => {
+    const callGateway = createGatewayMock({ status: "started" });
+    const sendMessage = createSendMessageMock();
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
+    const internalEvents: AgentInternalEvent[] = [
+      {
+        type: "task_completion",
+        source: "image_generation",
+        childSessionKey: "image_generate:task-123",
+        childSessionId: "task-123",
+        announceType: "image generation task",
+        taskLabel: "daily media",
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "Generated 1 image.\nMEDIA:/tmp/generated-daily.png",
+        mediaUrls: ["/tmp/generated-daily.png"],
+        replyInstruction: "Deliver the generated image through the requester run.",
+      },
+    ];
+
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      queueEmbeddedAgentMessageWithOutcome,
+      sessionId: "inactive-cron-run-session",
+      isActive: false,
+      requesterSessionKey: "agent:main:cron:daily-media:run:run-123",
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-inactive-cron-media",
+      sourceTool: "image_generate",
+      internalEvents,
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expectGatewayAgentParams(callGateway, {
+      sessionKey: "agent:main:cron:daily-media:run:run-123",
+      message: "child done",
+      deliver: false,
+      sourceReplyDeliveryMode: "message_tool_only",
+      idempotencyKey: "announce-inactive-cron-media",
+    });
+    const agentParams = mockCallArg(callGateway, 0, 0).params as Record<string, unknown>;
+    expect(agentParams.internalEvents).toBe(internalEvents);
+    expect(agentParams.inputProvenance).toEqual({
+      kind: "inter_session",
+      sourceSessionKey: undefined,
+      sourceChannel: "webchat",
+      sourceTool: "image_generate",
+    });
+  });
+
   it("directly delivers stale isolated cron run media completions", async () => {
     const callGateway = createGatewayMock();
     const sendMessage = createSendMessageMock();
@@ -3003,6 +3062,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       queueEmbeddedAgentMessageWithOutcome,
       sessionId: "stale-cron-run-session",
       isActive: false,
+      requesterAbandoned: true,
       requesterSessionKey: "agent:main:cron:daily-media:run:run-123",
       expectsCompletionMessage: true,
       directIdempotencyKey: "announce-stale-cron-media",

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1073,13 +1073,13 @@ async function sendSubagentAnnounceDirectly(params: {
       completionRouteRequiresMessageToolDelivery ||
       (agentMediatedCompletion && expectedMediaUrls.length > 0);
     const requesterActivity = resolveRequesterSessionActivity(canonicalRequesterSessionKey);
-    if (
+    const requesterSessionAbandoned =
       params.expectsCompletionMessage &&
       subagentAnnounceDeliveryDeps.isRequesterSessionAbandoned(
         canonicalRequesterSessionKey,
         requesterActivity.sessionId,
-      )
-    ) {
+      );
+    if (requesterSessionAbandoned && !isCronRunSessionKey(canonicalRequesterSessionKey)) {
       return {
         delivered: false,
         path: "none",
@@ -1165,9 +1165,11 @@ async function sendSubagentAnnounceDirectly(params: {
       isCronRunSessionKey(canonicalRequesterSessionKey) &&
       !resolveRequesterSessionActivity(canonicalRequesterSessionKey).isActive
     ) {
-      const generatedMediaDelivery = await tryGeneratedMediaDirectDelivery();
-      if (generatedMediaDelivery) {
-        return generatedMediaDelivery;
+      if (requesterSessionAbandoned) {
+        const generatedMediaDelivery = await tryGeneratedMediaDirectDelivery();
+        if (generatedMediaDelivery) {
+          return generatedMediaDelivery;
+        }
       }
       if (!agentMediatedCompletion) {
         return {


### PR DESCRIPTION
## Summary
- keep inactive-but-not-abandoned isolated cron generated-media completions on the requester-agent handoff path
- only use generated-media direct fallback for abandoned cron runs that are truly stale
- add regression coverage that proves inactive cron `image_generate` callbacks call the requester agent instead of external `sendMessage`

Fixes #88001.

## Real behavior proof
- Behavior or issue addressed: `image_generate` completion callbacks for isolated cron run sessions must return to the cron requester-agent path so the cron workflow can resume, instead of direct-sending the image to the channel while the cron stops before later steps.
- Real environment tested: Local OpenClaw checkout at PR head `60cb1896c8caf59aed7e06fc678258e93dce2597` on macOS, running the real `src/agents/subagent-announce-delivery.ts` module through `node --import tsx`. The command exercised the actual delivery routing code with a high-fidelity isolated cron run key and generated-media internal event; external Slack/image-provider calls were stubbed so no live provider credentials were needed.
- Exact steps or command run after this patch: Ran a `node --import tsx --input-type=module` terminal script that imported `deliverSubagentAnnouncement` and `testing` from `./src/agents/subagent-announce-delivery.ts`, then executed two callback-routing scenarios: inactive cron run not abandoned, and abandoned/stale cron run.
- Evidence after fix: Terminal output from that after-fix command:

```json
{
  "inactiveNotAbandoned": {
    "abandoned": false,
    "result": {
      "delivered": true,
      "path": "direct"
    },
    "gatewayCalls": [
      {
        "method": "agent",
        "sessionKey": "agent:main:cron:proof-media:run:run-123",
        "deliver": false,
        "sourceReplyDeliveryMode": "message_tool_only",
        "internalEventCount": 1,
        "statusReturned": "started"
      }
    ],
    "sentMessages": []
  },
  "abandonedStale": {
    "abandoned": true,
    "result": {
      "delivered": true,
      "path": "direct"
    },
    "gatewayCalls": [],
    "sentMessages": [
      {
        "channel": "slack",
        "to": "channel:C123",
        "content": "The generated image is ready.",
        "mediaUrls": [
          "/tmp/proof-image.png"
        ],
        "idempotencyKey": "proof-image-callback:generated-media-direct"
      }
    ]
  }
}
```

- Observed result after fix: For an inactive isolated cron run that is not abandoned, the generated image callback made one requester-agent call for `agent:main:cron:proof-media:run:run-123`, carried the generated-media event back with `sourceReplyDeliveryMode: "message_tool_only"`, and made zero external `sendMessage` calls. For an abandoned stale cron run, the fallback still direct-sent `The generated image is ready.` with the media URL, preserving stale-callback behavior.
- What was not tested: I did not run a live paid image provider or a real Slack delivery. The routing behavior was verified against the real OpenClaw delivery module with controlled gateway/channel boundaries, and the focused test suite covers the same path permanently.

## Validation
- `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/media-generate-background-shared.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/cron/isolated-agent.session-identity.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts` — 9 files, 446 tests passed
- `pnpm check:test-types`
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts`
- `git diff --check`

If this PR is squash-merged or reworked, please preserve author attribution for Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>