### PR TITLE
fix #88214: [Feature]: Dashboard sidebar Recent sessions should filter by currently selected agent

### DIFF
--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -946,7 +946,7 @@ export async function runBeforeToolCallHook(args: {
         params,
       };
     }
-    let trustedApprovalParams: unknown | undefined;
+    let trustedApprovalParams: unknown;
     let trustedApprovalResolution: PluginApprovalResolution | undefined;
     if (trustedPolicyResult?.requireApproval) {
       const approvalOutcome = await resolveBeforeToolCallApprovalOutcome({

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -355,6 +355,33 @@ describe("refreshChat", () => {
     expect(sessionsListPayload.agentId).toBe("ops");
   });
 
+  it("keeps unknown chat refresh session rows unscoped", async () => {
+    const request = vi.fn(() => new Promise<unknown>(() => undefined));
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "unknown",
+      assistantAgentId: "work",
+      agentsList: { defaultId: "main" },
+    });
+
+    const refresh = refreshChat(host);
+    const outcome = await raceWithMacrotask(refresh);
+
+    expect(outcome).toBe("resolved");
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "unknown",
+      limit: 100,
+      maxChars: 4000,
+    });
+    const sessionsListPayload = findRequestPayload(
+      request as unknown as MockCallSource,
+      "sessions.list",
+      "unknown sessions list payload",
+    );
+    expect(sessionsListPayload).not.toHaveProperty("agentId");
+    expect(sessionsListPayload.includeUnknown).toBe(true);
+  });
+
   it("can wait for history without waiting for secondary metadata refreshes", async () => {
     const history = createDeferred<unknown>();
     const requestUpdate = vi.fn();

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -302,6 +302,28 @@ describe("refreshChat", () => {
     expect(sessionsListPayload.includeGlobal).toBe(true);
   });
 
+  it("scopes agent session refresh rows before the list limit", async () => {
+    const request = vi.fn(() => new Promise<unknown>(() => undefined));
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "agent:work:dashboard",
+      agentsList: { defaultId: "main", mainKey: "main" },
+    });
+
+    const refresh = refreshChat(host);
+    const outcome = await raceWithMacrotask(refresh);
+
+    expect(outcome).toBe("resolved");
+    const sessionsListPayload = findRequestPayload(
+      request as unknown as MockCallSource,
+      "sessions.list",
+      "agent direct sessions list payload",
+    );
+    expect(sessionsListPayload.agentId).toBe("work");
+    expect(sessionsListPayload.limit).toBe(50);
+    expect(sessionsListPayload.includeGlobal).toBe(true);
+  });
+
   it("uses hello default for global chat refresh before agents list loads", async () => {
     const request = vi.fn(() => new Promise<unknown>(() => undefined));
     const host = makeHost({

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -153,7 +153,7 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     chatModelSwitchPromises: {},
     chatModelsLoading: false,
     chatModelCatalog: [],
-    refreshSessionsAfterChat: new Set<string>(),
+    refreshSessionsAfterChat: new Map(),
     toolStreamById: new Map(),
     toolStreamOrder: [],
     toolStreamSyncTimer: null,

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -235,7 +235,7 @@ describe("refreshChat", () => {
       "sessions list payload",
     );
     expect(sessionsListPayload).not.toHaveProperty("activeMinutes");
-    expect(sessionsListPayload).not.toHaveProperty("agentId");
+    expect(sessionsListPayload.agentId).toBe("main");
     expect(sessionsListPayload.includeGlobal).toBe(true);
     expect(sessionsListPayload.includeUnknown).toBe(true);
     expect(sessionsListPayload.limit).toBe(50);
@@ -694,7 +694,7 @@ describe("refreshChat", () => {
         "sessions list payload",
       );
       expect(sessionsListPayload).not.toHaveProperty("activeMinutes");
-      expect(sessionsListPayload).not.toHaveProperty("agentId");
+      expect(sessionsListPayload.agentId).toBe("main");
       expect(sessionsListPayload.includeGlobal).toBe(true);
       expect(sessionsListPayload.includeUnknown).toBe(true);
       expect(sessionsListPayload.limit).toBe(50);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -305,9 +305,11 @@ export function scopedAgentListParamsForSession(
   const normalizedSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
   const agentId =
     parsed?.agentId ??
-    (normalizedSessionKey === "global" || normalizedSessionKey === "unknown"
+    (normalizedSessionKey === "global"
       ? resolveSelectedGlobalAgentId(host)
-      : resolveDefaultAgentIdForList(host));
+      : normalizedSessionKey === "unknown"
+        ? undefined
+        : resolveDefaultAgentIdForList(host));
   return agentId ? { agentId: normalizeAgentId(agentId) } : {};
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -291,6 +291,15 @@ export function scopedAgentParamsForSession(
   return agentId ? { agentId } : {};
 }
 
+export function scopedAgentListParamsForSession(
+  host: Pick<ChatHost, "assistantAgentId" | "agentsList" | "hello">,
+  sessionKey: string,
+) {
+  const parsed = parseAgentSessionKey(sessionKey);
+  const agentId = parsed?.agentId ?? scopedAgentParamsForSession(host, sessionKey).agentId;
+  return agentId ? { agentId: normalizeAgentId(agentId) } : {};
+}
+
 export async function handleAbortChat(host: ChatHost, opts?: ChatAbortOptions) {
   const activeRunId = host.chatRunId;
   const clearDraft = () => {
@@ -596,6 +605,7 @@ async function sendQueuedChatMessage(
       if (ack.status === "ok") {
         void loadSessions(host as unknown as SessionsState, {
           ...createChatSessionsLoadOverrides(host),
+          ...scopedAgentListParamsForSession(host, host.sessionKey),
         });
       } else {
         host.refreshSessionsAfterChat.add(ack.runId);
@@ -1299,7 +1309,7 @@ export async function refreshChat(
   const secondaryRefresh = Promise.allSettled([
     loadSessions(host as unknown as SessionsState, {
       ...createChatSessionsLoadOverrides(host),
-      ...scopedAgentParamsForSession(host, host.sessionKey),
+      ...scopedAgentListParamsForSession(host, host.sessionKey),
     }),
     refreshChatAvatar(host),
     refreshChatModels(host),

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -250,6 +250,12 @@ function resolveSelectedGlobalAgentId(
   return agentId ? normalizeAgentId(agentId) : undefined;
 }
 
+function resolveDefaultAgentIdForList(host: Pick<ChatHost, "agentsList" | "hello">): string {
+  return normalizeAgentId(
+    host.agentsList?.defaultId ?? readHelloDefaultAgentId(host) ?? DEFAULT_AGENT_ID,
+  );
+}
+
 function scopedAgentIdForSession(host: ChatHost, sessionKey: string | undefined | null) {
   return isGlobalSessionKey(sessionKey)
     ? resolveSelectedGlobalAgentId(host)
@@ -296,7 +302,12 @@ export function scopedAgentListParamsForSession(
   sessionKey: string,
 ) {
   const parsed = parseAgentSessionKey(sessionKey);
-  const agentId = parsed?.agentId ?? scopedAgentParamsForSession(host, sessionKey).agentId;
+  const normalizedSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
+  const agentId =
+    parsed?.agentId ??
+    (normalizedSessionKey === "global" || normalizedSessionKey === "unknown"
+      ? resolveSelectedGlobalAgentId(host)
+      : resolveDefaultAgentIdForList(host));
   return agentId ? { agentId: normalizeAgentId(agentId) } : {};
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -45,7 +45,7 @@ import { isSessionRunActive } from "./session-run-state.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
 import type { SessionsListResult } from "./types.ts";
-import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
+import type { ChatAttachment, ChatQueueItem, ChatSessionRefreshTarget } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
 import { isRenderableControlUiAvatarUrl } from "./views/agents-utils.ts";
 
@@ -77,7 +77,7 @@ export type ChatHost = ChatInputHistoryState & {
   sessionsShowArchived?: boolean;
   updateComplete?: Promise<unknown>;
   requestUpdate?: () => void;
-  refreshSessionsAfterChat: Set<string>;
+  refreshSessionsAfterChat: Map<string, ChatSessionRefreshTarget>;
   pendingAbort?: { runId?: string | null; sessionKey: string; agentId?: string } | null;
   chatSubmitGuards?: Map<string, Promise<void>>;
   assistantAgentId?: string | null;
@@ -297,6 +297,16 @@ export function scopedAgentListParamsForSession(
 ) {
   const parsed = parseAgentSessionKey(sessionKey);
   const agentId = parsed?.agentId ?? scopedAgentParamsForSession(host, sessionKey).agentId;
+  return agentId ? { agentId: normalizeAgentId(agentId) } : {};
+}
+
+export function scopedAgentListParamsForRefreshTarget(
+  host: Pick<ChatHost, "assistantAgentId" | "agentsList" | "hello">,
+  target: ChatSessionRefreshTarget,
+) {
+  const agentId =
+    normalizeOptionalString(target.agentId) ??
+    scopedAgentListParamsForSession(host, target.sessionKey).agentId;
   return agentId ? { agentId: normalizeAgentId(agentId) } : {};
 }
 
@@ -602,13 +612,17 @@ async function sendQueuedChatMessage(
       }
     }
     if (prepared.refreshSessions) {
+      const refreshTarget = {
+        sessionKey,
+        agentId: prepared.agentId,
+      };
       if (ack.status === "ok") {
         void loadSessions(host as unknown as SessionsState, {
           ...createChatSessionsLoadOverrides(host),
-          ...scopedAgentListParamsForSession(host, host.sessionKey),
+          ...scopedAgentListParamsForRefreshTarget(host, refreshTarget),
         });
       } else {
-        host.refreshSessionsAfterChat.add(ack.runId);
+        host.refreshSessionsAfterChat.set(ack.runId, refreshTarget);
       }
     }
     discardChatAttachmentDataUrls(excludeComposerAttachments(host, attachments));

--- a/ui/src/ui/app-gateway-chat-load.node.test.ts
+++ b/ui/src/ui/app-gateway-chat-load.node.test.ts
@@ -60,6 +60,10 @@ vi.mock("./app-chat.ts", () => ({
   CHAT_SESSIONS_ACTIVE_MINUTES: 60,
   CHAT_SESSIONS_REFRESH_LIMIT: 50,
   createChatSessionsLoadOverrides: () => ({ activeMinutes: 60, limit: 50 }),
+  scopedAgentListParamsForSession: (_host: unknown, sessionKey: string) => {
+    const [, agentId] = sessionKey.split(":");
+    return sessionKey.startsWith("agent:") && agentId ? { agentId } : {};
+  },
   clearPendingQueueItemsForRun: vi.fn(),
   flushChatQueueForEvent: vi.fn(),
   hasReconnectableQueuedChatSends: vi.fn(() => false),

--- a/ui/src/ui/app-gateway-chat-load.node.test.ts
+++ b/ui/src/ui/app-gateway-chat-load.node.test.ts
@@ -64,6 +64,16 @@ vi.mock("./app-chat.ts", () => ({
     const [, agentId] = sessionKey.split(":");
     return sessionKey.startsWith("agent:") && agentId ? { agentId } : {};
   },
+  scopedAgentListParamsForRefreshTarget: (
+    _host: unknown,
+    target: { sessionKey: string; agentId?: string },
+  ) => {
+    if (target.agentId) {
+      return { agentId: target.agentId };
+    }
+    const [, agentId] = target.sessionKey.split(":");
+    return target.sessionKey.startsWith("agent:") && agentId ? { agentId } : {};
+  },
   clearPendingQueueItemsForRun: vi.fn(),
   flushChatQueueForEvent: vi.fn(),
   hasReconnectableQueuedChatSends: vi.fn(() => false),
@@ -179,7 +189,7 @@ function createHost(tab: Tab) {
     toolStreamOrder: [],
     toolStreamSyncTimer: null,
     pendingAbort: null,
-    refreshSessionsAfterChat: new Set<string>(),
+    refreshSessionsAfterChat: new Map(),
     execApprovalQueue: [],
     execApprovalError: null,
     updateAvailable: null,

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -183,7 +183,7 @@ function createHost(): TestGatewayHost {
     toolStreamById: new Map(),
     toolStreamOrder: [],
     toolStreamSyncTimer: null,
-    refreshSessionsAfterChat: new Set<string>(),
+    refreshSessionsAfterChat: new Map(),
     chatSideResultTerminalRuns: new Set<string>(),
     execApprovalQueue: [],
     execApprovalBusy: false,

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -27,6 +27,16 @@ vi.mock("./app-chat.ts", () => ({
       ? { agentId: host.assistantAgentId }
       : {};
   },
+  scopedAgentListParamsForRefreshTarget: (
+    _host: { assistantAgentId?: string | null },
+    target: { sessionKey: string; agentId?: string },
+  ) => {
+    if (target.agentId) {
+      return { agentId: target.agentId };
+    }
+    const [, agentId] = target.sessionKey.split(":");
+    return target.sessionKey.startsWith("agent:") && agentId ? { agentId } : {};
+  },
   clearPendingQueueItemsForRun: clearPendingQueueItemsForRunMock,
   flushChatQueueForEvent: flushChatQueueForEventMock,
   refreshChatAvatar: vi.fn(),
@@ -148,7 +158,7 @@ function createHost() {
     sessionKey: "main",
     chatRunId: null,
     toolStreamOrder: [],
-    refreshSessionsAfterChat: new Set<string>(),
+    refreshSessionsAfterChat: new Map(),
     execApprovalQueue: [],
     execApprovalError: null,
     updateAvailable: null,
@@ -165,7 +175,7 @@ describe("handleGatewayEvent sessions.changed", () => {
     handleChatEventMock.mockReset().mockReturnValue("final");
     const host = createHost();
     host.sessionKey = "agent:ops:main";
-    host.refreshSessionsAfterChat.add("run-1");
+    host.refreshSessionsAfterChat.set("run-1", { sessionKey: "agent:ops:main" });
 
     handleGatewayEvent(host, {
       type: "event",
@@ -186,8 +196,8 @@ describe("handleGatewayEvent sessions.changed", () => {
     handleChatEventMock.mockReset().mockReturnValue("final");
     const host = createHost();
     host.sessionKey = "global";
-    host.assistantAgentId = "work";
-    host.refreshSessionsAfterChat.add("run-1");
+    host.assistantAgentId = "main";
+    host.refreshSessionsAfterChat.set("run-1", { sessionKey: "global", agentId: "work" });
 
     handleGatewayEvent(host, {
       type: "event",

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -15,6 +15,18 @@ vi.mock("./app-chat.ts", () => ({
   createChatSessionsLoadOverrides: () => ({ activeMinutes: 10, limit: 25 }),
   scopedAgentParamsForSession: (host: { assistantAgentId?: string | null }, sessionKey: string) =>
     sessionKey === "global" && host.assistantAgentId ? { agentId: host.assistantAgentId } : {},
+  scopedAgentListParamsForSession: (
+    host: { assistantAgentId?: string | null },
+    sessionKey: string,
+  ) => {
+    const [, agentId] = sessionKey.split(":");
+    if (sessionKey.startsWith("agent:") && agentId) {
+      return { agentId };
+    }
+    return sessionKey === "global" && host.assistantAgentId
+      ? { agentId: host.assistantAgentId }
+      : {};
+  },
   clearPendingQueueItemsForRun: clearPendingQueueItemsForRunMock,
   flushChatQueueForEvent: flushChatQueueForEventMock,
   refreshChatAvatar: vi.fn(),
@@ -165,6 +177,7 @@ describe("handleGatewayEvent sessions.changed", () => {
     expect(loadSessionsMock).toHaveBeenCalledWith(host, {
       activeMinutes: 10,
       limit: 25,
+      agentId: "ops",
     });
   });
 
@@ -685,6 +698,7 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadSessionsMock).toHaveBeenCalledWith(host, {
       activeMinutes: 10,
       limit: 25,
+      agentId: "qa",
       publishChatRunStatus: false,
     });
     await Promise.resolve();

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -10,6 +10,7 @@ import {
   hasReconnectableQueuedChatSends,
   markQueuedChatSendsWaitingForReconnect,
   refreshChatAvatar,
+  scopedAgentListParamsForRefreshTarget,
   retryReconnectableQueuedChatSends,
   scopedAgentListParamsForSession,
   scopedAgentParamsForSession,
@@ -85,6 +86,7 @@ import type {
   StatusSummary,
   UpdateAvailable,
 } from "./types.ts";
+import type { ChatSessionRefreshTarget } from "./ui-types.ts";
 
 function isGenericBrowserFetchFailure(message: string): boolean {
   return /^(?:typeerror:\s*)?(?:fetch failed|failed to fetch)$/i.test(message.trim());
@@ -123,7 +125,7 @@ type GatewayHost = {
   sessionsShowArchived: boolean;
   chatRunId: string | null;
   pendingAbort?: { runId?: string | null; sessionKey: string; agentId?: string } | null;
-  refreshSessionsAfterChat: Set<string>;
+  refreshSessionsAfterChat: Map<string, ChatSessionRefreshTarget>;
   sessionsLoading?: boolean;
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalBusy: boolean;
@@ -795,12 +797,13 @@ function handleTerminalChatEvent(
     payload?.runId,
   );
   const runId = payload?.runId;
-  if (runId && host.refreshSessionsAfterChat.has(runId)) {
+  const refreshTarget = runId ? host.refreshSessionsAfterChat.get(runId) : undefined;
+  if (runId && refreshTarget) {
     host.refreshSessionsAfterChat.delete(runId);
     if (state === "final") {
       void loadSessions(host as unknown as SessionsState, {
         ...createChatSessionsLoadOverrides(host),
-        ...scopedAgentListParamsForSession(host, host.sessionKey),
+        ...scopedAgentListParamsForRefreshTarget(host, refreshTarget),
       });
     }
   }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -11,6 +11,7 @@ import {
   markQueuedChatSendsWaitingForReconnect,
   refreshChatAvatar,
   retryReconnectableQueuedChatSends,
+  scopedAgentListParamsForSession,
   scopedAgentParamsForSession,
 } from "./app-chat.ts";
 import type { EventLogEntry } from "./app-events.ts";
@@ -799,7 +800,7 @@ function handleTerminalChatEvent(
     if (state === "final") {
       void loadSessions(host as unknown as SessionsState, {
         ...createChatSessionsLoadOverrides(host),
-        ...scopedAgentParamsForSession(host, host.sessionKey),
+        ...scopedAgentListParamsForSession(host, host.sessionKey),
       });
     }
   }
@@ -972,7 +973,7 @@ function handleSessionMessageGatewayEvent(
     const runIdBeforeRefresh = host.chatRunId;
     void loadSessions(host as unknown as SessionsState, {
       ...createChatSessionsLoadOverrides(host),
-      ...scopedAgentParamsForSession(host, host.sessionKey),
+      ...scopedAgentListParamsForSession(host, host.sessionKey),
       publishChatRunStatus: false,
     }).finally(() =>
       replayDeferredSessionMessageReloadAfterSessionsRefresh(

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -191,7 +191,7 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
     dreamingRestartConfirmLoading: false,
     dreamingStatusError: null,
     client: null,
-    refreshSessionsAfterChat: new Set(),
+    refreshSessionsAfterChat: new Map(),
     connect: vi.fn(),
     setTab: vi.fn(),
     setTheme: vi.fn(),

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -411,4 +411,52 @@ describe("renderApp assistant avatar routing", () => {
     );
     expect(labels).toEqual(["Main legacy", "Main old"]);
   });
+
+  it("uses hello default agent for global sidebar sessions before agent list hydration", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          sessionKey: "global",
+          assistantAgentId: null,
+          agentsList: null,
+          hello: {
+            snapshot: {
+              sessionDefaults: {
+                defaultAgentId: "ops",
+              },
+            },
+          } as AppViewState["hello"],
+          sessionsResult: {
+            ts: 0,
+            path: "",
+            count: 2,
+            defaults: { modelProvider: null, model: null, contextTokens: null },
+            sessions: [
+              {
+                key: "agent:main:dashboard:old",
+                kind: "direct",
+                label: "Main old",
+                updatedAt: 20,
+              },
+              {
+                key: "agent:ops:dashboard:new",
+                kind: "direct",
+                label: "Ops new",
+                updatedAt: 10,
+              },
+            ],
+          } as AppViewState["sessionsResult"],
+        }),
+      ),
+      container,
+    );
+
+    const labels = Array.from(container.querySelectorAll(".sidebar-recent-session__name")).map(
+      (node) => node.textContent?.trim(),
+    );
+    expect(labels).toEqual(["Ops new"]);
+  });
 });

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -305,4 +305,57 @@ describe("renderApp assistant avatar routing", () => {
 
     expect(container.querySelector(".shell")).toBeInstanceOf(HTMLElement);
   });
+
+  it("filters sidebar recent sessions to the active chat agent", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          sessionKey: "agent:work:main",
+          assistantAgentId: "work",
+          agentsList: {
+            defaultId: "main",
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "work", name: "Work" },
+            ],
+          } as AppViewState["agentsList"],
+          sessionsResult: {
+            ts: 0,
+            path: "",
+            count: 3,
+            defaults: { modelProvider: null, model: null, contextTokens: null },
+            sessions: [
+              {
+                key: "agent:main:dashboard:old",
+                kind: "direct",
+                label: "Main old",
+                updatedAt: 30,
+              },
+              {
+                key: "agent:work:dashboard:new",
+                kind: "direct",
+                label: "Work new",
+                updatedAt: 20,
+              },
+              {
+                key: "agent:work:dashboard:older",
+                kind: "direct",
+                label: "Work older",
+                updatedAt: 10,
+              },
+            ],
+          } as AppViewState["sessionsResult"],
+        }),
+      ),
+      container,
+    );
+
+    const labels = Array.from(container.querySelectorAll(".sidebar-recent-session__name")).map(
+      (node) => node.textContent?.trim(),
+    );
+    expect(labels).toEqual(["Work new", "Work older"]);
+  });
 });

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -358,4 +358,57 @@ describe("renderApp assistant avatar routing", () => {
     );
     expect(labels).toEqual(["Work new", "Work older"]);
   });
+
+  it("keeps legacy main sessions tied to the default agent when identity is stale", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          sessionKey: "main",
+          assistantAgentId: "work",
+          agentsList: {
+            defaultId: "main",
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "work", name: "Work" },
+            ],
+          } as AppViewState["agentsList"],
+          sessionsResult: {
+            ts: 0,
+            path: "",
+            count: 3,
+            defaults: { modelProvider: null, model: null, contextTokens: null },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                label: "Main legacy",
+                updatedAt: 30,
+              },
+              {
+                key: "agent:main:dashboard:old",
+                kind: "direct",
+                label: "Main old",
+                updatedAt: 20,
+              },
+              {
+                key: "agent:work:dashboard:new",
+                kind: "direct",
+                label: "Work new",
+                updatedAt: 10,
+              },
+            ],
+          } as AppViewState["sessionsResult"],
+        }),
+      ),
+      container,
+    );
+
+    const labels = Array.from(container.querySelectorAll(".sidebar-recent-session__name")).map(
+      (node) => node.textContent?.trim(),
+    );
+    expect(labels).toEqual(["Main legacy", "Main old"]);
+  });
 });

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -459,4 +459,57 @@ describe("renderApp assistant avatar routing", () => {
     );
     expect(labels).toEqual(["Ops new"]);
   });
+
+  it("keeps unknown sidebar sessions unscoped", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          sessionKey: "unknown",
+          assistantAgentId: "work",
+          agentsList: {
+            defaultId: "main",
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "work", name: "Work" },
+            ],
+          } as AppViewState["agentsList"],
+          sessionsResult: {
+            ts: 0,
+            path: "",
+            count: 3,
+            defaults: { modelProvider: null, model: null, contextTokens: null },
+            sessions: [
+              {
+                key: "agent:main:dashboard:old",
+                kind: "direct",
+                label: "Main old",
+                updatedAt: 30,
+              },
+              {
+                key: "agent:work:dashboard:new",
+                kind: "direct",
+                label: "Work new",
+                updatedAt: 20,
+              },
+              {
+                key: "unknown",
+                kind: "unknown",
+                label: "Unknown sentinel",
+                updatedAt: 10,
+              },
+            ],
+          } as AppViewState["sessionsResult"],
+        }),
+      ),
+      container,
+    );
+
+    const labels = Array.from(container.querySelectorAll(".sidebar-recent-session__name")).map(
+      (node) => node.textContent?.trim(),
+    );
+    expect(labels).toEqual(["Main old", "Work new"]);
+  });
 });

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -28,6 +28,10 @@ vi.mock("./app-chat.ts", () => ({
     includeUnknown: true,
     showArchived: false,
   }),
+  scopedAgentListParamsForSession: (_state: unknown, sessionKey: string) => {
+    const [, agentId] = sessionKey.split(":");
+    return sessionKey.startsWith("agent:") && agentId ? { agentId } : {};
+  },
   refreshChat: refreshChatMock,
   refreshChatAvatar: refreshChatAvatarMock,
 }));
@@ -786,6 +790,7 @@ describe("createChatSession", () => {
         includeGlobal: true,
         includeUnknown: true,
         showArchived: false,
+        agentId: "ops",
       },
     );
     expect(state.sessionKey).toBe("agent:ops:dashboard:new-chat");
@@ -988,6 +993,7 @@ describe("switchChatSession", () => {
       includeGlobal: true,
       includeUnknown: true,
       showArchived: false,
+      agentId: "main",
     });
     expect(
       (state as unknown as { announceSessionSwitch: ReturnType<typeof vi.fn> })

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -28,9 +28,26 @@ vi.mock("./app-chat.ts", () => ({
     includeUnknown: true,
     showArchived: false,
   }),
-  scopedAgentListParamsForSession: (_state: unknown, sessionKey: string) => {
+  scopedAgentParamsForSession: (state: unknown, sessionKey: string) => {
+    if (sessionKey === "global") {
+      return {
+        agentId: (state as { assistantAgentId?: string | null }).assistantAgentId ?? "main",
+      };
+    }
     const [, agentId] = sessionKey.split(":");
     return sessionKey.startsWith("agent:") && agentId ? { agentId } : {};
+  },
+  scopedAgentListParamsForSession: (state: unknown, sessionKey: string) => {
+    if (sessionKey === "global") {
+      return {
+        agentId: (state as { assistantAgentId?: string | null }).assistantAgentId ?? "main",
+      };
+    }
+    if (sessionKey === "unknown") {
+      return {};
+    }
+    const [, agentId] = sessionKey.split(":");
+    return sessionKey.startsWith("agent:") && agentId ? { agentId } : { agentId: "main" };
   },
   refreshChat: refreshChatMock,
   refreshChatAvatar: refreshChatAvatarMock,
@@ -801,6 +818,45 @@ describe("createChatSession", () => {
     ]);
     expect(state.chatMessages).toStrictEqual([]);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
+  });
+
+  it("creates selected global sessions under the same agent used for refresh", async () => {
+    const state = createChatSessionState({
+      sessionKey: "global",
+      assistantAgentId: "work",
+      sessionsResult: {
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        sessions: [row({ key: "global", kind: "global" })],
+      },
+    });
+    createSessionAndRefreshMock.mockResolvedValue("agent:work:dashboard:new-chat");
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    refreshSlashCommandsMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockResolvedValue(undefined);
+    loadSessionsMock.mockResolvedValue(undefined);
+
+    await createChatSession(state);
+
+    expect(createSessionAndRefreshMock).toHaveBeenCalledWith(
+      state,
+      {
+        agentId: "work",
+        parentSessionKey: "global",
+        emitCommandHooks: true,
+      },
+      {
+        activeMinutes: 120,
+        limit: 50,
+        includeGlobal: true,
+        includeUnknown: true,
+        showArchived: false,
+        agentId: "work",
+      },
+    );
+    expect(state.sessionKey).toBe("agent:work:dashboard:new-chat");
   });
 
   it("preserves draft and attachment edits made while session creation is in flight", async () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,6 +1,11 @@
 import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
-import { createChatSessionsLoadOverrides, refreshChat, refreshChatAvatar } from "./app-chat.ts";
+import {
+  createChatSessionsLoadOverrides,
+  refreshChat,
+  refreshChatAvatar,
+  scopedAgentListParamsForSession,
+} from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
@@ -717,6 +722,7 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
     },
     {
       ...createChatSessionsLoadOverrides(state),
+      ...scopedAgentListParamsForSession(state, previousSessionKey),
     },
   );
   if (
@@ -745,6 +751,7 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
     ...createChatSessionsLoadOverrides(state),
+    ...scopedAgentListParamsForSession(state, state.sessionKey),
   });
 }
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -4,6 +4,7 @@ import {
   createChatSessionsLoadOverrides,
   refreshChat,
   refreshChatAvatar,
+  scopedAgentParamsForSession,
   scopedAgentListParamsForSession,
 } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
