### PR TITLE
perf(agents): skip tool prep for toolless models

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
@@ -57,6 +57,21 @@ describe("runEmbeddedAttempt cwd/workspace split", () => {
     expect(resourceLoaderInit?.cwd).toBe(taskRepo);
   });
 
+  it("skips runtime tool construction when the selected model does not support tools", async () => {
+    hoisted.supportsModelToolsMock.mockReturnValueOnce(false);
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:main:main",
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+      },
+    });
+
+    expect(hoisted.createOpenClawCodingToolsMock).not.toHaveBeenCalled();
+  });
+
   it("rejects cwd overrides for sandboxed runs instead of silently ignoring them", async () => {
     hoisted.resolveSandboxContextMock.mockResolvedValueOnce({
       enabled: true,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1079,9 +1079,10 @@ export async function runEmbeddedAttempt(
           ]
         : toolsAllowWithForcedRuntimeTools;
     const shouldConstructTools =
-      toolConstructionPlan.constructTools ||
-      toolSearchControlsEnabledForRun ||
-      codeModeControlsEnabledForRun;
+      toolsEnabled &&
+      (toolConstructionPlan.constructTools ||
+        toolSearchControlsEnabledForRun ||
+        codeModeControlsEnabledForRun);
     let toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor | undefined;
     toolSearchCatalogRef =
       toolSearchControlsEnabledForRun || codeModeControlsEnabledForRun


### PR DESCRIPTION
## Summary

- skip OpenClaw runtime tool construction when the selected model declares `compat.supportsTools: false`
- add regression coverage so no-tool small-model runs do not pay the tool factory/import cost before the runner drops tools from the prompt

## Verification

Behavior addressed: no-tool small-model runs skip unnecessary OpenClaw runtime tool construction instead of building tool surfaces that the selected model cannot use.

Real environment tested: local targeted Vitest plus AWS Crabbox changed gate.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts`
- `node_modules/.bin/oxlint src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts`
- `git diff --check origin/main...HEAD`
- AWS Crabbox `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Evidence after fix:
- Targeted Vitest passed 24 tests across 2 shards in 9.93s.
- Format, lint, and diff whitespace checks passed.
- AWS Crabbox changed gate passed: provider `aws`, lease `cbx_4dd77aac383a`, slug `quick-hermit`, run `run_902ff8f228ac`, machine `c7a.8xlarge`, exit 0, `leaseStopped=true`.
- Autoreview clean: `overall: patch is correct (0.86)` with no accepted/actionable findings.

Observed result after fix: models with `supportsTools: false` avoid constructing runtime tools before the runner sends a toolless prompt.

What was not tested: live Ollama/API model call in this PR; this change is covered at the runner decision boundary and by the remote changed gate.
