### PR TITLE
feat(minimax): add MiniMax-M3 with native multimodal + 512K context

### DIFF
--- a/extensions/minimax/model-definitions.ts
+++ b/extensions/minimax/model-definitions.ts
@@ -65,16 +65,19 @@ export function buildMinimaxModelDefinition(params: {
   id: string;
   name?: string;
   reasoning?: boolean;
+  input?: ModelDefinitionConfig["input"];
   cost: ModelDefinitionConfig["cost"];
   contextWindow: number;
   maxTokens: number;
 }): ModelDefinitionConfig {
-  const catalog = MINIMAX_TEXT_MODEL_CATALOG[params.id as MinimaxCatalogId];
+  const catalog = MINIMAX_TEXT_MODEL_CATALOG[params.id as MinimaxCatalogId] as
+    | { name: string; reasoning: boolean; input?: readonly ("text" | "image")[] }
+    | undefined;
   return {
     id: params.id,
     name: params.name ?? catalog?.name ?? `MiniMax ${params.id}`,
     reasoning: params.reasoning ?? catalog?.reasoning ?? false,
-    input: ["text"],
+    input: params.input ?? (catalog?.input ? [...catalog.input] : ["text"]),
     cost: params.cost,
     contextWindow: params.contextWindow,
     maxTokens: params.maxTokens,
@@ -82,10 +85,13 @@ export function buildMinimaxModelDefinition(params: {
 }
 
 export function buildMinimaxApiModelDefinition(modelId: string): ModelDefinitionConfig {
+  const catalog = MINIMAX_TEXT_MODEL_CATALOG[modelId as MinimaxCatalogId] as
+    | { contextWindow?: number; maxTokens?: number }
+    | undefined;
   return buildMinimaxModelDefinition({
     id: modelId,
     cost: resolveMinimaxApiCost(modelId),
-    contextWindow: DEFAULT_MINIMAX_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
+    contextWindow: catalog?.contextWindow ?? DEFAULT_MINIMAX_CONTEXT_WINDOW,
+    maxTokens: catalog?.maxTokens ?? DEFAULT_MINIMAX_MAX_TOKENS,
   });
 }

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -34,6 +34,8 @@ function buildMinimaxModel(params: {
   reasoning: boolean;
   input: ModelDefinitionConfig["input"];
   cost: ModelDefinitionConfig["cost"];
+  contextWindow?: number;
+  maxTokens?: number;
 }): ModelDefinitionConfig {
   return {
     id: params.id,
@@ -41,8 +43,8 @@ function buildMinimaxModel(params: {
     reasoning: params.reasoning,
     input: params.input,
     cost: params.cost,
-    contextWindow: DEFAULT_MINIMAX_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
+    contextWindow: params.contextWindow ?? DEFAULT_MINIMAX_CONTEXT_WINDOW,
+    maxTokens: params.maxTokens ?? DEFAULT_MINIMAX_MAX_TOKENS,
   };
 }
 
@@ -51,18 +53,30 @@ function buildMinimaxTextModel(params: {
   name: string;
   reasoning: boolean;
   cost: ModelDefinitionConfig["cost"];
+  input?: ModelDefinitionConfig["input"];
+  contextWindow?: number;
+  maxTokens?: number;
 }): ModelDefinitionConfig {
-  return buildMinimaxModel({ ...params, input: ["text"] });
+  return buildMinimaxModel({ ...params, input: params.input ?? ["text"] });
 }
 
 function buildMinimaxCatalog(): ModelDefinitionConfig[] {
   return MINIMAX_TEXT_MODEL_ORDER.map((id) => {
-    const model = MINIMAX_TEXT_MODEL_CATALOG[id];
+    const model = MINIMAX_TEXT_MODEL_CATALOG[id] as {
+      name: string;
+      reasoning: boolean;
+      input?: readonly ("text" | "image")[];
+      contextWindow?: number;
+      maxTokens?: number;
+    };
     return buildMinimaxTextModel({
       id,
       name: model.name,
       reasoning: model.reasoning,
       cost: resolveMinimaxApiCost(id),
+      input: model.input ? [...model.input] : undefined,
+      contextWindow: model.contextWindow,
+      maxTokens: model.maxTokens,
     });
   });
 }

--- a/extensions/minimax/provider-models.ts
+++ b/extensions/minimax/provider-models.ts
@@ -3,9 +3,20 @@ import { matchesExactOrPrefix } from "openclaw/plugin-sdk/provider-model-shared"
 export const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.7";
 export const MINIMAX_DEFAULT_MODEL_REF = `minimax/${MINIMAX_DEFAULT_MODEL_ID}`;
 
-export const MINIMAX_TEXT_MODEL_ORDER = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"] as const;
+export const MINIMAX_TEXT_MODEL_ORDER = [
+  "MiniMax-M3",
+  "MiniMax-M2.7",
+  "MiniMax-M2.7-highspeed",
+] as const;
 
 export const MINIMAX_TEXT_MODEL_CATALOG = {
+  "MiniMax-M3": {
+    name: "MiniMax M3",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 512_000,
+    maxTokens: 196_608,
+  },
   "MiniMax-M2.7": { name: "MiniMax M2.7", reasoning: true },
   "MiniMax-M2.7-highspeed": { name: "MiniMax M2.7 Highspeed", reasoning: true },
 } as const;
@@ -14,7 +25,7 @@ export const MINIMAX_TEXT_MODEL_REFS = MINIMAX_TEXT_MODEL_ORDER.map(
   (modelId) => `minimax/${modelId}`,
 );
 
-const MINIMAX_MODERN_MODEL_MATCHERS = ["minimax-m2.7"] as const;
+const MINIMAX_MODERN_MODEL_MATCHERS = ["minimax-m2.7", "minimax-m3"] as const;
 
 export function isMiniMaxModernModelId(modelId: string): boolean {
   return matchesExactOrPrefix(modelId, MINIMAX_MODERN_MODEL_MATCHERS);


### PR DESCRIPTION
## What

Adds `MiniMax-M3` as a first-class minimax catalog entry with native multimodal (text + image) and the M3 capability spec, and unblocks the path so that the chat model receives images directly instead of being routed through the auxiliary `MiniMax-VL-01` description provider.

| field | value |
|---|---|
| contextWindow | 512_000 (vs M2.7's 204_800) |
| maxTokens | 196_608 (server hard cap) |
| input | `["text", "image"]` |
| reasoning | true |

## Files

| file | change |
|---|---|
| `extensions/minimax/provider-models.ts` | add M3 to `MINIMAX_TEXT_MODEL_ORDER` + `MINIMAX_TEXT_MODEL_CATALOG` with optional per-model `input` / `contextWindow` / `maxTokens` overrides. M2.7 / M2.7-highspeed entries unchanged. |
| `extensions/minimax/model-definitions.ts` | `buildMinimaxModelDefinition` now reads `input` from catalog (was hardcoded `["text"]`); `buildMinimaxApiModelDefinition` reads catalog `contextWindow` / `maxTokens` before falling back to the M2.x defaults. |
| `extensions/minimax/provider-catalog.ts` | `buildMinimaxModel` / `buildMinimaxTextModel` / `buildMinimaxCatalog` plumb the same three optional overrides through. |

## Why this is needed (root-cause)

End-to-end testing against M3 staging showed that without all three changes:

1. `buildMinimaxModelDefinition` returned `input: ["text"]` even for minimax/MiniMax-M3 → pi-ai's `downgradeUnsupportedImages` gate (`model.input.includes("image")`) silently replaced image content blocks with `"(image omitted: model does not support images)"`. M3 then literally replied "I don't see an image."
2. `buildMinimaxApiModelDefinition` returned `contextWindow: 204_800` → users with 400K+ contexts hit truncation logic that assumed M2.x.

With the catalog-driven override path, M3 routes natively through the Anthropic Messages adapter with the right caps.

## Verified

- Local hermes-bundled openclaw, image input via `infer model run --file <png> --model minimax/MiniMax-M3`: M3 responds `"A solid red circle on a light gray background."` (correct)
- Same flow without the patch: M3 responds `"I don't see any image attached to your message."`

## Not in this PR

- M3 cost mapping in `resolveMinimaxApiCost` defaults to `MINIMAX_API_COST` (= M2.7's pricing). Easy follow-up once final M3 prices are published.
- `media-understanding-provider.ts` still registers `MiniMax-VL-01` as the auxiliary vision provider; that's still useful for non-multimodal chat models so it stays.