@@ -716,7 +717,9 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
   const nextSessionKey = await createSessionAndRefresh(
     state as unknown as Parameters<typeof createSessionAndRefresh>[0],
     {
-      agentId: resolveAgentIdFromSessionKey(previousSessionKey),
+      agentId:
+        scopedAgentParamsForSession(state, previousSessionKey).agentId ??
+        resolveAgentIdFromSessionKey(previousSessionKey),
       parentSessionKey,
       emitCommandHooks: parentSessionKey !== undefined ? true : undefined,
     },

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -22,6 +22,7 @@ import { icons } from "./icons.ts";
 import { iconForTab, isSettingsTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } from "./session-display.ts";
 import {
+  isSessionKeyTiedToAgent,
   normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
@@ -756,16 +757,12 @@ function countHiddenCronSessions(state: AppViewState, sessions: SessionsListResu
     parseAgentSessionKey(state.sessionKey)?.agentId ?? state.agentsList?.defaultId ?? "main",
   );
   const defaultAgentId = normalizeAgentId(state.agentsList?.defaultId ?? "main");
-  const isTiedToActiveAgent = (key: string) => {
-    const parsed = parseAgentSessionKey(key);
-    if (parsed) {
-      return normalizeAgentId(parsed.agentId) === activeAgentId;
-    }
-    return activeAgentId === defaultAgentId;
-  };
 
   return sessions.sessions.filter(
-    (s) => isCronSessionKey(s.key) && s.key !== state.sessionKey && isTiedToActiveAgent(s.key),
+    (s) =>
+      isCronSessionKey(s.key) &&
+      s.key !== state.sessionKey &&
+      isSessionKeyTiedToAgent(s.key, activeAgentId, defaultAgentId),
   ).length;
 }
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -287,6 +287,8 @@ function isSidebarSessionForSelectedAgent(
 
 function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] {
   const selectedAgentId = resolveSidebarSelectedAgentId(state);
+  const shouldFilterByAgent =
+    normalizeOptionalString(state.sessionKey)?.toLowerCase() !== "unknown";
   return (state.sessionsResult?.sessions ?? [])
     .filter(
       (row) =>
@@ -297,7 +299,7 @@ function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] 
         !isCronSessionKey(row.key) &&
         !isSubagentSessionKey(row.key) &&
         !row.spawnedBy &&
-        isSidebarSessionForSelectedAgent(state, row, selectedAgentId),
+        (!shouldFilterByAgent || isSidebarSessionForSelectedAgent(state, row, selectedAgentId)),
     )
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
     .slice(0, 5);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -254,6 +254,15 @@ function isSidebarSessionBusy(state: AppViewState) {
   );
 }
 
