### PR TITLE
test: keep tool search fetch timeout refed

### DIFF
--- a/scripts/tool-search-gateway-e2e.ts
+++ b/scripts/tool-search-gateway-e2e.ts
@@ -154,7 +154,6 @@ export async function fetchJson(
       controller.abort(error);
       reject(error);
     }, timeoutMs);
-    timeout.unref?.();
   });
 
   let response: Response;


### PR DESCRIPTION
## Summary
- keep the tool-search gateway E2E fetch timeout timer ref'ed until it fires or is cleared
- fixes stalled mocked-fetch tests where the timeout promise must be the active handle that rejects the request

Fixes #88170.

## Real behavior proof
**Behavior or issue addressed:** A stalled fetch operation in the tool-search gateway E2E helper must reject via `ETIMEDOUT` promptly instead of waiting for Vitest's global 120s timeout.

**Real environment tested:** Local OpenClaw checkout on Node `v22.22.2`, branch `fix-tool-search-fetch-timeout`.

**Exact steps or command run after the patch:**
```bash
node -e 'const started = Date.now(); const controller = new AbortController(); const error = Object.assign(new Error("HTTP request to https://qa.example.invalid/debug/requests timed out after 25ms"), { code: "ETIMEDOUT" }); const timeoutPromise = new Promise((_, reject) => { setTimeout(() => { controller.abort(error); reject(error); }, 25); }); Promise.race([new Promise(() => {}), timeoutPromise]).catch((err) => { const elapsed = Date.now() - started; console.log("[live-timeout-probe] code=" + err.code); console.log("[live-timeout-probe] signalAborted=" + controller.signal.aborted); console.log("[live-timeout-probe] elapsedMs=" + elapsed); if (err.code !== "ETIMEDOUT" || !controller.signal.aborted || elapsed > 1000) process.exit(1); });'
```

**Evidence after fix: terminal output**
```text
[live-timeout-probe] code=ETIMEDOUT
[live-timeout-probe] signalAborted=true
[live-timeout-probe] elapsedMs=26
```

Supplemental focused validation:
```text
OPENCLAW_VITEST_MAX_WORKERS=2 pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts test/scripts/tool-search-gateway-e2e.test.ts

Test Files  1 passed (1)
Tests  4 passed (4)
Duration  9.76s
```

**Observed result after fix:** The timeout path aborts and rejects promptly with `ETIMEDOUT`; the focused tool-search gateway timeout test file completes instead of stalling.

**What was not tested:** Full repository CI is left to GitHub Actions on this PR.

## Notes
This is intentionally split from #86138 so the gateway config boundary change remains scoped to its own PR.

