### PR TITLE
fix(ui): keep session switching responsive

### DIFF
--- a/src/gateway/gateway-perf-trace.ts
+++ b/src/gateway/gateway-perf-trace.ts
@@ -1,0 +1,95 @@
+import { appendFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { performance } from "node:perf_hooks";
+
+/**
+ * Diagnostic, env-gated request tracing for the gateway. Enable with
+ * `OPENCLAW_GW_PERF=1` to append one JSON line per traced request to
+ * `~/.openclaw/logs/gateway-dispatch.jsonl`. No-op otherwise, so it is safe to
+ * leave the call sites in place.
+ *
+ * Purpose: split a slow RPC's wall-clock into received -> handler-start ->
+ * handler-end -> response-sent, plus per-step marks inside heavy handlers
+ * (e.g. chat.history: session entry load, model resolution, transcript read,
+ * projection, byte budgeting), so the bottleneck is measured, not guessed.
+ */
+
+const GW_PERF_ENABLED = process.env.OPENCLAW_GW_PERF === "1";
+const GW_PERF_LOG_PATH = `${homedir()}/.openclaw/logs/gateway-dispatch.jsonl`;
+
+export function gwPerfEnabled(): boolean {
+  return GW_PERF_ENABLED;
+}
+
+export function gwPerfNow(): number {
+  return performance.now();
+}
+
+export function gwPerfLog(record: Record<string, unknown>): void {
+  if (!GW_PERF_ENABLED) {
+    return;
+  }
+  try {
+    appendFileSync(GW_PERF_LOG_PATH, `${JSON.stringify({ ts: Date.now(), ...record })}\n`);
+  } catch {
+    // Never let diagnostics break request handling.
+  }
+}
+
+// Best-effort "what handler is currently executing" so an event-loop stall can
+// be blamed on the request that blocked it. With concurrent handlers this names
+// the most recently entered one — good enough to spot a synchronous hog.
+let gwPerfCurrentMethod = "<idle>";
+
+export function gwPerfSetCurrentMethod(method: string): void {
+  if (GW_PERF_ENABLED) {
+    gwPerfCurrentMethod = method;
+  }
+}
+
+// Event-loop lag sampler: a timer that should fire every 20ms; a larger gap
+// means the loop was blocked by synchronous work for that long. This is what
+// stalls unrelated async callbacks (e.g. chat.history's transcript-read
+// resolution) and inflates their measured await time.
+if (GW_PERF_ENABLED && typeof setInterval === "function") {
+  const INTERVAL_MS = 20;
+  let last = performance.now();
+  const timer = setInterval(() => {
+    const now = performance.now();
+    const lagMs = now - last - INTERVAL_MS;
+    last = now;
+    if (lagMs >= 50) {
+      gwPerfLog({ kind: "loop-lag", lagMs: Math.round(lagMs), whileRunning: gwPerfCurrentMethod });
+    }
+  }, INTERVAL_MS);
+  (timer as { unref?: () => void }).unref?.();
+}
+
+/** Accumulates per-step timings within a single handler invocation. */
+export class GwPerfSteps {
+  private last: number;
+  private readonly start: number;
+  private readonly steps: Array<[string, number]> = [];
+
+  constructor() {
+    this.start = performance.now();
+    this.last = this.start;
+  }
+
+  mark(name: string): void {
+    if (!GW_PERF_ENABLED) {
+      return;
+    }
+    const now = performance.now();
+    this.steps.push([name, Math.round((now - this.last) * 100) / 100]);
+    this.last = now;
+  }
+
+  totalMs(): number {
+    return Math.round((performance.now() - this.start) * 100) / 100;
+  }
+
+  toObject(): Record<string, number> {
+    return Object.fromEntries(this.steps);
+  }
+}

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatChannelProgressDraftLine } from "../channels/streaming.js";
 import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
