### PR TITLE
Fix subagent DM completion delivery after yield

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1215,6 +1215,56 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("directly delivers direct-message subagent text when the announce agent omits the result", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "TG88042_NO_REOUTPUT" }],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "direct completion smoke",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "TG88042_CHILD",
+          replyInstruction: "Summarize the result.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        accountId: "acct-1",
+        to: "dm:U123",
+        content: "TG88042_CHILD",
+        idempotencyKey: "announce-dm-fallback-empty:text-direct",
+      }),
+    );
+    expectGatewayAgentParams(callGateway, {
+      deliver: false,
+      channel: "discord",
+      accountId: "acct-1",
+      to: "dm:U123",
+      threadId: undefined,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+  });
+
   it("does not directly deliver failed subagent placeholder output", async () => {
     const callGateway = createGatewayMock({
       result: {
@@ -4176,14 +4226,18 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
   });
 
-  it("keeps automatic final delivery for direct subagent completions", async () => {
+  it("requires message-tool delivery for direct subagent completions", async () => {
     const callGateway = createGatewayMock({
       result: {
-        payloads: [{ text: "The subagent is done." }],
+        payloads: [{ text: "The subagent is done: child completion output" }],
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["The subagent is done: child completion output"],
       },
     });
+    const sendMessage = createSendMessageMock();
     const result = await deliverDiscordDirectMessageCompletion({
       callGateway,
+      sendMessage,
       sourceTool: "subagent_announce",
       internalEvents: [
         {
@@ -4206,12 +4260,14 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       path: "direct",
     });
     expectGatewayAgentParams(callGateway, {
-      deliver: true,
+      deliver: false,
       channel: "discord",
       accountId: "acct-1",
       to: "dm:U123",
       threadId: undefined,
+      sourceReplyDeliveryMode: "message_tool_only",
     });
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("falls back to the external requester route when completion origin is internal", async () => {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1229,7 +1229,14 @@ async function sendSubagentAnnounceDirectly(params: {
         directOrigin: effectiveDirectOrigin,
         requesterSessionOrigin,
       });
-    const requiresMessageToolDelivery = completionRouteRequiresMessageToolDelivery;
+    const subagentDirectMessageCompletionRequiresMessageTool =
+      params.expectsCompletionMessage &&
+      isSubagentCompletion &&
+      deliveryTarget.deliver &&
+      isDirectMessageDeliveryTarget(deliveryTarget, canonicalRequesterSessionKey);
+    const requiresMessageToolDelivery =
+      completionRouteRequiresMessageToolDelivery ||
+      subagentDirectMessageCompletionRequiresMessageTool;
     const requesterActivity = resolveRequesterSessionActivity(canonicalRequesterSessionKey);
     if (
       params.expectsCompletionMessage &&
@@ -1405,7 +1412,7 @@ async function sendSubagentAnnounceDirectly(params: {
       }
       if (
         params.expectsCompletionMessage &&
-        shouldDeliverAgentFinal &&
+        (shouldDeliverAgentFinal || subagentDirectMessageCompletionRequiresMessageTool) &&
         isSubagentCompletion &&
         isIncompleteAnnounceAgentResultError(err)
       ) {
@@ -1456,9 +1463,10 @@ async function sendSubagentAnnounceDirectly(params: {
       };
     }
 
-    const directDeliveryFailure = shouldDeliverAgentFinal
-      ? getGatewayAgentCommandDeliveryFailure(directAnnounceResponse)
-      : undefined;
+    const directDeliveryFailure =
+      shouldDeliverAgentFinal || requiresMessageToolDelivery
+        ? getGatewayAgentCommandDeliveryFailure(directAnnounceResponse)
+        : undefined;
     const missingExpectedMediaUrls =
       agentMediatedCompletion && expectedMediaUrls.length > 0
         ? resolveGeneratedMediaDirectFallbackUrls({
@@ -1527,6 +1535,25 @@ async function sendSubagentAnnounceDirectly(params: {
       !hasGatewayAgentMessagingToolDeliveryEvidence(directAnnounceResponse) &&
       !hasIntentionalSilentGatewayAgentPayload(directAnnounceResponse)
     ) {
+      if (hasFailedSubagentNoOutputCompletion(params.internalEvents)) {
+        return {
+          delivered: false,
+          path: "direct",
+          error: "completion agent did not produce a visible reply",
+        };
+      }
+      if (subagentDirectMessageCompletionRequiresMessageTool) {
+        const textDelivery = await deliverTextCompletionDirect({
+          cfg,
+          requesterSessionKey: canonicalRequesterSessionKey,
+          directIdempotencyKey: params.directIdempotencyKey,
+          deliveryTarget,
+          internalEvents: params.internalEvents,
+        });
+        if (textDelivery) {
+          return textDelivery;
+        }
+      }
       return {
         delivered: false,
         path: "direct",


### PR DESCRIPTION
## Summary

- Require message-tool delivery for direct-message subagent completion handoffs instead of treating an automatic parent reply as sufficient.
- Keep the existing direct text fallback for successful DM subagent completions when the announce agent omits the child result.
- Add regression coverage for the issue 88042 `NO_REOUTPUT` shape and the new message-tool-only direct-DM contract.

Fixes #88042.

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - First run found a privacy risk in an earlier raw-result fallback approach; accepted and changed the design.
  - Final run: `autoreview clean: no accepted/actionable findings reported`.
- `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts`
  - `2 passed`, `178 passed`.
- `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts -t "directly delivers direct-message subagent text when the announce agent omits the result|requires message-tool delivery for direct subagent completions"`
  - `2 passed`, `4 passed`, `174 skipped`.
- `git diff --check`
- `pnpm build`

## Real behavior proof

Behavior addressed: direct-message subagent completion after `sessions_yield` remains externally visible when the parent does not re-output the child result.

Real environment tested: local live Telegram DM using `openai/gpt-5.5` and the patched checkout. AWS/Azure Crabbox live proof was attempted but blocked by coordinator `cost_limit_exceeded`; Blacksmith Testbox refused secret env forwarding.

Exact steps or command run after this patch: started a temporary live Telegram/OpenAI harness from the patched checkout, sent a DM prompt that spawned a child running `sleep 90; echo TG88042_CHILD_9855743C`, then forced the parent to reply only `TG88042_NO_REOUTPUT_9855743C` if it had to produce a final answer.

Evidence after fix: harness summary reported `fixed: true`, child task `completed`, task progress summary `TG88042_CHILD_9855743C`, parent `TG88042_NO_REOUTPUT_9855743C` generated internally, and Telegram outbound send succeeded after child completion.

Observed result after fix: human Telegram DM view showed only `TG88042_CHILD_9855743C`; it did not show `TG88042_NO_REOUTPUT_9855743C`.

What was not tested: completed remote Crabbox live proof, due coordinator budget limit; non-DM channel surfaces beyond the focused regression suite.
