### PR TITLE
test(ci): align session cache and optional plugin expectations

### DIFF
--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as jsonFiles from "../infra/json-files.js";
+import { createCanonicalFixtureSkill } from "../skills/test-support/test-helpers.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import {
   getSerializedSessionStore,
@@ -740,7 +741,7 @@ describe("Session Store Cache", () => {
     await updateSessionStoreEntry({
       storePath,
       sessionKey: "session:1",
-      update: () => ({ displayName: "After", updatedAt: 123 }),
+      update: async () => ({ displayName: "After", updatedAt: 123 }),
       takeCacheOwnership: true,
     });
 
@@ -769,7 +770,7 @@ describe("Session Store Cache", () => {
     await updateSessionStoreEntry({
       storePath,
       sessionKey: "session:1",
-      update: () => ({ displayName: "After" }),
+      update: async () => ({ displayName: "After" }),
       takeCacheOwnership: true,
     });
 
@@ -788,12 +789,20 @@ describe("Session Store Cache", () => {
     await updateSessionStoreEntry({
       storePath,
       sessionKey: "session:1",
-      update: () => ({
+      update: async () => ({
         displayName: "After",
         skillsSnapshot: {
           prompt: "short prompt",
           skills: [{ name: "alpha" }],
-          resolvedSkills: [{ name: "alpha", body: "transient" }],
+          resolvedSkills: [
+            createCanonicalFixtureSkill({
+              name: "alpha",
+              description: "alpha skill",
+              filePath: "/skills/alpha/SKILL.md",
+              baseDir: "/skills/alpha",
+              source: "transient",
+            }),
+          ],
         } as SessionEntry["skillsSnapshot"],
       }),
       takeCacheOwnership: true,

--- a/src/wizard/setup.official-plugins.test.ts
+++ b/src/wizard/setup.official-plugins.test.ts
@@ -138,6 +138,11 @@ describe("setupOfficialPluginInstalls", () => {
           hint: "OpenClaw diff viewer plugin",
         },
         {
+          value: "copilot",
+          label: "GitHub Copilot agent runtime",
+          hint: "OpenClaw GitHub Copilot agent runtime plugin",
+        },
+        {
           value: "google-meet",
           label: "Google Meet",
           hint: "OpenClaw Google Meet participant plugin",
@@ -156,6 +161,11 @@ describe("setupOfficialPluginInstalls", () => {
           value: "openshell",
           label: "OpenShell Sandbox",
           hint: "OpenClaw OpenShell sandbox backend",
+        },
+        {
+          value: "pixverse",
+          label: "PixVerse",
+          hint: "OpenClaw PixVerse video generation provider plugin",
         },
         {
           value: "voice-call",


### PR DESCRIPTION
## Summary
- Fix main CI test type failures from `467b068fdc` (`perf(sessions): patch single-entry store writes`) by making the new cache test `updateSessionStoreEntry` callbacks async and using the canonical `Skill` fixture shape.
- Fix stale official optional plugin wizard expectations after `f3cfd752d3` (`feat(copilot): add GitHub Copilot agent runtime`) added `copilot` and `c18370574e` (`feat(pixverse): add video generation provider`) added `pixverse`; `1806b152a9` (`fix: add ClawHub plugin display names`) supplied the current PixVerse label/description asserted here.

## Regression refs
- `467b068fdc`: added the session-cache tests whose update callbacks did not match `updateSessionStoreEntry`'s Promise-returning contract and whose transient `resolvedSkills` fixture did not match the canonical `Skill` type.
- `f3cfd752d3`: added the Copilot runtime plugin, making `copilot` appear in the optional official plugin onboarding list.
- `c18370574e`: added the PixVerse plugin, making `pixverse` eligible for the same optional official plugin onboarding list.
- `1806b152a9`: added the PixVerse display name/description now shown in that onboarding prompt.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.wizard.config.ts src/wizard/setup.official-plugins.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/config/sessions.cache.test.ts --reporter=verbose`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `pnpm exec oxlint src/config/sessions.cache.test.ts src/wizard/setup.official-plugins.test.ts --format=unix`
- `git diff --check origin/main...HEAD`

## Real behavior proof
Behavior addressed: Main CI failures in `check:test-types` and `checks-node-core-runtime-media-ui` caused by stale test contracts.
Real environment tested: Local source checkout on Node/PNPM repo tooling.
Exact steps or command run after this patch: See Verification above.
Evidence after fix: Targeted wizard test, session cache test, core test typecheck, targeted oxlint, and diff whitespace check all passed locally.
Observed result after fix: The failing test expectations now match current async/session skill and official plugin catalog behavior.
What was not tested: Full CI/Testbox gate was not run for this quick main-CI fix.
