### PR TITLE
fix(agents): compact lean local tool catalogs

### DIFF
--- a/docs/concepts/experimental-features.md
+++ b/docs/concepts/experimental-features.md
@@ -30,7 +30,7 @@ Treat them differently from normal config:
 
 ## Local model lean mode
 
-`agents.defaults.experimental.localModelLean: true` is a pressure-release valve for weaker local-model setups. When it is on, OpenClaw drops three default tools — `browser`, `cron`, and `message` — from the agent's tool surface for every turn. Nothing else changes. Use `agents.list[].experimental.localModelLean` to enable or disable the same behavior for one configured agent.
+`agents.defaults.experimental.localModelLean: true` is a pressure-release valve for weaker local-model setups. When it is on, OpenClaw drops three default tools — `browser`, `cron`, and `message` — from the agent's tool surface for every turn. It also defaults that run to structured Tool Search controls when `tools.toolSearch` is not explicitly configured, so larger plugin, MCP, or client tool catalogs stay behind `tool_search`, `tool_describe`, and `tool_call` instead of being dumped into the prompt. Use `agents.list[].experimental.localModelLean` to enable or disable the same behavior for one configured agent.
 
 ### Why these three tools
 
@@ -40,7 +40,7 @@ These three tools have the largest descriptions and the most parameter shapes in
 - The model picking the right tool vs. emitting malformed tool calls because there are too many similar-looking schemas.
 - The Chat Completions adapter staying inside the server's structured-output limits vs. tripping a 400 on tool-call payload size.
 
-Removing them does not silently rewire OpenClaw — it just makes the tool list shorter. The model still has `read`, `write`, `edit`, `exec`, `apply_patch`, web search/fetch (when configured), memory, and session/agent tools available.
+Removing them does not silently rewire OpenClaw — it just makes the direct tool list shorter. The model still has `read`, `write`, `edit`, `exec`, `apply_patch`, web search/fetch (when configured), memory, and session/agent tools available. Extra catalogs remain callable through Tool Search unless you explicitly set `tools.toolSearch: false`.
 
 ### When to turn it on
 
@@ -55,6 +55,8 @@ Enable lean mode when you have already proved the model can talk to the Gateway 
 If your backend handles the full default runtime cleanly, leave this off. Lean mode is a workaround, not a default. It exists because some local stacks need a smaller tool surface to behave; hosted models and well-resourced local rigs do not.
 
 Lean mode also does not replace `tools.profile`, `tools.allow`/`tools.deny`, or the model `compat.supportsTools: false` escape hatch. If you need a permanent narrower tool surface for a specific agent, prefer those stable knobs over the experimental flag.
