### PR TITLE
feat(ios): refresh app store metadata

### DIFF
--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -5,6 +5,8 @@
 Maintenance update for the current OpenClaw release.
 
 - Added hosted push relay defaults, realtime Talk playback, and safer WebSocket ping handling for mobile sessions.
+- Updated App Store screenshots to cover Gateway pairing, Command, Chat, Talk, Agent, and Settings flows.
+- Highlighted realtime Talk relay, Gateway connection status, node capabilities, push wake, and privacy controls.
 
 ## 2026.5.28 - 2026-05-28
 

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -29,6 +29,14 @@ def clear_empty_env_var(key)
   ENV.delete(key) unless env_present?(ENV[key])
 end
 
+def screenshot_upload_requested?
+  ENV["DELIVER_SCREENSHOTS"] == "1"
+end
+
+def screenshot_paths
+  Dir[File.join(__dir__, "screenshots", "**", "*.png")]
+end
+
 def maybe_decode_hex_keychain_secret(value)
   return value unless env_present?(value)
 
@@ -314,6 +322,7 @@ platform :ios do
   desc "Upload App Store metadata (and optionally screenshots)"
   lane :metadata do
     sync_ios_versioning!
+    version_metadata = read_ios_version_metadata
     api_key = asc_api_key
     clear_empty_env_var("APP_STORE_CONNECT_API_KEY_PATH")
     app_identifier = ENV["ASC_APP_IDENTIFIER"]
@@ -321,11 +330,21 @@ platform :ios do
     app_identifier = nil unless env_present?(app_identifier)
     app_id = nil unless env_present?(app_id)
 
+    if screenshot_upload_requested? && screenshot_paths.empty?
+      UI.user_error!("DELIVER_SCREENSHOTS=1 but no PNG screenshots were found under apps/ios/fastlane/screenshots.")
+    end
+
     deliver_options = {
       api_key: api_key,
       force: true,
-      skip_screenshots: ENV["DELIVER_SCREENSHOTS"] != "1",
+      app_version: version_metadata[:short_version],
+      copyright: "2026 OpenClaw",
+      primary_category: "PRODUCTIVITY",
+      secondary_category: "UTILITIES",
+      skip_screenshots: !screenshot_upload_requested?,
       skip_metadata: ENV["DELIVER_METADATA"] != "1",
+      skip_binary_upload: true,
+      overwrite_screenshots: screenshot_upload_requested?,
       run_precheck_before_submit: false
     }
     deliver_options[:app_identifier] = app_identifier if app_identifier

--- a/apps/ios/fastlane/metadata/en-US/description.txt
+++ b/apps/ios/fastlane/metadata/en-US/description.txt
@@ -1,18 +1,19 @@
 OpenClaw is a personal AI assistant you run on your own devices.
 
-Pair this iPhone app with your OpenClaw Gateway to connect your phone as a secure node for voice, camera, and device automation.
+Pair this iPhone app with your OpenClaw Gateway to use your phone as a secure node for chat, voice, approvals, sharing, and device-aware automation.
 
 What you can do:
+- Pair with your private OpenClaw Gateway by QR code or setup code
 - Chat with your assistant from iPhone
-- Use voice wake and push-to-talk
-- Capture photos and short clips on request
-- Record screen snippets for troubleshooting and workflows
+- Use realtime Talk mode and push-to-talk
+- Review Gateway action approvals from your phone
 - Share text, links, and media directly from iOS into OpenClaw
-- Run location-aware and device-aware automations
+- Enable device capabilities such as camera, screen, location, photos, contacts, calendar, and reminders when you choose
+- Receive push wakes and node status updates for connected workflows
 
-OpenClaw is local-first: you control your gateway, keys, and configuration.
+OpenClaw is local-first: you control your gateway, keys, configuration, and permissions. Device access is managed by iOS permissions and can be enabled only for the capabilities you want to use.
 
 Getting started:
 1) Set up your OpenClaw Gateway
 2) Open the iOS app and pair with your gateway
-3) Start using commands and automations from your phone
+3) Start using chat, Talk mode, approvals, and automations from your phone

--- a/apps/ios/fastlane/metadata/en-US/keywords.txt
+++ b/apps/ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-openclaw,ai assistant,local ai,voice assistant,automation,gateway,chat,agent,node
+openclaw,ai assistant,local ai,iphone ai,voice assistant,automation,gateway,chat,agent

--- a/apps/ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/apps/ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Run OpenClaw from your iPhone: pair with your own gateway, trigger automations, and use voice, camera, and share actions.
+Pair your iPhone with your OpenClaw Gateway for chat, realtime voice, approvals, device capabilities, and private automation.

--- a/apps/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/apps/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,3 +1,5 @@
 Maintenance update for the current OpenClaw release.
 
 - Added hosted push relay defaults, realtime Talk playback, and safer WebSocket ping handling for mobile sessions.
+- Updated App Store screenshots to cover Gateway pairing, Command, Chat, Talk, Agent, and Settings flows.
+- Highlighted realtime Talk relay, Gateway connection status, node capabilities, push wake, and privacy controls.

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -7,7 +7,7 @@ read_when:
 title: "iOS app"
 ---
 
-Availability: internal preview. The iOS app is not publicly distributed yet.
+Availability: iPhone app builds are distributed through Apple channels when enabled for a release. Local development builds can also run from source.
 
 ## What it does
 


