### PR TITLE
fix(feishu): stream plain replies as cards

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -979,6 +979,33 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("keeps partial streaming text when final replies send regular media only", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    result.replyOptions.onPartialReply?.({ text: "caption from stream" });
+    await options.deliver(
+      {
+        mediaUrl: "https://example.com/image.png",
+      },
+      { kind: "final" },
+    );
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].discard).not.toHaveBeenCalled();
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("caption from stream", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMediaFeishuMock, "media send params", {
+      mediaUrl: "https://example.com/image.png",
+    });
+  });
+
   it("sends skipped voice text when final voice media degrades to a file attachment", async () => {
     sendMediaFeishuMock.mockResolvedValueOnce({
       messageId: "file_msg",

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -5,6 +5,7 @@ type StreamingSessionStub = {
   start: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  discard: ReturnType<typeof vi.fn>;
   isActive: ReturnType<typeof vi.fn>;
 };
 
@@ -82,6 +83,9 @@ vi.mock("./streaming-card.js", () => {
       });
       update = vi.fn(async () => {});
       close = vi.fn(async () => {
+        this.active = false;
+      });
+      discard = vi.fn(async () => {
         this.active = false;
       });
       isActive = vi.fn(() => this.active);
@@ -938,6 +942,34 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       { kind: "final" },
     );
 
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMediaFeishuMock, "media send params", {
+      mediaUrl: "https://example.com/reply.mp3",
+      audioAsVoice: true,
+    });
+  });
+
+  it("discards partial streaming text when final replies send voice media", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    result.replyOptions.onPartialReply?.({ text: "spoken reply" });
+    await options.deliver(
+      {
+        text: "spoken reply",
+        mediaUrl: "https://example.com/reply.mp3",
+        audioAsVoice: true,
+      },
+      { kind: "final" },
+    );
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].discard).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).not.toHaveBeenCalled();
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
     expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -163,7 +163,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
-  function setupNonStreamingAutoDispatcher() {
+  function useNonStreamingAutoAccount() {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -174,6 +174,10 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         streaming: false,
       },
     });
