### PR TITLE
ci: extend platform checkout fetch timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1672,6 +1672,7 @@ jobs:
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
+          fetch_timeout_seconds=90
           fetch_checkout_ref() {
             git -C "$GITHUB_WORKSPACE" \
               -c protocol.version=2 \
@@ -1680,7 +1681,7 @@ jobs:
             local fetch_pid="$!"
             local elapsed=0
             while kill -0 "$fetch_pid" 2>/dev/null; do
-              if [ "$elapsed" -ge 30 ]; then
+              if [ "$elapsed" -ge "$fetch_timeout_seconds" ]; then
                 kill -TERM "$fetch_pid" 2>/dev/null || true
                 sleep 10
                 kill -KILL "$fetch_pid" 2>/dev/null || true
@@ -1792,6 +1793,7 @@ jobs:
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
+          fetch_timeout_seconds=90
           fetch_checkout_ref() {
             git -C "$GITHUB_WORKSPACE" \
               -c protocol.version=2 \
@@ -1800,7 +1802,7 @@ jobs:
             local fetch_pid="$!"
             local elapsed=0
             while kill -0 "$fetch_pid" 2>/dev/null; do
-              if [ "$elapsed" -ge 30 ]; then
+              if [ "$elapsed" -ge "$fetch_timeout_seconds" ]; then
                 kill -TERM "$fetch_pid" 2>/dev/null || true
                 sleep 10
                 kill -KILL "$fetch_pid" 2>/dev/null || true
@@ -1858,6 +1860,7 @@ jobs:
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
+          fetch_timeout_seconds=90
           fetch_checkout_ref() {
             git -C "$GITHUB_WORKSPACE" \
               -c protocol.version=2 \
@@ -1866,7 +1869,7 @@ jobs:
             local fetch_pid="$!"
             local elapsed=0
             while kill -0 "$fetch_pid" 2>/dev/null; do
-              if [ "$elapsed" -ge 30 ]; then
+              if [ "$elapsed" -ge "$fetch_timeout_seconds" ]; then
                 kill -TERM "$fetch_pid" 2>/dev/null || true
                 sleep 10
                 kill -KILL "$fetch_pid" 2>/dev/null || true

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -74,9 +74,13 @@ describe("ci workflow guards", () => {
       const checkoutStep = workflow.jobs[jobName].steps.find((step) => step.name === "Checkout");
 
       expect(checkoutStep.run, jobName).toContain("fetch_checkout_ref()");
+      expect(checkoutStep.run, jobName).toContain("fetch_timeout_seconds=90");
       expect(checkoutStep.run, jobName).toContain("-c protocol.version=2");
       expect(checkoutStep.run, jobName).toContain(
         "fetch --no-tags --prune --no-recurse-submodules --depth=1 origin",
+      );
+      expect(checkoutStep.run, jobName).toContain(
+        'if [ "$elapsed" -ge "$fetch_timeout_seconds" ]; then',
       );
       expect(checkoutStep.run, jobName).toContain('kill -TERM "$fetch_pid"');
       expect(checkoutStep.run, jobName).toContain('kill -KILL "$fetch_pid"');


### PR DESCRIPTION
## Summary
- Increase the Windows/macOS CI checkout fetch watchdog from 30s to 90s.
- Keep the manual checkout bounded, but avoid killing `git fetch` while `index-pack` may still be writing/verifying the shallow pack.
- Add a workflow guard assertion for the platform checkout timeout.

## Failure
`CI / checks-windows-node-test` failed during `Checkout`, before deps or tests:

- `CHECKOUT_SHA=01650d0673a70361c04fd12c2c57b27367e2ad83`
- `fatal: fetch-pack: invalid index-pack output`
- exit `124`

The platform checkout helper was terminating fetches after 30s. On slower Windows runner fetches, that can interrupt Git during pack indexing and produce this checkout-level failure. Refs ed36f423dab.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/ci-workflow-guards.test.ts --reporter=verbose` - passed, 1 file / 9 tests.
- `git diff --check HEAD^ HEAD` - passed.
- `actionlint .github/workflows/ci.yml` - not run locally; `actionlint` is not installed in this checkout.

## Real behavior proof
Behavior addressed: platform checkout fetches should not be killed after 30s while Git may still be indexing a shallow pack.
Real environment tested: local macOS checkout, workflow parsed by repo tooling tests.
Exact steps or command run after this patch: focused workflow guard Vitest command listed above.
Evidence after fix: guard test confirms platform checkout steps keep bounded fetches and use the named 90s timeout budget.
Observed result after fix: checkout remains bounded but gives Windows/macOS fetches a more realistic window before termination.
What was not tested: live Windows runner checkout; PR CI will exercise workflow syntax and the normal checkout path.