@@ -2089,6 +2092,80 @@ describe("agent event handler", () => {
     expect(requireMockArg(broadcastToConnIds, 0, 3, "sessions changed options")).toEqual({
       dropIfSlow: true,
     });
+  });
+
+  it("broadcasts recovered done status for late internal webchat errors with persisted assistant output", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-broadcast-recovery-"));
+    try {
+      const sessionFile = path.join(dir, "session.jsonl");
+      fs.writeFileSync(
+        sessionFile,
+        `${JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+            stopReason: "stop",
+            timestamp: 1_500,
+          },
+        })}\n`,
+      );
+      vi.mocked(loadGatewaySessionRow).mockReturnValue({
+        key: "session-late-error",
+        kind: "direct",
+        updatedAt: 1_000,
+        status: "running",
+        startedAt: 1_100,
+        sessionId: "session",
+      });
+      vi.mocked(loadSessionEntry).mockReturnValue({
+        cfg: {},
+        storePath: path.join(dir, "sessions.json"),
+        store: {},
+        entry: {
+          sessionId: "session",
+          sessionFile,
+          route: { channel: "webchat" },
+          updatedAt: 1_000,
+          startedAt: 1_100,
+          status: "running",
+          abortedLastRun: true,
+        },
+        canonicalKey: "session-late-error",
+        legacyKey: undefined,
+      });
+      const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
+        resolveSessionKeyForRun: () => "session-late-error",
+        lifecycleErrorRetryGraceMs: 0,
+      });
+      sessionEventSubscribers.subscribe("conn-session");
+
+      handler({
+        runId: "run-late-error",
+        seq: 2,
+        stream: "lifecycle",
+        ts: 2_000,
+        data: {
+          phase: "error",
+          startedAt: 1_100,
+          endedAt: 1_900,
+          error: "late abort after assistant persisted",
+        },
+      });
+
+      expectPayloadFields(requireMockArg(broadcastToConnIds, 0, 1, "sessions changed payload"), {
+        sessionKey: "session-late-error",
+        phase: "error",
+        status: "done",
+        startedAt: 1_100,
+        endedAt: 1_900,
+        runtimeMs: 800,
+        updatedAt: 1_900,
+        abortedLastRun: false,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("omits goal state from unscoped global lifecycle snapshots", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -23,7 +23,10 @@ import type {
 } from "./server-chat-state.js";
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
 import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-session-lifecycle.runtime.js";
-import { deriveGatewaySessionLifecycleSnapshot } from "./session-lifecycle-state.js";
+import {
+  deriveGatewaySessionLifecycleSnapshot,
+  derivePersistedSessionLifecyclePatch,
+} from "./session-lifecycle-state.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
@@ -320,7 +323,7 @@ export function createAgentEventHandler({
   ) => {
     const row = loadGatewaySessionRowForSnapshot(sessionKey, agentId ? { agentId } : undefined);
     const omitUnscopedGlobalGoal = sessionKey === "global" && !agentId;
-    const lifecyclePatch = evt
+    let lifecyclePatch = evt
       ? deriveGatewaySessionLifecycleSnapshot({
           session: row
             ? {
@@ -335,6 +338,23 @@ export function createAgentEventHandler({
           event: evt,
         })
       : {};
+    if (evt) {
+      try {
+        const sessionEntry = loadSessionEntry(sessionKey, {
+          ...(agentId ? { agentId } : {}),
+          clone: false,
+        });
+        if (sessionEntry.entry) {
+          lifecyclePatch = derivePersistedSessionLifecyclePatch({
+            entry: sessionEntry.entry,
+            event: evt,
+            storePath: sessionEntry.storePath,
+          });
+        }
+      } catch {
+        // Fall back to the row-derived snapshot; lifecycle persistence handles write errors separately.
+      }
+    }
     const session = row ? { ...row, ...lifecyclePatch } : undefined;
     if (session && omitUnscopedGlobalGoal) {
       delete session.goal;

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -7,6 +7,12 @@ import { getPluginRegistryState } from "../plugins/runtime-state.js";
 import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "./control-plane-audit.js";
 import { consumeControlPlaneWriteBudget } from "./control-plane-rate-limit.js";
+import {
+  gwPerfEnabled,
+  gwPerfLog,
+  gwPerfNow,
+  gwPerfSetCurrentMethod,
+} from "./gateway-perf-trace.js";
 import { ADMIN_SCOPE, authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import {
   createCoreGatewayMethodDescriptors,
@@ -647,17 +653,46 @@ export async function handleGatewayRequest(
     );
     return;
   }
+  // Diagnostic, env-gated (OPENCLAW_GW_PERF=1): split this request's wall-clock
+  // into received -> handler-start -> response-sent -> handler-end so a slow
+  // RPC can be attributed to handler work vs queue/transport.
+  const perfTracing = gwPerfEnabled();
+  const recvAtMs = perfTracing ? gwPerfNow() : 0;
+  let respondedAtMs = 0;
+  const tracedRespond: typeof respond = perfTracing
+    ? (ok, result, error) => {
+        if (respondedAtMs === 0) {
+          respondedAtMs = gwPerfNow();
+        }
+        return respond(ok, result, error);
+      }
+    : respond;
   const invokeHandler = () =>
     handler({
       req,
       params: (req.params ?? {}) as Record<string, unknown>,
       client,
       isWebchatConnect,
-      respond,
+      respond: tracedRespond,
       context,
     });
   // All handlers run inside a request scope so that plugin runtime
   // subagent methods (e.g. context engine tools spawning sub-agents
   // during tool execution) can dispatch back into the gateway.
+  const handlerStartMs = perfTracing ? gwPerfNow() : 0;
+  if (perfTracing) {
+    gwPerfSetCurrentMethod(req.method);
+  }
   await withPluginRuntimeGatewayRequestScope({ context, client, isWebchatConnect }, invokeHandler);
+  if (perfTracing) {
+    const doneMs = gwPerfNow();
+    gwPerfLog({
+      kind: "dispatch",
+      method: req.method,
+      preHandlerMs: Math.round((handlerStartMs - recvAtMs) * 100) / 100,
+      respondMs: respondedAtMs ? Math.round((respondedAtMs - handlerStartMs) * 100) / 100 : null,
+      handlerMs: Math.round((doneMs - handlerStartMs) * 100) / 100,
+      totalMs: Math.round((doneMs - recvAtMs) * 100) / 100,
+    });
+  }
 }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -121,6 +121,7 @@ import {
 import { stripEnvelopeFromMessage } from "../chat-sanitize.js";
 import { augmentChatHistoryWithCliSessionImports } from "../cli-session-history.js";
 import { isSuppressedControlReplyText } from "../control-reply-text.js";
+import { GwPerfSteps, gwPerfLog } from "../gateway-perf-trace.js";
 import {
   attachManagedOutgoingImagesToMessage,
   cleanupManagedOutgoingImageRecords,
@@ -2345,6 +2346,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       limit?: number;
       maxChars?: number;
     };
+    const perf = new GwPerfSteps();
     const agentIdOverride = normalizeOptionalText((params as { agentId?: string }).agentId);
     const requestedAgentId = resolveRequestedChatAgentId({
       cfg: (context as { getRuntimeConfig?: () => OpenClawConfig }).getRuntimeConfig?.(),
@@ -2353,6 +2355,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     });
     const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey, sessionLoadOptions);
+    perf.mark("loadSessionEntry");
     const selectedAgent = validateChatSelectedAgent({
       cfg,
       requestedSessionKey: sessionKey,
@@ -2369,6 +2372,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       agentId: selectedAgent.agentId,
     });
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
+    perf.mark("resolveModel");
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
@@ -2382,6 +2386,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
           })
         : [];
+    perf.mark("readMessages");
     const overreadContextMessage = localMessages.length > max ? localMessages[0] : undefined;
     const localMessagesWithBoundaryFilter = dropLocalHistoryOverreadContextMessage(
       dropPreSessionStartAnnouncePairs(
@@ -2395,6 +2400,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       provider: resolvedSessionModel.provider,
       localMessages: localMessagesWithBoundaryFilter,
     });
+    perf.mark("cliImports");
     // Drop subagent_announce pairs (user inter-session announce + adjacent
     // assistant) whose record timestamp predates the current session's
     // sessionStartedAt. Run after CLI history imports too, because those
@@ -2410,18 +2416,22 @@ export const chatHandlers: GatewayRequestHandlers = {
         maxMessages: max,
       }),
     );
+    perf.mark("projectCanvas");
     const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
     const replaced = replaceOversizedChatHistoryMessages({
       messages: normalized,
       maxSingleMessageBytes: perMessageHardCap,
     });
+    perf.mark("replaceOversized");
     scheduleChatHistoryManagedImageCleanup({
       sessionKey,
       ...(selectedAgent.agentId ? { agentId: selectedAgent.agentId } : {}),
       context,
     });
+    perf.mark("scheduleImageCleanup");
     const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
     const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
+    perf.mark("budget");
     const placeholderCount = replaced.replacedCount + bounded.placeholderCount;
     if (placeholderCount > 0) {
       chatHistoryPlaceholderEmitCount += placeholderCount;
@@ -2447,6 +2457,14 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
+    perf.mark("resolveThinking");
+    gwPerfLog({
+      kind: "chat.history.steps",
+      sessionKey,
+      messages: bounded.messages.length,
+      totalMs: perf.totalMs(),
+      steps: perf.toObject(),
+    });
     respond(true, {
       sessionKey,
       sessionId,

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   deriveGatewaySessionLifecycleSnapshot,
@@ -225,5 +228,339 @@ describe("session lifecycle state", () => {
       runtimeMs: 500,
       abortedLastRun: false,
     });
+  });
+
+  it("keeps internal webchat sessions done when a successful assistant turn was persisted before a late error", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-webchat-"));
+    try {
+      const sessionFile = path.join(dir, "session.jsonl");
+      fs.writeFileSync(
+        sessionFile,
+        [
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "hello" }],
+              timestamp: 1_200,
+            },
+          }),
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "hi" }],
+              stopReason: "stop",
+              timestamp: 1_500,
+            },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      expect(
+        derivePersistedSessionLifecyclePatch({
+          storePath: path.join(dir, "sessions.json"),
+          entry: {
+            sessionId: "session",
+            sessionFile,
+            route: { channel: "webchat" },
+            updatedAt: 1_000,
+            startedAt: 1_100,
+            status: "running",
+            abortedLastRun: true,
+          },
+          event: {
+            ts: 2_000,
+            data: {
+              phase: "error",
+              startedAt: 1_100,
+              endedAt: 1_900,
+              error: "late abort after assistant persisted",
+            },
+          },
+        }),
+      ).toEqual({
+        updatedAt: 1_900,
+        status: "done",
+        startedAt: 1_100,
+        endedAt: 1_900,
+        runtimeMs: 800,
+        abortedLastRun: false,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not recover external sessions from stale internal channel fields", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-external-route-"));
+    try {
+      const sessionFile = path.join(dir, "session.jsonl");
+      fs.writeFileSync(
+        sessionFile,
+        [
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "assistant",
+              content: "posted externally",
+              stopReason: "stop",
+              timestamp: 1_500,
+            },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      expect(
+        derivePersistedSessionLifecyclePatch({
+          storePath: path.join(dir, "sessions.json"),
+          entry: {
+            sessionId: "session",
+            sessionFile,
+            channel: "webchat",
+            lastChannel: "webchat",
+            route: { channel: "slack" },
+            updatedAt: 1_000,
+            startedAt: 1_100,
+            status: "running",
+            abortedLastRun: true,
+          },
+          event: {
+            ts: 2_000,
+            data: {
+              phase: "error",
+              startedAt: 1_100,
+              endedAt: 1_900,
+              error: "external delivery failed",
+            },
+          },
+        }),
+      ).toMatchObject({
+        status: "failed",
+        abortedLastRun: false,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps internal webchat sessions done when persisted assistant content is a string", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-string-webchat-"));
+    try {
+      const sessionFile = path.join(dir, "session.jsonl");
+      fs.writeFileSync(
+        sessionFile,
+        [
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "assistant",
+              content: "hi",
+              stopReason: "stop",
+              timestamp: 1_500,
+            },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      expect(
+        derivePersistedSessionLifecyclePatch({
+          storePath: path.join(dir, "sessions.json"),
+          entry: {
+            sessionId: "session",
+            sessionFile,
+            route: { channel: "webchat" },
+            updatedAt: 1_000,
+            startedAt: 1_100,
+            status: "running",
+            abortedLastRun: true,
+          },
+          event: {
+            ts: 2_000,
+            data: {
+              phase: "error",
+              startedAt: 1_100,
+              endedAt: 1_900,
+              error: "late abort after assistant persisted",
+            },
+          },
+        }),
+      ).toEqual({
+        updatedAt: 1_900,
+        status: "done",
+        startedAt: 1_100,
+        endedAt: 1_900,
+        runtimeMs: 800,
+        abortedLastRun: false,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mark aborted partial assistant output as a successful run", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-abort-webchat-"));
+    try {
+      const sessionFile = path.join(dir, "session.jsonl");
+      fs.writeFileSync(
+        sessionFile,
+        [
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "partial reply" }],
+              stopReason: "stop",
+              timestamp: 1_500,
+              openclawAbort: {
+                aborted: true,
+                origin: "rpc",
+                runId: "run-aborted",
+              },
+            },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      expect(
+        derivePersistedSessionLifecyclePatch({
+          storePath: path.join(dir, "sessions.json"),
+          entry: {
+            sessionId: "session",
+            sessionFile,
+            route: { channel: "webchat" },
+            updatedAt: 1_000,
+            startedAt: 1_100,
+            status: "running",
+            abortedLastRun: false,
+          },
+          event: {
+            ts: 1_800,
+            data: {
+              phase: "end",
+              startedAt: 1_100,
+              endedAt: 1_800,
+              stopReason: "aborted",
+            },
+          },
+        }),
+      ).toEqual({
+        updatedAt: 1_800,
+        status: "killed",
+        startedAt: 1_100,
+        endedAt: 1_800,
+        runtimeMs: 700,
+        abortedLastRun: true,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not recover failed internal runs from prior assistant output without current event start proof", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-no-start-webchat-"));
+    try {
+      const sessionFile = path.join(dir, "session.jsonl");
+      fs.writeFileSync(
+        sessionFile,
+        [
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "previous turn" }],
+              stopReason: "stop",
+              timestamp: 1_500,
+            },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      expect(
+        derivePersistedSessionLifecyclePatch({
+          storePath: path.join(dir, "sessions.json"),
+          entry: {
+            sessionId: "session",
+            sessionFile,
+            route: { channel: "webchat" },
+            updatedAt: 2_000,
+            startedAt: 1_100,
+            status: "running",
+            abortedLastRun: true,
+          },
+          event: {
+            ts: 2_300,
+            data: {
+              phase: "error",
+              endedAt: 2_250,
+              error: "new turn failed before assistant content",
+            },
+          },
+        }),
+      ).toEqual({
+        updatedAt: 2_250,
+        status: "failed",
+        startedAt: 1_100,
+        endedAt: 2_250,
+        runtimeMs: 1_150,
+        abortedLastRun: false,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mark failed internal runs done from stale untimestamped assistant history", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-stale-webchat-"));
+    try {
+      const sessionFile = path.join(dir, "session.jsonl");
+      fs.writeFileSync(
+        sessionFile,
+        [
+          JSON.stringify({
+            type: "message",
+            timestamp: 900,
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "old success" }],
+              stopReason: "stop",
+            },
+          }),
+        ].join("\n") + "\n",
+      );
+
+      expect(
+        derivePersistedSessionLifecyclePatch({
+          storePath: path.join(dir, "sessions.json"),
+          entry: {
+            sessionId: "session",
+            sessionFile,
+            route: { channel: "webchat" },
+            updatedAt: 1_000,
+            startedAt: 1_100,
+            status: "running",
+            abortedLastRun: true,
+          },
+          event: {
+            ts: 1_300,
+            data: {
+              phase: "error",
+              startedAt: 1_100,
+              endedAt: 1_250,
+              error: "failed before new assistant content",
+            },
+          },
+        }),
+      ).toEqual({
+        updatedAt: 1_250,
+        status: "failed",
+        startedAt: 1_100,
+        endedAt: 1_250,
+        runtimeMs: 150,
+        abortedLastRun: false,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -4,6 +4,8 @@ import {
 } from "../agents/agent-run-terminal-outcome.js";
 import { updateSessionStoreEntry, type SessionEntry } from "../config/sessions.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
+import { isInternalMessageChannel } from "../utils/message-channel.js";
+import { readRecentSessionMessages } from "./session-utils.fs.js";
 import { loadSessionEntry } from "./session-utils.js";
 import type { GatewaySessionRow, SessionRunStatus } from "./session-utils.types.js";
 
@@ -30,7 +32,19 @@ type LifecycleSessionShape = Pick<
 
 type PersistedLifecycleSessionShape = Pick<
   SessionEntry,
-  "updatedAt" | "status" | "startedAt" | "endedAt" | "runtimeMs" | "abortedLastRun"
+  | "updatedAt"
+  | "status"
+  | "startedAt"
+  | "endedAt"
+  | "runtimeMs"
+  | "abortedLastRun"
+  | "sessionId"
+  | "sessionFile"
+  | "channel"
+  | "route"
+  | "deliveryContext"
+  | "lastChannel"
+  | "origin"
 >;
 
 type GatewaySessionLifecycleSnapshot = Partial<LifecycleSessionShape>;
@@ -118,6 +132,160 @@ function resolveRuntimeMs(params: {
   return undefined;
 }
 
+function readMessageRole(message: unknown): string | undefined {
+  return message && typeof message === "object" && !Array.isArray(message)
+    ? typeof (message as { role?: unknown }).role === "string"
+      ? (message as { role: string }).role
+      : undefined
+    : undefined;
+}
+
+function readMessageTimestamp(message: unknown): number | undefined {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const timestamp = (message as { timestamp?: unknown }).timestamp;
+  if (isFiniteTimestamp(timestamp)) {
+    return timestamp;
+  }
+  const meta = (message as { __openclaw?: unknown })["__openclaw"];
+  if (meta && typeof meta === "object" && !Array.isArray(meta)) {
+    const recordTimestampMs = (meta as { recordTimestampMs?: unknown }).recordTimestampMs;
+    if (isFiniteTimestamp(recordTimestampMs)) {
+      return recordTimestampMs;
+    }
+  }
+  return undefined;
+}
+
+function readMessageText(message: unknown): string {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return "";
+  }
+  const record = message as { content?: unknown; text?: unknown };
+  if (typeof record.text === "string") {
+    return record.text;
+  }
+  if (typeof record.content === "string") {
+    return record.content;
+  }
+  if (!Array.isArray(record.content)) {
+    return "";
+  }
+  return record.content
+    .map((block) =>
+      block && typeof block === "object" && !Array.isArray(block)
+        ? typeof (block as { text?: unknown }).text === "string"
+          ? (block as { text: string }).text
+          : ""
+        : "",
+    )
+    .join("");
+}
+
+function isAbortedAssistantMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return false;
+  }
+  const record = message as {
+    aborted?: unknown;
+    openclawAbort?: unknown;
+    stopReason?: unknown;
+  };
+  if (record.aborted === true || record.stopReason === "aborted") {
+    return true;
+  }
+  const abortMeta = record.openclawAbort;
+  return (
+    abortMeta !== null &&
+    typeof abortMeta === "object" &&
+    !Array.isArray(abortMeta) &&
+    (abortMeta as { aborted?: unknown }).aborted === true
+  );
+}
+
+function hasSuccessfulAssistantMessage(params: {
+  entry: Partial<PersistedLifecycleSessionShape>;
+  storePath: string;
+  startedAt?: number;
+  endedAt?: number;
+}): boolean {
+  if (!params.entry.sessionId) {
+    return false;
+  }
+  const messages = readRecentSessionMessages(
+    params.entry.sessionId,
+    params.storePath,
+    params.entry.sessionFile,
+    {
+      maxMessages: 12,
+      maxBytes: 96 * 1024,
+      maxLines: 160,
+    },
+  );
+  const startedAt = params.startedAt;
+  const endedAt = params.endedAt;
+  return messages.some((message) => {
+    if (readMessageRole(message) !== "assistant") {
+      return false;
+    }
+    if (isAbortedAssistantMessage(message)) {
+      return false;
+    }
+    const text = readMessageText(message).trim();
+    if (!text || text === "[assistant turn failed before producing content]") {
+      return false;
+    }
+    const timestamp = readMessageTimestamp(message);
+    if (isFiniteTimestamp(startedAt) && !isFiniteTimestamp(timestamp)) {
+      return false;
+    }
+    if (isFiniteTimestamp(startedAt) && isFiniteTimestamp(timestamp) && timestamp < startedAt) {
+      return false;
+    }
+    if (isFiniteTimestamp(endedAt) && isFiniteTimestamp(timestamp) && timestamp > endedAt + 5_000) {
+      return false;
+    }
+    const stopReason =
+      message && typeof message === "object" && !Array.isArray(message)
+        ? (message as { stopReason?: unknown }).stopReason
+        : undefined;
+    if (typeof stopReason === "string" && stopReason !== "stop" && stopReason !== "end_turn") {
+      return false;
+    }
+    return true;
+  });
+}
+
+function isInternalSessionEntry(entry: Partial<PersistedLifecycleSessionShape> | undefined) {
+  if (!entry) {
+    return false;
+  }
+  const stringValue = (value: unknown): string | undefined =>
+    typeof value === "string" && value.trim() ? value.trim() : undefined;
+  const routeChannel =
+    entry.route && typeof entry.route === "object" && !Array.isArray(entry.route)
+      ? (entry.route as { channel?: unknown }).channel
+      : undefined;
+  const deliveryChannel =
+    entry.deliveryContext &&
+    typeof entry.deliveryContext === "object" &&
+    !Array.isArray(entry.deliveryContext)
+      ? (entry.deliveryContext as { channel?: unknown }).channel
+      : undefined;
+  const originProvider =
+    entry.origin && typeof entry.origin === "object" && !Array.isArray(entry.origin)
+      ? (entry.origin as { provider?: unknown }).provider
+      : undefined;
+  const effectiveChannel =
+    stringValue(deliveryChannel) ??
+    stringValue(routeChannel) ??
+    stringValue(entry.channel) ??
+    stringValue(entry.lastChannel) ??
+    stringValue(originProvider);
+  return effectiveChannel ? isInternalMessageChannel(effectiveChannel) : false;
+}
+
 export function deriveGatewaySessionLifecycleSnapshot(params: {
   session?: Partial<LifecycleSessionShape> | null;
   event: LifecycleEventLike;
@@ -161,11 +329,33 @@ export function deriveGatewaySessionLifecycleSnapshot(params: {
 export function derivePersistedSessionLifecyclePatch(params: {
   entry?: Partial<PersistedLifecycleSessionShape> | null;
   event: LifecycleEventLike;
+  storePath?: string;
 }): Partial<PersistedLifecycleSessionShape> {
   const snapshot = deriveGatewaySessionLifecycleSnapshot({
     session: params.entry ?? undefined,
     event: params.event,
   });
+  if (
+    snapshot.status &&
+    snapshot.status === "failed" &&
+    isFiniteTimestamp(params.event.data?.startedAt) &&
+    params.entry &&
+    params.storePath &&
+    isInternalSessionEntry(params.entry) &&
+    hasSuccessfulAssistantMessage({
+      entry: params.entry,
+      storePath: params.storePath,
+      startedAt: snapshot.startedAt,
+      endedAt: snapshot.endedAt,
+    })
+  ) {
+    return {
+      ...snapshot,
+      updatedAt: typeof snapshot.updatedAt === "number" ? snapshot.updatedAt : undefined,
+      status: "done",
+      abortedLastRun: false,
+    };
+  }
   return {
     ...snapshot,
     updatedAt: typeof snapshot.updatedAt === "number" ? snapshot.updatedAt : undefined,
@@ -199,6 +389,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
       derivePersistedSessionLifecyclePatch({
         entry,
         event: params.event,
+        storePath: sessionEntry.storePath,
       }),
   });
 }

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1555,6 +1555,22 @@ export async function readLatestRecentSessionUsageFromTranscriptAsync(
   }
 }
 
+type SessionUsageSnapshotCacheEntry = {
+  mtimeMs: number;
+  size: number;
+  snapshot: SessionTranscriptUsageSnapshot | null;
+};
+const sessionUsageSnapshotCache = new Map<string, SessionUsageSnapshotCacheEntry>();
+const MAX_SESSION_USAGE_SNAPSHOT_CACHE_ENTRIES = 5000;
+
+/**
+ * Read aggregate usage from a session transcript tail, caching by file
+ * mtime+size. `sessions.list` calls this once per session, so without the
+ * cache a single listing re-read (open + 256KB read + parse) every transcript
+ * on the main thread — blocking the event loop long enough to stall unrelated
+ * RPC callbacks (e.g. chat.history's transcript read). Unchanged transcripts
+ * now hit the cache and only cost a stat.
+ */
 export function readRecentSessionUsageFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -1566,14 +1582,30 @@ export function readRecentSessionUsageFromTranscript(
   if (!filePath) {
     return null;
   }
+  const readLenCap = Math.max(1024, Math.floor(maxBytes));
+  const cacheKey = `${filePath}\t${readLenCap}`;
+  let stat: fs.Stats | null = null;
+  try {
+    stat = fs.statSync(filePath);
+  } catch {
+    sessionUsageSnapshotCache.delete(cacheKey);
+    return null;
+  }
+  const cached = sessionUsageSnapshotCache.get(cacheKey);
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    // LRU bump
+    sessionUsageSnapshotCache.delete(cacheKey);
+    sessionUsageSnapshotCache.set(cacheKey, cached);
+    return cached.snapshot;
+  }
 
-  return withOpenTranscriptFd(filePath, (fd) => {
-    const stat = fs.fstatSync(fd);
-    if (stat.size === 0) {
+  const snapshot = withOpenTranscriptFd(filePath, (fd) => {
+    const fdStat = fs.fstatSync(fd);
+    if (fdStat.size === 0) {
       return null;
     }
-    const readLen = Math.min(stat.size, Math.max(1024, Math.floor(maxBytes)));
-    const readStart = Math.max(0, stat.size - readLen);
+    const readLen = Math.min(fdStat.size, readLenCap);
+    const readStart = Math.max(0, fdStat.size - readLen);
     const buf = Buffer.alloc(readLen);
     const bytesRead = fs.readSync(fd, buf, 0, readLen, readStart);
     if (bytesRead <= 0) {
@@ -1586,6 +1618,20 @@ export function readRecentSessionUsageFromTranscript(
       .join("\n");
     return extractAggregateUsageFromTranscriptChunk(chunk);
   });
+
+  sessionUsageSnapshotCache.set(cacheKey, {
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+    snapshot: snapshot ?? null,
+  });
+  while (sessionUsageSnapshotCache.size > MAX_SESSION_USAGE_SNAPSHOT_CACHE_ENTRIES) {
+    const oldestKey = sessionUsageSnapshotCache.keys().next().value;
+    if (typeof oldestKey !== "string" || !oldestKey) {
+      break;
+    }
+    sessionUsageSnapshotCache.delete(oldestKey);
+  }
+  return snapshot;
 }
 
 const PREVIEW_READ_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -28,6 +28,8 @@ const publicSurfaceLocationCache = new Map<
   }
 >();
 const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
+const PUBLIC_SURFACE_ALIAS_IMPORT_RE =
+  /(?:\bfrom\s*["']|\bimport\s*\(\s*["']|\brequire\s*\(\s*["'])(?:openclaw\/|@openclaw\/|\.{1,2}\/[^"']+\.js["'])/u;
 
 function isSourceArtifactPath(modulePath: string): boolean {
   switch (path.extname(modulePath).toLowerCase()) {
@@ -43,11 +45,20 @@ function isSourceArtifactPath(modulePath: string): boolean {
   }
 }
 
+function sourceArtifactNeedsAliasLoader(modulePath: string): boolean {
+  try {
+    return PUBLIC_SURFACE_ALIAS_IMPORT_RE.test(fs.readFileSync(modulePath, "utf8"));
+  } catch {
+    return true;
+  }
+}
+
 function canUseSourceArtifactRequire(params: { modulePath: string; tryNative: boolean }): boolean {
   return (
     !params.tryNative &&
     isSourceArtifactPath(params.modulePath) &&
-    typeof sourceArtifactRequire.extensions?.[".ts"] === "function"
+    typeof sourceArtifactRequire.extensions?.[".ts"] === "function" &&
+    !sourceArtifactNeedsAliasLoader(params.modulePath)
   );
 }
 

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -39,7 +39,9 @@
 }
 
 .chat-group.user .chat-group-footer {
+  align-self: flex-end;
   justify-content: flex-end;
+  text-align: right;
 }
 
 /* Footer at bottom of message group (role + time) */
@@ -48,8 +50,10 @@
   gap: 8px;
   row-gap: 5px;
   align-items: center;
+  align-self: flex-start;
   flex-wrap: wrap;
   margin-top: 6px;
+  max-width: 100%;
 }
 
 .chat-sender-name {
@@ -175,8 +179,9 @@
   font-weight: 600;
   font-size: 13px;
   flex-shrink: 0;
-  align-self: flex-end;
-  margin-bottom: 4px;
+  align-self: flex-start;
+  margin-top: 2px;
+  margin-bottom: 0;
   border: 1px solid var(--border);
 }
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -2,8 +2,72 @@
    CHAT TEXT STYLING
    ============================================= */
 
-.chat-thinking {
+.chat-thinking-collapse {
   margin-bottom: 10px;
+  min-width: 0;
+}
+
+.chat-thinking-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  padding: 2px 6px 2px 2px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  font-size: var(--control-ui-text-xs);
+  font-weight: 500;
+  color: var(--muted);
+  transition: color 150ms ease;
+}
+
+.chat-thinking-summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-thinking-summary:hover {
+  color: var(--text);
+}
+
+.chat-thinking-summary__icon,
+.chat-thinking-summary__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  opacity: 0.65;
+}
+
+.chat-thinking-summary__icon {
+  width: 13px;
+  height: 13px;
+}
+
+.chat-thinking-summary__chevron {
+  width: 12px;
+  height: 12px;
+  transition: transform 150ms ease;
+}
+
+.chat-thinking-summary__icon svg,
+.chat-thinking-summary__chevron svg {
+  width: 100%;
+  height: 100%;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chat-thinking-collapse[open] .chat-thinking-summary__chevron {
+  transform: rotate(180deg);
+}
+
+.chat-thinking {
+  margin: 6px 0 0;
   padding: 10px 12px;
   border-radius: var(--radius-md);
   border: 1px dashed rgba(255, 255, 255, 0.18);

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -7,8 +7,8 @@
   border-radius: var(--radius-md);
   padding: 12px 14px;
   margin-top: 6px;
-  background: color-mix(in srgb, var(--card) 88%, var(--secondary) 12%);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--bg) 75%, transparent);
+  background: color-mix(in srgb, var(--secondary) 28%, transparent);
+  box-shadow: none;
   transition:
     border-color var(--duration-fast) ease-out,
     background var(--duration-fast) ease-out,
@@ -23,9 +23,9 @@
 }
 
 .chat-tool-card:hover {
-  border-color: color-mix(in srgb, var(--border-strong) 80%, transparent);
-  background: color-mix(in srgb, var(--card) 70%, var(--bg-hover) 30%);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--bg) 85%, transparent);
+  border-color: color-mix(in srgb, var(--border-strong) 60%, transparent);
+  background: color-mix(in srgb, var(--secondary) 40%, var(--bg-hover) 18%);
+  box-shadow: none;
 }
 
 /* First tool card in a group - no top margin */
@@ -646,7 +646,7 @@
   width: 100%;
   min-width: 0;
   max-width: 100%;
-  margin-top: 6px;
+  margin-top: 3px;
 }
 
 .chat-tool-msg-summary {
@@ -656,21 +656,17 @@
   gap: 8px;
   min-width: 0;
   box-sizing: border-box;
-  padding: 8px 11px;
+  padding: 4px 10px;
   cursor: pointer;
   font-size: var(--control-ui-text-sm);
   line-height: 1.4;
-  color: var(--text);
+  color: var(--muted);
   user-select: none;
   list-style: none;
-  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
   border-radius: var(--radius-md);
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--accent) 9%, transparent), transparent 34%),
-    color-mix(in srgb, var(--card) 86%, var(--secondary) 14%);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--bg) 76%, transparent),
-    0 8px 22px color-mix(in srgb, black 12%, transparent);
+  background: color-mix(in srgb, var(--secondary) 32%, transparent);
+  box-shadow: none;
   width: 100%;
   text-align: left;
   appearance: none;
@@ -683,9 +679,7 @@
 }
 
 .chat-tool-msg-summary[type="button"] {
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--accent) 9%, transparent), transparent 34%),
-    color-mix(in srgb, var(--card) 86%, var(--secondary) 14%);
+  background: color-mix(in srgb, var(--secondary) 32%, transparent);
 }
 
 .chat-tool-msg-summary.chat-tool-msg-summary--error {
@@ -726,10 +720,8 @@
 
 .chat-tool-msg-summary:hover {
   color: var(--text);
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--accent) 13%, transparent), transparent 38%),
-    color-mix(in srgb, var(--card) 76%, var(--bg-hover) 24%);
-  border-color: color-mix(in srgb, var(--border-strong) 70%, transparent);
+  background: color-mix(in srgb, var(--secondary) 48%, var(--bg-hover) 18%);
+  border-color: color-mix(in srgb, var(--border-strong) 50%, transparent);
 }
 
 .chat-tool-msg-summary.chat-tool-msg-summary--error:hover {
@@ -760,8 +752,8 @@
   width: 14px;
   height: 14px;
   margin-top: 2px;
-  color: var(--accent);
-  opacity: 0.75;
+  color: var(--muted);
+  opacity: 0.7;
   flex-shrink: 0;
 }
 
