### PR TITLE
fix: retry loopback probes without device identity after pairing repair

### DIFF
--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -4,7 +4,12 @@ const gatewayClientState = vi.hoisted(() => ({
   options: null as Record<string, unknown> | null,
   requests: [] as string[],
   startCalls: 0,
-  startMode: "hello" as "hello" | "close" | "connect-error-close" | "startup-retry-then-hello",
+  startMode: "hello" as
+    | "hello"
+    | "close"
+    | "connect-error-close"
+    | "repair-then-hello"
+    | "startup-retry-then-hello",
   close: { code: 1008, reason: "pairing required" },
   helloAuth: {
     role: "operator",
@@ -79,7 +84,11 @@ class MockGatewayClient {
           }
           return;
         }
-        if (gatewayClientState.startMode === "connect-error-close") {
+        if (
+          gatewayClientState.startMode === "connect-error-close" ||
+          (gatewayClientState.startMode === "repair-then-hello" &&
+            gatewayClientState.startCalls === 1)
+        ) {
           const onConnectError = this.opts.onConnectError;
           if (typeof onConnectError === "function") {
             onConnectError(
@@ -608,6 +617,25 @@ describe("probeGateway", () => {
       ok: false,
       error: "scope upgrade pending approval (requestId: req-123)",
       close: { code: 1008, reason: "pairing required" },
+    });
+  });
+
+  it("retries loopback probes without device identity after pairing-pending repair failures", async () => {
+    gatewayClientState.startMode = "repair-then-hello";
+
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 5_000,
+      includeDetails: false,
+    });
+
+    expect(gatewayClientState.startCalls).toBe(2);
+    expect(gatewayClientState.options?.deviceIdentity).toBeNull();
+    expectProbeResultFields(result, {
+      ok: true,
+      error: null,
+      close: null,
     });
   });
 

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -12,6 +12,7 @@ import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/t
 import { startGatewayClientWhenEventLoopReady } from "./client-start-readiness.js";
 import { GatewayClient, GatewayClientRequestError } from "./client.js";
 import { READ_SCOPE } from "./method-scopes.js";
+import { isLoopbackHost } from "./net.js";
 
 export type GatewayProbeAuth = {
   token?: string;
@@ -102,6 +103,43 @@ function isDeviceIdentityRequiredClose(close: GatewayProbeClose | null): boolean
 
 function hasProbeAuth(auth: GatewayProbeAuth | undefined): boolean {
   return Boolean(auth?.token?.trim() || auth?.password?.trim());
+}
+
+function isLoopbackProbeUrl(url: string): boolean {
+  try {
+    return isLoopbackHost(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function shouldRetryWithoutDeviceIdentity(params: {
+  url: string;
+  auth: GatewayProbeAuth | undefined;
+  deviceIdentity: unknown;
+  result: GatewayProbeResult;
+}): boolean {
+  if (params.deviceIdentity == null || !hasProbeAuth(params.auth)) {
+    return false;
+  }
+  if (!isLoopbackProbeUrl(params.url)) {
+    return false;
+  }
+  if (params.result.connectLatencyMs != null) {
+    return false;
+  }
+  if (params.result.auth.capability !== "pairing_pending") {
+    return false;
+  }
+  const details = params.result.connectErrorDetails;
+  if (!details || typeof details !== "object") {
+    return false;
+  }
+  return (details as { code?: unknown }).code === "PAIRING_REQUIRED";
+}
+
+function shouldPreferRetryResult(result: GatewayProbeResult): boolean {
+  return result.ok || result.connectLatencyMs != null || result.auth.capability !== "unknown";
 }
 
 function shouldShortCircuitDeviceRequiredProbe(cacheKey: string, nowMs: number): boolean {
@@ -233,16 +271,6 @@ export async function probeGateway(opts: {
   tlsFingerprint?: string;
   env?: NodeJS.ProcessEnv;
 }): Promise<GatewayProbeResult> {
-  const startedAt = Date.now();
-  const instanceId = randomUUID();
-  let connectLatencyMs: number | null = null;
-  let connectError: string | null = null;
-  let connectErrorDetails: unknown = null;
-  let close: GatewayProbeClose | null = null;
-  let auth = emptyProbeAuth();
-  let server = emptyProbeServer();
-  let authMetadataPresent = false;
-
   const detailLevel = opts.includeDetails === false ? "none" : (opts.detailLevel ?? "full");
 
   const deviceIdentity = await (async () => {
@@ -271,150 +299,232 @@ export async function probeGateway(opts: {
       return null;
     }
   })();
-  const cacheKey = resolveDeviceRequiredProbeCacheKey(opts.url);
-  const cacheEligible = deviceIdentity == null && !hasProbeAuth(opts.auth);
-  if (cacheEligible && shouldShortCircuitDeviceRequiredProbe(cacheKey, Date.now())) {
-    return makeDeviceRequiredShortCircuitResult(opts.url);
-  }
-  const initialProbeTimeoutMs = clampProbeTimeoutMs(opts.timeoutMs);
+  const runProbeAttempt = async (attemptDeviceIdentity: unknown): Promise<GatewayProbeResult> => {
+    const startedAt = Date.now();
+    const instanceId = randomUUID();
+    let connectLatencyMs: number | null = null;
+    let connectError: string | null = null;
+    let connectErrorDetails: unknown = null;
+    let close: GatewayProbeClose | null = null;
+    let auth = emptyProbeAuth();
+    let server = emptyProbeServer();
+    let authMetadataPresent = false;
+    const cacheKey = resolveDeviceRequiredProbeCacheKey(opts.url);
+    const cacheEligible = attemptDeviceIdentity == null && !hasProbeAuth(opts.auth);
+    if (cacheEligible && shouldShortCircuitDeviceRequiredProbe(cacheKey, Date.now())) {
+      return makeDeviceRequiredShortCircuitResult(opts.url);
+    }
+    const initialProbeTimeoutMs = clampProbeTimeoutMs(opts.timeoutMs);
 
-  return await new Promise<GatewayProbeResult>((resolve) => {
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    const startAbort = new AbortController();
-    const clearProbeTimer = () => {
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-      }
-    };
-    const armProbeTimer = (onTimeout: () => void, timeoutMs = initialProbeTimeoutMs) => {
-      clearProbeTimer();
-      timer = setTimeout(onTimeout, resolveSafeTimeoutDelayMs(timeoutMs));
-    };
-    const settle = (
-      result: Omit<GatewayProbeResult, "url" | "connectErrorDetails"> & {
-        connectErrorDetails?: unknown;
-      },
-    ) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      startAbort.abort();
-      clearProbeTimer();
-      void (async () => {
-        try {
-          await client.stopAndWait({ timeoutMs: PROBE_CLIENT_STOP_TIMEOUT_MS });
-        } catch {
-          client.stop();
+    return await new Promise<GatewayProbeResult>((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const startAbort = new AbortController();
+      const clearProbeTimer = () => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
         }
-        if (result.ok) {
-          clearDeviceRequiredProbeFailures(cacheKey);
-        } else if (cacheEligible && isDeviceIdentityRequiredClose(result.close)) {
-          noteDeviceRequiredProbeFailure(cacheKey, Date.now());
-        }
-        const { connectErrorDetails: resultConnectErrorDetails, ...rest } = result;
-        resolve({
-          url: opts.url,
-          ...rest,
-          ...(resultConnectErrorDetails != null
-            ? { connectErrorDetails: resultConnectErrorDetails }
-            : {}),
-        });
-      })();
-    };
-    const settleProbe = (params: {
-      ok: boolean;
-      error: string | null;
-      verifiedRead?: boolean;
-      health: unknown;
-      status: unknown;
-      presence: SystemPresence[] | null;
-      configSnapshot: unknown;
-    }) => {
-      settle({
-        ok: params.ok,
-        connectLatencyMs,
-        error: params.error,
-        connectErrorDetails,
-        close,
-        auth: resolveProbeAuthSummary({
-          role: auth.role,
-          scopes: auth.scopes,
-          authMetadataPresent,
-          error: params.error,
-          close,
-          verifiedRead: params.verifiedRead,
-          connectLatencyMs,
-        }),
-        server,
-        health: params.health,
-        status: params.status,
-        presence: params.presence,
-        configSnapshot: params.configSnapshot,
-      });
-    };
-
-    const client = new GatewayClient({
-      url: opts.url,
-      token: opts.auth?.token,
-      password: opts.auth?.password,
-      tlsFingerprint: opts.tlsFingerprint,
-      preauthHandshakeTimeoutMs: opts.preauthHandshakeTimeoutMs,
-      env: opts.env,
-      scopes: [READ_SCOPE],
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      clientVersion: "dev",
-      mode: GATEWAY_CLIENT_MODES.PROBE,
-      instanceId,
-      deviceIdentity,
-      onConnectError: (err) => {
-        connectError = formatErrorMessage(err);
-        connectErrorDetails = err instanceof GatewayClientRequestError ? err.details : null;
-      },
-      onClose: (code, reason) => {
-        close = { code, reason };
-        if (connectLatencyMs == null) {
-          settleProbe({
-            ok: false,
-            error: connectError || formatProbeCloseError(close),
-            health: null,
-            status: null,
-            presence: null,
-            configSnapshot: null,
-          });
-        }
-      },
-      onHelloOk: async (hello) => {
-        connectLatencyMs = Date.now() - startedAt;
-        authMetadataPresent = typeof hello?.auth === "object" && hello.auth !== null;
-        server = {
-          version: typeof hello?.server?.version === "string" ? hello.server.version : null,
-          connId: typeof hello?.server?.connId === "string" ? hello.server.connId : null,
-        };
-        auth = resolveProbeAuthSummary({
-          role: typeof hello?.auth?.role === "string" ? hello.auth.role : null,
-          scopes: Array.isArray(hello?.auth?.scopes)
-            ? hello.auth.scopes.filter((scope): scope is string => typeof scope === "string")
-            : [],
-          authMetadataPresent,
-        });
-        if (detailLevel === "none") {
-          settleProbe({
-            ok: true,
-            error: null,
-            verifiedRead: false,
-            health: null,
-            status: null,
-            presence: null,
-            configSnapshot: null,
-          });
+      };
+      const armProbeTimer = (onTimeout: () => void, timeoutMs = initialProbeTimeoutMs) => {
+        clearProbeTimer();
+        timer = setTimeout(onTimeout, resolveSafeTimeoutDelayMs(timeoutMs));
+      };
+      const settle = (
+        result: Omit<GatewayProbeResult, "url" | "connectErrorDetails"> & {
+          connectErrorDetails?: unknown;
+        },
+      ) => {
+        if (settled) {
           return;
         }
-        // Once the gateway has accepted the session, a slow follow-up RPC should no longer
-        // downgrade the probe to "unreachable". Give detail fetching its own budget.
-        armProbeTimer(() => {
+        settled = true;
+        startAbort.abort();
+        clearProbeTimer();
+        void (async () => {
+          try {
+            await client.stopAndWait({ timeoutMs: PROBE_CLIENT_STOP_TIMEOUT_MS });
+          } catch {
+            client.stop();
+          }
+          if (result.ok) {
+            clearDeviceRequiredProbeFailures(cacheKey);
+          } else if (cacheEligible && isDeviceIdentityRequiredClose(result.close)) {
+            noteDeviceRequiredProbeFailure(cacheKey, Date.now());
+          }
+          const { connectErrorDetails: resultConnectErrorDetails, ...rest } = result;
+          resolve({
+            url: opts.url,
+            ...rest,
+            ...(resultConnectErrorDetails != null
+              ? { connectErrorDetails: resultConnectErrorDetails }
+              : {}),
+          });
+        })();
+      };
+      const settleProbe = (params: {
+        ok: boolean;
+        error: string | null;
+        verifiedRead?: boolean;
+        health: unknown;
+        status: unknown;
+        presence: SystemPresence[] | null;
+        configSnapshot: unknown;
+      }) => {
+        settle({
+          ok: params.ok,
+          connectLatencyMs,
+          error: params.error,
+          connectErrorDetails,
+          close,
+          auth: resolveProbeAuthSummary({
+            role: auth.role,
+            scopes: auth.scopes,
+            authMetadataPresent,
+            error: params.error,
+            close,
+            verifiedRead: params.verifiedRead,
+            connectLatencyMs,
+          }),
+          server,
+          health: params.health,
+          status: params.status,
+          presence: params.presence,
+          configSnapshot: params.configSnapshot,
+        });
+      };
+
+      const client = new GatewayClient({
+        url: opts.url,
+        token: opts.auth?.token,
+        password: opts.auth?.password,
+        tlsFingerprint: opts.tlsFingerprint,
+        preauthHandshakeTimeoutMs: opts.preauthHandshakeTimeoutMs,
+        env: opts.env,
+        scopes: [READ_SCOPE],
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+        clientVersion: "dev",
+        mode: GATEWAY_CLIENT_MODES.PROBE,
+        instanceId,
+        deviceIdentity: attemptDeviceIdentity,
+        onConnectError: (err) => {
+          connectError = formatErrorMessage(err);
+          connectErrorDetails = err instanceof GatewayClientRequestError ? err.details : null;
+        },
+        onClose: (code, reason) => {
+          close = { code, reason };
+          if (connectLatencyMs == null) {
+            settleProbe({
+              ok: false,
+              error: connectError || formatProbeCloseError(close),
+              health: null,
+              status: null,
+              presence: null,
+              configSnapshot: null,
+            });
+          }
+        },
+        onHelloOk: async (hello) => {
+          connectLatencyMs = Date.now() - startedAt;
+          authMetadataPresent = typeof hello?.auth === "object" && hello.auth !== null;
+          server = {
+            version: typeof hello?.server?.version === "string" ? hello.server.version : null,
+            connId: typeof hello?.server?.connId === "string" ? hello.server.connId : null,
+          };
+          auth = resolveProbeAuthSummary({
+            role: typeof hello?.auth?.role === "string" ? hello.auth.role : null,
+            scopes: Array.isArray(hello?.auth?.scopes)
+              ? hello.auth.scopes.filter((scope): scope is string => typeof scope === "string")
+              : [],
+            authMetadataPresent,
+          });
+          if (detailLevel === "none") {
+            settleProbe({
+              ok: true,
+              error: null,
+              verifiedRead: false,
+              health: null,
+              status: null,
+              presence: null,
+              configSnapshot: null,
+            });
+            return;
+          }
+          // Once the gateway has accepted the session, a slow follow-up RPC should no longer
+          // downgrade the probe to "unreachable". Give detail fetching its own budget.
+          armProbeTimer(() => {
+            settleProbe({
+              ok: false,
+              error: "timeout",
+              health: null,
+              status: null,
+              presence: null,
+              configSnapshot: null,
+            });
+          });
+          try {
+            if (detailLevel === "presence") {
+              const presence = await client.request("system-presence");
+              settleProbe({
+                ok: true,
+                error: null,
+                verifiedRead: true,
+                health: null,
+                status: null,
+                presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
+                configSnapshot: null,
+              });
+              return;
+            }
+            const [health, status, presence, configSnapshot] = await Promise.all([
+              client.request("health"),
+              client.request("status"),
+              client.request("system-presence"),
+              client.request("config.get", {}),
+            ]);
+            settleProbe({
+              ok: true,
+              error: null,
+              verifiedRead: true,
+              health,
+              status,
+              presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
+              configSnapshot,
+            });
+          } catch (err) {
+            const error = formatErrorMessage(err);
+            settleProbe({
+              ok: false,
+              error,
+              health: null,
+              status: null,
+              presence: null,
+              configSnapshot: null,
+            });
+          }
+        },
+      });
+
+      armProbeTimer(() => {
+        const error = connectError ? `connect failed: ${connectError}` : "timeout";
+        settleProbe({
+          ok: false,
+          error,
+          health: null,
+          status: null,
+          presence: null,
+          configSnapshot: null,
+        });
+      });
+
+      void startGatewayClientWhenEventLoopReady(client, {
+        timeoutMs: initialProbeTimeoutMs,
+        signal: startAbort.signal,
+      })
+        .then((readiness) => {
+          if (settled || readiness.ready || readiness.aborted) {
+            return;
+          }
           settleProbe({
             ok: false,
             error: "timeout",
@@ -423,92 +533,31 @@ export async function probeGateway(opts: {
             presence: null,
             configSnapshot: null,
           });
-        });
-        try {
-          if (detailLevel === "presence") {
-            const presence = await client.request("system-presence");
-            settleProbe({
-              ok: true,
-              error: null,
-              verifiedRead: true,
-              health: null,
-              status: null,
-              presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
-              configSnapshot: null,
-            });
+        })
+        .catch((err) => {
+          if (settled) {
             return;
           }
-          const [health, status, presence, configSnapshot] = await Promise.all([
-            client.request("health"),
-            client.request("status"),
-            client.request("system-presence"),
-            client.request("config.get", {}),
-          ]);
-          settleProbe({
-            ok: true,
-            error: null,
-            verifiedRead: true,
-            health,
-            status,
-            presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
-            configSnapshot,
-          });
-        } catch (err) {
-          const error = formatErrorMessage(err);
+          connectError = formatErrorMessage(err);
           settleProbe({
             ok: false,
-            error,
+            error: connectError,
             health: null,
             status: null,
             presence: null,
             configSnapshot: null,
           });
-        }
-      },
-    });
-
-    armProbeTimer(() => {
-      const error = connectError ? `connect failed: ${connectError}` : "timeout";
-      settleProbe({
-        ok: false,
-        error,
-        health: null,
-        status: null,
-        presence: null,
-        configSnapshot: null,
-      });
-    });
-
-    void startGatewayClientWhenEventLoopReady(client, {
-      timeoutMs: initialProbeTimeoutMs,
-      signal: startAbort.signal,
-    })
-      .then((readiness) => {
-        if (settled || readiness.ready || readiness.aborted) {
-          return;
-        }
-        settleProbe({
-          ok: false,
-          error: "timeout",
-          health: null,
-          status: null,
-          presence: null,
-          configSnapshot: null,
         });
-      })
-      .catch((err) => {
-        if (settled) {
-          return;
-        }
-        connectError = formatErrorMessage(err);
-        settleProbe({
-          ok: false,
-          error: connectError,
-          health: null,
-          status: null,
-          presence: null,
-          configSnapshot: null,
-        });
-      });
-  });
+    });
+  };
+
+  const result = await runProbeAttempt(deviceIdentity);
+  if (
+    !shouldRetryWithoutDeviceIdentity({ url: opts.url, auth: opts.auth, deviceIdentity, result })
+  ) {
+    return result;
+  }
+
+  const retried = await runProbeAttempt(null);
+  return shouldPreferRetryResult(retried) ? retried : result;
 }


### PR DESCRIPTION
## Summary

Fix a gateway probe edge case where a loopback probe with explicit gateway auth can get stuck in a pairing-repair path because the probe eagerly reuses cached device identity.

The new behavior is narrow:

- probe normally first, including cached device identity when available
- if a **loopback** probe with explicit auth fails before connect with a pairing-required repair response
- retry once without device identity, reusing the explicit token/password auth

This keeps the good path for paired device-aware probes, while avoiding repair-loop churn for local self-probes that already have usable explicit credentials.

## Why

I hit this on a dedicated worker Mac where the main `~/.openclaw` state was doing mixed duty:

- unattended worker/node state
- local CLI self-probe state

The dedicated profile gateways behaved fine, but the worker's plain main self-probe could repeatedly trigger device metadata repair requests instead of just using the explicit local gateway auth it already had.

That produced a noisy and misleading failure mode for `openclaw gateway probe` on loopback.

## Change details

- add a targeted retry path in `src/gateway/probe.ts`
- only trigger that retry when all of these are true:
  - loopback URL
  - explicit probe auth is present
  - a cached device identity was attached
  - the first attempt fails in `pairing_pending` with `PAIRING_REQUIRED`
  - failure happens before a successful connect/hello
- add a focused regression test in `src/gateway/probe.test.ts`

## Validation

Ran:

```bash
NODE_OPTIONS=--max-old-space-size=8192 pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/probe.test.ts
```

Result:

- `1 passed`
- `29 passed`
