### PR TITLE
fix(config): cap runtime session-store cache retention

### DIFF
--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -209,18 +209,21 @@ describe("Session Store Cache", () => {
     clearSessionStoreCacheForTest();
 
     const readSpy = vi.spyOn(fs, "readFileSync");
+    try {
+      const loaded1 = loadSessionStore(storePath);
+      const loaded2 = loadSessionStore(storePath);
 
-    const loaded1 = loadSessionStore(storePath);
-    const loaded2 = loadSessionStore(storePath);
+      expect(loaded1).toEqual(testStore);
+      expect(loaded2).toEqual(testStore);
+      expect(loaded1).not.toBe(loaded2);
 
-    expect(loaded1).toEqual(testStore);
-    expect(loaded2).toEqual(testStore);
-    expect(loaded1).not.toBe(loaded2);
-    expect(readSpy).toHaveBeenCalledTimes(2);
-    expect(getSerializedSessionStoreCacheStatsForTest().entries).toBe(0);
-    expect(getSessionStoreSnapshotCacheStatsForTest().entries).toBe(0);
-
-    readSpy.mockRestore();
+      const storeReads = readSpy.mock.calls.filter(([file]) => file === storePath);
+      expect(storeReads).toHaveLength(2);
+      expect(getSerializedSessionStoreCacheStatsForTest().entries).toBe(0);
+      expect(getSessionStoreSnapshotCacheStatsForTest().entries).toBe(0);
+    } finally {
+      readSpy.mockRestore();
+    }
   });
 
   it("should not allow cached session mutations to leak across loads", async () => {
@@ -657,10 +660,12 @@ describe("Session Store Cache", () => {
       return result;
     });
 
-    const first = readSessionStoreSnapshot(storePath);
-    expect(first["session:1"].displayName).toBe("Before race");
-
-    readSpy.mockRestore();
+    try {
+      const first = readSessionStoreSnapshot(storePath);
+      expect(first["session:1"].displayName).toBe("Before race");
+    } finally {
+      readSpy.mockRestore();
+    }
 
     const second = readSessionStoreSnapshot(storePath);
     expect(second["session:1"].displayName).toBe("After cross-process race");

--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -13,6 +13,7 @@ import {
   readSessionStoreCache,
   setSerializedSessionStore,
   setSerializedSessionStorePromptRefs,
+  setSessionStoreRuntimeCacheMaxBytesForTest,
   writeSessionStoreCache,
 } from "./sessions/store-cache.js";
 import {
@@ -69,15 +70,15 @@ describe("Session Store Cache", () => {
 
     // Reset environment variable
     delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
-    delete process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES;
     delete process.env.OPENCLAW_SESSION_SERIALIZED_CACHE_MAX_BYTES;
+    setSessionStoreRuntimeCacheMaxBytesForTest(null);
   });
 
   afterEach(() => {
     clearSessionStoreCacheForTest();
     delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
-    delete process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES;
     delete process.env.OPENCLAW_SESSION_SERIALIZED_CACHE_MAX_BYTES;
+    setSessionStoreRuntimeCacheMaxBytesForTest(null);
   });
 
   it("bounds the serialized session store cache by total bytes", () => {
@@ -94,7 +95,7 @@ describe("Session Store Cache", () => {
   });
 
   it("drops oversized session store runtime caches instead of retaining them in memory", async () => {
-    process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES = "64";
+    setSessionStoreRuntimeCacheMaxBytesForTest(64);
     clearSessionStoreCacheForTest();
 
     const smallStore = {
@@ -191,7 +192,7 @@ describe("Session Store Cache", () => {
   });
 
   it("re-reads oversized session stores from disk instead of caching them", async () => {
-    process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES = "64";
+    setSessionStoreRuntimeCacheMaxBytesForTest(64);
     clearSessionStoreCacheForTest();
 
     const testStore = createSingleSessionStore(

--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -69,11 +69,14 @@ describe("Session Store Cache", () => {
 
     // Reset environment variable
     delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES;
+    delete process.env.OPENCLAW_SESSION_SERIALIZED_CACHE_MAX_BYTES;
   });
 
   afterEach(() => {
     clearSessionStoreCacheForTest();
     delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES;
     delete process.env.OPENCLAW_SESSION_SERIALIZED_CACHE_MAX_BYTES;
   });
 
@@ -88,6 +91,41 @@ describe("Session Store Cache", () => {
     expect(getSerializedSessionStore("store:2")).toBe("b".repeat(40));
     expect(getSerializedSessionStoreCacheStatsForTest().entries).toBe(1);
     expect(getSerializedSessionStoreCacheStatsForTest().totalBytes).toBe(40);
+  });
+
+  it("drops oversized session store runtime caches instead of retaining them in memory", async () => {
+    process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES = "64";
+    clearSessionStoreCacheForTest();
+
+    const smallStore = {
+      s: {
+        sessionId: "x",
+        updatedAt: 1,
+      },
+    } as Record<string, SessionEntry>;
+    const smallSerialized = JSON.stringify(smallStore);
+
+    writeSessionStoreCache({
+      storePath,
+      store: smallStore,
+      mtimeMs: 1,
+      sizeBytes: Buffer.byteLength(smallSerialized, "utf8"),
+      serialized: smallSerialized,
+      cloneSerialized: smallSerialized,
+    });
+
+    expect(getSerializedSessionStoreCacheStatsForTest().entries).toBe(1);
+    expect(getSessionStoreSnapshotCacheStatsForTest().entries).toBe(0);
+
+    expect(
+      readSessionStoreCache({
+        storePath,
+        mtimeMs: 1,
+        sizeBytes: 128,
+      }),
+    ).toBeNull();
+    expect(getSerializedSessionStoreCacheStatsForTest().entries).toBe(0);
+    expect(getSessionStoreSnapshotCacheStatsForTest().entries).toBe(0);
   });
 
   it("bounds the serialized session store cache by path count", () => {
@@ -149,6 +187,38 @@ describe("Session Store Cache", () => {
     const loaded2 = loadSessionStore(storePath);
     expect(loaded2).toEqual(testStore);
     expect(readSpy).toHaveBeenCalledTimes(0);
+    readSpy.mockRestore();
+  });
+
+  it("re-reads oversized session stores from disk instead of caching them", async () => {
+    process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES = "64";
+    clearSessionStoreCacheForTest();
+
+    const testStore = createSingleSessionStore(
+      createSessionEntry({
+        displayName: "Oversized session store",
+        skillsSnapshot: {
+          prompt: "oversized prompt ".repeat(40),
+          skills: [{ name: "alpha" }],
+        },
+      }),
+    );
+
+    await saveSessionStore(storePath, testStore);
+    clearSessionStoreCacheForTest();
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    const loaded1 = loadSessionStore(storePath);
+    const loaded2 = loadSessionStore(storePath);
+
+    expect(loaded1).toEqual(testStore);
+    expect(loaded2).toEqual(testStore);
+    expect(loaded1).not.toBe(loaded2);
+    expect(readSpy).toHaveBeenCalledTimes(2);
+    expect(getSerializedSessionStoreCacheStatsForTest().entries).toBe(0);
+    expect(getSessionStoreSnapshotCacheStatsForTest().entries).toBe(0);
+
     readSpy.mockRestore();
   });
 

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -62,6 +62,7 @@ const SESSION_STORE_STRING_INTERN_STATS = {
   skippedSmall: 0,
   skippedFull: 0,
 };
+let sessionStoreRuntimeCacheMaxBytesOverride: number | null = null;
 let sessionStoreSerializedCacheBytes = 0;
 
 function parseNonNegativeInteger(value: string | undefined): number | null {
@@ -74,6 +75,7 @@ function parseNonNegativeInteger(value: string | undefined): number | null {
 
 function getSessionStoreRuntimeCacheMaxBytes(): number {
   return (
+    sessionStoreRuntimeCacheMaxBytesOverride ??
     parseNonNegativeInteger(process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES) ??
     DEFAULT_SESSION_STORE_RUNTIME_CACHE_MAX_BYTES
   );
@@ -181,6 +183,10 @@ export function getSerializedSessionStoreCacheStatsForTest(): {
     maxBytes: getSerializedSessionStoreCacheMaxBytes(),
     runtimeMaxBytes: getSessionStoreRuntimeCacheMaxBytes(),
   };
+}
+
+export function setSessionStoreRuntimeCacheMaxBytesForTest(maxBytes: number | null): void {
+  sessionStoreRuntimeCacheMaxBytesOverride = maxBytes;
 }
 
 export function getSessionStoreSnapshotCacheStatsForTest(): {

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -39,6 +39,7 @@ type SerializedSessionStoreCacheEntry = {
 };
 
 const DEFAULT_SESSION_STORE_TTL_MS = 45_000; // 45 seconds (between 30-60s)
+const DEFAULT_SESSION_STORE_RUNTIME_CACHE_MAX_BYTES = 16 * 1024 * 1024;
 const DEFAULT_SESSION_STORE_SERIALIZED_CACHE_MAX_ENTRIES = 64;
 const DEFAULT_SESSION_STORE_SERIALIZED_CACHE_MAX_BYTES = 64 * 1024 * 1024;
 const LARGE_SESSION_STORE_STRING_MIN_CHARS = 512;
@@ -71,6 +72,13 @@ function parseNonNegativeInteger(value: string | undefined): number | null {
   return parseStrictNonNegativeInteger(trimmed) ?? null;
 }
 
+function getSessionStoreRuntimeCacheMaxBytes(): number {
+  return (
+    parseNonNegativeInteger(process.env.OPENCLAW_SESSION_CACHE_MAX_BYTES) ??
+    DEFAULT_SESSION_STORE_RUNTIME_CACHE_MAX_BYTES
+  );
+}
+
 function getSerializedSessionStoreCacheMaxBytes(): number {
   return (
     parseNonNegativeInteger(process.env.OPENCLAW_SESSION_SERIALIZED_CACHE_MAX_BYTES) ??
@@ -80,6 +88,20 @@ function getSerializedSessionStoreCacheMaxBytes(): number {
 
 function getSerializedSessionStoreCacheMaxEntries(): number {
   return DEFAULT_SESSION_STORE_SERIALIZED_CACHE_MAX_ENTRIES;
+}
+
+function isSessionStoreRuntimeCacheable(sizeBytes?: number): boolean {
+  const maxBytes = getSessionStoreRuntimeCacheMaxBytes();
+  // Keep oversized session stores out of the live object/snapshot caches.
+  // They can still be loaded from disk on demand, but they should not stay
+  // resident as parsed object graphs in the gateway heap.
+  return (
+    maxBytes > 0 &&
+    (typeof sizeBytes !== "number" ||
+      !Number.isFinite(sizeBytes) ||
+      sizeBytes < 0 ||
+      sizeBytes <= maxBytes)
+  );
 }
 
 function resetSessionStoreStringInternStats(): void {
@@ -149,6 +171,7 @@ export function getSerializedSessionStoreCacheStatsForTest(): {
   totalBytes: number;
   maxEntries: number;
   maxBytes: number;
+  runtimeMaxBytes: number;
 } {
   pruneSerializedSessionStoreCache();
   return {
@@ -156,6 +179,7 @@ export function getSerializedSessionStoreCacheStatsForTest(): {
     totalBytes: sessionStoreSerializedCacheBytes,
     maxEntries: getSerializedSessionStoreCacheMaxEntries(),
     maxBytes: getSerializedSessionStoreCacheMaxBytes(),
+    runtimeMaxBytes: getSessionStoreRuntimeCacheMaxBytes(),
   };
 }
 
@@ -349,6 +373,9 @@ export function setSerializedSessionStore(
     typeof sizeBytesHint === "number" && Number.isFinite(sizeBytesHint) && sizeBytesHint >= 0
       ? sizeBytesHint
       : Buffer.byteLength(serialized, "utf8");
+  if (!isSessionStoreRuntimeCacheable(sizeBytes)) {
+    return;
+  }
   const maxEntries = getSerializedSessionStoreCacheMaxEntries();
   const maxBytes = getSerializedSessionStoreCacheMaxBytes();
   if (maxEntries <= 0 || maxBytes <= 0 || sizeBytes > maxBytes) {
@@ -373,6 +400,10 @@ export function readSessionStoreSnapshotCache(params: {
   mtimeMs?: number;
   sizeBytes?: number;
 }): SessionStoreSnapshot | null {
+  if (!isSessionStoreRuntimeCacheable(params.sizeBytes)) {
+    invalidateSessionStoreCache(params.storePath);
+    return null;
+  }
   const cached = SESSION_STORE_SNAPSHOT_CACHE.get(params.storePath);
   if (!cached) {
     return null;
@@ -392,6 +423,9 @@ export function writeSessionStoreSnapshotCache(params: {
   serialized?: string;
 }): SessionStoreSnapshot {
   const snapshot = cloneSessionStoreSnapshot(params.store, params.serialized);
+  if (!isSessionStoreRuntimeCacheable(params.sizeBytes)) {
+    return snapshot;
+  }
   SESSION_STORE_SNAPSHOT_CACHE.set(params.storePath, {
     snapshot,
     mtimeMs: params.mtimeMs,
@@ -406,6 +440,10 @@ export function readSessionStoreCache(params: {
   sizeBytes?: number;
   clone?: boolean;
 }): Record<string, SessionEntry> | null {
+  if (!isSessionStoreRuntimeCacheable(params.sizeBytes)) {
+    invalidateSessionStoreCache(params.storePath);
+    return null;
+  }
   const cached = SESSION_STORE_CACHE.get(params.storePath);
   if (!cached) {
     return null;
@@ -425,6 +463,10 @@ export function takeMutableSessionStoreCache(params: {
   mtimeMs?: number;
   sizeBytes?: number;
 }): Record<string, SessionEntry> | null {
+  if (!isSessionStoreRuntimeCacheable(params.sizeBytes)) {
+    invalidateSessionStoreCache(params.storePath);
+    return null;
+  }
   const cached = SESSION_STORE_CACHE.get(params.storePath);
   if (!cached) {
     return null;
@@ -448,6 +490,12 @@ export function writeSessionStoreCache(params: {
   takeOwnership?: boolean;
 }): void {
   bumpSessionStoreCacheVersion(params.storePath);
+  if (!isSessionStoreRuntimeCacheable(params.sizeBytes)) {
+    deleteSerializedSessionStore(params.storePath);
+    SESSION_STORE_CACHE.delete(params.storePath);
+    SESSION_STORE_SNAPSHOT_CACHE.delete(params.storePath);
+    return;
+  }
   const store =
     params.takeOwnership === true ? params.store : cloneSessionStoreRecord(params.store);
   if (params.takeOwnership === true) {


### PR DESCRIPTION
# Fix: cap runtime session-store cache retention for oversized stores

## Summary

This patch adds a runtime byte cap to the live session-store object and snapshot caches so oversized `sessions.json` loads do not stay resident as parsed object graphs in the gateway heap.

The on-disk session store remains the source of truth. Large stores can still be reloaded on demand, but they are no longer retained in memory just because they were loaded once.

Scope note: this PR only covers the session-store work in this branch. It does not include the separate bootstrap-cache patch or the separate `webgate` patch from the other branch.

## Issue Evidence

- The gateway previously crashed with a V8 heap OOM on the same machine.
- Before the patch, the live session-store tree and quarantine tree were multi-gigabyte, and the runtime was repeatedly loading the full session store during startup/recovery paths.
- The old behavior kept parsed session-store object graphs and immutable snapshots in memory after load, which is the retention pattern this patch caps.

## Real Behavior Proof

Behavior or issue addressed: oversized session-store hydration could retain parsed object graphs and snapshots in the live gateway cache, which increased heap pressure during startup, recovery, and repeated session access.

Real environment tested: Local OpenClaw workspace on the same machine, using the source tree at `/root/.openclaw/openclaw-fork-rebase` and the same runtime files that back the gateway.

Exact steps or command run after this patch:
- I ran a local `tsx` script against the source tree at `/root/.openclaw/openclaw-fork-rebase`.
- The script created a temporary `sessions.json`, forced `OPENCLAW_SESSION_CACHE_MAX_BYTES=64`, loaded the store twice, and probed the serialized and snapshot caches.
- The temp store used a single oversized session entry; the raw payload is omitted here because the proof only needs cache behavior, not session content.

Evidence after fix:
```text
after save serialized entries= 0
after save snapshot entries= 0
storeReads= 2
sameReference= false
equalPayload= true
serialized entries after loads= 0
snapshot entries after loads= 0
small serialized entries= 1
oversize direct read null= true
after oversized direct read serialized entries= 0
after oversized direct read snapshot entries= 0
```

Observed result after fix: for an oversized store, `0` cache entries is the correct result because the patch intentionally keeps that store out of the runtime caches. Repeated loads still return correct data, and direct oversized cache reads invalidate instead of retaining the object graph in memory. The `small serialized entries= 1` line is the positive control that proves normal-sized stores can still enter the cache. In the live gateway, the process stayed healthy and recovered back down after spikes during normal use; the conservative internal "critical" warnings still fired at times, but the post-GC floor remained bounded in the observed window and did not show the earlier runaway crash pattern.

User observation: under heavy normal use, the gateway also seemed noticeably faster after this patch, with smoother response under load. That is currently anecdotal only and not backed by measurement yet, so it should be treated as a qualitative observation rather than proof.

What was not tested: an overnight soak or a full quarantine/restart-recovery cleanup pass after this specific patch. Supplemental runtime data can be added later if the long-run floor starts drifting.

## Before-Fix Evidence (Supplementary)

<details>
<summary>Pre-patch crash and pressure symptoms</summary>

- The gateway previously crashed with a V8 heap OOM rather than a native fault.
- The live process had repeated memory-pressure warnings before this patch.
- The on-disk session corpus was large enough to justify avoiding persistent in-memory retention of oversized stores.

</details>