### PR TITLE
plugins: Emit hooks for Codex native subagents

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-cf29066e9465cb5ac1387d1d482d0939b9176220ecc69964da9af1a471939269  plugin-sdk-api-baseline.json
-ab43993cf713a96b191c55cf89bb215c18ecdc2d8edf50f31369ce3b162c56e3  plugin-sdk-api-baseline.jsonl
+e94933dd5638231fc6132e1a15e352d6c50736973119467a2a538033f5a48d2c  plugin-sdk-api-baseline.json
+499d8db081d97fbbed69bf606567efb0bf1a8e486ab390c76ec518dab748a299  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -211,7 +211,7 @@ and pairing-path families.
     | `plugin-sdk/browser-config` | Supported browser config facade for normalized profile/defaults, CDP URL parsing, and browser-control auth helpers |
     | `plugin-sdk/agent-harness-task-runtime` | Generic task lifecycle and completion delivery helpers for harness-backed agents using a host-issued task scope |
     | `plugin-sdk/codex-mcp-projection` | Reserved bundled Codex helper for projecting user MCP server config into Codex thread config; not for third-party plugins |
-    | `plugin-sdk/codex-native-task-runtime` | Private bundled Codex helper for native task mirror/runtime wiring; not for third-party plugins |
+    | `plugin-sdk/codex-native-task-runtime` | Private bundled Codex helper for native task mirror, runtime wiring, and native subagent lifecycle hook emission; not for third-party plugins |
     | `plugin-sdk/channel-runtime-context` | Generic channel runtime-context registration and lookup helpers |
     | `plugin-sdk/matrix` | Deprecated Matrix compatibility facade for older third-party channel packages; new plugins should import `plugin-sdk/run-command` directly |
     | `plugin-sdk/mattermost` | Deprecated Mattermost compatibility facade for older third-party channel packages; new plugins should import generic SDK subpaths directly |
@@ -379,7 +379,7 @@ and pairing-path families.
     | Subpath | Owner and purpose |
     | --- | --- |
     | `plugin-sdk/codex-mcp-projection` | Bundled Codex plugin helper for projecting user MCP server config into Codex app-server thread config |
-    | `plugin-sdk/codex-native-task-runtime` | Bundled Codex plugin helper for mirroring Codex app-server native subagents into OpenClaw task state |
+    | `plugin-sdk/codex-native-task-runtime` | Bundled Codex plugin helper for mirroring Codex app-server native subagents into OpenClaw task state and lifecycle hooks |
 
   </Accordion>
 </AccordionGroup>

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -68,6 +68,8 @@ function createRuntime() {
         path: "direct" as const,
       }),
     ),
