### PR TITLE
fix(agents): normalize sessions_send message aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Release/CI/E2E: run the Telegram desktop proof gateway through the repo pnpm runner so native macOS proof uses the hydrated package-manager shim.
 - Docs/CI: run Mintlify anchor checks through the repo pnpm runner so docs link validation works when pnpm is only available through the hydrated package-manager shim.
 - Agents: keep configured fallback model metadata typed so provider params, context-token caps, and media input limits do not break changed-gate typechecks.
+- Agents: accept hidden `sessions_send` body aliases before validation while keeping the model-facing `message` schema canonical. (#88229) Thanks @zhangguiping-xydt.
 - CI/Crabbox: keep default runner capacity spot-only and provider-neutral so OpenClaw remote validation does not silently fall back to on-demand leases or stale AWS region hints.
 - CI/Crabbox: route Crabbox wrapper and Testbox workflow edits to their regression tests so changed-test gates do not silently run zero specs.
 - CI/workflows: route workflow sanity helper edits to their guard tests and cover composite-action input interpolation checks.

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -274,6 +274,13 @@ describe("sessions tools", () => {
       }
       return value;
     };
+    const hasSchemaProp = (toolName: string, prop: string) => {
+      const tool = byName(toolName);
+      const schema = tool.parameters as {
+        properties?: Record<string, unknown>;
+      };
+      return Object.hasOwn(schema.properties ?? {}, prop);
+    };
 
     expect(schemaProp("sessions_history", "limit").type).toBe("integer");
     expect(schemaProp("sessions_list", "limit").type).toBe("integer");
@@ -284,7 +291,114 @@ describe("sessions tools", () => {
     expect(schemaProp("sessions_list", "search").type).toBe("string");
     expect(schemaProp("sessions_list", "includeDerivedTitles").type).toBe("boolean");
     expect(schemaProp("sessions_list", "includeLastMessage").type).toBe("boolean");
+    expect(schemaProp("sessions_send", "message").type).toBe("string");
+    expect(hasSchemaProp("sessions_send", "SendMessage")).toBe(false);
+    expect(hasSchemaProp("sessions_send", "content")).toBe(false);
+    expect(hasSchemaProp("sessions_send", "text")).toBe(false);
     expect(schemaProp("sessions_send", "timeoutSeconds").type).toBe("integer");
+    const sendRequired =
+      (byName("sessions_send").parameters as { required?: string[] }).required ?? [];
+    expect(sendRequired).toContain("message");
+  });
+
+  it.each([
+    { alias: "SendMessage", value: "hello from SendMessage" },
+    { alias: "content", value: "hello from content" },
+    { alias: "text", value: "hello from text" },
+  ])("sessions_send prepares hidden $alias alias before validation", ({ alias, value }) => {
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+    if (!tool.prepareArguments) {
+      throw new Error("sessions_send missing prepareArguments");
+    }
+
+    const prepared = tool.prepareArguments({
+      sessionKey: "main",
+      [alias]: value,
+      timeoutSeconds: 0,
+    }) as Record<string, unknown>;
+
+    expect(prepared.message).toBe(value);
+    expect(prepared[alias]).toBeUndefined();
+  });
+
+  it.each([
+    { alias: "SendMessage", value: "hello from SendMessage" },
+    { alias: "content", value: "hello from content" },
+    { alias: "text", value: "hello from text" },
+  ])("sessions_send normalizes $alias alias to message", async ({ alias, value }) => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-alias", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-alias", {
+      sessionKey: "main",
+      [alias]: value,
+      timeoutSeconds: 0,
+    });
+
+    expect(sessionsSendDetails(result.details).status).toBe("accepted");
+    const agentCall = callGatewayMock.mock.calls
+      .map((call) => call[0] as GatewayCall)
+      .find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    expect(agentParams(agentCall ?? {}).message).toContain(value);
+  });
+
+  it("sessions_send sanitizes formatted reasoning from aliases", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-alias", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-alias", {
+      sessionKey: "main",
+      SendMessage: "Reasoning:\n_internal plan_\n\nVisible answer",
+      timeoutSeconds: 0,
+    });
+
+    expect(sessionsSendDetails(result.details).status).toBe("accepted");
+    const agentCall = callGatewayMock.mock.calls
+      .map((call) => call[0] as GatewayCall)
+      .find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    expect(agentParams(agentCall ?? {}).message).toContain("Visible answer");
+    expect(agentParams(agentCall ?? {}).message).not.toContain("internal plan");
+  });
+
+  it("sessions_send prepares sanitized aliases without exposing alias keys", () => {
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    if (!tool?.prepareArguments) {
+      throw new Error("missing sessions_send prepareArguments");
+    }
+
+    const prepared = tool.prepareArguments({
+      sessionKey: "main",
+      SendMessage: "Reasoning:\n_internal plan_\n\nVisible answer",
+      timeoutSeconds: 0,
+    }) as Record<string, unknown>;
+
+    expect(prepared.message).toBe("Visible answer");
+    expect(prepared.SendMessage).toBeUndefined();
   });
 
   it("sessions_list forwards mailbox filters and includes messages", async () => {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -16,6 +16,7 @@ import { annotateInterSessionPromptText } from "../../sessions/input-provenance.
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import { finiteSecondsToTimerSafeMilliseconds } from "../../shared/number-coercion.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
 import {
   type GatewayMessageChannel,
   INTERNAL_MESSAGE_CHANNEL,
@@ -61,6 +62,29 @@ const SessionsSendToolSchema = Type.Object({
 
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
+const SESSIONS_SEND_MESSAGE_ALIASES = ["SendMessage", "content", "text"] as const;
+
+function normalizeSessionsSendArguments(args: unknown): Record<string, unknown> {
+  const params =
+    args && typeof args === "object" && !Array.isArray(args)
+      ? { ...(args as Record<string, unknown>) }
+      : {};
+
+  if (typeof params.message !== "string" || !params.message.trim()) {
+    for (const alias of SESSIONS_SEND_MESSAGE_ALIASES) {
+      const value = readStringParam(params, alias);
+      if (value) {
+        params.message = stripFormattedReasoningMessage(value);
+        break;
+      }
+    }
+  }
+
+  for (const alias of SESSIONS_SEND_MESSAGE_ALIASES) {
+    delete params[alias];
+  }
+  return params;
+}
 
 function resolveRunScopedFallbackSessionKey(sessionKey: string): string | undefined {
   const match = /^(agent:[^:]+:.+):run:[^:]+$/.exec(sessionKey.trim());
@@ -280,8 +304,9 @@ export function createSessionsSendTool(opts?: {
     displaySummary: SESSIONS_SEND_TOOL_DISPLAY_SUMMARY,
     description: describeSessionsSendTool(),
     parameters: SessionsSendToolSchema,
+    prepareArguments: normalizeSessionsSendArguments,
     execute: async (_toolCallId, args) => {
-      const params = args as Record<string, unknown>;
+      const params = normalizeSessionsSendArguments(args);
       const gatewayCall = opts?.callGateway ?? callGateway;
       const message = readStringParam(params, "message", { required: true });
       const timeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds") ?? 30;


### PR DESCRIPTION
## Summary

- Keep the model-facing `sessions_send` schema canonical: `message` remains required and aliases are not advertised.
- Add hidden pre-validation normalization for model-emitted body aliases: `SendMessage`, `content`, and `text`.
- Reuse the same normalization at direct execution time so manual/test callers behave the same way.
- Strip formatted-reasoning content from alias values before forwarding inter-session messages.
- Add regression coverage for visible schema shape, hidden argument preparation, direct alias execution, and formatted-reasoning sanitization.

Closes #88146.

## Real behavior proof

- **Behavior or issue addressed:** `sessions_send` accepts model-emitted body aliases without exposing those aliases in the model-facing schema. Calls with `SendMessage`, `content`, or `text` are normalized to canonical `message` before validation/execution, and formatted reasoning is stripped from alias content.
- **Real environment tested:** Local OpenClaw checkout on PR head `a053e2c904` after `pnpm install` hydrated missing dependencies.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts`; `node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts`; `pnpm exec oxfmt --write --threads=1 src/agents/tools/sessions-send-tool.ts src/agents/openclaw-tools.sessions.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts && node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts && git diff --check"`.
- **Evidence after fix:** `src/agents/openclaw-tools.sessions.test.ts` asserts `sessions_send` still exposes only canonical `message` in schema, keeps `message` required, hides `SendMessage`/`content`/`text`, prepares hidden aliases before validation, removes alias keys from prepared arguments, and sanitizes formatted reasoning.
- **Observed result after fix:** Targeted Vitest files passed (`30` and `35` tests). Autoreview reported no accepted/actionable findings and reran the same focused tests plus `git diff --check` successfully.
- **What was not tested:** Full model-driven Anthropic/Pi A2A round trip. The previous PR proof showed direct live gateway acceptance; this rewrite preserves the same direct execution behavior while additionally hiding aliases from the public schema.
- **Target test file:** `src/agents/openclaw-tools.sessions.test.ts`

## Regression Test Plan

- `node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts && node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts && git diff --check"`

## Root Cause

- **Root cause:** #84079/#84102 fixed model-generated body alias normalization for the channel `message` tool, but `sessions_send` still required the canonical `message` property at its own validation boundary. Anthropic/Pi-backed agents can emit the body as `SendMessage`, so those calls failed validation before `sessions_send` could execute. The fix now normalizes known aliases before validation while keeping the public tool schema canonical.
