### PR TITLE
fix: recover stale diagnostic session lanes

### DIFF
--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -16,6 +16,7 @@ export type DiagnosticSessionRecoverySkipReason =
   | "active_lane_task"
   | "already_in_flight"
   | "missing_session_ref"
+  | "shared_lane_backpressure"
   | "stale_session_state";
 
 export type DiagnosticSessionRecoveryNoopReason = "no_active_work";

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -158,7 +158,7 @@ describe("stuck session recovery integration", () => {
     expect(getQueueSize(lane)).toBe(0);
   });
 
-  it("does not reset a blocked lane while unregistered lane work is still active", async () => {
+  it("resets a stale blocked lane when no active run is registered", async () => {
     const sessionKey = "agent:main:unregistered-work";
     const sessionId = "unregistered-work-session";
     const lane = resolveEmbeddedSessionLane(sessionKey);
@@ -179,10 +179,7 @@ describe("stuck session recovery integration", () => {
       queueDepth: 1,
     });
 
-    await expect(Promise.race([queued, delay(100)])).resolves.toBe("blocked");
-    expect(getQueueSize(lane)).toBe(2);
-
-    expect(resetCommandLane(lane)).toBe(1);
     await expect(queued).resolves.toBe("drained");
+    expect(getQueueSize(lane)).toBe(0);
   });
 });

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   isEmbeddedAgentRunActive: vi.fn(),
   isEmbeddedAgentRunHandleActive: vi.fn(),
   getCommandLaneSnapshot: vi.fn(),
+  getCommandLaneSnapshots: vi.fn(),
   resetCommandLane: vi.fn(),
   resolveActiveEmbeddedRunSessionId: vi.fn(),
   resolveActiveEmbeddedRunSessionIdBySessionFile: vi.fn(),
