### PR TITLE
fix(agents): surface terminal stream errors

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2523,6 +2523,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("keeps retrying and surfacing clean empty assistant turns without the silence flag", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
+    const onAgentEvent = vi.fn();
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
         assistantTexts: [],
@@ -2541,11 +2542,21 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       provider: "openai",
       model: "gpt-5.4",
       runId: "run-empty-assistant-error",
+      onAgentEvent,
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "assistant",
+        data: expect.objectContaining({
+          isError: true,
+          text: expect.stringContaining("couldn't generate a response"),
+        }),
+      }),
+    );
   });
 
   it("detects generic empty Gemini turns without visible text", () => {

--- a/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts
@@ -1,4 +1,5 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
 import { makeAttemptResult, makeCompactionSuccess } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
@@ -113,6 +114,7 @@ describe("timeout-triggered compaction", () => {
 
   beforeEach(() => {
     resetRunOverflowCompactionHarnessMocks();
+    resetAgentEventsForTest();
   });
 
   it("attempts compaction when LLM times out with high prompt token usage (>65%)", async () => {
@@ -298,6 +300,9 @@ describe("timeout-triggered compaction", () => {
   });
 
   it("points idle-timeout errors at provider timeout and the agent runtime ceiling", async () => {
+    const localAgentEvent = vi.fn();
+    const busEvent = vi.fn();
+    const stopBus = onAgentEvent(busEvent);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         timedOut: true,
@@ -308,13 +313,72 @@ describe("timeout-triggered compaction", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent(overflowBaseRunParams);
+    try {
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        onAgentEvent: localAgentEvent,
+        runId: "run-idle-timeout-error",
+      });
 
-    expect(mockedCompactDirect).not.toHaveBeenCalled();
+      expect(mockedCompactDirect).not.toHaveBeenCalled();
+      expect(result.payloads?.[0]?.isError).toBe(true);
+      expect(result.payloads?.[0]?.text).toContain("models.providers.<id>.timeoutSeconds");
+      expect(result.payloads?.[0]?.text).toContain("agents.defaults.timeoutSeconds");
+      expect(result.payloads?.[0]?.text).toContain("provider timeouts cannot extend");
+      expect(localAgentEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stream: "assistant",
+          data: expect.objectContaining({
+            isError: true,
+            text: expect.stringContaining("models.providers.<id>.timeoutSeconds"),
+          }),
+        }),
+      );
+      expect(busEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: "run-idle-timeout-error",
+          stream: "assistant",
+          data: expect.objectContaining({
+            isError: true,
+            text: expect.stringContaining("models.providers.<id>.timeoutSeconds"),
+          }),
+        }),
+      );
+      expect(localAgentEvent.mock.calls[0]?.[0].data).not.toHaveProperty("delta");
+      expect(busEvent.mock.calls[0]?.[0].data).not.toHaveProperty("delta");
+    } finally {
+      stopBus();
+    }
+  });
+
+  it("returns terminal idle-timeout errors when local event observers reject", async () => {
+    const onAgentEvent = vi.fn(async () => {
+      throw new Error("observer failed");
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        idleTimedOut: true,
+        lastAssistant: {
+          usage: { input: 20000 },
+        } as never,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      onAgentEvent,
+      runId: "run-idle-timeout-observer-error",
+    });
+
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("models.providers.<id>.timeoutSeconds");
-    expect(result.payloads?.[0]?.text).toContain("agents.defaults.timeoutSeconds");
-    expect(result.payloads?.[0]?.text).toContain("provider timeouts cannot extend");
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "assistant",
+        data: expect.objectContaining({ isError: true }),
+      }),
+    );
   });
 
   it("retries one silent idle timeout before surfacing an error", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -9,7 +9,7 @@ import {
   resolveContextEngine,
   resolveContextEngineOwnerPluginId,
 } from "../../context-engine/registry.js";
-import { emitAgentPlanEvent } from "../../infra/agent-events.js";
+import { emitAgentEvent, emitAgentPlanEvent } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -210,6 +210,36 @@ const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 const NO_REAL_CONVERSATION_MESSAGES_REASON = "no real conversation messages";
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
+
+function emitTerminalErrorAssistantText(params: {
+  onAgentEvent?: RunEmbeddedAgentParams["onAgentEvent"];
+  runId: string;
+  sessionKey?: string;
+  text: string;
+}): void {
+  const text = params.text.trim();
+  if (!text) {
+    return;
+  }
+  const event = {
+    stream: "assistant",
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    data: {
+      text,
+      isError: true,
+    },
+  } as const;
+  emitAgentEvent({
+    runId: params.runId,
+    ...event,
+  });
+  try {
+    const maybeDelivered = params.onAgentEvent?.(event);
+    void Promise.resolve(maybeDelivered).catch(() => undefined);
+  } catch {
+    // Event observers are best-effort; never hide the terminal error payload.
+  }
+}
 
 function isNoRealConversationCompactionNoop(params: {
   ok?: boolean;
@@ -485,7 +515,10 @@ export async function runEmbeddedAgent(
       },
       laneTaskTimeoutMs,
     );
-  const enqueueGlobal = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
+  const enqueueGlobal = <T>(
+    task: () => Promise<T>,
+    opts?: CommandQueueEnqueueOptions,
+  ): Promise<T> => {
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
@@ -494,7 +527,10 @@ export async function runEmbeddedAgent(
       ? params.enqueue(task, withLaneTimeout(globalOpts))
       : enqueueCommandInLane(globalLane, task, withLaneTimeout(globalOpts));
   };
-  const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
+  const enqueueSession = <T>(
+    task: () => Promise<T>,
+    opts?: CommandQueueEnqueueOptions,
+  ): Promise<T> => {
     const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
     return params.enqueue
       ? params.enqueue(task, sessionOpts)
@@ -3014,6 +3050,12 @@ export async function runEmbeddedAgent(
               timeoutPhase,
               providerStarted,
             });
+            emitTerminalErrorAssistantText({
+              onAgentEvent: params.onAgentEvent,
+              runId: params.runId,
+              sessionKey: params.sessionKey,
+              text: timeoutText,
+            });
             return {
               payloads: [
                 ...(hasPartialAssistantTextAfterPromptTimeout ? [] : payloadsWithToolMedia || []),
@@ -3261,6 +3303,12 @@ export async function runEmbeddedAgent(
               replayInvalid,
               livenessState,
             });
+            emitTerminalErrorAssistantText({
+              onAgentEvent: params.onAgentEvent,
+              runId: params.runId,
+              sessionKey: params.sessionKey,
+              text: STRICT_AGENTIC_BLOCKED_TEXT,
+            });
             return {
               payloads: [
                 {
@@ -3294,19 +3342,24 @@ export async function runEmbeddedAgent(
             };
           }
           if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
-            const replayInvalid = resolveReplayInvalidForAttempt(
-              "⚠️ Agent couldn't generate a response. Please try again.",
-            );
+            const terminalText = "⚠️ Agent couldn't generate a response. Please try again.";
+            const replayInvalid = resolveReplayInvalidForAttempt(terminalText);
             const livenessState = resolveRunLivenessState({
               payloadCount: 0,
               aborted,
               timedOut,
               attempt,
-              incompleteTurnText: "⚠️ Agent couldn't generate a response. Please try again.",
+              incompleteTurnText: terminalText,
             });
             attempt.setTerminalLifecycleMeta?.({
               replayInvalid,
               livenessState,
+            });
+            emitTerminalErrorAssistantText({
+              onAgentEvent: params.onAgentEvent,
+              runId: params.runId,
+              sessionKey: params.sessionKey,
+              text: terminalText,
             });
             if (lastProfileId) {
               await maybeMarkAuthProfileFailure({
@@ -3317,7 +3370,7 @@ export async function runEmbeddedAgent(
             return {
               payloads: [
                 {
-                  text: "⚠️ Agent couldn't generate a response. Please try again.",
+                  text: terminalText,
                   isError: true,
                 },
               ],
@@ -3410,6 +3463,12 @@ export async function runEmbeddedAgent(
             attempt.setTerminalLifecycleMeta?.({
               replayInvalid,
               livenessState,
+            });
+            emitTerminalErrorAssistantText({
+              onAgentEvent: params.onAgentEvent,
+              runId: params.runId,
+              sessionKey: params.sessionKey,
+              text: incompleteTurnText,
             });
             const incompleteStopReason = attempt.lastAssistant?.stopReason;
             const replayMetadata = resolveAttemptReplayMetadata(attempt);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Api, Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -25,6 +28,8 @@ type OpenAICompletionsOutput = Parameters<typeof testing.processOpenAICompletion
 type OpenAIResponsesOutput = Parameters<typeof testing.processResponsesStream>[1];
 
 type CapturedStreamEvent = { type?: string; delta?: string };
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 
 function createDeepSeekCompletionsModel(): Model<"openai-completions"> {
   return {
@@ -126,7 +131,58 @@ function expectRecordFields(record: unknown, expected: Record<string, unknown>) 
   return actual;
 }
 
+function readJsonFixture(relativePath: string): unknown {
+  return JSON.parse(readFileSync(join(TEST_DIR, relativePath), "utf8"));
+}
+
 describe("openai transport stream", () => {
+  it("parses the live xinflo chat completions stream snapshot into visible text", async () => {
+    const fixture = readJsonFixture(
+      "test-fixtures/xinflo-chat-completions-stream-ok.snapshot.json",
+    ) as {
+      chunks: unknown[];
+    };
+    const model = {
+      id: "openai/gpt-5.5",
+      name: "GPT-5.5 via xinflo",
+      api: "openai-completions",
+      provider: "xinflo",
+      baseUrl: "https://models.xinflo.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const events: unknown[] = [];
+
+    await testing.processOpenAICompletionsStream(streamChunks(fixture.chunks), output, model, {
+      push(event) {
+        events.push(event);
+      },
+    });
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content).toStrictEqual([{ type: "text", text: "OK" }]);
+    expectRecordFields(output.usage, {
+      input: 26,
+      output: 17,
+      cacheRead: 0,
+      reasoningTokens: 10,
+      totalTokens: 43,
+    });
+    expect(
+      events
+        .filter((event): event is CapturedStreamEvent => {
+          return Boolean(event && typeof event === "object" && "type" in event);
+        })
+        .filter((event) => event.type === "text_delta")
+        .map((event) => event.delta)
+        .join(""),
+    ).toBe("OK");
+  });
+
   it("fails Azure Responses streams when headers arrive but no first event follows", async () => {
     const model = createAzureResponsesModel();
     await expect(

--- a/src/agents/test-fixtures/xinflo-chat-completions-stream-ok.snapshot.json
+++ b/src/agents/test-fixtures/xinflo-chat-completions-stream-ok.snapshot.json
@@ -1,0 +1,84 @@
+{
+  "source": "xinflo chat.completions stream, sanitized from live probe",
+  "capturedAt": "2026-05-27T15:11:22.756Z",
+  "request": {
+    "model": "openai/gpt-5.5",
+    "stream": true,
+    "max_tokens": 64,
+    "reasoning_effort": "high",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a concise assistant. Always produce a visible final answer."
+      },
+      {
+        "role": "user",
+        "content": "只回复 OK"
+      }
+    ]
+  },
+  "chunks": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0
+        }
+      ],
+      "created": 1779890000,
+      "id": "chatcmpl-xinflo-snapshot",
+      "model": "openai/gpt-5.5",
+      "object": "chat.completion.chunk"
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "OK"
+          },
+          "finish_reason": null,
+          "index": 0
+        }
+      ],
+      "created": 1779890000,
+      "id": "chatcmpl-xinflo-snapshot",
+      "model": "openai/gpt-5.5",
+      "object": "chat.completion.chunk"
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0
+        }
+      ],
+      "created": 1779890000,
+      "id": "chatcmpl-xinflo-snapshot",
+      "model": "openai/gpt-5.5",
+      "object": "chat.completion.chunk",
+      "usage": {
+        "completion_tokens": 17,
+        "completion_tokens_details": {
+          "reasoning_tokens": 10
+        },
+        "input_tokens": 26,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 10
+        },
+        "prompt_tokens": 26,
+        "prompt_tokens_details": {
+          "cached_tokens": 0
+        },
+        "total_tokens": 43
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Surface terminal stream/timeout errors as assistant text events on both the process event bus and the local run observer.
- Preserve terminal error payload returns even if local event observers reject.
- Add coverage for OpenAI stream parsing, incomplete-turn handling, and timeout-triggered terminal assistant events.

## Verification
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
- `node openclaw.mjs --version`

## Real behavior proof
Behavior addressed: terminal provider/runtime stream errors now reach Control UI subscribers as assistant error text instead of only returning a final error payload.
Real environment tested: local OpenClaw source checkout on macOS using the repo Vitest wrapper and the OpenClaw CLI entrypoint.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`; `node openclaw.mjs --version`.
Evidence after fix:
```text
$ node openclaw.mjs --version
OpenClaw 2026.5.28 (c71cd1b)
$ .agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD
autoreview clean: no accepted/actionable findings reported
```
Observed result after fix: terminal timeout/incomplete-turn paths return `{ isError: true }` payloads and emit assistant error events, while observer failures do not mask the terminal error result.
What was not tested: live provider network failures against a real external model endpoint were not run; the covered behavior uses deterministic runner and stream fixtures.