+    emitAgentHarnessSubagentSpawnedHook: vi.fn(async () => {}),
+    emitAgentHarnessSubagentEndedHook: vi.fn(async () => {}),
   };
 }
 

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -202,7 +202,7 @@ export class CodexNativeSubagentMonitor {
     const state = this.resolveMirrorState(notification);
     if (state?.mirror) {
       try {
-        await state.mirror.handleNotification(notification);
+        state.mirror.handleNotification(notification);
       } catch (error) {
         embeddedAgentLog.warn("Failed to mirror Codex native subagent lifecycle event", {
           method: notification.method,

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -5,13 +5,15 @@ import { embeddedAgentLog, formatErrorMessage } from "openclaw/plugin-sdk/agent-
 import {
   createAgentHarnessTaskRuntime,
   deliverAgentHarnessTaskCompletion,
-  emitAgentHarnessSubagentEndedHook,
-  emitAgentHarnessSubagentSpawnedHook,
   isDurableAgentHarnessCompletionDelivery,
   type AgentHarnessTaskRuntimeScope,
   type AgentHarnessTaskRuntime,
   type AgentHarnessTaskRecord,
 } from "openclaw/plugin-sdk/agent-harness-task-runtime";
+import {
+  emitAgentHarnessSubagentEndedHook,
+  emitAgentHarnessSubagentSpawnedHook,
+} from "openclaw/plugin-sdk/codex-native-task-runtime";
 import { asFiniteNumber, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CodexAppServerClient } from "./client.js";
 import {

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -5,6 +5,8 @@ import { embeddedAgentLog, formatErrorMessage } from "openclaw/plugin-sdk/agent-
 import {
   createAgentHarnessTaskRuntime,
   deliverAgentHarnessTaskCompletion,
+  emitAgentHarnessSubagentEndedHook,
+  emitAgentHarnessSubagentSpawnedHook,
   isDurableAgentHarnessCompletionDelivery,
   type AgentHarnessTaskRuntimeScope,
   type AgentHarnessTaskRuntime,
@@ -32,6 +34,8 @@ import { isJsonObject } from "./protocol.js";
 type NativeSubagentMonitorRuntime = {
   createAgentHarnessTaskRuntime: typeof createAgentHarnessTaskRuntime;
   deliverAgentHarnessTaskCompletion: typeof deliverAgentHarnessTaskCompletion;
+  emitAgentHarnessSubagentSpawnedHook: typeof emitAgentHarnessSubagentSpawnedHook;
+  emitAgentHarnessSubagentEndedHook: typeof emitAgentHarnessSubagentEndedHook;
 };
 
 type ParentState = {
@@ -82,6 +86,8 @@ const RECENT_TERMINAL_TASK_RECONCILE_GRACE_MS = 60_000;
 const defaultRuntime: NativeSubagentMonitorRuntime = {
   createAgentHarnessTaskRuntime,
   deliverAgentHarnessTaskCompletion,
+  emitAgentHarnessSubagentSpawnedHook,
+  emitAgentHarnessSubagentEndedHook,
 };
 
 const monitors = new WeakMap<CodexAppServerClient, CodexNativeSubagentMonitor>();
@@ -196,7 +202,7 @@ export class CodexNativeSubagentMonitor {
     const state = this.resolveMirrorState(notification);
     if (state?.mirror) {
       try {
-        state.mirror.handleNotification(notification);
+        await state.mirror.handleNotification(notification);
       } catch (error) {
         embeddedAgentLog.warn("Failed to mirror Codex native subagent lifecycle event", {
           method: notification.method,
@@ -221,9 +227,14 @@ export class CodexNativeSubagentMonitor {
       {
         parentThreadId: state.parentThreadId,
         requesterSessionKey: state.requesterSessionKey,
+        taskRuntimeScope: state.taskRuntimeScope,
         agentId: state.agentId,
       },
       state.taskRuntime,
+      {
+        emitSubagentSpawnedHook: this.runtime.emitAgentHarnessSubagentSpawnedHook,
+        emitSubagentEndedHook: this.runtime.emitAgentHarnessSubagentEndedHook,
+      },
     );
   }
 

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
@@ -1,7 +1,9 @@
+import type { AgentHarnessTaskRuntimeScope } from "openclaw/plugin-sdk/agent-harness-task-runtime";
 import { describe, expect, it, vi } from "vitest";
 import {
   codexNativeSubagentRunId,
   CodexNativeSubagentTaskMirror,
+  type TaskLifecycleHookRuntime,
   type TaskLifecycleRuntime,
 } from "./native-subagent-task-mirror.js";
 
@@ -11,6 +13,17 @@ function createRuntime() {
     recordTaskRunProgressByRunId: vi.fn(() => []),
     finalizeTaskRunByRunId: vi.fn(() => []),
   } as unknown as TaskLifecycleRuntime;
+}
+
+function createHookRuntime() {
+  return {
+    emitSubagentSpawnedHook: vi.fn(async () => {}),
+    emitSubagentEndedHook: vi.fn(async () => {}),
+  } satisfies TaskLifecycleHookRuntime;
+}
+
+function createTaskScope(requesterSessionKey = "agent:main:main") {
+  return { requesterSessionKey } as AgentHarnessTaskRuntimeScope;
 }
 
 describe("CodexNativeSubagentTaskMirror", () => {
@@ -136,6 +149,87 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.createRunningTaskRun).toHaveBeenCalledTimes(1);
   });
 
+  it("emits subagent_spawned when a native Codex thread is first mirrored", () => {
+    const runtime = createRuntime();
+    const hookRuntime = createHookRuntime();
+    const taskRuntimeScope = createTaskScope("agent:main:discord:channel:C123");
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+        taskRuntimeScope,
+        agentId: "main",
+      },
+      runtime,
+      hookRuntime,
+    );
+
+    mirror.handleNotification({
+      method: "thread/started",
+      params: {
+        thread: {
+          id: "child-thread",
+          preview: "inspect the repo",
+          source: {
+            subAgent: {
+              thread_spawn: {
+                parent_thread_id: "parent-thread",
+                depth: 1,
+                agent_nickname: "research",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(hookRuntime.emitSubagentSpawnedHook).toHaveBeenCalledTimes(1);
+    expect(hookRuntime.emitSubagentSpawnedHook).toHaveBeenCalledWith({
+      scope: taskRuntimeScope,
+      runId: "codex-thread:child-thread",
+      childSessionKey: "codex-thread:child-thread",
+      agentId: "main",
+      label: "research",
+      threadRequested: false,
+      mode: "run",
+    });
+  });
+
+  it("deduplicates subagent_spawned hook emission for repeated thread mirrors", () => {
+    const runtime = createRuntime();
+    const hookRuntime = createHookRuntime();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        taskRuntimeScope: createTaskScope(),
+      },
+      runtime,
+      hookRuntime,
+    );
+    const notification = {
+      method: "thread/started",
+      params: {
+        thread: {
+          id: "child-thread",
+          source: {
+            subAgent: {
+              thread_spawn: {
+                parent_thread_id: "parent-thread",
+                depth: 1,
+              },
+            },
+          },
+        },
+      },
+    } as const;
+
+    mirror.handleNotification(notification);
+    mirror.handleNotification(notification);
+
+    expect(hookRuntime.emitSubagentSpawnedHook).toHaveBeenCalledTimes(1);
+  });
+
   it("maps Codex thread status changes onto the mirrored task run", () => {
     const runtime = createRuntime();
     const mirror = new CodexNativeSubagentTaskMirror(
@@ -179,6 +273,89 @@ describe("CodexNativeSubagentTaskMirror", () => {
       progressSummary: "Codex native subagent hit a system error.",
       terminalSummary: "Codex native subagent failed.",
     });
+  });
+
+  it("emits subagent_ended when native Codex thread status becomes terminal", () => {
+    const runtime = createRuntime();
+    const hookRuntime = createHookRuntime();
+    const taskRuntimeScope = createTaskScope();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        taskRuntimeScope,
+        now: () => 30_000,
+      },
+      runtime,
+      hookRuntime,
+    );
+
+    mirror.handleNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "child-thread",
+        status: { type: "idle" },
+      },
+    });
+    mirror.handleNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "failed-child",
+        status: { type: "systemError" },
+      },
+    });
+
+    expect(hookRuntime.emitSubagentEndedHook).toHaveBeenNthCalledWith(1, {
+      scope: taskRuntimeScope,
+      runId: "codex-thread:child-thread",
+      targetSessionKey: "codex-thread:child-thread",
+      reason: "subagent-complete",
+      outcome: "ok",
+      endedAt: 30_000,
+      error: undefined,
+    });
+    expect(hookRuntime.emitSubagentEndedHook).toHaveBeenNthCalledWith(2, {
+      scope: taskRuntimeScope,
+      runId: "codex-thread:failed-child",
+      targetSessionKey: "codex-thread:failed-child",
+      reason: "subagent-error",
+      outcome: "error",
+      endedAt: 30_000,
+      error: "Codex app-server reported a system error for the native subagent thread.",
+    });
+  });
+
+  it("emits subagent_ended only once for a native Codex child run", () => {
+    const runtime = createRuntime();
+    const hookRuntime = createHookRuntime();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        taskRuntimeScope: createTaskScope(),
+        now: () => 30_000,
+      },
+      runtime,
+      hookRuntime,
+    );
+
+    mirror.handleNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "child-thread",
+        status: { type: "idle" },
+      },
+    });
+    mirror.handleNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "child-thread",
+        status: { type: "systemError" },
+      },
+    });
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(2);
+    expect(hookRuntime.emitSubagentEndedHook).toHaveBeenCalledTimes(1);
   });
 
   it("creates and updates tasks from Codex collab agent item state", () => {
@@ -255,6 +432,46 @@ describe("CodexNativeSubagentTaskMirror", () => {
       lastEventAt: 40_000,
       progressSummary: "done",
       terminalSummary: "done",
+    });
+  });
+
+  it("emits subagent_spawned from Codex collab spawn item state", () => {
+    const runtime = createRuntime();
+    const hookRuntime = createHookRuntime();
+    const taskRuntimeScope = createTaskScope();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        taskRuntimeScope,
+        agentId: "main",
+        now: () => 40_000,
+      },
+      runtime,
+      hookRuntime,
+    );
+
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          prompt: "write the proof file",
+        },
+      },
+    });
+
+    expect(hookRuntime.emitSubagentSpawnedHook).toHaveBeenCalledWith({
+      scope: taskRuntimeScope,
+      runId: "codex-thread:child-thread",
+      childSessionKey: "codex-thread:child-thread",
+      agentId: "main",
+      label: "Codex subagent",
+      threadRequested: false,
+      mode: "run",
     });
   });
 
@@ -621,5 +838,90 @@ describe("CodexNativeSubagentTaskMirror", () => {
       progressSummary: "done",
       terminalSummary: "done",
     });
