### PR TITLE
fix(ios): guard websocket ping continuation

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -14,6 +14,22 @@ public protocol WebSocketTasking: AnyObject {
 
 extension URLSessionWebSocketTask: WebSocketTasking {}
 
+private final class WebSocketPingContinuationGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didResume = false
+
+    func resumeOnce(_ resume: () -> Void) {
+        self.lock.lock()
+        if self.didResume {
+            self.lock.unlock()
+            return
+        }
+        self.didResume = true
+        self.lock.unlock()
+        resume()
+    }
+}
+
 public struct WebSocketTaskBox: @unchecked Sendable {
     public let task: any WebSocketTasking
     public init(task: any WebSocketTasking) {
@@ -48,8 +64,13 @@ public struct WebSocketTaskBox: @unchecked Sendable {
 
     public func sendPing() async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let gate = WebSocketPingContinuationGate()
             self.task.sendPing { error in
-                ThrowingContinuationSupport.resumeVoid(continuation, error: error)
+                // URLSession can race ping callbacks with cancellation; only the first
+                // pong result owns this checked continuation or Swift traps the app.
+                gate.resumeOnce {
+                    ThrowingContinuationSupport.resumeVoid(continuation, error: error)
+                }
             }
         }
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -11,6 +11,42 @@ private extension NSLock {
     }
 }
 
+private final class DoubleCallbackPingWebSocketTask: WebSocketTasking, @unchecked Sendable {
+    private let callbacks: [Error?]
+
+    init(callbacks: [Error?]) {
+        self.callbacks = callbacks
+    }
+
+    var state: URLSessionTask.State { .running }
+
+    func resume() {}
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        _ = (closeCode, reason)
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        _ = message
+    }
+
+    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
+        for callback in self.callbacks {
+            pongReceiveHandler(callback)
+        }
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        throw URLError(.badServerResponse)
+    }
+
+    func receive(
+        completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)
+    {
+        completionHandler(.failure(URLError(.badServerResponse)))
+    }
+}
+
 private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Sendable {
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
@@ -193,6 +229,25 @@ private actor SeqGapProbe {
 
 @Suite(.serialized)
 struct GatewayNodeSessionTests {
+    @Test
+    func websocketPingIgnoresDuplicateSuccessCallbacks() async throws {
+        let task = DoubleCallbackPingWebSocketTask(callbacks: [nil, nil])
+        try await WebSocketTaskBox(task: task).sendPing()
+    }
+
+    @Test
+    func websocketPingIgnoresDuplicateCallbacksAfterFirstError() async throws {
+        let firstError = URLError(.networkConnectionLost)
+        let task = DoubleCallbackPingWebSocketTask(callbacks: [firstError, nil])
+
+        do {
+            try await WebSocketTaskBox(task: task).sendPing()
+            Issue.record("sendPing unexpectedly succeeded")
+        } catch let error as URLError {
+            #expect(error.code == firstError.code)
+        }
+    }
+
     @Test
     func scannedSetupCodePrefersBootstrapAuthOverStoredDeviceToken() async throws {
         let tempDir = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary

- Guard iOS/macOS WebSocket ping continuations so duplicate ping callbacks cannot resume a checked continuation twice.
- Add regression coverage for duplicate success callbacks and error-first duplicate callbacks.

## Verification

- `cd apps/shared/OpenClawKit && swift test --filter GatewayNodeSessionTests/websocketPingIgnoresDuplicateSuccessCallbacks` (reproduced pre-fix crash: `SWIFT TASK CONTINUATION MISUSE: sendPing() tried to resume its continuation more than once`)
- `cd apps/shared/OpenClawKit && swift test --filter GatewayNodeSessionTests/websocketPingIgnoresDuplicateSuccessCallbacks`
- `cd apps/shared/OpenClawKit && swift test --filter GatewayNodeSessionTests/websocketPingIgnoresDuplicateCallbacksAfterFirstError`
- `cd apps/shared/OpenClawKit && swift test --filter GatewayNodeSessionTests`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Latest shared App Store Connect TestFlight crash (`2026-05-30`, build `2026.5.25 (4)`) showed `EXC_BREAKPOINT` from `CheckedContinuation.resume(throwing:)` via `WebSocketTaskBox.sendPing()` / `ThrowingContinuationSupport.resumeVoid`.

Real environment tested: Local macOS Swift Package test runner for `apps/shared/OpenClawKit` on branch `fix/ios-websocket-ping-continuation-crash`.

Exact steps or command run after this patch: `cd apps/shared/OpenClawKit && swift test --filter GatewayNodeSessionTests`.

Evidence after fix: Regression tests simulate duplicate WebSocket ping callbacks; the full `GatewayNodeSessionTests` suite passed with 14 tests.

Observed result after fix: Duplicate ping callbacks no longer trap from checked-continuation double resume; first callback result wins.

What was not tested: A live iOS TestFlight build against App Store Connect crash reporting was not run for this branch.
