### PR TITLE
fix(agent): preserve media task success on delivery miss

### DIFF
--- a/src/agents/image-generation-task-status.test.ts
+++ b/src/agents/image-generation-task-status.test.ts
@@ -227,6 +227,49 @@ describe("image generation task status", () => {
     );
   });
 
+  it("does not use a delivery-blocked image task as a succeeded duplicate guard", () => {
+    const now = Date.now();
+    recordRecentMediaGenerationTaskStartForSession({
+      sessionKey: "agent:main",
+      taskKind: IMAGE_GENERATION_TASK_KIND,
+      sourcePrefix: "image_generate",
+      taskId: "task-blocked-delivery",
+      runId: "run-blocked-delivery",
+      taskLabel: "recent prompt",
+      requestKey: "image-request:blocked",
+      providerId: "xai",
+      progressSummary: "Generating image",
+      nowMs: now - 20_000,
+    });
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
+      {
+        taskId: "task-blocked-delivery",
+        runId: "run-blocked-delivery",
+        runtime: "cli",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:xai",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "recent prompt",
+        status: "succeeded",
+        terminalOutcome: "blocked",
+        terminalSummary: "Required completion delivery failed before reaching the requester.",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: now - 20_000,
+        endedAt: now - 10_000,
+        progressSummary: "Generated 1 image",
+      },
+    ]);
+
+    expect(
+      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+        requestKey: "image-request:blocked",
+      }),
+    ).toBeUndefined();
+  });
+
   it("does not use a recent succeeded image task without a matching request key", () => {
     const now = Date.now();
     recordRecentMediaGenerationTaskStartForSession({

--- a/src/agents/media-generation-task-status-shared.ts
+++ b/src/agents/media-generation-task-status-shared.ts
@@ -89,6 +89,7 @@ function isTaskRecentSuccessfulDuplicate(params: {
 }): boolean {
   return (
     params.task.status === "succeeded" &&
+    params.task.terminalOutcome !== "blocked" &&
     Boolean(params.requestKey && params.cachedRequestKey === params.requestKey) &&
     isRecentMediaGenerationTaskRecord({
       task: params.task,

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -1,15 +1,24 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const subagentAnnounceDeliveryMocks = vi.hoisted(() => ({
   deliverSubagentAnnouncement: vi.fn(),
 }));
+const taskRegistryDeliveryRuntimeMocks = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+}));
 
 vi.mock("../subagent-announce-delivery.js", () => subagentAnnounceDeliveryMocks);
+vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskRegistryDeliveryRuntimeMocks);
 
 import {
   createMediaGenerationTaskLifecycle,
   scheduleMediaGenerationTaskCompletion,
 } from "./media-generate-background-shared.js";
+
+beforeEach(() => {
+  subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockReset();
+  taskRegistryDeliveryRuntimeMocks.sendMessage.mockReset();
+});
 
 describe("scheduleMediaGenerationTaskCompletion", () => {
   it("keeps a generated media task active until completion delivery finishes", async () => {
@@ -71,12 +80,14 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       expect.objectContaining({
         count: 1,
         paths: ["/tmp/proof.png"],
+        terminalResult: undefined,
       }),
     );
   });
 
-  it("fails a generated media task when completion delivery cannot be confirmed", async () => {
+  it("completes a generated media task when completion delivery cannot be confirmed", async () => {
     const scheduled: Array<() => Promise<void>> = [];
+    const onWakeFailure = vi.fn();
     const lifecycle = {
       createTaskRun: vi.fn(),
       recordTaskProgress: vi.fn(),
@@ -98,7 +109,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       },
       progressSummary: "Generating image",
       toolName: "Image generation",
-      onWakeFailure: vi.fn(),
+      onWakeFailure,
       run: async () => ({
         provider: "openai",
         model: "gpt-image-1",
@@ -110,23 +121,29 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
 
     await scheduled[0]?.();
 
-    expect(lifecycle.completeTaskRun).not.toHaveBeenCalled();
-    expect(lifecycle.failTaskRun).toHaveBeenCalledWith(
+    expect(onWakeFailure).toHaveBeenCalledWith(
+      "Image generation completion delivery was not confirmed after successful generation",
       expect.objectContaining({
-        error: expect.objectContaining({
-          message: "Image generation completion delivery failed after successful generation",
-        }),
+        runId: "tool:image_generate:456",
+        taskId: "task-image-456",
       }),
     );
-    expect(lifecycle.wakeTaskCompletion).toHaveBeenCalledWith(
+    expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
-        status: "error",
-        result: "Image generation completion delivery failed after successful generation",
+        count: 1,
+        paths: ["/tmp/proof.png"],
+        terminalResult: {
+          terminalOutcome: "blocked",
+          terminalSummary:
+            "Required completion delivery failed before reaching the requester: completion delivery was not confirmed after successful generation.",
+        },
       }),
     );
+    expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+    expect(lifecycle.wakeTaskCompletion).toHaveBeenCalledTimes(1);
   });
 
-  it("reports a generated media task failure when completion wake throws", async () => {
+  it("completes a generated media task when completion wake throws", async () => {
     const scheduled: Array<() => Promise<void>> = [];
     const wakeError = new Error("requester wake failed");
     const lifecycle = {
@@ -134,7 +151,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       recordTaskProgress: vi.fn(),
       completeTaskRun: vi.fn(),
       failTaskRun: vi.fn(),
-      wakeTaskCompletion: vi.fn().mockRejectedValueOnce(wakeError).mockResolvedValueOnce(true),
+      wakeTaskCompletion: vi.fn().mockRejectedValueOnce(wakeError),
     };
     const onWakeFailure = vi.fn();
 
@@ -171,20 +188,178 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         taskId: "task-image-789",
       }),
     );
-    expect(lifecycle.completeTaskRun).not.toHaveBeenCalled();
+    expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        count: 1,
+        paths: ["/tmp/proof.png"],
+        terminalResult: {
+          terminalOutcome: "blocked",
+          terminalSummary:
+            "Required completion delivery failed before reaching the requester: requester wake failed.",
+        },
+      }),
+    );
+    expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+    expect(lifecycle.wakeTaskCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("records normal success when direct recovery handles a completion wake throw", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const wakeError = new Error("requester wake failed");
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn().mockRejectedValueOnce(wakeError),
+    };
+    taskRegistryDeliveryRuntimeMocks.sendMessage.mockResolvedValueOnce({});
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle: {
+        taskId: "task-image-direct-recovery",
+        runId: "tool:image_generate:direct-recovery",
+        requesterSessionKey: "agent:main:discord:channel:123",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:123",
+        },
+        taskLabel: "proof image",
+      },
+      scheduleBackgroundWork: (work) => {
+        scheduled.push(work);
+      },
+      progressSummary: "Generating image",
+      toolName: "Image generation",
+      onWakeFailure: vi.fn(),
+      run: async () => ({
+        provider: "openai",
+        model: "gpt-image-1",
+        count: 1,
+        paths: ["/tmp/proof.png"],
+        wakeResult: "generated",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    });
+
+    await scheduled[0]?.();
+
+    expect(taskRegistryDeliveryRuntimeMocks.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Image generation completed.",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    );
+    expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalResult: undefined,
+      }),
+    );
+    expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+  });
+
+  it("still delivers completion when the post-generation progress update throws", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const progressError = new Error("progress store failed");
+    const onWakeFailure = vi.fn();
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(() => {
+        throw progressError;
+      }),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn(async () => true),
+    };
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle: {
+        taskId: "task-image-progress-error",
+        runId: "tool:image_generate:progress-error",
+        requesterSessionKey: "agent:main:discord:channel:123",
+        taskLabel: "proof image",
+      },
+      scheduleBackgroundWork: (work) => {
+        scheduled.push(work);
+      },
+      progressSummary: "Generating image",
+      toolName: "Image generation",
+      onWakeFailure,
+      run: async () => ({
+        provider: "openai",
+        model: "gpt-image-1",
+        count: 1,
+        paths: ["/tmp/proof.png"],
+        wakeResult: "generated",
+      }),
+    });
+
+    await scheduled[0]?.();
+
+    expect(onWakeFailure).toHaveBeenCalledWith(
+      "Image generation completion progress update failed",
+      expect.objectContaining({
+        error: progressError,
+        runId: "tool:image_generate:progress-error",
+        taskId: "task-image-progress-error",
+      }),
+    );
+    expect(lifecycle.wakeTaskCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "ok",
+        result: "generated",
+      }),
+    );
+    expect(lifecycle.completeTaskRun).toHaveBeenCalled();
+    expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+  });
+
+  it("fails the media task when generation itself fails", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const generationError = new Error("provider returned no images");
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn(async () => true),
+    };
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle: {
+        taskId: "task-image-generation-error",
+        runId: "tool:image_generate:generation-error",
+        requesterSessionKey: "agent:main:discord:channel:123",
+        taskLabel: "proof image",
+      },
+      scheduleBackgroundWork: (work) => {
+        scheduled.push(work);
+      },
+      progressSummary: "Generating image",
+      toolName: "Image generation",
+      onWakeFailure: vi.fn(),
+      run: async () => {
+        throw generationError;
+      },
+    });
+
+    await scheduled[0]?.();
+
     expect(lifecycle.failTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
-        error: expect.objectContaining({
-          message: "Image generation completion delivery failed after successful generation",
-        }),
+        error: generationError,
       }),
     );
