### PR TITLE
Cache subagent read snapshots on gateway hot paths

### DIFF
--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -182,6 +182,7 @@ async function resumeOrphanedSession(params: {
  */
 export async function recoverOrphanedSubagentSessions(params: {
   getActiveRuns: () => Map<string, SubagentRunRecord>;
+  markActiveRunsMutated?: () => void;
   /** Persisted across retries so already-resumed sessions are not resumed again. */
   resumedSessionKeys?: Set<string>;
 }): Promise<{
@@ -237,6 +238,7 @@ export async function recoverOrphanedSubagentSessions(params: {
 
         if (isLegacyRestartInterruptedTimeout(runRecord, entry)) {
           reclassifyLegacyRestartInterruptedRun(runRecord);
+          params.markActiveRunsMutated?.();
         }
 
         // Terminal child outcomes are immutable. Restart resume only applies to
@@ -417,6 +419,7 @@ function buildRecoveryFailureMessage(params: { attempts: number; error?: string 
  */
 export function scheduleOrphanRecovery(params: {
   getActiveRuns: () => Map<string, SubagentRunRecord>;
+  markActiveRunsMutated?: () => void;
   delayMs?: number;
   maxRetries?: number;
 }): void {

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -179,6 +179,7 @@ function createLifecycleController({
     runs,
     resumedRuns: new Set(),
     subagentAnnounceTimeoutMs: 1_000,
+    markRunsMutated: vi.fn(),
     persist: vi.fn(),
     clearPendingLifecycleError: vi.fn(),
     countPendingDescendantRuns: () => 0,
@@ -264,6 +265,45 @@ describe("subagent registry lifecycle hardening", () => {
     browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd.mockClear();
     bundleMcpRuntimeMocks.retireSessionMcpRuntimeForSessionKey.mockClear();
     bundleMcpRuntimeMocks.retireSessionMcpRuntimeForSessionKey.mockResolvedValue(true);
+  });
+
+  it("marks in-memory snapshots dirty before awaiting terminal reply capture", async () => {
+    const entry = createRunEntry();
+    const markRunsMutated = vi.fn();
+    const persist = vi.fn();
+    let resolveCapture!: (value: string) => void;
+    const captureStarted = vi.fn();
+    const captureSubagentCompletionReply = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveCapture = resolve;
+          captureStarted();
+        }),
+    );
+    const controller = createLifecycleController({
+      entry,
+      markRunsMutated,
+      persist,
+      captureSubagentCompletionReply,
+    });
+
+    const completion = controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    await vi.waitFor(() => expect(captureStarted).toHaveBeenCalledTimes(1));
+    expect(entry.endedAt).toBe(4_000);
+    expect(markRunsMutated).toHaveBeenCalledTimes(1);
+    expect(persist).not.toHaveBeenCalled();
+
+    resolveCapture("final completion reply");
+    await completion;
+
+    expect(persist).toHaveBeenCalledTimes(1);
   });
 
   it("does not reject completion when task finalization throws", async () => {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -136,6 +136,7 @@ export function createSubagentRegistryLifecycleController(params: {
   runs: Map<string, SubagentRunRecord>;
   resumedRuns: Set<string>;
   subagentAnnounceTimeoutMs: number;
+  markRunsMutated(): void;
   persist(): void;
   clearPendingLifecycleError(runId: string): void;
   countPendingDescendantRuns(rootSessionKey: string): number;
@@ -1102,6 +1103,14 @@ export function createSubagentRegistryLifecycleController(params: {
     }
 
     let mutated = false;
+    let markedMutableSnapshotDirty = false;
+    const markMutableSnapshotDirty = () => {
+      if (!mutated || markedMutableSnapshotDirty) {
+        return;
+      }
+      params.markRunsMutated();
+      markedMutableSnapshotDirty = true;
+    };
     if (
       completeParams.reason === SUBAGENT_ENDED_REASON_COMPLETE &&
       entry.suppressAnnounceReason === "killed" &&
@@ -1189,6 +1198,7 @@ export function createSubagentRegistryLifecycleController(params: {
       mutated = true;
     }
 
+    markMutableSnapshotDirty();
     if (await freezeRunResultAtCompletion(entry, outcome)) {
       mutated = true;
     }

--- a/src/agents/subagent-registry-memory.ts
+++ b/src/agents/subagent-registry-memory.ts
@@ -1,3 +1,42 @@
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
-export const subagentRuns = new Map<string, SubagentRunRecord>();
+let subagentRegistryMemoryVersion = 0;
+
+export function getSubagentRegistryMemoryVersion(): number {
+  return subagentRegistryMemoryVersion;
+}
+
+export function bumpSubagentRegistryMemoryVersion(): number {
+  subagentRegistryMemoryVersion =
+    subagentRegistryMemoryVersion >= Number.MAX_SAFE_INTEGER
+      ? 1
+      : subagentRegistryMemoryVersion + 1;
+  return subagentRegistryMemoryVersion;
+}
+
+class VersionedSubagentRunMap extends Map<string, SubagentRunRecord> {
+  override set(runId: string, entry: SubagentRunRecord): this {
+    super.set(runId, entry);
+    bumpSubagentRegistryMemoryVersion();
+    return this;
+  }
+
+  override delete(runId: string): boolean {
+    const deleted = super.delete(runId);
+    if (deleted) {
+      bumpSubagentRegistryMemoryVersion();
+    }
+    return deleted;
+  }
+
+  override clear(): void {
+    if (this.size === 0) {
+      super.clear();
+      return;
+    }
+    super.clear();
+    bumpSubagentRegistryMemoryVersion();
+  }
+}
+
+export const subagentRuns = new VersionedSubagentRunMap();

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -1,8 +1,11 @@
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import type { ReadonlySubagentRunRecord } from "./subagent-registry.store.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { hasSubagentRunEnded, isLiveUnendedSubagentRun } from "./subagent-run-liveness.js";
 
-function resolveControllerSessionKey(entry: SubagentRunRecord): string {
+type SubagentRunReadRecord = SubagentRunRecord | ReadonlySubagentRunRecord;
+
+function resolveControllerSessionKey(entry: SubagentRunReadRecord): string {
   return entry.controllerSessionKey?.trim() || entry.requesterSessionKey;
 }
 
@@ -50,21 +53,21 @@ export function listRunsForControllerFromRuns(
   return [...runs.values()].filter((entry) => resolveControllerSessionKey(entry) === key);
 }
 
-type LatestRunPair = {
+type LatestRunPair<Entry extends SubagentRunReadRecord> = {
   runId: string;
-  entry: SubagentRunRecord;
+  entry: Entry;
 };
 
-export type SubagentRunReadIndex = {
-  getDisplaySubagentRun(childSessionKey: string): SubagentRunRecord | null;
+export type SubagentRunReadIndex<Entry extends SubagentRunReadRecord = SubagentRunRecord> = {
+  getDisplaySubagentRun(childSessionKey: string): Entry | null;
   countActiveDescendantRuns(rootSessionKey: string): number;
-  runsByControllerSessionKey: ReadonlyMap<string, readonly SubagentRunRecord[]>;
+  runsByControllerSessionKey: ReadonlyMap<string, readonly Entry[]>;
 };
 
-function rememberLatestRunEntry(
-  map: Map<string, SubagentRunRecord>,
+function rememberLatestRunEntry<Entry extends SubagentRunReadRecord>(
+  map: Map<string, Entry>,
   key: string,
-  entry: SubagentRunRecord,
+  entry: Entry,
 ): void {
   const existing = map.get(key);
   if (!existing || entry.createdAt > existing.createdAt) {
@@ -72,11 +75,11 @@ function rememberLatestRunEntry(
   }
 }
 
-function rememberLatestRunPair(
-  map: Map<string, LatestRunPair>,
+function rememberLatestRunPair<Entry extends SubagentRunReadRecord>(
+  map: Map<string, LatestRunPair<Entry>>,
   key: string,
   runId: string,
-  entry: SubagentRunRecord,
+  entry: Entry,
 ): void {
   const existing = map.get(key);
   if (!existing || entry.createdAt > existing.entry.createdAt) {
@@ -84,25 +87,28 @@ function rememberLatestRunPair(
   }
 }
 
-export function buildSubagentRunReadIndexFromRuns(params: {
-  runs: Map<string, SubagentRunRecord>;
-  inMemoryRuns?: Iterable<SubagentRunRecord>;
+export function buildSubagentRunReadIndexFromRuns<Entry extends SubagentRunReadRecord>(params: {
+  runs: ReadonlyMap<string, Entry>;
+  inMemoryRuns?: Iterable<Entry>;
   now?: number;
-}): SubagentRunReadIndex {
+}): SubagentRunReadIndex<Entry> {
   const { runs } = params;
   const now = params.now ?? Date.now();
   const inMemoryDisplayByChildSessionKey = new Map<
     string,
     {
-      latestInMemoryActive: SubagentRunRecord | null;
-      latestInMemoryEnded: SubagentRunRecord | null;
+      latestInMemoryActive: Entry | null;
+      latestInMemoryEnded: Entry | null;
     }
   >();
-  const latestSnapshotActiveByChildSessionKey = new Map<string, SubagentRunRecord>();
-  const latestSnapshotEndedByChildSessionKey = new Map<string, SubagentRunRecord>();
-  const latestRunByChildSessionKey = new Map<string, LatestRunPair>();
-  const runsByControllerSessionKey = new Map<string, SubagentRunRecord[]>();
-  const latestRunByRequesterAndChildSessionKey = new Map<string, Map<string, LatestRunPair>>();
+  const latestSnapshotActiveByChildSessionKey = new Map<string, Entry>();
+  const latestSnapshotEndedByChildSessionKey = new Map<string, Entry>();
+  const latestRunByChildSessionKey = new Map<string, LatestRunPair<Entry>>();
+  const runsByControllerSessionKey = new Map<string, Entry[]>();
+  const latestRunByRequesterAndChildSessionKey = new Map<
+    string,
+    Map<string, LatestRunPair<Entry>>
+  >();
   const activeDescendantCountBySessionKey = new Map<string, number>();
 
   for (const entry of params.inMemoryRuns ?? []) {
@@ -153,13 +159,13 @@ export function buildSubagentRunReadIndexFromRuns(params: {
     }
     let latestByChild = latestRunByRequesterAndChildSessionKey.get(requesterSessionKey);
     if (!latestByChild) {
-      latestByChild = new Map<string, LatestRunPair>();
+      latestByChild = new Map<string, LatestRunPair<Entry>>();
       latestRunByRequesterAndChildSessionKey.set(requesterSessionKey, latestByChild);
     }
     rememberLatestRunPair(latestByChild, childSessionKey, runId, entry);
   }
 
-  const getDisplaySubagentRun = (childSessionKey: string): SubagentRunRecord | null => {
+  const getDisplaySubagentRun = (childSessionKey: string): Entry | null => {
     const key = childSessionKey.trim();
     if (!key) {
       return null;

--- a/src/agents/subagent-registry-read-context.test.ts
+++ b/src/agents/subagent-registry-read-context.test.ts
@@ -7,6 +7,7 @@ import {
   type SubagentRunReadIndex,
 } from "./subagent-registry-queries.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { STALE_UNENDED_SUBAGENT_RUN_MS } from "./subagent-run-liveness.js";
 
 function makeRun(overrides: Partial<SubagentRunRecord>): SubagentRunRecord {
   const runId = overrides.runId ?? "run-default";
@@ -200,6 +201,34 @@ describe("subagent registry read index", () => {
     const index = buildSubagentRunReadIndexFromRuns({ runs });
 
     expect(index.getDisplaySubagentRun(normalizedChildSessionKey)).toBe(run);
+  });
+
+  it("derives liveness from the supplied now instead of caching raw snapshot answers", () => {
+    const startedAt = Date.UTC(2025, 0, 1);
+    const root = "agent:main:main";
+    const child = "agent:main:subagent:time-sensitive";
+    const runs = toRunMap([
+      makeRun({
+        runId: "run-time-sensitive",
+        childSessionKey: child,
+        controllerSessionKey: root,
+        requesterSessionKey: root,
+        createdAt: startedAt,
+        startedAt,
+      }),
+    ]);
+
+    const freshIndex = buildSubagentRunReadIndexFromRuns({
+      runs,
+      now: startedAt + 60_000,
+    });
+    const staleIndex = buildSubagentRunReadIndexFromRuns({
+      runs,
+      now: startedAt + STALE_UNENDED_SUBAGENT_RUN_MS + 60_000,
+    });
+
+    expect(freshIndex.countActiveDescendantRuns(root)).toBe(1);
+    expect(staleIndex.countActiveDescendantRuns(root)).toBe(0);
   });
 
   it("keeps the display-row preference for in-memory records over persisted snapshots", () => {

--- a/src/agents/subagent-registry-read.ts
+++ b/src/agents/subagent-registry-read.ts
@@ -8,7 +8,11 @@ import {
   listRunsForControllerFromRuns,
   type SubagentRunReadIndex,
 } from "./subagent-registry-queries.js";
-import { getSubagentRunsSnapshotForRead } from "./subagent-registry-state.js";
+import {
+  getSubagentRegistryReadSnapshot,
+  getSubagentRunsSnapshotForRead,
+} from "./subagent-registry-state.js";
+import type { ReadonlySubagentRunRecord } from "./subagent-registry.store.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 export {
@@ -17,10 +21,13 @@ export {
   resolveSubagentSessionStatus,
 } from "./subagent-session-metrics.js";
 
-export function buildSubagentRunReadIndex(now = Date.now()): SubagentRunReadIndex {
+export function buildSubagentRunReadIndex(
+  now = Date.now(),
+): SubagentRunReadIndex<ReadonlySubagentRunRecord> {
+  const snapshot = getSubagentRegistryReadSnapshot();
   return buildSubagentRunReadIndexFromRuns({
-    runs: getSubagentRunsSnapshotForRead(subagentRuns),
-    inMemoryRuns: subagentRuns.values(),
+    runs: snapshot.runsById,
+    inMemoryRuns: snapshot.inMemoryRunsById.values(),
     now,
   });
 }

--- a/src/agents/subagent-registry-state.ts
+++ b/src/agents/subagent-registry-state.ts
@@ -1,5 +1,37 @@
-import { loadSubagentRegistryFromDisk, saveSubagentRegistryToDisk } from "./subagent-registry.store.js";
+import { getSubagentRegistryMemoryVersion, subagentRuns } from "./subagent-registry-memory.js";
+import {
+  cloneReadonlySubagentRunRecord,
+  createReadonlySubagentRunMap,
+  getSubagentRegistryDiskReadSnapshot,
+  loadSubagentRegistryFromDisk,
+  saveSubagentRegistryToDisk,
+  type ReadonlySubagentRunRecord,
+} from "./subagent-registry.store.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+export type SubagentRegistryReadSnapshot = {
+  readonly source: "subagent-registry";
+  readonly diskSignature: string | null;
+  readonly memoryVersion: number;
+  readonly runsById: ReadonlyMap<string, ReadonlySubagentRunRecord>;
+  readonly inMemoryRunsById: ReadonlyMap<string, ReadonlySubagentRunRecord>;
+};
+
+type CachedSubagentRegistryReadSnapshot = {
+  readonly shouldReadDisk: boolean;
+  readonly diskSignature: string | null;
+  readonly memoryVersion: number;
+  readonly snapshot: SubagentRegistryReadSnapshot;
+};
+
+let cachedReadSnapshot: CachedSubagentRegistryReadSnapshot | null = null;
+
+function shouldReadPersistedSubagentRegistry(): boolean {
+  return (
+    process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK === "1" ||
+    !(process.env.VITEST || process.env.NODE_ENV === "test")
+  );
+}
 
 export function persistSubagentRunsToDisk(runs: Map<string, SubagentRunRecord>) {
   try {
@@ -35,13 +67,65 @@ export function restoreSubagentRunsFromDisk(params: {
   return added;
 }
 
+export function getSubagentRegistryReadSnapshot(): SubagentRegistryReadSnapshot {
+  const shouldReadDisk = shouldReadPersistedSubagentRegistry();
+  let diskSnapshot: ReturnType<typeof getSubagentRegistryDiskReadSnapshot> | null = null;
+  let diskReadFailed = false;
+  if (shouldReadDisk) {
+    try {
+      diskSnapshot = getSubagentRegistryDiskReadSnapshot();
+    } catch {
+      diskReadFailed = true;
+    }
+  }
+  const diskSignature = diskSnapshot?.diskSignature ?? null;
+  const memoryVersion = getSubagentRegistryMemoryVersion();
+  if (
+    !diskReadFailed &&
+    cachedReadSnapshot?.shouldReadDisk === shouldReadDisk &&
+    cachedReadSnapshot.diskSignature === diskSignature &&
+    cachedReadSnapshot.memoryVersion === memoryVersion
+  ) {
+    return cachedReadSnapshot.snapshot;
+  }
+
+  const inMemoryEntries = [...subagentRuns.entries()].map(
+    ([runId, entry]) => [runId, cloneReadonlySubagentRunRecord(entry)] as const,
+  );
+  const inMemoryRunsById = createReadonlySubagentRunMap(inMemoryEntries);
+  const mergedRuns = new Map<string, ReadonlySubagentRunRecord>();
+  if (diskSnapshot) {
+    for (const [runId, entry] of diskSnapshot.runsById.entries()) {
+      mergedRuns.set(runId, entry);
+    }
+  }
+  for (const [runId, entry] of inMemoryRunsById.entries()) {
+    mergedRuns.set(runId, entry);
+  }
+
+  const snapshot = Object.freeze({
+    source: "subagent-registry" as const,
+    diskSignature,
+    memoryVersion,
+    runsById: createReadonlySubagentRunMap(mergedRuns.entries()),
+    inMemoryRunsById,
+  });
+  if (!diskReadFailed) {
+    cachedReadSnapshot = {
+      shouldReadDisk,
+      diskSignature,
+      memoryVersion,
+      snapshot,
+    };
+  }
+  return snapshot;
+}
+
 export function getSubagentRunsSnapshotForRead(
   inMemoryRuns: Map<string, SubagentRunRecord>,
 ): Map<string, SubagentRunRecord> {
   const merged = new Map<string, SubagentRunRecord>();
-  const shouldReadDisk =
-    process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK === "1" ||
-    !(process.env.VITEST || process.env.NODE_ENV === "test");
+  const shouldReadDisk = shouldReadPersistedSubagentRegistry();
   if (shouldReadDisk) {
     try {
       // Persisted state lets other worker processes observe active runs.

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -12,11 +12,17 @@ import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { captureEnv, withEnv } from "../test-utils/env.js";
 import { persistSubagentSessionTiming } from "./subagent-registry-helpers.js";
-import { getSubagentRunsSnapshotForRead } from "./subagent-registry-state.js";
+import { buildSubagentRunReadIndexFromRuns } from "./subagent-registry-queries.js";
+import {
+  getSubagentRegistryReadSnapshot,
+  getSubagentRunsSnapshotForRead,
+} from "./subagent-registry-state.js";
 import {
   testing,
   addSubagentRunForTests,
   clearSubagentRunSteerRestart,
+  markSubagentRunForSteerRestart,
+  releaseSubagentRun,
   getLatestSubagentRunByChildSessionKey,
   getSubagentRunByChildSessionKey,
   initSubagentRegistry,
@@ -443,6 +449,251 @@ describe("subagent registry persistence", () => {
       } else {
         process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK = previousFlag;
       }
+    }
+  });
+
+
+  it("reuses immutable read snapshots while preserving mutable compatibility clones", async () => {
+    await writePersistedRegistry(
+      {
+        version: 2,
+        runs: {
+          "run-readonly": {
+            runId: "run-readonly",
+            childSessionKey: "agent:main:subagent:readonly",
+            requesterSessionKey: "agent:main:main",
+            requesterOrigin: { channel: "telegram", accountId: "readonly-account" },
+            requesterDisplayKey: "main",
+            task: "readonly persisted run",
+            cleanup: "keep",
+            createdAt: 1,
+            startedAt: 1,
+            outcome: { status: "ok" },
+            delivery: { status: "pending", attemptCount: 1 },
+          },
+        },
+      },
+      { seedChildSessions: false },
+    );
+
+    const first = withEnv({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1" }, () =>
+      getSubagentRegistryReadSnapshot(),
+    );
+    const second = withEnv({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1" }, () =>
+      getSubagentRegistryReadSnapshot(),
+    );
+    const readonlyEntry = first.runsById.get("run-readonly");
+    if (!readonlyEntry) {
+      throw new Error("expected readonly run");
+    }
+
+    expect(second).toBe(first);
+    expect(second.runsById.get("run-readonly")).toBe(readonlyEntry);
+    expect(Object.isFrozen(readonlyEntry)).toBe(true);
+    expect(Object.isFrozen(readonlyEntry.requesterOrigin)).toBe(true);
+    expect(Object.isFrozen(readonlyEntry.outcome)).toBe(true);
+    expect(Object.isFrozen(readonlyEntry.delivery)).toBe(true);
+    expect(() => {
+      (readonlyEntry as SubagentRunRecord).endedAt = 999;
+    }).toThrow(TypeError);
+    expect(() => {
+      (readonlyEntry.requesterOrigin as { accountId?: string }).accountId = "mutated";
+    }).toThrow(TypeError);
+
+    const mutable = loadSubagentRegistryFromDisk();
+    const mutableEntry = mutable.get("run-readonly");
+    if (!mutableEntry?.requesterOrigin || !mutableEntry.outcome) {
+      throw new Error("expected mutable run");
+    }
+    mutableEntry.requesterOrigin.accountId = "mutated-account";
+    mutableEntry.outcome.status = "error";
+    mutableEntry.delivery = { status: "failed", lastError: "mutated" };
+
+    const third = withEnv({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1" }, () =>
+      getSubagentRegistryReadSnapshot(),
+    );
+    expect(third).toBe(first);
+    expect(third.runsById.get("run-readonly")?.requesterOrigin?.accountId).toBe("readonly-account");
+    expect(third.runsById.get("run-readonly")?.outcome?.status).toBe("ok");
+    expect(third.runsById.get("run-readonly")?.delivery?.status).toBe("pending");
+
+    const compatibilityAgain = loadSubagentRegistryFromDisk();
+    expect(compatibilityAgain).not.toBe(mutable);
+    expect(compatibilityAgain.get("run-readonly")).not.toBe(mutableEntry);
+    expect(compatibilityAgain.get("run-readonly")?.requesterOrigin?.accountId).toBe(
+      "readonly-account",
+    );
+  });
+
+  it("invalidates immutable read snapshots when the persisted registry signature changes", async () => {
+    const registryPath = await writePersistedRegistry(
+      {
+        version: 2,
+        runs: {
+          "run-before-signature-change": {
+            runId: "run-before-signature-change",
+            childSessionKey: "agent:main:subagent:before-signature-change",
+            requesterSessionKey: "agent:main:main",
+            requesterDisplayKey: "main",
+            task: "before signature change",
+            cleanup: "keep",
+            createdAt: 1,
+            startedAt: 1,
+          },
+        },
+      },
+      { seedChildSessions: false },
+    );
+
+    const before = withEnv({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1" }, () =>
+      getSubagentRegistryReadSnapshot(),
+    );
+
+    await fs.writeFile(
+      registryPath,
+      `${JSON.stringify({
+        version: 2,
+        runs: {
+          "run-after-signature-change": {
+            runId: "run-after-signature-change",
+            childSessionKey: "agent:main:subagent:after-signature-change",
+            requesterSessionKey: "agent:main:main",
+            requesterDisplayKey: "main",
+            task: "after signature change with longer payload",
+            cleanup: "keep",
+            createdAt: 2,
+            startedAt: 2,
+          },
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    const after = withEnv({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1" }, () =>
+      getSubagentRegistryReadSnapshot(),
+    );
+
+    expect(after).not.toBe(before);
+    expect(after.diskSignature).not.toBe(before.diskSignature);
+    expect(after.runsById.has("run-before-signature-change")).toBe(false);
+    expect(after.runsById.has("run-after-signature-change")).toBe(true);
+  });
+
+  it("falls back to memory-only immutable snapshots when persisted registry reads fail", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    await fs.writeFile(path.join(tempStateDir, "subagents"), "not a directory", "utf8");
+    resetSubagentRegistryForTests({ persist: false });
+    addSubagentRunForTests({
+      runId: "run-memory-fallback",
+      childSessionKey: "agent:main:subagent:memory-fallback",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "memory fallback run",
+      cleanup: "keep",
+      createdAt: 1,
+      startedAt: 1,
+    });
+
+    const snapshot = withEnv({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1" }, () =>
+      getSubagentRegistryReadSnapshot(),
+    );
+
+    expect(snapshot.diskSignature).toBeNull();
+    expect(snapshot.runsById.get("run-memory-fallback")?.task).toBe("memory fallback run");
+  });
+
+  it("invalidates immutable read snapshots on in-memory add update and delete", () => {
+    resetSubagentRegistryForTests({ persist: false });
+    const empty = getSubagentRegistryReadSnapshot();
+
+    addSubagentRunForTests({
+      runId: "run-memory-versioned",
+      childSessionKey: "agent:main:subagent:memory-versioned",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "memory versioned run",
+      cleanup: "keep",
+      createdAt: 1,
+      startedAt: 1,
+      delivery: { status: "pending", attemptCount: 0 },
+    });
+
+    const afterAdd = getSubagentRegistryReadSnapshot();
+    expect(afterAdd).not.toBe(empty);
+    expect(afterAdd.runsById.get("run-memory-versioned")?.task).toBe("memory versioned run");
+    expect(getSubagentRegistryReadSnapshot()).toBe(afterAdd);
+
+    expect(markSubagentRunForSteerRestart("run-memory-versioned")).toBe(true);
+    const afterUpdate = getSubagentRegistryReadSnapshot();
+    expect(afterUpdate).not.toBe(afterAdd);
+    expect(afterUpdate.runsById.get("run-memory-versioned")?.suppressAnnounceReason).toBe(
+      "steer-restart",
+    );
+
+    releaseSubagentRun("run-memory-versioned");
+    const afterDelete = getSubagentRegistryReadSnapshot();
+    expect(afterDelete).not.toBe(afterUpdate);
+    expect(afterDelete.runsById.has("run-memory-versioned")).toBe(false);
+  });
+
+  it("builds row-like read indexes from immutable snapshots without repeated clone work", async () => {
+    await writePersistedRegistry(
+      {
+        version: 2,
+        runs: Object.fromEntries(
+          Array.from({ length: 12 }, (_, index) => {
+            const runId = `run-row-like-${index}`;
+            const childSessionKey = `agent:main:subagent:row-like-${index}`;
+            const requesterSessionKey =
+              index === 0 ? "agent:main:main" : `agent:main:subagent:row-like-${index - 1}`;
+            return [
+              runId,
+              {
+                runId,
+                childSessionKey,
+                controllerSessionKey: requesterSessionKey,
+                requesterSessionKey,
+                requesterDisplayKey: requesterSessionKey,
+                task: `row-like ${index}`,
+                cleanup: "keep",
+                createdAt: Date.UTC(2025, 0, 1) + index,
+                startedAt: Date.UTC(2025, 0, 1) + index,
+              },
+            ];
+          }),
+        ),
+      },
+      { seedChildSessions: false },
+    );
+
+    const originalStructuredClone = globalThis.structuredClone;
+    const cloneSpy = vi
+      .spyOn(globalThis, "structuredClone")
+      .mockImplementation((value: unknown, options?: StructuredSerializeOptions) =>
+        originalStructuredClone(value, options),
+      );
+    try {
+      const first = withEnv({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1" }, () =>
+        getSubagentRegistryReadSnapshot(),
+      );
+      cloneSpy.mockClear();
+
+      for (let index = 0; index < 20; index += 1) {
+        const snapshot = withEnv({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1" }, () =>
+          getSubagentRegistryReadSnapshot(),
+        );
+        expect(snapshot).toBe(first);
+        const readIndex = buildSubagentRunReadIndexFromRuns({
+          runs: snapshot.runsById,
+          now: Date.UTC(2025, 0, 1) + 60_000,
+        });
+        expect(readIndex.countActiveDescendantRuns("agent:main:main")).toBeGreaterThan(0);
+      }
+
+      expect(cloneSpy).not.toHaveBeenCalled();
+    } finally {
+      cloneSpy.mockRestore();
     }
   });
 

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -23,10 +23,28 @@ type PersistedSubagentRegistry = PersistedSubagentRegistryV1 | PersistedSubagent
 const REGISTRY_VERSION = 2 as const;
 const MAX_SUBAGENT_REGISTRY_READ_CACHE_ENTRIES = 32;
 
+export type DeepReadonly<T> = T extends readonly (infer Item)[]
+  ? readonly DeepReadonly<Item>[]
+  : T extends object
+    ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+    : T;
+export type ReadonlySubagentRunRecord = DeepReadonly<SubagentRunRecord>;
+
+export type SubagentRegistryDiskReadSnapshot = {
+  readonly source: "subagent-registry-disk";
+  readonly diskSignature: string | null;
+  readonly runsById: ReadonlyMap<string, ReadonlySubagentRunRecord>;
+};
+
 type PersistedSubagentRunRecord = SubagentRunRecord;
-type ReadonlySubagentRunRecord = Readonly<SubagentRunRecord>;
 
 type RegistryCacheEntry = {
+  signature: string;
+  runs: Map<string, SubagentRunRecord>;
+  readonlySnapshot?: SubagentRegistryDiskReadSnapshot;
+};
+
+type LoadedRegistryRead = {
   signature: string;
   runs: Map<string, SubagentRunRecord>;
 };
@@ -38,10 +56,78 @@ type LegacySubagentRunRecord = PersistedSubagentRunRecord & {
   requesterAccountId?: unknown;
 };
 
+class ImmutableReadonlyMap<K, V> implements ReadonlyMap<K, V> {
+  readonly #inner: Map<K, V>;
+
+  constructor(entries?: Iterable<readonly [K, V]>) {
+    this.#inner = new Map(entries);
+    Object.freeze(this);
+  }
+
+  get size(): number {
+    return this.#inner.size;
+  }
+
+  get [Symbol.toStringTag](): string {
+    return "Map";
+  }
+
+  get(key: K): V | undefined {
+    return this.#inner.get(key);
+  }
+
+  has(key: K): boolean {
+    return this.#inner.has(key);
+  }
+
+  entries(): MapIterator<[K, V]> {
+    return this.#inner.entries();
+  }
+
+  keys(): MapIterator<K> {
+    return this.#inner.keys();
+  }
+
+  values(): MapIterator<V> {
+    return this.#inner.values();
+  }
+
+  forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: unknown): void {
+    for (const [key, value] of this.#inner.entries()) {
+      callbackfn.call(thisArg, value, key, this);
+    }
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.entries();
+  }
+}
+
 const registryReadCache = new Map<string, RegistryCacheEntry>();
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): DeepReadonly<T> {
+  if (!value || typeof value !== "object") {
+    return value as DeepReadonly<T>;
+  }
+  if (seen.has(value)) {
+    return value as DeepReadonly<T>;
+  }
+  seen.add(value);
+  const record = value as Record<PropertyKey, unknown>;
+  for (const key of Reflect.ownKeys(record)) {
+    deepFreeze(record[key], seen);
+  }
+  return Object.freeze(value) as DeepReadonly<T>;
+}
 
 function cloneSubagentRunRecord(entry: SubagentRunRecord): SubagentRunRecord {
   return structuredClone(entry);
+}
+
+export function cloneReadonlySubagentRunRecord(
+  entry: SubagentRunRecord | ReadonlySubagentRunRecord,
+): ReadonlySubagentRunRecord {
+  return deepFreeze(structuredClone(entry));
 }
 
 function cloneSubagentRunMap(
@@ -50,20 +136,42 @@ function cloneSubagentRunMap(
   return new Map([...runs].map(([runId, entry]) => [runId, cloneSubagentRunRecord(entry)]));
 }
 
+export function createReadonlySubagentRunMap(
+  entries: Iterable<readonly [string, ReadonlySubagentRunRecord]>,
+): ReadonlyMap<string, ReadonlySubagentRunRecord> {
+  return new ImmutableReadonlyMap(entries);
+}
+
+function createReadonlySubagentRunMapFromMutable(
+  runs: ReadonlyMap<string, SubagentRunRecord>,
+): ReadonlyMap<string, ReadonlySubagentRunRecord> {
+  return createReadonlySubagentRunMap(
+    [...runs].map(([runId, entry]) => [runId, cloneReadonlySubagentRunRecord(entry)] as const),
+  );
+}
+
+function touchCachedRegistryRead(pathname: string, cached: RegistryCacheEntry): RegistryCacheEntry {
+  registryReadCache.delete(pathname);
+  registryReadCache.set(pathname, cached);
+  return cached;
+}
+
 function setCachedRegistryRead(
   pathname: string,
   signature: string,
   runs: Map<string, SubagentRunRecord>,
-): void {
+): RegistryCacheEntry {
+  const entry: RegistryCacheEntry = { signature, runs: cloneSubagentRunMap(runs) };
   registryReadCache.delete(pathname);
-  registryReadCache.set(pathname, { signature, runs: cloneSubagentRunMap(runs) });
+  registryReadCache.set(pathname, entry);
   if (registryReadCache.size <= MAX_SUBAGENT_REGISTRY_READ_CACHE_ENTRIES) {
-    return;
+    return entry;
   }
   const oldestKey = registryReadCache.keys().next().value;
   if (typeof oldestKey === "string") {
     registryReadCache.delete(oldestKey);
   }
+  return entry;
 }
 
 function resolveSubagentStateDir(env: NodeJS.ProcessEnv = process.env): string {
@@ -81,46 +189,18 @@ export function resolveSubagentRegistryPath(): string {
   return path.join(resolveSubagentStateDir(process.env), "subagents", "runs.json");
 }
 
-export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord>;
-export function loadSubagentRegistryFromDisk(options: {
-  clone: false;
-}): ReadonlyMap<string, ReadonlySubagentRunRecord>;
-export function loadSubagentRegistryFromDisk(options?: {
-  clone?: boolean;
-}): Map<string, SubagentRunRecord> | ReadonlyMap<string, ReadonlySubagentRunRecord> {
-  const snapshot = loadSubagentRegistrySnapshotForRead();
-  return options?.clone === false ? snapshot : cloneSubagentRunMap(snapshot);
-}
-
-function loadSubagentRegistrySnapshotForRead(): ReadonlyMap<string, ReadonlySubagentRunRecord> {
-  const pathname = resolveSubagentRegistryPath();
-  const signature = statRegistryFileSignature(pathname);
-  if (signature === null) {
-    registryReadCache.delete(pathname);
-    return new Map();
-  }
-  const cached = registryReadCache.get(pathname);
-  if (cached?.signature === signature) {
-    registryReadCache.delete(pathname);
-    registryReadCache.set(pathname, cached);
-    // No-clone reads share cached records; only read snapshot callers may use
-    // this path. Mutation/restore callers must keep the default cloned load.
-    return cached.runs;
-  }
+function readRegistryFile(pathname: string, signature: string): LoadedRegistryRead {
   const raw = loadJsonFile(pathname);
   if (!raw || typeof raw !== "object") {
-    setCachedRegistryRead(pathname, signature, new Map());
-    return new Map();
+    return { signature, runs: new Map() };
   }
   const record = raw as Partial<PersistedSubagentRegistry>;
   if (record.version !== 1 && record.version !== 2) {
-    setCachedRegistryRead(pathname, signature, new Map());
-    return new Map();
+    return { signature, runs: new Map() };
   }
   const runsRaw = record.runs;
   if (!runsRaw || typeof runsRaw !== "object") {
-    setCachedRegistryRead(pathname, signature, new Map());
-    return new Map();
+    return { signature, runs: new Map() };
   }
   const out = new Map<string, SubagentRunRecord>();
   const isLegacy = record.version === 1;
@@ -182,16 +262,70 @@ function loadSubagentRegistrySnapshotForRead(): ReadonlyMap<string, ReadonlySuba
       migrated = true;
     }
   }
-  if (migrated) {
-    try {
-      saveSubagentRegistryToDisk(out);
-    } catch {
-      // ignore migration write failures
-    }
-  } else {
-    setCachedRegistryRead(pathname, signature, out);
+  if (!migrated) {
+    return { signature, runs: out };
   }
-  return out;
+  try {
+    saveSubagentRegistryToDisk(out);
+    return { signature: statRegistryFileSignature(pathname) ?? signature, runs: out };
+  } catch {
+    // ignore migration write failures
+    return { signature, runs: out };
+  }
+}
+
+function getCachedRegistryRead(pathname: string, signature: string): RegistryCacheEntry {
+  const cached = registryReadCache.get(pathname);
+  if (cached?.signature === signature) {
+    return touchCachedRegistryRead(pathname, cached);
+  }
+  const loaded = readRegistryFile(pathname, signature);
+  const loadedCached = registryReadCache.get(pathname);
+  if (loadedCached?.signature === loaded.signature) {
+    return touchCachedRegistryRead(pathname, loadedCached);
+  }
+  return setCachedRegistryRead(pathname, loaded.signature, loaded.runs);
+}
+
+export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord>;
+export function loadSubagentRegistryFromDisk(options: {
+  clone: false;
+}): ReadonlyMap<string, ReadonlySubagentRunRecord>;
+export function loadSubagentRegistryFromDisk(options?: {
+  clone?: boolean;
+}): Map<string, SubagentRunRecord> | ReadonlyMap<string, ReadonlySubagentRunRecord> {
+  if (options?.clone === false) {
+    return getSubagentRegistryDiskReadSnapshot().runsById;
+  }
+  const pathname = resolveSubagentRegistryPath();
+  const signature = statRegistryFileSignature(pathname);
+  if (signature === null) {
+    registryReadCache.delete(pathname);
+    return new Map();
+  }
+  return cloneSubagentRunMap(getCachedRegistryRead(pathname, signature).runs);
+}
+
+export function getSubagentRegistryDiskReadSnapshot(): SubagentRegistryDiskReadSnapshot {
+  const pathname = resolveSubagentRegistryPath();
+  const signature = statRegistryFileSignature(pathname);
+  if (signature === null) {
+    registryReadCache.delete(pathname);
+    return Object.freeze({
+      source: "subagent-registry-disk" as const,
+      diskSignature: null,
+      runsById: createReadonlySubagentRunMap([]),
+    });
+  }
+  const cached = getCachedRegistryRead(pathname, signature);
+  if (!cached.readonlySnapshot) {
+    cached.readonlySnapshot = Object.freeze({
+      source: "subagent-registry-disk" as const,
+      diskSignature: cached.signature,
+      runsById: createReadonlySubagentRunMapFromMutable(cached.runs),
+    });
+  }
+  return cached.readonlySnapshot;
 }
 
 export function saveSubagentRegistryToDisk(runs: Map<string, SubagentRunRecord>) {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -43,7 +43,7 @@ import {
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
-import { subagentRuns } from "./subagent-registry-memory.js";
+import { bumpSubagentRegistryMemoryVersion, subagentRuns } from "./subagent-registry-memory.js";
 import {
   countActiveDescendantRunsFromRuns,
   countActiveRunsForSessionFromRuns,
@@ -262,10 +262,12 @@ async function resolveSubagentRegistryContextEngine(
 }
 
 function persistSubagentRuns() {
+  bumpSubagentRegistryMemoryVersion();
   subagentRegistryDeps.persistSubagentRunsToDisk(subagentRuns);
 }
 
 function persistSubagentRunsOrThrow() {
+  bumpSubagentRegistryMemoryVersion();
   subagentRegistryDeps.persistSubagentRunsToDiskOrThrow(subagentRuns);
 }
 
@@ -279,6 +281,7 @@ export function scheduleSubagentOrphanRecovery(params?: { delayMs?: number; maxR
     ({ scheduleOrphanRecovery }) => {
       scheduleOrphanRecovery({
         getActiveRuns: () => subagentRuns,
+        markActiveRunsMutated: bumpSubagentRegistryMemoryVersion,
         delayMs: params?.delayMs,
         maxRetries: params?.maxRetries,
       });
@@ -574,6 +577,7 @@ const subagentLifecycleController = createSubagentRegistryLifecycleController({
   runs: subagentRuns,
   resumedRuns,
   subagentAnnounceTimeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
+  markRunsMutated: bumpSubagentRegistryMemoryVersion,
   persist: persistSubagentRuns,
   clearPendingLifecycleError,
   countPendingDescendantRuns,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -95,6 +95,7 @@ import { reactivateCompletedSubagentSession } from "../session-subagent-reactiva
 import {
   archiveFileOnDisk,
   buildGatewaySessionRow,
+  buildSessionListRowContext,
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
   loadGatewaySessionRow,
@@ -1404,15 +1405,20 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       respond(true, { session: null }, undefined);
       return;
     }
+    const now = Date.now();
+    const rowContext = buildSessionListRowContext({ store, now });
     const row = buildGatewaySessionRow({
       cfg,
       storePath,
       store,
       key: target.canonicalKey,
       entry,
+      now,
       includeDerivedTitles: p.includeDerivedTitles,
       includeLastMessage: p.includeLastMessage,
       transcriptUsageMaxBytes: 64 * 1024,
+      storeChildSessionsByKey: rowContext.storeChildSessionsByKey,
+      rowContext,
     });
     respond(true, { session: row }, undefined);
   },

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -1,14 +1,24 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, test, expect, vi } from "vitest";
+import { resetSubagentRegistryForTests } from "../agents/subagent-registry.js";
+import type { SubagentRunRecord } from "../agents/subagent-registry.types.js";
 import * as thinking from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { resetAgentRunContextForTest } from "../infra/agent-events.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { withEnv } from "../test-utils/env.js";
 import * as usageFormat from "../utils/usage-format.js";
-import { listSessionsFromStore } from "./session-utils.js";
+import {
+  filterAndSortSessionEntries,
+  listSessionsFromStore,
+  loadGatewaySessionRow,
+} from "./session-utils.js";
 
 /**
  * Regression smoke for the per-list rowContext resolver cache. The bug we are
@@ -84,5 +94,190 @@ describe("listSessionsFromStore resolver cache", () => {
         costSpy.mockRestore();
       }
     });
+  });
+});
+
+type SubagentRegistryReadFixture = {
+  cfg: OpenClawConfig;
+  stateDir: string;
+  tempRoot: string;
+  storePath: string;
+  registryPath: string;
+  store: Record<string, SessionEntry>;
+  controllerSessionKey: string;
+  now: number;
+};
+
+const CODECLAW_SHAPED_SESSION_ENTRY_COUNT = 545;
+const CODECLAW_SHAPED_SUBAGENT_RUN_COUNT = 555;
+
+function createCodeClawShapedSubagentRegistryReadFixture(): SubagentRegistryReadFixture {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pr1-read-index-"));
+  const stateDir = path.join(tempRoot, "state");
+  const storePath = path.join(tempRoot, "sessions.json");
+  const registryPath = path.join(stateDir, "subagents", "runs.json");
+  fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+
+  const now = Date.now();
+  const controllerSessionKey = "agent:main:main";
+  const movedControllerSessionKey = "agent:main:subagent:moved-controller";
+  const store: Record<string, SessionEntry> = {
+    [controllerSessionKey]: { sessionId: "sess-main", updatedAt: now } as SessionEntry,
+  };
+  const runs: Record<string, SubagentRunRecord> = {};
+
+  for (let index = 0; index < CODECLAW_SHAPED_SESSION_ENTRY_COUNT - 1; index += 1) {
+    const childSessionKey = `agent:main:subagent:child-${String(index).padStart(4, "0")}`;
+    const isStoreOnly = index % 109 === 0;
+    const isMovedLatest = index === 7;
+    const isMovedAway = index === 8;
+    const isRecentlyEnded = index % 5 === 1;
+    const isStaleRunning = index % 5 === 2;
+    const startedAt = isStaleRunning ? now - 3 * 60 * 60_000 : now - 60_000 - index;
+    const endedAt = isRecentlyEnded ? now - 120_000 : undefined;
+
+    store[childSessionKey] = {
+      sessionId: `sess-child-${index}`,
+      updatedAt: now - index,
+      spawnedBy: controllerSessionKey,
+      status: isRecentlyEnded ? "done" : "running",
+      startedAt,
+      ...(endedAt === undefined ? {} : { endedAt, runtimeMs: 60_000 }),
+    } as SessionEntry;
+
+    if (isStoreOnly) {
+      continue;
+    }
+
+    runs[`run-child-${index}`] = {
+      runId: `run-child-${index}`,
+      childSessionKey,
+      controllerSessionKey: isMovedAway ? movedControllerSessionKey : controllerSessionKey,
+      requesterSessionKey: isMovedAway ? movedControllerSessionKey : controllerSessionKey,
+      requesterDisplayKey: "main",
+      task: "CodeClaw-shaped child",
+      cleanup: "keep",
+      createdAt: now - 10_000 + index,
+      startedAt,
+      ...(endedAt === undefined ? {} : { endedAt, outcome: { status: "ok" } }),
+      model: "openai/gpt-5.5",
+    };
+
+    if (isMovedLatest) {
+      runs[`run-child-${index}-moved-latest`] = {
+        runId: `run-child-${index}-moved-latest`,
+        childSessionKey,
+        controllerSessionKey: movedControllerSessionKey,
+        requesterSessionKey: movedControllerSessionKey,
+        requesterDisplayKey: "moved",
+        task: "moved child",
+        cleanup: "keep",
+        createdAt: now + index,
+        startedAt: now - 30_000,
+        model: "openai/gpt-5.5",
+      };
+    }
+  }
+
+  for (
+    let index = Object.keys(runs).length;
+    index < CODECLAW_SHAPED_SUBAGENT_RUN_COUNT;
+    index += 1
+  ) {
+    const childSessionKey = `agent:main:subagent:registry-only-${String(index).padStart(4, "0")}`;
+    runs[`run-extra-${index}`] = {
+      runId: `run-extra-${index}`,
+      childSessionKey,
+      controllerSessionKey,
+      requesterSessionKey: controllerSessionKey,
+      requesterDisplayKey: "main",
+      task: "registry-only extra",
+      cleanup: "keep",
+      createdAt: now - 1_000 + index,
+      startedAt: now - 500,
+      model: "openai/gpt-5.5",
+    };
+  }
+
+  fs.writeFileSync(storePath, JSON.stringify(store, null, 2), "utf-8");
+  fs.writeFileSync(registryPath, JSON.stringify({ version: 2, runs }, null, 2), "utf-8");
+
+  const cfg = {
+    session: { mainKey: "main", store: storePath },
+    agents: { list: [{ id: "main", default: true }] },
+  } as OpenClawConfig;
+
+  return { cfg, stateDir, tempRoot, storePath, registryPath, store, controllerSessionKey, now };
+}
+
+function countRegistryStatCalls(
+  spy: { mock: { calls: readonly (readonly unknown[])[] } },
+  registryPath: string,
+): number {
+  return spy.mock.calls.filter(
+    (call) => path.normalize(String(call[0])) === path.normalize(registryPath),
+  ).length;
+}
+
+function cleanupSubagentRegistryReadFixture(fixture: SubagentRegistryReadFixture): void {
+  resetSubagentRegistryForTests({ persist: false });
+  resetAgentRunContextForTest();
+  resetConfigRuntimeState();
+  fs.rmSync(fixture.tempRoot, { recursive: true, force: true });
+}
+
+describe("gateway session subagent read index", () => {
+  test("loads a full session row with one subagent registry snapshot for the operation", () => {
+    const fixture = createCodeClawShapedSubagentRegistryReadFixture();
+    setRuntimeConfigSnapshot(fixture.cfg);
+    const statSpy = vi.spyOn(fs, "statSync");
+    try {
+      const row = withEnv(
+        {
+          OPENCLAW_STATE_DIR: fixture.stateDir,
+          OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1",
+        },
+        () => loadGatewaySessionRow(fixture.controllerSessionKey, { now: fixture.now }),
+      );
+      const registryStatCalls = countRegistryStatCalls(statSpy, fixture.registryPath);
+
+      expect(row?.childSessions?.length).toBeGreaterThan(100);
+      expect(registryStatCalls).toBeLessThanOrEqual(1);
+    } finally {
+      statSpy.mockRestore();
+      cleanupSubagentRegistryReadFixture(fixture);
+    }
+  });
+
+  test("filters spawned subagent sessions with one registry snapshot when no row context is supplied", () => {
+    const fixture = createCodeClawShapedSubagentRegistryReadFixture();
+    setRuntimeConfigSnapshot(fixture.cfg);
+    const statSpy = vi.spyOn(fs, "statSync");
+    try {
+      const entries = withEnv(
+        {
+          OPENCLAW_STATE_DIR: fixture.stateDir,
+          OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK: "1",
+        },
+        () =>
+          filterAndSortSessionEntries({
+            cfg: fixture.cfg,
+            store: fixture.store,
+            now: fixture.now,
+            opts: {
+              spawnedBy: fixture.controllerSessionKey,
+              limit: CODECLAW_SHAPED_SESSION_ENTRY_COUNT,
+            },
+          }),
+      );
+      const registryStatCalls = countRegistryStatCalls(statSpy, fixture.registryPath);
+
+      expect(entries.length).toBeGreaterThan(100);
+      expect(registryStatCalls).toBeLessThanOrEqual(1);
+    } finally {
+      statSpy.mockRestore();
+      cleanupSubagentRegistryReadFixture(fixture);
+    }
   });
 });

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -12,6 +12,8 @@ import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/a
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { withEnv } from "../test-utils/env.js";
 import {
+  buildGatewaySessionRow,
+  buildSessionListRowContext,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
   resolveGatewayModelSupportsImages,
@@ -205,6 +207,170 @@ describe("listSessionsFromStore subagent metadata", () => {
     const failed = result.sessions.find((session) => session.key === "agent:main:subagent:failed");
     expect(failed?.status).toBe("failed");
     expect(failed?.runtimeMs).toBe(5_000);
+  });
+
+  test("matches fallback row semantics when using an operation-scoped subagent read index", () => {
+    const now = Date.now();
+    const root = "agent:main:main";
+    const active = "agent:main:subagent:active";
+    const staleParent = "agent:main:subagent:stale-parent";
+    const staleGrandchild = "agent:main:subagent:stale-grandchild";
+    const recentEnded = "agent:main:subagent:recent-ended";
+    const storeOnly = "agent:main:subagent:store-only";
+    const moved = "agent:main:subagent:moved";
+    const movedController = "agent:main:subagent:moved-controller";
+    const store: Record<string, SessionEntry> = {
+      [root]: { updatedAt: now } as SessionEntry,
+      [active]: {
+        updatedAt: now - 1,
+        spawnedBy: root,
+        status: "running",
+        startedAt: now - 60_000,
+      } as SessionEntry,
+      [staleParent]: {
+        updatedAt: now - 2,
+        spawnedBy: root,
+        status: "running",
+        startedAt: now - 3 * 60 * 60_000,
+      } as SessionEntry,
+      [staleGrandchild]: {
+        updatedAt: now - 3,
+        spawnedBy: staleParent,
+        status: "running",
+        startedAt: now - 30_000,
+      } as SessionEntry,
+      [recentEnded]: {
+        updatedAt: now - 4,
+        spawnedBy: root,
+        status: "done",
+        startedAt: now - 180_000,
+        endedAt: now - 120_000,
+        runtimeMs: 60_000,
+      } as SessionEntry,
+      [storeOnly]: {
+        updatedAt: now - 5,
+        spawnedBy: root,
+        status: "running",
+        startedAt: now - 15_000,
+      } as SessionEntry,
+      [moved]: {
+        updatedAt: now - 6,
+        spawnedBy: root,
+        status: "running",
+        startedAt: now - 15_000,
+      } as SessionEntry,
+    };
+
+    addSubagentRunForTests({
+      runId: "run-active",
+      childSessionKey: active,
+      controllerSessionKey: root,
+      requesterSessionKey: root,
+      requesterDisplayKey: "main",
+      task: "active task",
+      cleanup: "keep",
+      createdAt: now - 10_000,
+      startedAt: now - 60_000,
+      model: "openai/gpt-5.5",
+    });
+    registerAgentRunContext("run-active", { sessionKey: active });
+    addSubagentRunForTests({
+      runId: "run-stale-parent",
+      childSessionKey: staleParent,
+      controllerSessionKey: root,
+      requesterSessionKey: root,
+      requesterDisplayKey: "main",
+      task: "stale parent task",
+      cleanup: "keep",
+      createdAt: now - 20_000,
+      startedAt: now - 3 * 60 * 60_000,
+      model: "openai/gpt-5.5",
+    });
+    addSubagentRunForTests({
+      runId: "run-stale-grandchild",
+      childSessionKey: staleGrandchild,
+      controllerSessionKey: staleParent,
+      requesterSessionKey: staleParent,
+      requesterDisplayKey: "stale parent",
+      task: "active descendant task",
+      cleanup: "keep",
+      createdAt: now - 5_000,
+      startedAt: now - 30_000,
+      model: "openai/gpt-5.5",
+    });
+    registerAgentRunContext("run-stale-grandchild", { sessionKey: staleGrandchild });
+    addSubagentRunForTests({
+      runId: "run-recent-ended",
+      childSessionKey: recentEnded,
+      controllerSessionKey: root,
+      requesterSessionKey: root,
+      requesterDisplayKey: "main",
+      task: "recent ended task",
+      cleanup: "keep",
+      createdAt: now - 30_000,
+      startedAt: now - 180_000,
+      endedAt: now - 120_000,
+      outcome: { status: "ok" },
+      model: "openai/gpt-5.5",
+    });
+    addSubagentRunForTests({
+      runId: "run-moved-old",
+      childSessionKey: moved,
+      controllerSessionKey: root,
+      requesterSessionKey: root,
+      requesterDisplayKey: "main",
+      task: "moved old task",
+      cleanup: "keep",
+      createdAt: now - 40_000,
+      startedAt: now - 15_000,
+      model: "openai/gpt-5.5",
+    });
+    addSubagentRunForTests({
+      runId: "run-moved-latest",
+      childSessionKey: moved,
+      controllerSessionKey: movedController,
+      requesterSessionKey: movedController,
+      requesterDisplayKey: "moved controller",
+      task: "moved latest task",
+      cleanup: "keep",
+      createdAt: now - 1_000,
+      startedAt: now - 1_000,
+      model: "openai/gpt-5.5",
+    });
+
+    const rowContext = buildSessionListRowContext({ store, now });
+    const buildFallbackRow = (key: string) =>
+      buildGatewaySessionRow({
+        cfg,
+        storePath: "/tmp/sessions.json",
+        store,
+        key,
+        entry: store[key],
+        now,
+      });
+    const buildIndexedRow = (key: string) =>
+      buildGatewaySessionRow({
+        cfg,
+        storePath: "/tmp/sessions.json",
+        store,
+        key,
+        entry: store[key],
+        now,
+        storeChildSessionsByKey: rowContext.storeChildSessionsByKey,
+        rowContext,
+      });
+
+    for (const key of [root, active, staleParent, staleGrandchild, recentEnded, storeOnly, moved]) {
+      expect(buildIndexedRow(key)).toEqual(buildFallbackRow(key));
+    }
+    expect(buildIndexedRow(root).childSessions).toEqual([
+      active,
+      staleParent,
+      recentEnded,
+      storeOnly,
+    ]);
+    expect(buildIndexedRow(staleParent).childSessions).toEqual([staleGrandchild]);
+    expect(buildIndexedRow(moved).spawnedBy).toBe(movedController);
   });
 
   test("does not show stale registry-only subagent runs as actively running", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -425,7 +425,7 @@ function shouldKeepStoreOnlyChildLink(entry: SessionEntry, now: number): boolean
   );
 }
 
-type SessionListRowContext = {
+export type SessionListRowContext = {
   subagentRuns: ReturnType<typeof buildSubagentRunReadIndex>;
   storeChildSessionsByKey: Map<string, string[]>;
   selectedModelByOverrideRef: Map<string, ReturnType<typeof resolveSessionModelRef>>;
@@ -620,6 +620,7 @@ function resolveStoreChildSessionKeysFromCandidates(params: {
   key: string;
   now: number;
   candidates: ReadonlyMap<string, readonly string[]>;
+  subagentRuns?: SessionListRowContext["subagentRuns"];
 }): string[] | undefined {
   const childSessionKeys: string[] = [];
   for (const childKey of params.candidates.get(params.key) ?? []) {
@@ -627,7 +628,9 @@ function resolveStoreChildSessionKeysFromCandidates(params: {
     if (!entry) {
       continue;
     }
-    const latest = getSessionDisplaySubagentRunByChildSessionKey(childKey);
+    const latest = params.subagentRuns
+      ? params.subagentRuns.getDisplaySubagentRun(childKey)
+      : getSessionDisplaySubagentRunByChildSessionKey(childKey);
     if (latest) {
       const latestControllerSessionKey =
         normalizeOptionalString(latest.controllerSessionKey) ||
@@ -637,7 +640,9 @@ function resolveStoreChildSessionKeysFromCandidates(params: {
       }
       if (
         !shouldKeepSubagentRunChildLink(latest, {
-          activeDescendants: countActiveDescendantRuns(childKey),
+          activeDescendants: params.subagentRuns
+            ? params.subagentRuns.countActiveDescendantRuns(childKey)
+            : countActiveDescendantRuns(childKey),
           now: params.now,
         })
       ) {
@@ -654,14 +659,13 @@ function resolveStoreChildSessionKeysFromCandidates(params: {
   return childSessionKeys.length > 0 ? childSessionKeys : undefined;
 }
 
-function buildSessionListRowContext(params: {
-  store: Record<string, SessionEntry>;
-  now: number;
+function createSessionListRowContext(params: {
+  subagentRuns: SessionListRowContext["subagentRuns"];
+  storeChildSessionsByKey: Map<string, string[]>;
 }): SessionListRowContext {
-  const subagentRuns = buildSubagentRunReadIndex(params.now);
   return {
-    subagentRuns,
-    storeChildSessionsByKey: buildStoreChildSessionIndex(params.store, params.now, subagentRuns),
+    subagentRuns: params.subagentRuns,
+    storeChildSessionsByKey: params.storeChildSessionsByKey,
     selectedModelByOverrideRef: new Map(),
     thinkingMetadataByModelRef: new Map(),
     displayModelIdentityByKey: new Map(),
@@ -669,22 +673,78 @@ function buildSessionListRowContext(params: {
   };
 }
 
+export function buildSessionListRowContext(params: {
+  store: Record<string, SessionEntry>;
+  now: number;
+}): SessionListRowContext {
+  const subagentRuns = buildSubagentRunReadIndex(params.now);
+  return createSessionListRowContext({
+    subagentRuns,
+    storeChildSessionsByKey: buildStoreChildSessionIndex(params.store, params.now, subagentRuns),
+  });
+}
+
+const SINGLE_ROW_SUBAGENT_INDEX_CANDIDATE_THRESHOLD = 16;
+
+type SingleSessionRowContext = {
+  storeChildSessionsByKey: Map<string, string[]>;
+  rowContext?: SessionListRowContext;
+};
+
 function buildSingleRowStoreChildSessionsByKey(params: {
   store: Record<string, SessionEntry>;
-  storePath: string;
   key: string;
   now: number;
+  candidates: ReadonlyMap<string, readonly string[]>;
+  subagentRuns?: SessionListRowContext["subagentRuns"];
 }): Map<string, string[]> {
   const storeChildSessions = resolveStoreChildSessionKeysFromCandidates({
     store: params.store,
     key: params.key,
     now: params.now,
-    candidates: getSingleRowChildSessionCandidates({
-      storePath: params.storePath,
-      store: params.store,
-    }),
+    candidates: params.candidates,
+    subagentRuns: params.subagentRuns,
   });
   return storeChildSessions ? new Map([[params.key, storeChildSessions]]) : new Map();
+}
+
+function buildSingleSessionRowContext(params: {
+  store: Record<string, SessionEntry>;
+  storePath: string;
+  key: string;
+  now: number;
+}): SingleSessionRowContext {
+  const candidates = getSingleRowChildSessionCandidates({
+    storePath: params.storePath,
+    store: params.store,
+  });
+  const candidateCount = candidates.get(params.key)?.length ?? 0;
+  if (candidateCount < SINGLE_ROW_SUBAGENT_INDEX_CANDIDATE_THRESHOLD) {
+    return {
+      storeChildSessionsByKey: buildSingleRowStoreChildSessionsByKey({
+        store: params.store,
+        key: params.key,
+        now: params.now,
+        candidates,
+      }),
+    };
+  }
+
+  const subagentRuns = buildSubagentRunReadIndex(params.now);
+  const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
+    store: params.store,
+    key: params.key,
+    now: params.now,
+    candidates,
+    subagentRuns,
+  });
+  return {
+    storeChildSessionsByKey,
+    rowContext: createSessionListRowContext({
+      subagentRuns,
+      storeChildSessionsByKey,
+    }),
+  };
 }
 
 function createSessionRowModelCacheKey(provider: string | undefined, model: string | undefined) {
@@ -2216,7 +2276,7 @@ export function loadGatewaySessionRow(
   if (!entry) {
     return null;
   }
-  const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
+  const singleRowContext = buildSingleSessionRowContext({
     storePath,
     store,
     key: canonicalKey,
@@ -2232,7 +2292,8 @@ export function loadGatewaySessionRow(
     includeDerivedTitles: options?.includeDerivedTitles,
     includeLastMessage: options?.includeLastMessage,
     transcriptUsageMaxBytes: options?.transcriptUsageMaxBytes,
-    storeChildSessionsByKey,
+    storeChildSessionsByKey: singleRowContext.storeChildSessionsByKey,
+    rowContext: singleRowContext.rowContext,
     ...(options?.agentId ? { agentId: options.agentId } : {}),
   });
 }
@@ -2455,6 +2516,13 @@ function selectSessionEntries(params: {
   };
 }
 
+function sessionEntrySelectionNeedsRowContext(opts: SessionsListParams): boolean {
+  return (
+    Boolean(normalizeOptionalString(opts.spawnedBy)) ||
+    Boolean(normalizeOptionalString(opts.search))
+  );
+}
+
 export function filterAndSortSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
@@ -2462,7 +2530,12 @@ export function filterAndSortSessionEntries(params: {
   now: number;
   rowContext?: SessionListRowContext;
 }): [string, SessionEntry][] {
-  return selectSessionEntries(params).entries;
+  const rowContext =
+    params.rowContext ??
+    (sessionEntrySelectionNeedsRowContext(params.opts)
+      ? buildSessionListRowContext({ store: params.store, now: params.now })
+      : undefined);
+  return selectSessionEntries({ ...params, rowContext }).entries;
 }
 
 export function listSessionsFromStore(params: {
@@ -2483,17 +2556,13 @@ export function listSessionsFromStore(params: {
   };
   const includeDerivedTitles = opts.includeDerivedTitles === true;
   const includeLastMessage = opts.includeLastMessage === true;
-  const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
 
   const selection = selectSessionEntries({
     cfg,
     store,
     opts,
     now,
-    rowContext:
-      hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
-        ? getRowContext()
-        : undefined,
+    rowContext: sessionEntrySelectionNeedsRowContext(opts) ? getRowContext() : undefined,
     defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
   });
   const { entries, totalCount, limitApplied, offset, nextOffset, hasMore } = selection;
@@ -2563,17 +2632,13 @@ export async function listSessionsFromStoreAsync(params: {
   };
   const includeDerivedTitles = opts.includeDerivedTitles === true;
   const includeLastMessage = opts.includeLastMessage === true;
-  const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
 
   const selection = selectSessionEntries({
     cfg,
     store,
     opts,
     now,
-    rowContext:
-      hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
-        ? getRowContext()
-        : undefined,
+    rowContext: sessionEntrySelectionNeedsRowContext(opts) ? getRowContext() : undefined,
     defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
   });
   const { entries, totalCount, limitApplied, offset, nextOffset, hasMore } = selection;


### PR DESCRIPTION
## Summary

- Cache immutable subagent registry read snapshots by disk signature and in-memory version so hot read paths stop rebuilding the same merged registry state repeatedly.
- Reuse operation-scoped subagent read indexes/session row context for `sessions.list`, `sessions.get`, and gateway row loading while preserving existing child-session filtering semantics.
- Keep single-row session loads on the cheap candidate-cache path for small child sets and invalidate in-memory snapshots before lifecycle completion awaits can expose stale terminal state.

## Verification

- `node scripts/run-vitest.mjs src/gateway/session-utils.perf.test.ts src/gateway/session-utils.single-row-cache.test.ts src/gateway/session-utils.subagent.test.ts src/agents/subagent-registry-read-context.test.ts src/agents/subagent-registry.persistence.test.ts`
  - Passed before the Codex-review fix: 12 files / 156 tests.
- `node scripts/run-vitest.mjs src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry.persistence.test.ts src/agents/subagent-registry-read-context.test.ts src/gateway/session-utils.single-row-cache.test.ts src/gateway/session-utils.perf.test.ts src/gateway/session-utils.subagent.test.ts`
  - Passed after the Codex-review fix: 14 files / 214 tests.
- `pnpm check:changed`
  - Passed after rebase and after the Codex-review fix.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file /tmp/openclaw-codeclaw-pr-review-notes.md`
  - Initial Codex review found a stale in-memory snapshot window around in-place lifecycle mutations before awaited completion capture.
  - Fixed by marking in-memory snapshots dirty before the await and adding regression coverage.
  - Final Codex review after latest `origin/main` fetch: clean, no accepted/actionable findings.

## Real behavior proof

Behavior addressed: Repeated gateway/session hot-path reads rebuilt subagent registry snapshots, cloned persisted run maps, and rebuilt full subagent read indexes; the patch caches immutable read snapshots and shares row-scoped read context while preserving subagent/session row behavior.

Real environment tested: CodeClaw `codeclaw-triage` Docker deployment with the triage named volumes preserved. Evidence used a pinned comparison base plus identical gated hotpath instrumentation for the before and after builds.

Exact steps or command run after this patch: Built OpenClaw tarballs for before/after evidence branches, rebuilt and force-recreated `codeclaw-triage` for each build, ran a 10-minute warmup, enabled gated hotpath profiling for a 1-hour measurement window, then disabled profiling. The patched container was left running afterward for continued validation.

Evidence after fix: Sanitized before/after evidence showed:
- `subagent.registry.readIndex` total profiled time: `103.488ms` before -> `45.641ms` after (`-55.9%`).
- `gateway.session.childIndex` total profiled time: `178.942ms` before -> `82.271ms` after (`-54.0%`).
- `subagent.registry.cloneMap` total profiled time: `3682.616ms` before -> `2253.583ms` after (`-38.8%`).
- No OOM, fatal-error, uncaught-exception, or gateway-failed log matches in either 1-hour measurement window.
- After-window cgroup memory remained stable: `2453.1 MiB` -> `2454.3 MiB`; primary gateway RSS moved `712.3 MiB` -> `601.5 MiB`.

Observed result after fix: The patched CodeClaw container stayed running with restart count 0 and the patched OpenClaw build installed. Profiling was disabled after measurement so the container could continue running without accumulating profile logs.

What was not tested: Full CI was not run locally. Heap snapshots and CPU profiles were intentionally not collected. The 1-hour CodeClaw evidence was captured before the final Codex-review stale-cache fix; that follow-up fix only invalidates in-memory snapshots before an await and was covered by focused tests plus `pnpm check:changed`, not by rerunning another 1-hour CodeClaw evidence window.
