### PR TITLE
test(crabbox): pin wrapper provider expectations

### DIFF
--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -415,6 +415,7 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
     const result = runWrapper(
       "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
       ["run", "--target", "windows", "--", "echo ok"],
+      { env: { CRABBOX_PROVIDER: "aws" } },
     );
 
     expect(result.status).toBe(0);
@@ -449,7 +450,7 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
       "--",
       "echo ok",
     ]);
-    expect(result.stderr).toContain("provider=aws");
+    expect(result.stderr).toContain("provider=azure");
   });
 
   it("prefers Azure for unqualified Windows warmups", () => {


### PR DESCRIPTION
## Summary
- pin the Crabbox wrapper test that explicitly wants AWS-as-configured-provider with `CRABBOX_PROVIDER=aws`
- update the existing-lease Windows case to expect the repo's current configured default provider, `azure`

## Verification
- `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts --reporter=dot` (114 passed)
- `git diff --check`
- AWS Crabbox: `pnpm check:changed` via provider `aws`, lease `cbx_ee676470ed55`, run `run_723bf6965614`, exit 0

## Real behavior proof
Behavior addressed: current-base CI build-artifacts failed after `.crabbox.yaml` changed the default provider from `aws` to `azure`; two wrapper expectations still implicitly assumed the old default.
Real environment tested: local focused Vitest plus AWS Crabbox changed gate.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 60m --ttl 120m --timing-json --shell -- "pnpm check:changed"`.
Evidence after fix: focused test passed 114/114; Crabbox run `run_723bf6965614` passed with exit 0.
Observed result after fix: wrapper tests no longer depend on the old repo-default provider while preserving the intended Windows provider behavior.
What was not tested: full CI; this PR is scoped to the failed build-artifacts test surface.