@@ -60,6 +61,7 @@ vi.mock("../agents/embedded-agent-runner/lanes.js", () => ({
 
 vi.mock("../process/command-queue.js", () => ({
   getCommandLaneSnapshot: mocks.getCommandLaneSnapshot,
+  getCommandLaneSnapshots: mocks.getCommandLaneSnapshots,
   resetCommandLane: mocks.resetCommandLane,
 }));
 
@@ -91,6 +93,8 @@ function resetMocks() {
     draining: false,
     generation: 0,
   });
+  mocks.getCommandLaneSnapshots.mockReset();
+  mocks.getCommandLaneSnapshots.mockReturnValue([]);
   mocks.resetCommandLane.mockReset();
   mocks.resolveActiveEmbeddedRunSessionId.mockReset();
   mocks.resolveActiveEmbeddedRunSessionIdBySessionFile.mockReset();
@@ -411,21 +415,22 @@ describe("stuck session recovery", () => {
     );
   });
 
-  it("does not release the session lane while unregistered lane work is active", async () => {
+  it("releases a stale session lane when unregistered lane work is active", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
     mocks.getCommandLaneSnapshot.mockReturnValue({
       lane: "session:agent:main:main",
-      queuedCount: 1,
+      queuedCount: 0,
       activeCount: 1,
       maxConcurrent: 1,
       draining: false,
       generation: 0,
     });
+    mocks.resetCommandLane.mockReturnValue(1);
 
-    await recoverStuckDiagnosticSession({
+    const outcome = await recoverStuckDiagnosticSession({
       sessionId: "unregistered-work-session",
       sessionKey: "agent:main:main",
       ageMs: 180_000,
@@ -434,9 +439,66 @@ describe("stuck session recovery", () => {
 
     expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
     expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
-    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
+    expect(outcome).toMatchObject({ status: "released", action: "release_lane", released: 1 });
     expect(warnLogMessages()).toEqual([
-      "stuck session recovery outcome: status=skipped action=keep_lane sessionId=unregistered-work-session sessionKey=agent:main:main lane=session:agent:main:main reason=active_lane_task laneActive=1 laneQueued=1",
+      "stuck session recovery releasing stale lane task: reason=stale_active_lane_task action=release_lane sessionId=unregistered-work-session sessionKey=agent:main:main age=180s queueDepth=1 lane=session:agent:main:main laneActive=1 laneQueued=0",
+      "stuck session recovery: sessionId=unregistered-work-session sessionKey=agent:main:main age=180s action=release_lane aborted=false drained=true released=1",
+      "stuck session recovery outcome: status=released action=release_lane sessionId=unregistered-work-session sessionKey=agent:main:main lane=session:agent:main:main released=1",
+    ]);
+  });
+
+  it("keeps an unregistered session lane when shared lane backpressure can explain it", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:main:main",
+      queuedCount: 0,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+    mocks.getCommandLaneSnapshots.mockReturnValue([
+      {
+        lane: "session:agent:main:main",
+        queuedCount: 0,
+        activeCount: 1,
+        maxConcurrent: 1,
+        draining: false,
+        generation: 0,
+      },
+      {
+        lane: "cron-nested",
+        queuedCount: 2,
+        activeCount: 1,
+        maxConcurrent: 1,
+        draining: false,
+        generation: 0,
+      },
+    ]);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "queued-behind-shared-lane",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 1,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "shared_lane_backpressure",
+      lane: "session:agent:main:main",
+    });
+    expect(warnLogMessages()).toEqual([
+      "stuck session recovery skipped: reason=shared_lane_backpressure sessionId=queued-behind-shared-lane sessionKey=agent:main:main age=180s queueDepth=1 lane=session:agent:main:main laneActive=1 laneQueued=0 sharedLane=cron-nested sharedLaneActive=1 sharedLaneQueued=2",
+      "stuck session recovery outcome: status=skipped action=keep_lane sessionId=queued-behind-shared-lane sessionKey=agent:main:main lane=session:agent:main:main reason=shared_lane_backpressure",
     ]);
   });
 

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -8,7 +8,11 @@ import {
   resolveActiveEmbeddedRunHandleSessionId,
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
 } from "../agents/embedded-agent-runner/runs.js";
-import { getCommandLaneSnapshot, resetCommandLane } from "../process/command-queue.js";
+import {
+  getCommandLaneSnapshot,
+  getCommandLaneSnapshots,
+  resetCommandLane,
+} from "../process/command-queue.js";
 import { getDiagnosticSessionActivitySnapshot } from "./diagnostic-run-activity.js";
 import { diagnosticLogger as diag } from "./diagnostic-runtime.js";
 import {
@@ -79,6 +83,28 @@ function formatRecoveryContext(
     fields.push(`laneQueued=${extra.queuedCount}`);
   }
   return fields.join(" ");
+}
+
+function isSessionLaneSnapshot(lane: string): boolean {
+  return lane.startsWith("session:");
+}
+
+function findSharedLaneBackpressure(
+  sessionLane: string,
+): { lane: string; activeCount: number; queuedCount: number } | undefined {
+  for (const snapshot of getCommandLaneSnapshots()) {
+    if (snapshot.lane === sessionLane || isSessionLaneSnapshot(snapshot.lane)) {
+      continue;
+    }
+    if (snapshot.activeCount > 0 || snapshot.queuedCount > 0) {
+      return {
+        lane: snapshot.lane,
+        activeCount: snapshot.activeCount,
+        queuedCount: snapshot.queuedCount,
+      };
+    }
+  }
+  return undefined;
 }
 
 export async function recoverStuckDiagnosticSession(
@@ -229,18 +255,41 @@ export async function recoverStuckDiagnosticSession(
     if (!activeSessionId && sessionLane) {
       const laneSnapshot = getCommandLaneSnapshot(sessionLane);
       if (laneSnapshot.activeCount > 0) {
-        const outcome: StuckSessionRecoveryOutcome = {
-          status: "skipped",
-          action: "keep_lane",
-          reason: "active_lane_task",
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          lane: sessionLane,
-          activeCount: laneSnapshot.activeCount,
-          queuedCount: laneSnapshot.queuedCount,
-        };
-        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-        return outcome;
+        const sharedBackpressure = findSharedLaneBackpressure(sessionLane);
+        if (sharedBackpressure) {
+          const outcome: StuckSessionRecoveryOutcome = {
+            status: "skipped",
+            action: "keep_lane",
+            reason: "shared_lane_backpressure",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            lane: sessionLane,
+          };
+          diag.warn(
+            `stuck session recovery skipped: reason=shared_lane_backpressure ${formatRecoveryContext(
+              params,
+              {
+                lane: sessionLane,
+                activeCount: laneSnapshot.activeCount,
+                queuedCount: laneSnapshot.queuedCount,
+              },
+            )} sharedLane=${sharedBackpressure.lane} sharedLaneActive=${
+              sharedBackpressure.activeCount
+            } sharedLaneQueued=${sharedBackpressure.queuedCount}`,
+          );
+          diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+          return outcome;
+        }
+        diag.warn(
+          `stuck session recovery releasing stale lane task: reason=stale_active_lane_task action=release_lane ${formatRecoveryContext(
+            params,
+            {
+              lane: sessionLane,
+              activeCount: laneSnapshot.activeCount,
+              queuedCount: laneSnapshot.queuedCount,
+            },
+          )}`,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- release stale per-session command lanes when no embedded run owns the active lane task
- keep the lane only when a shared non-session lane has active or queued work that can explain the wait
- add diagnostic skip reason and focused runtime/integration coverage for stale lane release versus shared-lane backpressure

## Verification
- `PATH=/home/openclaw/.openclaw/tools/node-v22.22.0/bin:$PATH corepack pnpm exec oxfmt --write --threads=1 src/logging/diagnostic-session-recovery.ts src/logging/diagnostic-stuck-session-recovery.runtime.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts`
- `PATH=/home/openclaw/.openclaw/tools/node-v22.22.0/bin:$PATH node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts`
- `PATH=/home/openclaw/.openclaw/tools/node-v22.22.0/bin:$PATH node scripts/run-tsgo.mjs -b tsconfig.projects.json`

## Real behavior proof
Behavior addressed: OpenClaw gateway diagnostic recovery can leave a stale per-session lane active when no embedded run is active, or release it too aggressively while shared lane backpressure explains the wait.
Real environment tested: Local OpenClaw source checkout with Node 22.22.0; patched package was also built and installed locally for the project-flow job-hunter runtime before this PR.
Exact steps or command run after this patch: Focused vitest files, oxfmt on touched files, and project-wide tsgo command listed above.
Evidence after fix: Focused tests pass 24/24; tsgo exits 0; local gateway logs show `shared_lane_backpressure` skips instead of incorrect lane release while shared queue work is active.
Observed result after fix: Stale orphaned session lanes can be released when no embedded run owns them, while lanes queued behind shared work are preserved until backpressure clears.
What was not tested: Full OpenClaw `pnpm check`; the local checkout has unrelated release/lock drift, so broad pnpm check was not run here.
