### PR TITLE
fix(discord): unblock inbound queue after stuck run

### DIFF
--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -11,6 +11,10 @@ import {
   createDiscordPreflightContext,
 } from "./message-handler.test-helpers.js";
 
+const agentTimeoutMocks = vi.hoisted(() => ({
+  resolveAgentTimeoutMs: vi.fn(() => 48 * 60 * 60 * 1000),
+}));
+
 const earlyTypingMocks = vi.hoisted(() => ({
   createDiscordRestClient: vi.fn(() => ({
     token: "test-token",
@@ -18,6 +22,10 @@ const earlyTypingMocks = vi.hoisted(() => ({
     account: { accountId: "default", config: {} },
   })),
   sendTyping: vi.fn(async () => {}),
+}));
+
+vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
+  resolveAgentTimeoutMs: agentTimeoutMocks.resolveAgentTimeoutMs,
 }));
 
 vi.mock("../client.js", () => ({
@@ -172,6 +180,7 @@ async function createLifecycleStopScenario(params: {
 
 describe("createDiscordMessageHandler queue behavior", () => {
   beforeEach(() => {
+    agentTimeoutMocks.resolveAgentTimeoutMs.mockReset().mockReturnValue(48 * 60 * 60 * 1000);
     earlyTypingMocks.createDiscordRestClient.mockReset().mockReturnValue({
       token: "test-token",
       rest: { kind: "discord-rest" },
@@ -420,7 +429,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(visibleSideEffect).toHaveBeenCalledTimes(1);
   });
 
-  it("does not abort long queued runs with a Discord-owned channel timeout", async () => {
+  it("does not abort long queued runs before the Discord run watchdog expires", async () => {
     vi.useFakeTimers();
     try {
       preflightDiscordMessageMock.mockReset();
@@ -458,7 +467,8 @@ describe("createDiscordMessageHandler queue behavior", () => {
       await flushQueueWork();
 
       expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-      expect(capturedAbortSignals).toEqual([undefined]);
+      expect(capturedAbortSignals).toHaveLength(1);
+      expect(capturedAbortSignals[0]?.aborted).toBe(false);
       const runtimeError = params.runtime.error as unknown as MockCallSource;
       expect(
         mockCalls(runtimeError).some(([message]) => String(message).includes("timed out")),
@@ -469,7 +479,164 @@ describe("createDiscordMessageHandler queue behavior", () => {
       await flushQueueWork();
 
       expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
-      expect(capturedAbortSignals).toEqual([undefined, undefined]);
+      expect(capturedAbortSignals).toHaveLength(2);
+      expect(capturedAbortSignals[1]?.aborted).toBe(false);
+
+      secondRun.resolve();
+      await secondRun.promise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the configured agent timeout as the default Discord run watchdog", async () => {
+    vi.useFakeTimers();
+    try {
+      preflightDiscordMessageMock.mockReset();
+      processDiscordMessageMock.mockReset();
+
+      const run = createDeferred();
+      const ctx = createPreflightContext();
+      preflightDiscordMessageMock.mockResolvedValue(ctx);
+      processDiscordMessageMock.mockImplementation(async () => {
+        await run.promise;
+      });
+      const handler = createDiscordMessageHandler(createDiscordHandlerParams());
+
+      await expect(
+        handler(createMessageData("m-configured") as never, {} as never),
+      ).resolves.toBeUndefined();
+      await flushQueueWork();
+
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+      expect(agentTimeoutMocks.resolveAgentTimeoutMs).toHaveBeenCalledWith({ cfg: ctx.cfg });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await flushQueueWork();
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+
+      run.resolve();
+      await run.promise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts a stuck Discord run and lets later messages for the same session proceed", async () => {
+    vi.useFakeTimers();
+    try {
+      preflightDiscordMessageMock.mockReset();
+      processDiscordMessageMock.mockReset();
+
+      const firstRun = createDeferred();
+      const secondProcessed = vi.fn();
+      const capturedAbortSignals: Array<AbortSignal | undefined> = [];
+      processDiscordMessageMock.mockImplementationOnce(
+        async (ctx: { abortSignal?: AbortSignal }) => {
+          capturedAbortSignals.push(ctx.abortSignal);
+          await firstRun.promise;
+        },
+      );
+      processDiscordMessageMock.mockImplementationOnce(
+        async (ctx: { abortSignal?: AbortSignal }) => {
+          capturedAbortSignals.push(ctx.abortSignal);
+          secondProcessed();
+        },
+      );
+      installDefaultDiscordPreflight();
+      const params = createDiscordHandlerParams();
+      const handler = createDiscordMessageHandler({
+        ...params,
+        testing: { runTimeoutMs: 25 },
+      });
+
+      await expect(
+        handler(createMessageData("m-1") as never, {} as never),
+      ).resolves.toBeUndefined();
+      await expect(
+        handler(createMessageData("m-2") as never, {} as never),
+      ).resolves.toBeUndefined();
+      await flushQueueWork();
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(25);
+      await flushQueueWork();
+
+      expect(capturedAbortSignals[0]?.aborted).toBe(true);
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+      expect(secondProcessed).toHaveBeenCalledTimes(1);
+      const runtimeError = params.runtime.error as unknown as MockCallSource;
+      expect(
+        mockCalls(runtimeError).some(([message]) =>
+          String(message).includes("DiscordMessageRunTimeoutError"),
+        ),
+      ).toBe(true);
+
+      await expect(
+        handler(createMessageData("m-1") as never, {} as never),
+      ).resolves.toBeUndefined();
+      await flushQueueWork();
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+      expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(2);
+
+      firstRun.resolve();
+      await firstRun.promise;
+      await flushQueueWork();
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+      expect(params.runtime.error).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("can disable the Discord run watchdog with a zero timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      preflightDiscordMessageMock.mockReset();
+      processDiscordMessageMock.mockReset();
+
+      const firstRun = createDeferred();
+      const secondRun = createDeferred();
+      const capturedAbortSignals: Array<AbortSignal | undefined> = [];
+      processDiscordMessageMock.mockImplementationOnce(
+        async (ctx: { abortSignal?: AbortSignal }) => {
+          capturedAbortSignals.push(ctx.abortSignal);
+          await firstRun.promise;
+        },
+      );
+      processDiscordMessageMock.mockImplementationOnce(
+        async (ctx: { abortSignal?: AbortSignal }) => {
+          capturedAbortSignals.push(ctx.abortSignal);
+          await secondRun.promise;
+        },
+      );
+      installDefaultDiscordPreflight();
+      const params = createDiscordHandlerParams();
+      const handler = createDiscordMessageHandler({
+        ...params,
+        testing: { runTimeoutMs: 0 },
+      });
+
+      await expect(
+        handler(createMessageData("m-1") as never, {} as never),
+      ).resolves.toBeUndefined();
+      await expect(
+        handler(createMessageData("m-2") as never, {} as never),
+      ).resolves.toBeUndefined();
+      await flushQueueWork();
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      await flushQueueWork();
+
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+      expect(capturedAbortSignals).toEqual([undefined]);
+      expect(params.runtime.error).not.toHaveBeenCalled();
+
+      firstRun.resolve();
+      await firstRun.promise;
+      await flushQueueWork();
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
 
       secondRun.resolve();
       await secondRun.promise;

--- a/extensions/discord/src/monitor/message-handler.test-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.test-helpers.ts
@@ -53,6 +53,10 @@ export function createDiscordHandlerParams(overrides?: {
 
 export function createDiscordPreflightContext(channelId = "ch-1") {
   return {
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+    },
     data: {
       channel_id: channelId,
       message: {

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -1,3 +1,4 @@
+import { resolveAgentTimeoutMs } from "openclaw/plugin-sdk/agent-runtime";
 import { createChannelRunQueue } from "openclaw/plugin-sdk/channel-outbound";
 import type { ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
@@ -14,6 +15,13 @@ import { mergeAbortSignals } from "./timeouts.js";
 
 type ProcessDiscordMessage = typeof import("./message-handler.process.js").processDiscordMessage;
 
+class DiscordMessageRunTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Discord message run timed out after ${timeoutMs}ms`);
+    this.name = "DiscordMessageRunTimeoutError";
+  }
+}
+
 type DiscordMessageRunQueueParams = {
   runtime: RuntimeEnv;
   setStatus?: DiscordMonitorStatusSink;
@@ -29,6 +37,7 @@ type DiscordMessageRunQueue = {
 
 export type DiscordMessageRunQueueTestingHooks = {
   processDiscordMessage?: ProcessDiscordMessage;
+  runTimeoutMs?: number;
 };
 
 let messageProcessRuntimePromise:
@@ -40,6 +49,16 @@ async function loadMessageProcessRuntime() {
   return await messageProcessRuntimePromise;
 }
 
+function normalizeDiscordMessageRunTimeoutMs(params: {
+  value: unknown;
+  job: DiscordInboundJob;
+}): number {
+  if (typeof params.value === "number" && Number.isFinite(params.value)) {
+    return Math.max(0, Math.floor(params.value));
+  }
+  return resolveAgentTimeoutMs({ cfg: params.job.payload.cfg });
+}
+
 async function processDiscordQueuedMessage(params: {
   job: DiscordInboundJob;
   lifecycleSignal?: AbortSignal;
@@ -49,27 +68,76 @@ async function processDiscordQueuedMessage(params: {
   const processDiscordMessageImpl =
     params.testing?.processDiscordMessage ??
     (await loadMessageProcessRuntime()).processDiscordMessage;
-  const abortSignal = mergeAbortSignals([params.job.runtime.abortSignal, params.lifecycleSignal]);
-  try {
-    await processDiscordMessageImpl(materializeDiscordInboundJob(params.job, abortSignal));
-    await commitDiscordInboundReplay({
-      replayKeys: params.job.replayKeys,
-      replayGuard: params.replayGuard,
-    });
-  } catch (error) {
-    if (error instanceof DiscordRetryableInboundError) {
-      releaseDiscordInboundReplay({
+  const runTimeoutMs = normalizeDiscordMessageRunTimeoutMs({
+    value: params.testing?.runTimeoutMs,
+    job: params.job,
+  });
+  const timeoutController = runTimeoutMs > 0 ? new AbortController() : undefined;
+  const abortSignal = mergeAbortSignals([
+    params.job.runtime.abortSignal,
+    params.lifecycleSignal,
+    timeoutController?.signal,
+  ]);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const processPromise = (async () => {
+    try {
+      await processDiscordMessageImpl(materializeDiscordInboundJob(params.job, abortSignal));
+      if (timedOut) {
+        return;
+      }
+      await commitDiscordInboundReplay({
         replayKeys: params.job.replayKeys,
-        error,
         replayGuard: params.replayGuard,
       });
-    } else {
+    } catch (error) {
+      if (timedOut) {
+        return;
+      }
+      if (error instanceof DiscordRetryableInboundError) {
+        releaseDiscordInboundReplay({
+          replayKeys: params.job.replayKeys,
+          error,
+          replayGuard: params.replayGuard,
+        });
+      } else {
+        await commitDiscordInboundReplay({
+          replayKeys: params.job.replayKeys,
+          replayGuard: params.replayGuard,
+        });
+      }
+      throw error;
+    }
+  })();
+  try {
+    if (runTimeoutMs <= 0) {
+      await processPromise;
+      return;
+    }
+    await Promise.race([
+      processPromise,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          const error = new DiscordMessageRunTimeoutError(runTimeoutMs);
+          timeoutController?.abort(error);
+          reject(error);
+        }, runTimeoutMs);
+        timeoutId.unref?.();
+      }),
+    ]);
+  } catch (error) {
+    if (error instanceof DiscordMessageRunTimeoutError) {
       await commitDiscordInboundReplay({
         replayKeys: params.job.replayKeys,
         replayGuard: params.replayGuard,
       });
     }
     throw error;
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
   }
 }
 

--- a/extensions/discord/src/monitor/timeouts.ts
+++ b/extensions/discord/src/monitor/timeouts.ts
@@ -1,8 +1,14 @@
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 
-// Compatibility constants for existing imports. Discord no longer enforces
-// channel-owned listener or inbound run timeouts.
+// Compatibility constant for existing imports. Discord no longer uses this
+// listener timeout to cover full agent/message processing.
 export const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 120_000;
+
+/**
+ * @deprecated Compatibility export for callers that imported the previous
+ * Discord inbound worker default. Discord message-run watchdogs now use the
+ * configured agent timeout resolver instead of this constant.
+ */
 export const DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS = 30 * 60_000;
 
 export const DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS = 60_000;


### PR DESCRIPTION
## Summary

This adds a Discord-specific watchdog around queued inbound message runs so one stuck run cannot indefinitely block later messages for the same Discord session key.

The watchdog mirrors the existing configured agent timeout contract via the typed SDK resolver `resolveAgentTimeoutMs({ cfg })`. It does not add a new Discord-specific 30-minute production SLA.

## Problem

Discord inbound handling serializes work per route/session key. If one queued message run never settles after a stuck agent/tool path, later Discord messages for that same session key remain behind the unresolved queue tail. To users, later messages can look silently dropped because no new automatic agent turn starts.

Manual session injection can still work because it bypasses the Discord inbound run queue.

## Root cause

`createDiscordMessageRunQueue()` delegates to `createChannelRunQueue()`, which serializes per key and intentionally imposes no per-task timeout. A non-settling Discord inbound job can therefore hold the queue tail indefinitely.

## Fix

Wrap each Discord queued message run in a Discord-owned watchdog tied to the existing agent timeout resolver:

- resolve the watchdog timeout with `resolveAgentTimeoutMs({ cfg })` from `openclaw/plugin-sdk/agent-runtime`;
- pass a merged abort signal into `processDiscordMessage`;
- when that timeout fires, abort the signal;
- commit replay keys for the timed-out job;
- throw/log `DiscordMessageRunTimeoutError`;
- allow the keyed queue to advance to later messages.

The focused test hook can still inject a short `runTimeoutMs` so the queue-tail behavior is testable without waiting for the real agent timeout.

Late completion of the original timed-out job is ignored so replay keys are not committed twice.

## Compatibility

The shipped `DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS` export is preserved as a deprecated compatibility export. Production watchdog behavior no longer uses that constant.

## Real behavior proof

- **Behavior addressed**: A stuck Discord inbound message run can hold the per-session queue tail forever, so a later same-session Discord message does not get processed. After this patch, the queued run receives an abort signal when the configured agent timeout fires, replay is committed for the timed-out delivery, and the next same-session message can proceed.

- **Real setup tested**: Isolated source checkout for this PR head (`1440ed950a0d`) running the real Discord monitor queue implementation (`createDiscordMessageRunQueue` / `createDiscordMessageHandler`) under the repository's extension-discord Vitest project. This did not use the production Gateway or production Discord bot token.

- **Exact steps or command run after this patch**:

```text
openclaw-heavy-run --backend auto -- pnpm exec vitest run extensions/discord/src/monitor/message-handler.queue.test.ts
```

- **Evidence after fix**: Redacted terminal output from the isolated PR checkout:

```text
heavy-run: ok (heaviness=always backend=systemd reason=systemd guard passed)
RUN v4.1.7 <isolated-checkout>
✓ extension-discord ../../extensions/discord/src/monitor/message-handler.queue.test.ts (20 tests) 65ms

Test Files  1 passed (1)
Tests       20 passed (20)
Duration    7.81s
```

- **Observed result after fix**: The regression suite demonstrates the queue-tail behavior directly: message `m-1` starts a Discord run that never resolves, message `m-2` is queued for the same session key, the injected watchdog timeout aborts `m-1`, and `m-2` is processed instead of remaining stuck behind `m-1`. The suite also verifies replay protection for duplicate `m-1`, late resolution of the original `m-1` without double-commit/logging, and the default timeout path using the configured agent timeout resolver rather than a new Discord-specific 30-minute production SLA.

- **What was not tested**: I did not run this patch against a live production Gateway/runtime or production Discord bot. A maintainer/Mantis Discord live proof would still be valuable for the end-to-end visible-delivery path; I requested that separately in a PR comment.

## Replay semantics

A watchdog timeout is treated like a non-retryable consumed inbound delivery. This favors avoiding duplicate processing over replaying a message whose processing state is unknown.

## Scope / relation to existing work

This is intentionally narrower than #79562. It does not add queue caps, drop policy, persistence, or global channel queue behavior changes. It only prevents a stuck Discord message run from blocking later same-session Discord inbound messages indefinitely.

Related: #9238, #75346, #29497 / #29532, #79562.

A separate adjacent failure mode can still happen after a stuck run is aborted: session write locks may remain or block later writes, producing `SessionWriteLockTimeoutError`. That lock-cleanup/recovery seam is already covered by the session-lock issue/PR cluster (for example #21783, #31489, #86540, #86806) and is intentionally out of scope for this Discord queue-tail PR.

## Risks / limitations

The watchdog aborts cooperatively. If downstream work ignores abort signals, it may still complete later, so a timed-out run can overlap with a newer same-session run. This is preferred over an indefinite queue stall but is not a hard cancellation mechanism.

The timeout ceiling follows the existing agent timeout resolver. It does not add a new 30-minute production timeout.

Full root `tsc -p tsconfig.json --noEmit` was attempted in an isolated checkout before this revision but hit a Node heap OOM before type diagnostics. The focused Discord queue regression suite and diff check passed on current `origin/main`.

## Tests

```text
git diff --check
```

```text
openclaw-heavy-run --backend auto -- pnpm exec vitest run extensions/discord/src/monitor/message-handler.queue.test.ts
```

Targeted result:

```text
1 file passed, 20 tests passed
```
