### PR TITLE
fix(imessage): preserve SMS approval reply routes

### DIFF
--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -142,6 +142,14 @@ function resolveIMessageOutboundSessionRoute(params: {
     if (!handle) {
       return null;
     }
+    const account = resolveIMessageAccount({ cfg: params.cfg, accountId: params.accountId });
+    const service =
+      parsed.serviceExplicit || parsed.service !== "auto"
+        ? parsed.service
+        : account.config.service === "sms"
+          ? "sms"
+          : "imessage";
+    const directTarget = `${service}:${handle}`;
     const peer: RoutePeer = { kind: "direct", id: handle };
     const baseSessionKey = buildIMessageBaseSessionKey({
       cfg: params.cfg,
@@ -154,8 +162,8 @@ function resolveIMessageOutboundSessionRoute(params: {
       baseSessionKey,
       peer,
       chatType: "direct" as const,
-      from: `imessage:${handle}`,
-      to: `imessage:${handle}`,
+      from: directTarget,
+      to: directTarget,
     };
   }
 

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -29,7 +29,6 @@ import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sanitizeTerminalText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { resolveIMessageAccount } from "../accounts.js";
 import { resolveIMessageConversationRoute } from "../conversation-route.js";
 import {
   isKnownFromMeIMessageMessageId,
@@ -83,19 +82,6 @@ function isIMessageConversationAllowTarget(entry: string): boolean {
   return (
     parsed.kind === "chat_id" || parsed.kind === "chat_guid" || parsed.kind === "chat_identifier"
   );
-}
-
-function resolveIMessageDirectReplyTarget(params: {
-  cfg: OpenClawConfig;
-  accountId: string;
-  sender: string;
-}): string {
-  const account = resolveIMessageAccount({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  });
-  const servicePrefix = account.config.service === "sms" ? "sms" : "imessage";
-  return `${servicePrefix}:${params.sender}`;
 }
 
 function mergeIMessageGroupAllowFromWithLegacyChatTargets(params: {
@@ -916,13 +902,7 @@ export async function buildIMessageInboundContext(params: {
     });
   }
 
-  const imessageTo =
-    (decision.isGroup ? chatTarget : undefined) ||
-    resolveIMessageDirectReplyTarget({
-      cfg: params.cfg,
-      accountId: decision.route.accountId,
-      sender: decision.sender,
-    });
+  const imessageTo = (decision.isGroup ? chatTarget : undefined) || `imessage:${decision.sender}`;
   const inboundHistory =
     !decision.isGroup && params.dmHistory?.inboundHistory
       ? params.dmHistory.inboundHistory

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -903,14 +903,13 @@ export async function buildIMessageInboundContext(params: {
     });
   }
 
-  const directReplyTarget = decision.isGroup
-    ? undefined
+  const imessageTo = decision.isGroup
+    ? chatTarget || `imessage:${decision.sender}`
     : buildDirectIMessageReplyTarget({
         cfg: params.cfg,
         accountId: decision.route.accountId,
         sender: decision.sender,
       });
-  const imessageTo = (decision.isGroup ? chatTarget : undefined) || directReplyTarget;
   // Async follow-ups can resume from the stored origin instead of the immediate
   // reply target. Keep direct SMS origins service-qualified the same way as To,
   // or the final resumed message can fall back to imessage:<phone>.

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -29,6 +29,7 @@ import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sanitizeTerminalText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { resolveIMessageAccount } from "../accounts.js";
 import { resolveIMessageConversationRoute } from "../conversation-route.js";
 import {
   isKnownFromMeIMessageMessageId,
@@ -82,6 +83,19 @@ function isIMessageConversationAllowTarget(entry: string): boolean {
   return (
     parsed.kind === "chat_id" || parsed.kind === "chat_guid" || parsed.kind === "chat_identifier"
   );
+}
+
+function resolveIMessageDirectReplyTarget(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  sender: string;
+}): string {
+  const account = resolveIMessageAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const servicePrefix = account.config.service === "sms" ? "sms" : "imessage";
+  return `${servicePrefix}:${params.sender}`;
 }
 
 function mergeIMessageGroupAllowFromWithLegacyChatTargets(params: {
@@ -902,7 +916,13 @@ export async function buildIMessageInboundContext(params: {
     });
   }
 
-  const imessageTo = (decision.isGroup ? chatTarget : undefined) || `imessage:${decision.sender}`;
+  const imessageTo =
+    (decision.isGroup ? chatTarget : undefined) ||
+    resolveIMessageDirectReplyTarget({
+      cfg: params.cfg,
+      accountId: decision.route.accountId,
+      sender: decision.sender,
+    });
   const inboundHistory =
     !decision.isGroup && params.dmHistory?.inboundHistory
       ? params.dmHistory.inboundHistory

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -29,6 +29,7 @@ import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sanitizeTerminalText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { resolveIMessageAccount } from "../accounts.js";
 import { resolveIMessageConversationRoute } from "../conversation-route.js";
 import {
   isKnownFromMeIMessageMessageId,
@@ -902,7 +903,18 @@ export async function buildIMessageInboundContext(params: {
     });
   }
 
-  const imessageTo = (decision.isGroup ? chatTarget : undefined) || `imessage:${decision.sender}`;
+  const directReplyTarget = decision.isGroup
+    ? undefined
+    : buildDirectIMessageReplyTarget({
+        cfg: params.cfg,
+        accountId: decision.route.accountId,
+        sender: decision.sender,
+      });
+  const imessageTo = (decision.isGroup ? chatTarget : undefined) || directReplyTarget;
+  // Async follow-ups can resume from the stored origin instead of the immediate
+  // reply target. Keep direct SMS origins service-qualified the same way as To,
+  // or the final resumed message can fall back to imessage:<phone>.
+  const imessageFrom = decision.isGroup ? `imessage:group:${chatId ?? "unknown"}` : imessageTo;
   const inboundHistory =
     !decision.isGroup && params.dmHistory?.inboundHistory
       ? params.dmHistory.inboundHistory
@@ -940,9 +952,7 @@ export async function buildIMessageInboundContext(params: {
     messageId: messageSid,
     messageIdFull: messageGuid,
     timestamp: decision.createdAt,
-    from: decision.isGroup
-      ? `imessage:group:${chatId ?? "unknown"}`
-      : `imessage:${decision.sender}`,
+    from: imessageFrom,
     sender: {
       id: decision.sender,
       name: decision.senderNormalized,
@@ -1021,6 +1031,19 @@ function buildIMessageEchoScope(params: {
     scopes.push(`${params.accountId}:chat_identifier:${params.chatIdentifier}`);
   }
   return scopes;
+}
+
+function buildDirectIMessageReplyTarget(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  sender: string;
+}): string {
+  const account = resolveIMessageAccount({ cfg: params.cfg, accountId: params.accountId });
+  const configuredService = account.config.service;
+  if (configuredService === "sms") {
+    return `sms:${params.sender}`;
+  }
+  return `imessage:${params.sender}`;
 }
 
 export function describeIMessageEchoDropLog(params: {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -654,7 +654,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             logVerbose,
           })
         : undefined;
-    const { ctxPayload, chatTarget } = await buildIMessageInboundContext({
+    const { ctxPayload, chatTarget, imessageTo } = await buildIMessageInboundContext({
       cfg,
       decision,
       message,
@@ -671,7 +671,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       },
     });
 
-    const updateTarget = chatTarget || decision.sender;
+    const updateTarget = chatTarget || imessageTo;
     const pinnedMainDmOwner = resolvePinnedMainDmOwnerFromAllowlist({
       dmScope: cfg.session?.dmScope,
       allowFrom,

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -236,6 +236,16 @@ function isNumericMessageRowId(value: string | null | undefined): value is strin
   return typeof value === "string" && /^\d+$/.test(value.trim());
 }
 
+function resolveTargetService(target: ParsedIMessageTarget): IMessageService | undefined {
+  if (target.kind !== "handle") {
+    return undefined;
+  }
+  if (target.serviceExplicit || target.service !== "auto") {
+    return target.service;
+  }
+  return undefined;
+}
+
 function normalizeResolvedMessageGuid(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
@@ -799,8 +809,9 @@ export async function sendMessageIMessage(
   const target = parseIMessageTarget(opts.chatId ? formatIMessageChatTarget(opts.chatId) : to);
   const service =
     opts.service ??
-    (target.kind === "handle" ? target.service : undefined) ??
+    resolveTargetService(target) ??
     (account.config.service as IMessageService | undefined);
+  const timeoutMs = opts.timeoutMs ?? account.config.probeTimeoutMs;
   const region = opts.region?.trim() || account.config.region?.trim() || "US";
   const maxBytes =
     typeof opts.maxBytes === "number"
@@ -852,7 +863,7 @@ export async function sendMessageIMessage(
   const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
   const runCliJson =
     opts.runCliJson ??
-    ((args: readonly string[]) => runIMessageCliJson(cliPath, dbPath, args, opts.timeoutMs));
+    ((args: readonly string[]) => runIMessageCliJson(cliPath, dbPath, args, timeoutMs));
 
   if (filePath && !message.trim() && !resolvedReplyToId) {
     const attachmentResult = await trySendAttachmentForExplicitChat({
@@ -904,7 +915,7 @@ export async function sendMessageIMessage(
   try {
     try {
       result = await client.request<Record<string, unknown>>("send", params, {
-        timeoutMs: opts.timeoutMs,
+        timeoutMs,
       });
     } catch (error) {
       if (filePath || resolvedReplyToId || !isIMessageRpcSendTimeout(error)) {

--- a/extensions/imessage/src/targets.ts
+++ b/extensions/imessage/src/targets.ts
@@ -15,7 +15,7 @@ export type IMessageTarget =
   | { kind: "chat_id"; chatId: number }
   | { kind: "chat_guid"; chatGuid: string }
   | { kind: "chat_identifier"; chatIdentifier: string }
-  | { kind: "handle"; to: string; service: IMessageService };
+  | { kind: "handle"; to: string; service: IMessageService; serviceExplicit?: boolean };
 
 export type IMessageAllowTarget = ParsedChatTarget | { kind: "handle"; handle: string };
 
@@ -91,6 +91,9 @@ export function parseIMessageTarget(raw: string): IMessageTarget {
     parseTarget: parseIMessageTarget,
   });
   if (servicePrefixed) {
+    if (servicePrefixed.kind === "handle") {
+      return { ...servicePrefixed, serviceExplicit: true };
+    }
     return servicePrefixed;
   }
 


### PR DESCRIPTION
## Summary

- Preserves SMS-qualified iMessage routes across inbound context, session route storage, approval updates, and async follow-up delivery.
- Lets bare direct iMessage/SMS handle targets inherit the configured account service, while still honoring explicit `sms:`, `imessage:`, and `auto:` prefixes.
- Uses the configured iMessage probe timeout for live sends so the RPC path does not fall back to the shorter default timeout during approval delivery.
- Keeps the change scoped to the iMessage plugin; no `src/infra/*` files are touched.

## Linked context

Related #87770

Requested by maintainer in the PR isolation workflow.

## Real behavior proof

Behavior addressed: Direct SMS iMessage approval flows should deliver the approval request, approval acknowledgement, and final agent follow-up as SMS instead of falling back to `imessage:<phone>` or failing threaded reply delivery.

Real environment tested: Local macOS Messages database and Google Voice in Safari, using `OPENCLAW_PROFILE=prod` against the prod OpenClaw profile. The live SMS handle and phone numbers are intentionally redacted from this PR body.

Exact steps or command run after this patch:

```sh
git diff --check
OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs gatewayWatch
OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs extensions/imessage/src/channel.ts extensions/imessage/src/monitor/inbound-processing.ts extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/send.ts extensions/imessage/src/targets.ts
OPENCLAW_PROFILE=prod node dist/index.js channels status --channel imessage --probe
OPENCLAW_PROFILE=prod node dist/index.js gateway --port 18789
```

Live proof steps:

```text
1. Sent a Google Voice SMS prompt asking OpenClaw to run: touch /tmp/openclaw-imsg-fix-160123
2. Waited for the native Exec approval request over the iMessage channel.
3. Replied from Google Voice: /approve d73596e7-e7d7-41e1-a160-8788a261e5e4 allow-once
4. Verified the command side effect file existed.
5. Verified the approval request, acknowledgement, and final completion message were all Messages DB `SMS` rows with `error=0`.
```

Evidence after fix:

```text
Messages rows >= 66324:
66324 | inbound prompt       | SMS | error=0 | nonce imsg-fix-160123
66325 | approval request     | SMS | error=0 | Exec approval required, id d73596e7-e7d7-41e1-a160-8788a261e5e4
66326 | inbound approval     | SMS | error=0 | /approve d73596e7-e7d7-41e1-a160-8788a261e5e4 allow-once
66327 | approval ack         | SMS | error=0 | Approval allow-once submitted
66328 | final agent followup | SMS | error=0 | Command ran successfully. Exit code: 0

Command side effect:
-rw-r--r--@ 1 kevinlin wheel 0 May 29 16:03 /tmp/openclaw-imsg-fix-160123

Gateway log:
16:01:55 exec.approval.request succeeded
16:03:28 exec.approval.waitDecision succeeded
16:03:29 agent follow-up started for approval d73596e7-e7d7-41e1-a160-8788a261e5e4
16:03:36 Command ran successfully. Exit code: `0`.
```

Observed result after fix: The direct SMS approval request, `/approve` acknowledgement, and final async exec follow-up all stayed on SMS with `error=0`, and the requested command created `/tmp/openclaw-imsg-fix-160123`.

What was not tested: Unit tests were not run per maintainer instruction for this live integration proof. WhatsApp was not tested for this PR.

Before evidence: On the main checkout before this fix, the same prod-profile SMS approval path logged iMessage delivery failures such as `exec approvals: failed to deliver ... OutboundDeliveryError: imsg rpc timeout (send)`, and the expected `/tmp/openclaw-imsg-main-*` command side-effect files were absent.

## Tests and validation

Commands run:

```sh
git diff --check
OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs gatewayWatch
OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs extensions/imessage/src/channel.ts extensions/imessage/src/monitor/inbound-processing.ts extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/send.ts extensions/imessage/src/targets.ts
```

Live integration proof:

```text
iMessage/SMS prod approval proof passed for nonce imsg-fix-160123.
```

Regression coverage added or updated: None. The requested proof for this change was live iMessage/SMS integration behavior, not unit coverage.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Direct SMS iMessage approval replies and follow-ups should now remain SMS-qualified.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The iMessage direct SMS approval route and resumed async follow-up path.

How is that risk mitigated?

The change preserves explicit service prefixes, derives implicit direct routes from the configured iMessage account service, and keeps chat/group targets on the existing chat route path.

## Current review state

What is the next action?

Run CI and re-review the updated iMessage SMS route-preservation diff with the live proof above.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer/bot review.

Which bot or reviewer comments were addressed?

ClawSweeper's proof blocker was addressed with redacted live iMessage/SMS approval proof.