+  });
+
+  it("emits subagent_ended for completed, blocked, failed, interrupted, and shutdown collab statuses", () => {
+    const runtime = createRuntime();
+    const hookRuntime = createHookRuntime();
+    const taskRuntimeScope = createTaskScope();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        taskRuntimeScope,
+        now: () => 61_000,
+      },
+      runtime,
+      hookRuntime,
+    );
+
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          senderThreadId: "parent-thread",
+          agentsStates: {
+            completedChild: { status: "completed", message: "done" },
+            blockedChild: { status: "blocked", message: "needs input" },
+            failedChild: { status: "failed", message: "boom" },
+            interruptedChild: { status: "interrupted", message: "stopped by parent" },
+            shutdownChild: { status: "shutdown", message: "app-server stopped" },
+          },
+        },
+      },
+    });
+
+    expect(hookRuntime.emitSubagentEndedHook).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        scope: taskRuntimeScope,
+        runId: "codex-thread:completedChild",
+        targetSessionKey: "codex-thread:completedChild",
+        reason: "subagent-complete",
+        outcome: "ok",
+        endedAt: 61_000,
+      }),
+    );
+    expect(hookRuntime.emitSubagentEndedHook).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        runId: "codex-thread:blockedChild",
+        targetSessionKey: "codex-thread:blockedChild",
+        reason: "subagent-complete",
+        outcome: "ok",
+      }),
+    );
+    expect(hookRuntime.emitSubagentEndedHook).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        runId: "codex-thread:failedChild",
+        targetSessionKey: "codex-thread:failedChild",
+        reason: "subagent-error",
+        outcome: "error",
+        error: "boom",
+      }),
+    );
+    expect(hookRuntime.emitSubagentEndedHook).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        runId: "codex-thread:interruptedChild",
+        targetSessionKey: "codex-thread:interruptedChild",
+        reason: "subagent-killed",
+        outcome: "killed",
+        error: "stopped by parent",
+      }),
+    );
+    expect(hookRuntime.emitSubagentEndedHook).toHaveBeenNthCalledWith(
+      5,
+      expect.objectContaining({
+        runId: "codex-thread:shutdownChild",
+        targetSessionKey: "codex-thread:shutdownChild",
+        reason: "subagent-killed",
+        outcome: "killed",
+        error: "app-server stopped",
+      }),
+    );
   });
 });

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -1,16 +1,18 @@
 import type {
   AgentHarnessTaskRuntime,
   AgentHarnessTaskRuntimeScope,
+} from "openclaw/plugin-sdk/agent-harness-task-runtime";
+import type {
   emitAgentHarnessSubagentEndedHook,
   emitAgentHarnessSubagentSpawnedHook,
   SubagentLifecycleEndedOutcome,
   SubagentLifecycleEndedReason,
-} from "openclaw/plugin-sdk/agent-harness-task-runtime";
+} from "openclaw/plugin-sdk/codex-native-task-runtime";
 import {
   resolveAgentHarnessFailedSubagentEnd,
   resolveAgentHarnessKilledSubagentEnd,
   resolveAgentHarnessSucceededSubagentEnd,
-} from "openclaw/plugin-sdk/agent-harness-task-runtime";
+} from "openclaw/plugin-sdk/codex-native-task-runtime";
 import { CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX } from "./native-subagent-task-ids.js";
 import type {
   CodexServerNotification,

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -1,4 +1,16 @@
-import type { AgentHarnessTaskRuntime } from "openclaw/plugin-sdk/agent-harness-task-runtime";
+import type {
+  AgentHarnessTaskRuntime,
+  AgentHarnessTaskRuntimeScope,
+  emitAgentHarnessSubagentEndedHook,
+  emitAgentHarnessSubagentSpawnedHook,
+  SubagentLifecycleEndedOutcome,
+  SubagentLifecycleEndedReason,
+} from "openclaw/plugin-sdk/agent-harness-task-runtime";
+import {
+  resolveAgentHarnessFailedSubagentEnd,
+  resolveAgentHarnessKilledSubagentEnd,
+  resolveAgentHarnessSucceededSubagentEnd,
+} from "openclaw/plugin-sdk/agent-harness-task-runtime";
 import { CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX } from "./native-subagent-task-ids.js";
 import type {
   CodexServerNotification,
@@ -18,9 +30,23 @@ export type TaskLifecycleRuntime = Pick<
   "createRunningTaskRun" | "recordTaskRunProgressByRunId" | "finalizeTaskRunByRunId"
 >;
 
+export type TaskLifecycleHookRuntime = {
+  emitSubagentSpawnedHook: typeof emitAgentHarnessSubagentSpawnedHook;
+  emitSubagentEndedHook: typeof emitAgentHarnessSubagentEndedHook;
+};
+
+type EndedHookParams = {
+  runId: string;
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+  endedAt: number;
+  error?: string;
+};
+
 export type CodexNativeSubagentTaskMirrorParams = {
   parentThreadId: string;
   requesterSessionKey?: string;
+  taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
   agentId?: string;
   now?: () => number;
 };
@@ -28,11 +54,13 @@ export type CodexNativeSubagentTaskMirrorParams = {
 export class CodexNativeSubagentTaskMirror {
   private readonly mirroredThreadIds = new Set<string>();
   private readonly terminalRunIds = new Set<string>();
+  private readonly endedHookRunIds = new Set<string>();
   private readonly now: () => number;
 
   constructor(
     private readonly params: CodexNativeSubagentTaskMirrorParams,
     private readonly runtime: TaskLifecycleRuntime,
+    private readonly hookRuntime?: TaskLifecycleHookRuntime,
   ) {
     this.now = params.now ?? Date.now;
   }
@@ -94,6 +122,11 @@ export class CodexNativeSubagentTaskMirror {
       lastEventAt: this.now(),
       progressSummary: "Codex native subagent started.",
     });
+    this.emitSpawnedHook({
+      runId,
+      childSessionKey: runId,
+      label,
+    });
     this.applyStatus(threadId, thread.status);
   }
 
@@ -133,6 +166,11 @@ export class CodexNativeSubagentTaskMirror {
         progressSummary: "Codex native subagent is idle.",
         terminalSummary: "Codex native subagent finished.",
       });
+      this.emitEndedHook({
+        runId,
+        endedAt: eventAt,
+        ...resolveAgentHarnessSucceededSubagentEnd(),
+      });
       return;
     }
     if (statusType === "systemError") {
@@ -145,6 +183,12 @@ export class CodexNativeSubagentTaskMirror {
         error: "Codex app-server reported a system error for the native subagent thread.",
         progressSummary: "Codex native subagent hit a system error.",
         terminalSummary: "Codex native subagent failed.",
+      });
+      this.emitEndedHook({
+        runId,
+        endedAt: eventAt,
+        error: "Codex app-server reported a system error for the native subagent thread.",
+        ...resolveAgentHarnessFailedSubagentEnd(),
       });
       return;
     }
@@ -232,6 +276,11 @@ export class CodexNativeSubagentTaskMirror {
       lastEventAt: createdAt,
       progressSummary: "Codex native subagent spawned.",
     });
+    this.emitSpawnedHook({
+      runId,
+      childSessionKey: runId,
+      label: "Codex subagent",
+    });
   }
 
   private applyCollabAgentStatus(
@@ -270,6 +319,11 @@ export class CodexNativeSubagentTaskMirror {
         progressSummary: trimOptional(message) ?? "Codex native subagent completed.",
         terminalSummary: trimOptional(message) ?? "Codex native subagent finished.",
       });
+      this.emitEndedHook({
+        runId,
+        endedAt: eventAt,
+        ...resolveAgentHarnessSucceededSubagentEnd(),
+      });
       return;
     }
     if (normalizedStatus === "blocked") {
@@ -283,8 +337,18 @@ export class CodexNativeSubagentTaskMirror {
         terminalSummary: trimOptional(message) ?? "Codex native subagent blocked.",
         terminalOutcome: "blocked",
       });
+      this.emitEndedHook({
+        runId,
+        endedAt: eventAt,
+        ...resolveAgentHarnessSucceededSubagentEnd(),
+      });
       return;
     }
