### PR TITLE
fix(codex): prevent post-tool edit stream timeouts

### DIFF
--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -3,6 +3,7 @@ import {
   describeNotificationActivity,
   isAssistantCompletionReleaseNotification,
   isCodexTurnAbortMarkerNotification,
+  isFileChangePatchUpdatedNotification,
   isNativeToolProgressNotification,
   isNativeResponseStreamDeltaNotification,
   isPendingOpenClawDynamicToolCompletionNotification,
@@ -140,6 +141,10 @@ export function applyCodexTurnNotificationState(params: {
     turnCrossedToolHandoff &&
     isRawAssistantProgressNotification(notification) &&
     params.activeTurnItemIds.size === 0;
+  const postToolPatchUpdateNeedsTerminalGuard =
+    isCurrentTurnNotification &&
+    turnCrossedToolHandoff &&
+    isFileChangePatchUpdatedNotification(notification);
   const rawResponseItemCompletedWithNoActiveItems =
     isCurrentTurnNotification &&
     notification.method === "rawResponseItem/completed" &&
@@ -175,10 +180,13 @@ export function applyCodexTurnNotificationState(params: {
     turnWatches.disarmAssistantCompletionIdleWatch();
   } else if (isCurrentTurnNotification && assistantCompletionCanRelease) {
     turnWatches.armAssistantCompletionIdleWatch(describeNotificationActivity(notification));
-  } else if (postToolRawAssistantCompletionNeedsTerminalGuard) {
-    // A post-tool assistant status can be followed by native Codex streaming a
-    // large custom tool input. Forwarded raw deltas refresh activity at enqueue
-    // time; keep this guard conservative for versions that do not forward them.
+  } else if (
+    postToolRawAssistantCompletionNeedsTerminalGuard ||
+    postToolPatchUpdateNeedsTerminalGuard
+  ) {
+    // Post-tool assistant status and patch snapshots can be followed by more
+    // native edit streaming. Keep the short guard alive until Codex reports a
+    // terminal turn state instead of falling back to the long terminal watch.
     turnWatches.armCompletionIdleWatch({
       timeoutMs: params.postToolRawAssistantCompletionIdleTimeoutMs,
     });
@@ -212,6 +220,7 @@ export function applyCodexTurnNotificationState(params: {
     !trackedDynamicToolCompletion &&
     !rawToolOutputCompletion &&
     !postToolRawAssistantCompletionNeedsTerminalGuard &&
+    !postToolPatchUpdateNeedsTerminalGuard &&
     !rawResponseItemCompletedWithNoActiveItems &&
     !shouldArmPostReasoningSourceReplyWatch &&
     !shouldArmPostRawReasoningSourceReplyWatch &&

--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -6,7 +6,7 @@ import {
   isNativeToolProgressNotification,
   isNativeResponseStreamDeltaNotification,
   isPendingOpenClawDynamicToolCompletionNotification,
-  isRawAssistantCompletionNotification,
+  isRawAssistantProgressNotification,
   isRawReasoningCompletionNotification,
   isRawToolOutputCompletionNotification,
   isReasoningItemCompletionNotification,
@@ -138,7 +138,7 @@ export function applyCodexTurnNotificationState(params: {
   const postToolRawAssistantCompletionNeedsTerminalGuard =
     isCurrentTurnNotification &&
     turnCrossedToolHandoff &&
-    isRawAssistantCompletionNotification(notification) &&
+    isRawAssistantProgressNotification(notification) &&
     params.activeTurnItemIds.size === 0;
   const rawResponseItemCompletedWithNoActiveItems =
     isCurrentTurnNotification &&

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -185,9 +185,7 @@ export function isNativeResponseStreamDeltaNotification(
   return notification.method.startsWith("response.") && notification.method.endsWith(".delta");
 }
 
-export function isRawAssistantCompletionNotification(
-  notification: CodexServerNotification,
-): boolean {
+export function isRawAssistantProgressNotification(notification: CodexServerNotification): boolean {
   if (notification.method !== "rawResponseItem/completed" || !isJsonObject(notification.params)) {
     return false;
   }
@@ -196,9 +194,18 @@ export function isRawAssistantCompletionNotification(
     item &&
     readString(item, "type") === "message" &&
     readString(item, "role") === "assistant" &&
-    readString(item, "phase") !== "commentary" &&
     readRawAssistantTextPreview(item),
   );
+}
+
+export function isRawAssistantCompletionNotification(
+  notification: CodexServerNotification,
+): boolean {
+  if (!isRawAssistantProgressNotification(notification) || !isJsonObject(notification.params)) {
+    return false;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  return Boolean(item && readString(item, "phase") !== "commentary");
 }
 
 function readRawAssistantTextPreview(item: JsonObject): string | undefined {

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -185,6 +185,14 @@ export function isNativeResponseStreamDeltaNotification(
   return notification.method.startsWith("response.") && notification.method.endsWith(".delta");
 }
 
+export function isFileChangePatchUpdatedNotification(
+  notification: CodexServerNotification,
+): boolean {
+  return (
+    notification.method === "item/fileChange/patchUpdated" && isJsonObject(notification.params)
+  );
+}
+
 export function isRawAssistantProgressNotification(notification: CodexServerNotification): boolean {
   if (notification.method !== "rawResponseItem/completed" || !isJsonObject(notification.params)) {
     return false;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -612,6 +612,7 @@ describe("runCodexAppServerAttempt", () => {
             config?: {
               "features.code_mode"?: boolean;
               "features.code_mode_only"?: boolean;
+              "features.apply_patch_streaming_events"?: boolean;
             };
           }
         | undefined;
@@ -622,6 +623,7 @@ describe("runCodexAppServerAttempt", () => {
       expect(startParams?.cwd).toBe("/workspace");
       expect(startParams?.config?.["features.code_mode"]).toBe(true);
       expect(startParams?.config?.["features.code_mode_only"]).toBe(false);
+      expect(startParams?.config?.["features.apply_patch_streaming_events"]).toBe(true);
       expect(startParams?.dynamicTools?.map((tool) => tool.name)).toEqual(["message"]);
       expect(startParams?.environments).toEqual([
         { environmentId: environmentAddParams?.environmentId, cwd: "/workspace" },
@@ -935,6 +937,7 @@ describe("runCodexAppServerAttempt", () => {
       },
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.mcpServersFingerprint).toBe("mcp-v1");
@@ -4201,6 +4204,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(resumeConfig?.["features.hooks"]).toBe(true);
     expect(resumeConfig?.["features.code_mode"]).toBe(true);
     expect(resumeConfig?.["features.code_mode_only"]).toBe(false);
+    expect(resumeConfig?.["features.apply_patch_streaming_events"]).toBe(true);
     expect(resumeRequestParams?.developerInstructions).not.toContain(CODEX_GPT5_BEHAVIOR_CONTRACT);
     const turnRequest = requests.find((request) => request.method === "turn/start");
     const turnRequestParams = turnRequest?.params as Record<string, unknown> | undefined;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1364,9 +1364,8 @@ export async function runCodexAppServerAttempt(
       (!isNativeResponseStreamDelta && correlation.matchesActiveTurn !== false) ||
       nativeResponseStreamDeltaMatchesActiveTurn;
     if (notificationMatchesActiveTurn) {
-      // If a future Codex app-server exposes raw response deltas, treat them as
-      // activity only when scoped to this turn or attributable to a single lease.
-      // Today the durable app-server raw-event surface is rawResponseItem/completed.
+      // If Codex app-server exposes raw response deltas, treat them as activity
+      // only when scoped to this turn or attributable to a single lease.
       turnWatches.noteNotificationReceived(
         notification.method,
         isNativeResponseStreamDelta

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1589,6 +1589,114 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(result.promptError).toBeNull();
   });
 
+  it("keeps the post-tool guard armed for patch update snapshots", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    let handleRequest:
+      | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: (
+            handler: (request: {
+              id: string;
+              method: string;
+              params?: unknown;
+            }) => Promise<unknown>,
+          ) => {
+            handleRequest = handler;
+            return () => undefined;
+          },
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session-patch-snapshot-timeout.jsonl"),
+      path.join(tempDir, "workspace-patch-snapshot-timeout"),
+    );
+    params.timeoutMs = 2_000;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 500,
+      turnAssistantCompletionIdleTimeoutMs: 5,
+      postToolRawAssistantCompletionIdleTimeoutMs: 50,
+      turnTerminalIdleTimeoutMs: 1_000,
+    });
+    await vi.waitFor(() => expect(handleRequest).toBeTypeOf("function"), fastWait);
+
+    await handleRequest?.({
+      id: "request-tool-1",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: null,
+        tool: "message",
+        arguments: { action: "send", text: "already sent" },
+      },
+    });
+    await notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-status-1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "I'm writing a large patch now." }],
+        },
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await notify({
+      method: "item/fileChange/patchUpdated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "ctc-large-edit-1",
+        changes: [],
+      },
+    });
+
+    const result = await run;
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    const completionWarnCall = warn.mock.calls.find(
+      ([message]) => message === "codex app-server turn idle timed out waiting for completion",
+    );
+    const completionWarnData = completionWarnCall?.[1] as
+      | {
+          lastActivityReason?: string;
+          lastNotificationMethod?: string;
+          timeoutMs?: number;
+        }
+      | undefined;
+    expect(completionWarnData?.timeoutMs).toBe(50);
+    expect(completionWarnData?.lastActivityReason).toBe(
+      "notification:item/fileChange/patchUpdated",
+    );
+    expect(completionWarnData?.lastNotificationMethod).toBe("item/fileChange/patchUpdated");
+  });
+
   it("keeps the post-tool guard armed for scoped native response deltas", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1388,6 +1388,99 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(completionWarnData?.lastActivityReason).toBe("notification:rawResponseItem/completed");
   });
 
+  it("uses the post-tool timeout for commentary raw assistant progress", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    let handleRequest:
+      | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: (
+            handler: (request: {
+              id: string;
+              method: string;
+              params?: unknown;
+            }) => Promise<unknown>,
+          ) => {
+            handleRequest = handler;
+            return () => undefined;
+          },
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    let settled = false;
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 20,
+      turnAssistantCompletionIdleTimeoutMs: 5,
+      postToolRawAssistantCompletionIdleTimeoutMs: 100,
+      turnTerminalIdleTimeoutMs: 500,
+    }).finally(() => {
+      settled = true;
+    });
+    await vi.waitFor(() => expect(handleRequest).toBeTypeOf("function"), fastWait);
+
+    const toolResult = (await handleRequest?.({
+      id: "request-tool-1",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: null,
+        tool: "message",
+        arguments: { action: "send", text: "already sent" },
+      },
+    })) as { success?: boolean };
+    expect(toolResult.success).toBe(false);
+    await notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-status-1",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "I'm editing app.js now." }],
+        },
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(settled).toBe(false);
+
+    const result = await run;
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    const completionWarnCall = warn.mock.calls.find(
+      ([message]) => message === "codex app-server turn idle timed out waiting for completion",
+    );
+    const completionWarnData = completionWarnCall?.[1] as { timeoutMs?: number } | undefined;
+    expect(completionWarnData?.timeoutMs).toBe(100);
+  });
+
   it("counts native response deltas as post-tool raw assistant activity", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -405,6 +405,7 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(forkParams?.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
     expect(forkParams?.developerInstructions).toContain("You are in a side conversation");
     expect(forkParams?.developerInstructions).toContain(
@@ -806,6 +807,7 @@ describe("runCodexAppServerSideQuestion", () => {
       "features.hooks": false,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
       "hooks.PreToolUse": [],
       "hooks.PostToolUse": [],
       "hooks.PermissionRequest": [],

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -640,6 +640,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       ...config,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     };
 
     await startOrResumeThread({
@@ -708,6 +709,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
       hooks: { PreToolUse: [] },
       ...createPluginAppConfigPatch(),
     });
@@ -786,6 +788,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
       "hooks.PreToolUse": finalConfigPatch["hooks.PreToolUse"],
       ...createPluginAppConfigPatch(),
     });
@@ -793,6 +796,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
       "hooks.PreToolUse": finalConfigPatch["hooks.PreToolUse"],
     });
   });
@@ -854,12 +858,14 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
       ...createPluginAppConfigPatch(),
     });
     expect(requestCalls[1]?.[1].config).toEqual({
       "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
   });
 
@@ -922,6 +928,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(requestCalls[0]?.[1].config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
       apps: {
         _default: {
           enabled: false,
@@ -980,6 +987,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(requestCalls[0]?.[1].config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-existing");
@@ -1039,6 +1047,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       ...createPluginAppConfigPatch(),
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-recovered");
@@ -1104,6 +1113,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(requestCalls[0]?.[1].config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
   });
 
@@ -1159,6 +1169,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       ...createTwoPluginAppConfigPatch(),
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-recovered");
@@ -1223,6 +1234,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       ...createTwoCalendarAppConfigPatch(),
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-recovered");
@@ -1276,6 +1288,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       ...createPluginAppConfigPatch(),
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-plugins");

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -175,6 +175,7 @@ describe("Codex app-server native code mode config", () => {
       apps: { _default: { enabled: false } },
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
     expect(request.personality).toBe("none");
   });
@@ -213,6 +214,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": true,
+      "features.apply_patch_streaming_events": true,
     });
   });
 
@@ -231,6 +233,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": true,
+      "features.apply_patch_streaming_events": true,
     });
   });
 
