### PR TITLE
fix(agents): count stream deltas incrementally

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -190,7 +190,7 @@ message bodies are also approved for export.
 - `gen_ai.client.operation.duration` (histogram, seconds, GenAI semantic-conventions metric, attrs: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, optional `error.type`)
 - `openclaw.model_call.duration_ms` (histogram, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`, plus `openclaw.errorCategory` and `openclaw.failureKind` on classified errors)
 - `openclaw.model_call.request_bytes` (histogram, UTF-8 byte size of the final model request payload; no raw payload content)
-- `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed model response events; no raw response content)
+- `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed model response events excluding accumulated `partial` snapshots on delta events; no raw response content)
 - `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event)
 - `openclaw.model.failover` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.failover.to_provider`, `openclaw.failover.to_model`, `openclaw.failover.reason`, `openclaw.failover.suspended`, `openclaw.lane`)
 - `openclaw.skill.used` (counter, attrs: `openclaw.skill.name`, `openclaw.skill.source`, `openclaw.skill.activation`, optional `openclaw.agent`, optional `openclaw.toolName`)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -233,7 +233,7 @@ Model-call diagnostics record bounded request/response measurements without
 capturing raw prompt or response content:
 
 - `requestPayloadBytes`: UTF-8 byte size of the final model request payload
-- `responseStreamBytes`: UTF-8 byte size of streamed model response events
+- `responseStreamBytes`: UTF-8 byte size of streamed model response events, excluding accumulated `partial` snapshots on delta events
 - `timeToFirstByteMs`: elapsed time before the first streamed response event
 - `durationMs`: total model-call duration
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1450,7 +1450,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         "openclaw.model_call.response_bytes",
         {
           unit: "By",
-          description: "UTF-8 byte size of streamed model response events",
+          description:
+            "UTF-8 byte size of streamed model response events excluding accumulated partial snapshots",
         },
       );
       const modelCallTimeToFirstByteHistogram = meter.createHistogram(

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -346,6 +346,110 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     expect(JSON.stringify(events)).not.toContain("sk-original-secret");
   });
 
+  it("counts text deltas without serializing full partial snapshots", async () => {
+    const serializedPartial = vi.fn(() => {
+      throw new Error("partial snapshot should not be serialized for text deltas");
+    });
+    async function* stream() {
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "a",
+        partial: {
+          toJSON: serializedPartial,
+          role: "assistant",
+          content: [{ type: "text", text: "a".repeat(200_000) }],
+        },
+      };
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "bc",
+        partial: {
+          toJSON: serializedPartial,
+          role: "assistant",
+          content: [{ type: "text", text: "abc".repeat(200_000) }],
+        },
+      };
+    }
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream()) as unknown as StreamFn,
+      {
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-delta-bytes",
+      },
+    );
+
+    const events = await collectModelCallEvents(async () => {
+      await drain(wrapped({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
+    });
+
+    const completedEvent = getEvent(events, 1);
+    expect(completedEvent.type).toBe("model.call.completed");
+    expect(completedEvent.responseStreamBytes).toBe(
+      Buffer.byteLength(
+        JSON.stringify({ type: "text_delta", contentIndex: 0, delta: "a" }),
+        "utf8",
+      ) +
+        Buffer.byteLength(
+          JSON.stringify({ type: "text_delta", contentIndex: 0, delta: "bc" }),
+          "utf8",
+        ),
+    );
+    expect(serializedPartial).not.toHaveBeenCalled();
+  });
+
+  it("keeps streams alive when diagnostic byte inspection cannot read a chunk", async () => {
+    const opaqueChunk = new Proxy(
+      {},
+      {
+        get(_target, property) {
+          if (property === "then") {
+            return undefined;
+          }
+          throw new Error("chunk should not be inspected");
+        },
+      },
+    );
+    async function* stream() {
+      yield opaqueChunk;
+      yield { type: "text_delta", delta: "ok" };
+    }
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream()) as unknown as StreamFn,
+      {
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-opaque-chunk",
+      },
+    );
+
+    const chunks: unknown[] = [];
+    const events = await collectModelCallEvents(async () => {
+      for await (const chunk of wrapped(
+        {} as never,
+        {} as never,
+        {} as never,
+      ) as AsyncIterable<unknown>) {
+        chunks.push(chunk);
+      }
+    });
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toBe(opaqueChunk);
+    expect(chunks[1]).toEqual({ type: "text_delta", delta: "ok" });
+    const completedEvent = getEvent(events, 1);
+    expect(completedEvent.type).toBe("model.call.completed");
+    expect(completedEvent.responseStreamBytes).toBe(
+      Buffer.byteLength(JSON.stringify({ type: "text_delta", delta: "ok" }), "utf8"),
+    );
+  });
+
   it("captures model input, tools, and output only when content capture is enabled", async () => {
     const assistant = {
       role: "assistant",

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -113,6 +113,8 @@ function responseStreamChunkByteLengthUnchecked(chunk: unknown): number | undefi
   if (!("partial" in chunk)) {
     return utf8JsonByteLength(chunk);
   }
+  // Plain stream deltas can carry an accumulated partial snapshot. Byte metrics
+  // count the new stream event shape, not the answer-so-far replay.
   const { partial: _partial, ...snapshotlessChunk } = chunk;
   return utf8JsonByteLength(snapshotlessChunk);
 }

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -106,6 +106,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function responseStreamChunkByteLengthUnchecked(chunk: unknown): number | undefined {
+  if (!isRecord(chunk)) {
+    return utf8JsonByteLength(chunk);
+  }
+  if (!("partial" in chunk)) {
+    return utf8JsonByteLength(chunk);
+  }
+  const { partial: _partial, ...snapshotlessChunk } = chunk;
+  return utf8JsonByteLength(snapshotlessChunk);
+}
+
+function responseStreamChunkByteLength(chunk: unknown): number | undefined {
+  try {
+    return responseStreamChunkByteLengthUnchecked(chunk);
+  } catch {
+    return undefined;
+  }
+}
+
 function cloneDiagnosticContentValue(value: unknown): unknown {
   try {
     return structuredClone(value);
@@ -158,7 +177,7 @@ function observeResponseChunk(
 ): void {
   state.timeToFirstByteMs ??= Math.max(0, Date.now() - startedAt);
   observeOutputMessageContent(state, chunk);
-  const bytes = utf8JsonByteLength(chunk);
+  const bytes = responseStreamChunkByteLength(chunk);
   if (bytes !== undefined) {
     state.responseStreamBytes += bytes;
   }


### PR DESCRIPTION
## Summary

- fixes the diagnostics stream-byte counter introduced by `c6e98493511b3a18e6f2f402693ef7dc832a071f` so plain stream deltas are counted from incremental text/thinking/tool-call payloads instead of accumulated `partial` snapshots
- avoids serializing full assistant snapshots on every streamed chunk, removing the repeated answer-so-far diagnostic work called out in https://github.com/openclaw/openclaw/issues/86599#issuecomment-4555471713
- keeps diagnostic byte inspection best-effort so opaque or hostile chunk shapes cannot break the model stream
- documents that response byte metrics exclude accumulated `partial` snapshots on delta events

Refs https://github.com/openclaw/openclaw/issues/86599.

## Verification

Behavior addressed: model-call diagnostics no longer repeatedly stringify full accumulated assistant partial snapshots for ordinary `text_delta`, `thinking_delta`, and `toolcall_delta` stream chunks.

Real environment tested: focused local Vitest wrapper and AWS Crabbox Linux changed gate. Blacksmith Testbox proof is still blocked locally by missing Blacksmith auth, so the broad remote gate used direct AWS Crabbox.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts --reporter=dot
git diff --check origin/main...HEAD
node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"
```

Evidence after fix: refreshed head `0cfb9af1a4f4` on PR base `4e84d0eaa547`; focused local wrapper passed `src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts` and `extensions/diagnostics-otel/src/service.test.ts` with 86/86 tests; diff check passed; AWS Crabbox `pnpm check:changed` passed with provider `aws`, lease `cbx_31cf16a09928`, slug `brisk-prawn`, run `run_b95541cfd4e9`, machine `c7a.8xlarge`, exit `0`, `leaseStopped=true`. The changed gate selected lanes `core`, `coreTests`, `extensions`, `extensionTests`, and `docs`.

Observed result after fix: regression coverage proves diagnostic byte accounting does not call `toJSON` on full partial snapshots for text deltas, counts only incremental delta bytes, and keeps streaming alive when byte inspection cannot inspect a chunk.

What was not tested: Windows local-daemon reproduction from https://github.com/openclaw/openclaw/issues/86599 was not rerun in this PR. This removes the diagnostics amplification from the starvation cluster but does not claim to close every related local-provider responsiveness path alone.