+    const terminalEnd =
+      normalizedStatus === "interrupted" || normalizedStatus === "shutdown"
+        ? resolveAgentHarnessKilledSubagentEnd()
+        : resolveAgentHarnessFailedSubagentEnd();
+    const error = trimOptional(message) ?? `Codex native subagent status: ${normalizedStatus}`;
     this.terminalRunIds.add(runId);
     this.runtime.finalizeTaskRunByRunId({
       runId,
@@ -294,9 +358,49 @@ export class CodexNativeSubagentTaskMirror {
           : "failed",
       endedAt: eventAt,
       lastEventAt: eventAt,
-      error: trimOptional(message) ?? `Codex native subagent status: ${normalizedStatus}`,
+      error,
       progressSummary: trimOptional(message) ?? `Codex native subagent ${normalizedStatus}.`,
       terminalSummary: trimOptional(message) ?? "Codex native subagent did not complete.",
+    });
+    this.emitEndedHook({
+      runId,
+      endedAt: eventAt,
+      error,
+      ...terminalEnd,
+    });
+  }
+
+  private emitSpawnedHook(params: { runId: string; childSessionKey: string; label: string }): void {
+    if (!this.params.taskRuntimeScope || !this.hookRuntime) {
+      return;
+    }
+    void this.hookRuntime.emitSubagentSpawnedHook({
+      scope: this.params.taskRuntimeScope,
+      runId: params.runId,
+      childSessionKey: params.childSessionKey,
+      agentId: this.params.agentId,
+      label: params.label,
+      threadRequested: false,
+      mode: "run",
+    });
+  }
+
+  private emitEndedHook(params: EndedHookParams): void {
+    if (!this.params.taskRuntimeScope || !this.hookRuntime) {
+      return;
+    }
+    if (this.endedHookRunIds.has(params.runId)) {
+      return;
+    }
+    this.endedHookRunIds.add(params.runId);
+    void this.hookRuntime.emitSubagentEndedHook({
+      scope: this.params.taskRuntimeScope,
+      runId: params.runId,
+      targetSessionKey: params.runId,
+      reason: params.reason,
+      outcome: params.outcome,
+      endedAt: params.endedAt,
+      error: params.error,
     });
   }
 }

--- a/src/plugin-sdk/agent-harness-task-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-task-runtime.test.ts
@@ -1,14 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { deliverSubagentAnnouncement } from "../agents/subagent-announce-delivery.js";
-import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { createAgentHarnessTaskRuntimeScope } from "../tasks/agent-harness-task-runtime-scope.js";
 import { createRunningTaskRun, finalizeTaskRunByRunId } from "../tasks/detached-task-runtime.js";
 import { listTaskRecords } from "../tasks/runtime-internal.js";
 import {
   createAgentHarnessTaskRuntime,
   deliverAgentHarnessTaskCompletion,
-  emitAgentHarnessSubagentEndedHook,
-  emitAgentHarnessSubagentSpawnedHook,
   isDurableAgentHarnessCompletionDelivery,
 } from "./agent-harness-task-runtime.js";
 
@@ -32,15 +29,10 @@ vi.mock("../tasks/runtime-internal.js", () => ({
   listTaskRecords: vi.fn(() => []),
 }));
 
-vi.mock("../plugins/hook-runner-global.js", () => ({
-  getGlobalHookRunner: vi.fn(() => null),
-}));
-
 describe("agent-harness-task-runtime", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listTaskRecords).mockReturnValue([]);
-    vi.mocked(getGlobalHookRunner).mockReturnValue(null);
   });
 
   function createScope(
@@ -190,97 +182,6 @@ describe("agent-harness-task-runtime", () => {
         expectsCompletionMessage: true,
         directIdempotencyKey: "announce:harness:parent:child:succeeded",
       }),
-    );
-  });
-
-  it("emits subagent_spawned with requester metadata from the harness scope", async () => {
-    const runSubagentSpawned = vi.fn(async () => {});
-    vi.mocked(getGlobalHookRunner).mockReturnValue({
-      hasHooks: (hookName: string) => hookName === "subagent_spawned",
-      runSubagentSpawned,
-    } as never);
-    const scope = createScope("agent:main:discord:channel:C123", {
-      channel: "discord",
-      accountId: "work",
-      to: "channel:C123",
-      threadId: "456",
-    });
-
-    await emitAgentHarnessSubagentSpawnedHook({
-      scope,
-      runId: "codex-thread:child-thread",
-      childSessionKey: "codex-thread:child-thread",
-      agentId: "main",
-      label: "research",
-      threadRequested: false,
-      mode: "run",
-    });
-
-    expect(runSubagentSpawned).toHaveBeenCalledWith(
-      {
-        runId: "codex-thread:child-thread",
-        childSessionKey: "codex-thread:child-thread",
-        agentId: "main",
-        label: "research",
-        requester: {
-          channel: "discord",
-          accountId: "work",
-          to: "channel:C123",
-          threadId: "456",
-        },
-        threadRequested: false,
-        mode: "run",
-      },
-      {
-        runId: "codex-thread:child-thread",
-        childSessionKey: "codex-thread:child-thread",
-        requesterSessionKey: "agent:main:discord:channel:C123",
-      },
-    );
-  });
-
-  it("emits subagent_ended with requester account metadata and swallows hook failures", async () => {
-    const runSubagentEnded = vi.fn(async () => {
-      throw new Error("hook failed");
-    });
-    vi.mocked(getGlobalHookRunner).mockReturnValue({
-      hasHooks: (hookName: string) => hookName === "subagent_ended",
-      runSubagentEnded,
-    } as never);
-    const scope = createScope("agent:main:discord:channel:C123", {
-      channel: "discord",
-      accountId: "work",
-      to: "channel:C123",
-    });
-
-    await expect(
-      emitAgentHarnessSubagentEndedHook({
-        scope,
-        runId: "codex-thread:child-thread",
-        targetSessionKey: "codex-thread:child-thread",
-        reason: "subagent-error",
-        outcome: "error",
-        endedAt: 1_234,
-        error: "boom",
-      }),
-    ).resolves.toBeUndefined();
-
-    expect(runSubagentEnded).toHaveBeenCalledWith(
-      {
-        targetSessionKey: "codex-thread:child-thread",
-        targetKind: "subagent",
-        reason: "subagent-error",
-        accountId: "work",
-        runId: "codex-thread:child-thread",
-        endedAt: 1_234,
-        outcome: "error",
-        error: "boom",
-      },
-      {
-        runId: "codex-thread:child-thread",
-        childSessionKey: "codex-thread:child-thread",
-        requesterSessionKey: "agent:main:discord:channel:C123",
-      },
     );
   });
 

--- a/src/plugin-sdk/agent-harness-task-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-task-runtime.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { deliverSubagentAnnouncement } from "../agents/subagent-announce-delivery.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { createAgentHarnessTaskRuntimeScope } from "../tasks/agent-harness-task-runtime-scope.js";
 import { createRunningTaskRun, finalizeTaskRunByRunId } from "../tasks/detached-task-runtime.js";
 import { listTaskRecords } from "../tasks/runtime-internal.js";
 import {
   createAgentHarnessTaskRuntime,
   deliverAgentHarnessTaskCompletion,
+  emitAgentHarnessSubagentEndedHook,
+  emitAgentHarnessSubagentSpawnedHook,
   isDurableAgentHarnessCompletionDelivery,
 } from "./agent-harness-task-runtime.js";
 
@@ -29,14 +32,22 @@ vi.mock("../tasks/runtime-internal.js", () => ({
   listTaskRecords: vi.fn(() => []),
 }));
 
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
 describe("agent-harness-task-runtime", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listTaskRecords).mockReturnValue([]);
+    vi.mocked(getGlobalHookRunner).mockReturnValue(null);
   });
 
