### PR TITLE
fix(plugins): ignore helper files in extension roots

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -326,6 +326,8 @@ Use `--link` to avoid copying a local directory (adds to `plugins.load.paths`):
 openclaw plugins install -l ./my-plugin
 ```
 
+Standalone plugin files must be listed in `plugins.load.paths` rather than placed directly in `~/.openclaw/extensions` or `<workspace>/.openclaw/extensions`. Those auto-discovered roots load plugin package or bundle directories, while top-level script files are treated as local helpers and skipped.
+
 <Note>
 `--force` is not supported with `--link` because linked installs reuse the source path instead of copying over a managed install target.
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -214,7 +214,8 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
 }
 ```
 
-- Loaded from `~/.openclaw/extensions`, `<workspace>/.openclaw/extensions`, plus `plugins.load.paths`.
+- Loaded from package or bundle directories under `~/.openclaw/extensions` and `<workspace>/.openclaw/extensions`, plus files or directories listed in `plugins.load.paths`.
+- Put standalone plugin files in `plugins.load.paths`; auto-discovered extension roots ignore top-level `.js`, `.mjs`, and `.ts` files so helper scripts in those roots do not block startup.
 - Discovery accepts native OpenClaw plugins plus compatible Codex bundles and Claude bundles, including manifestless Claude default-layout bundles.
 - **Config changes require a gateway restart.**
 - `allow`: optional allowlist (only listed plugins load). `deny` wins.

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -963,6 +963,22 @@ describe("config plugin validation", () => {
     });
   });
 
