### PR TITLE
Protect session store writes with a file lock

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -1134,7 +1134,8 @@ describe("sessions", () => {
         { skipMaintenance: true },
       );
 
-      expect(readSpy).not.toHaveBeenCalled();
+      const storePathReads = readSpy.mock.calls.filter(([readPath]) => readPath === storePath);
+      expect(storePathReads).toEqual([]);
     } finally {
       readSpy.mockRestore();
     }

--- a/src/config/sessions/store-writer.test.ts
+++ b/src/config/sessions/store-writer.test.ts
@@ -1,4 +1,7 @@
 // Session store writer tests cover serialized session writes and cleanup.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clearSessionStoreCacheForTest,
@@ -49,6 +52,24 @@ describe("session store writer", () => {
 
     expect(order).toEqual(["first:start", "first:end", "second"]);
     expect(getSessionStoreWriterQueueSizeForTest()).toBe(0);
+  });
+
+  it("holds a cross-process file lock while running a writer", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-writer-"));
+    const storePath = path.join(tempDir, "sessions.json");
+    const started = createDeferred<void>();
+    const release = createDeferred<void>();
+
+    const write = withSessionStoreWriterForTest(storePath, async () => {
+      started.resolve();
+      await release.promise;
+    });
+
+    await started.promise;
+    await expect(fs.access(`${storePath}.lock`)).resolves.toBeUndefined();
+    release.resolve();
+    await write;
+    await fs.rm(tempDir, { force: true, recursive: true });
   });
 
   it("rejects empty store paths before enqueuing work", async () => {

--- a/src/config/sessions/store-writer.ts
+++ b/src/config/sessions/store-writer.ts
@@ -1,6 +1,24 @@
 // Session store writes are serialized per store path to avoid lost updates.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { type FileLockOptions, withFileLock } from "../../plugin-sdk/file-lock.js";
 import { runQueuedStoreWrite } from "../../shared/store-writer-queue.js";
 import { WRITER_QUEUES } from "./store-writer-state.js";
+
+const DEFAULT_SESSION_STORE_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    retries: 6,
+    factor: 1.35,
+    minTimeout: 8,
+    maxTimeout: 180,
+    randomize: true,
+  },
+  stale: 60_000,
+};
+
+async function ensureSessionStoreDir(storePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+}
 
 /** Runs a callback under the same per-store writer queue used in production. */
 export async function withSessionStoreWriterForTest<T>(
@@ -18,6 +36,9 @@ export async function runExclusiveSessionStoreWrite<T>(
     queues: WRITER_QUEUES,
     storePath,
     label: "runExclusiveSessionStoreWrite",
-    fn,
+    fn: async () => {
+      await ensureSessionStoreDir(storePath);
+      return await withFileLock(storePath, DEFAULT_SESSION_STORE_LOCK_OPTIONS, fn);
+    },
   });
 }

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -186,6 +186,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
       timeoutMs: 1_500_000,
       weight: 3,
     });
+    expect(lane.timeoutMs).toBeGreaterThanOrEqual(900000);
     expect(script).toContain("OPENCLAW_ENTRY=/app/openclaw.mjs");
     expect(script).toContain("OPENCLAW_KITCHEN_SINK_COMMAND_MAX_RSS_MIB");
     expect(script).toContain("docker_e2e_sample_stats_until_exit");


### PR DESCRIPTION
## Summary
- wrap session store writes in the shared file-lock helper so concurrent OpenClaw processes serialize writes to the same sessions store
- create the session-store parent directory before acquiring the advisory lock
- add coverage that the session writer holds the cross-process lock while a write is active

## Verification
- pnpm exec vitest run src/config/sessions/store-writer.test.ts
- pnpm exec oxlint src/config/sessions/store-writer.ts src/config/sessions/store-writer.test.ts
- git diff --check

## Note
- Full typecheck was attempted with `pnpm exec tsc -p tsconfig.json --noEmit` but the Coder workspace ran out of memory (Node heap OOM, then SIGKILL even with `NODE_OPTIONS=--max-old-space-size=6144`).


## Real behavior proof
- **Behavior or issue addressed:** Session store writes now use the shared per-store writer queue plus advisory file lock so concurrent OpenClaw processes/writers serialize writes to the same `sessions.json` path instead of losing updates.
- **Real environment tested:** Local macOS OpenClaw checkout on the PR branch (`d4cc5a9f0f`), using the real `src/config/sessions/store.ts` implementation and a real temp sessions file under `/Users/iyen/.openclaw/tmp/`.
- **Exact steps or command run after this patch:**

```bash
pnpm exec tsx .session-store-real-proof.mjs
```

The proof script imported `loadSessionStore` and `updateSessionStore` from `./src/config/sessions/store.ts`, created a real temp `sessions.json`, then ran two concurrent `updateSessionStore` calls against that same file.

- **Evidence after fix:** Copied terminal output from the real command:

```json
{
  "proof": "real-session-store-update",
  "storePath": "/Users/iyen/.openclaw/tmp/openclaw-session-lock-proof-CqsBHq/sessions.json",
  "mainThinking": "high",
  "secondaryExists": true,
  "keys": [
    "agent:main:main",
    "agent:main:secondary"
  ]
}
```

- **Observed result after fix:** Both concurrent writes were preserved in the on-disk session store: the original `agent:main:main` entry changed `thinkingLevel` to `high`, and the concurrent `agent:main:secondary` entry existed after reloading the file with `skipCache: true`.
- **What was not tested:** Cross-host/network-filesystem locking and Windows/macOS/Linux cross-OS behavior were not tested in this local proof; those remain covered by CI/release validation rather than this PR-body proof.

Supplemental regression gates from the latest fix commit:

```text
pnpm test -- src/config/sessions.test.ts
# 50 passed

pnpm test -- test/scripts/plugin-prerelease-test-plan.test.ts
# 11 passed

pnpm exec oxlint src/config/sessions.test.ts test/scripts/plugin-prerelease-test-plan.test.ts
# Found 0 warnings and 0 errors

git diff --check
# clean
```
