### PR TITLE
fix(update): prefer package root as managed-service handoff cwd (fixes #87889)

### DIFF
--- a/src/gateway/server-methods/update-managed-service-handoff.test.ts
+++ b/src/gateway/server-methods/update-managed-service-handoff.test.ts
@@ -135,8 +135,10 @@ describe("managed service update handoff", () => {
       KEEP_ME: "1",
     });
 
+    const handoffRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-cwd-test-"));
+    tempDirs.add(handoffRoot);
     const result = await startManagedServiceUpdateHandoff({
-      root: "/tmp/openclaw",
+      root: handoffRoot,
       timeoutMs: 1_800_000,
       restartDelayMs: 500,
       parentPid: 12345,
@@ -171,8 +173,8 @@ describe("managed service update handoff", () => {
     };
     expect(helperParams.metaPath).toMatch(/sentinel-meta\.json$/u);
     expect(helperParams.sentinelPath).toMatch(/restart-sentinel\.json$/u);
-    expect(options.cwd).toBe(os.homedir());
-    expect(helperParams.cwd).toBe(os.homedir());
+    expect(options.cwd).toBe(handoffRoot);
+    expect(helperParams.cwd).toBe(handoffRoot);
     expect(options.detached).toBe(true);
     expect(options.env.KEEP_ME).toBe("1");
     for (const [key, value] of Object.entries(serviceIdentityEnv)) {

--- a/src/gateway/server-methods/update-managed-service-handoff.ts
+++ b/src/gateway/server-methods/update-managed-service-handoff.ts
@@ -306,7 +306,7 @@ export function stripSupervisorHintEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEn
 }
 
 async function resolveManagedServiceHandoffCwd(root: string): Promise<string> {
-  const candidates = [os.homedir(), os.tmpdir(), path.dirname(process.execPath), root];
+  const candidates = [root, os.homedir(), os.tmpdir(), path.dirname(process.execPath)];
   for (const candidate of candidates) {
     if (!candidate.trim()) {
       continue;


### PR DESCRIPTION
## Summary

Fixes **#87889** — Dashboard updates for global installs are skipped with `managed-service-handoff-started`, while CLI updates succeed.

## Root Cause

`resolveManagedServiceHandoffCwd` preferred `os.homedir()` over the package `root` when choosing the working directory for the managed-service update handoff script. Because the handoff script runs `node <argv1> update ...` with a relative `argv1` (e.g. `dist/index.js`), running in the wrong directory caused the entry path to be unresolvable. The update silently failed after gateway restart.

CLI updates bypass the handoff path and call `runGatewayUpdate` directly with the correct `cwd`, which is why they succeeded while Dashboard updates failed.

## Changes

### `src/gateway/server-methods/update-managed-service-handoff.ts`
- Move `root` to the first candidate in `resolveManagedServiceHandoffCwd` so the handoff script runs in the package root directory.

### `src/gateway/server-methods/update-managed-service-handoff.test.ts`
- Update the test to assert that `cwd` matches the provided `root` instead of `os.homedir()`.
- Create a real temporary directory for `root` so `fs.stat` resolves it successfully.

## Real behavior proof

**Behavior or issue addressed:** Dashboard-initiated global install updates now run the handoff script in the correct package root instead of `os.homedir()`.

**Real environment tested:** Code analysis and unit-test validation on the PR branch.

**Exact steps or command run after this patch:**
1. Read `resolveManagedServiceHandoffCwd` to confirm `root` is now the first candidate.
2. Read `update.ts` to confirm the handoff `cwd` is derived from `resolveManagedServiceHandoffCwd(params.root)`.
3. Run the existing unit test `strips process supervisor hints while preserving service identity for the CLI handoff`.

**Evidence after fix:**
- `resolveManagedServiceHandoffCwd` candidate order is now `[root, os.homedir(), os.tmpdir(), path.dirname(process.execPath)]`.
- The test `options.cwd` and `helperParams.cwd` both assert against the provided `root` directory.

**Observed result after fix:**
- The handoff test passes with `cwd` set to the actual `root` temp directory.
- No change to CLI update behavior (it never used the handoff path).

**What was not tested:**
- Live Dashboard update on a real globally-installed gateway instance.
- End-to-end systemd/launchd handoff restart validation.

## Testing

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/update-managed-service-handoff.test.ts
```

## Risks

Risk is very low. The change only reorders the directory fallback list in `resolveManagedServiceHandoffCwd`. The previous behavior (always falling back to `os.homedir()`) was the unintended default because `os.homedir()` is almost always a valid directory.

Fixes #87889