### PR TITLE
fix(codex): trace app-server thread lifecycle timing

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CODEX_GPT5_BEHAVIOR_CONTRACT } from "../../prompt-overlay.js";
 import {
   buildDeveloperInstructions,
@@ -8,8 +11,15 @@ import {
   buildThreadResumeParams,
   buildThreadStartParams,
   codexDynamicToolsFingerprint,
+  formatCodexThreadLifecycleTimingSummary,
   resolveReasoningEffort,
+  shouldWarnCodexThreadLifecycleTimingSummary,
+  startOrResumeThread,
+  type CodexThreadLifecycleTimingLogger,
 } from "./thread-lifecycle.js";
+import { createCodexTestModel } from "./test-support.js";
+
+let tempDir: string;
 
 function createAttemptParams(params: {
   provider: string;
@@ -72,6 +82,102 @@ function createAppServerOptions() {
     approvalsReviewer: "user",
     sandbox: "workspace-write",
   } as const;
+}
+
+function createThreadLifecycleParams(
+  sessionFile: string,
+  workspaceDir: string,
+): EmbeddedRunAttemptParams {
+  return {
+    prompt: "hello",
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    sessionFile,
+    workspaceDir,
+    runId: "run-1",
+    provider: "codex",
+    modelId: "gpt-5.4-codex",
+    model: createCodexTestModel("codex"),
+    thinkLevel: "medium",
+    disableTools: true,
+    timeoutMs: 5_000,
+    authStorage: {} as never,
+    authProfileStore: { version: 1, profiles: {} },
+    modelRegistry: {} as never,
+  } as EmbeddedRunAttemptParams;
+}
+
+function createThreadLifecycleAppServerOptions(): Parameters<
+  typeof startOrResumeThread
+>[0]["appServer"] {
+  return {
+    start: {
+      transport: "stdio",
+      command: "codex",
+      args: ["app-server"],
+      headers: {},
+    },
+    codeModeOnly: false,
+    requestTimeoutMs: 60_000,
+    turnCompletionIdleTimeoutMs: 60_000,
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: "workspace-write",
+  };
+}
+
+function threadStartResult(threadId = "thread-1") {
+  return {
+    thread: {
+      id: threadId,
+      sessionId: "session-1",
+      forkedFromId: null,
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 1,
+      status: { type: "idle" },
+      path: null,
+      cwd: tempDir,
+      cliVersion: "0.125.0",
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+    model: "gpt-5.4-codex",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd: tempDir,
+    instructionSources: [],
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+    permissionProfile: null,
+    reasoningEffort: null,
+  };
+}
+
+function createTimingLogger(traceEnabled: boolean): CodexThreadLifecycleTimingLogger {
+  return {
+    isEnabled: vi.fn((level: "trace") => level === "trace" && traceEnabled),
+    trace: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+function expectSingleLogMessage(
+  log: CodexThreadLifecycleTimingLogger,
+  level: "trace" | "warn",
+): string {
+  const mock = log[level] as ReturnType<typeof vi.fn>;
+  expect(mock).toHaveBeenCalledTimes(1);
+  const message = mock.mock.calls[0]?.[0];
+  expect(typeof message).toBe("string");
+  return message as string;
 }
 
 describe("Codex app-server native code mode config", () => {
@@ -691,6 +797,176 @@ describe("Codex app-server model provider selection", () => {
     });
 
     expect(request.modelProvider).toBe("openai");
+  });
+});
+
+describe("Codex app-server thread lifecycle timing", () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-thread-lifecycle-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("formats stage summaries with run, session, action, and elapsed timing", () => {
+    const message = formatCodexThreadLifecycleTimingSummary({
+      runId: "run-a",
+      sessionId: "session-a",
+      sessionKey: "agent:main:session-a",
+      action: "started",
+      summary: {
+        totalMs: 12,
+        spans: [
+          { name: "read-binding", durationMs: 4, elapsedMs: 4 },
+          { name: "thread-start-request", durationMs: 8, elapsedMs: 12 },
+        ],
+      },
+    });
+
+    expect(message).toBe(
+      "[trace:codex-app-server] thread lifecycle: runId=run-a sessionId=session-a " +
+        "sessionKey=agent:main:session-a action=started totalMs=12 " +
+        "stages=read-binding:4ms@4ms,thread-start-request:8ms@12ms",
+    );
+  });
+
+  it("warns when the total or a single stage crosses the lifecycle threshold", () => {
+    expect(
+      shouldWarnCodexThreadLifecycleTimingSummary(
+        {
+          totalMs: 9,
+          spans: [{ name: "thread-start-request", durationMs: 10, elapsedMs: 10 }],
+        },
+        { totalThresholdMs: 50, stageThresholdMs: 10 },
+      ),
+    ).toBe(true);
+    expect(
+      shouldWarnCodexThreadLifecycleTimingSummary(
+        {
+          totalMs: 50,
+          spans: [{ name: "thread-start-request", durationMs: 1, elapsedMs: 1 }],
+        },
+        { totalThresholdMs: 50, stageThresholdMs: 10 },
+      ),
+    ).toBe(true);
+  });
+
+  it("emits a trace stage summary when starting a new thread with trace enabled", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    let nowMs = 0;
+    const log = createTimingLogger(true);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        nowMs += 17;
+        return threadStartResult("thread-started");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createThreadLifecycleParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      timing: {
+        enabled: true,
+        now: () => nowMs,
+        log,
+        totalThresholdMs: 1_000,
+        stageThresholdMs: 1_000,
+      },
+    });
+
+    const message = expectSingleLogMessage(log, "trace");
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(message).toContain("action=started");
+    expect(message).toContain("thread-start-request:17ms@17ms");
+    expect(message).toContain("thread-ready:0ms@17ms");
+  });
+
+  it("emits a trace stage summary when resuming an existing thread", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    let nowMs = 0;
+    const log = createTimingLogger(true);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-existing");
+      }
+      if (method === "thread/resume") {
+        nowMs += 9;
+        return threadStartResult("thread-existing");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const commonParams = {
+      client: { request } as never,
+      params: createThreadLifecycleParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+    };
+
+    await startOrResumeThread({
+      ...commonParams,
+      timing: {
+        enabled: true,
+        now: () => nowMs,
+        log: createTimingLogger(false),
+      },
+    });
+    await startOrResumeThread({
+      ...commonParams,
+      timing: {
+        enabled: true,
+        now: () => nowMs,
+        log,
+        totalThresholdMs: 1_000,
+        stageThresholdMs: 1_000,
+      },
+    });
+
+    const message = expectSingleLogMessage(log, "trace");
+    expect(message).toContain("action=resumed");
+    expect(message).toContain("thread-resume-request:9ms@9ms");
+  });
+
+  it("warns on slow start even when trace logging is disabled", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    let nowMs = 0;
+    const log = createTimingLogger(false);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        nowMs += 25;
+        return threadStartResult("thread-slow");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createThreadLifecycleParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      timing: {
+        enabled: true,
+        now: () => nowMs,
+        log,
+        totalThresholdMs: 10,
+        stageThresholdMs: 10,
+      },
+    });
+
+    const message = expectSingleLogMessage(log, "warn");
+    expect(log.trace).not.toHaveBeenCalled();
+    expect(message).toContain("action=started");
+    expect(message).toContain("thread-start-request:25ms@25ms");
   });
 });
 

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -119,32 +119,84 @@ const CODEX_TOOL_SEARCH_UNSUPPORTED_THREAD_CONFIG: JsonObject = {
   "features.multi_agent": false,
 };
 