### PR DESCRIPTION
## Summary

- Add a deterministic iOS screenshot sample flow for App Store captures, including real tab-bar screenshots for Command, Chat, Talk, Agent, and Settings.
- Refresh iOS App Store metadata, release notes, keywords, and support-doc availability wording for the current iOS release.
- Harden the Fastlane metadata lane so it targets the pinned iOS version, skips binary upload, sets category/copyright metadata, and only overwrites screenshots after local PNG assets are present.

## Verification

- `ruby -c apps/ios/fastlane/Fastfile`
- `pnpm ios:version:check`
- `pnpm format:docs:check docs/platforms/ios.md`
- `git diff --check`
- `cd apps/ios && swiftlint lint --config .swiftlint.yml Sources/Design/ScreenshotSampleScreens.swift Sources/RootTabs.swift`
- `cd apps/ios && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -configuration Debug build`
- `DELIVER_METADATA=1 DELIVER_SCREENSHOTS=1 fastlane ios metadata`
- ASC recheck confirmed version `2026.5.28`, metadata, copyright, and six iPhone 6.7 screenshots.
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean

## Real behavior proof

Behavior addressed: refreshed App Store Connect metadata and iOS screenshot assets for the current iOS release.
Real environment tested: local macOS/Xcode iPhone 17 Pro Max simulator and App Store Connect via Fastlane API key auth.
Exact steps or command run after this patch: `DELIVER_METADATA=1 DELIVER_SCREENSHOTS=1 fastlane ios metadata`; simulator screenshot capture with `--openclaw-screenshot-flow`; ASC summary recheck.
Evidence after fix: App Store Connect edit version is `2026.5.28` and the iPhone 6.7 screenshot set contains exactly `01-onboarding.png`, `02-command.png`, `03-chat.png`, `04-talk.png`, `05-agent.png`, and `06-settings.png`.
Observed result after fix: metadata and screenshots uploaded successfully; release notes are generated locally but ASC skipped release notes because it treats this as the first app version.
What was not tested: App Store review submission and binary upload.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted pi session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details

[user]
we need to create new iOS screenshots for the iOS app - can you please spec and plan how to do.
Also go over current app store connect information and see if it needs updating

[assistant]
I checked the repo metadata and live App Store Connect state, identified stale ASC version metadata, old screenshots, generic release notes, docs wording mismatch, and blank category metadata. I proposed a raw in-app screenshot plan covering onboarding, command, chat, talk, settings, and agent/node flows, with `1320x2868` assets under `apps/ios/fastlane/screenshots/en-US/`.

[user]
let's do raw inapp screenshots - take all sample flows
capture with simulator and control the conent
verify assets

[assistant]
Created deterministic screenshot sample-flow launch support and generated six App Store screenshots:
- `01-onboarding.png`
- `02-command.png`
- `03-chat.png`
- `04-talk.png`
- `05-agent.png`
- `06-settings.png`

Verified PNG format, `1320x2868` dimensions, visual output, Debug build, SwiftLint, and `git diff --check`.

[user]
why are the screenshots without the bottom nav bar?

[assistant]
Explained that the first implementation bypassed the real `TabView` with a screenshot-only root view, which removed the bottom nav. Proposed keeping `RootTabs` / `TabView` active and recapturing real app tab screenshots.

[user]
no no - let's use real app screens

[assistant]
Switched app tab flows to render inside the real `TabView`, with the bottom nav visible for Command, Chat, Talk, Agent, and Settings. Onboarding remained full-screen. Recaptured and verified all six screenshots.

[user]
What is the OpenClaw command center in the screenshot?

[assistant]
Explained that “OpenClaw Command Center” was sample/demo copy and recommended renaming it to match real app language, such as `Gateway`.

[user]
yes let's do that - rename to match actual screens

[assistant]
Renamed screenshot copy from `OpenClaw Command Center` to `Gateway`, recaptured all screenshots, and reverified PNG dimensions, build, SwiftLint, and `git diff --check`.

[user]
okay continue to update the metadata

[assistant]
Updated local metadata and App Store Connect:
- Updated description, promotional text, keywords, changelog, release notes, Fastlane lane, and iOS docs wording.
- Updated ASC version to `[REDACTED_VERSION]`.
- Uploaded metadata.
- Set copyright to `2026 OpenClaw`.
- Set categories to `PRODUCTIVITY` and `UTILITIES`.
- Replaced ASC screenshots cleanly with six iPhone 6.7 screenshots.
- Fixed Fastlane metadata lane to pass `app_version`, skip binary upload, and safely overwrite screenshots only when requested.

Validation included:
- `DELIVER_METADATA=1 DELIVER_SCREENSHOTS=1 fastlane ios metadata`
- ASC recheck confirming version, copyright, promo text, and six screenshots
- `pnpm ios:version:check`
- `pnpm format:docs:check docs/platforms/ios.md`
- `git diff --check`

[user]
commit and push changes to a branch

[assistant]
Committed and pushed:
- Branch: `ios-app-store-screenshots-metadata`
- Commit: `c574b0181b feat(ios): refresh app store metadata`
- Pushed to `origin/ios-app-store-screenshots-metadata`

Validation before commit:
- `ruby -c apps/ios/fastlane/Fastfile`
- `pnpm ios:version:check`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean
````

</details>
<!-- agent-transcript:end -->
