### PR TITLE
Persist subagent registry in SQLite

### DIFF
--- a/src/agents/subagent-registry-state.ts
+++ b/src/agents/subagent-registry-state.ts
@@ -1,23 +1,26 @@
-import { loadSubagentRegistryFromDisk, saveSubagentRegistryToDisk } from "./subagent-registry.store.js";
+import {
+  loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryToSqlite,
+} from "./subagent-registry.store.sqlite.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 export function persistSubagentRunsToDisk(runs: Map<string, SubagentRunRecord>) {
   try {
-    saveSubagentRegistryToDisk(runs);
+    saveSubagentRegistryToSqlite(runs);
   } catch {
     // ignore persistence failures
   }
 }
 
 export function persistSubagentRunsToDiskOrThrow(runs: Map<string, SubagentRunRecord>) {
-  saveSubagentRegistryToDisk(runs);
+  saveSubagentRegistryToSqlite(runs);
 }
 
 export function restoreSubagentRunsFromDisk(params: {
   runs: Map<string, SubagentRunRecord>;
   mergeOnly?: boolean;
 }) {
-  const restored = loadSubagentRegistryFromDisk();
+  const restored = loadSubagentRegistryFromSqlite();
   if (restored.size === 0) {
     return 0;
   }
@@ -45,7 +48,7 @@ export function getSubagentRunsSnapshotForRead(
   if (shouldReadDisk) {
     try {
       // Persisted state lets other worker processes observe active runs.
-      for (const [runId, entry] of loadSubagentRegistryFromDisk({ clone: false }).entries()) {
+      for (const [runId, entry] of loadSubagentRegistryFromSqlite().entries()) {
         merged.set(runId, entry);
       }
     } catch {

--- a/src/agents/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagent-registry.announce-loop-guard.test.ts
@@ -20,8 +20,8 @@ const mocks = vi.hoisted(() => ({
   onAgentEvent: vi.fn(),
   runSubagentAnnounceFlow: vi.fn().mockResolvedValue(false),
   captureSubagentCompletionReply: vi.fn(),
-  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
-  saveSubagentRegistryToDisk: vi.fn(),
+  loadSubagentRegistryFromSqlite: vi.fn(() => new Map()),
+  saveSubagentRegistryToSqlite: vi.fn(),
   resolveAgentTimeoutMs: vi.fn(() => 60_000),
   scheduleOrphanRecovery: vi.fn(),
 }));
@@ -53,9 +53,9 @@ vi.mock("../infra/agent-events.js", () => ({
   onAgentEvent: mocks.onAgentEvent,
 }));
 
-vi.mock("./subagent-registry.store.js", () => ({
-  loadSubagentRegistryFromDisk: mocks.loadSubagentRegistryFromDisk,
-  saveSubagentRegistryToDisk: mocks.saveSubagentRegistryToDisk,
+vi.mock("./subagent-registry.store.sqlite.js", () => ({
+  loadSubagentRegistryFromSqlite: mocks.loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryToSqlite: mocks.saveSubagentRegistryToSqlite,
 }));
 
 vi.mock("./timeout.js", () => ({
@@ -109,8 +109,8 @@ describe("announce loop guard (#18264)", () => {
     mocks.callGateway.mockClear();
     mocks.captureSubagentCompletionReply.mockClear();
     mocks.getRuntimeConfig.mockClear();
-    mocks.loadSubagentRegistryFromDisk.mockReset();
-    mocks.loadSubagentRegistryFromDisk.mockReturnValue(new Map());
+    mocks.loadSubagentRegistryFromSqlite.mockReset();
+    mocks.loadSubagentRegistryFromSqlite.mockReturnValue(new Map());
     mocks.onAgentEventStop.mockClear();
     mocks.onAgentEvent.mockReset();
     mocks.onAgentEvent.mockReturnValue(mocks.onAgentEventStop);
@@ -118,7 +118,7 @@ describe("announce loop guard (#18264)", () => {
     mocks.runSubagentAnnounceFlow.mockReset();
     mocks.runSubagentAnnounceFlow.mockResolvedValue(false);
     mocks.scheduleOrphanRecovery.mockClear();
-    mocks.saveSubagentRegistryToDisk.mockClear();
+    mocks.saveSubagentRegistryToSqlite.mockClear();
     mocks.updateSessionStore.mockClear();
     registry.resetSubagentRegistryForTests({ persist: false });
     registry.testing.setDepsForTest({
@@ -198,7 +198,7 @@ describe("announce loop guard (#18264)", () => {
     registry.resetSubagentRegistryForTests();
 
     const entry = createEntry(Date.now());
-    mocks.loadSubagentRegistryFromDisk.mockReturnValue(new Map([[entry.runId, entry]]));
+    mocks.loadSubagentRegistryFromSqlite.mockReturnValue(new Map([[entry.runId, entry]]));
 
     // Initialization attempts resume once, then gives up for exhausted entries.
     const beforeInit = Date.now();
@@ -216,7 +216,7 @@ describe("announce loop guard (#18264)", () => {
 
     const now = Date.now();
     const runId = "test-expired-completion-message";
-    mocks.loadSubagentRegistryFromDisk.mockReturnValue(
+    mocks.loadSubagentRegistryFromSqlite.mockReturnValue(
       new Map([
         [
           runId,
@@ -250,7 +250,7 @@ describe("announce loop guard (#18264)", () => {
 
     const now = Date.now();
     const runId = "test-announce-rejection";
-    mocks.loadSubagentRegistryFromDisk.mockReturnValue(
+    mocks.loadSubagentRegistryFromSqlite.mockReturnValue(
       new Map([
         [
           runId,

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { captureEnv } from "../test-utils/env.js";
+import {
+  loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryToSqlite,
+} from "./subagent-registry.store.sqlite.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+function createRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
+  return {
+    runId: "run-one",
+    childSessionKey: "agent:main:subagent:one",
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "check sqlite persistence",
+    cleanup: "keep",
+    createdAt: 100,
+    startedAt: 110,
+    endedAt: 250,
+    outcome: { status: "ok", startedAt: 110, endedAt: 250, elapsedMs: 140 },
+    expectsCompletionMessage: true,
+    completion: {
+      required: true,
+      resultText: "done",
+      capturedAt: 260,
+    },
+    delivery: {
+      status: "pending",
+      createdAt: 270,
+      lastAttemptAt: 280,
+      attemptCount: 2,
+      lastError: "retry later",
+      payload: {
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        childSessionKey: "agent:main:subagent:one",
+        childRunId: "run-one",
+        task: "check sqlite persistence",
+        startedAt: 110,
+        endedAt: 250,
+        outcome: { status: "ok" },
+        expectsCompletionMessage: true,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("subagent registry sqlite store", () => {
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+  let tempStateDir: string | null = null;
+
+  beforeEach(async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-sqlite-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    if (tempStateDir) {
+      await fs.rm(tempStateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      tempStateDir = null;
+    }
+    envSnapshot.restore();
+  });
+
+  it("persists subagent runs in the shared sqlite state database", async () => {
+    const run = createRun();
+
+    saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+    const restored = loadSubagentRegistryFromSqlite();
+    expect(restored.get(run.runId)).toMatchObject({
+      runId: run.runId,
+      childSessionKey: run.childSessionKey,
+      requesterSessionKey: run.requesterSessionKey,
+      task: run.task,
+      endedAt: run.endedAt,
+      outcome: run.outcome,
+      completion: run.completion,
+      delivery: run.delivery,
+    });
+    expect(await fs.stat(path.join(tempStateDir!, "state", "openclaw.sqlite"))).toBeTruthy();
+    await expect(fs.stat(path.join(tempStateDir!, "subagents", "runs.json"))).rejects.toThrow();
+  });
+
+  it("uses save calls as whole-registry snapshots", () => {
+    const first = createRun({ runId: "run-one", childSessionKey: "agent:main:subagent:one" });
+    const second = createRun({ runId: "run-two", childSessionKey: "agent:main:subagent:two" });
+
+    saveSubagentRegistryToSqlite(
+      new Map([
+        [first.runId, first],
+        [second.runId, second],
+      ]),
+    );
+    saveSubagentRegistryToSqlite(new Map([[second.runId, second]]));
+
+    expect([...loadSubagentRegistryFromSqlite().keys()]).toEqual(["run-two"]);
+  });
+
+  it("imports the legacy json registry when sqlite has no runs", async () => {
+    const legacyRun = createRun({
+      runId: "legacy-run",
+      childSessionKey: "agent:main:subagent:legacy",
+      task: "import legacy registry",
+    });
+    const registryPath = path.join(tempStateDir!, "subagents", "runs.json");
+    await fs.mkdir(path.dirname(registryPath), { recursive: true });
+    await fs.writeFile(
+      registryPath,
+      `${JSON.stringify({ version: 2, runs: { [legacyRun.runId]: legacyRun } })}\n`,
+      "utf8",
+    );
+
+    const imported = loadSubagentRegistryFromSqlite();
+
+    expect(imported.get(legacyRun.runId)?.task).toBe("import legacy registry");
+    await expect(fs.stat(registryPath)).rejects.toThrow();
+    expect(loadSubagentRegistryFromSqlite().get(legacyRun.runId)?.task).toBe(
+      "import legacy registry",
+    );
+    expect(
+      openOpenClawStateDatabase().db.prepare("SELECT COUNT(*) AS count FROM subagent_runs").get(),
+    ).toEqual({ count: 1 });
+  });
+});

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -1,0 +1,315 @@
+import fs from "node:fs";
+import type { Insertable, Selectable, Updateable } from "kysely";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
+import { normalizeSubagentRunState } from "./subagent-delivery-state.js";
+import {
+  loadSubagentRegistryFromDisk,
+  resolveSubagentRegistryPath,
+} from "./subagent-registry.store.js";
+import type {
+  PendingFinalDeliveryPayload,
+  SubagentCompletionDeliveryState,
+  SubagentCompletionState,
+  SubagentExecutionState,
+  SubagentRunRecord,
+} from "./subagent-registry.types.js";
+
+type SubagentRunsTable = OpenClawStateKyselyDatabase["subagent_runs"];
+type SubagentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "subagent_runs">;
+type SubagentRunSqliteRow = Selectable<SubagentRunsTable>;
+type SubagentRunSqliteInsert = Insertable<SubagentRunsTable>;
+type SubagentRunSqliteUpdate = Updateable<SubagentRunsTable>;
+
+function jsonStringify(value: unknown): string | null {
+  return value === undefined ? null : JSON.stringify(value);
+}
+
+function parseJson(raw: string | null): unknown {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function boolToSqlite(value: boolean | undefined): number | null {
+  return value === undefined ? null : value ? 1 : 0;
+}
+
+function sqliteBool(value: number | null): boolean | undefined {
+  return value == null ? undefined : value !== 0;
+}
+
+function normalizeFiniteNumber(value: number | null): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function createDeliveryFromTypedColumns(
+  row: SubagentRunSqliteRow,
+  fallback: SubagentCompletionDeliveryState | undefined,
+): SubagentCompletionDeliveryState | undefined {
+  const delivery = fallback ? { ...fallback } : undefined;
+  const payload = parseJson(row.pending_final_delivery_payload_json) as
+    | PendingFinalDeliveryPayload
+    | undefined;
+  const status =
+    row.expects_completion_message === 0
+      ? "not_required"
+      : row.pending_final_delivery
+        ? "pending"
+        : delivery?.status;
+  if (!status && row.completion_announced_at == null && row.last_announce_delivery_error == null) {
+    return delivery;
+  }
+  return {
+    status: status ?? "pending",
+    ...delivery,
+    ...(payload ? { payload } : {}),
+    ...(normalizeFiniteNumber(row.pending_final_delivery_created_at) !== undefined
+      ? { createdAt: row.pending_final_delivery_created_at ?? undefined }
+      : {}),
+    ...(normalizeFiniteNumber(row.pending_final_delivery_last_attempt_at) !== undefined
+      ? { lastAttemptAt: row.pending_final_delivery_last_attempt_at ?? undefined }
+      : {}),
+    ...(normalizeFiniteNumber(row.pending_final_delivery_attempt_count) !== undefined
+      ? { attemptCount: row.pending_final_delivery_attempt_count ?? undefined }
+      : {}),
+    ...(row.pending_final_delivery_last_error !== null
+      ? { lastError: row.pending_final_delivery_last_error }
+      : {}),
+    ...(row.completion_announced_at !== null
+      ? {
+          status: "delivered",
+          announcedAt: row.completion_announced_at,
+          deliveredAt: delivery?.deliveredAt ?? row.completion_announced_at,
+        }
+      : {}),
+  };
+}
+
+function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | null {
+  const payload = (parseJson(row.payload_json) as Partial<SubagentRunRecord> | undefined) ?? {};
+  const requesterOrigin =
+    (parseJson(row.requester_origin_json) as SubagentRunRecord["requesterOrigin"] | undefined) ??
+    payload.requesterOrigin;
+  const outcome =
+    (parseJson(row.outcome_json) as SubagentRunRecord["outcome"] | undefined) ?? payload.outcome;
+  const completion: SubagentCompletionState | undefined = {
+    ...(payload.completion ?? { required: row.expects_completion_message === 1 }),
+    required: payload.completion?.required ?? row.expects_completion_message === 1,
+    ...(row.frozen_result_text !== null ? { resultText: row.frozen_result_text } : {}),
+    ...(row.frozen_result_captured_at !== null
+      ? { capturedAt: row.frozen_result_captured_at }
+      : {}),
+    ...(row.fallback_frozen_result_text !== null
+      ? { fallbackResultText: row.fallback_frozen_result_text }
+      : {}),
+    ...(row.fallback_frozen_result_captured_at !== null
+      ? { fallbackCapturedAt: row.fallback_frozen_result_captured_at }
+      : {}),
+  };
+  const execution: SubagentExecutionState | undefined = payload.execution
+    ? {
+        ...payload.execution,
+        ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
+        ...(row.ended_at !== null ? { status: "terminal", endedAt: row.ended_at, outcome } : {}),
+      }
+    : undefined;
+  const delivery = createDeliveryFromTypedColumns(row, payload.delivery);
+  const record = normalizeSubagentRunState({
+    ...payload,
+    runId: row.run_id,
+    childSessionKey: row.child_session_key,
+    ...(row.controller_session_key ? { controllerSessionKey: row.controller_session_key } : {}),
+    requesterSessionKey: row.requester_session_key,
+    ...(requesterOrigin ? { requesterOrigin: normalizeDeliveryContext(requesterOrigin) } : {}),
+    requesterDisplayKey: row.requester_display_key,
+    task: row.task,
+    cleanup: row.cleanup === "delete" ? "delete" : "keep",
+    ...(row.task_name ? { taskName: row.task_name } : {}),
+    ...(row.label ? { label: row.label } : {}),
+    ...(row.model ? { model: row.model } : {}),
+    ...(row.agent_dir ? { agentDir: row.agent_dir } : {}),
+    ...(row.workspace_dir ? { workspaceDir: row.workspace_dir } : {}),
+    ...(row.run_timeout_seconds !== null ? { runTimeoutSeconds: row.run_timeout_seconds } : {}),
+    ...(row.spawn_mode === "session" || row.spawn_mode === "run"
+      ? { spawnMode: row.spawn_mode }
+      : {}),
+    createdAt: row.created_at,
+    ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
+    ...(row.session_started_at !== null ? { sessionStartedAt: row.session_started_at } : {}),
+    ...(row.accumulated_runtime_ms !== null
+      ? { accumulatedRuntimeMs: row.accumulated_runtime_ms }
+      : {}),
+    ...(row.ended_at !== null ? { endedAt: row.ended_at } : {}),
+    ...(outcome ? { outcome } : {}),
+    ...(row.archive_at_ms !== null ? { archiveAtMs: row.archive_at_ms } : {}),
+    ...(row.cleanup_completed_at !== null ? { cleanupCompletedAt: row.cleanup_completed_at } : {}),
+    ...(sqliteBool(row.cleanup_handled) !== undefined
+      ? { cleanupHandled: sqliteBool(row.cleanup_handled) }
+      : {}),
+    ...(row.suppress_announce_reason === "steer-restart" ||
+    row.suppress_announce_reason === "killed"
+      ? { suppressAnnounceReason: row.suppress_announce_reason }
+      : {}),
+    ...(sqliteBool(row.expects_completion_message) !== undefined
+      ? { expectsCompletionMessage: sqliteBool(row.expects_completion_message) }
+      : {}),
+    ...(row.ended_reason
+      ? { endedReason: row.ended_reason as SubagentRunRecord["endedReason"] }
+      : {}),
+    ...(row.pause_reason === "sessions_yield" ? { pauseReason: row.pause_reason } : {}),
+    ...(sqliteBool(row.wake_on_descendant_settle) !== undefined
+      ? { wakeOnDescendantSettle: sqliteBool(row.wake_on_descendant_settle) }
+      : {}),
+    ...(execution ? { execution } : {}),
+    completion,
+    ...(row.ended_hook_emitted_at !== null
+      ? { endedHookEmittedAt: row.ended_hook_emitted_at }
+      : {}),
+    ...(delivery ? { delivery } : {}),
+  });
+  return record.runId && record.childSessionKey && record.requesterSessionKey ? record : null;
+}
+
+function subagentRunRecordToSqliteInsert(entry: SubagentRunRecord): SubagentRunSqliteInsert {
+  const normalized = normalizeSubagentRunState(structuredClone(entry));
+  const delivery = normalized.delivery;
+  const completion = normalized.completion;
+  return {
+    run_id: normalized.runId,
+    child_session_key: normalized.childSessionKey,
+    controller_session_key: normalized.controllerSessionKey ?? null,
+    requester_session_key: normalized.requesterSessionKey,
+    requester_display_key: normalized.requesterDisplayKey,
+    requester_origin_json: jsonStringify(normalized.requesterOrigin),
+    task: normalized.task,
+    task_name: normalized.taskName ?? null,
+    cleanup: normalized.cleanup,
+    label: normalized.label ?? null,
+    model: normalized.model ?? null,
+    agent_dir: normalized.agentDir ?? null,
+    workspace_dir: normalized.workspaceDir ?? null,
+    run_timeout_seconds: normalized.runTimeoutSeconds ?? null,
+    spawn_mode: normalized.spawnMode ?? null,
+    created_at: normalized.createdAt,
+    started_at: normalized.startedAt ?? null,
+    session_started_at: normalized.sessionStartedAt ?? null,
+    accumulated_runtime_ms: normalized.accumulatedRuntimeMs ?? null,
+    ended_at: normalized.endedAt ?? null,
+    outcome_json: jsonStringify(normalized.outcome),
+    archive_at_ms: normalized.archiveAtMs ?? null,
+    cleanup_completed_at: normalized.cleanupCompletedAt ?? null,
+    cleanup_handled: boolToSqlite(normalized.cleanupHandled),
+    suppress_announce_reason: normalized.suppressAnnounceReason ?? null,
+    expects_completion_message: boolToSqlite(normalized.expectsCompletionMessage),
+    announce_retry_count: delivery?.attemptCount ?? null,
+    last_announce_retry_at: delivery?.lastAttemptAt ?? null,
+    last_announce_delivery_error: delivery?.lastError ?? null,
+    ended_reason: normalized.endedReason ?? null,
+    pause_reason: normalized.pauseReason ?? null,
+    wake_on_descendant_settle: boolToSqlite(normalized.wakeOnDescendantSettle),
+    frozen_result_text: completion?.resultText ?? null,
+    frozen_result_captured_at: completion?.capturedAt ?? null,
+    fallback_frozen_result_text: completion?.fallbackResultText ?? null,
+    fallback_frozen_result_captured_at: completion?.fallbackCapturedAt ?? null,
+    ended_hook_emitted_at: normalized.endedHookEmittedAt ?? null,
+    pending_final_delivery: boolToSqlite(
+      delivery?.status === "pending" || Boolean(delivery?.payload),
+    ),
+    pending_final_delivery_created_at: delivery?.createdAt ?? null,
+    pending_final_delivery_last_attempt_at: delivery?.lastAttemptAt ?? null,
+    pending_final_delivery_attempt_count: delivery?.attemptCount ?? null,
+    pending_final_delivery_last_error: delivery?.lastError ?? null,
+    pending_final_delivery_payload_json: jsonStringify(delivery?.payload),
+    completion_announced_at: delivery?.announcedAt ?? null,
+    payload_json: JSON.stringify(normalized),
+  };
+}
+
+function subagentRunRecordToSqliteUpdate(values: SubagentRunSqliteInsert): SubagentRunSqliteUpdate {
+  const { run_id: _runId, ...update } = values;
+  return update;
+}
+
+function readSubagentRegistryRows(): SubagentRunSqliteRow[] {
+  const { db } = openOpenClawStateDatabase();
+  const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
+  return executeSqliteQuerySync(
+    db,
+    stateDb
+      .selectFrom("subagent_runs")
+      .selectAll()
+      .orderBy("created_at", "asc")
+      .orderBy("run_id", "asc"),
+  ).rows;
+}
+
+function removeLegacySubagentRegistryFile(): void {
+  try {
+    fs.unlinkSync(resolveSubagentRegistryPath());
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function loadSubagentRegistryFromSqliteOnly(): Map<string, SubagentRunRecord> {
+  const runs = new Map<string, SubagentRunRecord>();
+  for (const row of readSubagentRegistryRows()) {
+    const entry = rowToSubagentRunRecord(row);
+    if (entry) {
+      runs.set(entry.runId, entry);
+    }
+  }
+  return runs;
+}
+
+export function loadSubagentRegistryFromSqlite(): Map<string, SubagentRunRecord> {
+  const runs = loadSubagentRegistryFromSqliteOnly();
+  if (runs.size > 0) {
+    return runs;
+  }
+  const legacyRuns = loadSubagentRegistryFromDisk();
+  if (legacyRuns.size === 0) {
+    return runs;
+  }
+  saveSubagentRegistryToSqlite(legacyRuns);
+  removeLegacySubagentRegistryFile();
+  return loadSubagentRegistryFromSqliteOnly();
+}
+
+export function saveSubagentRegistryToSqlite(runs: Map<string, SubagentRunRecord>): void {
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
+    const runIds: string[] = [];
+    for (const entry of runs.values()) {
+      const values = subagentRunRecordToSqliteInsert(entry);
+      runIds.push(values.run_id);
+      executeSqliteQuerySync(
+        db,
+        stateDb
+          .insertInto("subagent_runs")
+          .values(values)
+          .onConflict((conflict) =>
+            conflict.column("run_id").doUpdateSet(subagentRunRecordToSqliteUpdate(values)),
+          ),
+      );
+    }
+    const deleteQuery =
+      runIds.length === 0
+        ? stateDb.deleteFrom("subagent_runs")
+        : stateDb.deleteFrom("subagent_runs").where("run_id", "not in", runIds);
+    executeSqliteQuerySync(db, deleteQuery);
+  });
+}


### PR DESCRIPTION
## Summary

- Replaces the subagent registry JSON persistence path with the shared OpenClaw SQLite state database.
- Uses the existing generated Kysely schema for `subagent_runs` reads, upserts, and snapshot deletes.
- Imports existing `subagents/runs.json` once when SQLite is empty, then removes the legacy file so stale runs cannot be re-imported.

Replaces #88166 with the SQLite-backed approach discussed there.

## Verification

- `node scripts/run-vitest.mjs src/agents/subagent-registry.store.sqlite.test.ts src/agents/subagent-registry.persistence.test.ts src/gateway/session-utils.subagent.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `node scripts/run-oxlint.mjs src/agents/subagent-registry-state.ts src/agents/subagent-registry.store.sqlite.ts src/agents/subagent-registry.store.sqlite.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> `autoreview clean: no accepted/actionable findings reported`

## Real behavior proof

Behavior addressed: Subagent registry runs persist through the shared SQLite state database instead of a standalone JSON registry file, while existing JSON state migrates on first read.
Real environment tested: Local macOS checkout with Node/Vitest/tsgo/oxlint; SQLite state database exercised through temp `OPENCLAW_STATE_DIR` test fixtures.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/subagent-registry.store.sqlite.test.ts src/agents/subagent-registry.persistence.test.ts src/gateway/session-utils.subagent.test.ts`.
Evidence after fix: Focused tests covered SQLite persistence, whole-registry snapshot deletion, and one-shot legacy JSON import/removal.
Observed result after fix: 3 test files passed, 48 tests passed; `tsgo:core`, `tsgo:core:test`, targeted oxlint, and autoreview also passed.
What was not tested: Full `pnpm check:changed`; an earlier Testbox delegation was stopped after it became stale relative to a local cleanup patch.