-type CodexThreadLifecycleTimingSpan = {
+export type CodexThreadLifecycleTimingSpan = {
   name: string;
   durationMs: number;
   elapsedMs: number;
 };
 
-type CodexThreadLifecycleTimingSummary = {
+export type CodexThreadLifecycleTimingSummary = {
   totalMs: number;
   spans: CodexThreadLifecycleTimingSpan[];
+};
+
+export type CodexThreadLifecycleTimingLogger = {
+  isEnabled?: (level: "trace") => boolean;
+  trace: (message: string, meta?: Record<string, unknown>) => void;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+export type CodexThreadLifecycleTimingAction = "started" | "resumed" | "rotated";
+
+export type CodexThreadLifecycleTimingOptions = {
+  enabled?: boolean;
+  now?: () => number;
+  log?: CodexThreadLifecycleTimingLogger;
+  totalThresholdMs?: number;
+  stageThresholdMs?: number;
 };
 
 const CODEX_THREAD_LIFECYCLE_TIMING_WARN_TOTAL_MS = 1_000;
 const CODEX_THREAD_LIFECYCLE_TIMING_WARN_STAGE_MS = 500;
 
-function createCodexThreadLifecycleTimingTracker(options: { enabled?: boolean } = {}): {
+export function shouldWarnCodexThreadLifecycleTimingSummary(
+  summary: CodexThreadLifecycleTimingSummary,
+  options: CodexThreadLifecycleTimingOptions = {},
+): boolean {
+  const totalThresholdMs =
+    options.totalThresholdMs ?? CODEX_THREAD_LIFECYCLE_TIMING_WARN_TOTAL_MS;
+  const stageThresholdMs =
+    options.stageThresholdMs ?? CODEX_THREAD_LIFECYCLE_TIMING_WARN_STAGE_MS;
+  return (
+    summary.totalMs >= totalThresholdMs ||
+    summary.spans.some((span) => span.durationMs >= stageThresholdMs)
+  );
+}
+
+export function formatCodexThreadLifecycleTimingSummary(params: {
+  runId: string;
+  sessionId: string;
+  sessionKey?: string;
+  action: CodexThreadLifecycleTimingAction;
+  summary: CodexThreadLifecycleTimingSummary;
+}): string {
+  const spans =
+    params.summary.spans.length > 0
+      ? params.summary.spans
+          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+          .join(",")
+      : "none";
+  return (
+    `[trace:codex-app-server] thread lifecycle: runId=${params.runId} ` +
+    `sessionId=${params.sessionId} sessionKey=${params.sessionKey ?? "unknown"} ` +
+    `action=${params.action} totalMs=${params.summary.totalMs} stages=${spans}`
+  );
+}
+
+function createCodexThreadLifecycleTimingTracker(options: CodexThreadLifecycleTimingOptions = {}): {
   measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
   measureSync: <T>(name: string, run: () => T) => T;
-  logIfSlow: (params: {
+  mark: (name: string) => void;
+  logSummary: (params: {
     runId: string;
     sessionId: string;
     sessionKey?: string;
-    action: "started" | "resumed" | "rotated";
+    action: CodexThreadLifecycleTimingAction;
     threadId?: string;
   }) => void;
 } {
-  if (!options.enabled) {
+  const log = options.log ?? embeddedAgentLog;
+  if (!options.enabled && log.isEnabled?.("trace") !== true) {
     return {
       async measure(_name, run) {
         return await run();
@@ -152,37 +204,31 @@ function createCodexThreadLifecycleTimingTracker(options: { enabled?: boolean } 
       measureSync(_name, run) {
         return run();
       },
-      logIfSlow() {},
+      mark() {},
+      logSummary() {},
     };
   }
 
-  const startedAt = Date.now();
+  const now = options.now ?? Date.now;
+  const startedAt = now();
   let didLog = false;
   const spans: CodexThreadLifecycleTimingSpan[] = [];
   const toMs = (value: number) => Math.max(0, Math.round(value));
   const record = (name: string, spanStartedAt: number) => {
+    const currentAt = now();
     spans.push({
       name,
-      durationMs: toMs(Date.now() - spanStartedAt),
-      elapsedMs: toMs(Date.now() - startedAt),
+      durationMs: toMs(currentAt - spanStartedAt),
+      elapsedMs: toMs(currentAt - startedAt),
     });
   };
   const snapshot = (): CodexThreadLifecycleTimingSummary => ({
-    totalMs: toMs(Date.now() - startedAt),
+    totalMs: toMs(now() - startedAt),
     spans: spans.slice(),
   });
-  const shouldLog = (summary: CodexThreadLifecycleTimingSummary) =>
-    summary.totalMs >= CODEX_THREAD_LIFECYCLE_TIMING_WARN_TOTAL_MS ||
-    summary.spans.some((span) => span.durationMs >= CODEX_THREAD_LIFECYCLE_TIMING_WARN_STAGE_MS);
-  const formatSpans = (summary: CodexThreadLifecycleTimingSummary) =>
-    summary.spans.length > 0
-      ? summary.spans
-          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
-          .join(",")
-      : "none";
   return {
     async measure(name, run) {
-      const spanStartedAt = Date.now();
+      const spanStartedAt = now();
       try {
         return await run();
       } finally {
@@ -190,38 +236,47 @@ function createCodexThreadLifecycleTimingTracker(options: { enabled?: boolean } 
       }
     },
     measureSync(name, run) {
-      const spanStartedAt = Date.now();
+      const spanStartedAt = now();
       try {
         return run();
       } finally {
         record(name, spanStartedAt);
       }
     },
-    logIfSlow(params) {
+    mark(name) {
+      record(name, now());
+    },
+    logSummary(params) {
       if (didLog) {
         return;
       }
       const summary = snapshot();
-      if (!shouldLog(summary)) {
+      const shouldWarn = shouldWarnCodexThreadLifecycleTimingSummary(summary, options);
+      if (!shouldWarn && !log.isEnabled?.("trace")) {
         return;
       }
       didLog = true;
-      embeddedAgentLog.warn(
-        `codex app-server thread lifecycle timings runId=${params.runId} sessionId=${
-          params.sessionId
-        } sessionKey=${params.sessionKey ?? "unknown"} action=${params.action} totalMs=${
-          summary.totalMs
-        } stages=${formatSpans(summary)}`,
-        {
-          runId: params.runId,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          action: params.action,
-          threadId: params.threadId,
-          totalMs: summary.totalMs,
-          spans: summary.spans,
-        },
-      );
+      const message = formatCodexThreadLifecycleTimingSummary({
+        runId: params.runId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        action: params.action,
+        summary,
+      });
+      const meta = {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        action: params.action,
+        threadId: params.threadId,
+        totalMs: summary.totalMs,
+        spans: summary.spans,
+      };
+      if (shouldWarn) {
+        log.warn(message, meta);
+      } else {
+        log.trace(message, meta);
+      }
     },
   };
 }
@@ -249,19 +304,22 @@ export async function startOrResumeThread(params: {
   pluginThreadConfig?: CodexPluginThreadConfigProvider;
   contextEngineProjection?: CodexContextEngineThreadBootstrapProjection;
   signal?: AbortSignal;
+  timing?: CodexThreadLifecycleTimingOptions;
 }): Promise<CodexAppServerThreadLifecycleBinding> {
   // Thread lifecycle spans are useful when profiling startup churn, but normal
   // turns should not pay Date.now/span-array overhead while resuming threads.
   const lifecycleTiming = createCodexThreadLifecycleTimingTracker({
-    enabled: isCodexAppServerProfilerEnabled(params.params.config),
+    ...params.timing,
+    enabled:
+      params.timing?.enabled ?? isCodexAppServerProfilerEnabled(params.params.config),
   });
-  const dynamicToolsFingerprint = lifecycleTiming.measureSync("fingerprint_dynamic_tools", () =>
+  const dynamicToolsFingerprint = lifecycleTiming.measureSync("dynamic-tools-fingerprint", () =>
     fingerprintDynamicTools(params.dynamicTools),
   );
   const dynamicToolsContainDeferred = params.dynamicTools.some(
     (tool) => tool.deferLoading === true,
   );
-  const contextEngineBinding = lifecycleTiming.measureSync("context_engine_binding", () =>
+  const contextEngineBinding = lifecycleTiming.measureSync("context-engine-binding", () =>
     buildContextEngineBinding(params.params, params.contextEngineProjection),
   );
   const userMcpServersConfigPatch =
@@ -274,7 +332,7 @@ export async function startOrResumeThread(params: {
   const environmentSelectionFingerprint = fingerprintEnvironmentSelection(
     params.environmentSelection,
   );
-  let binding = await lifecycleTiming.measure("read_binding", () =>
+  let binding = await lifecycleTiming.measure("read-binding", () =>
     readCodexAppServerBinding(params.params.sessionFile, {
       authProfileStore: params.params.authProfileStore,
       agentDir: params.params.agentDir,
@@ -381,7 +439,7 @@ export async function startOrResumeThread(params: {
       })
     ) {
       try {
-        prebuiltPluginThreadConfig = await lifecycleTiming.measure("plugin_config_recovery", () =>
+        prebuiltPluginThreadConfig = await lifecycleTiming.measure("plugin-config-recovery", () =>
           params.pluginThreadConfig?.build(),
         );
         pluginBindingStale =
@@ -474,7 +532,7 @@ export async function startOrResumeThread(params: {
           userMcpServersConfigPatch,
           finalConfigPatch.configPatch,
         );
-        const resumeParams = lifecycleTiming.measureSync("thread_resume_params", () =>
+        const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
           buildThreadResumeParams(params.params, {
             threadId: binding.threadId,
             authProfileId,
@@ -487,7 +545,7 @@ export async function startOrResumeThread(params: {
           }),
         );
         const response = assertCodexThreadResumeResponse(
-          await lifecycleTiming.measure("thread_resume_request", () =>
+          await lifecycleTiming.measure("thread-resume-request", () =>
             params.client.request("thread/resume", resumeParams, { signal: params.signal }),
           ),
         );
@@ -504,7 +562,7 @@ export async function startOrResumeThread(params: {
           params.mcpServersFingerprintEvaluated === true
             ? params.mcpServersFingerprint
             : binding.mcpServersFingerprint;
-        await lifecycleTiming.measure("thread_resume_write_binding", () =>
+        await lifecycleTiming.measure("thread-resume-write-binding", () =>
           writeCodexAppServerBinding(
             params.params.sessionFile,
             {
@@ -544,7 +602,8 @@ export async function startOrResumeThread(params: {
             action: "resumed",
           });
         }
-        lifecycleTiming.logIfSlow({
+        lifecycleTiming.mark("thread-ready");
+        lifecycleTiming.logSummary({
           runId: params.params.runId,
           sessionId: params.params.sessionId,
           sessionKey: params.params.sessionKey,
@@ -585,7 +644,7 @@ export async function startOrResumeThread(params: {
 
   const pluginThreadConfig = params.pluginThreadConfig?.enabled
     ? (prebuiltPluginThreadConfig ??
-      (await lifecycleTiming.measure("plugin_config_build", () =>
+      (await lifecycleTiming.measure("plugin-config-build", () =>
         params.pluginThreadConfig?.build(),
       )))
     : undefined;
@@ -593,7 +652,7 @@ export async function startOrResumeThread(params: {
     configPatch: params.finalConfigPatch,
     nativeHookRelayGeneration: params.nativeHookRelayGeneration,
   };
-  const config = lifecycleTiming.measureSync("merge_thread_config", () =>
+  const config = lifecycleTiming.measureSync("merge-thread-config", () =>
     mergeCodexThreadConfigs(
       params.config,
       userMcpServersConfigPatch,
@@ -601,7 +660,7 @@ export async function startOrResumeThread(params: {
       finalConfigPatch.configPatch,
     ),
   );
-  const startParams = lifecycleTiming.measureSync("thread_start_params", () =>
+  const startParams = lifecycleTiming.measureSync("thread-start-params", () =>
     buildThreadStartParams(params.params, {
       cwd: params.cwd,
       dynamicTools: params.dynamicTools,
@@ -613,7 +672,7 @@ export async function startOrResumeThread(params: {
       environmentSelection: params.environmentSelection,
     }),
   );
-  const threadStartResponse = await lifecycleTiming.measure("thread_start_request", async () => {
+  const threadStartResponse = await lifecycleTiming.measure("thread-start-request", async () => {
     try {
       return await params.client.request("thread/start", startParams, { signal: params.signal });
     } catch (error) {
@@ -636,7 +695,7 @@ export async function startOrResumeThread(params: {
   const nextMcpServersFingerprint =
     params.mcpServersFingerprintEvaluated === true ? params.mcpServersFingerprint : undefined;
   if (!preserveExistingBinding) {
-    await lifecycleTiming.measure("thread_start_write_binding", () =>
+    await lifecycleTiming.measure("thread-start-write-binding", () =>
       writeCodexAppServerBinding(
         params.params.sessionFile,
         {
@@ -676,7 +735,8 @@ export async function startOrResumeThread(params: {
       });
     }
   }
-  lifecycleTiming.logIfSlow({
+  lifecycleTiming.mark("thread-ready");
+  lifecycleTiming.logSummary({
     runId: params.params.runId,
     sessionId: params.params.sessionId,
     sessionKey: params.params.sessionKey,


### PR DESCRIPTION
## Summary

Fixes #84640.

Adds Codex app-server thread lifecycle timing around `startOrResumeThread` so the hidden gap between embedded `attempt-dispatch` and Codex `session.started` is visible in trace logs. The summary records start/resume action, total time, session key, and per-stage timings for binding reads, thread start/resume requests, binding writes, and thread-ready.

The timing extends the existing profiler-gated lifecycle tracker: normal runs log at trace level when trace logging is enabled, and slow lifecycle spans still emit warning-level summaries when the configured thresholds are crossed.

## Real behavior proof

content: behavior

environment: Local OpenClaw source checkout rebased on `f499841be6`, host Node 22.22.2 and pnpm 11.1.0, OpenClaw CLI local agent run with Codex app-server auth profile.

steps:
1. Run a real local `openclaw agent --local` turn with trace logging against `openai/gpt-5.5`.
2. Confirm the Codex app-server lifecycle summary is emitted before the turn completes.
3. Run the focused Codex app-server lifecycle test with the Codex extension Vitest config.
4. Run extension production typecheck against the finalized branch.
5. Run `git diff --check` against `upstream/main`.

evidence:
```text
OPENCLAW_LOG_LEVEL=trace OPENCLAW_TEST_CONSOLE=1 pnpm openclaw agent --local --agent main --session-key codex-lifecycle-proof-84640-final --model openai/gpt-5.5 --message "Reply exactly: pong" --json

[agent/embedded] [trace:embedded-run] startup stages: runId=8436a207-b562-4392-a9aa-e46fa30954be sessionId=3b64f9d8-0d75-402e-a3af-f304a3c1e8e7 phase=attempt-dispatch totalMs=20947 stages=workspace:2ms@2ms,runtime-plugins:20237ms@20239ms,hooks:3ms@20242ms,model-resolution:416ms@20658ms,auth:224ms@20882ms,context-engine:5ms@20887ms,attempt-workspace:50ms@20937ms,attempt-prompt:0ms@20937ms,attempt-runtime-plan:10ms@20947ms,attempt-dispatch:0ms@20947ms
[agent/embedded] [trace:codex-app-server] thread lifecycle: runId=8436a207-b562-4392-a9aa-e46fa30954be sessionId=3b64f9d8-0d75-402e-a3af-f304a3c1e8e7 sessionKey=agent:main:codex-lifecycle-proof-84640-final action=started totalMs=3547 stages=dynamic-tools-fingerprint:8ms@8ms,context-engine-binding:0ms@8ms,read-binding:1ms@10ms,merge-thread-config:0ms@50ms,thread-start-params:6ms@56ms,thread-start-request:3404ms@3460ms,thread-start-write-binding:21ms@3546ms,thread-ready:0ms@3546ms
"agentHarnessId": "codex"
"finalAssistantVisibleText": "pong"

node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/thread-lifecycle.test.ts --reporter=verbose
RUN  v4.1.7
Test Files  1 passed (1)
Tests  48 passed (48)
Duration  87.17s

node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
exit code: 0

git diff --check upstream/main...HEAD
exit code: 0
```

observedResult: The finalized branch emits the embedded `attempt-dispatch` summary and the new Codex app-server `thread lifecycle` summary in the same real local agent turn, then completes successfully through the Codex harness. Focused tests also cover start, resume, formatting, and warning-threshold behavior.

notTested: Full Docker gateway live Codex harness was not rerun after resolving the conflict with upstream profiler changes. An earlier pre-rebase Docker harness run from this branch passed the focused start/resume lane, but the final post-rebase proof above uses the real local CLI runner. The full extension-test typecheck lane was also not completed locally; the broader `check-changed` run reached extension production typecheck successfully, then the extension-test typecheck was stopped after it remained CPU-bound for several minutes. CI should cover the full extension-test typecheck.

## Verification

```text
node scripts/changed-lanes.mjs --base upstream/main --head HEAD --json
OPENCLAW_LOG_LEVEL=trace OPENCLAW_TEST_CONSOLE=1 pnpm openclaw agent --local --agent main --session-key codex-lifecycle-proof-84640-final --model openai/gpt-5.5 --message "Reply exactly: pong" --json
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/thread-lifecycle.test.ts --reporter=verbose
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
git diff --check upstream/main...HEAD
```
