### PR TITLE
fix(commands): make /skill load workspace skills

### DIFF
--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -233,6 +233,39 @@ describe("info command handlers", () => {
     expect(listSkillCommandsForAgentsMock).not.toHaveBeenCalled();
   });
 
+  it("loads skills when named /skill receives an empty precomputed command list", async () => {
+    const params = buildInfoParams("/skill demo_skill input", {
+      commands: { text: true },
+    } as OpenClawConfig);
+    params.skillCommands = [];
+    params.loadSkillCommands = vi.fn(async () => [
+      {
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill",
+      },
+    ]);
+
+    const result = await handleSkillCommandUsage(params, true);
+
+    expect(result).toBeNull();
+    expect(params.loadSkillCommands).toHaveBeenCalledOnce();
+    expect(listSkillCommandsForAgentsMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps an empty precomputed /skill command list authoritative without a loader", async () => {
+    const params = buildInfoParams("/skill demo_skill input", {
+      commands: { text: true },
+    } as OpenClawConfig);
+    params.skillCommands = [];
+
+    const result = await handleSkillCommandUsage(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Unknown skill: demo_skill");
+    expect(listSkillCommandsForAgentsMock).not.toHaveBeenCalled();
+  });
+
   it("uses the canonical command sender identity for /whoami AllowFrom", async () => {
     const params = buildInfoParams(
       "/whoami",

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -24,8 +24,14 @@ import { resolveReplyToMode } from "./reply-threading.js";
 export { handleContextCommand } from "./commands-context-command.js";
 export { handleWhoamiCommand } from "./commands-whoami.js";
 
-async function resolveSkillCommands(params: HandleCommandsParams) {
-  if (params.skillCommands !== undefined) {
+async function resolveSkillCommands(
+  params: HandleCommandsParams,
+  options?: { requireFullList?: boolean },
+) {
+  if (
+    params.skillCommands !== undefined &&
+    (!options?.requireFullList || params.skillCommands.length > 0 || !params.loadSkillCommands)
+  ) {
     return params.skillCommands;
   }
   if (params.loadSkillCommands) {
@@ -137,7 +143,7 @@ export const handleSkillCommandUsage: CommandHandler = async (params, allowTextC
   }
 
   const [, rawName] = normalized.match(/^\/skill(?:\s+([^\s]+))?/u) ?? [];
-  const skillCommands = await resolveSkillCommands(params);
+  const skillCommands = await resolveSkillCommands(params, { requireFullList: true });
   if (
     rawName &&
     resolveSkillCommandInvocation({ commandBodyNormalized: normalized, skillCommands })

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -12,13 +12,19 @@ import { stripInlineStatus } from "./reply-inline.js";
 import { buildTestCtx } from "./test-ctx.js";
 import type { TypingController } from "./typing.js";
 
-const { buildStatusReplyMock, createOpenClawToolsMock, getChannelPluginMock, handleCommandsMock } =
-  vi.hoisted(() => ({
-    buildStatusReplyMock: vi.fn(),
-    createOpenClawToolsMock: vi.fn(),
-    getChannelPluginMock: vi.fn(),
-    handleCommandsMock: vi.fn(),
-  }));
+const {
+  buildStatusReplyMock,
+  createOpenClawToolsMock,
+  getChannelPluginMock,
+  handleCommandsMock,
+  listSkillCommandsForWorkspaceMock,
+} = vi.hoisted(() => ({
+  buildStatusReplyMock: vi.fn(),
+  createOpenClawToolsMock: vi.fn(),
+  getChannelPluginMock: vi.fn(),
+  handleCommandsMock: vi.fn(),
+  listSkillCommandsForWorkspaceMock: vi.fn(),
+}));
 
 type HandleInlineActionsInput = Parameters<
   typeof import("./get-reply-inline-actions.js").handleInlineActions
@@ -27,6 +33,10 @@ type HandleInlineActionsInput = Parameters<
 vi.mock("./commands.runtime.js", () => ({
   handleCommands: (...args: unknown[]) => handleCommandsMock(...args),
   buildStatusReply: (...args: unknown[]) => buildStatusReplyMock(...args),
+}));
+
+vi.mock("../../skills/discovery/chat-commands.runtime.js", () => ({
+  listSkillCommandsForWorkspace: (...args: unknown[]) => listSkillCommandsForWorkspaceMock(...args),
 }));
 
 vi.mock("../../agents/openclaw-tools.runtime.js", () => ({
@@ -180,10 +190,47 @@ function mockCallArgs(mock: ReturnType<typeof vi.fn>, label: string, callIndex =
   return call;
 }
 
+function mockToolDispatchedSkillCommand() {
+  const toolExecute = vi.fn(async () => ({ text: "sent" }));
+  createOpenClawToolsMock.mockReturnValue([
+    {
+      name: "send_status",
+      execute: toolExecute,
+    },
+  ]);
+  listSkillCommandsForWorkspaceMock.mockReturnValue([
+    {
+      name: "send_status",
+      skillName: "send-status",
+      description: "Send status",
+      dispatch: {
+        kind: "tool",
+        toolName: "send_status",
+        argMode: "raw",
+      },
+    },
+  ] satisfies SkillCommandSpec[]);
+  return toolExecute;
+}
+
+function officeHoursSkillCommands(): SkillCommandSpec[] {
+  return [
+    {
+      name: "office_hours",
+      skillName: "office-hours",
+      description: "Office hours",
+      promptTemplate: "Act as an engineering advisor.\n\nFocus on:\n$ARGUMENTS",
+      sourceFilePath: "/tmp/plugin/commands/office-hours.md",
+    },
+  ];
+}
+
 describe("handleInlineActions", () => {
   beforeEach(() => {
     handleCommandsMock.mockReset();
     handleCommandsMock.mockResolvedValue({ shouldContinue: true, reply: undefined });
+    listSkillCommandsForWorkspaceMock.mockReset();
+    listSkillCommandsForWorkspaceMock.mockReturnValue([]);
     getChannelPluginMock.mockReset();
     createOpenClawToolsMock.mockReset();
     buildStatusReplyMock.mockReset();
@@ -467,6 +514,76 @@ describe("handleInlineActions", () => {
     });
   });
 
+  it("skips stale queued /skill messages before loading or dispatching skills", async () => {
+    const typing = createTypingController();
+    const toolExecute = mockToolDispatchedSkillCommand();
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-skill",
+      updatedAt: Date.now(),
+      abortCutoffMessageSid: "42",
+      abortedLastRun: true,
+    };
+    const sessionStore = { "s:main": sessionEntry };
+    const ctx = buildTestCtx({
+      Body: "/skill send_status now",
+      CommandBody: "/skill send_status now",
+      MessageSid: "41",
+    });
+
+    await expectInlineActionSkipped({
+      ctx,
+      typing,
+      cleanedBody: "/skill send_status now",
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/skill send_status now",
+        commandBodyNormalized: "/skill send_status now",
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        sessionEntry,
+        sessionStore,
+        skillCommands: [],
+      },
+    });
+
+    expect(listSkillCommandsForWorkspaceMock).not.toHaveBeenCalled();
+    expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+    expect(toolExecute).not.toHaveBeenCalled();
+  });
+
+  it("skips empty-config /skill tool dispatch before loading skills", async () => {
+    const typing = createTypingController();
+    const toolExecute = mockToolDispatchedSkillCommand();
+    const ctx = buildTestCtx({
+      From: "whatsapp:+999",
+      To: "whatsapp:+123",
+      Body: "/skill send_status now",
+      CommandBody: "/skill send_status now",
+    });
+
+    await expectInlineActionSkipped({
+      ctx,
+      typing,
+      cleanedBody: "/skill send_status now",
+      command: {
+        isAuthorizedSender: true,
+        to: "whatsapp:+123",
+        rawBodyNormalized: "/skill send_status now",
+        commandBodyNormalized: "/skill send_status now",
+      },
+      overrides: {
+        allowTextCommands: true,
+        skillCommands: [],
+      },
+    });
+
+    expect(listSkillCommandsForWorkspaceMock).not.toHaveBeenCalled();
+    expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+    expect(toolExecute).not.toHaveBeenCalled();
+  });
+
   it("clears /stop cutoff when a newer message arrives", async () => {
     const typing = createTypingController();
     const sessionEntry: SessionEntry = {
@@ -554,15 +671,7 @@ describe("handleInlineActions", () => {
       Body: "/office_hours build me a deployment plan",
       CommandBody: "/office_hours build me a deployment plan",
     });
-    const skillCommands: SkillCommandSpec[] = [
-      {
-        name: "office_hours",
-        skillName: "office-hours",
-        description: "Office hours",
-        promptTemplate: "Act as an engineering advisor.\n\nFocus on:\n$ARGUMENTS",
-        sourceFilePath: "/tmp/plugin/commands/office-hours.md",
-      },
-    ];
+    const skillCommands = officeHoursSkillCommands();
 
     const result = await handleInlineActions(
       createHandleInlineActionsInput({
@@ -590,6 +699,43 @@ describe("handleInlineActions", () => {
     expect(requireRecord(commandArgs.ctx, "handleCommands ctx").Body).toBe(
       "Act as an engineering advisor.\n\nFocus on:\nbuild me a deployment plan",
     );
+  });
+
+  it("loads workspace skills when /skill gets an empty preloaded command list", async () => {
+    const typing = createTypingController();
+    handleCommandsMock.mockResolvedValue({ shouldContinue: false, reply: { text: "done" } });
+    const ctx = buildTestCtx({
+      Body: "/skill office_hours build me a deployment plan",
+      CommandBody: "/skill office_hours build me a deployment plan",
+    });
+    const skillCommands = officeHoursSkillCommands();
+    listSkillCommandsForWorkspaceMock.mockReturnValue(skillCommands);
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/skill office_hours build me a deployment plan",
+        command: {
+          isAuthorizedSender: true,
+          rawBodyNormalized: "/skill office_hours build me a deployment plan",
+          commandBodyNormalized: "/skill office_hours build me a deployment plan",
+        },
+        overrides: {
+          allowTextCommands: true,
+          cfg: { commands: { text: true } },
+          skillCommands: [],
+        },
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "done" } });
+    expect(listSkillCommandsForWorkspaceMock).toHaveBeenCalledOnce();
+    expect(ctx.Body).toBe(
+      "Act as an engineering advisor.\n\nFocus on:\nbuild me a deployment plan",
+    );
+    const commandArgs = mockObjectArg(handleCommandsMock, "handleCommands");
+    expect(commandArgs.skillCommands).toEqual(skillCommands);
   });
 
   it("passes requesterAgentIdOverride into inline tool runtimes", async () => {

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -261,6 +261,50 @@ export async function handleInlineActions(params: {
 
   let directives = initialDirectives;
   let cleanedBody = initialCleanedBody;
+  const targetSessionEntry = sessionStore?.[sessionKey] ?? sessionEntry;
+
+  const isStopLikeInbound = isAbortRequestText(command.rawBodyNormalized);
+  if (!isStopLikeInbound && targetSessionEntry) {
+    const cutoff = readAbortCutoffFromSessionEntry(targetSessionEntry);
+    const incoming = resolveAbortCutoffFromContext(ctx);
+    const shouldSkip = cutoff
+      ? shouldSkipMessageByAbortCutoff({
+          cutoffMessageSid: cutoff.messageSid,
+          cutoffTimestamp: cutoff.timestamp,
+          messageSid: incoming?.messageSid,
+          timestamp: incoming?.timestamp,
+        })
+      : false;
+    if (shouldSkip) {
+      typing.cleanup();
+      return { kind: "reply", reply: undefined };
+    }
+    if (cutoff) {
+      await (
+        await loadAbortCutoffRuntime()
+      ).clearAbortCutoffInSessionRuntime({
+        sessionEntry: targetSessionEntry,
+        sessionStore,
+        sessionKey,
+        storePath,
+      });
+    }
+  }
+
+  const isEmptyConfig = Object.keys(cfg).length === 0;
+  const skipWhenConfigEmpty = command.channelId
+    ? Boolean(getChannelPlugin(command.channelId)?.commands?.skipWhenConfigEmpty)
+    : false;
+  if (
+    skipWhenConfigEmpty &&
+    isEmptyConfig &&
+    command.from &&
+    command.to &&
+    command.from !== command.to
+  ) {
+    typing.cleanup();
+    return { kind: "reply", reply: undefined };
+  }
 
   const slashCommandName = resolveSlashCommandName(command.commandBodyNormalized);
   const shouldLoadSkillCommands =
@@ -269,7 +313,7 @@ export async function handleInlineActions(params: {
     // `/skill …` needs the full skill command list.
     (slashCommandName === "skill" || !getBuiltinSlashCommands().has(slashCommandName));
   const skillCommands =
-    shouldLoadSkillCommands && params.skillCommands
+    shouldLoadSkillCommands && params.skillCommands && params.skillCommands.length > 0
       ? params.skillCommands
       : shouldLoadSkillCommands
         ? (await loadSkillCommandsRuntime()).listSkillCommandsForWorkspace({
@@ -279,7 +323,6 @@ export async function handleInlineActions(params: {
             skillFilter,
           })
         : [];
-  const targetSessionEntry = sessionStore?.[sessionKey] ?? sessionEntry;
 
   const skillInvocation =
     allowTextCommands && skillCommands.length > 0
@@ -405,34 +448,6 @@ export async function handleInlineActions(params: {
     await opts.onBlockReply(reply);
   };
 
-  const isStopLikeInbound = isAbortRequestText(command.rawBodyNormalized);
-  if (!isStopLikeInbound && targetSessionEntry) {
-    const cutoff = readAbortCutoffFromSessionEntry(targetSessionEntry);
-    const incoming = resolveAbortCutoffFromContext(ctx);
-    const shouldSkip = cutoff
-      ? shouldSkipMessageByAbortCutoff({
-          cutoffMessageSid: cutoff.messageSid,
-          cutoffTimestamp: cutoff.timestamp,
-          messageSid: incoming?.messageSid,
-          timestamp: incoming?.timestamp,
-        })
-      : false;
-    if (shouldSkip) {
-      typing.cleanup();
-      return { kind: "reply", reply: undefined };
-    }
-    if (cutoff) {
-      await (
-        await loadAbortCutoffRuntime()
-      ).clearAbortCutoffInSessionRuntime({
-        sessionEntry: targetSessionEntry,
-        sessionStore,
-        sessionKey,
-        storePath,
-      });
-    }
-  }
-
   const inlineCommand =
     allowTextCommands && command.isAuthorizedSender
       ? extractInlineSimpleCommand(cleanedBody)
@@ -542,21 +557,6 @@ export async function handleInlineActions(params: {
 
   if (directiveAck) {
     await sendInlineReply(directiveAck);
-  }
-
-  const isEmptyConfig = Object.keys(cfg).length === 0;
-  const skipWhenConfigEmpty = command.channelId
-    ? Boolean(getChannelPlugin(command.channelId)?.commands?.skipWhenConfigEmpty)
-    : false;
-  if (
-    skipWhenConfigEmpty &&
-    isEmptyConfig &&
-    command.from &&
-    command.to &&
-    command.from !== command.to
-  ) {
-    typing.cleanup();
-    return { kind: "reply", reply: undefined };
   }
 
   let abortedLastRun = initialAbortedLastRun;


### PR DESCRIPTION
## Summary

Fixes #88056.

- Reload workspace skill commands for `/skill <name>` when the directive pass only supplied an empty placeholder list.
- Preserve authoritative empty skill command lists when there is no loader, so filtered/no-skill turns still stay empty.
- Move the `/stop` stale-message cutoff and empty-config channel suppression ahead of skill discovery and dispatch so queued or suppressed `/skill` messages cannot execute side-effecting skill tools.
- Rebased onto current `main` and dropped the stale `unit-fast` runtime setup change so the dedicated fake-timer lane remains authoritative.

## Verification

- `git diff --check origin/main`
- `node --import tsx -e 'const { createUnitFastVitestConfig } = await import("./test/vitest/vitest.unit-fast.config.ts"); console.log(JSON.stringify(createUnitFastVitestConfig({}).test.setupFiles));'` → `[]`
- `node --import tsx -e 'const { handleSkillCommandUsage } = await import("./src/auto-reply/reply/commands-info.ts"); const params = { cfg: { commands: { text: true } }, ctx: {}, command: { commandBodyNormalized: "/skill demo_skill input", isAuthorizedSender: true, senderId: "proof-user" }, skillCommands: [], loadSkillCommands: async () => [{ name: "demo_skill", skillName: "demo-skill", description: "Demo" }] }; const result = await handleSkillCommandUsage(params, true); console.log(result === null ? "continued-to-skill-dispatch" : JSON.stringify(result));'` → `continued-to-skill-dispatch`
- Added regression coverage for empty-config `/skill` tool dispatch being skipped before skill discovery/tool creation.

## Real behavior proof

Behavior addressed: `/skill <name> [input]` should invoke an available workspace skill command instead of returning `Unknown skill` when the directive pass provided an empty placeholder list. The PR also preserves the existing empty-config channel suppression boundary before `/skill` discovery or tool dispatch.

Real environment tested: Local OpenClaw source checkout on the rebased PR branch. The command-path proof called the production `/skill` handler with the same empty precomputed command list shape that regressed, while supplying a real loader result for `demo_skill`.

Exact steps or command run after this patch:

```sh
node --import tsx -e 'const { createUnitFastVitestConfig } = await import("./test/vitest/vitest.unit-fast.config.ts"); console.log(JSON.stringify(createUnitFastVitestConfig({}).test.setupFiles));'
node --import tsx -e 'const { handleSkillCommandUsage } = await import("./src/auto-reply/reply/commands-info.ts"); const params = { cfg: { commands: { text: true } }, ctx: {}, command: { commandBodyNormalized: "/skill demo_skill input", isAuthorizedSender: true, senderId: "proof-user" }, skillCommands: [], loadSkillCommands: async () => [{ name: "demo_skill", skillName: "demo-skill", description: "Demo" }] }; const result = await handleSkillCommandUsage(params, true); console.log(result === null ? "continued-to-skill-dispatch" : JSON.stringify(result));'
```

Evidence after fix: Terminal output from the direct command-path run showed the `unit-fast` setup list is empty on current main's fake-timer lane split, and the `/skill demo_skill input` handler continued into the skill dispatch path instead of producing an unknown-skill reply.

```text
[]
continued-to-skill-dispatch
```

Observed result after fix: The production `/skill` handler no longer treats an empty precomputed list as authoritative when a loader is available for a named `/skill` invocation; it loads the commands and returns `null` so the normal skill command path handles the request. The empty-config guard now runs before skill discovery and dispatch, with regression coverage asserting no skill load or tool execution occurs for that suppressed path.

What was not tested: Live chat provider end-to-end delivery was not exercised in the local sandbox; GitHub CI is used for the Linux Node 24 shard proof.
