### PR TITLE
Lower profile tool policy filter audit logs

### DIFF
--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -176,22 +176,25 @@ export function auditToolPolicyFilter(params: {
       tools: matchedRuleSourceTools,
     });
     const matchedRuleSuffix = matchedRules.length > 0 ? `; matched ${matchedRules.join(", ")}` : "";
-    toolPolicyAuditLogger.info(
-      `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}${matchedRuleSuffix}`,
-      {
-        rule,
-        ruleKind,
-        ...(matchedRules.length > 0
-          ? {
-              matchedRules,
-              ...(truncated ? { matchedRulesTruncated: true } : {}),
-            }
-          : {}),
-        removedToolCount: removed.length,
-        removedTools: toolNames,
-        removedToolsTruncated: truncated,
-      },
-    );
+    const message = `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}${matchedRuleSuffix}`;
+    const metadata = {
+      rule,
+      ruleKind,
+      ...(matchedRules.length > 0
+        ? {
+            matchedRules,
+            ...(truncated ? { matchedRulesTruncated: true } : {}),
+          }
+        : {}),
+      removedToolCount: removed.length,
+      removedTools: toolNames,
+      removedToolsTruncated: truncated,
+    };
+    if (rule.startsWith("tools.profile") || rule.startsWith("tools.byProvider.profile")) {
+      toolPolicyAuditLogger.debug(message, metadata);
+    } else {
+      toolPolicyAuditLogger.info(message, metadata);
+    }
   }
 }
 


### PR DESCRIPTION
Summary
- Log profile-stage tool catalog trimming at debug instead of info.
- Keep explicit allow/deny, sender/group, provider policy removals, and sandbox tool blocks visible at info.

Verification
- Not run (single log-level routing change requested).