### PR TITLE
perf: centralize skills indexing and visibility

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -204,7 +204,8 @@ vi.mock("../skills/lifecycle/source-install.js", () => ({
     raw.startsWith("/"),
 }));
 
-vi.mock("../skills/discovery/status.js", () => ({
+vi.mock("../skills/discovery/status.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../skills/discovery/status.js")>()),
   buildWorkspaceSkillStatus: (workspaceDir: string, options?: unknown) =>
     mocks.buildWorkspaceSkillStatusMock(workspaceDir, options),
 }));

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -85,6 +85,9 @@ const mocks = vi.hoisted(() => {
     updateSkillsFromClawHubMock: vi.fn(),
     readTrackedClawHubSkillSlugsMock: vi.fn(),
     resolveClawHubSkillVerificationTargetMock: vi.fn(),
+    readClawHubSkillsLockfileStatusSyncMock: vi.fn(() => ({ kind: "missing" })),
+    resolveClawHubSkillStatusLinkSyncMock: vi.fn(),
+    resolveLocalSkillCardStatusSyncMock: vi.fn(),
     fetchClawHubSkillVerificationMock: vi.fn(),
     fetchClawHubSkillCardMock: vi.fn(),
     buildWorkspaceSkillStatusMock,
@@ -107,6 +110,9 @@ const {
   updateSkillsFromClawHubMock,
   readTrackedClawHubSkillSlugsMock,
   resolveClawHubSkillVerificationTargetMock,
+  readClawHubSkillsLockfileStatusSyncMock,
+  resolveClawHubSkillStatusLinkSyncMock,
+  resolveLocalSkillCardStatusSyncMock,
   fetchClawHubSkillVerificationMock,
   fetchClawHubSkillCardMock,
   buildWorkspaceSkillStatusMock,
@@ -186,6 +192,12 @@ vi.mock("../skills/lifecycle/clawhub.js", () => ({
     mocks.readTrackedClawHubSkillSlugsMock(...args),
   resolveClawHubSkillVerificationTarget: (...args: unknown[]) =>
     mocks.resolveClawHubSkillVerificationTargetMock(...args),
+  readClawHubSkillsLockfileStatusSync: (...args: unknown[]) =>
+    mocks.readClawHubSkillsLockfileStatusSyncMock(...args),
+  resolveClawHubSkillStatusLinkSync: (...args: unknown[]) =>
+    mocks.resolveClawHubSkillStatusLinkSyncMock(...args),
+  resolveLocalSkillCardStatusSync: (...args: unknown[]) =>
+    mocks.resolveLocalSkillCardStatusSyncMock(...args),
 }));
 
 vi.mock("../infra/clawhub.js", () => ({
@@ -243,6 +255,9 @@ describe("skills cli commands", () => {
     updateSkillsFromClawHubMock.mockReset();
     readTrackedClawHubSkillSlugsMock.mockReset();
     resolveClawHubSkillVerificationTargetMock.mockReset();
+    readClawHubSkillsLockfileStatusSyncMock.mockReset();
+    resolveClawHubSkillStatusLinkSyncMock.mockReset();
+    resolveLocalSkillCardStatusSyncMock.mockReset();
     fetchClawHubSkillVerificationMock.mockReset();
     fetchClawHubSkillCardMock.mockReset();
     buildWorkspaceSkillStatusMock.mockReset();
@@ -262,6 +277,9 @@ describe("skills cli commands", () => {
     });
     updateSkillsFromClawHubMock.mockResolvedValue([]);
     readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
+    readClawHubSkillsLockfileStatusSyncMock.mockReturnValue({ kind: "missing" });
+    resolveClawHubSkillStatusLinkSyncMock.mockReturnValue(undefined);
+    resolveLocalSkillCardStatusSyncMock.mockReturnValue(undefined);
     resolveClawHubSkillVerificationTargetMock.mockResolvedValue({
       ok: true,
       slug: "agentreceipt",

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -1,5 +1,8 @@
-import { normalizeSkillIndexName } from "../skills/discovery/skill-index.js";
-import type { SkillStatusEntry, SkillStatusReport } from "../skills/discovery/status.js";
+import {
+  resolveSkillStatusEntry,
+  type SkillStatusEntry,
+  type SkillStatusReport,
+} from "../skills/discovery/status.js";
 import { sanitizeForLog, stripAnsi } from "../terminal/ansi.js";
 import { decorativeEmoji, decorativePrefix } from "../terminal/decorative-emoji.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
@@ -104,53 +107,6 @@ function formatSkillMissingSummary(skill: SkillStatusEntry): string {
   return missing.join("; ");
 }
 
-function normalizeSkillLookupToken(value: string): string {
-  return normalizeSkillIndexName(value);
-}
-
-function resolveSkillByName(
-  report: SkillStatusReport,
-  requestedName: string,
-): SkillStatusEntry | null {
-  const raw = requestedName.trim();
-  if (!raw) {
-    return null;
-  }
-
-  const direct = report.skills.find((s) => s.name === raw || s.skillKey === raw);
-  if (direct) {
-    return direct;
-  }
-
-  const lower = raw.toLowerCase();
-  const caseInsensitiveMatches = report.skills.filter(
-    (s) => s.name.toLowerCase() === lower || s.skillKey.toLowerCase() === lower,
-  );
-  if (caseInsensitiveMatches.length === 1) {
-    return caseInsensitiveMatches[0] ?? null;
-  }
-  if (caseInsensitiveMatches.length > 1) {
-    return null;
-  }
-
-  const normalized = normalizeSkillLookupToken(raw);
-  if (!normalized) {
-    return null;
-  }
-
-  const normalizedMatches = report.skills.filter(
-    (s) =>
-      normalizeSkillLookupToken(s.name) === normalized ||
-      normalizeSkillLookupToken(s.skillKey) === normalized,
-  );
-
-  if (normalizedMatches.length !== 1) {
-    return null;
-  }
-
-  return normalizedMatches[0] ?? null;
-}
-
 export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOptions): string {
   const isReadyForAgent = (skill: SkillStatusEntry) =>
     skill.eligible && !skill.blockedByAgentFilter;
@@ -233,7 +189,7 @@ export function formatSkillInfo(
 ): string {
   const requestedName = skillName.trim();
   const safeRequestedName = sanitizeJsonString(sanitizeForLog(requestedName));
-  const skill = resolveSkillByName(report, requestedName);
+  const skill = resolveSkillStatusEntry(report.skills, requestedName);
 
   if (!skill) {
     if (opts.json) {

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -1,3 +1,4 @@
+import { normalizeSkillIndexName } from "../skills/discovery/skill-index.js";
 import type { SkillStatusEntry, SkillStatusReport } from "../skills/discovery/status.js";
 import { sanitizeForLog, stripAnsi } from "../terminal/ansi.js";
 import { decorativeEmoji, decorativePrefix } from "../terminal/decorative-emoji.js";
@@ -104,13 +105,7 @@ function formatSkillMissingSummary(skill: SkillStatusEntry): string {
 }
 
 function normalizeSkillLookupToken(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[\s_/]+/g, "-")
-    .replace(/[^a-z0-9-]+/g, "")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  return normalizeSkillIndexName(value);
 }
 
 function resolveSkillByName(

--- a/src/skills/discovery/command-specs.test.ts
+++ b/src/skills/discovery/command-specs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
+import { createFixtureSkillEntry } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
 import { buildWorkspaceSkillCommandSpecs } from "./command-specs.js";
 
@@ -16,15 +16,15 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
   it("uses shared user-invocable skill exposure policy", () => {
     const specs = buildWorkspaceSkillCommandSpecs("/workspace", {
       entries: [
-        createEntry("visible"),
-        createEntry("hidden-by-exposure", {
+        createFixtureSkillEntry("visible"),
+        createFixtureSkillEntry("hidden-by-exposure", {
           exposure: {
             includeInRuntimeRegistry: true,
             includeInAvailableSkillsPrompt: true,
             userInvocable: false,
           },
         }),
-        createEntry("hidden-by-invocation", {
+        createFixtureSkillEntry("hidden-by-invocation", {
           invocation: {
             userInvocable: false,
             disableModelInvocation: false,
@@ -36,27 +36,3 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     expect(specs.map((spec) => spec.skillName)).toEqual(["visible"]);
   });
 });
-
-function createEntry(
-  name: string,
-  opts?: {
-    exposure?: SkillEntry["exposure"];
-    invocation?: SkillEntry["invocation"];
-  },
-): SkillEntry {
-  return {
-    skill: createCanonicalFixtureSkill({
-      name,
-      description: `${name} description`,
-      filePath: `/skills/${name}/SKILL.md`,
-      baseDir: `/skills/${name}`,
-      source: "openclaw-workspace",
-    }),
-    frontmatter: {},
-    invocation: opts?.invocation ?? {
-      userInvocable: true,
-      disableModelInvocation: false,
-    },
-    exposure: opts?.exposure,
-  };
-}

--- a/src/skills/discovery/command-specs.test.ts
+++ b/src/skills/discovery/command-specs.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
+import type { SkillEntry } from "../types.js";
+import { buildWorkspaceSkillCommandSpecs } from "./command-specs.js";
+
+vi.mock("../../plugins/bundle-commands.js", () => ({
+  loadEnabledClaudeBundleCommands: () => [],
+}));
+
+vi.mock("../loading/workspace.js", () => ({
+  filterWorkspaceSkillEntriesWithOptions: (entries: SkillEntry[]) => entries,
+  loadVisibleWorkspaceSkillEntries: () => [],
+}));
+
+describe("buildWorkspaceSkillCommandSpecs", () => {
+  it("uses shared user-invocable skill exposure policy", () => {
+    const specs = buildWorkspaceSkillCommandSpecs("/workspace", {
+      entries: [
+        createEntry("visible"),
+        createEntry("hidden-by-exposure", {
+          exposure: {
+            includeInRuntimeRegistry: true,
+            includeInAvailableSkillsPrompt: true,
+            userInvocable: false,
+          },
+        }),
+        createEntry("hidden-by-invocation", {
+          invocation: {
+            userInvocable: false,
+            disableModelInvocation: false,
+          },
+        }),
+      ],
+    });
+
+    expect(specs.map((spec) => spec.skillName)).toEqual(["visible"]);
+  });
+});
+
+function createEntry(
+  name: string,
+  opts?: {
+    exposure?: SkillEntry["exposure"];
+    invocation?: SkillEntry["invocation"];
+  },
+): SkillEntry {
+  return {
+    skill: createCanonicalFixtureSkill({
+      name,
+      description: `${name} description`,
+      filePath: `/skills/${name}/SKILL.md`,
+      baseDir: `/skills/${name}`,
+      source: "openclaw-workspace",
+    }),
+    frontmatter: {},
+    invocation: opts?.invocation ?? {
+      userInvocable: true,
+      disableModelInvocation: false,
+    },
+    exposure: opts?.exposure,
+  };
+}

--- a/src/skills/discovery/command-specs.ts
+++ b/src/skills/discovery/command-specs.ts
@@ -12,6 +12,7 @@ import {
 } from "../loading/workspace.js";
 import type { SkillEligibilityContext, SkillCommandSpec, SkillEntry } from "../types.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
+import { filterUserInvocableSkillEntries } from "./skill-index.js";
 
 const skillsLogger = createSubsystemLogger("skills");
 const skillCommandDebugOnce = new Set<string>();
@@ -98,7 +99,7 @@ export function buildWorkspaceSkillCommandSpecs(
         skillFilter: effectiveSkillFilter,
         eligibility: opts?.eligibility,
       });
-  const userInvocable = eligible.filter((entry) => entry.invocation?.userInvocable !== false);
+  const userInvocable = filterUserInvocableSkillEntries(eligible);
   const used = new Set<string>();
   for (const reserved of opts?.reservedNames ?? []) {
     used.add(normalizeLowercaseStringOrEmpty(reserved));

--- a/src/skills/discovery/skill-index.test.ts
+++ b/src/skills/discovery/skill-index.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
-import type { SkillEntry } from "../types.js";
+import { createFixtureSkillEntry } from "../test-support/test-helpers.js";
 import {
   buildSkillIndex,
   buildSkillIndexEntries,
@@ -21,8 +20,8 @@ describe("skill index", () => {
 
   it("indexes entries by exact and normalized name without changing input order", () => {
     const entries = [
-      createEntry("Excel XLSX", { skillKey: "excel_xlsx" }),
-      createEntry("GitHub Review"),
+      createFixtureSkillEntry("Excel XLSX", { skillKey: "excel_xlsx" }),
+      createFixtureSkillEntry("GitHub Review"),
     ];
 
     const index = buildSkillIndex(entries);
@@ -39,8 +38,8 @@ describe("skill index", () => {
 
   it("keeps ambiguous normalized names as multiple index entries", () => {
     const entries = [
-      createEntry("Excel/XLSX", { skillKey: "excel-slash" }),
-      createEntry("Excel_XLSX", { skillKey: "excel-underscore" }),
+      createFixtureSkillEntry("Excel/XLSX", { skillKey: "excel-slash" }),
+      createFixtureSkillEntry("Excel_XLSX", { skillKey: "excel-underscore" }),
     ];
 
     const index = buildSkillIndex(entries);
@@ -52,28 +51,28 @@ describe("skill index", () => {
   });
 
   it("centralizes runtime, prompt, and command exposure policy", () => {
-    const runtimeHidden = createEntry("runtime-hidden", {
+    const runtimeHidden = createFixtureSkillEntry("runtime-hidden", {
       exposure: {
         includeInRuntimeRegistry: false,
         includeInAvailableSkillsPrompt: true,
         userInvocable: true,
       },
     });
-    const promptHidden = createEntry("prompt-hidden", {
+    const promptHidden = createFixtureSkillEntry("prompt-hidden", {
       exposure: {
         includeInRuntimeRegistry: true,
         includeInAvailableSkillsPrompt: false,
         userInvocable: true,
       },
     });
-    const commandHidden = createEntry("command-hidden", {
+    const commandHidden = createFixtureSkillEntry("command-hidden", {
       exposure: {
         includeInRuntimeRegistry: true,
         includeInAvailableSkillsPrompt: true,
         userInvocable: false,
       },
     });
-    const legacyPromptHidden = createEntry("legacy-prompt-hidden", {
+    const legacyPromptHidden = createFixtureSkillEntry("legacy-prompt-hidden", {
       invocation: { disableModelInvocation: true, userInvocable: true },
     });
 
@@ -108,9 +107,9 @@ describe("skill index", () => {
   });
 
   it("records source, bundled state, skill key, and agent filter state", () => {
-    const bundled = createEntry("bundle", { source: "openclaw-bundled" });
-    const unknownBundled = createEntry("unknown-bundle", { source: "unknown" });
-    const workspace = createEntry("workspace", {
+    const bundled = createFixtureSkillEntry("bundle", { source: "openclaw-bundled" });
+    const unknownBundled = createFixtureSkillEntry("unknown-bundle", { source: "unknown" });
+    const workspace = createFixtureSkillEntry("workspace", {
       source: "openclaw-workspace",
       skillKey: "workspace-key",
     });
@@ -148,30 +147,3 @@ describe("skill index", () => {
     ]);
   });
 });
-
-function createEntry(
-  name: string,
-  opts?: {
-    source?: string;
-    skillKey?: string;
-    exposure?: SkillEntry["exposure"];
-    invocation?: SkillEntry["invocation"];
-  },
-): SkillEntry {
-  return {
-    skill: createCanonicalFixtureSkill({
-      name,
-      description: `${name} description`,
-      filePath: `/skills/${name}/SKILL.md`,
-      baseDir: `/skills/${name}`,
-      source: opts?.source ?? "openclaw-workspace",
-    }),
-    frontmatter: {},
-    metadata: opts?.skillKey ? { skillKey: opts.skillKey } : undefined,
-    invocation: opts?.invocation ?? {
-      userInvocable: true,
-      disableModelInvocation: false,
-    },
-    exposure: opts?.exposure,
-  };
-}

--- a/src/skills/discovery/skill-index.test.ts
+++ b/src/skills/discovery/skill-index.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
+import type { SkillEntry } from "../types.js";
+import {
+  buildSkillIndex,
+  isSkillPromptVisible,
+  isSkillRuntimeVisible,
+  isSkillUserInvocable,
+  normalizeSkillIndexName,
+} from "./skill-index.js";
+
+describe("skill index", () => {
+  it("normalizes skill names for case-insensitive separator-tolerant lookup", () => {
+    expect(normalizeSkillIndexName(" Excel_XLSX/demo ")).toBe("excel-xlsx-demo");
+    expect(normalizeSkillIndexName("Excel   XLSX")).toBe("excel-xlsx");
+    expect(normalizeSkillIndexName("@@")).toBe("");
+  });
+
+  it("indexes entries by exact and normalized name without changing input order", () => {
+    const entries = [
+      createEntry("Excel XLSX", { skillKey: "excel_xlsx" }),
+      createEntry("GitHub Review"),
+    ];
+
+    const index = buildSkillIndex(entries);
+
+    expect(index.entries.map((entry) => entry.name)).toEqual(["Excel XLSX", "GitHub Review"]);
+    expect(index.byName.get("Excel XLSX")?.entry).toBe(entries[0]);
+    expect(index.byNormalizedName.get("excel-xlsx")?.map((entry) => entry.name)).toEqual([
+      "Excel XLSX",
+    ]);
+    expect(index.byNormalizedName.get("github-review")?.map((entry) => entry.name)).toEqual([
+      "GitHub Review",
+    ]);
+  });
+
+  it("keeps ambiguous normalized names as multiple index entries", () => {
+    const entries = [
+      createEntry("Excel/XLSX", { skillKey: "excel-slash" }),
+      createEntry("Excel_XLSX", { skillKey: "excel-underscore" }),
+    ];
+
+    const index = buildSkillIndex(entries);
+
+    expect(index.byNormalizedName.get("excel-xlsx")?.map((entry) => entry.name)).toEqual([
+      "Excel/XLSX",
+      "Excel_XLSX",
+    ]);
+  });
+
+  it("centralizes runtime, prompt, and command exposure policy", () => {
+    const runtimeHidden = createEntry("runtime-hidden", {
+      exposure: {
+        includeInRuntimeRegistry: false,
+        includeInAvailableSkillsPrompt: true,
+        userInvocable: true,
+      },
+    });
+    const promptHidden = createEntry("prompt-hidden", {
+      exposure: {
+        includeInRuntimeRegistry: true,
+        includeInAvailableSkillsPrompt: false,
+        userInvocable: true,
+      },
+    });
+    const commandHidden = createEntry("command-hidden", {
+      exposure: {
+        includeInRuntimeRegistry: true,
+        includeInAvailableSkillsPrompt: true,
+        userInvocable: false,
+      },
+    });
+    const legacyPromptHidden = createEntry("legacy-prompt-hidden", {
+      invocation: { disableModelInvocation: true, userInvocable: true },
+    });
+
+    const index = buildSkillIndex([runtimeHidden, promptHidden, commandHidden, legacyPromptHidden]);
+
+    expect(index.runtimeEntries.map((entry) => entry.skill.name)).toEqual([
+      "prompt-hidden",
+      "command-hidden",
+      "legacy-prompt-hidden",
+    ]);
+    expect(index.promptVisibleEntries.map((entry) => entry.skill.name)).toEqual([
+      "runtime-hidden",
+      "command-hidden",
+    ]);
+    expect(index.userInvocableEntries.map((entry) => entry.skill.name)).toEqual([
+      "runtime-hidden",
+      "prompt-hidden",
+      "legacy-prompt-hidden",
+    ]);
+    expect(isSkillRuntimeVisible(runtimeHidden)).toBe(false);
+    expect(isSkillPromptVisible(legacyPromptHidden)).toBe(false);
+    expect(isSkillUserInvocable(commandHidden)).toBe(false);
+  });
+
+  it("records source, bundled state, skill key, and agent filter state", () => {
+    const bundled = createEntry("bundle", { source: "openclaw-bundled" });
+    const unknownBundled = createEntry("unknown-bundle", { source: "unknown" });
+    const workspace = createEntry("workspace", {
+      source: "openclaw-workspace",
+      skillKey: "workspace-key",
+    });
+
+    const index = buildSkillIndex([bundled, unknownBundled, workspace], {
+      bundledNames: new Set(["unknown-bundle"]),
+      agentSkillFilter: ["workspace"],
+    });
+
+    expect(index.byName.get("bundle")).toMatchObject({
+      source: "openclaw-bundled",
+      bundled: true,
+      agentAllowed: false,
+    });
+    expect(index.byName.get("unknown-bundle")).toMatchObject({
+      source: "unknown",
+      bundled: true,
+      agentAllowed: false,
+    });
+    expect(index.byName.get("workspace")).toMatchObject({
+      source: "openclaw-workspace",
+      bundled: false,
+      skillKey: "workspace-key",
+      agentAllowed: true,
+    });
+  });
+});
+
+function createEntry(
+  name: string,
+  opts?: {
+    source?: string;
+    skillKey?: string;
+    exposure?: SkillEntry["exposure"];
+    invocation?: SkillEntry["invocation"];
+  },
+): SkillEntry {
+  return {
+    skill: createCanonicalFixtureSkill({
+      name,
+      description: `${name} description`,
+      filePath: `/skills/${name}/SKILL.md`,
+      baseDir: `/skills/${name}`,
+      source: opts?.source ?? "openclaw-workspace",
+    }),
+    frontmatter: {},
+    metadata: opts?.skillKey ? { skillKey: opts.skillKey } : undefined,
+    invocation: opts?.invocation ?? {
+      userInvocable: true,
+      disableModelInvocation: false,
+    },
+    exposure: opts?.exposure,
+  };
+}

--- a/src/skills/discovery/skill-index.test.ts
+++ b/src/skills/discovery/skill-index.test.ts
@@ -3,6 +3,9 @@ import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
 import {
   buildSkillIndex,
+  buildSkillIndexEntries,
+  filterPromptVisibleSkillEntries,
+  filterUserInvocableSkillEntries,
   isSkillPromptVisible,
   isSkillRuntimeVisible,
   isSkillUserInvocable,
@@ -90,6 +93,15 @@ describe("skill index", () => {
       "prompt-hidden",
       "legacy-prompt-hidden",
     ]);
+    expect(filterPromptVisibleSkillEntries(index.entries.map((entry) => entry.entry))).toEqual([
+      runtimeHidden,
+      commandHidden,
+    ]);
+    expect(filterUserInvocableSkillEntries(index.entries.map((entry) => entry.entry))).toEqual([
+      runtimeHidden,
+      promptHidden,
+      legacyPromptHidden,
+    ]);
     expect(isSkillRuntimeVisible(runtimeHidden)).toBe(false);
     expect(isSkillPromptVisible(legacyPromptHidden)).toBe(false);
     expect(isSkillUserInvocable(commandHidden)).toBe(false);
@@ -124,6 +136,16 @@ describe("skill index", () => {
       skillKey: "workspace-key",
       agentAllowed: true,
     });
+    expect(
+      buildSkillIndexEntries([bundled, unknownBundled, workspace], {
+        bundledNames: new Set(["unknown-bundle"]),
+        agentSkillFilter: ["workspace"],
+      }).map(({ name, bundled, agentAllowed }) => ({ name, bundled, agentAllowed })),
+    ).toEqual([
+      { name: "bundle", bundled: true, agentAllowed: false },
+      { name: "unknown-bundle", bundled: true, agentAllowed: false },
+      { name: "workspace", bundled: false, agentAllowed: true },
+    ]);
   });
 });
 

--- a/src/skills/discovery/skill-index.ts
+++ b/src/skills/discovery/skill-index.ts
@@ -1,0 +1,139 @@
+import { resolveSkillKey } from "../loading/frontmatter.js";
+import { resolveSkillSource } from "../loading/source.js";
+import type { SkillEntry } from "../types.js";
+
+export type SkillIndexEntry = {
+  entry: SkillEntry;
+  name: string;
+  normalizedName: string;
+  skillKey: string;
+  normalizedSkillKey: string;
+  source: string;
+  bundled: boolean;
+  agentAllowed: boolean;
+  runtimeVisible: boolean;
+  promptVisible: boolean;
+  userInvocable: boolean;
+};
+
+export type SkillIndex = {
+  entries: SkillIndexEntry[];
+  runtimeEntries: SkillEntry[];
+  promptVisibleEntries: SkillEntry[];
+  userInvocableEntries: SkillEntry[];
+  byName: ReadonlyMap<string, SkillIndexEntry>;
+  byNormalizedName: ReadonlyMap<string, readonly SkillIndexEntry[]>;
+};
+
+export type BuildSkillIndexOptions = {
+  bundledNames?: ReadonlySet<string>;
+  agentSkillFilter?: readonly string[];
+};
+
+export function normalizeSkillIndexName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_/]+/g, "-")
+    .replace(/[^a-z0-9-]+/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function isSkillRuntimeVisible(entry: SkillEntry): boolean {
+  return entry.exposure?.includeInRuntimeRegistry ?? true;
+}
+
+export function isSkillPromptVisible(entry: SkillEntry): boolean {
+  if (entry.exposure) {
+    return entry.exposure.includeInAvailableSkillsPrompt ?? true;
+  }
+  if (entry.invocation) {
+    return !entry.invocation.disableModelInvocation;
+  }
+  return !entry.skill.disableModelInvocation;
+}
+
+export function isSkillUserInvocable(entry: SkillEntry): boolean {
+  if (entry.exposure) {
+    return entry.exposure.userInvocable ?? true;
+  }
+  if (entry.invocation) {
+    return entry.invocation.userInvocable ?? true;
+  }
+  return true;
+}
+
+export function buildSkillIndex(
+  entries: readonly SkillEntry[],
+  opts?: BuildSkillIndexOptions,
+): SkillIndex {
+  const byName = new Map<string, SkillIndexEntry>();
+  const normalized = new Map<string, SkillIndexEntry[]>();
+  const indexedEntries: SkillIndexEntry[] = [];
+  const runtimeEntries: SkillEntry[] = [];
+  const promptVisibleEntries: SkillEntry[] = [];
+  const userInvocableEntries: SkillEntry[] = [];
+
+  for (const entry of entries) {
+    const name = entry.skill.name;
+    const skillKey = resolveSkillKey(entry.skill, entry);
+    const source = resolveSkillSource(entry.skill);
+    const indexed: SkillIndexEntry = {
+      entry,
+      name,
+      normalizedName: normalizeSkillIndexName(name),
+      skillKey,
+      normalizedSkillKey: normalizeSkillIndexName(skillKey),
+      source,
+      bundled:
+        source === "openclaw-bundled" ||
+        (source === "unknown" && opts?.bundledNames?.has(name) === true),
+      agentAllowed: opts?.agentSkillFilter === undefined || opts.agentSkillFilter.includes(name),
+      runtimeVisible: isSkillRuntimeVisible(entry),
+      promptVisible: isSkillPromptVisible(entry),
+      userInvocable: isSkillUserInvocable(entry),
+    };
+
+    indexedEntries.push(indexed);
+    byName.set(name, indexed);
+    addNormalizedEntry(normalized, indexed.normalizedName, indexed);
+    addNormalizedEntry(normalized, indexed.normalizedSkillKey, indexed);
+    if (indexed.runtimeVisible) {
+      runtimeEntries.push(entry);
+    }
+    if (indexed.promptVisible) {
+      promptVisibleEntries.push(entry);
+    }
+    if (indexed.userInvocable) {
+      userInvocableEntries.push(entry);
+    }
+  }
+
+  return {
+    entries: indexedEntries,
+    runtimeEntries,
+    promptVisibleEntries,
+    userInvocableEntries,
+    byName,
+    byNormalizedName: normalized,
+  };
+}
+
+function addNormalizedEntry(
+  normalized: Map<string, SkillIndexEntry[]>,
+  key: string,
+  entry: SkillIndexEntry,
+) {
+  if (!key) {
+    return;
+  }
+  const existing = normalized.get(key);
+  if (existing) {
+    if (!existing.includes(entry)) {
+      existing.push(entry);
+    }
+    return;
+  }
+  normalized.set(key, [entry]);
+}

--- a/src/skills/discovery/skill-index.ts
+++ b/src/skills/discovery/skill-index.ts
@@ -64,49 +64,46 @@ export function isSkillUserInvocable(entry: SkillEntry): boolean {
   return true;
 }
 
+export function filterPromptVisibleSkillEntries(entries: readonly SkillEntry[]): SkillEntry[] {
+  return entries.filter(isSkillPromptVisible);
+}
+
+export function filterUserInvocableSkillEntries(entries: readonly SkillEntry[]): SkillEntry[] {
+  return entries.filter(isSkillUserInvocable);
+}
+
+export function buildSkillIndexEntries(
+  entries: readonly SkillEntry[],
+  opts?: BuildSkillIndexOptions,
+): SkillIndexEntry[] {
+  const agentSkillSet =
+    opts?.agentSkillFilter === undefined ? undefined : new Set(opts.agentSkillFilter);
+  return entries.map((entry) => createSkillIndexEntry(entry, opts, agentSkillSet));
+}
+
 export function buildSkillIndex(
   entries: readonly SkillEntry[],
   opts?: BuildSkillIndexOptions,
 ): SkillIndex {
   const byName = new Map<string, SkillIndexEntry>();
   const normalized = new Map<string, SkillIndexEntry[]>();
-  const indexedEntries: SkillIndexEntry[] = [];
+  const indexedEntries = buildSkillIndexEntries(entries, opts);
   const runtimeEntries: SkillEntry[] = [];
   const promptVisibleEntries: SkillEntry[] = [];
   const userInvocableEntries: SkillEntry[] = [];
 
-  for (const entry of entries) {
-    const name = entry.skill.name;
-    const skillKey = resolveSkillKey(entry.skill, entry);
-    const source = resolveSkillSource(entry.skill);
-    const indexed: SkillIndexEntry = {
-      entry,
-      name,
-      normalizedName: normalizeSkillIndexName(name),
-      skillKey,
-      normalizedSkillKey: normalizeSkillIndexName(skillKey),
-      source,
-      bundled:
-        source === "openclaw-bundled" ||
-        (source === "unknown" && opts?.bundledNames?.has(name) === true),
-      agentAllowed: opts?.agentSkillFilter === undefined || opts.agentSkillFilter.includes(name),
-      runtimeVisible: isSkillRuntimeVisible(entry),
-      promptVisible: isSkillPromptVisible(entry),
-      userInvocable: isSkillUserInvocable(entry),
-    };
-
-    indexedEntries.push(indexed);
-    byName.set(name, indexed);
+  for (const indexed of indexedEntries) {
+    byName.set(indexed.name, indexed);
     addNormalizedEntry(normalized, indexed.normalizedName, indexed);
     addNormalizedEntry(normalized, indexed.normalizedSkillKey, indexed);
     if (indexed.runtimeVisible) {
-      runtimeEntries.push(entry);
+      runtimeEntries.push(indexed.entry);
     }
     if (indexed.promptVisible) {
-      promptVisibleEntries.push(entry);
+      promptVisibleEntries.push(indexed.entry);
     }
     if (indexed.userInvocable) {
-      userInvocableEntries.push(entry);
+      userInvocableEntries.push(indexed.entry);
     }
   }
 
@@ -117,6 +114,31 @@ export function buildSkillIndex(
     userInvocableEntries,
     byName,
     byNormalizedName: normalized,
+  };
+}
+
+function createSkillIndexEntry(
+  entry: SkillEntry,
+  opts: BuildSkillIndexOptions | undefined,
+  agentSkillSet: ReadonlySet<string> | undefined,
+): SkillIndexEntry {
+  const name = entry.skill.name;
+  const skillKey = resolveSkillKey(entry.skill, entry);
+  const source = resolveSkillSource(entry.skill);
+  return {
+    entry,
+    name,
+    normalizedName: normalizeSkillIndexName(name),
+    skillKey,
+    normalizedSkillKey: normalizeSkillIndexName(skillKey),
+    source,
+    bundled:
+      source === "openclaw-bundled" ||
+      (source === "unknown" && opts?.bundledNames?.has(name) === true),
+    agentAllowed: agentSkillSet === undefined || agentSkillSet.has(name),
+    runtimeVisible: isSkillRuntimeVisible(entry),
+    promptVisible: isSkillPromptVisible(entry),
+    userInvocable: isSkillUserInvocable(entry),
   };
 }
 

--- a/src/skills/discovery/status-workspace.test.ts
+++ b/src/skills/discovery/status-workspace.test.ts
@@ -39,7 +39,7 @@ function makeEntry(params: {
   const filePath = `/tmp/${params.name}/SKILL.md`;
   const baseDir = `/tmp/${params.name}`;
   return {
-    skill: createFixtureSkill({
+    skill: createCanonicalFixtureSkill({
       name: params.name,
       description: `desc:${params.name}`,
       filePath,
@@ -54,16 +54,6 @@ function makeEntry(params: {
       ...(params.requires?.env?.[0] ? { primaryEnv: params.requires.env[0] } : {}),
     },
   };
-}
-
-function createFixtureSkill(params: {
-  name: string;
-  description: string;
-  filePath: string;
-  baseDir: string;
-  source: string;
-}): SkillEntry["skill"] {
-  return createCanonicalFixtureSkill(params);
 }
 
 type WorkspaceSkillStatus = ReturnType<typeof buildWorkspaceSkillStatus>["skills"][number];

--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -246,7 +246,7 @@ describe("buildWorkspaceSkillStatus", () => {
     const mismatchedOs = process.platform === "darwin" ? "linux" : "darwin";
 
     const entry: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "os-scoped",
         description: "test",
         filePath: "/tmp/os-scoped",
@@ -313,7 +313,7 @@ describe("buildWorkspaceSkillStatus", () => {
   it("does not expose raw config values in config checks", () => {
     const secret = "discord-token-secret-abc"; // pragma: allowlist secret
     const entry: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "discord",
         description: "test",
         filePath: "/tmp/discord/SKILL.md",
@@ -346,7 +346,7 @@ describe("buildWorkspaceSkillStatus", () => {
 
   it("reports prompt and command visibility separately from eligibility", () => {
     const entry: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "background-only",
         description: "test",
         filePath: "/tmp/background-only/SKILL.md",
@@ -370,7 +370,7 @@ describe("buildWorkspaceSkillStatus", () => {
 
   it("uses default-visible exposure semantics when older entries omit exposure fields", () => {
     const entry: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "legacy-exposure",
         description: "test",
         filePath: "/tmp/legacy-exposure/SKILL.md",
@@ -393,7 +393,7 @@ describe("buildWorkspaceSkillStatus", () => {
 
   it("reports skills blocked by an agent skill filter", () => {
     const alpha: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "alpha",
         description: "test",
         filePath: "/tmp/alpha/SKILL.md",
@@ -403,7 +403,7 @@ describe("buildWorkspaceSkillStatus", () => {
       frontmatter: {},
     };
     const beta: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "beta",
         description: "test",
         filePath: "/tmp/beta/SKILL.md",
@@ -620,7 +620,7 @@ function createEntry(
 ): SkillEntry {
   const baseDir = params.baseDir ?? `/tmp/${name}`;
   return {
-    skill: createFixtureSkill({
+    skill: createCanonicalFixtureSkill({
       name,
       description: params.description ?? `${name} skill`,
       filePath: `${baseDir}/SKILL.md`,
@@ -686,14 +686,4 @@ async function writeClawHubStatusFixture(params: {
     )}\n`,
     "utf8",
   );
-}
-
-function createFixtureSkill(params: {
-  name: string;
-  description: string;
-  filePath: string;
-  baseDir: string;
-  source: string;
-}): SkillEntry["skill"] {
-  return createCanonicalFixtureSkill(params);
 }

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -241,7 +241,7 @@ type BuildSkillStatusContext = {
   config?: OpenClawConfig;
   prefs: SkillsInstallPreferences;
   eligibility?: SkillEligibilityContext;
-  allowBundled: string[] | undefined;
+  allowBundled: ReadonlySet<string> | undefined;
   agentSkillFilter?: string[];
   workspaceDir: string;
   clawhubLockRead: ClawHubSkillsLockfileStatusRead;

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -28,7 +28,7 @@ import type {
   SkillsInstallPreferences,
 } from "../types.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
-import { buildSkillIndex, type SkillIndexEntry } from "./skill-index.js";
+import { buildSkillIndexEntries, type SkillIndexEntry } from "./skill-index.js";
 
 export type SkillStatusConfigCheck = RequirementConfigCheck;
 
@@ -285,7 +285,7 @@ export function buildWorkspaceSkillStatus(
     });
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   const clawhubLockRead = readClawHubSkillsLockfileStatusSync(workspaceDir);
-  const skillIndex = buildSkillIndex(skillEntries, {
+  const skillIndexEntries = buildSkillIndexEntries(skillEntries, {
     bundledNames: bundledContext.names,
     agentSkillFilter,
   });
@@ -294,7 +294,7 @@ export function buildWorkspaceSkillStatus(
     managedSkillsDir,
     agentId: opts?.agentId,
     agentSkillFilter,
-    skills: skillIndex.entries.map((entry) =>
+    skills: skillIndexEntries.map((entry) =>
       buildSkillStatus(
         entry,
         opts?.config,

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -20,7 +20,6 @@ import {
   resolveSkillConfig,
   resolveSkillsInstallPreferences,
 } from "../loading/config.js";
-import { resolveSkillSource } from "../loading/source.js";
 import { loadWorkspaceSkillEntries } from "../loading/workspace.js";
 import type {
   SkillEntry,
@@ -29,6 +28,7 @@ import type {
   SkillsInstallPreferences,
 } from "../types.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
+import { buildSkillIndex, type SkillIndexEntry } from "./skill-index.js";
 
 export type SkillStatusConfigCheck = RequirementConfigCheck;
 
@@ -73,10 +73,6 @@ export type SkillStatusReport = {
   agentSkillFilter?: string[];
   skills: SkillStatusEntry[];
 };
-
-function resolveSkillKey(entry: SkillEntry): string {
-  return entry.metadata?.skillKey ?? entry.skill.name;
-}
 
 function selectPreferredInstallSpec(
   install: SkillInstallSpec[],
@@ -186,46 +182,22 @@ function normalizeInstallOptions(
   return [toOption(preferred.spec, preferred.index)];
 }
 
-function isSkillVisibleInAvailableSkillsPrompt(entry: SkillEntry): boolean {
-  if (entry.exposure) {
-    return (
-      entry.exposure.includeInAvailableSkillsPrompt ||
-      !("includeInAvailableSkillsPrompt" in entry.exposure)
-    );
-  }
-  if (entry.invocation) {
-    return !entry.invocation.disableModelInvocation;
-  }
-  return !entry.skill.disableModelInvocation;
-}
-
-function isSkillUserInvocable(entry: SkillEntry): boolean {
-  if (entry.exposure) {
-    return entry.exposure.userInvocable || !("userInvocable" in entry.exposure);
-  }
-  if (entry.invocation) {
-    return entry.invocation.userInvocable || !("userInvocable" in entry.invocation);
-  }
-  return true;
-}
-
 function buildSkillStatus(
-  entry: SkillEntry,
+  indexed: SkillIndexEntry,
   config?: OpenClawConfig,
   prefs?: SkillsInstallPreferences,
   eligibility?: SkillEligibilityContext,
-  bundledNames?: Set<string>,
   agentSkillFilter?: string[],
   workspaceDir?: string,
   clawhubLockRead?: ClawHubSkillsLockfileStatusRead,
 ): SkillStatusEntry {
-  const skillKey = resolveSkillKey(entry);
+  const entry = indexed.entry;
+  const skillKey = indexed.skillKey;
   const skillConfig = resolveSkillConfig(config, skillKey);
   const disabled = skillConfig?.enabled === false;
   const allowBundled = resolveBundledAllowlist(config);
   const blockedByAllowlist = !isBundledSkillAllowed(entry, allowBundled);
-  const blockedByAgentFilter =
-    agentSkillFilter !== undefined && !agentSkillFilter.includes(entry.skill.name);
+  const blockedByAgentFilter = agentSkillFilter !== undefined && !indexed.agentAllowed;
   const always = entry.metadata?.always === true;
   const isEnvSatisfied = (envName: string) =>
     Boolean(
@@ -234,10 +206,8 @@ function buildSkillStatus(
       (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
     );
   const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
-  const skillSource = resolveSkillSource(entry.skill);
-  const bundled =
-    skillSource === "openclaw-bundled" ||
-    (skillSource === "unknown" && bundledNames?.has(entry.skill.name) === true);
+  const skillSource = indexed.source;
+  const bundled = indexed.bundled;
 
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
     evaluateEntryRequirementsForCurrentPlatform({
@@ -250,7 +220,7 @@ function buildSkillStatus(
     });
   const eligible = !disabled && !blockedByAllowlist && requirementsSatisfied;
   const availableToAgent = eligible && !blockedByAgentFilter;
-  const userInvocable = isSkillUserInvocable(entry);
+  const userInvocable = indexed.userInvocable;
 
   const clawhub =
     workspaceDir && !bundled
@@ -279,7 +249,7 @@ function buildSkillStatus(
     blockedByAllowlist,
     blockedByAgentFilter,
     eligible,
-    modelVisible: availableToAgent && isSkillVisibleInAvailableSkillsPrompt(entry),
+    modelVisible: availableToAgent && indexed.promptVisible,
     userInvocable,
     commandVisible: availableToAgent && userInvocable,
     requirements: required,
@@ -315,18 +285,21 @@ export function buildWorkspaceSkillStatus(
     });
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   const clawhubLockRead = readClawHubSkillsLockfileStatusSync(workspaceDir);
+  const skillIndex = buildSkillIndex(skillEntries, {
+    bundledNames: bundledContext.names,
+    agentSkillFilter,
+  });
   return {
     workspaceDir,
     managedSkillsDir,
     agentId: opts?.agentId,
     agentSkillFilter,
-    skills: skillEntries.map((entry) =>
+    skills: skillIndex.entries.map((entry) =>
       buildSkillStatus(
         entry,
         opts?.config,
         prefs,
         opts?.eligibility,
-        bundledContext.names,
         agentSkillFilter,
         workspaceDir,
         clawhubLockRead,

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -237,18 +237,23 @@ function normalizeInstallOptions(
   return [toOption(preferred.spec, preferred.index)];
 }
 
+type BuildSkillStatusContext = {
+  config?: OpenClawConfig;
+  prefs: SkillsInstallPreferences;
+  eligibility?: SkillEligibilityContext;
+  allowBundled: string[] | undefined;
+  agentSkillFilter?: string[];
+  workspaceDir: string;
+  clawhubLockRead: ClawHubSkillsLockfileStatusRead;
+};
+
 function buildSkillStatus(
   indexed: SkillIndexEntry,
-  config?: OpenClawConfig,
-  prefs?: SkillsInstallPreferences,
-  eligibility?: SkillEligibilityContext,
-  allowBundled?: string[],
-  agentSkillFilter?: string[],
-  workspaceDir?: string,
-  clawhubLockRead?: ClawHubSkillsLockfileStatusRead,
+  context: BuildSkillStatusContext,
 ): SkillStatusEntry {
   const entry = indexed.entry;
   const skillKey = indexed.skillKey;
+  const { config, prefs, eligibility, allowBundled, agentSkillFilter, workspaceDir } = context;
   const skillConfig = resolveSkillConfig(config, skillKey);
   const disabled = skillConfig?.enabled === false;
   const blockedByAllowlist = !isBundledSkillAllowed(entry, allowBundled);
@@ -283,7 +288,7 @@ function buildSkillStatus(
           workspaceDir,
           skillDir: entry.skill.baseDir,
           skillKey,
-          lockRead: clawhubLockRead,
+          lockRead: context.clawhubLockRead,
         })
       : undefined;
   const skillCard = resolveLocalSkillCardStatusSync(entry.skill.baseDir);
@@ -310,7 +315,7 @@ function buildSkillStatus(
     requirements: required,
     missing,
     configChecks,
-    install: normalizeInstallOptions(entry, prefs ?? resolveSkillsInstallPreferences(config)),
+    install: normalizeInstallOptions(entry, prefs),
     ...(clawhub ? { clawhub } : {}),
     ...(skillCard ? { skillCard } : {}),
   };
@@ -351,16 +356,15 @@ export function buildWorkspaceSkillStatus(
     agentId: opts?.agentId,
     agentSkillFilter,
     skills: skillIndexEntries.map((entry) =>
-      buildSkillStatus(
-        entry,
-        opts?.config,
+      buildSkillStatus(entry, {
+        config: opts?.config,
         prefs,
-        opts?.eligibility,
+        eligibility: opts?.eligibility,
         allowBundled,
         agentSkillFilter,
         workspaceDir,
         clawhubLockRead,
-      ),
+      }),
     ),
   };
 }

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -242,6 +242,7 @@ function buildSkillStatus(
   config?: OpenClawConfig,
   prefs?: SkillsInstallPreferences,
   eligibility?: SkillEligibilityContext,
+  allowBundled?: string[],
   agentSkillFilter?: string[],
   workspaceDir?: string,
   clawhubLockRead?: ClawHubSkillsLockfileStatusRead,
@@ -250,7 +251,6 @@ function buildSkillStatus(
   const skillKey = indexed.skillKey;
   const skillConfig = resolveSkillConfig(config, skillKey);
   const disabled = skillConfig?.enabled === false;
-  const allowBundled = resolveBundledAllowlist(config);
   const blockedByAllowlist = !isBundledSkillAllowed(entry, allowBundled);
   const blockedByAgentFilter = agentSkillFilter !== undefined && !indexed.agentAllowed;
   const always = entry.metadata?.always === true;
@@ -339,6 +339,7 @@ export function buildWorkspaceSkillStatus(
       bundledSkillsDir: bundledContext.dir,
     });
   const prefs = resolveSkillsInstallPreferences(opts?.config);
+  const allowBundled = resolveBundledAllowlist(opts?.config);
   const clawhubLockRead = readClawHubSkillsLockfileStatusSync(workspaceDir);
   const skillIndexEntries = buildSkillIndexEntries(skillEntries, {
     bundledNames: bundledContext.names,
@@ -355,6 +356,7 @@ export function buildWorkspaceSkillStatus(
         opts?.config,
         prefs,
         opts?.eligibility,
+        allowBundled,
         agentSkillFilter,
         workspaceDir,
         clawhubLockRead,

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -28,7 +28,11 @@ import type {
   SkillsInstallPreferences,
 } from "../types.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
-import { buildSkillIndexEntries, type SkillIndexEntry } from "./skill-index.js";
+import {
+  buildSkillIndexEntries,
+  normalizeSkillIndexName,
+  type SkillIndexEntry,
+} from "./skill-index.js";
 
 export type SkillStatusConfigCheck = RequirementConfigCheck;
 
@@ -73,6 +77,57 @@ export type SkillStatusReport = {
   agentSkillFilter?: string[];
   skills: SkillStatusEntry[];
 };
+
+export function resolveSkillStatusEntry(
+  skills: readonly SkillStatusEntry[],
+  requestedName: string,
+): SkillStatusEntry | null {
+  const raw = requestedName.trim();
+  if (!raw) {
+    return null;
+  }
+
+  const lower = raw.toLowerCase();
+  const normalized = normalizeSkillIndexName(raw);
+  let caseInsensitiveMatch: SkillStatusEntry | null = null;
+  let caseInsensitiveMatches = 0;
+  let normalizedMatch: SkillStatusEntry | null = null;
+  let normalizedMatches = 0;
+
+  for (const skill of skills) {
+    if (skill.name === raw || skill.skillKey === raw) {
+      return skill;
+    }
+
+    const nameLower = skill.name.toLowerCase();
+    const keyLower = skill.skillKey.toLowerCase();
+    if (nameLower === lower || keyLower === lower) {
+      caseInsensitiveMatch = skill;
+      caseInsensitiveMatches += 1;
+      continue;
+    }
+
+    if (
+      normalized &&
+      (normalizeSkillIndexName(skill.name) === normalized ||
+        normalizeSkillIndexName(skill.skillKey) === normalized)
+    ) {
+      normalizedMatch = skill;
+      normalizedMatches += 1;
+    }
+  }
+
+  if (caseInsensitiveMatches > 1) {
+    return null;
+  }
+  if (caseInsensitiveMatches === 1) {
+    return caseInsensitiveMatch;
+  }
+  if (normalizedMatches === 1) {
+    return normalizedMatch;
+  }
+  return null;
+}
 
 function selectPreferredInstallSpec(
   install: SkillInstallSpec[],

--- a/src/skills/lifecycle/install-download.test.ts
+++ b/src/skills/lifecycle/install-download.test.ts
@@ -39,7 +39,7 @@ function buildEntry(name: string): SkillEntry {
   const skillDir = path.join(workspaceDir, "skills", name);
   const filePath = path.join(skillDir, "SKILL.md");
   return {
-    skill: createFixtureSkill({
+    skill: createCanonicalFixtureSkill({
       name,
       description: `${name} test skill`,
       filePath,
@@ -48,16 +48,6 @@ function buildEntry(name: string): SkillEntry {
     }),
     frontmatter: {},
   };
-}
-
-function createFixtureSkill(params: {
-  name: string;
-  description: string;
-  filePath: string;
-  baseDir: string;
-  source: string;
-}): SkillEntry["skill"] {
-  return createCanonicalFixtureSkill(params);
 }
 
 function buildDownloadSpec(params: {

--- a/src/skills/loading/config.ts
+++ b/src/skills/loading/config.ts
@@ -88,17 +88,17 @@ export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): 
 export function shouldIncludeSkill(params: {
   entry: SkillEntry;
   config?: OpenClawConfig;
+  bundledAllowlist: string[] | undefined;
   eligibility?: SkillEligibilityContext;
 }): boolean {
-  const { entry, config, eligibility } = params;
+  const { entry, config, bundledAllowlist, eligibility } = params;
   const skillKey = resolveSkillKey(entry.skill, entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
-  const allowBundled = normalizeAllowlist(config?.skills?.allowBundled);
 
   if (skillConfig?.enabled === false) {
     return false;
   }
-  if (!isBundledSkillAllowed(entry, allowBundled)) {
+  if (!isBundledSkillAllowed(entry, bundledAllowlist)) {
     return false;
   }
   return evaluateRuntimeEligibility({

--- a/src/skills/loading/config.ts
+++ b/src/skills/loading/config.ts
@@ -53,7 +53,7 @@ export function resolveSkillConfig(
   return entry;
 }
 
-function normalizeAllowlist(input: unknown): string[] | undefined {
+function normalizeAllowlist(input: unknown): ReadonlySet<string> | undefined {
   if (!input) {
     return undefined;
   }
@@ -61,7 +61,7 @@ function normalizeAllowlist(input: unknown): string[] | undefined {
     return undefined;
   }
   const normalized = normalizeStringEntries(input);
-  return normalized.length > 0 ? normalized : undefined;
+  return normalized.length > 0 ? new Set(normalized) : undefined;
 }
 
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
@@ -70,25 +70,25 @@ function isBundledSkill(entry: SkillEntry): boolean {
   return BUNDLED_SOURCES.has(resolveSkillSource(entry.skill));
 }
 
-export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | undefined {
+export function resolveBundledAllowlist(config?: OpenClawConfig): ReadonlySet<string> | undefined {
   return normalizeAllowlist(config?.skills?.allowBundled);
 }
 
-export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
+export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: ReadonlySet<string>): boolean {
+  if (!allowlist || allowlist.size === 0) {
     return true;
   }
   if (!isBundledSkill(entry)) {
     return true;
   }
   const key = resolveSkillKey(entry.skill, entry);
-  return allowlist.includes(key) || allowlist.includes(entry.skill.name);
+  return allowlist.has(key) || allowlist.has(entry.skill.name);
 }
 
 export function shouldIncludeSkill(params: {
   entry: SkillEntry;
   config?: OpenClawConfig;
-  bundledAllowlist: string[] | undefined;
+  bundledAllowlist: ReadonlySet<string> | undefined;
   eligibility?: SkillEligibilityContext;
 }): boolean {
   const { entry, config, bundledAllowlist, eligibility } = params;

--- a/src/skills/loading/prompt-resolution.test.ts
+++ b/src/skills/loading/prompt-resolution.test.ts
@@ -13,7 +13,7 @@ describe("resolveSkillsPromptForRun", () => {
   });
   it("builds prompt from entries when snapshot is missing", () => {
     const entry: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "demo-skill",
         description: "Demo",
         filePath: "/app/skills/demo-skill/SKILL.md",
@@ -32,7 +32,7 @@ describe("resolveSkillsPromptForRun", () => {
 
   it("keeps legacy entries with disableModelInvocation hidden when exposure metadata is absent", () => {
     const hidden: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "hidden-skill",
         description: "Hidden",
         filePath: "/app/skills/hidden-skill/SKILL.md",
@@ -53,7 +53,7 @@ describe("resolveSkillsPromptForRun", () => {
 
   it("inherits agents.defaults.skills when rebuilding prompt for an agent", () => {
     const visible: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "github",
         description: "GitHub",
         filePath: "/app/skills/github/SKILL.md",
@@ -63,7 +63,7 @@ describe("resolveSkillsPromptForRun", () => {
       frontmatter: {},
     };
     const hidden: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "hidden-skill",
         description: "Hidden",
         filePath: "/app/skills/hidden-skill/SKILL.md",
@@ -93,7 +93,7 @@ describe("resolveSkillsPromptForRun", () => {
 
   it("uses agents.list[].skills as a full replacement for defaults", () => {
     const inheritedEntry: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "weather",
         description: "Weather",
         filePath: "/app/skills/weather/SKILL.md",
@@ -103,7 +103,7 @@ describe("resolveSkillsPromptForRun", () => {
       frontmatter: {},
     };
     const explicitEntry: SkillEntry = {
-      skill: createFixtureSkill({
+      skill: createCanonicalFixtureSkill({
         name: "docs-search",
         description: "Docs",
         filePath: "/app/skills/docs-search/SKILL.md",
@@ -131,14 +131,3 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).toContain("/app/skills/docs-search/SKILL.md");
   });
 });
-
-function createFixtureSkill(params: {
-  name: string;
-  description: string;
-  filePath: string;
-  baseDir: string;
-  source: string;
-  disableModelInvocation?: boolean;
-}): SkillEntry["skill"] {
-  return createCanonicalFixtureSkill(params);
-}

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -7,6 +7,7 @@ import type { ResourceDiagnostic } from "../../agents/sessions/diagnostics.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "../../agents/sessions/source-info.js";
 import { parseFrontmatter } from "../../agents/utils/frontmatter.js";
 import { canonicalizePath } from "../../agents/utils/paths.js";
+import { formatSkillsForPrompt as formatSkillContractForPrompt } from "./skill-contract.js";
 
 /** Max name length per spec */
 const MAX_NAME_LENGTH = 64;
@@ -343,39 +344,7 @@ function loadSkillFromFile(
  */
 export function formatSkillsForPrompt(skills: Skill[]): string {
   const visibleSkills = skills.filter((s) => !s.disableModelInvocation);
-
-  if (visibleSkills.length === 0) {
-    return "";
-  }
-
-  const lines = [
-    "\n\nThe following skills provide specialized instructions for specific tasks.",
-    "Use the read tool to load a skill's file when the task matches its description.",
-    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
-    "",
-    "<available_skills>",
-  ];
-
-  for (const skill of visibleSkills) {
-    lines.push("  <skill>");
-    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
-    lines.push(`    <description>${escapeXml(skill.description)}</description>`);
-    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
-    lines.push("  </skill>");
-  }
-
-  lines.push("</available_skills>");
-
-  return lines.join("\n");
-}
-
-function escapeXml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
+  return formatSkillContractForPrompt(visibleSkills);
 }
 
 export interface LoadSkillsOptions {

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -15,7 +15,7 @@ import {
   resolveEffectiveAgentSkillsLimits,
 } from "../discovery/agent-filter.js";
 import { normalizeSkillFilter } from "../discovery/filter.js";
-import { buildSkillIndex } from "../discovery/skill-index.js";
+import { filterPromptVisibleSkillEntries } from "../discovery/skill-index.js";
 import type {
   OpenClawSkillMetadata,
   ParsedSkillFrontmatter,
@@ -1383,7 +1383,7 @@ function resolveWorkspaceSkillPromptState(
     effectiveSkillFilter,
     opts?.eligibility,
   );
-  const promptEntries = buildSkillIndex(eligible).promptVisibleEntries;
+  const promptEntries = filterPromptVisibleSkillEntries(eligible);
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
   // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -15,6 +15,7 @@ import {
   resolveEffectiveAgentSkillsLimits,
 } from "../discovery/agent-filter.js";
 import { normalizeSkillFilter } from "../discovery/filter.js";
+import { buildSkillIndex } from "../discovery/skill-index.js";
 import type {
   OpenClawSkillMetadata,
   ParsedSkillFrontmatter,
@@ -104,16 +105,6 @@ function normalizeCompactedSkillPath(filePath: string, matchedHomePrefix: string
 
 function compactPathForConsoleMessage(filePath: string): string {
   return compactHomePath(filePath, resolveCompactHomePrefixes());
-}
-
-function isSkillVisibleInAvailableSkillsPrompt(entry: SkillEntry): boolean {
-  if (entry.exposure) {
-    return entry.exposure.includeInAvailableSkillsPrompt ?? true;
-  }
-  if (entry.invocation) {
-    return !entry.invocation.disableModelInvocation;
-  }
-  return !entry.skill.disableModelInvocation;
 }
 
 function filterSkillEntries(
@@ -1392,7 +1383,7 @@ function resolveWorkspaceSkillPromptState(
     effectiveSkillFilter,
     opts?.eligibility,
   );
-  const promptEntries = eligible.filter((entry) => isSkillVisibleInAvailableSkillsPrompt(entry));
+  const promptEntries = buildSkillIndex(eligible).promptVisibleEntries;
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
   // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -119,10 +119,12 @@ function filterSkillEntries(
     const normalized = normalizeSkillFilter(skillFilter) ?? [];
     const label = normalized.length > 0 ? normalized.join(", ") : "(none)";
     skillsLogger.debug(`Applying skill filter: ${label}`);
-    filtered =
-      normalized.length > 0
-        ? filtered.filter((entry) => normalized.includes(entry.skill.name))
-        : [];
+    if (normalized.length > 0) {
+      const allowed = new Set(normalized);
+      filtered = filtered.filter((entry) => allowed.has(entry.skill.name));
+    } else {
+      filtered = [];
+    }
     skillsLogger.debug(
       `After skill filter: ${filtered.map((entry) => entry.skill.name).join(", ") || "(none)"}`,
     );

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1209,8 +1209,8 @@ function loadSkillEntries(
         exposure: {
           includeInRuntimeRegistry: true,
           // Freshly loaded entries preserve the documented disable-model-invocation
-          // contract, while legacy entries without exposure metadata still use the
-          // fallback in isSkillVisibleInAvailableSkillsPrompt().
+          // contract, while legacy entries without exposure metadata still use
+          // the centralized prompt visibility fallback.
           includeInAvailableSkillsPrompt: !invocation.disableModelInvocation,
           userInvocable: invocation.userInvocable ?? true,
         },

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -24,7 +24,7 @@ import type {
   SkillSnapshot,
 } from "../types.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
-import { shouldIncludeSkill } from "./config.js";
+import { resolveBundledAllowlist, shouldIncludeSkill } from "./config.js";
 import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "./frontmatter.js";
 import { loadSkillsFromDirSafe, readSkillFrontmatterSafe } from "./local-loader.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
@@ -113,7 +113,10 @@ function filterSkillEntries(
   skillFilter?: string[],
   eligibility?: SkillEligibilityContext,
 ): SkillEntry[] {
-  let filtered = entries.filter((entry) => shouldIncludeSkill({ entry, config, eligibility }));
+  const bundledAllowlist = resolveBundledAllowlist(config);
+  let filtered = entries.filter((entry) =>
+    shouldIncludeSkill({ entry, config, bundledAllowlist, eligibility }),
+  );
   // If skillFilter is provided, only include skills in the filter list.
   if (skillFilter !== undefined) {
     const normalized = normalizeSkillFilter(skillFilter) ?? [];

--- a/src/skills/test-support/test-helpers.ts
+++ b/src/skills/test-support/test-helpers.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { createSyntheticSourceInfo, type Skill } from "../loading/skill-contract.js";
+import type { SkillEntry } from "../types.js";
 
 export async function writeSkill(params: {
   dir: string;
@@ -44,5 +45,32 @@ export function createCanonicalFixtureSkill(params: {
       origin: "top-level",
     }),
     disableModelInvocation: params.disableModelInvocation ?? false,
+  };
+}
+
+export function createFixtureSkillEntry(
+  name: string,
+  opts?: {
+    source?: string;
+    skillKey?: string;
+    exposure?: SkillEntry["exposure"];
+    invocation?: SkillEntry["invocation"];
+  },
+): SkillEntry {
+  return {
+    skill: createCanonicalFixtureSkill({
+      name,
+      description: `${name} description`,
+      filePath: `/skills/${name}/SKILL.md`,
+      baseDir: `/skills/${name}`,
+      source: opts?.source ?? "openclaw-workspace",
+    }),
+    frontmatter: {},
+    metadata: opts?.skillKey ? { skillKey: opts.skillKey } : undefined,
+    invocation: opts?.invocation ?? {
+      userInvocable: true,
+      disableModelInvocation: false,
+    },
+    exposure: opts?.exposure,
   };
 }


### PR DESCRIPTION
## Summary

- Add a reusable in-memory skills index for normalized lookup, model-visible entries, and user-invocable entries.
- Centralize skill visibility, command exposure, allowlist, and status decisions inside `src/skills`.
- Reuse the shared skills prompt formatter so current `<available_skills>` prompt behavior is preserved while the internals are cleaner.
- Reduce repeated per-skill work by preparing bundled allowlists and filter lookups once per status/snapshot pass.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/cli/skills-cli.test.ts src/cli/skills-cli.formatting.test.ts src/skills/discovery/skill-index.test.ts src/skills/discovery/command-specs.test.ts src/skills/discovery/status.test.ts src/skills/discovery/status-workspace.test.ts src/skills/loading/prompt-resolution.test.ts src/skills/lifecycle/install-download.test.ts`
- Auto-review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- OCM live test on `Violet-media-live-20260527` with runtime `skills-index-live`
  - verified `skills list`, `skills check`, `skills info`
  - verified `skills search weather --json --limit 3`
  - verified `skills verify weather --card`
  - verified `skills update` validation
  - verified real gateway-backed agent weather turn used the skills prompt path and executed `wttr.in`
  - verified non-weather `session-logs` agent turn
  - verified `/weather Paris` through gateway `chat.send`
  - verified temporary workspace skill install, visibility refresh, agent prompt inclusion, and cleanup
  - verified `skills.allowBundled` behavior in a disposable OCM clone
