### PR TITLE
fix: let approval commands bypass active reply lane

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -5,7 +5,10 @@ import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
-import { shouldBypassAcpDispatchForCommand } from "./dispatch-acp-command-bypass.js";
+import {
+  shouldBypassAcpDispatchForCommand,
+  shouldBypassReplyOperationForApproveCommand,
+} from "./dispatch-acp-command-bypass.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 describe("shouldBypassAcpDispatchForCommand", () => {
@@ -283,5 +286,43 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     } as OpenClawConfig;
 
     expect(shouldBypassAcpDispatchForCommand(ctx, cfg)).toBe(true);
+  });
+
+  it("lets authorized text /approve bypass active reply operation admission", () => {
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      CommandSource: "text",
+      CommandAuthorized: true,
+      CommandBody: "/approve plugin:abc deny",
+      BodyForCommands: "/approve plugin:abc deny",
+    });
+
+    expect(shouldBypassReplyOperationForApproveCommand(ctx)).toBe(true);
+  });
+
+  it("lets authorized /approve bypass active reply operation admission without source metadata", () => {
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      CommandAuthorized: true,
+      CommandBody: "/approve plugin:abc deny",
+      BodyForCommands: "/approve plugin:abc deny",
+    });
+
+    expect(shouldBypassReplyOperationForApproveCommand(ctx)).toBe(true);
+  });
+
+  it("keeps unauthorized /approve on the normal reply operation lane", () => {
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      CommandSource: "text",
+      CommandAuthorized: false,
+      CommandBody: "/approve plugin:abc deny",
+      BodyForCommands: "/approve plugin:abc deny",
+    });
+
+    expect(shouldBypassReplyOperationForApproveCommand(ctx)).toBe(false);
   });
 });

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveCommandTurnContext } from "../command-turn-context.js";
 import { isCommandEnabled } from "../commands-registry-list.js";
 import { maybeResolveTextAlias } from "../commands-registry-normalize.js";
+import { normalizeCommandBody } from "../commands-registry.js";
 import { shouldHandleTextCommands } from "../commands-text-routing.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import { resolveFirstContextText } from "./context-text.js";
