### PR TITLE
feat(onboard): add --custom-context-window flag for non-interactive setup

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -88,11 +88,13 @@ openclaw onboard --non-interactive \
   --custom-api-key "$CUSTOM_API_KEY" \
   --secret-input-mode plaintext \
   --custom-compatibility openai \
-  --custom-image-input
+  --custom-image-input \
+  --custom-context-window 200000
 ```
 
 `--custom-api-key` is optional in non-interactive mode. If omitted, onboarding checks `CUSTOM_API_KEY`.
 OpenClaw marks common vision model IDs as image-capable automatically. Pass `--custom-image-input` for unknown custom vision IDs, or `--custom-text-input` to force text-only metadata.
+Pass `--custom-context-window <tokens>` when wrapping a model whose real context window is larger than the conservative default (128k non-Azure, 400k Azure); re-running onboard with this flag replaces the stored value.
 
 LM Studio also supports a provider-specific key flag in non-interactive mode:
 

--- a/docs/start/wizard-cli-automation.md
+++ b/docs/start/wizard-cli-automation.md
@@ -167,12 +167,14 @@ openclaw onboard --non-interactive \
       --custom-provider-id "my-custom" \
       --custom-compatibility anthropic \
       --custom-image-input \
+      --custom-context-window 200000 \
       --gateway-port 18789 \
       --gateway-bind loopback
     ```
 
     `--custom-api-key` is optional. If omitted, onboarding checks `CUSTOM_API_KEY`.
     OpenClaw marks common vision model IDs as image-capable automatically. Add `--custom-image-input` for unknown custom vision IDs, or `--custom-text-input` to force text-only metadata.
+    Pass `--custom-context-window <tokens>` when wrapping a model whose real context window is larger than the conservative default (128k non-Azure, 400k Azure); re-running onboard with this flag replaces the stored value.
 
     Ref-mode variant:
 

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -221,6 +221,7 @@ What you set:
     - `--custom-provider-id` (optional)
     - `--custom-compatibility <openai|anthropic>` (optional; default `openai`)
     - `--custom-image-input` / `--custom-text-input` (optional; override inferred model input capability)
+    - `--custom-context-window <tokens>` (optional; override the default 128k non-Azure / 400k Azure context window; re-running onboard replaces the stored value)
 
   </Accordion>
   <Accordion title="Skip">

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -145,6 +145,10 @@ export function registerOnboardCommand(program: Command): void {
     )
     .option("--custom-image-input", "Mark the custom provider model as image-capable")
     .option("--custom-text-input", "Mark the custom provider model as text-only")
+    .option(
+      "--custom-context-window <tokens>",
+      "Custom provider model context window size in tokens (default: 128000 non-Azure, 400000 Azure)",
+    )
     .option("--gateway-port <port>", "Gateway port")
     .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
     .option("--gateway-auth <mode>", "Gateway auth: token|password")