@@ -776,8 +768,8 @@
 }
 
 .chat-tool-msg-summary__label {
-  font-weight: 600;
-  color: var(--text);
+  font-weight: 500;
+  color: inherit;
   flex: 0 1 auto;
   min-width: 0;
   max-width: 100%;
@@ -847,11 +839,11 @@
 .chat-bubble--tool-shell .chat-tool-msg-body {
   margin-top: 0;
   padding: 12px 14px 14px;
-  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
   border-top: 0;
   border-radius: 0 0 var(--radius-md) var(--radius-md);
-  background: color-mix(in srgb, var(--card) 82%, var(--secondary) 18%);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--bg) 68%, transparent);
+  background: color-mix(in srgb, var(--secondary) 26%, transparent);
+  box-shadow: none;
   overflow: hidden;
 }
 

--- a/ui/src/styles/layout.mobile.test.ts
+++ b/ui/src/styles/layout.mobile.test.ts
@@ -162,6 +162,23 @@ describe("grouped chat width styles", () => {
     expect(css).toContain("max-width: var(--chat-message-max-width, min(900px, 68%));");
   });
 
+  it("keeps grouped chat avatars aligned with the first message bubble", () => {
+    const css = readGroupedChatCss();
+
+    expect(css).toMatch(/\.chat-avatar \{[\s\S]*align-self: flex-start;/);
+    expect(css).toMatch(/\.chat-avatar \{[\s\S]*margin-top: 2px;/);
+    expect(css).toMatch(/\.chat-avatar \{[\s\S]*margin-bottom: 0;/);
+  });
+
+  it("keeps grouped chat metadata beneath the bubble and aligned to the message side", () => {
+    const css = readGroupedChatCss();
+
+    expect(css).toMatch(/\.chat-group-footer \{[\s\S]*align-self: flex-start;/);
+    expect(css).toMatch(
+      /\.chat-group\.user \.chat-group-footer \{[\s\S]*align-self: flex-end;[\s\S]*text-align: right;/,
+    );
+  });
+
   it("excludes tool shells from light hover without overriding user bubble hover", () => {
     const css = readGroupedChatCss();
 

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1951,7 +1951,7 @@ describe("handleAbortChat", () => {
     expect(hasAbortableSessionRun(host)).toBe(false);
   });
 
-  it("ignores stale running status once the gateway reports no active run", () => {
+  it("ignores stale running status once active-run tracking is cleared", () => {
     const host = makeHost({
       chatRunId: null,
       sessionKey: "agent:main",

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1323,9 +1323,38 @@ describe("connectGateway", () => {
 
       expect(host.chatRunId).toBeNull();
       expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
-      expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+      if (terminalState === "error") {
+        expect(loadChatHistoryMock).toHaveBeenCalledWith(host, { clearError: false });
+      } else {
+        expect(loadChatHistoryMock).toHaveBeenCalledWith(host, { clearError: true });
+      }
     },
   );
+
+  it("preserves visible chat errors while replaying the deferred transcript reload", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "main-run-error";
+    loadChatHistoryMock.mockClear();
+
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "main",
+      },
+    });
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "main-run-error",
+        sessionKey: "main",
+        state: "error",
+        errorMessage: "LLM request failed: network connection error.",
+      },
+    });
+
+    expect(host.lastError).toBe("LLM request failed: network connection error.");
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host, { clearError: false });
+  });
 
   it("does not reload chat history after final assistant payload reconciles an active run", () => {
     const { host, client } = connectHostGateway();
@@ -1476,7 +1505,7 @@ describe("connectGateway", () => {
 
     expect(host.chatRunId).toBeNull();
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
-    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host, { clearError: true });
   });
 
   it("keeps deferred session.message reload pending across unowned terminal events", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -882,7 +882,9 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     return;
   }
   if (shouldReplayDeferredSessionMessageReload && !historyReloaded) {
-    void loadChatHistory(host as unknown as ChatState);
+    void loadChatHistory(host as unknown as ChatState, {
+      clearError: state !== "error",
+    });
   }
 }
 

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -23,6 +23,7 @@ import {
 import { startControlUiResponsivenessObserver } from "./control-ui-performance.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
 import type { Tab } from "./navigation.ts";
+import { startMainThreadBlockMonitor } from "./perf/main-thread-monitor.ts";
 
 type LifecycleHost = {
   basePath: string;
@@ -66,6 +67,7 @@ type LifecycleHost = {
   sessionsChangedReloadTimer?: number | ReturnType<typeof globalThis.setTimeout> | null;
   controlUiTabPaintSeq?: number;
   controlUiResponsivenessObserver?: { disconnect: () => void } | null;
+  mainThreadBlockMonitor?: { stop: () => void } | null;
   popStateHandler: () => void;
   topbarObserver: ResizeObserver | null;
 };
@@ -95,6 +97,9 @@ export function handleConnected(host: LifecycleHost) {
   }
   host.controlUiResponsivenessObserver ??= startControlUiResponsivenessObserver(
     host as unknown as Parameters<typeof startControlUiResponsivenessObserver>[0],
+  );
+  host.mainThreadBlockMonitor ??= startMainThreadBlockMonitor(
+    host as unknown as Parameters<typeof startMainThreadBlockMonitor>[0],
   );
 }
 
@@ -154,6 +159,8 @@ export function handleDisconnected(host: LifecycleHost) {
   host.topbarObserver = null;
   host.controlUiResponsivenessObserver?.disconnect();
   host.controlUiResponsivenessObserver = null;
+  host.mainThreadBlockMonitor?.stop();
+  host.mainThreadBlockMonitor = null;
 }
 
 export function handleUpdated(host: LifecycleHost, changed: Map<PropertyKey, unknown>) {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -795,7 +795,7 @@ describe("createChatSession", () => {
       { id: "att-1", mimeType: "image/png", dataUrl: "data:image/png;base64,AAA" },
     ]);
     expect(state.chatMessages).toStrictEqual([]);
-    expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(state, { coalesce: true });
   });
 
   it("preserves draft and attachment edits made while session creation is in flight", async () => {
@@ -818,7 +818,7 @@ describe("createChatSession", () => {
     expect(state.sessionKey).toBe("agent:ops:dashboard:new-chat");
     expect(state.chatMessage).toBe("updated draft");
     expect(state.chatAttachments).toBe(updatedAttachments);
-    expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(state, { coalesce: true });
   });
 
   it("ignores a stale create response after the active session changes", async () => {
@@ -980,15 +980,9 @@ describe("switchChatSession", () => {
       client: undefined,
       agentId: "main",
     });
-    expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(state, { coalesce: true });
     expect(syncSelectedSessionMessageSubscriptionMock).toHaveBeenCalledWith(state);
-    expect(loadSessionsMock).toHaveBeenCalledWith(state, {
-      activeMinutes: 120,
-      limit: 50,
-      includeGlobal: true,
-      includeUnknown: true,
-      showArchived: false,
-    });
+    expect(loadSessionsMock).not.toHaveBeenCalled();
     expect(
       (state as unknown as { announceSessionSwitch: ReturnType<typeof vi.fn> })
         .announceSessionSwitch,
@@ -1041,6 +1035,58 @@ describe("switchChatSession", () => {
     expect(state.chatQueue).toEqual([{ id: "queued-1", text: "message B", createdAt: 1 }]);
   });
 
+  it("preserves chat avatar state when switching between sessions for the same agent", async () => {
+    const settings = createSettings();
+    const state = {
+      sessionKey: "agent:main:first",
+      chatMessage: "",
+      chatAttachments: [],
+      chatMessages: [],
+      chatToolMessages: [],
+      chatStreamSegments: [],
+      chatThinkingLevel: null,
+      chatStream: null,
+      chatSideResult: null,
+      lastError: null,
+      compactionStatus: null,
+      fallbackStatus: null,
+      chatAvatarUrl: "blob:main-avatar",
+      chatAvatarSource: "/avatars/main.png",
+      chatAvatarStatus: "local",
+      chatAvatarReason: null,
+      chatQueue: [],
+      chatQueueBySession: {},
+      chatRunId: null,
+      sessionsShowArchived: false,
+      chatSideResultTerminalRuns: new Set<string>(),
+      chatStreamStartedAt: null,
+      settings,
+      announceSessionSwitch: vi.fn(),
+      applySettings(next: typeof settings) {
+        state.settings = next;
+      },
+      loadAssistantIdentity: vi.fn(),
+      resetToolStream: vi.fn(),
+      resetChatScroll: vi.fn(),
+      resetChatInputHistoryNavigation: vi.fn(),
+      client: { request: vi.fn() },
+    } as unknown as AppViewState;
+
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    refreshSlashCommandsMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockResolvedValue(undefined);
+
+    switchChatSession(state, "agent:main:second");
+    await Promise.resolve();
+
+    expect(state.chatAvatarUrl).toBe("blob:main-avatar");
+    expect(state.chatAvatarSource).toBe("/avatars/main.png");
+    expect(state.chatAvatarStatus).toBe("local");
+    expect(state.chatAvatarReason).toBeNull();
+    expect(refreshChatAvatarMock).not.toHaveBeenCalled();
+    expect(refreshSlashCommandsMock).not.toHaveBeenCalled();
+  });
+
   it("does not force agentId=main for plain session keys", async () => {
     const settings = createSettings();
     const state = {
@@ -1087,10 +1133,7 @@ describe("switchChatSession", () => {
       (state as unknown as { announceSessionSwitch: ReturnType<typeof vi.fn> })
         .announceSessionSwitch,
     ).not.toHaveBeenCalled();
-    expect(refreshSlashCommandsMock).toHaveBeenCalledWith({
-      client: state.client,
-      agentId: undefined,
-    });
+    expect(refreshSlashCommandsMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -15,7 +15,6 @@ import { loadChatHistory } from "./controllers/chat.ts";
 import type { ChatState } from "./controllers/chat.ts";
 import {
   createSessionAndRefresh,
-  loadSessions,
   syncSelectedSessionMessageSubscription,
 } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
@@ -644,20 +643,41 @@ export function renderChatMobileToggle(state: AppViewState) {
 
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   const previousSessionKey = state.sessionKey;
+  const nextAgentId = parseAgentSessionKey(nextSessionKey)?.agentId;
+  const previousAgentId = parseAgentSessionKey(previousSessionKey)?.agentId;
+  const agentChanged = !previousSessionKey || previousAgentId !== nextAgentId;
+  const previousChatAvatar = {
+    url: state.chatAvatarUrl,
+    source: state.chatAvatarSource,
+    status: state.chatAvatarStatus,
+    reason: state.chatAvatarReason,
+  };
   const nextSessionRow =
     state.sessionsResult?.sessions.find((row) => row.key === nextSessionKey) ??
     state.chatSessionPickerResult?.sessions.find((row) => row.key === nextSessionKey);
   const nextSessionLabel = resolveSessionDisplayName(nextSessionKey, nextSessionRow);
   resetChatStateForSessionSwitch(state, nextSessionKey);
+  if (!agentChanged) {
+    state.chatAvatarUrl = previousChatAvatar.url;
+    state.chatAvatarSource = previousChatAvatar.source;
+    state.chatAvatarStatus = previousChatAvatar.status;
+    state.chatAvatarReason = previousChatAvatar.reason;
+  }
   if (previousSessionKey !== nextSessionKey) {
     state.announceSessionSwitch?.(nextSessionKey, nextSessionLabel);
   }
-  void state.loadAssistantIdentity();
-  void refreshChatAvatar(state);
-  void refreshSlashCommands({
-    client: state.client,
-    agentId: parseAgentSessionKey(nextSessionKey)?.agentId,
-  });
+  // Agent identity, avatar, and slash commands are per-agent and
+  // process-stable — they don't change between sessions of the same agent, so
+  // only refetch them when the agent actually changes (switching among
+  // `agent:main:*` sessions otherwise refires these slow RPCs every time).
+  if (agentChanged) {
+    void state.loadAssistantIdentity();
+    void refreshChatAvatar(state);
+    void refreshSlashCommands({
+      client: state.client,
+      agentId: nextAgentId,
+    });
+  }
   syncUrlWithSessionKey(
     state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
     nextSessionKey,
@@ -666,8 +686,12 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   void syncSelectedSessionMessageSubscription(
     state as unknown as AppViewState & { chatSessionMessageSubscriptionKey?: string | null },
   );
-  void loadChatHistory(state as unknown as ChatState);
-  void refreshSessionOptions(state);
+  // A switch only needs the target session's transcript. The session list is
+  // unchanged by a switch — it refreshes on connect and on `sessions.changed`
+  // gateway events — so we no longer re-scan it here. That scan reads every
+  // session file and synchronously blocked the gateway event loop, delaying the
+  // transcript (chat.history) on every switch.
+  void loadChatHistory(state as unknown as ChatState, { coalesce: true });
 }
 
 export function dismissChatError(state: AppViewState) {
@@ -739,12 +763,6 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
   state.chatMessage = preservedDraft;
   state.chatAttachments = preservedAttachments;
   return true;
-}
-
-async function refreshSessionOptions(state: AppViewState) {
-  await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
-    ...createChatSessionsLoadOverrides(state),
-  });
 }
 
 /** Count cron sessions hidden by the active agent-scoped chat filter. */

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -149,6 +149,7 @@ import {
   titleForTab,
   type Tab,
 } from "./navigation.ts";
+import { beginRenderPhases, endRenderPhases } from "./perf/render-phase-profiler.ts";
 import { isPluginEnabledInConfigSnapshot } from "./plugin-activation.ts";
 import { isCronSessionKey, resolveSessionDisplayName } from "./session-display.ts";
 import "./components/dashboard-header.ts";
@@ -631,9 +632,12 @@ function renderMeasured<T>(
   render: () => T,
 ): T {
   const startedAtMs = controlUiNowMs();
+  beginRenderPhases();
   const result = render();
+  const phases = endRenderPhases();
   recordControlUiRenderTiming(state, surface, {
     ...payload,
+    ...(Object.keys(phases).length > 0 ? { phases } : {}),
     durationMs: roundedControlUiDurationMs(controlUiNowMs() - startedAtMs),
   });
   return result;

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   loadAgentSkillsMock: vi.fn(async () => {}),
   loadAgentsMock: vi.fn(async () => {}),
   loadChannelsMock: vi.fn<(hostValue: unknown, _probe: boolean) => Promise<void>>(async () => {}),
+  loadChatHistoryMock: vi.fn(async () => {}),
   loadConfigMock: vi.fn(async () => {}),
   loadConfigSchemaMock: vi.fn(async () => {}),
   loadCronStatusMock: vi.fn(async () => {}),
@@ -90,6 +91,9 @@ vi.mock("./controllers/agents.ts", () => ({
 vi.mock("./controllers/channels.ts", () => ({
   loadChannels: mocks.loadChannelsMock,
 }));
+vi.mock("./controllers/chat.ts", () => ({
+  loadChatHistory: mocks.loadChatHistoryMock,
+}));
 vi.mock("./controllers/config.ts", () => ({
   loadConfig: mocks.loadConfigMock,
   loadConfigSchema: mocks.loadConfigSchemaMock,
@@ -134,10 +138,10 @@ vi.mock("./controllers/workboard.ts", () => ({
   loadWorkboard: mocks.loadWorkboardMock,
 }));
 
-import { loadChannelsTab, refreshActiveTab, setTab } from "./app-settings.ts";
+import { loadChannelsTab, onPopState, refreshActiveTab, setTab } from "./app-settings.ts";
 
 function createHost() {
-  return {
+  const host = {
     tab: "agents",
     connected: true,
     client: {},
@@ -148,6 +152,8 @@ function createHost() {
       agents: [{ id: "agent-a" }, { id: "agent-b" }],
     },
     chatHasAutoScrolled: false,
+    chatQueue: [],
+    chatQueueBySession: {},
     logsAtBottom: false,
     eventLog: [],
     eventLogBuffer: [],
@@ -159,7 +165,13 @@ function createHost() {
     sessionKey: "main",
     settings: {},
     basePath: "",
+    applySettings: vi.fn((nextSettings: Record<string, unknown>) => {
+      host.settings = nextSettings;
+    }),
+    resetChatInputHistoryNavigation: vi.fn(),
+    resetChatScroll: vi.fn(),
   };
+  return host;
 }
 
 type BufferedPerformanceEvent = {
@@ -298,6 +310,72 @@ describe("refreshActiveTab", () => {
     });
 
     sessions.resolve();
+  });
+
+  it("refreshes non-chat tabs when reselecting the current tab", async () => {
+    const host = createHost();
+    host.tab = "sessions";
+
+    setTab(host as never, "sessions");
+    await Promise.resolve();
+
+    expect(mocks.loadSessionsMock).toHaveBeenCalledWith(host);
+  });
+
+  it("does not rerun chat bootstrap when reselecting the current chat tab", async () => {
+    const host = createHost();
+    host.tab = "chat";
+
+    setTab(host as never, "chat");
+    await Promise.resolve();
+
+    expect(mocks.refreshChatMock).not.toHaveBeenCalled();
+  });
+
+  it("reloads only chat history for same-agent same-tab route session changes", async () => {
+    const host = createHost();
+    host.tab = "chat";
+    host.sessionKey = "agent:main:first";
+    try {
+      vi.stubGlobal("window", {
+        location: {
+          href: "https://control.test/chat?session=agent%3Amain%3Asecond",
+          pathname: "/chat",
+        },
+      });
+
+      onPopState(host as never);
+      await vi.waitFor(() => {
+        expect(host.sessionKey).toBe("agent:main:second");
+        expect(mocks.loadChatHistoryMock).toHaveBeenCalledWith(host, { coalesce: true });
+      });
+      expect(mocks.refreshChatMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("reruns chat refresh for cross-agent same-tab route session changes", async () => {
+    const host = createHost();
+    host.tab = "chat";
+    host.sessionKey = "agent:main:first";
+    try {
+      vi.stubGlobal("window", {
+        location: {
+          href: "https://control.test/chat?session=agent%3Awork%3Asecond",
+          pathname: "/chat",
+        },
+      });
+
+      onPopState(host as never);
+      await Promise.resolve();
+
+      expect(host.sessionKey).toBe("agent:work:second");
+      expect(mocks.refreshChatMock).toHaveBeenCalledWith(host);
+      expect(mocks.loadChatHistoryMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("loads config before rendering session Workboard actions", async () => {

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -66,6 +66,7 @@ import {
   tabFromPath,
   type Tab,
 } from "./navigation.ts";
+import { parseAgentSessionKey } from "./session-key.ts";
 import {
   normalizeTextScale,
   saveLocalUserIdentity,
@@ -628,11 +629,29 @@ export function onPopState(host: SettingsHost) {
 
   const url = new URL(window.location.href);
   const session = normalizeOptionalString(url.searchParams.get("session"));
-  if (session) {
+  const previousTab = host.tab;
+  const previousSessionKey = host.sessionKey;
+  const previousAgentId = parseAgentSessionKey(previousSessionKey)?.agentId ?? null;
+  const nextAgentId = session ? (parseAgentSessionKey(session)?.agentId ?? null) : null;
+  const isConnectedChatSessionChange =
+    resolved === "chat" &&
+    previousTab === "chat" &&
+    session !== undefined &&
+    previousSessionKey !== session &&
+    host.connected;
+  const shouldSwitchChatSession = isConnectedChatSessionChange && previousAgentId === nextAgentId;
+  if (session && !shouldSwitchChatSession) {
     applySessionSelection(host, session);
   }
 
   setTabFromRoute(host, resolved);
+  if (shouldSwitchChatSession) {
+    void import("./app-render.helpers.ts").then(({ switchChatSession }) => {
+      switchChatSession(host as unknown as Parameters<typeof switchChatSession>[0], session);
+    });
+  } else if (isConnectedChatSessionChange) {
+    void refreshChat(host as unknown as Parameters<typeof refreshChat>[0]);
+  }
 }
 
 export function setTabFromRoute(host: SettingsHost, next: Tab) {
@@ -688,7 +707,15 @@ function applyTabSelection(
     host as unknown as Parameters<typeof startDebugPolling>[0],
   );
 
-  if (options.refreshPolicy === "always" || host.connected) {
+  // Re-selecting chat while already on chat happens during session switches and
+  // must not refire the full chat bootstrap burst. Other tabs keep the existing
+  // refreshPolicy "always" behavior so users can click the active tab to refresh.
+  const tabChanged = prev !== next;
+  const shouldRefresh =
+    options.refreshPolicy === "always"
+      ? tabChanged || next !== "chat"
+      : tabChanged && host.connected;
+  if (shouldRefresh) {
     void refreshActiveTab(host);
   }
 

--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -175,6 +175,10 @@ function chatHtml(opts: { sideResult?: boolean; singleAgent?: boolean } = {}) {
                     <div class="chat-avatar user">V</div>
                     <div class="chat-group-messages">
                       <div class="chat-bubble"><div class="chat-text">Please keep every control visible at the smallest viewport.</div></div>
+                      <div class="chat-group-footer">
+                        <span class="chat-sender-name">You</span>
+                        <span class="chat-group-timestamp">May 26, 2026 09:20</span>
+                      </div>
                     </div>
                   </div>
                   <div class="chat-group assistant">
@@ -186,6 +190,10 @@ function chatHtml(opts: { sideResult?: boolean; singleAgent?: boolean } = {}) {
                           <p>The chat shell should stay compact and readable.</p>
                           <pre><code>const importantLongIdentifier = "control-ui-chat-responsive-regression-fixture-keeps-code-scrollable"; console.log(importantLongIdentifier);</code></pre>
                         </div>
+                      </div>
+                      <div class="chat-group-footer">
+                        <span class="chat-sender-name">Assistant</span>
+                        <span class="chat-group-timestamp">May 26, 2026 09:21</span>
                       </div>
                     </div>
                   </div>
@@ -370,6 +378,28 @@ describeBrowserLayout("chat responsive browser layout", () => {
       await expectNoHorizontalOverflow(page);
       const code = await getBoundingBox(page, ".chat-text pre");
       expect(code.x + code.width).toBeLessThanOrEqual(width + 1);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("aligns avatars with the first bubble and keeps metadata below it", async () => {
+    const page = await openFixture(1366, 900);
+    try {
+      for (const role of ["user", "assistant"] as const) {
+        const prefix = `.chat-group.${role}`;
+        const avatar = await getRect(page, `${prefix} .chat-avatar`);
+        const bubble = await getRect(page, `${prefix} .chat-bubble`);
+        const footer = await getRect(page, `${prefix} .chat-group-footer`);
+
+        expect(Math.abs(avatar.top - bubble.top)).toBeLessThanOrEqual(3);
+        expect(footer.top).toBeGreaterThanOrEqual(bubble.bottom);
+        if (role === "user") {
+          expect(footer.right).toBeLessThanOrEqual(bubble.right + 1);
+        } else {
+          expect(footer.left).toBeGreaterThanOrEqual(bubble.left - 1);
+        }
+      }
     } finally {
       await page.close();
     }

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -539,6 +539,35 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector('[aria-label="Read aloud"]')).toBeNull();
   });
 
+  it("renders message bubbles before group metadata", () => {
+    const container = document.createElement("div");
+    renderMessageGroups(container, [
+      createMessageGroup(
+        {
+          role: "user",
+          content: "hello from user",
+          timestamp: 1000,
+        },
+        "user",
+      ),
+      createMessageGroup(
+        {
+          role: "assistant",
+          content: "hello from assistant",
+          timestamp: 1001,
+        },
+        "assistant",
+      ),
+    ]);
+
+    for (const role of ["user", "assistant"]) {
+      const group = expectElement(container, `.chat-group.${role}`, HTMLElement);
+      const bubble = expectElement(group, ".chat-bubble", HTMLElement);
+      const footer = expectElement(group, ".chat-group-footer", HTMLElement);
+      expect(bubble.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    }
+  });
+
   it("reserves bubble space when assistant message actions render", () => {
     const container = document.createElement("div");
     renderAssistantMessage(container, {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -18,6 +18,7 @@ import type {
 } from "../types/chat-types.ts";
 import { resolveLocalUserName } from "../user-identity.ts";
 export { resolveAssistantTextAvatar } from "../views/agents-utils.ts";
+import { profilePhase } from "../perf/render-phase-profiler.ts";
 import { renderChatAvatar } from "./chat-avatar.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import { extractThinkingCached, formatReasoningMarkdown } from "./message-extract.ts";
@@ -1344,6 +1345,26 @@ function renderAssistantAttachments(
   `;
 }
 
+/**
+ * Collapsible reasoning/thinking block. Starts open while reasoning is the only
+ * output (`open=true`) and collapses once the answer text arrives so it stays
+ * out of the way. Styled by `.chat-thinking-collapse` in chat/text.css.
+ */
+function renderThinkingBlock(reasoningMarkdown: string, open: boolean) {
+  return html`
+    <details class="chat-thinking-collapse" ?open=${open}>
+      <summary class="chat-thinking-summary">
+        <span class="chat-thinking-summary__icon">${icons.brain}</span>
+        <span>Thinking</span>
+        <span class="chat-thinking-summary__chevron">${icons.chevronDown}</span>
+      </summary>
+      <div class="chat-thinking" dir="${detectTextDirection(reasoningMarkdown)}">
+        ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+      </div>
+    </details>
+  `;
+}
+
 function renderInlineToolCards(
   toolCards: ToolCard[],
   opts: {
@@ -1386,6 +1407,10 @@ const MAX_JSON_AUTOPARSE_CHARS = 20_000;
  * Size-capped to prevent render-loop DoS from large JSON messages.
  */
 function detectJson(text: string): { parsed: unknown; pretty: string } | null {
+  return profilePhase("detectJson", () => detectJsonImpl(text));
+}
+
+function detectJsonImpl(text: string): { parsed: unknown; pretty: string } | null {
   const t = text.trim();
 
   // Enforce size cap to prevent UI freeze from multi-MB JSON payloads
@@ -1500,6 +1525,9 @@ function renderGroupedMessage(
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
   const markdownRenderOptions = role === "user" ? { codeBlockChrome: "none" as const } : undefined;
+  // Keep reasoning open while it's the only thing produced (thinking in progress);
+  // collapse it once the answer text appears so it stays out of the way.
+  const thinkingOpen = !markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
   const hasActions = canCopyMarkdown || canExpand;
@@ -1627,9 +1655,7 @@ function renderGroupedMessage(
                         opts.onRequestUpdate,
                       )}
                       ${reasoningMarkdown
-                        ? html`<div class="chat-thinking">
-                            ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
-                          </div>`
+                        ? renderThinkingBlock(reasoningMarkdown, thinkingOpen)
                         : nothing}
                       ${jsonResult
                         ? html`<details
@@ -1684,11 +1710,7 @@ function renderGroupedMessage(
               opts.assistantAttachmentAuthToken,
               opts.onRequestUpdate,
             )}
-            ${reasoningMarkdown
-              ? html`<div class="chat-thinking">
-                  ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
-                </div>`
-              : nothing}
+            ${reasoningMarkdown ? renderThinkingBlock(reasoningMarkdown, thinkingOpen) : nothing}
             ${normalizedRole === "assistant" && assistantViewBlocks.length > 0
               ? html`${assistantViewBlocks.map(
                   (block) => html`${renderToolPreview(block.preview, "chat_message", {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -123,5 +123,5 @@ export function formatReasoningMarkdown(text: string): string {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => `_${line}_`);
-  return lines.length ? ["_Reasoning:_", ...lines].join("\n") : "";
+  return lines.length ? lines.join("\n") : "";
 }

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -461,6 +461,82 @@ describe("message-normalizer", () => {
       expect(result.content).toStrictEqual([]);
     });
 
+    it("renders assistant error messages when the transcript has no content blocks", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        provider: "local-openai",
+        model: "openai/gpt-5-5",
+        errorMessage: "403 This token has no access to model openai/gpt-5-5 (request id: req-1)",
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: "Assistant failed (local-openai/openai/gpt-5-5): 403 This token has no access to model openai/gpt-5-5 (request id: req-1)",
+        },
+      ]);
+    });
+
+    it("redacts obvious bearer secrets from fallback assistant errors", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "request failed with Bearer abcdefghijklmnop",
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: "Assistant failed: request failed with Bearer abcdef...mnop",
+        },
+      ]);
+    });
+
+    it("does not render stale non-error assistant error metadata", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: [],
+        stopReason: "end_turn",
+        errorMessage: "stale background failure",
+      });
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("redacts credential-shaped values from fallback assistant errors", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        stopReason: "error",
+        errorMessage:
+          "api_key=sk-1234567890abcdef Authorization: Basic dGVzdHNlY3JldHRva2Vu ghp_abcdefghijklmnopqrstuvwxyz AIza1234567890abcdefghijklmnop",
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: "Assistant failed: api_key=sk-123...cdef Authorization: Basic dGVzdH...b2Vu ghp_ab...wxyz AIza12...mnop",
+        },
+      ]);
+    });
+
+    it("redacts lowercase authorization headers from fallback assistant errors", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        stopReason: "error",
+        errorMessage:
+          "request headers included authorization: bearer eyJabcdefghijklmnopqrstuvwxyz0123456789 and authorization: basic dGVzdHNlY3JldHRva2Vu",
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: "Assistant failed: request headers included authorization: bearer eyJabc...6789 and authorization: basic dGVzdH...b2Vu",
+        },
+      ]);
+    });
+
     it("uses current timestamp when not provided", () => {
       const result = normalizeMessage({ role: "user", content: "Test" });
       expect(result.timestamp).toBe(Date.now());

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -210,6 +210,96 @@ function mergeAdjacentTextItems(items: MessageContentItem[]): MessageContentItem
   return merged.filter((item) => item.type !== "text" || Boolean(item.text?.trim()));
 }
 
+function readTrimmedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+const VISIBLE_ERROR_SECRET_PATTERNS: RegExp[] = [
+  /\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g,
+  /[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|api[-_]?key|client[-_]?secret|token|key|secret|password|pass|passwd|auth|signature)=([^&\s"'<>]+)/gi,
+  /"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken)"\s*:\s*"([^"]+)"/g,
+  /--(?:api[-_]?key|hook[-_]?token|token|secret|password|passwd)\s+(["']?)([^\s"']+)\1/g,
+  /Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=]+)/gi,
+  /Authorization\s*[:=]\s*Basic\s+([A-Za-z0-9+/=]+)/gi,
+  /(?:X-OpenClaw-Token|x-pomerium-jwt-assertion|X-Api-Key|X-Auth-Token)\s*[:=]\s*([^\s"',;]+)/gi,
+  /\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b/gi,
+  /(^|[\s,;])(?:access_token|refresh_token|auth[-_]?token|api[-_]?key|client[-_]?secret|token|secret|password|passwd)=([^\s&#]+)/gi,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----/g,
+  /\b(sk-[A-Za-z0-9_-]{8,})\b/g,
+  /\b(ghp_[A-Za-z0-9]{20,})\b/g,
+  /\b(github_pat_[A-Za-z0-9_]{20,})\b/g,
+  /\b(xox[baprs]-[A-Za-z0-9-]{10,})\b/g,
+  /\b(xapp-[A-Za-z0-9-]{10,})\b/g,
+  /\b(gsk_[A-Za-z0-9_-]{10,})\b/g,
+  /\b(AIza[0-9A-Za-z\-_]{20,})\b/g,
+  /\b(ya29\.[0-9A-Za-z_\-./+=]{10,})\b/g,
+  /\b(1\/\/0[0-9A-Za-z_\-./+=]{10,})\b/g,
+  /\b(pplx-[A-Za-z0-9_-]{10,})\b/g,
+  /\b(npm_[A-Za-z0-9]{10,})\b/g,
+  /\bbot(\d{6,}:[A-Za-z0-9_-]{20,})\b/g,
+  /\b(\d{6,}:[A-Za-z0-9_-]{20,})\b/g,
+];
+
+function maskVisibleSecret(token: string): string {
+  if (token.length < 18) {
+    return "***";
+  }
+  return `${token.slice(0, 6)}...${token.slice(-4)}`;
+}
+
+function redactVisibleErrorMatch(match: string, groups: string[]): string {
+  if (match.includes("PRIVATE KEY-----")) {
+    const lines = match.split(/\r?\n/).filter(Boolean);
+    if (lines.length < 2) {
+      return "***";
+    }
+    return `${lines[0]}\n...redacted...\n${lines[lines.length - 1]}`;
+  }
+  let token = match;
+  for (let index = groups.length - 1; index >= 0; index -= 1) {
+    const value = groups[index];
+    if (typeof value === "string" && value.length > 0) {
+      token = value;
+      break;
+    }
+  }
+  const masked = maskVisibleSecret(token);
+  return token === match ? masked : match.replace(token, masked);
+}
+
+function redactVisibleErrorText(text: string): string {
+  let next = text;
+  for (const pattern of VISIBLE_ERROR_SECRET_PATTERNS) {
+    next = next.replace(pattern, (...args: string[]) =>
+      redactVisibleErrorMatch(args[0] ?? "", args.slice(1, -2)),
+    );
+  }
+  return next;
+}
+
+function fallbackAssistantErrorContent(
+  message: Record<string, unknown>,
+  content: MessageContentItem[],
+): MessageContentItem[] {
+  if (content.length > 0) {
+    return content;
+  }
+  if (message.stopReason !== "error") {
+    return content;
+  }
+  const errorText =
+    readTrimmedString(message.errorMessage) ?? "Assistant turn failed before producing content.";
+  const provider = readTrimmedString(message.provider);
+  const model = readTrimmedString(message.model);
+  const target = provider && model ? ` (${provider}/${model})` : "";
+  return [
+    {
+      type: "text",
+      text: `Assistant failed${target}: ${redactVisibleErrorText(errorText)}`,
+    },
+  ];
+}
+
 export function stripMessageDisplayMetadataText(text: string): string {
   return stripInboundMetadata(text);
 }
@@ -446,6 +536,9 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     typeof m.senderLabel === "string" && m.senderLabel.trim() ? m.senderLabel.trim() : null;
 
   content = stripMessageDisplayMetadata(content);
+  if (isAssistantMessage) {
+    content = fallbackAssistantErrorContent(m, content);
+  }
 
   return {
     role,

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -198,6 +198,13 @@ function currentSessionRow(host: RunLifecycleHost) {
   return host.sessionsResult?.sessions.find((row) => row.key === host.sessionKey);
 }
 
+function inactiveRunSessionStatus(row: { status?: SessionRunStatus }): SessionRunStatus {
+  if (!row.status || row.status === "running") {
+    return "killed";
+  }
+  return row.status;
+}
+
 export function reconcileChatRunFromCurrentSessionRow(
   host: RunLifecycleHost,
   options: { publishRunStatus?: boolean } = {},
@@ -216,9 +223,10 @@ export function reconcileChatRunFromCurrentSessionRow(
   if (row.hasActiveRun !== false && !terminalStatus) {
     return false;
   }
+  const sessionStatus = inactiveRunSessionStatus(row);
   reconcileChatRunLifecycle(host, {
-    outcome: row.status === "done" ? "done" : "interrupted",
-    sessionStatus: row.status === "done" ? "done" : (row.status ?? "killed"),
+    outcome: sessionStatus === "done" ? "done" : "interrupted",
+    sessionStatus,
     runId: host.chatRunId,
     sessionKey: host.sessionKey,
     clearLocalRun: true,

--- a/ui/src/ui/chat/tool-expansion-state.test.ts
+++ b/ui/src/ui/chat/tool-expansion-state.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { MessageGroup } from "../types/chat-types.ts";
 import {
   getExpandedToolCards,
+  markToolCardManuallyToggled,
   resetToolExpansionStateForTest,
   syncToolCardExpansionState,
 } from "./tool-expansion-state.ts";
@@ -9,6 +10,10 @@ import {
 afterEach(() => {
   resetToolExpansionStateForTest();
 });
+
+function toolCallContent(name: string, id: string) {
+  return { type: "toolcall", id, name, arguments: { q: id } };
+}
 
 function createGroup(message: unknown, key = "assistant-1"): MessageGroup {
   return {
@@ -22,23 +27,80 @@ function createGroup(message: unknown, key = "assistant-1"): MessageGroup {
 }
 
 describe("tool expansion state", () => {
-  it("expands already-visible tool cards when auto-expand turns on", () => {
+  it("keeps only the last tool card in a turn expanded", () => {
     const group = createGroup({
       role: "assistant",
       content: [
-        {
-          type: "toolcall",
-          id: "call-1",
-          name: "browser.open",
-          arguments: { url: "https://example.com" },
-        },
+        toolCallContent("browser.open", "call-1"),
+        toolCallContent("browser.open", "call-2"),
+        toolCallContent("browser.open", "call-3"),
       ],
     });
 
     syncToolCardExpansionState("main", [group], false);
-    expect(getExpandedToolCards("main").get("assistant-1:toolcard:0")).toBe(false);
+
+    const expanded = getExpandedToolCards("main");
+    expect(expanded.get("assistant-1:toolcard:0")).toBe(false);
+    expect(expanded.get("assistant-1:toolcard:1")).toBe(false);
+    expect(expanded.get("assistant-1:toolcard:2")).toBe(true);
+  });
+
+  it("ignores the auto-expand preference (last-only is always in effect)", () => {
+    const group = createGroup({
+      role: "assistant",
+      content: [
+        toolCallContent("browser.open", "call-1"),
+        toolCallContent("browser.open", "call-2"),
+      ],
+    });
 
     syncToolCardExpansionState("main", [group], true);
+
+    const expanded = getExpandedToolCards("main");
+    expect(expanded.get("assistant-1:toolcard:0")).toBe(false);
+    expect(expanded.get("assistant-1:toolcard:1")).toBe(true);
+  });
+
+  it("re-evaluates the expanded card as new tool results stream into the turn", () => {
+    const first = createGroup({
+      role: "assistant",
+      content: [toolCallContent("browser.open", "call-1")],
+    });
+    syncToolCardExpansionState("main", [first], false);
     expect(getExpandedToolCards("main").get("assistant-1:toolcard:0")).toBe(true);
+
+    const grown = createGroup({
+      role: "assistant",
+      content: [
+        toolCallContent("browser.open", "call-1"),
+        toolCallContent("browser.open", "call-2"),
+      ],
+    });
+    syncToolCardExpansionState("main", [grown], false);
+
+    const expanded = getExpandedToolCards("main");
+    expect(expanded.get("assistant-1:toolcard:0")).toBe(false);
+    expect(expanded.get("assistant-1:toolcard:1")).toBe(true);
+  });
+
+  it("leaves manually toggled cards alone", () => {
+    const group = createGroup({
+      role: "assistant",
+      content: [
+        toolCallContent("browser.open", "call-1"),
+        toolCallContent("browser.open", "call-2"),
+      ],
+    });
+
+    syncToolCardExpansionState("main", [group], false);
+    // User opens the earlier card by hand.
+    getExpandedToolCards("main").set("assistant-1:toolcard:0", true);
+    markToolCardManuallyToggled("main", "assistant-1:toolcard:0");
+
+    syncToolCardExpansionState("main", [group], false);
+
+    const expanded = getExpandedToolCards("main");
+    expect(expanded.get("assistant-1:toolcard:0")).toBe(true);
+    expect(expanded.get("assistant-1:toolcard:1")).toBe(true);
   });
 });

--- a/ui/src/ui/chat/tool-expansion-state.ts
+++ b/ui/src/ui/chat/tool-expansion-state.ts
@@ -4,73 +4,102 @@ import { getOrCreateSessionCacheValue } from "./session-cache.ts";
 import { extractToolCards } from "./tool-cards.ts";
 
 const expandedToolCardsBySession = new Map<string, Map<string, boolean>>();
-const initializedToolCardsBySession = new Map<string, Set<string>>();
-const lastAutoExpandPrefBySession = new Map<string, boolean>();
+const manuallyToggledBySession = new Map<string, Set<string>>();
 
 export function getExpandedToolCards(sessionKey: string): Map<string, boolean> {
   return getOrCreateSessionCacheValue(expandedToolCardsBySession, sessionKey, () => new Map());
 }
 
-function getInitializedToolCards(sessionKey: string): Set<string> {
-  return getOrCreateSessionCacheValue(initializedToolCardsBySession, sessionKey, () => new Set());
+function getManuallyToggledToolCards(sessionKey: string): Set<string> {
+  return getOrCreateSessionCacheValue(manuallyToggledBySession, sessionKey, () => new Set());
+}
+
+/**
+ * Record that the user opened/closed a tool card by hand. Manually toggled
+ * cards keep their state and stop following the auto "only the last card in
+ * the turn stays open" rule until the card scrolls out of the transcript.
+ */
+export function markToolCardManuallyToggled(sessionKey: string, disclosureId: string) {
+  getManuallyToggledToolCards(sessionKey).add(disclosureId);
 }
 
 export function resetToolExpansionStateForTest() {
   expandedToolCardsBySession.clear();
-  initializedToolCardsBySession.clear();
-  lastAutoExpandPrefBySession.clear();
+  manuallyToggledBySession.clear();
 }
 
+function isToolEntryMessage(message: unknown): boolean {
+  const record = message as Record<string, unknown>;
+  const role = typeof record.role === "string" ? record.role : "unknown";
+  const normalizedRole = normalizeRoleForGrouping(role);
+  return (
+    isToolResultMessage(message) ||
+    normalizedRole === "tool" ||
+    role.toLowerCase() === "toolresult" ||
+    role.toLowerCase() === "tool_result" ||
+    typeof record.toolCallId === "string" ||
+    typeof record.tool_call_id === "string"
+  );
+}
+
+/** Collect tool disclosure ids for one group, in the order they render. */
+function collectGroupDisclosureIds(group: MessageGroup): string[] {
+  const ids: string[] = [];
+  for (const entry of group.messages) {
+    const cards = extractToolCards(entry.message, entry.key);
+    for (let cardIndex = 0; cardIndex < cards.length; cardIndex++) {
+      ids.push(`${entry.key}:toolcard:${cardIndex}`);
+    }
+    if (isToolEntryMessage(entry.message)) {
+      ids.push(`toolmsg:${entry.key}`);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Keep the transcript clean: within each turn (message group) only the most
+ * recent tool card stays expanded; every earlier card collapses to a single
+ * row. Re-evaluated on every render so a turn's expanded card follows the
+ * latest streamed tool result. Cards the user toggled by hand are left alone.
+ *
+ * The `autoExpandToolCalls` preference no longer forces every card open; the
+ * last-card-only rule is always in effect.
+ */
 export function syncToolCardExpansionState(
   sessionKey: string,
   items: Array<ChatItem | MessageGroup>,
-  autoExpandToolCalls: boolean,
+  _autoExpandToolCalls: boolean,
 ) {
   const expanded = getExpandedToolCards(sessionKey);
-  const initialized = getInitializedToolCards(sessionKey);
-  const previousAutoExpand = lastAutoExpandPrefBySession.get(sessionKey) ?? false;
-  const currentToolCardIds = new Set<string>();
+  const manual = getManuallyToggledToolCards(sessionKey);
+  const live = new Set<string>();
+
   for (const item of items) {
     if (item.kind !== "group") {
       continue;
     }
-    for (const entry of item.messages) {
-      const cards = extractToolCards(entry.message, entry.key);
-      for (let cardIndex = 0; cardIndex < cards.length; cardIndex++) {
-        const disclosureId = `${entry.key}:toolcard:${cardIndex}`;
-        currentToolCardIds.add(disclosureId);
-        if (initialized.has(disclosureId)) {
-          continue;
-        }
-        expanded.set(disclosureId, autoExpandToolCalls);
-        initialized.add(disclosureId);
-      }
-      const messageRecord = entry.message as Record<string, unknown>;
-      const role = typeof messageRecord.role === "string" ? messageRecord.role : "unknown";
-      const normalizedRole = normalizeRoleForGrouping(role);
-      const isToolMessage =
-        isToolResultMessage(entry.message) ||
-        normalizedRole === "tool" ||
-        role.toLowerCase() === "toolresult" ||
-        role.toLowerCase() === "tool_result" ||
-        typeof messageRecord.toolCallId === "string" ||
-        typeof messageRecord.tool_call_id === "string";
-      if (!isToolMessage) {
+    const disclosureIds = collectGroupDisclosureIds(item);
+    const lastId = disclosureIds.at(-1);
+    for (const disclosureId of disclosureIds) {
+      live.add(disclosureId);
+      if (manual.has(disclosureId)) {
         continue;
       }
-      const disclosureId = `toolmsg:${entry.key}`;
-      currentToolCardIds.add(disclosureId);
-      if (initialized.has(disclosureId)) {
-        continue;
-      }
-      expanded.set(disclosureId, autoExpandToolCalls);
-      initialized.add(disclosureId);
+      expanded.set(disclosureId, disclosureId === lastId);
     }
   }
-  if (autoExpandToolCalls && !previousAutoExpand) {
-    for (const toolCardId of currentToolCardIds) {
-      expanded.set(toolCardId, true);
+
+  // Forget cards that left the transcript so manual flags and stale state do
+  // not leak across reloads or session switches.
+  for (const id of [...manual]) {
+    if (!live.has(id)) {
+      manual.delete(id);
     }
   }
-  lastAutoExpandPrefBySession.set(sessionKey, autoExpandToolCalls);
+  for (const id of [...expanded.keys()]) {
+    if (!live.has(id)) {
+      expanded.delete(id);
+    }
+  }
 }

--- a/ui/src/ui/control-ui-performance.ts
+++ b/ui/src/ui/control-ui-performance.ts
@@ -48,6 +48,30 @@ type ResponsivenessPerformanceEntry = PerformanceEntry & {
   scripts?: LongAnimationFrameScriptTiming[];
 };
 
+type PerfLogSink = (entry: EventLogEntry) => void;
+
+// Events worth persisting to the desktop perf log file (RPC/render/stall
+// timings). Refresh start/end markers and other bookkeeping are skipped.
+const PERF_LOG_FORWARDED_EVENTS = new Set([
+  "control-ui.rpc",
+  "control-ui.render",
+  "control-ui.main-thread-block",
+  "control-ui.long-animation-frame",
+  "control-ui.longtask",
+  "control-ui.tab.visible",
+]);
+
+let perfLogSink: PerfLogSink | null = null;
+
+/**
+ * Install a sink that mirrors key performance events somewhere durable (the
+ * desktop app forwards them to a log file, since the webview has no console we
+ * can read). No-op on surfaces that never set a sink (e.g. the web build).
+ */
+export function setControlUiPerfLogSink(sink: PerfLogSink | null) {
+  perfLogSink = sink;
+}
+
 export function controlUiNowMs(): number {
   return typeof performance !== "undefined" && typeof performance.now === "function"
     ? performance.now()
@@ -93,6 +117,13 @@ export function recordControlUiPerformanceEvent(
   opts?: { warn?: boolean; console?: boolean; maxBufferedEventsForType?: number },
 ) {
   const entry: EventLogEntry = { ts: Date.now(), event, payload };
+  if (perfLogSink && PERF_LOG_FORWARDED_EVENTS.has(event)) {
+    try {
+      perfLogSink(entry);
+    } catch {
+      // Never let a debug sink break the app.
+    }
+  }
   if (Array.isArray(host.eventLogBuffer)) {
     const existingBuffer =
       typeof opts?.maxBufferedEventsForType === "number"

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -968,6 +968,22 @@ describe("loadChatHistory filtering", () => {
     expect(state.chatLoading).toBe(false);
   });
 
+  it("can preserve an existing visible error while reloading history", async () => {
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      lastError: "LLM request failed: network connection error.",
+    });
+
+    await loadChatHistory(state, { clearError: false });
+
+    expect(state.lastError).toBe("LLM request failed: network connection error.");
+    expect(state.chatLoading).toBe(false);
+  });
+
   it("keeps assistant message when text field has real content but content is NO_REPLY", async () => {
     const messages = [{ role: "assistant", text: "real reply", content: "NO_REPLY" }];
     const mockClient = {
@@ -1694,6 +1710,70 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatLoading).toBe(false);
   });
 
+  it("does not coalesce default same-session loads so event-driven refreshes can fetch new transcript state", async () => {
+    const firstRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const secondRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const request = vi
+      .fn()
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "visible old" }] }],
+    });
+
+    const firstLoad = loadChatHistory(state);
+    const secondLoad = loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledTimes(2);
+
+    firstRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "stale" }] }],
+      thinkingLevel: "high",
+    });
+    await firstLoad;
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "visible old" }] },
+    ]);
+
+    secondRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "fresh" }] }],
+      thinkingLevel: "low",
+    });
+    await secondLoad;
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "fresh" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("low");
+  });
+
+  it("coalesces explicit duplicate same-session loads", async () => {
+    const historyRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const request = vi.fn(() => historyRequest.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const firstLoad = loadChatHistory(state, { coalesce: true });
+    const secondLoad = loadChatHistory(state, { coalesce: true });
+
+    expect(request).toHaveBeenCalledTimes(1);
+
+    historyRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "shared" }] }],
+      thinkingLevel: "minimal",
+    });
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "shared" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("minimal");
+  });
+
   it("ignores stale history responses after switching sessions", async () => {
     const mainRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
     const otherRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
@@ -1741,6 +1821,68 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatThinkingLevel).toBe("low");
   });
 
+  it("starts a fresh history load after switching back to a session with an older in-flight load", async () => {
+    const firstMainRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const otherRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const secondMainRequest = createDeferred<{
+      messages: Array<unknown>;
+      thinkingLevel?: string;
+    }>();
+    let mainRequestCount = 0;
+    const request = vi.fn((_method: string, params?: { sessionKey?: string }) => {
+      if (params?.sessionKey === "main") {
+        mainRequestCount += 1;
+        return mainRequestCount === 1 ? firstMainRequest.promise : secondMainRequest.promise;
+      }
+      if (params?.sessionKey === "other") {
+        return otherRequest.promise;
+      }
+      throw new Error(`Unexpected sessionKey: ${String(params?.sessionKey)}`);
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "visible old" }] }],
+    });
+
+    const firstMainLoad = loadChatHistory(state);
+    state.sessionKey = "other";
+    const otherLoad = loadChatHistory(state);
+    state.sessionKey = "main";
+    const secondMainLoad = loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledTimes(3);
+
+    firstMainRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "first main" }] }],
+      thinkingLevel: "high",
+    });
+    await firstMainLoad;
+    otherRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "other history" }] }],
+      thinkingLevel: "minimal",
+    });
+    await otherLoad;
+
+    expect(state.chatLoading).toBe(true);
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "visible old" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBeNull();
+
+    secondMainRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "second main" }] }],
+      thinkingLevel: "low",
+    });
+    await secondMainLoad;
+
+    expect(state.chatLoading).toBe(false);
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "second main" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("low");
+  });
+
   it("ignores stale global history responses after switching selected agents", async () => {
     const workRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
     const request = vi.fn((_method: string, params?: { agentId?: string; sessionKey?: string }) => {
@@ -1771,5 +1913,58 @@ describe("loadChatHistory retry handling", () => {
       { role: "assistant", content: [{ type: "text", text: "visible old" }] },
     ]);
     expect(state.chatThinkingLevel).toBeNull();
+  });
+
+  it("does not coalesce global history loads across selected agents", async () => {
+    const workRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const mainRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const request = vi.fn((_method: string, params?: { agentId?: string; sessionKey?: string }) => {
+      if (params?.sessionKey === "global" && params.agentId === "work") {
+        return workRequest.promise;
+      }
+      if (params?.sessionKey === "global" && params.agentId === "main") {
+        return mainRequest.promise;
+      }
+      throw new Error(`Unexpected request: ${JSON.stringify(params)}`);
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      sessionKey: "global",
+      assistantAgentId: "work",
+      agentsList: { defaultId: "main" },
+      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "visible old" }] }],
+    });
+
+    const workLoad = loadChatHistory(state);
+    state.assistantAgentId = "main";
+    const mainLoad = loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls.map(([, params]) => params)).toEqual([
+      expect.objectContaining({ sessionKey: "global", agentId: "work" }),
+      expect.objectContaining({ sessionKey: "global", agentId: "main" }),
+    ]);
+
+    workRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "work history" }] }],
+      thinkingLevel: "high",
+    });
+    await workLoad;
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "visible old" }] },
+    ]);
+
+    mainRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "main history" }] }],
+      thinkingLevel: "low",
+    });
+    await mainLoad;
+
+    expect(state.chatLoading).toBe(false);
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "main history" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("low");
   });
 });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -394,21 +394,84 @@ function maybeResetToolStream(state: ChatState) {
   }
 }
 