-  function createScope(requesterSessionKey = "agent:main:channel:C123") {
-    return createAgentHarnessTaskRuntimeScope({ requesterSessionKey });
+  function createScope(
+    requesterSessionKey = "agent:main:channel:C123",
+    requesterOrigin?: Parameters<typeof createAgentHarnessTaskRuntimeScope>[0]["requesterOrigin"],
+  ) {
+    return createAgentHarnessTaskRuntimeScope({ requesterSessionKey, requesterOrigin });
   }
 
   it("scopes task lifecycle mutations to the owning requester session", () => {
@@ -179,6 +190,97 @@ describe("agent-harness-task-runtime", () => {
         expectsCompletionMessage: true,
         directIdempotencyKey: "announce:harness:parent:child:succeeded",
       }),
+    );
+  });
+
+  it("emits subagent_spawned with requester metadata from the harness scope", async () => {
+    const runSubagentSpawned = vi.fn(async () => {});
+    vi.mocked(getGlobalHookRunner).mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "subagent_spawned",
+      runSubagentSpawned,
+    } as never);
+    const scope = createScope("agent:main:discord:channel:C123", {
+      channel: "discord",
+      accountId: "work",
+      to: "channel:C123",
+      threadId: "456",
+    });
+
+    await emitAgentHarnessSubagentSpawnedHook({
+      scope,
+      runId: "codex-thread:child-thread",
+      childSessionKey: "codex-thread:child-thread",
+      agentId: "main",
+      label: "research",
+      threadRequested: false,
+      mode: "run",
+    });
+
+    expect(runSubagentSpawned).toHaveBeenCalledWith(
+      {
+        runId: "codex-thread:child-thread",
+        childSessionKey: "codex-thread:child-thread",
+        agentId: "main",
+        label: "research",
+        requester: {
+          channel: "discord",
+          accountId: "work",
+          to: "channel:C123",
+          threadId: "456",
+        },
+        threadRequested: false,
+        mode: "run",
+      },
+      {
+        runId: "codex-thread:child-thread",
+        childSessionKey: "codex-thread:child-thread",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+      },
+    );
+  });
+
+  it("emits subagent_ended with requester account metadata and swallows hook failures", async () => {
+    const runSubagentEnded = vi.fn(async () => {
+      throw new Error("hook failed");
+    });
+    vi.mocked(getGlobalHookRunner).mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "subagent_ended",
+      runSubagentEnded,
+    } as never);
+    const scope = createScope("agent:main:discord:channel:C123", {
+      channel: "discord",
+      accountId: "work",
+      to: "channel:C123",
+    });
+
+    await expect(
+      emitAgentHarnessSubagentEndedHook({
+        scope,
+        runId: "codex-thread:child-thread",
+        targetSessionKey: "codex-thread:child-thread",
+        reason: "subagent-error",
+        outcome: "error",
+        endedAt: 1_234,
+        error: "boom",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runSubagentEnded).toHaveBeenCalledWith(
+      {
+        targetSessionKey: "codex-thread:child-thread",
+        targetKind: "subagent",
+        reason: "subagent-error",
+        accountId: "work",
+        runId: "codex-thread:child-thread",
+        endedAt: 1_234,
+        outcome: "error",
+        error: "boom",
+      },
+      {
+        runId: "codex-thread:child-thread",
+        childSessionKey: "codex-thread:child-thread",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+      },
     );
   });
 

--- a/src/plugin-sdk/agent-harness-task-runtime.ts
+++ b/src/plugin-sdk/agent-harness-task-runtime.ts
@@ -14,19 +14,6 @@ import {
   resolveSubagentCompletionOrigin,
 } from "../agents/subagent-announce-delivery.js";
 import { resolveAnnounceOrigin } from "../agents/subagent-announce-origin.js";
-import {
-  SUBAGENT_ENDED_OUTCOME_ERROR,
-  SUBAGENT_ENDED_OUTCOME_KILLED,
-  SUBAGENT_ENDED_OUTCOME_OK,
-  SUBAGENT_ENDED_REASON_COMPLETE,
-  SUBAGENT_ENDED_REASON_ERROR,
-  SUBAGENT_ENDED_REASON_KILLED,
-  SUBAGENT_TARGET_KIND_SUBAGENT,
-  type SubagentLifecycleEndedOutcome,
-  type SubagentLifecycleEndedReason,
-} from "../agents/subagent-lifecycle-events.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
   assertAgentHarnessTaskRuntimeScope,
@@ -43,7 +30,6 @@ import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 
 export type { TaskRecord as AgentHarnessTaskRecord };
 export type { AgentHarnessTaskRuntimeScope };
-export type { SubagentLifecycleEndedOutcome, SubagentLifecycleEndedReason };
 
 type AgentHarnessTaskRuntimeId = Parameters<typeof createRunningTaskRun>[0]["runtime"];
 type CreateRunningTaskRunParams = Parameters<typeof createRunningTaskRun>[0];
@@ -97,7 +83,6 @@ export type AgentHarnessCompletionDelivery = Awaited<
 >;
 
 const AGENT_HARNESS_COMPLETION_SOURCE_TOOL = "agent_harness_task";
