### PR TITLE
fix(codex): omit tool controls without tools

### DIFF
--- a/src/llm/providers/openai-codex-responses.test.ts
+++ b/src/llm/providers/openai-codex-responses.test.ts
@@ -266,6 +266,66 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(payload).toMatchObject({ prompt_cache_key: "stable-cache-key" });
   });
 
+  it("omits tool controls when no tools are available", async () => {
+    let payload: Record<string, unknown> | undefined;
+
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      transport: "sse",
+      onPayload: (nextPayload) => {
+        payload = nextPayload as Record<string, unknown>;
+        throw new Error("stop after payload capture");
+      },
+    });
+
+    await stream.result();
+
+    expect(payload).toBeDefined();
+    expect(payload).not.toHaveProperty("tools");
+    expect(payload).not.toHaveProperty("tool_choice");
+    expect(payload).not.toHaveProperty("parallel_tool_calls");
+  });
+
+  it("keeps tool controls when tools are available", async () => {
+    let payload: Record<string, unknown> | undefined;
+
+    const stream = streamOpenAICodexResponses(
+      model,
+      {
+        ...context,
+        tools: [
+          {
+            name: "read",
+            description: "Read a file",
+            parameters: { type: "object", properties: { path: { type: "string" } } },
+          },
+        ],
+      },
+      {
+        apiKey: createJwt({
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "acct-1",
+          },
+        }),
+        transport: "sse",
+        onPayload: (nextPayload) => {
+          payload = nextPayload as Record<string, unknown>;
+          throw new Error("stop after payload capture");
+        },
+      },
+    );
+
+    await stream.result();
+
+    expect(payload?.tools).toHaveLength(1);
+    expect(payload?.tool_choice).toBe("auto");
+    expect(payload?.parallel_tool_calls).toBe(true);
+  });
+
   it.each(["1.5", "0x10"])(
     "ignores invalid Retry-After header delay values: %s",
     async (retryAfter) => {

--- a/src/llm/providers/openai-codex-responses.ts
+++ b/src/llm/providers/openai-codex-responses.ts
@@ -491,8 +491,6 @@ function buildRequestBody(
       options?.cacheRetention === "none"
         ? undefined
         : clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
-    tool_choice: "auto",
-    parallel_tool_calls: true,
   };
 
   if (options?.temperature !== undefined) {
@@ -505,6 +503,8 @@ function buildRequestBody(
 
   if (context.tools && context.tools.length > 0) {
     body.tools = convertResponsesTools(context.tools, { strict: null });
+    body.tool_choice = "auto";
+    body.parallel_tool_calls = true;
   }
 
   if (options?.reasoningEffort !== undefined) {


### PR DESCRIPTION
## Summary

- Stops the legacy `openai-codex-responses` transport from sending `tool_choice` and `parallel_tool_calls` when the request has no tools.
- Preserves the existing `tool_choice: "auto"` and `parallel_tool_calls: true` payload when tools are present.
- Adds regression coverage for both no-tool and tool-enabled Codex Responses request bodies.

## Context

Hermes hit the same class of Codex Responses bug in https://github.com/NousResearch/hermes-agent/pull/32777 and https://github.com/ryanleeai/hermes-agent/pull/16: tool-only controls survived after the request had no tools. OpenClaw's provider-owned native path already avoids the main no-tools shape, but the legacy built-in Codex Responses transport still set the controls unconditionally.

## Verification

- `git diff --check HEAD~1..HEAD`
- `node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/openai-codex-responses.ts src/llm/providers/openai-codex-responses.test.ts`
- `node_modules/.bin/oxlint src/llm/providers/openai-codex-responses.ts src/llm/providers/openai-codex-responses.test.ts`
- `node --import tsx --input-type=module -e "...payload assertion..."`
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 45m --ttl 90m --timing-json --shell -- "pnpm check:changed"` (`provider=aws`, `lease=cbx_0aa2248a72cd`, `run=run_3f2cb22f984d`, exit 0)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean, no accepted/actionable findings)

## Real behavior proof

Behavior addressed: Codex Responses request payloads without tools no longer include tool-only controls that can make strict Responses backends reject the request.

Real environment tested: Local source checkout plus AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: `node --import tsx --input-type=module -e "...payload assertion..."`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 45m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: Source-level payload assertion returned `{"noToolsHasTools":false,"noToolsHasToolChoice":false,"noToolsHasParallel":false,"withToolsLength":1,"withToolsToolChoice":"auto","withToolsParallel":true}`; AWS Crabbox `pnpm check:changed` completed with exit 0.

Observed result after fix: No-tool Codex Responses payloads omit `tools`, `tool_choice`, and `parallel_tool_calls`; tool-enabled payloads still include one converted tool plus `tool_choice: "auto"` and `parallel_tool_calls: true`.

What was not tested: Live OpenAI Codex network call. Local Vitest runs for this file were not usable on this host while other long local Vitest lanes were active; the regression test is included for CI.
