### PR TITLE
fix(session): normalize codex oauth session routes

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3505,7 +3505,7 @@ describe("persistSessionUsageUpdate", () => {
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
-    expect(stored[sessionKey].modelProvider).toBe("openai-codex");
+    expect(stored[sessionKey].modelProvider).toBe("openai");
     expect(stored[sessionKey].model).toBe("gpt-5.4");
     expect(stored[sessionKey].inputTokens).toBe(1_200);
     expect(stored[sessionKey].outputTokens).toBe(100);
@@ -3569,7 +3569,7 @@ describe("persistSessionUsageUpdate", () => {
     });
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
-    expect(stored[sessionKey].modelProvider).toBe("openai-codex");
+    expect(stored[sessionKey].modelProvider).toBe("openai");
     expect(stored[sessionKey].model).toBe("gpt-5.5");
     expect(stored[sessionKey].contextTokens).toBe(200_000);
     expect(stored[sessionKey].inputTokens).toBe(1_234);

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -24,7 +24,12 @@ import {
   updateSessionStoreEntry,
 } from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
-import { mergeSessionEntry, mergeSessionEntryWithPolicy, type SessionEntry } from "./types.js";
+import {
+  mergeSessionEntry,
+  mergeSessionEntryWithPolicy,
+  setSessionRuntimeModel,
+  type SessionEntry,
+} from "./types.js";
 
 type WriteTextAtomicCall = Parameters<typeof jsonFiles.writeTextAtomic>;
 
@@ -820,6 +825,40 @@ describe("session store writer queue", () => {
     expect(store[key]?.model).toBeUndefined();
   });
 
+  it("normalizes OpenAI Codex OAuth provider IDs out of persisted session routes", async () => {
+    const key = "agent:main:telegram:direct:1316000566";
+    const { storePath } = await makeTmpStore({
+      [key]: {
+        sessionId: "sess-openai-codex-oauth",
+        updatedAt: 100,
+        modelProvider: "openai-codex",
+        model: "gpt-5.5",
+      },
+    });
+
+    await updateSessionStore(storePath, async (store) => {
+      const entry = store[key];
+      entry.updatedAt = Date.now();
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[key]?.modelProvider).toBe("openai");
+    expect(store[key]?.model).toBe("gpt-5.5");
+  });
+
+  it("normalizes OpenAI Codex OAuth provider IDs at runtime model write boundary", () => {
+    const entry: SessionEntry = { sessionId: "sess-runtime-write", updatedAt: 100 };
+
+    const updated = setSessionRuntimeModel(entry, {
+      provider: "openai-codex",
+      model: "gpt-5.5",
+    });
+
+    expect(updated).toBe(true);
+    expect(entry.modelProvider).toBe("openai");
+    expect(entry.model).toBe("gpt-5.5");
+  });
+
   it("preserves ACP metadata when replacing a session entry wholesale", async () => {
     const key = "agent:codex:acp:binding:discord:default:feedface";
     const acp = {
@@ -849,7 +888,7 @@ describe("session store writer queue", () => {
 
     const store = loadSessionStore(storePath);
     expect(store[key]?.acp).toEqual(acp);
-    expect(store[key]?.modelProvider).toBe("openai-codex");
+    expect(store[key]?.modelProvider).toBe("openai");
     expect(store[key]?.model).toBe("gpt-5.4");
   });
 

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -452,14 +452,19 @@ export function normalizeSessionRuntimeModelFields(entry: SessionEntry): Session
     return next;
   }
 
-  if (entry.model !== normalizedModel) {
+  const routeModel = normalizeSessionRouteModel(normalizedModel);
+  const routeProvider = normalizedProvider
+    ? normalizeSessionRouteProvider({ provider: normalizedProvider, model: routeModel })
+    : undefined;
+
+  if (entry.model !== routeModel) {
     if (next === entry) {
       next = { ...next };
     }
-    next.model = normalizedModel;
+    next.model = routeModel;
   }
 
-  if (!normalizedProvider) {
+  if (!routeProvider) {
     if (entry.modelProvider !== undefined) {
       if (next === entry) {
         next = { ...next };
@@ -469,21 +474,50 @@ export function normalizeSessionRuntimeModelFields(entry: SessionEntry): Session
     return next;
   }
 
-  if (entry.modelProvider !== normalizedProvider) {
+  if (entry.modelProvider !== routeProvider) {
     if (next === entry) {
       next = { ...next };
     }
-    next.modelProvider = normalizedProvider;
+    next.modelProvider = routeProvider;
   }
   return next;
+}
+
+const OPENAI_PROVIDER_ID = "openai";
+const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+const OPENAI_CODEX_MODEL_REF_PREFIX = `${OPENAI_CODEX_PROVIDER_ID}/`;
+const OPENAI_MODEL_REF_PREFIX = `${OPENAI_PROVIDER_ID}/`;
+
+function isOpenAIGptModelId(model: string): boolean {
+  return model.toLowerCase().startsWith("gpt-");
+}
+
+function normalizeSessionRouteModel(model: string): string {
+  return model.startsWith(OPENAI_CODEX_MODEL_REF_PREFIX)
+    ? `${OPENAI_MODEL_REF_PREFIX}${model.slice(OPENAI_CODEX_MODEL_REF_PREFIX.length)}`
+    : model;
+}
+
+export function normalizeSessionRouteProvider(runtime: {
+  provider: string;
+  model: string;
+}): string {
+  if (
+    runtime.provider === OPENAI_CODEX_PROVIDER_ID &&
+    (isOpenAIGptModelId(runtime.model) || runtime.model.startsWith(OPENAI_MODEL_REF_PREFIX))
+  ) {
+    return OPENAI_PROVIDER_ID;
+  }
+  return runtime.provider;
 }
 
 export function setSessionRuntimeModel(
   entry: SessionEntry,
   runtime: { provider: string; model: string },
 ): boolean {
-  const provider = runtime.provider.trim();
-  const model = runtime.model.trim();
+  const rawProvider = runtime.provider.trim();
+  const model = normalizeSessionRouteModel(runtime.model.trim());
+  const provider = normalizeSessionRouteProvider({ provider: rawProvider, model });
   if (!provider || !model) {
     return false;
   }


### PR DESCRIPTION
## Summary

Fixes `openai-codex` OAuth/runtime identities being persisted as the user-facing session route provider.

When the Codex-backed OpenAI OAuth path runs a GPT model, the runtime provider can be `openai-codex`, but the durable session route should stay the logical model provider:

- persisted route: `modelProvider: "openai"`, `model: "gpt-*"`
- auth/OAuth profile: `openai-codex:*`

Persisting `openai-codex` in session route state makes `openclaw doctor --fix` clean stale routes, then later runs can recreate the same warning.

## Changes

- Normalize session route model/provider at the session persistence boundary in `src/config/sessions/types.ts`.
- Convert `openai-codex` + GPT/OpenAI model route persistence to `openai`.
- Keep non-OpenAI providers untouched.
- Add regression coverage for store normalization and runtime model writes.
- Update auto-reply session tests to expect the logical OpenAI route.

## Verification

Passed locally:

```bash
node scripts/test-projects.mjs src/config/sessions/sessions.test.ts src/auto-reply/reply/session.test.ts
pnpm format:check -- src/config/sessions/types.ts src/config/sessions/sessions.test.ts src/auto-reply/reply/session.test.ts
```

Known unrelated local blocker:

```bash
pnpm tsgo:test:src
```

currently fails in existing `src/config/sessions.cache.test.ts` async mock/type errors unrelated to this diff.

## Notes

Ask Molty/local source search confirmed this matches the existing upstream bug report `#87436` and the intended split between logical `openai/*` model routes and `openai-codex:*` OAuth auth profiles.

Related: #87436, #87463, #87851


## Maintainer routing note

Prefer the broader proven branch if that is the desired landing path. This PR can be paused if maintainers want to resolve and land the route-aware implementation from #87851 instead.
