### PR TITLE
test(xai): type oauth note mock

### DIFF
--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -389,7 +389,7 @@ describe("xAI OAuth", () => {
         }),
       );
     vi.stubGlobal("fetch", fetchImpl);
-    const note = vi.fn(async () => {});
+    const note = vi.fn<(message: string, title?: string) => Promise<void>>(async () => undefined);
     const openUrl = vi.fn(async () => {});
     const log = vi.fn();
     const runtime = { ...createRuntimeEnv(), log };
@@ -478,7 +478,7 @@ describe("xAI OAuth", () => {
         }),
       );
     vi.stubGlobal("fetch", fetchImpl);
-    const note = vi.fn(async () => {});
+    const note = vi.fn<(message: string, title?: string) => Promise<void>>(async () => undefined);
     const ctx: ProviderAuthContext = {
       config: {},
       isRemote: true,


### PR DESCRIPTION
## Summary
- Type the xAI OAuth device-code note mocks to match `WizardPrompter.note(message, title?)`.
- Fixes the extension-test typecheck failure where `note.mock.calls[0][0]` was inferred from a zero-argument mock.

## Verification
- `git diff --check`
- AWS Crabbox `cbx_a77eea15518a` / `run_acad1e03848a`: `node scripts/run-vitest.mjs run extensions/xai/xai-oauth.test.ts && pnpm check:changed`

## Real behavior proof
Behavior addressed: xAI OAuth test typecheck no longer rejects note mock call inspection.
Real environment tested: AWS Crabbox Linux, Node 24.16.0, pnpm 11.2.2.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/xai/xai-oauth.test.ts && pnpm check:changed`
Evidence after fix: Crabbox lease `cbx_a77eea15518a`, run `run_acad1e03848a`, exit 0.
Observed result after fix: xAI OAuth test passed 13/13; changed gate passed extension-test typecheck and lint.
What was not tested: full repo check; this is a one-file test typing fix.
