### PR TITLE
fix(agents): normalize send_to_task body aliases to message (A2A broken for Anthropic/Pi agents)

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -55,7 +55,14 @@ const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
   label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
   agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
-  message: Type.String(),
+  // Canonical body field. Kept optional at the schema layer so model-emitted
+  // alias keys (SendMessage/content/text) are not rejected before execute can
+  // normalize them; execute still enforces a non-empty message.
+  message: Type.Optional(Type.String()),
+  // Non-canonical body aliases some models emit instead of `message`.
+  SendMessage: Type.Optional(Type.String()),
+  content: Type.Optional(Type.String()),
+  text: Type.Optional(Type.String()),
   timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
 });
 
@@ -283,6 +290,19 @@ export function createSessionsSendTool(opts?: {
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const gatewayCall = opts?.callGateway ?? callGateway;
+      // Models may emit the body under non-canonical aliases. Mirror the
+      // message-tool normalization so cross-agent sends are delivered instead
+      // of rejected for a missing `message`.
+      if (typeof params.message !== "string" || !params.message.trim()) {
+        for (const alias of ["SendMessage", "content", "text"] as const) {
+          const value = params[alias];
+          if (typeof value === "string" && value.trim()) {
+            params.message = value;
+            console.warn(`[send_to_task] normalized alias "${alias}" to "message"`);
+            break;
+          }
+        }
+      }
       const message = readStringParam(params, "message", { required: true });
       const timeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds") ?? 30;
       const { cfg, mainKey, alias, effectiveRequesterKey, restrictToSpawned } =

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -786,6 +786,56 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it.each(["SendMessage", "content", "text"])(
+    "normalizes the %s body alias to message",
+    async (alias) => {
+      const tool = createMainSessionsSendTool();
+
+      // Pass the body only under the alias (no canonical `message`). If the
+      // alias were not normalized, the required-`message` read would throw
+      // before target validation; reaching the target error proves the body
+      // was populated from the alias.
+      const result = await tool.execute("call-alias", {
+        [alias]: "hi",
+        timeoutSeconds: 5,
+      });
+
+      const details = requireDetails(result);
+      expect(details.status).toBe("error");
+      expect(details.error).toBe("Either sessionKey or label is required");
+      expect(callGatewayMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("prefers the canonical message over body aliases", async () => {
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-alias-precedence", {
+      message: "canonical",
+      SendMessage: "alias",
+      timeoutSeconds: 5,
+    });
+
+    // Still no target, so it errors out the same way, but without throwing the
+    // required-`message` error: canonical message is kept.
+    const details = requireDetails(result);
+    expect(details.status).toBe("error");
+    expect(details.error).toBe("Either sessionKey or label is required");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when no message or body alias is provided", async () => {
+    const tool = createMainSessionsSendTool();
+
+    await expect(
+      tool.execute("call-no-body", {
+        sessionKey: MAIN_AGENT_SESSION_KEY,
+        timeoutSeconds: 5,
+      }),
+    ).rejects.toThrow("message required");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it.each([1.5, -1, "1sec"])("rejects invalid timeoutSeconds value %s", async (timeoutSeconds) => {
     const tool = createMainSessionsSendTool();
 

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -793,16 +793,17 @@ describe("sessions_send gating", () => {
 
       // Pass the body only under the alias (no canonical `message`). If the
       // alias were not normalized, the required-`message` read would throw
-      // before target validation; reaching the target error proves the body
-      // was populated from the alias.
-      const result = await tool.execute("call-alias", {
+      // `message required`; the call instead reaching normal target validation
+      // (without that throw) proves the body was populated from the alias.
+      const run = tool.execute("call-alias", {
         [alias]: "hi",
         timeoutSeconds: 5,
       });
 
-      const details = requireDetails(result);
+      await expect(run).resolves.toBeDefined();
+      const details = requireDetails(await run);
       expect(details.status).toBe("error");
-      expect(details.error).toBe("Either sessionKey or label is required");
+      expect(details.error).not.toContain("message required");
       expect(callGatewayMock).not.toHaveBeenCalled();
     },
   );
@@ -830,6 +831,25 @@ describe("sessions_send gating", () => {
     await expect(
       tool.execute("call-no-body", {
         sessionKey: MAIN_AGENT_SESSION_KEY,
+        timeoutSeconds: 5,
+      }),
+    ).rejects.toThrow("message required");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when message and all body aliases are whitespace-only", async () => {
+    const tool = createMainSessionsSendTool();
+
+    // Guards the edge case where normalization finds no non-empty alias and the
+    // canonical message is blank: the required read must still reject rather
+    // than letting an empty body through.
+    await expect(
+      tool.execute("call-blank-body", {
+        sessionKey: MAIN_AGENT_SESSION_KEY,
+        message: "   ",
+        SendMessage: "  ",
+        content: "",
+        text: "\n",
         timeoutSeconds: 5,
       }),
     ).rejects.toThrow("message required");

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -961,6 +961,9 @@
           "minLength": 1,
           "type": "string"
         },
+        "content": {
+          "type": "string"
+        },
         "label": {
           "maxLength": 512,
           "minLength": 1,
@@ -969,7 +972,13 @@
         "message": {
           "type": "string"
         },
+        "SendMessage": {
+          "type": "string"
+        },
         "sessionKey": {
+          "type": "string"
+        },
+        "text": {
           "type": "string"
         },
         "timeoutSeconds": {
@@ -977,7 +986,6 @@
           "type": "integer"
         }
       },
-      "required": ["message"],
       "type": "object"
     },
     "name": "sessions_send",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -997,6 +997,9 @@
           "minLength": 1,
           "type": "string"
         },
+        "content": {
+          "type": "string"
+        },
         "label": {
           "maxLength": 512,
           "minLength": 1,
@@ -1005,7 +1008,13 @@
         "message": {
           "type": "string"
         },
+        "SendMessage": {
+          "type": "string"
+        },
         "sessionKey": {
+          "type": "string"
+        },
+        "text": {
           "type": "string"
         },
         "timeoutSeconds": {
@@ -1013,7 +1022,6 @@
           "type": "integer"
         }
       },
-      "required": ["message"],
       "type": "object"
     },
     "name": "sessions_send",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -961,6 +961,9 @@
           "minLength": 1,
           "type": "string"
         },
+        "content": {
+          "type": "string"
+        },
         "label": {
           "maxLength": 512,
           "minLength": 1,
@@ -969,7 +972,13 @@
         "message": {
           "type": "string"
         },
+        "SendMessage": {
+          "type": "string"
+        },
         "sessionKey": {
+          "type": "string"
+        },
+        "text": {
           "type": "string"
         },
         "timeoutSeconds": {
@@ -977,7 +986,6 @@
           "type": "integer"
         }
       },
-      "required": ["message"],
       "type": "object"
     },
     "name": "sessions_send",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41277,
-    "roughTokens": 10320
+    "chars": 41353,
+    "roughTokens": 10339
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68979,
-    "roughTokens": 17245
+    "chars": 69055,
+    "roughTokens": 17264
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41222,
-    "roughTokens": 10306
+    "chars": 41277,
+    "roughTokens": 10320
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68924,
-    "roughTokens": 17231
+    "chars": 68979,
+    "roughTokens": 17245
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40998,
-    "roughTokens": 10250
+    "chars": 41074,
+    "roughTokens": 10269
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67176,
-    "roughTokens": 16794
+    "chars": 67252,
+    "roughTokens": 16813
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40943,
-    "roughTokens": 10236
+    "chars": 40998,
+    "roughTokens": 10250
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67121,
-    "roughTokens": 16781
+    "chars": 67176,
+    "roughTokens": 16794
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 42038,
-    "roughTokens": 10510
+    "chars": 42169,
+    "roughTokens": 10543
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69159,
-    "roughTokens": 17290
+    "chars": 69290,
+    "roughTokens": 17323
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary

- `send_to_task` (the agent-to-agent / sessions-send tool) requires a body property literally named `message`, but Anthropic/Pi-backed agents reliably emit the body under the non-canonical alias `SendMessage`. The required-`message` schema rejects every such call with `must have required properties message`, so cross-agent (A2A) messaging is effectively broken for these models.
- This mirrors the already-fixed `message`-tool behavior from #84079, whose alias normalization was only wired into the channel `message` tool (`message-action-runner`), never into `send_to_task`.
- Fix: make `message` optional in `SessionsSendToolSchema`, accept `SendMessage`/`content`/`text` as optional aliases, and coalesce the first non-empty alias into `message` at the start of `execute` (before the required read). Execute still enforces a non-empty message.
- Out of scope: the separate thread-key rejection for inter-agent coordination (existing, intended behavior) and any change to delivery/routing/policy.
- Success: an Anthropic/Pi agent that emits `SendMessage` can send and reply via `send_to_task` instead of failing validation.
- Reviewers should focus on `src/agents/tools/sessions-send-tool.ts` (schema + the normalization block) — it is intentionally a 1:1 mirror of the `message-action-runner` precedent.

## Linked context

Closes #88146

Related #84079 (same alias-normalization bug fixed for the `message` tool; this is the un-fixed `send_to_task` counterpart)

Was this requested by a maintainer or owner? No — community bug report + fix.

## Real behavior proof (required for third-party PRs)

- **Behavior or issue addressed:** A2A `send_to_task` rejected every Anthropic-agent send because the model emitted the body as `SendMessage` while the tool required `message`.
- **Real environment tested:** OCPlatform `2026.5.27` (commit 27ae826) on macOS (arm64), Node v25, embedded/Pi runtime, Anthropic provider (`claude-opus-4-8`), multiple isolated agents with `tools.agentToAgent.enabled = true`.
- **Exact steps or command run after this patch:** Applied the same code change to the running instance and restarted the gateway; from agent "Navi" called `send_to_task` targeting agent "Tank" with the body emitted as `SendMessage` (the failing shape); then had Tank call `send_to_task` back to Navi's main session.
- **Evidence after fix:** copied live output (terminal/console capture) from a real running gateway. BEFORE the fix, an Anthropic agent calling `send_to_task` with the body under `SendMessage` is rejected before delivery:

  ```text
  Validation failed for tool "send_to_task":
    - message: must have required properties message

  Received arguments:
  {
    "sessionKey": "agent:tank:telegram:group:-1003607281706:topic:326",
    "SendMessage": "[Navi to Tank] Connectivity test ...",
    "timeoutSeconds": 60
  }
  ```

  AFTER the fix (same code change as this PR, applied to the running instance + gateway restarted), the identical `SendMessage`-bodied call is normalized and delivered, and the peer agent replies back through `send_to_task`:

  ```text
  # runtime log emitted by the normalization:
  [send_to_task] normalized alias "SendMessage" to "message"

  # tool result returned to the caller (no validation error; delivered):
  {
    "runId": "59285968-adaf-40a1-826a-f48cf4837d2c",
    "status": "ok",
    "reply": "Bidirectional confirmed. Your patched message reached me clean ...",
    "sessionKey": "agent:navi:main",
    "delivery": { "status": "pending", "mode": "announce" }
  }
  ```

- **Observed result after fix:** the previously-rejected `SendMessage`-bodied `send_to_task` call is delivered on a real instance, and the peer agent successfully replies back via `send_to_task` (`status: ok`). Bidirectional agent-to-agent messaging works end to end; before the fix every such call failed validation with `must have required properties message`.
- **What was not tested:** non-Anthropic providers that already emit canonical `message` (unaffected by this change); the `content`/`text` aliases are covered by unit tests rather than a live model emitting them.
- **Proof limitations or environment constraints:** the live before/after capture was produced against the installed release bundle carrying the same code change as this PR's source edit (that is the running instance); the source build itself is validated via the commands below.

## Tests and validation

Which commands did you run?

- `pnpm vitest run src/agents/tools/sessions.test.ts` → passes, including 5 new alias tests (each of `SendMessage`/`content`/`text` normalized, canonical-precedence, and still-throws-when-empty).
- `pnpm vitest run src/agents/tools/sessions.test.ts src/agents/tools/message-tool.test.ts` → 214 tests pass.
- `pnpm tsgo:all` (typecheck) → pass.
- `pnpm lint` (oxlint, all shards) → 0 warnings, 0 errors.
- `pnpm prompt:snapshots:gen` → refreshed the codex prompt-snapshot fixtures for the new schema aliases (committed).

What regression coverage was added or updated?

- `src/agents/tools/sessions.test.ts`: parametrized normalization test for each alias, a canonical-over-alias precedence test, and a no-body-throws test.

What failed before this fix, if known?

- Any `send_to_task` call whose body was under `SendMessage` failed schema validation with `must have required properties message`.

## Risk checklist

- Did user-visible behavior change? **Yes** — previously-rejected A2A sends now succeed.
- Did config, environment, or migration behavior change? **No.**
- Did security, auth, secrets, network, or tool execution behavior change? **Surface touched, behavior unchanged.** This edits `send_to_task`, which is both a message-delivery path and a cross-agent (A2A) authorization boundary, so I'm calling those surfaces out explicitly:
  - **message-delivery (🚨):** the change only populates `params.message` from an alias *before* the existing required read. It does not touch target resolution (`sessionKey`/`label`/`agentId`), the thread-key rejection, announce/delivery dispatch, or ping-pong logic. It cannot drop, duplicate, misroute, suppress, or re-target a message — a previously-rejected call now reaches the *same* downstream routing it always would have with a canonical `message`. Net effect is strictly: rejected-for-bad-body → delivered-normally.
  - **security-boundary (🚨):** no change to A2A enablement, the `agentToAgent` allowlist, `resolveSessionToolContext`, visibility gating, `restrictToSpawned`, sandbox checks, credentials, or sensitive-data handling. The added schema fields are optional strings; an unauthorized sender is still blocked by the unchanged policy path regardless of which body key carried the text.
- Highest-risk area: schema relaxation (`message` now optional at the schema layer). Mitigated by enforcing a non-empty `message` in `execute` via the existing `readStringParam(..., { required: true })` — verified by both the "throws when no message or body alias is provided" and "throws when message and all body aliases are whitespace-only" tests, so no empty/blank body can slip through.

## Current review state

- Next action: maintainer review.
- Waiting on: nothing actionable from the author. The `merge-risk: message-delivery` and `merge-risk: security-boundary` labels reflect the touched surface (`send_to_task`); the Risk checklist above documents why behavior on both surfaces is unchanged (body-read normalization only; routing, authorization, visibility, and delivery paths untouched).
- Bot/reviewer comments addressed: all 4 Copilot comments handled in `ce75fd2e` (whitespace edge-case test added; alias tests decoupled from the exact downstream error string; `params` mutation and `[send_to_task]` log prefix kept intentionally to match the `message-action-runner` precedent). Prompt-snapshot fixtures refreshed after the `check-additional-boundaries-a` drift signal.

---

🤖 AI-assisted: implemented with an AI coding assistant. The diff is a deliberate, reviewed mirror of the #84079 `message`-tool normalization. The before/after behavior proof above is copied live output from a real running OCPlatform instance, not tests/mocks.

