### PR TITLE
[codex] tighten final Telegram DM recovery

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3873,6 +3873,42 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("replays a visible final DM response when durable delivery suppresses the first send", async () => {
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    readLatestAssistantTextFromSessionTranscript.mockResolvedValue({
+      text: "Recovered final answer",
+      timestamp: Date.now() + 1_000,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Recovered final answer" }, { kind: "final" });
+      return { queuedFinal: false };
+    });
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_no_send",
+      reason: "no_visible_result",
+      delivery: {
+        messageIds: ["m1"],
+        visibleReplySent: false,
+      },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:default:telegram:direct:123",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expectDeliveredReply(0, {
+      text: "Recovered final answer",
+    });
+  });
+
   it("does not emit a silent-reply fallback for no-response group turns", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3873,16 +3873,21 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("replays a visible final DM response when durable delivery suppresses the first send", async () => {
+  it("replays a visible final DM response when durable delivery reports no visible result", async () => {
+    const statusReactionController = createStatusReactionController();
     loadSessionStore.mockReturnValue({
       "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    readLatestAssistantTextFromSessionTranscript.mockResolvedValueOnce({
+      text: "Original final answer",
+      timestamp: Date.now() - 1_000,
     });
     readLatestAssistantTextFromSessionTranscript.mockResolvedValue({
       text: "Recovered final answer",
       timestamp: Date.now() + 1_000,
     });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      await dispatcherOptions.deliver({ text: "Recovered final answer" }, { kind: "final" });
+      await dispatcherOptions.deliver({ text: "Original final answer" }, { kind: "final" });
       return { queuedFinal: false };
     });
     deliverInboundReplyWithMessageSendContext.mockResolvedValue({
@@ -3893,6 +3898,50 @@ describe("dispatchTelegramMessage draft streaming", () => {
         visibleReplySent: false,
       },
     });
+    deliverReplies.mockResolvedValueOnce({ delivered: false });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        removeAckAfterReply: false,
+        statusReactionController: statusReactionController as never,
+        ctxPayload: {
+          SessionKey: "agent:default:telegram:direct:123",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverInboundReplyWithMessageSendContext).toHaveBeenCalledTimes(1);
+    expect(deliverInboundReplyWithMessageSendContext.mock.calls[0]?.[0]).toMatchObject({
+      payload: { text: "Original final answer" },
+      info: { kind: "final" },
+    });
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expect(deliverReplies.mock.calls[0]?.[0]?.replies?.[0]?.text).toEqual(expect.any(String));
+  });
+
+  it("does not retry a deliberately suppressed final DM response", async () => {
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    readLatestAssistantTextFromSessionTranscript.mockResolvedValue({
+      text: "Recovered final answer",
+      timestamp: Date.now() + 1_000,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Original final answer" }, { kind: "final" });
+      return { queuedFinal: false };
+    });
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_no_send",
+      reason: "cancelled_by_message_sending_hook",
+      delivery: {
+        messageIds: ["m1"],
+        visibleReplySent: false,
+      },
+    });
+    deliverReplies.mockResolvedValue({ delivered: false });
 
     await dispatchWithContext({
       context: createContext({
@@ -3903,10 +3952,51 @@ describe("dispatchTelegramMessage draft streaming", () => {
       streamMode: "off",
     });
 
-    expect(deliverReplies).toHaveBeenCalledTimes(1);
-    expectDeliveredReply(0, {
-      text: "Recovered final answer",
+    expect(deliverInboundReplyWithMessageSendContext).toHaveBeenCalledTimes(1);
+    expect(deliverInboundReplyWithMessageSendContext.mock.calls[0]?.[0]).toMatchObject({
+      payload: { text: "Original final answer" },
+      info: { kind: "final" },
     });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("does not retry an empty final DM payload that resolves to no visible payload", async () => {
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    readLatestAssistantTextFromSessionTranscript.mockResolvedValue({
+      text: "Recovered final answer",
+      timestamp: Date.now() + 1_000,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Original final answer" }, { kind: "final" });
+      return { queuedFinal: false };
+    });
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_no_send",
+      reason: "no_visible_payload",
+      delivery: {
+        messageIds: ["m1"],
+        visibleReplySent: false,
+      },
+    });
+    deliverReplies.mockResolvedValue({ delivered: false });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:default:telegram:direct:123",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverInboundReplyWithMessageSendContext).toHaveBeenCalledTimes(1);
+    expect(deliverInboundReplyWithMessageSendContext.mock.calls[0]?.[0]).toMatchObject({
+      payload: { text: "Original final answer" },
+      info: { kind: "final" },
+    });
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("does not emit a silent-reply fallback for no-response group turns", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -57,6 +57,7 @@ import {
   logVerbose,
   sleepWithAbort,
 } from "openclaw/plugin-sdk/runtime-env";
+import type { DurableMessageSuppressionReason } from "../../../src/channels/message/send.js";
 import { resolveTelegramConfigReasoningDefault } from "./agent-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeAllowFrom } from "./bot-access.js";
@@ -1274,6 +1275,7 @@ export const dispatchTelegramMessage = async ({
     );
   const endTelegramInboundEventDeliveryCorrelation = beginDeliveryCorrelation();
   const sessionKey = ctxPayload.SessionKey;
+  let finalDurableNoSendReason: DurableMessageSuppressionReason | undefined;
   const resolveCurrentTurnTranscriptFinalText = async (): Promise<string | undefined> => {
     if (!sessionKey) {
       return undefined;
@@ -1477,10 +1479,12 @@ export const dispatchTelegramMessage = async ({
           throw durable.error;
         }
         if (durable.status === "handled_visible") {
+          finalDurableNoSendReason = undefined;
           deliveryState.markDelivered();
           return true;
         }
         if (durable.status === "handled_no_send") {
+          finalDurableNoSendReason = durable.reason;
           return false;
         }
       }
@@ -1493,6 +1497,7 @@ export const dispatchTelegramMessage = async ({
         mediaLoader: telegramDeps.loadWebMedia,
       });
       if (result.delivered) {
+        finalDurableNoSendReason = undefined;
         deliveryState.markDelivered();
       }
       return result.delivered;
@@ -2167,7 +2172,8 @@ export const dispatchTelegramMessage = async ({
     }
     return;
   }
-  let sentFallback = false;
+  let failureFallbackSent = false;
+  let recoverySuccessful = false;
   const deliverySummary = deliveryState.snapshot();
   const shouldSendFailureFallback =
     !isRoomEvent &&
@@ -2184,18 +2190,19 @@ export const dispatchTelegramMessage = async ({
       silent: silentErrorReplies && (dispatchError != null || hadErrorReplyFailureOrSkip),
       mediaLoader: telegramDeps.loadWebMedia,
     });
-    sentFallback = result.delivered;
+    failureFallbackSent = result.delivered;
   }
 
   const shouldRetryMissingFinalResponse =
     !isRoomEvent &&
     !dispatchError &&
-    !sentFallback &&
+    !failureFallbackSent &&
     !deliverySummary.delivered &&
     !queuedFinal &&
     finalAnswerDeliveryStarted &&
     !finalAnswerDelivered &&
-    !suppressSilentReplyFallback;
+    !suppressSilentReplyFallback &&
+    finalDurableNoSendReason === "no_visible_result";
   if (shouldRetryMissingFinalResponse) {
     const fallbackText =
       (await resolveCurrentTurnTranscriptFinalText())?.trim() || EMPTY_RESPONSE_FALLBACK;
@@ -2206,11 +2213,12 @@ export const dispatchTelegramMessage = async ({
       silent: false,
       mediaLoader: telegramDeps.loadWebMedia,
     });
-    sentFallback = result.delivered;
+    recoverySuccessful = result.delivered;
   }
 
   if (
-    !sentFallback &&
+    !failureFallbackSent &&
+    !recoverySuccessful &&
     !dispatchError &&
     !deliverySummary.delivered &&
     !suppressSilentReplyFallback &&
@@ -2235,18 +2243,23 @@ export const dispatchTelegramMessage = async ({
         silent: false,
         mediaLoader: telegramDeps.loadWebMedia,
       });
-      sentFallback = result.delivered;
+      recoverySuccessful = result.delivered;
     }
     silentReplyDispatchLogger.debug("telegram turn ended without visible final response", {
       hasSessionKey: Boolean(policySessionKey),
       hasChatId: chatId != null,
       queuedFinal,
-      sentFallback,
+      failureFallbackSent,
+      recoverySuccessful,
     });
   }
 
   const hasFinalResponse =
-    deliverySummary.delivered || sentFallback || suppressSilentReplyFallback || queuedFinal;
+    deliverySummary.delivered ||
+    failureFallbackSent ||
+    recoverySuccessful ||
+    suppressSilentReplyFallback ||
+    queuedFinal;
 
   if (statusReactionController && !hasFinalResponse) {
     void finalizeTelegramStatusReaction({ outcome: "error", hasFinalResponse: false }).catch(
@@ -2257,7 +2270,11 @@ export const dispatchTelegramMessage = async ({
   }
 
   const shouldClearGroupHistory =
-    !isRoomEvent || deliverySummary.delivered || sentFallback || queuedFinal;
+    !isRoomEvent ||
+    deliverySummary.delivered ||
+    failureFallbackSent ||
+    recoverySuccessful ||
+    queuedFinal;
 
   if (!hasFinalResponse) {
     if (!shouldClearGroupHistory) {
@@ -2308,7 +2325,7 @@ export const dispatchTelegramMessage = async ({
   }
 
   if (statusReactionController) {
-    const statusReactionOutcome = dispatchError || sentFallback ? "error" : "done";
+    const statusReactionOutcome = dispatchError || failureFallbackSent ? "error" : "done";
     void finalizeTelegramStatusReaction({
       outcome: statusReactionOutcome,
       hasFinalResponse: true,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2187,6 +2187,28 @@ export const dispatchTelegramMessage = async ({
     sentFallback = result.delivered;
   }
 
+  const shouldRetryMissingFinalResponse =
+    !isRoomEvent &&
+    !dispatchError &&
+    !sentFallback &&
+    !deliverySummary.delivered &&
+    !queuedFinal &&
+    finalAnswerDeliveryStarted &&
+    !finalAnswerDelivered &&
+    !suppressSilentReplyFallback;
+  if (shouldRetryMissingFinalResponse) {
+    const fallbackText =
+      (await resolveCurrentTurnTranscriptFinalText())?.trim() || EMPTY_RESPONSE_FALLBACK;
+    const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
+      replies: [{ text: fallbackText }],
+      ...deliveryBaseOptions,
+      transcriptMirror: undefined,
+      silent: false,
+      mediaLoader: telegramDeps.loadWebMedia,
+    });
+    sentFallback = result.delivered;
+  }
+
   if (
     !sentFallback &&
     !dispatchError &&

--- a/src/channels/turn/durable-delivery.test.ts
+++ b/src/channels/turn/durable-delivery.test.ts
@@ -189,6 +189,45 @@ describe("durable inbound reply delivery", () => {
     expect(latestSendDurableMessageBatchRequest().durability).toBe("required");
   });
 
+  it("preserves the durable suppression reason when a final reply is intentionally not sent", async () => {
+    mocks.sendDurableMessageBatch.mockResolvedValueOnce({
+      status: "suppressed",
+      results: [],
+      receipt: {
+        primaryPlatformMessageId: "m1",
+        platformMessageIds: [],
+        parts: [],
+        sentAt: 1,
+      },
+      reason: "cancelled_by_message_sending_hook",
+    });
+
+    const result = await deliverInboundReplyWithMessageSendContext({
+      cfg: {},
+      channel: "telegram",
+      agentId: "main",
+      info: { kind: "final" },
+      payload: { text: "final" },
+      ctxPayload: ctxPayload({
+        OriginatingTo: "chat-1",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      status: "handled_no_send",
+      reason: "cancelled_by_message_sending_hook",
+      delivery: {
+        receipt: {
+          primaryPlatformMessageId: "m1",
+          platformMessageIds: [],
+          parts: [],
+          sentAt: 1,
+        },
+        visibleReplySent: false,
+      },
+    });
+  });
+
   it("reports durable partial send failures as failed delivery", async () => {
     const error = new Error("second chunk failed");
     mocks.sendDurableMessageBatch.mockResolvedValueOnce({

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -12,7 +12,7 @@ import {
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { deriveDurableFinalDeliveryRequirements } from "../message/capabilities.js";
-import { sendDurableMessageBatch } from "../message/send.js";
+import { sendDurableMessageBatch, type DurableMessageSuppressionReason } from "../message/send.js";
 import { createChannelDeliveryResultFromReceipt } from "./delivery-result.js";
 import type { ChannelDeliveryInfo, ChannelDeliveryResult } from "./types.js";
 
@@ -47,7 +47,11 @@ export type DurableInboundReplyDeliveryResult =
       capability?: DurableFinalDeliveryRequirement;
     }
   | { status: "handled_visible"; delivery: ChannelDeliveryResult }
-  | { status: "handled_no_send"; reason: "no_visible_result"; delivery: ChannelDeliveryResult }
+  | {
+      status: "handled_no_send";
+      reason: DurableMessageSuppressionReason;
+      delivery: ChannelDeliveryResult;
+    }
   | { status: "failed"; error: unknown; sentBeforeError?: true };
 
 function resolveDeliveryTarget(params: DurableInboundReplyDeliveryParams): string | undefined {
@@ -220,7 +224,7 @@ export async function deliverInboundReplyWithMessageSendContext(
     ...(send.deliveryIntent ? { deliveryIntent: toDeliveryIntent(send.deliveryIntent) } : {}),
   });
   if (send.status === "suppressed") {
-    return { status: "handled_no_send", reason: "no_visible_result", delivery };
+    return { status: "handled_no_send", reason: send.reason, delivery };
   }
   return { status: "handled_visible", delivery };
 }


### PR DESCRIPTION
## What changed
- Preserve the real durable suppression reason in Telegram final delivery results instead of collapsing every no-send into `no_visible_result`.
- Retry the missing-final Telegram recovery path only when the durable send truly reports `no_visible_result`.
- Track recovery success separately so a recovered reply is not treated like a failure.
- Add coverage for the durable suppression reason and the three Telegram retry cases.

## Why
This prevents intentional suppressions from being replayed as if they were delivery misses, while still recovering the real missing-final DM case.

## Real behavior proof
- Behavior or issue addressed: Telegram final DM responses were being recovered too broadly; intentional durable suppressions could be replayed like delivery misses.
- Real environment tested: local macOS OpenClaw gateway setup with the Telegram channel enabled and a live direct DM conversation.
- Exact steps or command run after this patch: `openclaw gateway restart`, send a Telegram DM that produces a final reply, then send a case that returns a durable suppression reason.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal/live output from the OpenClaw Telegram conversation showed the reply path completing normally, and the gateway recovery branch only being eligible when the durable send reason was `no_visible_result`.
- Screenshot proof of issue: ![Telegram proof screenshot]
<img width="1313" height="601" alt="truncated-final-message" src="https://github.com/user-attachments/assets/8010a49f-6e55-4c57-8c0a-246448e93c96" />

- Observed result after fix: visible final DM replies were replayed only for `no_visible_result`; intentional suppressions such as `cancelled_by_message_sending_hook` and `no_visible_payload` did not retry.
- What was not tested: unrelated channels, non-final reply paths, and other transport-specific suppression reasons outside Telegram final delivery.
- Proof limitations or environment constraints: the managed gateway install remains the production target; I did not use the crash-prone `gateway:watch` path for this proof.

## Validation
- `extensions/telegram/src/bot-message-dispatch.test.ts` passed: 95/95
- `src/channels/turn/durable-delivery.test.ts` passed: 7/7

