### PR TITLE
fix(agents): adopt rotated session id and file after embedded compaction rotation

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -309,6 +309,67 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("persists a transcript rotation even on a preserved-state heartbeat run", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-rotation-preserve";
+      const sessionId = "pre-rotation-heartbeat";
+      const rotatedSessionId = "post-rotation-heartbeat";
+      const rotatedSessionFile = "/tmp/post-rotation-heartbeat.jsonl";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          sessionFile: "/tmp/pre-rotation-heartbeat.jsonl",
+          updatedAt: 1,
+          sessionStartedAt: 1,
+          modelProvider: "anthropic",
+          model: "claude-opus-4-6",
+          contextTokens: 400_000,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedAgentRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            // A heartbeat turn can still hit a compaction rotation; the embedded
+            // runner reports the post-rotation openclaw identity here.
+            sessionId: rotatedSessionId,
+            sessionFile: rotatedSessionFile,
+            provider: "ollama",
+            model: "llama3.2:1b",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        contextTokensOverride: 200_000,
+        sessionStore,
+        defaultProvider: "ollama",
+        defaultModel: "llama3.2:1b",
+        result,
+        preserveUserFacingSessionModelState: true,
+      });
+
+      const persisted = loadSessionStore(storePath);
+      // The physical transcript rotation must reach disk even in preserve mode,
+      // or the next turn reopens the rotated-away file and deadlocks (#88040).
+      expect(persisted[sessionKey]?.sessionId).toBe(rotatedSessionId);
+      expect(persisted[sessionKey]?.sessionFile).toBe(rotatedSessionFile);
+      // A rotated identity is a new session, so the start timestamp resets.
+      expect(persisted[sessionKey]?.sessionStartedAt).not.toBe(1);
+      // Preserve mode still keeps the prior user-facing runtime model rather than
+      // adopting the heartbeat model — only the transcript identity is updated.
+      expect(persisted[sessionKey]?.model).toBe("claude-opus-4-6");
+      expect(persisted[sessionKey]?.modelProvider).toBe("anthropic");
+    });
+  });
+
   it("uses the runtime context budget from agent metadata instead of cold fallback", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -197,6 +197,118 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("adopts the rotated session id and file after embedded auto-compaction rotation", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-rotation";
+      const sessionId = "pre-rotation-session";
+      const rotatedSessionId = "post-rotation-session";
+      const rotatedSessionFile = "/tmp/post-rotation-session.jsonl";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          sessionFile: "/tmp/pre-rotation-session.jsonl",
+          updatedAt: 1,
+          sessionStartedAt: 1,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedAgentRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            // Embedded runner reports the post-rotation openclaw identity here.
+            sessionId: rotatedSessionId,
+            sessionFile: rotatedSessionFile,
+            provider: "openai",
+            model: "gpt-5.5",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        contextTokensOverride: 200_000,
+        sessionStore,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+        result,
+      });
+
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.sessionId).toBe(rotatedSessionId);
+      expect(persisted[sessionKey]?.sessionFile).toBe(rotatedSessionFile);
+      // A rotated identity is a new session, so the start timestamp resets rather
+      // than carrying the pre-rotation value.
+      expect(persisted[sessionKey]?.sessionStartedAt).not.toBe(1);
+      expect(sessionStore[sessionKey]?.sessionId).toBe(rotatedSessionId);
+      expect(sessionStore[sessionKey]?.sessionFile).toBe(rotatedSessionFile);
+    });
+  });
+
+  it("keeps the openclaw session id for CLI runs where agentMeta.sessionId is the external tool id", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": {
+                command: "claude",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-cli-no-rotation";
+      const sessionId = "openclaw-session-id";
+      const sessionFile = "/tmp/openclaw-session-id.jsonl";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          sessionFile,
+          updatedAt: 1,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedAgentRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            // For CLI providers this is the external tool's session id, not a
+            // rotated openclaw session id, and no sessionFile is emitted — so the
+            // openclaw identity must be left untouched.
+            sessionId: "external-claude-cli-id",
+            provider: "claude-cli",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        contextTokensOverride: 200_000,
+        sessionStore,
+        defaultProvider: "claude-cli",
+        defaultModel: "claude-sonnet-4-6",
+        result,
+      });
+
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.sessionId).toBe(sessionId);
+      expect(persisted[sessionKey]?.sessionFile).toBe(sessionFile);
+      // The external id is recorded only as the CLI binding, never as the openclaw id.
+      expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe("external-claude-cli-id");
+    });
+  });
+
   it("uses the runtime context budget from agent metadata instead of cold fallback", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -282,6 +282,17 @@ export async function updateSessionStoreAfterAgentRun(params: {
     ? {
         updatedAt: next.updatedAt,
         ...(touchInteraction ? { lastInteractionAt: next.lastInteractionAt } : {}),
+        // A physical transcript rotation must still reach sessions.json on a
+        // preserved-state (heartbeat) turn: it is filesystem identity, not
+        // user-facing model state. Skipping it would leave the stale pointer
+        // so the next turn reopens the rotated-away file and deadlocks (#88040).
+        ...(sessionRotated && rotatedSessionFile
+          ? {
+              sessionId: effectiveSessionId,
+              sessionFile: rotatedSessionFile,
+              sessionStartedAt: next.sessionStartedAt,
+            }
+          : {}),
       }
     : removeLifecycleStateFromMetadataPatch(next);
   const persisted = await updateSessionStore(

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -118,16 +118,29 @@ export async function updateSessionStoreAfterAgentRun(params: {
 
   const preserveUserFacingRunState = params.preserveUserFacingSessionModelState === true;
   const preserveRuntimeModel = params.preserveRuntimeModel === true || preserveUserFacingRunState;
+  // Embedded auto-compaction with `truncateAfterCompaction` rotates the transcript
+  // to a new session id + file mid-run. Adopt the rotated identity so sessions.json
+  // stops pointing at the stale pre-rotation file, whose write lock the next turn
+  // would otherwise block on. Only the embedded runner sets agentMeta.sessionFile;
+  // CLI runs leave it unset and reuse agentMeta.sessionId for the external tool's
+  // id, so this guard never rewrites a CLI session's openclaw identity.
+  const rotatedSessionId = normalizeOptionalString(result.meta.agentMeta?.sessionId);
+  const rotatedSessionFile = normalizeOptionalString(result.meta.agentMeta?.sessionFile);
+  const sessionRotated = Boolean(
+    rotatedSessionFile && rotatedSessionId && rotatedSessionId !== sessionId,
+  );
+  const effectiveSessionId = sessionRotated && rotatedSessionId ? rotatedSessionId : sessionId;
   const entry = sessionStore[sessionKey] ?? {
-    sessionId,
+    sessionId: effectiveSessionId,
     updatedAt: now,
     sessionStartedAt: now,
   };
   const next: SessionEntry = {
     ...entry,
-    sessionId,
+    sessionId: effectiveSessionId,
     updatedAt: now,
-    sessionStartedAt: entry.sessionId === sessionId ? (entry.sessionStartedAt ?? now) : now,
+    sessionStartedAt:
+      entry.sessionId === effectiveSessionId ? (entry.sessionStartedAt ?? now) : now,
     lastInteractionAt: touchInteraction ? now : entry.lastInteractionAt,
     ...(preserveRuntimeModel
       ? {}
@@ -135,6 +148,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
           contextTokens,
         }),
   };
+  if (sessionRotated && rotatedSessionFile) {
+    next.sessionFile = rotatedSessionFile;
+  }
   if (preserveRuntimeModel) {
     // Keep the pre-existing runtime model and context window so a background
     // heartbeat turn using a different model does not bleed into the main


### PR DESCRIPTION
## Summary

When the embedded agent runner hits its context limit mid-run, auto-compaction with `truncateAfterCompaction` **rotates the transcript to a brand-new session id + file** (`compaction-successor-transcript.ts` mints a fresh `randomUUID()`; `run/attempt.ts` updates `sessionIdUsed`/`sessionFileUsed`; `run.ts` surfaces both on `result.meta.agentMeta`).

But `updateSessionStoreAfterAgentRun` persisted the **pre-rotation** `sessionId` and **never wrote `sessionFile`**. So after a rotation `sessions.json` kept pointing at the stale pre-rotation transcript. Because `resolveSessionTranscriptFile` prefers the stored `sessionEntry.sessionFile`, the next turn reopened the stale file and blocked on its write lock — the deadlock / crash-loop reported in #88040.

### Fix

`updateSessionStoreAfterAgentRun` now detects a rotation and adopts the new identity (id **and** file):

- Rotation is recognized only when `agentMeta.sessionFile` is present and `agentMeta.sessionId` differs from the run's `sessionId`.
- `sessionStartedAt` resets when the id actually changes (a rotated transcript is a new session).

**Why the guard matters (CLI safety):** only the *embedded* runner sets `agentMeta.sessionFile`. For CLI providers, `agentMeta.sessionId` is the **external CLI tool's** session id (see `cli-runner.ts`) and `sessionFile` is unset — so the guard never rewrites a CLI session's openclaw identity. A naive `agentMeta.sessionId ?? sessionId` adoption would corrupt every CLI run's session id and still leave `sessionFile` stale; this fix avoids both.

## Linked context

Closes #88040

## Real behavior proof (required for external PRs)

Behavior addressed: after embedded auto-compaction rotated the transcript to a new session id/file, sessions.json kept the pre-rotation id and stale sessionFile, so the next turn blocked on the stale transcript's write lock (deadlock). After this patch the on-disk store adopts the rotated id + file; CLI session identity is left untouched.

Real environment tested: local macOS checkout, branch `fix/88040-session-rotation` based on current `upstream/main`. The proof drives the real production function `updateSessionStoreAfterAgentRun` against a real on-disk session store (temp dir, no store mock) with a `result.meta.agentMeta` carrying the rotated `sessionId`+`sessionFile` the embedded runner emits after rotation, then reloads sessions.json from disk to assert the persisted contents. A second case feeds a CLI-shaped `agentMeta` (external `sessionId`, no `sessionFile`) to prove the openclaw id is preserved.

Exact steps or command run after this patch: I isolated the fix by reverting only the production file to unpatched `upstream/main` while keeping the new tests, ran the production code path with `node`, then restored the fix and re-ran. Commands:

```
git checkout upstream/main -- src/agents/command/session-store.ts
node scripts/run-vitest.mjs src/agents/command/session-store.test.ts -t "rotat"
git checkout HEAD -- src/agents/command/session-store.ts
node scripts/run-vitest.mjs src/agents/command/session-store.test.ts
```

Evidence after fix: copied live console output from `node scripts/run-vitest.mjs`. Against the unpatched production file the run reproduces the deadlock condition (the on-disk store keeps the stale identity); with the fix restored it resolves —

```
UNPATCHED production file (bug reproduces):
  FAIL  updateSessionStoreAfterAgentRun > adopts the rotated session id and file after embedded auto-compaction rotation
  AssertionError: expected 'pre-rotation-session' to be 'post-rotation-session'
  Expected: "post-rotation-session"
  Received: "pre-rotation-session"   <- sessions.json kept the stale pre-rotation identity and sessionFile

PATCHED production file (this branch):
  Test Files  2 passed (2)
  Tests  70 passed (70)
```

Observed result after fix: with the fix restored, the `node scripts/run-vitest.mjs` run shows the reloaded on-disk sessions.json adopts the rotated `sessionId` and `sessionFile` (no stale pointer, so the next turn does not block on the stale transcript's write lock). The CLI case keeps `sessionId` equal to the openclaw id with `sessionFile` unchanged and records the external tool id under `cliSessionIds`.

What was not tested: an end-to-end live agent run driven all the way to an in-flight context-limit compaction rotation (that requires a long real model run, infeasible offline). The proof instead exercises the identical post-rotation production path (`updateSessionStoreAfterAgentRun` writing/reloading a real sessions.json) with the exact `agentMeta` shape the embedded runner emits after rotation.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/command/session-store.test.ts` -> 70 passed (2 new: embedded-rotation adoption of id+file with `sessionStartedAt` reset; CLI run preserves openclaw id and leaves `sessionFile` untouched).
- Before/after isolation above: the rotation test fails on the unpatched production file and passes with the fix.
- `oxfmt --check` clean, `oxlint` clean, `git diff --check` clean, `tsgo:core` exit 0, `tsgo:core:test` exit 0.

## Note on #88055

I opened this after noticing #88055 targets the same issue with a one-line `sessionId: result?.meta?.agentMeta?.sessionId ?? sessionId` at the call site. That approach has two problems this PR avoids: (1) for CLI providers `agentMeta.sessionId` is the external tool's id, so it would overwrite the openclaw session id on every CLI run; (2) it never updates `sessionFile`, so `resolveSessionTranscriptFile` still resolves the stale transcript and the deadlock persists. Happy to defer to maintainers on which to take.
