### PR TITLE
fix(infra): classify WebSocket close-before-established as benign uncaught exception

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -400,6 +400,12 @@ describe("isTransientUnhandledRejectionError", () => {
     const wrappedDestroyedHttp2Session = Object.assign(new Error("model call failed"), {
       cause: destroyedHttp2Session,
     });
+    const wsClosedBeforeEstablished = new Error(
+      "WebSocket was closed before the connection was established",
+    );
+    const wrappedWsClosed = Object.assign(new Error("channel transport failed"), {
+      cause: wsClosedBeforeEstablished,
+    });
     const generic = new Error("boom");
 
     expect(isBenignUncaughtExceptionError(epipe)).toBe(true);
@@ -414,6 +420,8 @@ describe("isTransientUnhandledRejectionError", () => {
     expect(isBenignUncaughtExceptionError(destroyedHttp2Session)).toBe(true);
     expect(isBenignUncaughtExceptionError(wrappedDestroyedHttp2Session)).toBe(true);
     expect(isBenignUncaughtExceptionError(new Error("ERR_HTTP2_INVALID_SESSION"))).toBe(true);
+    expect(isBenignUncaughtExceptionError(wsClosedBeforeEstablished)).toBe(true);
+    expect(isBenignUncaughtExceptionError(wrappedWsClosed)).toBe(true);
     expect(isBenignUncaughtExceptionError(generic)).toBe(false);
   });
   it("returns true for transient SQLite errors", () => {

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -112,6 +112,14 @@ const TRANSIENT_NETWORK_MESSAGE_CODE_RE =
 const BENIGN_UNCAUGHT_EXCEPTION_NETWORK_MESSAGE_CODE_RE =
   /\b(ECONNREFUSED|ENETDOWN|EHOSTUNREACH|ENETUNREACH|EADDRNOTAVAIL|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED|UND_ERR_CONNECT|ERR_HTTP2_INVALID_SESSION)\b/i;
 
+/**
+ * WebSocket and other network-related message snippets that indicate recoverable
+ * transient failures and should not crash the gateway process.
+ */
+const BENIGN_UNCAUGHT_EXCEPTION_NETWORK_MESSAGE_SNIPPETS = [
+  "WebSocket was closed before the connection was established",
+];
+
 const TRANSIENT_SQLITE_MESSAGE_CODE_RE =
   /\b(SQLITE_BUSY|SQLITE_CANTOPEN|SQLITE_IOERR|SQLITE_LOCKED)\b/i;
 
@@ -438,6 +446,14 @@ function isBenignUncaughtNetworkException(err: unknown): boolean {
     }
     const message = normalizeLowercaseStringOrEmpty((candidate as { message?: unknown }).message);
     if (message && BENIGN_UNCAUGHT_EXCEPTION_NETWORK_MESSAGE_CODE_RE.test(message)) {
+      return true;
+    }
+    if (
+      message &&
+      BENIGN_UNCAUGHT_EXCEPTION_NETWORK_MESSAGE_SNIPPETS.some((snippet) =>
+        message.includes(snippet.toLowerCase()),
+      )
+    ) {
       return true;
     }
   }


### PR DESCRIPTION
Fixes #88257

## Summary

WebSocket connections (Feishu, etc.) that close before handshake complete throw `uncaughtException` with message `WebSocket was closed before the connection was established`. This is a transient network failure that should not crash the gateway process.

## Changes

- Add `BENIGN_UNCAUGHT_EXCEPTION_NETWORK_MESSAGE_SNIPPETS` array for WebSocket and similar network message patterns
- Include WebSocket close message in `isBenignUncaughtNetworkException` classifier
- Add regression tests for direct and wrapped WebSocket close errors

## Test plan

```bash
node scripts/run-vitest.mjs src/infra/unhandled-rejections.test.ts
```

Expected: `isBenignUncaughtExceptionError` returns `true` for WebSocket close errors and wrapped variants, matching HTTP2 session behavior.