### PR TITLE
Fix Codex native thread overflow rotation

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -1174,6 +1174,82 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(savedBinding?.contextEngine?.projection?.epoch).toBe("epoch-before");
   });
 
+  it("clears a resumed context-engine binding when a turn terminally overflows", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("pre-compaction context", Date.now()) as never,
+    );
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-old",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"contextTokenBudget":400000,"projectionMaxChars":1000000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-before",
+        },
+      },
+    });
+    const compact = vi.fn<ContextEngine["compact"]>(async () => ({
+      ok: true,
+      compacted: true,
+      result: { summary: "summary", firstKeptEntryId: "entry-1", tokensBefore: 100_000 },
+    }));
+    const assemble = vi.fn(
+      async ({ messages, prompt }: Parameters<ContextEngine["assemble"]>[0]) => ({
+        messages: [...messages, userMessage(prompt ?? "", 11)],
+        estimatedTokens: 42,
+        systemPromptAddition: "context-engine system",
+        contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-before" },
+      }),
+    );
+    const contextEngine = createContextEngine({ assemble, compact });
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-old");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-old");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.contextTokenBudget = 400_000;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-old",
+        turnId: "turn-old",
+        turn: {
+          id: "turn-old",
+          status: "failed",
+          error: { message: "Codex ran out of room in the model's context window" },
+          items: [],
+        },
+      },
+    });
+    const result = await run;
+
+    expect(result.promptError).toBe("Codex ran out of room in the model's context window");
+    expect(compact).not.toHaveBeenCalled();
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/resume",
+      "turn/start",
+      "thread/unsubscribe",
+    ]);
+    expect(await readCodexAppServerBinding(sessionFile)).toBeUndefined();
+  });
+
   it("does not pre-compact over-budget rendered context-engine prompts before Codex turn/start", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -545,109 +545,171 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     await secondRun;
   });
 
-  it.each([
-    [
-      "token",
+  it("resumes a matching thread-bootstrap binding even when the bootstrap turn exceeded the opt-in native byte guard", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-bootstrapped",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"projectionMaxChars":24000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-1",
+        },
+      },
+    });
+    await fs.writeFile(
+      path.join(path.dirname(sessionFile), "sessions.json"),
+      JSON.stringify({
+        "agent:main:session-1": {
+          sessionFile,
+          totalTokens: 12_000,
+        },
+      }),
+    );
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-bootstrapped.jsonl"),
+      "x".repeat(2_000),
+    );
+    const contextEngine = createContextEngine({
+      assemble: vi.fn(async ({ prompt }) => ({
+        messages: [
+          assistantMessage("already bootstrapped context", 10),
+          userMessage(prompt ?? "", 11),
+        ],
+        estimatedTokens: 42,
+        systemPromptAddition: "context-engine system",
+        contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-1" },
+      })),
+    });
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-bootstrapped");
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.agentDir = agentDir;
+    params.contextEngine = contextEngine;
+    params.config = {
+      agents: {
+        defaults: {
+          compaction: {
+            truncateAfterCompaction: true,
+            maxActiveTranscriptBytes: 1_000,
+          },
+        },
+      },
+    } as EmbeddedRunAttemptParams["config"];
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/resume",
+      "turn/start",
+    ]);
+    const inputText = getRequestInputText(harness);
+    expect(inputText).not.toContain("OpenClaw assembled context for this turn:");
+    expect(inputText).not.toContain("already bootstrapped context");
+    expect(inputText).toBe("hello");
+
+    await harness.completeTurn("completed", "thread-bootstrapped");
+    await run;
+  });
+
+  it("starts a fresh thread instead of resuming a token-pressured thread-bootstrap binding", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-bootstrapped",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"projectionMaxChars":24000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-1",
+        },
+      },
+    });
+    await fs.writeFile(
+      path.join(path.dirname(sessionFile), "sessions.json"),
+      JSON.stringify({
+        "agent:main:session-1": {
+          sessionFile,
+          totalTokens: 12_000,
+        },
+      }),
+    );
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-bootstrapped.jsonl"),
       `${JSON.stringify({
         payload: {
           type: "token_count",
           info: {
             last_token_usage: {
-              total_tokens: 300_000,
+              total_tokens: 241_198,
             },
+            model_context_window: 258_400,
           },
         },
       })}\n`,
-      "1mb",
-    ],
-    ["byte", "x".repeat(2_000), 1_000],
-  ] as const)(
-    "resumes a matching thread-bootstrap binding even when the bootstrap turn exceeded the native %s guard",
-    async (_guard, rolloutContent, maxActiveTranscriptBytes) => {
-      const sessionFile = path.join(tempDir, "session.jsonl");
-      const workspaceDir = path.join(tempDir, "workspace");
-      const agentDir = path.join(tempDir, "agent");
-      await writeCodexAppServerBinding(sessionFile, {
-        threadId: "thread-bootstrapped",
-        cwd: workspaceDir,
-        dynamicToolsFingerprint: "[]",
-        contextEngine: {
-          schemaVersion: 1,
-          engineId: "lossless-claw",
-          policyFingerprint:
-            '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"projectionMaxChars":24000}',
-          projection: {
-            schemaVersion: 1,
-            mode: "thread_bootstrap",
-            epoch: "epoch-1",
-          },
-        },
-      });
-      await fs.writeFile(
-        path.join(path.dirname(sessionFile), "sessions.json"),
-        JSON.stringify({
-          "agent:main:session-1": {
-            sessionFile,
-            totalTokens: 12_000,
-          },
-        }),
-      );
-      const rolloutDir = path.join(agentDir, "codex-home", "sessions");
-      await fs.mkdir(rolloutDir, { recursive: true });
-      await fs.writeFile(
-        path.join(rolloutDir, "rollout-thread-bootstrapped.jsonl"),
-        rolloutContent,
-      );
-      const contextEngine = createContextEngine({
-        assemble: vi.fn(async ({ prompt }) => ({
-          messages: [
-            assistantMessage("already bootstrapped context", 10),
-            userMessage(prompt ?? "", 11),
-          ],
-          estimatedTokens: 42,
-          systemPromptAddition: "context-engine system",
-          contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-1" },
-        })),
-      });
-      const harness = createStartedThreadHarness(async (method) => {
-        if (method === "thread/resume") {
-          return threadStartResult("thread-bootstrapped");
-        }
-        if (method === "thread/start") {
-          return threadStartResult("thread-fresh");
-        }
-        return undefined;
-      });
-      const params = createParams(sessionFile, workspaceDir);
-      params.agentDir = agentDir;
-      params.contextEngine = contextEngine;
-      params.config = {
-        agents: {
-          defaults: {
-            compaction: {
-              truncateAfterCompaction: true,
-              maxActiveTranscriptBytes,
-            },
-          },
-        },
-      } as EmbeddedRunAttemptParams["config"];
+    );
+    const contextEngine = createContextEngine({
+      assemble: vi.fn(async ({ prompt }) => ({
+        messages: [assistantMessage("reprojected context", 10), userMessage(prompt ?? "", 11)],
+        estimatedTokens: 42,
+        systemPromptAddition: "context-engine system",
+        contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-1" },
+      })),
+    });
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-bootstrapped");
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.agentDir = agentDir;
+    params.contextEngine = contextEngine;
 
-      const run = runCodexAppServerAttempt(params);
-      await harness.waitForMethod("turn/start");
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
 
-      expect(harness.requests.map((request) => request.method)).toEqual([
-        "thread/resume",
-        "turn/start",
-      ]);
-      const inputText = getRequestInputText(harness);
-      expect(inputText).not.toContain("OpenClaw assembled context for this turn:");
-      expect(inputText).not.toContain("already bootstrapped context");
-      expect(inputText).toBe("hello");
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/start",
+      "turn/start",
+    ]);
+    const inputText = getRequestInputText(harness);
+    expect(inputText).toContain("OpenClaw assembled context for this turn:");
+    expect(inputText).toContain("reprojected context");
 