-    expect(lifecycle.wakeTaskCompletion).toHaveBeenLastCalledWith(
+    expect(lifecycle.wakeTaskCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
         status: "error",
-        result: "Image generation completion delivery failed after successful generation",
+        result: "provider returned no images",
       }),
     );
+    expect(lifecycle.completeTaskRun).not.toHaveBeenCalled();
   });
 });
 
@@ -260,5 +435,133 @@ describe("createMediaGenerationTaskLifecycle", () => {
         result: "generated",
       }),
     ).resolves.toBe(true);
+  });
+
+  it("direct-delivers generated media when the completion wake misses the requester", async () => {
+    subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
+      delivered: false,
+      error: "completion agent did not deliver generated media",
+    });
+    taskRegistryDeliveryRuntimeMocks.sendMessage.mockResolvedValueOnce({});
+    const lifecycle = createMediaGenerationTaskLifecycle({
+      toolName: "image_generate",
+      taskKind: "image_generation",
+      label: "Image generation",
+      queuedProgressSummary: "Queued image generation",
+      generatedLabel: "image",
+      failureProgressSummary: "Image generation failed",
+      eventSource: "image_generation",
+      announceType: "image generation task",
+      completionLabel: "image",
+    });
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-direct",
+          runId: "tool:image_generate:direct",
+          requesterSessionKey: "agent:main:discord:channel:123",
+          taskLabel: "proof image",
+          requesterOrigin: {
+            channel: "discord",
+            to: "channel:123",
+          },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "generated",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    ).resolves.toBe(true);
+
+    expect(taskRegistryDeliveryRuntimeMocks.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "channel:123",
+        content: "Image generation completed.",
+        mediaUrls: ["/tmp/proof.png"],
+        idempotencyKey: "image_generate:task-image-direct:ok:direct",
+      }),
+    );
+  });
+
+  it("does not direct-deliver generated media after requester abandonment", async () => {
+    subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
+      delivered: false,
+      path: "none",
+      error: "requester session abandoned after timeout",
+    });
+    const lifecycle = createMediaGenerationTaskLifecycle({
+      toolName: "image_generate",
+      taskKind: "image_generation",
+      label: "Image generation",
+      queuedProgressSummary: "Queued image generation",
+      generatedLabel: "image",
+      failureProgressSummary: "Image generation failed",
+      eventSource: "image_generation",
+      announceType: "image generation task",
+      completionLabel: "image",
+    });
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-abandoned",
+          runId: "tool:image_generate:abandoned",
+          requesterSessionKey: "agent:main:discord:channel:123",
+          taskLabel: "proof image",
+          requesterOrigin: {
+            channel: "discord",
+            to: "channel:123",
+          },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "generated",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    ).resolves.toBe(false);
+
+    expect(taskRegistryDeliveryRuntimeMocks.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not direct-deliver generated media after a generic handoff failure", async () => {
+    subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
+      delivered: false,
+      path: "direct",
+      error: "gateway request timeout for agent",
+    });
+    const lifecycle = createMediaGenerationTaskLifecycle({
+      toolName: "image_generate",
+      taskKind: "image_generation",
+      label: "Image generation",
+      queuedProgressSummary: "Queued image generation",
+      generatedLabel: "image",
+      failureProgressSummary: "Image generation failed",
+      eventSource: "image_generation",
+      announceType: "image generation task",
+      completionLabel: "image",
+    });
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-timeout",
+          runId: "tool:image_generate:timeout",
+          requesterSessionKey: "agent:main:discord:channel:123",
+          taskLabel: "proof image",
+          requesterOrigin: {
+            channel: "discord",
+            to: "channel:123",
+          },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "generated",
+        mediaUrls: ["/tmp/proof.png"],
+      }),
+    ).resolves.toBe(false);
+
+    expect(taskRegistryDeliveryRuntimeMocks.sendMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -10,6 +10,10 @@ import {
   failTaskRunByRunId,
   recordTaskRunProgressByRunId,
 } from "../../tasks/detached-task-runtime.js";
+import {
+  resolveRequiredCompletionDeliveryFailureTerminalResult,
+  type RequiredCompletionTerminalResult,
+} from "../../tasks/task-completion-contract.js";
 import { normalizeDeliveryContext, type DeliveryContext } from "../../utils/delivery-context.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
@@ -66,6 +70,7 @@ type CompleteMediaGenerationTaskRunParams = {
   model: string;
   count: number;
   paths: string[];
+  terminalResult?: RequiredCompletionTerminalResult;
 };
 
 type FailMediaGenerationTaskRunParams = {
@@ -203,6 +208,7 @@ function completeMediaGenerationTaskRun(params: {
   count: number;
   paths: string[];
   generatedLabel: string;
+  terminalResult?: RequiredCompletionTerminalResult;
 }) {
   if (!params.handle) {
     return;
@@ -217,7 +223,10 @@ function completeMediaGenerationTaskRun(params: {
       endedAt,
       lastEventAt: endedAt,
       progressSummary: `Generated ${params.count} ${params.generatedLabel}${params.count === 1 ? "" : "s"}`,
-      terminalSummary: `Generated ${params.count} ${params.generatedLabel}${params.count === 1 ? "" : "s"} with ${params.provider}/${params.model}${target ? ` -> ${target}` : ""}.`,
+      terminalSummary:
+        params.terminalResult?.terminalSummary ??
+        `Generated ${params.count} ${params.generatedLabel}${params.count === 1 ? "" : "s"} with ${params.provider}/${params.model}${target ? ` -> ${target}` : ""}.`,
+      terminalOutcome: params.terminalResult?.terminalOutcome,
     });
   } finally {
     clearAgentRunContext(params.handle.runId);
@@ -355,48 +364,12 @@ export function scheduleMediaGenerationTaskCompletion<
   onWakeFailure: (message: string, meta?: Record<string, unknown>) => void;
 }) {
   params.scheduleBackgroundWork(async () => {
+    let executed: T;
     try {
-      const executed = await withMediaGenerationTaskKeepalive({
+      executed = await withMediaGenerationTaskKeepalive({
         handle: params.handle,
         progressSummary: params.progressSummary,
         run: params.run,
-      });
-      params.lifecycle.recordTaskProgress({
-        handle: params.handle,
-        progressSummary: "Generated media; delivering completion",
-      });
-      let completionDelivered = false;
-      try {
-        completionDelivered = await params.lifecycle.wakeTaskCompletion({
-          config: params.config,
-          handle: params.handle,
-          status: "ok",
-          statusLabel: "completed successfully",
-          result: executed.wakeResult,
-          attachments: executed.attachments,
-          mediaUrls: executed.mediaUrls,
-        });
-      } catch (error) {
-        params.onWakeFailure(
-          `${params.toolName} completion wake failed after successful generation`,
-          {
-            taskId: params.handle?.taskId,
-            runId: params.handle?.runId,
-            error,
-          },
-        );
-      }
-      if (!completionDelivered) {
-        throw new Error(
-          `${params.toolName} completion delivery failed after successful generation`,
-        );
-      }
-      params.lifecycle.completeTaskRun({
-        handle: params.handle,
-        provider: executed.provider,
-        model: executed.model,
-        count: executed.count,
-        paths: executed.paths,
       });
     } catch (error) {
       params.lifecycle.failTaskRun({
@@ -409,6 +382,95 @@ export function scheduleMediaGenerationTaskCompletion<
         status: "error",
         statusLabel: "failed",
         result: formatErrorMessage(error),
+      });
+      return;
+    }
+
+    try {
+      params.lifecycle.recordTaskProgress({
+        handle: params.handle,
+        progressSummary: "Generated media; delivering completion",
+      });
+    } catch (error) {
+      params.onWakeFailure(`${params.toolName} completion progress update failed`, {
+        taskId: params.handle?.taskId,
+        runId: params.handle?.runId,
+        error,
+      });
+    }
+    let terminalResult: RequiredCompletionTerminalResult | undefined;
+    try {
+      const completionDelivered = await params.lifecycle.wakeTaskCompletion({
+        config: params.config,
+        handle: params.handle,
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: executed.wakeResult,
+        attachments: executed.attachments,
+        mediaUrls: executed.mediaUrls,
+      });
+      if (!completionDelivered) {
+        terminalResult = resolveRequiredCompletionDeliveryFailureTerminalResult(
+          "completion delivery was not confirmed after successful generation",
+        );
+        params.onWakeFailure(
+          `${params.toolName} completion delivery was not confirmed after successful generation`,
+          {
+            taskId: params.handle?.taskId,
+            runId: params.handle?.runId,
+          },
+        );
+      }
+    } catch (error) {
+      terminalResult = resolveRequiredCompletionDeliveryFailureTerminalResult(
+        formatErrorMessage(error),
+      );
+      if (params.handle) {
+        const mediaUrls = Array.from(
+          new Set([
+            ...(executed.mediaUrls ?? []),
+            ...mediaUrlsFromGeneratedAttachments(executed.attachments),
+          ]),
+        );
+        const delivered = await tryDeliverMediaGenerationDirect({
+          config: params.config,
+          handle: params.handle,
+          toolName: params.toolName,
+          content: `${params.toolName} completed.`,
+          mediaUrls,
+          idempotencySuffix: "blocked",
+        });
+        if (delivered) {
+          terminalResult = undefined;
+        }
+      }
+      params.onWakeFailure(
+        `${params.toolName} completion wake failed after successful generation`,
+        {
+          taskId: params.handle?.taskId,
+          runId: params.handle?.runId,
+          error,
+        },
+      );
+    }
+    try {
+      params.lifecycle.completeTaskRun({
+        handle: params.handle,
+        provider: executed.provider,
+        model: executed.model,
+        count: executed.count,
+        paths: executed.paths,
+        terminalResult,
+      });
+    } catch (error) {
+      params.onWakeFailure(`${params.toolName} completion state update failed`, {
+        taskId: params.handle?.taskId,
+        runId: params.handle?.runId,
+        error,
+      });
+      params.lifecycle.failTaskRun({
+        handle: params.handle,
+        error,
       });
     }
   });
@@ -493,13 +555,36 @@ async function wakeMediaGenerationTaskCompletion(params: {
     });
     return true;
   }
-  if (params.status === "error") {
-    const delivered = await tryDeliverMediaGenerationFailureDirect({
+  const canTryDirectCompletionFallback =
+    delivery.error === "completion agent did not deliver generated media" ||
+    delivery.error === "completion agent did not produce a visible reply" ||
+    delivery.error ===
+      "completion agent did not use the message tool for message-tool-only delivery";
+  if (params.status === "ok" && canTryDirectCompletionFallback) {
+    const label = `${params.completionLabel[0]?.toUpperCase() ?? "M"}${params.completionLabel.slice(1)}`;
+    const delivered = await tryDeliverMediaGenerationDirect({
       config: params.config,
       handle: params.handle,
       toolName: params.toolName,
-      completionLabel: params.completionLabel,
-      result: params.result,
+      content:
+        mediaUrls.length > 0
+          ? `${label} generation completed.`
+          : `${label} generation completed, but the generated media could not be attached here.`,
+      mediaUrls,
+      idempotencySuffix: "ok",
+    });
+    if (delivered) {
+      return true;
+    }
+  }
+  if (params.status === "error") {
+    const label = `${params.completionLabel[0]?.toUpperCase() ?? "M"}${params.completionLabel.slice(1)}`;
+    const delivered = await tryDeliverMediaGenerationDirect({
+      config: params.config,
+      handle: params.handle,
+      toolName: params.toolName,
+      content: `${label} generation failed: ${params.result}`,
+      idempotencySuffix: "error",
     });
     if (delivered) {
       return true;
@@ -516,20 +601,20 @@ async function wakeMediaGenerationTaskCompletion(params: {
   return false;
 }
 
-async function tryDeliverMediaGenerationFailureDirect(params: {
+async function tryDeliverMediaGenerationDirect(params: {
   config?: OpenClawConfig;
   handle: MediaGenerationTaskHandle;
   toolName: string;
-  completionLabel: string;
-  result: string;
+  content: string;
+  mediaUrls?: string[];
+  idempotencySuffix: string;
 }): Promise<boolean> {
   const origin = normalizeDeliveryContext(params.handle.requesterOrigin);
   if (!origin?.channel || !origin.to || !isDeliverableMessageChannel(origin.channel)) {
     return false;
   }
-  const label = `${params.completionLabel[0]?.toUpperCase() ?? "M"}${params.completionLabel.slice(1)}`;
   const agentId = resolveAgentIdFromSessionKey(params.handle.requesterSessionKey);
-  const idempotencyKey = `${params.toolName}:${params.handle.taskId}:error:direct`;
+  const idempotencyKey = `${params.toolName}:${params.handle.taskId}:${params.idempotencySuffix}:direct`;
   try {
     const { sendMessage } = await import("../../tasks/task-registry-delivery-runtime.js");
     await sendMessage({
@@ -538,7 +623,8 @@ async function tryDeliverMediaGenerationFailureDirect(params: {
       to: origin.to,
       accountId: origin.accountId,
       threadId: origin.threadId,
-      content: `${label} generation failed: ${params.result}`,
+      content: params.content,
+      mediaUrls: params.mediaUrls,
       requesterSessionKey: params.handle.requesterSessionKey,
       agentId,
       idempotencyKey,


### PR DESCRIPTION
Summary
- Keep successful media generation separate from requester completion delivery failures.
- Recover known generated-media delivery misses with deterministic direct delivery instead of a second error wake.
- Mark unrecovered delivery misses as blocked, and allow retry after blocked media delivery.

Proof
- Distill pass: generation result, requester delivery, and retry blocking are separate states.
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- Result: autoreview clean; no accepted/actionable findings.
- git diff --check origin/main..HEAD
- CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node --no-maglev ./node_modules/vitest/vitest.mjs run src/agents/tools/media-generate-background-shared.test.ts src/agents/image-generation-task-status.test.ts --reporter=dot --testTimeout=10000 --hookTimeout=10000
- Result: 4 test files passed, 46 tests passed.
