### PR TITLE
fix(ui): stop pulsing completed stream segments

### DIFF
--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -194,6 +194,7 @@ describe("buildChatItems", () => {
         key: "stream:main:1",
         text: "Visible reply",
         startedAt: 1,
+        isStreaming: true,
       },
     ]);
   });
@@ -389,6 +390,7 @@ describe("buildChatItems", () => {
       kind: "stream",
       text: "Older streamed output.",
       startedAt: 1_000,
+      isStreaming: false,
     });
     expect(requireGroup(items[1]).role).toBe("assistant");
   });
@@ -406,6 +408,7 @@ describe("buildChatItems", () => {
       kind: "stream",
       text: "Timestamped stream.",
       startedAt: Number.MAX_SAFE_INTEGER,
+      isStreaming: false,
     });
     expect(messageRecord(requireGroup(items[1])).content).toBe("Missing timestamp.");
   });

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -572,6 +572,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
           key: `stream-seg:${props.sessionKey}:${i}`,
           text: visibleText,
           startedAt: segments[i].ts,
+          isStreaming: false,
         });
       }
     }
@@ -595,6 +596,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
           key,
           text: visibleText,
           startedAt: props.streamStartedAt ?? Date.now(),
+          isStreaming: true,
         });
       }
     } else if (props.stream.trim().length === 0) {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -878,6 +878,15 @@ describe("grouped chat rendering", () => {
     expect(streamingTime?.textContent?.trim()).toBe(display.label);
   });
 
+  it("omits streaming bubble class for completed stream segments", () => {
+    const container = document.createElement("div");
+
+    render(renderStreamingGroup("Completed segment", 1, false), container);
+
+    const bubble = container.querySelector(".chat-bubble");
+    expect(bubble?.classList.contains("streaming")).toBe(false);
+  });
+
   it("renders configured local user names", () => {
     const renderUser = (opts: Partial<RenderMessageGroupOptions>) => {
       const container = document.createElement("div");

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -347,6 +347,7 @@ export function renderReadingIndicatorGroup(
 export function renderStreamingGroup(
   text: string,
   startedAt: number,
+  isStreaming = true,
   onOpenSidebar?: (content: SidebarContent) => void,
   assistant?: AssistantIdentity,
   basePath?: string,
@@ -365,7 +366,7 @@ export function renderStreamingGroup(
             timestamp: startedAt,
           },
           `stream:${startedAt}`,
-          { isStreaming: true, showReasoning: false },
+          { isStreaming, showReasoning: false },
           onOpenSidebar,
         )}
         <div class="chat-group-footer">

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -13,7 +13,7 @@ export type ChatItem =
       action?: { kind: "session-checkpoints"; label: string };
       timestamp: number;
     }
-  | { kind: "stream"; key: string; text: string; startedAt: number }
+  | { kind: "stream"; key: string; text: string; startedAt: number; isStreaming: boolean }
   | { kind: "reading-indicator"; key: string };
 
 /** A group of consecutive messages from the same role (Slack-style layout) */

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -115,6 +115,7 @@ vi.mock("../chat/build-chat-items.ts", () => ({
               key: "stream:test",
               text: props.stream,
               startedAt: props.streamStartedAt ?? 1,
+              isStreaming: true,
             },
           ]
         : [{ kind: "reading-indicator", key: "reading:test" }];

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1249,6 +1249,7 @@ export function renderChat(props: ChatProps) {
               return renderStreamingGroup(
                 item.text,
                 item.startedAt,
+                item.isStreaming,
                 props.onOpenSidebar,
                 assistantIdentity,
                 props.basePath,


### PR DESCRIPTION
## Summary

- Fix WebChat completed stream segments keeping the pulsing `streaming` bubble class after the live response has moved on.
- Preserve completed stream segments in the transcript ordering, but mark them as non-streaming so only the current live stream bubble animates.
- Keep the fix scoped to the WebChat UI item/render contract; no gateway, provider, protocol, config, or session lifecycle changes.

What problem does this PR solve?

Completed WebChat stream segment bubbles can render with the same `streaming` CSS class as the actively streaming assistant response. That leaves the pulsing border animation on content that is no longer live.

Why does this matter now?

This is the message-card companion to the completed-run cleanup in #87810. That PR fixed the status bar showing stale in-progress state; this PR fixes the remaining stale in-progress visual state on WebChat message bubbles.

What is the intended outcome?

Only the active live assistant stream renders with the `streaming` bubble class. Completed stream segments still render in their existing position, but without the pulsing animation.

What is intentionally out of scope?

- No gateway or provider streaming protocol changes.
- No changes to how stream segments are stored, ordered, or cleared.
- No mobile, desktop-native, config, migration, auth, or session status behavior changes.

What does success look like?

After an assistant response completes or stream text is committed into completed segments, the completed message cards remain visible but no longer pulse as if the assistant is still responding.

What should reviewers focus on?

- Whether `ChatItem.kind === "stream"` should carry an explicit `isStreaming` flag instead of deriving active state from the existence of a stream item.
- Whether completed `streamSegments` should continue rendering without animation rather than being hidden or cleared in `buildChatItems`.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes # (no linked issue; discovered while reviewing the WebChat stale streaming visual state)

Which issues, PRs, or discussions are related?

Related #87810 - fixes the same completed-run stale in-progress class of problem for the status bar/session active-run state.

Was this requested by a maintainer or owner?

No formal issue request. This was discussed as a follow-up to the #87810-style lifecycle cleanup: the status bar was fixed there, while WebChat message cards still needed their stale streaming visual state corrected.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  Completed WebChat stream segment bubbles rendered through `renderStreamingGroup` could keep the `chat-bubble streaming` class, so they continued showing the pulsing-border animation even after the live response was no longer active.

- Real environment tested:
  Local source checkout with focused WebChat UI tests and UI test typecheck. No live browser/manual WebChat session was rerun for this branch after the patch.

- Exact steps or command run after this patch:
  `node scripts/run-vitest.mjs ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/views/chat.test.ts -- -t "stream|completed stream segments|full dates with message and streaming timestamps|deduplicates accumulated stream snapshots"`

  `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui-stream-artifacts.tsbuildinfo`

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  After-fix video:

https://github.com/user-attachments/assets/d074d865-47fd-43d8-8404-aa07032a3698



  Focused Vitest proof passed: `Test Files 3 passed (3)`, `Tests 131 passed (131)`.

  UI test typecheck passed with no diagnostics.

- Observed result after fix:
  `buildChatItems` now marks completed stream segments with `isStreaming: false` and live stream items with `isStreaming: true`. `renderStreamingGroup` passes that flag into `renderGroupedMessage`, and the new grouped-render regression test verifies completed stream segments do not include the `streaming` bubble class.

- What was not tested:
  A live browser DevTools inspection against a running Gateway was not rerun for this branch. Rapid send/cancel/send cycles were not manually exercised.

- Proof limitations or environment constraints:
  This branch has focused local UI proof, not a full UI E2E/browser recording.

- Before evidence (optional but encouraged):
  Before-fix video:

https://github.com/user-attachments/assets/698edbe2-b650-428f-b3a4-c9994be73745



  Before this patch, `renderStreamingGroup` always called `renderGroupedMessage` with `{ isStreaming: true }`, so every `kind: "stream"` item rendered with the same animated `streaming` class regardless of whether it represented completed segment text or the active live stream.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

```sh
node scripts/run-vitest.mjs ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/views/chat.test.ts -- -t "stream|completed stream segments|full dates with message and streaming timestamps|deduplicates accumulated stream snapshots"
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui-stream-artifacts.tsbuildinfo
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

What regression coverage was added or updated?

- `build-chat-items.test.ts` now asserts live stream items are marked `isStreaming: true` and completed stream segments are marked `isStreaming: false`.
- `grouped-render.test.ts` adds a regression check that completed stream segments omit the `streaming` bubble class.
- `views/chat.test.ts` updates its mocked stream item shape to match the explicit stream-state contract.

What failed before this fix, if known?

Before this patch, `renderStreamingGroup` hardcoded `isStreaming: true`, so completed stream segment items could not render without the animated `streaming` class.

If no test was added, why not?

Tests were added and updated.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Completed WebChat stream segment bubbles no longer show the pulsing streaming animation.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The UI `ChatItem` stream shape now carries an explicit `isStreaming` field, so all stream item producers and test mocks need to set it correctly.

How is that risk mitigated?

There are only two production stream item producers in `buildChatItems`: completed `streamSegments` and the current live `stream`. Both now set the flag explicitly, and focused tests cover both values plus the rendering class behavior.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

Ready for review.

What is still waiting on author, maintainer, CI, or external proof?

No known author-side blocker. CI and any maintainer-requested browser/E2E proof are still pending after PR creation.

Which bot or reviewer comments were addressed?

No PR comments yet. Local autoreview completed cleanly with no accepted/actionable findings.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