-      await harness.completeTurn("completed", "thread-bootstrapped");
-      await run;
-    },
-  );
+    await harness.completeTurn("completed", "thread-fresh");
+    await run;
+  });
 
   it("projects mirrored history when an oversized thread-bootstrap binding has no active context engine", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -1236,6 +1236,78 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(savedBinding?.contextEngine?.projection?.epoch).toBe("epoch-before");
   });
 
+  it("preserves a newer context-engine binding when a stale resumed thread overflows", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("pre-compaction context", Date.now()) as never,
+    );
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-old",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"contextTokenBudget":400000,"projectionMaxChars":1000000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-before",
+        },
+      },
+    });
+    const compact = vi.fn<ContextEngine["compact"]>(async () => ({
+      ok: true,
+      compacted: true,
+      result: { summary: "summary", firstKeptEntryId: "entry-1", tokensBefore: 100_000 },
+    }));
+    const assemble = vi.fn(
+      async ({ messages, prompt }: Parameters<ContextEngine["assemble"]>[0]) => ({
+        messages: [...messages, userMessage(prompt ?? "", 11)],
+        estimatedTokens: 42,
+        systemPromptAddition: "context-engine system",
+        contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-before" },
+      }),
+    );
+    const contextEngine = createContextEngine({ assemble, compact });
+    const harness = createStartedThreadHarness(async (method, requestParams) => {
+      const request = requireRecord(requestParams, `${method} params`);
+      if (method === "thread/resume") {
+        return threadStartResult("thread-old");
+      }
+      if (method === "turn/start" && request.threadId === "thread-old") {
+        await writeCodexAppServerBinding(sessionFile, {
+          threadId: "thread-new",
+          cwd: workspaceDir,
+          dynamicToolsFingerprint: "[]",
+        });
+        throw new Error("Codex ran out of room in the model's context window");
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.contextTokenBudget = 400_000;
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow(
+      "Codex ran out of room in the model's context window",
+    );
+
+    expect(compact).not.toHaveBeenCalled();
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/resume",
+      "turn/start",
+      "thread/unsubscribe",
+    ]);
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-new");
+  });
+
   it("clears a resumed context-engine binding when a turn terminally overflows", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3763,6 +3763,54 @@ describe("runCodexAppServerAttempt", () => {
     expect(savedBinding?.threadId).toBe("thread-1");
   });
 
+  it("starts a fresh Codex thread before turn/start when the next prompt would exhaust native headroom", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    await fs.writeFile(
+      path.join(path.dirname(sessionFile), "sessions.json"),
+      JSON.stringify({
+        "agent:main:session-1": {
+          sessionFile,
+          totalTokens: 12_000,
+        },
+      }),
+    );
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-existing.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 220_000,
+            },
+            model_context_window: 258_400,
+          },
+        },
+      })}\n`,
+    );
+    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.agentDir = agentDir;
+    params.prompt = "large prompt ".repeat(12_000);
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await waitForMethod("turn/start");
+    await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    expect(requests.map((entry) => entry.method)).toContain("thread/start");
+    expect(requests.map((entry) => entry.method)).not.toContain("thread/resume");
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-1");
+  });
+
   it("preserves bound auth when rotating a fallback-fuse native rollout", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -246,7 +246,16 @@ import {
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 
 const CODEX_NATIVE_HOOK_RELAY_RENEW_INTERVAL_MS = 60_000;
+const CODEX_APP_SERVER_PROJECTED_CHARS_PER_TOKEN = 4;
 const ensuredCodexWorkspaceDirs = new Set<string>();
+
+function estimateCodexAppServerProjectedTurnTokens(params: {
+  prompt: string;
+  developerInstructions?: string;
+}): number {
+  const inputChars = params.prompt.length + (params.developerInstructions?.length ?? 0);
+  return Math.max(1, Math.ceil(inputChars / CODEX_APP_SERVER_PROJECTED_CHARS_PER_TOKEN));
+}
 
 async function ensureCodexWorkspaceDirOnce(workspaceDir: string): Promise<void> {
   const normalized = path.resolve(workspaceDir);
@@ -673,6 +682,15 @@ export async function runCodexAppServerAttempt(
   let developerInstructions = baseDeveloperInstructions;
   let prePromptMessageCount = historyMessages.length;
   let contextEngineProjection: CodexContextEngineThreadBootstrapProjection | undefined;
+  const applyMirroredHistoryProjectionForFreshThread = () => {
+    const projection = projectContextEngineAssemblyForCodex({
+      assembledMessages: historyMessages,
+      originalHistoryMessages: historyMessages,
+      prompt: params.prompt,
+    });
+    promptText = projection.promptText;
+    prePromptMessageCount = projection.prePromptMessageCount;
+  };
   const applyActiveContextEngineProjection = async (
     decisionStartupBinding: CodexAppServerThreadBinding | undefined,
   ) => {
@@ -764,13 +782,7 @@ export async function runCodexAppServerAttempt(
       forceProject: !nativeToolSurfaceEnabled,
     })
   ) {
-    const projection = projectContextEngineAssemblyForCodex({
-      assembledMessages: historyMessages,
-      originalHistoryMessages: historyMessages,
-      prompt: params.prompt,
-    });
-    promptText = projection.promptText;
-    prePromptMessageCount = projection.prePromptMessageCount;
+    applyMirroredHistoryProjectionForFreshThread();
   }
   const buildPromptFromCurrentInputs = () =>
     resolveAgentHarnessBeforePromptBuildResult({
@@ -794,6 +806,60 @@ export async function runCodexAppServerAttempt(
       promptBuild.developerInstructions,
       buildCodexTurnCollaborationDeveloperInstructions(),
     );
+  const rebuildCodexTurnPromptFromCurrentProjection = async () => {
+    promptBuild = await buildPromptFromCurrentInputs();
+    codexTurnPromptText = decorateCodexTurnPromptText(promptBuild.prompt);
+  };
+  const rotateStartupBindingForProjectedTurn = async () => {
+    if (!startupBinding?.threadId) {
+      return;
+    }
+    const previousThreadId = startupBinding.threadId;
+    const projectedTurnTokens = estimateCodexAppServerProjectedTurnTokens({
+      prompt: codexTurnPromptText,
+      developerInstructions: buildRenderedCodexDeveloperInstructions(),
+    });
+    startupBinding = await rotateOversizedCodexAppServerStartupBinding({
+      binding: startupBinding,
+      sessionFile: params.sessionFile,
+      agentDir,
+      codexHome: appServer.start.env?.CODEX_HOME,
+      config: params.config,
+      contextEngineActive: Boolean(activeContextEngine),
+      projectedTurnTokens,
+    });
+    if (startupBinding?.threadId) {
+      return;
+    }
+    if (activeContextEngine) {
+      contextEngineProjection = undefined;
+      try {
+        await applyActiveContextEngineProjection(undefined);
+      } catch (assembleErr) {
+        embeddedAgentLog.warn("context engine assemble failed; using Codex baseline prompt", {
+          error: formatErrorMessage(assembleErr),
+        });
+      }
+    } else if (
+      shouldProjectMirroredHistoryForCodexStart({
+        startupBinding,
+        dynamicToolsFingerprint: codexDynamicToolsFingerprint(toolBridge.specs),
+        historyMessages,
+        forceProject: !nativeToolSurfaceEnabled,
+      })
+    ) {
+      applyMirroredHistoryProjectionForFreshThread();
+    }
+    await rebuildCodexTurnPromptFromCurrentProjection();
+    embeddedAgentLog.info("codex app-server rebuilt turn prompt after native thread rotation", {
+      sessionId: params.sessionId,
+      sessionKey: contextSessionKey,
+      previousThreadId,
+      promptChars: codexTurnPromptText.length,
+      developerInstructionChars: buildRenderedCodexDeveloperInstructions()?.length ?? 0,
+    });
+  };
+  await rotateStartupBindingForProjectedTurn();
   const systemPromptReport = buildCodexSystemPromptReport({
     attempt: params,
     sessionKey: contextSessionKey,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1738,19 +1738,33 @@ export async function runCodexAppServerAttempt(
       );
       try {
         const preRetrySessionFile = activeSessionFile;
-        await clearCodexAppServerBinding(preRetrySessionFile);
-        if (activeSessionFile !== preRetrySessionFile) {
-          await clearCodexAppServerBinding(activeSessionFile);
-        }
-        thread = await restartContextEngineCodexThread();
-        emitCodexAppServerEvent(params, {
-          stream: "codex_app_server.lifecycle",
-          data: { phase: "thread_ready_retry", threadId: thread.threadId },
-        });
-        try {
-          turn = await startCodexTurn();
-        } catch (retryError) {
-          turnStartError = retryError;
+        const clearedPreRetryBinding = await clearCodexAppServerBindingForThread(
+          preRetrySessionFile,
+          thread.threadId,
+        );
+        const clearedActiveBinding =
+          activeSessionFile !== preRetrySessionFile
+            ? await clearCodexAppServerBindingForThread(activeSessionFile, thread.threadId)
+            : false;
+        if (!clearedPreRetryBinding && !clearedActiveBinding) {
+          embeddedAgentLog.warn(
+            "codex app-server preserved newer context-engine binding after resume overflow; skipping fresh retry",
+            {
+              threadId: thread.threadId,
+              error: formatErrorMessage(turnStartError),
+            },
+          );
+        } else {
+          thread = await restartContextEngineCodexThread();
+          emitCodexAppServerEvent(params, {
+            stream: "codex_app_server.lifecycle",
+            data: { phase: "thread_ready_retry", threadId: thread.threadId },
+          });
+          try {
+            turn = await startCodexTurn();
+          } catch (retryError) {
+            turnStartError = retryError;
+          }
         }
       } catch (retrySetupError) {
         turnStartError = retrySetupError;
@@ -2046,9 +2060,9 @@ export async function runCodexAppServerAttempt(
         },
       );
       const preClearSessionFile = activeSessionFile;
-      await clearCodexAppServerBinding(preClearSessionFile);
+      await clearCodexAppServerBindingForThread(preClearSessionFile, thread.threadId);
       if (activeSessionFile !== preClearSessionFile) {
-        await clearCodexAppServerBinding(activeSessionFile);
+        await clearCodexAppServerBindingForThread(activeSessionFile, thread.threadId);
       }
     }
     const refreshedUsageLimitPromptError = await refreshCodexUsageLimitPromptError({

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1653,7 +1653,7 @@ export async function runCodexAppServerAttempt(
   } catch (error) {
     let turnStartError = error;
     if (
-      shouldRetryContextEngineTurnOnFreshCodexThread({
+      shouldUseFreshCodexThreadAfterContextEngineOverflow({
         error: turnStartError,
         contextEngineActive: Boolean(activeContextEngine),
         thread,
@@ -1964,6 +1964,27 @@ export async function runCodexAppServerAttempt(
         error: finalPromptErrorMessage,
       });
     }
+    if (
+      shouldUseFreshCodexThreadAfterContextEngineOverflow({
+        error: finalPromptError,
+        contextEngineActive: Boolean(activeContextEngine),
+        thread,
+      })
+    ) {
+      embeddedAgentLog.warn(
+        "codex app-server context-engine turn overflowed after resume; clearing thread binding for recovery",
+        {
+          threadId: thread.threadId,
+          turnId: activeTurnId,
+          error: finalPromptErrorMessage,
+        },
+      );
+      const preClearSessionFile = activeSessionFile;
+      await clearCodexAppServerBinding(preClearSessionFile);
+      if (activeSessionFile !== preClearSessionFile) {
+        await clearCodexAppServerBinding(activeSessionFile);
+      }
+    }
     const refreshedUsageLimitPromptError = await refreshCodexUsageLimitPromptError({
       client,
       message: finalPromptErrorMessage,
@@ -2259,7 +2280,7 @@ function isUnscopedCodexNotification(
   );
 }
 
-function shouldRetryContextEngineTurnOnFreshCodexThread(params: {
+function shouldUseFreshCodexThreadAfterContextEngineOverflow(params: {
   error: unknown;
   contextEngineActive: boolean;
   thread: CodexAppServerThreadLifecycleBinding;

--- a/extensions/codex/src/app-server/startup-binding.test.ts
+++ b/extensions/codex/src/app-server/startup-binding.test.ts
@@ -300,8 +300,6 @@ describe("Codex app-server startup binding", () => {
         }),
       ].join("\n") + "\n",
     );
-    const readFileSpy = vi.spyOn(fs, "readFile");
-
     const binding = await rotateOversizedCodexAppServerStartupBinding({
       binding: await readCodexAppServerBinding(sessionFile),
       sessionFile,
@@ -319,7 +317,6 @@ describe("Codex app-server startup binding", () => {
     });
 
     expect(binding).toBeUndefined();
-    expect(readFileSpy.mock.calls.some(([file]) => file === rolloutFile)).toBe(false);
     const savedBinding = await readCodexAppServerBinding(sessionFile);
     expect(savedBinding).toBeUndefined();
   });
@@ -448,7 +445,7 @@ describe("Codex app-server startup binding", () => {
     await fs.mkdir(rolloutDir, { recursive: true });
     const rolloutFile = path.join(rolloutDir, "rollout-thread-existing.jsonl");
     await fs.writeFile(rolloutFile, "x".repeat(2_000));
-    const readFileSpy = vi.spyOn(fs, "readFile");
+    const openSpy = vi.spyOn(fs, "open");
 
     const binding = await rotateOversizedCodexAppServerStartupBinding({
       binding: await readCodexAppServerBinding(sessionFile),
@@ -467,7 +464,7 @@ describe("Codex app-server startup binding", () => {
     });
 
     expect(binding).toBeUndefined();
-    expect(readFileSpy.mock.calls.some(([file]) => file === rolloutFile)).toBe(false);
+    expect(openSpy.mock.calls.some(([file]) => String(file) === rolloutFile)).toBe(false);
     const savedBinding = await readCodexAppServerBinding(sessionFile);
     expect(savedBinding).toBeUndefined();
   });

--- a/extensions/codex/src/app-server/startup-binding.test.ts
+++ b/extensions/codex/src/app-server/startup-binding.test.ts
@@ -77,6 +77,41 @@ describe("Codex app-server startup binding", () => {
     expect(savedBinding?.threadId).toBe("thread-existing");
   });
 
+  it("checks native rollout token pressure under default compaction config", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    await writeSessionRecord(sessionFile, { totalTokens: 12_000 });
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-existing.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 241_198,
+            },
+            model_context_window: 258_400,
+          },
+        },
+      })}\n`,
+    );
+
+    const binding = await rotateOversizedCodexAppServerStartupBinding({
+      binding: await readCodexAppServerBinding(sessionFile),
+      sessionFile,
+      agentDir,
+      config: undefined,
+    });
+
+    expect(binding).toBeUndefined();
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding).toBeUndefined();
+  });
+
   it("honors shorthand byte units for native rollout limits", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -331,6 +366,76 @@ describe("Codex app-server startup binding", () => {
     expect(binding?.threadId).toBe("thread-existing");
     const savedBinding = await readCodexAppServerBinding(sessionFile);
     expect(savedBinding?.threadId).toBe("thread-existing");
+  });
+
+  it("includes projected turn tokens in the native rollout pressure check", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    await writeSessionRecord(sessionFile, { totalTokens: 12_000 });
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-existing.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 220_000,
+            },
+            model_context_window: 258_400,
+          },
+        },
+      })}\n`,
+    );
+
+    const binding = await rotateOversizedCodexAppServerStartupBinding({
+      binding: await readCodexAppServerBinding(sessionFile),
+      sessionFile,
+      agentDir,
+      config: undefined,
+      projectedTurnTokens: 30_000,
+    });
+
+    expect(binding).toBeUndefined();
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding).toBeUndefined();
+  });
+
+  it("uses the session context window when the native rollout omits its model window", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    await writeSessionRecord(sessionFile, { totalTokens: 12_000, contextTokens: 258_400 });
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-existing.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 241_198,
+            },
+          },
+        },
+      })}\n`,
+    );
+
+    const binding = await rotateOversizedCodexAppServerStartupBinding({
+      binding: await readCodexAppServerBinding(sessionFile),
+      sessionFile,
+      agentDir,
+      config: undefined,
+    });
+
+    expect(binding).toBeUndefined();
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding).toBeUndefined();
   });
 
   it("clears byte-oversized rollouts before reading their contents", async () => {

--- a/extensions/codex/src/app-server/startup-binding.test.ts
+++ b/extensions/codex/src/app-server/startup-binding.test.ts
@@ -112,6 +112,41 @@ describe("Codex app-server startup binding", () => {
     expect(savedBinding).toBeUndefined();
   });
 
+  it("caps the default native reserve so small context windows keep prompt budget", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    await writeSessionRecord(sessionFile, { totalTokens: 100 });
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-existing.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 100,
+            },
+            model_context_window: 16_000,
+          },
+        },
+      })}\n`,
+    );
+
+    const binding = await rotateOversizedCodexAppServerStartupBinding({
+      binding: await readCodexAppServerBinding(sessionFile),
+      sessionFile,
+      agentDir,
+      config: undefined,
+    });
+
+    expect(binding?.threadId).toBe("thread-existing");
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-existing");
+  });
+
   it("honors shorthand byte units for native rollout limits", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/startup-binding.ts
+++ b/extensions/codex/src/app-server/startup-binding.ts
@@ -296,6 +296,29 @@ export async function rotateOversizedCodexAppServerStartupBinding(params: {
     binding.threadId,
     params.codexHome,
   );
+  const compaction = readCompactionConfig(params.config);
+  const shouldDeferByteGuard =
+    compaction?.truncateAfterCompaction === true &&
+    params.contextEngineActive === true &&
+    hasContextEngineThreadBootstrapProjection(binding);
+  if (compaction?.truncateAfterCompaction === true && !shouldDeferByteGuard) {
+    const maxBytes = parseCodexAppServerByteLimit(compaction.maxActiveTranscriptBytes);
+    if (maxBytes !== undefined) {
+      const oversizedFiles = rolloutFiles.filter((file) => file.bytes >= maxBytes);
+      if (oversizedFiles.length > 0) {
+        embeddedAgentLog.warn(
+          "codex app-server native transcript exceeded active byte limit; starting a fresh thread",
+          {
+            threadId: binding.threadId,
+            maxBytes,
+            files: oversizedFiles.map((file) => ({ path: file.path, bytes: file.bytes })),
+          },
+        );
+        await clearCodexAppServerBinding(params.sessionFile);
+        return undefined;
+      }
+    }
+  }
   const nativeTokenSnapshots = await Promise.all(
     rolloutFiles.map(async (file) => readCodexAppServerRolloutTokenSnapshot(file.path)),
   );
@@ -342,11 +365,10 @@ export async function rotateOversizedCodexAppServerStartupBinding(params: {
     await clearCodexAppServerBinding(params.sessionFile);
     return undefined;
   }
-  const compaction = readCompactionConfig(params.config);
   if (compaction?.truncateAfterCompaction !== true) {
     return binding;
   }
-  if (params.contextEngineActive === true && hasContextEngineThreadBootstrapProjection(binding)) {
+  if (shouldDeferByteGuard) {
     embeddedAgentLog.debug(
       "codex app-server deferring native transcript byte guard for context-engine thread bootstrap",
       {
@@ -357,22 +379,6 @@ export async function rotateOversizedCodexAppServerStartupBinding(params: {
       },
     );
     return binding;
-  }
-  const maxBytes = parseCodexAppServerByteLimit(compaction.maxActiveTranscriptBytes);
-  if (maxBytes !== undefined) {
-    const oversizedFiles = rolloutFiles.filter((file) => file.bytes >= maxBytes);
-    if (oversizedFiles.length > 0) {
-      embeddedAgentLog.warn(
-        "codex app-server native transcript exceeded active byte limit; starting a fresh thread",
-        {
-          threadId: binding.threadId,
-          maxBytes,
-          files: oversizedFiles.map((file) => ({ path: file.path, bytes: file.bytes })),
-        },
-      );
-      await clearCodexAppServerBinding(params.sessionFile);
-      return undefined;
-    }
   }
   return binding;
 }

--- a/extensions/codex/src/app-server/startup-binding.ts
+++ b/extensions/codex/src/app-server/startup-binding.ts
@@ -13,6 +13,8 @@ import { clearCodexAppServerBinding, type CodexAppServerThreadBinding } from "./
 // thread that is already too close to the server-side window for the next turn.
 const CODEX_APP_SERVER_NATIVE_THREAD_FALLBACK_MAX_TOKENS = 300_000;
 const CODEX_APP_SERVER_NATIVE_THREAD_DEFAULT_RESERVE_TOKENS = 20_000;
+const CODEX_APP_SERVER_NATIVE_THREAD_MIN_PROMPT_BUDGET_TOKENS = 8_000;
+const CODEX_APP_SERVER_NATIVE_THREAD_MIN_PROMPT_BUDGET_RATIO = 0.5;
 const CODEX_APP_SERVER_BYTE_UNITS: Record<string, number> = {
   b: 1,
   k: 1024,
@@ -250,7 +252,15 @@ function resolveCodexAppServerNativeThreadTokenFuse(params: {
       : 0;
   const contextWindow =
     params.modelContextWindow ?? CODEX_APP_SERVER_NATIVE_THREAD_FALLBACK_MAX_TOKENS;
-  return Math.max(1, contextWindow - params.reserveTokens - projectedTurnTokens);
+  const minPromptBudget = Math.min(
+    CODEX_APP_SERVER_NATIVE_THREAD_MIN_PROMPT_BUDGET_TOKENS,
+    Math.max(1, Math.floor(contextWindow * CODEX_APP_SERVER_NATIVE_THREAD_MIN_PROMPT_BUDGET_RATIO)),
+  );
+  const effectiveReserveTokens = Math.min(
+    params.reserveTokens,
+    Math.max(0, contextWindow - minPromptBudget),
+  );
+  return Math.max(1, contextWindow - effectiveReserveTokens - projectedTurnTokens);
 }
 
 function maxFiniteNumber(values: Array<number | undefined>): number | undefined {

--- a/extensions/codex/src/app-server/startup-binding.ts
+++ b/extensions/codex/src/app-server/startup-binding.ts
@@ -9,10 +9,10 @@ import { resolveCodexAppServerHomeDir } from "./auth-bridge.js";
 import { isJsonObject, type JsonValue } from "./protocol.js";
 import { clearCodexAppServerBinding, type CodexAppServerThreadBinding } from "./session-binding.js";
 
-// Codex owns proactive auto-compaction and derives its limit from the active model context
-// window. OpenClaw only clears a bound native thread as a recovery fuse when Codex does
-// not report that window, so the fallback stays well above normal compaction pressure.
+// Codex owns proactive auto-compaction, but OpenClaw must not resume a native
+// thread that is already too close to the server-side window for the next turn.
 const CODEX_APP_SERVER_NATIVE_THREAD_FALLBACK_MAX_TOKENS = 300_000;
+const CODEX_APP_SERVER_NATIVE_THREAD_DEFAULT_RESERVE_TOKENS = 20_000;
 const CODEX_APP_SERVER_BYTE_UNITS: Record<string, number> = {
   b: 1,
   k: 1024,
@@ -209,10 +209,48 @@ function readCodexAppServerRolloutTokenSnapshotLine(
   }
 }
 
-function resolveCodexAppServerNativeThreadTokenFuse(
-  modelContextWindow: number | undefined,
+function toNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function readCompactionConfig(config: EmbeddedRunAttemptParams["config"] | undefined) {
+  return isJsonObject(config?.agents?.defaults?.compaction)
+    ? config.agents.defaults.compaction
+    : undefined;
+}
+
+function resolveCodexAppServerNativeThreadReserveTokens(
+  config: EmbeddedRunAttemptParams["config"] | undefined,
 ): number {
-  return modelContextWindow ?? CODEX_APP_SERVER_NATIVE_THREAD_FALLBACK_MAX_TOKENS;
+  const compaction = readCompactionConfig(config);
+  const reserveTokens = toNonNegativeInt(compaction?.reserveTokens);
+  const reserveTokensFloor = toNonNegativeInt(compaction?.reserveTokensFloor);
+  if (reserveTokens !== undefined) {
+    return Math.max(
+      reserveTokens,
+      reserveTokensFloor ?? CODEX_APP_SERVER_NATIVE_THREAD_DEFAULT_RESERVE_TOKENS,
+    );
+  }
+  return reserveTokensFloor ?? CODEX_APP_SERVER_NATIVE_THREAD_DEFAULT_RESERVE_TOKENS;
+}
+
+function resolveCodexAppServerNativeThreadTokenFuse(params: {
+  modelContextWindow: number | undefined;
+  reserveTokens: number;
+  projectedTurnTokens?: number;
+}): number {
+  const projectedTurnTokens =
+    typeof params.projectedTurnTokens === "number" &&
+    Number.isFinite(params.projectedTurnTokens) &&
+    params.projectedTurnTokens > 0
+      ? Math.floor(params.projectedTurnTokens)
+      : 0;
+  const contextWindow =
+    params.modelContextWindow ?? CODEX_APP_SERVER_NATIVE_THREAD_FALLBACK_MAX_TOKENS;
+  return Math.max(1, contextWindow - params.reserveTokens - projectedTurnTokens);
 }
 
 function maxFiniteNumber(values: Array<number | undefined>): number | undefined {
@@ -223,6 +261,16 @@ function maxFiniteNumber(values: Array<number | undefined>): number | undefined 
     return undefined;
   }
   return Math.max(...nums);
+}
+
+function minFiniteNumber(values: Array<number | undefined>): number | undefined {
+  const nums = values.filter(
+    (value): value is number => typeof value === "number" && Number.isFinite(value),
+  );
+  if (nums.length === 0) {
+    return undefined;
+  }
+  return Math.min(...nums);
 }
 
 function hasContextEngineThreadBootstrapProjection(binding: CodexAppServerThreadBinding): boolean {
@@ -236,50 +284,18 @@ export async function rotateOversizedCodexAppServerStartupBinding(params: {
   codexHome?: string;
   config: EmbeddedRunAttemptParams["config"] | undefined;
   contextEngineActive?: boolean;
+  projectedTurnTokens?: number;
 }): Promise<CodexAppServerThreadBinding | undefined> {
   const binding = params.binding;
   if (!binding?.threadId) {
     return binding;
   }
-  if (params.config?.agents?.defaults?.compaction?.truncateAfterCompaction !== true) {
-    return binding;
-  }
-  if (params.contextEngineActive === true && hasContextEngineThreadBootstrapProjection(binding)) {
-    embeddedAgentLog.debug(
-      "codex app-server deferring native transcript size guard for context-engine thread bootstrap",
-      {
-        threadId: binding.threadId,
-        engineId: binding.contextEngine?.engineId,
-        epoch: binding.contextEngine?.projection?.epoch,
-        fingerprint: binding.contextEngine?.projection?.fingerprint,
-      },
-    );
-    return binding;
-  }
   const sessionRecord = await readCodexSessionRecordForSessionFile(params.sessionFile);
-  const maxBytes = parseCodexAppServerByteLimit(
-    params.config?.agents?.defaults?.compaction?.maxActiveTranscriptBytes,
-  );
   const rolloutFiles = await listCodexAppServerRolloutFilesForThread(
     params.agentDir,
     binding.threadId,
     params.codexHome,
   );
-  if (maxBytes !== undefined) {
-    const oversizedFiles = rolloutFiles.filter((file) => file.bytes >= maxBytes);
-    if (oversizedFiles.length > 0) {
-      embeddedAgentLog.warn(
-        "codex app-server native transcript exceeded active byte limit; starting a fresh thread",
-        {
-          threadId: binding.threadId,
-          maxBytes,
-          files: oversizedFiles.map((file) => ({ path: file.path, bytes: file.bytes })),
-        },
-      );
-      await clearCodexAppServerBinding(params.sessionFile);
-      return undefined;
-    }
-  }
   const nativeTokenSnapshots = await Promise.all(
     rolloutFiles.map(async (file) => readCodexAppServerRolloutTokenSnapshot(file.path)),
   );
@@ -289,7 +305,18 @@ export async function rotateOversizedCodexAppServerStartupBinding(params: {
   const nativeModelContextWindow = maxFiniteNumber(
     nativeTokenSnapshots.map((snapshot) => snapshot?.modelContextWindow),
   );
-  const maxTokens = resolveCodexAppServerNativeThreadTokenFuse(nativeModelContextWindow);
+  const sessionModelContextWindow =
+    typeof sessionRecord?.contextTokens === "number" &&
+    Number.isFinite(sessionRecord.contextTokens) &&
+    sessionRecord.contextTokens > 0
+      ? Math.floor(sessionRecord.contextTokens)
+      : undefined;
+  const reserveTokens = resolveCodexAppServerNativeThreadReserveTokens(params.config);
+  const maxTokens = resolveCodexAppServerNativeThreadTokenFuse({
+    modelContextWindow: minFiniteNumber([nativeModelContextWindow, sessionModelContextWindow]),
+    reserveTokens,
+    projectedTurnTokens: params.projectedTurnTokens,
+  });
   const sessionTokens =
     sessionRecord?.totalTokensFresh !== false &&
     typeof sessionRecord?.totalTokens === "number" &&
@@ -307,10 +334,45 @@ export async function rotateOversizedCodexAppServerStartupBinding(params: {
         sessionTokens,
         nativeTokens,
         nativeModelContextWindow,
+        sessionModelContextWindow,
+        reserveTokens,
+        projectedTurnTokens: params.projectedTurnTokens,
       },
     );
     await clearCodexAppServerBinding(params.sessionFile);
     return undefined;
+  }
+  const compaction = readCompactionConfig(params.config);
+  if (compaction?.truncateAfterCompaction !== true) {
+    return binding;
+  }
+  if (params.contextEngineActive === true && hasContextEngineThreadBootstrapProjection(binding)) {
+    embeddedAgentLog.debug(
+      "codex app-server deferring native transcript byte guard for context-engine thread bootstrap",
+      {
+        threadId: binding.threadId,
+        engineId: binding.contextEngine?.engineId,
+        epoch: binding.contextEngine?.projection?.epoch,
+        fingerprint: binding.contextEngine?.projection?.fingerprint,
+      },
+    );
+    return binding;
+  }
+  const maxBytes = parseCodexAppServerByteLimit(compaction.maxActiveTranscriptBytes);
+  if (maxBytes !== undefined) {
+    const oversizedFiles = rolloutFiles.filter((file) => file.bytes >= maxBytes);
+    if (oversizedFiles.length > 0) {
+      embeddedAgentLog.warn(
+        "codex app-server native transcript exceeded active byte limit; starting a fresh thread",
+        {
+          threadId: binding.threadId,
+          maxBytes,
+          files: oversizedFiles.map((file) => ({ path: file.path, bytes: file.bytes })),
+        },
+      );
+      await clearCodexAppServerBinding(params.sessionFile);
+      return undefined;
+    }
   }
   return binding;
 }
@@ -319,4 +381,5 @@ export const testing = {
   parseCodexAppServerByteLimit,
   readCodexAppServerRolloutTokenSnapshotLine,
   resolveCodexAppServerNativeThreadTokenFuse,
+  resolveCodexAppServerNativeThreadReserveTokens,
 };

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -441,6 +441,79 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(recordCliCompactionInStore).not.toHaveBeenCalled();
   });
 
+  it("treats Codex automatic compaction ownership as a non-fatal CLI budget skip", async () => {
+    const sessionKey = "agent:main:codex-native-auto-compaction";
+    const sessionId = "session-codex-native-auto-compaction";
+    const sessionFile = path.join(tmpDir, "session-codex-native-auto-compaction.jsonl");
+    const storePath = path.join(tmpDir, "sessions-codex-native-auto-compaction.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const compactAgentHarnessSession = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "codex app-server owns automatic compaction",
+      result: {
+        summary: "",
+        firstKeptEntryId: "",
+        tokensBefore: 950,
+      },
+    }));
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      recordCliCompactionInStore,
+    });
+
+    const result = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "codex",
+      model: "gpt-5.5",
+    });
+
+    expect(result).toBe(sessionEntry);
+    expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+  });
+
   it("does not fall back when native harness compaction returns no result", async () => {
     const sessionKey = "agent:main:codex-native-empty";
     const sessionId = "session-codex-native-empty";

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -441,7 +441,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(recordCliCompactionInStore).not.toHaveBeenCalled();
   });
 
-  it("treats Codex automatic compaction ownership as a non-fatal CLI budget skip", async () => {
+  it("falls back to context-engine compaction when Codex owns automatic compaction", async () => {
     const sessionKey = "agent:main:codex-native-auto-compaction";
     const sessionId = "session-codex-native-auto-compaction";
     const sessionFile = path.join(tmpDir, "session-codex-native-auto-compaction.jsonl");
@@ -461,6 +461,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
 
     const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
     const compactAgentHarnessSession = vi.fn(async () => ({
       ok: true,
       compacted: false,
@@ -471,7 +472,10 @@ describe("runCliTurnCompactionLifecycle", () => {
         tokensBefore: 950,
       },
     }));
-    const recordCliCompactionInStore = vi.fn();
+    const recordCliCompactionInStore = vi.fn(async () => ({
+      ...sessionEntry,
+      compactionCount: 1,
+    }));
     setCliCompactionTestDeps({
       resolveContextEngine: async () => buildContextEngine({ compactCalls }),
       ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
@@ -491,6 +495,7 @@ describe("runCliTurnCompactionLifecycle", () => {
         effectiveReserveTokens: 200,
       }),
       resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
       recordCliCompactionInStore,
     });
 
@@ -508,10 +513,20 @@ describe("runCliTurnCompactionLifecycle", () => {
       model: "gpt-5.5",
     });
 
-    expect(result).toBe(sessionEntry);
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
-    expect(compactCalls).toHaveLength(0);
-    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0]?.sessionId).toBe(sessionId);
+    expect(compactCalls[0]?.sessionKey).toBe(sessionKey);
+    expect(compactCalls[0]?.currentTokenCount).toBe(950);
+    expect(maintenance).toHaveBeenCalledTimes(1);
+    expect(recordCliCompactionInStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "codex",
+        sessionKey,
+        tokensAfter: undefined,
+      }),
+    );
+    expect(result?.compactionCount).toBe(1);
   });
 
   it("does not fall back when native harness compaction returns no result", async () => {

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -183,7 +183,7 @@ function isIntentionalNativeAutoCompactionSkip(
 ): boolean {
   return (
     result?.ok === true &&
-    result.compacted === false &&
+    !result.compacted &&
     result.reason === CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON
   );
 }

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -71,7 +71,6 @@ type NativeHarnessCliCompactionOutcome = {
   compacted: boolean;
   result?: EmbeddedAgentCompactResult;
   fallbackToContextEngine?: boolean;
-  skipped?: boolean;
   failureReason?: string;
 };
 type CliTranscriptCompactionOutcome = {
@@ -416,7 +415,7 @@ async function compactNativeHarnessCliTranscript(params: {
     if (isIntentionalNativeAutoCompactionSkip(result)) {
       return {
         compacted: false,
-        skipped: true,
+        fallbackToContextEngine: true,
         failureReason: CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON,
       };
     }
@@ -540,8 +539,6 @@ export async function runCliTurnCompactionLifecycle(params: {
       compacted = true;
       nativeCompactionResult = nativeOutcome.result;
       useContextEngineCompaction = false;
-    } else if (nativeOutcome.skipped) {
-      return params.sessionEntry;
     } else if (!nativeOutcome.fallbackToContextEngine) {
       throw new Error(
         `CLI native harness compaction failed for ${params.provider}/${params.model}: ${

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -30,6 +30,8 @@ import type { AgentMessage } from "../runtime/index.js";
 import { SessionManager } from "../sessions/index.js";
 import { recordCliCompactionInStore as recordCliCompactionInStoreImpl } from "./session-store.js";
 
+const CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON = "codex app-server owns automatic compaction";
+
 type SessionManagerLike = ReturnType<typeof SessionManager.open>;
 type SettingsManagerLike = {
   getCompactionReserveTokens: () => number;
@@ -69,6 +71,7 @@ type NativeHarnessCliCompactionOutcome = {
   compacted: boolean;
   result?: EmbeddedAgentCompactResult;
   fallbackToContextEngine?: boolean;
+  skipped?: boolean;
   failureReason?: string;
 };
 type CliTranscriptCompactionOutcome = {
@@ -173,6 +176,16 @@ function isUnsupportedNativeHarnessCompaction(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
   return result?.ok === false && result.failure?.reason === "unsupported_harness_compaction";
+}
+
+function isIntentionalNativeAutoCompactionSkip(
+  result: EmbeddedAgentCompactResult | undefined,
+): boolean {
+  return (
+    result?.ok === true &&
+    result.compacted === false &&
+    result.reason === CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON
+  );
 }
 
 function readAgentIdFromSessionKey(sessionKey: string): string | undefined {
@@ -400,6 +413,13 @@ async function compactNativeHarnessCliTranscript(params: {
   }
 
   if (!result?.compacted) {
+    if (isIntentionalNativeAutoCompactionSkip(result)) {
+      return {
+        compacted: false,
+        skipped: true,
+        failureReason: CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON,
+      };
+    }
     const fallbackToContextEngine =
       isUnsupportedNativeHarnessCompaction(result) ||
       isRecoverableNativeHarnessBindingFailure(result);
@@ -520,6 +540,8 @@ export async function runCliTurnCompactionLifecycle(params: {
       compacted = true;
       nativeCompactionResult = nativeOutcome.result;
       useContextEngineCompaction = false;
+    } else if (nativeOutcome.skipped) {
+      return params.sessionEntry;
     } else if (!nativeOutcome.fallbackToContextEngine) {
       throw new Error(
         `CLI native harness compaction failed for ${params.provider}/${params.model}: ${


### PR DESCRIPTION
## Summary

- keep the existing Codex terminal-overflow repair stack together: clear/resume unsafe context-engine bindings, tolerate Codex-owned automatic compaction skips, and rotate stale native Codex threads before they can overflow
- run the native rollout token-pressure scan under default config and context-engine thread-bootstrap bindings; keep byte-size rollout truncation opt-in behind `truncateAfterCompaction`
- include the projected next turn prompt/developer instructions in the native headroom check and rebuild projected context when that late guard starts a fresh thread

This PR is intentionally scoped to the Codex terminal-overflow path:

```text
extensions/codex/src/app-server/run-attempt.context-engine.test.ts
extensions/codex/src/app-server/run-attempt.test.ts
extensions/codex/src/app-server/run-attempt.ts
extensions/codex/src/app-server/startup-binding.test.ts
extensions/codex/src/app-server/startup-binding.ts
src/agents/command/cli-compaction.test.ts
src/agents/command/cli-compaction.ts
src/gateway/session-utils.fs.ts
```

## Behavioral Proof

Before, a budget-triggered Codex app-server session entered the bad path because OpenClaw skipped non-manual Codex app-server compaction and then failed the native compaction fallback:

```text
openclaw-2026-05-29.log:<line> skipping codex app-server compaction for non-manual trigger sessionId=<redacted-session-id> sessionKey=<redacted-channel-session-key> trigger=budget
openclaw-2026-05-29.log:<line> agent errorCode=UNAVAILABLE errorMessage=Error: CLI native harness compaction failed for openai-codex/gpt-5.5: codex app-server owns automatic compaction runId=<redacted-run-id>
```

The matching runtime state had OpenClaw session totals below the budget but Codex native rollout pressure already near the native window:

```text
sessionTotalTokens=87792
sessionContextTokens=272000
nativeTotalTokens=241198
nativeModelContextWindow=258400
config=default / truncateAfterCompaction unset
```

After installing this branch locally as the packaged OpenClaw build from this PR and restarting the managed Gateway onto the same build, I recreated that state with redacted synthetic identifiers, `trigger=budget`, model `openai-codex/gpt-5.5`, default compaction config, stale Codex binding, and the native rollout token snapshot above.

```text
[agent/embedded] codex app-server native transcript exceeded active token limit; starting a fresh thread
methods: thread/start, turn/start, thread/unsubscribe
resumedOversizedThread: false
startedFreshThreadBeforeTurn: true
savedThreadId: thread-fresh-before-overflow
```

## Verification

- `CI=true pnpm build`
- `pnpm pack --pack-destination <temp-dir>`
- `pnpm add -g <packed-openclaw-tarball>`
- `openclaw --version` -> packaged OpenClaw build from this PR
- `openclaw gateway install --force --port <local-port> --wrapper <local-openclaw-wrapper>`
- `openclaw gateway status --deep` -> CLI and Gateway both on the packaged PR build
- installed-package synthetic repro described above
- `node --no-maglev <vitest> run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/startup-binding.test.ts --reporter=verbose` -> 12 passed
- `node --no-maglev <vitest> run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/run-attempt.test.ts -t "starts a fresh Codex thread before turn/start when the next prompt would exhaust native headroom" --reporter=verbose` -> 1 passed
- `node --no-maglev <vitest> run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts -t "starts a fresh thread instead of resuming a token-pressured thread-bootstrap binding|resumes a matching thread-bootstrap binding even when the bootstrap turn exceeded the opt-in native byte guard" --reporter=verbose` -> 2 passed
- `git diff --check`

## Real behavior proof

- Behavior addressed: Budget-triggered Codex app-server sessions no longer resume a native Codex thread whose persisted rollout token usage is already too close to the native context window; OpenClaw starts a fresh Codex thread before `turn/start` instead of entering the previous overflow/failed-compaction state.
- Real environment tested: Local packaged OpenClaw install from this PR, with the managed Gateway reinstalled/restarted onto the same package on a local loopback port.
- Exact steps or command run after this patch: Built and packed the branch, installed the tarball globally, reinstalled the Gateway LaunchAgent using a local `openclaw` wrapper, then executed an installed-package run-attempt repro with redacted session identifiers, budget trigger, default compaction config, stale Codex binding, `sessionTotalTokens=87792`, `contextTokens=272000`, native rollout `total_tokens=241198`, and `model_context_window=258400`.
- Evidence after fix: Redacted terminal transcript from the installed packaged build:

  ```text
  [agent/embedded] codex app-server native transcript exceeded active token limit; starting a fresh thread
  methods: thread/start, turn/start, thread/unsubscribe
  resumedOversizedThread: false
  startedFreshThreadBeforeTurn: true
  savedThreadId: thread-fresh-before-overflow
  ```
- Observed result after fix: Copied live output showed `thread/start` before `turn/start`, no `thread/resume` for the oversized stale thread, and a rewritten binding value of `thread-fresh-before-overflow`.
- What was not tested: A live OpenAI Codex model call was not made; the proof uses the installed OpenClaw package and a local app-server harness seeded with the persisted session/rollout token state from the observed failure.
