### PR TITLE
fix(codex): refresh stale managed runtime plugin

### DIFF
--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -739,6 +739,97 @@ describe("buildStatusReply subagent summary", () => {
     );
   });
 
+  it("uses Codex usage for bare codex models running on the Codex harness", async () => {
+    registerStatusCodexHarness();
+
+    await withTempHome(
+      async (dir) => {
+        const authPath = path.join(
+          dir,
+          ".openclaw",
+          "agents",
+          "main",
+          "agent",
+          "auth-profiles.json",
+        );
+        fs.mkdirSync(path.dirname(authPath), { recursive: true });
+        fs.writeFileSync(
+          authPath,
+          JSON.stringify({
+            version: 1,
+            profiles: {
+              "openai-codex:status": {
+                type: "oauth",
+                provider: "openai-codex",
+                access: "access-token",
+                refresh: "refresh-token",
+                expires: Date.now() + 60 * 60_000,
+              },
+            },
+          }),
+          "utf8",
+        );
+        const usageResetBase = Math.floor(Date.now() / 1000);
+        providerUsageMock.loadProviderUsageSummary.mockResolvedValue({
+          updatedAt: Date.now(),
+          providers: [
+            {
+              provider: "openai-codex",
+              displayName: "Codex",
+              windows: [
+                {
+                  label: "5h",
+                  usedPercent: 8,
+                  resetAt: (usageResetBase + 60 * 60) * 1000,
+                },
+              ],
+            },
+          ],
+        });
+
+        const text = await buildStatusText({
+          cfg: baseCfg,
+          sessionEntry: {
+            sessionId: "sess-status-bare-codex-oauth",
+            updatedAt: 0,
+          },
+          sessionKey: "agent:main:main",
+          parentSessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          statusChannel: "mobilechat",
+          provider: "codex",
+          model: "gpt-5.5",
+          contextTokens: 32_000,
+          resolvedFastMode: false,
+          resolvedVerboseLevel: "off",
+          resolvedReasoningLevel: "off",
+          resolveDefaultThinkingLevel: async () => undefined,
+          isGroup: false,
+          defaultGroupActivation: () => "mention",
+        });
+
+        const normalized = normalizeTestText(text);
+        expect(normalized).toContain("Model: codex/gpt-5.5");
+        expect(normalized).toContain("oauth (openai-codex:status)");
+        expect(normalized).toContain("Runtime: OpenAI Codex");
+        expect(normalized).toContain("Usage: 5h 92% left");
+        const providerUsageCall = providerUsageMock.loadProviderUsageSummary.mock.calls.find(
+          ([params]) => params?.providers?.includes("openai-codex"),
+        );
+        if (!providerUsageCall) {
+          throw new Error("expected provider usage summary call for openai-codex");
+        }
+        expect(providerUsageCall[0]?.providers).toEqual(["openai-codex"]);
+      },
+      {
+        env: {
+          OPENAI_API_KEY: undefined,
+          OPENAI_OAUTH_TOKEN: undefined,
+        },
+      },
+    );
+  });
+
   it("uses Codex OAuth auth labels for explicit OpenAI OpenClaw auth order", async () => {
     await withTempHome(
       async (dir) => {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -1757,6 +1757,161 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result.warnings).toStrictEqual([]);
   });
 
+  it("refreshes a stale managed Codex runtime plugin selected by the OpenAI Codex route", async () => {
+    const installDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(installDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: "2026.5.6" }),
+    );
+    const records = {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        resolvedName: "@openclaw/codex",
+        resolvedSpec: "@openclaw/codex@2026.5.6",
+        resolvedVersion: "2026.5.6",
+        version: "2026.5.6",
+        integrity: "sha512-old-codex",
+        installPath: installDir,
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: "2026.5.6",
+          providers: ["codex"],
+        },
+      ],
+      diagnostics: [],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: "2026.5.6",
+            providers: ["codex"],
+          },
+        ],
+      ]),
+    });
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "codex",
+      targetDir: "/tmp/openclaw-plugins/codex",
+      version: VERSION,
+      npmResolution: {
+        name: "@openclaw/codex",
+        version: VERSION,
+        resolvedSpec: `@openclaw/codex@${VERSION}`,
+        integrity: "sha512-new-codex",
+        resolvedAt: "2026-05-01T00:00:00.000Z",
+      },
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        install: {
+          npmSpec: "@openclaw/codex",
+          defaultChoice: "npm",
+        },
+      },
+    ]);
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      expectedPluginId: "codex",
+      trustedSourceLinkedOfficialInstall: true,
+      mode: "update",
+    });
+    expect(result.changes).toEqual([
+      `Installed missing configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+    ]);
+    expectRecordFields(result.records.codex, {
+      source: "npm",
+      spec: "@openclaw/codex",
+      installPath: "/tmp/openclaw-plugins/codex",
+      version: VERSION,
+      resolvedName: "@openclaw/codex",
+      resolvedVersion: VERSION,
+      resolvedSpec: `@openclaw/codex@${VERSION}`,
+    });
+  });
+
+  it("does not downgrade a newer managed Codex runtime plugin", async () => {
+    const installDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(installDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: "9999.1.1" }),
+    );
+    const records = {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        resolvedName: "@openclaw/codex",
+        resolvedSpec: "@openclaw/codex@9999.1.1",
+        resolvedVersion: "9999.1.1",
+        version: "9999.1.1",
+        integrity: "sha512-newer-codex",
+        installPath: installDir,
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: "9999.1.1",
+          providers: ["codex", "openai-codex", "openai"],
+        },
+      ],
+      diagnostics: [],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: "9999.1.1",
+            providers: ["codex", "openai-codex", "openai"],
+          },
+        ],
+      ]),
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(result).toEqual({ changes: [], warnings: [], records });
+  });
+
   it.each([
     [
       "default OpenAI model route",

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -1854,6 +1854,137 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
   });
 
+  it("does not refresh a converged beta Codex runtime plugin on the second doctor pass", async () => {
+    const installDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(installDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: "2026.5.6" }),
+    );
+    const records = {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        resolvedName: "@openclaw/codex",
+        resolvedSpec: "@openclaw/codex@2026.5.6",
+        resolvedVersion: "2026.5.6",
+        version: "2026.5.6",
+        integrity: "sha512-old-codex",
+        installPath: installDir,
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: "2026.5.6",
+          providers: ["codex"],
+        },
+      ],
+      diagnostics: [],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: "2026.5.6",
+            providers: ["codex"],
+          },
+        ],
+      ]),
+    });
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "codex",
+      targetDir: installDir,
+      version: `${VERSION}-beta.4`,
+      npmResolution: {
+        name: "@openclaw/codex",
+        version: `${VERSION}-beta.4`,
+        resolvedSpec: `@openclaw/codex@${VERSION}-beta.4`,
+        integrity: "sha512-new-codex-beta",
+        resolvedAt: "2026-05-01T00:00:00.000Z",
+      },
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        install: {
+          npmSpec: "@openclaw/codex",
+          defaultChoice: "npm",
+        },
+      },
+    ]);
+
+    const cfg = {
+      update: { channel: "beta" as const },
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+        },
+      },
+    };
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const firstPass = await repairMissingConfiguredPluginInstalls({
+      cfg,
+      env: {},
+    });
+
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: "@openclaw/codex@beta",
+      expectedPluginId: "codex",
+      trustedSourceLinkedOfficialInstall: true,
+      mode: "update",
+    });
+    expect(firstPass.changes).toEqual([
+      'Installed missing configured plugin "codex" from @openclaw/codex@beta.',
+    ]);
+    expectRecordFields(firstPass.records.codex, {
+      source: "npm",
+      spec: "@openclaw/codex",
+      installPath: installDir,
+      version: `${VERSION}-beta.4`,
+      resolvedName: "@openclaw/codex",
+      resolvedVersion: `${VERSION}-beta.4`,
+      resolvedSpec: `@openclaw/codex@${VERSION}-beta.4`,
+    });
+
+    mocks.installPluginFromNpmSpec.mockClear();
+    mocks.writePersistedInstalledPluginIndexInstallRecords.mockClear();
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce(firstPass.records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: `${VERSION}-beta.4`,
+          providers: ["codex"],
+        },
+      ],
+      diagnostics: [],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: `${VERSION}-beta.4`,
+            providers: ["codex"],
+          },
+        ],
+      ]),
+    });
+
+    const secondPass = await repairMissingConfiguredPluginInstalls({
+      cfg,
+      env: {},
+    });
+
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(secondPass).toEqual({ changes: [], warnings: [], records: firstPass.records });
+  });
+
   it("does not downgrade a newer managed Codex runtime plugin", async () => {
     const installDir = makeTempDir();
     fs.writeFileSync(

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -1841,7 +1841,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       mode: "update",
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Refreshed stale configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
     ]);
     expectRecordFields(result.records.codex, {
       source: "npm",
@@ -1939,7 +1939,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       mode: "update",
     });
     expect(firstPass.changes).toEqual([
-      'Installed missing configured plugin "codex" from @openclaw/codex@beta.',
+      'Refreshed stale configured plugin "codex" from @openclaw/codex@beta.',
     ]);
     expectRecordFields(firstPass.records.codex, {
       source: "npm",

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -86,6 +86,8 @@ const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
   "requires compiled runtime output",
 ] as const;
 const VERSION_BOUND_RUNTIME_PLUGIN_IDS = new Set(["codex"]);
+const OPENCLAW_UNCORRECTED_STABLE_VERSION_RE = /^(\d{4}\.[1-9]\d?\.[1-9]\d?)$/;
+const OPENCLAW_BETA_COMPANION_VERSION_RE = /^(\d{4}\.[1-9]\d?\.[1-9]\d?)-beta\.[1-9]\d*$/;
 
 function shouldFallbackClawHubToNpm(params: {
   result: { ok: false; code?: string };
@@ -538,18 +540,38 @@ function resolveInstalledRuntimePackageVersion(params: {
 function installedRuntimePackageVersionIsStale(params: {
   installedVersion: string | undefined;
   currentVersion: string;
+  updateChannel: UpdateChannel;
 }): boolean {
   if (!params.installedVersion) {
+    return false;
+  }
+  if (
+    params.updateChannel === "beta" &&
+    betaCompanionMatchesCurrentStableVersion({
+      installedVersion: params.installedVersion,
+      currentVersion: params.currentVersion,
+    })
+  ) {
     return false;
   }
   const comparison = compareOpenClawReleaseVersions(params.installedVersion, params.currentVersion);
   return comparison === null ? params.installedVersion !== params.currentVersion : comparison < 0;
 }
 
+function betaCompanionMatchesCurrentStableVersion(params: {
+  installedVersion: string;
+  currentVersion: string;
+}): boolean {
+  const installedBase = OPENCLAW_BETA_COMPANION_VERSION_RE.exec(params.installedVersion)?.[1];
+  const currentBase = OPENCLAW_UNCORRECTED_STABLE_VERSION_RE.exec(params.currentVersion)?.[1];
+  return Boolean(installedBase && currentBase && installedBase === currentBase);
+}
+
 function collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages(params: {
   snapshot: PluginMetadataSnapshot;
   installRecords: Record<string, PluginInstallRecord>;
   configuredPluginIds: ReadonlySet<string>;
+  updateChannel: UpdateChannel;
 }): Set<string> {
   const pluginIds = new Set<string>();
   const currentVersion = normalizeOptionalLowercaseString(VERSION);
@@ -576,6 +598,7 @@ function collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages(params: {
       installedRuntimePackageVersionIsStale({
         installedVersion,
         currentVersion,
+        updateChannel: params.updateChannel,
       })
     ) {
       pluginIds.add(candidate.pluginId);
@@ -1202,6 +1225,10 @@ async function repairMissingPluginInstalls(params: {
       configuredChannelIds: params.channelIds,
     });
   const records = params.baselineRecords ?? (await loadInstalledPluginIndexInstallRecords({ env }));
+  const updateChannel = resolveRegistryUpdateChannel({
+    configChannel: normalizeUpdateChannel(params.cfg.update?.channel),
+    currentVersion: VERSION,
+  });
   const installedPluginIdsWithRepairablePackageDiagnostics =
     collectInstalledPluginIdsWithRepairablePackageDiagnostics({
       snapshot,
@@ -1212,6 +1239,7 @@ async function repairMissingPluginInstalls(params: {
       snapshot,
       installRecords: records,
       configuredPluginIds: params.pluginIds,
+      updateChannel,
     });
   const installedPluginIdsWithRepairablePackages = new Set([
     ...installedPluginIdsWithRepairablePackageDiagnostics,
@@ -1231,10 +1259,6 @@ async function repairMissingPluginInstalls(params: {
   const warnings: string[] = [];
   const failedPluginIds = new Set<string>();
   const deferredPluginIds = new Set<string>();
-  const updateChannel = resolveRegistryUpdateChannel({
-    configChannel: normalizeUpdateChannel(params.cfg.update?.channel),
-    currentVersion: VERSION,
-  });
   const preferNpmInstalls = isLegacyPackageUpdateDoctorPass(env);
   let nextRecords = records;
 

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -852,6 +852,18 @@ function recordClawHubPackageName(value: string | undefined): string | undefined
   return parseClawHubPluginSpec(trimmed)?.name ?? trimmed;
 }
 
+type InstallCandidateRepairReason = "stale-version-bound-runtime";
+
+function formatInstalledConfiguredPluginChange(params: {
+  pluginId: string;
+  installSpec: string;
+  repairReason?: InstallCandidateRepairReason;
+}): string {
+  return params.repairReason === "stale-version-bound-runtime"
+    ? `Refreshed stale configured plugin "${params.pluginId}" from ${params.installSpec}.`
+    : `Installed missing configured plugin "${params.pluginId}" from ${params.installSpec}.`;
+}
+
 async function installCandidate(params: {
   candidate: DownloadableInstallCandidate;
   records: Record<string, PluginInstallRecord>;
@@ -859,6 +871,7 @@ async function installCandidate(params: {
   updateChannel?: UpdateChannel;
   mode?: "install" | "update";
   preferNpm?: boolean;
+  repairReason?: InstallCandidateRepairReason;
 }): Promise<{
   records: Record<string, PluginInstallRecord>;
   changes: string[];
@@ -936,7 +949,13 @@ async function installCandidate(params: {
             installedAt: new Date().toISOString(),
           },
         },
-        changes: [`Installed missing configured plugin "${pluginId}" from ${clawhubInstallSpec}.`],
+        changes: [
+          formatInstalledConfiguredPluginChange({
+            pluginId,
+            installSpec: clawhubInstallSpec,
+            repairReason: params.repairReason,
+          }),
+        ],
         warnings: [],
       };
     }
@@ -1017,7 +1036,11 @@ async function installCandidate(params: {
     },
     changes: [
       ...changes,
-      `Installed missing configured plugin "${pluginId}" from ${npmInstallSpec}.`,
+      formatInstalledConfiguredPluginChange({
+        pluginId,
+        installSpec: npmInstallSpec,
+        repairReason: params.repairReason,
+      }),
     ],
     warnings: [],
   };
@@ -1339,9 +1362,11 @@ async function repairMissingPluginInstalls(params: {
     for (const outcome of updateResult.outcomes) {
       if (outcome.status === "updated" || outcome.status === "unchanged") {
         changes.push(
-          installedPluginIdsWithRepairablePackages.has(outcome.pluginId)
-            ? `Repaired broken installed plugin "${outcome.pluginId}".`
-            : `Repaired missing configured plugin "${outcome.pluginId}".`,
+          installedPluginIdsWithStaleVersionBoundRuntimePackages.has(outcome.pluginId)
+            ? `Refreshed stale configured plugin "${outcome.pluginId}".`
+            : installedPluginIdsWithRepairablePackageDiagnostics.has(outcome.pluginId)
+              ? `Repaired broken installed plugin "${outcome.pluginId}".`
+              : `Repaired missing configured plugin "${outcome.pluginId}".`,
         );
       } else if (outcome.status === "error") {
         warnings.push(outcome.message);
@@ -1421,6 +1446,9 @@ async function repairMissingPluginInstalls(params: {
       updateChannel,
       mode: shouldReplaceBrokenOfficialInstall ? "update" : "install",
       preferNpm: preferNpmInstalls,
+      ...(installedPluginIdsWithStaleVersionBoundRuntimePackages.has(candidate.pluginId)
+        ? { repairReason: "stale-version-bound-runtime" as const }
+        : {}),
     });
     if (shouldReplaceBrokenOfficialInstall) {
       const installedRecord = installed.records[candidate.pluginId];

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -9,7 +9,11 @@ import { listChannelPluginCatalogEntries } from "../../../channels/plugins/catal
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../../../infra/clawhub-spec.js";
-import { isOpenClawOrgNpmSpec, parseRegistryNpmSpec } from "../../../infra/npm-registry-spec.js";
+import {
+  compareOpenClawReleaseVersions,
+  isOpenClawOrgNpmSpec,
+  parseRegistryNpmSpec,
+} from "../../../infra/npm-registry-spec.js";
 import {
   normalizeUpdateChannel,
   resolveRegistryUpdateChannel,
@@ -81,6 +85,7 @@ const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
   "extension entry unreadable",
   "requires compiled runtime output",
 ] as const;
+const VERSION_BOUND_RUNTIME_PLUGIN_IDS = new Set(["codex"]);
 
 function shouldFallbackClawHubToNpm(params: {
   result: { ok: false; code?: string };
@@ -509,6 +514,71 @@ function collectInstalledPluginIdsWithRepairablePackageDiagnostics(params: {
       )
     ) {
       pluginIds.add(pluginId);
+    }
+  }
+  return pluginIds;
+}
+
+function resolveInstalledRuntimePackageVersion(params: {
+  pluginId: string;
+  snapshot: PluginMetadataSnapshot;
+  record: PluginInstallRecord;
+}): string | undefined {
+  const plugin =
+    params.snapshot.byPluginId?.get(params.pluginId) ??
+    params.snapshot.plugins.find((entry) => entry.id === params.pluginId);
+  return normalizeOptionalLowercaseString(
+    params.record.resolvedVersion ??
+      params.record.version ??
+      plugin?.packageVersion ??
+      plugin?.version,
+  );
+}
+
+function installedRuntimePackageVersionIsStale(params: {
+  installedVersion: string | undefined;
+  currentVersion: string;
+}): boolean {
+  if (!params.installedVersion) {
+    return false;
+  }
+  const comparison = compareOpenClawReleaseVersions(params.installedVersion, params.currentVersion);
+  return comparison === null ? params.installedVersion !== params.currentVersion : comparison < 0;
+}
+
+function collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages(params: {
+  snapshot: PluginMetadataSnapshot;
+  installRecords: Record<string, PluginInstallRecord>;
+  configuredPluginIds: ReadonlySet<string>;
+}): Set<string> {
+  const pluginIds = new Set<string>();
+  const currentVersion = normalizeOptionalLowercaseString(VERSION);
+  if (!currentVersion) {
+    return pluginIds;
+  }
+  for (const candidate of CONFIGURED_RUNTIME_PLUGIN_INSTALL_CANDIDATES) {
+    if (
+      !VERSION_BOUND_RUNTIME_PLUGIN_IDS.has(candidate.pluginId) ||
+      !params.configuredPluginIds.has(candidate.pluginId)
+    ) {
+      continue;
+    }
+    const record = params.installRecords[candidate.pluginId];
+    if (!record) {
+      continue;
+    }
+    const installedVersion = resolveInstalledRuntimePackageVersion({
+      pluginId: candidate.pluginId,
+      snapshot: params.snapshot,
+      record,
+    });
+    if (
+      installedRuntimePackageVersionIsStale({
+        installedVersion,
+        currentVersion,
+      })
+    ) {
+      pluginIds.add(candidate.pluginId);
     }
   }
   return pluginIds;
@@ -1137,10 +1207,20 @@ async function repairMissingPluginInstalls(params: {
       snapshot,
       installRecords: records,
     });
+  const installedPluginIdsWithStaleVersionBoundRuntimePackages =
+    collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages({
+      snapshot,
+      installRecords: records,
+      configuredPluginIds: params.pluginIds,
+    });
+  const installedPluginIdsWithRepairablePackages = new Set([
+    ...installedPluginIdsWithRepairablePackageDiagnostics,
+    ...installedPluginIdsWithStaleVersionBoundRuntimePackages,
+  ]);
   const officialReplacementInstallCandidates = collectOfficialReplacementInstallCandidates({
     cfg: params.cfg,
     env,
-    repairablePluginIds: installedPluginIdsWithRepairablePackageDiagnostics,
+    repairablePluginIds: installedPluginIdsWithRepairablePackages,
     configuredPluginIds: params.pluginIds,
     configuredChannelIds: params.channelIds,
     configuredChannelOwnerPluginIds,
@@ -1200,7 +1280,7 @@ async function repairMissingPluginInstalls(params: {
       ((params.pluginIds.has(pluginId) &&
         (!knownIds.has(pluginId) || isInstalledRecordMissingOnDisk(nextRecords[pluginId], env))) ||
         configuredPluginIdsWithStaleDescriptors.has(pluginId) ||
-        installedPluginIdsWithRepairablePackageDiagnostics.has(pluginId)),
+        installedPluginIdsWithRepairablePackages.has(pluginId)),
   );
 
   if (missingRecordedPluginIds.length > 0) {
@@ -1235,7 +1315,7 @@ async function repairMissingPluginInstalls(params: {
     for (const outcome of updateResult.outcomes) {
       if (outcome.status === "updated" || outcome.status === "unchanged") {
         changes.push(
-          installedPluginIdsWithRepairablePackageDiagnostics.has(outcome.pluginId)
+          installedPluginIdsWithRepairablePackages.has(outcome.pluginId)
             ? `Repaired broken installed plugin "${outcome.pluginId}".`
             : `Repaired missing configured plugin "${outcome.pluginId}".`,
         );

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -164,7 +164,7 @@ function resolveStatusRuntimeProvider(params: {
 }): string {
   const harness = normalizeOptionalLowercaseString(params.effectiveHarness);
   const provider = normalizeOptionalLowercaseString(params.provider);
-  if (harness === "codex" && provider === "openai") {
+  if (harness === "codex" && (provider === "openai" || provider === "codex")) {
     return "openai-codex";
   }
   if (harness === "claude-cli" && provider === "anthropic") {


### PR DESCRIPTION
## Summary

This PR fixes the Codex stale-plugin convergence path behind https://github.com/openclaw/openclaw/issues/87650, including the duplicate evidence from https://github.com/openclaw/openclaw/issues/88120.

What changes:

- Refreshes stale version-bound managed `@openclaw/codex` runtime packages through the trusted configured-plugin repair path when the installed package version is older than the running OpenClaw version.
- Leaves newer managed Codex packages alone so doctor does not downgrade a local/future install.
- Treats same-release beta-channel `@openclaw/codex@beta` companion packages as converged so repeated `doctor --fix` runs do not reinstall them.
- Restores `/status` usage lookup for bare `codex/gpt-*` routes by mapping Codex harness status auth through `openai-codex`.

## Linked context

Closes https://github.com/openclaw/openclaw/issues/87650.

Refs https://github.com/openclaw/openclaw/issues/88120. ClawSweeper closed that issue as a duplicate and asked that its stale-plugin-version, providerIds, config-backup, screenshot, and `codex/gpt-*` status evidence be folded into #87650.

Related but separate: https://github.com/openclaw/openclaw/pull/87851 and https://github.com/openclaw/openclaw/issues/87436. That PR handles logical OpenAI session-route persistence after Codex-backed runs. This PR does not touch that persistence surface and is not intended as the repair for issue #87436. The changes are complementary: #87851 keeps durable session route state canonical, while this PR repairs stale managed Codex runtime package installs and the `codex/gpt-*` status/auth display path.

## Real behavior proof

- Behavior addressed: stale managed `@openclaw/codex` packages could survive an OpenClaw update and leave the Codex runtime package behind the main app version, matching the reported `provider is not one of codex` failure evidence. A bare `codex/gpt-*` workaround route could also lose the Codex usage/auth status line because status looked up `codex` instead of the `openai-codex` auth provider.
- Real environment tested: Mantis native Telegram Desktop proof against this PR's `/status` path, plus local Windows source worktree proof on current PR head `99405a3b7c0d834ec0c0845b56caa5eab94d2dda` rebased onto current `main` through https://github.com/openclaw/openclaw/commit/f6e1bc393b39c637e4b116b0d7b702676de5c869, including https://github.com/openclaw/openclaw/pull/88137 and later main-CI fixes. No live VPS/user install was changed for this PR.
- Exact steps or command run after this patch: Mantis ran the `telegram-desktop-proof` scenario for `/status` on a `codex/gpt-5.5` route; local verification ran `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts`, `node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts`, `node scripts/run-vitest.mjs src/commands/doctor/shared/release-configured-plugin-installs.test.ts`, `node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts`, `node --import tsx scripts/check-madge-import-cycles.ts`, changed-file `oxlint`, changed-file `oxfmt --check`, and `git diff --check upstream/main...HEAD`.
- Evidence after fix: Mantis proof comment https://github.com/openclaw/openclaw/pull/88135#issuecomment-4580013044 and artifact https://github.com/openclaw/openclaw/actions/runs/26662206002/artifacts/7301427679 show before/after native Telegram Desktop proof. Candidate proof shows the Codex OAuth status line restored for `/status` on `codex/gpt-5.5`; main proof omits that line. Motion clips are linked from the Mantis comment.
- Observed result after fix: native Telegram Desktop proof shows the candidate status card includes the Codex OAuth status line for the affected route. Focused doctor/status regression tests passed, the beta-channel second doctor pass now converges without reinstalling `@openclaw/codex@beta`, adjacent doctor Codex route warning tests passed, current-main import-cycle check passed, changed-file lint passed, formatting check passed, and whitespace diff check passed.
- Installed/package doctor proof after fix: captured on 2026-05-29 from a disposable local npm install of this PR package, without touching my live VPS/user install. I packed PR head `d082b78c6b1139936b47361020dbadf0404552f0`, installed the tarball into an isolated npm prefix, configured an isolated `OPENCLAW_HOME` / `OPENCLAW_STATE_DIR`, set `update.channel=beta` and `agents.defaults.model=openai/gpt-5.5`, seeded a real stale managed `@openclaw/codex@2026.5.6` npm payload plus install record, then ran `openclaw doctor --fix --non-interactive`.
- Evidence from that installed/package proof: `openclaw --version` reported `OpenClaw 2026.5.28 (d082b78)`. Before doctor, the `codex` install record and installed `package.json` were both `2026.5.6`. Doctor reported `Installed missing configured plugin "codex" from @openclaw/codex@beta`. After doctor, the `codex` install record had `source=npm`, `spec=@openclaw/codex`, `resolvedName=@openclaw/codex`, `resolvedVersion=2026.5.28-beta.4`, `resolvedSpec=@openclaw/codex@2026.5.28-beta.4`, and the installed package payload was `@openclaw/codex 2026.5.28-beta.4`.
- Follow-up convergence proof after ClawSweeper review: on source head `99405a3b7c0d834ec0c0845b56caa5eab94d2dda`, added regression coverage where the first beta-channel doctor pass repairs stale `@openclaw/codex@2026.5.6` to `2026.5.28-beta.4`, then a second doctor pass makes no install call and returns no changes.
- Note on package channel: at capture time npm reported `@openclaw/codex` dist-tags `latest=2026.5.27` and `beta=2026.5.28-beta.4`; beta channel was used so the managed Codex runtime package refreshed onto the current beta companion line for the PR package.
- What was not tested: no live VPS/user install was changed for this installed-package proof; the disposable temp state, npm prefix, and npm cache were deleted after capture.

## Verification

Passed locally after the latest follow-up commit:

- `src/commands/doctor/shared/missing-configured-plugin-install.test.ts`: 63 tests passed, including beta-channel second-pass convergence.
- `src/auto-reply/reply/commands-status.test.ts`: 23 tests passed.
- `src/commands/doctor/shared/release-configured-plugin-installs.test.ts`: 17 tests passed.
- `src/commands/doctor/shared/codex-route-warnings.test.ts`: 104 tests passed.
- `node --import tsx scripts/check-madge-import-cycles.ts`: 0 cycles.
- `pnpm exec oxlint ...changed files...`: passed.
- `pnpm exec oxfmt --check ...changed files...`: passed.
- `git diff --check upstream/main...HEAD`: passed.

Known local proof gap:

- `src/plugins/update.test.ts` has one unrelated local Windows failure in `reuses the recorded managed extensions root when updating external plugins`; no files in that test surface are changed by this PR.