@@ -224,6 +228,8 @@ export function registerOnboardCommand(program: Command): void {
               : opts.customImageInput === true
                 ? true
                 : undefined,
+          customContextWindow:
+            opts.customContextWindow === undefined ? undefined : Number(opts.customContextWindow),
           gatewayPort: gatewayPort ?? undefined,
           gatewayBind: opts.gatewayBind as GatewayBind | undefined,
           gatewayAuth: opts.gatewayAuth as GatewayAuthChoice | undefined,

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -12,6 +12,7 @@ import type {
   TailscaleMode,
 } from "../../commands/onboard-types.js";
 import { resolveManifestProviderOnboardAuthFlags } from "../../plugins/provider-auth-choices.js";
+import { parseStrictPositiveInteger } from "../../shared/number-coercion.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
@@ -229,7 +230,9 @@ export function registerOnboardCommand(program: Command): void {
                 ? true
                 : undefined,
           customContextWindow:
-            opts.customContextWindow === undefined ? undefined : Number(opts.customContextWindow),
+            opts.customContextWindow === undefined
+              ? undefined
+              : (parseStrictPositiveInteger(opts.customContextWindow) ?? Number.NaN),
           gatewayPort: gatewayPort ?? undefined,
           gatewayBind: opts.gatewayBind as GatewayBind | undefined,
           gatewayAuth: opts.gatewayAuth as GatewayAuthChoice | undefined,

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -139,6 +139,36 @@ describe("applyCustomApiConfig", () => {
     expect(model?.contextWindow).toBe(expectedContextWindow);
   });
 
+  it("uses explicit contextWindow override for newly added custom models", () => {
+    const result = applyCustomApiConfig({
+      config: buildCustomProviderConfig(),
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "foo-large",
+      compatibility: "openai",
+      providerId: "custom",
+      contextWindow: 200_000,
+    });
+    const model = result.config.models?.providers?.custom?.models?.find(
+      (entry) => entry.id === "foo-large",
+    );
+    expect(model?.contextWindow).toBe(200_000);
+  });
+
+  it("uses explicit contextWindow override to replace existing custom model values", () => {
+    const result = applyCustomApiConfig({
+      config: buildCustomProviderConfig(CONTEXT_WINDOW_HARD_MIN_TOKENS),
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "foo-large",
+      compatibility: "openai",
+      providerId: "custom",
+      contextWindow: 200_000,
+    });
+    const model = result.config.models?.providers?.custom?.models?.find(
+      (entry) => entry.id === "foo-large",
+    );
+    expect(model?.contextWindow).toBe(200_000);
+  });
+
   it.each([
     {
       name: "invalid compatibility values at runtime",
@@ -473,6 +503,25 @@ describe("parseNonInteractiveCustomApiFlags", () => {
     expect(result.supportsImageInput).toBe(true);
   });
 
+  it("parses an explicit context window override", () => {
+    const result = parseNonInteractiveCustomApiFlags({
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "foo-large",
+      contextWindow: 200_000,
+    });
+
+    expect(result.contextWindow).toBe(200_000);
+  });
+
+  it("omits context window when not provided", () => {
+    const result = parseNonInteractiveCustomApiFlags({
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "foo-large",
+    });
+
+    expect(result.contextWindow).toBeUndefined();
+  });
+
   it.each([
     {
       name: "missing required flags",
@@ -496,6 +545,24 @@ describe("parseNonInteractiveCustomApiFlags", () => {
         providerId: "!!!",
       },
       expectedMessage: "Custom provider ID must include letters, numbers, or hyphens.",
+    },
+    {
+      name: "non-integer context window",
+      flags: {
+        baseUrl: "https://llm.example.com/v1",
+        modelId: "foo-large",
+        contextWindow: Number.NaN,
+      },
+      expectedMessage: "Invalid --custom-context-window (expected a positive integer token count).",
+    },
+    {
+      name: "context window below hard minimum",
+      flags: {
+        baseUrl: "https://llm.example.com/v1",
+        modelId: "foo-large",
+        contextWindow: 1024,
+      },
+      expectedMessage: `Invalid --custom-context-window (must be at least ${CONTEXT_WINDOW_HARD_MIN_TOKENS} tokens).`,
     },
   ])("rejects $name", ({ flags, expectedMessage }) => {
     expect(() => parseNonInteractiveCustomApiFlags(flags)).toThrow(expectedMessage);

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -184,6 +184,7 @@ export type ApplyCustomApiConfigParams = {
   providerId?: string;
   alias?: string;
   supportsImageInput?: boolean;
+  contextWindow?: number;
 };
 
 export type ParseNonInteractiveCustomApiFlagsParams = {
@@ -193,6 +194,7 @@ export type ParseNonInteractiveCustomApiFlagsParams = {
   apiKey?: string;
   providerId?: string;
   supportsImageInput?: boolean;
+  contextWindow?: number;
 };
 
 export type ParsedNonInteractiveCustomApiFlags = {
@@ -202,6 +204,7 @@ export type ParsedNonInteractiveCustomApiFlags = {
   apiKey?: string;
   providerId?: string;
   supportsImageInput?: boolean;
+  contextWindow?: number;
 };
 
 export type CustomApiErrorCode =
@@ -210,7 +213,8 @@ export type CustomApiErrorCode =
   | "invalid_base_url"
   | "invalid_model_id"
   | "invalid_provider_id"
-  | "invalid_alias";
+  | "invalid_alias"
+  | "invalid_context_window";
 
 export class CustomApiError extends Error {
   readonly code: CustomApiErrorCode;
@@ -455,6 +459,25 @@ function parseCustomApiCompatibility(raw?: string): CustomApiCompatibility {
   return compatibilityRaw;
 }
 
+function parseCustomApiContextWindow(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new CustomApiError(
+      "invalid_context_window",
+      "Invalid --custom-context-window (expected a positive integer token count).",
+    );
+  }
+  if (value < CONTEXT_WINDOW_HARD_MIN_TOKENS) {
+    throw new CustomApiError(
+      "invalid_context_window",
+      `Invalid --custom-context-window (must be at least ${CONTEXT_WINDOW_HARD_MIN_TOKENS} tokens).`,
+    );
+  }
+  return value;
+}
+
 export function resolveCustomProviderId(
   params: ResolveCustomProviderIdParams,
 ): ResolvedCustomProviderId {
@@ -507,6 +530,7 @@ export function parseNonInteractiveCustomApiFlags(
       "Custom provider ID must include letters, numbers, or hyphens.",
     );
   }
+  const contextWindow = parseCustomApiContextWindow(params.contextWindow);
   return {
     baseUrl,
     modelId,
@@ -516,6 +540,7 @@ export function parseNonInteractiveCustomApiFlags(
     ...(params.supportsImageInput === undefined
       ? {}
       : { supportsImageInput: params.supportsImageInput }),
+    ...(contextWindow === undefined ? {} : { contextWindow }),
   };
 }
 
@@ -536,6 +561,8 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   if (!modelId) {
     throw new CustomApiError("invalid_model_id", "Custom provider model ID is required.");
   }
+
+  const explicitContextWindow = parseCustomApiContextWindow(params.contextWindow);
 
   const isAzure = isAzureUrl(baseUrl);
   const isAzureOpenAi = isAzureOpenAiUrl(baseUrl);
@@ -580,7 +607,7 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
     ? {
         id: modelId,
         name: `${modelId} (Custom Provider)`,
-        contextWindow: AZURE_DEFAULT_CONTEXT_WINDOW,
+        contextWindow: explicitContextWindow ?? AZURE_DEFAULT_CONTEXT_WINDOW,
         maxTokens: AZURE_DEFAULT_MAX_TOKENS,
         input: generatedInput,
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -590,7 +617,7 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
     : {
         id: modelId,
         name: `${modelId} (Custom Provider)`,
-        contextWindow: DEFAULT_CONTEXT_WINDOW,
+        contextWindow: explicitContextWindow ?? DEFAULT_CONTEXT_WINDOW,
         maxTokens: DEFAULT_MAX_TOKENS,
         input: generatedInput,
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -605,7 +632,8 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
               ...(explicitInput ? { input: explicitInput } : {}),
               name: model.name ?? nextModel.name,
               cost: model.cost ?? nextModel.cost,
-              contextWindow: normalizeContextWindowForCustomModel(model.contextWindow),
+              contextWindow:
+                explicitContextWindow ?? normalizeContextWindowForCustomModel(model.contextWindow),
               maxTokens: model.maxTokens ?? nextModel.maxTokens,
             }
           : model,

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -562,7 +562,7 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
     throw new CustomApiError("invalid_model_id", "Custom provider model ID is required.");
   }
 
-  const explicitContextWindow = parseCustomApiContextWindow(params.contextWindow);
+  const explicitContextWindow = params.contextWindow;
 
   const isAzure = isAzureUrl(baseUrl);
   const isAzureOpenAi = isAzureOpenAiUrl(baseUrl);

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -181,6 +181,7 @@ export async function applyNonInteractiveAuthChoice(params: {
         apiKey: opts.customApiKey,
         providerId: opts.customProviderId,
         supportsImageInput: opts.customImageInput,
+        contextWindow: opts.customContextWindow,
       });
       const resolvedProviderId = resolveCustomProviderId({
         config: nextConfig,
@@ -218,6 +219,7 @@ export async function applyNonInteractiveAuthChoice(params: {
         apiKey: customApiKeyInput,
         providerId: customAuth.providerId,
         supportsImageInput: customAuth.supportsImageInput,
+        contextWindow: customAuth.contextWindow,
       });
       if (result.providerIdRenamedFrom && result.providerId) {
         runtime.log(
@@ -230,6 +232,7 @@ export async function applyNonInteractiveAuthChoice(params: {
         switch (err.code) {
           case "missing_required":
           case "invalid_compatibility":
+          case "invalid_context_window":
             runtime.error(err.message);
             break;
           default:

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -61,6 +61,7 @@ export type OnboardOptions = OnboardDynamicProviderOptions & {
   customProviderId?: string;
   customCompatibility?: "openai" | "anthropic";
   customImageInput?: boolean;
+  customContextWindow?: number;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `openclaw onboard --non-interactive --auth-choice custom-api-key` has no way to declare the model's context window. Custom providers always land with the conservative default (128k non-Azure, 400k Azure), even when the proxied model has a larger window. The pre-prompt overflow precheck in `preemptive-compaction.ts` sizes its budget off the stored `contextWindow`, so a wrapper for a 200k-window model (e.g. `claude-sonnet-4-6`, `claude-opus-4-7`) caps its usable prompt budget at ~112k instead of ~184k, and sessions that the real model would have served can trip the guard and surface "Context limit exceeded. I've reset our conversation…" from `agent-runner-execution.ts:1284`.

Why does this matter now?

- Non-interactive onboard is the supported path for wrappers that front-end a known LLM (third-party gateways that proxy `claude-sonnet-4-6`, etc.). Without this flag those installs need a manual `~/.openclaw/openclaw.json` edit after every onboard, which is brittle and does not survive `--reset`.

What is the intended outcome?

- `--custom-context-window <tokens>` overrides the default on newly added model entries, and replaces the stored value when re-onboarding the same model. Omitting the flag preserves all existing behavior.
- The flag is validated strictly at the CLI seam (`parseStrictPositiveInteger`, the same helper used by `parseTcpPort`), so hex/octal literals like `0x100000` are rejected up front instead of silently coerced by `Number()`.

What is intentionally out of scope?

- Interactive wizard prompt for context window (the wizard keeps using the existing inference path; this flag affects only `--non-interactive`).
- `--modern` / Crestodian onboarding (separate code path, not touched).
- Changing the existing 128k / 400k defaults.

What does success look like?

- `openclaw onboard --non-interactive ... --custom-context-window 200000` writes `contextWindow: 200000` to the provider's model entry in `openclaw.json`. Re-running with `--custom-context-window 1000000` updates it in place. Omitting the flag still writes `128000`.

What should reviewers focus on?

- Single-seam validation: `parseNonInteractiveCustomApiFlags` is the only place that rejects invalid values; `applyCustomApiConfig` trusts its typed `number | undefined` parameter.
- CLI conversion uses `parseStrictPositiveInteger`; whitespace is trimmed (matches `parseTcpPort`), hex is rejected.
- Re-onboard path in `applyCustomApiConfig`: the `mergedModels` branch uses `explicitContextWindow ?? normalizeContextWindowForCustomModel(model.contextWindow)` so passing the flag overrides an existing entry, omitting it preserves whatever was there.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

No. Surfaced while debugging a non-interactive `custom-api-key` install whose stored `contextWindow` was below the proxied model's real window, tripping the precheck guard on sessions that the real model would have served.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Non-interactive onboard of a custom Anthropic-compatible provider for `claude-sonnet-4-6` stores `contextWindow: 128000`. After the runner's reserve floor (`reserveTokens ≈ 16k` with `MIN_PROMPT_BUDGET_TOKENS=8000`, `MIN_PROMPT_BUDGET_RATIO=0.5`), the usable prompt budget is ~112k versus the ~184k the real 200k-window model would have offered. Long-running sessions can then trip the precheck guard even though the real model would have served them. The new flag lets the wrapper declare the real window at onboard time and heals existing installs on re-onboard.
- **Real environment tested:** macOS 15.5, fresh clone of `openclaw/openclaw` at `dc7bd4abf5`, branch `ericlevine/onboard-custom-context-window`, `pnpm install && pnpm build`. CLI exercised against an isolated `OPENCLAW_HOME=/tmp/...` so the test does not touch the developer's local install.
- **Exact steps or command run after this patch:**

  ```bash
  # 1. --help surfaces the flag
  ./openclaw.mjs onboard --help | grep custom-

  # 2. Onboard with the flag set
  rm -rf /tmp/oc-proof
  OPENCLAW_HOME=/tmp/oc-proof ./openclaw.mjs onboard --non-interactive --accept-risk \
    --skip-channels --skip-skills --skip-search --skip-health --skip-ui --skip-hooks \
    --skip-bootstrap --skip-daemon \
    --auth-choice custom-api-key \
    --custom-base-url "http://localhost:25297/api/v1" \
    --custom-model-id "claude-sonnet-4-6" \
    --custom-api-key "dummy" \
    --custom-compatibility anthropic \
    --custom-context-window 200000
  jq '.models.providers["custom-localhost-25297"].models[0].contextWindow' \
    /tmp/oc-proof/.openclaw/openclaw.json

  # 3. Re-onboard with a different value (overrides in place)
  OPENCLAW_HOME=/tmp/oc-proof ./openclaw.mjs onboard --non-interactive --accept-risk \
    ... --custom-context-window 1000000
  jq '.models.providers["custom-localhost-25297"].models[0].contextWindow' \
    /tmp/oc-proof/.openclaw/openclaw.json

  # 4. Default preserved when flag omitted
  rm -rf /tmp/oc-proof-default
  OPENCLAW_HOME=/tmp/oc-proof-default ./openclaw.mjs onboard --non-interactive --accept-risk \
    ... (no --custom-context-window)
  jq '.models.providers["custom-localhost-25297"].models[0].contextWindow' \
    /tmp/oc-proof-default/.openclaw/openclaw.json

  # 5. Validator rejection paths
  ... --custom-context-window 1024
  ... --custom-context-window not-a-number
  ... --custom-context-window 0x100000
  ```

- **Evidence after fix (copied live terminal output):**

  ```text
  --custom-context-window <tokens>  Custom provider model context window size in tokens (default: 128000 non-Azure, 400000 Azure)
  --custom-image-input              Mark the custom provider model as image-capable
  --custom-text-input               Mark the custom provider model as text-only

  # onboard with 200000:
  200000

  # re-onboard with 1000000:
  1000000

  # onboard without the flag:
  128000

  # rejections:
  Invalid --custom-context-window (must be at least 4000 tokens).
  Invalid --custom-context-window (expected a positive integer token count).
  Invalid --custom-context-window (expected a positive integer token count).
  ```

- **Observed result after fix:**
  - `--help` lists the new flag in its expected position between `--custom-text-input` and `--gateway-port`.
  - Onboard writes the requested `contextWindow` (200000) verbatim to the model entry.
  - Re-onboard replaces the stored value (200000 → 1000000) without duplicating the provider/model record.
  - Omitting the flag preserves the existing 128k default — no regression.
  - All three invalid-input paths reject with the expected error before any config is written.

- **What was not tested:**
  - Interactive wizard flow (the wizard never sets `contextWindow` via this path; the new field defaults to `undefined`, which falls through to the existing inference helpers).
  - `--modern` / Crestodian onboarding (separate code path).
  - Live agent run against a real proxy to confirm the precheck guard stops firing. Verified manually on the bug-report install by hand-editing `openclaw.json` to 200000 before this PR existed; this PR removes the need for that manual edit but does not change runtime behavior.

- **Proof limitations or environment constraints:**
  - CLI-only change, no UI surface — no screenshot artifact, only terminal capture.
  - Local test uses a stub `--custom-api-key` and points at `http://localhost:25297` (a stopped service in this environment). The flag's effect on `openclaw.json` is independent of whether the provider responds, so the proof intentionally skips network verification.

- **Before evidence:** Same `onboard` invocation without `--custom-context-window 200000` on the unpatched branch wrote `contextWindow: 128000` to the same field (the conservative default). Verified by running the same `jq` against `/tmp/oc-proof-default/.openclaw/openclaw.json` (case 4 above, which uses the patched build but omits the flag, exercising the unchanged default path).

## Tests and validation

Which commands did you run?

- `pnpm exec vitest run src/commands/onboard-custom-config.test.ts` — 43 passed (5 new cases).
- `pnpm exec vitest run src/commands/onboard-custom-config.test.ts src/commands/onboard-non-interactive/local/auth-choice.test.ts` — 50 passed.
- `pnpm tsgo:core` — clean.
- `pnpm tsgo:core:test` — clean.
- `pnpm exec oxfmt --check --threads=1 <touched code + docs files>` — clean.
- `pnpm exec oxlint <touched files>` — clean.
- `pnpm build` — clean.

What regression coverage was added or updated?

Five new cases in `src/commands/onboard-custom-config.test.ts`:

- `parseNonInteractiveCustomApiFlags > parses an explicit context window override`
- `parseNonInteractiveCustomApiFlags > omits context window when not provided`
- `parseNonInteractiveCustomApiFlags > rejects 'non-integer context window'`
- `parseNonInteractiveCustomApiFlags > rejects 'context window below hard minimum'`
- `applyCustomApiConfig > uses explicit contextWindow override for newly added custom models`
- `applyCustomApiConfig > uses explicit contextWindow override to replace existing custom model values`

What failed before this fix, if known?

- `openclaw onboard --non-interactive --auth-choice custom-api-key ... --custom-compatibility anthropic` stored `contextWindow: 128000` regardless of the real model window. There was no CLI surface for this on `main`, so there is no failing CLI behavior — just a missing capability.

If no test was added, why not?

- N/A — tests added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — a new CLI flag is added. Existing onboard invocations (without the flag) behave exactly as before.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes — when `--custom-context-window` is passed, `applyCustomApiConfig` writes the requested integer to the provider's model `contextWindow` field. On re-onboard it replaces an existing value at that key. No new top-level config keys, no migration, no schema change.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The re-onboard replacement path. A user who hand-edited `contextWindow` after onboarding and then re-runs onboard with `--custom-context-window` will have their hand-edit overwritten by the flag value. Symmetric to how `--custom-image-input` already overrides existing `input` on re-onboard, but worth calling out.

How is that risk mitigated?

- Only triggers when `--custom-context-window` is explicitly passed. Omitting it falls through to `normalizeContextWindowForCustomModel(model.contextWindow)`, which preserves any existing user value at or above `CONTEXT_WINDOW_HARD_MIN_TOKENS`.
- Documented in the three docs files: "re-running onboard with this flag replaces the stored value."

## Current review state

What is the next action?

Maintainer review. Branch on fork `ericlevine/openclaw`, no draft state — open as ready when posted.

What is still waiting on author, maintainer, CI, or external proof?

- Nothing on the author side. Locally: tests + typecheck + lint + format + build all clean.
- CI: not yet run (PR not opened).
- External proof: covered above; no further proof needed unless reviewers request a live-agent run.

Which bot or reviewer comments were addressed?

- Three review notes raised on the initial commit (`d37de3aa05`) were addressed in `4fe55665be`:
  - **P2** — docs missing the flag: added to `docs/cli/onboard.md`, `docs/start/wizard-cli-reference.md`, `docs/start/wizard-cli-automation.md`.
  - **P3** — `Number()` accepts hex/whitespace: switched CLI conversion to `parseStrictPositiveInteger`, so `0x100000` is now rejected by the existing validator. Whitespace is still trimmed (matches `parseTcpPort` and the rest of `src/shared/number-coercion.ts`).
  - **P3** — duplicate validation in `applyCustomApiConfig`: removed the re-run of `parseCustomApiContextWindow` inside `applyCustomApiConfig`; validation now lives only at the `parseNonInteractiveCustomApiFlags` seam.
