### PR TITLE
fix(approvals): handle stale plugin waits

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -13,7 +13,10 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
-import { requestPluginApproval } from "./plugin-approval-roundtrip.js";
+import {
+  requestPluginApproval,
+  waitForPluginApprovalDecision,
+} from "./plugin-approval-roundtrip.js";
 
 vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>()),
@@ -2286,6 +2289,52 @@ describe("Codex app-server approval bridge", () => {
     expect(mockCallGatewayTool).toHaveBeenCalledTimes(1);
     expect(onNativeToolFailureDisposition).toHaveBeenCalledWith("patch-1", "failed");
     findApprovalEvent(params, { status: "unavailable", reason: "needs write access" });
+  });
+
+  it("fails closed when waitDecision reports a stale approval id", async () => {
+    const params = createParams();
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-stale", status: "accepted" })
+      .mockRejectedValueOnce(new Error("approval expired or not found"));
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/fileChange/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "patch-stale",
+        reason: "needs write access",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(result).toEqual({ decision: "decline" });
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
+    findApprovalEvent(params, {
+      status: "unavailable",
+      approvalId: "plugin:approval-stale",
+      reason: "needs write access",
+      message: "Codex app-server approval unavailable.",
+    });
+  });
+
+  it("does not classify a matching abort reason as a stale gateway wait", async () => {
+    const controller = new AbortController();
+    mockCallGatewayTool.mockImplementationOnce(() => new Promise(() => {}));
+
+    const pending = waitForPluginApprovalDecision({
+      approvalId: "plugin:approval-abort",
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(mockCallGatewayTool).toHaveBeenCalledOnce());
+    controller.abort(new Error("approval expired or not found"));
+
+    await expect(pending).rejects.toThrow("approval expired or not found");
   });
 
   it("preserves an accepted approval expiry as timed out", async () => {

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -93,7 +93,7 @@ export async function waitForPluginApprovalDecision(params: {
     "plugin.approval.waitDecision",
     { timeoutMs: resolveCodexGatewayTimeoutWithGraceMs(timeoutMs) },
     { id: params.approvalId },
-  ).catch((error) => {
+  ).catch((error: unknown) => {
     if (isApprovalNotFoundError(error)) {
       return null;
     }

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -6,6 +6,7 @@ import {
   callGatewayTool,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexGatewayTimeoutWithGraceMs } from "./attempt-timeouts.js";
 
@@ -88,17 +89,22 @@ export async function waitForPluginApprovalDecision(params: {
   signal?: AbortSignal;
 }): Promise<ExecApprovalDecision | null | undefined> {
   const timeoutMs = DEFAULT_CODEX_APPROVAL_TIMEOUT_MS;
-  const waitPromise: Promise<ApprovalWaitResult | undefined> = callGatewayTool(
+  const waitPromise: Promise<ApprovalWaitResult | null | undefined> = callGatewayTool(
     "plugin.approval.waitDecision",
     { timeoutMs: resolveCodexGatewayTimeoutWithGraceMs(timeoutMs) },
     { id: params.approvalId },
-  );
+  ).catch((error) => {
+    if (isApprovalNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  });
   // Bind the verdict to the approval that parked this prompt. A stale or
   // misrouted reply maps to "unavailable" instead of releasing another gate.
   const bindDecision = (
-    result: ApprovalWaitResult | undefined,
+    result: ApprovalWaitResult | null | undefined,
   ): ExecApprovalDecision | null | undefined =>
-    result?.id === params.approvalId ? result.decision : undefined;
+    result === null ? null : result?.id === params.approvalId ? result.decision : undefined;
   if (!params.signal) {
     return bindDecision(await waitPromise);
   }

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -7,10 +7,8 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString as parseString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString as parseString } from "@openclaw/normalization-core/string-coerce";
+import { isApprovalNotFoundError } from "../infra/approval-errors.js";
 import type {
   ExecApprovalCommandSpan,
   ExecApprovalUnavailableDecision,
@@ -197,8 +195,7 @@ export async function resolveRegisteredExecApprovalDecision(params: {
     return parseDecision(decisionResult).value;
   } catch (err) {
     // Timeout/cleanup path: treat missing/expired as no decision so askFallback applies.
-    const message = normalizeLowercaseStringOrEmpty(String(err));
-    if (message.includes("approval expired or not found")) {
+    if (isApprovalNotFoundError(err)) {
       return null;
     }
     throw err;

--- a/src/agents/harness/native-hook-relay.approval-wait.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-wait.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { callGatewayTool } from "../tools/gateway.js";
+import { invokeNativeHookRelay, registerNativeHookRelay, testing } from "./native-hook-relay.js";
+
+vi.mock("../tools/gateway.js", () => ({
+  callGatewayTool: vi.fn(),
+}));
+
+const mockCallGatewayTool = vi.mocked(callGatewayTool);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  mockCallGatewayTool.mockReset();
+  testing.clearNativeHookRelaysForTests();
+});
+
+describe("native hook relay approval wait handling", () => {
+  it("defers when waitDecision reports a stale approval id", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-stale", status: "accepted" })
+      .mockRejectedValueOnce(new Error("approval expired or not found"));
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: "Bash",
+          tool_input: { command: "cat /tmp/private-key" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
+  });
+});

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -18,6 +18,7 @@ import {
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
 import { toErrorObject } from "../../infra/errors.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -2138,7 +2139,12 @@ async function waitForNativeHookRelayApprovalDecision(params: {
       "plugin.approval.waitDecision",
       { timeoutMs: params.timeoutMs + 10_000 },
       { id: params.approvalId },
-    );
+    ).catch((error) => {
+      if (isApprovalNotFoundError(error)) {
+        return undefined;
+      }
+      throw error;
+    });
   if (!params.signal) {
     return waitPromise;
   }

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -2139,7 +2139,7 @@ async function waitForNativeHookRelayApprovalDecision(params: {
       "plugin.approval.waitDecision",
       { timeoutMs: params.timeoutMs + 10_000 },
       { id: params.approvalId },
-    ).catch((error) => {
+    ).catch((error: unknown) => {
       if (isApprovalNotFoundError(error)) {
         return undefined;
       }

--- a/src/infra/approval-errors.test.ts
+++ b/src/infra/approval-errors.test.ts
@@ -21,6 +21,7 @@ describe("isApprovalNotFoundError", () => {
 
   it("matches legacy message-only not-found errors", () => {
     expect(isApprovalNotFoundError(new Error("unknown or expired approval id"))).toBe(true);
+    expect(isApprovalNotFoundError(new Error("approval expired or not found"))).toBe(true);
   });
 
   it("ignores unrelated errors", () => {

--- a/src/infra/approval-errors.ts
+++ b/src/infra/approval-errors.ts
@@ -4,6 +4,8 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 const INVALID_REQUEST = "INVALID_REQUEST";
 const APPROVAL_NOT_FOUND = "APPROVAL_NOT_FOUND";
 const APPROVAL_ALREADY_RESOLVED = "APPROVAL_ALREADY_RESOLVED";
+const LEGACY_APPROVAL_NOT_FOUND_RE =
+  /\b(?:unknown or expired approval id|approval expired or not found)\b/i;
 
 function readErrorCode(value: unknown): string | null {
   return typeof value === "string" ? (normalizeOptionalString(value) ?? null) : null;
@@ -33,7 +35,7 @@ export function isApprovalNotFoundError(err: unknown): boolean {
   if (gatewayCode === INVALID_REQUEST && detailsReason === APPROVAL_NOT_FOUND) {
     return true;
   }
-  return /unknown or expired approval id/i.test(err.message);
+  return LEGACY_APPROVAL_NOT_FOUND_RE.test(err.message);
 }
 
 /** Detects approval failures that mean a pending prompt is no longer actionable. */


### PR DESCRIPTION
Closes #88111

## What Problem This Solves

Fixes stale `plugin.approval.waitDecision` identifiers escaping as generic runtime failures from exec, Codex app-server, and native PermissionRequest waits. Approval state can legitimately disappear after expiry, restart, or caller lifecycle drift; those cases must stay fail closed without crashing the whole turn.

## Why This Change Was Made

The shared approval-not-found classifier now recognizes both gateway message variants. Exec uses the canonical classifier; Codex app-server maps stale waits to unavailable/decline; native PermissionRequest maps them to no hook verdict so Codex continues through its normal guardian/user approval path. Error classification is attached only to gateway wait promises, so abort races and unrelated errors preserve their existing propagation.

Current main's newer phase-aware before-tool classification is retained and the obsolete Plugin SDK budget churn is omitted.

## User Impact

Expired approval waits deny or defer cleanly instead of terminating agent turns with misleading generic errors. No stale approval can authorize a tool.

## Evidence

- Focused suites: approval classifier 7, exec/native 15, Codex bridge 82 — 104 passed.
- Current before-tool sibling suite — 84 passed.
- Structured autoreview found two abort-race issues; both were fixed. Final autoreview clean, confidence 0.95.
- Contributor real-behavior proof used an authenticated isolated loopback gateway and confirmed the live error `approval expired or not found` is recognized by the shared classifier.

Direct Codex contract check at sibling `9970cd706fc4f25bbb97b42f4b68d993dabe91e2`:
- `codex-rs/hooks/src/events/permission_request.rs:1-15,50-60,98-117` defines no hook verdict as deferral to normal approval.
- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:57-114` defines decline as denial while continuing the turn.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1885-1922` fails closed on missing/failed approval responses.

## Credit

Maintainer rewrite of Andy Ye's contribution (@TurboTheTurtle), preserved with `Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`.
