### PR TITLE
fix(nostr): decode npub allowFrom entries to hex correctly

### DIFF
--- a/extensions/nostr/src/nostr-bus.test.ts
+++ b/extensions/nostr/src/nostr-bus.test.ts
@@ -192,6 +192,30 @@ describe("normalizePubkey", () => {
       expect(() => normalizePubkey("invalid")).toThrow("Pubkey must be 64 hex characters");
     });
   });
+
+  describe("normalizePubkey npub format", () => {
+    // Regression: pre-fix this returned a 128-char garbage string because the
+    // implementation treated nip19.decode(npub).data as a Uint8Array, but
+    // nostr-tools >=2.0 returns it as the hex string directly. allowFrom
+    // entries written as npubs therefore never matched any hex sender pubkey.
+    const HEX = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const NPUB = pubkeyToNpub(HEX);
+
+    it("decodes npub to the original 64-char hex pubkey", () => {
+      const result = normalizePubkey(NPUB);
+      expect(result).toBe(HEX);
+      expect(result).toMatch(/^[0-9a-f]{64}$/);
+      expect(result.length).toBe(64);
+    });
+
+    it("survives a hex→npub→normalizePubkey roundtrip", () => {
+      expect(normalizePubkey(pubkeyToNpub(HEX))).toBe(HEX);
+    });
+
+    it("trims surrounding whitespace before decoding", () => {
+      expect(normalizePubkey(`  ${NPUB}  `)).toBe(HEX);
+    });
+  });
 });
 
 describe("getPublicKeyFromPrivate", () => {

--- a/extensions/nostr/src/nostr-key-utils.ts
+++ b/extensions/nostr/src/nostr-key-utils.ts
@@ -68,13 +68,11 @@ export function normalizePubkey(input: string): string {
   // npub format - decode to hex
   if (trimmed.startsWith("npub1")) {
     const decoded = nip19.decode(trimmed);
-    if (decoded.type !== "npub") {
+    if (decoded.type !== "npub" || typeof decoded.data !== "string") {
       throw new Error("Invalid npub key");
     }
-    // Convert Uint8Array to hex string
-    return Array.from(decoded.data as unknown as Uint8Array)
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
+    // nip19.decode(npub).data is already the hex pubkey (string), not Uint8Array.
+    return decoded.data.toLowerCase();
   }
 
   // Already hex - validate and return lowercase


### PR DESCRIPTION
## Summary

`normalizePubkey` treated `nip19.decode(npub).data` as a `Uint8Array` (via `as unknown as Uint8Array`) and ran `Array.from(...).map(b => b.toString(16).padStart(2, "0"))` on it. In `nostr-tools >=2.0`, `npub` decodes to `{ type: 'npub', data: string }` where `data` is the **hex pubkey string directly**, so:

```js
Array.from("3129509e...f506").map(c => c.toString(16).padStart(2, "0"))
//  → "03010209050000390510..."   (128 chars of garbage)
```

Any `channels.nostr.allowFrom` entry written as an npub therefore never matched the hex sender pubkey, and the gateway dropped legitimate DMs as `dm_policy_not_allowlisted`. `extensions/nostr/src/config-schema.ts` documents `allowFrom` as accepting "npub or hex format", so npub support is intended.

This PR returns `decoded.data.toLowerCase()` directly and defensively rejects any non-string decoded payload.

### nostr-tools 2.23.5 type signature

```ts
{ type: 'npub', data: string }  // hex pubkey string
{ type: 'nsec', data: Uint8Array }
```

(Note `validatePrivateKey` 30 lines above correctly handles the `nsec` bytes case — the author knew the shape there.)

### Why CI didn't catch it

The `normalizePubkey hex format` sub-describe in `nostr-bus.test.ts` only exercised the hex branch. Elsewhere (e.g. `channel.inbound.test.ts`) the function is mocked entirely. This PR adds an `npub format` sub-describe that asserts a hex → npub → `normalizePubkey` roundtrip returns the original 64-char hex.

## Test plan

- [x] Added 3 regression tests for the npub branch under `describe("normalizePubkey npub format")` in `nostr-bus.test.ts`:
  - `decodes npub to the original 64-char hex pubkey`
  - `survives a hex → npub → normalizePubkey roundtrip`
  - `trims surrounding whitespace before decoding`
  - **Note:** I did not run the full monorepo test suite locally — please run focused Nostr CI to confirm.
- [x] Verified the patched logic in isolation against `nostr-tools@2.23.5`: `normalizePubkey(nip19.npubEncode(HEX)) === HEX`. Before the patch, `Array.from(decoded.data).map(...)` produced a 128-char garbage string.

---

## Real behavior proof

**Behavior or issue addressed:** Pre-patch, `normalizePubkey(npub)` returns a 128-char garbage string instead of the 64-char hex pubkey. Any `channels.nostr.allowFrom` entry written as an npub therefore never matches the (hex) sender pubkey on inbound DMs, and the gateway drops the message as `dm_policy_not_allowlisted`. Patched, the roundtrip is correct.

**Real environment tested:** Self-hosted OpenClaw gateway on Debian, `node v22.22.1`. `@openclaw/nostr@2026.5.27-spectr.1` (a local tarball install of the v2026.5.27 plugin source with this single PR's `nostr-key-utils.ts` patch applied) running against `nostr-tools@2.23.5` (the exact version the plugin's `package.json` pins). Gateway process: `openclaw-gateway.service` (systemd user unit), uptime 6h at proof time, PID 3250600, real anthropic provider configured. Nostr channel enabled with `dmPolicy: allowlist`, relays `wss://relay.damus.io` + `wss://nos.lol`.

**Exact steps or command run after this patch:** ran the verbatim pre-patch and post-patch `normalizePubkey` source against the installed `nostr-tools@2.23.5` on the gateway box. Both functions imported from the same nostr-tools build the gateway uses at runtime; the only difference is the `normalizePubkey` body itself.

```
node --input-type=module -e '
import { nip19 } from "/home/redacted/.openclaw/npm/node_modules/@openclaw/nostr/node_modules/nostr-tools/lib/esm/index.js";
function normalizePubkey_pre(input){const t=input.trim();if(t.startsWith("npub1")){const d=nip19.decode(t);if(d.type!=="npub")throw new Error("Invalid npub key");return Array.from(d.data).map(b=>b.toString(16).padStart(2,"0")).join("")}if(!/^[0-9a-fA-F]{64}$/.test(t))throw new Error("Pubkey must be 64 hex characters or npub format");return t.toLowerCase()}
function normalizePubkey_post(input){const t=input.trim();if(t.startsWith("npub1")){const d=nip19.decode(t);if(d.type!=="npub"||typeof d.data!=="string")throw new Error("Invalid npub key");return d.data.toLowerCase()}if(!/^[0-9a-fA-F]{64}$/.test(t))throw new Error("Pubkey must be 64 hex characters or npub format");return t.toLowerCase()}
const HEX="abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
const NPUB=nip19.npubEncode(HEX);
console.log("input npub :", NPUB);
console.log("expect hex :", HEX);
console.log("PRE-patch  :", normalizePubkey_pre(NPUB),  "  len=", normalizePubkey_pre(NPUB).length);
console.log("POST-patch :", normalizePubkey_post(NPUB), "  len=", normalizePubkey_post(NPUB).length);
'
```

**Evidence after fix:** Live terminal output captured from the gateway box after the patch.

```
=== ENVIRONMENT ===
v22.22.1
Plugin:
  "name": "@openclaw/nostr",
  "version": "2026.5.27-spectr.1",
nostr-tools:
  "version": "2.23.5",

=== BEFORE FIX (source matching v2026.5.27 npm release) ===
input  npub : npub140x77qfrg4ncn27dauqjx3t83x4ummcpydzk0zdtehhszg69v7ystddknj
expect hex  : abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
got         : 0a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f00010203040506070809
length      : 128 (expected 64)
matches hex : false

→ Allowlist check: if a config has allowFrom=[npub] and a sender sends with hex=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
  normalized allow entry would be: 0a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f00010203040506070809
  normalized sender pubkey would be: abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
  match? NO → DM dropped as dm_policy_not_allowlisted

=== AFTER FIX (PR #88221 patch applied) ===
input  npub : npub140x77qfrg4ncn27dauqjx3t83x4ummcpydzk0zdtehhszg69v7ystddknj
expect hex  : abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
got         : abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
length      : 64 (expected 64)
matches hex : true

→ Allowlist check: same scenario as above
  normalized allow entry: abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
  normalized sender hex : abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
  match? YES → DM authorized
```

**Observed result after fix:** With the patched `normalizePubkey`, an npub-form `allowFrom` entry now produces the same 64-char hex pubkey as the sender hex, so the existing equality-based allowlist match succeeds and the DM passes the `dm_policy_not_allowlisted` gate. Pre-patch, the same input produced a 128-char garbage string that could never match.

End-to-end (chat-half) round-trip on the same gateway was independently proven prior to this PR: NIP-04 DM in → agent's Nostr channel receives → NIP-04 decrypt → allowlist (using a hex pubkey to work around this bug) → LLM → encrypted reply published → decrypted reply received. The active config uses hex `allowFrom` entries verbatim today because the npub branch was broken; with this patch the same setup also works with npub entries.

**What was not tested:** I did not run the full upstream monorepo suite locally, only the targeted `normalizePubkey` logic against the pinned `nostr-tools@2.23.5` on the installed plugin. Focused Nostr CI in this PR runs the full suite.

---

**Related:** part of a 3-PR series fixing the nostr channel. The other two (#88220 + #88222) turned out to be duplicates of upstream fixes (8a76cc3470 + a5241782ca) that landed independently within ~24h of my PRs and I closed them with thanks. All three bugs share the same `as unknown as X` cast pattern that silenced a type error the compiler was correct about; the `subscribeMany` fix tightened it further by using `satisfies Parameters<typeof pool.subscribeMany>[1]`. This npub one is the last of the three still outstanding.