+  }
+
+  function setupNonStreamingAutoDispatcher() {
+    useNonStreamingAutoAccount();
 
     createFeishuReplyDispatcher({
       cfg: {} as never,
@@ -378,8 +382,56 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
-  it("keeps auto mode plain text on non-streaming send path", async () => {
+  it("streams auto mode plain final text when streaming is enabled", async () => {
     const { options } = createDispatcherHarness();
+    await options.deliver({ text: "plain text" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("plain text", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps auto mode plain tool text on the message path when streaming is enabled", async () => {
+    const { options } = createDispatcherHarness();
+    await options.deliver({ text: "tool summary" }, { kind: "tool" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMessageFeishuMock, "message send params", {
+      text: "tool summary",
+    });
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps active auto mode streaming sessions from swallowing tool text", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onAssistantMessageStart?.();
+    await options.deliver({ text: "tool summary" }, { kind: "tool" });
+    await options.deliver({ text: "plain final answer" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMessageFeishuMock, "message send params", {
+      text: "tool summary",
+    });
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("plain final answer", {
+      note: "Agent: agent",
+    });
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps auto mode plain text on the message path when streaming is disabled", async () => {
+    const options = setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain text" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(0);
@@ -387,7 +439,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
-  it("does not attach automatic mentions to plain text replies", async () => {
+  it("does not attach automatic mentions to non-streaming plain text replies", async () => {
+    useNonStreamingAutoAccount();
+
     const { options } = createDispatcherHarness({
       replyToMessageId: "om_msg",
     });
@@ -609,6 +663,55 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("waits for deliverable text before starting a card after assistant message start", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onAssistantMessageStart?.();
+    await options.deliver({ text: "plain final answer" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("plain final answer", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("does not create an empty card when assistant message start has no deliverable final", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onAssistantMessageStart?.();
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("starts a streaming card from partial snapshots in auto mode", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    result.replyOptions.onPartialReply?.({ text: "plain" });
+    result.replyOptions.onPartialReply?.({ text: "plain streamed answer" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("plain streamed answer", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
   });
 
   it("skips distinct late final text after streaming card close", async () => {
@@ -889,6 +992,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("preserves captions for regular audio attachments", async () => {
+    useNonStreamingAutoAccount();
     const { options } = createDispatcherHarness();
     await options.deliver(
       {
@@ -928,6 +1032,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("falls back to legacy mediaUrl when mediaUrls is an empty array", async () => {
+    useNonStreamingAutoAccount();
     const { options } = createDispatcherHarness();
     await options.deliver(
       { text: "caption", mediaUrl: "https://example.com/a.png", mediaUrls: [] },
@@ -961,6 +1066,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("passes replyInThread to sendMessageFeishu for plain text", async () => {
+    useNonStreamingAutoAccount();
     const { options } = createDispatcherHarness({
       replyToMessageId: "om_msg",
       replyInThread: true,
@@ -974,6 +1080,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("allows top-level fallback for normal group quoted replies", async () => {
+    useNonStreamingAutoAccount();
     const { options } = createDispatcherHarness({
       replyToMessageId: "om_quote_reply",
       replyInThread: true,
@@ -990,6 +1097,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps native topic replies opted out of top-level fallback", async () => {
+    useNonStreamingAutoAccount();
     const { options } = createDispatcherHarness({
       replyToMessageId: "om_topic_root",
       replyInThread: true,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -375,6 +375,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     })();
   };
 
+  const resetStreamingState = () => {
+    streaming = null;
+    streamingStartPromise = null;
+    partialUpdateQueue = Promise.resolve();
+    streamText = "";
+    lastPartial = "";
+    reasoningText = "";
+    statusLine = "";
+    snapshotBaseText = "";
+    lastSnapshotTextLength = 0;
+  };
+
   const closeStreaming = async (options?: { markClosedForReply?: boolean }) => {
     try {
       if (streamingStartPromise) {
@@ -397,15 +409,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
       }
     } finally {
-      streaming = null;
-      streamingStartPromise = null;
-      partialUpdateQueue = Promise.resolve();
-      streamText = "";
-      lastPartial = "";
-      reasoningText = "";
-      statusLine = "";
-      snapshotBaseText = "";
-      lastSnapshotTextLength = 0;
+      resetStreamingState();
+    }
+  };
+
+  const discardStreamingPreview = async () => {
+    try {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
+      }
+      await partialUpdateQueue;
+      if (streaming?.isActive()) {
+        await streaming.discard();
+      }
+    } finally {
+      resetStreamingState();
     }
   };
 
@@ -561,9 +579,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           !hasVoiceMedia &&
           !skipTextForDuplicateFinal &&
           !skipTextForClosedStreamingFinal;
+        const shouldDiscardStreamingPreview =
+          info?.kind === "final" && hasMedia && !shouldDeliverText;
 
         if (!shouldDeliverText && !hasMedia) {
           return;
+        }
+
+        if (shouldDiscardStreamingPreview) {
+          await discardStreamingPreview();
         }
 
         if (shouldDeliverText) {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -409,9 +409,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
   };
 
-  const updateStreamingStatusLine = (nextStatusLine: string) => {
+  const updateStreamingStatusLine = (
+    nextStatusLine: string,
+    options?: { startIfNeeded?: boolean },
+  ) => {
     statusLine = nextStatusLine;
-    if (!streaming?.isActive() && !streamingStartPromise && renderMode !== "card") {
+    const hasStreamingSession = Boolean(streaming?.isActive() || streamingStartPromise);
+    if (!hasStreamingSession && (options?.startIfNeeded === false || renderMode !== "card")) {
       return;
     }
     startStreaming();
@@ -536,9 +540,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               ...(payload.audioAsVoice === true ? { audioAsVoice: true } : {}),
             }),
           );
+        const streamingCardEnabledForReplyKind = streamingEnabled && info?.kind === "final";
         const useCard =
           hasText &&
-          (renderMode === "card" ||
+          (streamingCardEnabledForReplyKind ||
+            renderMode === "card" ||
             (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
             (renderMode === "auto" && shouldUseCard(text)));
         const skipTextForDuplicateFinal =
@@ -580,7 +586,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
           }
 
-          if (streaming?.isActive()) {
+          const shouldStreamText = info?.kind === "block" || info?.kind === "final";
+          if (streaming?.isActive() && shouldStreamText) {
             if (info?.kind === "block") {
               // Some runtimes emit block payloads without onPartial/final callbacks.
               // Mirror block text into streamText so onIdle close still sends content.
@@ -684,6 +691,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (!cleaned) {
               return;
             }
+            startStreaming();
             queueStreamingUpdate(cleaned, {
               dedupeWithLastPartial: true,
               mode: "snapshot",
@@ -729,7 +737,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         : undefined,
       onAssistantMessageStart: streamingEnabled
         ? () => {
-            updateStreamingStatusLine("");
+            updateStreamingStatusLine("", { startIfNeeded: false });
           }
         : undefined,
       onCompactionStart: streamingEnabled

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -580,7 +580,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           !skipTextForDuplicateFinal &&
           !skipTextForClosedStreamingFinal;
         const shouldDiscardStreamingPreview =
-          info?.kind === "final" && hasMedia && !shouldDeliverText;
+          info?.kind === "final" &&
+          hasMedia &&
+          ((hasVoiceMedia && !shouldDeliverText) || skipTextForDuplicateFinal);
 
         if (!shouldDeliverText && !hasMedia) {
           return;

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -535,8 +535,9 @@ export class FeishuStreamingSession {
     const text = finalText ?? pendingMerged;
     const apiBase = resolveApiBase(this.creds.domain);
 
-    // Only send final update if content differs from what's already displayed
-    if (text && text !== this.state.sentText) {
+    // Only send final update if content differs from what's already displayed.
+    // An explicit empty final text clears a transient preview before closeout.
+    if ((text || finalText !== undefined) && text !== this.state.sentText) {
       const sent = text.startsWith(this.state.sentText)
         ? await this.updateCardContent(
             resolveStreamingCardAppendContent(this.state.sentText, text),
@@ -587,6 +588,32 @@ export class FeishuStreamingSession {
     this.pendingText = null;
 
     this.log?.(`Closed streaming: cardId=${finalState.cardId}`);
+  }
+
+  async discard(): Promise<void> {
+    if (!this.state || this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.clearFlushTimer();
+    await this.queue;
+
+    const currentState = this.state;
+    try {
+      const response = await this.client.im.message.delete({
+        path: { message_id: currentState.messageId },
+      });
+      if (response.code !== undefined && response.code !== 0) {
+        throw new Error(`Delete streaming card message failed: ${response.msg ?? response.code}`);
+      }
+      this.state = null;
+      this.pendingText = null;
+      this.log?.(`Discarded streaming card: cardId=${currentState.cardId}`);
+    } catch (error) {
+      this.log?.(`Discard failed: ${String(error)}`);
+      this.closed = false;
+      await this.close("");
+    }
   }
 
   isActive(): boolean {


### PR DESCRIPTION
## Summary

- Treat Feishu `channels.feishu.streaming=true` as the documented streaming-card delivery path for ordinary final assistant text in `renderMode: "auto"`, instead of falling through to normal text bubbles.
- Start the Feishu streaming-card session when assistant output begins or partial snapshots arrive, so Codex/app-server replies can use one card lifecycle before the final close.
- Keep non-final delivery boundaries intact: completed block replies still require `blockStreaming`, `streaming:false` still sends plain messages, and tool-summary replies stay on the normal message path.

## Real behavior proof

- Behavior or issue addressed: Feishu/Lark replies with `channels.feishu.streaming=true` and default `renderMode:auto` should render ordinary final assistant text as an interactive streaming card from the first visible reply, not as an ordinary grey text bubble.
- Real environment tested: Local OpenClaw gateway built from this PR branch (`codex/feishu-streaming-card-replies`, head `f3bc7f738c7820e53b813522e26a8a0fd97524c1`) running as version `2026.5.30` on macOS against a real Feishu p2p bot conversation. Config had `channels.feishu.streaming=true`, `channels.feishu.footer.elapsed=true`, `channels.feishu.footer.status=true`, and `messages.visibleReplies=automatic`.
- Exact steps or command run after this patch:
  1. Stopped the installed `2026.5.27` LaunchAgent gateway.
  2. Started this PR branch from source on the normal gateway port with:
     ```bash
     node scripts/run-node.mjs gateway run --bind loopback --port 18789 --force --verbose --ws-log compact --raw-stream --raw-stream-path /tmp/openclaw-pr-feishu-streaming-proof-raw.jsonl
     ```
  3. Confirmed `openclaw gateway status --require-rpc --timeout 15000` reported CLI version `2026.5.27` but running Gateway version `2026.5.30`, with Feishu enabled and connected.
  4. Sent this real Feishu p2p prompt to the bot: `PR proof 88276-1621：请直接普通回复这一句，不要调用任何工具，不要发图片或附件，只回复：PATCHED_FEISHU_STREAMING_CARD_88276_1621`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): A tester-provided Feishu screenshot captured at `2026-05-30 16:48 Asia/Shanghai` shows the reply under `1 条回复` as a white bordered card, containing `PATCHED_FEISHU_STREAMING_CARD_88276_1621`, with footer text `已完成 · 耗时 14.5s`. Redacted runtime log from the same run:
  ```text
  2026-05-30T16:48:11.428+08:00 feishu[default][msg:<redacted inbound om_...>]: phase transition (from=idle, to=creating, source=ensureCardCreated)
  2026-05-30T16:48:11.711+08:00 feishu[default][msg:<redacted inbound om_...>]: cardkit card.create response (code=0, msg=success, context=cardId=<redacted>)
  2026-05-30T16:48:11.714+08:00 feishu[default][msg:<redacted inbound om_...>]: created CardKit entity (cardId=<redacted>, initialSequence=1)
  2026-05-30T16:48:12.481+08:00 feishu[default][msg:<redacted inbound om_...>]: phase transition (from=creating, to=streaming, source=ensureCardCreated.cardkit)
  2026-05-30T16:48:12.485+08:00 feishu[default][msg:<redacted inbound om_...>]: sent CardKit card (messageId=<redacted reply om_...>)
  2026-05-30T16:48:12.543+08:00 feishu[default][msg:<redacted inbound om_...>]: phase transition (from=streaming, to=completed, source=onIdle, reason=normal)
  2026-05-30T16:48:12.886+08:00 feishu[default][msg:<redacted inbound om_...>]: cardkit card.settings response (code=0, msg=success, context=seq=2, streaming_mode=false)
  2026-05-30T16:48:13.210+08:00 feishu[default][msg:<redacted inbound om_...>]: cardkit card.update response (code=0, msg=success, context=seq=3, cardId=<redacted>)
  2026-05-30T16:48:13.213+08:00 feishu[default][msg:<redacted inbound om_...>]: reply completed, card finalized (elapsedMs=14823, isCardKit=true)
  ```
- Observed result after fix: The first visible bot reply was the streaming-card reply container, not a grey plain message bubble. The runtime created and sent a CardKit card, finalized it with `streaming_mode=false`, and the final Feishu UI showed the status/elapsed footer.
- What was not tested: No additional gaps for this Feishu p2p final-reply path.
- Proof limitations or environment constraints: The screenshot was captured in a private Feishu tenant and is described/redacted here instead of uploading private tenant imagery. `lark-cli im +messages-search` was not used because the local user token lacks `search:message`; the live gateway/CardKit runtime log above is the API-side proof.

## Verification

- `npm exec --yes --package=pnpm@11.2.2 -- pnpm exec node scripts/run-vitest.mjs run extensions/feishu/src/reply-dispatcher.test.ts` — 59 tests passed.
- `npm exec --yes --package=pnpm@11.2.2 -- pnpm exec oxlint extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `npm exec --yes --package=pnpm@11.2.2 -- pnpm exec oxfmt --check extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `git diff --check`
- Earlier adjacent hook sanity on the first revision: `npm exec --yes --package=pnpm@11.2.2 -- pnpm exec node scripts/run-vitest.mjs run extensions/codex/src/app-server/event-projector.test.ts src/auto-reply/reply/agent-runner-execution.test.ts --testNamePattern "assistant message start|onPartialReply|bridges CLI assistant agent events"`

## Risk Checklist

- User-visible behavior changed: Yes. Feishu `streaming:true` now applies to ordinary final assistant text in auto mode, matching the channel documentation.
- Config, environment, or migration behavior changed: No.
- Security, auth, secrets, network, or tool execution behavior changed: No.
- Highest-risk area: accidentally changing non-final deliveries. Mitigation: the implementation now gates forced streaming cards on `info.kind === "final"`; a regression test proves plain `tool` text still uses `sendMessageFeishu` when streaming is enabled.

## Current Review State

- Addressed ClawSweeper P1 feedback by narrowing the forced streaming-card predicate from non-block replies to final replies only.
- Added a regression test for `streaming:true` tool-summary delivery.
- Added live Feishu/CardKit proof from a real p2p run on this PR branch.
- Supersedes the earlier message-tool routing attempt in #88228; this PR targets the actual Feishu streaming-card reply path.
