### PR TITLE
Fix compaction timeout continuation snapshots

### DIFF
--- a/src/agents/embedded-agent-runner/run/compaction-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-timeout.test.ts
@@ -97,7 +97,7 @@ describe("compaction-timeout helpers", () => {
   });
 
   it("uses pre-compaction snapshot when compaction timeout occurs", () => {
-    const pre = [castAgentMessage({ role: "assistant", content: "pre" })] as const;
+    const pre = [castAgentMessage({ role: "user", content: "pre" })] as const;
     const current = [castAgentMessage({ role: "assistant", content: "current" })] as const;
     expectSelectedSnapshot({
       timedOutDuringCompaction: true,
@@ -111,8 +111,100 @@ describe("compaction-timeout helpers", () => {
     });
   });
 
+  it("trims assistant-tailed pre-compaction snapshots after compaction timeout", () => {
+    const user = castAgentMessage({ role: "user", content: "pre-user" });
+    const pre = [user, castAgentMessage({ role: "assistant", content: "pre-assistant" })] as const;
+    const current = [
+      castAgentMessage({ role: "user", content: "current-user" }),
+      castAgentMessage({ role: "assistant", content: "current-assistant" }),
+    ] as const;
+    expectSelectedSnapshot({
+      timedOutDuringCompaction: true,
+      preCompactionSnapshot: [...pre],
+      preCompactionSessionId: "session-pre",
+      currentSnapshot: [...current],
+      currentSessionId: "session-current",
+      expectedSource: "pre-compaction",
+      expectedSessionIdUsed: "session-pre",
+      expectedSnapshot: [user],
+    });
+  });
+
+  it("keeps tool-result tails continuable after compaction timeout", () => {
+    const toolResult = castAgentMessage({
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "lookup",
+      content: [{ type: "text", text: "result" }],
+      isError: false,
+      timestamp: 1,
+    });
+    const pre = [
+      castAgentMessage({ role: "user", content: "pre-user" }),
+      castAgentMessage({ role: "assistant", content: "tool call" }),
+      toolResult,
+      castAgentMessage({ role: "assistant", content: "pre-assistant" }),
+    ] as const;
+    expectSelectedSnapshot({
+      timedOutDuringCompaction: true,
+      preCompactionSnapshot: [...pre],
+      preCompactionSessionId: "session-pre",
+      currentSnapshot: [castAgentMessage({ role: "user", content: "current-user" })],
+      currentSessionId: "session-current",
+      expectedSource: "pre-compaction",
+      expectedSessionIdUsed: "session-pre",
+      expectedSnapshot: pre.slice(0, 3),
+    });
+  });
+
+  it("keeps replay-normalized summary tails continuable after compaction timeout", () => {
+    const summary = castAgentMessage({
+      role: "compactionSummary",
+      summary: "older work was summarized",
+      tokensBefore: 120_000,
+      timestamp: 1,
+    });
+    expectSelectedSnapshot({
+      timedOutDuringCompaction: true,
+      preCompactionSnapshot: null,
+      preCompactionSessionId: "session-pre",
+      currentSnapshot: [summary],
+      currentSessionId: "session-current",
+      expectedSource: "current",
+      expectedSessionIdUsed: "session-current",
+      expectedSnapshot: [summary],
+    });
+  });
+
+  it("falls back to current snapshot when the pre-compaction timeout snapshot has no continuable tail", () => {
+    const current = [castAgentMessage({ role: "user", content: "current" })] as const;
+    expectSelectedSnapshot({
+      timedOutDuringCompaction: true,
+      preCompactionSnapshot: [castAgentMessage({ role: "assistant", content: "pre" })],
+      preCompactionSessionId: "session-pre",
+      currentSnapshot: [...current],
+      currentSessionId: "session-current",
+      expectedSource: "current",
+      expectedSessionIdUsed: "session-current",
+      expectedSnapshot: current,
+    });
+  });
+
+  it("returns an empty snapshot when compaction timeout leaves only assistant-tailed snapshots", () => {
+    expectSelectedSnapshot({
+      timedOutDuringCompaction: true,
+      preCompactionSnapshot: [castAgentMessage({ role: "assistant", content: "pre" })],
+      preCompactionSessionId: "session-pre",
+      currentSnapshot: [castAgentMessage({ role: "assistant", content: "current" })],
+      currentSessionId: "session-current",
+      expectedSource: "current",
+      expectedSessionIdUsed: "session-current",
+      expectedSnapshot: [],
+    });
+  });
+
   it("falls back to current snapshot when pre-compaction snapshot is unavailable", () => {
-    const current = [castAgentMessage({ role: "assistant", content: "current" })] as const;
+    const current = [castAgentMessage({ role: "user", content: "current" })] as const;
     expectSelectedSnapshot({
       timedOutDuringCompaction: true,
       preCompactionSnapshot: null,

--- a/src/agents/embedded-agent-runner/run/compaction-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-timeout.ts
@@ -45,6 +45,29 @@ export type SnapshotSelection = {
   source: "pre-compaction" | "current";
 };
 
+function canContinueFromMessage(message: AgentMessage | undefined): boolean {
+  switch (message?.role) {
+    case "user":
+    case "toolResult":
+    case "branchSummary":
+    case "compactionSummary":
+    case "custom":
+      return true;
+    case "bashExecution":
+      return message.excludeFromContext !== true;
+    default:
+      return false;
+  }
+}
+
+function trimToContinuableTail(messages: AgentMessage[]): AgentMessage[] | null {
+  let end = messages.length;
+  while (end > 0 && !canContinueFromMessage(messages[end - 1])) {
+    end -= 1;
+  }
+  return end > 0 ? messages.slice(0, end) : null;
+}
+
 export function selectCompactionTimeoutSnapshot(
   params: SnapshotSelectionParams,
 ): SnapshotSelection {
@@ -57,15 +80,27 @@ export function selectCompactionTimeoutSnapshot(
   }
 
   if (params.preCompactionSnapshot) {
+    const continuablePreCompactionSnapshot = trimToContinuableTail(params.preCompactionSnapshot);
+    if (continuablePreCompactionSnapshot) {
+      return {
+        messagesSnapshot: continuablePreCompactionSnapshot,
+        sessionIdUsed: params.preCompactionSessionId,
+        source: "pre-compaction",
+      };
+    }
+  }
+
+  const continuableCurrentSnapshot = trimToContinuableTail(params.currentSnapshot);
+  if (continuableCurrentSnapshot) {
     return {
-      messagesSnapshot: params.preCompactionSnapshot,
-      sessionIdUsed: params.preCompactionSessionId,
-      source: "pre-compaction",
+      messagesSnapshot: continuableCurrentSnapshot,
+      sessionIdUsed: params.currentSessionId,
+      source: "current",
     };
   }
 
   return {
-    messagesSnapshot: params.currentSnapshot,
+    messagesSnapshot: [],
     sessionIdUsed: params.currentSessionId,
     source: "current",
   };


### PR DESCRIPTION
## Summary
- Fix compaction-timeout recovery so continuation snapshots never end on an assistant-only tail.
- Trim timeout snapshots back to the last replay-continuable boundary, while preserving tool results and replay-normalized user-like messages such as compaction summaries.
- Add regression coverage for assistant-tailed pre/current snapshots, tool-result tails, summary tails, and empty fallback behavior.

Fixes #87472

## Verification
- `pnpm test src/agents/embedded-agent-runner/run/compaction-timeout.test.ts -- --reporter=verbose`
- `git diff --check`
- `autoreview --mode local` (clean: no accepted/actionable findings)
- `pnpm check:changed` delegated to Blacksmith Testbox `tbx_01kstj16xmefgz259yebnvzk56` / https://github.com/openclaw/openclaw/actions/runs/26656703158 and failed after core typecheck passed on unrelated latest-main type errors in `src/config/sessions.cache.test.ts`.

## Real behavior proof
Behavior addressed: compaction-timeout recovery no longer selects assistant-tailed snapshots for continuation metadata.

Real environment tested: local macOS checkout, plus a Blacksmith Testbox changed-gate attempt.

Exact steps or command run after this patch: `pnpm test src/agents/embedded-agent-runner/run/compaction-timeout.test.ts -- --reporter=verbose`; `git diff --check`; `autoreview --mode local`; `pnpm check:changed`.

Evidence after fix: focused regression suite passed 13/13, whitespace check passed, and autoreview reported no accepted/actionable findings.

Observed result after fix: timeout snapshots trim to a continuable user/toolResult/user-like replay tail, fall back to current when the pre-compaction snapshot has no continuable boundary, and return an empty snapshot rather than an assistant-tailed one when neither side can continue.

What was not tested: a fully green changed gate; latest `main` currently fails unrelated typechecks in `src/config/sessions.cache.test.ts` during the Testbox run above.


## Landing note
Fresh rebase head: `8a4a9dd511a7943ae3b8fe2756fc0a38b64b95da` on `origin/main` `c8f5a2e0e2e466da35d23f6ace8d22d5134120a3`.

Current focused proof after rebase: `pnpm test src/agents/embedded-agent-runner/run/compaction-timeout.test.ts -- --reporter=verbose` passed 13/13; `git diff --check origin/main...HEAD` passed.

Current Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/26658848950. It still fails unrelated current-main lanes outside this PR diff: `check-test-types` in `src/config/sessions.cache.test.ts` and `checks-node-core-runtime-media-ui` in `src/wizard/setup.official-plugins.test.ts`. This PR diff only touches `src/agents/embedded-agent-runner/run/compaction-timeout.ts` and `src/agents/embedded-agent-runner/run/compaction-timeout.test.ts`.


## Final landing note
Final rebased head: `35bd932a0222cfe0902f5d43f86319a9c0cc60e7` on `origin/main` `fb8b9e91380b71bcf6f14db2a4b720b839051eed`.

Final focused proof after rebase: `pnpm test src/agents/embedded-agent-runner/run/compaction-timeout.test.ts -- --reporter=verbose` passed 13/13; `git diff --check origin/main...HEAD` passed. CI run https://github.com/openclaw/openclaw/actions/runs/26659041898 passed after rerunning flaky `checks-node-agentic-agents` (isolated local proof for `src/agents/code-mode.test.ts -t "terminates hostile infinite loops outside the main event loop"` also passed).
