### PR TITLE
fix(cron): accept sub-second --at datetimes resolved in a timezone

### DIFF
--- a/src/infra/format-time/parse-offsetless-zoned-datetime.test.ts
+++ b/src/infra/format-time/parse-offsetless-zoned-datetime.test.ts
@@ -19,6 +19,11 @@ describe("parseOffsetlessIsoDateTimeInTimeZone", () => {
     ["2026-03-29T02:30:00", "Europe/Oslo", null],
     ["2026-03-23T23:00:00+02:00", "Europe/Oslo", null],
     ["2026-03-23T23:00:00", "Invalid/Timezone", null],
+    // Sub-second precision is accepted by the regex and must round-trip rather
+    // than being silently rejected (the offset must be computed at ms resolution).
+    ["2026-03-23T23:00:00.250", "UTC", "2026-03-23T23:00:00.250Z"],
+    ["2026-03-23T23:00:00.999", "UTC", "2026-03-23T23:00:00.999Z"],
+    ["2026-03-23T23:00:00.123", "Europe/Oslo", "2026-03-23T22:00:00.123Z"],
   ])("parses zoned datetime %s in %s", (input, timezone, expected) => {
     expect(parseOffsetlessIsoDateTimeInTimeZone(input, timezone)).toBe(expected);
   });

--- a/src/infra/format-time/parse-offsetless-zoned-datetime.ts
+++ b/src/infra/format-time/parse-offsetless-zoned-datetime.ts
@@ -87,6 +87,10 @@ function getTimeZoneOffsetMs(utcMs: number, timeZone: string): number {
     parts.hour,
     parts.minute,
     parts.second,
+    // Include the sub-second component (carried from utcMs via getUTCMilliseconds)
+    // so the offset is exact. Dropping it makes the offset wrong by the fraction,
+    // which fails the millisecond re-validation and rejects valid sub-second input.
+    parts.millisecond,
   );
 
   return localAsUtc - utcMs;


### PR DESCRIPTION
## Summary

`getTimeZoneOffsetMs` in `src/infra/format-time/parse-offsetless-zoned-datetime.ts` built `localAsUtc` with `Date.UTC(...)` but omitted the millisecond argument. The timezone offset is therefore wrong by the sub-second fraction of the instant, which corrupts `resolvedMs` and then fails the exact-millisecond re-validation in `matchesOffsetlessIsoDateTimeParts`. As a result, `parseOffsetlessIsoDateTimeInTimeZone` returns `null` for any offset-less datetime that carries sub-second precision.

The parser's own regex (`OFFSETLESS_ISO_DATETIME_RE`) explicitly accepts fractional seconds (`(\.\d+)?`), so this is a supported input shape that silently fails.

User impact: the consumer is `parseAt(input, tz)` in `src/cli/cron-cli/shared.ts`, reached when running `openclaw cron … --at <offset-less ISO> --tz <IANA zone>`. A sub-second `--at` value with a timezone is rejected ("couldn't parse") instead of scheduling at the intended instant. (`.500` happens to survive a double-offset coincidence; `.250` / `.123` / `.999` all fail.)

### Fix

Pass `parts.millisecond` — carried from `utcMs` via `getUTCMilliseconds()`, so it reflects the true sub-second component — as the 7th `Date.UTC` argument, so the offset is exact. One-line change plus a regression test.

## Real behavior proof (required for external PRs)

Behavior addressed: offset-less `--at` datetimes with sub-second precision plus a timezone were silently rejected (parser returned null) because the computed timezone offset dropped the millisecond fraction. After this patch they resolve to the intended UTC instant.

Real environment tested: local macOS checkout on fresh main. The proof drives the real production parser `parseOffsetlessIsoDateTimeInTimeZone` (the exact function `openclaw cron --at` calls through `parseAt`) against real `Intl.DateTimeFormat` timezone resolution for both UTC and Europe/Oslo. No mocks of the function under test.

Exact steps or command run after this patch: I added three fractional-second rows to the parser's table test, ran them against the unpatched `getTimeZoneOffsetMs` (they returned null), then applied the one-line fix and re-ran. Command:

```
node scripts/run-vitest.mjs src/infra/format-time/parse-offsetless-zoned-datetime.test.ts
```

Evidence after fix: copied live console output from `node scripts/run-vitest.mjs` —

```
BEFORE (unpatched getTimeZoneOffsetMs, ms dropped):
  x parses zoned datetime 2026-03-23T23:00:00.250 in UTC
  AssertionError: expected null to be '2026-03-23T23:00:00.250Z'
  x parses zoned datetime 2026-03-23T23:00:00.999 in UTC
  x parses zoned datetime 2026-03-23T23:00:00.123 in Europe/Oslo
  Tests  3 failed | 8 passed (11)

AFTER (this fix):
  Test Files  1 passed (1)
  Tests  11 passed (11)
```

Observed result after fix: the `node scripts/run-vitest.mjs` run shows `parseOffsetlessIsoDateTimeInTimeZone` now round-trips sub-second input — `2026-03-23T23:00:00.250` in UTC resolves to `2026-03-23T23:00:00.250Z`, and `2026-03-23T23:00:00.123` in Europe/Oslo to `2026-03-23T22:00:00.123Z` — where it previously returned null.

What was not tested: I did not run `openclaw cron add --at … --tz …` end-to-end (it needs a running gateway and would schedule a real job). The proof drives the exact parser that the CLI's `parseAt` calls, against real `Intl` timezone math.

## Tests and validation

- `node scripts/run-vitest.mjs src/infra/format-time/parse-offsetless-zoned-datetime.test.ts` -> 11 passed (3 new fractional-second rows: `.250`/`.999` in UTC, `.123` in Europe/Oslo).
- Before/after isolation above: the 3 rows fail (null) on the unpatched source and pass with the fix.
- `oxfmt --check` clean, `oxlint` clean, `tsgo:core` exit 0, `tsgo:core:test` exit 0, `git diff --check` clean. Diff is +9 lines across 2 files.
