### PR TITLE
fix(logging): refresh file log hostname per write

### DIFF
--- a/src/logging/logger-redaction-behavior.test.ts
+++ b/src/logging/logger-redaction-behavior.test.ts
@@ -207,6 +207,30 @@ describe("file log redaction", () => {
     expect(record.message).toBe("request completed");
   });
 
+  it("rechecks hostname for each JSONL file log write after an empty value", () => {
+    const logPath = logPathTracker.nextPath();
+    setLoggerOverride({ level: "info", file: logPath });
+    const hostnames = ["", "lr-macbook"];
+    loggerTest.setHostnameResolverForTests(() => hostnames.shift() ?? "lr-macbook");
+
+    getLogger().info({ route: "/api/health" }, "first request");
+    getLogger().info({ route: "/api/health" }, "second request");
+
+    const records = fs
+      .readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toHaveLength(2);
+    expect(records[0]?.hostname).toBe("unknown");
+    expect(records[0]?.message).toBe("first request");
+    expect(records[1]?.hostname).toBe("lr-macbook");
+    expect(records[1]?.message).toBe("second request");
+    expect((records[1]?.["_meta"] as Record<string, unknown> | undefined)?.hostname).toBe(
+      "lr-macbook",
+    );
+  });
+
   it("promotes agent, session, and channel context to top-level JSONL fields", () => {
     const logPath = logPathTracker.nextPath();
     setLoggerOverride({ level: "info", file: logPath });

--- a/src/logging/logger-redaction-behavior.test.ts
+++ b/src/logging/logger-redaction-behavior.test.ts
@@ -207,25 +207,34 @@ describe("file log redaction", () => {
     expect(record.message).toBe("request completed");
   });
 
-  it("rechecks hostname for each JSONL file log write after an empty value", () => {
+  it("retries hostname resolution after an empty value and caches the first real value", () => {
     const logPath = logPathTracker.nextPath();
     setLoggerOverride({ level: "info", file: logPath });
-    const hostnames = ["", "lr-macbook"];
-    loggerTest.setHostnameResolverForTests(() => hostnames.shift() ?? "lr-macbook");
+    const hostnames = ["", "lr-macbook", "changed-host"];
+    const resolvedHostnames: string[] = [];
+    loggerTest.setHostnameResolverForTests(() => {
+      const hostname = hostnames.shift() ?? "changed-host";
+      resolvedHostnames.push(hostname);
+      return hostname;
+    });
 
     getLogger().info({ route: "/api/health" }, "first request");
     getLogger().info({ route: "/api/health" }, "second request");
+    getLogger().info({ route: "/api/health" }, "third request");
 
     const records = fs
       .readFileSync(logPath, "utf8")
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as Record<string, unknown>);
-    expect(records).toHaveLength(2);
+    expect(records).toHaveLength(3);
+    expect(resolvedHostnames).toEqual(["", "lr-macbook"]);
     expect(records[0]?.hostname).toBe("unknown");
     expect(records[0]?.message).toBe("first request");
     expect(records[1]?.hostname).toBe("lr-macbook");
     expect(records[1]?.message).toBe("second request");
+    expect(records[2]?.hostname).toBe("lr-macbook");
+    expect(records[2]?.message).toBe("third request");
     expect((records[1]?.["_meta"] as Record<string, unknown> | undefined)?.hostname).toBe(
       "lr-macbook",
     );

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -72,6 +72,7 @@ type ResolvedSettings = {
 export type LoggerResolvedSettings = ResolvedSettings;
 type TsLogRecord = Record<string, unknown>;
 type LoggerConfigLoader = () => OpenClawConfig["logging"] | undefined;
+type HostnameResolver = () => string;
 
 type DiagnosticLogCode = {
   line?: number;
@@ -95,7 +96,8 @@ const MAX_DIAGNOSTIC_LOG_NAME_CHARS = 120;
 const MAX_FILE_LOG_MESSAGE_CHARS = 4 * 1024;
 const MAX_FILE_LOG_CONTEXT_VALUE_CHARS = 512;
 const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
-const HOSTNAME = os.hostname() || "unknown";
+const defaultHostnameResolver: HostnameResolver = () => os.hostname();
+let hostnameResolver: HostnameResolver = defaultHostnameResolver;
 
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
 
@@ -295,6 +297,17 @@ function buildFileLogMessage(numericArgs: readonly unknown[]): string | undefine
   return clampFileLogText(parts.join(" "), MAX_FILE_LOG_MESSAGE_CHARS);
 }
 
+function resolveLogHostname(): string {
+  return hostnameResolver().trim() || "unknown";
+}
+
+function withResolvedLogMetaHostname(meta: unknown, hostname: string): unknown {
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+    return meta;
+  }
+  return { ...(meta as Record<string, unknown>), hostname };
+}
+
 function extractLogBindingPrefix(numericArgs: unknown[]): {
   bindings?: Record<string, unknown>;
   args: unknown[];
@@ -361,7 +374,7 @@ function buildStructuredFileLogFields(logObj: TsLogRecord): Record<string, strin
   const sessionId = readFirstContextString(sources, ["session_id", "sessionId", "sessionKey"]);
   const channel = readFirstContextString(sources, ["channel", "messageProvider"]);
   return {
-    hostname: HOSTNAME,
+    hostname: resolveLogHostname(),
     ...(message ? { message } : {}),
     ...(agentId ? { agent_id: agentId } : {}),
     ...(sessionId ? { session_id: sessionId } : {}),
@@ -576,7 +589,13 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
       const time = formatTimestamp(logObj.date ?? new Date(), { style: "long" });
       const traceFields = buildTraceFileLogFields(logObj as TsLogRecord);
       const structuredFields = buildStructuredFileLogFields(logObj as TsLogRecord);
-      const record = { ...logObj, time, ...structuredFields, ...traceFields };
+      const record = {
+        ...logObj,
+        _meta: withResolvedLogMetaHostname(logObj["_meta"], structuredFields.hostname),
+        time,
+        ...structuredFields,
+        ...traceFields,
+      };
       const line = redactSensitiveText(JSON.stringify(redactLogRecordForTransport(record)));
       const payload = `${line}\n`;
       const payloadBytes = Buffer.byteLength(payload, "utf8");
@@ -705,10 +724,14 @@ export function resetLogger() {
   loggingState.cachedConsoleSettings = null;
   loggingState.overrideSettings = null;
   loadLoggerConfig = loadLoggerConfigDefault;
+  hostnameResolver = defaultHostnameResolver;
 }
 
 export const testApi = {
   resolveActiveLogFile,
+  setHostnameResolverForTests: (resolver?: HostnameResolver) => {
+    hostnameResolver = resolver ?? defaultHostnameResolver;
+  },
   shouldSkipMutatingLoggingConfigRead,
 };
 export { testApi as __test__ };

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -98,6 +98,7 @@ const MAX_FILE_LOG_CONTEXT_VALUE_CHARS = 512;
 const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
 const defaultHostnameResolver: HostnameResolver = () => os.hostname();
 let hostnameResolver: HostnameResolver = defaultHostnameResolver;
+let cachedHostname: string | null = null;
 
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
 
@@ -298,7 +299,15 @@ function buildFileLogMessage(numericArgs: readonly unknown[]): string | undefine
 }
 
 function resolveLogHostname(): string {
-  return hostnameResolver().trim() || "unknown";
+  if (cachedHostname) {
+    return cachedHostname;
+  }
+  const hostname = hostnameResolver().trim();
+  if (!hostname) {
+    return "unknown";
+  }
+  cachedHostname = hostname;
+  return hostname;
 }
 
 function withResolvedLogMetaHostname(meta: unknown, hostname: string): unknown {
@@ -725,12 +734,14 @@ export function resetLogger() {
   loggingState.overrideSettings = null;
   loadLoggerConfig = loadLoggerConfigDefault;
   hostnameResolver = defaultHostnameResolver;
+  cachedHostname = null;
 }
 
 export const testApi = {
   resolveActiveLogFile,
   setHostnameResolverForTests: (resolver?: HostnameResolver) => {
     hostnameResolver = resolver ?? defaultHostnameResolver;
+    cachedHostname = null;
   },
   shouldSkipMutatingLoggingConfigRead,
 };


### PR DESCRIPTION
## Summary

- Fixes #87258.
- Resolve file-log hostnames lazily for each JSONL write instead of freezing the module-load value.
- Keep the `"unknown"` fallback for transient empty hostnames, but allow later writes to recover once `os.hostname()` returns a real value.
- Keep top-level `hostname` and tslog `_meta.hostname` aligned from the same resolved value.
- Add regression coverage for an initial empty hostname followed by a later real hostname.

## Verification

- PASS: `node scripts/run-vitest.mjs src/logging/logger-redaction-behavior.test.ts src/logger.test.ts`
- PASS: `node_modules/.bin/oxfmt --check --threads=1 src/logging/logger.ts src/logging/logger-redaction-behavior.test.ts`
- PASS: `git diff --check origin/main...HEAD`
- PASS: `codex review --uncommitted` after the `_meta.hostname` alignment fix reported no correctness issues.

## Real behavior proof

Behavior addressed: JSONL file logs no longer permanently report `_meta.hostname: "unknown"` when the first hostname lookup during module startup is empty.

Real environment tested: macOS local checkout on `fix/87258-lazy-log-hostname` (HEAD `62127b16823`, rebased onto current `origin/main`), using the file JSONL transport with `OPENCLAW_TEST_FILE_LOG=1`.

Exact steps or command run after this patch:
```
$ OPENCLAW_TEST_FILE_LOG=1 node --import tsx/esm -e '
  const fs = await import("node:fs");
  const os = await import("node:os");
  const path = await import("node:path");
  const { getLogger, setLoggerOverride, resetLogger } = await import("./src/logging.js");
  const logPath = path.join(os.tmpdir(), `openclaw-log-proof-${process.pid}.jsonl`);
  setLoggerOverride({ level: "info", file: logPath });
  getLogger().info({ route: "/" }, "hello");
  resetLogger();
  const record = JSON.parse(fs.readFileSync(logPath, "utf8"));
  fs.unlinkSync(logPath);
  console.log(JSON.stringify({ top: record.hostname, meta: record._meta?.hostname, message: record.message }));
'
```

Evidence after fix: live `node` stdout from the command above (terminal output):
```
{"top":"Shubhankars-MacBook-Pro.local","meta":"Shubhankars-MacBook-Pro.local","message":"hello"}
```

Both the top-level `hostname` and the tslog `_meta.hostname` resolve to the real macOS hostname instead of the `"unknown"` fallback that the pre-fix code locked in at module load. The regression test in `src/logging/logger-redaction-behavior.test.ts` complements this by stubbing `os.hostname()` to return `""` on the first write and `"lr-macbook"` on the second, asserting the second write recovers — which `node scripts/run-vitest.mjs src/logging/logger-redaction-behavior.test.ts` confirms passes.

Observed result after fix: a Gateway whose first hostname read happened during an empty-hostname window now records the real hostname on its next file-log write instead of staying pinned to `"unknown"` for the lifetime of the process. Operators reading JSONL logs see actual host identity in both the top-level field and `_meta.hostname` without restarting the Gateway.

What was not tested: a separate long-running Gateway restart reproducing the intermittent macOS startup timing in production. The source-level race is covered by the stubbed-resolver regression test plus the live file-log proof above.