-const log = createSubsystemLogger("plugin-sdk/agent-harness-task-runtime");
 
 export function createAgentHarnessTaskRuntime(
   params: AgentHarnessTaskRuntimeScopeParams,
@@ -233,130 +218,6 @@ export async function deliverAgentHarnessTaskCompletion(params: {
     directIdempotencyKey: buildAnnounceIdempotencyKey(params.announceId),
     signal: params.signal,
   });
-}
-
-export async function emitAgentHarnessSubagentSpawnedHook(params: {
-  scope: AgentHarnessTaskRuntimeScope;
-  runId: string;
-  childSessionKey: string;
-  agentId?: string;
-  label?: string;
-  mode: "run" | "session";
-  threadRequested: boolean;
-}): Promise<void> {
-  const hookRunner = getGlobalHookRunner();
-  if (!hookRunner?.hasHooks("subagent_spawned")) {
-    return;
-  }
-  try {
-    const scope = assertAgentHarnessTaskRuntimeScope(params.scope);
-    const requesterOrigin = resolveAgentHarnessRequesterOrigin(scope);
-    await hookRunner.runSubagentSpawned(
-      {
-        runId: params.runId,
-        childSessionKey: params.childSessionKey,
-        agentId: params.agentId?.trim() || "unknown",
-        label: normalizeOptionalString(params.label),
-        requester: {
-          channel: requesterOrigin?.channel,
-          accountId: requesterOrigin?.accountId,
-          to: requesterOrigin?.to,
-          threadId: requesterOrigin?.threadId,
-        },
-        threadRequested: params.threadRequested,
-        mode: params.mode,
-      },
-      {
-        runId: params.runId,
-        childSessionKey: params.childSessionKey,
-        requesterSessionKey: scope.requesterSessionKey,
-      },
-    );
-  } catch (error) {
-    log.warn("failed to emit agent harness subagent_spawned hook", {
-      runId: params.runId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
-export async function emitAgentHarnessSubagentEndedHook(params: {
-  scope: AgentHarnessTaskRuntimeScope;
-  runId: string;
-  targetSessionKey: string;
-  reason: SubagentLifecycleEndedReason;
-  outcome: SubagentLifecycleEndedOutcome;
-  endedAt?: number;
-  error?: string;
-}): Promise<void> {
-  const hookRunner = getGlobalHookRunner();
-  if (!hookRunner?.hasHooks("subagent_ended")) {
-    return;
-  }
-  try {
-    const scope = assertAgentHarnessTaskRuntimeScope(params.scope);
-    const requesterOrigin = resolveAgentHarnessRequesterOrigin(scope);
-    await hookRunner.runSubagentEnded(
-      {
-        targetSessionKey: params.targetSessionKey,
-        targetKind: SUBAGENT_TARGET_KIND_SUBAGENT,
-        reason: params.reason,
-        accountId: requesterOrigin?.accountId,
-        runId: params.runId,
-        endedAt: params.endedAt,
-        outcome: params.outcome,
-        error: params.error,
-      },
-      {
-        runId: params.runId,
-        childSessionKey: params.targetSessionKey,
-        requesterSessionKey: scope.requesterSessionKey,
-      },
-    );
-  } catch (error) {
-    log.warn("failed to emit agent harness subagent_ended hook", {
-      runId: params.runId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
-export function resolveAgentHarnessSucceededSubagentEnd(): {
-  reason: SubagentLifecycleEndedReason;
-  outcome: SubagentLifecycleEndedOutcome;
-} {
-  return {
-    reason: SUBAGENT_ENDED_REASON_COMPLETE,
-    outcome: SUBAGENT_ENDED_OUTCOME_OK,
-  };
-}
-
-export function resolveAgentHarnessFailedSubagentEnd(): {
-  reason: SubagentLifecycleEndedReason;
-  outcome: SubagentLifecycleEndedOutcome;
-} {
-  return {
-    reason: SUBAGENT_ENDED_REASON_ERROR,
-    outcome: SUBAGENT_ENDED_OUTCOME_ERROR,
-  };
-}
-
-export function resolveAgentHarnessKilledSubagentEnd(): {
-  reason: SubagentLifecycleEndedReason;
-  outcome: SubagentLifecycleEndedOutcome;
-} {
-  return {
-    reason: SUBAGENT_ENDED_REASON_KILLED,
-    outcome: SUBAGENT_ENDED_OUTCOME_KILLED,
-  };
-}
-
-function resolveAgentHarnessRequesterOrigin(scope: AgentHarnessTaskRuntimeScope) {
-  if (isInternalAnnounceRequesterSession(scope.requesterSessionKey)) {
-    return scope.requesterOrigin;
-  }
-  const { entry } = loadRequesterSessionEntry(scope.requesterSessionKey);
-  return resolveAnnounceOrigin(entry, scope.requesterOrigin);
 }
 
 function mapHarnessCompletionStatus(

--- a/src/plugin-sdk/agent-harness-task-runtime.ts
+++ b/src/plugin-sdk/agent-harness-task-runtime.ts
@@ -14,6 +14,19 @@ import {
   resolveSubagentCompletionOrigin,
 } from "../agents/subagent-announce-delivery.js";
 import { resolveAnnounceOrigin } from "../agents/subagent-announce-origin.js";
+import {
+  SUBAGENT_ENDED_OUTCOME_ERROR,
+  SUBAGENT_ENDED_OUTCOME_KILLED,
+  SUBAGENT_ENDED_OUTCOME_OK,
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+  SUBAGENT_ENDED_REASON_KILLED,
+  SUBAGENT_TARGET_KIND_SUBAGENT,
+  type SubagentLifecycleEndedOutcome,
+  type SubagentLifecycleEndedReason,
+} from "../agents/subagent-lifecycle-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
   assertAgentHarnessTaskRuntimeScope,
@@ -30,6 +43,7 @@ import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 
 export type { TaskRecord as AgentHarnessTaskRecord };
 export type { AgentHarnessTaskRuntimeScope };
+export type { SubagentLifecycleEndedOutcome, SubagentLifecycleEndedReason };
 
 type AgentHarnessTaskRuntimeId = Parameters<typeof createRunningTaskRun>[0]["runtime"];
 type CreateRunningTaskRunParams = Parameters<typeof createRunningTaskRun>[0];
@@ -83,6 +97,7 @@ export type AgentHarnessCompletionDelivery = Awaited<
 >;
 
 const AGENT_HARNESS_COMPLETION_SOURCE_TOOL = "agent_harness_task";
+const log = createSubsystemLogger("plugin-sdk/agent-harness-task-runtime");
 
 export function createAgentHarnessTaskRuntime(
   params: AgentHarnessTaskRuntimeScopeParams,
@@ -218,6 +233,130 @@ export async function deliverAgentHarnessTaskCompletion(params: {
     directIdempotencyKey: buildAnnounceIdempotencyKey(params.announceId),
     signal: params.signal,
   });
+}
+
+export async function emitAgentHarnessSubagentSpawnedHook(params: {
+  scope: AgentHarnessTaskRuntimeScope;
+  runId: string;
+  childSessionKey: string;
+  agentId?: string;
+  label?: string;
+  mode: "run" | "session";
+  threadRequested: boolean;
+}): Promise<void> {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("subagent_spawned")) {
+    return;
+  }
+  try {
+    const scope = assertAgentHarnessTaskRuntimeScope(params.scope);
+    const requesterOrigin = resolveAgentHarnessRequesterOrigin(scope);
+    await hookRunner.runSubagentSpawned(
+      {
+        runId: params.runId,
+        childSessionKey: params.childSessionKey,
+        agentId: params.agentId?.trim() || "unknown",
+        label: normalizeOptionalString(params.label),
+        requester: {
+          channel: requesterOrigin?.channel,
+          accountId: requesterOrigin?.accountId,
+          to: requesterOrigin?.to,
+          threadId: requesterOrigin?.threadId,
+        },
+        threadRequested: params.threadRequested,
+        mode: params.mode,
+      },
+      {
+        runId: params.runId,
+        childSessionKey: params.childSessionKey,
+        requesterSessionKey: scope.requesterSessionKey,
+      },
+    );
+  } catch (error) {
+    log.warn("failed to emit agent harness subagent_spawned hook", {
+      runId: params.runId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function emitAgentHarnessSubagentEndedHook(params: {
+  scope: AgentHarnessTaskRuntimeScope;
+  runId: string;
+  targetSessionKey: string;
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+  endedAt?: number;
+  error?: string;
+}): Promise<void> {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("subagent_ended")) {
+    return;
+  }
+  try {
+    const scope = assertAgentHarnessTaskRuntimeScope(params.scope);
+    const requesterOrigin = resolveAgentHarnessRequesterOrigin(scope);
+    await hookRunner.runSubagentEnded(
+      {
+        targetSessionKey: params.targetSessionKey,
+        targetKind: SUBAGENT_TARGET_KIND_SUBAGENT,
+        reason: params.reason,
+        accountId: requesterOrigin?.accountId,
+        runId: params.runId,
+        endedAt: params.endedAt,
+        outcome: params.outcome,
+        error: params.error,
+      },
+      {
+        runId: params.runId,
+        childSessionKey: params.targetSessionKey,
+        requesterSessionKey: scope.requesterSessionKey,
+      },
+    );
+  } catch (error) {
+    log.warn("failed to emit agent harness subagent_ended hook", {
+      runId: params.runId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export function resolveAgentHarnessSucceededSubagentEnd(): {
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+} {
+  return {
+    reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    outcome: SUBAGENT_ENDED_OUTCOME_OK,
+  };
+}
+
+export function resolveAgentHarnessFailedSubagentEnd(): {
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+} {
+  return {
+    reason: SUBAGENT_ENDED_REASON_ERROR,
+    outcome: SUBAGENT_ENDED_OUTCOME_ERROR,
+  };
+}
+
+export function resolveAgentHarnessKilledSubagentEnd(): {
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+} {
+  return {
+    reason: SUBAGENT_ENDED_REASON_KILLED,
+    outcome: SUBAGENT_ENDED_OUTCOME_KILLED,
+  };
+}
+
+function resolveAgentHarnessRequesterOrigin(scope: AgentHarnessTaskRuntimeScope) {
+  if (isInternalAnnounceRequesterSession(scope.requesterSessionKey)) {
+    return scope.requesterOrigin;
+  }
+  const { entry } = loadRequesterSessionEntry(scope.requesterSessionKey);
+  return resolveAnnounceOrigin(entry, scope.requesterOrigin);
 }
 
 function mapHarnessCompletionStatus(

--- a/src/plugin-sdk/codex-native-task-runtime.test.ts
+++ b/src/plugin-sdk/codex-native-task-runtime.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createAgentHarnessTaskRuntimeScope } from "../tasks/agent-harness-task-runtime-scope.js";
+import {
+  emitAgentHarnessSubagentEndedHook,
+  emitAgentHarnessSubagentSpawnedHook,
+} from "./codex-native-task-runtime.js";
+
+vi.mock("../agents/subagent-announce-delivery.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/subagent-announce-delivery.js")>();
+  return {
+    ...actual,
+    isInternalAnnounceRequesterSession: vi.fn(() => true),
+  };
+});
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+describe("codex-native-task-runtime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getGlobalHookRunner).mockReturnValue(null);
+  });
+
+  function createScope(
+    requesterSessionKey = "agent:main:channel:C123",
+    requesterOrigin?: Parameters<typeof createAgentHarnessTaskRuntimeScope>[0]["requesterOrigin"],
+  ) {
+    return createAgentHarnessTaskRuntimeScope({ requesterSessionKey, requesterOrigin });
+  }
+
+  it("emits subagent_spawned with requester metadata from the harness scope", async () => {
+    const runSubagentSpawned = vi.fn(async () => {});
+    vi.mocked(getGlobalHookRunner).mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "subagent_spawned",
+      runSubagentSpawned,
+    } as never);
+    const scope = createScope("agent:main:discord:channel:C123", {
+      channel: "discord",
+      accountId: "work",
+      to: "channel:C123",
+      threadId: "456",
+    });
+
+    await emitAgentHarnessSubagentSpawnedHook({
+      scope,
+      runId: "codex-thread:child-thread",
+      childSessionKey: "codex-thread:child-thread",
+      agentId: "main",
+      label: "research",
+      threadRequested: false,
+      mode: "run",
+    });
+
+    expect(runSubagentSpawned).toHaveBeenCalledWith(
+      {
+        runId: "codex-thread:child-thread",
+        childSessionKey: "codex-thread:child-thread",
+        agentId: "main",
+        label: "research",
+        requester: {
+          channel: "discord",
+          accountId: "work",
+          to: "channel:C123",
+          threadId: "456",
+        },
+        threadRequested: false,
+        mode: "run",
+      },
+      {
+        runId: "codex-thread:child-thread",
+        childSessionKey: "codex-thread:child-thread",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+      },
+    );
+  });
+
+  it("emits subagent_ended with requester account metadata and swallows hook failures", async () => {
+    const runSubagentEnded = vi.fn(async () => {
+      throw new Error("hook failed");
+    });
+    vi.mocked(getGlobalHookRunner).mockReturnValue({
+      hasHooks: (hookName: string) => hookName === "subagent_ended",
+      runSubagentEnded,
+    } as never);
+    const scope = createScope("agent:main:discord:channel:C123", {
+      channel: "discord",
+      accountId: "work",
+      to: "channel:C123",
+    });
+
+    await expect(
+      emitAgentHarnessSubagentEndedHook({
+        scope,
+        runId: "codex-thread:child-thread",
+        targetSessionKey: "codex-thread:child-thread",
+        reason: "subagent-error",
+        outcome: "error",
+        endedAt: 1_234,
+        error: "boom",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runSubagentEnded).toHaveBeenCalledWith(
+      {
+        targetSessionKey: "codex-thread:child-thread",
+        targetKind: "subagent",
+        reason: "subagent-error",
+        accountId: "work",
+        runId: "codex-thread:child-thread",
+        endedAt: 1_234,
+        outcome: "error",
+        error: "boom",
+      },
+      {
+        runId: "codex-thread:child-thread",
+        childSessionKey: "codex-thread:child-thread",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+      },
+    );
+  });
+});

--- a/src/plugin-sdk/codex-native-task-runtime.ts
+++ b/src/plugin-sdk/codex-native-task-runtime.ts
@@ -3,6 +3,30 @@
 // task registry without promoting detached task mutation helpers to the public
 // plugin SDK.
 
+import {
+  isInternalAnnounceRequesterSession,
+  loadRequesterSessionEntry,
+} from "../agents/subagent-announce-delivery.js";
+import { resolveAnnounceOrigin } from "../agents/subagent-announce-origin.js";
+import {
+  SUBAGENT_ENDED_OUTCOME_ERROR,
+  SUBAGENT_ENDED_OUTCOME_KILLED,
+  SUBAGENT_ENDED_OUTCOME_OK,
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+  SUBAGENT_ENDED_REASON_KILLED,
+  SUBAGENT_TARGET_KIND_SUBAGENT,
+  type SubagentLifecycleEndedOutcome,
+  type SubagentLifecycleEndedReason,
+} from "../agents/subagent-lifecycle-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+import {
+  assertAgentHarnessTaskRuntimeScope,
+  type AgentHarnessTaskRuntimeScope,
+} from "../tasks/agent-harness-task-runtime-scope.js";
+
 export {
   CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX,
   CODEX_NATIVE_SUBAGENT_RUNTIME,
@@ -15,3 +39,132 @@ export {
   finalizeTaskRunByRunId,
   recordTaskRunProgressByRunId,
 } from "../tasks/detached-task-runtime.js";
+
+export type { AgentHarnessTaskRuntimeScope };
+export type { SubagentLifecycleEndedOutcome, SubagentLifecycleEndedReason };
+
+const log = createSubsystemLogger("plugin-sdk/codex-native-task-runtime");
+
+export async function emitAgentHarnessSubagentSpawnedHook(params: {
+  scope: AgentHarnessTaskRuntimeScope;
+  runId: string;
+  childSessionKey: string;
+  agentId?: string;
+  label?: string;
+  mode: "run" | "session";
+  threadRequested: boolean;
+}): Promise<void> {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("subagent_spawned")) {
+    return;
+  }
+  try {
+    const scope = assertAgentHarnessTaskRuntimeScope(params.scope);
+    const requesterOrigin = resolveAgentHarnessRequesterOrigin(scope);
+    await hookRunner.runSubagentSpawned(
+      {
+        runId: params.runId,
+        childSessionKey: params.childSessionKey,
+        agentId: params.agentId?.trim() || "unknown",
+        label: normalizeOptionalString(params.label),
+        requester: {
+          channel: requesterOrigin?.channel,
+          accountId: requesterOrigin?.accountId,
+          to: requesterOrigin?.to,
+          threadId: requesterOrigin?.threadId,
+        },
+        threadRequested: params.threadRequested,
+        mode: params.mode,
+      },
+      {
+        runId: params.runId,
+        childSessionKey: params.childSessionKey,
+        requesterSessionKey: scope.requesterSessionKey,
+      },
+    );
+  } catch (error) {
+    log.warn("failed to emit Codex native subagent_spawned hook", {
+      runId: params.runId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function emitAgentHarnessSubagentEndedHook(params: {
+  scope: AgentHarnessTaskRuntimeScope;
+  runId: string;
+  targetSessionKey: string;
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+  endedAt?: number;
+  error?: string;
+}): Promise<void> {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("subagent_ended")) {
+    return;
+  }
+  try {
+    const scope = assertAgentHarnessTaskRuntimeScope(params.scope);
+    const requesterOrigin = resolveAgentHarnessRequesterOrigin(scope);
+    await hookRunner.runSubagentEnded(
+      {
+        targetSessionKey: params.targetSessionKey,
+        targetKind: SUBAGENT_TARGET_KIND_SUBAGENT,
+        reason: params.reason,
+        accountId: requesterOrigin?.accountId,
+        runId: params.runId,
+        endedAt: params.endedAt,
+        outcome: params.outcome,
+        error: params.error,
+      },
+      {
+        runId: params.runId,
+        childSessionKey: params.targetSessionKey,
+        requesterSessionKey: scope.requesterSessionKey,
+      },
+    );
+  } catch (error) {
+    log.warn("failed to emit Codex native subagent_ended hook", {
+      runId: params.runId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export function resolveAgentHarnessSucceededSubagentEnd(): {
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+} {
+  return {
+    reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    outcome: SUBAGENT_ENDED_OUTCOME_OK,
+  };
+}
+
+export function resolveAgentHarnessFailedSubagentEnd(): {
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+} {
+  return {
+    reason: SUBAGENT_ENDED_REASON_ERROR,
+    outcome: SUBAGENT_ENDED_OUTCOME_ERROR,
+  };
+}
+
+export function resolveAgentHarnessKilledSubagentEnd(): {
+  reason: SubagentLifecycleEndedReason;
+  outcome: SubagentLifecycleEndedOutcome;
+} {
+  return {
+    reason: SUBAGENT_ENDED_REASON_KILLED,
+    outcome: SUBAGENT_ENDED_OUTCOME_KILLED,
+  };
+}
+
+function resolveAgentHarnessRequesterOrigin(scope: AgentHarnessTaskRuntimeScope) {
+  if (isInternalAnnounceRequesterSession(scope.requesterSessionKey)) {
+    return scope.requesterOrigin;
+  }
+  const { entry } = loadRequesterSessionEntry(scope.requesterSessionKey);
+  return resolveAnnounceOrigin(entry, scope.requesterOrigin);
+}


### PR DESCRIPTION
## Summary

Codex native subagents were already mirrored into OpenClaw task state, but they did not emit the normal plugin lifecycle hooks that OpenClaw-managed subagents emit. That meant plugins listening for `subagent_spawned` or `subagent_ended` could see OpenClaw subagents but not native Codex child threads.

This PR bridges that gap by emitting normal subagent lifecycle hooks from the Codex native subagent mirror path, where the mirror already has the run id, child thread id, label, prompt preview, agent id, task runtime, and dedupe state needed to describe the subagent accurately.

## What Changed

- Added best-effort native Codex lifecycle hook helpers behind the private bundled-Codex `plugin-sdk/codex-native-task-runtime` subpath.
- Kept the public `plugin-sdk/agent-harness-task-runtime` contract focused on task lifecycle and completion delivery; this PR does not promote the hook bridge as third-party Plugin SDK API.
- Reused the existing requester-origin resolution pattern from completion delivery so lifecycle hooks include requester metadata when available.
- Wired the Codex native subagent monitor to pass the parent task runtime scope and hook emitters into the native task mirror.
- Emitted `subagent_spawned` when a Codex native child thread is first mirrored, using `codex-thread:<childThreadId>` for both `runId` and `childSessionKey`.
- Emitted `subagent_ended` when the mirror observes terminal Codex native statuses, with simple per-run dedupe and no timer/ordering machinery.
- Added unit coverage for the private Codex hook helpers and Codex native mirror hook behavior.
- Updated the Plugin SDK API hash and private subpath docs for the internal Codex runtime surface.

## Why

Plugins should not need to know whether a child agent came from the OpenClaw harness path or Codex native child-thread creation. Both represent a subagent lifecycle from the plugin author's perspective, so both should surface through the same hook contract.

The hook emission intentionally lives in the mirror path rather than lower-level child-thread registration because the mirror is where OpenClaw already derives task labels, run ids, agent ids, and terminal outcomes. Keeping the bridge there avoids duplicating lifecycle interpretation in the monitor bookkeeping layer.

The bridge is private bundled-Codex runtime wiring. It is not intended to be a new public helper surface for third-party plugins.

## How

The private Codex runtime subpath exposes two best-effort helpers used by the bundled Codex monitor:

- `emitAgentHarnessSubagentSpawnedHook(...)`
- `emitAgentHarnessSubagentEndedHook(...)`

Each helper checks whether a global hook runner exists and whether the relevant hook is registered before resolving requester metadata and invoking the hook. Hook failures are logged and swallowed so plugin hook delivery cannot break Codex native task mirroring.

The Codex native task mirror calls those helpers from the existing mirror lifecycle transitions. Successful completions map to `complete/ok`, failures map to `error/error`, and interrupted or shutdown statuses map to `killed/killed`.

## Validation

Testing degree: lightly tested locally with targeted validation, build, contracts, API baseline checks, and a broad suite attempt. The broad suite is not fully green due failures outside this PR's touched behavior.

Passed locally:

- `pnpm plugin-sdk:api:check`
- `pnpm lint --threads=8`
- `pnpm vitest run src/plugin-sdk/agent-harness-task-runtime.test.ts src/plugin-sdk/codex-native-task-runtime.test.ts extensions/codex/src/app-server/native-subagent-task-mirror.test.ts extensions/codex/src/app-server/native-subagent-monitor.test.ts`
- `pnpm check:test-types`
- `pnpm test:extensions:package-boundary`
- `git diff --check`
- `node scripts/check-sdk-package-extension-import-boundary.mjs --json`
- `pnpm test:contracts:plugins`
- `pnpm build`
- `codex review --base origin/main` reported no findings

Attempted but not clean:

- `pnpm check` failed on the npm shrinkwrap freshness guard. `package.json`, `pnpm-lock.yaml`, and `npm-shrinkwrap.json` are unchanged versus `origin/main`, so I treated this as unrelated baseline state and did not touch security-owned shrinkwrap files.
- `pnpm test` completed with unrelated failures/timeouts in broad-suite areas outside this PR, including compaction planning worker import resolution, crabbox wrapper provider expectations, provider/iMessage/OpenRouter/Telegram tests, and gateway-client/WhatsApp no-output timeouts. The focused tests for this change passed.

Not covered:

- I have not supplied a live Codex native subagent run with a plugin hook installed. Current evidence is unit/integration-style mirror coverage plus local build/check lanes.
- This PR only emits lifecycle hooks for Codex native child-thread creation and terminal status. It does not change mirrored task completion delivery status from `silent` / `not_applicable`.

## PR Readiness

- No UI or visual changes; screenshots are not applicable.
- No security-owned paths were modified.
- Local Codex review was run before submission and had no findings.
- Review feedback about public SDK API growth was addressed by moving the bridge to the private bundled-Codex runtime subpath and updating API baseline proof.

## AI-Assisted Disclosure

This PR was implemented with Codex assistance. I reviewed the diff, validation output, and failure caveats, and I understand the code being submitted.
