### PR TITLE
fix(windows): disable scheduled task before stop to prevent PT3M re-trigger during update

### DIFF
--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1331,6 +1331,8 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
       }
     }
   }
+  // Disable the task to prevent PT3M repeat triggers from re-launching during update window
+  await execSchtasks(["/Change", "/TN", taskName, "/DISABLE"]);
   stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
 }
 
@@ -1354,6 +1356,8 @@ export async function restartScheduledTask({
   }
   const taskName = resolveTaskName(effectiveEnv);
   await execSchtasks(["/End", "/TN", taskName]);
+  // Re-enable the task before re-launching (it was disabled by stopScheduledTask)
+  await execSchtasks(["/Change", "/TN", taskName, "/ENABLE"]);
   const manageGatewayPort = shouldManageGatewayListenerPort(effectiveEnv);
   const restartPort = manageGatewayPort ? await resolveScheduledTaskPort(effectiveEnv) : null;
   if (manageGatewayPort) {


### PR DESCRIPTION
fix(windows): disable scheduled task before stop to prevent PT3M re-trigger during update

The Windows scheduled task uses a PT3M LogonTrigger which repeats every 3 minutes.
Previously, stopScheduledTask only called schtasks /End, leaving the trigger active.
During an openclaw update (which can take several minutes), the trigger would
re-activate the gateway mid-update, causing a race condition.

This change adds /DISABLE after /End in stopScheduledTask, and /ENABLE before
re-launch in restartScheduledTask (since runScheduledTaskOrThrow re-creates the
task afresh and would otherwise start it enabled).