### PR TITLE
test(infra): avoid max fake-timer jumps

### DIFF
--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -55,7 +55,7 @@ describe("Feishu app registration", () => {
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
 
-    await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+    await vi.runOnlyPendingTimersAsync();
     await expect(poll).resolves.toEqual({ status: "timeout" });
   });
 });

--- a/src/infra/transport-ready.test.ts
+++ b/src/infra/transport-ready.test.ts
@@ -109,6 +109,7 @@ describe("waitForTransportReady", () => {
 
   it("caps oversized timeout values before computing the deadline", async () => {
     vi.setSystemTime(1_000);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const runtime = createRuntime();
     const waitPromise = waitForTransportReady({
       label: "test transport",
@@ -122,8 +123,9 @@ describe("waitForTransportReady", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     expect(runtime.error).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
 
-    await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS - 1);
+    await vi.runOnlyPendingTimersAsync();
     await asserted;
     expect(latestRuntimeErrorMessage(runtime)).toContain(
       `not ready after ${MAX_TIMER_TIMEOUT_MS}ms`,


### PR DESCRIPTION
## Summary
- Avoid advancing Vitest fake timers by `MAX_TIMER_TIMEOUT_MS` in max-timeout tests.
- Keep explicit assertions that oversized inputs are clamped to `MAX_TIMER_TIMEOUT_MS` before timers are scheduled.
- Covers the remaining sibling cases in Feishu app registration polling and transport readiness polling.

## CI Failure
`checks-node-core-runtime-infra-state` failed in run 26665643653 because an oversized-timeout test advanced fake time to the max timer boundary and surfaced an unhandled rejection. The direct HTTP CONNECT case is fixed on `main`; this PR applies the same safer test pattern to the remaining matching tests.

refs bafa6de76d

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/net/http-connect-tunnel.test.ts src/infra/transport-ready.test.ts --reporter=verbose` - passed, 2 files / 18 tests.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/app-registration.test.ts --reporter=verbose` - passed, 1 file / 2 tests.
- `git diff --check origin/main...HEAD` - passed.
- Search for direct max-timeout fake-time advancement - no remaining matches.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - passed.

## Real behavior proof
Behavior addressed: CI-only fake timer overflow/flakiness in max-timeout tests.
Real environment tested: local macOS checkout with repo Vitest shard configs.
Exact steps or command run after this patch: focused infra and Feishu Vitest commands listed above.
Evidence after fix: tests pass and still assert `MAX_TIMER_TIMEOUT_MS` scheduling.
Observed result after fix: promises settle without advancing fake time by the full max timer interval.
What was not tested: full CI locally; PR CI is running on the pushed head.