@@ -244,6 +247,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
   });
 
@@ -305,6 +309,7 @@ describe("Codex app-server native code mode config", () => {
       "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
   });
 
@@ -325,6 +330,7 @@ describe("Codex app-server native code mode config", () => {
       project_doc_max_bytes: 64_000,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.apply_patch_streaming_events": true,
     });
   });
 });
@@ -442,6 +448,7 @@ describe("Codex app-server turn params", () => {
       config: {
         "features.code_mode": true,
         "features.code_mode_only": false,
+        "features.apply_patch_streaming_events": true,
       },
       sandbox: "danger-full-access",
       serviceTier: "flex",

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -262,6 +262,7 @@ describe("Codex app-server native code mode config", () => {
       config: {
         "features.code_mode": true,
         "features.code_mode_only": true,
+        "features.apply_patch_streaming_events": true,
       },
     });
 
@@ -277,6 +278,9 @@ describe("Codex app-server native code mode config", () => {
       appServer: createAppServerOptions() as never,
       developerInstructions: "test instructions",
       nativeCodeModeEnabled: false,
+      config: {
+        "features.apply_patch_streaming_events": true,
+      },
     });
 
     expect(request.config).toEqual({

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -96,9 +96,11 @@ export type CodexPluginThreadConfigProvider = {
 
 export const CODEX_NATIVE_PERSONALITY_NONE = "none";
 
+// Stream structured patch snapshots so large generated edits keep the turn active.
 export const CODEX_CODE_MODE_THREAD_CONFIG: JsonObject = {
   "features.code_mode": true,
   "features.code_mode_only": false,
+  "features.apply_patch_streaming_events": true,
 };
 
 export const CODEX_CODE_MODE_DISABLED_THREAD_CONFIG: JsonObject = {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -870,11 +870,16 @@ export function buildCodexRuntimeThreadConfig(
     "features.code_mode_only": options.nativeCodeModeOnlyEnabled === true,
   };
   if (options.nativeCodeModeEnabled === false) {
-    return (
-      mergeCodexThreadConfigs(codeModeConfig, config, CODEX_CODE_MODE_DISABLED_THREAD_CONFIG) ?? {
-        ...CODEX_CODE_MODE_DISABLED_THREAD_CONFIG,
-      }
-    );
+    const disabledConfig = mergeCodexThreadConfigs(
+      config,
+      CODEX_CODE_MODE_DISABLED_THREAD_CONFIG,
+    ) ?? {
+      ...CODEX_CODE_MODE_DISABLED_THREAD_CONFIG,
+    };
+    // Native patch streaming is part of native code mode, so do not send it
+    // when runtime policy disables that tool surface.
+    delete disabledConfig["features.apply_patch_streaming_events"];
+    return disabledConfig;
   }
   if (options.nativeCodeModeOnlyEnabled === true) {
     return (

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -78,6 +78,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false
   },
@@ -116,6 +117,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false
   },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -78,6 +78,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false
   },
@@ -116,6 +117,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false
   },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -78,6 +78,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false
   },
@@ -117,6 +118,7 @@
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "config": {
+    "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false
   },


### PR DESCRIPTION
## Summary
- Treat post-tool raw assistant commentary/progress messages as activity that needs the conservative post-tool terminal guard.
- Enable Codex `features.apply_patch_streaming_events` so large generated file edits emit official turn-scoped `item/fileChange/patchUpdated` progress while the patch is being generated.
- Keep forwarded raw `response.*.delta` activity handling scoped/concurrent-safe for app-server versions that expose those deltas, without adding any SQLite/log polling relay.
- Keep commentary excluded from final-answer release semantics.

## Why
Telegram topic 2728 timed out after a post-tool assistant progress message like `I'm editing app.js...` while native Codex was still building a large edit/tool input. The earlier commentary guard covers the quiet post-tool gap with the 5-minute fallback. This update also turns on Codex's documented structured patch streaming event, so file-change/apply_patch generation can surface official `item/fileChange/patchUpdated` notifications that OpenClaw already counts as current-turn activity.

## Validation
Latest patch:
- `git diff --check`
- Not run: build, test suite, gateway restart, or live retry per operator instruction.

Earlier validation for the commentary-guard portion:
- `pnpm exec oxfmt --check extensions/codex/src/app-server/attempt-notifications.ts extensions/codex/src/app-server/attempt-notification-state.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts`
- `git diff --check`
- `pnpm tsgo:extensions`
- `pnpm exec vitest run extensions/codex/src/app-server/run-attempt.turn-watches.test.ts`
- `pnpm exec vitest run extensions/codex/src/app-server/run-attempt.turn-watches.test.ts -t "uses the post-tool timeout for commentary raw assistant progress"`

Live evidence: Telegram topic 2728 timed out at 2026-05-30 05:45:20 IST after raw assistant commentary `I'm editing app.js...`; watchdog used `timeoutMs: 60000` instead of the post-tool 300000ms guard, while native Codex continued streaming the edit payload.
