### PR TITLE
test(config): satisfy async session cache update types

### DIFF
--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -740,7 +740,7 @@ describe("Session Store Cache", () => {
     await updateSessionStoreEntry({
       storePath,
       sessionKey: "session:1",
-      update: () => ({ displayName: "After", updatedAt: 123 }),
+      update: async () => ({ displayName: "After", updatedAt: 123 }),
       takeCacheOwnership: true,
     });
 
@@ -769,7 +769,7 @@ describe("Session Store Cache", () => {
     await updateSessionStoreEntry({
       storePath,
       sessionKey: "session:1",
-      update: () => ({ displayName: "After" }),
+      update: async () => ({ displayName: "After" }),
       takeCacheOwnership: true,
     });
 
@@ -788,12 +788,28 @@ describe("Session Store Cache", () => {
     await updateSessionStoreEntry({
       storePath,
       sessionKey: "session:1",
-      update: () => ({
+      update: async () => ({
         displayName: "After",
         skillsSnapshot: {
           prompt: "short prompt",
           skills: [{ name: "alpha" }],
-          resolvedSkills: [{ name: "alpha", body: "transient" }],
+          resolvedSkills: [
+            {
+              name: "alpha",
+              description: "test skill",
+              filePath: path.join(testDir, "alpha", "SKILL.md"),
+              baseDir: path.join(testDir, "alpha"),
+              source: "test",
+              sourceInfo: {
+                path: path.join(testDir, "alpha", "SKILL.md"),
+                source: "test",
+                scope: "temporary",
+                origin: "top-level",
+                baseDir: path.join(testDir, "alpha"),
+              },
+              disableModelInvocation: false,
+            },
+          ],
         } as SessionEntry["skillsSnapshot"],
       }),
       takeCacheOwnership: true,


### PR DESCRIPTION
## Summary
- Update `updateSessionStoreEntry` test callbacks to match the async callback contract.
- Expand the transient `resolvedSkills` fixture to the current persisted skill shape so core-test typechecking passes again.

## Verification
- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs run src/config/sessions.cache.test.ts --reporter=dot` (38 tests passed)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean, no accepted/actionable findings)
- AWS Crabbox `check:changed`: provider `aws`, lease `cbx_2f1b0c650aea`, run `run_902fe710c804`, exit 0

## Real behavior proof
Behavior addressed: `pnpm check:changed` was failing in `typecheck core tests` on current main because `src/config/sessions.cache.test.ts` no longer satisfied the async session-store update callback and `Skill` fixture types.
Real environment tested: AWS Crabbox Linux changed gate plus focused local Vitest wrapper in a Codex worktree.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/config/sessions.cache.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 45m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.
Evidence after fix: focused Vitest passed 38 tests; Crabbox run `run_902fe710c804` completed with exit 0.
Observed result after fix: the coreTests changed lane passes typecheck and lint for the session cache test patch.
What was not tested: no runtime session-store behavior beyond the existing focused regression test; this is a test type-alignment fix.
