### PR TITLE
[codex] fix ControlUI session picker switching

### DIFF
--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -104,6 +104,13 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
     chatRunId: null,
     chatSideResult: null,
     chatSideResultTerminalRuns: new Set(),
+    chatSessionPickerOpen: false,
+    chatSessionPickerSurface: null,
+    chatSessionPickerQuery: "",
+    chatSessionPickerAppliedQuery: "",
+    chatSessionPickerLoading: false,
+    chatSessionPickerError: null,
+    chatSessionPickerResult: null,
     compactionStatus: null,
     fallbackStatus: null,
     chatAvatarUrl: null,
@@ -135,6 +142,8 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
     sidebarError: null,
     splitRatio: 0.6,
     scrollToBottom: vi.fn(),
+    resetChatInputHistoryNavigation: vi.fn(),
+    resetChatScroll: vi.fn(),
     presenceEntries: [],
     sessionsResult: null,
     cronStatus: null,
@@ -241,6 +250,59 @@ describe("renderApp assistant avatar routing", () => {
 
     const shell = container.querySelector<HTMLElement>(".shell");
     expect(shell?.style.getPropertyValue("--chat-message-max-width")).toBe("min(1280px, 82%)");
+  });
+
+  it("switches chat sessions from the header session picker", async () => {
+    const container = document.createElement("div");
+    const sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 2,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        { key: "main", kind: "direct", label: "Main", updatedAt: 2 },
+        { key: "agent:main:work", kind: "direct", label: "Work", updatedAt: 1 },
+      ],
+    } as NonNullable<AppViewState["sessionsResult"]>;
+    const request = vi.fn((method: string) => {
+      if (method === "sessions.list") {
+        return Promise.resolve(sessionsResult);
+      }
+      if (method === "chat.history") {
+        return Promise.resolve({ messages: [] });
+      }
+      if (method === "commands.list") {
+        return Promise.resolve({ commands: [] });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const state = createState({
+      client: { request } as unknown as AppViewState["client"],
+      tab: "chat",
+      sessionsResult,
+    });
+
+    render(renderApp(state), container);
+    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    await vi.waitFor(() => expect(state.chatSessionPickerResult).not.toBeNull());
+    render(renderApp(state), container);
+
+    const workOption = [
+      ...container.querySelectorAll<HTMLButtonElement>(
+        'button[data-chat-session-picker-option="true"]',
+      ),
+    ].find((button) => button.dataset.sessionKey === "agent:main:work");
+    expect(workOption).toBeInstanceOf(HTMLButtonElement);
+
+    workOption!.click();
+
+    expect(state.sessionKey).toBe("agent:main:work");
+    expect(state.applySettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastActiveSessionKey: "agent:main:work",
+        sessionKey: "agent:main:work",
+      }),
+    );
   });
 
   it("marks the logs route so the page can hand scroll ownership to the log stream", () => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1895,7 +1895,7 @@ export function renderApp(state: AppViewState) {
             >
               <div>
                 ${isChat
-                  ? renderChatSessionSelect(state)
+                  ? renderChatSessionSelect(state, switchChatSession)
                   : html`<div class="page-title">${titleForTab(state.tab)}</div>`}
                 ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
               </div>


### PR DESCRIPTION
Fixes #87984.

## Summary

- Wire the Chat page header session picker to the existing `switchChatSession` handler.
- Add an app-render regression test that opens the header picker, selects another session, and verifies the active session changes.

## Root Cause

The Chat header rendered `renderChatSessionSelect(state)` without passing the switch callback. The picker option click path depends on the injected callback, and the component default is a no-op, so clicking a right-side picker option only closed the picker instead of changing the active chat.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts ui/src/ui/app-render.assistant-avatar.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Selecting another conversation from the Control UI Chat header session picker now routes through the same `switchChatSession` path used by the left sidebar.

Real environment tested: Local OpenClaw source checkout on macOS, Vite-served Control UI page, deterministic gateway fixture, and installed Google Chrome driven headlessly through Playwright.

Exact steps or command run after this patch: Started the local Control UI dev server with `node --import tsx scripts/control-ui-mock-dev.ts --host 127.0.0.1 --port 5187`, opened `http://127.0.0.1:5187/chat` in Chrome, clicked the visible `button[data-chat-session-select="true"]` header picker, selected `button[data-chat-session-picker-option="true"][data-session-key="agent:history-001"]`, and waited for the URL/header to reflect the selected chat.

Evidence after fix: Copied terminal output from the browser run:

```text
OPENCLAW_SESSION_PICKER_BROWSER_PROOF
before_url=http://127.0.0.1:5187/chat?session=main
before_header_label=Alpha planning
clicked_header_session_picker=true
selected_session_key=agent:history-001
after_url=http://127.0.0.1:5187/chat?session=agent%3Ahistory-001
after_header_label=Long running session 001
browser_assertion=header_picker_changed_active_chat
```

Observed result after fix: The header picker click changed the active chat from `Alpha planning` to `Long running session 001`, and the browser URL updated from `session=main` to `session=agent%3Ahistory-001`.

What was not tested: A remote hosted gateway and live model provider were not used; this proof is scoped to the Control UI session-picker behavior fixed by this PR.