@@ -19,6 +21,22 @@ function isAcpCommandCandidate(text: string): boolean {
 
 function isLocalCommandCandidate(text: string): boolean {
   return /^\/(?:status|unfocus)(?:\s|$)/i.test(text) || /^\/(?:verbose|v)(?:[\s:]|$)/i.test(text);
+}
+
+export function shouldBypassReplyOperationForApproveCommand(ctx: FinalizedMsgContext): boolean {
+  const commandTurn = resolveCommandTurnContext(ctx);
+  const isAuthorizedCommand =
+    (commandTurn.kind === "native" || commandTurn.kind === "text-slash") && commandTurn.authorized;
+  if (!isAuthorizedCommand && ctx.CommandAuthorized !== true) {
+    return false;
+  }
+  const commandBody = normalizeCommandBody(
+    commandTurn.body ?? ctx.CommandBody ?? ctx.BodyForCommands ?? ctx.RawBody ?? ctx.Body ?? "",
+    {
+      botUsername: ctx.BotUsername,
+    },
+  );
+  return /^\/approve(?:@[\w.-]+)?(?:\s|$)/i.test(commandBody);
 }
 
 export function shouldBypassAcpDispatchForCommand(

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -112,6 +112,7 @@ import type { FinalizedMsgContext } from "../templating.js";
 import { normalizeVerboseLevel } from "../thinking.js";
 import { resolveSessionRuntimeOverrideForProvider } from "./agent-runner-execution.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
+import { shouldBypassReplyOperationForApproveCommand } from "./dispatch-acp-command-bypass.js";
 import {
   createInternalHookEvent,
   loadSessionStore,
@@ -1087,11 +1088,15 @@ export async function dispatchReplyFromConfig(
   const boundAcpDispatchSessionKey = resolveBoundAcpDispatchSessionKey({ ctx, cfg });
   const acpDispatchSessionKey =
     boundAcpDispatchSessionKey ?? initialSessionStoreEntry.sessionKey ?? sessionKey;
+  const bypassReplyOperationForCommand = shouldBypassReplyOperationForApproveCommand(ctx);
   // initialSessionStoreEntry is command-target-aware, so native command turns
   // stay target-keyed here. Bound ACP dispatch remains source-key owned while
   // ACP routing uses acpDispatchSessionKey.
-  const dispatchOperationSessionKey =
-    initialSessionStoreEntry.sessionKey ?? sessionKey ?? acpDispatchSessionKey;
+  // Approval commands must resolve while the active tool call owns the lane.
+  // Command authorization still happens in the normal /approve handler.
+  const dispatchOperationSessionKey = bypassReplyOperationForCommand
+    ? undefined
+    : (initialSessionStoreEntry.sessionKey ?? sessionKey ?? acpDispatchSessionKey);
   if (
     params.replyOptions?.isHeartbeat === true &&
     dispatchOperationSessionKey &&

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { testing } from "./get-reply-native-slash-fast-path.js";
+
+describe("native slash fast path", () => {
+  it("keeps native slash commands on the fast path", () => {
+    expect(
+      testing.shouldRunNativeSlashCommandFastPath({
+        Body: "/status",
+        CommandBody: "/status",
+        CommandSource: "native",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("runs text /approve on the fast path so approval commands do not queue behind approvals", () => {
+    expect(
+      testing.shouldRunNativeSlashCommandFastPath({
+        Body: "/approve plugin:abc deny",
+        CommandBody: "/approve plugin:abc deny",
+        CommandSource: "text",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("runs authorized /approve on the fast path when channel command-source metadata is absent", () => {
+    expect(
+      testing.shouldRunNativeSlashCommandFastPath({
+        Body: "/approve plugin:abc deny",
+        CommandBody: "/approve plugin:abc deny",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not move other text slash commands onto the native fast path", () => {
+    expect(
+      testing.shouldRunNativeSlashCommandFastPath({
+        Body: "/status",
+        CommandBody: "/status",
+        CommandSource: "text",
+        CommandAuthorized: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -7,7 +7,11 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
-import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
+import {
+  isNativeCommandTurn,
+  isTextSlashCommandTurn,
+  resolveCommandTurnContext,
+} from "../command-turn-context.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
@@ -41,8 +45,13 @@ function loadStatusCommandRuntime() {
   return statusCommandRuntimeLoader.load();
 }
 
-function resolveNativeSlashCommandName(ctx: MsgContext): string | undefined {
-  if (!isNativeCommandTurn(resolveCommandTurnContext(ctx))) {
+function resolveFastPathSlashCommandName(ctx: MsgContext): string | undefined {
+  const commandTurn = resolveCommandTurnContext(ctx);
+  if (
+    !isNativeCommandTurn(commandTurn) &&
+    !isTextSlashCommandTurn(commandTurn) &&
+    ctx.CommandAuthorized !== true
+  ) {
     return undefined;
   }
   const commandText = stripStructuralPrefixes(
@@ -53,9 +62,23 @@ function resolveNativeSlashCommandName(ctx: MsgContext): string | undefined {
 }
 
 function shouldRunNativeSlashCommandFastPath(ctx: MsgContext): boolean {
-  const commandName = resolveNativeSlashCommandName(ctx);
-  return Boolean(commandName && commandName !== "new" && commandName !== "reset");
+  const commandTurn = resolveCommandTurnContext(ctx);
+  const commandName = resolveFastPathSlashCommandName(ctx);
+  if (!commandName || commandName === "new" || commandName === "reset") {
+    return false;
+  }
+  if (isNativeCommandTurn(commandTurn)) {
+    return true;
+  }
+  return (
+    commandName === "approve" &&
+    (isTextSlashCommandTurn(commandTurn) || ctx.CommandAuthorized === true)
+  );
 }
+
+export const testing = {
+  shouldRunNativeSlashCommandFastPath,
+};
 
 async function resolveNativeSlashDefaultThinkingLevel(params: {
   cfg: OpenClawConfig;


### PR DESCRIPTION
## Summary
- Let authorized `/approve` commands bypass active reply-operation admission so they can resolve the approval currently holding the lane.
- Run authorized text `/approve` through the native slash fast path for SMS-style channels that do not provide native slash metadata.
- Add focused tests that keep the bypass scoped to authorized approval commands.

## Verification
- `git diff --check origin/main...HEAD`

## Real behavior proof
Behavior addressed: text-channel approval replies can resolve pending approvals instead of queueing behind the active approval turn.
Real environment tested: prod approval matrix was validated before extracting this patch from PR #87770.
Exact steps or command run after this patch: `git diff --check origin/main...HEAD`.
Evidence after fix: branch contains only the approval command routing patch extracted from PR #87770.
Observed result after fix: diff whitespace/conflict sanity passed.
What was not tested: no unit tests were run in this extraction pass.