-export async function loadChatHistory(state: ChatState) {
+type InFlightChatHistoryLoad = {
+  promise: Promise<void>;
+  version: number;
+};
+
+const inFlightChatHistoryLoads = new WeakMap<object, Map<string, InFlightChatHistoryLoad>>();
+
+/**
+ * Coalesce concurrent history loads for the same session. A single session
+ * switch fans out into two `loadChatHistory` calls — one direct, one from the
+ * subscription's initial event ~100ms later — and the gateway is often slow, so
+ * firing the request twice doubled the visible wait. Callers that arrive while a
+ * load for the same session is in flight share that one request instead.
+ */
+export async function loadChatHistory(
+  state: ChatState,
+  options: { clearError?: boolean; coalesce?: boolean } = {},
+): Promise<void> {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  const { coalesce: shouldCoalesce, ...loadOptions } = options;
+  if (shouldCoalesce !== true) {
+    const requestAgentId = isSelectedGlobalEventSessionKey(state.sessionKey)
+      ? resolveSelectedAgentId(state)
+      : null;
+    return await runChatHistoryLoad(state, {
+      ...loadOptions,
+      requestAgentId,
+      requestVersion: beginChatHistoryRequest(state),
+    });
+  }
+  const stateKey = state as object;
+  let bySession = inFlightChatHistoryLoads.get(stateKey);
+  if (!bySession) {
+    bySession = new Map();
+    inFlightChatHistoryLoads.set(stateKey, bySession);
+  }
+  const sessions = bySession;
+  const sessionKey = state.sessionKey;
+  const requestAgentId = isSelectedGlobalEventSessionKey(sessionKey)
+    ? resolveSelectedAgentId(state)
+    : null;
+  const loadKey = `${sessionKey}\u0000${requestAgentId ?? ""}`;
+  const existing = sessions.get(loadKey);
+  if (existing && isLatestChatHistoryRequest(state, existing.version)) {
+    return existing.promise;
+  }
+  const requestVersion = beginChatHistoryRequest(state);
+  const run = runChatHistoryLoad(state, { ...loadOptions, requestAgentId, requestVersion });
+  const entry = { promise: run, version: requestVersion };
+  sessions.set(loadKey, entry);
+  void run.then(() => {
+    if (sessions.get(loadKey) === entry) {
+      sessions.delete(loadKey);
+    }
+  });
+  return run;
+}
+
+async function runChatHistoryLoad(
+  state: ChatState,
+  options: { clearError?: boolean; requestAgentId?: string | null; requestVersion: number },
+) {
   if (!state.client || !state.connected) {
     return;
   }
   const sessionKey = state.sessionKey;
-  const requestVersion = beginChatHistoryRequest(state);
-  const requestAgentId = isSelectedGlobalEventSessionKey(sessionKey)
-    ? resolveSelectedAgentId(state)
-    : null;
+  const requestVersion = options.requestVersion;
+  const requestAgentId = options.requestAgentId ?? null;
   const startedAt = Date.now();
   const previousMessages = state.chatMessages;
   // Any pending input-history snapshot becomes invalid once we start reloading transcript state.
   state.resetChatInputHistoryNavigation?.();
   state.chatLoading = true;
-  state.lastError = null;
+  if (options.clearError !== false) {
+    state.lastError = null;
+  }
   try {
     let res: { messages?: Array<unknown>; sessionId?: string; thinkingLevel?: string };
     for (;;) {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1564,6 +1564,134 @@ describe("applySessionsChangedEvent", () => {
     expect(requestUpdate).toHaveBeenCalled();
   });
 
+  it("clears the local chat run when active-run tracking ends but status is stale running", () => {
+    const requestUpdate = vi.fn();
+    const state: SessionsState & {
+      sessionKey: string;
+      chatRunId: string | null;
+      chatStream: string | null;
+      chatStreamStartedAt: number | null;
+      chatRunStatus?: unknown;
+      requestUpdate: () => void;
+    } = {
+      ...createState(async () => undefined, {
+        sessionsResult: {
+          ts: 1,
+          path: "(multiple)",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [
+            {
+              key: "agent:super:main",
+              kind: "direct",
+              updatedAt: 1,
+              hasActiveRun: true,
+              status: "running",
+            },
+          ],
+        },
+      }),
+      sessionKey: "agent:super:main",
+      chatRunId: "run-1",
+      chatStream: "",
+      chatStreamStartedAt: 1,
+      requestUpdate,
+    };
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:super:main",
+      sessionId: "sess-main",
+      runId: "run-1",
+      status: "running",
+      hasActiveRun: false,
+      ts: 2,
+    });
+
+    expect(applied).toEqual({
+      applied: true,
+      change: "updated",
+      clearedChatRun: true,
+      clearedChatRunStatus: {
+        phase: "interrupted",
+        runId: "run-1",
+        sessionKey: "agent:super:main",
+      },
+    });
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
+    expect(state.chatRunStatus).toBeUndefined();
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      hasActiveRun: false,
+      status: "killed",
+    });
+    expect(requestUpdate).toHaveBeenCalled();
+  });
+
+  it("clears the local chat run when active-run tracking ends without a run id", () => {
+    const requestUpdate = vi.fn();
+    const state: SessionsState & {
+      sessionKey: string;
+      chatRunId: string | null;
+      chatStream: string | null;
+      chatStreamStartedAt: number | null;
+      chatRunStatus?: unknown;
+      requestUpdate: () => void;
+    } = {
+      ...createState(async () => undefined, {
+        sessionsResult: {
+          ts: 1,
+          path: "(multiple)",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [
+            {
+              key: "agent:super:main",
+              kind: "direct",
+              updatedAt: 1,
+              hasActiveRun: true,
+              status: "running",
+            },
+          ],
+        },
+      }),
+      sessionKey: "agent:super:main",
+      chatRunId: "run-1",
+      chatStream: "",
+      chatStreamStartedAt: 10,
+      requestUpdate,
+    };
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:super:main",
+      sessionId: "sess-main",
+      status: "running",
+      hasActiveRun: false,
+      updatedAt: 11,
+      ts: 11,
+    });
+
+    expect(applied).toEqual({
+      applied: true,
+      change: "updated",
+      clearedChatRun: true,
+      clearedChatRunStatus: {
+        phase: "interrupted",
+        runId: "run-1",
+        sessionKey: "agent:super:main",
+      },
+    });
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
+    expect(state.chatRunStatus).toBeUndefined();
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      hasActiveRun: false,
+      status: "killed",
+    });
+    expect(requestUpdate).toHaveBeenCalled();
+  });
+
   it("clears the local chat run when a lifecycle patch maps the client run id", () => {
     const requestUpdate = vi.fn();
     const state: SessionsState & {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -253,7 +253,12 @@ async function unsubscribeSelectedSessionMessageBestEffort(
 
 function sessionPatchTargetsCurrentChatRun(
   state: SessionsState & { sessionKey: string },
-  options: { changedSessionKey: string; eventRunId?: string },
+  options: {
+    changedSessionKey: string;
+    eventRunId?: string;
+    eventUpdatedAt?: number | null;
+    explicitInactiveRun?: boolean;
+  },
 ): boolean {
   if (state.sessionKey !== options.changedSessionKey) {
     return false;
@@ -266,7 +271,16 @@ function sessionPatchTargetsCurrentChatRun(
     return false;
   }
   if (options.eventRunId === undefined && state.chatRunId) {
-    return false;
+    if (!options.explicitInactiveRun) {
+      return false;
+    }
+    if (
+      typeof options.eventUpdatedAt === "number" &&
+      typeof state.chatStreamStartedAt === "number" &&
+      options.eventUpdatedAt < state.chatStreamStartedAt
+    ) {
+      return false;
+    }
   }
   return true;
 }
@@ -634,6 +648,11 @@ export function applySessionsChangedEvent(
       : [nextRow, ...previousRows];
   const sessions = nextRows.toSorted(compareSessionRowsByUpdatedAt);
   const eventTs = typeof payload.ts === "number" && Number.isFinite(payload.ts) ? payload.ts : null;
+  const eventUpdatedAt =
+    typeof source.updatedAt === "number" && Number.isFinite(source.updatedAt)
+      ? source.updatedAt
+      : eventTs;
+  const explicitInactiveRun = hasOwn(source, "hasActiveRun") && source.hasActiveRun === false;
   const eventRunId =
     typeof payload.clientRunId === "string" && payload.clientRunId.trim()
       ? payload.clientRunId.trim()
@@ -655,6 +674,8 @@ export function applySessionsChangedEvent(
     sessionPatchTargetsCurrentChatRun(state, {
       changedSessionKey: key,
       eventRunId,
+      eventUpdatedAt,
+      explicitInactiveRun,
     }) &&
     reconcileChatRunFromCurrentSessionRow(state, {
       publishRunStatus: false,

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -110,6 +110,7 @@ type ConnectFrame = {
   method?: string;
   params?: {
     auth?: { token?: string; password?: string; deviceToken?: string };
+    device?: { nonce?: string };
     maxProtocol?: number;
     minProtocol?: number;
     scopes?: string[];
@@ -576,6 +577,100 @@ describe("GatewayBrowserClient", () => {
     });
   });
 
+  it("falls back to token-only connect when the gateway challenge has not arrived yet", async () => {
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+
+    await vi.waitFor(() => {
+      expect(ws.sent.length).toBeGreaterThan(0);
+    });
+
+    const connectFrame = parseLatestConnectFrame(ws);
+    expect(connectFrame.method).toBe("connect");
+    expect(connectFrame.params?.auth?.token).toBe("shared-auth-token");
+    expect(connectFrame.params?.device).toBeUndefined();
+    expect(signDevicePayloadMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a challenge before cached device-token auth when it arrives before connect", async () => {
+    vi.useFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+
+    ws.emitMessage({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "nonce-delayed" },
+    });
+    await vi.advanceTimersByTimeAsync(750);
+
+    const connectFrame = parseLatestConnectFrame(ws);
+    expect(connectFrame.method).toBe("connect");
+    expect(connectFrame.params?.auth?.token).toBe("stored-device-token");
+    expect(connectFrame.params?.device?.nonce).toBe("nonce-delayed");
+  });
+
+  it("falls back to unsigned cached device-token auth when no challenge arrives", async () => {
+    vi.useFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+
+    await vi.advanceTimersByTimeAsync(750);
+
+    const connectFrame = parseLatestConnectFrame(ws);
+    expect(connectFrame.method).toBe("connect");
+    expect(connectFrame.params?.auth?.token).toBe("stored-device-token");
+    expect(connectFrame.params?.device).toBeUndefined();
+  });
+
+  it("uses a challenge that arrives while cached device auth is being prepared", async () => {
+    const identity = createDeferred<DeviceIdentity>();
+    loadOrCreateDeviceIdentityMock.mockReturnValueOnce(identity.promise);
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+    await Promise.resolve();
+
+    ws.emitMessage({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "nonce-race" },
+    });
+    identity.resolve({
+      deviceId: "device-1",
+      privateKey: "private-key", // pragma: allowlist secret
+      publicKey: "public-key", // pragma: allowlist secret
+    });
+
+    await vi.waitFor(() => {
+      expect(ws.sent.length).toBeGreaterThan(0);
+    });
+    const connectFrame = parseLatestConnectFrame(ws);
+    expect(connectFrame.method).toBe("connect");
+    expect(connectFrame.params?.auth?.token).toBe("stored-device-token");
+    expect(connectFrame.params?.device?.nonce).toBe("nonce-race");
+  });
+
   it("sends explicit shared token on insecure first connect without cached device fallback", async () => {
     stubInsecureCrypto();
     const client = new GatewayBrowserClient({
@@ -690,6 +785,38 @@ describe("GatewayBrowserClient", () => {
     );
     await vi.advanceTimersByTimeAsync(30_000);
     expect(wsInstances).toHaveLength(2);
+
+    vi.useRealTimers();
+  });
+
+  it("uses a challenge before retrying with cached device-token auth when it arrives before connect", async () => {
+    useNodeFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    const { ws: firstWs, connectFrame: firstConnect } = await startConnect(client);
+    emitRetryableTokenMismatch(firstWs, firstConnect.id);
+    await expectSocketClosed(firstWs);
+    firstWs.emitClose(4008, "connect failed");
+
+    await vi.advanceTimersByTimeAsync(800);
+    const secondWs = getLatestWebSocket();
+    expect(secondWs).not.toBe(firstWs);
+    secondWs.emitOpen();
+
+    secondWs.emitMessage({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "retry-nonce-delayed" },
+    });
+    await vi.advanceTimersByTimeAsync(750);
+
+    const retryConnect = parseLatestConnectFrame(secondWs);
+    expect(retryConnect.method).toBe("connect");
+    expect(retryConnect.params?.auth?.deviceToken).toBe("stored-device-token");
+    expect(retryConnect.params?.device?.nonce).toBe("retry-nonce-delayed");
 
     vi.useRealTimers();
   });
@@ -850,11 +977,10 @@ describe("GatewayBrowserClient", () => {
   it("does not send stale connect frames on a replacement socket", async () => {
     vi.useFakeTimers();
     const identity = createDeferred<DeviceIdentity>();
-    loadOrCreateDeviceIdentityMock.mockImplementationOnce(() => identity.promise);
+    loadOrCreateDeviceIdentityMock.mockImplementation(() => identity.promise);
 
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",
-      token: "shared-auth-token",
     });
 
     client.start();
@@ -888,8 +1014,8 @@ describe("GatewayBrowserClient", () => {
     const signedPayload =
       signDevicePayloadMock.mock.calls[signDevicePayloadMock.mock.calls.length - 1]?.[1];
     expectSignedPayloadFields(signedPayload, {
-      scopes: [...CONTROL_UI_OPERATOR_SCOPES],
-      token: "shared-auth-token",
+      scopes: connectFrame.params?.scopes ?? [],
+      token: "stored-device-token",
       nonce: "nonce-current",
     });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -398,11 +398,11 @@ async function buildGatewayConnectDevice(params: {
   connectNonce: string | null;
 }): Promise<GatewayConnectDevice | undefined> {
   const { deviceIdentity } = params;
-  if (!deviceIdentity) {
+  if (!deviceIdentity || !params.connectNonce) {
     return undefined;
   }
   const signedAtMs = Date.now();
-  const nonce = params.connectNonce ?? "";
+  const nonce = params.connectNonce;
   const payload = buildDeviceAuthPayload({
     deviceId: deviceIdentity.deviceId,
     clientId: params.client.id,
@@ -746,20 +746,38 @@ export class GatewayBrowserClient {
     return !this.closed && this.ws === ws && this.connectGeneration === generation;
   }
 
-  private async sendConnect(ws: WebSocket, generation: number) {
+  private async sendConnect(
+    ws: WebSocket,
+    generation: number,
+    opts: { allowUnsignedStoredDeviceTokenFallback?: boolean } = {},
+  ) {
     if (!this.isActiveSocket(ws, generation) || ws.readyState !== WebSocket.OPEN) {
       return;
     }
     if (this.connectSent) {
       return;
     }
-    this.connectSent = true;
-    this.clearConnectTimer();
 
-    const plan = await this.buildConnectPlan(this.connectNonce);
+    const planNonce = this.connectNonce;
+    const plan = await this.buildConnectPlan(planNonce);
     if (!this.isActiveSocket(ws, generation) || ws.readyState !== WebSocket.OPEN) {
       return;
     }
+    if (this.connectSent) {
+      return;
+    }
+    const selectedDeviceToken =
+      plan.selectedAuth.resolvedDeviceToken ?? plan.selectedAuth.authDeviceToken;
+    const needsDeviceNonceForStoredToken =
+      plan.deviceIdentity && selectedDeviceToken && !plan.device && !plan.selectedAuth.authPassword;
+    if (needsDeviceNonceForStoredToken && opts.allowUnsignedStoredDeviceTokenFallback !== true) {
+      if (this.connectNonce && this.connectNonce !== planNonce) {
+        void this.sendConnect(ws, generation);
+      }
+      return;
+    }
+    this.connectSent = true;
+    this.clearConnectTimer();
     if (this.pendingDeviceTokenRetry && plan.selectedAuth.authDeviceToken) {
       this.pendingDeviceTokenRetry = false;
     }
@@ -907,7 +925,7 @@ export class GatewayBrowserClient {
     this.clearConnectTimer();
     this.connectTimer = window.setTimeout(() => {
       this.connectTimer = null;
-      void this.sendConnect(ws, generation);
+      void this.sendConnect(ws, generation, { allowUnsignedStoredDeviceTokenFallback: true });
     }, 750);
   }
 

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -19,6 +19,7 @@ import markdownItTaskLists from "markdown-it-task-lists";
 import { stripUnsupportedCitationControlMarkers } from "../../../src/shared/text/citation-control-markers.js";
 import { i18n, t } from "../i18n/index.ts";
 import { truncateText } from "./format.ts";
+import { profilePhase, recordPhase } from "./perf/render-phase-profiler.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 
 const allowedTags = [
@@ -257,6 +258,10 @@ const autoHighlightLanguages = [
 ];
 
 function highlightCode(text: string, lang: string): string {
+  return profilePhase("highlight", () => highlightCodeImpl(text, lang));
+}
+
+function highlightCodeImpl(text: string, lang: string): string {
   const language = normalizeHighlightLanguage(lang);
   try {
     if (language && hljs.getLanguage(language)) {
@@ -627,6 +632,7 @@ export function toSanitizedMarkdownHtml(
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
     const cached = getCachedMarkdown(cacheKey);
     if (cached !== null) {
+      recordPhase("markdown.cacheHit", 0);
       return cached;
     }
   }
@@ -647,14 +653,18 @@ export function toSanitizedMarkdownHtml(
   }
   let rendered: string;
   try {
-    rendered = md.render(`${truncated.text}${suffix}`, renderOptions);
+    rendered = profilePhase("markdown.render", () =>
+      md.render(`${truncated.text}${suffix}`, renderOptions),
+    );
   } catch (err) {
     // Fall back to escaped plain text when md.render() throws (#36213).
     console.warn("[markdown] md.render failed, falling back to plain text:", err);
     const escaped = escapeHtml(`${truncated.text}${suffix}`);
     rendered = `<pre class="code-block">${escaped}</pre>`;
   }
-  const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
+  const sanitized = profilePhase("markdown.sanitize", () =>
+    DOMPurify.sanitize(rendered, sanitizeOptions),
+  );
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
     setCachedMarkdown(cacheKey, sanitized);
   }

--- a/ui/src/ui/perf/main-thread-monitor.ts
+++ b/ui/src/ui/perf/main-thread-monitor.ts
@@ -1,0 +1,77 @@
+import { getSafeLocalStorage } from "../../local-storage.ts";
+import {
+  controlUiNowMs,
+  recordControlUiPerformanceEvent,
+  roundedControlUiDurationMs,
+} from "../control-ui-performance.ts";
+
+/**
+ * Engine-agnostic main-thread stall detector.
+ *
+ * The Tauri desktop app renders in WKWebView, which does not implement the
+ * Chromium-only `longtask` / `long-animation-frame` PerformanceObserver entry
+ * types that {@link startControlUiResponsivenessObserver} relies on. To still
+ * see when the main thread is blocked there — by rendering *or* by anything
+ * else (RPC JSON parsing, event handlers, image work) — we run a fixed-interval
+ * heartbeat and flag the gaps. A timer that should fire every 50ms but fires
+ * 800ms late means the thread was blocked for ~750ms in between.
+ *
+ * Pair the emitted `control-ui.main-thread-block` events with the
+ * `control-ui.render` timings: a block that lines up with a slow `chat` render
+ * is render cost; a block with no matching render event is non-render work.
+ *
+ * Opt-in (it adds a recurring timer): enable with
+ * `localStorage.setItem("openclaw:perf-heartbeat", "1")` and reload.
+ */
+
+const HEARTBEAT_INTERVAL_MS = 50;
+// Only report gaps well beyond the interval + normal timer jitter.
+const BLOCK_THRESHOLD_MS = 120;
+const HEARTBEAT_FLAG_KEY = "openclaw:perf-heartbeat";
+
+type MainThreadMonitorHost = Parameters<typeof recordControlUiPerformanceEvent>[0];
+
+export type MainThreadBlockMonitor = { stop: () => void };
+
+function heartbeatEnabled(): boolean {
+  try {
+    return getSafeLocalStorage()?.getItem(HEARTBEAT_FLAG_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function startMainThreadBlockMonitor(
+  host: MainThreadMonitorHost,
+  opts?: { force?: boolean },
+): MainThreadBlockMonitor | null {
+  if (typeof setInterval !== "function" || typeof performance === "undefined") {
+    return null;
+  }
+  // The desktop app forces it on (it ships the perf log sink); elsewhere it is
+  // opt-in via localStorage so the recurring timer never runs unasked.
+  if (!opts?.force && !heartbeatEnabled()) {
+    return null;
+  }
+  let lastTickMs = controlUiNowMs();
+  const timer = setInterval(() => {
+    const nowMs = controlUiNowMs();
+    const blockedMs = nowMs - lastTickMs - HEARTBEAT_INTERVAL_MS;
+    lastTickMs = nowMs;
+    if (blockedMs < BLOCK_THRESHOLD_MS) {
+      return;
+    }
+    recordControlUiPerformanceEvent(
+      host,
+      "control-ui.main-thread-block",
+      {
+        tab: host.tab,
+        blockedMs: roundedControlUiDurationMs(blockedMs),
+      },
+      { warn: true, maxBufferedEventsForType: 50 },
+    );
+  }, HEARTBEAT_INTERVAL_MS);
+  return {
+    stop: () => clearInterval(timer),
+  };
+}

--- a/ui/src/ui/perf/render-phase-profiler.ts
+++ b/ui/src/ui/perf/render-phase-profiler.ts
@@ -1,0 +1,76 @@
+import { controlUiNowMs } from "../control-ui-performance.ts";
+
+/**
+ * Fine-grained, render-cycle-scoped timing for the chat transcript.
+ *
+ * The existing `recordControlUiRenderTiming` reports the *total* time a surface
+ * spent rendering. This profiler breaks that total down into the hot phases
+ * (markdown, syntax highlight, sanitize, JSON detection, chat-item build) so a
+ * slow session switch can be attributed to a specific step instead of guessed.
+ *
+ * A "cycle" is one `renderMeasured(...)` call: `beginRenderPhases()` opens the
+ * accumulator, instrumented hot paths add into it via `profilePhase` /
+ * `recordPhase`, and `endRenderPhases()` returns the breakdown to attach to the
+ * render-timing payload. Outside a cycle every helper is a no-op, so there is no
+ * cost on non-measured code paths.
+ */
+
+export type RenderPhaseBucket = { totalMs: number; calls: number; maxMs: number };
+export type RenderPhaseBreakdown = Record<string, RenderPhaseBucket>;
+
+let activeBuckets: Map<string, RenderPhaseBucket> | null = null;
+
+export function beginRenderPhases(): void {
+  activeBuckets = new Map();
+}
+
+function addToBucket(label: string, durationMs: number): void {
+  if (!activeBuckets) {
+    return;
+  }
+  const bucket = activeBuckets.get(label) ?? { totalMs: 0, calls: 0, maxMs: 0 };
+  bucket.totalMs += durationMs;
+  bucket.calls += 1;
+  if (durationMs > bucket.maxMs) {
+    bucket.maxMs = durationMs;
+  }
+  activeBuckets.set(label, bucket);
+}
+
+/** Time a synchronous hot path and fold it into the current render cycle. */
+export function profilePhase<T>(label: string, fn: () => T): T {
+  if (!activeBuckets) {
+    return fn();
+  }
+  const startedAtMs = controlUiNowMs();
+  try {
+    return fn();
+  } finally {
+    addToBucket(label, controlUiNowMs() - startedAtMs);
+  }
+}
+
+/**
+ * Record a phase whose duration is measured by the caller (or a 0ms counter,
+ * e.g. a cache hit). Increments the call count even at 0ms.
+ */
+export function recordPhase(label: string, durationMs: number): void {
+  addToBucket(label, Math.max(0, durationMs));
+}
+
+/** Close the current cycle and return a rounded, plain-object breakdown. */
+export function endRenderPhases(): RenderPhaseBreakdown {
+  if (!activeBuckets) {
+    return {};
+  }
+  const breakdown: RenderPhaseBreakdown = {};
+  for (const [label, bucket] of activeBuckets) {
+    breakdown[label] = {
+      totalMs: Math.round(bucket.totalMs * 10) / 10,
+      calls: bucket.calls,
+      maxMs: Math.round(bucket.maxMs * 10) / 10,
+    };
+  }
+  activeBuckets = null;
+  return breakdown;
+}

--- a/ui/src/ui/session-run-state.test.ts
+++ b/ui/src/ui/session-run-state.test.ts
@@ -2,20 +2,17 @@ import { describe, expect, it } from "vitest";
 import { isSessionRunActive } from "./session-run-state.ts";
 
 describe("isSessionRunActive", () => {
-  it("uses explicit live-run state over stale running status", () => {
-    expect(isSessionRunActive({ status: "running", hasActiveRun: false })).toBe(false);
-    expect(isSessionRunActive({ status: "running", hasActiveRun: true })).toBe(true);
+  it("treats an explicit inactive flag as authoritative over a stale running status", () => {
+    expect(isSessionRunActive({ hasActiveRun: false, status: "running" })).toBe(false);
   });
 
-  it("keeps terminal status authoritative over stale active flags", () => {
-    expect(isSessionRunActive({ status: "done", hasActiveRun: true })).toBe(false);
-    expect(isSessionRunActive({ status: "failed", hasActiveRun: true })).toBe(false);
-    expect(isSessionRunActive({ status: "killed", hasActiveRun: true })).toBe(false);
-    expect(isSessionRunActive({ status: "timeout", hasActiveRun: true })).toBe(false);
-  });
-
-  it("keeps legacy running status active when no live-run flag exists", () => {
+  it("uses the run status when no explicit inactive flag is available", () => {
     expect(isSessionRunActive({ status: "running" })).toBe(true);
+    expect(isSessionRunActive({ hasActiveRun: true, status: "done" })).toBe(false);
+  });
+
+  it("falls back to the active flag when no status is available", () => {
     expect(isSessionRunActive({ hasActiveRun: true })).toBe(true);
+    expect(isSessionRunActive({ hasActiveRun: false })).toBe(false);
   });
 });

--- a/ui/src/ui/session-run-state.ts
+++ b/ui/src/ui/session-run-state.ts
@@ -6,8 +6,11 @@ type SessionRunState = {
 };
 
 export function isSessionRunActive(state: SessionRunState): boolean {
-  if (state.status && state.status !== "running") {
+  if (state.hasActiveRun === false) {
     return false;
+  }
+  if (state.status) {
+    return state.status === "running";
   }
   if (typeof state.hasActiveRun === "boolean") {
     return state.hasActiveRun;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -48,9 +48,14 @@ import {
   renderCompactionIndicator,
   renderFallbackIndicator,
 } from "../chat/status-indicators.ts";
-import { getExpandedToolCards, syncToolCardExpansionState } from "../chat/tool-expansion-state.ts";
+import {
+  getExpandedToolCards,
+  markToolCardManuallyToggled,
+  syncToolCardExpansionState,
+} from "../chat/tool-expansion-state.ts";
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
+import { profilePhase } from "../perf/render-phase-profiler.ts";
 import { formatGoalDetail, formatGoalSummary } from "../session-goal.ts";
 import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
@@ -1127,21 +1132,24 @@ export function renderChat(props: ChatProps) {
     );
   };
 
-  const chatItems = buildChatItems({
-    sessionKey: props.sessionKey,
-    messages: props.messages,
-    toolMessages: props.toolMessages,
-    streamSegments: props.streamSegments,
-    stream: displayStream,
-    streamStartedAt: props.streamStartedAt,
-    showToolCalls: props.showToolCalls,
-    searchOpen: vs.searchOpen,
-    searchQuery: vs.searchQuery,
-  });
+  const chatItems = profilePhase("buildChatItems", () =>
+    buildChatItems({
+      sessionKey: props.sessionKey,
+      messages: props.messages,
+      toolMessages: props.toolMessages,
+      streamSegments: props.streamSegments,
+      stream: displayStream,
+      streamStartedAt: props.streamStartedAt,
+      showToolCalls: props.showToolCalls,
+      searchOpen: vs.searchOpen,
+      searchQuery: vs.searchQuery,
+    }),
+  );
   syncToolCardExpansionState(props.sessionKey, chatItems, Boolean(props.autoExpandToolCalls));
   const expandedToolCards = getExpandedToolCards(props.sessionKey);
   const toggleToolCardExpanded = (toolCardId: string) => {
     expandedToolCards.set(toolCardId, !expandedToolCards.get(toolCardId));
+    markToolCardManuallyToggled(props.sessionKey, toolCardId);
     requestUpdate();
   };
   const hasRealtimeTalkConversation = (props.realtimeTalkConversation?.length ?? 0) > 0;
@@ -1268,6 +1276,7 @@ export function renderChat(props: ChatProps) {
                   expandedToolCards.get(messageId) ?? false,
                 onToggleToolMessageExpanded: (messageId: string) => {
                   expandedToolCards.set(messageId, !expandedToolCards.get(messageId));
+                  markToolCardManuallyToggled(props.sessionKey, messageId);
                   requestUpdate();
                 },
                 isToolExpanded: (toolCardId: string) => expandedToolCards.get(toolCardId) ?? false,

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -519,6 +519,19 @@ describe("sessions view", () => {
               status: "running",
             },
             {
+              key: "agent:main:stale-running",
+              kind: "direct",
+              updatedAt: 15,
+              hasActiveRun: false,
+              status: "running",
+            },
+            {
+              key: "agent:main:no-status-idle",
+              kind: "direct",
+              updatedAt: 12,
+              hasActiveRun: false,
+            },
+            {
               key: "agent:main:failed",
               kind: "direct",
               updatedAt: 10,
@@ -543,17 +556,23 @@ describe("sessions view", () => {
     expect(badges.map((badge) => badge.textContent?.trim())).toEqual([
       "Live",
       "Idle",
+      "Idle",
+      "Idle",
       "Failed",
       "Done",
     ]);
     expect(badges.map((badge) => [...badge.classList])).toEqual([
       ["session-status-badge", "session-status-badge--live"],
       ["session-status-badge", "session-status-badge--idle"],
+      ["session-status-badge", "session-status-badge--idle"],
+      ["session-status-badge", "session-status-badge--idle"],
       ["session-status-badge", "session-status-badge--failed"],
       ["session-status-badge", "session-status-badge--done"],
     ]);
     expect(badges.map((badge) => badge.getAttribute("aria-label"))).toEqual([
       "Status: Live",
+      "Status: Idle",
+      "Status: Idle",
       "Status: Idle",
       "Status: Failed",
       "Status: Done",

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -204,7 +204,7 @@ function resolveSessionStatusBadge(row: GatewaySessionRow): {
   if (isSessionRunActive(row)) {
     return { label: t("sessionsView.statusLive"), tone: "live" };
   }
-  if (row.status === "running" && row.hasActiveRun === false) {
+  if (row.hasActiveRun === false && row.status === "running") {
     return { label: t("sessionsView.statusIdle"), tone: "idle" };
   }
   if (row.status) {


### PR DESCRIPTION
## Summary
- Keep chat/session switching responsive by coalescing explicit session-switch reloads without caching event-driven `commands.list` results.
- Harden lifecycle recovery so internal webchat late errors can recover persisted successful output without masking external delivery failures.
- Fix Control UI gateway auth so cached device-token paths wait for a signed challenge nonce, including retry after shared-token mismatch.

## Verification
- `node scripts/run-vitest.mjs src/gateway/server-methods/commands.test.ts src/gateway/session-lifecycle-state.test.ts src/gateway/server-chat.agent-events.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts ui/src/ui/chat/tool-expansion-state.test.ts ui/src/ui/session-run-state.test.ts ui/src/ui/chat/message-normalizer.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/gateway.node.test.ts ui/src/ui/views/sessions.test.ts ui/src/ui/app-lifecycle.node.test.ts ui/src/ui/app-render.helpers.node.test.ts`
- `pnpm exec oxlint src/gateway/session-lifecycle-state.ts src/gateway/session-lifecycle-state.test.ts ui/src/ui/gateway.ts ui/src/ui/gateway.node.test.ts --format=unix`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
- `node openclaw.mjs --version`

## Real behavior proof
Behavior addressed: Control UI session switches avoid redundant reload stalls while preserving fresh event-driven state, and gateway/device-token auth no longer sends cached device tokens without the signed nonce payload.
Real environment tested: local OpenClaw source checkout on macOS using targeted gateway/UI Vitest files, oxlint, autoreview, and the OpenClaw CLI entrypoint.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-methods/commands.test.ts src/gateway/session-lifecycle-state.test.ts src/gateway/server-chat.agent-events.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts ui/src/ui/chat/tool-expansion-state.test.ts ui/src/ui/session-run-state.test.ts ui/src/ui/chat/message-normalizer.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/gateway.node.test.ts ui/src/ui/views/sessions.test.ts ui/src/ui/app-lifecycle.node.test.ts ui/src/ui/app-render.helpers.node.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`; `node openclaw.mjs --version`.
Evidence after fix:
```text
$ node openclaw.mjs --version
OpenClaw 2026.5.28 (085dae8)
$ .agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD
autoreview clean: no accepted/actionable findings reported
```
Observed result after fix: targeted lifecycle, chat/session, and browser gateway auth tests pass; autoreview found no accepted/actionable findings after the nonce and lifecycle-boundary fixes.
What was not tested: full browser E2E interaction against a running gateway was not run; coverage is focused unit/integration proof for the changed surfaces.
