### PR TITLE
Update Teams CLI install command

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -37,14 +37,10 @@ The [`@microsoft/teams.cli`](https://www.npmjs.com/package/@microsoft/teams.cli)
 **1. Install and log in**
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 teams login
 teams status   # verify you're logged in and see your tenant info
 ```
-
-<Note>
-The Teams CLI is currently in preview. Commands and flags may change between releases.
-</Note>
 
 **2. Start a tunnel** (Teams can't reach localhost)
 


### PR DESCRIPTION
## Summary

Updates the Microsoft Teams setup docs to install `@microsoft/teams.cli` without the old `@preview` tag.

## Why

Teams CLI is out of preview now, so the docs should point folks at the current stable package. Less vintage npm incantation, more happy setup.

## Interesting bits

Also removed the note warning that Teams CLI is currently in preview, since that is no longer true.

## Real behavior proof

Behavior addressed: Microsoft Teams setup docs now install the GA `@microsoft/teams.cli` package instead of the old `@preview` tag.

Real environment tested: Local OpenClaw docs source checkout, plus the public npm registry state for `@microsoft/teams.cli`.

Exact steps or command run after this patch:

```bash
pnpm docs:list | rg -i 'msteams|teams|channels' || true
npm view @microsoft/teams.cli dist-tags version --json
rg -n "@microsoft/teams\\.cli@preview|Teams CLI is currently in preview|teams\\.cli@preview" docs/channels/msteams.md || true
git diff --check
```

Evidence after fix:

```text
channels/msteams.md - Microsoft Teams bot support status, capabilities, and configuration
{
  "dist-tags": {
    "$(npmtag)": "2.0.6-preview.1",
    "next": "2.0.11-preview.8",
    "latest": "3.0.0",
    "preview": "3.0.0-preview.9"
  },
  "version": "3.0.0"
}
```

The stale-preview `rg` command produced no matches, and `git diff --check` produced no output.

Supporting screenshots:

![Terminal output showing no stale preview mentions](https://github.com/user-attachments/assets/0cbeb55c-58e9-49c2-b53a-2a23b813e22c)

![npm package page for @microsoft/teams.cli](https://github.com/user-attachments/assets/0ebbdeba-3a1a-4d47-a2ad-a099372b6e29)

Observed result after fix: No stale `@microsoft/teams.cli@preview` install command remains, and the docs now show `npm install -g @microsoft/teams.cli`.

What was not tested: Docs site rendering was not built; this is a docs-only command update.
