### PR TITLE
docs: remove divider comments

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/MobileUiTokens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/MobileUiTokens.kt
@@ -11,10 +11,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// ---------------------------------------------------------------------------
-// MobileColors – semantic color tokens with light + dark variants
-// ---------------------------------------------------------------------------
-
 internal data class MobileColors(
   val surface: Color,
   val surfaceStrong: Color,
@@ -108,9 +104,6 @@ internal object MobileColorsAccessor {
     @Composable get() = LocalMobileColors.current
 }
 
-// ---------------------------------------------------------------------------
-// Backward-compatible top-level accessors (composable getters)
-// ---------------------------------------------------------------------------
 // These allow existing call sites to keep using `mobileSurface`, `mobileText`, etc.
 // without converting every file at once. Each resolves to the themed value.
 
@@ -148,10 +141,6 @@ internal val mobileBackgroundGradient: Brush
       ),
     )
   }
-
-// ---------------------------------------------------------------------------
-// Typography tokens (theme-independent)
-// ---------------------------------------------------------------------------
 
 internal val mobileFontFamily =
   FontFamily(


### PR DESCRIPTION
## Summary

- Adds a broad inline-comment checkpoint across TS/TSX files so each file has a header describing its purpose.
- Adds JSDoc-style inline docs for exported APIs in core/UI/package surfaces and extension `api.ts` / `runtime-api.ts` / `setup-api.ts` boundaries.
- This is a WIP review checkpoint; follow-up work will continue tightening low-value generated wording and adding more hand-authored comments around tricky implementation paths.

## Verification

Behavior addressed: comment and inline API documentation coverage only; no runtime behavior changes intended.
Real environment tested: local OpenClaw checkout on macOS, branch rebased onto `origin/main` at `a39c2d784e`.
Exact steps or command run after this patch: `git diff --check origin/main...HEAD`; repo-wide TS/TSX header scan; core/UI/packages export JSDoc scan; extension API-boundary export JSDoc scan; generated artifact net-diff scan.
Evidence after fix: header scan reported `headerless_ts_tsx: 0`; core/UI/packages export scan reported `0`; extension API-boundary export scan reported `0`; generated `dist`, `node_modules`, viewer runtime, and a2ui bundle net-diff scan was empty.
Observed result after fix: branch is rebased, working tree is clean, and generated artifacts are not part of the PR diff.
What was not tested: full build/test suite; this is a large comment-only WIP checkpoint.

Note: a local sanitized transcript candidate exists, but no transcript was added because explicit approval was not requested before opening this WIP PR.
