### PR TITLE
fix(telegram): recover missing final DM replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3873,6 +3873,42 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("replays a visible final DM response when durable delivery suppresses the first send", async () => {
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    readLatestAssistantTextFromSessionTranscript.mockResolvedValue({
+      text: "Recovered final answer",
+      timestamp: Date.now() + 1_000,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Recovered final answer" }, { kind: "final" });
+      return { queuedFinal: false };
+    });
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_no_send",
+      reason: "no_visible_result",
+      delivery: {
+        messageIds: ["m1"],
+        visibleReplySent: false,
+      },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:default:telegram:direct:123",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expectDeliveredReply(0, {
+      text: "Recovered final answer",
+    });
+  });
+
   it("does not emit a silent-reply fallback for no-response group turns", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2187,6 +2187,28 @@ export const dispatchTelegramMessage = async ({
     sentFallback = result.delivered;
   }
 
+  const shouldRetryMissingFinalResponse =
+    !isRoomEvent &&
+    !dispatchError &&
+    !sentFallback &&
+    !deliverySummary.delivered &&
+    !queuedFinal &&
+    finalAnswerDeliveryStarted &&
+    !finalAnswerDelivered &&
+    !suppressSilentReplyFallback;
+  if (shouldRetryMissingFinalResponse) {
+    const fallbackText =
+      (await resolveCurrentTurnTranscriptFinalText())?.trim() || EMPTY_RESPONSE_FALLBACK;
+    const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
+      replies: [{ text: fallbackText }],
+      ...deliveryBaseOptions,
+      transcriptMirror: undefined,
+      silent: false,
+      mediaLoader: telegramDeps.loadWebMedia,
+    });
+    sentFallback = result.delivered;
+  }
+
   if (
     !sentFallback &&
     !dispatchError &&


### PR DESCRIPTION
## Summary
- Retry Telegram final replies when the durable send path suppresses the first visible send
- Cover the DM regression where the final assistant answer exists in the transcript but never appears as a Telegram bubble

## Validation
- `corepack pnpm exec vitest run extensions/telegram/src/bot-message-dispatch.test.ts`
