### PR TITLE
fix(minimax): guard oauth fetches

### DIFF
--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -2,6 +2,10 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { resolveExpiresAtMsFromDurationOrEpoch } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 
 export type MiniMaxRegion = "cn" | "global";
 
@@ -78,39 +82,47 @@ async function requestOAuthCode(params: {
   region: MiniMaxRegion;
 }): Promise<MiniMaxOAuthAuthorization> {
   const endpoints = getOAuthEndpoints(params.region);
-  const response = await fetch(endpoints.codeEndpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-      "x-request-id": randomUUID(),
+  const { response, release } = await fetchWithSsrFGuard({
+    url: endpoints.codeEndpoint,
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "x-request-id": randomUUID(),
+      },
+      body: toFormUrlEncoded({
+        response_type: "code",
+        client_id: endpoints.clientId,
+        scope: MINIMAX_OAUTH_SCOPE,
+        code_challenge: params.challenge,
+        code_challenge_method: "S256",
+        state: params.state,
+      }),
     },
-    body: toFormUrlEncoded({
-      response_type: "code",
-      client_id: endpoints.clientId,
-      scope: MINIMAX_OAUTH_SCOPE,
-      code_challenge: params.challenge,
-      code_challenge_method: "S256",
-      state: params.state,
-    }),
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(endpoints.baseUrl),
+    auditContext: "minimax.oauth.code",
   });
+  try {
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`MiniMax OAuth authorization failed: ${text || response.statusText}`);
+    }
 
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`MiniMax OAuth authorization failed: ${text || response.statusText}`);
+    const payload = (await response.json()) as MiniMaxOAuthAuthorization & { error?: string };
+    if (!payload.user_code || !payload.verification_uri) {
+      throw new Error(
+        payload.error ??
+          "MiniMax OAuth authorization returned an incomplete payload (missing user_code or verification_uri).",
+      );
+    }
+    if (payload.state !== params.state) {
+      throw new Error("MiniMax OAuth state mismatch: possible CSRF attack or session corruption.");
+    }
+    return payload;
+  } finally {
+    await release();
   }