+function resolveSidebarDefaultAgentId(state: AppViewState): string {
+  const snapshot = state.hello?.snapshot as
+    | { sessionDefaults?: { defaultAgentId?: string } }
+    | undefined;
+  return normalizeAgentId(
+    state.agentsList?.defaultId ?? snapshot?.sessionDefaults?.defaultAgentId ?? "main",
+  );
+}
+
 function resolveSidebarSelectedAgentId(state: AppViewState): string {
   const parsed = parseAgentSessionKey(state.sessionKey);
   if (parsed) {
@@ -262,8 +271,8 @@ function resolveSidebarSelectedAgentId(state: AppViewState): string {
   const sessionKey = normalizeOptionalString(state.sessionKey)?.toLowerCase();
   const fallbackAgentId =
     sessionKey === "global" || sessionKey === "unknown"
-      ? (state.assistantAgentId ?? state.agentsList?.defaultId ?? "main")
-      : (state.agentsList?.defaultId ?? "main");
+      ? (state.assistantAgentId ?? resolveSidebarDefaultAgentId(state))
+      : resolveSidebarDefaultAgentId(state);
   return normalizeAgentId(fallbackAgentId);
 }
 
@@ -272,7 +281,7 @@ function isSidebarSessionForSelectedAgent(
   row: GatewaySessionRow,
   selectedAgentId: string,
 ): boolean {
-  return isSessionKeyTiedToAgent(row.key, selectedAgentId, state.agentsList?.defaultId ?? "main");
+  return isSessionKeyTiedToAgent(row.key, selectedAgentId, resolveSidebarDefaultAgentId(state));
 }
 
 function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -155,6 +155,7 @@ import { isCronSessionKey, resolveSessionDisplayName } from "./session-display.t
 import "./components/dashboard-header.ts";
 import {
   buildAgentMainSessionKey,
+  isSessionKeyTiedToAgent,
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
@@ -265,11 +266,7 @@ function isSidebarSessionForSelectedAgent(
   row: GatewaySessionRow,
   selectedAgentId: string,
 ): boolean {
-  const parsed = parseAgentSessionKey(row.key);
-  if (parsed?.agentId) {
-    return normalizeAgentId(parsed.agentId) === selectedAgentId;
-  }
-  return selectedAgentId === normalizeAgentId(state.agentsList?.defaultId ?? "main");
+  return isSessionKeyTiedToAgent(row.key, selectedAgentId, state.agentsList?.defaultId ?? "main");
 }
 
 function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -6,6 +6,7 @@ import {
   createChatSessionsLoadOverrides,
   hasAbortableSessionRun,
   refreshChat,
+  scopedAgentListParamsForSession,
   scopedAgentParamsForSession,
 } from "./app-chat.ts";
 import { DEFAULT_CRON_FORM } from "./app-defaults.ts";
@@ -2944,6 +2945,7 @@ export function renderApp(state: AppViewState) {
                     state.setTab("sessions" as import("./navigation.ts").Tab);
                     void loadSessions(state, {
                       ...createChatSessionsLoadOverrides(state),
+                      ...scopedAgentListParamsForSession(state, state.sessionKey),
                     });
                   },
                   onToggleRealtimeTalk: () => state.toggleRealtimeTalk(),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -156,6 +156,7 @@ import "./components/dashboard-header.ts";
 import {
   buildAgentMainSessionKey,
   isSubagentSessionKey,
+  normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "./session-key.ts";
@@ -252,7 +253,27 @@ function isSidebarSessionBusy(state: AppViewState) {
   );
 }
 
+function resolveSidebarSelectedAgentId(state: AppViewState): string {
+  const parsed = parseAgentSessionKey(state.sessionKey);
+  return normalizeAgentId(
+    parsed?.agentId ?? state.assistantAgentId ?? state.agentsList?.defaultId ?? "main",
+  );
+}
+
+function isSidebarSessionForSelectedAgent(
+  state: AppViewState,
+  row: GatewaySessionRow,
+  selectedAgentId: string,
+): boolean {
+  const parsed = parseAgentSessionKey(row.key);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId) === selectedAgentId;
+  }
+  return selectedAgentId === normalizeAgentId(state.agentsList?.defaultId ?? "main");
+}
+
 function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] {
+  const selectedAgentId = resolveSidebarSelectedAgentId(state);
   return (state.sessionsResult?.sessions ?? [])
     .filter(
       (row) =>
@@ -262,7 +283,8 @@ function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] 
         row.kind !== "cron" &&
         !isCronSessionKey(row.key) &&
         !isSubagentSessionKey(row.key) &&
-        !row.spawnedBy,
+        !row.spawnedBy &&
+        isSidebarSessionForSelectedAgent(state, row, selectedAgentId),
     )
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
     .slice(0, 5);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -256,9 +256,15 @@ function isSidebarSessionBusy(state: AppViewState) {
 
 function resolveSidebarSelectedAgentId(state: AppViewState): string {
   const parsed = parseAgentSessionKey(state.sessionKey);
-  return normalizeAgentId(
-    parsed?.agentId ?? state.assistantAgentId ?? state.agentsList?.defaultId ?? "main",
-  );
+  if (parsed) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  const sessionKey = normalizeOptionalString(state.sessionKey)?.toLowerCase();
+  const fallbackAgentId =
+    sessionKey === "global" || sessionKey === "unknown"
+      ? (state.assistantAgentId ?? state.agentsList?.defaultId ?? "main")
+      : (state.agentsList?.defaultId ?? "main");
+  return normalizeAgentId(fallbackAgentId);
 }
 
 function isSidebarSessionForSelectedAgent(

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -133,6 +133,7 @@ export type AppViewState = {
   chatSessionPickerLoading: boolean;
   chatSessionPickerError: string | null;
   chatSessionPickerResult: SessionsListResult | null;
+  chatAgentSessionRowsByAgent?: Record<string, SessionsListResult["sessions"]>;
   announceSessionSwitch?: (sessionKey: string, label: string) => void;
   chatQueue: ChatQueueItem[];
   chatQueueBySession: Record<string, ChatQueueItem[]>;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -460,7 +460,7 @@ export type AppViewState = {
     overviewLogLines: string[];
     overviewLogCursor: number;
     client: GatewayBrowserClient | null;
-    refreshSessionsAfterChat: Set<string>;
+    refreshSessionsAfterChat: Map<string, import("./ui-types.js").ChatSessionRefreshTarget>;
     connect: () => void;
     setTab: (tab: Tab) => void;
     setChatMobileControlsOpen: (

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -133,6 +133,7 @@ export type AppViewState = {
   chatSessionPickerLoading: boolean;
   chatSessionPickerError: string | null;
   chatSessionPickerResult: SessionsListResult | null;
+  sessionsResultAgentId?: string | null;
   chatAgentSessionRowsByAgent?: Record<string, SessionsListResult["sessions"]>;
   announceSessionSwitch?: (sessionKey: string, label: string) => void;
   chatQueue: ChatQueueItem[];

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -657,7 +657,7 @@ export class OpenClawApp extends LitElement {
   controlUiResponsivenessObserver: { disconnect: () => void } | null = null;
   toolStreamById = new Map<string, ToolStreamEntry>();
   toolStreamOrder: string[] = [];
-  refreshSessionsAfterChat = new Set<string>();
+  refreshSessionsAfterChat = new Map<string, import("./ui-types.js").ChatSessionRefreshTarget>();
   chatSideResultTerminalRuns = new Set<string>();
   basePath = "";
   popStateHandler = () =>

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { t } from "../../i18n/index.ts";
-import { createChatSessionsLoadOverrides } from "../app-chat.ts";
+import { createChatSessionsLoadOverrides, scopedAgentListParamsForSession } from "../app-chat.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import { createChatModelOverride } from "../chat-model-ref.ts";
 import {
@@ -111,6 +111,7 @@ function resolveNextChatSessionOffset(
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
     ...createChatSessionsLoadOverrides(state),
+    ...scopedAgentListParamsForSession(state, state.sessionKey),
   });
 }
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -19,6 +19,7 @@ import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
 import { isCronSessionKey, resolveSessionDisplayName } from "../session-display.ts";
 import {
   buildAgentMainSessionKey,
+  isSessionKeyTiedToAgent,
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
@@ -1118,14 +1119,6 @@ type ChatAgentFilterOption = {
 function resolveChatAgentFilterId(state: AppViewState, sessionKey: string): string {
   const parsed = parseAgentSessionKey(sessionKey);
   return normalizeAgentId(parsed?.agentId ?? state.agentsList?.defaultId ?? "main");
-}
-
-function isSessionKeyTiedToAgent(key: string, agentId: string, defaultAgentId: string): boolean {
-  const parsed = parseAgentSessionKey(key);
-  if (parsed) {
-    return normalizeAgentId(parsed.agentId) === agentId;
-  }
-  return agentId === defaultAgentId;
 }
 
 function resolvePreferredSessionForAgent(state: AppViewState, agentId: string): string {

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -58,6 +58,7 @@ export function renderChatSessionSelect(
   onSwitchSession: ChatSessionSwitchHandler = () => undefined,
   options: { surface?: ChatSessionSelectSurface } = {},
 ) {
+  rememberChatAgentSessionRows(state, state.sessionsResult);
   const sessionGroups = resolveSessionOptionGroups(state, state.sessionKey, state.sessionsResult);
   const agentOptions = resolveChatAgentFilterOptions(state);
   const hasAgentSelect = agentOptions.length > 1;
@@ -1122,24 +1123,75 @@ function resolveChatAgentFilterId(state: AppViewState, sessionKey: string): stri
   return normalizeAgentId(parsed?.agentId ?? state.agentsList?.defaultId ?? "main");
 }
 
+function resolvePreferredSessionCandidateAgentId(
+  row: SessionsListResult["sessions"][number],
+  defaultAgentId: string,
+): string | null {
+  if (row.kind === "global" || row.kind === "unknown" || isCronSessionKey(row.key)) {
+    return null;
+  }
+  if (isSubagentSessionKey(row.key) || row.spawnedBy) {
+    return null;
+  }
+  const parsed = parseAgentSessionKey(row.key);
+  return normalizeAgentId(parsed?.agentId ?? defaultAgentId);
+}
+
+function rememberChatAgentSessionRows(
+  state: AppViewState,
+  sessions: SessionsListResult | null,
+): void {
+  const rows = sessions?.sessions ?? [];
+  if (rows.length === 0) {
+    return;
+  }
+  const defaultAgentId = normalizeAgentId(state.agentsList?.defaultId ?? "main");
+  const grouped = new Map<string, SessionsListResult["sessions"]>();
+  for (const row of rows) {
+    const agentId = resolvePreferredSessionCandidateAgentId(row, defaultAgentId);
+    if (!agentId) {
+      continue;
+    }
+    grouped.set(agentId, [...(grouped.get(agentId) ?? []), row]);
+  }
+  if (grouped.size === 0) {
+    return;
+  }
+  state.chatAgentSessionRowsByAgent ??= {};
+  for (const [agentId, agentRows] of grouped) {
+    state.chatAgentSessionRowsByAgent[agentId] = agentRows;
+  }
+}
+
+function rowsForPreferredAgentSession(
+  state: AppViewState,
+  normalizedAgentId: string,
+  defaultAgentId: string,
+): SessionsListResult["sessions"] {
+  const byKey = new Map<string, SessionsListResult["sessions"][number]>();
+  for (const row of state.chatAgentSessionRowsByAgent?.[normalizedAgentId] ?? []) {
+    byKey.set(row.key, row);
+  }
+  for (const row of state.sessionsResult?.sessions ?? []) {
+    if (resolvePreferredSessionCandidateAgentId(row, defaultAgentId) === normalizedAgentId) {
+      byKey.set(row.key, row);
+    }
+  }
+  return [...byKey.values()];
+}
+
 function resolvePreferredSessionForAgent(state: AppViewState, agentId: string): string {
   const normalizedAgentId = normalizeAgentId(agentId);
   if (resolveChatAgentFilterId(state, state.sessionKey) === normalizedAgentId) {
     return state.sessionKey;
   }
   const defaultAgentId = normalizeAgentId(state.agentsList?.defaultId ?? "main");
-  const eligible = (state.sessionsResult?.sessions ?? [])
+  const eligible = rowsForPreferredAgentSession(state, normalizedAgentId, defaultAgentId)
     .filter((row) => {
       if (!isSessionKeyTiedToAgent(row.key, normalizedAgentId, defaultAgentId)) {
         return false;
       }
-      if (row.kind === "global" || row.kind === "unknown") {
-        return false;
-      }
-      if (isCronSessionKey(row.key)) {
-        return false;
-      }
-      return !isSubagentSessionKey(row.key) && !row.spawnedBy;
+      return resolvePreferredSessionCandidateAgentId(row, defaultAgentId) === normalizedAgentId;
     })
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
   if (eligible[0]?.key) {

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1141,10 +1141,11 @@ function rememberChatAgentSessionRows(
   state: AppViewState,
   sessions: SessionsListResult | null,
 ): void {
-  const rows = sessions?.sessions ?? [];
-  if (rows.length === 0) {
+  if (!sessions) {
     return;
   }
+  const rows = sessions.sessions;
+  const refreshedAgentId = normalizeOptionalString(state.sessionsResultAgentId);
   const defaultAgentId = normalizeAgentId(state.agentsList?.defaultId ?? "main");
   const grouped = new Map<string, SessionsListResult["sessions"]>();
   for (const row of rows) {
@@ -1154,10 +1155,13 @@ function rememberChatAgentSessionRows(
     }
     grouped.set(agentId, [...(grouped.get(agentId) ?? []), row]);
   }
-  if (grouped.size === 0) {
+  if (grouped.size === 0 && !refreshedAgentId) {
     return;
   }
   state.chatAgentSessionRowsByAgent ??= {};
+  if (refreshedAgentId) {
+    state.chatAgentSessionRowsByAgent[refreshedAgentId] = grouped.get(refreshedAgentId) ?? [];
+  }
   for (const [agentId, agentRows] of grouped) {
     state.chatAgentSessionRowsByAgent[agentId] = agentRows;
   }

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1283,6 +1283,43 @@ describe("applySessionsChangedEvent", () => {
     ]);
   });
 
+  it("keeps out-of-scope session events out of scoped results", () => {
+    const state = createState(async () => undefined, {
+      sessionsResultAgentId: "work",
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:work:main", kind: "direct", updatedAt: 1 }],
+      },
+      chatAgentSessionRowsByAgent: {
+        ops: [{ key: "agent:ops:old", kind: "direct", updatedAt: 1 }],
+      },
+    });
+
+    const applied = applySessionsChangedEvent(state, {
+      session: {
+        key: "agent:ops:main",
+        kind: "direct",
+        agentId: "ops",
+        updatedAt: 2,
+      },
+      reason: "message",
+      ts: 2,
+    });
+
+    expect(applied).toEqual({ applied: true, change: "inserted" });
+    expect(state.sessionsResult?.count).toBe(1);
+    expect(state.sessionsResult?.sessions.map((session) => session.key)).toEqual([
+      "agent:work:main",
+    ]);
+    expect(state.chatAgentSessionRowsByAgent?.ops?.map((session) => session.key)).toEqual([
+      "agent:ops:main",
+      "agent:ops:old",
+    ]);
+  });
+
   it("does not synthesize new sessions from partial events without a store-backed row", () => {
     const state = createState(async () => undefined, {
       sessionsResult: {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1251,6 +1251,38 @@ describe("applySessionsChangedEvent", () => {
     expect(state.sessionsResult?.count).toBe(1);
   });
 
+  it("removes deleted sessions from cached chat agent targets", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: 1 }],
+      },
+      chatAgentSessionRowsByAgent: {
+        work: [
+          { key: "agent:work:dashboard:deleted", kind: "direct", updatedAt: 3 },
+          { key: "agent:work:main", kind: "direct", updatedAt: 1 },
+        ],
+      },
+    });
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:work:dashboard:deleted",
+      reason: "delete",
+      ts: 2,
+    });
+
+    expect(applied).toEqual({ applied: true, change: "deleted" });
+    expect(state.sessionsResult?.sessions.map((session) => session.key)).toEqual([
+      "agent:main:main",
+    ]);
+    expect(state.chatAgentSessionRowsByAgent?.work?.map((session) => session.key)).toEqual([
+      "agent:work:main",
+    ]);
+  });
+
   it("does not synthesize new sessions from partial events without a store-backed row", () => {
     const state = createState(async () => undefined, {
       sessionsResult: {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -30,6 +30,7 @@ export type SessionsState = SessionsChatRunState & {
   connected: boolean;
   sessionsLoading: boolean;
   sessionsResult: SessionsListResult | null;
+  sessionsResultAgentId?: string | null;
   sessionsError: string | null;
   sessionsFilterActive: string;
   sessionsFilterLimit: string;
@@ -839,6 +840,7 @@ async function loadSessionsOnce(
       configuredAgentsOnly,
     };
     const agentId = overrides?.agentId?.trim();
+    const resultAgentId = agentId ? normalizeAgentId(agentId) : null;
     if (agentId) {
       params.agentId = agentId;
     }
@@ -866,6 +868,7 @@ async function loadSessionsOnce(
         overrides?.append === true && offset > 0 && state.sessionsResult
           ? appendSessionsResult(state.sessionsResult, projected)
           : projected;
+      state.sessionsResultAgentId = resultAgentId;
       if (hasCurrentChatSession(state)) {
         reconcileChatRunFromCurrentSessionRow(state, {
           publishRunStatus: overrides?.publishChatRunStatus !== false,

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -31,6 +31,7 @@ export type SessionsState = SessionsChatRunState & {
   sessionsLoading: boolean;
   sessionsResult: SessionsListResult | null;
   sessionsResultAgentId?: string | null;
+  chatAgentSessionRowsByAgent?: Record<string, SessionsListResult["sessions"]>;
   sessionsError: string | null;
   sessionsFilterActive: string;
   sessionsFilterLimit: string;
@@ -447,6 +448,23 @@ function invalidateCheckpointCacheForKey(state: SessionsState, key: string) {
   state.sessionsCheckpointErrorByKey = nextErrors;
 }
 
+function invalidateCachedChatAgentSessionRow(state: SessionsState, key: string): boolean {
+  const rowsByAgent = state.chatAgentSessionRowsByAgent;
+  if (!rowsByAgent) {
+    return false;
+  }
+  let removed = false;
+  for (const [agentId, rows] of Object.entries(rowsByAgent)) {
+    const nextRows = rows.filter((row) => row.key !== key);
+    if (nextRows.length === rows.length) {
+      continue;
+    }
+    rowsByAgent[agentId] = nextRows;
+    removed = true;
+  }
+  return removed;
+}
+
 async function fetchSessionCompactionCheckpoints(state: SessionsState, key: string) {
   state.sessionsCheckpointLoadingKey = key;
   state.sessionsCheckpointErrorByKey = {
@@ -565,8 +583,9 @@ export function applySessionsChangedEvent(
   const previousRows = state.sessionsResult.sessions;
   const existingIndex = previousRows.findIndex((row) => row.key === key);
   if (payload.reason === "delete") {
+    const removedCachedRow = invalidateCachedChatAgentSessionRow(state, key);
     if (existingIndex < 0) {
-      return { applied: false };
+      return removedCachedRow ? { applied: true, change: "deleted" } : { applied: false };
     }
     state.sessionsResult = {
       ...state.sessionsResult,
@@ -617,8 +636,9 @@ export function applySessionsChangedEvent(
     delete nextRow.totalTokens;
   }
   if (!state.sessionsShowArchived && isArchivedSessionRow(nextRow)) {
+    const removedCachedRow = invalidateCachedChatAgentSessionRow(state, key);
     if (existingIndex < 0) {
-      return { applied: false };
+      return removedCachedRow ? { applied: true, change: "deleted" } : { applied: false };
     }
     state.sessionsResult = {
       ...state.sessionsResult,

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -3,7 +3,7 @@ import {
   type ChatRunUiStatus,
 } from "../chat/run-lifecycle.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../gateway.ts";
-import { normalizeAgentId, parseAgentSessionKey } from "../session-key.ts";
+import { isSubagentSessionKey, normalizeAgentId, parseAgentSessionKey } from "../session-key.ts";
 import type {
   GatewaySessionRow,
   SessionCompactionCheckpoint,
@@ -177,15 +177,47 @@ function sessionsChangedGlobalAgentMatches(
     return true;
   }
   const eventSession = isRecord(payload.session) ? payload.session : null;
-  const rawAgentId =
-    (typeof payload.agentId === "string" && payload.agentId.trim()) ||
-    (typeof eventSession?.agentId === "string" && eventSession.agentId.trim());
-  const eventAgentId = rawAgentId ? normalizeAgentId(rawAgentId) : null;
+  const eventAgentId = readSessionsChangedEventAgentId(payload, eventSession);
   const selectedAgentId = resolveSelectedGlobalAgentId(state);
   if (eventAgentId) {
     return eventAgentId === selectedAgentId;
   }
   return selectedAgentId === resolveDefaultGlobalAgentId(state);
+}
+
+function readSessionsChangedEventAgentId(
+  payload: Record<string, unknown>,
+  eventSession: Record<string, unknown> | null,
+): string | null {
+  const rawAgentId =
+    (typeof payload.agentId === "string" && payload.agentId.trim()) ||
+    (typeof eventSession?.agentId === "string" && eventSession.agentId.trim());
+  return rawAgentId ? normalizeAgentId(rawAgentId) : null;
+}
+
+function sessionsChangedResultScopeMatches(
+  state: SessionsState,
+  payload: Record<string, unknown>,
+  eventSession: Record<string, unknown> | null,
+  key: string,
+  existing: GatewaySessionRow | undefined,
+): boolean {
+  const resultAgentId =
+    typeof state.sessionsResultAgentId === "string" && state.sessionsResultAgentId.trim()
+      ? normalizeAgentId(state.sessionsResultAgentId)
+      : null;
+  if (!resultAgentId) {
+    return true;
+  }
+  const eventAgentId = readSessionsChangedEventAgentId(payload, eventSession);
+  if (eventAgentId) {
+    return eventAgentId === resultAgentId;
+  }
+  const parsed = parseAgentSessionKey(key);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId) === resultAgentId;
+  }
+  return Boolean(existing);
 }
 
 function buildSelectedSessionMessageSubscriptionParams(state: SessionsState, key: string) {
@@ -465,6 +497,37 @@ function invalidateCachedChatAgentSessionRow(state: SessionsState, key: string):
   return removed;
 }
 
+function resolveCachedChatAgentSessionRowAgentId(
+  state: SessionsState,
+  row: GatewaySessionRow,
+): string | null {
+  if (row.kind === "global" || row.kind === "unknown" || row.kind === "cron") {
+    return null;
+  }
+  if (isSubagentSessionKey(row.key) || row.spawnedBy) {
+    return null;
+  }
+  const parsed = parseAgentSessionKey(row.key);
+  return normalizeAgentId(parsed?.agentId ?? state.agentsList?.defaultId ?? "main");
+}
+
+function upsertCachedChatAgentSessionRow(state: SessionsState, row: GatewaySessionRow): boolean {
+  if (!state.sessionsShowArchived && isArchivedSessionRow(row)) {
+    return invalidateCachedChatAgentSessionRow(state, row.key);
+  }
+  const agentId = resolveCachedChatAgentSessionRowAgentId(state, row);
+  if (!agentId) {
+    return false;
+  }
+  state.chatAgentSessionRowsByAgent ??= {};
+  const existingRows = state.chatAgentSessionRowsByAgent[agentId] ?? [];
+  state.chatAgentSessionRowsByAgent[agentId] = [
+    row,
+    ...existingRows.filter((r) => r.key !== row.key),
+  ].toSorted(compareSessionRowsByUpdatedAt);
+  return true;
+}
+
 async function fetchSessionCompactionCheckpoints(state: SessionsState, key: string) {
   state.sessionsCheckpointLoadingKey = key;
   state.sessionsCheckpointErrorByKey = {
@@ -582,8 +645,15 @@ export function applySessionsChangedEvent(
 
   const previousRows = state.sessionsResult.sessions;
   const existingIndex = previousRows.findIndex((row) => row.key === key);
+  const existing = existingIndex >= 0 ? previousRows[existingIndex] : undefined;
   if (payload.reason === "delete") {
     const removedCachedRow = invalidateCachedChatAgentSessionRow(state, key);
+    if (
+      !sessionsChangedGlobalAgentMatches(state, payload, key) ||
+      !sessionsChangedResultScopeMatches(state, payload, eventSession, key, existing)
+    ) {
+      return removedCachedRow ? { applied: true, change: "deleted" } : { applied: false };
+    }
     if (existingIndex < 0) {
       return removedCachedRow ? { applied: true, change: "deleted" } : { applied: false };
     }
@@ -595,7 +665,9 @@ export function applySessionsChangedEvent(
     invalidateCheckpointCacheForKey(state, key);
     return { applied: true, change: "deleted" };
   }
-  const existing = existingIndex >= 0 ? previousRows[existingIndex] : undefined;
+  const matchesResultScope =
+    sessionsChangedGlobalAgentMatches(state, payload, key) &&
+    sessionsChangedResultScopeMatches(state, payload, eventSession, key, existing);
   const hasReliableSource =
     existingIndex >= 0 || eventSession !== null || typeof source.sessionId === "string";
   if (!hasReliableSource) {
@@ -634,6 +706,11 @@ export function applySessionsChangedEvent(
   }
   if (nextRow.totalTokensFresh === false && !hasOwn(source, "totalTokens")) {
     delete nextRow.totalTokens;
+  }
+  if (!matchesResultScope) {
+    return upsertCachedChatAgentSessionRow(state, nextRow)
+      ? { applied: true, change: existingIndex >= 0 ? "updated" : "inserted" }
+      : { applied: false };
   }
   if (!state.sessionsShowArchived && isArchivedSessionRow(nextRow)) {
     const removedCachedRow = invalidateCachedChatAgentSessionRow(state, key);

--- a/ui/src/ui/session-key.ts
+++ b/ui/src/ui/session-key.ts
@@ -87,6 +87,19 @@ export function resolveAgentIdFromSessionKey(sessionKey: string | undefined | nu
   return normalizeAgentId(parsed?.agentId ?? DEFAULT_AGENT_ID);
 }
 
+export function isSessionKeyTiedToAgent(
+  sessionKey: string | undefined | null,
+  agentId: string,
+  defaultAgentId: string = DEFAULT_AGENT_ID,
+): boolean {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (parsed) {
+    return normalizeAgentId(parsed.agentId) === normalizedAgentId;
+  }
+  return normalizedAgentId === normalizeAgentId(defaultAgentId);
+}
+
 export function isSubagentSessionKey(sessionKey: string | undefined | null): boolean {
   const raw = normalizeOptionalString(sessionKey) ?? "";
   if (!raw) {

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -25,6 +25,11 @@ export type ChatQueueItem = {
   agentId?: string;
 };
 
+export type ChatSessionRefreshTarget = {
+  sessionKey: string;
+  agentId?: string;
+};
+
 export const CRON_CHANNEL_LAST = "last";
 
 export type CronFormState = {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1401,6 +1401,7 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state, onSwitchSession), container);
 
+    state.sessionsResultAgentId = "alpha";
     state.sessionsResult = {
       ts: 1,
       path: "",
@@ -1417,6 +1418,51 @@ describe("chat session controls", () => {
     agentSelect!.dispatchEvent(new Event("change", { bubbles: true }));
 
     expect(onSwitchSession).toHaveBeenCalledWith(state, "agent:beta:dashboard:beta-recent");
+  });
+
+  it("clears cached agent switch targets after a scoped empty refresh", () => {
+    const { state } = createChatHeaderState();
+    const onSwitchSession = vi.fn();
+    state.sessionKey = "agent:alpha:main";
+    state.agentsList = {
+      defaultId: "alpha",
+      mainKey: "agent:alpha:main",
+      scope: "all",
+      agents: [
+        { id: "alpha", name: "Deep Chat" },
+        { id: "beta", name: "Coding" },
+      ],
+    };
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 2,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        { key: "agent:alpha:main", kind: "direct", updatedAt: 4 },
+        { key: "agent:beta:dashboard:deleted", kind: "direct", updatedAt: 3 },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state, onSwitchSession), container);
+
+    state.sessionsResultAgentId = "beta";
+    state.sessionsResult = {
+      ts: 1,
+      path: "",
+      count: 0,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [],
+    };
+    render(renderChatSessionSelect(state, onSwitchSession), container);
+
+    const agentSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-agent-filter="true"]',
+    );
+    agentSelect!.value = "beta";
+    agentSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(onSwitchSession).toHaveBeenCalledWith(state, "agent:beta:main");
   });
 
   it("renders selector labels from the active locale", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1374,6 +1374,51 @@ describe("chat session controls", () => {
     expect(onSwitchSession).toHaveBeenCalledWith(state, "agent:beta:dashboard:beta-recent");
   });
 
+  it("keeps agent switch targets after scoped session refreshes", () => {
+    const { state } = createChatHeaderState();
+    const onSwitchSession = vi.fn();
+    state.sessionKey = "agent:alpha:main";
+    state.agentsList = {
+      defaultId: "alpha",
+      mainKey: "agent:alpha:main",
+      scope: "all",
+      agents: [
+        { id: "alpha", name: "Deep Chat" },
+        { id: "beta", name: "Coding" },
+      ],
+    };
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 3,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        { key: "agent:alpha:main", kind: "direct", updatedAt: 4 },
+        { key: "agent:beta:dashboard:beta-recent", kind: "direct", updatedAt: 3 },
+        { key: "agent:beta:main", kind: "direct", updatedAt: 2 },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state, onSwitchSession), container);
+
+    state.sessionsResult = {
+      ts: 1,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [{ key: "agent:alpha:main", kind: "direct", updatedAt: 5 }],
+    };
+    render(renderChatSessionSelect(state, onSwitchSession), container);
+
+    const agentSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-agent-filter="true"]',
+    );
+    agentSelect!.value = "beta";
+    agentSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(onSwitchSession).toHaveBeenCalledWith(state, "agent:beta:dashboard:beta-recent");
+  });
+
   it("renders selector labels from the active locale", async () => {
     await i18n.setLocale("zh-CN");
     const { state } = createChatHeaderState();


### PR DESCRIPTION
## Summary

- Behavior or issue addressed: dashboard sidebar Recent sessions no longer mixes sessions from other agents when an agent-scoped chat is active.
- Filter the dashboard sidebar Recent session list to the currently selected agent.
- Keep legacy non-agent session keys visible only for the default agent, while preserving existing exclusions for archived, cron, global, unknown, subagent, and spawned sessions.
- Add a render-level regression test that mixes Main and Work agent sessions and verifies the sidebar only lists the active Work agent sessions.

## Real behavior proof

- Behavior or issue addressed: dashboard sidebar Recent sessions no longer mixes sessions from other agents when an agent-scoped chat is active.
- Real environment tested: headless Google Chrome driven by Playwright, with a Vite proof page loading the real `ui/src/ui/app-render.ts` from this worktree and rendering mixed Main/Work sessions.
- Evidence after fix: terminal capture from `/media/vdc/code/ai/aispace/openclaw-issue-88214-evidence/sidebar-recent-agent-filter-browser.log`, JSON output at `/media/vdc/code/ai/aispace/openclaw-issue-88214-evidence/sidebar-recent-agent-filter-browser.json`, and screenshot generated at `/media/vdc/code/ai/aispace/openclaw-issue-88214-evidence/sidebar-recent-agent-filter-browser.png`.
- Target test file: `ui/src/ui/app-render.assistant-avatar.test.ts`
- Exact steps or command run after this patch: `node /media/vdc/code/ai/aispace/openclaw-issue-88214-evidence/capture-sidebar-proof.mjs`
- Observed result after fix: Chromium rendered the sidebar Recent list with labels `Work new` and `Work older`; `Main old` was absent from sidebar Recent labels.
- What was not tested: a full gateway-backed manual app session; the browser proof uses a Vite harness with real `renderApp` and synthetic session rows to isolate the sidebar Recent behavior.

```json
{
  "labels": [
    "Work new",
    "Work older"
  ],
  "mainOldVisible": 0,
  "passed": true
}
```

## Regression Test Plan

- Exact steps or command run after this patch: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm --dir /media/vdc/code/ai/aispace/openclaw-worktrees/issue-88214 tsgo:test:ui` and `cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-88214/ui && pnpm exec vitest run --config vitest.config.ts --project unit src/ui/app-render.assistant-avatar.test.ts`.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm --dir /media/vdc/code/ai/aispace/openclaw-worktrees/issue-88214 tsgo:test:ui`
  - Evidence: `/media/vdc/code/ai/aispace/openclaw-issue-88214-evidence/ui-tsgo-test-ui.log`
- `cd ui && pnpm exec vitest run --config vitest.config.ts --project unit src/ui/app-render.assistant-avatar.test.ts`
  - Evidence: `/media/vdc/code/ai/aispace/openclaw-issue-88214-evidence/ui-vitest-app-render-sidebar-targeted.log`
- `node /media/vdc/code/ai/aispace/openclaw-issue-88214-evidence/capture-sidebar-proof.mjs`
  - Evidence: `/media/vdc/code/ai/aispace/openclaw-issue-88214-evidence/sidebar-recent-agent-filter-browser.log`
- What was not tested: a full gateway-backed manual app session; no external service or user data was required for this isolated sidebar rendering proof.

## Root Cause

- Root cause: the dashboard sidebar Recent list only filtered out non-user-facing session types and then sorted globally, so agent-scoped dashboard sessions from other agents remained eligible for the active agent's sidebar.
- The top-level chat/session state already carries the selected agent through agent-prefixed session keys and agent selection state; the sidebar list needed to apply the same selected-agent boundary before slicing recent sessions.
