### PR TITLE
fix(active-memory): trim recall prompt envelope

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3649,6 +3649,51 @@ describe("active-memory plugin", () => {
     expect(prompt).not.toContain("Bounded memory search query:\nUntrusted Discord message body");
   });
 
+  it("trims OpenClaw runtime envelopes before building the recall conversation context", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      allowedChatTypes: ["direct", "group"],
+      queryMode: "recent",
+      recentUserChars: 120,
+      recentAssistantChars: 80,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const runtimeEnvelope = [
+      "OpenClaw runtime context for this turn:",
+      "Treat this OpenClaw-provided context as supporting project/user reference.",
+      "Conversation context (untrusted, chronological, selected for current message):",
+      "RUNTIME_CONTEXT_FILLER ".repeat(1_500),
+      "Current user request:",
+      "do you remember my flight seat preference?",
+    ].join("\n");
+
+    await hooks.before_prompt_build(
+      {
+        prompt: runtimeEnvelope,
+        messages: [
+          { role: "user", content: "i am booking a flight tomorrow" },
+          { role: "assistant", content: "sure, let's plan it" },
+        ],
+      },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:telegram:group:private-topic",
+        messageProvider: "telegram",
+        channelId: "telegram",
+      },
+    );
+
+    const prompt = lastEmbeddedPrompt();
+    expect(prompt).toContain(
+      "Bounded memory search query:\ndo you remember my flight seat preference?",
+    );
+    expect(prompt).toContain("Latest user message:\ndo you remember my flight seat preference?");
+    expect(prompt).toContain("user: i am booking a flight tomorrow");
+    expect(prompt).not.toContain("OpenClaw runtime context for this turn");
+    expect(prompt).not.toContain("RUNTIME_CONTEXT_FILLER");
+  });
+
   it("supports full mode by sending the whole conversation", async () => {
     api.pluginConfig = {
       agents: ["main"],

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -90,6 +90,7 @@ const DEFAULT_TRANSCRIPT_READ_MAX_LINES = 2_000;
 const DEFAULT_TRANSCRIPT_READ_MAX_BYTES = 50 * 1024 * 1024;
 const TIMEOUT_PARTIAL_DATA_GRACE_MS = 500;
 const MAX_ACTIVE_MEMORY_SEARCH_QUERY_CHARS = 480;
+const MAX_ACTIVE_MEMORY_LATEST_MESSAGE_CHARS = 2_000;
 const TERMINAL_MEMORY_SEARCH_POLL_INTERVAL_MS = 25;
 
 const NO_RECALL_VALUES = new Set([
@@ -2216,6 +2217,46 @@ function stripExternalUntrustedBlocks(text: string): string {
   );
 }
 
+function extractCurrentUserRequestFromPrompt(prompt: string): string {
+  const matches = [...prompt.matchAll(/(?:^|\n)Current user request:\s*\n?/gi)];
+  const lastMatch = matches.at(-1);
+  if (!lastMatch || lastMatch.index === undefined) {
+    return prompt;
+  }
+  return prompt.slice(lastMatch.index + lastMatch[0].length);
+}
+
+function clampLatestUserMessage(text: string): string {
+  const normalized = text.trim();
+  return normalized.length > MAX_ACTIVE_MEMORY_LATEST_MESSAGE_CHARS
+    ? normalized.slice(0, MAX_ACTIVE_MEMORY_LATEST_MESSAGE_CHARS).trim()
+    : normalized;
+}
+
+function deriveLatestUserMessageForRecall(params: {
+  prompt: string;
+  recentTurns: ActiveRecallRecentTurn[];
+}): string {
+  const extractedPrompt = extractCurrentUserRequestFromPrompt(params.prompt);
+  if (extractedPrompt !== params.prompt) {
+    return clampLatestUserMessage(
+      stripActiveMemoryXmlBlocks(stripExternalUntrustedBlocks(extractedPrompt)),
+    );
+  }
+  if (params.prompt.trim().length <= MAX_ACTIVE_MEMORY_LATEST_MESSAGE_CHARS) {
+    return clampLatestUserMessage(stripActiveMemoryXmlBlocks(params.prompt));
+  }
+  const latestRecentUser = [...params.recentTurns]
+    .toReversed()
+    .find((turn) => turn.role === "user" && turn.text.trim().length > 0);
+  if (latestRecentUser) {
+    return clampLatestUserMessage(latestRecentUser.text);
+  }
+  return clampLatestUserMessage(
+    stripActiveMemoryXmlBlocks(stripJsonFences(stripExternalUntrustedBlocks(params.prompt))),
+  );
+}
+
 function stripJsonFences(text: string): string {
   return text.replace(/```(?:json)?\s*[\s\S]*?```/gi, " ");
 }
@@ -3108,13 +3149,17 @@ export default definePluginEntry({
             return undefined;
           }
           const recentTurns = extractRecentTurns(event.messages);
+          const latestUserMessage = deriveLatestUserMessageForRecall({
+            prompt: event.prompt,
+            recentTurns,
+          });
           const query = buildQuery({
-            latestUserMessage: event.prompt,
+            latestUserMessage,
             recentTurns,
             config,
           });
           const searchQuery = buildSearchQuery({
-            latestUserMessage: event.prompt,
+            latestUserMessage,
             recentTurns,
           });
           const result = await maybeResolveActiveRecall({


### PR DESCRIPTION
## Summary

- Trim Active Memory's recall "latest user message" before building the recall subagent conversation context.
- Prefer the explicit `Current user request:` section when a prompt envelope contains OpenClaw runtime context, then fall back to short prompts, then to the latest recent user turn for oversized prompts.
- Keep the existing `searchQueryChars <= 480` behavior; this patch also prevents the unbounded `queryChars=30k` conversation context from reaching the recall subagent.
- Intentionally out of scope: changing Active Memory defaults, disabling group recall, changing provider routing, or changing Codex compaction behavior.
- Review focus: the fallback order in `deriveLatestUserMessageForRecall`, whether the `Current user request:` marker is acceptable as an OpenClaw envelope boundary, and the regression test's coverage of Telegram-style runtime envelopes.

## Linked context

Closes #88077

Related #72015
Related #86996
Related #72359
Related #83773

This is AI-assisted. I understand the change: it keeps Active Memory enabled, but prevents the blocking recall subagent from receiving the full OpenClaw runtime/prompt envelope as the latest user message context.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Active Memory could log `queryChars=29351` / `30179` for normal Telegram group-topic turns because the recall subagent conversation context used full `event.prompt`; after this patch, the regression path derives the current user request and strips the runtime envelope before building recall context.
- Real environment tested: Local OpenClaw source checkout on Linux, cloned from `openclaw/openclaw`, with repo dependencies installed via `pnpm install`. The observed before evidence came from a live `OpenClaw 2026.5.28-beta.1 (84fd629)` Telegram group-topic gateway.
- Exact steps or command run after this patch:

```shell
node scripts/run-vitest.mjs run extensions/active-memory/index.test.ts -t "trims OpenClaw runtime envelopes"
node scripts/run-vitest.mjs run extensions/active-memory/index.test.ts
pnpm exec oxfmt --check --threads=1 extensions/active-memory/index.ts extensions/active-memory/index.test.ts
git diff --check
```

- Evidence after fix:

```text
RUN  v4.1.7 /Users/chapati/code/openclaw

Test Files  1 passed (1)
Tests  128 passed (128)
Duration  15.43s (transform 3.86s, setup 215ms, import 7.03s, tests 8.02s, environment 0ms)
```

```text
Checking formatting...

All matched files use the correct format.
Finished in 23ms on 2 files using 1 threads.
```

`git diff --check` produced no output.

- Observed result after fix: The new regression test builds a synthetic Telegram-style OpenClaw runtime envelope with a large filler block and `Current user request:` marker. The embedded recall prompt contains `Bounded memory search query:\ndo you remember my flight seat preference?` and `Latest user message:\ndo you remember my flight seat preference?`, while excluding `OpenClaw runtime context for this turn` and the large filler text.
- What was not tested: I did not install this branch into the live production gateway. The local `codex review --base origin/main` command was attempted but failed with OpenAI 401 auth (`Missing bearer or basic authentication in header`). No live Telegram after-fix log line is available from this branch.
- Proof limitations or environment constraints: This proof is focused plugin-level behavior proof plus live before logs. It does not prove a packaged/npm beta install or a production gateway restart with the patch.
- Before evidence:

```shell
2026-05-29T17:24:24.249+02:00 [plugins] active-memory: agent=main session=agent:main:telegram:group:-1003352789296:topic:74 activeProvider=xai activeModel=grok-4.20-beta-latest-non-reasoning start timeoutMs=8000 queryChars=30179 searchQueryChars=480
2026-05-29T17:24:28.158+02:00 [plugins] active-memory: agent=main session=agent:main:telegram:group:-1003352789296:topic:74 activeProvider=xai activeModel=grok-4.20-beta-latest-non-reasoning done status=ok elapsedMs=3910 summaryChars=157

2026-05-29T17:28:01.163+02:00 [plugins] active-memory: agent=main session=agent:main:telegram:group:-1003352789296:topic:74 activeProvider=xai activeModel=grok-4.20-beta-latest-non-reasoning start timeoutMs=8000 queryChars=29351 searchQueryChars=479
2026-05-29T17:28:04.493+02:00 [plugins] active-memory: agent=main session=agent:main:telegram:group:-1003352789296:topic:74 activeProvider=xai activeModel=grok-4.20-beta-latest-non-reasoning done status=no_relevant_memory elapsedMs=3331 summaryChars=0
```

## Tests and validation

Commands run:

```shell
pnpm install
node scripts/run-vitest.mjs run extensions/active-memory/index.test.ts -t "trims OpenClaw runtime envelopes"
node scripts/run-vitest.mjs run extensions/active-memory/index.test.ts
pnpm exec oxfmt --check --threads=1 extensions/active-memory/index.ts extensions/active-memory/index.test.ts
git diff --check
```

Regression coverage added:

- Adds an Active Memory test that passes a large OpenClaw runtime envelope containing a `Current user request:` marker.
- Asserts the recall subagent prompt uses the current user request for both bounded search query and latest-user-message context.
- Asserts the runtime envelope and large filler block are not included in the recall prompt.

What failed before this fix:

- Source inspection showed both `buildQuery` and `buildSearchQuery` received raw `event.prompt`. `buildSearchQuery` sanitized/clamped the memory tool query, but `buildQuery` still preserved the full envelope in recall conversation context.
- Live gateway logs showed `queryChars=29351` / `30179` while `searchQueryChars` stayed bounded at `479` / `480`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Active Memory recall should consider the actual current user request instead of channel/runtime envelopes when deciding what memory to surface.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Recall quality: if a non-OpenClaw prompt happens to contain `Current user request:`, Active Memory will treat the text after the last marker as the latest user request.

How is that risk mitigated?

The marker is used as a boundary only for deriving the latest-user-message recall context; the change is bounded to Active Memory's plugin hook. Existing recent-turn context still remains available for disambiguation, search query clamping remains in place, and the full Active Memory test file passes.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Maintainer judgment on the `Current user request:` marker as the envelope boundary.
- CI and/or maintainer-run live gateway proof if production Telegram after-fix evidence is required.
- `codex review --base origin/main` could not complete locally due OpenAI 401 auth.

Which bot or reviewer comments were addressed?

None yet.