+
+If you already tune Tool Search globally, OpenClaw leaves that operator config alone. Set `tools.toolSearch: false` to opt out of the lean-mode Tool Search default.
 
 ### Enable
 

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -315,7 +315,7 @@ If the model loads cleanly but full agent turns misbehave, work top-down — con
    openclaw infer model run --gateway --model <provider/model> --prompt "Reply with exactly: pong" --json
    ```
 
-3. **Try lean mode.** If both probes pass but real agent turns fail with malformed tool calls or oversized prompts, enable `agents.defaults.experimental.localModelLean: true`. It drops the three heaviest default tools (`browser`, `cron`, `message`) so the prompt shape is smaller and less brittle. See [Experimental Features → Local model lean mode](/concepts/experimental-features#local-model-lean-mode) for the full explanation, when to use it, and how to confirm it is on.
+3. **Try lean mode.** If both probes pass but real agent turns fail with malformed tool calls or oversized prompts, enable `agents.defaults.experimental.localModelLean: true`. It drops the three heaviest default tools (`browser`, `cron`, `message`) and defaults larger tool catalogs behind structured Tool Search controls, so the prompt shape is smaller and less brittle. See [Experimental Features → Local model lean mode](/concepts/experimental-features#local-model-lean-mode) for the full explanation, when to use it, and how to confirm it is on.
 
 4. **Disable tools entirely as a last resort.** If lean mode is not enough, set `models.providers.<provider>.models[].compat.supportsTools: false` for that model entry. The agent will then operate without tool calls on that model.
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -692,7 +692,7 @@ Use these as starting points and replace model IDs with the exact names from `ol
     ```
 
     Use `compat.supportsTools: false` only when the model or server reliably fails on tool schemas. It trades agent capability for stability.
-    `localModelLean` removes the browser, cron, and message tools from the agent surface, but it does not change Ollama's runtime context or thinking mode. Pair it with explicit `params.num_ctx` and `params.thinking: false` for small Qwen-style thinking models that loop or spend their response budget on hidden reasoning.
+    `localModelLean` removes the browser, cron, and message tools from the direct agent surface and defaults larger catalogs behind structured Tool Search controls, but it does not change Ollama's runtime context or thinking mode. Pair it with explicit `params.num_ctx` and `params.thinking: false` for small Qwen-style thinking models that loop or spend their response budget on hidden reasoning.
 
   </Accordion>
 </AccordionGroup>

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -284,6 +284,47 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(toolSearchControlsCase.toolSearchCatalogRef).toEqual({});
   });
 
+  it("defaults local-model lean embedded runs to Tool Search controls", async () => {
+    await createContextEngineAttemptRunner({
+      contextEngine: {
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 1 }),
+      },
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+        config: {
+          agents: {
+            defaults: {
+              experimental: {
+                localModelLean: true,
+              },
+            },
+          },
+        } as OpenClawConfig,
+      },
+    });
+
+    expect(hoisted.createOpenClawCodingToolsMock).toHaveBeenCalledTimes(1);
+    const options = mockParams(
+      hoisted.createOpenClawCodingToolsMock,
+      0,
+      "createOpenClawCodingTools options",
+    );
+    expect(options.includeToolSearchControls).toBe(true);
+    const optionsConfig = requireRecord(options.config, "createOpenClawCodingTools config");
+    const toolsConfig = requireRecord(
+      optionsConfig.tools,
+      "createOpenClawCodingTools tools config",
+    );
+    expect(toolsConfig.toolSearch).toEqual({
+      enabled: true,
+      mode: "tools",
+      searchDefaultLimit: 5,
+      maxSearchLimit: 10,
+    });
+  });
+
   it("quarantines unsupported tool schemas before creating the model session", async () => {
     hoisted.createOpenClawCodingToolsMock.mockReturnValue([
       {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -151,6 +151,7 @@ import { runAgentEndSideEffects } from "../../harness/agent-end-side-effects.js"
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import {
+  applyLocalModelLeanToolSearchDefaults,
   filterLocalModelLeanTools,
   isLocalModelLeanEnabled,
   resolveLocalModelLeanPreserveToolNames,
@@ -1105,6 +1106,11 @@ export async function runEmbeddedAttempt(
     });
     const toolsEnabled = supportsModelTools(params.model);
     const codeModeConfig = resolveCodeModeConfig(params.config, sessionAgentId);
+    const toolSearchRuntimeConfig = applyLocalModelLeanToolSearchDefaults({
+      config: params.config,
+      agentId: sessionAgentId,
+      sessionKey: sandboxSessionKey,
+    });
     const codeModeControlsEnabledForRun =
       toolsEnabled &&
       params.disableTools !== true &&
@@ -1117,7 +1123,7 @@ export async function runEmbeddedAttempt(
       !isRawModelRun &&
       params.toolsAllow?.length !== 0 &&
       !codeModeControlsEnabledForRun &&
-      resolveToolSearchConfig(params.config).enabled;
+      resolveToolSearchConfig(toolSearchRuntimeConfig).enabled;
     const effectiveToolsAllow =
       toolSearchControlsEnabledForRun && toolsAllowWithForcedRuntimeTools
         ? [
@@ -1192,7 +1198,7 @@ export async function runEmbeddedAttempt(
                     sandbox,
                     resolvedWorkspace,
                   }),
-            config: params.config,
+            config: toolSearchRuntimeConfig,
             abortSignal: runAbortController.signal,
             modelProvider: params.provider,
             modelId: params.modelId,
@@ -1553,7 +1559,7 @@ export async function runEmbeddedAttempt(
         })
       : applyToolSearchCatalog({
           tools: effectiveTools,
-          config: params.config,
+          config: toolSearchRuntimeConfig,
           sessionId: params.sessionId,
           sessionKey: sandboxSessionKey,
           agentId: sessionAgentId,
@@ -2160,7 +2166,7 @@ export async function runEmbeddedAttempt(
           })
         : addClientToolsToToolSearchCatalog({
             tools: clientToolDefs,
-            config: params.config,
+            config: toolSearchRuntimeConfig,
             sessionId: params.sessionId,
             sessionKey: sandboxSessionKey,
             agentId: sessionAgentId,

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import {
+  applyLocalModelLeanToolSearchDefaults,
   filterLocalModelLeanTools,
   isLocalModelLeanEnabled,
   resolveLocalModelLeanPreserveToolNames,
@@ -224,5 +225,45 @@ describe("local model lean tool filtering", () => {
         sessionKey: "agent:gemma:main",
       }).map((tool) => tool.name),
     ).toEqual(["read", "exec"]);
+  });
+
+  it("defaults lean runs to structured Tool Search controls", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+    };
+
+    const resolved = applyLocalModelLeanToolSearchDefaults({ config: cfg, agentId: "main" });
+
+    expect(resolved).not.toBe(cfg);
+    expect(resolved?.tools?.toolSearch).toEqual({
+      enabled: true,
+      mode: "tools",
+      searchDefaultLimit: 5,
+      maxSearchLimit: 10,
+    });
+    expect(cfg.tools?.toolSearch).toBeUndefined();
+  });
+
+  it("preserves explicit Tool Search operator config", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+      tools: {
+        toolSearch: false,
+      },
+    };
+
+    expect(applyLocalModelLeanToolSearchDefaults({ config: cfg, agentId: "main" })).toBe(cfg);
   });
 });

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -5,6 +5,12 @@ import type { AnyAgentTool } from "./agent-tools.types.js";
 import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
 
 const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set(["browser", "cron", "message"]);
+const LOCAL_MODEL_LEAN_TOOL_SEARCH_DEFAULTS = {
+  enabled: true,
+  mode: "tools",
+  searchDefaultLimit: 5,
+  maxSearchLimit: 10,
+} as const;
 
 function resolvePreservedLocalModelLeanToolNames(names?: Iterable<string>): Set<string> {
   if (!names) {
@@ -80,4 +86,24 @@ export function filterLocalModelLeanTools(params: {
       !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(normalizedName)
     );
   });
+}
+
+export function applyLocalModelLeanToolSearchDefaults(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+}): OpenClawConfig | undefined {
+  if (!params.config || !isLocalModelLeanEnabled(params)) {
+    return params.config;
+  }
+  if (params.config.tools?.toolSearch !== undefined) {
+    return params.config;
+  }
+  return {
+    ...params.config,
+    tools: {
+      ...params.config.tools,
+      toolSearch: LOCAL_MODEL_LEAN_TOOL_SEARCH_DEFAULTS,
+    },
+  };
 }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -254,7 +254,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.list[].experimental":
     "Per-agent experimental flags. Omitted fields inherit agents.defaults.experimental.",
   "agents.list[].experimental.localModelLean":
-    "Per-agent override for lean local-model mode. Enable it for one smaller local-model agent without trimming tools from every agent.",
+    "Per-agent override for lean local-model mode. Enable it for one smaller local-model agent without trimming every agent; when tools.toolSearch is unset, lean runs also default larger tool catalogs behind Tool Search controls. Set tools.toolSearch: false to opt out.",
   "agents.defaults.contextLimits":
     "Focused per-agent-context budget defaults for selected high-volume excerpts and injected prompt blocks. Use this to tune bounded read/injection sizes without reopening any unbounded call paths.",
   "agents.defaults.contextLimits.memoryGetMaxChars":
@@ -1127,7 +1127,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.experimental":
     "Experimental agent-default flags. Keep these off unless you are intentionally testing a preview surface.",
   "agents.defaults.experimental.localModelLean":
-    "Experimental local-model prompt trim. When enabled, OpenClaw drops heavyweight default tools like browser, cron, and message for weaker or smaller local-model backends.",
+    "Experimental local-model prompt trim. When enabled, OpenClaw drops heavyweight default tools like browser, cron, and message for weaker or smaller local-model backends. If tools.toolSearch is unset, lean runs also default larger tool catalogs behind Tool Search controls; set tools.toolSearch: false to opt out.",
   "agents.defaults.bootstrapPromptTruncationWarning":
     'Inject agent-visible warning text when bootstrap files are truncated: "off", "once", or "always" (default).',
   "agents.defaults.startupContext":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -268,7 +268,8 @@ export type AgentDefaultsConfig = {
   experimental?: {
     /**
      * Drop heavyweight non-essential default tools for weaker or smaller local
-     * model backends. Experimental preview only.
+     * model backends. When Tool Search is unset, lean runs default larger tool
+     * catalogs behind Tool Search controls. Experimental preview only.
      */
     localModelLean?: boolean;
   };


### PR DESCRIPTION
## Summary

- default `agents.*.experimental.localModelLean` to compact Tool Search controls when no operator `tools.toolSearch` preference is set
- keep explicit `tools.toolSearch` configuration authoritative, including `false`
- document the local-model lean default in public docs, config help, and exported config comments so small/local model users get a smaller prompt-facing tool catalog without losing tool reachability

Relates to https://github.com/openclaw/openclaw/issues/86599. This is a complementary small-model prompt/tool-pressure mitigation; the direct stream-starvation fixes from that issue are https://github.com/openclaw/openclaw/pull/87818 and https://github.com/openclaw/openclaw/pull/88153.

## Verification

Behavior addressed: Lean local-model agents no longer receive a huge direct tool catalog by default when Tool Search can compact it behind `tool_search`, `tool_describe`, and `tool_call`. Operator-facing config help now also names the Tool Search default and the `tools.toolSearch: false` opt-out.

Real environment tested: focused Vitest wrapper, docs formatting, diff check, AWS Crabbox Linux changed gate, autoreview, and targeted Ollama Cloud live provider smoke. Blacksmith Testbox proof is still blocked locally by missing Blacksmith auth, so the broad remote gate used direct AWS Crabbox.

Exact steps or command run after this patch:

```sh
node_modules/.bin/oxfmt --check --threads=1 src/config/schema.help.ts src/config/types.agent-defaults.ts src/agents/local-model-lean.ts src/agents/embedded-agent-runner/run/attempt.ts docs/concepts/experimental-features.md docs/gateway/local-models.md docs/providers/ollama.md
node scripts/run-vitest.mjs src/config/schema.help.quality.test.ts src/config/schema.hints.test.ts src/agents/local-model-lean.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts --reporter=dot
node scripts/format-docs.mjs --check docs/concepts/experimental-features.md docs/gateway/local-models.md docs/providers/ollama.md
git diff --check origin/main...HEAD
node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 90m --ttl 240m --timing-json --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_OLLAMA=1 OPENCLAW_LIVE_OLLAMA_BASE_URL=https://ollama.com OPENCLAW_LIVE_OLLAMA_MODEL=glm-5.1:cloud OPENCLAW_LIVE_OLLAMA_WEB_SEARCH=0 OPENCLAW_LIVE_OLLAMA_EMBEDDINGS=0 node scripts/test-live.mjs -- extensions/ollama/ollama.live.test.ts --reporter=dot
```

Evidence after fix: final refreshed head `9187659a7a1` rebased onto `origin/main` `9c6f7553be0`; formatting passed; focused wrapper passed four Vitest shards / 100 tests; docs formatting reported `Docs formatting clean (660 files)`; diff check passed. AWS Crabbox `pnpm check:changed` passed with provider `aws`, lease `cbx_ae3c25c29127`, slug `amber-barnacle`, run `run_39130c232f17`, machine `c7a.8xlarge`, exit `0`, `leaseStopped=true`, selected lanes `core`, `coreTests`, and `docs`. Autoreview on the final branch reported `autoreview clean: no accepted/actionable findings reported`. Targeted Ollama Cloud live smoke passed earlier on runtime-equivalent head `fda5bdfce761` with `extensions/ollama/ollama.live.test.ts`: `2` tests passed and `2` skipped intentionally because web search and embeddings were disabled for that run; later commits only align config help/type comments and rebase on main.

Observed result after fix: `localModelLean` applies compact Tool Search defaults only when the operator did not configure Tool Search, the embedded runner uses the derived runtime config for control-tool exposure and cataloging, and generated/operator config help now describes the new default plus opt-out. Ollama Cloud still runs through the live provider path with the same runtime checkout.

What was not tested: local Ollama daemon model execution was not rerun because the local endpoint had no usable model list during validation. Non-Ollama small-model API families were not run because no matching API keys or auth profiles were available in this environment.
