### PR TITLE
test: prune minimax oauth raw-fetch exemptions

### DIFF
--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -33,8 +33,6 @@ const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("matrix", "src/matrix/sdk/transport.ts", 112),
   bundledPluginCallsite("microsoft-foundry", "onboard.ts", 479),
   bundledPluginCallsite("microsoft", "speech-provider.ts", 140),
-  bundledPluginCallsite("minimax", "oauth.ts", 82),
-  bundledPluginCallsite("minimax", "oauth.ts", 123),
   bundledPluginCallsite("minimax", "tts.ts", 52),
   bundledPluginCallsite("msteams", "src/graph.ts", 47),
   bundledPluginCallsite("msteams", "src/sdk.ts", 400),


### PR DESCRIPTION
## Summary

Fixes the stale MiniMax OAuth raw-fetch exemptions left in the channel/plugin boundary checker after the MiniMax OAuth requests were migrated to guarded fetches on current `main`.

Current `main` already routes the MiniMax OAuth code/token requests through `fetchWithSsrFGuard()` via #88088. This PR removes the two obsolete allowlist entries for the old raw-fetch callsites so the boundary checker baseline is no looser than the code requires.

## Implementation

- Removes stale MiniMax OAuth entries from `scripts/check-no-raw-channel-fetch.mjs`
- Leaves the remaining MiniMax TTS legacy exemption unchanged
- Keeps the PR scoped to the ClawSweeper finding from #88086

## Real behavior proof

Behavior or issue addressed: ClawSweeper found that the MiniMax OAuth raw-fetch callsites were fixed, but their old exemptions remained in the no-raw-channel-fetch checker. Stale exemptions weaken the boundary-check baseline because future raw fetches at the same file/line keys could be ignored.

Real environment tested: Fresh local OpenClaw repository worktree rebased onto upstream `main` at `b9d7dd4a84`, with this PR head `33fc391e6d`, running the repository boundary checker under Node from the local development environment. This proof contains no credentials, user content, private channels, hostnames beyond public MiniMax endpoint context already in source, or tokens.

Exact steps or command run after the patch:
```text
node scripts/check-no-raw-channel-fetch.mjs
git diff --check
```

Evidence after fix:
```text
node_exit:0
diff_exit:0
```

Observed result after fix: The boundary checker exits successfully after the obsolete MiniMax OAuth raw-fetch exemptions are removed. The PR diff is now only the two deleted allowlist entries.

What was not tested: I did not run a live MiniMax OAuth browser/device-code flow. This PR only tightens the repository boundary-check allowlist after the runtime guarded-fetch change already landed on `main`.

## Risk

Low. This removes two stale allowlist entries for callsites that no longer contain raw fetches on current `main`.

## Linked issue

Fixes #88091