-
-  const payload = (await response.json()) as MiniMaxOAuthAuthorization & { error?: string };
-  if (!payload.user_code || !payload.verification_uri) {
-    throw new Error(
-      payload.error ??
-        "MiniMax OAuth authorization returned an incomplete payload (missing user_code or verification_uri).",
-    );
-  }
-  if (payload.state !== params.state) {
-    throw new Error("MiniMax OAuth state mismatch: possible CSRF attack or session corruption.");
-  }
-  return payload;
 }
 
 async function pollOAuthToken(params: {
@@ -119,83 +131,92 @@ async function pollOAuthToken(params: {
   region: MiniMaxRegion;
 }): Promise<TokenResult> {
   const endpoints = getOAuthEndpoints(params.region);
-  const response = await fetch(endpoints.tokenEndpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
+  const { response, release } = await fetchWithSsrFGuard({
+    url: endpoints.tokenEndpoint,
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: toFormUrlEncoded({
+        grant_type: MINIMAX_OAUTH_GRANT_TYPE,
+        client_id: endpoints.clientId,
+        user_code: params.userCode,
+        code_verifier: params.verifier,
+      }),
     },
-    body: toFormUrlEncoded({
-      grant_type: MINIMAX_OAUTH_GRANT_TYPE,
-      client_id: endpoints.clientId,
-      user_code: params.userCode,
-      code_verifier: params.verifier,
-    }),
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(endpoints.baseUrl),
+    auditContext: "minimax.oauth.token",
   });
 
-  const text = await response.text();
-  let payload:
-    | {
-        status?: string;
-        base_resp?: { status_code?: number; status_msg?: string };
+  try {
+    const text = await response.text();
+    let payload:
+      | {
+          status?: string;
+          base_resp?: { status_code?: number; status_msg?: string };
+        }
+      | undefined;
+    if (text) {
+      try {
+        payload = JSON.parse(text) as typeof payload;
+      } catch {
+        payload = undefined;
       }
-    | undefined;
-  if (text) {
-    try {
-      payload = JSON.parse(text) as typeof payload;
-    } catch {
-      payload = undefined;
     }
-  }
 
-  if (!response.ok) {
-    return {
-      status: "error",
-      message:
-        (payload?.base_resp?.status_msg ?? text) || "MiniMax OAuth failed to parse response.",
+    if (!response.ok) {
+      return {
+        status: "error",
+        message:
+          (payload?.base_resp?.status_msg ?? text) || "MiniMax OAuth failed to parse response.",
+      };
+    }
+
+    if (!payload) {
+      return { status: "error", message: "MiniMax OAuth failed to parse response." };
+    }
+
+    const tokenPayload = payload as {
+      status: string;
+      access_token?: string | null;
+      refresh_token?: string | null;
+      expired_in?: unknown;
+      token_type?: string;
+      resource_url?: string;
+      notification_message?: string;
     };
-  }
 
-  if (!payload) {
-    return { status: "error", message: "MiniMax OAuth failed to parse response." };
-  }
+    if (tokenPayload.status === "error") {
+      return { status: "error", message: "An error occurred. Please try again later" };
+    }
 
-  const tokenPayload = payload as {
-    status: string;
-    access_token?: string | null;
-    refresh_token?: string | null;
-    expired_in?: unknown;
-    token_type?: string;
-    resource_url?: string;
-    notification_message?: string;
-  };
+    if (tokenPayload.status !== "success") {
+      return { status: "pending", message: "current user code is not authorized" };
+    }
 
-  if (tokenPayload.status === "error") {
-    return { status: "error", message: "An error occurred. Please try again later" };
-  }
+    if (!tokenPayload.access_token || !tokenPayload.refresh_token || !tokenPayload.expired_in) {
+      return { status: "error", message: "MiniMax OAuth returned incomplete token payload." };
+    }
+    const expires = normalizeOAuthExpires(tokenPayload.expired_in);
+    if (expires === undefined) {
+      return { status: "error", message: "MiniMax OAuth returned invalid token expiry." };
+    }
 
-  if (tokenPayload.status !== "success") {
-    return { status: "pending", message: "current user code is not authorized" };
+    return {
+      status: "success",
+      token: {
+        access: tokenPayload.access_token,
+        refresh: tokenPayload.refresh_token,
+        expires,
+        resourceUrl: tokenPayload.resource_url,
+        notification_message: tokenPayload.notification_message,
+      },
+    };
+  } finally {
+    await release();
   }
-
-  if (!tokenPayload.access_token || !tokenPayload.refresh_token || !tokenPayload.expired_in) {
-    return { status: "error", message: "MiniMax OAuth returned incomplete token payload." };
-  }
-  const expires = normalizeOAuthExpires(tokenPayload.expired_in);
-  if (expires === undefined) {
-    return { status: "error", message: "MiniMax OAuth returned invalid token expiry." };
-  }
-
-  return {
-    status: "success",
-    token: {
-      access: tokenPayload.access_token,
-      refresh: tokenPayload.refresh_token,
-      expires,
-      resourceUrl: tokenPayload.resource_url,
-      notification_message: tokenPayload.notification_message,
-    },
-  };
 }
 
 export async function loginMiniMaxPortalOAuth(params: {


### PR DESCRIPTION
## Summary
- Wrap MiniMax OAuth authorization and token POSTs in `fetchWithSsrFGuard`.
- Use the existing MiniMax base-host SSRF policy for the CN/global OAuth endpoints.
- Release the guard handle after response consumption so the raw-fetch boundary check stays green.

## Provenance
The raw OAuth `fetch()` calls were introduced with the MiniMax portal auth implementation in `1287328b6fa` by Peter Steinberger. The current CI break became visible after `604a6b5452` (`fix(minimax): reject unsafe oauth expiry`) touched `extensions/minimax/oauth.ts` on `main`; `check-additional-boundaries-bcd` now reports those existing raw fetches at `extensions/minimax/oauth.ts:81` and `:122`.

## Verification
- `node scripts/check-no-raw-channel-fetch.mjs`
- `git diff --check`

Focused Vitest note: `node scripts/run-vitest.mjs extensions/minimax/oauth.test.ts` hung locally without output in this Codex worktree, matching the local runner hang seen on the dependency-guard work. No failure output was produced.
