### PR TITLE
test(codex): guard prompt authority boundary

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1157,6 +1157,58 @@ describe("runCodexAppServerAttempt", () => {
     ]);
   });
 
+  it("keeps mixed-source skill descriptions out of both Codex developer-instruction lanes", async () => {
+    const sessionFile = path.join(tempDir, "session-skill-source-boundary.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-skill-source-boundary");
+    const soulGuidance = "Soul voice goes here.";
+    await fs.mkdir(workspaceDir, { recursive: true });
+    // Populate the collaboration developer lane with legitimate identity content so the
+    // "skills are absent" assertions below are meaningful (the lane is non-empty).
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), soulGuidance);
+    await fs.writeFile(path.join(workspaceDir, "IDENTITY.md"), "Identity guidance goes here.");
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "User profile goes here.");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    setAgentWorkspaceForTest(params, workspaceDir);
+    // Author-controlled metadata from a non-bundled skill (workspace/project/personal/
+    // managed/plugin-generated). It must stay in the user/reference lane and never gain
+    // developer authority (boundary set by #83454/#84331).
+    const untrustedSkillDescription = "UNTRUSTED_SKILL_DESCRIPTION_SENTINEL";
+    params.skillsSnapshot = {
+      prompt: `<available_skills><skill><name>workspace-demo</name><description>${untrustedSkillDescription}</description><location>~/.agents/skills/workspace-demo</location></skill></available_skills>`,
+      skills: [{ name: "workspace-demo" }],
+    };
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const threadStart = harness.requests.find((request) => request.method === "thread/start");
+    const threadStartParams = threadStart?.params as { developerInstructions?: string };
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const turnStartParams = turnStart?.params as {
+      input?: Array<{ text?: string }>;
+      collaborationMode?: { settings?: { developer_instructions?: string | null } };
+    };
+    const collaborationInstructions =
+      turnStartParams.collaborationMode?.settings?.developer_instructions ?? "";
+    const inputText = turnStartParams.input?.[0]?.text ?? "";
+
+    // Thread-level developer instructions: no skills catalog, no author-controlled metadata.
+    expect(threadStartParams.developerInstructions ?? "").not.toContain("<available_skills>");
+    expect(threadStartParams.developerInstructions ?? "").not.toContain(untrustedSkillDescription);
+    // Turn-scoped collaboration developer instructions (highest-precedence lane): populated
+    // with identity content, but never the skills catalog or its descriptions.
+    expect(collaborationInstructions).toContain(soulGuidance);
+    expect(collaborationInstructions).not.toContain("<available_skills>");
+    expect(collaborationInstructions).not.toContain(untrustedSkillDescription);
+    // The skills catalog stays visible in the non-authoritative user/reference lane.
+    expect(inputText).toContain("<available_skills>");
+    expect(inputText).toContain(untrustedSkillDescription);
+  });
+
   it("keeps leading delivery hints out of the Codex current user request", async () => {
     const sessionFile = path.join(tempDir, "session-delivery-hint.jsonl");
     const workspaceDir = path.join(tempDir, "workspace-delivery-hint");
@@ -3705,6 +3757,67 @@ describe("runCodexAppServerAttempt", () => {
     const resumeRequest = requests.find((request) => request.method === "thread/resume");
     const resumeRequestParams = resumeRequest?.params as Record<string, unknown> | undefined;
     expect(resumeRequestParams?.developerInstructions).not.toContain(CODEX_GPT5_BEHAVIOR_CONTRACT);
+  });
+
+  it("keeps reused-snapshot skills and MEMORY.md body out of developer instructions on resume", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const soulGuidance = "Soul voice goes here.";
+    const memorySummary = "Persisted memory body goes here.";
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    // Populate the collaboration developer lane with legitimate identity content so the
+    // collaboration-sink assertions below are non-trivial (the lane is non-empty on resume).
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), soulGuidance);
+    await fs.writeFile(path.join(workspaceDir, "IDENTITY.md"), "Identity guidance goes here.");
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "User profile goes here.");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    const { requests, waitForMethod, completeTurn } = createResumeHarness();
+
+    const params = createParams(sessionFile, workspaceDir);
+    setAgentWorkspaceForTest(params, workspaceDir);
+    // Lightweight persisted snapshot: per-skill source is runtime-only and stripped on
+    // persistence (SessionSkillSnapshot keeps only prompt + catalog), so on a reused
+    // snapshot the render path cannot reconstruct trust. The mixed-source prompt must
+    // therefore never be promoted into a developer-instruction lane on resume.
+    const untrustedSkillDescription = "UNTRUSTED_REUSED_SKILL_DESCRIPTION_SENTINEL";
+    params.skillsSnapshot = {
+      prompt: `<available_skills><skill><name>workspace-demo</name><description>${untrustedSkillDescription}</description><location>~/.agents/skills/workspace-demo</location></skill></available_skills>`,
+      skills: [{ name: "workspace-demo" }],
+    };
+
+    const run = runCodexAppServerAttempt(params);
+    await waitForMethod("turn/start");
+    await completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await run;
+
+    const resumeRequest = requests.find((request) => request.method === "thread/resume");
+    const resumeDeveloperInstructions =
+      (resumeRequest?.params as { developerInstructions?: string } | undefined)
+        ?.developerInstructions ?? "";
+    const turnStart = requests.find((request) => request.method === "turn/start");
+    const turnStartParams = turnStart?.params as {
+      input?: Array<{ text?: string }>;
+      collaborationMode?: { settings?: { developer_instructions?: string | null } };
+    };
+    const collaborationInstructions =
+      turnStartParams.collaborationMode?.settings?.developer_instructions ?? "";
+    const inputText = turnStartParams.input?.[0]?.text ?? "";
+
+    // Resume thread-level developer instructions: no reused skills, no persisted memory body.
+    expect(resumeDeveloperInstructions).not.toContain("<available_skills>");
+    expect(resumeDeveloperInstructions).not.toContain(untrustedSkillDescription);
+    expect(resumeDeveloperInstructions).not.toContain(memorySummary);
+    // Turn-scoped collaboration developer instructions: populated with identity content, but
+    // never the reused skills catalog or the persisted memory body.
+    expect(collaborationInstructions).toContain(soulGuidance);
+    expect(collaborationInstructions).not.toContain("<available_skills>");
+    expect(collaborationInstructions).not.toContain(untrustedSkillDescription);
+    expect(collaborationInstructions).not.toContain(memorySummary);
+    // The reused skills catalog and bounded MEMORY.md body stay in the user/reference lane.
+    expect(inputText).toContain("<available_skills>");
+    expect(inputText).toContain(untrustedSkillDescription);
+    expect(inputText).toContain(memorySummary);
   });
 
   it("starts a fresh Codex thread before resume when the native rollout reaches the fallback fuse", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -158,6 +158,22 @@ describe("Codex app-server native code mode config", () => {
     expect(instructions).not.toContain("<available_skills>");
   });
 
+  it("keeps OpenClaw skill catalogs out of the turn collaboration developer instructions", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    params.skillsSnapshot = {
+      prompt: "<available_skills><skill><name>demo</name></skill></available_skills>",
+      skills: [],
+    };
+
+    // The collaboration builder has no skills input; pin that wiring skillsSnapshot in here
+    // (a future context-reduction shortcut) would fail closed.
+    const collaboration = buildTurnCollaborationMode(params, {
+      turnScopedDeveloperInstructions: "Soul voice goes here.",
+    });
+
+    expect(collaboration.settings.developer_instructions ?? "").not.toContain("<available_skills>");
+  });
+
   it("enables Codex code mode on thread/start without clobbering other config", () => {
     const request = buildThreadStartParams(createAttemptParams({ provider: "openai" }), {
       cwd: "/repo",

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -973,6 +973,9 @@ export function buildTurnCollaborationMode(
   };
 }
 
+// Authority boundary: highest-precedence developer lane (collaborationMode overrides
+// developer_instructions). Only allow-listed workspace identity files (SOUL/IDENTITY/USER)
+// belong here; never route the mixed-source skills catalog or MEMORY.md body in.
 function buildTurnScopedCollaborationInstructions(
   params: EmbeddedRunAttemptParams,
   options: {
@@ -1126,6 +1129,9 @@ function compareJsonFingerprint(left: JsonValue, right: JsonValue): number {
   return JSON.stringify(left).localeCompare(JSON.stringify(right));
 }
 
+// Authority boundary: keep the mixed-source skills catalog and MEMORY.md body out of this
+// thread-level developer lane (only OpenClaw-owned/static content + allow-listed workspace
+// files belong here); promoting author-controlled metadata would grant it developer authority.
 export function buildDeveloperInstructions(
   params: EmbeddedRunAttemptParams,
   options: { dynamicTools?: readonly CodexDynamicToolSpec[] } = {},


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Add **test-only** guardrails that pin OpenClaw's Codex prompt authority boundary: the mixed-source skills catalog and the `MEMORY.md` body must not enter either Codex developer-instruction lane — neither thread-level `developerInstructions` nor the higher-precedence `collaborationMode.settings.developer_instructions`.
- Add two short comments documenting the boundary at the two prompt-assembly choke points (`buildDeveloperInstructions`, `buildTurnScopedCollaborationInstructions`).

Why does this matter now?

- The developer-instruction lanes are higher-authority than user input (Codex `collaborationMode` "takes precedence over … developer instructions if set"). Skill `description` text is author-controlled (workspace / project / personal / managed / plugin-generated sources) and is rendered verbatim. Pinning this boundary now means future prompt-routing / context-compaction changes **fail closed** instead of silently promoting that metadata to developer authority.
- This PR makes **no claim of a current leak**. On `main` the boundary already holds; the pre-existing skills invariant only covered the thread-level sink on a fresh start. This PR locks the boundary in and extends coverage to the two paths a future change is most likely to take: the collaboration developer lane, and the reused/persisted `thread/resume` snapshot.

What is the intended outcome?

- Zero runtime behavior change and zero token delta. A regression that routed mixed-source skills or the `MEMORY.md` body into a developer lane would turn these tests red.

What is intentionally out of scope?

- No token reduction / context-compaction change.
- No prompt-routing change; no relocation of skills or memory into the developer lane.
- No new runtime enforcement (e.g. a throwing source-trust check) — this is a CI-level invariant only.
- No change to `SOUL.md` / `IDENTITY.md` / `USER.md` / `TOOLS.md` routing; those remain intentionally developer-authoritative.
- No dependency, workflow, secrets, or tool-access change.

What does success look like?

- On both fresh `thread/start` and reused `thread/resume`, neither developer-instruction sink carries the skills catalog or the `MEMORY.md` body; a mutation that violates this fails the new tests.

What should reviewers focus on?

- Whether the asserted boundary matches the intended trust model: the mixed-source skills catalog and the `MEMORY.md` body stay in the user/reference lane, while `SOUL/IDENTITY/USER/TOOLS.md` stay developer-authoritative.
- `extensions/codex/src/app-server/run-attempt.test.ts` (two new invariant tests) and `thread-lifecycle.test.ts` (one builder-contract guard).

## Linked context

Which issue does this close?

Closes #  <!-- none: proactive guardrail, not an issue fix -->

Which issues, PRs, or discussions are related?

Related #85646
Related #87788

Was this requested by a maintainer or owner?

No — proactive hardening of an existing trust boundary.

### Relationship to #85646 / #87788 (neutral)

- #87788 surfaced a useful direction for the **memory pointer**: routing only a generic `MEMORY.md` *pointer* (no body) into developer instructions can be safe. A full mixed-source `skillsSnapshot.prompt` → `developer_instructions` route, by contrast, is exactly what these tests catch.
- #85646's **bundled-only** skills split is compatible with this guardrail — it passes these tests.
- This is a neutral invariant that any future routing change must satisfy; it is not a claim that either PR is wrong or "wins".

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: authority-boundary invariant for Codex prompt assembly — the mixed-source skills catalog and the `MEMORY.md` body must never reach a developer-instruction lane. This PR changes no runtime behavior; the proof below drives the production prompt-assembly path and includes a mutation that proves the guard fails closed.
- Real environment tested: the OpenClaw Codex app-server prompt-assembly path (`runCodexAppServerAttempt` → `buildThreadStartParams` / `buildTurnStartParams` / `buildDeveloperInstructions` / `buildTurnCollaborationMode`), driven end-to-end by the integration harness on Linux / Node 24.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts`
  - mutation check: temporarily route `skillsSnapshot.prompt` into the collaboration developer lane, re-run the new tests, then revert.
- Evidence after fix (terminal output):
```
# boundary intact:
run-attempt.test.ts        Tests  80 passed (80)
thread-lifecycle.test.ts   Tests  44 passed (44)

# after routing the mixed-source skills catalog into collaboration developer_instructions:
thread-lifecycle.test.ts  "keeps OpenClaw skill catalogs out of the turn collaboration developer instructions"  -> 1 failed
run-attempt.test.ts       "keeps mixed-source skill descriptions out of both Codex developer-instruction lanes"  -> 1 failed
run-attempt.test.ts       "keeps reused-snapshot skills and MEMORY.md body out of developer instructions on resume" -> 1 failed

# after reverting that change:
all three                 -> green
```
- Observed result after fix: with the boundary intact, the skills catalog, a non-bundled `SKILL.md` description sentinel, and the `MEMORY.md` body appear only in the user/reference input lane and are absent from both developer-instruction sinks on `thread/start` and `thread/resume`. The mutation makes all three new tests fail; reverting restores green — the guard fails closed.
- What was not tested: live channel/model output is not applicable here — this PR changes no runtime behavior, so there is no user-visible output to capture.
- Proof limitations or environment constraints: because the change is a zero-behavior CI invariant, the appropriate proof is the prompt-assembly invariant plus the mutation demonstration rather than a live channel or model capture.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts` → 80 + 44 passing
- `oxfmt --check` on the changed files → clean
- `node scripts/run-oxlint.mjs` on the changed files → clean
- `OPENCLAW_LOCAL_CHECK=1 node scripts/check-changed.mjs --base upstream/main` → typecheck (extensions + extension tests) + lint + import-cycles clean
- `codex review --base upstream/main` → no findings

What regression coverage was added or updated?

- `run-attempt.test.ts`: skills + a non-bundled `SKILL.md` description are absent from both developer sinks on a fresh start; reused-snapshot skills and the `MEMORY.md` body are absent from both developer sinks on `thread/resume`.
- `thread-lifecycle.test.ts`: `buildTurnCollaborationMode` carries no skills even when `skillsSnapshot` is set.

What failed before this fix, if known?

- Nothing — the boundary holds on `main`. The pre-existing skills invariant only covered the thread-level sink on a fresh start; this PR adds the collaboration sink and the reused-snapshot path so a future change cannot regress them silently.

If no test was added, why not?

- N/A — this PR is the tests.

## Risk checklist

Did user-visible behavior change? No

Did config, environment, or migration behavior change? No

Did security, auth, secrets, network, or tool execution behavior change? No — test-only; it strengthens a security invariant but does not alter runtime trust handling.

What is the highest-risk area? Test coupling to the prompt-assembly path.

How is that risk mitigated? Assertions key on a stable sentinel description and the `<available_skills>` marker rather than incidental formatting, and are mutation-tested (they fail when the boundary is violated, pass when intact).

### Security / trust boundary

- This is a prompt authority / trust-boundary guardrail. Automated scanners may see a tests/docs-only diff; the substantive invariant is that **user-/workspace-/plugin-controlled skill metadata and the `MEMORY.md` body must not be promoted into the higher-authority developer-instruction lanes**.
- It does not claim an active leak on `main`; it pins the boundary so future context-compaction changes fail closed.

## Current review state

- Ready for maintainer review. Scope is intentionally minimal (tests + two comments); no runtime behavior or token-cost change.
