### PR TITLE
fix(clipboard): use shell-based clip.exe on WSL2

### DIFF
--- a/src/infra/clipboard.test.ts
+++ b/src/infra/clipboard.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
+const isWSLSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
+}));
+
+vi.mock("./wsl.js", () => ({
+  isWSLSync: () => isWSLSyncMock(),
 }));
 
 const { copyToClipboard } = await import("./clipboard.js");
@@ -11,6 +16,7 @@ const { copyToClipboard } = await import("./clipboard.js");
 describe("copyToClipboard", () => {
   beforeEach(() => {
     runCommandWithTimeoutMock.mockReset();
+    isWSLSyncMock.mockReturnValue(false);
   });
 
   it("returns true on the first successful clipboard command", async () => {
@@ -48,5 +54,28 @@ describe("copyToClipboard", () => {
 
     await expect(copyToClipboard("hello")).resolves.toBe(false);
     expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("uses shell-based clip.exe on WSL", async () => {
+    isWSLSyncMock.mockReturnValue(true);
+    runCommandWithTimeoutMock
+      .mockRejectedValueOnce(new Error("missing pbcopy"))
+      .mockRejectedValueOnce(new Error("missing xclip"))
+      .mockRejectedValueOnce(new Error("missing wl-copy"))
+      .mockResolvedValueOnce({ code: 0, killed: false });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(runCommandWithTimeoutMock.mock.calls[3][0]).toEqual(["sh", "-c", "cat | clip.exe"]);
+  });
+
+  it("uses direct clip.exe outside WSL", async () => {
+    runCommandWithTimeoutMock
+      .mockRejectedValueOnce(new Error("missing pbcopy"))
+      .mockRejectedValueOnce(new Error("missing xclip"))
+      .mockRejectedValueOnce(new Error("missing wl-copy"))
+      .mockResolvedValueOnce({ code: 0, killed: false });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(runCommandWithTimeoutMock.mock.calls[3][0]).toEqual(["clip.exe"]);
   });
 });

--- a/src/infra/clipboard.ts
+++ b/src/infra/clipboard.ts
@@ -1,11 +1,15 @@
 import { runCommandWithTimeout } from "../process/exec.js";
+import { isWSLSync } from "./wsl.js";
 
 export async function copyToClipboard(value: string): Promise<boolean> {
   const attempts: Array<{ argv: string[] }> = [
     { argv: ["pbcopy"] },
     { argv: ["xclip", "-selection", "clipboard"] },
     { argv: ["wl-copy"] },
-    { argv: ["clip.exe"] }, // WSL / Windows
+    // On WSL, Node's spawn() cannot invoke Windows PE executables directly
+    // (ENOENT or SIGTERM). Route through the shell so binfmt_misc interop
+    // can handle clip.exe with piped stdin.
+    isWSLSync() ? { argv: ["sh", "-c", "cat | clip.exe"] } : { argv: ["clip.exe"] },
     { argv: ["powershell", "-NoProfile", "-Command", "Set-Clipboard"] },
   ];
   for (const attempt of attempts) {


### PR DESCRIPTION
Fixes #88080.

## Summary

- Detect WSL with the existing `isWSLSync()` helper and route the Windows clipboard backend through `sh -c "cat | clip.exe"` so WSL interop handles the Windows PE executable with stdin.
- Preserve the direct `clip.exe` path outside WSL, so native Windows behavior stays unchanged.
- Add focused coverage for both the WSL shell path and the non-WSL direct path.

## Real behavior proof

- **Behavior addressed:** `openclaw dashboard` clipboard delivery on WSL2 can silently fail because direct Node spawn of `clip.exe` does not reliably invoke the Windows PE executable through WSL interop. The patch switches only the WSL clipboard attempt to a shell pipeline while keeping the native Windows attempt direct.
- **Real environment tested:** AWS Crabbox WSL2 runner `run_1b1eaa93e3a2` / `cbx_881bdc049361` on `6.6.114.1-microsoft-standard-WSL2`; AWS Crabbox native Windows runner `run_db63ca12dafc` / `cbx_c6adc2b62bf4`.
- **Exact steps or command run after this patch:**

  ```bash
  node scripts/crabbox-wrapper.mjs run --provider aws --target windows --windows-mode wsl2 --no-hydrate --script-stdin <wsl clipboard roundtrip script>
  crabbox run --provider aws --target windows --windows-mode normal --no-sync --shell -- "powershell -NoProfile -EncodedCommand <native clipboard roundtrip script>"
  ```

- **Evidence after fix:** copied terminal output from the live WSL2 and native Windows runs:

  ```console
  run=run_1b1eaa93e3a2 lease=cbx_881bdc049361 provider=aws target=windows mode=wsl2
  kernel: Linux EC2AMAZ-P1SLE6D 6.6.114.1-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Mon Dec  1 20:46:23 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
  clip_path: /mnt/c/Windows/system32/clip.exe
  clipboard_live: ok
  ```

  ```console
  run=run_db63ca12dafc lease=cbx_c6adc2b62bf4 provider=aws target=windows mode=native
  native_clip_live: ok
  ```

- **Observed result after fix:** WSL uses the shell-based clipboard backend and the live WSL2 runner wrote a sentinel to the Windows clipboard, then read the same sentinel back with PowerShell `Get-Clipboard`. Native Windows still uses direct `clip.exe`, and the native runner also wrote/read the clipboard sentinel successfully.
- **What was not tested:** A full live `openclaw dashboard --no-open` command on WSL2. The AWS WSL2 image did not have Node without Actions hydration, and the Testbox path was blocked by missing `blacksmith auth login`; the dashboard URL-to-clipboard call is covered by focused tests, while the WSL/native clipboard OS contracts were verified live.

## Verification

- `node scripts/run-vitest.mjs src/infra/clipboard.test.ts src/infra/wsl.test.ts src/commands/dashboard.links.test.ts src/commands/dashboard.test.ts -- --run`
- `git diff --check origin/main...HEAD`
- AWS Crabbox WSL2 clipboard proof: `run_1b1eaa93e3a2` / `cbx_881bdc049361`
- AWS Crabbox native Windows clipboard proof: `run_db63ca12dafc` / `cbx_c6adc2b62bf4`
- AWS Crabbox `pnpm check:changed`: `run_e2fdac25ee15` / `cbx_d1bda2a031c9`
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
