### PR TITLE
fix(doctor): quiet tool policy removal audits

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1907,7 +1907,9 @@ process.stdin.on("end", () => {
         });
       });
 
-      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
       const addr = server.address() as { port: number };
 
       try {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -513,6 +513,8 @@ export function createOpenClawCodingTools(options?: {
   onYield?: (message: string) => Promise<void> | void;
   /** Optional instrumentation callback for tool preparation stage timing. */
   recordToolPrepStage?: (name: string) => void;
+  /** Lower routine policy-removal audits for diagnostic-only tool probes. */
+  toolPolicyAuditLogLevel?: "info" | "debug";
   /** Live observer called after wrapped tool outcomes are recorded. */
   onToolOutcome?: ToolOutcomeObserver;
   /** Runtime-only resolved skill paths that the read tool may load under workspaceOnly. */
@@ -1114,6 +1116,7 @@ export function createOpenClawCodingTools(options?: {
       },
       { policy: inheritedToolPolicy, label: "inherited tools", unavailableCoreToolReason },
     ],
+    auditLogLevel: options?.toolPolicyAuditLogLevel,
   });
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, subagentFiltered);

--- a/src/agents/embedded-agent-runner/effective-tool-policy.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.ts
@@ -54,6 +54,7 @@ type FinalEffectiveToolPolicyParams = {
   senderUsername?: string | null;
   senderE164?: string | null;
   warn: (message: string) => void;
+  toolPolicyAuditLogLevel?: "info" | "debug";
 };
 
 export function applyFinalEffectiveToolPolicy(
@@ -173,5 +174,6 @@ export function applyFinalEffectiveToolPolicy(
     toolMeta: (tool) => getPluginToolMeta(tool),
     warn: params.warn,
     steps: pipelineSteps,
+    auditLogLevel: params.toolPolicyAuditLogLevel,
   });
 }

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -176,7 +176,7 @@ export function auditToolPolicyFilter(params: {
       tools: matchedRuleSourceTools,
     });
     const matchedRuleSuffix = matchedRules.length > 0 ? `; matched ${matchedRules.join(", ")}` : "";
