### PR TITLE
fix(agents): cap bootstrap snapshot cache

### DIFF
--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -81,6 +81,24 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(r2).toBe(files2);
     expect(mockLoad()).toHaveBeenCalledTimes(2);
   });
+
+  it("evicts the oldest snapshot once the cache exceeds its cap", async () => {
+    for (let index = 0; index <= 64; index += 1) {
+      await getOrLoadBootstrapFiles({
+        workspaceDir: "/ws",
+        sessionKey: `session-${index}`,
+      });
+    }
+
+    expect(mockLoad()).toHaveBeenCalledTimes(65);
+
+    await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws",
+      sessionKey: "session-0",
+    });
+
+    expect(mockLoad()).toHaveBeenCalledTimes(66);
+  });
 });
 
 describe("clearBootstrapSnapshot", () => {

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -5,6 +5,7 @@ type BootstrapSnapshot = {
   files: WorkspaceBootstrapFile[];
 };
 
+const MAX_BOOTSTRAP_SNAPSHOTS = 64;
 const cache = new Map<string, BootstrapSnapshot>();
 
 function bootstrapFilesEqual(
@@ -27,10 +28,21 @@ function bootstrapFilesEqual(
   });
 }
 
+function pruneOldestBootstrapSnapshots(): void {
+  while (cache.size > MAX_BOOTSTRAP_SNAPSHOTS) {
+    const oldestKey = cache.keys().next().value;
+    if (typeof oldestKey !== "string") {
+      return;
+    }
+    cache.delete(oldestKey);
+  }
+}
+
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
 }): Promise<WorkspaceBootstrapFile[]> {
+  pruneOldestBootstrapSnapshots();
   const existing = cache.get(params.sessionKey);
   // Refresh per turn so long-lived sessions pick up edits; loadWorkspaceBootstrapFiles
   // handles unchanged file content through its guarded inode/mtime cache.
@@ -40,11 +52,22 @@ export async function getOrLoadBootstrapFiles(params: {
     existing.workspaceDir === params.workspaceDir &&
     bootstrapFilesEqual(existing.files, files)
   ) {
+    cache.delete(params.sessionKey);
+    cache.set(params.sessionKey, existing);
     return existing.files;
   }
 
   cache.set(params.sessionKey, { workspaceDir: params.workspaceDir, files });
+  pruneOldestBootstrapSnapshots();
   return files;
+}
+
+export function getBootstrapSnapshotCacheSizeForTest(): number {
+  return cache.size;
+}
+
+export function hasBootstrapSnapshotForTest(sessionKey: string): boolean {
+  return cache.has(sessionKey);
 }
 
 export function clearBootstrapSnapshot(sessionKey: string): void {


### PR DESCRIPTION
# Fix: cap bootstrap-cache retention per session key

## Summary

This patch caps the in-memory bootstrap-cache so the gateway does not retain an unbounded number of loaded workspace bootstrap bundles per session key.

The on-disk bootstrap files remain the source of truth. Cached bundles can still be reused while active, but older session keys are evicted instead of remaining resident forever.

Scope note: this PR only covers the bootstrap-cache work in this branch. It does not include the separate session-store patch or the separate `webgate` patch from the other branch.

## Issue Evidence

- The bootstrap loader retained one loaded bundle per distinct session key with no eviction.
- Under session churn, that made the bootstrap cache a persistent in-memory accumulator instead of a bounded reuse layer.
- The cache retention problem was separate from the large session-store hydration issue.

## Real Behavior Proof

Behavior or issue addressed: bootstrap-cache retention could grow without bound across distinct session keys, increasing resident memory during long-lived gateway operation.

Real environment tested: Local OpenClaw workspace on the same machine, using the source tree at `/root/.openclaw/openclaw-fork-rebase`.

Exact steps or command run after this patch:
```bash
node --import tsx --input-type=module <<'EOF'
import {
  clearAllBootstrapSnapshots,
  getBootstrapSnapshotCacheSizeForTest,
  getOrLoadBootstrapFiles,
  hasBootstrapSnapshotForTest,
} from './src/agents/bootstrap-cache.ts';

clearAllBootstrapSnapshots();
console.log('initial size=', getBootstrapSnapshotCacheSizeForTest());

for (let i = 0; i < 65; i += 1) {
  await getOrLoadBootstrapFiles({ workspaceDir: process.cwd(), sessionKey: `session-${i}` });
}

console.log('after 65 unique session keys size=', getBootstrapSnapshotCacheSizeForTest());
console.log('session-0 retained=', hasBootstrapSnapshotForTest('session-0'));

await getOrLoadBootstrapFiles({ workspaceDir: process.cwd(), sessionKey: 'session-0' });
console.log('after reloading session-0 size=', getBootstrapSnapshotCacheSizeForTest());
console.log('session-0 retained after reload=', hasBootstrapSnapshotForTest('session-0'));
EOF
```

Evidence after fix:
```text
initial size=0
after 65 unique session keys size=64
session-0 retained=false
after reloading session-0 size=64
session-0 retained after reload=true
```

Observed result after fix: the bootstrap-cache stays bounded, oldest entries are evicted when the cap is exceeded, and active session keys can still be reloaded without growing the cache past the limit.

What was not tested: an overnight soak specifically isolated to bootstrap-cache churn.

## Before-Fix Evidence (Supplementary)

<details>
<summary>Pre-patch retention symptoms</summary>

- The old behavior had no eviction bound for distinct session keys.
- That meant each new session key could add another resident bootstrap bundle.
- This was a separate retention layer from the session-store cache.

</details>