+  it("ignores standalone helper scripts in auto-discovered global extensions", async () => {
+    const helperPath = path.join(suiteHome, ".openclaw", "extensions", "my-helper.mjs");
+    await mkdirSafe(path.dirname(helperPath));
+    await fs.writeFile(helperPath, "export default {};\n", "utf-8");
+    try {
+      const res = validateInSuite({
+        agents: { list: [{ id: "openclaw" }] },
+        plugins: { enabled: true },
+      });
+
+      expect(res.ok).toBe(true);
+    } finally {
+      await fs.rm(helperPath, { force: true });
+    }
+  });
+
   it("surfaces plugin config diagnostics", () => {
     const res = validateInSuite({
       agents: { list: [{ id: "openclaw" }] },

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -470,16 +470,35 @@ describe("discoverOpenClawPlugins", () => {
     const stateDir = makeTempDir();
     const workspaceDir = path.join(stateDir, "workspace");
 
-    const globalExt = path.join(stateDir, "extensions");
-    mkdirSafe(globalExt);
-    fs.writeFileSync(path.join(globalExt, "alpha.ts"), "export default function () {}", "utf-8");
-
-    const workspaceExt = path.join(workspaceDir, ".openclaw", "extensions");
-    mkdirSafe(workspaceExt);
-    fs.writeFileSync(path.join(workspaceExt, "beta.ts"), "export default function () {}", "utf-8");
+    createPackagePluginWithEntry({
+      packageDir: path.join(stateDir, "extensions", "alpha"),
+      packageName: "@openclaw/alpha",
+      pluginId: "alpha",
+    });
+    createPackagePluginWithEntry({
+      packageDir: path.join(workspaceDir, ".openclaw", "extensions", "beta"),
+      packageName: "@openclaw/beta",
+      pluginId: "beta",
+    });
 
     const { candidates } = await discoverWithStateDir(stateDir, { workspaceDir });
     expectCandidateIds(candidates, { includes: ["alpha", "beta"] });
+  });
+
+  it("ignores standalone helper scripts in auto-discovered extension roots", async () => {
+    const stateDir = makeTempDir();
+    const workspaceDir = path.join(stateDir, "workspace");
+    const globalExt = path.join(stateDir, "extensions");
+    const workspaceExt = path.join(workspaceDir, ".openclaw", "extensions");
+    mkdirSafe(globalExt);
+    mkdirSafe(workspaceExt);
+    fs.writeFileSync(path.join(globalExt, "my-helper.mjs"), "export default {}", "utf-8");
+    fs.writeFileSync(path.join(workspaceExt, "workspace-helper.js"), "export default {}", "utf-8");
+
+    const { candidates, diagnostics } = await discoverWithStateDir(stateDir, { workspaceDir });
+
+    expectCandidateIds(candidates, { excludes: ["my-helper", "workspace-helper"] });
+    expect(diagnostics).toStrictEqual([]);
   });
 
   it("warns without blocking when a plugin requires a missing plugin", async () => {
@@ -637,9 +656,11 @@ describe("discoverOpenClawPlugins", () => {
     const stateDir = makeTempDir();
     const homeDir = makeTempDir();
     const workspaceRoot = path.join(homeDir, "workspace");
-    const workspaceExt = path.join(workspaceRoot, ".openclaw", "extensions");
-    mkdirSafe(workspaceExt);
-    fs.writeFileSync(path.join(workspaceExt, "tilde-workspace.ts"), "export default {}", "utf-8");
+    createPackagePluginWithEntry({
+      packageDir: path.join(workspaceRoot, ".openclaw", "extensions", "tilde-workspace"),
+      packageName: "@openclaw/tilde-workspace",
+      pluginId: "tilde-workspace",
+    });
 
     const result = discoverOpenClawPlugins({
       workspaceDir: "~/workspace",
@@ -722,7 +743,11 @@ describe("discoverOpenClawPlugins", () => {
       path.join(bundledDir, "music-generation-providers.live.test.ts"),
       "export default {}",
     );
-    writeStandalonePlugin(path.join(bundledDir, "real-plugin.ts"), "export default {}");
+    createPackagePluginWithEntry({
+      packageDir: path.join(bundledDir, "real-plugin"),
+      packageName: "@openclaw/real-plugin",
+      pluginId: "real-plugin",
+    });
 
     const { candidates, diagnostics } = withOpenClawPackageArgv(packageRoot, () =>
       discoverOpenClawPlugins({
@@ -2259,11 +2284,13 @@ describe("discoverOpenClawPlugins", () => {
 
   it.runIf(process.platform !== "win32")("blocks world-writable plugin paths", async () => {
     const stateDir = makeTempDir();
-    const globalExt = path.join(stateDir, "extensions");
-    mkdirSafe(globalExt);
-    const pluginPath = path.join(globalExt, "world-open.ts");
-    fs.writeFileSync(pluginPath, "export default function () {}", "utf-8");
-    fs.chmodSync(pluginPath, 0o777);
+    const pluginDir = path.join(stateDir, "extensions", "world-open");
+    createPackagePluginWithEntry({
+      packageDir: pluginDir,
+      packageName: "@openclaw/world-open",
+      pluginId: "world-open",
+    });
+    fs.chmodSync(pluginDir, 0o777);
 
     const result = await discoverWithStateDir(stateDir, {});
 
@@ -2305,13 +2332,11 @@ describe("discoverOpenClawPlugins", () => {
     "blocks suspicious ownership when uid mismatch is detected",
     async () => {
       const stateDir = makeTempDir();
-      const globalExt = path.join(stateDir, "extensions");
-      mkdirSafe(globalExt);
-      fs.writeFileSync(
-        path.join(globalExt, "owner-mismatch.ts"),
-        "export default function () {}",
-        "utf-8",
-      );
+      createPackagePluginWithEntry({
+        packageDir: path.join(stateDir, "extensions", "owner-mismatch"),
+        packageName: "@openclaw/owner-mismatch",
+        pluginId: "owner-mismatch",
+      });
 
       const actualUid = (process as NodeJS.Process & { getuid: () => number }).getuid();
       const result = await discoverWithStateDir(stateDir, { ownershipUid: actualUid + 1 });
@@ -2393,16 +2418,18 @@ describe("discoverOpenClawPlugins", () => {
 
   it("reflects plugin root changes on the next discovery call", () => {
     const stateDir = makeTempDir();
-    const globalExt = path.join(stateDir, "extensions");
-    mkdirSafe(globalExt);
-    const pluginPath = path.join(globalExt, "fresh.ts");
-    fs.writeFileSync(pluginPath, "export default function () {}", "utf-8");
+    const pluginDir = path.join(stateDir, "extensions", "fresh");
+    createPackagePluginWithEntry({
+      packageDir: pluginDir,
+      packageName: "@openclaw/fresh",
+      pluginId: "fresh",
+    });
 
     const env = buildDiscoveryEnvWithOverrides(stateDir);
     const first = discoverWithEnv({ env });
     expect(first.candidates.map((candidate) => candidate.idHint)).toContain("fresh");
 
-    fs.rmSync(pluginPath, { force: true });
+    fs.rmSync(pluginDir, { recursive: true, force: true });
 
     const second = discoverWithEnv({ env });
     expect(second.candidates.map((candidate) => candidate.idHint)).not.toContain("fresh");
@@ -2465,8 +2492,16 @@ describe("discoverOpenClawPlugins", () => {
       setup: () => {
         const stateDirA = makeTempDir();
         const stateDirB = makeTempDir();
-        writeStandalonePlugin(path.join(stateDirA, "extensions", "alpha.ts"));
-        writeStandalonePlugin(path.join(stateDirB, "extensions", "beta.ts"));
+        createPackagePluginWithEntry({
+          packageDir: path.join(stateDirA, "extensions", "alpha"),
+          packageName: "@openclaw/alpha",
+          pluginId: "alpha",
+        });
+        createPackagePluginWithEntry({
+          packageDir: path.join(stateDirB, "extensions", "beta"),
+          packageName: "@openclaw/beta",
+          pluginId: "beta",
+        });
         return {
           first: discoverWithEnv({ env: buildDiscoveryEnvWithOverrides(stateDirA) }),
           second: discoverWithEnv({ env: buildDiscoveryEnvWithOverrides(stateDirB) }),
@@ -2512,6 +2547,20 @@ describe("discoverOpenClawPlugins", () => {
   ] as const)("$name", ({ setup }) => {
     const { first, second, assert } = setup();
     assert(first, second);
+  });
+
+  it("discovers standalone files from configured load-path directories", () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "plugins");
+    const pluginPath = path.join(pluginDir, "alpha.ts");
+    writeStandalonePlugin(pluginPath, "export default {}");
+
+    const result = discoverWithEnv({
+      extraPaths: [pluginDir],
+      env: buildDiscoveryEnvWithOverrides(stateDir),
+    });
+
+    expectCandidateSource(result.candidates, "alpha", pluginPath);
   });
 
   it("preserves configured load-path order", () => {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -927,6 +927,7 @@ function discoverInDirectory(params: {
   seen: Set<string>;
   realpathCache: Map<string, string>;
   packageManifestCache?: Map<string, PackageManifest | null>;
+  scanFiles?: boolean;
   recurseDirectories?: boolean;
   skipDirectories?: Set<string>;
   visitedDirectories?: Set<string>;
@@ -958,7 +959,7 @@ function discoverInDirectory(params: {
     const fullPath = path.join(params.dir, entry.name);
     const entryType = resolveScannedEntryType(entry, fullPath);
     if (entryType === "file") {
-      if (!isExtensionFile(fullPath)) {
+      if (!params.scanFiles || !isExtensionFile(fullPath)) {
         continue;
       }
       addCandidate({
@@ -1408,6 +1409,7 @@ function discoverFromPath(params: {
       seen: params.seen,
       realpathCache: params.realpathCache,
       packageManifestCache: params.packageManifestCache,
+      scanFiles: params.origin === "config",
       ...(params.requireBuiltRuntimeEntry !== undefined
         ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry }
         : {}),

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -959,7 +959,8 @@ function discoverInDirectory(params: {
     const fullPath = path.join(params.dir, entry.name);
     const entryType = resolveScannedEntryType(entry, fullPath);
     if (entryType === "file") {
-      if (!params.scanFiles || !isExtensionFile(fullPath)) {
+      const shouldScanFile = params.scanFiles ?? params.origin === "bundled";
+      if (!shouldScanFile || !isExtensionFile(fullPath)) {
         continue;
       }
       addCandidate({
@@ -1208,6 +1209,7 @@ function discoverFromPath(params: {
   requireBuiltRuntimeEntry?: boolean;
   managedPluginDirs?: Set<string>;
   skipRootDirKeys?: Set<string>;
+  scanFiles?: boolean;
   env: NodeJS.ProcessEnv;
   candidates: PluginCandidate[];
   diagnostics: PluginDiagnostic[];
@@ -1409,7 +1411,9 @@ function discoverFromPath(params: {
       seen: params.seen,
       realpathCache: params.realpathCache,
       packageManifestCache: params.packageManifestCache,
-      scanFiles: params.origin === "config",
+      ...(params.scanFiles !== undefined || params.origin === "config"
+        ? { scanFiles: params.scanFiles ?? true }
+        : {}),
       ...(params.requireBuiltRuntimeEntry !== undefined
         ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry }
         : {}),
@@ -1588,6 +1592,7 @@ export function discoverOpenClawPlugins(params: {
           workspaceDir,
           requireBuiltRuntimeEntry: installedPath.requireBuiltRuntimeEntry,
           managedPluginDirs,
+          scanFiles: true,
           env,
           candidates: result.candidates,
           diagnostics: result.diagnostics,


### PR DESCRIPTION
## Summary

- Problem: standalone helper scripts placed directly in auto-discovered `.openclaw/extensions` roots were treated as plugin candidates, which made plugin validation look for a missing `openclaw.plugin.json` and could block gateway startup.
- Solution: keep standalone file discovery for explicit configured plugin load-path directories, but disable top-level file scanning for auto-discovered global/workspace extension roots.
- What changed: `src/plugins/discovery.ts` now distinguishes auto-discovered roots from configured load paths, regression coverage locks the discovery and config-validation behavior, and the plugin docs spell out the standalone-file upgrade path through `plugins.load.paths`.
- What did NOT change: explicitly configured standalone plugin files, configured plugin directories, bundled plugin roots, and persisted installed plugin records remain supported.

Fixes #88198

## Real behavior proof

- **Behavior or issue addressed:** Auto-discovered `~/.openclaw/extensions` helper files no longer become plugin candidates or fail config validation because they lack `openclaw.plugin.json`.
- **Real environment tested:** Linux worktree at `pr-88236`, Node via repository test runner, production `discoverOpenClawPlugins` and `validateConfigObjectWithPlugins` called directly with a temporary OpenClaw state directory.
- **Exact steps or command run after this patch:**

  ```bash
  node --import tsx --input-type=module <<'JS'
  import fs from "node:fs/promises";
  import os from "node:os";
  import path from "node:path";
  import { discoverOpenClawPlugins } from "./src/plugins/discovery.ts";
  import { validateConfigObjectWithPlugins } from "./src/config/validation.ts";

  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-88198-proof-"));
  const stateDir = path.join(root, "state");
  const helperPath = path.join(stateDir, "extensions", "my-helper.mjs");
  await fs.mkdir(path.dirname(helperPath), { recursive: true });
  await fs.writeFile(helperPath, "export default {};\n", "utf-8");

  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
  const discovery = await discoverOpenClawPlugins({ env });
  const validation = validateConfigObjectWithPlugins({ agents: { list: [{ id: "openclaw" }] }, plugins: { enabled: true } }, { env });
  const helperCandidates = discovery.candidates.filter((candidate) => candidate.source === helperPath);
  console.log(JSON.stringify({
    helperFile: "extensions/my-helper.mjs",
    helperCandidateCount: helperCandidates.length,
    diagnostics: discovery.diagnostics,
    validationOk: validation.ok,
    validationIssues: validation.issues ?? [],
  }, null, 2));
  await fs.rm(root, { recursive: true, force: true });
  JS
  ```

- **Evidence after fix:** Copied terminal console output from the command above:

  ```json
  {
    "helperFile": "extensions/my-helper.mjs",
    "helperCandidateCount": 0,
    "diagnostics": [],
    "validationOk": true,
    "validationIssues": []
  }
  ```

- **Observed result after fix:** the helper file is ignored during auto-discovery, no diagnostics are emitted, and config validation succeeds.
- **What was not tested:** live gateway startup with a persistent user home; the proof uses the same production discovery and config-validation functions with a temporary OpenClaw state directory.

## Regression Test Plan

- Coverage level: unit tests plus direct production-function proof.
- Target test file: `src/plugins/discovery.test.ts`, `src/config/config.plugin-validation.test.ts`.
- Scenario locked in: helper scripts in auto-discovered extension roots are ignored, while configured load-path directories can still discover standalone plugin files and the docs direct existing standalone files to that explicit path.
- Why this is the smallest reliable guardrail: it covers the discovery boundary that caused the bad plugin candidate, the config-validation path that previously surfaced the missing manifest failure, and the documented compatibility path for intentional standalone files.

## Verification

```bash
node scripts/run-vitest.mjs src/plugins/discovery.test.ts src/config/config.plugin-validation.test.ts
node scripts/run-oxlint.mjs src/plugins/discovery.ts src/plugins/discovery.test.ts src/config/config.plugin-validation.test.ts
git diff --check
pnpm changed:lanes --json
pnpm check:changed
```

## Root Cause

- Root cause: directory auto-discovery treated standalone `.js/.mjs/.ts` files in extension roots like configured plugin load paths, so helper scripts became plugin candidates without manifests.
- Missing detection / guardrail: tests covered file-based configured paths and package plugins, but not standalone helper files in auto-discovered extension roots.