-    toolPolicyAuditLogger.info(
+    toolPolicyAuditLogger.debug(
       `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}${matchedRuleSuffix}`,
       {
         rule,

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -7,6 +7,8 @@ const MAX_AUDIT_TOOL_NAMES = 50;
 const MAX_AUDIT_FIELD_LENGTH = 160;
 const toolPolicyAuditLogger = createSubsystemLogger("agents/tool-policy");
 
+export type ToolPolicyAuditLogLevel = "info" | "debug";
+
 type ToolPolicyRuleKind = "allow" | "deny" | "allow+deny" | "unknown";
 
 function toolPolicyRuleKind(policy: ToolPolicyLike): ToolPolicyRuleKind {
@@ -157,6 +159,7 @@ export function auditToolPolicyFilter(params: {
   policy: ToolPolicyLike;
   before: readonly { name: string }[];
   after: readonly { name: string }[];
+  logLevel?: ToolPolicyAuditLogLevel;
 }): void {
   const removedByRule = removedToolNamesByRule({
     policy: params.policy,
@@ -176,22 +179,25 @@ export function auditToolPolicyFilter(params: {
       tools: matchedRuleSourceTools,
     });
     const matchedRuleSuffix = matchedRules.length > 0 ? `; matched ${matchedRules.join(", ")}` : "";
-    toolPolicyAuditLogger.debug(
-      `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}${matchedRuleSuffix}`,
-      {
-        rule,
-        ruleKind,
-        ...(matchedRules.length > 0
-          ? {
-              matchedRules,
-              ...(truncated ? { matchedRulesTruncated: true } : {}),
-            }
-          : {}),
-        removedToolCount: removed.length,
-        removedTools: toolNames,
-        removedToolsTruncated: truncated,
-      },
-    );
+    const message = `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}${matchedRuleSuffix}`;
+    const metadata = {
+      rule,
+      ruleKind,
+      ...(matchedRules.length > 0
+        ? {
+            matchedRules,
+            ...(truncated ? { matchedRulesTruncated: true } : {}),
+          }
+        : {}),
+      removedToolCount: removed.length,
+      removedTools: toolNames,
+      removedToolsTruncated: truncated,
+    };
+    if (params.logLevel === "debug") {
+      toolPolicyAuditLogger.debug(message, metadata);
+    } else {
+      toolPolicyAuditLogger.info(message, metadata);
+    }
   }
 }
 

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -6,12 +6,14 @@ import {
 } from "./tool-policy-pipeline.js";
 import { resolveToolProfilePolicy } from "./tool-policy.js";
 
-const { toolPolicyAuditInfo } = vi.hoisted(() => ({
+const { toolPolicyAuditDebug, toolPolicyAuditInfo } = vi.hoisted(() => ({
+  toolPolicyAuditDebug: vi.fn(),
   toolPolicyAuditInfo: vi.fn(),
 }));
 
 vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: () => ({
+    debug: toolPolicyAuditDebug,
     info: toolPolicyAuditInfo,
   }),
 }));
@@ -49,6 +51,7 @@ function runAllowlistWarningStep(params: {
 describe("tool-policy-pipeline", () => {
   beforeEach(() => {
     resetToolPolicyWarningCacheForTest();
+    toolPolicyAuditDebug.mockClear();
     toolPolicyAuditInfo.mockClear();
   });
 
@@ -308,7 +311,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 2 tool(s) via agent tools.allow: browser, write",
       {
         rule: "agent tools.allow",
@@ -318,6 +321,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 
   test("audits deny removals with the deny config key", () => {
@@ -335,7 +339,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via tools.deny: browser; matched browser",
       {
         rule: "tools.deny",
@@ -346,6 +350,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 
   test("splits mixed allow and deny policy audit entries by cause", () => {
@@ -367,7 +372,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker.tools.deny: browser; matched browser",
       {
         rule: "agents.worker.tools.deny",
@@ -378,7 +383,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker.tools.allow: write",
       {
         rule: "agents.worker.tools.allow",
@@ -388,6 +393,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 
   test("does not audit policy steps that leave the tool surface unchanged", () => {
@@ -405,6 +411,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
+    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
     expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 
@@ -423,7 +430,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker\\nbad.tools.allow: exec\\nbad",
       {
         rule: "agents.worker\\nbad.tools.allow",
@@ -433,5 +440,6 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -311,13 +311,42 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
       "tool policy removed 2 tool(s) via agent tools.allow: browser, write",
       {
         rule: "agent tools.allow",
         ruleKind: "allow",
         removedToolCount: 2,
         removedTools: ["browser", "write"],
+        removedToolsTruncated: false,
+      },
+    );
+    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
+  });
+
+  test("can lower removal audits for diagnostic-only policy probes", () => {
+    const tools = [{ name: "exec" }, { name: "browser" }] as unknown as DummyTool[];
+
+    applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      auditLogLevel: "debug",
+      steps: [
+        {
+          policy: { allow: ["exec"] },
+          label: "doctor tools.profile (coding)",
+        },
+      ],
+    });
+
+    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
+      "tool policy removed 1 tool(s) via doctor tools.profile (coding): browser",
+      {
+        rule: "doctor tools.profile (coding)",
+        ruleKind: "allow",
+        removedToolCount: 1,
+        removedTools: ["browser"],
         removedToolsTruncated: false,
       },
     );
@@ -339,7 +368,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via tools.deny: browser; matched browser",
       {
         rule: "tools.deny",
@@ -350,7 +379,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
+    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
   });
 
   test("splits mixed allow and deny policy audit entries by cause", () => {
@@ -372,7 +401,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker.tools.deny: browser; matched browser",
       {
         rule: "agents.worker.tools.deny",
@@ -383,7 +412,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker.tools.allow: write",
       {
         rule: "agents.worker.tools.allow",
@@ -393,7 +422,7 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
+    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
   });
 
   test("does not audit policy steps that leave the tool surface unchanged", () => {
@@ -430,7 +459,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
 
-    expect(toolPolicyAuditDebug).toHaveBeenCalledWith(
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
       "tool policy removed 1 tool(s) via agents.worker\\nbad.tools.allow: exec\\nbad",
       {
         rule: "agents.worker\\nbad.tools.allow",
@@ -440,6 +469,6 @@ describe("tool-policy-pipeline", () => {
         removedToolsTruncated: false,
       },
     );
-    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
+    expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -1,7 +1,7 @@
 import { filterToolsByPolicy } from "./agent-tools.policy.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { isKnownCoreToolId } from "./tool-catalog.js";
-import { auditToolPolicyFilter } from "./tool-policy-audit.js";
+import { auditToolPolicyFilter, type ToolPolicyAuditLogLevel } from "./tool-policy-audit.js";
 import {
   analyzeAllowlistByToolType,
   buildPluginToolGroups,
@@ -120,6 +120,7 @@ export function applyToolPolicyPipeline(params: {
   toolMeta: (tool: AnyAgentTool) => { pluginId: string } | undefined;
   warn: (message: string) => void;
   steps: ToolPolicyPipelineStep[];
+  auditLogLevel?: ToolPolicyAuditLogLevel;
 }): AnyAgentTool[] {
   const coreToolNames = new Set(
     params.tools
@@ -191,6 +192,7 @@ export function applyToolPolicyPipeline(params: {
       policy: expanded,
       before,
       after: filtered,
+      logLevel: params.auditLogLevel,
     });
   }
   return filtered;

--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -103,6 +103,9 @@ describe("active tool schema doctor warnings", () => {
     ).toEqual([
       '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema (dofbot_move_angles.parameters.type must be "object"). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
     ]);
+    expect(toolState.createTools).toHaveBeenCalledWith(
+      expect.objectContaining({ toolPolicyAuditLogLevel: "debug" }),
+    );
   });
 
   it("warns about unreadable active tool entries without crashing", () => {

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -158,6 +158,7 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
         modelCompat: runtimeModelContext.modelCompat,
         modelContextWindowTokens: runtimeModelContext.modelContextWindowTokens,
         allowGatewaySubagentBinding: true,
+        toolPolicyAuditLogLevel: "debug",
       });
     } catch (error) {
       warnings.push(

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -332,10 +332,10 @@ describe("doctor runtime tool schema checks", () => {
         "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
     });
     expect(mocks.createOpenClawCodingTools).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "main" }),
+      expect.objectContaining({ agentId: "main", toolPolicyAuditLogLevel: "debug" }),
     );
     expect(mocks.createOpenClawCodingTools).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "worker" }),
+      expect.objectContaining({ agentId: "worker", toolPolicyAuditLogLevel: "debug" }),
     );
     expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledTimes(1);
     expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -605,6 +605,7 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
     modelProvider: params.modelRef.provider,
     modelId: params.modelRef.model,
     warn: () => {},
+    toolPolicyAuditLogLevel: "debug",
   });
   const preNormalizationFindings: HealthFinding[] = [];
 
@@ -694,6 +695,7 @@ function collectAgentRuntimeToolSchemaFindings(params: {
       modelContextWindowTokens: params.model.contextWindow,
       allowGatewaySubagentBinding: true,
       emitBeforeToolCallDiagnostics: false,
+      toolPolicyAuditLogLevel: "debug",
     });
   } catch (error) {
     return [agentRuntimeToolLoadFailureFinding({ agentId: params.agentId, error })];
@@ -866,6 +868,7 @@ function shouldReportBundleMcpRuntimeDiagnostic(params: {
       modelProvider: params.modelRef.provider,
       modelId: params.modelRef.model,
       warn: () => {},
+      toolPolicyAuditLogLevel: "debug",
     }).length > 0
   );
 }

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -845,22 +845,18 @@ describe("chat voice controls", () => {
     const model = container.querySelector<HTMLInputElement>(
       '.agent-chat__talk-options-primary input[placeholder="Auto"]',
     );
-    const voice = container.querySelector<HTMLSelectElement>(
-      ".agent-chat__talk-options-primary label:nth-of-type(1) select",
-    );
-    const sensitivity = container.querySelector<HTMLSelectElement>(
-      ".agent-chat__talk-options-primary label:nth-of-type(3) select",
-    );
+    const voice = container.querySelector<HTMLElement>('[data-talk-select="voice"]');
+    const sensitivity = container.querySelector<HTMLElement>('[data-talk-select="sensitivity"]');
     const voiceOptions = Array.from(
       container.querySelectorAll<HTMLOptionElement>(
-        ".agent-chat__talk-options-primary label:nth-of-type(1) option",
+        '[data-talk-select="voice"] [data-talk-select-option]',
       ),
-    ).map((option) => option.value);
+    ).map((option) => option.dataset.talkSelectOption ?? "");
     const reasoningOptions = Array.from(
       container.querySelectorAll<HTMLOptionElement>(
-        ".agent-chat__talk-options-advanced label:nth-of-type(3) option",
+        '[data-talk-select="reasoning"] [data-talk-select-option]',
       ),
-    ).map((option) => option.value);
+    ).map((option) => option.dataset.talkSelectOption ?? "");
 
     if (voice === null) {
       throw new Error("expected Talk voice select");
@@ -881,14 +877,14 @@ describe("chat voice controls", () => {
       "marin",
       "cedar",
     ]);
-    expect(sensitivity.value).toBe("__custom");
-    expect(Array.from(sensitivity.options).map((option) => option.value)).toEqual([
-      "",
-      "0.65",
-      "0.5",
-      "0.35",
-      "__custom",
-    ]);
+    expect(
+      sensitivity.querySelector<HTMLElement>('[aria-selected="true"]')?.dataset.talkSelectOption,
+    ).toBe("__custom");
+    expect(
+      Array.from(sensitivity.querySelectorAll<HTMLElement>("[data-talk-select-option]")).map(
+        (option) => option.dataset.talkSelectOption ?? "",
+      ),
+    ).toEqual(["", "0.65", "0.5", "0.35", "__custom"]);
     expect(reasoningOptions).toEqual(["", "minimal", "low", "medium", "high"]);
     expect(container.textContent).toContain("Sensitivity");
     expect(container.textContent).toContain("Advanced");
@@ -898,12 +894,19 @@ describe("chat voice controls", () => {
     if (model === null) {
       throw new Error("expected Talk model input");
     }
+    const chooseOption = (root: HTMLElement, value: string) => {
+      const option = Array.from(
+        root.querySelectorAll<HTMLButtonElement>("[data-talk-select-option]"),
+      ).find((button) => button.dataset.talkSelectOption === value);
+      if (!option) {
+        throw new Error(`expected Talk option ${value}`);
+      }
+      option.click();
+    };
     model.value = "gpt-realtime-mini";
     model.dispatchEvent(new Event("input", { bubbles: true }));
-    sensitivity.value = "0.35";
-    sensitivity.dispatchEvent(new Event("change", { bubbles: true }));
-    sensitivity.value = "";
-    sensitivity.dispatchEvent(new Event("change", { bubbles: true }));
+    chooseOption(sensitivity, "0.35");
+    chooseOption(sensitivity, "");
 
     expect(onRealtimeTalkOptionsChange).toHaveBeenCalledWith({ model: "gpt-realtime-mini" });
     expect(onRealtimeTalkOptionsChange).toHaveBeenCalledWith({ vadThreshold: "0.35" });
@@ -923,16 +926,18 @@ describe("chat voice controls", () => {
       },
       onRealtimeTalkOptionsChange,
     });
-    const defaultSensitivity = defaultContainer.querySelector<HTMLSelectElement>(
-      ".agent-chat__talk-options-primary label:nth-of-type(3) select",
+    const defaultSensitivity = defaultContainer.querySelector<HTMLElement>(
+      '[data-talk-select="sensitivity"]',
     );
-    expect(defaultSensitivity?.value).toBe("");
-    expect(Array.from(defaultSensitivity?.options ?? []).map((option) => option.value)).toEqual([
-      "",
-      "0.65",
-      "0.5",
-      "0.35",
-    ]);
+    expect(
+      defaultSensitivity?.querySelector<HTMLElement>('[aria-selected="true"]')?.dataset
+        .talkSelectOption,
+    ).toBe("");
+    expect(
+      Array.from(
+        defaultSensitivity?.querySelectorAll<HTMLElement>("[data-talk-select-option]") ?? [],
+      ).map((option) => option.dataset.talkSelectOption ?? ""),
+    ).toEqual(["", "0.65", "0.5", "0.35"]);
   });
 
   it("renders composer and Talk labels from the active locale", async () => {


### PR DESCRIPTION
## Summary

- Keep runtime tool-policy removal audits at the normal `info` level by default.
- Lower diagnostic-only doctor tool-schema probes to `debug` so expected profile filtering does not pollute normal `openclaw doctor` output.
- Keep actionable sandbox policy block audits at `info`.
- Add regression coverage for the default audit level and the doctor-specific debug path.

Fixes #87798.

## Validation

- `node scripts/run-vitest.mjs src/agents/tool-policy-pipeline.test.ts src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts src/agents/agent-bundle-mcp-runtime.test.ts`
- `node scripts/test-projects.mjs test/vitest/vitest.gateway-methods.config.ts`
- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/agent-chat-include.json node scripts/test-projects.mjs test/vitest/vitest.gateway-server.config.ts`
- `pnpm lint --threads=8`
- `git diff --check`
- `node node_modules/oxfmt/bin/oxfmt --check ...` on touched files
- `pnpm exec oxlint ...` on touched files
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## CI

- CI: https://github.com/openclaw/openclaw/actions/runs/26727664397
- Real behavior proof: https://github.com/openclaw/openclaw/actions/runs/26727667473
- Head: `b7af1f56ec1638298fd01258c098e2d079f1851d`

## Surface Area

- No new config key, CLI flag, environment variable, migration, or compatibility surface.
- Adds an internal per-call audit verbosity option for doctor probes only.
