### PR TITLE
fix(agents): extend terminal outcome projections

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -61,7 +61,7 @@ function runStatusFromWaitPayload(payload: unknown): RunResult["status"] {
   const pendingError = record.pendingError === true;
   const timeoutPhase =
     typeof record.timeoutPhase === "string" ? record.timeoutPhase.toLowerCase() : undefined;
-  const statusAlreadyTimeoutAttributed = status === "timeout" || status === "error";
+  const statusAlreadyTimeoutAttributed = status === "timeout" || status === "timed_out";
   const hardTimeout =
     !pendingError &&
     ((record.providerStarted === true && statusAlreadyTimeoutAttributed) ||

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -59,12 +59,24 @@ function runStatusFromWaitPayload(payload: unknown): RunResult["status"] {
   const status = typeof record.status === "string" ? record.status.toLowerCase() : undefined;
   const stopReason = typeof record.stopReason === "string" ? record.stopReason.toLowerCase() : "";
   const pendingError = record.pendingError === true;
+  const timeoutPhase =
+    typeof record.timeoutPhase === "string" ? record.timeoutPhase.toLowerCase() : undefined;
+  const statusAlreadyTimeoutAttributed = status === "timeout" || status === "error";
+  const hardTimeout =
+    !pendingError &&
+    ((record.providerStarted === true && statusAlreadyTimeoutAttributed) ||
+      timeoutPhase === "preflight" ||
+      timeoutPhase === "provider" ||
+      timeoutPhase === "post_turn");
   const hasTerminalTimeoutMetadata =
     readOptionalTimestamp(record.endedAt) !== undefined ||
     (!pendingError && readOptionalString(record.error) !== undefined) ||
     stopReason.length > 0 ||
     typeof record.livenessState === "string" ||
     record.yielded === true;
+  if (hardTimeout) {
+    return "timed_out";
+  }
   if (
     status === "aborted" ||
     status === "cancelled" ||

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -182,6 +182,24 @@ describe("OpenClaw SDK", () => {
     expect(result.error?.message).toBe("provider request timed out");
   });
 
+  it("does not map provider-started wait errors to timed_out without timeout attribution", async () => {
+    const transport = new FakeTransport({
+      "agent.wait": {
+        status: "error",
+        runId: "run_provider_error",
+        providerStarted: true,
+        error: "provider authentication failed",
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const result = await oc.runs.wait("run_provider_error");
+
+    expect(result.runId).toBe("run_provider_error");
+    expect(result.status).toBe("failed");
+    expect(result.error?.message).toBe("provider authentication failed");
+  });
+
   it("does not treat successful provider-started wait snapshots as timed_out", async () => {
     const transport = new FakeTransport({
       "agent.wait": {
@@ -1150,9 +1168,31 @@ describe("OpenClaw SDK", () => {
       providerStarted: true,
     });
 
-    const hardTimeoutEnd = normalizeGatewayEvent({
+    const providerStartedError = normalizeGatewayEvent({
       event: "agent",
       seq: 8,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: {
+          phase: "error",
+          error: "provider authentication failed",
+          providerStarted: true,
+        },
+      },
+    });
+    expect(providerStartedError.type).toBe("run.failed");
+    expect(providerStartedError.runId).toBe("run_1");
+    expect(providerStartedError.data).toEqual({
+      phase: "error",
+      error: "provider authentication failed",
+      providerStarted: true,
+    });
+
+    const hardTimeoutEnd = normalizeGatewayEvent({
+      event: "agent",
+      seq: 9,
       payload: {
         runId: "run_1",
         stream: "lifecycle",
@@ -1174,7 +1214,7 @@ describe("OpenClaw SDK", () => {
 
     const providerStartedEnd = normalizeGatewayEvent({
       event: "agent",
-      seq: 9,
+      seq: 10,
       payload: {
         runId: "run_1",
         stream: "lifecycle",

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -143,6 +143,61 @@ describe("OpenClaw SDK", () => {
     expect(result.error?.message).toBe("aborted by operator");
   });
 
+  it("maps provider-started rpc timeout wait snapshots to timed_out", async () => {
+    const transport = new FakeTransport({
+      "agent.wait": {
+        status: "timeout",
+        runId: "run_hard_timeout",
+        stopReason: "rpc",
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "provider request timed out",
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const result = await oc.runs.wait("run_hard_timeout");
+
+    expect(result.runId).toBe("run_hard_timeout");
+    expect(result.status).toBe("timed_out");
+    expect(result.error?.message).toBe("provider request timed out");
+  });
+
+  it("maps provider timeout wait errors to timed_out", async () => {
+    const transport = new FakeTransport({
+      "agent.wait": {
+        status: "error",
+        runId: "run_timeout_error",
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "provider request timed out",
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const result = await oc.runs.wait("run_timeout_error");
+
+    expect(result.runId).toBe("run_timeout_error");
+    expect(result.status).toBe("timed_out");
+    expect(result.error?.message).toBe("provider request timed out");
+  });
+
+  it("does not treat successful provider-started wait snapshots as timed_out", async () => {
+    const transport = new FakeTransport({
+      "agent.wait": {
+        status: "ok",
+        runId: "run_provider_started_ok",
+        providerStarted: true,
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const result = await oc.runs.wait("run_provider_started_ok");
+
+    expect(result.runId).toBe("run_provider_started_ok");
+    expect(result.status).toBe("completed");
+  });
+
   it("maps auth-revoked wait snapshots to cancelled", async () => {
     const transport = new FakeTransport({
       "agent.wait": {
@@ -190,6 +245,26 @@ describe("OpenClaw SDK", () => {
     expect(result.runId).toBe("run_pending_error");
     expect(result.status).toBe("accepted");
     expect(result.error?.message).toBe("429 RESOURCE_EXHAUSTED");
+  });
+
+  it("keeps provider-attributed pending-error wait deadlines non-terminal", async () => {
+    const transport = new FakeTransport({
+      "agent.wait": {
+        status: "timeout",
+        runId: "run_pending_provider_error",
+        error: "provider request timed out",
+        pendingError: true,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const result = await oc.runs.wait("run_pending_provider_error");
+
+    expect(result.runId).toBe("run_pending_provider_error");
+    expect(result.status).toBe("accepted");
+    expect(result.error?.message).toBe("provider request timed out");
   });
 
   it("maps terminal runtime timeout snapshots to timed_out", async () => {
@@ -1025,9 +1100,101 @@ describe("OpenClaw SDK", () => {
     expect(cancelled.runId).toBe("run_1");
     expect(cancelled.data).toEqual({ phase: "end", aborted: true, stopReason: "rpc" });
 
-    const authRevoked = normalizeGatewayEvent({
+    const hardTimeout = normalizeGatewayEvent({
       event: "agent",
       seq: 6,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: {
+          phase: "end",
+          aborted: true,
+          stopReason: "rpc",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      },
+    });
+    expect(hardTimeout.type).toBe("run.timed_out");
+    expect(hardTimeout.runId).toBe("run_1");
+    expect(hardTimeout.data).toEqual({
+      phase: "end",
+      aborted: true,
+      stopReason: "rpc",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+
+    const hardTimeoutError = normalizeGatewayEvent({
+      event: "agent",
+      seq: 7,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: {
+          phase: "error",
+          error: "provider request timed out",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      },
+    });
+    expect(hardTimeoutError.type).toBe("run.timed_out");
+    expect(hardTimeoutError.runId).toBe("run_1");
+    expect(hardTimeoutError.data).toEqual({
+      phase: "error",
+      error: "provider request timed out",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+
+    const hardTimeoutEnd = normalizeGatewayEvent({
+      event: "agent",
+      seq: 8,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: {
+          phase: "end",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      },
+    });
+    expect(hardTimeoutEnd.type).toBe("run.timed_out");
+    expect(hardTimeoutEnd.runId).toBe("run_1");
+    expect(hardTimeoutEnd.data).toEqual({
+      phase: "end",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+
+    const providerStartedEnd = normalizeGatewayEvent({
+      event: "agent",
+      seq: 9,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: {
+          phase: "end",
+          providerStarted: true,
+        },
+      },
+    });
+    expect(providerStartedEnd.type).toBe("run.completed");
+    expect(providerStartedEnd.runId).toBe("run_1");
+    expect(providerStartedEnd.data).toEqual({
+      phase: "end",
+      providerStarted: true,
+    });
+
+    const authRevoked = normalizeGatewayEvent({
+      event: "agent",
+      seq: 10,
       payload: {
         runId: "run_1",
         stream: "lifecycle",
@@ -1045,7 +1212,7 @@ describe("OpenClaw SDK", () => {
 
     const timedOut = normalizeGatewayEvent({
       event: "agent",
-      seq: 7,
+      seq: 11,
       payload: {
         runId: "run_1",
         stream: "lifecycle",

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -16,9 +16,24 @@ function readLowerString(value: unknown): string | undefined {
   return readString(value)?.toLowerCase();
 }
 
+function hasHardTimeoutMetadata(data: JsonObject, statusAlreadyTimeoutAttributed = false): boolean {
+  const timeoutPhase = readLowerString(data.timeoutPhase);
+  return (
+    (statusAlreadyTimeoutAttributed && data.providerStarted === true) ||
+    timeoutPhase === "preflight" ||
+    timeoutPhase === "provider" ||
+    timeoutPhase === "post_turn"
+  );
+}
+
 function normalizeLifecycleEndEventType(data: JsonObject): OpenClawEventType {
   const status = readLowerString(data.status);
   const stopReason = readLowerString(data.stopReason);
+  const statusAlreadyTimeoutAttributed =
+    status === "timeout" || status === "timed_out" || data.aborted === true;
+  if (hasHardTimeoutMetadata(data, statusAlreadyTimeoutAttributed)) {
+    return "run.timed_out";
+  }
   if (
     status === "aborted" ||
     status === "cancelled" ||
@@ -71,6 +86,9 @@ function normalizeAgentEventType(payload: JsonObject): OpenClawEventType {
       return normalizeLifecycleEndEventType(data);
     }
     if (phase === "error") {
+      if (hasHardTimeoutMetadata(data, true)) {
+        return "run.timed_out";
+      }
       return "run.failed";
     }
   }

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -86,7 +86,7 @@ function normalizeAgentEventType(payload: JsonObject): OpenClawEventType {
       return normalizeLifecycleEndEventType(data);
     }
     if (phase === "error") {
-      if (hasHardTimeoutMetadata(data, true)) {
+      if (hasHardTimeoutMetadata(data, false)) {
         return "run.timed_out";
       }
       return "run.failed";

--- a/scripts/package-changelog.mjs
+++ b/scripts/package-changelog.mjs
@@ -118,6 +118,7 @@ export async function restorePackageChangelog(cwd = process.cwd()) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
         `Refusing to restore stale packaged changelog backup from ${BACKUP_PATH}: ${message}`,
+        { cause: error },
       );
     }
     if (current !== expectedPackaged) {

--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -72,6 +72,19 @@ describe("agent run terminal outcome", () => {
     });
   });
 
+  it("does not treat successful provider-started metadata as timeout without attribution phase", () => {
+    expect(
+      buildAgentRunTerminalOutcome({
+        status: "ok",
+        providerStarted: true,
+      }),
+    ).toEqual({
+      reason: "completed",
+      status: "ok",
+      providerStarted: true,
+    });
+  });
+
   it("prefers hard timeout evidence over default rpc cancellation metadata", () => {
     const timeout = buildAgentRunTerminalOutcome({
       status: "timeout",
@@ -88,6 +101,52 @@ describe("agent run terminal outcome", () => {
     expect(timeout.reason).toBe("hard_timeout");
     expect(timeout.status).toBe("timeout");
     expect(mergeAgentRunTerminalOutcome(timeout, earlierCompletion)).toBe(earlierCompletion);
+  });
+
+  it("classifies provider timeout lifecycle errors as hard timeouts", () => {
+    expect(
+      buildAgentRunTerminalOutcome({
+        status: "error",
+        error: "provider request timed out",
+        stopReason: "error",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      }),
+    ).toMatchObject({
+      reason: "hard_timeout",
+      status: "timeout",
+      error: "provider request timed out",
+    });
+  });
+
+  it("classifies timeout attribution metadata as a hard timeout even on end events", () => {
+    expect(
+      buildAgentRunTerminalOutcome({
+        status: "ok",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      }),
+    ).toMatchObject({
+      reason: "hard_timeout",
+      status: "timeout",
+    });
+  });
+
+  it("lets timeout attribution outrank blocked liveness", () => {
+    expect(
+      buildAgentRunTerminalOutcome({
+        status: "error",
+        error: "provider request timed out",
+        livenessState: "blocked",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      }),
+    ).toMatchObject({
+      reason: "hard_timeout",
+      status: "timeout",
+      error: "provider request timed out",
+      livenessState: "blocked",
+    });
   });
 
   it("keeps a hard timeout over later aborts or failures for the same run", () => {

--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -85,6 +85,22 @@ describe("agent run terminal outcome", () => {
     });
   });
 
+  it("does not treat provider-started errors as timeouts without timeout attribution", () => {
+    expect(
+      buildAgentRunTerminalOutcome({
+        status: "error",
+        error: "provider authentication failed",
+        stopReason: "error",
+        providerStarted: true,
+      }),
+    ).toMatchObject({
+      reason: "failed",
+      status: "error",
+      error: "provider authentication failed",
+      providerStarted: true,
+    });
+  });
+
   it("prefers hard timeout evidence over default rpc cancellation metadata", () => {
     const timeout = buildAgentRunTerminalOutcome({
       status: "timeout",

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -82,22 +82,24 @@ export function buildAgentRunTerminalOutcome(
   // Queue and gateway-draining timeouts are wait-layer uncertainty. Only
   // provider-started or provider-phase timeouts are sticky child-run facts.
   const hardTimeout =
-    input.status === "timeout" &&
-    (isHardAgentRunTimeoutPhase(timeoutPhase) || providerStarted === true);
+    isHardAgentRunTimeoutPhase(timeoutPhase) ||
+    ((input.status === "timeout" || input.status === "error") && providerStarted === true);
   const aborted = isAbortedAgentStopReason(stopReason);
   // ACP/model `stop` can be a normal successful finish. Treat rpc/stop as
   // cancellation only for non-success terminal payloads from abort paths.
   const cancelled = input.status !== "ok" && isCancellationStopReason(stopReason);
   const blocked = isBlockedLivenessState(livenessState);
-  const error = blocked
-    ? formatBlockedLivenessError(rawError)
-    : aborted && !rawError
-      ? AGENT_RUN_ABORTED_ERROR
-      : rawError;
-  const reason: AgentRunTerminalReason = blocked
-    ? "blocked"
-    : hardTimeout
-      ? "hard_timeout"
+  const error = hardTimeout
+    ? rawError
+    : blocked
+      ? formatBlockedLivenessError(rawError)
+      : aborted && !rawError
+        ? AGENT_RUN_ABORTED_ERROR
+        : rawError;
+  const reason: AgentRunTerminalReason = hardTimeout
+    ? "hard_timeout"
+    : blocked
+      ? "blocked"
       : aborted
         ? "aborted"
         : cancelled
@@ -112,8 +114,8 @@ export function buildAgentRunTerminalOutcome(
     status:
       reason === "completed"
         ? "ok"
-        : input.status === "timeout" &&
-            (reason === "hard_timeout" || reason === "timed_out" || reason === "cancelled")
+        : reason === "hard_timeout" ||
+            (input.status === "timeout" && (reason === "timed_out" || reason === "cancelled"))
           ? "timeout"
           : "error",
     ...(error ? { error } : {}),

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -79,11 +79,11 @@ export function buildAgentRunTerminalOutcome(
   const timeoutPhase = normalizeAgentRunTimeoutPhase(input.timeoutPhase);
   const providerStarted = normalizeProviderStarted(input.providerStarted);
   const rawError = asNonEmptyString(input.error);
-  // Queue and gateway-draining timeouts are wait-layer uncertainty. Only
-  // provider-started or provider-phase timeouts are sticky child-run facts.
+  // Queue and gateway-draining timeouts are wait-layer uncertainty. Provider
+  // errors need explicit timeout attribution; providerStarted only proves reach.
   const hardTimeout =
     isHardAgentRunTimeoutPhase(timeoutPhase) ||
-    ((input.status === "timeout" || input.status === "error") && providerStarted === true);
+    (input.status === "timeout" && providerStarted === true);
   const aborted = isAbortedAgentStopReason(stopReason);
   // ACP/model `stop` can be a normal successful finish. Treat rpc/stop as
   // cancellation only for non-success terminal payloads from abort paths.

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import {
   applyCodeModeCatalog,
@@ -93,7 +93,12 @@ async function runUntilCompleted(params: {
 }
 
 describe("Code Mode", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
   afterEach(() => {
+    vi.useRealTimers();
     testing.activeRuns.clear();
     testing.resumingRunIds.clear();
     testing.setTypescriptRuntimeForTest(null);

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -268,7 +268,7 @@ describe("waitForAgentRun", () => {
     });
   });
 
-  it("preserves timing metadata from agent.wait", async () => {
+  it("preserves timing metadata on provider-attributed wait timeouts", async () => {
     callGatewayMock.mockResolvedValue({
       status: "ok",
       startedAt: 100,
@@ -280,7 +280,7 @@ describe("waitForAgentRun", () => {
     const result = await waitForAgentRun({ runId: "run-2", timeoutMs: 500 });
 
     expect(result).toEqual({
-      status: "ok",
+      status: "timeout",
       startedAt: 100,
       endedAt: 200,
       timeoutPhase: "provider",

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -288,6 +288,26 @@ describe("waitForAgentRun", () => {
     });
   });
 
+  it("keeps hard wait timeouts stronger than blocked liveness", async () => {
+    callGatewayMock.mockResolvedValue({
+      status: "error",
+      error: "model timed out",
+      livenessState: "blocked",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+
+    const result = await waitForAgentRun({ runId: "run-blocked-timeout", timeoutMs: 500 });
+
+    expect(result).toEqual({
+      status: "timeout",
+      error: "model timed out",
+      livenessState: "blocked",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+  });
+
   it("normalizes blocked ok waits to errors", async () => {
     callGatewayMock.mockResolvedValue({
       status: "ok",

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -2,7 +2,10 @@ import { callGateway } from "../gateway/call.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeBlockedLivenessWaitStatus } from "../shared/agent-liveness.js";
 import { parseFiniteNumber } from "../shared/number-coercion.js";
-import { buildAgentRunTerminalOutcome } from "./agent-run-terminal-outcome.js";
+import {
+  buildAgentRunTerminalOutcome,
+  type AgentRunTerminalOutcome,
+} from "./agent-run-terminal-outcome.js";
 import {
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
@@ -79,11 +82,7 @@ function normalizeAgentWaitResult(
           startedAt: wait?.startedAt,
           endedAt: wait?.endedAt,
         });
-  const normalized = normalizeBlockedLivenessWaitStatus({
-    status: terminalOutcome?.status ?? status,
-    livenessState: wait?.livenessState,
-    error: terminalOutcome?.error,
-  });
+  const normalized = normalizeTerminalOutcomeForWait(terminalOutcome, status, wait?.livenessState);
   return {
     status: normalized.status,
     error: normalized.error,
@@ -96,6 +95,21 @@ function normalizeAgentWaitResult(
     timeoutPhase: normalizeAgentRunTimeoutPhase(wait?.timeoutPhase),
     providerStarted: normalizeProviderStarted(wait?.providerStarted),
   };
+}
+
+function normalizeTerminalOutcomeForWait(
+  outcome: AgentRunTerminalOutcome | undefined,
+  fallbackStatus: AgentWaitResult["status"],
+  livenessState?: unknown,
+): { status: AgentWaitResult["status"]; error?: string } {
+  if (outcome?.reason === "hard_timeout") {
+    return { status: outcome.status, error: outcome.error };
+  }
+  return normalizeBlockedLivenessWaitStatus({
+    status: outcome?.status ?? fallbackStatus,
+    livenessState,
+    error: outcome?.error,
+  });
 }
 
 const RECOVERABLE_AGENT_WAIT_ERROR_PATTERNS: readonly RegExp[] = [

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -147,6 +147,46 @@ describe("agent wait dedupe helper", () => {
     });
   });
 
+  it("keeps hard timeout snapshots stronger than blocked liveness", () => {
+    const dedupe = new Map();
+    const runId = "run-blocked-provider-timeout";
+
+    setRunEntry({
+      dedupe,
+      kind: "agent",
+      runId,
+      payload: {
+        runId,
+        status: "error",
+        startedAt: 100,
+        endedAt: 200,
+        error: "model timed out",
+        result: {
+          meta: {
+            livenessState: "blocked",
+            timeoutPhase: "provider",
+            providerStarted: true,
+          },
+        },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "timeout",
+      startedAt: 100,
+      endedAt: 200,
+      error: "model timed out",
+      livenessState: "blocked",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+  });
+
   it("normalizes blocked ok agent snapshots to errors", () => {
     const dedupe = new Map();
     const runId = "run-blocked-agent";

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -26,6 +26,16 @@ export type AgentWaitTerminalSnapshot = {
 
 const AGENT_WAITERS_BY_RUN_ID = new Map<string, Set<() => void>>();
 
+function normalizeTerminalOutcomeForWaitSnapshot(outcome: AgentRunTerminalOutcome): {
+  status: AgentWaitTerminalSnapshot["status"];
+  error?: string;
+} {
+  if (outcome.reason === "hard_timeout") {
+    return { status: outcome.status, error: outcome.error };
+  }
+  return normalizeBlockedLivenessWaitStatus(outcome);
+}
+
 function parseRunIdFromDedupeKey(key: string): string | null {
   if (key.startsWith("agent:")) {
     return key.slice("agent:".length) || null;
@@ -126,7 +136,7 @@ function readTerminalSnapshotFromDedupeEntry(entry: DedupeEntry): AgentWaitTermi
       startedAt,
       endedAt,
     });
-    const normalized = normalizeBlockedLivenessWaitStatus(terminalOutcome);
+    const normalized = normalizeTerminalOutcomeForWaitSnapshot(terminalOutcome);
     return {
       status: normalized.status,
       startedAt,
@@ -157,11 +167,17 @@ function readTerminalSnapshotFromDedupeEntry(entry: DedupeEntry): AgentWaitTermi
       startedAt,
       endedAt,
     });
+    const normalized = normalizeTerminalOutcomeForWaitSnapshot(terminalOutcome);
     return {
-      status: "error",
+      status: normalized.status,
       startedAt,
       endedAt,
-      error: terminalOutcome.error,
+      error:
+        normalized.status === "error"
+          ? normalized.error
+          : normalized.status === "timeout"
+            ? terminalOutcome.error
+            : undefined,
       stopReason,
       livenessState,
       ...(yielded ? { yielded } : {}),

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -112,4 +112,118 @@ describe("session lifecycle state", () => {
       abortedLastRun: false,
     });
   });
+
+  it("keeps provider hard timeouts stronger than rpc cancellation metadata", () => {
+    expect(
+      derivePersistedSessionLifecyclePatch({
+        entry: {
+          updatedAt: 1_000,
+          startedAt: 1_050,
+        },
+        event: {
+          ts: 2_000,
+          data: {
+            phase: "end",
+            aborted: true,
+            stopReason: "rpc",
+            timeoutPhase: "provider",
+            providerStarted: true,
+            endedAt: 1_550,
+          },
+        },
+      }),
+    ).toEqual({
+      updatedAt: 1_550,
+      status: "timeout",
+      startedAt: 1_050,
+      endedAt: 1_550,
+      runtimeMs: 500,
+      abortedLastRun: false,
+    });
+  });
+
+  it("maps non-hard rpc lifecycle aborts to killed sessions", () => {
+    expect(
+      derivePersistedSessionLifecyclePatch({
+        entry: {
+          updatedAt: 1_000,
+          startedAt: 1_050,
+        },
+        event: {
+          ts: 2_000,
+          data: {
+            phase: "end",
+            aborted: true,
+            stopReason: "rpc",
+            timeoutPhase: "queue",
+            providerStarted: false,
+            endedAt: 1_550,
+          },
+        },
+      }),
+    ).toEqual({
+      updatedAt: 1_550,
+      status: "killed",
+      startedAt: 1_050,
+      endedAt: 1_550,
+      runtimeMs: 500,
+      abortedLastRun: true,
+    });
+  });
+
+  it("maps provider timeout lifecycle errors to timed out sessions", () => {
+    expect(
+      derivePersistedSessionLifecyclePatch({
+        entry: {
+          updatedAt: 1_000,
+          startedAt: 1_050,
+        },
+        event: {
+          ts: 2_000,
+          data: {
+            phase: "error",
+            error: "provider request timed out",
+            livenessState: "blocked",
+            timeoutPhase: "provider",
+            providerStarted: true,
+            endedAt: 1_550,
+          },
+        },
+      }),
+    ).toEqual({
+      updatedAt: 1_550,
+      status: "timeout",
+      startedAt: 1_050,
+      endedAt: 1_550,
+      runtimeMs: 500,
+      abortedLastRun: false,
+    });
+  });
+
+  it("maps provider timeout lifecycle end metadata to timed out sessions", () => {
+    expect(
+      derivePersistedSessionLifecyclePatch({
+        entry: {
+          updatedAt: 1_000,
+          startedAt: 1_050,
+        },
+        event: {
+          ts: 2_000,
+          data: {
+            phase: "end",
+            timeoutPhase: "provider",
+            providerStarted: true,
+            endedAt: 1_550,
+          },
+        },
+      }),
+    ).toEqual({
+      updatedAt: 1_550,
+      status: "timeout",
+      startedAt: 1_050,
+      endedAt: 1_550,
+      runtimeMs: 500,
+      abortedLastRun: false,
+    });
+  });
 });

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -59,9 +59,9 @@ function mapAgentRunTerminalOutcomeToSessionStatus(
     case "blocked":
     case "failed":
       return "failed";
+    default:
+      return outcome.reason satisfies never;
   }
-  const unhandledReason: never = outcome.reason;
-  throw new Error(`Unhandled agent run terminal outcome: ${unhandledReason}`);
 }
 
 function resolveTerminalStatus(event: LifecycleEventLike): SessionRunStatus {

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -60,6 +60,8 @@ function mapAgentRunTerminalOutcomeToSessionStatus(
     case "failed":
       return "failed";
   }
+  const unhandledReason: never = outcome.reason;
+  throw new Error(`Unhandled agent run terminal outcome: ${unhandledReason}`);
 }
 
 function resolveTerminalStatus(event: LifecycleEventLike): SessionRunStatus {

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -1,3 +1,7 @@
+import {
+  buildAgentRunTerminalOutcome,
+  type AgentRunTerminalOutcome,
+} from "../agents/agent-run-terminal-outcome.js";
 import { updateSessionStoreEntry, type SessionEntry } from "../config/sessions.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import { loadSessionEntry } from "./session-utils.js";
@@ -12,6 +16,10 @@ type LifecycleEventLike = Pick<AgentEventPayload, "ts"> & {
     endedAt?: unknown;
     aborted?: unknown;
     stopReason?: unknown;
+    error?: unknown;
+    livenessState?: unknown;
+    timeoutPhase?: unknown;
+    providerStarted?: unknown;
   };
 };
 
@@ -36,18 +44,37 @@ function resolveLifecyclePhase(event: LifecycleEventLike): LifecyclePhase | null
   return phase === "start" || phase === "end" || phase === "error" ? phase : null;
 }
 
+function mapAgentRunTerminalOutcomeToSessionStatus(
+  outcome: AgentRunTerminalOutcome,
+): SessionRunStatus {
+  switch (outcome.reason) {
+    case "completed":
+      return "done";
+    case "hard_timeout":
+    case "timed_out":
+      return "timeout";
+    case "cancelled":
+    case "aborted":
+      return "killed";
+    case "blocked":
+    case "failed":
+      return "failed";
+  }
+}
+
 function resolveTerminalStatus(event: LifecycleEventLike): SessionRunStatus {
   const phase = resolveLifecyclePhase(event);
-  if (phase === "error") {
-    return "failed";
-  }
-
-  const stopReason = typeof event.data?.stopReason === "string" ? event.data.stopReason : "";
-  if (stopReason === "aborted") {
-    return "killed";
-  }
-
-  return event.data?.aborted === true ? "timeout" : "done";
+  const terminal = buildAgentRunTerminalOutcome({
+    status: phase === "error" ? "error" : event.data?.aborted === true ? "timeout" : "ok",
+    error: event.data?.error,
+    stopReason: event.data?.stopReason,
+    livenessState: event.data?.livenessState,
+    timeoutPhase: event.data?.timeoutPhase,
+    providerStarted: event.data?.providerStarted,
+    startedAt: event.data?.startedAt,
+    endedAt: event.data?.endedAt ?? event.ts,
+  });
+  return mapAgentRunTerminalOutcomeToSessionStatus(terminal);
 }
 
 function resolveLifecycleStartedAt(

--- a/src/security/audit-sandbox-browser.test.ts
+++ b/src/security/audit-sandbox-browser.test.ts
@@ -85,10 +85,11 @@ describe("security audit sandbox browser findings", () => {
   });
 
   it("bounds sandbox browser Docker probes that do not return", async () => {
+    vi.useFakeTimers();
     let probeSignal: AbortSignal | undefined;
     const startedAt = Date.now();
 
-    const findings = await collectSandboxBrowserHashLabelFindings({
+    const findingsPromise = collectSandboxBrowserHashLabelFindings({
       timeoutMs: 1,
       execDockerRawFn: async (_args, opts) => {
         probeSignal = opts?.signal;
@@ -99,6 +100,8 @@ describe("security audit sandbox browser findings", () => {
         );
       },
     });
+    await vi.advanceTimersByTimeAsync(250);
+    const findings = await findingsPromise;
 
     expect(Date.now() - startedAt).toBeLessThan(1000);
     expect(probeSignal?.aborted).toBe(true);
@@ -111,9 +114,10 @@ describe("security audit sandbox browser findings", () => {
   });
 
   it("stops probing remaining sandbox browser containers after a Docker timeout", async () => {
+    vi.useFakeTimers();
     const calls: string[] = [];
 
-    const findings = await collectSandboxBrowserHashLabelFindings({
+    const findingsPromise = collectSandboxBrowserHashLabelFindings({
       timeoutMs: 1,
       execDockerRawFn: async (args, opts) => {
         calls.push(`${args[0] ?? ""}:${args.at(-1) ?? ""}`);
@@ -131,6 +135,8 @@ describe("security audit sandbox browser findings", () => {
         );
       },
     });
+    await vi.advanceTimersByTimeAsync(250);
+    const findings = await findingsPromise;
 
     expect(calls).toEqual(["ps:{{.Names}}", "inspect:openclaw-sbx-browser-hung"]);
     expect(findings).toEqual([

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -581,6 +581,147 @@ describe("task-registry", () => {
     });
   });
 
+  it("uses shared agent terminal precedence for lifecycle task projection", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-hard-timeout-task",
+        task: "Provider timeout should not look cancelled",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-rpc-cancel-task",
+        task: "Caller abort should cancel task",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-aborted-task",
+        task: "Aborted runner stop should cancel task",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-provider-error-timeout-task",
+        task: "Provider timeout error should time out task",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-provider-end-timeout-task",
+        task: "Provider timeout end metadata should time out task",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId: "run-hard-timeout-task",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          aborted: true,
+          stopReason: "rpc",
+          timeoutPhase: "provider",
+          providerStarted: true,
+          endedAt: 200,
+        },
+      });
+      emitAgentEvent({
+        runId: "run-rpc-cancel-task",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          aborted: true,
+          stopReason: "rpc",
+          timeoutPhase: "queue",
+          providerStarted: false,
+          endedAt: 210,
+        },
+      });
+      emitAgentEvent({
+        runId: "run-aborted-task",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          stopReason: "aborted",
+          endedAt: 220,
+        },
+      });
+      emitAgentEvent({
+        runId: "run-provider-error-timeout-task",
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          error: "provider request timed out",
+          livenessState: "blocked",
+          timeoutPhase: "provider",
+          providerStarted: true,
+          endedAt: 230,
+        },
+      });
+      emitAgentEvent({
+        runId: "run-provider-end-timeout-task",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          timeoutPhase: "provider",
+          providerStarted: true,
+          endedAt: 240,
+        },
+      });
+
+      expectRecordFields(requireTaskByRunId("run-hard-timeout-task"), {
+        status: "timed_out",
+        endedAt: 200,
+      });
+      expectRecordFields(requireTaskByRunId("run-rpc-cancel-task"), {
+        status: "cancelled",
+        endedAt: 210,
+      });
+      expectRecordFields(requireTaskByRunId("run-aborted-task"), {
+        status: "cancelled",
+        endedAt: 220,
+      });
+      expectRecordFields(requireTaskByRunId("run-provider-error-timeout-task"), {
+        status: "timed_out",
+        endedAt: 230,
+        error: "provider request timed out",
+      });
+      expectRecordFields(requireTaskByRunId("run-provider-end-timeout-task"), {
+        status: "timed_out",
+        endedAt: 240,
+      });
+    });
+  });
+
   it("does not downgrade failed run-scoped tasks when a late success arrives", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1,5 +1,9 @@
 import crypto from "node:crypto";
 import { createRequire } from "node:module";
+import {
+  buildAgentRunTerminalOutcome,
+  type AgentRunTerminalOutcome,
+} from "../agents/agent-run-terminal-outcome.js";
 import { shouldRouteCompletionThroughRequesterSession } from "../auto-reply/reply/completion-delivery-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { onAgentEvent } from "../infra/agent-events.js";
@@ -440,6 +444,46 @@ function resolveTaskTerminalOutcome(params: {
     return normalized;
   }
   return params.status === "succeeded" ? "succeeded" : undefined;
+}
+
+function mapAgentRunTerminalOutcomeToTaskStatus(
+  outcome: AgentRunTerminalOutcome,
+): Extract<TaskStatus, "succeeded" | "failed" | "timed_out" | "cancelled"> {
+  switch (outcome.reason) {
+    case "completed":
+      return "succeeded";
+    case "hard_timeout":
+    case "timed_out":
+      return "timed_out";
+    case "cancelled":
+    case "aborted":
+      return "cancelled";
+    case "blocked":
+    case "failed":
+      return "failed";
+  }
+}
+
+function buildTaskLifecycleTerminalOutcome(params: {
+  phase: "end" | "error";
+  data?: Record<string, unknown>;
+  startedAt?: number;
+  endedAt?: number;
+}): AgentRunTerminalOutcome {
+  const status =
+    params.phase === "error" ? "error" : params.data?.aborted === true ? "timeout" : "ok";
+  // Lifecycle events carry runner/provider terminal facts. Keep the precedence
+  // centralized so task projections match agent.wait and gateway snapshots.
+  return buildAgentRunTerminalOutcome({
+    status,
+    error: params.data?.error,
+    stopReason: params.data?.stopReason,
+    livenessState: params.data?.livenessState,
+    timeoutPhase: params.data?.timeoutPhase,
+    providerStarted: params.data?.providerStarted,
+    startedAt: params.startedAt,
+    endedAt: params.endedAt,
+  });
 }
 
 function appendTaskEvent(event: {
@@ -1457,12 +1501,27 @@ function ensureListener() {
         if (phase === "start") {
           patch.status = "running";
         } else if (phase === "end") {
-          patch.status = evt.data?.aborted === true ? "timed_out" : "succeeded";
-          patch.endedAt = endedAt ?? now;
+          const terminal = buildTaskLifecycleTerminalOutcome({
+            phase,
+            data: evt.data,
+            startedAt,
+            endedAt: endedAt ?? now,
+          });
+          patch.status = mapAgentRunTerminalOutcomeToTaskStatus(terminal);
+          patch.endedAt = terminal.endedAt ?? now;
+          if (terminal.error) {
+            patch.error = terminal.error;
+          }
         } else if (phase === "error") {
-          patch.status = "failed";
-          patch.endedAt = endedAt ?? now;
-          patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
+          const terminal = buildTaskLifecycleTerminalOutcome({
+            phase,
+            data: evt.data,
+            startedAt,
+            endedAt: endedAt ?? now,
+          });
+          patch.status = mapAgentRunTerminalOutcomeToTaskStatus(terminal);
+          patch.endedAt = terminal.endedAt ?? now;
+          patch.error = terminal.error ?? current.error;
         }
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -462,6 +462,8 @@ function mapAgentRunTerminalOutcomeToTaskStatus(
     case "failed":
       return "failed";
   }
+  const unhandledReason: never = outcome.reason;
+  throw new Error(`Unhandled agent run terminal outcome: ${unhandledReason}`);
 }
 
 function buildTaskLifecycleTerminalOutcome(params: {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -461,9 +461,9 @@ function mapAgentRunTerminalOutcomeToTaskStatus(
     case "blocked":
     case "failed":
       return "failed";
+    default:
+      return outcome.reason satisfies never;
   }
-  const unhandledReason: never = outcome.reason;
-  throw new Error(`Unhandled agent run terminal outcome: ${unhandledReason}`);
 }
 
 function buildTaskLifecycleTerminalOutcome(params: {

--- a/test/scripts/e2e-websocket-open.test.ts
+++ b/test/scripts/e2e-websocket-open.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { waitForWebSocketOpen } from "../../scripts/e2e/lib/websocket-open.mjs";
 
 class FakeWebSocket extends EventEmitter {
@@ -15,6 +15,10 @@ class FakeWebSocket extends EventEmitter {
 }
 
 describe("E2E WebSocket open guard", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
   it("consumes abort errors after open timeouts", async () => {
     const ws = new FakeWebSocket();
     const keepAlive = setTimeout(() => {}, 100);

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildReadPermissions,
   githubJson,
@@ -11,6 +11,10 @@ import {
 } from "../../scripts/gh-read.js";
 
 describe("gh-read helpers", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
   it("finds repo from gh args", () => {
     expect(parseRepoArg(["pr", "view", "42", "-R", "openclaw/openclaw"])).toBe("openclaw/openclaw");
     expect(parseRepoArg(["run", "list", "--repo=openclaw/docs"])).toBe("openclaw/docs");
@@ -55,6 +59,7 @@ describe("gh-read helpers", () => {
   });
 
   it("aborts stalled GitHub API fetches at the request timeout", async () => {
+    vi.useFakeTimers();
     let signal: AbortSignal | undefined;
     const request = githubJson("/app", "token", undefined, {
       timeoutMs: 5,
@@ -64,18 +69,25 @@ describe("gh-read helpers", () => {
       }) as typeof fetch,
     });
 
-    await expect(request).rejects.toThrow(/GitHub API GET \/app exceeded timeout/u);
+    const rejected = expect(request).rejects.toThrow(/GitHub API GET \/app exceeded timeout/u);
+    await vi.advanceTimersByTimeAsync(5);
+    await rejected;
     expect(signal?.aborted).toBe(true);
   });
 
   it("times out stalled GitHub API response body reads", async () => {
+    vi.useFakeTimers();
     const response = new Response(new ReadableStream({}), { status: 200 });
     const request = githubJson("/app/installations", "token", undefined, {
       timeoutMs: 5,
       fetchImpl: (() => Promise.resolve(response)) as typeof fetch,
     });
 
-    await expect(request).rejects.toThrow(/GitHub API GET \/app\/installations exceeded timeout/u);
+    const rejected = expect(request).rejects.toThrow(
+      /GitHub API GET \/app\/installations exceeded timeout/u,
+    );
+    await vi.advanceTimersByTimeAsync(5);
+    await rejected;
   });
 
   it("bounds GitHub API error response bodies", async () => {

--- a/test/scripts/mcp-websocket-open.test.ts
+++ b/test/scripts/mcp-websocket-open.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { waitForWebSocketOpen } from "../../scripts/e2e/mcp-websocket-open.ts";
 
 class FakeWebSocket extends EventEmitter {
@@ -20,6 +20,10 @@ class FakeWebSocket extends EventEmitter {
 }
 
 describe("mcp channel WebSocket open guard", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
   it("consumes abort errors after open timeouts", async () => {
     const ws = new FakeWebSocket();
     const keepAlive = setTimeout(() => {}, 100);


### PR DESCRIPTION
## Summary

- Routes task and session lifecycle terminal projections through the shared agent-run terminal outcome helper.
- Extends timeout attribution precedence so provider timeout metadata wins over rpc/cancel/error/blocked surfaces without turning plain provider-started success into timeout.
- Aligns SDK wait and normalized event surfaces with the same timeout/cancel precedence.

## Real behavior proof

Behavior addressed: provider-attributed agent run timeouts remain timeouts across task, session, SDK wait, and SDK event projections.
Real environment tested: local source checkout on Node/pnpm.
Exact steps or command run after this patch: pnpm test src/agents/agent-run-terminal-outcome.test.ts src/tasks/task-registry.test.ts packages/sdk/src/index.test.ts src/gateway/session-lifecycle-state.test.ts -- --reporter=verbose
Evidence after fix: 4 Vitest shards passed: unit-fast, unit, gateway, and tasks.
Observed result after fix: provider timeout metadata maps to timed_out/timeout while pending retry-grace and successful provider-started snapshots remain non-terminal/completed.
What was not tested: full repository CI locally; GitHub CI will cover the broader matrix.

## Verification

- pnpm test src/agents/agent-run-terminal-outcome.test.ts src/tasks/task-registry.test.ts packages/sdk/src/index.test.ts src/gateway/session-lifecycle-state.test.ts -- --reporter=verbose
- node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
- pnpm --filter @openclaw/sdk build
- git diff --check
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main
