### PR TITLE
fix(agents): avoid full stream replay on text deltas

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -291,7 +291,7 @@ const server = await createServer({
   base: "/",
   cacheDir: path.join(repoRoot, ".artifacts", "control-ui-mock-vite"),
   clearScreen: false,
-  configFile: false,
+  configFile: path.join(uiRoot, "vite.config.ts"),
   define: {
     OPENCLAW_CONTROL_UI_BUILD_ID: JSON.stringify("mock"),
   },

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -33,6 +33,7 @@ function createMessageUpdateContext(
     state?: Record<string, unknown>;
   } = {},
 ) {
+  const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   return {
     params: {
       runId: "run-1",
@@ -66,7 +67,11 @@ function createMessageUpdateContext(
     log: { debug: params.debug ?? vi.fn() },
     noteLastAssistant: vi.fn(),
     stripBlockTags: params.stripBlockTags ?? vi.fn((text: string) => text),
-    consumePartialReplyDirectives: params.consumePartialReplyDirectives ?? vi.fn(() => null),
+    consumePartialReplyDirectives:
+      params.consumePartialReplyDirectives ??
+      vi.fn((text: string, options?: { final?: boolean }) =>
+        partialReplyDirectiveAccumulator.consume(text, options),
+      ),
     emitReasoningStream: vi.fn(),
     flushBlockReplyBuffer: params.flushBlockReplyBuffer ?? vi.fn(),
     resetAssistantMessageState: params.resetAssistantMessageState ?? vi.fn(),
@@ -330,6 +335,85 @@ describe("handleMessageUpdate text signatures", () => {
         data: { text: "Hello world", delta: " world" },
       },
     ]);
+  });
+
+  it("holds incomplete streaming directive tails without emitting them as text", () => {
+    const onAgentEvent = vi.fn();
+    const accumulator = createStreamingDirectiveAccumulator();
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      consumePartialReplyDirectives: vi.fn((text: string, options?: { final?: boolean }) =>
+        accumulator.consume(text, options),
+      ),
+    });
+
+    const createNonPhaseEvent = (delta: string) =>
+      ({
+        type: "message_update",
+        message: { role: "assistant", content: [] },
+        assistantMessageEvent: {
+          type: "text_delta",
+          delta,
+        },
+      }) as never;
+
+    handleMessageUpdate(context, createNonPhaseEvent("Hello\n"));
+    handleMessageUpdate(context, createNonPhaseEvent("M"));
+
+    expect(onAgentEvent).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(onAgentEvent, "agent event")).toMatchObject({
+      stream: "assistant",
+      data: { text: "Hello", delta: "Hello" },
+    });
+    expect(context.state.lastStreamedAssistantCleaned).toBe("Hello");
+  });
+
+  it("keeps stripped reply directives out of later plain deltas", () => {
+    const onAgentEvent = vi.fn();
+    const context = createMessageUpdateContext({ onAgentEvent });
+
+    const createNonPhaseEvent = (delta: string) =>
+      ({
+        type: "message_update",
+        message: { role: "assistant", content: [] },
+        assistantMessageEvent: {
+          type: "text_delta",
+          delta,
+        },
+      }) as never;
+
+    handleMessageUpdate(context, createNonPhaseEvent("[[reply_to_current]]\nHello"));
+    handleMessageUpdate(context, createNonPhaseEvent(" world"));
+
+    expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject([
+      {
+        stream: "assistant",
+        data: { text: "Hello", delta: "Hello" },
+      },
+      {
+        stream: "assistant",
+        data: { text: "Hello world", delta: " world" },
+      },
+    ]);
+  });
+
+  it("does not expose complete legacy media directives on plain deltas", () => {
+    const onAgentEvent = vi.fn();
+    const context = createMessageUpdateContext({ onAgentEvent });
+
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Here it is.\nMEDIA:/tmp/final.png\n",
+      },
+    } as never);
+
+    expect(firstMockArg(onAgentEvent, "agent event")).toMatchObject({
+      stream: "assistant",
+      data: { text: "Here it is.", delta: "Here it is." },
+    });
   });
 
   it("uses full partial text for suffix deltas after a suppressed commentary item", () => {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -384,6 +384,63 @@ function mergeReplyDirectiveResults(
   };
 }
 
+function parseFullStreamingReplyText(text: string): string {
+  return parseReplyDirectives(splitTrailingDirective(text).text).text;
+}
+
+function containsCompleteMediaDirectiveLine(text: string): boolean {
+  return /(?:^|\n)\s*MEDIA:\s*\S[^\n]*(?:\n|$)/i.test(text);
+}
+
+function resolveIncrementalStreamingReplyText(params: {
+  evtType: "text_delta" | "text_start" | "text_end";
+  next: string;
+  previousRawText: string;
+  previousCleaned: string;
+  visibleDelta: string;
+  parsedStreamDirectives: ReplyDirectiveParseResult | null;
+  shouldUsePhaseAwareBlockReply: boolean;
+}): string | undefined {
+  if (
+    params.evtType === "text_end" ||
+    !params.parsedStreamDirectives ||
+    params.parsedStreamDirectives.isSilent ||
+    hasReplyDirectiveMetadata(params.parsedStreamDirectives) ||
+    containsCompleteMediaDirectiveLine(params.visibleDelta) ||
+    params.parsedStreamDirectives.text !== params.visibleDelta
+  ) {
+    return undefined;
+  }
+
+  if (
+    !params.shouldUsePhaseAwareBlockReply &&
+    params.previousCleaned === params.previousRawText.trim()
+  ) {
+    return params.next;
+  }
+
+  const cleanedCandidate = `${params.previousCleaned}${params.parsedStreamDirectives.text}`.trim();
+  return cleanedCandidate === params.next ? cleanedCandidate : undefined;
+}
+
+function resolveStreamingReplyText(params: {
+  evtType: "text_delta" | "text_start" | "text_end";
+  next: string;
+  previousRawText: string;
+  previousCleaned: string;
+  visibleDelta: string;
+  parsedStreamDirectives: ReplyDirectiveParseResult | null;
+  shouldUsePhaseAwareBlockReply: boolean;
+}): string {
+  if (!params.parsedStreamDirectives) {
+    return params.evtType === "text_delta"
+      ? params.previousCleaned
+      : parseFullStreamingReplyText(params.next);
+  }
+
+  return resolveIncrementalStreamingReplyText(params) ?? parseFullStreamingReplyText(params.next);
+}
+
 export function recordPendingAssistantReplyDirectives(
   state: Pick<EmbeddedAgentSubscribeState, "pendingAssistantReplyDirectives">,
   parsed: ReplyDirectiveParseResult | null | undefined,
@@ -671,10 +728,18 @@ export function handleMessageUpdate(
     if (shouldUsePhaseAwareBlockReply) {
       recordPendingAssistantReplyDirectives(ctx.state, parsedStreamDirectives);
     }
-    const cleanedText = parseReplyDirectives(splitTrailingDirective(next).text).text;
+    const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
+    const cleanedText = resolveStreamingReplyText({
+      evtType,
+      next,
+      previousRawText: ctx.state.lastStreamedAssistant ?? "",
+      previousCleaned,
+      visibleDelta,
+      parsedStreamDirectives,
+      shouldUsePhaseAwareBlockReply,
+    });
     const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
     const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
-    const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
 
     let shouldEmit = false;
     let deltaText = "";


### PR DESCRIPTION
## Summary
- avoid reparsing the full accumulated assistant stream for ordinary plain text deltas in the embedded subscriber
- keep full reply-directive parsing for `text_end`, silent tokens, media/reply/audio directives, replacement-like chunks, and directive-bearing deltas
- keep phase-aware final-answer streams incremental when the visible delta exactly reconstructs the current cleaned text
- add regressions for held directive tails, stripped directive metadata staying out of later deltas, and complete legacy `MEDIA:` lines not leaking through the fast path

Relates to https://github.com/openclaw/openclaw/issues/86599.

## Verification
- Refreshed onto current `origin/main`; pushed head `9d4642a75b82`.
- `git diff --check origin/main...HEAD` - passed.
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-subscribe.handlers.messages.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts` - passed.
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-subscribe.handlers.messages.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts` - passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.messages.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.emits-block-replies-text-end-does-not.test.ts --reporter=dot` - 2 files / 43 tests passed after final rebase.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings; `overall: patch is correct (0.82)`.
- AWS Crabbox changed gate: `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 90m --ttl 180m --timing-json --shell -- "pnpm check:changed"`; provider `aws`, lease `cbx_eaddac9dbf46`, slug `amber-crayfish`, run `run_a1213a884835`, machine `c7a.8xlarge`, exit `0`, `leaseStopped=true`, lanes `core`, `coreTests`.
- Blacksmith Testbox-through-Crabbox remains unavailable in this environment from maintainer auth (`not authenticated`).

## Real behavior proof
Behavior addressed: Plain assistant text deltas no longer force full accumulated reply-directive parsing on every chunk while directive-bearing, final, silent, media/reply/audio, and replacement-like paths keep the canonical full parse.
Real environment tested: Focused local Vitest wrapper, formatting/lint checks, autoreview, and AWS Crabbox changed gate.
Exact steps or command run after this patch: See the Verification section above.
Evidence after fix: Focused subscriber and block-reply regression tests pass after rebasing onto current `origin/main`; the `MEDIA:` regression proves complete legacy media directives do not leak through the incremental fast path; AWS Crabbox `pnpm check:changed` passed on the refreshed branch.
Observed result after fix: Ordinary plain deltas reuse the incremental visible delta instead of replaying the full accumulated stream, while incomplete directive tails, stripped reply directives, complete media directives, final chunks, and replacement-like paths retain full directive parsing behavior.
What was not tested: Live Ollama/API runtime was not rerun for this focused subscriber hot-path PR.
