### PR TITLE
refactor(agents): type media completion delivery misses

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1295,6 +1295,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: false,
       path: "direct",
+      reason: "visible_reply_missing",
       error: "completion agent did not produce a visible reply",
     });
     expect(sendMessage).not.toHaveBeenCalled();
@@ -2075,6 +2076,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: false,
       path: "none",
+      reason: "requester_abandoned",
       error: "requester session abandoned after timeout",
     });
     expect(result.phases).toEqual([
@@ -2082,6 +2084,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         phase: "direct-primary",
         delivered: false,
         path: "none",
+        reason: "requester_abandoned",
         error: "requester session abandoned after timeout",
       }),
       expect.objectContaining({
@@ -3267,6 +3270,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: false,
       path: "direct",
+      reason: "generated_media_missing",
       error: "completion agent did not deliver generated media",
     });
     expectGatewayAgentParams(callGateway, {
@@ -4175,6 +4179,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: false,
       path: "direct",
+      reason: "message_tool_delivery_missing",
       error: "completion agent did not use the message tool for message-tool-only delivery",
     });
   });

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1248,6 +1248,7 @@ async function sendSubagentAnnounceDirectly(params: {
       return {
         delivered: false,
         path: "none",
+        reason: "requester_abandoned",
         error: "requester session abandoned after timeout",
       };
     }
@@ -1454,6 +1455,7 @@ async function sendSubagentAnnounceDirectly(params: {
         return {
           delivered: false,
           path: "direct",
+          reason: "completion_handoff_pending",
           error: "completion agent handoff is still pending",
         };
       }
@@ -1493,6 +1495,7 @@ async function sendSubagentAnnounceDirectly(params: {
       return {
         delivered: false,
         path: "direct",
+        reason: "generated_media_missing",
         error: "completion agent did not deliver generated media",
       };
     }
@@ -1525,6 +1528,7 @@ async function sendSubagentAnnounceDirectly(params: {
         return {
           delivered: false,
           path: "direct",
+          reason: "visible_reply_missing",
           error: "completion agent did not produce a visible reply",
         };
       }
@@ -1539,6 +1543,7 @@ async function sendSubagentAnnounceDirectly(params: {
         return {
           delivered: false,
           path: "direct",
+          reason: "visible_reply_missing",
           error: "completion agent did not produce a visible reply",
         };
       }
@@ -1557,6 +1562,7 @@ async function sendSubagentAnnounceDirectly(params: {
       return {
         delivered: false,
         path: "direct",
+        reason: "message_tool_delivery_missing",
         error: "completion agent did not use the message tool for message-tool-only delivery",
       };
     }
@@ -1569,6 +1575,7 @@ async function sendSubagentAnnounceDirectly(params: {
       return {
         delivered: false,
         path: "direct",
+        reason: "visible_reply_missing",
         error: "completion agent did not produce a visible reply",
       };
     }

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -1,4 +1,10 @@
 type SubagentDeliveryPath = "steered" | "direct" | "none";
+export type SubagentAnnounceDeliveryFailureReason =
+  | "completion_handoff_pending"
+  | "generated_media_missing"
+  | "message_tool_delivery_missing"
+  | "requester_abandoned"
+  | "visible_reply_missing";
 
 type SubagentAnnounceSteerOutcome =
   | { status: "steered"; deliveredAt?: number; enqueuedAt?: number }
@@ -9,6 +15,7 @@ export type SubagentAnnounceDeliveryResult = {
   path: SubagentDeliveryPath;
   deliveredAt?: number;
   enqueuedAt?: number;
+  reason?: SubagentAnnounceDeliveryFailureReason;
   error?: string;
   terminal?: boolean;
   phases?: SubagentAnnounceDispatchPhaseResult[];
@@ -22,6 +29,7 @@ type SubagentAnnounceDispatchPhaseResult = {
   path: SubagentDeliveryPath;
   deliveredAt?: number;
   enqueuedAt?: number;
+  reason?: SubagentAnnounceDeliveryFailureReason;
   error?: string;
 };
 
@@ -59,6 +67,7 @@ export async function runSubagentAnnounceDispatch(params: {
       path: result.path,
       deliveredAt: result.deliveredAt,
       enqueuedAt: result.enqueuedAt,
+      ...(result.reason ? { reason: result.reason } : {}),
       error: result.error,
     });
   };

--- a/src/agents/tools/image-generate-background.test.ts
+++ b/src/agents/tools/image-generate-background.test.ts
@@ -128,6 +128,7 @@ describe("image generate background helpers", () => {
     announceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValue({
       delivered: false,
       path: "direct",
+      reason: "generated_media_missing",
       error: "completion agent did not deliver generated media",
     });
     const completion = createMediaCompletionFixture({

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -440,6 +440,7 @@ describe("createMediaGenerationTaskLifecycle", () => {
   it("direct-delivers generated media when the completion wake misses the requester", async () => {
     subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
       delivered: false,
+      reason: "generated_media_missing",
       error: "completion agent did not deliver generated media",
     });
     taskRegistryDeliveryRuntimeMocks.sendMessage.mockResolvedValueOnce({});
@@ -489,6 +490,7 @@ describe("createMediaGenerationTaskLifecycle", () => {
     subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
       delivered: false,
       path: "none",
+      reason: "requester_abandoned",
       error: "requester session abandoned after timeout",
     });
     const lifecycle = createMediaGenerationTaskLifecycle({

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -25,9 +25,15 @@ import {
 } from "../generated-attachments.js";
 import { formatAgentInternalEventsForPrompt, type AgentInternalEvent } from "../internal-events.js";
 import { deliverSubagentAnnouncement } from "../subagent-announce-delivery.js";
+import type { SubagentAnnounceDeliveryFailureReason } from "../subagent-announce-dispatch.js";
 
 const log = createSubsystemLogger("agents/tools/media-generate-background-shared");
 const MEDIA_GENERATION_TASK_KEEPALIVE_INTERVAL_MS = 60_000;
+const MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS = new Set<SubagentAnnounceDeliveryFailureReason>([
+  "generated_media_missing",
+  "message_tool_delivery_missing",
+  "visible_reply_missing",
+]);
 
 export type MediaGenerationTaskHandle = {
   taskId: string;
@@ -556,10 +562,7 @@ async function wakeMediaGenerationTaskCompletion(params: {
     return true;
   }
   const canTryDirectCompletionFallback =
-    delivery.error === "completion agent did not deliver generated media" ||
-    delivery.error === "completion agent did not produce a visible reply" ||
-    delivery.error ===
-      "completion agent did not use the message tool for message-tool-only delivery";
+    delivery.reason != null && MEDIA_DIRECT_FALLBACK_DELIVERY_REASONS.has(delivery.reason);
   if (params.status === "ok" && canTryDirectCompletionFallback) {
     const label = `${params.completionLabel[0]?.toUpperCase() ?? "M"}${params.completionLabel.slice(1)}`;
     const delivered = await tryDeliverMediaGenerationDirect({

--- a/src/agents/tools/music-generate-background.test.ts
+++ b/src/agents/tools/music-generate-background.test.ts
@@ -143,6 +143,7 @@ describe("music generate background helpers", () => {
     announceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValue({
       delivered: false,
       path: "direct",
+      reason: "generated_media_missing",
       error: "completion agent did not deliver generated media",
     });
     const completion = createMediaCompletionFixture({

--- a/src/agents/tools/video-generate-background.test.ts
+++ b/src/agents/tools/video-generate-background.test.ts
@@ -207,6 +207,7 @@ describe("video generate background helpers", () => {
     announceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValue({
       delivered: false,
       path: "direct",
+      reason: "generated_media_missing",
       error: "completion agent did not deliver generated media",
     });
 


### PR DESCRIPTION
## Summary

- Follow-up to #88083: make media completion fallback key off typed subagent delivery failure reasons instead of exact error strings.
- Preserve the existing human-readable delivery errors while carrying the stable reason through dispatch phase records.
- Cover the media/image/music/video fallback mocks and direct-delivery failure tests with the new reason field.

## Verification

Behavior addressed: media generation completion fallback no longer depends on matching subagent delivery error prose.
Real environment tested: local macOS checkout plus delegated Blacksmith Testbox changed-check run.
Exact steps or command run after this patch: `pnpm test src/agents/subagent-announce-delivery.test.ts src/agents/tools/media-generate-background-shared.test.ts src/agents/tools/image-generate-background.test.ts src/agents/tools/music-generate-background.test.ts src/agents/tools/video-generate-background.test.ts src/agents/image-generation-task-status.test.ts`; `pnpm check:changed`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.
Evidence after fix: focused Vitest passed 6 files / 133 tests; Testbox `tbx_01ksvpvnns2sxbj8gjs0xx7n1f` exited 0; both autoreview runs reported no accepted/actionable findings.
Observed result after fix: delivery fallback eligibility comes from `SubagentAnnounceDeliveryFailureReason`, with success paths and non-fallback failures unchanged.
What was not tested: live media provider generation round-trip.
