### PR TITLE
fix(models): prefer exact configured provider refs before aliases

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -53,6 +53,17 @@ type ModelAliasCandidate = {
   alias: string;
 };
 
+type ExactConfiguredProviderRefParts = {
+  configuredProvider: string;
+  modelRaw: string;
+};
+
+function hasSlashFormModelRef(raw: string): boolean {
+  const trimmed = raw.trim();
+  const slash = trimmed.indexOf("/");
+  return slash > 0 && slash < trimmed.length - 1;
+}
+
 function resolveManifestPluginsForModelIdNormalization(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
@@ -384,7 +395,10 @@ function parseModelRefWithCompatAlias(
   );
 }
 
-function findExactConfiguredProviderRefParts(params: { cfg?: OpenClawConfig; raw: string }) {
+function findExactConfiguredProviderRefParts(params: {
+  cfg?: OpenClawConfig;
+  raw: string;
+}): ExactConfiguredProviderRefParts | null {
   const slash = params.raw.indexOf("/");
   if (slash <= 0 || !params.cfg?.models?.providers) {
     return null;
@@ -411,22 +425,13 @@ function findExactConfiguredProviderRefParts(params: { cfg?: OpenClawConfig; raw
   return { configuredProvider, modelRaw };
 }
 
-function resolveExactConfiguredProviderRef(
+function normalizeExactConfiguredProviderRef(
+  parts: ExactConfiguredProviderRefParts,
   params: {
-    cfg?: OpenClawConfig;
-    raw: string;
     allowManifestNormalization?: boolean;
-    allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
-): ModelRef | null {
-  const exactConfigured = findExactConfiguredProviderRefParts({
-    cfg: params.cfg,
-    raw: params.raw,
-  });
-  if (!exactConfigured) {
-    return null;
-  }
-  const { configuredProvider, modelRaw } = exactConfigured;
+): ModelRef {
+  const { configuredProvider, modelRaw } = parts;
   const provider = normalizeLowercaseStringOrEmpty(configuredProvider);
   return {
     provider,
@@ -442,6 +447,24 @@ function resolveExactConfiguredProviderRef(
       },
     ),
   };
+}
+
+function resolveExactConfiguredProviderRef(
+  params: {
+    cfg?: OpenClawConfig;
+    raw: string;
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
+  } & ModelManifestNormalizationContext,
+): ModelRef | null {
+  const exactConfigured = findExactConfiguredProviderRefParts({
+    cfg: params.cfg,
+    raw: params.raw,
+  });
+  if (!exactConfigured) {
+    return null;
+  }
+  return normalizeExactConfiguredProviderRef(exactConfigured, params);
 }
 
 export function resolveAllowlistModelKey(
@@ -698,30 +721,54 @@ export function resolveConfiguredModelRef(
     const trimmed = rawModel.trim();
     const { model: modelWithoutProfile } = splitTrailingAuthProfile(trimmed);
     const manifestPluginContext = createModelManifestPluginContext(params);
-    const exactConfiguredPrimaryRaw = modelWithoutProfile || trimmed;
-    if (
-      findExactConfiguredProviderRefParts({
+    const primaryWithoutProfile = modelWithoutProfile || trimmed;
+    const exactConfiguredPrimary = findExactConfiguredProviderRefParts({
+      cfg: params.cfg,
+      raw: primaryWithoutProfile,
+    });
+    if (exactConfiguredPrimary) {
+      return normalizeExactConfiguredProviderRef(exactConfiguredPrimary, {
+        allowManifestNormalization: params.allowManifestNormalization,
+        manifestPlugins: manifestPluginContext.get(),
+      });
+    }
+    const profileStripped = Boolean(modelWithoutProfile && modelWithoutProfile !== trimmed);
+    const exactAliasCandidate = findModelAliasCandidate(params.cfg, trimmed);
+    if (profileStripped && exactAliasCandidate) {
+      const aliasRef = parseModelRefWithCompatAlias({
         cfg: params.cfg,
-        raw: exactConfiguredPrimaryRaw,
-      })
-    ) {
-      const exactConfiguredPrimary = resolveExactConfiguredProviderRef({
-        cfg: params.cfg,
-        raw: exactConfiguredPrimaryRaw,
+        raw: exactAliasCandidate.keyRaw,
+        defaultProvider: params.defaultProvider,
         allowManifestNormalization: params.allowManifestNormalization,
         allowPluginNormalization: params.allowPluginNormalization,
         manifestPlugins: manifestPluginContext.get(),
       });
-      if (exactConfiguredPrimary) {
-        return exactConfiguredPrimary;
+      if (aliasRef) {
+        return aliasRef;
       }
     }
-    const aliasCandidate =
-      findModelAliasCandidate(params.cfg, trimmed) ??
-      (modelWithoutProfile && modelWithoutProfile !== trimmed
-        ? findModelAliasCandidate(params.cfg, modelWithoutProfile)
-        : undefined);
+    const strippedAliasCandidate = profileStripped
+      ? findModelAliasCandidate(params.cfg, modelWithoutProfile)
+      : undefined;
+    const aliasCandidate = exactAliasCandidate ?? strippedAliasCandidate;
     const manifestPlugins = manifestPluginContext.peek();
+    if (
+      aliasCandidate &&
+      hasSlashFormModelRef(primaryWithoutProfile) &&
+      !hasSlashFormModelRef(aliasCandidate.keyRaw)
+    ) {
+      const primaryRef = parseModelRefWithCompatAlias({
+        cfg: params.cfg,
+        raw: primaryWithoutProfile,
+        defaultProvider: params.defaultProvider,
+        allowManifestNormalization: params.allowManifestNormalization,
+        allowPluginNormalization: params.allowPluginNormalization,
+        manifestPlugins: manifestPluginContext.get(),
+      });
+      if (primaryRef) {
+        return primaryRef;
+      }
+    }
     if (aliasCandidate) {
       const aliasRef = parseModelRefWithCompatAlias({
         cfg: params.cfg,

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -723,10 +723,16 @@ export function resolveConfiguredModelRef(
     const manifestPluginContext = createModelManifestPluginContext(params);
     const profileStripped = Boolean(modelWithoutProfile && modelWithoutProfile !== trimmed);
     const exactAliasCandidate = findModelAliasCandidate(params.cfg, trimmed);
-    if (profileStripped && exactAliasCandidate) {
+    const strippedAliasCandidate = profileStripped
+      ? findModelAliasCandidate(params.cfg, modelWithoutProfile)
+      : undefined;
+    const profileAliasCandidate = profileStripped
+      ? (exactAliasCandidate ?? strippedAliasCandidate)
+      : undefined;
+    if (profileAliasCandidate) {
       const aliasRef = parseModelRefWithCompatAlias({
         cfg: params.cfg,
-        raw: exactAliasCandidate.keyRaw,
+        raw: profileAliasCandidate.keyRaw,
         defaultProvider: params.defaultProvider,
         allowManifestNormalization: params.allowManifestNormalization,
         allowPluginNormalization: params.allowPluginNormalization,
@@ -747,10 +753,7 @@ export function resolveConfiguredModelRef(
         manifestPlugins: manifestPluginContext.get(),
       });
     }
-    const strippedAliasCandidate = profileStripped
-      ? findModelAliasCandidate(params.cfg, modelWithoutProfile)
-      : undefined;
-    const aliasCandidate = exactAliasCandidate ?? strippedAliasCandidate;
+    const aliasCandidate = profileStripped ? undefined : exactAliasCandidate;
     const manifestPlugins = manifestPluginContext.peek();
     if (
       aliasCandidate &&

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -384,14 +384,7 @@ function parseModelRefWithCompatAlias(
   );
 }
 
-function resolveExactConfiguredProviderRef(
-  params: {
-    cfg?: OpenClawConfig;
-    raw: string;
-    allowManifestNormalization?: boolean;
-    allowPluginNormalization?: boolean;
-  } & ModelManifestNormalizationContext,
-): ModelRef | null {
+function findExactConfiguredProviderRefParts(params: { cfg?: OpenClawConfig; raw: string }) {
   const slash = params.raw.indexOf("/");
   if (slash <= 0 || !params.cfg?.models?.providers) {
     return null;
@@ -415,6 +408,25 @@ function resolveExactConfiguredProviderRef(
   if (!apiOwner || apiOwner === normalizedConfiguredProvider) {
     return null;
   }
+  return { configuredProvider, modelRaw };
+}
+
+function resolveExactConfiguredProviderRef(
+  params: {
+    cfg?: OpenClawConfig;
+    raw: string;
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
+  } & ModelManifestNormalizationContext,
+): ModelRef | null {
+  const exactConfigured = findExactConfiguredProviderRefParts({
+    cfg: params.cfg,
+    raw: params.raw,
+  });
+  if (!exactConfigured) {
+    return null;
+  }
+  const { configuredProvider, modelRaw } = exactConfigured;
   const provider = normalizeLowercaseStringOrEmpty(configuredProvider);
   return {
     provider,
@@ -686,6 +698,24 @@ export function resolveConfiguredModelRef(
     const trimmed = rawModel.trim();
     const { model: modelWithoutProfile } = splitTrailingAuthProfile(trimmed);
     const manifestPluginContext = createModelManifestPluginContext(params);
+    const exactConfiguredPrimaryRaw = modelWithoutProfile || trimmed;
+    if (
+      findExactConfiguredProviderRefParts({
+        cfg: params.cfg,
+        raw: exactConfiguredPrimaryRaw,
+      })
+    ) {
+      const exactConfiguredPrimary = resolveExactConfiguredProviderRef({
+        cfg: params.cfg,
+        raw: exactConfiguredPrimaryRaw,
+        allowManifestNormalization: params.allowManifestNormalization,
+        allowPluginNormalization: params.allowPluginNormalization,
+        manifestPlugins: manifestPluginContext.get(),
+      });
+      if (exactConfiguredPrimary) {
+        return exactConfiguredPrimary;
+      }
+    }
     const aliasCandidate =
       findModelAliasCandidate(params.cfg, trimmed) ??
       (modelWithoutProfile && modelWithoutProfile !== trimmed

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -721,17 +721,6 @@ export function resolveConfiguredModelRef(
     const trimmed = rawModel.trim();
     const { model: modelWithoutProfile } = splitTrailingAuthProfile(trimmed);
     const manifestPluginContext = createModelManifestPluginContext(params);
-    const primaryWithoutProfile = modelWithoutProfile || trimmed;
-    const exactConfiguredPrimary = findExactConfiguredProviderRefParts({
-      cfg: params.cfg,
-      raw: primaryWithoutProfile,
-    });
-    if (exactConfiguredPrimary) {
-      return normalizeExactConfiguredProviderRef(exactConfiguredPrimary, {
-        allowManifestNormalization: params.allowManifestNormalization,
-        manifestPlugins: manifestPluginContext.get(),
-      });
-    }
     const profileStripped = Boolean(modelWithoutProfile && modelWithoutProfile !== trimmed);
     const exactAliasCandidate = findModelAliasCandidate(params.cfg, trimmed);
     if (profileStripped && exactAliasCandidate) {
@@ -746,6 +735,17 @@ export function resolveConfiguredModelRef(
       if (aliasRef) {
         return aliasRef;
       }
+    }
+    const primaryWithoutProfile = modelWithoutProfile || trimmed;
+    const exactConfiguredPrimary = findExactConfiguredProviderRefParts({
+      cfg: params.cfg,
+      raw: primaryWithoutProfile,
+    });
+    if (exactConfiguredPrimary) {
+      return normalizeExactConfiguredProviderRef(exactConfiguredPrimary, {
+        allowManifestNormalization: params.allowManifestNormalization,
+        manifestPlugins: manifestPluginContext.get(),
+      });
     }
     const strippedAliasCandidate = profileStripped
       ? findModelAliasCandidate(params.cfg, modelWithoutProfile)

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -2039,6 +2039,38 @@ describe("model-selection", () => {
       expect(result).toEqual({ provider: "openai", model: "gpt-5.5" });
     });
 
+    it("prefers exact auth-profile aliases before configured-provider stripping", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "nemotron-bolt/nemotron-3-super-120b@prod" },
+            models: {
+              "openai/gpt-5.5": {
+                alias: "nemotron-bolt/nemotron-3-super-120b@prod",
+              },
+            },
+          },
+        },
+        models: {
+          providers: {
+            "nemotron-bolt": {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [{ id: "nemotron-3-super-120b", name: "Nemotron" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+      });
+
+      expect(result).toEqual({ provider: "openai", model: "gpt-5.5" });
+    });
+
     it("resolves provider-qualified defaults without normalizing every aliasless configured model", () => {
       providerModelNormalizationMock.normalizeProviderModelIdWithRuntime.mockClear();
       const models = Object.fromEntries(

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -2071,6 +2071,41 @@ describe("model-selection", () => {
       expect(result).toEqual({ provider: "openai", model: "gpt-5.5" });
     });
 
+    it("prefers stripped auth-profile aliases before configured-provider stripping", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "nemotron-bolt/nemotron-3-super-120b@prod" },
+            models: {
+              "openai/nemotron-bolt/nemotron-3-super-120b": {
+                alias: "nemotron-bolt/nemotron-3-super-120b",
+              },
+            },
+          },
+        },
+        models: {
+          providers: {
+            "nemotron-bolt": {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [{ id: "nemotron-3-super-120b", name: "Nemotron" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+      });
+
+      expect(result).toEqual({
+        provider: "openai",
+        model: "nemotron-bolt/nemotron-3-super-120b",
+      });
+    });
+
     it("resolves provider-qualified defaults without normalizing every aliasless configured model", () => {
       providerModelNormalizationMock.normalizeProviderModelIdWithRuntime.mockClear();
       const models = Object.fromEntries(

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1888,6 +1888,65 @@ describe("model-selection", () => {
       });
     });
 
+    it("keeps exact configured provider refs before slash-form alias values that point to them", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "nemotron-bolt/nemotron-3-super-120b" },
+            models: {
+              "openai/nemotron-bolt/nemotron-3-super-120b": {
+                alias: "nemotron-bolt/nemotron-3-super-120b",
+              },
+            },
+          },
+        },
+        models: {
+          providers: {
+            "nemotron-bolt": {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [{ id: "nemotron-3-super-120b", name: "Nemotron" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+      });
+
+      expect(result).toEqual({
+        provider: "nemotron-bolt",
+        model: "nemotron-3-super-120b",
+      });
+    });
+
+    it("keeps built-in provider refs before bare alias values that point to them", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+            models: {
+              opus: { alias: "anthropic/claude-opus-4-6" },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+      });
+
+      expect(result).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+    });
+
     it("prefers slash-form aliases for configured default models", () => {
       const cfg = {
         agents: {
@@ -1942,6 +2001,29 @@ describe("model-selection", () => {
             models: {
               "openai/gpt-5.5": {
                 alias: "gpt@prod",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+      });
+
+      expect(result).toEqual({ provider: "openai", model: "gpt-5.5" });
+    });
+
+    it("prefers exact slash-form aliases before stripping auth-profile suffixes", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6@prod" },
+            models: {
+              "openai/gpt-5.5": {
+                alias: "anthropic/claude-opus-4-6@prod",
               },
             },
           },

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1855,6 +1855,39 @@ describe("model-selection", () => {
       });
     });
 
+    it("keeps exact configured provider refs before alias values that point to them", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "nemotron-bolt/nemotron-3-super-120b" },
+            models: {
+              nemotron: { alias: "nemotron-bolt/nemotron-3-super-120b" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            "nemotron-bolt": {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [{ id: "nemotron-3-super-120b", name: "Nemotron" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+      });
+
+      expect(result).toEqual({
+        provider: "nemotron-bolt",
+        model: "nemotron-3-super-120b",
+      });
+    });
+
     it("prefers slash-form aliases for configured default models", () => {
       const cfg = {
         agents: {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes model default resolution when agents.defaults.models contains an alias whose value is the same fully qualified custom provider ref used as agents.defaults.model.primary.
- Before this change, a primary such as nemotron-bolt/nemotron-3-super-120b could be reverse-matched through alias key nemotron and collapse to openai/nemotron.
- The fix makes exact configured custom provider refs authoritative before alias-value reverse matching.
- Also updates the Crabbox wrapper tests that failed in CI after the repo default provider moved to Azure, so those tests explicitly exercise the non-Azure configured-provider path they assert.

Why does this matter now?

- Issue #88218 reports this as a current 5.x regression that can make valid custom-provider configs fail at gateway startup with Unknown model: openai/<alias-key>.
- The failure points users at a model they did not configure, making diagnosis harder during upgrades.

What is the intended outcome?

- Direct use of a configured custom provider ref resolves to that provider/model.
- Alias behavior still works when the user actually selects the alias.
- Existing slash-form alias behavior remains covered by existing tests.

What is intentionally out of scope?

- No schema changes.
- No new model alias configuration surface.
- No provider catalog or runtime auth changes.

What does success look like?

- The issue repro resolves to nemotron-bolt/nemotron-3-super-120b instead of openai/nemotron.
- Existing model-selection tests continue to pass.
- The previously failing crabbox-wrapper CI tests pass under the current Azure default.

What should reviewers focus on?

- The precedence change in resolveConfiguredModelRef.
- Whether the exact configured provider check is narrow enough to preserve current alias behavior.
- The small test-only Crabbox wrapper update, which now sets CRABBOX_PROVIDER=aws for tests that intentionally assert the non-Azure configured-provider path.

## Linked context

Which issue does this close?

Closes #88218

Which issues, PRs, or discussions are related?

Related #88218

Was this requested by a maintainer or owner?

- Picked from the open issue queue as a source-reproducible, queueable fix candidate.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: exact configured custom provider refs were being reverse-matched by agents.defaults.models alias values before the ref itself was parsed.
- Real environment tested: local OpenClaw source checkout on Linux with Node/pnpm, running the actual resolver implementation from src/agents/model-selection.ts.
- Exact steps or command run after this patch:

    COREPACK_HOME=/tmp/corepack pnpm exec tsx -e '
    import { resolveConfiguredModelRef } from "./src/agents/model-selection.ts";
    const cfg = {
      agents: { defaults: { model: { primary: "nemotron-bolt/nemotron-3-super-120b" }, models: { nemotron: { alias: "nemotron-bolt/nemotron-3-super-120b" } } } },
      models: { providers: { "nemotron-bolt": { api: "openai-completions", baseUrl: "http://127.0.0.1:8080/v1", models: [{ id: "nemotron-3-super-120b", name: "Nemotron" }] } } },
    };
    console.log(JSON.stringify(resolveConfiguredModelRef({ cfg: cfg as any, defaultProvider: "openai", defaultModel: "gpt-5.4" })));
    '

- Evidence after fix: Terminal console output copied from the command above:

    {"provider":"nemotron-bolt","model":"nemotron-3-super-120b"}

- Observed result after fix: the configured primary resolves to the custom provider/model instead of openai/nemotron.
- What was not tested: a live gateway boot with a real self-hosted Nemotron backend.
- Proof limitations or environment constraints: the issue is deterministic in the resolver and does not require contacting the model provider; the proof executes the production resolver path directly rather than starting a full gateway.
- Before evidence (optional but encouraged): the added regression test failed before the implementation with Received { provider: "openai", model: "nemotron" }.

## Tests and validation

Which commands did you run?

    COREPACK_HOME=/tmp/corepack pnpm exec tsx -e '...resolver repro command above...'
    COREPACK_HOME=/tmp/corepack node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/model-selection.test.ts -t "keeps exact configured provider refs" --reporter=verbose
    COREPACK_HOME=/tmp/corepack node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/model-selection.test.ts --reporter=verbose
    COREPACK_HOME=/tmp/corepack node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/crabbox-wrapper.test.ts -t "configured non-Azure provider" --reporter=verbose
    COREPACK_HOME=/tmp/corepack node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/crabbox-wrapper.test.ts --reporter=verbose
    git diff --check

What regression coverage was added or updated?

- Added a focused resolveConfiguredModelRef regression test for an exact custom provider primary whose configured alias value points at the same ref.
- Updated two Crabbox wrapper tests so the tests explicitly set CRABBOX_PROVIDER=aws when they assert the non-Azure configured-provider path.

What failed before this fix, if known?

- The new model-selection regression test failed before the resolver change, returning openai/nemotron instead of nemotron-bolt/nemotron-3-super-120b.
- CI build-artifacts also failed in test/scripts/crabbox-wrapper.test.ts because two tests expected the configured provider to be AWS while the current repo config defaults to Azure.

If no test was added, why not?

- A test was added for the model-resolution regression, and failing CI tests were corrected.

## Risk checklist

Did user-visible behavior change? (Yes/No)

Yes.

Did config, environment, or migration behavior change? (Yes/No)

No migration or environment change. Existing config resolution behavior changes for the reported alias-target collision.

Did security, auth, secrets, network, or tool execution behavior change? (Yes/No)

No.

What is the highest-risk area?

- Model alias precedence: preserving existing slash-form alias and explicit alias behavior while fixing exact configured provider refs.
- Keeping the Crabbox wrapper test update scoped to tests only.

How is that risk mitigated?

- The model-resolution change is limited to exact configured custom provider refs.
- Existing slash-form alias tests still pass.
- The full src/agents/model-selection.test.ts suite passes.
- The full test/scripts/crabbox-wrapper.test.ts suite passes.

## Current review state

What is the next action?

- CI rerun and reviewer feedback.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on CI/review. The PR body was updated with after-fix terminal console output for the real behavior proof gate.

Which bot or reviewer comments were addressed?

- Initial PR body was rewritten to follow the repository PR template.
- Real behavior proof gate failure was addressed by adding explicit terminal console output evidence.
- build-artifacts failure was addressed by updating the two affected Crabbox wrapper tests.
